### PR TITLE
ModelCheckpoint: Add '\n' before printing

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -404,7 +404,7 @@ class ModelCheckpoint(Callback):
                 else:
                     if self.monitor_op(current, self.best):
                         if self.verbose > 0:
-                            print('Epoch %05d: %s improved from %0.5f to %0.5f,'
+                            print('\nEpoch %05d: %s improved from %0.5f to %0.5f,'
                                   ' saving model to %s'
                                   % (epoch + 1, self.monitor, self.best,
                                      current, filepath))
@@ -415,11 +415,11 @@ class ModelCheckpoint(Callback):
                             self.model.save(filepath, overwrite=True)
                     else:
                         if self.verbose > 0:
-                            print('Epoch %05d: %s did not improve' %
+                            print('\nEpoch %05d: %s did not improve' %
                                   (epoch + 1, self.monitor))
             else:
                 if self.verbose > 0:
-                    print('Epoch %05d: saving model to %s' % (epoch + 1, filepath))
+                    print('\nEpoch %05d: saving model to %s' % (epoch + 1, filepath))
                 if self.save_weights_only:
                     self.model.save_weights(filepath, overwrite=True)
                 else:


### PR DESCRIPTION
like in other callbacks. Otherwise it gets overwritten by the progbar.