### PR TITLE
fix __init__.py config with tensorflow

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -57,7 +57,7 @@ if not os.path.exists(_config_path):
         'epsilon': epsilon(),
         'backend': _BACKEND,
         'image_data_format': image_data_format(),
-        "image_dim_ordering": _BACKEND
+        'image_dim_ordering': _BACKEND
     }
     try:
         with open(_config_path, 'w') as f:

--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -56,7 +56,8 @@ if not os.path.exists(_config_path):
         'floatx': floatx(),
         'epsilon': epsilon(),
         'backend': _BACKEND,
-        'image_data_format': image_data_format()
+        'image_data_format': image_data_format(),
+        "image_dim_ordering": _BACKEND
     }
     try:
         with open(_config_path, 'w') as f:


### PR DESCRIPTION
I raised a new issue today #8994

There is something wrong with the default config at ~/.keras/keras.json

```
    _config = {
        'floatx': floatx(),
        'epsilon': epsilon(),
        'backend': _BACKEND,
        'image_data_format': image_data_format(),
        'image_dim_ordering': _BACKEND
    }
```
"image_dim_ordering" should be determined.
  
  
  