### PR TITLE
Add SeparableConv1D

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1502,6 +1502,11 @@ def conv2d(x, kernel, strides=(1, 1), padding='valid',
     return _postprocess_conv2d_output(x, data_format)
 
 
+def separable_conv1d(x, depthwise_kernel, pointwise_kernel, strides=1,
+                     padding='valid', data_format=None, dilation_rate=1):
+    raise NotImplementedError
+
+
 def separable_conv2d(x, depthwise_kernel, pointwise_kernel, strides=(1, 1),
                      padding='valid', data_format=None, dilation_rate=(1, 1)):
     raise NotImplementedError

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3398,9 +3398,6 @@ def separable_conv1d(x, depthwise_kernel, pointwise_kernel, strides=1,
         data_format = image_data_format()
     if data_format not in {'channels_first', 'channels_last'}:
         raise ValueError('Unknown data_format ' + str(data_format))
-    if strides[0] > 1:
-        raise ValueError('In `SeparableConv1D`, strides greater than 1 '
-                         'are not supported. You can set `strides` to 1.')
 
     x, tf_data_format = _preprocess_conv1d_input(x, data_format)
     padding = _preprocess_padding(padding)

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3154,6 +3154,27 @@ def in_top_k(predictions, targets, k):
 # CONVOLUTIONS
 
 
+def _preprocess_conv1d_input(x, data_format):
+    """Transpose and cast the input before the conv1d.
+
+    # Arguments
+        x: input tensor.
+        data_format: string, `"channels_last"` or `"channels_first"`.
+
+    # Returns
+        A tensor.
+    """
+    if dtype(x) == 'float64':
+        x = tf.cast(x, 'float32')
+    tf_data_format = 'NHWC'  # to pass TF Conv2dNative operations
+    if data_format == 'channels_first':
+        if not _has_nchw_support():
+            x = tf.transpose(x, (0, 2, 1))  # NCW -> NWC
+        else:
+            tf_data_format = 'NCHW'
+    return x, tf_data_format
+
+
 def _preprocess_conv2d_input(x, data_format):
     """Transpose and cast the input before the conv2d.
 
@@ -3351,6 +3372,60 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
                                data_format=tf_data_format)
     if data_format == 'channels_first' and tf_data_format == 'NHWC':
         x = tf.transpose(x, (0, 3, 1, 2))  # NHWC -> NCHW
+    return x
+
+
+def separable_conv1d(x, depthwise_kernel, pointwise_kernel, strides=1,
+                     padding='valid', data_format=None, dilation_rate=1):
+    """1D convolution with separable filters.
+
+    # Arguments
+        x: input tensor
+        depthwise_kernel: convolution kernel for the depthwise convolution.
+        pointwise_kernel: kernel for the 1x1 convolution.
+        strides: stride integer.
+        padding: string, `"same"` or `"valid"`.
+        data_format: string, `"channels_last"` or `"channels_first"`.
+        dilation_rate: integer dilation rate.
+
+    # Returns
+        Output tensor.
+
+    # Raises
+        ValueError: if `data_format` is neither `channels_last` or `channels_first`.
+    """
+    if data_format is None:
+        data_format = image_data_format()
+    if data_format not in {'channels_first', 'channels_last'}:
+        raise ValueError('Unknown data_format ' + str(data_format))
+    if strides[0] > 1:
+        raise ValueError('In `SeparableConv1D`, strides greater than 1 '
+                         'are not supported. You can set `strides` to 1.')
+
+    x, tf_data_format = _preprocess_conv1d_input(x, data_format)
+    padding = _preprocess_padding(padding)
+    if tf_data_format == 'NHWC':
+        spatial_start_dim = 1
+        strides = (1, 1) + strides + (1,)
+    else:
+        spatial_start_dim = 2
+        strides = (1, 1, 1) + strides
+    x = tf.expand_dims(x, spatial_start_dim)
+    depthwise_kernel = tf.expand_dims(depthwise_kernel, 0)
+    pointwise_kernel = tf.expand_dims(pointwise_kernel, 0)
+    dilation_rate = (1,) + dilation_rate
+
+    x = tf.nn.separable_conv2d(x, depthwise_kernel, pointwise_kernel,
+                               strides=strides,
+                               padding=padding,
+                               rate=dilation_rate,
+                               data_format=tf_data_format)
+
+    x = tf.squeeze(x, [spatial_start_dim])
+
+    if data_format == 'channels_first' and tf_data_format == 'NHWC':
+        x = tf.transpose(x, (0, 2, 1))  # NWC -> NCW
+
     return x
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1972,6 +1972,11 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
     return conv_out
 
 
+def separable_conv1d(x, depthwise_kernel, pointwise_kernel, strides=1,
+                     padding='valid', data_format=None, dilation_rate=1):
+    raise NotImplementedError
+
+
 def separable_conv2d(x, depthwise_kernel, pointwise_kernel, strides=(1, 1),
                      padding='valid', data_format=None, dilation_rate=(1, 1)):
     raise NotImplementedError

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1037,7 +1037,348 @@ class Conv3DTranspose(Conv3D):
         return config
 
 
-class SeparableConv2D(Conv2D):
+class _SeparableConv(_Conv):
+    """Abstract nD depthwise separable convolution layer (private).
+
+    Separable convolutions consist in first performing
+    a depthwise spatial convolution
+    (which acts on each input channel separately)
+    followed by a pointwise convolution which mixes together the resulting
+    output channels. The `depth_multiplier` argument controls how many
+    output channels are generated per input channel in the depthwise step.
+
+    Intuitively, separable convolutions can be understood as
+    a way to factorize a convolution kernel into two smaller kernels,
+    or as an extreme version of an Inception block.
+
+    # Arguments
+        rank: An integer, the rank of the convolution,
+            e.g. "2" for 2D convolution.
+        filters: Integer, the dimensionality of the output space
+            (i.e. the number output of filters in the convolution).
+        kernel_size: An integer or tuple/list of 2 integers, specifying the
+            width and height of the 2D convolution window.
+            Can be a single integer to specify the same value for
+            all spatial dimensions.
+        strides: An integer or tuple/list of 2 integers,
+            specifying the strides of the convolution along the width and height.
+            Can be a single integer to specify the same value for
+            all spatial dimensions.
+            Specifying any stride value != 1 is incompatible with specifying
+            any `dilation_rate` value != 1.
+        padding: one of `"valid"` or `"same"` (case-insensitive).
+        data_format: A string,
+            one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs.
+            `channels_last` corresponds to inputs with shape
+            `(batch, height, width, channels)` while `channels_first`
+            corresponds to inputs with shape
+            `(batch, channels, height, width)`.
+            It defaults to the `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "channels_last".
+        depth_multiplier: The number of depthwise convolution output channels
+            for each input channel.
+            The total number of depthwise convolution output
+            channels will be equal to `filterss_in * depth_multiplier`.
+        activation: Activation function to use
+            (see [activations](../activations.md)).
+            If you don't specify anything, no activation is applied
+            (ie. "linear" activation: `a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        depthwise_initializer: Initializer for the depthwise kernel matrix
+            (see [initializers](../initializers.md)).
+        pointwise_initializer: Initializer for the pointwise kernel matrix
+            (see [initializers](../initializers.md)).
+        bias_initializer: Initializer for the bias vector
+            (see [initializers](../initializers.md)).
+        depthwise_regularizer: Regularizer function applied to
+            the depthwise kernel matrix
+            (see [regularizer](../regularizers.md)).
+        pointwise_regularizer: Regularizer function applied to
+            the pointwise kernel matrix
+            (see [regularizer](../regularizers.md)).
+        bias_regularizer: Regularizer function applied to the bias vector
+            (see [regularizer](../regularizers.md)).
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+            (see [regularizer](../regularizers.md)).
+        depthwise_constraint: Constraint function applied to
+            the depthwise kernel matrix
+            (see [constraints](../constraints.md)).
+        pointwise_constraint: Constraint function applied to
+            the pointwise kernel matrix
+            (see [constraints](../constraints.md)).
+        bias_constraint: Constraint function applied to the bias vector
+            (see [constraints](../constraints.md)).
+
+    # Input shape
+        4D tensor with shape:
+        `(batch, channels, rows, cols)` if data_format='channels_first'
+        or 4D tensor with shape:
+        `(batch, rows, cols, channels)` if data_format='channels_last'.
+
+    # Output shape
+        4D tensor with shape:
+        `(batch, filters, new_rows, new_cols)` if data_format='channels_first'
+        or 4D tensor with shape:
+        `(batch, new_rows, new_cols, filters)` if data_format='channels_last'.
+        `rows` and `cols` values might have changed due to padding.
+    """
+
+    def __init__(self, rank,
+                 filters,
+                 kernel_size,
+                 strides=1,
+                 padding='valid',
+                 data_format=None,
+                 depth_multiplier=1,
+                 activation=None,
+                 use_bias=True,
+                 depthwise_initializer='glorot_uniform',
+                 pointwise_initializer='glorot_uniform',
+                 bias_initializer='zeros',
+                 depthwise_regularizer=None,
+                 pointwise_regularizer=None,
+                 bias_regularizer=None,
+                 activity_regularizer=None,
+                 depthwise_constraint=None,
+                 pointwise_constraint=None,
+                 bias_constraint=None,
+                 **kwargs):
+        super(_SeparableConv, self).__init__(
+            rank=rank,
+            filters=filters,
+            kernel_size=kernel_size,
+            strides=strides,
+            padding=padding,
+            data_format=data_format,
+            activation=activation,
+            use_bias=use_bias,
+            bias_regularizer=bias_regularizer,
+            activity_regularizer=activity_regularizer,
+            bias_constraint=bias_constraint,
+            **kwargs)
+        self.depth_multiplier = depth_multiplier
+        self.depthwise_initializer = initializers.get(depthwise_initializer)
+        self.pointwise_initializer = initializers.get(pointwise_initializer)
+        self.depthwise_regularizer = regularizers.get(depthwise_regularizer)
+        self.pointwise_regularizer = regularizers.get(pointwise_regularizer)
+        self.depthwise_constraint = constraints.get(depthwise_constraint)
+        self.pointwise_constraint = constraints.get(pointwise_constraint)
+
+    def build(self, input_shape):
+        if len(input_shape) < self.rank + 2:
+            raise ValueError('Inputs to `SeparableConv' + str(self.rank) + 'D` '
+                             'should have rank ' + str(self.rank + 2) + '. '
+                             'Received input shape:', str(input_shape))
+        channel_axis = 1 if self.data_format == 'channels_first' else -1
+        if input_shape[channel_axis] is None:
+            raise ValueError('The channel dimension of the inputs '
+                             'should be defined. Found `None`.')
+        input_dim = int(input_shape[channel_axis])
+        depthwise_kernel_shape = self.kernel_size + (input_dim, self.depth_multiplier)
+        pointwise_kernel_shape = (1,) * self.rank + (self.depth_multiplier * input_dim, self.filters)
+
+        self.depthwise_kernel = self.add_weight(
+            shape=depthwise_kernel_shape,
+            initializer=self.depthwise_initializer,
+            name='depthwise_kernel',
+            regularizer=self.depthwise_regularizer,
+            constraint=self.depthwise_constraint)
+        self.pointwise_kernel = self.add_weight(
+            shape=pointwise_kernel_shape,
+            initializer=self.pointwise_initializer,
+            name='pointwise_kernel',
+            regularizer=self.pointwise_regularizer,
+            constraint=self.pointwise_constraint)
+
+        if self.use_bias:
+            self.bias = self.add_weight(shape=(self.filters,),
+                                        initializer=self.bias_initializer,
+                                        name='bias',
+                                        regularizer=self.bias_regularizer,
+                                        constraint=self.bias_constraint)
+        else:
+            self.bias = None
+        # Set input spec.
+        self.input_spec = InputSpec(ndim=self.rank + 2,
+                                    axes={channel_axis: input_dim})
+        self.built = True
+
+    def call(self, inputs):
+        if self.rank == 1:
+            outputs = K.separable_conv1d(
+                inputs,
+                self.depthwise_kernel,
+                self.pointwise_kernel,
+                data_format=self.data_format,
+                strides=self.strides,
+                padding=self.padding,
+                dilation_rate=self.dilation_rate)
+        if self.rank == 2:
+            outputs = K.separable_conv2d(
+                inputs,
+                self.depthwise_kernel,
+                self.pointwise_kernel,
+                data_format=self.data_format,
+                strides=self.strides,
+                padding=self.padding,
+                dilation_rate=self.dilation_rate)
+
+        if self.bias:
+            outputs = K.bias_add(
+                outputs,
+                self.bias,
+                data_format=self.data_format)
+
+        if self.activation is not None:
+            return self.activation(outputs)
+        return outputs
+
+    def get_config(self):
+        config = super(_SeparableConv, self).get_config()
+        config.pop('rank')
+        config.pop('kernel_initializer')
+        config.pop('kernel_regularizer')
+        config.pop('kernel_constraint')
+        config['depth_multiplier'] = self.depth_multiplier
+        config['depthwise_initializer'] = initializers.serialize(self.depthwise_initializer)
+        config['pointwise_initializer'] = initializers.serialize(self.pointwise_initializer)
+        config['depthwise_regularizer'] = regularizers.serialize(self.depthwise_regularizer)
+        config['pointwise_regularizer'] = regularizers.serialize(self.pointwise_regularizer)
+        config['depthwise_constraint'] = constraints.serialize(self.depthwise_constraint)
+        config['pointwise_constraint'] = constraints.serialize(self.pointwise_constraint)
+        return config
+
+
+class SeparableConv1D(_SeparableConv):
+    """Depthwise separable 1D convolution.
+
+    Separable convolutions consist in first performing
+    a depthwise spatial convolution
+    (which acts on each input channel separately)
+    followed by a pointwise convolution which mixes together the resulting
+    output channels. The `depth_multiplier` argument controls how many
+    output channels are generated per input channel in the depthwise step.
+
+    Intuitively, separable convolutions can be understood as
+    a way to factorize a convolution kernel into two smaller kernels,
+    or as an extreme version of an Inception block.
+
+    # Arguments
+        filters: Integer, the dimensionality of the output space
+            (i.e. the number output of filters in the convolution).
+        kernel_size: An integer or tuple/list of single integer,
+            specifying the length of the 1D convolution window.
+        strides: An integer or tuple/list of single integer,
+            specifying the stride length of the convolution.
+            Specifying any stride value != 1 is incompatible with specifying
+            any `dilation_rate` value != 1.
+        padding: one of `"valid"` or `"same"` (case-insensitive).
+        data_format: A string,
+            one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs.
+            `channels_last` corresponds to inputs with shape
+            `(batch, height, width, channels)` while `channels_first`
+            corresponds to inputs with shape
+            `(batch, channels, height, width)`.
+            It defaults to the `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "channels_last".
+        depth_multiplier: The number of depthwise convolution output channels
+            for each input channel.
+            The total number of depthwise convolution output
+            channels will be equal to `filterss_in * depth_multiplier`.
+        activation: Activation function to use
+            (see [activations](../activations.md)).
+            If you don't specify anything, no activation is applied
+            (ie. "linear" activation: `a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        depthwise_initializer: Initializer for the depthwise kernel matrix
+            (see [initializers](../initializers.md)).
+        pointwise_initializer: Initializer for the pointwise kernel matrix
+            (see [initializers](../initializers.md)).
+        bias_initializer: Initializer for the bias vector
+            (see [initializers](../initializers.md)).
+        depthwise_regularizer: Regularizer function applied to
+            the depthwise kernel matrix
+            (see [regularizer](../regularizers.md)).
+        pointwise_regularizer: Regularizer function applied to
+            the pointwise kernel matrix
+            (see [regularizer](../regularizers.md)).
+        bias_regularizer: Regularizer function applied to the bias vector
+            (see [regularizer](../regularizers.md)).
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+            (see [regularizer](../regularizers.md)).
+        depthwise_constraint: Constraint function applied to
+            the depthwise kernel matrix
+            (see [constraints](../constraints.md)).
+        pointwise_constraint: Constraint function applied to
+            the pointwise kernel matrix
+            (see [constraints](../constraints.md)).
+        bias_constraint: Constraint function applied to the bias vector
+            (see [constraints](../constraints.md)).
+
+    # Input shape
+        3D tensor with shape:
+        `(batch, channels, steps)` if data_format='channels_first'
+        or 3D tensor with shape:
+        `(batch, steps, channels)` if data_format='channels_last'.
+
+    # Output shape
+        3D tensor with shape:
+        `(batch, filters, new_steps)` if data_format='channels_first'
+        or 3D tensor with shape:
+        `(batch, new_steps, filters)` if data_format='channels_last'.
+        `new_steps` values might have changed due to padding or strides.
+    """
+
+    @interfaces.legacy_separable_conv2d_support
+    def __init__(self, filters,
+                 kernel_size,
+                 strides=1,
+                 padding='valid',
+                 data_format=None,
+                 depth_multiplier=1,
+                 activation=None,
+                 use_bias=True,
+                 depthwise_initializer='glorot_uniform',
+                 pointwise_initializer='glorot_uniform',
+                 bias_initializer='zeros',
+                 depthwise_regularizer=None,
+                 pointwise_regularizer=None,
+                 bias_regularizer=None,
+                 activity_regularizer=None,
+                 depthwise_constraint=None,
+                 pointwise_constraint=None,
+                 bias_constraint=None,
+                 **kwargs):
+        super(SeparableConv1D, self).__init__(
+            rank=1,
+            filters=filters,
+            kernel_size=kernel_size,
+            strides=strides,
+            padding=padding,
+            data_format=data_format,
+            depth_multiplier=depth_multiplier,
+            activation=activation,
+            use_bias=use_bias,
+            depthwise_initializer=depthwise_initializer,
+            pointwise_initializer=pointwise_initializer,
+            bias_initializer=bias_initializer,
+            depthwise_regularizer=depthwise_regularizer,
+            pointwise_regularizer=pointwise_regularizer,
+            bias_regularizer=bias_regularizer,
+            activity_regularizer=activity_regularizer,
+            depthwise_constraint=depthwise_constraint,
+            pointwise_constraint=pointwise_constraint,
+            bias_constraint=bias_constraint,
+            **kwargs)
+
+
+class SeparableConv2D(_SeparableConv):
     """Depthwise separable 2D convolution.
 
     Separable convolutions consist in first performing
@@ -1145,104 +1486,26 @@ class SeparableConv2D(Conv2D):
                  bias_constraint=None,
                  **kwargs):
         super(SeparableConv2D, self).__init__(
+            rank=2,
             filters=filters,
             kernel_size=kernel_size,
             strides=strides,
             padding=padding,
             data_format=data_format,
+            depth_multiplier=depth_multiplier,
             activation=activation,
             use_bias=use_bias,
+            depthwise_initializer=depthwise_initializer,
+            pointwise_initializer=pointwise_initializer,
+            bias_initializer=bias_initializer,
+            depthwise_regularizer=depthwise_regularizer,
+            pointwise_regularizer=pointwise_regularizer,
             bias_regularizer=bias_regularizer,
             activity_regularizer=activity_regularizer,
+            depthwise_constraint=depthwise_constraint,
+            pointwise_constraint=pointwise_constraint,
             bias_constraint=bias_constraint,
             **kwargs)
-        self.depth_multiplier = depth_multiplier
-        self.depthwise_initializer = initializers.get(depthwise_initializer)
-        self.pointwise_initializer = initializers.get(pointwise_initializer)
-        self.depthwise_regularizer = regularizers.get(depthwise_regularizer)
-        self.pointwise_regularizer = regularizers.get(pointwise_regularizer)
-        self.depthwise_constraint = constraints.get(depthwise_constraint)
-        self.pointwise_constraint = constraints.get(pointwise_constraint)
-
-    def build(self, input_shape):
-        if len(input_shape) < 4:
-            raise ValueError('Inputs to `SeparableConv2D` should have rank 4. '
-                             'Received input shape:', str(input_shape))
-        if self.data_format == 'channels_first':
-            channel_axis = 1
-        else:
-            channel_axis = 3
-        if input_shape[channel_axis] is None:
-            raise ValueError('The channel dimension of the inputs to '
-                             '`SeparableConv2D` '
-                             'should be defined. Found `None`.')
-        input_dim = int(input_shape[channel_axis])
-        depthwise_kernel_shape = (self.kernel_size[0],
-                                  self.kernel_size[1],
-                                  input_dim,
-                                  self.depth_multiplier)
-        pointwise_kernel_shape = (1, 1,
-                                  self.depth_multiplier * input_dim,
-                                  self.filters)
-
-        self.depthwise_kernel = self.add_weight(
-            shape=depthwise_kernel_shape,
-            initializer=self.depthwise_initializer,
-            name='depthwise_kernel',
-            regularizer=self.depthwise_regularizer,
-            constraint=self.depthwise_constraint)
-        self.pointwise_kernel = self.add_weight(
-            shape=pointwise_kernel_shape,
-            initializer=self.pointwise_initializer,
-            name='pointwise_kernel',
-            regularizer=self.pointwise_regularizer,
-            constraint=self.pointwise_constraint)
-
-        if self.use_bias:
-            self.bias = self.add_weight(shape=(self.filters,),
-                                        initializer=self.bias_initializer,
-                                        name='bias',
-                                        regularizer=self.bias_regularizer,
-                                        constraint=self.bias_constraint)
-        else:
-            self.bias = None
-        # Set input spec.
-        self.input_spec = InputSpec(ndim=4, axes={channel_axis: input_dim})
-        self.built = True
-
-    def call(self, inputs):
-        outputs = K.separable_conv2d(
-            inputs,
-            self.depthwise_kernel,
-            self.pointwise_kernel,
-            data_format=self.data_format,
-            strides=self.strides,
-            padding=self.padding,
-            dilation_rate=self.dilation_rate)
-
-        if self.bias:
-            outputs = K.bias_add(
-                outputs,
-                self.bias,
-                data_format=self.data_format)
-
-        if self.activation is not None:
-            return self.activation(outputs)
-        return outputs
-
-    def get_config(self):
-        config = super(SeparableConv2D, self).get_config()
-        config.pop('kernel_initializer')
-        config.pop('kernel_regularizer')
-        config.pop('kernel_constraint')
-        config['depth_multiplier'] = self.depth_multiplier
-        config['depthwise_initializer'] = initializers.serialize(self.depthwise_initializer)
-        config['pointwise_initializer'] = initializers.serialize(self.pointwise_initializer)
-        config['depthwise_regularizer'] = regularizers.serialize(self.depthwise_regularizer)
-        config['pointwise_regularizer'] = regularizers.serialize(self.pointwise_regularizer)
-        config['depthwise_constraint'] = constraints.serialize(self.depthwise_constraint)
-        config['pointwise_constraint'] = constraints.serialize(self.pointwise_constraint)
-        return config
 
 
 class UpSampling1D(Layer):
@@ -2101,6 +2364,7 @@ class Cropping3D(Layer):
 Convolution1D = Conv1D
 Convolution2D = Conv2D
 Convolution3D = Conv3D
+SeparableConvolution1D = SeparableConv1D
 SeparableConvolution2D = SeparableConv2D
 Convolution2DTranspose = Conv2DTranspose
 Deconvolution2D = Deconv2D = Conv2DTranspose

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1335,7 +1335,6 @@ class SeparableConv1D(_SeparableConv):
         `new_steps` values might have changed due to padding or strides.
     """
 
-    @interfaces.legacy_separable_conv2d_support
     def __init__(self, filters,
                  kernel_size,
                  strides=1,

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -231,6 +231,61 @@ def test_conv2d_transpose():
 
 @pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TF backend')
 @keras_test
+def test_separable_conv_1d():
+    num_samples = 2
+    filters = 6
+    stack_size = 3
+    num_step = 9
+
+    for padding in _convolution_paddings:
+        for multiplier in [1, 2]:
+            for dilation_rate in [1, 2]:
+                if padding == 'same':
+                    continue
+                if dilation_rate != 1:
+                    continue
+
+                layer_test(convolutional.SeparableConv1D,
+                           kwargs={'filters': filters,
+                                   'kernel_size': 3,
+                                   'padding': padding,
+                                   'strides': 1,
+                                   'depth_multiplier': multiplier,
+                                   'dilation_rate': dilation_rate},
+                           input_shape=(num_samples, num_step, stack_size))
+
+    layer_test(convolutional.SeparableConv1D,
+               kwargs={'filters': filters,
+                       'kernel_size': 3,
+                       'padding': padding,
+                       'data_format': 'channels_first',
+                       'activation': None,
+                       'depthwise_regularizer': 'l2',
+                       'pointwise_regularizer': 'l2',
+                       'bias_regularizer': 'l2',
+                       'activity_regularizer': 'l2',
+                       'pointwise_constraint': 'unit_norm',
+                       'depthwise_constraint': 'unit_norm',
+                       'strides': 1,
+                       'depth_multiplier': multiplier},
+               input_shape=(num_samples, stack_size, num_step))
+
+    # Test invalid use case
+    with pytest.raises(ValueError):
+        model = Sequential([convolutional.SeparableConv1D(filters=filters,
+                                                          kernel_size=3,
+                                                          padding=padding,
+                                                          batch_input_shape=(None, 5, None))])
+
+    with pytest.raises(ValueError):
+        model = Sequential([convolutional.SeparableConv1D(filters=filters,
+                                                          kernel_size=3,
+                                                          padding=padding,
+                                                          strides=2)])
+
+
+@pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TF backend')
+@keras_test
 def test_separable_conv_2d():
     num_samples = 2
     filters = 6

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -277,12 +277,6 @@ def test_separable_conv_1d():
                                                           padding=padding,
                                                           batch_input_shape=(None, 5, None))])
 
-    with pytest.raises(ValueError):
-        model = Sequential([convolutional.SeparableConv1D(filters=filters,
-                                                          kernel_size=3,
-                                                          padding=padding,
-                                                          strides=2)])
-
 
 @pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TF backend')
 @keras_test


### PR DESCRIPTION
This PR adds `SeparableConv1D` described in "Requests for Contributions".

1. Adds the `_SeparableConv` class, an abtract nD separable convolution layer.
2. Makes the new `SeparableConv1D` and the existing `SeparableConv2D` inherit it.
3. Adds test codes for `SeparableConv1D`.