### PR TITLE
Utilize check_batch_axis in Model._standardize_user_data

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -181,7 +181,7 @@ def _standardize_sample_weights(sample_weight, output_names):
 
 
 def _check_array_lengths(inputs, targets, weights=None):
-    """Checks if batch axes are the same for all numpy arrays.
+    """Checks if batch axes are the same for numpy arrays.
 
     # Arguments
         inputs: list of Numpy arrays of inputs.

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -180,7 +180,7 @@ def _standardize_sample_weights(sample_weight, output_names):
                                                 'sample_weight')
 
 
-def _check_batch_axes_coincide(inputs, targets, weights=None):
+def _check_array_lengths(inputs, targets, weights=None):
     """Checks if batch axes are the same for all inputs.
 
     # Arguments
@@ -1399,9 +1399,9 @@ class Model(Container):
             return outs[0]
         return outs
 
-    def _standardize_training_data(self, x, y,
-                                   sample_weight=None, class_weight=None,
-                                   check_batch_axes_coincide=True, batch_size=None):
+    def _standardize_user_data(self, x, y,
+                               sample_weight=None, class_weight=None,
+                               check_array_lengths=True, batch_size=None):
         if not hasattr(self, 'optimizer'):
             raise RuntimeError('You must compile a model before '
                                'training/testing. '
@@ -1438,8 +1438,8 @@ class Model(Container):
                           for (ref, sw, cw, mode)
                           in zip(y, sample_weights, class_weights, self._feed_sample_weight_modes)]
 
-        if check_batch_axes_coincide:
-            _check_batch_axes_coincide(x, y, sample_weights)
+        if check_array_lengths:
+            _check_array_lengths(x, y, sample_weights)
         _check_loss_and_target_compatibility(y,
                                              self._feed_loss_fns,
                                              self._feed_output_shapes)
@@ -1589,7 +1589,7 @@ class Model(Container):
                              'you should specify the `steps_per_epoch` '
                              'argument.')
         # Validate user data.
-        x, y, sample_weights = self._standardize_training_data(
+        x, y, sample_weights = self._standardize_user_data(
             x, y,
             sample_weight=sample_weight,
             class_weight=class_weight,
@@ -1610,7 +1610,7 @@ class Model(Container):
                                  'items, however it contains %d items' %
                                  len(validation_data))
 
-            val_x, val_y, val_sample_weights = self._standardize_training_data(
+            val_x, val_y, val_sample_weights = self._standardize_user_data(
                 val_x, val_y,
                 sample_weight=val_sample_weight,
                 batch_size=batch_size)
@@ -1728,7 +1728,7 @@ class Model(Container):
                              'you should specify the `steps` '
                              'argument.')
         # Validate user data.
-        x, y, sample_weights = self._standardize_training_data(
+        x, y, sample_weights = self._standardize_user_data(
             x, y,
             sample_weight=sample_weight,
             batch_size=batch_size)
@@ -1837,7 +1837,7 @@ class Model(Container):
             and/or metrics). The attribute `model.metrics_names` will give you
             the display labels for the scalar outputs.
         """
