### PR TITLE
[WIP] Add support for sparse arrays in fit, predict and evaluate.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1273,10 +1273,9 @@ class Model(Container):
             else:
                 progbar = Progbar(target=num_samples)
 
-        feed = self._feed_inputs + self._feed_targets + self._feed_sample_weights
         indices_for_conversion_to_dense = []
-        for i in range(len(feed)):
-            if issparse(ins[i]) and not K.is_sparse(feed[i]):
+        for i in range(len(self._feed_inputs)):
+            if issparse(ins[i]) and not K.is_sparse(self._feed_inputs[i]):
                 indices_for_conversion_to_dense.append(i)
 
         if steps is not None:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -56,7 +56,7 @@ def _standardize_input_data(data, names, shapes=None,
         if data is not None and hasattr(data, '__len__') and len(data):
             raise ValueError('Error when checking model ' +
                              exception_prefix + ': '
-                                                'expected no data, but got:', data)
+                             'expected no data, but got:', data)
         return []
     if data is None:
         return [None for _ in range(len(names))]
@@ -185,8 +185,8 @@ def _standardize_sample_or_class_weights(x_weight, output_names, weight_type):
                              str(len(x_weight)) +
                              ' elements, but the model has ' +
                              str(len(output_names)) + ' outputs. '
-                                                      'You should provide one `' + weight_type + '`'
-                                                                                                 'array per model output.')
+                             'You should provide one `' + weight_type + '`'
+                             'array per model output.')
         return x_weight
     if isinstance(x_weight, dict):
         x_weights = []
@@ -196,8 +196,8 @@ def _standardize_sample_or_class_weights(x_weight, output_names, weight_type):
     else:
         raise TypeError('The model has multiple outputs, so `' +
                         weight_type + '` '
-                                      'should be either a list or a dict. '
-                                      'Provided `' + weight_type +
+                        'should be either a list or a dict. '
+                        'Provided `' + weight_type +
                         '` type not understood: ' +
                         str(x_weight))
 
