### PR TITLE
[Requests for Contributions] Refactoring _standardize_input_data to make it faster. With explanations and benchmarks.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -27,8 +27,8 @@ from ..legacy import interfaces
 
 
 def _standardize_input_data(data, names, shapes=None,
-                                     check_batch_axis=True,
-                                     exception_prefix=''):
+                            check_batch_axis=True,
+                            exception_prefix=''):
     """Normalizes inputs and targets provided by users.
     Users may pass data as a list of arrays, dictionary of arrays,
     or as a single array. We normalize this to an ordered list of
@@ -57,7 +57,6 @@ def _standardize_input_data(data, names, shapes=None,
         return [None for _ in range(len(names))]
     if isinstance(data, dict):
         try:
-            
             arrays = [data[name].values if data[name].__class__.__name__ == 'DataFrame' else data[name] 
                       for name in names]
             

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -30,12 +30,12 @@ def _standardize_input_data(data, names, shapes=None,
                             check_batch_axis=True,
                             exception_prefix=''):
     """Normalizes inputs and targets provided by users.
-	
+
     Users may pass data as a list of arrays, dictionary of arrays,
     or as a single array. We normalize this to an ordered list of
     arrays (same order as `names`), while checking that the provided
     arrays have shapes that match the network's expectations.
-	
+
     # Arguments
         data: User-provided input data (polymorphic).
         names: List of expected array names.
@@ -44,10 +44,10 @@ def _standardize_input_data(data, names, shapes=None,
             the batch axis of the arrays matches the expected
             value found in `shapes`.
         exception_prefix: String prefix used for exception formatting.
-		
+
     # Returns
         List of standardized input arrays (one array per model input).
-		
+
     # Raises
         ValueError: in case of improperly formatted user-provided data.
     """

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -61,7 +61,7 @@ def _standardize_input_data(data, names, shapes=None,
         return [None for _ in range(len(names))]
     if isinstance(data, dict):
         try:
-            arrays = [data[name].values if data[name].__class__.__name__ == 'DataFrame' else data[name] 
+            arrays = [data[name].values if data[name].__class__.__name__ == 'DataFrame' else data[name]
                       for name in names]
             
         except KeyError:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -64,9 +64,9 @@ def _standardize_input_data(data, names, shapes=None,
             arrays = [data[name].values if data[name].__class__.__name__ == 'DataFrame' else data[name]
                       for name in names]
 
-        except KeyError:
+        except KeyError as e:
             raise ValueError('No data provided for "' +
-                             name + '". Need data for each key in: ' +
+                             e.args[0] + '". Need data for each key in: ' +
                              str(names))
 
     elif isinstance(data, list):
@@ -117,7 +117,7 @@ def _standardize_input_data(data, names, shapes=None,
         arrays = [data]
 
     # Make arrays at least 2D.
-    arrays = [np.expand_dims(array, 1) if len(array.shape) == 1 else array for array in arrays]
+    arrays = [np.expand_dims(array, 1) if array.ndim == 1 else array for array in arrays]
 
     # Check shapes compatibility.
     if shapes:
@@ -125,7 +125,7 @@ def _standardize_input_data(data, names, shapes=None,
         for i in range(len(names)):
             if shapes[i] is not None:
                 array_shape = arrays[i].shape
-                if len(array_shape) != len(shapes[i]):
+                if arrays[i].ndim != len(shapes[i]):
                     raise ValueError('Error when checking ' + exception_prefix +
                                      ': expected ' + names[i] +
                                      ' to have ' + str(len(shapes[i])) +

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -30,10 +30,12 @@ def _standardize_input_data(data, names, shapes=None,
                             check_batch_axis=True,
                             exception_prefix=''):
     """Normalizes inputs and targets provided by users.
+	
     Users may pass data as a list of arrays, dictionary of arrays,
     or as a single array. We normalize this to an ordered list of
     arrays (same order as `names`), while checking that the provided
     arrays have shapes that match the network's expectations.
+	
     # Arguments
         data: User-provided input data (polymorphic).
         names: List of expected array names.
@@ -42,8 +44,10 @@ def _standardize_input_data(data, names, shapes=None,
             the batch axis of the arrays matches the expected
             value found in `shapes`.
         exception_prefix: String prefix used for exception formatting.
+		
     # Returns
         List of standardized input arrays (one array per model input).
+		
     # Raises
         ValueError: in case of improperly formatted user-provided data.
     """

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -63,12 +63,12 @@ def _standardize_input_data(data, names, shapes=None,
         try:
             arrays = [data[name].values if data[name].__class__.__name__ == 'DataFrame' else data[name]
                       for name in names]
-            
+
         except KeyError:
             raise ValueError('No data provided for "' +
                              name + '". Need data for each key in: ' +
                              str(names))
-        
+
     elif isinstance(data, list):
         arrays = [x.values if x.__class__.__name__ == 'DataFrame' else x for x in data]
         if len(arrays) != len(names):


### PR DESCRIPTION
Hi! First pull request, I hope it'll work out.

So I got inspired by the other pull request and decided to have a take at it. 
You can see the results of the benchmark in the notebook or if you don't want to bother with the notebook, there is a PDF version.

### Benchmark results:

data is a list and we don't test the shapes : 10.2% speedup.
data is a list and we test the shapes: 15% speedup.
data is a dictionary and we don't test the shapes: 17.9% speedup.
data is a single array and we don't test the shapes: 9.68% speedup.
data is a single array and we test the shapes: 10.4% speedup.

### Modifications:

When treating a dictionary:
- we can check the keys at the same time as looking for a DataFrame by doing a list comprehension with a try catch block.

When dealing with lists:
- checking for a DataFrame with a list comprehension is faster than using a for loop. 
- I removed a variable assignment.

When dealing with single arrays:
- no changes

For all types of inputs:
- List comprehension to expand the dimensions if necessary rather than a for loop.

When checking the shapes:
- Removed a continue by inverting a if statement.
- When check_batch_axis is set to true, the variable start is set to 1 instead of 0, so we know where we need to start checking the dimensions.

All of this have been done with a line profiler, I tried to balance readability and speed. For the future, using the notebook I made to test speed can be useful.

[benchmark.pdf](https://github.com/keras-team/keras/files/1594519/benchmark.pdf)
[notebook.zip](https://github.com/keras-team/keras/files/1594521/notebook.zip)
