### PR TITLE
Fix `multi_gpu_model` errors

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1106,6 +1106,22 @@ class SimpleRNN(RNN):
     def recurrent_dropout(self):
         return self.cell.recurrent_dropout
 
+    @property
+    def dropout_mask(self):
+        return self.cell._dropout_mask
+
+    @property
+    def recurrent_dropout_mask(self):
+        return self.cell._recurrent_dropout_mask
+
+    @dropout_mask.setter
+    def dropout_mask(self, value):
+        self.cell._dropout_mask = value
+
+    @recurrent_dropout_mask.setter
+    def recurrent_dropout_mask(self, value):
+        self.cell._recurrent_dropout_mask = value
+
     def get_config(self):
         config = {'units': self.units,
                   'activation': activations.serialize(self.activation),
@@ -1576,6 +1592,22 @@ class GRU(RNN):
     @property
     def recurrent_dropout(self):
         return self.cell.recurrent_dropout
+
+    @property
+    def dropout_mask(self):
+        return self.cell._dropout_mask
+
+    @property
+    def recurrent_dropout_mask(self):
+        return self.cell._recurrent_dropout_mask
+
+    @dropout_mask.setter
+    def dropout_mask(self, value):
+        self.cell._dropout_mask = value
+
+    @recurrent_dropout_mask.setter
+    def recurrent_dropout_mask(self, value):
+        self.cell._recurrent_dropout_mask = value
 
     @property
     def implementation(self):
@@ -2088,6 +2120,22 @@ class LSTM(RNN):
     @property
     def recurrent_dropout(self):
         return self.cell.recurrent_dropout
+
+    @property
+    def dropout_mask(self):
+        return self.cell._dropout_mask
+
+    @property
+    def recurrent_dropout_mask(self):
+        return self.cell._recurrent_dropout_mask
+
+    @dropout_mask.setter
+    def dropout_mask(self, value):
+        self.cell._dropout_mask = value
+
+    @recurrent_dropout_mask.setter
+    def recurrent_dropout_mask(self, value):
+        self.cell._recurrent_dropout_mask = value
 
     @property
     def implementation(self):

--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -149,6 +149,12 @@ def multi_gpu_model(model, gpus):
     for i in range(len(model.outputs)):
         all_outputs.append([])
 
+    for l in model.layers:
+        if hasattr(l, 'dropout_mask') and l.dropout_mask is not None:
+            l.dropout_mask = None
+        if hasattr(l, 'recurrent_dropout_mask') and l.recurrent_dropout_mask is not None:
+            l.recurrent_dropout_mask = None
+
     # Place a copy of the model on each GPU,
     # each getting a slice of the inputs.
     for i, gpu_id in enumerate(target_gpu_ids):


### PR DESCRIPTION
This PR addresses `multi_gpu_model` errors described in #8976. The example codes are:
```python
import numpy as np
import tensorflow as tf
from keras.models import Sequential
from keras.layers import Dense, LSTM, Conv2D
from keras.utils import multi_gpu_model

with tf.device('/cpu:0'):
    model0 = Sequential()
    model0.add(LSTM(32, dropout=0.2, recurrent_dropout=0.2, input_shape=(24, 8)))

model = multi_gpu_model(model0, gpus=2)
model.compile(loss='mse', optimizer='adam')

x_train = np.random.random((200, 24, 8))
y_train = np.random.random((200, 32))

model.fit(x_train, y_train, epochs=1, batch_size=20)
```
And the results are:
```
   InvalidArgumentError (see above for traceback): Incompatible shapes: [10,128] vs. [20,128]
 [[Node: replica_0/sequential_1/lstm_1/while/mul_5 = Mul[T=DT_FLOAT, _device="/job:localhost/replica:0/task:0/gpu:0"](replica_0/sequential_1/lstm_1/while/Identity_2, replica_0/sequential_1/lstm_1/while/mul_5/Enter)]]
```

The error arises from the dropout masking (e.g., `h_tm1_i = h_tm1 * rec_dp_mask[0]`). The batch-size of the dropout mask (`rec_dp_mask[0]`) is determined when the CPU model is built, while the the one of the previous states (`h_tm1`) is done when the multi-GPU model is constructed.

Thus, one of the possible solutions is to release the dropout mask generated by the CPU model in order to make new dropout mask when `multi_gpu_model(model0, gpus=2)` is called.