@@ -225,7 +225,6 @@ def _check_array_lengths(inputs, targets, weights=None):
     # Raises
         ValueError: in case of incorrectly formatted data.
     """
-
     def set_of_lengths(x):
         # return a set with the variation between
         # different shapes, with None => 0
@@ -249,7 +248,7 @@ def _check_array_lengths(inputs, targets, weights=None):
         raise ValueError('Input arrays should have '
                          'the same number of samples as target arrays. '
                          'Found ' + str(list(set_x)[0]) + ' input samples '
-                                                          'and ' + str(list(set_y)[0]) + ' target samples.')
+                         'and ' + str(list(set_y)[0]) + ' target samples.')
     if len(set_w) > 1:
         raise ValueError('All sample_weight arrays should have '
                          'the same number of samples. Got array shapes: ' +
@@ -306,9 +305,9 @@ def _check_loss_and_target_compatibility(targets, loss_fns, output_shapes):
                         'A target array with shape ' + str(y.shape) +
                         ' was passed for an output of shape ' + str(shape) +
                         ' while using as loss `' + loss.__name__ + '`. '
-                                                                   'This loss expects '
-                                                                   'targets to have the same shape '
-                                                                   'as the output.')
+                        'This loss expects '
+                        'targets to have the same shape '
+                        'as the output.')
 
 
 def _collect_metrics(metrics, output_names):
@@ -477,7 +476,6 @@ def _weighted_masked_objective(fn):
             score_array *= weights
             score_array /= K.mean(K.cast(K.not_equal(weights, 0), K.floatx()))
         return K.mean(score_array)
-
     return weighted
 
 
@@ -512,38 +510,38 @@ def _standardize_weights(y, sample_weight=None, class_weight=None,
             raise ValueError('Found a sample_weight array for '
                              'an input with shape ' +
                              str(y.shape) + '. '
-                                            'Timestep-wise sample weighting (use of '
-                                            'sample_weight_mode="temporal") is restricted to '
-                                            'outputs that are at least 3D, i.e. that have '
-                                            'a time dimension.')
+                             'Timestep-wise sample weighting (use of '
+                             'sample_weight_mode="temporal") is restricted to '
+                             'outputs that are at least 3D, i.e. that have '
+                             'a time dimension.')
         if sample_weight is not None and len(sample_weight.shape) != 2:
             raise ValueError('Found a sample_weight array with shape ' +
                              str(sample_weight.shape) + '. '
-                                                        'In order to use timestep-wise sample weighting, '
-                                                        'you should pass a 2D sample_weight array.')
+                             'In order to use timestep-wise sample weighting, '
+                             'you should pass a 2D sample_weight array.')
     else:
         if sample_weight is not None and len(sample_weight.shape) != 1:
             raise ValueError('Found a sample_weight array with shape ' +
                              str(sample_weight.shape) + '. '
-                                                        'In order to use timestep-wise sample weights, '
-                                                        'you should specify '
-                                                        'sample_weight_mode="temporal" '
-                                                        'in compile(). If you just mean to use '
-                                                        'sample-wise weights, make sure your '
-                                                        'sample_weight array is 1D.')
+                             'In order to use timestep-wise sample weights, '
+                             'you should specify '
+                             'sample_weight_mode="temporal" '
+                             'in compile(). If you just mean to use '
+                             'sample-wise weights, make sure your '
+                             'sample_weight array is 1D.')
 
     if sample_weight is not None:
         if len(sample_weight.shape) > len(y.shape):
             raise ValueError('Found a sample_weight with shape' +
                              str(sample_weight.shape) + '.'
-                                                        'Expected sample_weight with rank '
-                                                        'less than or equal to ' + str(len(y.shape)))
+                             'Expected sample_weight with rank '
+                             'less than or equal to ' + str(len(y.shape)))
 
         if y.shape[:sample_weight.ndim] != sample_weight.shape:
             raise ValueError('Found a sample_weight array with shape ' +
                              str(sample_weight.shape) + ' for an input with shape ' +
                              str(y.shape) + '. '
-                                            'sample_weight cannot be broadcast.')
+                             'sample_weight cannot be broadcast.')
         return sample_weight
     elif isinstance(class_weight, dict):
         if len(y.shape) > 2:
@@ -645,7 +643,7 @@ class Model(Container):
                 if name not in self.output_names:
                     raise ValueError('Unknown entry in loss '
                                      'dictionary: "' + name + '". '
-                                                              'Only expected the following keys: ' +
+                                     'Only expected the following keys: ' +
                                      str(self.output_names))
             loss_functions = []
             for name in self.output_names:
@@ -696,7 +694,7 @@ class Model(Container):
                 if name not in self.output_names:
                     raise ValueError('Unknown entry in loss_weights '
                                      'dictionary: "' + name + '". '
-                                                              'Only expected the following keys: ' +
+                                     'Only expected the following keys: ' +
                                      str(self.output_names))
             loss_weights_list = []
             for name in self.output_names:
@@ -731,7 +729,7 @@ class Model(Container):
                     if name not in self.output_names:
                         raise ValueError('Unknown entry in `target_tensors` '
                                          'dictionary: "' + name + '". '
-                                                                  'Only expected the following keys: ' +
+                                         'Only expected the following keys: ' +
                                          str(self.output_names))
                 _target_tensors = []
                 for name in self.output_names:
@@ -774,7 +772,7 @@ class Model(Container):
                     raise ValueError('Unknown entry in '
                                      'sample_weight_mode dictionary: "' +
                                      name + '". '
-                                            'Only expected the following keys: ' +
+                                     'Only expected the following keys: ' +
                                      str(self.output_names))
             for i, name in enumerate(self.output_names):
                 if i in skip_target_weighing_indices:
@@ -912,7 +910,7 @@ class Model(Container):
                             # (because of class mode duality)
                             output_shape = self.internal_output_shapes[i]
                             if (output_shape[-1] == 1 or
-                                    self.loss_functions[i] == losses.binary_crossentropy):
+                               self.loss_functions[i] == losses.binary_crossentropy):
                                 # case: binary accuracy
                                 acc_fn = metrics_module.binary_accuracy
                             elif self.loss_functions[i] == losses.sparse_categorical_crossentropy:
@@ -1820,7 +1818,7 @@ class Model(Container):
                                  'a number of samples that can be '
                                  'divided by the batch size. Found: ' +
                                  str(x[0].shape[0]) + ' samples. '
-                                                      'Batch size: ' + str(batch_size) + '.')
+                                 'Batch size: ' + str(batch_size) + '.')
 
         # Prepare inputs, delegate logic to `_predict_loop`.
         if self.uses_learning_phase and not isinstance(K.learning_phase(), int):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -10,6 +10,7 @@ import six
 from keras.utils import Sequence
 from keras.utils import GeneratorEnqueuer
 from keras.utils import OrderedEnqueuer
+from scipy.sparse import issparse
 
 try:
     import queue
@@ -55,7 +56,7 @@ def _standardize_input_data(data, names, shapes=None,
         if data is not None and hasattr(data, '__len__') and len(data):
             raise ValueError('Error when checking model ' +
                              exception_prefix + ': '
-                             'expected no data, but got:', data)
+                                                'expected no data, but got:', data)
         return []
     if data is None:
         return [None for _ in range(len(names))]
@@ -184,8 +185,8 @@ def _standardize_sample_or_class_weights(x_weight, output_names, weight_type):
                              str(len(x_weight)) +
                              ' elements, but the model has ' +
                              str(len(output_names)) + ' outputs. '
-                             'You should provide one `' + weight_type + '`'
-                             'array per model output.')
+                                                      'You should provide one `' + weight_type + '`'
+                                                                                                 'array per model output.')
         return x_weight
     if isinstance(x_weight, dict):
         x_weights = []
@@ -195,8 +196,8 @@ def _standardize_sample_or_class_weights(x_weight, output_names, weight_type):
     else:
         raise TypeError('The model has multiple outputs, so `' +
                         weight_type + '` '
-                        'should be either a list or a dict. '
-                        'Provided `' + weight_type +
+                                      'should be either a list or a dict. '
+                                      'Provided `' + weight_type +
                         '` type not understood: ' +
                         str(x_weight))
 
@@ -224,6 +225,7 @@ def _check_array_lengths(inputs, targets, weights=None):
     # Raises
         ValueError: in case of incorrectly formatted data.
     """
