### PR TITLE
Fix Adam saving

### DIFF
--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -443,7 +443,7 @@ class Adam(Optimizer):
         if self.amsgrad:
             vhats = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
         else:
-            vhats = [None for p in params]
+            vhats = [K.zeros(1) for _ in params]
         self.weights = [self.iterations] + ms + vs + vhats
 
         for p, g, m, v, vhat in zip(params, grads, ms, vs, vhats):

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -84,7 +84,7 @@ def test_functional_model_saving():
 
     model = Model(inputs, outputs)
     model.compile(loss=losses.MSE,
-                  optimizer=optimizers.RMSprop(lr=0.0001),
+                  optimizer=optimizers.Adam(),
                   metrics=[metrics.categorical_accuracy])
     x = np.random.random((1, 3))
     y = np.random.random((1, 3))


### PR DESCRIPTION
Fix a bug in model saving caused by PR #8693.

`K.batch_get_value` does not support `None` values. An error occurs when it is called in `save_model` to get `Adam(amsgrad=False)` optimizer weights (on all 3 backends).

Fix it by creating size-1 zero tensors instead of `None`. Cannot use size-0 tensors because `K.batch_set_value` would fail on size-0 tensors during model loading.

Also changed a test in test_model_saving.py (switching from `RMSprop` to `Adam`) to cover this case.