### PR TITLE
Fix models for sklearn ensemble

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1731,7 +1731,6 @@ class Model(Container):
                                batch_size=batch_size,
                                verbose=verbose,
                                steps=steps)
-
     def predict(self, x,
                 batch_size=None,
                 verbose=0,
@@ -1788,6 +1787,48 @@ class Model(Container):
         return self._predict_loop(f, ins, batch_size=batch_size,
                                   verbose=verbose, steps=steps)
 
+        def predict_proba(self, x, batch_size=None, verbose=0):
+        """Generates class probability predictions for the input samples.
+
+        The input samples are processed batch by batch.
+
+        # Arguments
+            x: input data, as a Numpy array or list of Numpy arrays
+                (if the model has multiple inputs).
+            batch_size: Integer. If unspecified, it will default to 32.
+            verbose: verbosity mode, 0 or 1.
+
+        # Returns
+            A Numpy array of probability predictions.
+        """
+        preds = self.predict(x, batch_size, verbose)
+        if preds.min() < 0. or preds.max() > 1.:
+            warnings.warn('Network returning invalid probability values. '
+                          'The last layer might not normalize predictions '
+                          'into probabilities '
+                          '(like softmax or sigmoid would).')
+        return preds
+
+    def predict_classes(self, x, batch_size=None, verbose=0):
+        """Generate class predictions for the input samples.
+
+        The input samples are processed batch by batch.
+
+        # Arguments
+            x: input data, as a Numpy array or list of Numpy arrays
+                (if the model has multiple inputs).
+            batch_size: Integer. If unspecified, it will default to 32.
+            verbose: verbosity mode, 0 or 1.
+
+        # Returns
+            A numpy array of class predictions.
+        """
+        proba = self.predict(x, batch_size=batch_size, verbose=verbose)
+        if proba.shape[-1] > 1:
+            return proba.argmax(axis=-1)
+        else:
+            return (proba > 0.5).astype('int32')
+    
     def train_on_batch(self, x, y,
                        sample_weight=None,
                        class_weight=None):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1787,7 +1787,7 @@ class Model(Container):
         return self._predict_loop(f, ins, batch_size=batch_size,
                                   verbose=verbose, steps=steps)
 
-        def predict_proba(self, x, batch_size=None, verbose=0):
+    def predict_proba(self, x, batch_size=None, verbose=0):
         """Generates class probability predictions for the input samples.
 
         The input samples are processed batch by batch.

--- a/keras/models.py
+++ b/keras/models.py
@@ -1097,48 +1097,6 @@ class Sequential(Model):
         return self.model.test_on_batch(x, y,
                                         sample_weight=sample_weight)
 
-    def predict_proba(self, x, batch_size=None, verbose=0):
-        """Generates class probability predictions for the input samples.
-
-        The input samples are processed batch by batch.
-
-        # Arguments
-            x: input data, as a Numpy array or list of Numpy arrays
-                (if the model has multiple inputs).
-            batch_size: Integer. If unspecified, it will default to 32.
-            verbose: verbosity mode, 0 or 1.
-
-        # Returns
-            A Numpy array of probability predictions.
-        """
-        preds = self.predict(x, batch_size, verbose)
-        if preds.min() < 0. or preds.max() > 1.:
-            warnings.warn('Network returning invalid probability values. '
-                          'The last layer might not normalize predictions '
-                          'into probabilities '
-                          '(like softmax or sigmoid would).')
-        return preds
-
-    def predict_classes(self, x, batch_size=None, verbose=0):
-        """Generate class predictions for the input samples.
-
-        The input samples are processed batch by batch.
-
-        # Arguments
-            x: input data, as a Numpy array or list of Numpy arrays
-                (if the model has multiple inputs).
-            batch_size: Integer. If unspecified, it will default to 32.
-            verbose: verbosity mode, 0 or 1.
-
-        # Returns
-            A numpy array of class predictions.
-        """
-        proba = self.predict(x, batch_size=batch_size, verbose=verbose)
-        if proba.shape[-1] > 1:
-            return proba.argmax(axis=-1)
-        else:
-            return (proba > 0.5).astype('int32')
-
     @interfaces.legacy_generator_methods_support
     def fit_generator(self, generator,
                       steps_per_epoch=None,


### PR DESCRIPTION
When using the sklearn VotingClassifier ensemble technique, it looks for predict_proba and predict_classes methods.  These methods exist on Sequential but not on Model.  Moving these methods to Model fixing this issue and maintains functionality for Sequential, as a subclass of Model.