+
     def set_of_lengths(x):
         # return a set with the variation between
         # different shapes, with None => 0
@@ -247,7 +249,7 @@ def _check_array_lengths(inputs, targets, weights=None):
         raise ValueError('Input arrays should have '
                          'the same number of samples as target arrays. '
                          'Found ' + str(list(set_x)[0]) + ' input samples '
-                         'and ' + str(list(set_y)[0]) + ' target samples.')
+                                                          'and ' + str(list(set_y)[0]) + ' target samples.')
     if len(set_w) > 1:
         raise ValueError('All sample_weight arrays should have '
                          'the same number of samples. Got array shapes: ' +
@@ -304,9 +306,9 @@ def _check_loss_and_target_compatibility(targets, loss_fns, output_shapes):
                         'A target array with shape ' + str(y.shape) +
                         ' was passed for an output of shape ' + str(shape) +
                         ' while using as loss `' + loss.__name__ + '`. '
-                        'This loss expects '
-                        'targets to have the same shape '
-                        'as the output.')
+                                                                   'This loss expects '
+                                                                   'targets to have the same shape '
+                                                                   'as the output.')
 
 
 def _collect_metrics(metrics, output_names):
@@ -475,6 +477,7 @@ def _weighted_masked_objective(fn):
             score_array *= weights
             score_array /= K.mean(K.cast(K.not_equal(weights, 0), K.floatx()))
         return K.mean(score_array)
+
     return weighted
 
 
@@ -509,38 +512,38 @@ def _standardize_weights(y, sample_weight=None, class_weight=None,
             raise ValueError('Found a sample_weight array for '
                              'an input with shape ' +
                              str(y.shape) + '. '
-                             'Timestep-wise sample weighting (use of '
-                             'sample_weight_mode="temporal") is restricted to '
-                             'outputs that are at least 3D, i.e. that have '
-                             'a time dimension.')
+                                            'Timestep-wise sample weighting (use of '
+                                            'sample_weight_mode="temporal") is restricted to '
+                                            'outputs that are at least 3D, i.e. that have '
+                                            'a time dimension.')
         if sample_weight is not None and len(sample_weight.shape) != 2:
             raise ValueError('Found a sample_weight array with shape ' +
                              str(sample_weight.shape) + '. '
-                             'In order to use timestep-wise sample weighting, '
-                             'you should pass a 2D sample_weight array.')
+                                                        'In order to use timestep-wise sample weighting, '
+                                                        'you should pass a 2D sample_weight array.')
     else:
         if sample_weight is not None and len(sample_weight.shape) != 1:
             raise ValueError('Found a sample_weight array with shape ' +
                              str(sample_weight.shape) + '. '
-                             'In order to use timestep-wise sample weights, '
-                             'you should specify '
-                             'sample_weight_mode="temporal" '
-                             'in compile(). If you just mean to use '
-                             'sample-wise weights, make sure your '
-                             'sample_weight array is 1D.')
+                                                        'In order to use timestep-wise sample weights, '
+                                                        'you should specify '
+                                                        'sample_weight_mode="temporal" '
+                                                        'in compile(). If you just mean to use '
+                                                        'sample-wise weights, make sure your '
+                                                        'sample_weight array is 1D.')
 
     if sample_weight is not None:
         if len(sample_weight.shape) > len(y.shape):
             raise ValueError('Found a sample_weight with shape' +
                              str(sample_weight.shape) + '.'
-                             'Expected sample_weight with rank '
-                             'less than or equal to ' + str(len(y.shape)))
+                                                        'Expected sample_weight with rank '
+                                                        'less than or equal to ' + str(len(y.shape)))
 
         if y.shape[:sample_weight.ndim] != sample_weight.shape:
             raise ValueError('Found a sample_weight array with shape ' +
                              str(sample_weight.shape) + ' for an input with shape ' +
                              str(y.shape) + '. '
-                             'sample_weight cannot be broadcast.')
+                                            'sample_weight cannot be broadcast.')
         return sample_weight
     elif isinstance(class_weight, dict):
         if len(y.shape) > 2:
