### PR TITLE
Fix TimeDistributed for multi-output layers

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -250,9 +250,6 @@ class TimeDistributed(Wrapper):
             y = y[0]
         return y
 
-    def compute_mask(self, inputs, mask=None):
-        return self.layer.compute_mask(inputs, mask)
-
 
 class Bidirectional(Wrapper):
     """Bidirectional wrapper for RNNs.

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -172,7 +172,7 @@ class TimeDistributed(Wrapper):
 
     def call(self, inputs, training=None, mask=None):
         class LPWrapper:
-            # hack equivalent to nonlocal keyword
+            # workaround equivalent to nonlocal keyword
             # This design was chosen for Python 2.7 compatibility.
             uses_learning_phase = False
 

--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -109,7 +109,6 @@ def test_TimeDistributed():
     assert uid in td._input_map
     assert K.int_shape(td._input_map[uid]) == (None, 2)
 
-
     # test layers with multiple outputs
 
     # define layer

--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -111,6 +111,10 @@ def test_TimeDistributed():
 
     # test layers with multiple outputs
 
+    # define parameters
+    samples = 2
+    timesteps = 4
+
     # define layer
     def func(x):
         return [x * 0.2, x * 0.3]
@@ -129,22 +133,18 @@ def test_TimeDistributed():
 
     model = Model(inputs=x, outputs=x1)
     model.compile(optimizer='rmsprop', loss='mse')
-    model.fit(x=np.random.random((16, 3, 2)),
-              y=[np.random.random((16, 3, 2)), np.random.random((16, 3, 2))],
-              batch_size=16,
-              epochs=1)
+    model.train_on_batch(x=np.random.random((samples, 3, 2)),
+                         y=[np.random.random((samples, 3, 2)),
+                            np.random.random((samples, 3, 2))])
 
-    # test single TimeDistributed layer with multiple outputs
-    timesteps = 10
+    # test a TimeDistributed-wrapped model with multiple outputs
     x = Input(shape=(timesteps, 3, 2))
     y = wrappers.TimeDistributed(model)(x)
     outer_model = Model(inputs=x, outputs=y)
-    # plot_model(model=outer_model, to_file='full_model.png', show_shapes=True)
     outer_model.compile(optimizer='rmsprop', loss='mse')
-    outer_model.fit(x=np.random.random((48, timesteps, 3, 2)),
-                    y=[np.random.random((48, timesteps, 3, 2)), np.random.random((48, timesteps, 3, 2))],
-                    batch_size=16,
-                    epochs=1)
+    outer_model.train_on_batch(x=np.random.random((samples, timesteps, 3, 2)),
+                               y=[np.random.random((samples, timesteps, 3, 2)),
+                                  np.random.random((samples, timesteps, 3, 2))])
 
 
 @keras_test


### PR DESCRIPTION
This PR modifies TimeDistributed so that it works with layers that have multiple outputs.

~~Note: There are no tests that cover [the activity regularizer case](https://github.com/fchollet/keras/blob/master/keras/layers/wrappers.py#L210-L214) at all so TimeDistributed **will** crash if it's used on a layer that has multiple outputs and `layer.activity_regularizer is not None`.~~