### PR TITLE
Format state_spec in the error message

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -65,6 +65,15 @@ class InputSpec(object):
         self.min_ndim = min_ndim
         self.axes = axes or {}
 
+    def __repr__(self):
+        spec = [('dtype=' + str(self.dtype)) if self.dtype else '',
+                ('shape=' + str(self.shape)) if self.shape else '',
+                ('ndim=' + str(self.ndim)) if self.ndim else '',
+                ('max_ndim=' + str(self.max_ndim)) if self.max_ndim else '',
+                ('min_ndim=' + str(self.min_ndim)) if self.min_ndim else '',
+                ('axes=' + str(self.axes)) if self.axes else '']
+        return 'InputSpec(%s)' % ', '.join(x for x in spec if x)
+
 
 class Node(object):
     """A `Node` describes the connectivity between two layers.

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -459,9 +459,9 @@ class RNN(Layer):
             # initial_state was passed in call, check compatibility
             if [spec.shape[-1] for spec in self.state_spec] != state_size:
                 raise ValueError(
-                    'An initial_state was passed that is not compatible with '
+                    'An `initial_state` was passed that is not compatible with '
                     '`cell.state_size`. Received `state_spec`={}; '
-                    'However `cell.state_size` is '
+                    'however `cell.state_size` is '
                     '{}'.format(self.state_spec, self.cell.state_size))
         else:
             self.state_spec = [InputSpec(shape=(None, dim))


### PR DESCRIPTION
Right now the error message is not quite useful when an incompatible state is passed to an RNN. For example,

```python
x = Input(shape=(None, 10))
states = [Input((32,)), Input((32,))]
x = RNN([GRUCell(32), GRUCell(64)])(x, initial_state=states)
```
gives the error:
```
ValueError: An initial_state was passed that is not compatible with `cell.state_size`. Received `state_spec`=[<keras.engine.topology.InputSpec object at 0x7f740559fd50>, <keras.engine.topology.InputSpec object at 0x7f740559fd90>]; However `cell.state_size` is (64, 32)
```
Printing the `state_spec` is good for debugging purpose, but the default python formatting generates something like `<keras.engine.topology.InputSpec object at 0x7f740559fd50>`.

This PR implements `__repr__` method for `InputSpec` so that the printed `state_spec` is more useful for debugging purpose:

```
ValueError: An `initial_state` was passed that is not compatible with `cell.state_size`. Received `state_spec`=[InputSpec(shape=(None, 32), ndim=2), InputSpec(shape=(None, 32), ndim=2)]; however `cell.state_size` is (64, 32)
```