### PR TITLE
Prevent loading HD5Stores into memory

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -771,7 +771,9 @@ class NumpyArrayIterator(Iterator):
 
         if data_format is None:
             data_format = K.image_data_format()
-        self.x = np.asarray(x, dtype=K.floatx())
+        if not getattr(x, 'dtype', None) != K.floatx():
+            x = np.asarray(x, dtype=K.floatx())
+        self.x = x
 
         if self.x.ndim != 4:
             raise ValueError('Input data in `NumpyArrayIterator` '

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -771,7 +771,9 @@ class NumpyArrayIterator(Iterator):
 
         if data_format is None:
             data_format = K.image_data_format()
-        if not getattr(x, 'dtype', None) != K.floatx():
+
+        dtype = getattr(x, 'dtype', None)
+        if dtype != K.floatx():
             x = np.asarray(x, dtype=K.floatx())
         self.x = x
 


### PR DESCRIPTION
The command np.asarray loads the whole thing into memory causing an out of memory error when using bcolz, HD5Store or anything similar. 

This changes it to only convert type if needed.