### PR TITLE
Fixing another deserialization backwards compatability problem

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -226,10 +226,11 @@ def func_load(code, defaults=None, closure=None, globs=None):
         closure = tuple(ensure_value_to_cell(_) for _ in closure)
     try:
         raw_code = codecs.decode(code.encode('ascii'), 'base64')
-    except (UnicodeEncodeError, binascii.Error):
+        code = marshal.loads(raw_code)
+    except (UnicodeEncodeError, binascii.Error, ValueError):
         # backwards compatibility for models serialized prior to 2.1.2
         raw_code = code.encode('raw_unicode_escape')
-    code = marshal.loads(raw_code)
+        code = marshal.loads(raw_code)
     if globs is None:
         globs = globals()
     return python_types.FunctionType(code, globs,

--- a/tests/keras/utils/generic_utils_test.py
+++ b/tests/keras/utils/generic_utils_test.py
@@ -121,7 +121,7 @@ def test_func_dump_and_load_closure():
 
 
 @pytest.mark.parametrize(
-    'test_func', [activations.softmax, np.argmax, lambda x: x**2])
+    'test_func', [activations.softmax, np.argmax, lambda x: x**2, lambda x: x])
 def test_func_dump_and_load_backwards_compat(test_func):
     # this test ensures that models serialized prior to version 2.1.2 can still be
     # deserialized


### PR DESCRIPTION
Continuation of https://github.com/keras-team/keras/pull/8762.

I made a dumb mistake in my previous fix to this: I put a try/except around the acsii encoding/base64 decoding... unfortunately some strings encoded in the old format pass this without raising an except but then cannot be unpacked by marshall (marshall.load raises a ValueError).  One simple example of this is `lambda x:x` -- I added this case to the unit test.  Note that this is actually not a contrived example, we had some older models with Lambda layers where `output_shape=lambda x:x` and they were not deserialize-able with 2.1.3 due to this issue.