### PR TITLE
Speed up application tests

### DIFF
--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -1,4 +1,7 @@
 import pytest
+import numpy as np
+import time
+import random
 from multiprocessing import Process, Queue
 from keras.utils.test_utils import keras_test
 from keras.utils.test_utils import layer_test
@@ -6,6 +9,13 @@ from keras.utils.generic_utils import CustomObjectScope
 from keras.models import Sequential
 from keras import applications
 from keras import backend as K
+
+
+DENSENET_LIST = [(applications.DenseNet121, 1024),
+                 (applications.DenseNet169, 1664),
+                 (applications.DenseNet201, 1920)]
+NASNET_LIST = [(applications.NASNetMobile, 1056),
+               (applications.NASNetLarge, 4032)]
 
 
 @keras_test
@@ -311,12 +321,10 @@ def test_mobilenet_image_size():
 
 
 @keras_test
-@pytest.mark.parametrize('fun', [
-    applications.DenseNet121,
-    applications.DenseNet169,
-    applications.DenseNet201],
-    ids=['DenseNet121', 'DenseNet169', 'DenseNet201'])
-def test_densenet(fun):
+def test_densenet():
+    random.seed(time.time())
+    fun, _ = DENSENET_LIST[random.randint(0, 2)]
+
     def target(queue):
         model = fun(weights=None)
         queue.put(model.output_shape)
@@ -330,12 +338,10 @@ def test_densenet(fun):
 
 
 @keras_test
-@pytest.mark.parametrize('fun,dim', [
-    (applications.DenseNet121, 1024),
-    (applications.DenseNet169, 1664),
-    (applications.DenseNet201, 1920)],
-    ids=['DenseNet121', 'DenseNet169', 'DenseNet201'])
-def test_densenet_no_top(fun, dim):
+def test_densenet_no_top():
+    random.seed(time.time())
+    fun, dim = DENSENET_LIST[random.randint(0, 2)]
+
     def target(queue):
         model = fun(weights=None, include_top=False)
         queue.put(model.output_shape)
@@ -349,12 +355,10 @@ def test_densenet_no_top(fun, dim):
 
 
 @keras_test
-@pytest.mark.parametrize('fun,dim', [
-    (applications.DenseNet121, 1024),
-    (applications.DenseNet169, 1664),
-    (applications.DenseNet201, 1920)],
-    ids=['DenseNet121', 'DenseNet169', 'DenseNet201'])
-def test_densenet_pooling(fun, dim):
+def test_densenet_pooling():
+    random.seed(time.time())
+    fun, dim = DENSENET_LIST[random.randint(0, 2)]
+
     def target(queue):
         model = fun(weights=None, include_top=False, pooling='avg')
         queue.put(model.output_shape)
@@ -368,16 +372,13 @@ def test_densenet_pooling(fun, dim):
 
 
 @keras_test
-@pytest.mark.parametrize('fun,dim', [
-    (applications.DenseNet121, 1024),
-    (applications.DenseNet169, 1664),
-    (applications.DenseNet201, 1920)],
-    ids=['DenseNet121', 'DenseNet169', 'DenseNet201'])
-def test_densenet_variable_input_channels(fun, dim):
+def test_densenet_variable_input_channels():
+    random.seed(time.time())
+    fun, dim = DENSENET_LIST[random.randint(0, 2)]
+
     def target(queue, input_shape):
         model = fun(weights=None, include_top=False, input_shape=input_shape)
         queue.put(model.output_shape)
-
     queue = Queue()
     p = Process(target=target, args=(queue, (None, None, 1)))
     p.start()
@@ -398,10 +399,9 @@ def test_densenet_variable_input_channels(fun, dim):
 @pytest.mark.skipif((K.backend() != 'tensorflow'),
                     reason='NASNets are supported only on TensorFlow')
 def test_nasnet():