@@ -642,7 +645,7 @@ class Model(Container):
                 if name not in self.output_names:
                     raise ValueError('Unknown entry in loss '
                                      'dictionary: "' + name + '". '
-                                     'Only expected the following keys: ' +
+                                                              'Only expected the following keys: ' +
                                      str(self.output_names))
             loss_functions = []
             for name in self.output_names:
@@ -693,7 +696,7 @@ class Model(Container):
                 if name not in self.output_names:
                     raise ValueError('Unknown entry in loss_weights '
                                      'dictionary: "' + name + '". '
-                                     'Only expected the following keys: ' +
+                                                              'Only expected the following keys: ' +
                                      str(self.output_names))
             loss_weights_list = []
             for name in self.output_names:
@@ -728,7 +731,7 @@ class Model(Container):
                     if name not in self.output_names:
                         raise ValueError('Unknown entry in `target_tensors` '
                                          'dictionary: "' + name + '". '
-                                         'Only expected the following keys: ' +
+                                                                  'Only expected the following keys: ' +
                                          str(self.output_names))
                 _target_tensors = []
                 for name in self.output_names:
@@ -771,7 +774,7 @@ class Model(Container):
                     raise ValueError('Unknown entry in '
                                      'sample_weight_mode dictionary: "' +
                                      name + '". '
-                                     'Only expected the following keys: ' +
+                                            'Only expected the following keys: ' +
                                      str(self.output_names))
             for i, name in enumerate(self.output_names):
                 if i in skip_target_weighing_indices:
@@ -909,7 +912,7 @@ class Model(Container):
                             # (because of class mode duality)
                             output_shape = self.internal_output_shapes[i]
                             if (output_shape[-1] == 1 or
-                               self.loss_functions[i] == losses.binary_crossentropy):
+                                    self.loss_functions[i] == losses.binary_crossentropy):
                                 # case: binary accuracy
                                 acc_fn = metrics_module.binary_accuracy
                             elif self.loss_functions[i] == losses.sparse_categorical_crossentropy:
@@ -1157,6 +1160,17 @@ class Model(Container):
         for cbk in callbacks:
             cbk.validation_data = val_ins
 
+        # To prevent a slowdown, we find beforehand the arrays that need conversion.
+        indices_for_conversion_to_dense = []
+        for i in range(len(self.input_layers)):
+            if issparse(ins[i]) and not self.get_layer(self._feed_input_names[i]).sparse:
+                indices_for_conversion_to_dense.append(i)
+
+        if steps_per_epoch is not None:
+            # Done before the loop since ins won't be modified in this case.
+            for i in indices_for_conversion_to_dense:
+                ins[i] = ins[i].toarray()
+
         for epoch in range(initial_epoch, epochs):
             callbacks.on_epoch_begin(epoch)
             epoch_logs = {}
@@ -1210,6 +1224,9 @@ class Model(Container):
                     batch_logs['batch'] = batch_index
                     batch_logs['size'] = len(batch_ids)
                     callbacks.on_batch_begin(batch_index, batch_logs)
+                    for i in indices_for_conversion_to_dense:
+                        ins_batch[i] = ins_batch[i].toarray()
+
                     outs = f(ins_batch)
                     if not isinstance(outs, list):
                         outs = [outs]
@@ -1261,6 +1278,13 @@ class Model(Container):
                 progbar = Progbar(target=steps)
             else:
                 progbar = Progbar(target=num_samples)
+
+        # To prevent a slowdown, we find beforehand the arrays that need conversion.
+        indices_for_conversion_to_dense = []
+        for i in range(len(self._feed_input_names)):
+            if issparse(ins[i]) and not self.get_layer(self._feed_input_names[i]).sparse:
+                indices_for_conversion_to_dense.append(i)
+
         if steps is not None:
             # Step-based predictions.
             # Since we do not know how many samples
@@ -1268,6 +1292,10 @@ class Model(Container):
             # the returned Numpy arrays.
             # Instead, we store one array per batch seen
             # and concatenate them upon returning.
+
+            # Done before the loop since ins won't be modified in this case.
+            for i in indices_for_conversion_to_dense:
+                ins[i] = ins[i].toarray()
             unconcatenated_outs = []
             for step in range(steps):
                 batch_outs = f(ins)
@@ -1296,6 +1324,9 @@ class Model(Container):
                     ins_batch = _slice_arrays(ins[:-1], batch_ids) + [ins[-1]]
                 else:
                     ins_batch = _slice_arrays(ins, batch_ids)
+                for i in indices_for_conversion_to_dense:
+                    ins_batch[i] = ins_batch[i].toarray()
+
                 batch_outs = f(ins_batch)
                 if not isinstance(batch_outs, list):
                     batch_outs = [batch_outs]
