### PR TITLE
change ImageDataGenerator's output from stdout to stderr

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -11,6 +11,7 @@ from scipy import linalg
 import scipy.ndimage as ndi
 from six.moves import range
 import os
+from sys import stderr
 import threading
 import warnings
 import multiprocessing.pool
@@ -1103,7 +1104,7 @@ class DirectoryIterator(Iterator):
                                     (os.path.join(directory, subdir)
                                      for subdir in classes)))
 
-        print('Found %d images belonging to %d classes.' % (self.samples, self.num_classes))
+        print('Found %d images belonging to %d classes.' % (self.samples, self.num_classes), file=stderr)
 
         # second, build an index of the images in the different class subfolders
         results = []


### PR DESCRIPTION
refined PR of #7936
change the output destination of ImageDataGenerator's  DirectoryIterator from stdout to stderr.

# Why
In situation where I write `find` command like program with keras and do ./keras_find_cat_image image_dir | xargs -I {} mv image_dir/{} dst_dir, Found %d images belonging to %d classes. is only noise for application.

stdout contents should be owned application programmers, not framework programmers.
All output which is not assumed by application programmers or application users should be written into stderr.