### PR TITLE
Add .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[report]
+fail_under = 79
+show_missing = True
+omit =
+    keras/applications/*
+    keras/datasets/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [report]
-fail_under = 79
+fail_under = 84
 show_missing = True
 omit =
     keras/applications/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,17 @@ install:
       conda install pydot graphviz;
     fi
 
+  # exclude different backends to measure a coverage for the designated backend only
+  - if [[ "$KERAS_BACKEND" != "tensorflow" ]]; then
+      echo '    keras/backend/tensorflow_backend.py' >> .coveragerc;
+    fi
+  - if [[ "$KERAS_BACKEND" != "theano" ]]; then
+      echo '    keras/backend/theano_backend.py' >> .coveragerc;
+    fi
+  - if [[ "$KERAS_BACKEND" != "cntk" ]]; then
+      echo '    keras/backend/cntk_backend.py' >> .coveragerc;
+    fi
+
   #install open mpi
   - rm -rf ~/mpi
   - mkdir ~/mpi
@@ -96,5 +107,5 @@ script:
     elif [[ "$TEST_MODE" == "DOC" ]]; then
         PYTHONPATH=$PWD:$PYTHONPATH py.test tests/test_documentation.py;
     else
-       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --cov=keras tests/ --cov-fail-under 79 --cov-report term-missing;
+       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --cov-config .coveragerc --cov=keras tests/;
     fi


### PR DESCRIPTION
Although the current tests (`tests/*`) covers most of the core functions (`keras/*`), the test coverages are quite low (about 79-83% currently). In my opinion,

- We need to check the normal operation of the modules `keras/applications/*` and `keras/datasets/*`, but I think it is a little unreasonable that they affect a test coverage because they are not core functions.
- There are three different backends and those pytest environments. However, most of the missing lines occur from different backend functions not designated backend. For example, one of the recent [tests](https://travis-ci.org/keras-team/keras/jobs/326628967) under `KERAS_BACKEND=theano` did not cover 511 and 334 lines in `cntk_backend.py` and `tensorflow_backend.py` respectively. Even if these are not included in test coverages measurement, the test coverages can increase by 5% (total 16117 lines).

The point is not excluding tests but evaluating test coverages except for non-core functions with respect to designated backend.