### PR TITLE
Add function for learning_phase default config

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -141,6 +141,26 @@ def set_learning_phase(value):
     _GRAPH_LEARNING_PHASES[tf.get_default_graph()] = value
 
 
+def set_default_learning_phase(value):
+    """Sets the learning phase to a placeholder with default value.
+
+    # Arguments
+        value: Learning phase value, either 0 or 1 (integers).
+
+    # Raises
+        ValueError: if `value` is neither `0` nor `1`.
+    """
+    global _GRAPH_LEARNING_PHASES
+    if value not in {0, 1}:
+        raise ValueError('Expected learning phase to be '
+                         '0 or 1.')
+
+    phase = tf.placeholder_with_default(input=value,
+                                        shape=(),
+                                        name='keras_learning_phase')
+    _GRAPH_LEARNING_PHASES[tf.get_default_graph()] = phase
+
+
 def get_session():
     """Returns the TF session to be used by the backend.
 


### PR DESCRIPTION
This is a follow-on to a previous pull request that was [closed and ignored](https://github.com/keras-team/keras/pull/8913).

This issue addressed by this patch is that a production model will rarely want to export the `keras_learning_phase` placeholder to a serving interface. A train only Keras graph may be faster but it's also useless except in the rare circumstance that training features (BN, dropout, etc) are desired at evaluation and prediction time. Without a default placeholder or a fixed value the `keras_learning_phase` must be either fed as part of a prediction request (exposing it and adding unneeded complexity to the interface), reprogram the serving endpoint to transparently feed this (essentially a hack, and possibly not possible), or have the pleasure of performing TensorSurgery to convert the placeholder to a constant on the fly into the SavedModel protobuffer (a laborious and unpleasant hack). Beyond this, the only other option is to rewrite without Keras, something we've had to do with our current model due to this current limitation.