### PR TITLE
Regularization bug. Tests and fix.

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -447,7 +447,7 @@ def random_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
                              'Please provide fixed dimension '
                              'instead of `None`.')
     # how to apply mean and stddev
-    return random_normal_variable(shape=shape, mean=mean, scale=1.0)
+    return random_normal_variable(shape=shape, mean=mean, scale=1.0, seed=seed)
 
 
 def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1943,7 +1943,15 @@ class Container(Layer):
                 losses += layer.get_losses_for(None)
         # Add any potential unconditional model-level loss.
         losses += self.get_losses_for(None)
-        return losses
+
+        losses_without_duplicates = []
+        for i, loss in enumerate(losses):
+            for loss2 in losses[i + 1:]:
+                if loss is loss2:
+                    break
+            else:
+                losses_without_duplicates.append(loss)
+        return losses_without_duplicates
 
     @property
     def uses_learning_phase(self):

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -906,7 +906,7 @@ class TestBackend(object):
         mean = 0.
         std = 1.
         for k in BACKENDS:
-            rand = k.eval(k.random_normal((300, 100), mean=mean, stddev=std))
+            rand = k.eval(k.random_normal((300, 100), mean=mean, stddev=std, seed=1337))
             assert rand.shape == (300, 100)
             assert np.abs(np.mean(rand) - mean) < 0.015
             assert np.abs(np.std(rand) - std) < 0.015

--- a/tests/keras/regularizers_test.py
+++ b/tests/keras/regularizers_test.py
@@ -1,7 +1,7 @@
 import pytest
 
-from keras.models import Sequential
-from keras.layers import Dense
+from keras.models import Sequential, Model
+from keras.layers import Dense, Input, Average
 from keras.utils import np_utils
 from keras.utils import test_utils
 from keras import regularizers
@@ -34,6 +34,16 @@ def create_model(kernel_regularizer=None, activity_regularizer=None):
     return model
 
 
+def create_multi_input_model_from(layer1, layer2):
+    input_1 = Input(shape=(data_dim,))
+    input_2 = Input(shape=(data_dim,))
+    out1 = layer1(input_1)
+    out2 = layer2(input_2)
+    out = Average()([out1, out2])
+    model = Model([input_1, input_2], out)
+    return model
+
+
 def test_kernel_regularization():
     (x_train, y_train), (x_test, y_test) = get_data()
     for reg in [regularizers.l1(),
@@ -54,6 +64,40 @@ def test_activity_regularization():
         assert len(model.losses) == 1
         model.fit(x_train, y_train, batch_size=batch_size,
                   epochs=epochs, verbose=0)
+
+
+def test_regularization_shared_layer():
+    dense_layer = Dense(num_classes,
+                        kernel_regularizer=regularizers.l1())
+
+    model = create_multi_input_model_from(dense_layer, dense_layer)
+    model.compile(loss='categorical_crossentropy', optimizer='sgd')
+    assert len(model.losses) == 1
+
+
+def test_regularization_shared_model():
+    dense_layer = Dense(num_classes,
+                        kernel_regularizer=regularizers.l1())
+
+    input_tensor = Input(shape=(data_dim,))
+    dummy_model = Model(input_tensor, dense_layer(input_tensor))
+
+    model = create_multi_input_model_from(dummy_model, dummy_model)
+    model.compile(loss='categorical_crossentropy', optimizer='sgd')
+    assert len(model.losses) == 1
+
+
+def test_regularization_shared_layer_in_different_models():
+    dense_layer = Dense(num_classes,
+                        kernel_regularizer=regularizers.l1())
+    models = []
+    for _ in range(2):
+        input_tensor = Input(shape=(data_dim,))
+        models.append(Model(input_tensor, dense_layer(input_tensor)))
+
+    model = create_multi_input_model_from(*models)
+    model.compile(loss='categorical_crossentropy', optimizer='sgd')
+    assert len(model.losses) == 1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR and the new and clean version of this PR: #8932 

## The bug:
The bug was that when using two models sharing layers in a bigger model, the regularization loss was duplicated. Here are the tests that were written to show the bug.

### test_regularization_shared_layer() -> PASSED
The same layer is used twice in the final model.

### test_regularization_shared_model() -> FAILED
The same model is used twice in the final model

### test_regularization_shared_layer_in_different_models() -> FAILED
Two different model instances are used in the final model. 
But those two model instances refer to a single unique layer.

## Why does it happen?
Because when models/containers gather losses, there is no check on the provenance of the loss. This can be seen in `Layer.add_loss(self, losses, inputs=None)`.

## The fix:
This bug has been fixed. This was done in the function `def losses(self)` as suggested in the previous PR.
We run over the list and de-dupe at this stage. We use the `is` operator. This was the only way I found to compare the origins of the losses.

