### PR TITLE
Fix renamed `inbound_nodes` in CuDNN recurrent test

### DIFF
--- a/tests/keras/layers/cudnn_recurrent_test.py
+++ b/tests/keras/layers/cudnn_recurrent_test.py
@@ -295,7 +295,7 @@ def test_specify_initial_state_keras_tensor():
             output = layer(inputs, initial_state=initial_state[0])
         else:
             output = layer(inputs, initial_state=initial_state)
-        assert initial_state[0] in layer.inbound_nodes[0].input_tensors
+        assert initial_state[0] in layer._inbound_nodes[0].input_tensors
 
         model = keras.models.Model([inputs] + initial_state, output)
         model.compile(loss='categorical_crossentropy', optimizer='adam')


### PR DESCRIPTION
- forgotten in commit 958239c (Make private topological properties Python-private)
- rename `inbound_nodes` to `_inbound_nodes`
- BTW: tests from `cudnn_recurrent_test.py` are not ran on Travis CI (without GPU), thus it slipped through