### PR TITLE
adding custom_objects argument to initializers get function

### DIFF
--- a/keras/initializers.py
+++ b/keras/initializers.py
@@ -490,12 +490,12 @@ def deserialize(config, custom_objects=None):
                                     printable_module_name='initializer')
 
 
-def get(identifier):
+def get(identifier, custom_objects=None):
     if isinstance(identifier, dict):
-        return deserialize(identifier)
+        return deserialize(identifier, custom_objects=custom_objects)
     elif isinstance(identifier, six.string_types):
         config = {'class_name': str(identifier), 'config': {}}
-        return deserialize(config)
+        return deserialize(config, custom_objects=custom_objects)
     elif callable(identifier):
         return identifier
     else:


### PR DESCRIPTION
I have custom initializers which I want to use in custom layers. In this custom layer I use what seems to be the correct interface to instantiate my custom initializer (`initializers.get`).

This function dosn't accept a `custom_object`argument so `None` is eventually passed to the `deserialize`function, causing a crash with my custom initializer.

I may have missed something, but I don't really see other way around that would preserve a unified way to get initializers. Therefore I suggest only adding a `custom_objects`argument to `get`, and pass it to `deserialize`.