### PR TITLE
Fix stacked rnn compute output shape

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -395,9 +395,10 @@ class RNN(Layer):
             input_shape = input_shape[0]
 
         if hasattr(self.cell.state_size, '__len__'):
-            output_dim = self.cell.state_size[0]
+            state_size = self.cell.state_size
         else:
-            output_dim = self.cell.state_size
+            state_size = [self.cell.state_size]
+        output_dim = state_size[0]
 
         if self.return_sequences:
             output_shape = (input_shape[0], input_shape[1], output_dim)
@@ -405,7 +406,7 @@ class RNN(Layer):
             output_shape = (input_shape[0], output_dim)
 
         if self.return_state:
-            state_shape = [(input_shape[0], output_dim) for _ in self.states]
+            state_shape = [(input_shape[0], dim) for dim in state_size]
             return [output_shape] + state_shape
         else:
             return output_shape

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -596,6 +596,20 @@ def test_stacked_rnn_attributes():
     assert layer.get_losses_for(x) == [y]
 
 
+@keras_test
+def test_stacked_rnn_compute_output_shape():
+    cells = [recurrent.LSTMCell(3),
+             recurrent.LSTMCell(6)]
+    layer = recurrent.RNN(cells, return_state=True, return_sequences=True)
+    output_shape = layer.compute_output_shape((None, timesteps, embedding_dim))
+    expected_output_shape = [(None, timesteps, 6),
+                             (None, 6),
+                             (None, 6),
+                             (None, 3),
+                             (None, 3)]
+    assert output_shape == expected_output_shape
+
+
 @rnn_test
 def test_batch_size_equal_one(layer_class):
     inputs = Input(batch_shape=(1, timesteps, embedding_dim))


### PR DESCRIPTION
Right now, `RNN.compute_output_shape` returns the same output shape for all the cell states when `return_state=True`. However, in a stacked RNN, the states could come from different cells with different number of `units`.

Since `_keras_shape` is set with the output of `compute_output_shape` (in `_add_inbound_node`), `_keras_shape` (and also `K.int_shape`) will be wrong for these cell state tensors. 

For example, the following simple seq2seq model will fail before this fix:

```python
encoder_in = Input((None, 5))
encoder_out, *state = RNN([LSTMCell(16), LSTMCell(32)], return_state=True)(encoder_in)
decoder_in = Input((None, 5))
decoder_out = RNN([LSTMCell(16), LSTMCell(32)])(decoder_in, initial_state=state)
```

because `state_spec` of the decoder is computed based on incorrect `_keras_shape`s. 
```
ValueError: An initial_state was passed that is not compatible with `cell.state_size`.
Received `state_spec`=[<keras.engine.topology.InputSpec object at 0x1225dbeb8>, <keras.engine.topology.InputSpec object at 0x1225db7b8>, <keras.engine.topology.InputSpec object at 0x1225ea588>, <keras.engine.topology.InputSpec object at 0x1225ea4a8>];
However `cell.state_size` is (32, 32, 16, 16)
```