### PR TITLE
 Use tensorflow leaky_relu op for efficiency

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2915,15 +2915,14 @@ def relu(x, alpha=0., max_value=None):
         A tensor.
     """
     if alpha != 0.:
-        negative_part = tf.nn.relu(-x)
-    x = tf.nn.relu(x)
+        x = tf.nn.leaky_relu(x, alpha)
+    else:
+        x = tf.nn.relu(x)
+        
     if max_value is not None:
         max_value = _to_tensor(max_value, x.dtype.base_dtype)
-        zero = _to_tensor(0., x.dtype.base_dtype)
-        x = tf.clip_by_value(x, zero, max_value)
-    if alpha != 0.:
-        alpha = _to_tensor(alpha, x.dtype.base_dtype)
-        x -= alpha * negative_part
+        x = tf.maximum(x, max_value)
+
     return x
 
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2918,7 +2918,7 @@ def relu(x, alpha=0., max_value=None):
         x = tf.nn.leaky_relu(x, alpha)
     else:
         x = tf.nn.relu(x)
-        
+
     if max_value is not None:
         max_value = _to_tensor(max_value, x.dtype.base_dtype)
         x = tf.minimum(x, max_value)

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2921,8 +2921,7 @@ def relu(x, alpha=0., max_value=None):
         
     if max_value is not None:
         max_value = _to_tensor(max_value, x.dtype.base_dtype)
-        x = tf.maximum(x, max_value)
-
+        x = tf.minimum(x, max_value)
     return x
 
 


### PR DESCRIPTION
The current implementation for leaky_relu is extremely inefficient. In my specific usecase it took as much time as the convolution itself and led to tensorslow being much slower than theano. The old inefficient implementation was the result of tensorflow not having the leaky_relu op, but it was recently added.

fixes https://github.com/keras-team/keras/issues/3150