### PR TITLE
Refactor `Subtract`, `Concatenate`, and `Dot`

### DIFF
--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -96,6 +96,9 @@ class _Merge(Layer):
             self._reshape_required = True
 
     def call(self, inputs):
+        if not isinstance(inputs, list):
+            raise ValueError('A merge layer should be called '
+                             'on a list of inputs.')
         if self._reshape_required:
             reshaped_inputs = []
             input_ndims = list(map(K.ndim, inputs))
@@ -241,13 +244,16 @@ class Subtract(_Merge):
     ```
     """
 
+    def build(self, input_shape):
+        super(Subtract, self).build(input_shape)
+        if len(input_shape) != 2:
+            raise ValueError('A `Subtract` layer should be called '
+                             'on exactly 2 inputs')
+
     def _merge_function(self, inputs):
         if len(inputs) != 2:
-            raise ValueError('`Subtract` layer should be called '
+            raise ValueError('A `Subtract` layer should be called '
                              'on exactly 2 inputs')
-        if K.int_shape(inputs[0]) != K.int_shape(inputs[1]):
-            raise ValueError('`Subtract` layer should be called '
-                             'on inputs of the same shape')
         return inputs[0] - inputs[1]
 
 
@@ -327,11 +333,12 @@ class Concatenate(_Merge):
         super(Concatenate, self).__init__(**kwargs)
         self.axis = axis
         self.supports_masking = True
+        self._reshape_required = False
 
     def build(self, input_shape):
         # Used purely for shape validation.
         if not isinstance(input_shape, list) or len(input_shape) < 2:
-            raise ValueError('`Concatenate` layer should be called '
+            raise ValueError('A `Concatenate` layer should be called '
                              'on a list of of at least 2 inputs')
         if all([shape is None for shape in input_shape]):
             return
@@ -341,15 +348,12 @@ class Concatenate(_Merge):
             del reduced_inputs_shapes[i][self.axis]
             shape_set.add(tuple(reduced_inputs_shapes[i]))
         if len(shape_set) > 1:
-            raise ValueError('`Concatenate` layer requires '
+            raise ValueError('A `Concatenate` layer requires '
                              'inputs with matching shapes '
                              'except for the concat axis. '
                              'Got inputs shapes: %s' % (input_shape))
 
-    def call(self, inputs):
-        if not isinstance(inputs, list):
-            raise ValueError('A `Concatenate` layer should be called '
-                             'on a list of inputs.')
+    def _merge_function(self, inputs):
         return K.concatenate(inputs, axis=self.axis)
 
     def compute_output_shape(self, input_shape):
@@ -434,6 +438,7 @@ class Dot(_Merge):
         self.axes = axes
         self.normalize = normalize
         self.supports_masking = True
+        self._reshape_required = False
 
     def build(self, input_shape):
         # Used purely for shape validation.
@@ -457,7 +462,10 @@ class Dot(_Merge):
                 '%s != %s. ' % (shape1[axes[0]], shape2[axes[1]]) +
                 'Layer shapes: %s, %s' % (shape1, shape2))
 
-    def call(self, inputs):
+    def _merge_function(self, inputs):
+        if len(inputs) != 2:
+            raise ValueError('A `Dot` layer should be called '
+                             'on exactly 2 inputs')
         x1 = inputs[0]
         x2 = inputs[1]
         if isinstance(self.axes, int):

--- a/tests/keras/layers/merge_test.py
+++ b/tests/keras/layers/merge_test.py
@@ -75,8 +75,6 @@ def test_merge_subtract():
         subtract_layer([i1, i2, i3])
     with pytest.raises(ValueError):
         subtract_layer([i1])
-    with pytest.raises(ValueError):
-        subtract_layer([i1, i4])
 
 
 @keras_test
@@ -206,6 +204,8 @@ def test_merge_concatenate():
         concat_layer.compute_mask(i1, [None, None])
     with pytest.raises(ValueError):
         concat_layer.compute_mask([i1, i2], [None])
+    with pytest.raises(ValueError):
+        concat_layer([i1])
 
 
 @keras_test


### PR DESCRIPTION
This PR refactors `Subtract`, `Concatenate`, and `Dot`.

- The shape checkings have been conducted in `build(self, input_shape)` except for `Subtract`.
- The common shape checking can be replaced by `super(..., self).build(input_shape)` in `Concatenate` and `Dot`.
- The core operations have been conducted in `_merge_function(self, inputs)` except for `Concatenate` and `Dot`.