### PR TITLE
Fix predict_generator output shape for multi-output models when batch size is larger than the dataset.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2445,6 +2445,6 @@ class Model(Container):
             else:
                 return np.concatenate(all_outs[0])
         if steps_done == 1:
-            return [out for out in all_outs]
+            return [out[0] for out in all_outs]
         else:
             return [np.concatenate(out) for out in all_outs]

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -412,22 +412,22 @@ def test_model_methods():
                                   callbacks=[tracker_cb])
 
     # predict_generator output shape behavior should be consistent
-    def expected_shape(samples, batches):
-        return (samples * batches, 4), (samples * batches, 3)
+    def expected_shape(batch_size, n_batches):
+        return (batch_size * n_batches, 4), (batch_size * n_batches, 3)
 
     # Multiple outputs and one step.
-    n_samples = 5
+    batch_size = 5
     sequence_length = 1
-    shape_0, shape_1 = expected_shape(n_samples, sequence_length)
-    out = model.predict_generator(RandomSequence(n_samples,
+    shape_0, shape_1 = expected_shape(batch_size, sequence_length)
+    out = model.predict_generator(RandomSequence(batch_size,
                                                  sequence_length=sequence_length))
     assert np.shape(out[0]) == shape_0 and np.shape(out[1]) == shape_1
 
     # Multiple outputs and multiple steps.
-    n_samples = 5
+    batch_size = 5
     sequence_length = 2
-    shape_0, shape_1 = expected_shape(n_samples, sequence_length)
-    out = model.predict_generator(RandomSequence(n_samples,
+    shape_0, shape_1 = expected_shape(batch_size, sequence_length)
+    out = model.predict_generator(RandomSequence(batch_size,
                                                  sequence_length=sequence_length))
     assert np.shape(out[0]) == shape_0 and np.shape(out[1]) == shape_1
 
@@ -436,18 +436,18 @@ def test_model_methods():
     single_output_model.compile(optimizer, loss, metrics=[], sample_weight_mode=None)
 
     # Single output and one step.
-    n_samples = 5
+    batch_size = 5
     sequence_length = 1
-    shape_0, _ = expected_shape(n_samples, sequence_length)
-    out = single_output_model.predict_generator(RandomSequence(n_samples,
+    shape_0, _ = expected_shape(batch_size, sequence_length)
+    out = single_output_model.predict_generator(RandomSequence(batch_size,
                                                 sequence_length=sequence_length))
     assert np.shape(out) == shape_0
 
     # Single output and multiple steps.
-    n_samples = 5
+    batch_size = 5
     sequence_length = 2
-    shape_0, _ = expected_shape(n_samples, sequence_length)
-    out = single_output_model.predict_generator(RandomSequence(n_samples,
+    shape_0, _ = expected_shape(batch_size, sequence_length)
+    out = single_output_model.predict_generator(RandomSequence(batch_size,
                                                 sequence_length=sequence_length))
     assert np.shape(out) == shape_0
 

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -22,11 +22,12 @@ from keras.callbacks import LambdaCallback
 
 
 class RandomSequence(Sequence):
-    def __init__(self, batch_size):
+    def __init__(self, batch_size, sequence_length=12):
         self.batch_size = batch_size
+        self.sequence_length = sequence_length
 
     def __len__(self):
-        return 12
+        return self.sequence_length
 
     def __getitem__(self, idx):
         return [np.random.random((self.batch_size, 3)), np.random.random((self.batch_size, 3))], [

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -411,6 +411,46 @@ def test_model_methods():
                                   initial_epoch=0, validation_data=gen_data(),
                                   callbacks=[tracker_cb])
 
+    # predict_generator output shape behavior should be consistent
+    def expected_shape(samples, batches):
+        return (samples * batches, 4), (samples * batches, 3)
+
+    # Multiple outputs and one step.
+    n_samples = 5
+    sequence_length = 1
+    shape_0, shape_1 = expected_shape(n_samples, sequence_length)
+    out = model.predict_generator(RandomSequence(n_samples,
+                                                 sequence_length=sequence_length))
+    assert np.shape(out[0]) == shape_0 and np.shape(out[1]) == shape_1
+
+    # Multiple outputs and multiple steps.
+    n_samples = 5
+    sequence_length = 2
+    shape_0, shape_1 = expected_shape(n_samples, sequence_length)
+    out = model.predict_generator(RandomSequence(n_samples,
+                                                 sequence_length=sequence_length))
+    assert np.shape(out[0]) == shape_0 and np.shape(out[1]) == shape_1
+
+    # Create a model with a single output.
+    single_output_model = Model([a, b], a_2)
+    single_output_model.compile(optimizer, loss, metrics=[], sample_weight_mode=None)
+
+    # Single output and one step.
+    n_samples = 5
+    sequence_length = 1
+    shape_0, _ = expected_shape(n_samples, sequence_length)
+    out = single_output_model.predict_generator(RandomSequence(n_samples,
+                                                sequence_length=sequence_length))
+    assert np.shape(out) == shape_0
+
+    # Single output and multiple steps.
+    n_samples = 5
+    sequence_length = 2
+    shape_0, _ = expected_shape(n_samples, sequence_length)
+    out = single_output_model.predict_generator(RandomSequence(n_samples,
+                                                sequence_length=sequence_length))
+    assert np.shape(out) == shape_0
+
 
 @pytest.mark.skipif(sys.version_info < (3,), reason='Cannot catch warnings in python 2')
 @keras_test


### PR DESCRIPTION
For a multi-output model, if a data generator's batch size is larger than the data set size, predict_generator's output shape is incorrect.

For example:
*  I have a data generator with batch_size=64.
* There are 50 samples in my data set.
* My model is multi-output with 5 outputs containing 3 classes per output.

This scenario will reach [L2448 in training.py](https://github.com/keras-team/keras/blob/master/keras/engine/training.py#L2448):
```
if steps_done == 1:
    return [out for out in all_outs]
else:
    return [np.concatenate(out) for out in all_outs]
```
Because the batch_size is larger than the data set, steps_done will be equal to 1.

The result will be of shape (5, 1, 50, 3) because `[out for out in all_outs]` doesn't change the output shape.  This differs from the case where the batch size is less than the dataset size.  In that case the result will be (5, 50, 3) due to `[np.concatenate(out) for out in all_outs]`.

I'm proposing the following fix:
`return [out[0] for out in all_outs]`

This will convert the (5, 1, 50, 3) to the expected (5, 50, 3).
*****
Edit: It seems like another solution would be to change
```
if steps_done == 1:
    return [out for out in all_outs]
else:
    return [np.concatenate(out) for out in all_outs]
```
to a single return statement:
```
return [np.concatenate(out) for out in all_outs]
```