### PR TITLE
Fix StackedRNNCells step input shape

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -106,7 +106,7 @@ class StackedRNNCells(Layer):
                 output_dim = cell.state_size[0]
             else:
                 output_dim = cell.state_size
-            input_shape = (input_shape[0], input_shape[1], output_dim)
+            input_shape = (input_shape[0], output_dim)
         self.built = True
 
     def get_config(self):

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -517,6 +517,9 @@ def test_minimal_rnn_cell_layer():
             super(MinimalRNNCell, self).__init__(**kwargs)
 
         def build(self, input_shape):
+            # no time axis in the input shape passed to RNN cells
+            assert len(input_shape) == 2
+
             self.kernel = self.add_weight(shape=(input_shape[-1], self.units),
                                           initializer='uniform',
                                           name='kernel')


### PR DESCRIPTION
In `RNN.build`, instead of the original `input_shape`, `step_input_shape` (input shape with the time axis removed) is passed to the underlying cell(s):
```python
    if isinstance(self.cell, Layer):
        step_input_shape = (input_shape[0],) + input_shape[2:]
        if constants_shape is not None:
            self.cell.build([step_input_shape] + constants_shape)
        else:
            self.cell.build(step_input_shape)
```

However, in `StackedRNNCells.build`, axis 1 is added back to the shape after the bottommost cell is built:
```python
    def build(self, input_shape):
        for cell in self.cells:
            if isinstance(cell, Layer):
                cell.build(input_shape)
            if hasattr(cell.state_size, '__len__'):
                output_dim = cell.state_size[0]
            else:
                output_dim = cell.state_size
            input_shape = (input_shape[0], input_shape[1], output_dim)
        self.built = True
```

For example, in building the following RNN:
```python
x = Input((None, 5))
out = RNN([GRUCell(16), GRUCell(32)])(x)
```
The bottom cell receives the correct step input shape `(None, 5)`, but the top cell receives `(None, 5, 16)`.

This PR also adds a check for `input_shape` to `MinimalRNNCell.build` in `test_minimal_rnn_cell_layer`.