### PR TITLE
Skip application tests when non-core files have changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,12 @@ install:
       echo '    keras/backend/cntk_backend.py' >> .coveragerc;
     fi
 
+  # detect whether core files are changed or not
+  - export CORE_CHANGED=False;
+  - for entry in `git diff --name-only HEAD~1`; do if [[ "$entry" == "keras/backend/"* ]] || [[ "$entry" == "keras/engine/"* ]] || [[ "$entry" == "keras/layers/"* ]]; then export CORE_CHANGED=True; fi; done
+  - export APP_CHANGED=False;
+  - for entry in `git diff --name-only HEAD~1`; do if [[ "$entry" == "keras/applications/"* ]]; then export APP_CHANGED=True; fi; done
+
   #install open mpi
   - rm -rf ~/mpi
   - mkdir ~/mpi
@@ -99,11 +105,11 @@ script:
   - sed -i -e 's/"backend":[[:space:]]*"[^"]*/"backend":\ "'$KERAS_BACKEND'/g' ~/.keras/keras.json;
   - echo -e "Running tests with the following config:\n$(cat ~/.keras/keras.json)"
   - if [[ "$TEST_MODE" == "INTEGRATION_TESTS" ]]; then
-       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/integration_tests;
+      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/integration_tests;
     elif [[ "$TEST_MODE" == "PEP8" ]]; then
-       PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0;
+      PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0;
     elif [[ "$TEST_MODE" == "DOC" ]]; then
-        PYTHONPATH=$PWD:$PYTHONPATH py.test tests/test_documentation.py;
+      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/test_documentation.py;
     else
-       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --cov-config .coveragerc --cov=keras tests/;
+      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --cov-config .coveragerc --cov=keras tests/;
     fi

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from multiprocessing import Process, Queue
 from keras.utils.test_utils import keras_test
 from keras.utils.test_utils import layer_test
@@ -6,6 +7,11 @@ from keras.utils.generic_utils import CustomObjectScope
 from keras.models import Sequential
 from keras import applications
 from keras import backend as K
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ['CORE_CHANGED'] == 'False' and os.environ['APP_CHANGED'] == 'False',
+    reason='runs only when the relevant files have been modified')
 
 
 def clean_run(model_fn):


### PR DESCRIPTION
This PR helps pytest to skip application tests when non-core files have changed.