### PR TITLE
Maintain Backwards compatibility for models serialized with earlier Keras version

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -221,8 +221,11 @@ def func_load(code, defaults=None, closure=None, globs=None):
 
     if closure is not None:
         closure = tuple(ensure_value_to_cell(_) for _ in closure)
-    raw_code = codecs.decode(code.encode('ascii'), 'base64')
-    code = marshal.loads(raw_code)
+    try:
+        raw_code = codecs.decode(code.encode('ascii'), 'base64')
+        code = marshal.loads(raw_code)
+    except: # Backwards compatibility for earlier versions of Keras
+        code = marshal.loads(code.encode('raw_unicode_escape'))
     if globs is None:
         globs = globals()
     return python_types.FunctionType(code, globs,


### PR DESCRIPTION
The PR #8572 change the way functions are serialized. Unfortunately this breaks backwards compatibility with models persisted before Keras 2.1.2. To resolve the issue, I wrap the original code in a try statement and retry using the old way. Unfortunately I can't catch specific exceptions as depending on the value different exceptions are thrown.