### PR TITLE
Pass current learning rate to schedule() in LearningRateScheduler

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -558,8 +558,8 @@ class LearningRateScheduler(Callback):
 
     # Arguments
         schedule: a function that takes an epoch index as input
-            (integer, indexed from 0) and returns a new
-            learning rate as output (float).
+            (integer, indexed from 0) and current learning rate
+            and returns a new learning rate as output (float).
     """
 
     def __init__(self, schedule):
@@ -569,7 +569,11 @@ class LearningRateScheduler(Callback):
     def on_epoch_begin(self, epoch, logs=None):
         if not hasattr(self.model.optimizer, 'lr'):
             raise ValueError('Optimizer must have a "lr" attribute.')
-        lr = self.schedule(epoch)
+        lr = float(K.get_value(self.model.optimizer.lr))
+        try: # new API
+            lr = self.schedule(epoch, lr)
+        except TypeError: # old API for backward compatibility
+            lr = self.schedule(epoch)
         if not isinstance(lr, (float, np.float32, np.float64)):
             raise ValueError('The output of the "schedule" function '
                              'should be float.')


### PR DESCRIPTION
this allows things like not overriding other ways to set `lr`, halving `lr` every k epochs, etc.