### PR TITLE
Fix progress bar when total number of steps is unknown

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -327,7 +327,7 @@ class Progbar(object):
         info = ' - %.0fs' % (now - self.start)
         if self.verbose == 1:
             if (not force and (now - self.last_update) < self.interval and
-                    current < self.target):
+                    (self.target is not None and current < self.target)):
                 return
 
             prev_total_width = self.total_width

--- a/tests/keras/utils/generic_utils_test.py
+++ b/tests/keras/utils/generic_utils_test.py
@@ -16,8 +16,12 @@ from keras import regularizers
 def test_progbar():
     n = 2
     input_arr = np.random.random((n, n, n))
-    bar = Progbar(n)
 
+    bar = Progbar(n)
+    for i, arr in enumerate(input_arr):
+        bar.update(i, list(arr))
+
+    bar = Progbar(None)
     for i, arr in enumerate(input_arr):
         bar.update(i, list(arr))
 


### PR DESCRIPTION
Fix an error in the progress bar when `self.target=None`.

This error occurs when, for example, the file size is unknown in `get_file`.
```python
from keras.utils import get_file
listing_url = 'https://sites.google.com/site/brainrobotdata/home/grasping-dataset/grasp_listing.txt'
grasp_listing_path = get_file('grasp_listing.txt', listing_url)
```
```
Downloading data from https://sites.google.com/site/brainrobotdata/home/grasping-dataset/grasp_listing.txt
   8192/Unknown - 0s 0us/step
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```

Also update the test about `Progbar` to cover this case.