### PR TITLE
Fix loading bidirectional CuDNNLSTM to cpu

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2898,20 +2898,19 @@ def preprocess_weights_for_loading(layer, weights,
     # Returns
         A list of weights values (Numpy arrays).
     """
+    if layer.__class__.__name__ == 'Bidirectional':
+        num_weights_per_layer = len(weights) // 2
+        forward_weights = preprocess_weights_for_loading(layer.forward_layer,
+                                                         weights[:num_weights_per_layer],
+                                                         original_keras_version,
+                                                         original_backend)
+        backward_weights = preprocess_weights_for_loading(layer.backward_layer,
+                                                          weights[num_weights_per_layer:],
+                                                          original_keras_version,
+                                                          original_backend)
+        weights = forward_weights + backward_weights
+
     if original_keras_version == '1':
-        if layer.__class__.__name__ == 'Bidirectional':
-            num_weights_per_layer = len(weights) // 2
-
-            forward_weights = preprocess_weights_for_loading(layer.forward_layer,
-                                                             weights[:num_weights_per_layer],
-                                                             original_keras_version,
-                                                             original_backend)
-            backward_weights = preprocess_weights_for_loading(layer.backward_layer,
-                                                              weights[num_weights_per_layer:],
-                                                              original_keras_version,
-                                                              original_backend)
-            weights = forward_weights + backward_weights
-
         if layer.__class__.__name__ == 'TimeDistributed':
             weights = preprocess_weights_for_loading(layer.layer,
                                                      weights,

--- a/tests/keras/layers/cudnn_recurrent_test.py
+++ b/tests/keras/layers/cudnn_recurrent_test.py
@@ -368,10 +368,30 @@ def test_load_weights_into_noncudnn_lstm():
     units = 2
     num_samples = 32
 
+    # basic case
     input_shape = (timesteps, input_size)
     rnn_layer = keras.layers.LSTM(units, input_shape=input_shape,
                                   recurrent_activation='sigmoid')
     cudnn_rnn_layer = keras.layers.CuDNNLSTM(units, input_shape=input_shape)
+
+    model = keras.models.Sequential([rnn_layer])
+    cudnn_model = keras.models.Sequential([cudnn_rnn_layer])
+
+    weights = cudnn_rnn_layer.get_weights()
+    weights = keras.engine.topology.preprocess_weights_for_loading(rnn_layer, weights)
+    rnn_layer.set_weights(weights)
+
+    inputs = np.random.random((num_samples, timesteps, input_size))
+    out = model.predict(inputs)
+    cudnn_out = cudnn_model.predict(inputs)
+    assert_allclose(out, cudnn_out, atol=1e-4)
+
+    # bidirectional case
+    input_shape = (timesteps, input_size)
+    rnn_layer = keras.layers.LSTM(units, recurrent_activation='sigmoid')
+    rnn_layer = keras.layers.Bidirectional(rnn_layer, input_shape=input_shape)
+    cudnn_rnn_layer = keras.layers.CuDNNLSTM(units)
+    cudnn_rnn_layer = keras.layers.Bidirectional(cudnn_rnn_layer, input_shape=input_shape)
 
     model = keras.models.Sequential([rnn_layer])
     cudnn_model = keras.models.Sequential([cudnn_rnn_layer])


### PR DESCRIPTION
Fixes #8860.

Originally `Bidirectional` layers are skipped in `preprocess_weights_for_loading` if `original_keras_version` is not Keras 1. 

Now `preprocess_weights_for_loading` is called recursively even when loading Keras 2 weights, so that the wrapped `CuDNNLSTM` weights will also be converted.

Also modified the test so that it fails before this fix:
```
[gw0] FAILED tests/keras/layers/cudnn_recurrent_test.py::test_load_weights_into_noncudnn_lstm
E               ValueError: Layer weight shape (8,) not compatible with provided weight shape (16,)
```
and passes after this fix. Other CuDNN tests also pass locally.