### PR TITLE
Add option to allow loading of weights with mismatch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas pytest h5py
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy nose scipy matplotlib pandas pytest h5py
   - source activate test-environment
   - conda install mkl mkl-service
   - pip install theano

--- a/keras/models.py
+++ b/keras/models.py
@@ -727,7 +727,7 @@ class Sequential(Model):
             self.build()
         self.model.set_weights(weights)
 
-    def load_weights(self, filepath, by_name=False):
+    def load_weights(self, filepath, by_name=False, skip_mismatch=False):
         if h5py is None:
             raise ImportError('`load_weights` requires h5py.')
         f = h5py.File(filepath, mode='r')
@@ -740,7 +740,8 @@ class Sequential(Model):
         else:
             layers = self.layers
         if by_name:
-            topology.load_weights_from_hdf5_group_by_name(f, layers)
+            topology.load_weights_from_hdf5_group_by_name(f, layers,
+                                                          skip_mismatch=skip_mismatch)
         else:
             topology.load_weights_from_hdf5_group(f, layers)
         if hasattr(f, 'close'):


### PR DESCRIPTION
This PR adds two boolean arguments to `load_weights`. The first, `skip_mismatch`, makes the loading skip copying of weights for layers where the shape mismatches that of the shape found in the weights file. It will print a warning about skipping this layer, unless the second flag, `quiet_skip` is set.

This is useful for training a network on some number of classes and then refining that same network on a different number of classes. These flags would make the [`notop`](https://github.com/fchollet/keras/blob/master/keras/applications/resnet50.py#L37) models redundant for the networks in `keras.applications`.