### PR TITLE
feat(docs): add links to runnable examples in sequential-model-guide.md

### DIFF
--- a/docs/templates/getting-started/sequential-model-guide.md
+++ b/docs/templates/getting-started/sequential-model-guide.md
@@ -180,6 +180,7 @@ model.fit(x_train, y_train,
           batch_size=128)
 score = model.evaluate(x_test, y_test, batch_size=128)
 ```
+[Try it in your browser](https://machinelabs.ai/editor/Hysvh3euZ/1504626424570-BJ-ZvB2Kb?tab=editor)
 
 
 ### MLP for binary classification:
@@ -211,6 +212,7 @@ model.fit(x_train, y_train,
           batch_size=128)
 score = model.evaluate(x_test, y_test, batch_size=128)
 ```
+[Try it in your browser](https://machinelabs.ai/editor/HkJrCXMO-/1504626625362-B1YTPr3Y-?tab=editor)
 
 
 ### VGG-like convnet:
@@ -253,6 +255,7 @@ model.compile(loss='categorical_crossentropy', optimizer=sgd)
 model.fit(x_train, y_train, batch_size=32, epochs=10)
 score = model.evaluate(x_test, y_test, batch_size=32)
 ```
+[Try it in your browser](https://machinelabs.ai/editor/Sy8beEzuW/1504626945348-r1FZKShYb?tab=editor)
 
 
 ### Sequence classification with LSTM:
@@ -347,6 +350,7 @@ model.fit(x_train, y_train,
           batch_size=64, epochs=5,
           validation_data=(x_val, y_val))
 ```
+[Try it in your browser](https://machinelabs.ai/editor/rJPrQ4GO-/1504627240813-S1Z4qr2tZ?tab=editor)
 
 
 ### Same stacked LSTM model, rendered "stateful"
@@ -393,3 +397,4 @@ model.fit(x_train, y_train,
           batch_size=batch_size, epochs=5, shuffle=False,
           validation_data=(x_val, y_val))
 ```
+[Try it in your browser](https://machinelabs.ai/editor/rJPrQ4GO-/1504627321614-SkzY9SnYW?tab=editor)


### PR DESCRIPTION
This commit adds links to runnable [MachineLabs](https://machinelabs.ai) executions for all examples on the ["Guide to the Sequential model"](https://keras.io/getting-started/sequential-model-guide) documentation page.

Each complete example in the documentation will now have a dedicated "lab" in MachineLabs, with its link pointing to that lab's original execution (see picture below)

<img width="1435" alt="screen shot 2017-08-23 at 22 16 50" src="https://user-images.githubusercontent.com/4638332/29636848-77e26fcc-8852-11e7-9614-ff6e63cafd13.png">