@@ -1339,7 +1370,18 @@ class Model(Container):
                 progbar = Progbar(target=steps)
             else:
                 progbar = Progbar(target=num_samples)
+
+        # To prevent a slowdown, we find beforehand the arrays that need conversion.
+        indices_for_conversion_to_dense = []
+        for i in range(len(self.input_layers)):
+            if issparse(ins[i]) and not self.get_layer(self._feed_input_names[i]).sparse:
+                indices_for_conversion_to_dense.append(i)
+
         if steps is not None:
+
+            # Done before the loop since ins won't be modified in this case.
+            for i in indices_for_conversion_to_dense:
+                ins[i] = ins[i].toarray()
             for step in range(steps):
                 batch_outs = f(ins)
                 if isinstance(batch_outs, list):
@@ -1366,6 +1408,8 @@ class Model(Container):
                     ins_batch = _slice_arrays(ins[:-1], batch_ids) + [ins[-1]]
                 else:
                     ins_batch = _slice_arrays(ins, batch_ids)
+                for i in indices_for_conversion_to_dense:
+                    ins_batch[i] = ins_batch[i].toarray()
 
                 batch_outs = f(ins_batch)
                 if isinstance(batch_outs, list):
@@ -1776,7 +1820,7 @@ class Model(Container):
                                  'a number of samples that can be '
                                  'divided by the batch size. Found: ' +
                                  str(x[0].shape[0]) + ' samples. '
-                                 'Batch size: ' + str(batch_size) + '.')
+                                                      'Batch size: ' + str(batch_size) + '.')
 
         # Prepare inputs, delegate logic to `_predict_loop`.
         if self.uses_learning_phase and not isinstance(K.learning_phase(), int):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1162,7 +1162,7 @@ class Model(Container):
 
         # To prevent a slowdown, we find beforehand the arrays that need conversion.
         indices_for_conversion_to_dense = []
-        for i in range(len(self.input_layers)):
+        for i in range(len(self._feed_input_names)):
             if issparse(ins[i]) and not self.get_layer(self._feed_input_names[i]).sparse:
                 indices_for_conversion_to_dense.append(i)
 
@@ -1373,7 +1373,7 @@ class Model(Container):
 
         # To prevent a slowdown, we find beforehand the arrays that need conversion.
         indices_for_conversion_to_dense = []
-        for i in range(len(self.input_layers)):
+        for i in range(len(self._feed_input_names)):
             if issparse(ins[i]) and not self.get_layer(self._feed_input_names[i]).sparse:
                 indices_for_conversion_to_dense.append(i)
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1164,11 +1164,6 @@ class Model(Container):
             if issparse(ins[i]) and not self.get_layer(self._feed_input_names[i]).sparse:
                 indices_for_conversion_to_dense.append(i)
 
-        if steps_per_epoch is not None:
-            # Done before the loop since ins won't be modified in this case.
-            for i in indices_for_conversion_to_dense:
-                ins[i] = ins[i].toarray()
-
         for epoch in range(initial_epoch, epochs):
             callbacks.on_epoch_begin(epoch)
             epoch_logs = {}
@@ -1290,10 +1285,6 @@ class Model(Container):
             # the returned Numpy arrays.
             # Instead, we store one array per batch seen
             # and concatenate them upon returning.
-
-            # Done before the loop since ins won't be modified in this case.
-            for i in indices_for_conversion_to_dense:
-                ins[i] = ins[i].toarray()
             unconcatenated_outs = []
             for step in range(steps):
                 batch_outs = f(ins)
@@ -1376,10 +1367,6 @@ class Model(Container):
                 indices_for_conversion_to_dense.append(i)
 
         if steps is not None:
-
-            # Done before the loop since ins won't be modified in this case.
-            for i in indices_for_conversion_to_dense:
-                ins[i] = ins[i].toarray()
             for step in range(steps):
                 batch_outs = f(ins)
                 if isinstance(batch_outs, list):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1159,9 +1159,10 @@ class Model(Container):
             cbk.validation_data = val_ins
 
         # To prevent a slowdown, we find beforehand the arrays that need conversion.
+        feed = self._feed_inputs + self._feed_targets + self._feed_sample_weights
         indices_for_conversion_to_dense = []
-        for i in range(len(self._feed_input_names)):
-            if issparse(ins[i]) and not self.get_layer(self._feed_input_names[i]).sparse:
+        for i in range(len(feed)):
+            if issparse(ins[i]) and not K.is_sparse(feed[i]):
                 indices_for_conversion_to_dense.append(i)
 
         for epoch in range(initial_epoch, epochs):
@@ -1272,10 +1273,10 @@ class Model(Container):
             else:
                 progbar = Progbar(target=num_samples)
 
