### PR TITLE
denoising_autoencoder: Change loss, increase epochs, improve visualization, use seed

### DIFF
--- a/examples/mnist_denoising_autoencoder.py
+++ b/examples/mnist_denoising_autoencoder.py
@@ -134,11 +134,11 @@ x_decoded = autoencoder.predict(x_test_noisy)
 rows, cols = 10, 30
 num = rows * cols
 imgs = np.concatenate([x_test[:num], x_test_noisy[:num], x_decoded[:num]])
-imgs = imgs.reshape((rows*3, cols, image_size, image_size))
+imgs = imgs.reshape((rows * 3, cols, image_size, image_size))
 imgs = np.vstack(np.split(imgs, rows, axis=1))
-imgs = imgs.reshape((rows*3, -1, image_size, image_size))
+imgs = imgs.reshape((rows * 3, -1, image_size, image_size))
 imgs = np.vstack([np.hstack(i) for i in imgs])
-imgs = (imgs*255).astype(np.uint8)
+imgs = (imgs * 255).astype(np.uint8)
 plt.figure()
 plt.axis('off')
 plt.title('Original images: top rows, '

--- a/examples/mnist_denoising_autoencoder.py
+++ b/examples/mnist_denoising_autoencoder.py
@@ -28,6 +28,9 @@ from keras import backend as K
 from keras.datasets import mnist
 import numpy as np
 import matplotlib.pyplot as plt
+from PIL import Image
+
+np.random.seed(1337)
 
 # MNIST dataset
 (x_train, _), (x_test, _) = mnist.load_data()
@@ -115,26 +118,32 @@ decoder.summary()
 autoencoder = Model(inputs, decoder(encoder(inputs)), name='autoencoder')
 autoencoder.summary()
 
-# Mean Square Error (MSE) loss function, Adam optimizer
 autoencoder.compile(loss='mse', optimizer='adam')
 
 # Train the autoencoder
 autoencoder.fit(x_train_noisy,
                 x_train,
                 validation_data=(x_test_noisy, x_test),
-                epochs=10,
+                epochs=30,
                 batch_size=batch_size)
 
 # Predict the Autoencoder output from corrupted test images
 x_decoded = autoencoder.predict(x_test_noisy)
 
 # Display the 1st 8 corrupted and denoised images
-imgs = np.concatenate([x_test_noisy[:8], x_decoded[:8]])
-imgs = imgs.reshape((4, 4, image_size, image_size))
+rows, cols = 10, 30
+num = rows * cols
+imgs = np.concatenate([x_test[:num], x_test_noisy[:num], x_decoded[:num]])
+imgs = imgs.reshape((rows*3, cols, image_size, image_size))
+imgs = np.vstack(np.split(imgs, rows, axis=1))
+imgs = imgs.reshape((rows*3, -1, image_size, image_size))
 imgs = np.vstack([np.hstack(i) for i in imgs])
+imgs = (imgs*255).astype(np.uint8)
 plt.figure()
 plt.axis('off')
-plt.title('Corrupted Input: top 2 rows, Output is Denoised Input: last 2 rows')
+plt.title('Original images: top rows, '
+          'Corrupted Input: middle rows, '
+          'Denoised Input:  third rows')
 plt.imshow(imgs, interpolation='none', cmap='gray')
-plt.savefig('corrupted_and_denoised.png')
+Image.fromarray(imgs).save("corrupted_and_denoised.png")
 plt.show()

--- a/examples/mnist_denoising_autoencoder.py
+++ b/examples/mnist_denoising_autoencoder.py
@@ -145,5 +145,5 @@ plt.title('Original images: top rows, '
           'Corrupted Input: middle rows, '
           'Denoised Input:  third rows')
 plt.imshow(imgs, interpolation='none', cmap='gray')
-Image.fromarray(imgs).save("corrupted_and_denoised.png")
+Image.fromarray(imgs).save('corrupted_and_denoised.png')
 plt.show()


### PR DESCRIPTION
1. Change loss from mse to binary_crossentropy. This
- 1. trains slightly faster (stops improving after 30 epochs, as opposed to 40 for mse
- 2. has slightly lower **mse** test error 0.015480 vs 0.015491, when trained with mse loss.
- 3. most of the time produces better and/or less blurry result

2. Increase epochs from 10 to 30.
3. use seed. this allows comparison between mse and binary_crossentropy
4. Improve visualization (add orig images, increase amount) 

![denoisingautoencoder bce2](https://user-images.githubusercontent.com/14060629/34853831-c931deec-f6ea-11e7-8d43-8093eb0a3705.png)

@roatienza 