### PR TITLE
Weights are now loaded by name in "applications".

### DIFF
--- a/keras/applications/densenet.py
+++ b/keras/applications/densenet.py
@@ -276,7 +276,7 @@ def DenseNet(blocks,
                     DENSENET201_WEIGHT_PATH_NO_TOP,
                     cache_subdir='models',
                     file_hash='1c2de60ee40562448dbac34a0737e798')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
     elif weights is not None:
         model.load_weights(weights)
 

--- a/keras/applications/inception_resnet_v2.py
+++ b/keras/applications/inception_resnet_v2.py
@@ -374,7 +374,7 @@ def InceptionResNetV2(include_top=True,
                                     BASE_WEIGHT_URL + weights_filename,
                                     cache_subdir='models',
                                     file_hash='d19885ff4a710c122648d3b5c3b684e4')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
     elif weights is not None:
         model.load_weights(weights)
 

--- a/keras/applications/inception_v3.py
+++ b/keras/applications/inception_v3.py
@@ -388,7 +388,7 @@ def InceptionV3(include_top=True,
                 WEIGHTS_PATH_NO_TOP,
                 cache_subdir='models',
                 file_hash='bcbd6486424b2319ff4ef7d526e38f63')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
     elif weights is not None:
         model.load_weights(weights)
 

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -533,7 +533,7 @@ def MobileNet(input_shape=None,
             weights_path = get_file(model_name,
                                     weigh_path,
                                     cache_subdir='models')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
     elif weights is not None:
         model.load_weights(weights)
 

--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -274,7 +274,7 @@ def NASNet(input_shape=None,
 
             weights_file = get_file(model_name, weight_path,
                                     cache_subdir='models')
-            model.load_weights(weights_file)
+            model.load_weights(weights_file, by_name=True)
 
         elif default_size == 331:  # large version
             if include_top:
@@ -286,7 +286,7 @@ def NASNet(input_shape=None,
 
             weights_file = get_file(model_name, weight_path,
                                     cache_subdir='models')
-            model.load_weights(weights_file)
+            model.load_weights(weights_file, by_name=True)
         else:
             raise ValueError(
                 'ImageNet weights can only be loaded with NASNetLarge'

--- a/keras/applications/resnet50.py
+++ b/keras/applications/resnet50.py
@@ -265,7 +265,7 @@ def ResNet50(include_top=True, weights='imagenet',
                                     WEIGHTS_PATH_NO_TOP,
                                     cache_subdir='models',
                                     md5_hash='a268eb855778b3df3c7506639542a6af')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
         if K.backend() == 'theano':
             layer_utils.convert_all_kernels_in_model(model)
             if include_top:

--- a/keras/applications/vgg16.py
+++ b/keras/applications/vgg16.py
@@ -173,7 +173,7 @@ def VGG16(include_top=True, weights='imagenet',
                                     WEIGHTS_PATH_NO_TOP,
                                     cache_subdir='models',
                                     file_hash='6d6bbae143d832006294945121d1f1fc')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
         if K.backend() == 'theano':
             layer_utils.convert_all_kernels_in_model(model)
 

--- a/keras/applications/vgg19.py
+++ b/keras/applications/vgg19.py
@@ -176,7 +176,7 @@ def VGG19(include_top=True, weights='imagenet',
                                     WEIGHTS_PATH_NO_TOP,
                                     cache_subdir='models',
                                     file_hash='253f8cb515780f3b799900260a226db6')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
         if K.backend() == 'theano':
             layer_utils.convert_all_kernels_in_model(model)
 

--- a/keras/applications/xception.py
+++ b/keras/applications/xception.py
@@ -260,7 +260,7 @@ def Xception(include_top=True, weights='imagenet',
                                     TF_WEIGHTS_PATH_NO_TOP,
                                     cache_subdir='models',
                                     file_hash='b0042744bf5b25fce3cb969f33bebb97')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
     elif weights is not None:
         model.load_weights(weights)
 


### PR DESCRIPTION
## The bug:

#8998 
When using applications models with a input tensor passed in argument to the function that creates the model, imagenet weights can't get loaded. This is because the final model has more layers than expected and the loading of the weights is based on the topology of the model.

## A minimal script to reproduce the bug

```
from keras.layers import *
from keras.applications.vgg16 import VGG16
from keras.models import Model

a = Input(shape=(None, None, 3))
b = Conv2D(3,3, padding="same")(a)
model = VGG16(include_top=False,weights='imagenet',input_tensor=b)
```
The message given is:

```
ValueError                                Traceback (most recent call last)
<ipython-input-1-f23c5c6a7e7b> in <module>()
      5 a = Input(shape=(None, None, 3))
      6 b = Conv2D(3,3, padding="same")(a)
----> 7 model = VGG16(include_top=False,weights='imagenet',input_tensor=b)

c:\users\a\desktop\gabriel\keras\keras\applications\vgg16.py in VGG16(include_top, weights, input_tensor, input_shape, pooling, classes)
    174                                     cache_subdir='models',
    175                                     file_hash='6d6bbae143d832006294945121d1f1fc')
--> 176         model.load_weights(weights_path)
    177         if K.backend() == 'theano':
    178             layer_utils.convert_all_kernels_in_model(model)

c:\users\a\desktop\gabriel\keras\keras\engine\topology.py in load_weights(self, filepath, by_name, skip_mismatch)
   2637                 f, self.layers, skip_mismatch=skip_mismatch)
   2638         else:
-> 2639             load_weights_from_hdf5_group(f, self.layers)
   2640 
   2641         if hasattr(f, 'close'):

c:\users\a\desktop\gabriel\keras\keras\engine\topology.py in load_weights_from_hdf5_group(f, layers)
   3130                          'containing ' + str(len(layer_names)) +
   3131                          ' layers into a model with ' +
-> 3132                          str(len(filtered_layers)) + ' layers.')
   3133 
   3134     # We batch weight value assignments in a single backend call

ValueError: You are trying to load a weight file containing 13 layers into a model with 14 layers.
```

## The fix
There are two possibilities:
- The weights files were created from models having the same layers names as what is currently in keras/applications/*. In this case, the fix is simple, adding `by_name=True` when calling `load_weights()`. I've bet on this so that is what I applied (but I have actually no idea since I don't know how the weights files were created).
- The other possibility is that the weights files have random names for the layers, in which case there should be an exception raised when trying to load the weights from imagenet and passing a custom tensor as input. It should be easy too.

## The tests
I could have added tests, but since keras tests on Travis are really slow, and downloading the weights takes a long time, I chose not to do it. If the bosses say it's necessary, I'll do it though. I just have to know if I must test each model or not.

Thanks for reviewing! 
  