### PR TITLE
Allow weights trained with CuDNNGRU to be used without GPU

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -3048,19 +3048,16 @@ def preprocess_weights_for_loading(layer, weights,
 
 
 def _convert_rnn_weights(layer, weights):
-    """
-    Converts weights for RNN layers between native and CuDNN format.
+    """Converts weights for RNN layers between native and CuDNN format.
     """
 
     def transform_kernels(kernels, func, n_gates):
-        """
-        Transforms kernel for each gate separately using given function.
+        """Transforms kernel for each gate separately using given function.
         """
         return np.hstack([func(k) for k in np.hsplit(kernels, n_gates)])
 
     def transpose_input(from_cudnn):
-        """
-        Transforms input kernels from/to CuDNN format.
+        """Transforms input kernels from/to CuDNN format.
         """
         order = 'F' if from_cudnn else 'C'
 
@@ -3085,7 +3082,7 @@ def _convert_rnn_weights(layer, weights):
         elif bias_shape == (units * n_gates,):
             source = 'LSTM'
         else:
-            raise ValueError('Unknown bias shape:', bias_shape)
+            raise ValueError('Invalid bias shape: ' + str(bias_shape))
 
         def convert_weights(weights, from_cudnn=True):
             # transpose (and reshape) input and recurrent kernels
@@ -3125,7 +3122,7 @@ def _convert_rnn_weights(layer, weights):
         elif bias_shape == (units * n_gates,):
             source = 'GRU(reset_after=False)'
         else:
-            raise ValueError('Unknown bias shape:', bias_shape)
+            raise ValueError('Invalid bias shape: ' + str(bias_shape))
 
         if target_class == 'CuDNNGRU':
             target = 'CuDNNGRU'

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -3064,7 +3064,7 @@ def preprocess_weights_for_loading(layer, weights,
             weights[2] = bias[:units * 4] + bias[units * 4:]
 
     # convert the weights of CuDNNGRU so that they could be loaded into
-    if layer.__class__.__name__ == 'GRUResetAfter' and len(weights) == 3:
+    if layer.__class__.__name__ == 'GRU' and len(weights) == 3:
         # determine if we're loading a CuDNNGRU layer from the number of bias weights:
         # CuDNNGRU has (units * 6) weights; while GRU has (units * 3)
         # if there's no bias weight in the file, skip this conversion

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -3063,7 +3063,7 @@ def preprocess_weights_for_loading(layer, weights,
             # split the bias into half and merge
             weights[2] = bias[:units * 4] + bias[units * 4:]
 
-    # convert the weights of CuDNNGRU so that they could be loaded into
+    # convert the weights of CuDNNGRU so that they could be loaded into GRU
     if layer.__class__.__name__ == 'GRU' and len(weights) == 3:
         # determine if we're loading a CuDNNGRU layer from the number of bias weights:
         # CuDNNGRU has (units * 6) weights; while GRU has (units * 3)

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1259,7 +1259,9 @@ class GRUCell(Layer):
             if not self.reset_after:
                 self.input_bias, self.recurrent_bias = self.bias, None
             else:
-                self.input_bias, self.recurrent_bias = self.bias[0], self.bias[1]
+                # NOTE: need to flatten, since slicing in CNTK gives 2D array
+                self.input_bias = K.flatten(self.bias[0])
+                self.recurrent_bias = K.flatten(self.bias[1])
         else:
             self.bias = None
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1277,22 +1277,22 @@ class GRUCell(Layer):
 
         if self.use_bias:
             # bias for inputs
-            self.bias_z_i = self.input_bias[:self.units]
-            self.bias_r_i = self.input_bias[self.units: self.units * 2]
-            self.bias_h_i = self.input_bias[self.units * 2:]
+            self.input_bias_z = self.input_bias[:self.units]
+            self.input_bias_r = self.input_bias[self.units: self.units * 2]
+            self.input_bias_h = self.input_bias[self.units * 2:]
             # bias for hidden state - just for compatibility with CuDNN
             if self.reset_after:
-                self.bias_z = self.recurrent_bias[:self.units]
-                self.bias_r = self.recurrent_bias[self.units: self.units * 2]
-                self.bias_h = self.recurrent_bias[self.units * 2:]
+                self.recurrent_bias_z = self.recurrent_bias[:self.units]
+                self.recurrent_bias_r = self.recurrent_bias[self.units: self.units * 2]
+                self.recurrent_bias_h = self.recurrent_bias[self.units * 2:]
         else:
-            self.bias_z_i = None
-            self.bias_r_i = None
-            self.bias_h_i = None
+            self.input_bias_z = None
+            self.input_bias_r = None
+            self.input_bias_h = None
             if self.reset_after:
-                self.bias_z = None
-                self.bias_r = None
-                self.bias_h = None
+                self.recurrent_bias_z = None
+                self.recurrent_bias_r = None
+                self.recurrent_bias_h = None
         self.built = True
 
     def call(self, inputs, states, training=None):
@@ -1331,9 +1331,9 @@ class GRUCell(Layer):
             x_r = K.dot(inputs_r, self.kernel_r)
             x_h = K.dot(inputs_h, self.kernel_h)
             if self.use_bias:
-                x_z = K.bias_add(x_z, self.bias_z_i)
-                x_r = K.bias_add(x_r, self.bias_r_i)
-                x_h = K.bias_add(x_h, self.bias_h_i)
+                x_z = K.bias_add(x_z, self.input_bias_z)
+                x_r = K.bias_add(x_r, self.input_bias_r)
+                x_h = K.bias_add(x_h, self.input_bias_h)
 
             if 0. < self.recurrent_dropout < 1.:
                 h_tm1_z = h_tm1 * rec_dp_mask[0]
@@ -1347,8 +1347,8 @@ class GRUCell(Layer):
             recurrent_z = K.dot(h_tm1_z, self.recurrent_kernel_z)
             recurrent_r = K.dot(h_tm1_r, self.recurrent_kernel_r)
             if self.reset_after and self.use_bias:
-                recurrent_z = K.bias_add(recurrent_z, self.bias_z)
-                recurrent_r = K.bias_add(recurrent_r, self.bias_r)
+                recurrent_z = K.bias_add(recurrent_z, self.recurrent_bias_z)
+                recurrent_r = K.bias_add(recurrent_r, self.recurrent_bias_r)
 
             z = self.recurrent_activation(x_z + recurrent_z)
             r = self.recurrent_activation(x_r + recurrent_r)
@@ -1357,7 +1357,7 @@ class GRUCell(Layer):
             if self.reset_after:
                 recurrent_h = K.dot(h_tm1_h, self.recurrent_kernel_h)
                 if self.use_bias:
-                    recurrent_h = K.bias_add(recurrent_h, self.bias_h)
+                    recurrent_h = K.bias_add(recurrent_h, self.recurrent_bias_h)
                 recurrent_h = r * recurrent_h
             else:
                 recurrent_h = K.dot(r * h_tm1_h, self.recurrent_kernel_h)

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1321,11 +1321,13 @@ class GRUCell(Layer):
                                              self.recurrent_kernel_h))
         else:
             if 0. < self.dropout < 1.:
+                # TODO: this might be a bug: same dropout mask for all gates
                 inputs *= dp_mask[0]
             matrix_x = K.dot(inputs, self.kernel)
             if self.use_bias:
                 matrix_x = K.bias_add(matrix_x, self.bias)
             if 0. < self.recurrent_dropout < 1.:
+                # TODO: this might be a bug: same dropout mask for all gates
                 h_tm1 *= rec_dp_mask[0]
             matrix_inner = K.dot(h_tm1,
                                  self.recurrent_kernel[:, :2 * self.units])
@@ -1440,6 +1442,7 @@ class GRU(RNN):
             Unrolling is only suitable for short sequences.
 
     # References
+        - [Learning Phrase Representations using RNN Encoder-Decoder for Statistical Machine Translation](https://arxiv.org/abs/1406.1078v3)
         - [On the Properties of Neural Machine Translation: Encoder-Decoder Approaches](https://arxiv.org/abs/1409.1259)
         - [Empirical Evaluation of Gated Recurrent Neural Networks on Sequence Modeling](http://arxiv.org/abs/1412.3555v1)
         - [A Theoretically Grounded Application of Dropout in Recurrent Neural Networks](http://arxiv.org/abs/1512.05287)
@@ -2109,6 +2112,525 @@ class LSTM(RNN):
                   'recurrent_dropout': self.recurrent_dropout,
                   'implementation': self.implementation}
         base_config = super(LSTM, self).get_config()
+        del base_config['cell']
+        return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config):
+        if 'implementation' in config and config['implementation'] == 0:
+            config['implementation'] = 1
+        return cls(**config)
+
+
+# TODO: merge with GRU - allow selecting one of two definitions via argument
+
+class GRUResetAfterCell(Layer):
+    """Cell class for the GRUResetAfter layer.
+
+    # Arguments
+        units: Positive integer, dimensionality of the output space.
+        activation: Activation function to use
+            (see [activations](../activations.md)).
+            If you pass None, no activation is applied
+            (ie. "linear" activation: `a(x) = x`).
+        recurrent_activation: Activation function to use
+            for the recurrent step
+            (see [activations](../activations.md)).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        kernel_initializer: Initializer for the `kernel` weights matrix,
+            used for the linear transformation of the inputs.
+            (see [initializers](../initializers.md)).
+        recurrent_initializer: Initializer for the `recurrent_kernel`
+            weights matrix,
+            used for the linear transformation of the recurrent state.
+            (see [initializers](../initializers.md)).
+        bias_initializer: Initializer for the bias vector
+            (see [initializers](../initializers.md)).
+        kernel_regularizer: Regularizer function applied to
+            the `kernel` weights matrix
+            (see [regularizer](../regularizers.md)).
+        recurrent_regularizer: Regularizer function applied to
+            the `recurrent_kernel` weights matrix
+            (see [regularizer](../regularizers.md)).
+        bias_regularizer: Regularizer function applied to the bias vector
+            (see [regularizer](../regularizers.md)).
+        kernel_constraint: Constraint function applied to
+            the `kernel` weights matrix
+            (see [constraints](../constraints.md)).
+        recurrent_constraint: Constraint function applied to
+            the `recurrent_kernel` weights matrix
+            (see [constraints](../constraints.md)).
+        bias_constraint: Constraint function applied to the bias vector
+            (see [constraints](../constraints.md)).
+        dropout: Float between 0 and 1.
+            Fraction of the units to drop for
+            the linear transformation of the inputs.
+        recurrent_dropout: Float between 0 and 1.
+            Fraction of the units to drop for
+            the linear transformation of the recurrent state.
+        implementation: Implementation mode, either 1 or 2.
+            Mode 1 will structure its operations as a larger number of
+            smaller dot products and additions, whereas mode 2 will
+            batch them into fewer, larger operations. These modes will
+            have different performance profiles on different hardware and
+            for different applications.
+    """
+
+    def __init__(self, units,
+                 activation='tanh',
+                 recurrent_activation='hard_sigmoid',
+                 use_bias=True,
+                 kernel_initializer='glorot_uniform',
+                 recurrent_initializer='orthogonal',
+                 bias_initializer='zeros',
+                 kernel_regularizer=None,
+                 recurrent_regularizer=None,
+                 bias_regularizer=None,
+                 kernel_constraint=None,
+                 recurrent_constraint=None,
+                 bias_constraint=None,
+                 dropout=0.,
+                 recurrent_dropout=0.,
+                 implementation=1,
+                 **kwargs):
+        super(GRUResetAfterCell, self).__init__(**kwargs)
+        self.units = units
+        self.activation = activations.get(activation)
+        self.recurrent_activation = activations.get(recurrent_activation)
+        self.use_bias = use_bias
+
+        self.kernel_initializer = initializers.get(kernel_initializer)
+        self.recurrent_initializer = initializers.get(recurrent_initializer)
+        self.bias_initializer = initializers.get(bias_initializer)
+
+        self.kernel_regularizer = regularizers.get(kernel_regularizer)
+        self.recurrent_regularizer = regularizers.get(recurrent_regularizer)
+        self.bias_regularizer = regularizers.get(bias_regularizer)
+
+        self.kernel_constraint = constraints.get(kernel_constraint)
+        self.recurrent_constraint = constraints.get(recurrent_constraint)
+        self.bias_constraint = constraints.get(bias_constraint)
+
+        self.dropout = min(1., max(0., dropout))
+        self.recurrent_dropout = min(1., max(0., recurrent_dropout))
+        self.implementation = implementation
+        self.state_size = self.units
+        self._dropout_mask = None
+        self._recurrent_dropout_mask = None
+
+    def build(self, input_shape):
+        input_dim = input_shape[-1]
+        self.kernel = self.add_weight(shape=(input_dim, self.units * 3),
+                                      name='kernel',
+                                      initializer=self.kernel_initializer,
+                                      regularizer=self.kernel_regularizer,
+                                      constraint=self.kernel_constraint)
+        self.recurrent_kernel = self.add_weight(
+            shape=(self.units, self.units * 3),
+            name='recurrent_kernel',
+            initializer=self.recurrent_initializer,
+            regularizer=self.recurrent_regularizer,
+            constraint=self.recurrent_constraint)
+
+        if self.use_bias:
+            self.bias = self.add_weight(shape=(self.units * 6,),
+                                        name='bias',
+                                        initializer=self.bias_initializer,
+                                        regularizer=self.bias_regularizer,
+                                        constraint=self.bias_constraint)
+        else:
+            self.bias = None
+
+        # input/update gate
+        self.kernel_z = self.kernel[:, :self.units]
+        self.recurrent_kernel_z = self.recurrent_kernel[:, :self.units]
+        # reset gate
+        self.kernel_r = self.kernel[:, self.units: self.units * 2]
+        self.recurrent_kernel_r = self.recurrent_kernel[:, self.units: self.units * 2]
+        # new gate
+        self.kernel_h = self.kernel[:, self.units * 2:]
+        self.recurrent_kernel_h = self.recurrent_kernel[:, self.units * 2:]
+
+        if self.use_bias:
+            # bias for inputs
+            self.bias_z_i = self.bias[:self.units]
+            self.bias_r_i = self.bias[self.units: self.units * 2]
+            self.bias_h_i = self.bias[self.units * 2: self.units * 3]
+            # bias for hidden state
+            self.bias_z = self.bias[self.units * 3: self.units * 4]
+            self.bias_r = self.bias[self.units * 4: self.units * 5]
+            self.bias_h = self.bias[self.units * 5:]
+        else:
+            self.bias_z_i = None
+            self.bias_r_i = None
+            self.bias_h_i = None
+            self.bias_z = None
+            self.bias_r = None
+            self.bias_h = None
+        self.built = True
+
+    def call(self, inputs, states, training=None):
+        h_tm1 = states[0]  # previous memory
+
+        if 0 < self.dropout < 1 and self._dropout_mask is None:
+            self._dropout_mask = _generate_dropout_mask(
+                _generate_dropout_ones(inputs, K.shape(inputs)[-1]),
+                self.dropout,
+                training=training,
+                count=3)
+        if (0 < self.recurrent_dropout < 1 and
+                self._recurrent_dropout_mask is None):
+            self._recurrent_dropout_mask = _generate_dropout_mask(
+                _generate_dropout_ones(inputs, self.units),
+                self.recurrent_dropout,
+                training=training,
+                count=3)
+
+        # dropout matrices for input units
+        dp_mask = self._dropout_mask
+        # dropout matrices for recurrent units
+        rec_dp_mask = self._recurrent_dropout_mask
+
+        if self.implementation == 1:
+            if 0. < self.dropout < 1.:
+                inputs_z = inputs * dp_mask[0]
+                inputs_r = inputs * dp_mask[1]
+                inputs_h = inputs * dp_mask[2]
+            else:
+                inputs_z = inputs
+                inputs_r = inputs
+                inputs_h = inputs
+
+            x_z = K.dot(inputs_z, self.kernel_z)
+            x_r = K.dot(inputs_r, self.kernel_r)
+            x_h = K.dot(inputs_h, self.kernel_h)
+            if self.use_bias:
+                x_z = K.bias_add(x_z, self.bias_z_i)
+                x_r = K.bias_add(x_r, self.bias_r_i)
+                x_h = K.bias_add(x_h, self.bias_h_i)
+
+            if 0. < self.recurrent_dropout < 1.:
+                h_tm1_z = h_tm1 * rec_dp_mask[0]
+                h_tm1_r = h_tm1 * rec_dp_mask[1]
+                h_tm1_h = h_tm1 * rec_dp_mask[2]
+            else:
+                h_tm1_z = h_tm1
+                h_tm1_r = h_tm1
+                h_tm1_h = h_tm1
+
+            recurrent_z = K.dot(h_tm1_z, self.recurrent_kernel_z)
+            recurrent_r = K.dot(h_tm1_r, self.recurrent_kernel_r)
+            recurrent_h = K.dot(h_tm1_h, self.recurrent_kernel_h)
+            if self.use_bias:
+                # another set of biases (just for compatibility with CuDNN convention)
+                recurrent_z = K.bias_add(recurrent_z, self.bias_z)
+                recurrent_r = K.bias_add(recurrent_r, self.bias_r)
+                recurrent_h = K.bias_add(recurrent_h, self.bias_h)
+
+            z = self.recurrent_activation(x_z + recurrent_z)
+            r = self.recurrent_activation(x_r + recurrent_r)
+
+            hh = self.activation(x_h + r * recurrent_h)
+        else:
+            if 0. < self.dropout < 1.:
+                # TODO: this might be a bug: same dropout mask for all gates
+                inputs *= dp_mask[0]
+
+            # inputs projected by all gate matrices at once
+            matrix_x = K.dot(inputs, self.kernel)
+            if self.use_bias:
+                # biases: bias_z_i, bias_r_i, bias_h_i
+                matrix_x = K.bias_add(matrix_x, self.bias[:self.units * 3])
+
+            if 0. < self.recurrent_dropout < 1.:
+                # TODO: this might be a bug: same dropout mask for all gates
+                h_tm1 *= rec_dp_mask[0]
+
+            # hidden state projected by all gate matrices at once
+            # We can do this using GRU v1 definition, not GRU v3.
+            # See http://svail.github.io/diff_graphs/ for a visualization.
+            matrix_h = K.dot(h_tm1, self.recurrent_kernel)
+            if self.use_bias:
+                matrix_h = K.bias_add(matrix_h, self.bias[self.units * 3:])
+
+            x_z = matrix_x[:, :self.units]
+            x_r = matrix_x[:, self.units: 2 * self.units]
+            x_h = matrix_x[:, 2 * self.units:]
+            recurrent_z = matrix_h[:, :self.units]
+            recurrent_r = matrix_h[:, self.units: 2 * self.units]
+
+            z = self.recurrent_activation(x_z + recurrent_z)
+            r = self.recurrent_activation(x_r + recurrent_r)
+
+            recurrent_h = r * matrix_h[:, 2 * self.units:]
+            hh = self.activation(x_h + recurrent_h)
+
+        h = z * h_tm1 + (1 - z) * hh
+        if 0 < self.dropout + self.recurrent_dropout:
+            if training is None:
+                h._uses_learning_phase = True
+        return h, [h]
+
+    def get_config(self):
+        config = {'units': self.units,
+                  'activation': activations.serialize(self.activation),
+                  'recurrent_activation': activations.serialize(self.recurrent_activation),
+                  'use_bias': self.use_bias,
+                  'kernel_initializer': initializers.serialize(self.kernel_initializer),
+                  'recurrent_initializer': initializers.serialize(self.recurrent_initializer),
+                  'bias_initializer': initializers.serialize(self.bias_initializer),
+                  'kernel_regularizer': regularizers.serialize(self.kernel_regularizer),
+                  'recurrent_regularizer': regularizers.serialize(self.recurrent_regularizer),
+                  'bias_regularizer': regularizers.serialize(self.bias_regularizer),
+                  'kernel_constraint': constraints.serialize(self.kernel_constraint),
+                  'recurrent_constraint': constraints.serialize(self.recurrent_constraint),
+                  'bias_constraint': constraints.serialize(self.bias_constraint),
+                  'dropout': self.dropout,
+                  'recurrent_dropout': self.recurrent_dropout,
+                  'implementation': self.implementation}
+        base_config = super(GRUResetAfterCell, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+class GRUResetAfter(RNN):
+    """Gated Recurrent Unit - Cho et al. 2014 (original definition 1406.1078v1).
+
+    This is compatible with CuDNNGRU and allows CPU-inference for weights
+    trained on GPU CuDNNGRU.
+
+    It differs from keras.layers.GRU (based on definition from 1406.1078v3):
+
+    - reset gate applied after matrix multiplication
+    - separate biases for kernel and recurrent_kernel
+
+    Use recurrent_activation='sigmoid' for weights trained via CuDNNGRU, instead
+    of the default 'hard_sigmoid'.
+
+    Weights have to be converted via
+    `keras.engine.topology.preprocess_weights_for_loading()`.
+
+    # Arguments
+        units: Positive integer, dimensionality of the output space.
+        activation: Activation function to use
+            (see [activations](../activations.md)).
+            If you pass None, no activation is applied
+            (ie. "linear" activation: `a(x) = x`).
+        recurrent_activation: Activation function to use
+            for the recurrent step
+            (see [activations](../activations.md)).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        kernel_initializer: Initializer for the `kernel` weights matrix,
+            used for the linear transformation of the inputs.
+            (see [initializers](../initializers.md)).
+        recurrent_initializer: Initializer for the `recurrent_kernel`
+            weights matrix,
+            used for the linear transformation of the recurrent state.
+            (see [initializers](../initializers.md)).
+        bias_initializer: Initializer for the bias vector
+            (see [initializers](../initializers.md)).
+        kernel_regularizer: Regularizer function applied to
+            the `kernel` weights matrix
+            (see [regularizer](../regularizers.md)).
+        recurrent_regularizer: Regularizer function applied to
+            the `recurrent_kernel` weights matrix
+            (see [regularizer](../regularizers.md)).
+        bias_regularizer: Regularizer function applied to the bias vector
+            (see [regularizer](../regularizers.md)).
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+            (see [regularizer](../regularizers.md)).
+        kernel_constraint: Constraint function applied to
+            the `kernel` weights matrix
+            (see [constraints](../constraints.md)).
+        recurrent_constraint: Constraint function applied to
+            the `recurrent_kernel` weights matrix
+            (see [constraints](../constraints.md)).
+        bias_constraint: Constraint function applied to the bias vector
+            (see [constraints](../constraints.md)).
+        dropout: Float between 0 and 1.
+            Fraction of the units to drop for
+            the linear transformation of the inputs.
+        recurrent_dropout: Float between 0 and 1.
+            Fraction of the units to drop for
+            the linear transformation of the recurrent state.
+        implementation: Implementation mode, either 1 or 2.
+            Mode 1 will structure its operations as a larger number of
+            smaller dot products and additions, whereas mode 2 will
+            batch them into fewer, larger operations. These modes will
+            have different performance profiles on different hardware and
+            for different applications.
+        return_sequences: Boolean. Whether to return the last output.
+            in the output sequence, or the full sequence.
+        return_state: Boolean. Whether to return the last state
+            in addition to the output.
+        go_backwards: Boolean (default False).
+            If True, process the input sequence backwards and return the
+            reversed sequence.
+        stateful: Boolean (default False). If True, the last state
+            for each sample at index i in a batch will be used as initial
+            state for the sample of index i in the following batch.
+        unroll: Boolean (default False).
+            If True, the network will be unrolled,
+            else a symbolic loop will be used.
+            Unrolling can speed-up a RNN,
+            although it tends to be more memory-intensive.
+            Unrolling is only suitable for short sequences.
+
+    # References
+        - [Learning Phrase Representations using RNN Encoder-Decoder for Statistical Machine Translation](https://arxiv.org/abs/1406.1078v1) - v1
+        - [A Theoretically Grounded Application of Dropout in Recurrent Neural Networks](http://arxiv.org/abs/1512.05287)
+    """
+
+    @interfaces.legacy_recurrent_support
+    def __init__(self, units,
+                 activation='tanh',
+                 recurrent_activation='hard_sigmoid',
+                 use_bias=True,
+                 kernel_initializer='glorot_uniform',
+                 recurrent_initializer='orthogonal',
+                 bias_initializer='zeros',
+                 kernel_regularizer=None,
+                 recurrent_regularizer=None,
+                 bias_regularizer=None,
+                 activity_regularizer=None,
+                 kernel_constraint=None,
+                 recurrent_constraint=None,
+                 bias_constraint=None,
+                 dropout=0.,
+                 recurrent_dropout=0.,
+                 implementation=1,
+                 return_sequences=False,
+                 return_state=False,
+                 go_backwards=False,
+                 stateful=False,
+                 unroll=False,
+                 **kwargs):
+        if implementation == 0:
+            warnings.warn('`implementation=0` has been deprecated, '
+                          'and now defaults to `implementation=1`.'
+                          'Please update your layer call.')
+        if K.backend() == 'theano':
+            warnings.warn(
+                'RNN dropout is no longer supported with the Theano backend '
+                'due to technical limitations. '
+                'You can either set `dropout` and `recurrent_dropout` to 0, '
+                'or use the TensorFlow backend.')
+            dropout = 0.
+            recurrent_dropout = 0.
+
+        cell = GRUResetAfterCell(units,
+                       activation=activation,
+                       recurrent_activation=recurrent_activation,
+                       use_bias=use_bias,
+                       kernel_initializer=kernel_initializer,
+                       recurrent_initializer=recurrent_initializer,
+                       bias_initializer=bias_initializer,
+                       kernel_regularizer=kernel_regularizer,
+                       recurrent_regularizer=recurrent_regularizer,
+                       bias_regularizer=bias_regularizer,
+                       kernel_constraint=kernel_constraint,
+                       recurrent_constraint=recurrent_constraint,
+                       bias_constraint=bias_constraint,
+                       dropout=dropout,
+                       recurrent_dropout=recurrent_dropout,
+                       implementation=implementation)
+        super(GRUResetAfter, self).__init__(cell,
+                                  return_sequences=return_sequences,
+                                  return_state=return_state,
+                                  go_backwards=go_backwards,
+                                  stateful=stateful,
+                                  unroll=unroll,
+                                  **kwargs)
+        self.activity_regularizer = regularizers.get(activity_regularizer)
+
+    def call(self, inputs, mask=None, training=None, initial_state=None):
+        return super(GRUResetAfter, self).call(inputs,
+                                     mask=mask,
+                                     training=training,
+                                     initial_state=initial_state)
+
+    @property
+    def units(self):
+        return self.cell.units
+
+    @property
+    def activation(self):
+        return self.cell.activation
+
+    @property
+    def recurrent_activation(self):
+        return self.cell.recurrent_activation
+
+    @property
+    def use_bias(self):
+        return self.cell.use_bias
+
+    @property
+    def kernel_initializer(self):
+        return self.cell.kernel_initializer
+
+    @property
+    def recurrent_initializer(self):
+        return self.cell.recurrent_initializer
+
+    @property
+    def bias_initializer(self):
+        return self.cell.bias_initializer
+
+    @property
+    def kernel_regularizer(self):
+        return self.cell.kernel_regularizer
+
+    @property
+    def recurrent_regularizer(self):
+        return self.cell.recurrent_regularizer
+
+    @property
+    def bias_regularizer(self):
+        return self.cell.bias_regularizer
+
+    @property
+    def kernel_constraint(self):
+        return self.cell.kernel_constraint
+
+    @property
+    def recurrent_constraint(self):
+        return self.cell.recurrent_constraint
+
+    @property
+    def bias_constraint(self):
+        return self.cell.bias_constraint
+
+    @property
+    def dropout(self):
+        return self.cell.dropout
+
+    @property
+    def recurrent_dropout(self):
+        return self.cell.recurrent_dropout
+
+    @property
+    def implementation(self):
+        return self.cell.implementation
+
+    def get_config(self):
+        config = {'units': self.units,
+                  'activation': activations.serialize(self.activation),
+                  'recurrent_activation': activations.serialize(self.recurrent_activation),
+                  'use_bias': self.use_bias,
+                  'kernel_initializer': initializers.serialize(self.kernel_initializer),
+                  'recurrent_initializer': initializers.serialize(self.recurrent_initializer),
+                  'bias_initializer': initializers.serialize(self.bias_initializer),
+                  'kernel_regularizer': regularizers.serialize(self.kernel_regularizer),
+                  'recurrent_regularizer': regularizers.serialize(self.recurrent_regularizer),
+                  'bias_regularizer': regularizers.serialize(self.bias_regularizer),
+                  'activity_regularizer': regularizers.serialize(self.activity_regularizer),
+                  'kernel_constraint': constraints.serialize(self.kernel_constraint),
+                  'recurrent_constraint': constraints.serialize(self.recurrent_constraint),
+                  'bias_constraint': constraints.serialize(self.bias_constraint),
+                  'dropout': self.dropout,
+                  'recurrent_dropout': self.recurrent_dropout,
+                  'implementation': self.implementation}
+        base_config = super(GRUResetAfter, self).get_config()
         del base_config['cell']
         return dict(list(base_config.items()) + list(config.items()))
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1417,7 +1417,8 @@ class GRUCell(Layer):
                   'bias_constraint': constraints.serialize(self.bias_constraint),
                   'dropout': self.dropout,
                   'recurrent_dropout': self.recurrent_dropout,
-                  'implementation': self.implementation}
+                  'implementation': self.implementation,
+                  'reset_after': self.reset_after}
         base_config = super(GRUCell, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
@@ -1534,7 +1535,7 @@ class GRU(RNN):
                  go_backwards=False,
                  stateful=False,
                  unroll=False,
-                 reset_after=True,
+                 reset_after=False,
                  **kwargs):
         if implementation == 0:
             warnings.warn('`implementation=0` has been deprecated, '

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1374,6 +1374,15 @@ class GRUCell(Layer):
 class GRU(RNN):
     """Gated Recurrent Unit - Cho et al. 2014.
 
+    There are two variants. The default one is based on 1406.1078v3 and
+    has reset gate applied to hidden state before matrix multiplication. The
+    other one is based on original 1406.1078v1 and has the order reversed.
+
+    The second variant is compatible with CuDNNGRU (GPU-only) and allows
+    inference on CPU. Thus it has separate biases for `kernel` and
+    `recurrent_kernel`. Use `variant='reset_after'` and
+    `recurrent_activation='sigmoid'`.
+
     # Arguments
         units: Positive integer, dimensionality of the output space.
         activation: Activation function to use
@@ -1440,9 +1449,12 @@ class GRU(RNN):
             Unrolling can speed-up a RNN,
             although it tends to be more memory-intensive.
             Unrolling is only suitable for short sequences.
+        variant: GRU convention 'reset_before' (reset before multiplication,
+            default), 'reset_after' (reset after multiplication -
+            CuDNN-compatible)
 
     # References
-        - [Learning Phrase Representations using RNN Encoder-Decoder for Statistical Machine Translation](https://arxiv.org/abs/1406.1078v3)
+        - [Learning Phrase Representations using RNN Encoder-Decoder for Statistical Machine Translation](https://arxiv.org/abs/1406.1078)
         - [On the Properties of Neural Machine Translation: Encoder-Decoder Approaches](https://arxiv.org/abs/1409.1259)
         - [Empirical Evaluation of Gated Recurrent Neural Networks on Sequence Modeling](http://arxiv.org/abs/1412.3555v1)
         - [A Theoretically Grounded Application of Dropout in Recurrent Neural Networks](http://arxiv.org/abs/1512.05287)
@@ -1471,6 +1483,7 @@ class GRU(RNN):
                  go_backwards=False,
                  stateful=False,
                  unroll=False,
+                 variant='reset_before',
                  **kwargs):
         if implementation == 0:
             warnings.warn('`implementation=0` has been deprecated, '
@@ -1485,7 +1498,12 @@ class GRU(RNN):
             dropout = 0.
             recurrent_dropout = 0.
 
-        cell = GRUCell(units,
+        if variant == 'reset_after':
+            GRUCellImpl = GRUResetAfterCell
+        else:
+            GRUCellImpl = GRUCell
+
+        cell = GRUCellImpl(units,
                        activation=activation,
                        recurrent_activation=recurrent_activation,
                        use_bias=use_bias,
@@ -1509,6 +1527,7 @@ class GRU(RNN):
                                   unroll=unroll,
                                   **kwargs)
         self.activity_regularizer = regularizers.get(activity_regularizer)
+        self.variant = variant
 
     def call(self, inputs, mask=None, training=None, initial_state=None):
         return super(GRU, self).call(inputs,
@@ -1580,6 +1599,10 @@ class GRU(RNN):
     def implementation(self):
         return self.cell.implementation
 
+    @property
+    def variant(self):
+        return self.variant
+
     def get_config(self):
         config = {'units': self.units,
                   'activation': activations.serialize(self.activation),
@@ -1597,7 +1620,8 @@ class GRU(RNN):
                   'bias_constraint': constraints.serialize(self.bias_constraint),
                   'dropout': self.dropout,
                   'recurrent_dropout': self.recurrent_dropout,
-                  'implementation': self.implementation}
+                  'implementation': self.implementation,
+                  'variant': self.variant}
         base_config = super(GRU, self).get_config()
         del base_config['cell']
         return dict(list(base_config.items()) + list(config.items()))
@@ -2122,10 +2146,9 @@ class LSTM(RNN):
         return cls(**config)
 
 
-# TODO: merge with GRU - allow selecting one of two definitions via argument
 
 class GRUResetAfterCell(Layer):
-    """Cell class for the GRUResetAfter layer.
+    """Cell class for the GRU layer.
 
     # Arguments
         units: Positive integer, dimensionality of the output space.
@@ -2390,255 +2413,6 @@ class GRUResetAfterCell(Layer):
                   'implementation': self.implementation}
         base_config = super(GRUResetAfterCell, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
-
-class GRUResetAfter(RNN):
-    """Gated Recurrent Unit - Cho et al. 2014 (original definition 1406.1078v1).
-
-    This is compatible with CuDNNGRU and allows CPU-inference for weights
-    trained on GPU CuDNNGRU.
-
-    It differs from keras.layers.GRU (based on definition from 1406.1078v3):
-
-    - reset gate applied after matrix multiplication
-    - separate biases for kernel and recurrent_kernel
-
-    Use recurrent_activation='sigmoid' for weights trained via CuDNNGRU, instead
-    of the default 'hard_sigmoid'.
-
-    Weights have to be converted via
-    `keras.engine.topology.preprocess_weights_for_loading()`.
-
-    # Arguments
-        units: Positive integer, dimensionality of the output space.
-        activation: Activation function to use
-            (see [activations](../activations.md)).
-            If you pass None, no activation is applied
-            (ie. "linear" activation: `a(x) = x`).
-        recurrent_activation: Activation function to use
-            for the recurrent step
-            (see [activations](../activations.md)).
-        use_bias: Boolean, whether the layer uses a bias vector.
-        kernel_initializer: Initializer for the `kernel` weights matrix,
-            used for the linear transformation of the inputs.
-            (see [initializers](../initializers.md)).
-        recurrent_initializer: Initializer for the `recurrent_kernel`
-            weights matrix,
-            used for the linear transformation of the recurrent state.
-            (see [initializers](../initializers.md)).
-        bias_initializer: Initializer for the bias vector
-            (see [initializers](../initializers.md)).
-        kernel_regularizer: Regularizer function applied to
-            the `kernel` weights matrix
-            (see [regularizer](../regularizers.md)).
-        recurrent_regularizer: Regularizer function applied to
-            the `recurrent_kernel` weights matrix
-            (see [regularizer](../regularizers.md)).
-        bias_regularizer: Regularizer function applied to the bias vector
-            (see [regularizer](../regularizers.md)).
-        activity_regularizer: Regularizer function applied to
-            the output of the layer (its "activation").
-            (see [regularizer](../regularizers.md)).
-        kernel_constraint: Constraint function applied to
-            the `kernel` weights matrix
-            (see [constraints](../constraints.md)).
-        recurrent_constraint: Constraint function applied to
-            the `recurrent_kernel` weights matrix
-            (see [constraints](../constraints.md)).
-        bias_constraint: Constraint function applied to the bias vector
-            (see [constraints](../constraints.md)).
-        dropout: Float between 0 and 1.
-            Fraction of the units to drop for
-            the linear transformation of the inputs.
-        recurrent_dropout: Float between 0 and 1.
-            Fraction of the units to drop for
-            the linear transformation of the recurrent state.
-        implementation: Implementation mode, either 1 or 2.
-            Mode 1 will structure its operations as a larger number of
-            smaller dot products and additions, whereas mode 2 will
-            batch them into fewer, larger operations. These modes will
-            have different performance profiles on different hardware and
-            for different applications.
-        return_sequences: Boolean. Whether to return the last output.
-            in the output sequence, or the full sequence.
-        return_state: Boolean. Whether to return the last state
-            in addition to the output.
-        go_backwards: Boolean (default False).
-            If True, process the input sequence backwards and return the
-            reversed sequence.
-        stateful: Boolean (default False). If True, the last state
-            for each sample at index i in a batch will be used as initial
-            state for the sample of index i in the following batch.
-        unroll: Boolean (default False).
-            If True, the network will be unrolled,
-            else a symbolic loop will be used.
-            Unrolling can speed-up a RNN,
-            although it tends to be more memory-intensive.
-            Unrolling is only suitable for short sequences.
-
-    # References
-        - [Learning Phrase Representations using RNN Encoder-Decoder for Statistical Machine Translation](https://arxiv.org/abs/1406.1078v1) - v1
-        - [A Theoretically Grounded Application of Dropout in Recurrent Neural Networks](http://arxiv.org/abs/1512.05287)
-    """
-
-    @interfaces.legacy_recurrent_support
-    def __init__(self, units,
-                 activation='tanh',
-                 recurrent_activation='hard_sigmoid',
-                 use_bias=True,
-                 kernel_initializer='glorot_uniform',
-                 recurrent_initializer='orthogonal',
-                 bias_initializer='zeros',
-                 kernel_regularizer=None,
-                 recurrent_regularizer=None,
-                 bias_regularizer=None,
-                 activity_regularizer=None,
-                 kernel_constraint=None,
-                 recurrent_constraint=None,
-                 bias_constraint=None,
-                 dropout=0.,
-                 recurrent_dropout=0.,
-                 implementation=1,
-                 return_sequences=False,
-                 return_state=False,
-                 go_backwards=False,
-                 stateful=False,
-                 unroll=False,
-                 **kwargs):
-        if implementation == 0:
-            warnings.warn('`implementation=0` has been deprecated, '
-                          'and now defaults to `implementation=1`.'
-                          'Please update your layer call.')
-        if K.backend() == 'theano':
-            warnings.warn(
-                'RNN dropout is no longer supported with the Theano backend '
-                'due to technical limitations. '
-                'You can either set `dropout` and `recurrent_dropout` to 0, '
-                'or use the TensorFlow backend.')
-            dropout = 0.
-            recurrent_dropout = 0.
-
-        cell = GRUResetAfterCell(units,
-                       activation=activation,
-                       recurrent_activation=recurrent_activation,
-                       use_bias=use_bias,
-                       kernel_initializer=kernel_initializer,
-                       recurrent_initializer=recurrent_initializer,
-                       bias_initializer=bias_initializer,
-                       kernel_regularizer=kernel_regularizer,
-                       recurrent_regularizer=recurrent_regularizer,
-                       bias_regularizer=bias_regularizer,
-                       kernel_constraint=kernel_constraint,
-                       recurrent_constraint=recurrent_constraint,
-                       bias_constraint=bias_constraint,
-                       dropout=dropout,
-                       recurrent_dropout=recurrent_dropout,
-                       implementation=implementation)
-        super(GRUResetAfter, self).__init__(cell,
-                                  return_sequences=return_sequences,
-                                  return_state=return_state,
-                                  go_backwards=go_backwards,
-                                  stateful=stateful,
-                                  unroll=unroll,
-                                  **kwargs)
-        self.activity_regularizer = regularizers.get(activity_regularizer)
-
-    def call(self, inputs, mask=None, training=None, initial_state=None):
-        return super(GRUResetAfter, self).call(inputs,
-                                     mask=mask,
-                                     training=training,
-                                     initial_state=initial_state)
-
-    @property
-    def units(self):
-        return self.cell.units
-
-    @property
-    def activation(self):
-        return self.cell.activation
-
-    @property
-    def recurrent_activation(self):
-        return self.cell.recurrent_activation
-
-    @property
-    def use_bias(self):
-        return self.cell.use_bias
-
-    @property
-    def kernel_initializer(self):
-        return self.cell.kernel_initializer
-
-    @property
-    def recurrent_initializer(self):
-        return self.cell.recurrent_initializer
-
-    @property
-    def bias_initializer(self):
-        return self.cell.bias_initializer
-
-    @property
-    def kernel_regularizer(self):
-        return self.cell.kernel_regularizer
-
-    @property
-    def recurrent_regularizer(self):
-        return self.cell.recurrent_regularizer
-
-    @property
-    def bias_regularizer(self):
-        return self.cell.bias_regularizer
-
-    @property
-    def kernel_constraint(self):
-        return self.cell.kernel_constraint
-
-    @property
-    def recurrent_constraint(self):
-        return self.cell.recurrent_constraint
-
-    @property
-    def bias_constraint(self):
-        return self.cell.bias_constraint
-
-    @property
-    def dropout(self):
-        return self.cell.dropout
-
-    @property
-    def recurrent_dropout(self):
-        return self.cell.recurrent_dropout
-
-    @property
-    def implementation(self):
-        return self.cell.implementation
-
-    def get_config(self):
-        config = {'units': self.units,
-                  'activation': activations.serialize(self.activation),
-                  'recurrent_activation': activations.serialize(self.recurrent_activation),
-                  'use_bias': self.use_bias,
-                  'kernel_initializer': initializers.serialize(self.kernel_initializer),
-                  'recurrent_initializer': initializers.serialize(self.recurrent_initializer),
-                  'bias_initializer': initializers.serialize(self.bias_initializer),
-                  'kernel_regularizer': regularizers.serialize(self.kernel_regularizer),
-                  'recurrent_regularizer': regularizers.serialize(self.recurrent_regularizer),
-                  'bias_regularizer': regularizers.serialize(self.bias_regularizer),
-                  'activity_regularizer': regularizers.serialize(self.activity_regularizer),
-                  'kernel_constraint': constraints.serialize(self.kernel_constraint),
-                  'recurrent_constraint': constraints.serialize(self.recurrent_constraint),
-                  'bias_constraint': constraints.serialize(self.bias_constraint),
-                  'dropout': self.dropout,
-                  'recurrent_dropout': self.recurrent_dropout,
-                  'implementation': self.implementation}
-        base_config = super(GRUResetAfter, self).get_config()
-        del base_config['cell']
-        return dict(list(base_config.items()) + list(config.items()))
-
-    @classmethod
-    def from_config(cls, config):
-        if 'implementation' in config and config['implementation'] == 0:
-            config['implementation'] = 1
-        return cls(**config)
 
 
 def _generate_dropout_ones(inputs, dims):

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1179,6 +1179,9 @@ class GRUCell(Layer):
             batch them into fewer, larger operations. These modes will
             have different performance profiles on different hardware and
             for different applications.
+        variant: GRU convention 'reset_before' (reset before multiplication,
+            default), 'reset_after' (reset after multiplication -
+            CuDNN-compatible)
     """
 
     def __init__(self, units,
@@ -1197,6 +1200,7 @@ class GRUCell(Layer):
                  dropout=0.,
                  recurrent_dropout=0.,
                  implementation=1,
+                 variant='reset_before',
                  **kwargs):
         super(GRUCell, self).__init__(**kwargs)
         self.units = units
@@ -1219,9 +1223,11 @@ class GRUCell(Layer):
         self.dropout = min(1., max(0., dropout))
         self.recurrent_dropout = min(1., max(0., recurrent_dropout))
         self.implementation = implementation
+        self.variant = variant
         self.state_size = self.units
         self._dropout_mask = None
         self._recurrent_dropout_mask = None
+        self._reset_after = variant == 'reset_after'
 
     def build(self, input_shape):
         input_dim = input_shape[-1]
@@ -1238,7 +1244,8 @@ class GRUCell(Layer):
             constraint=self.recurrent_constraint)
 
         if self.use_bias:
-            self.bias = self.add_weight(shape=(self.units * 3,),
+            bias_count = 3 if not self._reset_after else 6
+            self.bias = self.add_weight(shape=(self.units * bias_count,),
                                         name='bias',
                                         initializer=self.bias_initializer,
                                         regularizer=self.bias_regularizer,
@@ -1246,23 +1253,36 @@ class GRUCell(Layer):
         else:
             self.bias = None
 
+        # update gate
         self.kernel_z = self.kernel[:, :self.units]
         self.recurrent_kernel_z = self.recurrent_kernel[:, :self.units]
+        # reset gate
         self.kernel_r = self.kernel[:, self.units: self.units * 2]
         self.recurrent_kernel_r = self.recurrent_kernel[:,
                                                         self.units:
                                                         self.units * 2]
+        # new gate
         self.kernel_h = self.kernel[:, self.units * 2:]
         self.recurrent_kernel_h = self.recurrent_kernel[:, self.units * 2:]
 
         if self.use_bias:
-            self.bias_z = self.bias[:self.units]
-            self.bias_r = self.bias[self.units: self.units * 2]
-            self.bias_h = self.bias[self.units * 2:]
+            # bias for inputs
+            self.bias_z_i = self.bias[:self.units]
+            self.bias_r_i = self.bias[self.units: self.units * 2]
+            self.bias_h_i = self.bias[self.units * 2: self.units * 3]
+            # bias for hidden state - just for compatibility with CuDNN
+            if self._reset_after:
+                self.bias_z = self.bias[self.units * 3: self.units * 4]
+                self.bias_r = self.bias[self.units * 4: self.units * 5]
+                self.bias_h = self.bias[self.units * 5:]
         else:
-            self.bias_z = None
-            self.bias_r = None
-            self.bias_h = None
+            self.bias_z_i = None
+            self.bias_r_i = None
+            self.bias_h_i = None
+            if self._reset_after:
+                self.bias_z = None
+                self.bias_r = None
+                self.bias_h = None
         self.built = True
 
     def call(self, inputs, states, training=None):
@@ -1296,13 +1316,14 @@ class GRUCell(Layer):
                 inputs_z = inputs
                 inputs_r = inputs
                 inputs_h = inputs
+
             x_z = K.dot(inputs_z, self.kernel_z)
             x_r = K.dot(inputs_r, self.kernel_r)
             x_h = K.dot(inputs_h, self.kernel_h)
             if self.use_bias:
-                x_z = K.bias_add(x_z, self.bias_z)
-                x_r = K.bias_add(x_r, self.bias_r)
-                x_h = K.bias_add(x_h, self.bias_h)
+                x_z = K.bias_add(x_z, self.bias_z_i)
+                x_r = K.bias_add(x_r, self.bias_r_i)
+                x_h = K.bias_add(x_h, self.bias_h_i)
 
             if 0. < self.recurrent_dropout < 1.:
                 h_tm1_z = h_tm1 * rec_dp_mask[0]
@@ -1312,42 +1333,73 @@ class GRUCell(Layer):
                 h_tm1_z = h_tm1
                 h_tm1_r = h_tm1
                 h_tm1_h = h_tm1
-            z = self.recurrent_activation(x_z + K.dot(h_tm1_z,
-                                                      self.recurrent_kernel_z))
-            r = self.recurrent_activation(x_r + K.dot(h_tm1_r,
-                                                      self.recurrent_kernel_r))
 
-            hh = self.activation(x_h + K.dot(r * h_tm1_h,
-                                             self.recurrent_kernel_h))
+            recurrent_z = K.dot(h_tm1_z, self.recurrent_kernel_z)
+            recurrent_r = K.dot(h_tm1_r, self.recurrent_kernel_r)
+            if self._reset_after and self.use_bias:
+                recurrent_z = K.bias_add(recurrent_z, self.bias_z)
+                recurrent_r = K.bias_add(recurrent_r, self.bias_r)
+
+            z = self.recurrent_activation(x_z + recurrent_z)
+            r = self.recurrent_activation(x_r + recurrent_r)
+
+            # reset gate applied after/before matrix multiplication
+            if self._reset_after:
+                recurrent_h = K.dot(h_tm1_h, self.recurrent_kernel_h)
+                if self.use_bias:
+                    recurrent_h = K.bias_add(recurrent_h, self.bias_h)
+                recurrent_h = r * recurrent_h
+            else:
+                recurrent_h = K.dot(r * h_tm1_h, self.recurrent_kernel_h)
+
+            hh = self.activation(x_h + recurrent_h)
         else:
             if 0. < self.dropout < 1.:
-                # TODO: this might be a bug: same dropout mask for all gates
                 inputs *= dp_mask[0]
+
+            # inputs projected by all gate matrices at once
             matrix_x = K.dot(inputs, self.kernel)
             if self.use_bias:
-                matrix_x = K.bias_add(matrix_x, self.bias)
-            if 0. < self.recurrent_dropout < 1.:
-                # TODO: this might be a bug: same dropout mask for all gates
-                h_tm1 *= rec_dp_mask[0]
-            matrix_inner = K.dot(h_tm1,
-                                 self.recurrent_kernel[:, :2 * self.units])
-
+                # biases: bias_z_i, bias_r_i, bias_h_i
+                matrix_x = K.bias_add(matrix_x, self.bias[:self.units * 3])
             x_z = matrix_x[:, :self.units]
             x_r = matrix_x[:, self.units: 2 * self.units]
+            x_h = matrix_x[:, 2 * self.units:]
+
+            if 0. < self.recurrent_dropout < 1.:
+                h_tm1 *= rec_dp_mask[0]
+
+            if self._reset_after:
+                # hidden state projected by all gate matrices at once
+                matrix_inner = K.dot(h_tm1, self.recurrent_kernel)
+                if self.use_bias:
+                    matrix_inner = K.bias_add(matrix_inner, self.bias[self.units * 3:])
+            else:
+                # hidden state projected separately for update/reset and new
+                matrix_inner = K.dot(h_tm1,
+                                     self.recurrent_kernel[:, :2 * self.units])
+
             recurrent_z = matrix_inner[:, :self.units]
             recurrent_r = matrix_inner[:, self.units: 2 * self.units]
 
             z = self.recurrent_activation(x_z + recurrent_z)
             r = self.recurrent_activation(x_r + recurrent_r)
 
-            x_h = matrix_x[:, 2 * self.units:]
-            recurrent_h = K.dot(r * h_tm1,
-                                self.recurrent_kernel[:, 2 * self.units:])
+            if self._reset_after:
+                recurrent_h = r * matrix_inner[:, 2 * self.units:]
+            else:
+                recurrent_h = K.dot(r * h_tm1,
+                                    self.recurrent_kernel[:, 2 * self.units:])
+
             hh = self.activation(x_h + recurrent_h)
+
+        # previous and candidate state mixed by update gate
         h = z * h_tm1 + (1 - z) * hh
+
         if 0 < self.dropout + self.recurrent_dropout:
             if training is None:
                 h._uses_learning_phase = True
+
         return h, [h]
 
     def get_config(self):
@@ -1498,12 +1550,7 @@ class GRU(RNN):
             dropout = 0.
             recurrent_dropout = 0.
 
-        if variant == 'reset_after':
-            GRUCellImpl = GRUResetAfterCell
-        else:
-            GRUCellImpl = GRUCell
-
-        cell = GRUCellImpl(units,
+        cell = GRUCell(units,
                        activation=activation,
                        recurrent_activation=recurrent_activation,
                        use_bias=use_bias,
@@ -1518,7 +1565,8 @@ class GRU(RNN):
                        bias_constraint=bias_constraint,
                        dropout=dropout,
                        recurrent_dropout=recurrent_dropout,
-                       implementation=implementation)
+                       implementation=implementation,
+                       variant=variant)
         super(GRU, self).__init__(cell,
                                   return_sequences=return_sequences,
                                   return_state=return_state,
@@ -1527,7 +1575,6 @@ class GRU(RNN):
                                   unroll=unroll,
                                   **kwargs)
         self.activity_regularizer = regularizers.get(activity_regularizer)
-        self.variant = variant
 
     def call(self, inputs, mask=None, training=None, initial_state=None):
         return super(GRU, self).call(inputs,
@@ -1601,7 +1648,7 @@ class GRU(RNN):
 
     @property
     def variant(self):
-        return self.variant
+        return self.cell.variant
 
     def get_config(self):
         config = {'units': self.units,
@@ -2144,275 +2191,6 @@ class LSTM(RNN):
         if 'implementation' in config and config['implementation'] == 0:
             config['implementation'] = 1
         return cls(**config)
-
-
-
-class GRUResetAfterCell(Layer):
-    """Cell class for the GRU layer.
-
-    # Arguments
-        units: Positive integer, dimensionality of the output space.
-        activation: Activation function to use
-            (see [activations](../activations.md)).
-            If you pass None, no activation is applied
-            (ie. "linear" activation: `a(x) = x`).
-        recurrent_activation: Activation function to use
-            for the recurrent step
-            (see [activations](../activations.md)).
-        use_bias: Boolean, whether the layer uses a bias vector.
-        kernel_initializer: Initializer for the `kernel` weights matrix,
-            used for the linear transformation of the inputs.
-            (see [initializers](../initializers.md)).
-        recurrent_initializer: Initializer for the `recurrent_kernel`
-            weights matrix,
-            used for the linear transformation of the recurrent state.
-            (see [initializers](../initializers.md)).
-        bias_initializer: Initializer for the bias vector
-            (see [initializers](../initializers.md)).
-        kernel_regularizer: Regularizer function applied to
-            the `kernel` weights matrix
-            (see [regularizer](../regularizers.md)).
-        recurrent_regularizer: Regularizer function applied to
-            the `recurrent_kernel` weights matrix
-            (see [regularizer](../regularizers.md)).
-        bias_regularizer: Regularizer function applied to the bias vector
-            (see [regularizer](../regularizers.md)).
-        kernel_constraint: Constraint function applied to
-            the `kernel` weights matrix
-            (see [constraints](../constraints.md)).
-        recurrent_constraint: Constraint function applied to
-            the `recurrent_kernel` weights matrix
-            (see [constraints](../constraints.md)).
-        bias_constraint: Constraint function applied to the bias vector
-            (see [constraints](../constraints.md)).
-        dropout: Float between 0 and 1.
-            Fraction of the units to drop for
-            the linear transformation of the inputs.
-        recurrent_dropout: Float between 0 and 1.
-            Fraction of the units to drop for
-            the linear transformation of the recurrent state.
-        implementation: Implementation mode, either 1 or 2.
-            Mode 1 will structure its operations as a larger number of
-            smaller dot products and additions, whereas mode 2 will
-            batch them into fewer, larger operations. These modes will
-            have different performance profiles on different hardware and
-            for different applications.
-    """
-
-    def __init__(self, units,
-                 activation='tanh',
-                 recurrent_activation='hard_sigmoid',
-                 use_bias=True,
-                 kernel_initializer='glorot_uniform',
-                 recurrent_initializer='orthogonal',
-                 bias_initializer='zeros',
-                 kernel_regularizer=None,
-                 recurrent_regularizer=None,
-                 bias_regularizer=None,
-                 kernel_constraint=None,
-                 recurrent_constraint=None,
-                 bias_constraint=None,
-                 dropout=0.,
-                 recurrent_dropout=0.,
-                 implementation=1,
-                 **kwargs):
-        super(GRUResetAfterCell, self).__init__(**kwargs)
-        self.units = units
-        self.activation = activations.get(activation)
-        self.recurrent_activation = activations.get(recurrent_activation)
-        self.use_bias = use_bias
-
-        self.kernel_initializer = initializers.get(kernel_initializer)
-        self.recurrent_initializer = initializers.get(recurrent_initializer)
-        self.bias_initializer = initializers.get(bias_initializer)
-
-        self.kernel_regularizer = regularizers.get(kernel_regularizer)
-        self.recurrent_regularizer = regularizers.get(recurrent_regularizer)
-        self.bias_regularizer = regularizers.get(bias_regularizer)
-
-        self.kernel_constraint = constraints.get(kernel_constraint)
-        self.recurrent_constraint = constraints.get(recurrent_constraint)
-        self.bias_constraint = constraints.get(bias_constraint)
-
-        self.dropout = min(1., max(0., dropout))
-        self.recurrent_dropout = min(1., max(0., recurrent_dropout))
-        self.implementation = implementation
-        self.state_size = self.units
-        self._dropout_mask = None
-        self._recurrent_dropout_mask = None
-
-    def build(self, input_shape):
-        input_dim = input_shape[-1]
-        self.kernel = self.add_weight(shape=(input_dim, self.units * 3),
-                                      name='kernel',
-                                      initializer=self.kernel_initializer,
-                                      regularizer=self.kernel_regularizer,
-                                      constraint=self.kernel_constraint)
-        self.recurrent_kernel = self.add_weight(
-            shape=(self.units, self.units * 3),
-            name='recurrent_kernel',
-            initializer=self.recurrent_initializer,
-            regularizer=self.recurrent_regularizer,
-            constraint=self.recurrent_constraint)
-
-        if self.use_bias:
-            self.bias = self.add_weight(shape=(self.units * 6,),
-                                        name='bias',
-                                        initializer=self.bias_initializer,
-                                        regularizer=self.bias_regularizer,
-                                        constraint=self.bias_constraint)
-        else:
-            self.bias = None
-
-        # input/update gate
-        self.kernel_z = self.kernel[:, :self.units]
-        self.recurrent_kernel_z = self.recurrent_kernel[:, :self.units]
-        # reset gate
-        self.kernel_r = self.kernel[:, self.units: self.units * 2]
-        self.recurrent_kernel_r = self.recurrent_kernel[:, self.units: self.units * 2]
-        # new gate
-        self.kernel_h = self.kernel[:, self.units * 2:]
-        self.recurrent_kernel_h = self.recurrent_kernel[:, self.units * 2:]
-
-        if self.use_bias:
-            # bias for inputs
-            self.bias_z_i = self.bias[:self.units]
-            self.bias_r_i = self.bias[self.units: self.units * 2]
-            self.bias_h_i = self.bias[self.units * 2: self.units * 3]
-            # bias for hidden state
-            self.bias_z = self.bias[self.units * 3: self.units * 4]
-            self.bias_r = self.bias[self.units * 4: self.units * 5]
-            self.bias_h = self.bias[self.units * 5:]
-        else:
-            self.bias_z_i = None
-            self.bias_r_i = None
-            self.bias_h_i = None
-            self.bias_z = None
-            self.bias_r = None
-            self.bias_h = None
-        self.built = True
-
-    def call(self, inputs, states, training=None):
-        h_tm1 = states[0]  # previous memory
-
-        if 0 < self.dropout < 1 and self._dropout_mask is None:
-            self._dropout_mask = _generate_dropout_mask(
-                _generate_dropout_ones(inputs, K.shape(inputs)[-1]),
-                self.dropout,
-                training=training,
-                count=3)
-        if (0 < self.recurrent_dropout < 1 and
-                self._recurrent_dropout_mask is None):
-            self._recurrent_dropout_mask = _generate_dropout_mask(
-                _generate_dropout_ones(inputs, self.units),
-                self.recurrent_dropout,
-                training=training,
-                count=3)
-
-        # dropout matrices for input units
-        dp_mask = self._dropout_mask
-        # dropout matrices for recurrent units
-        rec_dp_mask = self._recurrent_dropout_mask
-
-        if self.implementation == 1:
-            if 0. < self.dropout < 1.:
-                inputs_z = inputs * dp_mask[0]
-                inputs_r = inputs * dp_mask[1]
-                inputs_h = inputs * dp_mask[2]
-            else:
-                inputs_z = inputs
-                inputs_r = inputs
-                inputs_h = inputs
-
-            x_z = K.dot(inputs_z, self.kernel_z)
-            x_r = K.dot(inputs_r, self.kernel_r)
-            x_h = K.dot(inputs_h, self.kernel_h)
-            if self.use_bias:
-                x_z = K.bias_add(x_z, self.bias_z_i)
-                x_r = K.bias_add(x_r, self.bias_r_i)
-                x_h = K.bias_add(x_h, self.bias_h_i)
-
-            if 0. < self.recurrent_dropout < 1.:
-                h_tm1_z = h_tm1 * rec_dp_mask[0]
-                h_tm1_r = h_tm1 * rec_dp_mask[1]
-                h_tm1_h = h_tm1 * rec_dp_mask[2]
-            else:
-                h_tm1_z = h_tm1
-                h_tm1_r = h_tm1
-                h_tm1_h = h_tm1
-
-            recurrent_z = K.dot(h_tm1_z, self.recurrent_kernel_z)
-            recurrent_r = K.dot(h_tm1_r, self.recurrent_kernel_r)
-            recurrent_h = K.dot(h_tm1_h, self.recurrent_kernel_h)
-            if self.use_bias:
-                # another set of biases (just for compatibility with CuDNN convention)
-                recurrent_z = K.bias_add(recurrent_z, self.bias_z)
-                recurrent_r = K.bias_add(recurrent_r, self.bias_r)
-                recurrent_h = K.bias_add(recurrent_h, self.bias_h)
-
-            z = self.recurrent_activation(x_z + recurrent_z)
-            r = self.recurrent_activation(x_r + recurrent_r)
-
-            hh = self.activation(x_h + r * recurrent_h)
-        else:
-            if 0. < self.dropout < 1.:
-                # TODO: this might be a bug: same dropout mask for all gates
-                inputs *= dp_mask[0]
-
-            # inputs projected by all gate matrices at once
-            matrix_x = K.dot(inputs, self.kernel)
-            if self.use_bias:
-                # biases: bias_z_i, bias_r_i, bias_h_i
-                matrix_x = K.bias_add(matrix_x, self.bias[:self.units * 3])
-
-            if 0. < self.recurrent_dropout < 1.:
-                # TODO: this might be a bug: same dropout mask for all gates
-                h_tm1 *= rec_dp_mask[0]
-
-            # hidden state projected by all gate matrices at once
-            # We can do this using GRU v1 definition, not GRU v3.
-            # See http://svail.github.io/diff_graphs/ for a visualization.
-            matrix_h = K.dot(h_tm1, self.recurrent_kernel)
-            if self.use_bias:
-                matrix_h = K.bias_add(matrix_h, self.bias[self.units * 3:])
-
-            x_z = matrix_x[:, :self.units]
-            x_r = matrix_x[:, self.units: 2 * self.units]
-            x_h = matrix_x[:, 2 * self.units:]
-            recurrent_z = matrix_h[:, :self.units]
-            recurrent_r = matrix_h[:, self.units: 2 * self.units]
-
-            z = self.recurrent_activation(x_z + recurrent_z)
-            r = self.recurrent_activation(x_r + recurrent_r)
-
-            recurrent_h = r * matrix_h[:, 2 * self.units:]
-            hh = self.activation(x_h + recurrent_h)
-
-        h = z * h_tm1 + (1 - z) * hh
-        if 0 < self.dropout + self.recurrent_dropout:
-            if training is None:
-                h._uses_learning_phase = True
-        return h, [h]
-
-    def get_config(self):
-        config = {'units': self.units,
-                  'activation': activations.serialize(self.activation),
-                  'recurrent_activation': activations.serialize(self.recurrent_activation),
-                  'use_bias': self.use_bias,
-                  'kernel_initializer': initializers.serialize(self.kernel_initializer),
-                  'recurrent_initializer': initializers.serialize(self.recurrent_initializer),
-                  'bias_initializer': initializers.serialize(self.bias_initializer),
-                  'kernel_regularizer': regularizers.serialize(self.kernel_regularizer),
-                  'recurrent_regularizer': regularizers.serialize(self.recurrent_regularizer),
-                  'bias_regularizer': regularizers.serialize(self.bias_regularizer),
-                  'kernel_constraint': constraints.serialize(self.kernel_constraint),
-                  'recurrent_constraint': constraints.serialize(self.recurrent_constraint),
-                  'bias_constraint': constraints.serialize(self.bias_constraint),
-                  'dropout': self.dropout,
-                  'recurrent_dropout': self.recurrent_dropout,
-                  'implementation': self.implementation}
-        base_config = super(GRUResetAfterCell, self).get_config()
-        return dict(list(base_config.items()) + list(config.items()))
 
 
 def _generate_dropout_ones(inputs, dims):

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -608,7 +608,8 @@ def convert_weights(layer, weights):
                       data_format='channels_first'),
 ])
 def test_preprocess_weights_for_loading(layer):
-    model = Sequential([layer])
+    # A model is needed to initialize weights.
+    _ = Sequential([layer])
     weights1 = layer.get_weights()
     weights2 = topology.preprocess_weights_for_loading(
         layer, convert_weights(layer, weights1),

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -606,7 +606,7 @@ def convert_weights(layer, weights):
     layers.ConvLSTM2D(5, (3, 3),
                       input_shape=[6, 6, 6, 6],
                       data_format='channels_first'),
-])
+], ids=['GRU', 'LSTM', 'ConvLSTM2D'])
 def test_preprocess_weights_for_loading(layer):
     # A model is needed to initialize weights.
     _ = Sequential([layer])
@@ -624,7 +624,7 @@ def test_preprocess_weights_for_loading(layer):
     layers.Conv2DTranspose(2, (5, 5),
                            input_shape=[7, 7, 3],
                            data_format='channels_first'),
-])
+], ids=['Conv2D', 'Conv2DTranspose'])
 def test_preprocess_weights_for_loading_for_model(layer):
     model = Sequential([layer])
     weights1 = model.get_weights()

--- a/tests/keras/layers/cudnn_recurrent_test.py
+++ b/tests/keras/layers/cudnn_recurrent_test.py
@@ -176,8 +176,8 @@ def test_cudnn_rnn_basics():
     for layer_class in [keras.layers.CuDNNGRU, keras.layers.CuDNNLSTM]:
         for return_sequences in [True, False]:
             with keras.utils.CustomObjectScope(
-                {'keras.layers.CuDNNGRU': keras.layers.CuDNNGRU,
-                 'keras.layers.CuDNNLSTM': keras.layers.CuDNNLSTM}):
+                    {'keras.layers.CuDNNGRU': keras.layers.CuDNNGRU,
+                     'keras.layers.CuDNNLSTM': keras.layers.CuDNNLSTM}):
                 layer_test(
                     layer_class,
                     kwargs={'units': units,
@@ -185,8 +185,8 @@ def test_cudnn_rnn_basics():
                     input_shape=(num_samples, timesteps, input_size))
         for go_backwards in [True, False]:
             with keras.utils.CustomObjectScope(
-                {'keras.layers.CuDNNGRU': keras.layers.CuDNNGRU,
-                 'keras.layers.CuDNNLSTM': keras.layers.CuDNNLSTM}):
+                    {'keras.layers.CuDNNGRU': keras.layers.CuDNNGRU,
+                     'keras.layers.CuDNNLSTM': keras.layers.CuDNNLSTM}):
                 layer_test(
                     layer_class,
                     kwargs={'units': units,
@@ -358,14 +358,15 @@ def test_statefulness():
 
 
 @keras_test
-@pytest.mark.parametrize('rnn_type', ['LSTM', 'GRU'], ids=['LSTM', 'GRU'])
-@pytest.mark.parametrize('to_cudnn', [False, True], ids=['from_cudnn', 'to_cudnn'])
+@pytest.mark.parametrize('implementation', [1, 2], ids=['impl1', 'impl2'])
 @pytest.mark.parametrize('bidirectional', [False, True], ids=['single', 'bidirectional'])
+@pytest.mark.parametrize('to_cudnn', [False, True], ids=['from_cudnn', 'to_cudnn'])
+@pytest.mark.parametrize('rnn_type', ['LSTM', 'GRU'], ids=['LSTM', 'GRU'])
 @pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
                     reason='Requires TensorFlow backend')
 @pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
                     reason='Requires GPU')
-def test_load_weights_between_noncudnn_rnn(rnn_type, to_cudnn, bidirectional):
+def test_load_weights_between_noncudnn_rnn(rnn_type, to_cudnn, bidirectional, implementation):
     input_size = 10
     timesteps = 6
     input_shape = (timesteps, input_size)
@@ -376,7 +377,8 @@ def test_load_weights_between_noncudnn_rnn(rnn_type, to_cudnn, bidirectional):
     rnn_layer_kwargs = {
         'recurrent_activation': 'sigmoid',
         # ensure biases are non-zero and properly converted
-        'bias_initializer': 'random_uniform'
+        'bias_initializer': 'random_uniform',
+        'implementation': implementation
     }
     if rnn_type == 'LSTM':
         rnn_layer_class = keras.layers.LSTM

--- a/tests/keras/layers/cudnn_recurrent_test.py
+++ b/tests/keras/layers/cudnn_recurrent_test.py
@@ -471,31 +471,6 @@ def test_cudnnrnn_bidirectional():
     model.fit(x, y, epochs=1, batch_size=1)
 
 
-@keras_test
-@pytest.mark.parametrize('layer_class,layer_args', [
-    (keras.layers.GRU, {'units': 2, 'input_shape': [3, 5]}),
-    (keras.layers.GRU, {'units': 2, 'input_shape': [3, 5], 'reset_after': True}),
-    (keras.layers.LSTM, {'units': 2, 'input_shape': [3, 5]}),
-    (keras.layers.CuDNNGRU, {'units': 2, 'input_shape': [3, 5]}),
-    (keras.layers.CuDNNLSTM, {'units': 2, 'input_shape': [3, 5]}),
-])
-@pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
-def test_preprocess_weights_for_loading_rnn_should_be_idempotent(layer_class, layer_args):
-    """
-    Loading weights from a RNN class to itself should not convert the weights.
-    """
-    # layer can be instantiated only for supported backends
-    layer = layer_class(**layer_args)
-    # A model is needed to initialize weights.
-    _ = keras.models.Sequential([layer])
-    weights1 = layer.get_weights()
-    weights2 = keras.engine.topology.preprocess_weights_for_loading(layer, weights1)
-    assert all([np.allclose(x, y, 1e-5) for (x, y) in zip(weights1, weights2)])
-
-
 @pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
                     reason='Requires TensorFlow backend')
 @pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),

--- a/tests/keras/layers/cudnn_recurrent_test.py
+++ b/tests/keras/layers/cudnn_recurrent_test.py
@@ -361,11 +361,11 @@ def test_statefulness():
 @pytest.mark.parametrize(
     'rnn_type,to_cudnn',
     [
-        ('LSTM', True),
         # conversion LSTM to CuDNNLSTM not implemented yet
+        ('LSTM', False),
         ('GRU', True),
         ('GRU', False),
-    ], ids=['LSTM to CuDNN', 'GRU to CuDNN', 'LSTM from CuDNN'])
+    ], ids=['LSTM from CuDNN', 'GRU to CuDNN', 'GRU from CuDNN'])
 @pytest.mark.parametrize('bidirectional', [False, True], ids=['single', 'bidirectional'])
 @pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
                     reason='Requires TensorFlow backend')
@@ -384,7 +384,7 @@ def test_load_weights_between_noncudnn_rnn(rnn_type, to_cudnn, bidirectional):
         # ensure biases are non-zero and properly converted
         'bias_initializer': 'random_uniform'
     }
-    if rnn_type == 'lstm':
+    if rnn_type == 'LSTM':
         rnn_layer_class = keras.layers.LSTM
         cudnn_rnn_layer_class = keras.layers.CuDNNLSTM
     else:

--- a/tests/keras/layers/cudnn_recurrent_test.py
+++ b/tests/keras/layers/cudnn_recurrent_test.py
@@ -479,26 +479,29 @@ def test_cudnnrnn_bidirectional():
 
 
 @keras_test
-@pytest.mark.parametrize('layer', [
-    keras.layers.GRU(2, input_shape=[3, 5]),
-    keras.layers.GRU(2, input_shape=[3, 5], reset_after=True),
-    keras.layers.LSTM(2, input_shape=[3, 5]),
-    keras.layers.CuDNNGRU(2, input_shape=[3, 5]),
-    keras.layers.CuDNNLSTM(2, input_shape=[3, 5]),
+@pytest.mark.parametrize('layer_class,layer_args', [
+    (keras.layers.GRU, {'units': 2, 'input_shape': [3, 5]}),
+    (keras.layers.GRU, {'units': 2, 'input_shape': [3, 5], 'reset_after': True}),
+    (keras.layers.LSTM, {'units': 2, 'input_shape': [3, 5]}),
+    (keras.layers.CuDNNGRU, {'units': 2, 'input_shape': [3, 5]}),
+    (keras.layers.CuDNNLSTM, {'units': 2, 'input_shape': [3, 5]}),
 ])
 @pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
                     reason='Requires TensorFlow backend')
 @pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
                     reason='Requires GPU')
-def test_preprocess_weights_for_loading_rnn_should_be_idempotent(layer):
+def test_preprocess_weights_for_loading_rnn_should_be_idempotent(layer_class, layer_args):
     """
     Loading weights from a RNN class to itself should not convert the weights.
     """
+    # layer can be instantiated only for supported backends
+    layer = layer_class(**layer_args)
     # A model is needed to initialize weights.
     _ = keras.models.Sequential([layer])
     weights1 = layer.get_weights()
     weights2 = keras.engine.topology.preprocess_weights_for_loading(layer, weights1)
     assert all([np.allclose(x, y, 1e-5) for (x, y) in zip(weights1, weights2)])
+
 
 @pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
                     reason='Requires TensorFlow backend')

--- a/tests/keras/layers/cudnn_recurrent_test.py
+++ b/tests/keras/layers/cudnn_recurrent_test.py
@@ -376,7 +376,7 @@ def test_load_weights_into_noncudnn_rnn(rnn_type):
     else:
         rnn_layer_class = keras.layers.GRU
         cudnn_rnn_layer_class = keras.layers.CuDNNGRU
-        rnn_layer_kwargs = {'variant': 'reset_after'}
+        rnn_layer_kwargs = {'reset_after': True}
 
     # basic case
     input_shape = (timesteps, input_size)

--- a/tests/keras/layers/cudnn_recurrent_test.py
+++ b/tests/keras/layers/cudnn_recurrent_test.py
@@ -358,14 +358,8 @@ def test_statefulness():
 
 
 @keras_test
-@pytest.mark.parametrize(
-    'rnn_type,to_cudnn',
-    [
-        # conversion LSTM to CuDNNLSTM not implemented yet
-        ('LSTM', False),
-        ('GRU', True),
-        ('GRU', False),
-    ], ids=['LSTM from CuDNN', 'GRU to CuDNN', 'GRU from CuDNN'])
+@pytest.mark.parametrize('rnn_type', ['LSTM', 'GRU'], ids=['LSTM', 'GRU'])
+@pytest.mark.parametrize('to_cudnn', [False, True], ids=['from_cudnn', 'to_cudnn'])
 @pytest.mark.parametrize('bidirectional', [False, True], ids=['single', 'bidirectional'])
 @pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
                     reason='Requires TensorFlow backend')

--- a/tests/keras/layers/cudnn_recurrent_test.py
+++ b/tests/keras/layers/cudnn_recurrent_test.py
@@ -419,8 +419,9 @@ def test_load_weights_into_noncudnn_gru():
 
     # basic case
     input_shape = (timesteps, input_size)
-    rnn_layer = keras.layers.GRUResetAfter(units, input_shape=input_shape,
-                                  recurrent_activation='sigmoid')
+    rnn_layer = keras.layers.GRU(units, input_shape=input_shape,
+                                 variant='reset_after',
+                                 recurrent_activation='sigmoid')
     cudnn_rnn_layer = keras.layers.CuDNNGRU(units, input_shape=input_shape)
 
     model = keras.models.Sequential([rnn_layer])
@@ -437,7 +438,9 @@ def test_load_weights_into_noncudnn_gru():
 
     # bidirectional case
     input_shape = (timesteps, input_size)
-    rnn_layer = keras.layers.GRUResetAfter(units, recurrent_activation='sigmoid')
+    rnn_layer = keras.layers.GRU(units,
+                                 variant='reset_after',
+                                 recurrent_activation='sigmoid')
     rnn_layer = keras.layers.Bidirectional(rnn_layer, input_shape=input_shape)
     cudnn_rnn_layer = keras.layers.CuDNNGRU(units)
     cudnn_rnn_layer = keras.layers.Bidirectional(cudnn_rnn_layer, input_shape=input_shape)


### PR DESCRIPTION
TL;DR: This PR extends the plain Keras `GRU` layer with a CuDNN-compatible mode, so that we can reuse weights trained on GPU with `CuDNNGRU` for inference on CPU.

Since #8860 (#8307) we're able to train a LSTM layer quickly on GPU with CuDNN and load the weights to plain LSTM implementation which runs also on a CPU. Since GRU in CuDNN is based on a slightly different convention we can't directly load its weights in a similar way. A possible solution is to provide implementation of GRU layer in plain Keras (similar to existing one) but using the same convention as in CuDNN, so that we can reuse the weights.

As I [described in detail](https://github.com/keras-team/keras/pull/8307#issuecomment-354652830) there are two conventions of GRU:

- most common (Keras, TensorFlow, etc.): hidden input first multiplied by reset gate, then projected by matrix 
- original paper (CuDNN): hidden input first projected, then multiplied by reset gate

In addition CuDNN uses two sets of biases, while Keras just one set.

Note that default `recurrent_activation` (for gates) in Keras is `hard_sigmoid`, while CuDNN uses `sigmoid`, so we should specify that option explicitly.

In this PR we're adding a mode to the `GRU` layer (resp. its `GRUCell`) to use the latter CuDNN-compatible convention and code to convert weights the analogously to the LSTM case (#8307).

Making a separate class for GRU layer or cell allowed easier development/debugging, but results in much code duplication and worse usage, so in the end I just added one more boolean parameter to `GRUCell` to switch between code paths: `variant` which can take values 'reset_before' (reset before multiplication, default), 'reset_after' (reset after multiplication - CuDNN-compatible).

`GRUCell` has already two `implementation`s, one simple, other with fused matrices where possible. Both have been adapted to both conventions. So we have four modes in total.

A basic test for converting weights from CuDNNGRU to GRU is available. Besides that the code has been manually tested on the IMDB RNN example to obtain same results up to numerical precision.

Documentation has been extended to cover this case and reference also the original paper.

UPDATE: I've made a notebook with example of using the code on IMDB example and measuring precision of results and speedup: https://gist.github.com/bzamecnik/bd3786a074f8cb891bc2a397343070f1.

Request for comments:
- Mixing two variants and two implementations is not perfectly readable, but different classes result in too much duplication. At least I tried to deduplicate common code between the two variants. Can you imagine a better way how to structure the code?
- Do you think of any better names for the flag and its values?

Thanks.

UPDATE - results of discussion:

- new `GRU` argument is `reset_after` boolean, default `False`, indicates using the original CuDNN-compatible convention
- shape of stored weights is the same (compared to CuDNNGRU) for kernels, but different for biases
  - ordering of individual weights is different and conversion is possible
  - biases (for input and recurrent kernels) are of shape `(2, 3 * units)`, while in CuDNNGRU, they're flat
    - this is the least bad way to allow distinguishing between weights from `GRU(reset_after=True)` and `CuDNNGRU` since we do not store layer metadata beyond name (such as type or arguments)
- it's possible to convert weights between `GRU(reset_after=True)` and `CuDNNGRU` and also `CuDNNLSTM` and `LSTM` in both directions!