-        x, y, sample_weights = self._standardize_training_data(
+        x, y, sample_weights = self._standardize_user_data(
             x, y,
             sample_weight=sample_weight,
             class_weight=class_weight)
@@ -1879,7 +1879,7 @@ class Model(Container):
             and/or metrics). The attribute `model.metrics_names` will give you
             the display labels for the scalar outputs.
         """
-        x, y, sample_weights = self._standardize_training_data(
+        x, y, sample_weights = self._standardize_user_data(
             x, y,
             sample_weight=sample_weight)
         if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
@@ -2111,7 +2111,7 @@ class Model(Container):
                                          '`(val_x, val_y, val_sample_weight)` '
                                          'or `(val_x, val_y)`. Found: ' +
                                          str(validation_data))
-                    val_x, val_y, val_sample_weights = self._standardize_training_data(
+                    val_x, val_y, val_sample_weights = self._standardize_user_data(
                         val_x, val_y, val_sample_weight)
                     val_data = val_x + val_y + val_sample_weights
                     if self.uses_learning_phase and not isinstance(K.learning_phase(), int):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1590,7 +1590,6 @@ class Model(Container):
             x, y,
             sample_weight=sample_weight,
             class_weight=class_weight,
-            check_batch_axis=False,
             batch_size=batch_size)
         # Prepare validation data.
         do_validation = False
@@ -1611,7 +1610,6 @@ class Model(Container):
             val_x, val_y, val_sample_weights = self._standardize_user_data(
                 val_x, val_y,
                 sample_weight=val_sample_weight,
-                check_batch_axis=False,
                 batch_size=batch_size)
             if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
                 val_ins = val_x + val_y + val_sample_weights + [0.]
@@ -1730,7 +1728,6 @@ class Model(Container):
         x, y, sample_weights = self._standardize_user_data(
             x, y,
             sample_weight=sample_weight,
-            check_batch_axis=False,
             batch_size=batch_size)
         # Prepare inputs, delegate logic to `_test_loop`.
         if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
@@ -1840,8 +1837,7 @@ class Model(Container):
         x, y, sample_weights = self._standardize_user_data(
             x, y,
             sample_weight=sample_weight,
-            class_weight=class_weight,
-            check_batch_axis=True)
+            class_weight=class_weight)
         if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
             ins = x + y + sample_weights + [1.]
         else:
@@ -1882,8 +1878,7 @@ class Model(Container):
         """
         x, y, sample_weights = self._standardize_user_data(
             x, y,
-            sample_weight=sample_weight,
-            check_batch_axis=True)
+            sample_weight=sample_weight)
         if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
             ins = x + y + sample_weights + [0.]
         else:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -180,8 +180,8 @@ def _standardize_sample_weights(sample_weight, output_names):
                                                 'sample_weight')
 
 
-def _check_array_lengths(inputs, targets, weights=None):
-    """Does user input validation for numpy arrays.
+def _check_batch_axis(inputs, targets, weights=None):
+    """Checks batch axis for numpy arrays.
 
     # Arguments
         inputs: list of Numpy arrays of inputs.
@@ -1435,7 +1435,8 @@ class Model(Container):
         sample_weights = [_standardize_weights(ref, sw, cw, mode)
                           for (ref, sw, cw, mode)
                           in zip(y, sample_weights, class_weights, self._feed_sample_weight_modes)]
-        _check_array_lengths(x, y, sample_weights)
+        if check_batch_axis:
+            _check_batch_axis(x, y, sample_weights)
         _check_loss_and_target_compatibility(y,
                                              self._feed_loss_fns,
                                              self._feed_output_shapes)

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -181,7 +181,7 @@ def _standardize_sample_weights(sample_weight, output_names):
 
 
 def _check_array_lengths(inputs, targets, weights=None):
-    """Checks if batch axes are the same for all inputs.
+    """Checks if batch axes are the same for all numpy arrays.
 
     # Arguments
         inputs: list of Numpy arrays of inputs.

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -12,7 +12,7 @@ from keras.engine.topology import Input
 from keras.engine.training import Model
 from keras.engine.training import _check_loss_and_target_compatibility
 from keras.engine.training import _weighted_masked_objective
-from keras.engine.training import _check_array_lengths
+from keras.engine.training import _check_batch_axis
 from keras.engine.training import _slice_arrays
 from keras.models import Sequential
 from keras import backend as K
@@ -40,23 +40,23 @@ class RandomSequence(Sequence):
 
 @keras_test
 def test_check_array_lengths():
-    _check_array_lengths(None, None, None)
+    _check_batch_axis(None, None, None)
     a_np = np.random.random((4, 3, 3))
-    _check_array_lengths(a_np, a_np, a_np)
-    _check_array_lengths([a_np, a_np], [a_np, a_np], [a_np, a_np])
-    _check_array_lengths([None], [None], [None])
+    _check_batch_axis(a_np, a_np, a_np)
+    _check_batch_axis([a_np, a_np], [a_np, a_np], [a_np, a_np])
+    _check_batch_axis([None], [None], [None])
 
     b_np = np.random.random((3, 4))
     with pytest.raises(ValueError):
-        _check_array_lengths(a_np, None, None)
+        _check_batch_axis(a_np, None, None)
     with pytest.raises(ValueError):
-        _check_array_lengths(a_np, a_np, None)
+        _check_batch_axis(a_np, a_np, None)
     with pytest.raises(ValueError):
-        _check_array_lengths([a_np], [None], None)
+        _check_batch_axis([a_np], [None], None)
     with pytest.raises(ValueError):
-        _check_array_lengths([a_np], [b_np], None)
+        _check_batch_axis([a_np], [b_np], None)
     with pytest.raises(ValueError):