-        # To prevent a slowdown, we find beforehand the arrays that need conversion.
+        feed = self._feed_inputs + self._feed_targets + self._feed_sample_weights
         indices_for_conversion_to_dense = []
-        for i in range(len(self._feed_input_names)):
-            if issparse(ins[i]) and not self.get_layer(self._feed_input_names[i]).sparse:
+        for i in range(len(feed)):
+            if issparse(ins[i]) and not K.is_sparse(feed[i]):
                 indices_for_conversion_to_dense.append(i)
 
         if steps is not None:
@@ -1361,9 +1362,10 @@ class Model(Container):
                 progbar = Progbar(target=num_samples)
 
         # To prevent a slowdown, we find beforehand the arrays that need conversion.
+        feed = self._feed_inputs + self._feed_targets + self._feed_sample_weights
         indices_for_conversion_to_dense = []
-        for i in range(len(self._feed_input_names)):
-            if issparse(ins[i]) and not self.get_layer(self._feed_input_names[i]).sparse:
+        for i in range(len(feed)):
+            if issparse(ins[i]) and not K.is_sparse(feed[i]):
                 indices_for_conversion_to_dense.append(i)
 
         if steps is not None:

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -488,7 +488,7 @@ def test_warnings():
 @keras_test
 def test_sparse_input_target_fit():
     test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
-    test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 4)]
+    test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 5)]
     in1 = Input(shape=(3,))
     in2 = Input(shape=(3,))
     out1 = Dropout(0.5, name='dropout')(in1)
@@ -501,7 +501,7 @@ def test_sparse_input_target_fit():
 @keras_test
 def test_sparse_input_target_evaluate():
     test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
-    test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 4)]
+    test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 5)]
     in1 = Input(shape=(3,))
     in2 = Input(shape=(3,))
     out1 = Dropout(0.5, name='dropout')(in1)
@@ -527,7 +527,7 @@ def test_sparse_input_predict():
 @keras_test
 def test_sparse_placeholder_fit():
     test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
-    test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 4)]
+    test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 5)]
     in1 = Input(shape=(3,))
     in2 = Input(shape=(3,), sparse=True)
     out1 = Dropout(0.5, name='dropout')(in1)
@@ -541,7 +541,7 @@ def test_sparse_placeholder_fit():
 @keras_test
 def test_sparse_placeholder_evaluate():
     test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
-    test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 4)]
+    test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 5)]
     in1 = Input(shape=(3,))
     in2 = Input(shape=(3,), sparse=True)
     out1 = Dropout(0.5, name='dropout')(in1)

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -499,34 +499,40 @@ def test_sparse_input_validation_split():
 
 @keras_test
 def test_sparse_input_fit():
-    test_input = sparse.random(6, 3, density=0.25).tocsr()
+    test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
+    test_outputs = [sparse.random(6, 4, density=0.25).tocsr(), sparse.random(6, 3, density=0.25).tocsr()]
     in1 = Input(shape=(3,))
-    out1 = Dense(4)(in1)
-    test_output = np.random.random((6, 4))
-    model = Model(in1, out1)
+    in2 = Input(shape=(3,), sparse=True)
+    out1 = Dense(4, name='dense_1')(in1)
+    out2 = Dropout(0.5, name='dropout')(in2)
+    model = Model([in1, in2], [out1, out2])
     model.compile('rmsprop', 'mse')
-    model.fit(test_input, test_output, epochs=1, batch_size=2, validation_split=0.2)
+    model.fit(test_inputs, test_outputs, epochs=1, batch_size=2, validation_split=0.2)
 
 
 @keras_test
 def test_sparse_input_evaluate():
-    test_input = sparse.random(6, 3, density=0.25).tocsr()
+    test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
+    test_outputs = [sparse.random(6, 4, density=0.25).tocsr(), sparse.random(6, 3, density=0.25).tocsr()]
     in1 = Input(shape=(3,))
-    out1 = Dense(4)(in1)
-    test_output = np.random.random((6, 4))
-    model = Model(in1, out1)
+    in2 = Input(shape=(3,), sparse=True)
+    out1 = Dense(4, name='dense_1')(in1)
+    out2 = Dropout(0.5, name='dropout')(in2)
+    model = Model([in1, in2], [out1, out2])
     model.compile('rmsprop', 'mse')
-    model.evaluate(test_input, test_output, batch_size=2)
+    model.evaluate(test_inputs, test_outputs, batch_size=2)
 
 
 @keras_test
 def test_sparse_input_predict():
-    test_input = sparse.random(6, 3, density=0.25).tocsr()
+    test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
     in1 = Input(shape=(3,))
-    out1 = Dense(4)(in1)
-    model = Model(in1, out1)
+    in2 = Input(shape=(3,), sparse=True)
+    out1 = Dense(4, name='dense_1')(in1)
+    out2 = Dropout(0.5, name='dropout')(in2)
+    model = Model([in1, in2], [out1, out2])
     model.compile('rmsprop', 'mse')
