### PR TITLE
LearningRateScheduler: add verbose flag.

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -560,6 +560,7 @@ class LearningRateScheduler(Callback):
         schedule: a function that takes an epoch index as input
             (integer, indexed from 0) and returns a new
             learning rate as output (float).
+        verbose: int. 0: quiet, 1: update messages.
     """
 
     def __init__(self, schedule, verbose=0):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -562,9 +562,10 @@ class LearningRateScheduler(Callback):
             learning rate as output (float).
     """
 
-    def __init__(self, schedule):
+    def __init__(self, schedule, verbose=0):
         super(LearningRateScheduler, self).__init__()
         self.schedule = schedule
+        self.verbose = verbose
 
     def on_epoch_begin(self, epoch, logs=None):
         if not hasattr(self.model.optimizer, 'lr'):
@@ -573,7 +574,11 @@ class LearningRateScheduler(Callback):
         if not isinstance(lr, (float, np.float32, np.float64)):
             raise ValueError('The output of the "schedule" function '
                              'should be float.')
-        K.set_value(self.model.optimizer.lr, lr)
+        if lr < float(K.get_value(self.model.optimizer.lr)):
+            K.set_value(self.model.optimizer.lr, lr)
+            if self.verbose > 0:
+                print('\nEpoch %05d: LearningRateScheduler reducing learning '
+                      'rate to %s.' % (epoch + 1, lr))
 
 
 class TensorBoard(Callback):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -575,11 +575,9 @@ class LearningRateScheduler(Callback):
         if not isinstance(lr, (float, np.float32, np.float64)):
             raise ValueError('The output of the "schedule" function '
                              'should be float.')
-        if lr < float(K.get_value(self.model.optimizer.lr)):
-            K.set_value(self.model.optimizer.lr, lr)
-            if self.verbose > 0:
-                print('\nEpoch %05d: LearningRateScheduler reducing learning '
-                      'rate to %s.' % (epoch + 1, lr))
+        if self.verbose > 0:
+            print('\nEpoch %05d: LearningRateScheduler reducing learning '
+                  'rate to %s.' % (epoch + 1, lr))
 
 
 class TensorBoard(Callback):


### PR DESCRIPTION
1. Add `verbose` flag, similar to `ReduceLROnPlateau` callback.
2. Don't increase `lr`. Lower current `lr` almost certainty means that another callback (like `ReduceLROnPlateau` in cifar10_resnet.py example) reduced it.

Yes, some papers advocate increasing `lr` from time to time, but it's an exotic advice, doesn't work AFAIK, and if needed we can add another parameter `force` or something.