### PR TITLE
add ability to use lists of regularizers

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -403,7 +403,10 @@ class Layer(object):
                             name=name,
                             constraint=constraint)
         if regularizer is not None:
-            self.add_loss(regularizer(weight))
+            if type(regularizer) is not list:
+                regularizer = [regularizer]
+            for reg in regularizer:
+                self.add_loss(reg(weight))
         if trainable:
             self._trainable_weights.append(weight)
         else:

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -74,6 +74,8 @@ def deserialize(config, custom_objects=None):
 
 
 def get(identifier):
+    if type(identifier) is list:
+        return [get(i) for i in identifier]
     if identifier is None:
         return None
     if isinstance(identifier, dict):


### PR DESCRIPTION
Sometimes it may be desirable to use multiple regularization penalties on model weights. This is a simple, non-breaking change to allow regularization options can take lists of regularizers e.g.:
```
spatial_kernel_regularizer=[TVRegularizer(.00002, .00002, axes=[0, 1]), LocalOrthoRegularizer()]
```