### PR TITLE
Tokenizer: add optional OOV token for sequences

### DIFF
--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -125,6 +125,8 @@ class Tokenizer(object):
         lower: boolean. Whether to convert the texts to lowercase.
         split: character or string to use for token splitting.
         char_level: if True, every character will be treated as a token.
+        oov_token: if given, it will be added to word_index and used to
+            replace out-of-vocabulary words during text_to_sequence calls
 
     By default, all punctuation is removed, turning the texts into
     space-separated sequences of words
@@ -139,6 +141,7 @@ class Tokenizer(object):
                  lower=True,
                  split=' ',
                  char_level=False,
+                 oov_token=None,
                  **kwargs):
         # Legacy support
         if 'nb_words' in kwargs:
@@ -156,6 +159,7 @@ class Tokenizer(object):
         self.num_words = num_words
         self.document_count = 0
         self.char_level = char_level
+        self.oov_token = oov_token
 
     def fit_on_texts(self, texts):
         """Updates internal vocabulary based on a list of texts.
@@ -189,6 +193,11 @@ class Tokenizer(object):
         sorted_voc = [wc[0] for wc in wcounts]
         # note that index 0 is reserved, never assigned to an existing word
         self.word_index = dict(list(zip(sorted_voc, list(range(1, len(sorted_voc) + 1)))))
+
+        if self.oov_token is not None:
+            i = self.word_index.get(self.oov_token)
+            if i is None:
+                self.word_index[self.oov_token] = len(self.word_index) + 1
 
         self.index_docs = {}
         for w, c in list(self.word_docs.items()):
@@ -256,6 +265,10 @@ class Tokenizer(object):
                     if num_words and i >= num_words:
                         continue
                     else:
+                        vect.append(i)
+                elif self.oov_token is not None:
+                    i = self.word_index.get(self.oov_token)
+                    if i is not None:
                         vect.append(i)
             yield vect
 

--- a/tests/keras/preprocessing/text_test.py
+++ b/tests/keras/preprocessing/text_test.py
@@ -67,5 +67,25 @@ def test_tokenizer_unicode():
     assert len(tokenizer.word_counts) == 5
 
 
+def test_tokenizer_oov_flag():
+    """
+    Test of Out of Vocabulary (OOV) flag in Tokenizer
+    """
+    x_train = ['This text has only known words']
+    x_test = ['This text has some unknown words']  # 2 OOVs: some, unknown
+
+    # Defalut, without OOV flag
+    tokenizer =  Tokenizer()
+    tokenizer.fit_on_texts(x_train)
+    x_test_seq = tokenizer.texts_to_sequences(x_test)
+    assert len(x_test_seq[0]) == 4  # discards 2 OOVs
+
+    # With OOV feature
+    tokenizer =  Tokenizer(oov_token='<unk>')
+    tokenizer.fit_on_texts(x_train)
+    x_test_seq = tokenizer.texts_to_sequences(x_test)
+    assert len(x_test_seq[0]) == 6  # OOVs marked in place
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
This update adds an optional feature to `keras.preprocessing.text.Tokenizer`, for dealing with out-of-vocabulary words when covering texts to sequences.  
The current implementation of `texts_to_sequences`silently omits words that were not seen during `fit_on_texts`. While this is fine for many applications it can lead to hard to trace bugs in some cases, especially when it is followed with `pad_sequences`. For example in Sequence Labeling, when evaluating a model with text that contains unseen words, converting the input text into a sequence and then padding it could inadvertently change the sequence in an unexpected way. Then we end up predicting and evaluating a wrong sequence. 

Demo:
```
x_train = ['This text has only known words']
x_test = ['But this text has some unknown words']

# current behavior:
tokenizer =  Tokenizer(num_words=MAX_NUM_WORDS)
tokenizer.fit_on_texts(x_train)

x_test_seq = pad_sequences(tokenizer.texts_to_sequences(x_test), maxlen=MAX_SEQUENCE_LENGTH)
print(x_test_seq)
# >>> [[0 0 0 0 0 0 1 2 3 6]]   # we lose trace of 3 OOV words


# With new changes
tokenizer =  Tokenizer(num_words=MAX_NUM_WORDS, oov_token='<unk>')
tokenizer.fit_on_texts(x_train)

x_test_seq = pad_sequences(tokenizer.texts_to_sequences(x_test), maxlen=MAX_SEQUENCE_LENGTH)
print(x_test_seq)
# >>> [[0 0 0 7 1 2 3 7 7 6]]   # we get sequence of all 7 words with placeholder for OOVs

```

Of course, a careful and informed user can deal with the issue through a little bit of pre and post-processing of the data, but it is much easier and keras like to do it with a simple flag like this. 

Note: This update should not affect the behavior of existing uses of the Tokenizer API, it only works if intentionally turned on.

