### PR TITLE
Factorize backend tests

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -309,8 +309,7 @@ class TestBackend(object):
                     x = K.placeholder(shape=shape)
                     y = K.repeat_elements(x, reps, axis=rep_axis)
                     assert y._keras_shape == tuple(shape)
-                if K.backend() == 'tensorflow':
-                    assert y._keras_shape == tuple(y.get_shape().as_list())
+                    assert y._keras_shape == K.int_shape(y)
 
     def test_tile(self):
         shape = (3, 4)
@@ -323,7 +322,7 @@ class TestBackend(object):
         if K.backend() == 'theano':
             x = K.placeholder(shape=(None, 4))
             n = 2
-            y = KTH.tile(x, n)
+            y = K.tile(x, n)
             assert y._keras_shape == (None, 8)
             n = (4, 3)
             y = K.tile(x, n)
@@ -543,7 +542,7 @@ class TestBackend(object):
         W_o_val = np.random.random((output_dim, output_dim)).astype(np.float32)
         np_mask = np.random.randint(2, size=(num_samples, timesteps))
 
-        def rnn_step_fn(input_dim, output_dim, k):
+        def rnn_step_fn(k):
             W_i = k.variable(W_i_val)
             W_o = k.variable(W_o_val)
 
@@ -561,7 +560,7 @@ class TestBackend(object):
         state_list = [[], [], [], [], [], []]
 
         for k in BACKENDS:
-            rnn_fn = rnn_step_fn(input_dim, output_dim, k)
+            rnn_fn = rnn_step_fn(k)
             inputs = k.variable(input_val)
             initial_states = [k.variable(init_state_val)]
             mask = k.variable(np_mask)
@@ -611,18 +610,19 @@ class TestBackend(object):
             assert_allclose(b_s, b_u_s, atol=1e-04)
 
         for m_l, u_m_l, k in zip(last_output_list[4], last_output_list[5], BACKENDS):
-            # skip this compare on tensorflow
-            if k != KTF:
-                assert_allclose(m_l, u_m_l, atol=1e-04)
+            if k == KTF:
+                m_l = m_l * np.expand_dims(np_mask[:, -1], -1)
+                u_m_l = u_m_l * np.expand_dims(np_mask[:, -1], -1)
+            assert_allclose(m_l, u_m_l, atol=1e-04)
 
         for m_o, u_m_o, k in zip(outputs_list[4], outputs_list[5], BACKENDS):
-            # skip this compare on tensorflow
-            if k != KTF:
-                assert_allclose(m_o, u_m_o, atol=1e-04)
+            if k == KTF:
+                m_o = m_o * np.expand_dims(np_mask, -1)
+                u_m_o = u_m_o * np.expand_dims(np_mask, -1)
+            assert_allclose(m_o, u_m_o, atol=1e-04)
 
         for m_s, u_m_s, k in zip(state_list[4], state_list[5], BACKENDS):
-            if k != KTF:
-                assert_allclose(m_s, u_m_s, atol=1e-04)
+            assert_allclose(m_s, u_m_s, atol=1e-04)
 
     def test_rnn_no_states(self):
         # implement a simple RNN without states
@@ -633,12 +633,12 @@ class TestBackend(object):
         input_val = np.random.random((32, timesteps, input_dim))
         W_i_val = np.random.random((input_dim, output_dim))
 
-        def rnn_step_fn(input_dim, output_dim, K):
-            W_i = K.variable(W_i_val)
+        def rnn_step_fn(k):
+            W_i = k.variable(W_i_val)
 
             def step_function(x, states):
                 assert len(states) == 0
-                output = K.dot(x, W_i)
+                output = k.dot(x, W_i)
                 return output, []
 
             return step_function
@@ -648,7 +648,7 @@ class TestBackend(object):
         outputs_list = []
 
         for k in BACKENDS:
-            rnn_fn = rnn_step_fn(input_dim, output_dim, k)
+            rnn_fn = rnn_step_fn(k)
             inputs = k.variable(input_val)
             initial_states = []
             last_output, outputs, new_states = k.rnn(rnn_fn, inputs,
@@ -1080,18 +1080,19 @@ class TestBackend(object):
             assert zth.shape == ztf.shape
             assert zth.shape == zc.shape
 
-    def test_ctc(self):
+    # the Theano and TensorFlow CTC code use different methods to ensure
+    # numerical stability.  The Theano code subtracts out the max
+    # before the final log, so the results are different but scale
+    # identically and still train properly
+    @pytest.mark.parametrize('k,ref', [
+        (KTF, [3.34211, 5.42262]),
+        (KTH, [1.73308, 3.81351]),
+    ], ids=['TensorFlow', 'Theano'])
+    def test_ctc(self, k, ref):
         # simplified version of TensorFlow's test
 
         label_lens = np.expand_dims(np.asarray([5, 4]), 1)
         input_lens = np.expand_dims(np.asarray([5, 5]), 1)  # number of timesteps
-
-        # the Theano and TensorFlow CTC code use different methods to ensure
-        # numerical stability.  The Theano code subtracts out the max
-        # before the final log, so the results are different but scale
-        # identically and still train properly
-        loss_log_probs_tf = [3.34211, 5.42262]
-        loss_log_probs_th = [1.73308, 3.81351]
 
         # dimensions are batch x time x categories
         labels = np.asarray([[0, 1, 2, 1, 0], [0, 1, 1, 0, -1]])
@@ -1108,19 +1109,12 @@ class TestBackend(object):
               [0.423286, 0.315517, 0.0338439, 0.0393744, 0.0339315, 0.154046]]],
             dtype=np.float32)
 
