### PR TITLE
Increase test converage

### DIFF
--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -574,9 +574,19 @@ def test_stacked_rnn_dropout():
 
 
 @keras_test
-def test_stacked_rnn_attributes():
-    cells = [recurrent.LSTMCell(3),
-             recurrent.LSTMCell(3, kernel_regularizer='l2')]
+@pytest.mark.parametrize('cells', [
+    [recurrent.SimpleRNNCell(units),
+     recurrent.SimpleRNNCell(units, kernel_regularizer='l2')],
+    [recurrent.GRUCell(units),
+     recurrent.GRUCell(units, kernel_regularizer='l2')],
+    [recurrent.LSTMCell(units),
+     recurrent.LSTMCell(units, kernel_regularizer='l2')]
+], ids=[
+    'Two RNNs',
+    'Two GRUs',
+    'Two LSTMs'
+])
+def test_stacked_rnn_attributes(cells):
     layer = recurrent.RNN(cells)
     layer.build((None, None, 5))
 
@@ -594,6 +604,14 @@ def test_stacked_rnn_attributes():
     y = K.sum(x)
     cells[0].add_loss(y, inputs=x)
     assert layer.get_losses_for(x) == [y]
+
+    # Test `trainable` of layer
+    layer.trainable = False
+    assert len(layer.trainable_weights) == 0
+    assert len(layer.non_trainable_weights) == 6
+
+    # Test get and set weights
+    layer.set_weights(layer.get_weights())
 
 
 @rnn_test


### PR DESCRIPTION
This PR adds topology tests for the [current](https://travis-ci.org/keras-team/keras/jobs/319538173) following missing lines:

```
keras/layers/recurrent.py                     792     53    93%   45, 48, 128, 142-146, 155-159, 168-176, 357, 360, 455, 507, 543, 546, 553, 571, 607, 647, 657, 660, 699, 746, 991-997, 1107, 1432, 1436-1442, 1564, 1691, 1918, 1922-1928, 2056, 2064-2065
```