### PR TITLE
Suppress float64 warnings

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -62,7 +62,7 @@ def parse_shape_or_val(shape_or_val):
     if isinstance(shape_or_val, np.ndarray):
         return shape_or_val.shape, shape_or_val
     else:
-        return shape_or_val, np.random.random(shape_or_val) - 0.5
+        return shape_or_val, np.random.random(shape_or_val).astype(np.float32) - 0.5
 
 
 def assert_list_pairwise(z_list, shape=True, allclose=True, itself=False, atol=1e-05):


### PR DESCRIPTION
This PR helps travis to suppress unnecessary float64 warnings.