-        _check_array_lengths([a_np], None, [b_np])
+        _check_batch_axis([a_np], None, [b_np])
 
 
 @keras_test

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -12,7 +12,7 @@ from keras.engine.topology import Input
 from keras.engine.training import Model
 from keras.engine.training import _check_loss_and_target_compatibility
 from keras.engine.training import _weighted_masked_objective
-from keras.engine.training import _check_batch_axis
+from keras.engine.training import _check_batch_axes_coincide
 from keras.engine.training import _slice_arrays
 from keras.models import Sequential
 from keras import backend as K
@@ -40,23 +40,23 @@ class RandomSequence(Sequence):
 
 @keras_test
 def test_check_array_lengths():
-    _check_batch_axis(None, None, None)
+    _check_batch_axes_coincide(None, None, None)
     a_np = np.random.random((4, 3, 3))
-    _check_batch_axis(a_np, a_np, a_np)
-    _check_batch_axis([a_np, a_np], [a_np, a_np], [a_np, a_np])
-    _check_batch_axis([None], [None], [None])
+    _check_batch_axes_coincide(a_np, a_np, a_np)
+    _check_batch_axes_coincide([a_np, a_np], [a_np, a_np], [a_np, a_np])
+    _check_batch_axes_coincide([None], [None], [None])
 
     b_np = np.random.random((3, 4))
     with pytest.raises(ValueError):
-        _check_batch_axis(a_np, None, None)
+        _check_batch_axes_coincide(a_np, None, None)
     with pytest.raises(ValueError):
-        _check_batch_axis(a_np, a_np, None)
+        _check_batch_axes_coincide(a_np, a_np, None)
     with pytest.raises(ValueError):
-        _check_batch_axis([a_np], [None], None)
+        _check_batch_axes_coincide([a_np], [None], None)
     with pytest.raises(ValueError):
-        _check_batch_axis([a_np], [b_np], None)
+        _check_batch_axes_coincide([a_np], [b_np], None)
     with pytest.raises(ValueError):
-        _check_batch_axis([a_np], None, [b_np])
+        _check_batch_axes_coincide([a_np], None, [b_np])
 
 
 @keras_test

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -12,7 +12,7 @@ from keras.engine.topology import Input
 from keras.engine.training import Model
 from keras.engine.training import _check_loss_and_target_compatibility
 from keras.engine.training import _weighted_masked_objective
-from keras.engine.training import _check_batch_axes_coincide
+from keras.engine.training import _check_array_lengths
 from keras.engine.training import _slice_arrays
 from keras.models import Sequential
 from keras import backend as K
@@ -40,23 +40,23 @@ class RandomSequence(Sequence):
 
 @keras_test
 def test_check_array_lengths():
-    _check_batch_axes_coincide(None, None, None)
+    _check_array_lengths(None, None, None)
     a_np = np.random.random((4, 3, 3))
-    _check_batch_axes_coincide(a_np, a_np, a_np)
-    _check_batch_axes_coincide([a_np, a_np], [a_np, a_np], [a_np, a_np])
-    _check_batch_axes_coincide([None], [None], [None])
+    _check_array_lengths(a_np, a_np, a_np)
+    _check_array_lengths([a_np, a_np], [a_np, a_np], [a_np, a_np])
+    _check_array_lengths([None], [None], [None])
 
     b_np = np.random.random((3, 4))
     with pytest.raises(ValueError):
-        _check_batch_axes_coincide(a_np, None, None)
+        _check_array_lengths(a_np, None, None)
     with pytest.raises(ValueError):
-        _check_batch_axes_coincide(a_np, a_np, None)
+        _check_array_lengths(a_np, a_np, None)
     with pytest.raises(ValueError):
-        _check_batch_axes_coincide([a_np], [None], None)
+        _check_array_lengths([a_np], [None], None)
     with pytest.raises(ValueError):
-        _check_batch_axes_coincide([a_np], [b_np], None)
+        _check_array_lengths([a_np], [b_np], None)
     with pytest.raises(ValueError):
-        _check_batch_axes_coincide([a_np], None, [b_np])
+        _check_array_lengths([a_np], None, [b_np])
 
 
 @keras_test


### PR DESCRIPTION
Previous PR, problem definition and discussion: https://github.com/keras-team/keras/pull/9110

In short, the problem is that `check_batch_axis` is not used within `Model._standardize_user_data` and you can not easily disable the validation of input data's batch axis (when you really need it).
