### PR TITLE
Removed redundant os.path.expanduser call.

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -171,7 +171,7 @@ def get_file(fname,
         Path to the downloaded file
     """
     if cache_dir is None:
-        cache_dir = os.path.expanduser(os.path.join('~', '.keras'))
+        cache_dir = os.path.join('~', '.keras')
     if md5_hash is not None and file_hash is None:
         file_hash = md5_hash
         hash_algorithm = 'md5'

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -171,7 +171,7 @@ def get_file(fname,
         Path to the downloaded file
     """
     if cache_dir is None:
-        cache_dir = os.path.join('~', '.keras')
+        cache_dir = os.path.join(os.path.expanduser('~'), '.keras')
     if md5_hash is not None and file_hash is None:
         file_hash = md5_hash
         hash_algorithm = 'md5'


### PR DESCRIPTION
Hi!

The function `os.path.expanduser` is called twice on the same variable if `cache_dir` is `None` in `get_file()`.
But calling `os.path.expanduser` twice is equivalent to one function call so I removed it.