### PR TITLE
Cleanup some remaining uses of explicit epoch iteration in examples

### DIFF
--- a/examples/addition_rnn.py
+++ b/examples/addition_rnn.py
@@ -27,6 +27,7 @@ Five digits inverted:
 '''
 
 from __future__ import print_function
+from keras.callbacks import LambdaCallback
 from keras.models import Sequential
 from keras import layers
 import numpy as np
@@ -174,19 +175,14 @@ model.compile(loss='categorical_crossentropy',
               metrics=['accuracy'])
 model.summary()
 
-# Train the model each generation and show predictions against the validation
-# dataset.
-for iteration in range(1, 200):
+
+def on_epoch_end(epoch, logs):
+    """Function invoked at end of each epoch. Prints 10 samples from the
+    validation set at random so we can visualize errors."""
     print()
     print('-' * 50)
-    print('Iteration', iteration)
-    model.fit(x_train, y_train,
-              batch_size=BATCH_SIZE,
-              epochs=1,
-              validation_data=(x_val, y_val))
-    # Select 10 samples from the validation set at random so we can visualize
-    # errors.
-    for i in range(10):
+    print('After epoch %d:' % epoch)
+    for _ in range(10):
         ind = np.random.randint(0, len(x_val))
         rowx, rowy = x_val[np.array([ind])], y_val[np.array([ind])]
         preds = model.predict_classes(rowx, verbose=0)
@@ -200,3 +196,11 @@ for iteration in range(1, 200):
         else:
             print(colors.fail + '☒' + colors.close, end=' ')
         print(guess)
+
+print_callback = LambdaCallback(on_epoch_end=on_epoch_end)
+
+model.fit(x_train, y_train,
+          batch_size=BATCH_SIZE,
+          epochs=200,
+          callbacks=[print_callback],
+          validation_data=(x_val, y_val))

--- a/examples/lstm_stateful.py
+++ b/examples/lstm_stateful.py
@@ -38,6 +38,7 @@ from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
+from keras.callbacks import Callback
 from keras.models import Sequential
 from keras.layers import Dense, LSTM
 
@@ -188,23 +189,22 @@ print('y_train.shape: ', y_train.shape)
 print('x_test.shape: ', x_test.shape)
 print('y_test.shape: ', y_test.shape)
 
+
+class ResetStateCallback(Callback):
+    def on_epoch_end(self, epoch, logs):
+        print()
+        print('Resetting state after epoch %d.' % epoch)
+        self.model.reset_states()
+
 print('Training')
-for i in range(epochs):
-    print('Epoch', i + 1, '/', epochs)
-    # Note that the last state for sample i in a batch will
-    # be used as initial state for sample i in the next batch.
-    # Thus we are simultaneously training on batch_size series with
-    # lower resolution than the original series contained in data_input.
-    # Each of these series are offset by one step and can be
-    # extracted with data_input[i::batch_size].
-    model_stateful.fit(x_train,
-                       y_train,
-                       batch_size=batch_size,
-                       epochs=1,
-                       verbose=1,
-                       validation_data=(x_test, y_test),
-                       shuffle=False)
-    model_stateful.reset_states()
+model_stateful.fit(x_train,
+                   y_train,
+                   batch_size=batch_size,
+                   epochs=epochs,
+                   verbose=1,
+                   callbacks=[ResetStateCallback()],
+                   validation_data=(x_test, y_test),
+                   shuffle=False)
 
 print('Predicting')
 predicted_stateful = model_stateful.predict(x_test, batch_size=batch_size)


### PR DESCRIPTION
Replace some examples of explicit iteration over epochs in favor of callbacks.