### PR TITLE
BN: Use sample variance - unbiased estimator of population variance

### DIFF
--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -180,6 +180,12 @@ class BatchNormalization(Layer):
             inputs, self.gamma, self.beta, reduction_axes,
             epsilon=self.epsilon)
 
+        sample_size = K.prod([K.shape(inputs)[axis] for axis in reduction_axes])
+        sample_size = K.cast(sample_size, dtype=K.dtype(inputs))
+
+        # sample variance - unbiased estimator of population variance
+        variance *= sample_size/(sample_size-(1.0+self.epsilon))
+
         self.add_update([K.moving_average_update(self.moving_mean,
                                                  mean,
                                                  self.momentum),

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -180,11 +180,13 @@ class BatchNormalization(Layer):
             inputs, self.gamma, self.beta, reduction_axes,
             epsilon=self.epsilon)
 
-        sample_size = K.prod([K.shape(inputs)[axis] for axis in reduction_axes])
-        sample_size = K.cast(sample_size, dtype=K.dtype(inputs))
+        if K.backend() != 'cntk':
+            sample_size = K.prod([K.shape(inputs)[axis]
+                                  for axis in reduction_axes])
+            sample_size = K.cast(sample_size, dtype=K.dtype(inputs))
 
-        # sample variance - unbiased estimator of population variance
-        variance *= sample_size/(sample_size-(1.0+self.epsilon))
+            # sample variance - unbiased estimator of population variance
+            variance *= sample_size / (sample_size - (1.0 + self.epsilon))
 
         self.add_update([K.moving_average_update(self.moving_mean,
                                                  mean,


### PR DESCRIPTION
Resolves Issue https://github.com/keras-team/keras/issues/8982

Currently, with `N=2`, the code in Issue https://github.com/keras-team/keras/issues/8982 produces wrong population variance (**0.47084832**), while the correct one is **1.0+-...** (with this PR the result is **0.99781173**). This is due to current code using wrong "variance of the sample"  `1/N` biased estimator instead of correct unbiased "sample variance" estimator `(1/(N-1)`, which for N=2 is exactly 2x smaller.

This is contrary to the "Batch Normalization" paper (https://arxiv.org/abs/1502.03167), where Algorithm 2, step 10 uses unbiased estimator: 
```
Var[x] ← m/(m−1) E_B[σ_B^2]
``` 
and everywhere else the paper consistently uses `Var[x]`, not `E[Var[B]]` or something (although "Batch renormalization" paper has it garbled).

The reason we don't typically see the obvious manifestation of the bug is because typically N is larger, and we normalize across the whole feature map (but we should see is for small N for Dense layers). Nevertheless, for **cifar10_resnet.py** example, after **epoch 1**,  **val_acc** improves from **0.5118** to **0.5235** (and together with PR https://github.com/keras-team/keras/pull/9003 improves again to **0.5860**. FWIW, final **val_acc** "improved" from **0.9195** to **0.9223**).
  
  