-    model = applications.NASNetMobile(weights=None)
-    assert model.output_shape == (None, 1000)
-
-    model = applications.NASNetLarge(weights=None)
+    random.seed(time.time())
+    fun, _ = NASNET_LIST[random.randint(0, 1)]
+    model = fun(weights=None)
     assert model.output_shape == (None, 1000)
 
 
@@ -409,41 +409,35 @@ def test_nasnet():
 @pytest.mark.skipif((K.backend() != 'tensorflow'),
                     reason='NASNets are supported only on TensorFlow')
 def test_nasnet_no_top():
-    model = applications.NASNetMobile(weights=None, include_top=False)
-    assert model.output_shape == (None, None, None, 1056)
-
-    model = applications.NASNetLarge(weights=None, include_top=False)
-    assert model.output_shape == (None, None, None, 4032)
+    random.seed(time.time())
+    fun, dim = NASNET_LIST[random.randint(0, 1)]
+    model = fun(weights=None, include_top=False)
+    assert model.output_shape == (None, None, None, dim)
 
 
 @keras_test
 @pytest.mark.skipif((K.backend() != 'tensorflow'),
                     reason='NASNets are supported only on TensorFlow')
 def test_nasnet_pooling():
-    model = applications.NASNetMobile(weights=None, include_top=False, pooling='avg')
-    assert model.output_shape == (None, 1056)
-
-    model = applications.NASNetLarge(weights=None, include_top=False, pooling='avg')
-    assert model.output_shape == (None, 4032)
+    random.seed(time.time())
+    fun, dim = NASNET_LIST[random.randint(0, 1)]
+    model = fun(weights=None, include_top=False, pooling='avg')
+    assert model.output_shape == (None, dim)
 
 
 @keras_test
 @pytest.mark.skipif((K.backend() != 'tensorflow'),
                     reason='NASNets are supported only on TensorFlow')
 def test_nasnet_variable_input_channels():
+    random.seed(time.time())
+    fun, dim = NASNET_LIST[random.randint(0, 1)]
     input_shape = (1, None, None) if K.image_data_format() == 'channels_first' else (None, None, 1)
-    model = applications.NASNetMobile(weights=None, include_top=False, input_shape=input_shape)
-    assert model.output_shape == (None, None, None, 1056)
-
-    model = applications.NASNetLarge(weights=None, include_top=False, input_shape=input_shape)
-    assert model.output_shape == (None, None, None, 4032)
+    model = fun(weights=None, include_top=False, input_shape=input_shape)
+    assert model.output_shape == (None, None, None, dim)
 
     input_shape = (4, None, None) if K.image_data_format() == 'channels_first' else (None, None, 4)
-    model = applications.NASNetMobile(weights=None, include_top=False, input_shape=input_shape)
-    assert model.output_shape == (None, None, None, 1056)
-
-    model = applications.NASNetLarge(weights=None, include_top=False, input_shape=input_shape)
-    assert model.output_shape == (None, None, None, 4032)
+    model = fun(weights=None, include_top=False, input_shape=input_shape)
+    assert model.output_shape == (None, None, None, dim)
 
 
 @pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TF backend')


### PR DESCRIPTION
Compared to the builds of previous versions (e.g., [2.1.1](https://travis-ci.org/keras-team/keras/builds/302166968) and [2.1.0](https://travis-ci.org/keras-team/keras/builds/301611719)), test times increased by about 10 min nowadays for all pytest environments.

- TF: 16-18 min -> 29-42 min
- TH: 23-25 min -> 26-36 min
- C: 13-17 min -> 19-29 min

This is because new applications, NASNet and DenseNet, have been added. Unlike other applications (resnet, inception, vgg, ...), the new applications share internal base functions with different parameters (NASNetMobile, NASNetLarge call NASNet; DenseNet121, DenseNet169, DenseNet201 call DenseNet). Thus, we need not to test all the variants, but to test a single representative application. This PR addresses this issue by introducing random test numbers.