### PR TITLE
Change interpolation in apply_transform() from nearest to bilinear.

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -219,7 +219,7 @@ def apply_transform(x,
         x_channel,
         final_affine_matrix,
         final_offset,
-        order=0,
+        order=1,
         mode=fill_mode,
         cval=cval) for x_channel in x]
     x = np.stack(channel_images, axis=0)


### PR DESCRIPTION
Before https://github.com/keras-team/keras/pull/2446, interpolation was inconsistently sometimes nearest, sometimes bicubic. AFAIK, in other libraries and tools default interpolation is never 'nearest'. Sometimes it's bicubic, sometimes it's bilinear. For Keras bilinear is better because it's much faster, and is something a single (de)convolutional layer can learn (i.e. it is, basically a single hardcoded non-trainable (de)convolutional layer. Which is not true of nearest, even with pooling.

Also see `load_img()` https://github.com/keras-team/keras/pull/8435