-    model.predict(test_input, batch_size=2)
+    model.predict(test_inputs, batch_size=2)
 
 
 @keras_test

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -498,6 +498,38 @@ def test_sparse_input_validation_split():
 
 
 @keras_test
+def test_sparse_input_fit():
+    test_input = sparse.random(6, 3, density=0.25).tocsr()
+    in1 = Input(shape=(3,))
+    out1 = Dense(4)(in1)
+    test_output = np.random.random((6, 4))
+    model = Model(in1, out1)
+    model.compile('rmsprop', 'mse')
+    model.fit(test_input, test_output, epochs=1, batch_size=2, validation_split=0.2)
+
+
+@keras_test
+def test_sparse_input_evaluate():
+    test_input = sparse.random(6, 3, density=0.25).tocsr()
+    in1 = Input(shape=(3,))
+    out1 = Dense(4)(in1)
+    test_output = np.random.random((6, 4))
+    model = Model(in1, out1)
+    model.compile('rmsprop', 'mse')
+    model.evaluate(test_input, test_output, batch_size=2)
+
+
+@keras_test
+def test_sparse_input_predict():
+    test_input = sparse.random(6, 3, density=0.25).tocsr()
+    in1 = Input(shape=(3,))
+    out1 = Dense(4)(in1)
+    model = Model(in1, out1)
+    model.compile('rmsprop', 'mse')
+    model.predict(test_input, batch_size=2)
+
+
+@keras_test
 def test_trainable_argument():
     x = np.random.random((5, 3))
     y = np.random.random((5, 2))

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -485,24 +485,12 @@ def test_warnings():
     assert all(['Sequence' not in str(w_.message) for w_ in w]), 'A warning was raised for Sequence.'
 
 
-@pytest.mark.skipif(K.backend() != 'tensorflow', reason='sparse operations supported only by TensorFlow')
-@keras_test
-def test_sparse_input_validation_split():
-    test_input = sparse.random(6, 3, density=0.25).tocsr()
-    in1 = Input(shape=(3,), sparse=True)
-    out1 = Dense(4)(in1)
-    test_output = np.random.random((6, 4))
-    model = Model(in1, out1)
-    model.compile('rmsprop', 'mse')
-    model.fit(test_input, test_output, epochs=1, batch_size=2, validation_split=0.2)
-
-
 @keras_test
 def test_sparse_input_target_fit():
     test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
     test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 4)]
     in1 = Input(shape=(3,))
-    in2 = Input(shape=(3,), sparse=True)
+    in2 = Input(shape=(3,))
     out1 = Dropout(0.5, name='dropout')(in1)
     out2 = Dense(4, name='dense_1')(in2)
     model = Model([in1, in2], [out1, out2])
@@ -515,7 +503,7 @@ def test_sparse_input_target_evaluate():
     test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
     test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 4)]
     in1 = Input(shape=(3,))
-    in2 = Input(shape=(3,), sparse=True)
+    in2 = Input(shape=(3,))
     out1 = Dropout(0.5, name='dropout')(in1)
     out2 = Dense(4, name='dense_1')(in2)
     model = Model([in1, in2], [out1, out2])
@@ -527,13 +515,54 @@ def test_sparse_input_target_evaluate():
 def test_sparse_input_predict():
     test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
     in1 = Input(shape=(3,))
-    in2 = Input(shape=(3,), sparse=True)
+    in2 = Input(shape=(3,))
     out1 = Dropout(0.5, name='dropout')(in1)
     out2 = Dense(4, name='dense_1')(in2)
     model = Model([in1, in2], [out1, out2])
     model.compile('rmsprop', 'mse')
     model.predict(test_inputs, batch_size=2)
 
