### PR TITLE
Enabling limited TensorBoard callback use with Theano and CNTK.

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -585,7 +585,7 @@ class LearningRateScheduler(Callback):
 
 
 class TensorBoard(Callback):
-    """Tensorboard basic visualizations.
+    """TensorBoard basic visualizations.
 
     [TensorBoard](https://www.tensorflow.org/get_started/summaries_and_tensorboard)
     is a visualization tool provided with TensorFlow.
@@ -601,8 +601,8 @@ class TensorBoard(Callback):
     tensorboard --logdir=/full_path_to_your_logs
     ```
 
-    When using a backend other than Tensorflow, Tensorboard will still work
-    (if you have Tensorflow installed), but the only feature available will
+    When using a backend other than TensorFlow, TensorBoard will still work
+    (if you have TensorFlow installed), but the only feature available will
     be the display of the losses and metrics plots.
 
     # Arguments
@@ -642,13 +642,30 @@ class TensorBoard(Callback):
                  embeddings_layer_names=None,
                  embeddings_metadata=None):
         super(TensorBoard, self).__init__()
-
         global tf, projector
         try:
             import tensorflow as tf
             from tensorflow.contrib.tensorboard.plugins import projector
         except ImportError:
-            raise ImportError("You need the TensorFlow module installed to use TensorBoard.")
+            raise ImportError('You need the TensorFlow module installed to use TensorBoard.')
+
+        if K.backend() != 'tensorflow':
+            if histogram_freq != 0:
+                warnings.warn('You are not using the TensorFlow backend. '
+                              'histogram_freq was set to 0')
+                histogram_freq = 0
+            if write_graph:
+                warnings.warn('You are not using the TensorFlow backend. '
+                              'write_graph was set to False')
+                write_graph = False
+            if write_images:
+                warnings.warn('You are not using the TensorFlow backend. '
+                              'write_images was set to False')
+                write_images = False
+            if embeddings_freq != 0:
+                warnings.warn('You are not using the TensorFlow backend. '
+                              'embeddings_freq was set to 0')
+                embeddings_freq = 0
 
         self.log_dir = log_dir
         self.histogram_freq = histogram_freq
@@ -660,25 +677,6 @@ class TensorBoard(Callback):
         self.embeddings_layer_names = embeddings_layer_names
         self.embeddings_metadata = embeddings_metadata or {}
         self.batch_size = batch_size
-
-        if K.backend() != 'tensorflow':
-            compatibility_dict = {"histogram_freq": 0,
-                                  "write_graph": False,
-                                  "write_images": False,
-                                  "embeddings_freq": 0}
-
-            warning_message = ["You're not using TensorFlow as backend. ",
-                               "Certain functions of the TensorBoard callback are going to be disabled.\n"]
-            display_warning = False
-            # We find the arguments incompatible with our current backend.
-            for key, value in compatibility_dict.items():
-                if self.__dict__[key] != value:
-                    warning_message += [key + " was set to " + str(value), ".\n"]
-                    display_warning = True
-            self.__dict__.update(compatibility_dict)
-
-            if display_warning:
-                warnings.warn("".join(warning_message), RuntimeWarning)
 
     def set_model(self, model):
         self.model = model

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -601,6 +601,10 @@ class TensorBoard(Callback):
     tensorboard --logdir=/full_path_to_your_logs
     ```
 
+    When using a backend other than Tensorflow, Tensorboard will still work
+    (if you have Tensorflow installed), but the only feature available will
+    be the display of the losses and metrics plots.
+
     # Arguments
         log_dir: the path of the directory where to save the log
             files to be parsed by TensorBoard.
@@ -658,23 +662,23 @@ class TensorBoard(Callback):
         self.batch_size = batch_size
 
         if K.backend() != 'tensorflow':
-            compatibility_list = [("histogram_freq", "0"),
-                                  ("write_graph", "False"),
-                                  ("write_images", "False"),
-                                  ("embeddings_freq", "0")]
-            # We find the arguments incompatible with our current backend.
-            incompatible_args = []
-            for x in compatibility_list:
-                if eval(x[0] + " != " + x[1]):
-                    incompatible_args.append(x)
+            compatibility_dict = {"histogram_freq": 0,
+                                  "write_graph": False,
+                                  "write_images": False,
+                                  "embeddings_freq": 0}
 
-            if len(incompatible_args) > 0:
-                warning_message = ["You're not using TensorFlow as backend.",
-                                   "Certain functions of the TensorBoard callback are going to be disabled."]
-                for arg, value in incompatible_args:
-                    exec("self." + arg + " = " + value)
-                    warning_message += [arg, "was set to", value, ","]
-                warnings.warn(" ".join(warning_message), RuntimeWarning)
+            warning_message = ["You're not using TensorFlow as backend. ",
+                               "Certain functions of the TensorBoard callback are going to be disabled.\n"]
+            display_warning = False
+            # We find the arguments incompatible with our current backend.
+            for key, value in compatibility_dict.items():
+                if self.__dict__[key] != value:
+                    warning_message += [key + " was set to " + str(value), ".\n"]
+                    display_warning = True
+            self.__dict__.update(compatibility_dict)
+
+            if display_warning:
+                warnings.warn("".join(warning_message), RuntimeWarning)
 
     def set_model(self, model):
         self.model = model

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -398,8 +398,6 @@ def test_CSVLogger(tmpdir):
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
 def test_TensorBoard(tmpdir):
     np.random.seed(np.random.randint(1, 1e7))
     filepath = str(tmpdir / 'logs')
@@ -546,8 +544,6 @@ def test_TensorBoard_histogram_freq_must_have_validation_data(tmpdir):
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
 def test_TensorBoard_multi_input_output(tmpdir):
     np.random.seed(np.random.randint(1, 1e7))
     filepath = str(tmpdir / 'logs')
@@ -623,8 +619,6 @@ def test_TensorBoard_multi_input_output(tmpdir):
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
 def test_TensorBoard_convnet(tmpdir):
     np.random.seed(np.random.randint(1, 1e7))
     filepath = str(tmpdir / 'logs')
@@ -748,8 +742,6 @@ def test_LambdaCallback():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow'),
-                    reason="Requires TensorFlow backend")
 def test_TensorBoard_with_ReduceLROnPlateau(tmpdir):
     import shutil
     np.random.seed(np.random.randint(1, 1e7))


### PR DESCRIPTION
## Motivations
- TensorBoard is very useful to visualize metrics and losses. This doesn't technically require to use TensorFlow as a backend. 

- Users should be able to use this functionality within the callback even if TensorFlow isn't the backend. It would also enable users to switch more easily between backends (less code to change).

## Design choices
- If the user has given arguments that are not compatible with the backend (let's say write_graph with Theano or CNTK), the callback won't throw an error, it will just give a warning saying that the argument has been overwritten.
- I make use of `excec` and` eval`, which is debatable in terms of code design. I could do without, it can easily be changed if required. The code would be a bit longer though because I didn't find a clean way to iterate over the arguments.

## Tests
- I believe all the tests needed were already created. I removed the decorators saying to skip them if the backend wasn't TensorFlow.

## API changes
- None

Thank you for reviewing.