### PR TITLE
training.py _check_loss_and_target_compatibility() fix crash if y is None

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -259,7 +259,7 @@ def _check_loss_and_target_compatibility(targets, loss_fns, output_shapes):
                   'binary_crossentropy',
                   'categorical_crossentropy'}
     for y, loss, shape in zip(targets, loss_fns, output_shapes):
-        if loss is None:
+        if y is None or loss is None:
             continue
         if loss.__name__ == 'categorical_crossentropy':
             if y.shape[-1] == 1:


### PR DESCRIPTION
Don't access `y` param of `model.fit()` if it is `None`. This prevents a crash when `model.fit(None,None, ...)` is called and loss is provided to `model.compile()`.