### PR TITLE
Allow learning_phase to remain feedable when set

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -124,7 +124,7 @@ def learning_phase():
 
 
 def set_learning_phase(value):
-    """Sets the learning phase to a fixed value.
+    """Sets the learning phase to a default fixed value.
 
     # Arguments
         value: Learning phase value, either 0 or 1 (integers).
@@ -136,7 +136,10 @@ def set_learning_phase(value):
     if value not in {0, 1}:
         raise ValueError('Expected learning phase to be '
                          '0 or 1.')
-    _GRAPH_LEARNING_PHASES[tf.get_default_graph()] = value
+    _GRAPH_LEARNING_PHASES[tf.get_default_graph()] = (
+        tf.placeholder_with_default(input=value, shape=(),
+                                    name='keras_learning_phase')
+    )
 
 
 def get_session():


### PR DESCRIPTION
When your model needs to manipulate `keras_learning_phase` while training and evaluating you don't necessarily want to expose this to a serving interface. Without this, your model is either forced to pick, avoid Keras layers that relay on learning_phase, or have the serving interface feed this value.

This fixes that issue by allowing a model to set the learning_phase as a default instead of a constant before adding graph components with Keras. It also allows calling `keras.backend.learning_phase()` to get a feed handle to the placeholder instead of an integer.

It's also backward compatible.