### PR TITLE
add option to return output of session.run(fetches)

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2419,7 +2419,7 @@ class Function(object):
         `options`, `run_metadata`
     """
 
-    def __init__(self, inputs, outputs, updates=None, name=None, **session_kwargs):
+    def __init__(self, inputs, outputs, updates=None, name=None, return_fetches=False, **session_kwargs):
         updates = updates or []
         if not isinstance(inputs, (list, tuple)):
             raise TypeError('`inputs` to a TensorFlow backend function '
@@ -2447,6 +2447,7 @@ class Function(object):
         self.feed_dict = session_kwargs.pop('feed_dict', {})
         # additional operations
         self.fetches = session_kwargs.pop('fetches', [])
+        self.return_fetches = return_fetches
         if not isinstance(self.fetches, list):
             self.fetches = [self.fetches]
         self.session_kwargs = session_kwargs
@@ -2466,7 +2467,10 @@ class Function(object):
         session = get_session()
         updated = session.run(fetches=fetches, feed_dict=feed_dict,
                               **self.session_kwargs)
-        return updated[:len(self.outputs)]
+        if self.return_fetches:
+            return updated
+        else:
+            return updated[:len(self.outputs)]
 
 
 def function(inputs, outputs, updates=None, **kwargs):


### PR DESCRIPTION
This PR adds an option `return_fetches=False` which returns all fetches variables to the user on the TensorFlow backend when set to `True`.

Motivation: We are attempting to visualize a tfrecord dataset + predictions made with that data, so all data must be acquired in a single `session.run()` call. We are able to provide additional tensors via the `model.compile(fetches=tensors)` parameter but the actual results of the added parameters are not returned without this flag.

After the TODOs are done is this a PR for which there is interest?

TODO:
- [ ] add unit test
- [ ] update docstring of tensorflow_backend `Function()` and `model.compile()`