### PR TITLE
Add softmax as layer, so that the axis arg can be used.

### DIFF
--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+from .. import activations
 from .. import initializers
 from .. import regularizers
 from .. import constraints
@@ -207,4 +208,33 @@ class ThresholdedReLU(Layer):
     def get_config(self):
         config = {'theta': float(self.theta)}
         base_config = super(ThresholdedReLU, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class Softmax(Layer):
+    """Softmax activation function.
+
+    # Input shape
+        Arbitrary. Use the keyword argument `input_shape`
+        (tuple of integers, does not include the samples axis)
+        when using this layer as the first layer in a model.
+
+    # Output shape
+        Same shape as the input.
+
+    # Arguments
+        axis: Integer, axis along which the softmax normalization is applied.
+    """
+
+    def __init__(self, axis=-1, **kwargs):
+        super(Softmax, self).__init__(**kwargs)
+        self.supports_masking = True
+        self.axis = axis
+
+    def call(self, inputs):
+        return activations.softmax(inputs, axis=self.axis)
+
+    def get_config(self):
+        config = {'axis': self.axis}
+        base_config = super(Softmax, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/tests/keras/layers/advanced_activations_test.py
+++ b/tests/keras/layers/advanced_activations_test.py
@@ -36,5 +36,12 @@ def test_thresholded_relu():
                input_shape=(2, 3, 4))
 
 
+@keras_test
+def test_softmax():
+    for axis in [1, -1]:
+        layer_test(layers.Softmax, kwargs={'axis': axis},
+                   input_shape=(2, 3, 4))
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
The softmax activation has an `axis` argument. However, it is impossible to use this arg while not creating a custom layer or custom activation. Such custom items does not promote portability of the model.

Here added is the softmax activation as a layer. In principle, I think all the activations could (or should) also be layers. The use-case for this one is straight forward, and there have been several questions on-line about this (all solved with custom layers).

The default axis arg for softmax is -1. This is valid when you are using `image_data_format` as `channels_last`, **but** when you are using `channels_first`, the softmax will be applied over the width axis (in the case of the common `NCHW` formatting).