### PR TITLE
 Propagate uses_learning_phase via RNN initial states

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -895,8 +895,7 @@ class SimpleRNNCell(Layer):
             output = self.activation(output)
 
         # Properly set learning phase on output tensor.
-        if (0 < self.dropout + self.recurrent_dropout or
-                getattr(states[0], '_uses_learning_phase', False)):
+        if 0 < self.dropout + self.recurrent_dropout:
             if training is None:
                 output._uses_learning_phase = True
         return output, [output]
@@ -1344,8 +1343,7 @@ class GRUCell(Layer):
                                 self.recurrent_kernel[:, 2 * self.units:])
             hh = self.activation(x_h + recurrent_h)
         h = z * h_tm1 + (1 - z) * hh
-        if (0 < self.dropout + self.recurrent_dropout or
-                getattr(states[0], '_uses_learning_phase', False)):
+        if 0 < self.dropout + self.recurrent_dropout:
             if training is None:
                 h._uses_learning_phase = True
         return h, [h]
@@ -1845,8 +1843,7 @@ class LSTMCell(Layer):
             o = self.recurrent_activation(z3)
 
         h = o * self.activation(c)
-        if (0 < self.dropout + self.recurrent_dropout or
-                getattr(states[0], '_uses_learning_phase', False)):
+        if 0 < self.dropout + self.recurrent_dropout:
             if training is None:
                 h._uses_learning_phase = True
         return h, [h, c]

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -602,6 +602,8 @@ class RNN(Layer):
         # Properly set learning phase
         if getattr(last_output, '_uses_learning_phase', False):
             output._uses_learning_phase = True
+            for state in states:
+                state._uses_learning_phase = True
 
         if self.return_state:
             if not isinstance(states, (list, tuple)):
@@ -893,7 +895,8 @@ class SimpleRNNCell(Layer):
             output = self.activation(output)
 
         # Properly set learning phase on output tensor.
-        if 0 < self.dropout + self.recurrent_dropout:
+        if (0 < self.dropout + self.recurrent_dropout or
+                getattr(states[0], '_uses_learning_phase', False)):
             if training is None:
                 output._uses_learning_phase = True
         return output, [output]
@@ -1341,7 +1344,8 @@ class GRUCell(Layer):
                                 self.recurrent_kernel[:, 2 * self.units:])
             hh = self.activation(x_h + recurrent_h)
         h = z * h_tm1 + (1 - z) * hh
-        if 0 < self.dropout + self.recurrent_dropout:
+        if (0 < self.dropout + self.recurrent_dropout or
+                getattr(states[0], '_uses_learning_phase', False)):
             if training is None:
                 h._uses_learning_phase = True
         return h, [h]
@@ -1841,7 +1845,8 @@ class LSTMCell(Layer):
             o = self.recurrent_activation(z3)
 
         h = o * self.activation(c)
-        if 0 < self.dropout + self.recurrent_dropout:
+        if (0 < self.dropout + self.recurrent_dropout or
+                getattr(states[0], '_uses_learning_phase', False)):
             if training is None:
                 h._uses_learning_phase = True
         return h, [h, c]

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -419,7 +419,7 @@ def test_state_reuse(layer_class):
 def test_state_reuse_with_dropout(layer_class):
     input1 = Input(batch_shape=(num_samples, timesteps, embedding_dim))
     layer = layer_class(units, return_state=True, return_sequences=True, dropout=0.2)
-    _, *state = layer(input1)
+    state = layer(input1)[1:]
 
     input2 = Input(batch_shape=(num_samples, timesteps, embedding_dim))
     output = layer_class(units)(input2, initial_state=state)

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -413,6 +413,23 @@ def test_state_reuse(layer_class):
     outputs = model.predict(inputs)
 
 
+@rnn_test
+@pytest.mark.skipif((K.backend() in ['theano']),
+                    reason='Not supported.')
+def test_state_reuse_with_dropout(layer_class):
+    input1 = Input(batch_shape=(num_samples, timesteps, embedding_dim))
+    layer = layer_class(units, return_state=True, return_sequences=True, dropout=0.2)
+    _, *state = layer(input1)
+
+    input2 = Input(batch_shape=(num_samples, timesteps, embedding_dim))
+    output = layer_class(units)(input2, initial_state=state)
+    model = Model([input1, input2], output)
+
+    inputs = [np.random.random((num_samples, timesteps, embedding_dim)),
+              np.random.random((num_samples, timesteps, embedding_dim))]
+    outputs = model.predict(inputs)
+
+
 @keras_test
 def test_minimal_rnn_cell_non_layer():
 


### PR DESCRIPTION
The states returned by an RNN layer with `return_state=True` do not carry the `uses_learning_phase` information. Therefore, for a seq2seq model whose decoder uses no dropout and receives only states from the encoder, `uses_learning_phase` is not set correctly.

To reproduce the error, the following lines
```python
encoder_input = Input((None, 5))
_, *states = LSTM(32, return_state=True, dropout=0.2)(encoder_input)
decoder_input = Input((None, 5))
decoder_output = LSTM(32)(decoder_input, initial_state=states)
model = Model([encoder_input, decoder_input], decoder_output)
model.predict([np.zeros((1, 2, 5)), np.zeros((1, 2, 5))])
```
will throw an error:
```
InvalidArgumentError (see above for traceback): You must feed a value for placeholder tensor 'lstm_1/keras_learning_phase' with dtype bool
	 [[Node: lstm_1/keras_learning_phase = Placeholder[dtype=DT_BOOL, shape=<unknown>, _device="/job:localhost/replica:0/task:0/device:GPU:0"]()]]
	 [[Node: lstm_2/TensorArrayReadV3/_19 = _Recv[client_terminated=false, recv_device="/job:localhost/replica:0/task:0/device:CPU:0", send_device="/job:localhost/replica:0/task:0/device:GPU:0", send_device_incarnation=1, tensor_name="edge_508_lstm_2/TensorArrayReadV3", tensor_type=DT_FLOAT, _device="/job:localhost/replica:0/task:0/device:CPU:0"]()]]
```
Fix it by adding `_uses_learning_phase` to the states returned by an RNN layer, and check if previous `state[0]` uses learning phase in the step functions.