### PR TITLE
Removed unnecessary check.

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -846,8 +846,7 @@ def concatenate(tensors, axis=-1):
 def reshape(x, shape):
     y = T.reshape(x, shape)
     if _is_explicit_shape(shape):
-        if -1 in shape:
-            shape = tuple(x if x != -1 else None for x in shape)
+        shape = tuple(x if x != -1 else None for x in shape)
         y._keras_shape = shape
         if hasattr(x, '_uses_learning_phase'):
             y._uses_learning_phase = x._uses_learning_phase


### PR DESCRIPTION
It's said that it's harder to remove code than to write code.

```
if -1 in shape:
    shape = tuple(x if x != -1 else None for x in shape)
```

becomes 

`shape = tuple(x if x != -1 else None for x in shape)`

because even if there is not -1 in the iterable, then the only behavior difference with the previous version is that we could end up with a tuple instead of a list, and a minor speed difference. But I don't believe it's important.

Thank you for reviewing.