### PR TITLE
Support generic formats for saving models

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -19,6 +19,7 @@ from ..utils.layer_utils import print_summary as print_layer_summary
 from ..utils.generic_utils import has_arg
 from ..utils import conv_utils
 from ..legacy import interfaces
+from ..serializer import serialize_weights, save_dict_to_hdf5_group, load_dict_from_hdf5_group, deserialize_weights
 
 try:
     import h5py
@@ -2809,32 +2810,8 @@ def _collect_input_shape(input_tensors):
 
 
 def save_weights_to_hdf5_group(f, layers):
-    from .. import __version__ as keras_version
-
-    f.attrs['layer_names'] = [layer.name.encode('utf8') for layer in layers]
-    f.attrs['backend'] = K.backend().encode('utf8')
-    f.attrs['keras_version'] = str(keras_version).encode('utf8')
-
-    for layer in layers:
-        g = f.create_group(layer.name)
-        symbolic_weights = layer.weights
-        weight_values = K.batch_get_value(symbolic_weights)
-        weight_names = []
-        for i, (w, val) in enumerate(zip(symbolic_weights, weight_values)):
-            if hasattr(w, 'name') and w.name:
-                name = str(w.name)
-            else:
-                name = 'param_' + str(i)
-            weight_names.append(name.encode('utf8'))
-        g.attrs['weight_names'] = weight_names
-        for name, val in zip(weight_names, weight_values):
-            param_dset = g.create_dataset(name, val.shape,
-                                          dtype=val.dtype)
-            if not val.shape:
-                # scalar
-                param_dset[()] = val
-            else:
-                param_dset[:] = val
+    weights = serialize_weights(layers)
+    save_dict_to_hdf5_group(f, weights)
 
 
 def preprocess_weights_for_loading(layer, weights,
@@ -3010,61 +2987,8 @@ def load_weights_from_hdf5_group(f, layers):
         ValueError: in case of mismatch between provided layers
             and weights file.
     """
-    if 'keras_version' in f.attrs:
-        original_keras_version = f.attrs['keras_version'].decode('utf8')
-    else:
-        original_keras_version = '1'
-    if 'backend' in f.attrs:
-        original_backend = f.attrs['backend'].decode('utf8')
-    else:
-        original_backend = None
-
-    filtered_layers = []
-    for layer in layers:
-        weights = layer.weights
-        if weights:
-            filtered_layers.append(layer)
-
-    layer_names = [n.decode('utf8') for n in f.attrs['layer_names']]
-    filtered_layer_names = []
-    for name in layer_names:
-        g = f[name]
-        weight_names = [n.decode('utf8') for n in g.attrs['weight_names']]
-        if weight_names:
-            filtered_layer_names.append(name)
-    layer_names = filtered_layer_names
-    if len(layer_names) != len(filtered_layers):
-        raise ValueError('You are trying to load a weight file '
-                         'containing ' + str(len(layer_names)) +
-                         ' layers into a model with ' +
-                         str(len(filtered_layers)) + ' layers.')
-
-    # We batch weight value assignments in a single backend call
-    # which provides a speedup in TensorFlow.
-    weight_value_tuples = []
-    for k, name in enumerate(layer_names):
-        g = f[name]
-        weight_names = [n.decode('utf8') for n in g.attrs['weight_names']]
-        weight_values = [g[weight_name] for weight_name in weight_names]
-        layer = filtered_layers[k]
-        symbolic_weights = layer.weights
-        weight_values = preprocess_weights_for_loading(layer,
-                                                       weight_values,
-                                                       original_keras_version,
-                                                       original_backend)
-        if len(weight_values) != len(symbolic_weights):
-            raise ValueError('Layer #' + str(k) +
-                             ' (named "' + layer.name +
-                             '" in the current model) was found to '
-                             'correspond to layer ' + name +
-                             ' in the save file. '
-                             'However the new layer ' + layer.name +
-                             ' expects ' + str(len(symbolic_weights)) +
-                             ' weights, but the saved weights have ' +
-                             str(len(weight_values)) +
-                             ' elements.')
-        weight_value_tuples += zip(symbolic_weights, weight_values)
-    K.batch_set_value(weight_value_tuples)
+    weights = load_dict_from_hdf5_group(f)
+    return deserialize_weights(weights, layers)
 
 
 def load_weights_from_hdf5_group_by_name(f, layers):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -682,6 +682,8 @@ class Lambda(Layer):
 
     @classmethod
     def from_config(cls, config, custom_objects=None):
+        import copy
+        config = copy.deepcopy(config)
         globs = globals()
         if custom_objects:
             globs = dict(list(globs.items()) + list(custom_objects.items()))

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -96,9 +96,9 @@ class Wrapper(Layer):
     @classmethod
     def from_config(cls, config, custom_objects=None):
         from . import deserialize as deserialize_layer
-        layer = deserialize_layer(config.pop('layer'),
+        layer = deserialize_layer(config['layer'],
                                   custom_objects=custom_objects)
-        return cls(layer, **config)
+        return cls(layer, **{i: config[i] for i in config if i != 'layer'})
 
 
 class TimeDistributed(Wrapper):

--- a/keras/models.py
+++ b/keras/models.py
@@ -82,12 +82,11 @@ def _save_model(model, f, include_optimizer=True):
         'config': model.get_config()
     }, default=get_json_type).encode('utf8')
 
-    model_weights_group = f.create_group('model_weights')
     if legacy_models.needs_legacy_support(model):
         model_layers = legacy_models.legacy_sequential_layers(model)
     else:
         model_layers = model.layers
-    topology.save_weights_to_hdf5_group(model_weights_group, model_layers)
+    topology.save_weights_to_hdf5_group(f.create_group('model_weights'), model_layers)
 
     if include_optimizer and hasattr(model, 'optimizer'):
         if isinstance(model.optimizer, optimizers.TFOptimizer):

--- a/keras/models.py
+++ b/keras/models.py
@@ -28,32 +28,14 @@ except ImportError:
     h5py = None
 
 
-def save_model(model, filepath, overwrite=True, include_optimizer=True):
-    """Save a model to a HDF5 file.
-
-    The saved model contains:
-        - the model's configuration (topology)
-        - the model's weights
-        - the model's optimizer's state (if any)
-
-    Thus the saved model can be reinstantiated in
-    the exact same state, without any of the code
-    used for model definition or training.
+def _save_model(model, f, include_optimizer=True):
+    """Private method to save a model to a HDF5 file.
 
     # Arguments
         model: Keras model instance to be saved.
-        filepath: String, path where to save the model.
-        overwrite: Whether we should overwrite any existing
-            model at the target location, or instead
-            ask the user with a manual prompt.
+        f: an opened HDF file descriptor (or group of it)
         include_optimizer: If True, save optimizer's state together.
-
-    # Raises
-        ImportError: if h5py is not available.
     """
-
-    if h5py is None:
-        raise ImportError('`save_model` requires h5py.')
 
     def get_json_type(obj):
         """Serialize any object to a JSON-serializable structure.
@@ -93,95 +75,130 @@ def save_model(model, filepath, overwrite=True, include_optimizer=True):
 
     from . import __version__ as keras_version
 
-    # If file exists and should not be overwritten.
-    if not overwrite and os.path.isfile(filepath):
-        proceed = ask_to_proceed_with_overwrite(filepath)
-        if not proceed:
-            return
+    f.attrs['keras_version'] = str(keras_version).encode('utf8')
+    f.attrs['backend'] = K.backend().encode('utf8')
+    f.attrs['model_config'] = json.dumps({
+        'class_name': model.__class__.__name__,
+        'config': model.get_config()
+    }, default=get_json_type).encode('utf8')
 
-    with h5py.File(filepath, mode='w') as f:
-        f.attrs['keras_version'] = str(keras_version).encode('utf8')
-        f.attrs['backend'] = K.backend().encode('utf8')
-        f.attrs['model_config'] = json.dumps({
-            'class_name': model.__class__.__name__,
-            'config': model.get_config()
-        }, default=get_json_type).encode('utf8')
+    model_weights_group = f.create_group('model_weights')
+    if legacy_models.needs_legacy_support(model):
+        model_layers = legacy_models.legacy_sequential_layers(model)
+    else:
+        model_layers = model.layers
+    topology.save_weights_to_hdf5_group(model_weights_group, model_layers)
 
-        model_weights_group = f.create_group('model_weights')
-        if legacy_models.needs_legacy_support(model):
-            model_layers = legacy_models.legacy_sequential_layers(model)
+    if include_optimizer and hasattr(model, 'optimizer'):
+        if isinstance(model.optimizer, optimizers.TFOptimizer):
+            warnings.warn(
+                'TensorFlow optimizers do not '
+                'make it possible to access '
+                'optimizer attributes or optimizer state '
+                'after instantiation. '
+                'As a result, we cannot save the optimizer '
+                'as part of the model save file.'
+                'You will have to compile your model again '
+                'after loading it. '
+                'Prefer using a Keras optimizer instead '
+                '(see keras.io/optimizers).')
         else:
-            model_layers = model.layers
-        topology.save_weights_to_hdf5_group(model_weights_group, model_layers)
+            f.attrs['training_config'] = json.dumps({
+                'optimizer_config': {
+                    'class_name': model.optimizer.__class__.__name__,
+                    'config': model.optimizer.get_config()
+                },
+                'loss': model.loss,
+                'metrics': model.metrics,
+                'sample_weight_mode': model.sample_weight_mode,
+                'loss_weights': model.loss_weights,
+            }, default=get_json_type).encode('utf8')
 
-        if include_optimizer and hasattr(model, 'optimizer'):
-            if isinstance(model.optimizer, optimizers.TFOptimizer):
-                warnings.warn(
-                    'TensorFlow optimizers do not '
-                    'make it possible to access '
-                    'optimizer attributes or optimizer state '
-                    'after instantiation. '
-                    'As a result, we cannot save the optimizer '
-                    'as part of the model save file.'
-                    'You will have to compile your model again '
-                    'after loading it. '
-                    'Prefer using a Keras optimizer instead '
-                    '(see keras.io/optimizers).')
-            else:
-                f.attrs['training_config'] = json.dumps({
-                    'optimizer_config': {
-                        'class_name': model.optimizer.__class__.__name__,
-                        'config': model.optimizer.get_config()
-                    },
-                    'loss': model.loss,
-                    'metrics': model.metrics,
-                    'sample_weight_mode': model.sample_weight_mode,
-                    'loss_weights': model.loss_weights,
-                }, default=get_json_type).encode('utf8')
-
-                # Save optimizer weights.
-                symbolic_weights = getattr(model.optimizer, 'weights')
-                if symbolic_weights:
-                    optimizer_weights_group = f.create_group('optimizer_weights')
-                    weight_values = K.batch_get_value(symbolic_weights)
-                    weight_names = []
-                    for i, (w, val) in enumerate(zip(symbolic_weights,
-                                                     weight_values)):
-                        # Default values of symbolic_weights is /variable
-                        # for theano and cntk
-                        if K.backend() == 'theano' or K.backend() == 'cntk':
-                            if hasattr(w, 'name'):
-                                if w.name.split('/')[-1] == 'variable':
-                                    name = str(w.name) + '_' + str(i)
-                                else:
-                                    name = str(w.name)
+            # Save optimizer weights.
+            symbolic_weights = getattr(model.optimizer, 'weights')
+            if symbolic_weights:
+                optimizer_weights_group = f.create_group('optimizer_weights')
+                weight_values = K.batch_get_value(symbolic_weights)
+                weight_names = []
+                for i, (w, val) in enumerate(zip(symbolic_weights,
+                                                 weight_values)):
+                    # Default values of symbolic_weights is /variable
+                    #  for theano and cntk
+                    if K.backend() == 'theano' or K.backend() == 'cntk':
+                        if hasattr(w, 'name'):
+                            if w.name.split('/')[-1] == 'variable':
+                                name = str(w.name) + '_' + str(i)
                             else:
-                                name = 'param_' + str(i)
-                        else:
-                            if hasattr(w, 'name') and w.name:
                                 name = str(w.name)
-                            else:
-                                name = 'param_' + str(i)
-                        weight_names.append(name.encode('utf8'))
-                    optimizer_weights_group.attrs['weight_names'] = weight_names
-                    for name, val in zip(weight_names, weight_values):
-                        param_dset = optimizer_weights_group.create_dataset(
-                            name,
-                            val.shape,
-                            dtype=val.dtype)
-                        if not val.shape:
-                            # scalar
-                            param_dset[()] = val
                         else:
-                            param_dset[:] = val
-        f.flush()
+                            name = 'param_' + str(i)
+                    else:
+                        if hasattr(w, 'name') and w.name:
+                            name = str(w.name)
+                        else:
+                            name = 'param_' + str(i)
+                    weight_names.append(name.encode('utf8'))
+                optimizer_weights_group.attrs['weight_names'] = weight_names
+                for name, val in zip(weight_names, weight_values):
+                    param_dset = optimizer_weights_group.create_dataset(
+                        name,
+                        val.shape,
+                        dtype=val.dtype)
+                    if not val.shape:
+                        # scalar
+                        param_dset[()] = val
+                    else:
+                        param_dset[:] = val
 
 
-def load_model(filepath, custom_objects=None, compile=True):
-    """Loads a model saved via `save_model`.
+def save_model(model, filepath_or_f, overwrite=True, include_optimizer=True):
+    """Save a model to a HDF5 file.
+
+    The saved model contains:
+        - the model's configuration (topology)
+        - the model's weights
+        - the model's optimizer's state (if any)
+
+    Thus the saved model can be reinstantiated in
+    the exact same state, without any of the code
+    used for model definition or training.
 
     # Arguments
-        filepath: String, path to the saved model.
+        model: Keras model instance to be saved.
+        filepath_or_f: either a String, path to the saved model, or an opened HDF file (or group of it)
+        overwrite: Whether we should overwrite any existing
+            model at the target location, or instead
+            ask the user with a manual prompt.
+        include_optimizer: If True, save optimizer's state together.
+
+    # Raises
+        ImportError: if h5py is not available.
+    """
+    if h5py is None:
+        raise ImportError('`save_model` requires h5py.')
+
+    if isinstance(filepath_or_f, str):
+        filepath = filepath_or_f
+
+        # If file exists and should not be overwritten.
+        if not overwrite and os.path.isfile(filepath):
+            proceed = ask_to_proceed_with_overwrite(filepath)
+            if not proceed:
+                return
+
+        with h5py.File(filepath, 'w') as f:
+            _save_model(model, f, include_optimizer)
+            f.flush()
+    else:
+        f = filepath_or_f
+        _save_model(model, f, include_optimizer)
+
+
+def _load_model(f, custom_objects=None, compile=True):
+    """Private method to load a model to a HDF5 file.
+
+    # Arguments
+        f: an opened HDF file descriptor (or group of it)
         custom_objects: Optional dictionary mapping names
             (strings) to custom classes or functions to be
             considered during deserialization.
@@ -230,64 +247,103 @@ def load_model(filepath, custom_objects=None, compile=True):
         if obj in custom_objects:
             return custom_objects[obj]
         return obj
-    with h5py.File(filepath, mode='r') as f:
-        # instantiate model
-        model_config = f.attrs.get('model_config')
-        if model_config is None:
-            raise ValueError('No model found in config file.')
-        model_config = json.loads(model_config.decode('utf-8'))
-        model = model_from_config(model_config, custom_objects=custom_objects)
 
-        # set weights
-        topology.load_weights_from_hdf5_group(f['model_weights'], model.layers)
+    # instantiate model
+    model_config = f.attrs.get('model_config')
+    if model_config is None:
+        raise ValueError('No model found in config file.')
+    model_config = json.loads(model_config.decode('utf-8'))
+    model = model_from_config(model_config, custom_objects=custom_objects)
 
-        # Early return if compilation is not required.
-        if not compile:
-            return model
+    # set weights
+    topology.load_weights_from_hdf5_group(f['model_weights'], model.layers)
 
-        # instantiate optimizer
-        training_config = f.attrs.get('training_config')
-        if training_config is None:
-            warnings.warn('No training configuration found in save file: '
-                          'the model was *not* compiled. Compile it manually.')
-            return model
-        training_config = json.loads(training_config.decode('utf-8'))
-        optimizer_config = training_config['optimizer_config']
-        optimizer = optimizers.deserialize(optimizer_config,
-                                           custom_objects=custom_objects)
+    # Early return if compilation is not required.
+    if not compile:
+        return model
 
-        # Recover loss functions and metrics.
-        loss = convert_custom_objects(training_config['loss'])
-        metrics = convert_custom_objects(training_config['metrics'])
-        sample_weight_mode = training_config['sample_weight_mode']
-        loss_weights = training_config['loss_weights']
+    # instantiate optimizer
+    training_config = f.attrs.get('training_config')
+    if training_config is None:
+        warnings.warn('No training configuration found in save file: '
+                      'the model was *not* compiled. Compile it manually.')
+        return model
+    training_config = json.loads(training_config.decode('utf-8'))
+    optimizer_config = training_config['optimizer_config']
+    optimizer = optimizers.deserialize(optimizer_config,
+                                       custom_objects=custom_objects)
 
-        # Compile model.
-        model.compile(optimizer=optimizer,
-                      loss=loss,
-                      metrics=metrics,
-                      loss_weights=loss_weights,
-                      sample_weight_mode=sample_weight_mode)
+    # Recover loss functions and metrics.
+    loss = convert_custom_objects(training_config['loss'])
+    metrics = convert_custom_objects(training_config['metrics'])
+    sample_weight_mode = training_config['sample_weight_mode']
+    loss_weights = training_config['loss_weights']
 
-        # Set optimizer weights.
-        if 'optimizer_weights' in f:
-            # Build train function (to get weight updates).
-            if isinstance(model, Sequential):
-                model.model._make_train_function()
-            else:
-                model._make_train_function()
-            optimizer_weights_group = f['optimizer_weights']
-            optimizer_weight_names = [n.decode('utf8') for n in
-                                      optimizer_weights_group.attrs['weight_names']]
-            optimizer_weight_values = [optimizer_weights_group[n] for n in
-                                       optimizer_weight_names]
-            try:
-                model.optimizer.set_weights(optimizer_weight_values)
-            except ValueError:
-                warnings.warn('Error in loading the saved optimizer '
-                              'state. As a result, your model is '
-                              'starting with a freshly initialized '
-                              'optimizer.')
+    # Compile model.
+    model.compile(optimizer=optimizer,
+                  loss=loss,
+                  metrics=metrics,
+                  loss_weights=loss_weights,
+                  sample_weight_mode=sample_weight_mode)
+
+    # Set optimizer weights.
+    if 'optimizer_weights' in f:
+        # Build train function (to get weight updates).
+        if isinstance(model, Sequential):
+            model.model._make_train_function()
+        else:
+            model._make_train_function()
+        optimizer_weights_group = f['optimizer_weights']
+        optimizer_weight_names = [n.decode('utf8') for n in
+                                  optimizer_weights_group.attrs['weight_names']]
+        optimizer_weight_values = [optimizer_weights_group[n] for n in
+                                   optimizer_weight_names]
+        try:
+            model.optimizer.set_weights(optimizer_weight_values)
+        except ValueError:
+            warnings.warn('Error in loading the saved optimizer '
+                          'state. As a result, your model is '
+                          'starting with a freshly initialized '
+                          'optimizer.')
+
+    return model
+
+
+def load_model(filepath_or_f, custom_objects=None, compile=True):
+    """Loads a model saved via `save_model`.
+
+    # Arguments
+        filepath_or_f: either a String, path where to load the model from, or an opened HDF file (or group of it)
+        custom_objects: Optional dictionary mapping names
+            (strings) to custom classes or functions to be
+            considered during deserialization.
+        compile: Boolean, whether to compile the model
+            after loading.
+
+    # Returns
+        A Keras model instance. If an optimizer was found
+        as part of the saved model, the model is already
+        compiled. Otherwise, the model is uncompiled and
+        a warning will be displayed. When `compile` is set
+        to False, the compilation is omitted without any
+        warning.
+
+    # Raises
+        ImportError: if h5py is not available.
+        ValueError: In case of an invalid savefile.
+    """
+    if h5py is None:
+        raise ImportError('`load_model` requires h5py.')
+
+    if isinstance(filepath_or_f, str):
+        filepath = filepath_or_f
+
+        with h5py.File(filepath, mode='r') as f:
+            model = _load_model(f, custom_objects, compile)
+    else:
+        f = filepath_or_f
+        model = _load_model(f, custom_objects, compile)
+
     return model
 
 

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -681,7 +681,7 @@ def deserialize(config, custom_objects=None):
     }
     # Make deserialization case-insensitive for built-in optimizers.
     if config['class_name'].lower() in all_classes:
-        config['class_name'] = config['class_name'].lower()
+        all_classes = {config['class_name']: all_classes[config['class_name'].lower()]}
     return deserialize_keras_object(config,
                                     module_objects=all_classes,
                                     custom_objects=custom_objects,

--- a/keras/serializer.py
+++ b/keras/serializer.py
@@ -1,0 +1,222 @@
+import numpy as np
+import warnings
+try:
+    import h5py
+except ImportError:
+    h5py = None
+
+
+def _slash_get(dictionary, key):
+    """Gets the value from the dictionary associated with the key as if the key represented a path.
+    For example,
+
+    >>> _slash_get({'a': {'b': 'c'}}, 'a/b')
+    'c'
+
+    When the key starts with `/`, the retrieved item is without `/`.
+
+    # Arguments
+        dictionary: a dictionary
+        key: a string
+
+    # Returns
+        an item of the dictionary
+    """
+    if key.startswith('/'):
+        key = key[1:]
+
+    sub_keys = key.split('/')
+    if len(sub_keys) == 1:
+        dictionary = dictionary[key]
+    else:
+        for sub_layer in sub_keys:
+            dictionary = dictionary[sub_layer]
+    return dictionary
+
+
+def _slash_set(dictionary, key, value):
+    """Sets the key of the dictionary to the value as if the key represented a path.
+    For example,
+
+    >>> model_dict = {}
+    >>> _slash_set(model_dict, 'a/b', 'c')
+    model_dict == {'a': {'b': 'c'}}
+
+    When the key starts with `/`, the retrieved item is without `/`.
+
+    # Arguments
+        dictionary: a dictionary
+        key: a string
+
+    # Returns
+        an item of the dictionary
+    """
+    if key.startswith('/'):
+        key = key[1:]
+
+    sub_layers = key.split('/')
+    if len(sub_layers) == 1:
+        dictionary[key] = value
+    else:
+        base = dictionary
+        for sub_layer in sub_layers[:-1]:
+            if sub_layer not in base:
+                base[sub_layer] = {}
+            base = base[sub_layer]
+        base[sub_layers[-1]] = value
+
+
+def save_dict_to_hdf5_group(f, dictionary):
+    """Saves a dictionary to an H5 group `f`.
+
+    # Arguments
+        f: an H5 group
+        dictionary: a dictionary
+
+    # Returns
+        None
+
+    # Raises
+        TypeError: if the dictionary contains a non-serializable type
+    """
+    for key, value in dictionary.items():
+        if isinstance(value, list):
+            f.attrs[key] = [x.encode('utf-8') for x in value]
+        elif isinstance(value, str):
+            f.attrs[key] = value.encode('utf-8')
+        elif isinstance(value, (np.ndarray, np.generic)):
+            param_dset = f.create_dataset(key, value.shape, dtype=value.dtype)
+            if not value.shape:
+                # scalar
+                param_dset[()] = value
+            else:
+                param_dset[:] = value
+        elif isinstance(value, dict):
+            save_dict_to_hdf5_group(f.create_group(key), value)
+        else:
+            raise TypeError('Cannot save type "%s" to HDF5' % type(value))
+
+
+def load_dict_from_hdf5_group(f):
+    """Load a dictionary from an H5 group `f`.
+
+    # Arguments
+        f: an H5 group
+
+    # Returns
+        a dictionary
+
+    # Raises
+        TypeError: if the group contains a non-serializable object
+    """
+    if isinstance(f, h5py.Dataset):
+        return f.value
+    # else, it is a group, so we recursively get data
+    layers_dict = {}
+    for key, value in f.attrs.items():
+        if isinstance(value, bytes):
+            layers_dict[key] = value.decode('utf-8')
+        elif isinstance(value, (np.ndarray, np.generic)):
+            if value.dtype.kind == 'S':  # an array of strings
+                layers_dict[key] = [x.decode('utf-8') for x in value.tolist()]
+            else:
+                layers_dict[key] = value
+        else:
+            raise TypeError('Can\'t decode object "%s"' % type(value))
+    for key, value in f.items():
+        layers_dict[key] = load_dict_from_hdf5_group(value)
+    return layers_dict
+
+
+def serialize_weights(layers):
+    """Convert a list of layers into a dictionary
+
+    # Arguments
+        layers: list of layers (e.g. model.layers)
+
+    # Returns
+        a dictionary
+    """
+    from keras import backend as K
+    from . import __version__ as keras_version
+    result = {'layer_names': [layer.name for layer in layers],
+              'backend': K.backend(),
+              'keras_version': str(keras_version)}
+
+    for layer in layers:
+        result[layer.name] = {}
+        symbolic_weights = layer.weights
+        weight_values = K.batch_get_value(symbolic_weights)
+        weight_names = []
+        for i, (w, val) in enumerate(zip(symbolic_weights, weight_values)):
+            if hasattr(w, 'name') and w.name:
+                name = str(w.name)
+            else:
+                name = 'param_' + str(i)
+            weight_names.append(name)
+
+        result[layer.name]['weight_names'] = weight_names
+        for name, val in zip(weight_names, weight_values):
+            _slash_set(result[layer.name], name, val)
+    return result
+
+
+def deserialize_weights(layers_dict, layers):
+    """Populates a list of `layer`s with the data from `layers_dict`.
+
+    # Arguments
+        layers: list of layers (e.g. model.layers)
+
+    # Returns
+        a dictionary
+
+    # Raises
+        ValueError: when the number of layers in the dictionary differs from the number of `layers`.
+        ValueError: when the number of weights of a layer in the dictionary differs from the number of weights in the corresponding layer.
+    """
+    from keras import backend as K
+    from keras.engine import topology
+    filtered_layers = []
+
+    for layer in layers:
+        weights = layer.weights
+        if weights:
+            filtered_layers.append(layer)
+
+    layer_names = [n for n in layers_dict['layer_names']]
+    filtered_layer_names = []
+    for layer_name in layer_names:
+        root = _slash_get(layers_dict, layer_name)
+        weight_names = [n for n in root['weight_names']]
+        if weight_names:
+            filtered_layer_names.append(layer_name)
+    layer_names = filtered_layer_names
+    if len(layer_names) != len(filtered_layers):
+        raise ValueError('You are trying to load a weight dict '
+                         'containing ' + str(len(layer_names)) +
+                         ' layers into a model with ' +
+                         str(len(filtered_layers)) + ' layers.')
+
+    # We batch weight value assignments in a single backend call
+    # which provides a speedup in TensorFlow.
+    weight_value_tuples = []
+    for k, layer_name in enumerate(layer_names):
+        root = _slash_get(layers_dict, layer_name)
+        weight_names = [n for n in root['weight_names']]
+        weight_values = [_slash_get(root, weight_name) for weight_name in weight_names]
+        layer = filtered_layers[k]
+        symbolic_weights = layer.weights
+        weight_values = topology.preprocess_weights_for_loading(layer, weight_values)
+        if len(weight_values) != len(symbolic_weights):
+            raise ValueError('Layer #' + str(k) +
+                             ' (named "' + layer.name +
+                             '" in the current model) was found to '
+                             'correspond to layer ' + layer_name +
+                             ' in the save file. '
+                             'However the new layer ' + layer.name +
+                             ' expects ' + str(len(symbolic_weights)) +
+                             ' weights, but the saved weights have ' +
+                             str(len(weight_values)) +
+                             ' elements.')
+        weight_value_tuples += zip(symbolic_weights, weight_values)
+    K.batch_set_value(weight_value_tuples)

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -172,7 +172,8 @@ def func_dump(func):
     # Returns
         A tuple `(code, defaults, closure)`.
     """
-    code = marshal.dumps(func.__code__).decode('raw_unicode_escape')
+    # We need two passes here because the first `dumps` and `loads` changes the object.
+    code = marshal.dumps(marshal.loads(marshal.dumps(func.__code__))).decode('raw_unicode_escape')
     defaults = func.__defaults__
     if func.__closure__:
         closure = tuple(c.cell_contents for c in func.__closure__)

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -40,7 +40,6 @@ def _test_optimizer(optimizer, target=0.75):
     config = optimizers.serialize(optimizer)
     optim = optimizers.deserialize(config)
     new_config = optimizers.serialize(optim)
-    new_config['class_name'] = new_config['class_name'].lower()
     assert config == new_config
 
     # Test constraints.

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -303,6 +303,19 @@ def square_fn(x):
 
 
 @keras_test
+def test_serialize_functions():
+    """Tests that `X = func_dump(func_load(X))`"""
+    from keras.utils.generic_utils import func_dump, func_load
+
+    result = func_dump(square_fn)
+    result1 = func_dump(func_load(*result))
+
+    expected_string = result[0]
+    obtained_string = result1[0]
+    assert expected_string == obtained_string
+
+
+@keras_test
 def test_saving_lambda_custom_objects():
     inputs = Input(shape=(3,))
     x = Lambda(lambda x: square_fn(x), output_shape=(3,))(inputs)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,0 +1,26 @@
+from keras.serializer import _slash_get, _slash_set
+from keras.utils.test_utils import keras_test
+
+
+@keras_test
+def test_slash_get():
+    assert _slash_get({'a': {'b': 'c'}}, 'a/b') == 'c'
+
+    assert _slash_get({'a': {'b': 'c'}}, '/a') == {'b': 'c'}
+
+
+@keras_test
+def test_slash_set():
+    a = {}
+    _slash_set(a, 'a/b', 'c')
+    assert a == {'a': {'b': 'c'}}
+
+    _slash_set(a, 'a/b', 'd')
+    assert a == {'a': {'b': 'd'}}
+
+    _slash_set(a, 'a/c', 'd')
+    assert a == {'a': {'b': 'd', 'c': 'd'}}
+
+    a = {}
+    _slash_set(a, '/a', 'c')
+    assert a == {'a': 'c'}


### PR DESCRIPTION
This proposes to change the internals of saving and loading Keras objects to allow generic file formats (i.e. not restricted to H5) in a way that maintains backward compatibility (API and saved models).

Currently, the way we save a model is to dump it into HDF5. It works very well. However, HDF5 is just one format out of many other formats to store information. This PR proposes a way to generalize this to any other format.

Our current approach to save a Keras model is

```
model -> (save_model, save_weights_to_hdf5_group) -> HDF5
HDF5 -> (load_model, load_weights_to_hdf5_group) -> model
```

This PR proposes this to be changed to

```
model -> (model_to_dict) -> Python dictionary -> (dict_to_h5_group) -> HDF5
HDF5 -> (dict_from_h5_group) -> Python dictionary -> (model_from_dict) -> model
```

By exposing the functions `model_to_dict` and `model_from_dict`, we allow any other format because a developer can write its own serializer of a Python dictionary.

This PR essentially splits the `save_model/load_model` (`save_weights/load_weights`) into two parts, one for generating a dictionary from a model (layers), and the other to serialize said dictionaries to HDF5 in a way that keeps what we currently have.

A corollary of this proposal is that we could support pickle of Keras models with just

```
    def __getstate__(self):
        return model_to_dict(self)

    def __setstate__(self, state):
        self.__dict__ = dict_to_model(state).__dict__
```

This PR currently passes all `model_saving` tests, and contains all tests for the transformation `model <-> Python dictionary`.

Before moving to tests and other cleanups, I would like to have some feedback (especially @fchollet) on whether this is something that Keras would like to have incorporated.