### PR TITLE
Revert #9025 because it introduces a bug

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -748,11 +748,10 @@ class ImageDataGenerator(object):
 
         if self.zca_whitening:
             flat_x = np.reshape(x, (x.shape[0], x.shape[1] * x.shape[2] * x.shape[3]))
-            num_examples = flat_x.shape[0]
-            _, s, vt = linalg.svd(flat_x / np.sqrt(num_examples))
-            s_expand = np.hstack((s, np.zeros(vt.shape[0] - num_examples,
-                                              dtype=flat_x.dtype)))
-            self.principal_components = (vt.T / np.sqrt(s_expand ** 2 + self.zca_epsilon)).dot(vt)
+            sigma = np.dot(flat_x.T, flat_x) / flat_x.shape[0]
+            u, s, _ = linalg.svd(sigma)
+            s_inv = 1. / np.sqrt(s[np.newaxis] + self.zca_epsilon)
+            self.principal_components = (u * s_inv).dot(u.T)
 
 
 class Iterator(Sequence):

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -123,6 +123,9 @@ class TestImage(object):
         # Test RBG
         x = np.random.random((32, 10, 10, 3))
         generator.fit(x)
+        # Test more samples than dims
+        x = np.random.random((32, 4, 4, 1))
+        generator.fit(x)
         generator = image.ImageDataGenerator(
             featurewise_center=True,
             samplewise_center=True,
@@ -135,6 +138,9 @@ class TestImage(object):
         generator.fit(x)
         # Test RBG
         x = np.random.random((32, 3, 10, 10))
+        generator.fit(x)
+        # Test more samples than dims
+        x = np.random.random((32, 1, 4, 4))
         generator.fit(x)
 
     def test_directory_iterator(self, tmpdir):


### PR DESCRIPTION
#9025 introduces a bug in zca_whitening so that it doesn't work when the samples are more than the dimensions. It **breaks most people's pipelines**.

Quick example to show which pipelines are broken.

```python
from keras.datasets import cifar10
from keras.preprocessing.image import ImageDataGenerator

(x_train, _), _ = cifar10.load_data()
gen = ImageDataGenerator(zca_whitening=True, featurewise_center=True)
gen.fit(x_train) # ValueError and much more time waiting
```

Detailed examples follow that explain what is going on.

```python
import numpy as np
import numpy.random as npr
import numpy.linalg as linalg

def princomps_old(flat_x):
    sigma = np.dot(flat_x.T, flat_x) / flat_x.shape[0]
    u, s, _ = linalg.svd(sigma)
    principal_components = np.dot(np.dot(u, np.diag(1. / np.sqrt(s + 1e-5))), u.T)
    return principal_components
 
def princomps_new(flat_x):
    n_examples = flat_x.shape[0]
    u, s, vt = linalg.svd(flat_x / np.sqrt(n_examples))
    # s_expand = np.hstack((s, np.zeros(max(0, vt.shape[0] - n_examples), dtype=flat_x.dtype)))
    s_expand = np.hstack((s, np.zeros(vt.shape[0] - n_examples, dtype=flat_x.dtype)))
    principal_components = (vt.T / np.sqrt(s_expand**2 + 1e-5)).dot(vt)
    return principal_components

x = np.random.rand(100, 50)
x -= x.mean()
princomps_new(x) # ValueError
```

Although the error can be fixed by introducing `max(0, vt.shape[0] - n_examples)` I argue that the reasoning behind the PR is a bit flawed. The bottleneck in that code is SVD so the speedup only comes when N < dims. Otherwise that code causes a slowdown.

```python
x = np.random.rand(1000, 500)
x -= x.mean()
%timeit princomps_old(x)
10 loops, best of 3: 90.4 ms per loop
%timeit princomps_new_fixed(x)
1 loop, best of 3: 156 ms per loop
```

Finally regarding the extra dot product to compute the principal components. It is redundant in `princomps_old` as well.