### PR TITLE
Implement NCHW/NHWC for keras.json

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -35,6 +35,10 @@ if os.path.exists(_config_path):
     assert _backend in {'theano', 'tensorflow', 'cntk'}
     _image_data_format = _config.get('image_data_format',
                                      image_data_format())
+    if _image_data_format == 'NCHW':
+        _image_data_format = 'channels_first'
+    elif _image_data_format == 'NHWC':
+        _image_data_format = 'channels_last'
     assert _image_data_format in {'channels_last', 'channels_first'}
 
     set_floatx(_floatx)


### PR DESCRIPTION
This PR will try to implement `NCHW`/`NHWC` for `keras.json`.
If this PR is merged, such `keras.json` will be legal:
```
{
    "floatx": "float32",
    "epsilon": 1e-07,
    "backend": "tensorflow",
    "image_data_format": "NCHW"
}
```
which is more friendly if someone is porting from other frameworks (Caffe etc) to Keras.

Old config file will not be affected, as this PR is simply a transformation from `NCHW`/`NHWC` to `channels_first`/`channels_last`.

BTW, I don't know how to add a unit test for this case, as I can't find anywhere to set `keras.json` in Travis.  Can someone gives a hint?