### PR TITLE
Update Training utils multi_gpu_model to create unique model names.

### DIFF
--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -171,7 +171,8 @@ def multi_gpu_model(model, gpus):
     # Merge outputs on CPU.
     with tf.device('/cpu:0'):
         merged = []
-        for name, outputs in zip(model.output_names, all_outputs):
+        for n,(name, outputs) in enumerate(zip(model.output_names, all_outputs)):
             merged.append(concatenate(outputs,
-                                      axis=0, name=name))
+                                      axis=0, name=name+'_gpu_'+str(n)))
+        
         return Model(model.inputs, merged)


### PR DESCRIPTION
Fix for #8962 by giving duplicate outputs a unique suffix based upon the index of the GPU they're assigned to.