+
+@pytest.mark.skipif(K.backend() != 'tensorflow', reason='sparse operations supported only by TensorFlow')
+@keras_test
+def test_sparse_placeholder_fit():
+    test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
+    test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 4)]
+    in1 = Input(shape=(3,))
+    in2 = Input(shape=(3,), sparse=True)
+    out1 = Dropout(0.5, name='dropout')(in1)
+    out2 = Dense(4, name='dense_1')(in2)
+    model = Model([in1, in2], [out1, out2])
+    model.compile('rmsprop', 'mse')
+    model.fit(test_inputs, test_outputs, epochs=1, batch_size=2, validation_split=0.2)
+
+
+@pytest.mark.skipif(K.backend() != 'tensorflow', reason='sparse operations supported only by TensorFlow')
+@keras_test
+def test_sparse_placeholder_evaluate():
+    test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
+    test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 4)]
+    in1 = Input(shape=(3,))
+    in2 = Input(shape=(3,), sparse=True)
+    out1 = Dropout(0.5, name='dropout')(in1)
+    out2 = Dense(4, name='dense_1')(in2)
+    model = Model([in1, in2], [out1, out2])
+    model.compile('rmsprop', 'mse')
+    model.evaluate(test_inputs, test_outputs, batch_size=2)
+
+
+@pytest.mark.skipif(K.backend() != 'tensorflow', reason='sparse operations supported only by TensorFlow')
+@keras_test
+def test_sparse_placeholder_predict():
+    test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
+    in1 = Input(shape=(3,))
+    in2 = Input(shape=(3,), sparse=True)
+    out1 = Dropout(0.5, name='dropout')(in1)
+    out2 = Dense(4, name='dense_1')(in2)
+    model = Model([in1, in2], [out1, out2])
+    model.compile('rmsprop', 'mse')
+    model.predict(test_inputs, batch_size=2)
+    
 
 @keras_test
 def test_trainable_argument():

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -498,26 +498,26 @@ def test_sparse_input_validation_split():
 
 
 @keras_test
-def test_sparse_input_fit():
+def test_sparse_input_target_fit():
     test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
-    test_outputs = [sparse.random(6, 4, density=0.25).tocsr(), sparse.random(6, 3, density=0.25).tocsr()]
+    test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 4)]
     in1 = Input(shape=(3,))
     in2 = Input(shape=(3,), sparse=True)
-    out1 = Dense(4, name='dense_1')(in1)
-    out2 = Dropout(0.5, name='dropout')(in2)
+    out1 = Dropout(0.5, name='dropout')(in1)
+    out2 = Dense(4, name='dense_1')(in2)
     model = Model([in1, in2], [out1, out2])
     model.compile('rmsprop', 'mse')
     model.fit(test_inputs, test_outputs, epochs=1, batch_size=2, validation_split=0.2)
 
 
 @keras_test
-def test_sparse_input_evaluate():
+def test_sparse_input_target_evaluate():
     test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
-    test_outputs = [sparse.random(6, 4, density=0.25).tocsr(), sparse.random(6, 3, density=0.25).tocsr()]
+    test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 4)]
     in1 = Input(shape=(3,))
     in2 = Input(shape=(3,), sparse=True)
-    out1 = Dense(4, name='dense_1')(in1)
-    out2 = Dropout(0.5, name='dropout')(in2)
+    out1 = Dropout(0.5, name='dropout')(in1)
+    out2 = Dense(4, name='dense_1')(in2)
     model = Model([in1, in2], [out1, out2])
     model.compile('rmsprop', 'mse')
     model.evaluate(test_inputs, test_outputs, batch_size=2)
@@ -528,8 +528,8 @@ def test_sparse_input_predict():
     test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
     in1 = Input(shape=(3,))
     in2 = Input(shape=(3,), sparse=True)
-    out1 = Dense(4, name='dense_1')(in1)
-    out2 = Dropout(0.5, name='dropout')(in2)
+    out1 = Dropout(0.5, name='dropout')(in1)
+    out2 = Dense(4, name='dense_1')(in2)
     model = Model([in1, in2], [out1, out2])
     model.compile('rmsprop', 'mse')
     model.predict(test_inputs, batch_size=2)

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -562,7 +562,7 @@ def test_sparse_placeholder_predict():
     model = Model([in1, in2], [out1, out2])
     model.compile('rmsprop', 'mse')
     model.predict(test_inputs, batch_size=2)
-    
+
 
 @keras_test
 def test_trainable_argument():


### PR DESCRIPTION
Hi!
This is the pull request for the "New additions" in the Requests for Contributions.

## The idea:
- When giving sparse arrays to keras in fit, predict or evaluate, if the corresponding Input layer wasn't specified as sparse when creating the model, the backend would complain about it.

## Request for comments

- My pull request only works for input data. If the target of the model is a sparse array, the backend will still complain . This is because of how I check if a conversion is necessary. See "modifications" for explanations. Ideas to solve this are welcome.

- If steps_per_epoch (or steps in predict and evaluate) is set, I noticed that the variable "ins" isn't sliced and never changes but the model is trained with it multiple times (it felt strange). So I applied the conversion before the loop to make it faster. I don't really understand if I'm wrong or not about "ins" never changing. Please be careful when reviewing this part.

## Modifications
- Before any loop, I create a list containing the indices of the arrays which need to a conversion to dense.
I loop though this list before calling f. 
- So in the case that the list is empty (no conversion needed) is still fast because the loop doesn't run a single iteration. It could be faster if we were just checking a boolean before the for loop, but it would bloat the code a bit.
- I use the attribute "sparse" of the corresponding input layer to know if the array needs to be converted or not.
- I made 3 test functions (one for fit, one for predict and one for evaluate). I didn't change the previous test function checking sparse arrays with Tensorflow.

Thank you.