### PR TITLE
Adding the option of custom logs (e.g. learning rate) to tensorboard callback

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -628,7 +628,7 @@ class TensorBoard(Callback):
             used for all embedding layers, string can be passed.
         custom_log_func: a functions that returns a dict with custom logs
             (e.g. learning rate) that should be added to tensorboard, in
-            the same format as the original logs dict. This function takes the same params as on_epoch_end
+            the same format as the original logs dict. This function takes the same params as on_epoch_end.
     """
 
     def __init__(self, log_dir='./logs',


### PR DESCRIPTION
**Problem**: Right now TensorBoard only tracks ```loss```,  ```acc```, ```val_loss```, ```val_acc``` but nothing more.

I have not found a way to add custom values (e.g. the learning rate) to TensorBoard, so that they can be tracked as well. 

**Solution:** A little callback to the [TensorBoard callback](https://github.com/keras-team/keras/blob/master/keras/callbacks.py#L587) that is called at the end of each epoch, right before the logs are added to TensorBoard. It provides a way to add your custom values, so that they also show up on TensorBoard.

**Example:**

In my model:

```python
# Define tbCallback as usual, but add custom_log_func
tbCallback = TensorBoard(log_dir='./logs'
                         ...
                         custom_log_func=self.custom_log_func)
...

def custom_log_func(self, tensorboard, epoch, logs=None):
    """Add the custom logs to tensorboard. This function is executed at the end of each epoch."""

    # Add learning rate
    optimizer = tensorboard.model.optimizer
    learning_rate = ... # Calculate learning rate per epoch here

    return {
        "learning_rate": learning_rate
    }
```

The returned dict from ```custom_log_func``` is merged with the existing ```logs``` dict, so that my custom values (```learning_rate``` here) are submitted to TensorBoard as well. 


