### PR TITLE
[Request for Contributions (Issues)] Adding test to show that fit() is reducing reproducibility.

### DIFF
--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -1112,5 +1112,32 @@ def test_pandas_dataframe():
                           [output_a_df, output_b_df])
 
 
+@pytest.mark.skipif(K.backend() != 'tensorflow', reason='Necessitate set_random_seed')
+@keras_test
+def test_reproducibility():
+    seed = 1337
+    from tensorflow import set_random_seed
+    set_random_seed(seed)
+
+    # Generate some data
+    data = np.random.randn(100)
+    labels = data < 0.5
+
+    # Generate stub model
+    model = Sequential()
+    model.add(Dense(units=1, activation='sigmoid', input_shape=(1,)))
+    model.compile(loss='mse', optimizer='adam')
+
+    # Consume and reseed global randomness
+    np.random.seed(seed)
+    ref_val = np.random.rand()
+
+    np.random.seed(seed)
+    model.fit(data, labels, epochs=1, shuffle=True, verbose=0)
+    post_fit_val = np.random.rand()
+
+    assert_allclose(ref_val, post_fit_val)
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Hi!

Folowing #8906 

Calling fit changes the numpy random state. I don't think this is a bug, but I don't have much experience so I'm giving it the benefit of the doubt. Please tell me if this necessitate changes in the codebase, so that I can make a PR.

Citing @MaxG87 :

> Checking the source code I noticed that model.fit finally invokes np.random.shuffle(...), thus altering the global random state. This can be fixed very easily by introducing a new member of type np.random.RandomState, and then using this one instead of the global one.
I would appreciate very much if this could be fixed as it would remove one source of irreproducibility.
In my opinion, calling functions should not alter the global random state.
