### PR TITLE
Add my_transformations params to ImageDataGenerator

### DIFF
--- a/docs/templates/preprocessing/image.md
+++ b/docs/templates/preprocessing/image.md
@@ -92,7 +92,7 @@ Generate batches of tensor image data with real-time data augmentation. The data
             - __directory__: path to the target directory. It should contain one subdirectory per class.
                 Any PNG, JPG, BMP or PPM images inside each of the subdirectories directory tree will be included in the generator.
                 See [this script](https://gist.github.com/fchollet/0830affa1f7f19fd47b06d4cf89ed44d) for more details.
-            - __target_size__: tuple of integers `(height, width)`, default: `(256, 256)`.
+            - __target_size__: tuple of integers `(height, width)`, default: `(256, 256)`. 
                 The dimensions to which all images found will be resized.
             - __color_mode__: one of "grayscale", "rbg". Default: "rgb". Whether the images will be converted to have 1 or 3 color channels.
             - __classes__: optional list of class subdirectories (e.g. `['dogs', 'cats']`). Default: None. If not provided, the list of classes will be automatically inferred from the subdirectory names/structure under `directory`, where each subdirectory will be treated as a different class (and the order of the classes, which will map to the label indices, will be alphanumeric). The dictionary containing the mapping from class names to class indices can be obtained via the attribute `class_indices`.

--- a/docs/templates/preprocessing/image.md
+++ b/docs/templates/preprocessing/image.md
@@ -92,7 +92,7 @@ Generate batches of tensor image data with real-time data augmentation. The data
             - __directory__: path to the target directory. It should contain one subdirectory per class.
                 Any PNG, JPG, BMP or PPM images inside each of the subdirectories directory tree will be included in the generator.
                 See [this script](https://gist.github.com/fchollet/0830affa1f7f19fd47b06d4cf89ed44d) for more details.
-            - __target_size__: tuple of integers `(height, width)`, default: `(256, 256)`. 
+            - __target_size__: tuple of integers `(height, width)`, default: `(256, 256)`.
                 The dimensions to which all images found will be resized.
             - __color_mode__: one of "grayscale", "rbg". Default: "rgb". Whether the images will be converted to have 1 or 3 color channels.
             - __classes__: optional list of class subdirectories (e.g. `['dogs', 'cats']`). Default: None. If not provided, the list of classes will be automatically inferred from the subdirectory names/structure under `directory`, where each subdirectory will be treated as a different class (and the order of the classes, which will map to the label indices, will be alphanumeric). The dictionary containing the mapping from class names to class indices can be obtained via the attribute `class_indices`.
@@ -211,3 +211,25 @@ model.fit_generator(
     steps_per_epoch=2000,
     epochs=50)
 ```
+
+Example of customize transformation.
+```python
+def add_1(x):
+    return x + 1
+
+def random_dropout(x, percentage_iterator, cval):
+    h, w, c = x.shape  # On 2d colored images
+    nb = (h * w * c) * next(percentage_iterator)   # Python3
+    nb = (h * w * c) * percentage_iterator.next()  # Python2
+    nb = int(nb)
+    hr = np.random.randint(0, h, size=nb)
+    wr = np.random.randint(0, w, size=nb)
+    cr = np.random.randint(0, c, size=nb)
+    x[hr, wr, cr] = cval
+    return x
+
+def percentage_iterator():
+    while True:
+        yield np.random.rand()
+
+datagen = ImageDataGenerator(my_transformations=[(add_1, {}), (random_dropout, {"percentage_iterator": percentage_iterator(), "cval": 0})])

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -410,6 +410,7 @@ class ImageDataGenerator(object):
             It defaults to the `image_data_format` value found in your
             Keras config file at `~/.keras/keras.json`.
             If you never set it, then it will be "channels_last".
+        my_transformations: list of tuples like : (function, kwargs)
     """
 
     def __init__(self,
@@ -431,7 +432,8 @@ class ImageDataGenerator(object):
                  vertical_flip=False,
                  rescale=None,
                  preprocessing_function=None,
-                 data_format=None):
+                 data_format=None,
+                 my_transformations=[]):  # List of tuples like : (function_to_call, kwargs)
         if data_format is None:
             data_format = K.image_data_format()
         self.featurewise_center = featurewise_center
@@ -452,6 +454,8 @@ class ImageDataGenerator(object):
         self.vertical_flip = vertical_flip
         self.rescale = rescale
         self.preprocessing_function = preprocessing_function
+
+        self.my_transformations = my_transformations
 
         if data_format not in {'channels_last', 'channels_first'}:
             raise ValueError('`data_format` should be `"channels_last"` (channel after row and '
@@ -672,6 +676,9 @@ class ImageDataGenerator(object):
         if self.vertical_flip:
             if np.random.random() < 0.5:
                 x = flip_axis(x, img_row_axis)
+
+        for trans in self.my_transformations:
+            x = trans[0](x, **trans[1])
 
         return x
 

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -434,7 +434,7 @@ class ImageDataGenerator(object):
                  rescale=None,
                  preprocessing_function=None,
                  data_format=None,
-                 my_transformations=[]):  # List of tuples like : (function_to_call, kwargs)
+                 my_transformations=[]):
         if data_format is None:
             data_format = K.image_data_format()
         self.featurewise_center = featurewise_center

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -411,6 +411,7 @@ class ImageDataGenerator(object):
             Keras config file at `~/.keras/keras.json`.
             If you never set it, then it will be "channels_last".
         my_transformations: list of tuples like : (function, kwargs)
+            Functions have to take as first parameter an image, other parameters are given by **kwargs
     """
 
     def __init__(self,


### PR DESCRIPTION
One might want using the ImageDataGenerator interface to do custom transformations (such as dropout, elastic...). This one is easy to use, just pass a list of tuples like : (function, kwargs). "func" have to take an image as first positioned argument. 

Example of use has been added.

That's my first ever contribution of my life, let's hope I didn't do anything wrong

Thanks all, have a good day

Edit:
If this PR is accepted, i'll do another one to standardize every transformations so everything will be treated the same way. I just didn't want to do a too big PR

Edit 2:
Someone told me I could use the preprocess parameter. Actually no. If in the preprocess function we modify the colors, brightess... Normalization could go wrong if done on the image.