### PR TITLE
Update lr in LearningRateScheduler.

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -575,6 +575,7 @@ class LearningRateScheduler(Callback):
         if not isinstance(lr, (float, np.float32, np.float64)):
             raise ValueError('The output of the "schedule" function '
                              'should be float.')
+        K.set_value(self.model.optimizer.lr, lr)
         if self.verbose > 0:
             print('\nEpoch %05d: LearningRateScheduler reducing learning '
                   'rate to %s.' % (epoch + 1, lr))


### PR DESCRIPTION
It was removed in PR #8829.
https://github.com/keras-team/keras/pull/8829/commits/b847f4235c4595432397d8c5486c6eaad4a08f00

Currently we calculate "lr", and log it in case of verbose logging, but do not use the actual value.