-        labels_tf = KTF.variable(labels, dtype="int32")
-        inputs_tf = KTF.variable(inputs, dtype="float32")
-        input_lens_tf = KTF.variable(input_lens, dtype="int32")
-        label_lens_tf = KTF.variable(label_lens, dtype="int32")
-        res = KTF.eval(KTF.ctc_batch_cost(labels_tf, inputs_tf, input_lens_tf, label_lens_tf))
-        assert_allclose(res[:, 0], loss_log_probs_tf, atol=1e-05)
-
-        labels_th = KTH.variable(labels, dtype="int32")
-        inputs_th = KTH.variable(inputs, dtype="float32")
-        input_lens_th = KTH.variable(input_lens, dtype="int32")
-        label_lens_th = KTH.variable(label_lens, dtype="int32")
-        res = KTH.eval(KTH.ctc_batch_cost(labels_th, inputs_th, input_lens_th, label_lens_th))
-        assert_allclose(res[0, :], loss_log_probs_th, atol=1e-05)
+        k_labels = k.variable(labels, dtype="int32")
+        k_inputs = k.variable(inputs, dtype="float32")
+        k_input_lens = k.variable(input_lens, dtype="int32")
+        k_label_lens = k.variable(label_lens, dtype="int32")
+        res = k.eval(k.ctc_batch_cost(k_labels, k_inputs, k_input_lens, k_label_lens))
+        assert_allclose(res[:, 0] if k == KTF else res[0, :], ref, atol=1e-05)
 
     '''only tensorflow tested, need special handle'''
 
@@ -1261,10 +1255,10 @@ class TestBackend(object):
             # Theano has some dependency issues for sparse
             backends.append(KTH)
 
-        for K in backends:
-            t_W = K.variable(W)
-            k_s = K.eval(K.dot(K.variable(x_sparse), t_W))
-            k_d = K.eval(K.dot(K.variable(x_dense), t_W))
+        for k in backends:
+            t_W = k.variable(W)
+            k_s = k.eval(k.dot(k.variable(x_sparse), t_W))
+            k_d = k.eval(k.dot(k.variable(x_dense), t_W))
 
             assert k_s.shape == k_d.shape
             assert_allclose(k_s, k_d, atol=1e-05)
@@ -1291,13 +1285,13 @@ class TestBackend(object):
             # Theano has some dependency issues for sparse
             backends.append(KTH)
 
-        for K in backends:
-            k_s = K.concatenate([K.variable(x_sparse_1), K.variable(x_sparse_2)])
-            assert K.is_sparse(k_s)
+        for k in backends:
+            k_s = k.concatenate([k.variable(x_sparse_1), k.variable(x_sparse_2)])
+            assert k.is_sparse(k_s)
 
-            k_s_d = K.eval(k_s)
+            k_s_d = k.eval(k_s)
 
-            k_d = K.eval(K.concatenate([K.variable(x_dense_1), K.variable(x_dense_2)]))
+            k_d = k.eval(k.concatenate([k.variable(x_dense_1), k.variable(x_dense_2)]))
 
             assert k_s_d.shape == k_d.shape
             assert_allclose(k_s_d, k_d, atol=1e-05)
@@ -1367,18 +1361,18 @@ class TestBackend(object):
                 assert np.array_equal(a_list[i], a_list[i + 1])
 
         for dtype in ('int32', 'int64', 'float32', 'float64'):
-            for backend in [KTH, KTF]:
-                t = backend.arange(10, dtype=dtype)
-                assert backend.dtype(t) == dtype
+            for k in [KTH, KTF]:
+                t = k.arange(10, dtype=dtype)
+                assert k.dtype(t) == dtype
 
-        for backend in [KTH, KTF]:
-            start = backend.constant(1, dtype='int32')
-            t = backend.arange(start)
-            assert len(backend.eval(t)) == 1
+        for k in [KTH, KTF]:
+            start = k.constant(1, dtype='int32')
+            t = k.arange(start)
+            assert len(k.eval(t)) == 1
 
-            start = backend.constant(-1, dtype='int32')
-            t = backend.arange(start)
-            assert len(backend.eval(t)) == 0
+            start = k.constant(-1, dtype='int32')
+            t = k.arange(start)
+            assert len(k.eval(t)) == 0
 
     def test_in_train_phase(self):
         for training in [True, False]:


### PR DESCRIPTION
This PR factorizes backend tests including:
- enabling of disabled backend tests,
- making local backend variables consistent (`K` and `backend`->`k`),
- parameterizing `test_ctc`.