### PR TITLE
Rename "nb_classes" to "num_classes"

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2002,8 +2002,8 @@ def spatial_3d_padding(x, padding=((1, 1), (1, 1), (1, 1)), data_format=None):
     return x
 
 
-def one_hot(indices, nb_classes):
-    return C.one_hot(indices, nb_classes)
+def one_hot(indices, num_classes):
+    return C.one_hot(indices, num_classes)
 
 
 def get_value(x):


### PR DESCRIPTION
Rename "nb_classes" (in cntk_backend.py) to "num_classes" for consistency with other backends.

cntk_backend.py
`def one_hot(indices, nb_classes):`  -> num_classes

theano_backend.py and tensorflow_backend.py
`def one_hot(indices, num_classes):`