### PR TITLE
Support arbitrary values of the batch axes in {train/test}_on_batch

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -210,7 +210,7 @@ def _check_batch_axis(inputs, targets, weights=None):
         raise ValueError('All target arrays (y) should have '
                          'the same number of samples. Got array shapes: ' +
                          str([y.shape for y in targets]))
-    if list(set_x)[0] != list(set_y)[0]:
+    if set_x and set_y and list(set_x)[0] != list(set_y)[0]:
         raise ValueError('Input arrays should have '
                          'the same number of samples as target arrays. '
                          'Found ' + str(list(set_x)[0]) + ' input samples '
@@ -219,7 +219,7 @@ def _check_batch_axis(inputs, targets, weights=None):
         raise ValueError('All sample_weight arrays should have '
                          'the same number of samples. Got array shapes: ' +
                          str([w.shape for w in weights]))
-    if list(set_y)[0] != list(set_w)[0]:
+    if set_y and set_w and list(set_y)[0] != list(set_w)[0]:
         raise ValueError('Sample_weight arrays should have '
                          'the same number of samples as target arrays. Got ' +
                          str(list(set_y)[0]) + ' input samples and ' +

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -12,7 +12,7 @@ from keras.engine.topology import Input
 from keras.engine.training import Model
 from keras.engine.training import _check_loss_and_target_compatibility
 from keras.engine.training import _weighted_masked_objective
-from keras.engine.training import _check_array_lengths
+from keras.engine.training import _check_batch_axis
 from keras.engine.training import _slice_arrays
 from keras.models import Sequential
 from keras import backend as K
@@ -40,23 +40,23 @@ class RandomSequence(Sequence):
 
 @keras_test
 def test_check_array_lengths():
-    _check_array_lengths(None, None, None)
+    _check_batch_axis(None, None, None)
     a_np = np.random.random((4, 3, 3))
-    _check_array_lengths(a_np, a_np, a_np)
-    _check_array_lengths([a_np, a_np], [a_np, a_np], [a_np, a_np])
-    _check_array_lengths([None], [None], [None])
+    _check_batch_axis(a_np, a_np, a_np)
+    _check_batch_axis([a_np, a_np], [a_np, a_np], [a_np, a_np])
+    _check_batch_axis([None], [None], [None])
 
     b_np = np.random.random((3, 4))
     with pytest.raises(ValueError):
-        _check_array_lengths(a_np, None, None)
+        _check_batch_axis(a_np, None, None)
     with pytest.raises(ValueError):
-        _check_array_lengths(a_np, a_np, None)
+        _check_batch_axis(a_np, a_np, None)
     with pytest.raises(ValueError):
-        _check_array_lengths([a_np], [None], None)
+        _check_batch_axis([a_np], [None], None)
     with pytest.raises(ValueError):
-        _check_array_lengths([a_np], [b_np], None)
+        _check_batch_axis([a_np], [b_np], None)
     with pytest.raises(ValueError):
-        _check_array_lengths([a_np], None, [b_np])
+        _check_batch_axis([a_np], None, [b_np])
 
 
 @keras_test


### PR DESCRIPTION
This is useful when implementing custom loss functions that require additional data-dependent inputs precomputed somehow outside the graph.

Other related issues (without any answer, unfortunately)
https://github.com/keras-team/keras/issues/8943
https://github.com/keras-team/keras/issues/3660