### PR TITLE
Model.load_weights(): add new reshape option

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2628,6 +2628,8 @@ class Container(Layer):
                 where there is a mismatch in the number of weights,
                 or a mismatch in the shape of the weight
                 (only valid when `by_name`=True).
+        reshape: Reshape weights to fit the layer when the correct number
+            of values are present but the shape does not match.
 
 
         # Raises
@@ -2906,6 +2908,8 @@ def preprocess_weights_for_loading(layer, weights,
         original_keras_version: Keras version for the weights, as a string.
         original_backend: Keras backend the weights were trained with,
             as a string.
+        reshape: Reshape weights to fit the layer when the correct number
+            of values are present but the shape does not match.
 
     # Returns
         A list of weights values (Numpy arrays).
@@ -3039,7 +3043,6 @@ def preprocess_weights_for_loading(layer, weights,
                     weights = weights[num_weights:]
             weights = new_weights
 
-    print('Layer class name:', layer.__class__.__name__, ' layer.name: ', layer.name)
     conv_layers = ['Conv1D',
                    'Conv2D',
                    'Conv3D',
@@ -3111,6 +3114,8 @@ def load_weights_from_hdf5_group(f, layers, reshape=False):
     # Arguments
         f: A pointer to a HDF5 group.
         layers: a list of target layers.
+        reshape: Reshape weights to fit the layer when the correct number
+            of values are present but the shape does not match.
 
     # Raises
         ValueError: in case of mismatch between provided layers
@@ -3152,7 +3157,6 @@ def load_weights_from_hdf5_group(f, layers, reshape=False):
         g = f[name]
         weight_names = [n.decode('utf8') for n in g.attrs['weight_names']]
         weight_values = [g[weight_name] for weight_name in weight_names]
-        print('load_weights_from_hdf5_group layer: ' + name + ' weight_names: ' + str(weight_names))
         layer = filtered_layers[k]
         symbolic_weights = layer.weights
         weight_values = preprocess_weights_for_loading(layer,
@@ -3188,6 +3192,8 @@ def load_weights_from_hdf5_group_by_name(f, layers, skip_mismatch=False, reshape
         skip_mismatch: Boolean, whether to skip loading of layers
             where there is a mismatch in the number of weights,
             or a mismatch in the shape of the weights.
+        reshape: Reshape weights to fit the layer when the correct number
+            of values are present but the shape does not match.
 
     # Raises
         ValueError: in case of mismatch between provided layers
@@ -3218,7 +3224,6 @@ def load_weights_from_hdf5_group_by_name(f, layers, skip_mismatch=False, reshape
         g = f[name]
         weight_names = [n.decode('utf8') for n in g.attrs['weight_names']]
         weight_values = [g[weight_name] for weight_name in weight_names]
-        print('layer name: ' + name + ' weight_names: ' + str(weight_names))
 
         for layer in index.get(name, []):
             symbolic_weights = layer.weights

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -3055,6 +3055,16 @@ def preprocess_weights_for_loading(layer, weights,
             if layer.__class__.__name__ == 'ConvLSTM2D':
                 weights[1] = conv_utils.convert_kernel(weights[1])
         if reshape and layer_weights_shape != weights[0].shape:
+            if weights[0].size != np.prod(layer_weights_shape):
+                raise ValueError('Weights must be of equal size to ' +
+                                 'apply a reshape operation. ' +
+                                 'Layer ' + layer.__class__.__name__ +
+                                 '\'s weights have shape ' +
+                                 str(layer_weights_shape) + ' and size ' +
+                                 str(np.prod(layer_weights_shape)) + '. ' +
+                                 'The weights for loading have shape ' +
+                                 str(weights[0].shape) + ' and size ' +
+                                 str(weights[0].size) + '. ')
             weights[0] = np.reshape(weights[0], layer_weights_shape)
         elif layer_weights_shape != weights[0].shape:
             weights[0] = np.transpose(weights[0], (3, 2, 0, 1))

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2605,7 +2605,8 @@ class Container(Layer):
         f.flush()
         f.close()
 
-    def load_weights(self, filepath, by_name=False, skip_mismatch=False, reshape=False):
+    def load_weights(self, filepath, by_name=False,
+                     skip_mismatch=False, reshape=False):
         """Loads all layer weights from a HDF5 save file.
 
         If `by_name` is False (default) weights are loaded
@@ -3058,7 +3059,7 @@ def preprocess_weights_for_loading(layer, weights,
             if weights[0].size != np.prod(layer_weights_shape):
                 raise ValueError('Weights must be of equal size to ' +
                                  'apply a reshape operation. ' +
-                                 'Layer ' + layer.__class__.__name__ +
+                                 'Layer ' + layer.name +
                                  '\'s weights have shape ' +
                                  str(layer_weights_shape) + ' and size ' +
                                  str(np.prod(layer_weights_shape)) + '. ' +
@@ -3189,7 +3190,8 @@ def load_weights_from_hdf5_group(f, layers, reshape=False):
     K.batch_set_value(weight_value_tuples)
 
 
-def load_weights_from_hdf5_group_by_name(f, layers, skip_mismatch=False, reshape=False):
+def load_weights_from_hdf5_group_by_name(f, layers, skip_mismatch=False,
+                                         reshape=False):
     """Implements name-based weight loading.
 
     (instead of topological weight loading).

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2605,7 +2605,7 @@ class Container(Layer):
         f.flush()
         f.close()
 
-    def load_weights(self, filepath, by_name=False, skip_mismatch=False):
+    def load_weights(self, filepath, by_name=False, skip_mismatch=False, reshape=False):
         """Loads all layer weights from a HDF5 save file.
 
         If `by_name` is False (default) weights are loaded
@@ -2640,9 +2640,11 @@ class Container(Layer):
             f = f['model_weights']
         if by_name:
             load_weights_from_hdf5_group_by_name(
-                f, self.layers, skip_mismatch=skip_mismatch)
+                f, self.layers, skip_mismatch=skip_mismatch,
+                reshape=reshape)
         else:
-            load_weights_from_hdf5_group(f, self.layers)
+            load_weights_from_hdf5_group(
+                f, self.layers, reshape=reshape)
 
         if hasattr(f, 'close'):
             f.close()
@@ -2894,7 +2896,8 @@ def save_weights_to_hdf5_group(f, layers):
 
 def preprocess_weights_for_loading(layer, weights,
                                    original_keras_version=None,
-                                   original_backend=None):
+                                   original_backend=None,
+                                   reshape=False):
     """Converts layers weights from Keras 1 format to Keras 2.
 
     # Arguments
@@ -3036,17 +3039,21 @@ def preprocess_weights_for_loading(layer, weights,
                     weights = weights[num_weights:]
             weights = new_weights
 
+    print('Layer class name:', layer.__class__.__name__, ' layer.name: ', layer.name)
     conv_layers = ['Conv1D',
                    'Conv2D',
                    'Conv3D',
                    'Conv2DTranspose',
                    'ConvLSTM2D']
     if layer.__class__.__name__ in conv_layers:
+        layer_weights_shape = K.int_shape(layer.weights[0])
         if _need_convert_kernel(original_backend):
             weights[0] = conv_utils.convert_kernel(weights[0])
             if layer.__class__.__name__ == 'ConvLSTM2D':
                 weights[1] = conv_utils.convert_kernel(weights[1])
-        if K.int_shape(layer.weights[0]) != weights[0].shape:
+        if reshape and layer_weights_shape != weights[0].shape:
+            weights[0] = np.reshape(weights[0], layer_weights_shape)
+        elif layer_weights_shape != weights[0].shape:
             weights[0] = np.transpose(weights[0], (3, 2, 0, 1))
             if layer.__class__.__name__ == 'ConvLSTM2D':
                 weights[1] = np.transpose(weights[1], (3, 2, 0, 1))
@@ -3098,7 +3105,7 @@ def _need_convert_kernel(original_backend):
     return uses_correlation[original_backend] != uses_correlation[K.backend()]
 
 
-def load_weights_from_hdf5_group(f, layers):
+def load_weights_from_hdf5_group(f, layers, reshape=False):
     """Implements topological (order-based) weight loading.
 
     # Arguments
@@ -3145,12 +3152,14 @@ def load_weights_from_hdf5_group(f, layers):
         g = f[name]
         weight_names = [n.decode('utf8') for n in g.attrs['weight_names']]
         weight_values = [g[weight_name] for weight_name in weight_names]
+        print('load_weights_from_hdf5_group layer: ' + name + ' weight_names: ' + str(weight_names))
         layer = filtered_layers[k]
         symbolic_weights = layer.weights
         weight_values = preprocess_weights_for_loading(layer,
                                                        weight_values,
                                                        original_keras_version,
-                                                       original_backend)
+                                                       original_backend,
+                                                       reshape=reshape)
         if len(weight_values) != len(symbolic_weights):
             raise ValueError('Layer #' + str(k) +
                              ' (named "' + layer.name +
@@ -3166,7 +3175,7 @@ def load_weights_from_hdf5_group(f, layers):
     K.batch_set_value(weight_value_tuples)
 
 
-def load_weights_from_hdf5_group_by_name(f, layers, skip_mismatch=False):
+def load_weights_from_hdf5_group_by_name(f, layers, skip_mismatch=False, reshape=False):
     """Implements name-based weight loading.
 
     (instead of topological weight loading).
@@ -3209,6 +3218,7 @@ def load_weights_from_hdf5_group_by_name(f, layers, skip_mismatch=False):
         g = f[name]
         weight_names = [n.decode('utf8') for n in g.attrs['weight_names']]
         weight_values = [g[weight_name] for weight_name in weight_names]
+        print('layer name: ' + name + ' weight_names: ' + str(weight_names))
 
         for layer in index.get(name, []):
             symbolic_weights = layer.weights
@@ -3216,7 +3226,8 @@ def load_weights_from_hdf5_group_by_name(f, layers, skip_mismatch=False):
                 layer,
                 weight_values,
                 original_keras_version,
-                original_backend)
+                original_backend,
+                reshape=reshape)
             if len(weight_values) != len(symbolic_weights):
                 if skip_mismatch:
                     warnings.warn('Skipping loading of weights for layer {}'.format(layer.name) +

--- a/keras/models.py
+++ b/keras/models.py
@@ -718,7 +718,7 @@ class Sequential(Model):
             self.build()
         self.model.set_weights(weights)
 
-    def load_weights(self, filepath, by_name=False, skip_mismatch=False):
+    def load_weights(self, filepath, by_name=False, skip_mismatch=False, reshape=False):
         if h5py is None:
             raise ImportError('`load_weights` requires h5py.')
         f = h5py.File(filepath, mode='r')
@@ -732,9 +732,10 @@ class Sequential(Model):
             layers = self.layers
         if by_name:
             topology.load_weights_from_hdf5_group_by_name(f, layers,
-                                                          skip_mismatch=skip_mismatch)
+                                                          skip_mismatch=skip_mismatch,
+                                                          reshape=reshape)
         else:
-            topology.load_weights_from_hdf5_group(f, layers)
+            topology.load_weights_from_hdf5_group(f, layers, reshape=reshape)
         if hasattr(f, 'close'):
             f.close()
 

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -211,6 +211,9 @@ def test_loading_weights_by_name_and_reshape():
     # load weights from first model
     with pytest.raises(ValueError):
         model.load_weights(fname, by_name=True, reshape=False)
+    with pytest.raises(ValueError):
+        model.load_weights(fname, by_name=False, reshape=False)
+    model.load_weights(fname, by_name=False, reshape=True)
     model.load_weights(fname, by_name=True, reshape=True)
     os.remove(fname)
 

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose, assert_raises
 from keras import backend as K
 from keras.models import Model, Sequential
 from keras.layers import Dense, Lambda, RepeatVector, TimeDistributed, LSTM
+from keras.layers import Conv2D, Flatten
 from keras.layers import Input
 from keras import optimizers
 from keras import losses
@@ -173,7 +174,7 @@ def test_saving_unused_layers_is_ok():
 
 
 @keras_test
-def test_loading_weights_by_name():
+def test_loading_weights_by_name_and_reshape():
     """
     test loading model weights by name on:
         - sequential model
@@ -185,11 +186,12 @@ def test_loading_weights_by_name():
 
     # sequential model
     model = Sequential()
-    model.add(Dense(2, input_shape=(3,), name='rick'))
+    model.add(Conv2D(2, (1, 1), input_shape=(1, 1, 1), name='rick'))
+    model.add(Flatten())
     model.add(Dense(3, name='morty'))
     model.compile(loss=custom_loss, optimizer=custom_opt(), metrics=['acc'])
 
-    x = np.random.random((1, 3))
+    x = np.random.random((1, 1, 1, 1))
     y = np.random.random((1, 3))
     model.train_on_batch(x, y)
 
@@ -202,20 +204,24 @@ def test_loading_weights_by_name():
     # delete and recreate model
     del(model)
     model = Sequential()
-    model.add(Dense(2, input_shape=(3,), name='rick'))
-    model.add(Dense(3, name='morty'))
+    model.add(Conv2D(2, (1, 1), input_shape=(1, 1, 1), name='rick'))
+    model.add(Conv2D(3, (1, 1), name='morty'))
     model.compile(loss=custom_loss, optimizer=custom_opt(), metrics=['acc'])
 
     # load weights from first model
-    model.load_weights(fname, by_name=True)
+    with pytest.raises(ValueError):
+        model.load_weights(fname, by_name=True, reshape=False)
+    model.load_weights(fname, by_name=True, reshape=True)
     os.remove(fname)
 
     out2 = model.predict(x)
-    assert_allclose(out, out2, atol=1e-05)
+    assert_allclose(np.squeeze(out), np.squeeze(out2), atol=1e-05)
     for i in range(len(model.layers)):
         new_weights = model.layers[i].get_weights()
         for j in range(len(new_weights)):
-            assert_allclose(old_weights[i][j], new_weights[j], atol=1e-05)
+            # only compare layers that have weights, skipping Flatten()
+            if old_weights[i]:
+                assert_allclose(old_weights[i][j], new_weights[j], atol=1e-05)
 
 
 @keras_test


### PR DESCRIPTION
Adds option `load_weights(reshape=False)`. This option is essential for converting single label 
weights to other problems. A common example use case is dense prediction at each pixel in [Fully Convolutional Networks](https://arxiv.org/abs/1411.4038). 

Flags add cognitive overhead and should thus be avoided when possible. However, I suspect that weight conversion is common, but much less common than accidental changes to model shape where a failure to load is correct. For these reasons, reshape is added as a flag which is disabled by default and thus requires explicit action for users that know they wish to enable it.

TODO:
- [x] add unit test once `load_weights(reshape=False)` API change is approved