### PR TITLE
fix #8087, K.arange accept tensor input on tensorflow backend

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2055,8 +2055,16 @@ def arange(start, stop=None, step=1, dtype='int32'):
 
     """
     # Match the behavior of numpy and Theano by returning an empty seqence.
-    if stop is None and start < 0:
-        start = 0
+    if stop is None:
+        try:
+            if start < 0:
+                start = 0
+        except TypeError:
+            # Handle case where start is a tensor
+            start = tf.cond(start < 0,
+                            true_fn=lambda: tf.constant(0, dtype=start.dtype),
+                            false_fn=lambda: start)
+
     result = tf.range(start, limit=stop, delta=step, name='arange')
     if dtype != 'int32':
         result = cast(result, dtype)

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1371,6 +1371,15 @@ class TestBackend(object):
                 t = backend.arange(10, dtype=dtype)
                 assert backend.dtype(t) == dtype
 
+        for backend in [KTH, KTF]:
+            start = backend.constant(1, dtype='int32')
+            t = backend.arange(start)
+            assert len(backend.eval(t)) == 1
+
+            start = backend.constant(-1, dtype='int32')
+            t = backend.arange(start)
+            assert len(backend.eval(t)) == 0
+
     def test_in_train_phase(self):
         for training in [True, False]:
             check_two_tensor_operation('in_train_phase', (3, 3), (2, 2), [KTH, KTF],


### PR DESCRIPTION
Allows you to create a dynamically sized range object in tensorflow.

As in #8087:
```python
import tensorflow as tf
from keras import backend as K

K.arange(K.constant(1))
```