### PR TITLE
 Fix for progress bar output in jupyter notebooks

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -330,7 +330,7 @@ class Progbar(object):
 
             prev_total_width = self.total_width
             if self._dynamic_display:
-                sys.stdout.write('\b' * prev_total_width)
+                sys.stdout.write('\s' * prev_total_width)
                 sys.stdout.write('\r')
             else:
                 sys.stdout.write('\n')


### PR DESCRIPTION
Fixes the issue with jupyter notebooks being unable to display '\b' character properly.
The idea is that instead of backspacing all the characters printed in the previous iteration, we just fill this line with spaces. This way the notebook outputs the text correctly and the browser window wouldn't hang.