### PR TITLE
 Support constants in StackedRNNCells

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -73,7 +73,7 @@ class StackedRNNCells(Layer):
                 state_size.append(cell.state_size)
         return tuple(state_size)
 
-    def call(self, inputs, states, **kwargs):
+    def call(self, inputs, states, constants=None, **kwargs):
         # Recover per-cell states.
         nested_states = []
         for cell in self.cells[::-1]:
@@ -88,7 +88,12 @@ class StackedRNNCells(Layer):
         # Call the cells in order and store the returned states.
         new_nested_states = []
         for cell, states in zip(self.cells, nested_states):
-            inputs, states = cell.call(inputs, states, **kwargs)
+            if has_arg(cell.call, 'constants'):
+                inputs, states = cell.call(inputs, states,
+                                           constants=constants,
+                                           **kwargs)
+            else:
+                inputs, states = cell.call(inputs, states, **kwargs)
             new_nested_states.append(states)
 
         # Format the new states as a flat list
@@ -99,9 +104,15 @@ class StackedRNNCells(Layer):
         return inputs, states
 
     def build(self, input_shape):
+        if isinstance(input_shape, list):
+            constants_shape = input_shape[1:]
+            input_shape = input_shape[0]
         for cell in self.cells:
             if isinstance(cell, Layer):
-                cell.build(input_shape)
+                if has_arg(cell.call, 'constants'):
+                    cell.build([input_shape] + constants_shape)
+                else:
+                    cell.build(input_shape)
             if hasattr(cell.state_size, '__len__'):
                 output_dim = cell.state_size[0]
             else:

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -695,6 +695,7 @@ def test_batch_size_equal_one(layer_class):
     model.train_on_batch(x, y)
 
 
+@keras_test
 def test_rnn_cell_with_constants_layer():
 
     class RNNCellWithConstants(keras.layers.Layer):
@@ -803,6 +804,7 @@ def test_rnn_cell_with_constants_layer():
     assert_allclose(y_np, y_np_2, atol=1e-4)
 
 
+@keras_test
 def test_rnn_cell_with_constants_layer_passing_initial_state():
 
     class RNNCellWithConstants(keras.layers.Layer):


### PR DESCRIPTION
This PR is probably useful for implementing (some variants of) attention RNNs.

1.  Enable the `constants` argument in `StackedRNNCells.call`. The constants will be routed to an underlying cell if it also supports `constants`.
2. Handle the shape of the constants properly in `StackedRNNCells.build` so that an RNN cell with constants can be stacked on top of another cell. Before this PR,
- If the bottom cell does not support `constants`: 
```python
constants = Input((32,))
x = Input((None, 5))
x = RNN([GRUCell(16), RNNCellWithConstants(32)])(x, constants=constants)
```
The `GRUCell` fails to build because `input_shape`, which is now a list `[step_input_shape] + constants_shape`, is passed to `GRUCell.build` directly. We should only pass `step_input_shape` to `GRUCell.build` in this case.

- If the bottom cell also supports `constants`: 
```python
constants = Input((32,))
x = Input((None, 5))
x = RNN([RNNCellWithConstants(16), RNNCellWithConstants(32)])(x, constants=constants)
```
The top cell fails to build because the `input_shape` passed to it is incorrect.

Also modified the test to cover the two cases above.