### PR TITLE
Make automatic class weight calculation compatible with HDF5Matrix

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -514,7 +514,7 @@ def _standardize_weights(y, sample_weight=None, class_weight=None,
             raise ValueError('`class_weight` not supported for '
                              '3+ dimensional targets.')
         if y.shape[1] > 1:
-            y_classes = y.argmax(axis=1)
+            y_classes = np.argmax(y, axis=1)
         elif y.shape[1] == 1:
             y_classes = np.reshape(y, y.shape[0])
         else:


### PR DESCRIPTION
This pull request calls a numpy method from the module rather than on the array directly so that the y variable can be either a np.array object or an HDF5 dataset.