### PR TITLE
[DOCS] added validation split while training in example

### DIFF
--- a/examples/mnist_cnn.py
+++ b/examples/mnist_cnn.py
@@ -64,7 +64,7 @@ model.fit(x_train, y_train,
           batch_size=batch_size,
           epochs=epochs,
           verbose=1,
-          validation_data=(x_test, y_test))
+          validation_split=0.2)
 score = model.evaluate(x_test, y_test, verbose=0)
 print('Test loss:', score[0])
 print('Test accuracy:', score[1])


### PR DESCRIPTION
As per the issue: https://github.com/keras-team/keras/issues/8796
This adds a validation split while training.
Other things are kept unchanged