### PR TITLE
fix "UnboundLocalError: local variable 'epoch_logs' referenced before assignment" is really annoying error

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2106,6 +2106,8 @@ class Model(Container):
                 output_generator = generator
 
             callback_model.stop_training = False
+            # Construct epoch logs.
+            epoch_logs = {}
             while epoch < epochs:
                 callbacks.on_epoch_begin(epoch)
                 steps_done = 0
@@ -2152,8 +2154,6 @@ class Model(Container):
 
                     callbacks.on_batch_end(batch_index, batch_logs)
 
-                    # Construct epoch logs.
-                    epoch_logs = {}
                     batch_index += 1
                     steps_done += 1
 


### PR DESCRIPTION
Moved epoch_logs = {} before batch loop to avoid UnboundLocalError.

"UnboundLocalError: local variable 'epoch_logs' referenced before assignment" is really annoying error. 
This pr borrows idea from https://github.com/keras-team/keras/commit/cb3469215ab78219a0ae58f566ddeba2fe6242fb, which seems to be a appropriate method.