### PR TITLE
Add Stateful (Global) Metrics

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -213,8 +213,10 @@ class BaseLogger(Callback):
         logs = logs or {}
         batch_size = logs.get('size', 0)
         self.seen += batch_size
-        _, global_metric_names = get_global_metrics(self.model.metrics)
-        
+
+        if hasattr(self.model, 'metrics'):
+            _, global_metric_names = get_global_metrics(self.model.metrics)
+
         for k, v in logs.items():
             if str(k) in global_metric_names:
                 self.totals[k] = v
@@ -225,6 +227,8 @@ class BaseLogger(Callback):
                     self.totals[k] = v * batch_size
 
     def on_epoch_end(self, epoch, logs=None):
+        if hasattr(self.model, 'metrics'):
+            _, global_metric_names = get_global_metrics(self.model.metrics)
         _, global_metric_names = get_global_metrics(self.model.metrics)
         if logs is not None:
             for k in self.params['metrics']:

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -16,7 +16,7 @@ import warnings
 from collections import deque
 from collections import OrderedDict
 from collections import Iterable
-from .metrics import get_global_metrics
+from .metrics import get_stateful_metrics
 from .utils.generic_utils import Progbar
 from . import backend as K
 
@@ -215,10 +215,10 @@ class BaseLogger(Callback):
         self.seen += batch_size
 
         if hasattr(self.model, 'metrics'):
-            _, global_metric_names = get_global_metrics(self.model.metrics)
+            _, stateful_metric_names = get_stateful_metrics(self.model.metrics)
 
         for k, v in logs.items():
-            if str(k) in global_metric_names:
+            if str(k) in stateful_metric_names:
                 self.totals[k] = v
             else:
                 if k in self.totals:
@@ -228,13 +228,12 @@ class BaseLogger(Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         if hasattr(self.model, 'metrics'):
-            _, global_metric_names = get_global_metrics(self.model.metrics)
-        _, global_metric_names = get_global_metrics(self.model.metrics)
+            _, stateful_metric_names = get_stateful_metrics(self.model.metrics)
         if logs is not None:
             for k in self.params['metrics']:
                 if k in self.totals:
                     # Make value available to next callbacks.
-                    if str(k) in global_metric_names:
+                    if str(k) in stateful_metric_names:
                         logs[k] = self.totals[k]
                     else:
                         logs[k] = self.totals[k] / self.seen

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1341,8 +1341,8 @@ class Model(Container):
         if hasattr(self, 'metrics'):
             metrics_module.reset_stateful_metrics(self.metrics)
             _, stateful_metric_names = metrics_module.get_stateful_metrics(self.metrics)
-            stateful_metric_indices = [i for i, name in enumerate(self.metrics_names)
-                                       if str(name) in stateful_metric_names]
+            stateful_metric_indices = [self.metrics_names.index(name) 
+                                       for name in stateful_metric_names]
         else:
             stateful_metric_indices = []
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1148,7 +1148,8 @@ class Model(Container):
                 indices_for_conversion_to_dense.append(i)
 
         for epoch in range(initial_epoch, epochs):
-            metrics_module.reset_global_metrics(self.metrics)
+            if hasattr(self, 'metrics'):
+                metrics_module.reset_global_metrics(self.metrics)
             callbacks.on_epoch_begin(epoch)
             epoch_logs = {}
             if steps_per_epoch is not None:
@@ -1247,7 +1248,9 @@ class Model(Container):
             or list of arrays of predictions
             (if the model has multiple outputs).
         """
-        metrics_module.reset_global_metrics(self.metrics)
+        
+        if hasattr(self, 'metrics'):
+            metrics_module.reset_global_metrics(self.metrics)
         num_samples = self._check_num_samples(ins, batch_size,
                                               steps,
                                               'steps')
@@ -1334,7 +1337,9 @@ class Model(Container):
             and/or metrics). The attribute `model.metrics_names` will give you
             the display labels for the scalar outputs.
         """
-        metrics_module.reset_global_metrics(self.metrics)
+        
+        if hasattr(self, 'metrics'):
+            metrics_module.reset_global_metrics(self.metrics)
         _, global_metric_names = metrics_module.get_global_metrics(self.metrics)
         global_metric_indices = [i for i, name in enumerate(self.metrics_names) 
                                  if str(name) in global_metric_names]

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -903,7 +903,7 @@ class Model(Container):
                         else:
                             metric_fn = metrics_module.get(metric)
                             weighted_metric_fn = _weighted_masked_objective(metric_fn)
-                            metric_name = metric_name_prefix + metric_fn.__name__
+                            metric_name = metric_name_prefix + metrics_module.serialize(metric_fn)
 
                         with K.name_scope(metric_name):
                             metric_result = weighted_metric_fn(y_true, y_pred,
@@ -1341,7 +1341,7 @@ class Model(Container):
         if hasattr(self, 'metrics'):
             metrics_module.reset_stateful_metrics(self.metrics)
             _, stateful_metric_names = metrics_module.get_stateful_metrics(self.metrics)
-            stateful_metric_indices = [self.metrics_names.index(name) 
+            stateful_metric_indices = [self.metrics_names.index(name)
                                        for name in stateful_metric_names]
         else:
             stateful_metric_indices = []

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1341,8 +1341,8 @@ class Model(Container):
         if hasattr(self, 'metrics'):
             metrics_module.reset_stateful_metrics(self.metrics)
             _, stateful_metric_names = metrics_module.get_stateful_metrics(self.metrics)
-            stateful_metric_indices = [self.metrics_names.index(name)
-                                       for name in stateful_metric_names]
+            stateful_metric_indices = [i for i, name in enumerate(self.metrics_names)
+                                       if str(name) in stateful_metric_names]
         else:
             stateful_metric_indices = []
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -24,8 +24,8 @@ from .utils.generic_utils import deserialize_keras_object
 from .engine.topology import _to_snake_case
 
 
-class GlobalMetric(object):
-    """Base class for global metrics, which persist over epochs. Global Metrics
+class StatefulMetric(object):
+    """Base class for stateful metrics, which persist over epochs. Stateful Metrics
     must inherit from this class.
 
     # Properties:
@@ -36,7 +36,7 @@ class GlobalMetric(object):
         reset_states(self)
     """
     def __init__(self):
-        """Initialize the Global Metric and give it a name.
+        """Initialize the Stateful Metric and give it a name.
         """
         # Instance name is class name with underscores
         cls_name = self.__class__.__name__
@@ -72,38 +72,38 @@ class GlobalMetric(object):
         raise NotImplementedError("Method not implemented.")
 
 
-def reset_global_metrics(metrics):
-    """Call reset_states() for all global metrics.
+def reset_stateful_metrics(metrics):
+    """Call reset_states() for all stateful metrics.
 
     # Arguments
         metrics: a list of metric instances.
     """
     if metrics is not None:
         for metric in metrics:
-            if isinstance(metric, GlobalMetric):
+            if isinstance(metric, StatefulMetric):
                 metric.reset_states()
 
 
-def get_global_metrics(metrics):
-    """ Return a list of global metrics.
+def get_stateful_metrics(metrics):
+    """ Return a list of stateful metrics.
 
     # Arguments
         metrics: a list of metric instances.
     """
-    global_metrics = []
-    global_metric_names = []
+    stateful_metrics = []
+    stateful_metric_names = []
 
     if metrics is not None:
         for m in metrics:
-            if isinstance(m, GlobalMetric):
-                global_metrics.append(m)
-                global_metric_names.append(serialize(m))
+            if isinstance(m, StatefulMetric):
+                stateful_metrics.append(m)
+                stateful_metric_names.append(serialize(m))
 
-    return global_metrics, global_metric_names
+    return stateful_metrics, stateful_metric_names
 
 
-class TruePositives(GlobalMetric):
-    """Global Metric to count the total true positives over all batches.
+class TruePositives(StatefulMetric):
+    """Stateful Metric to count the total true positives over all batches.
 
     # Properties
         threshold: the lower limit on y_pred that counts as a positive class prediction
@@ -189,7 +189,7 @@ def serialize(metric):
 
 def deserialize(name, custom_objects=None):
     return deserialize_keras_object(name,
-                                    module_objects=globals(),
+                                    module_objects=statefuls(),
                                     custom_objects=custom_objects,
                                     printable_module_name='metric function')
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -196,7 +196,7 @@ def serialize(metric):
 
 def deserialize(name, custom_objects=None):
     return deserialize_keras_object(name,
-                                    module_objects=statefuls(),
+                                    module_objects=globals(),
                                     custom_objects=custom_objects,
                                     printable_module_name='metric function')
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -32,7 +32,7 @@ class GlobalMetric(object):
         __name__
 
     # Methods:
-        update_states(self. y_true, y_pred)
+        add_update(self. y_true, y_pred)
         reset_states(self)
     """
     def __init__(self):
@@ -43,10 +43,10 @@ class GlobalMetric(object):
         self.__name__ = _to_snake_case(cls_name)
 
     def __call__(self, y_true, y_pred):
-        return self.update_states(y_true, y_pred)
+        return self.add_update(y_true, y_pred)
 
     @abstractmethod
-    def update_states(self, y_true, y_pred):
+    def add_update(self, y_true, y_pred):
         """Update the state of the metric with the current values of y_true,
         y_pred.
 
@@ -127,7 +127,7 @@ class TruePositives(GlobalMetric):
         """
         K.set_value(self.state, 0)
 
-    def update_states(self, y_true, y_pred):
+    def add_update(self, y_true, y_pred):
         """Update the state at the completion of each batch.
 
         # Arguments:

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -110,20 +110,16 @@ class TruePositives(GlobalMetric):
         state: the current state of the metric through the current batch
     """
 
-    def __init__(self, threshold=None):
+    def __init__(self, threshold=0.5):
         """Set the threshold and name the metric
 
-        # Keyword Arguments
+        # Arguments
             threshold: the lower limit on y_pred that counts as a postive class prediction.
                 Defaults to 0.5
         """
         super(TruePositives, self).__init__()
 
-        if threshold is None:
-            self.threshold = K.variable(value=0.5)
-        else:
-            self.threshold = K.variable(value=threshold)
-
+        self.threshold = K.variable(value=threshold)
         self.state = K.variable(value=0.0)
 
     def reset_states(self):

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -141,7 +141,6 @@ class TruePositives(GlobalMetric):
         # Slice the positive score
         y_true = y_true[:, 1]
         y_pred = y_pred[:, 1]
-        K.sum(y_true * y_pred, axis = -1)
         # Softmax -> probabilities
         y_pred = K.cast(y_pred >= self.threshold, 'float32')
         # c = correct classifications

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -40,7 +40,7 @@ class StatefulMetric(object):
         """
         # Instance name is class name with underscores
         cls_name = self.__class__.__name__
-        self.__name__ = _to_snake_case(cls_name)
+        self.name = _to_snake_case(cls_name)
 
     def __call__(self, y_true, y_pred):
         return self.add_update(y_true, y_pred)
@@ -191,7 +191,10 @@ cosine = cosine_proximity
 
 
 def serialize(metric):
-    return metric.__name__
+    if isinstance(metric, StatefulMetric):
+        return metric.name
+    else:
+        return metric.__name__
 
 
 def deserialize(name, custom_objects=None):

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -25,7 +25,7 @@ from .engine.topology import _to_snake_case
 
 
 class StatefulMetric(object):
-    """Base class for stateful metrics, which persist over epochs.
+    """Base class for stateful metrics.
     Stateful Metrics must inherit from this class.
 
     # Properties

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -73,14 +73,15 @@ class GlobalMetric(object):
 
 
 def reset_global_metrics(metrics):
-    """Call reset_states() for all global metrics. 
+    """Call reset_states() for all global metrics.
 
     # Arguments
         metrics: a list of metric instances.
     """
-    for metric in metrics:
-        if isinstance(metric, GlobalMetric):
-            metric.reset_states()
+    if metrics is not None:
+        for metric in metrics:
+            if isinstance(metric, GlobalMetric):
+                metric.reset_states()
 
 
 def get_global_metrics(metrics):
@@ -91,10 +92,13 @@ def get_global_metrics(metrics):
     """
     global_metrics = []
     global_metric_names = []
-    for m in metrics:
-        if isinstance(m, GlobalMetric):
-            global_metrics.append(m)
-            global_metric_names.append(serialize(m))
+
+    if metrics is not None:
+        for m in metrics:
+            if isinstance(m, GlobalMetric):
+                global_metrics.append(m)
+                global_metric_names.append(serialize(m))
+
     return global_metrics, global_metric_names
 
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -87,7 +87,7 @@ def reset_stateful_metrics(metrics):
 
 
 def get_stateful_metrics(metrics):
-    """ Return a list of stateful metrics.
+    """ Return a list of stateful metrics and stateful metric names.
 
     # Arguments
         metrics: a list of metric instances.

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -25,13 +25,13 @@ from .engine.topology import _to_snake_case
 
 
 class StatefulMetric(object):
-    """Base class for stateful metrics, which persist over epochs. Stateful Metrics
-    must inherit from this class.
+    """Base class for stateful metrics, which persist over epochs.
+    Stateful Metrics must inherit from this class.
 
-    # Properties:
+    # Properties
         __name__
 
-    # Methods:
+    # Method
         add_update(self. y_true, y_pred)
         reset_states(self)
     """
@@ -51,23 +51,25 @@ class StatefulMetric(object):
         y_pred.
 
         # Arguments
-            y_true: the true labels, either binary or categorical.
-            y_pred: the predictions, either binary or categorical.
+            y_true: the true labels.
+            y_pred: the predictions.
 
         # Returns
             The current state of the metric.
 
         # Raises
-            NotImplementedError: if the derived class fails to implement the method.
+            NotImplementedError: if the derived class fails to implement
+                the method.
         """
         raise NotImplementedError("Method not implemented.")
 
     @abstractmethod
     def reset_states(self):
-        """Resets the state of the metric at the beginning of training and validation for each epoch.
+        """Resets the state of the metric.
 
         # Raises
-            NotImplementedError: if the derived class fails to implement the method.
+            NotImplementedError: if the derived class fails to implement
+                the method.
         """
         raise NotImplementedError("Method not implemented.")
 
@@ -106,16 +108,19 @@ class TruePositives(StatefulMetric):
     """Stateful Metric to count the total true positives over all batches.
 
     # Properties
-        threshold: the lower limit on y_pred that counts as a positive class prediction
+        threshold: the lower limit on y_pred that counts as a
+            positive class prediction
         state: the current state of the metric through the current batch
+    # Note
+        y_true, y_pred must be [?, 2] tensors that are one-hot encoded.
     """
 
     def __init__(self, threshold=0.5):
         """Set the threshold and name the metric
 
         # Arguments
-            threshold: the lower limit on y_pred that counts as a postive class prediction.
-                Defaults to 0.5
+            threshold: the lower limit on y_pred that counts as a
+                positive class prediction. Defaults to 0.5
         """
         super(TruePositives, self).__init__()
 
@@ -123,19 +128,21 @@ class TruePositives(StatefulMetric):
         self.state = K.variable(value=0.0)
 
     def reset_states(self):
-        """Reset the state at the beginning of training and evaluation for each epoch.
+        """Reset the state at the beginning of training and evaluation for each
+         epoch.
         """
         K.set_value(self.state, 0)
 
     def add_update(self, y_true, y_pred):
         """Update the state at the completion of each batch.
 
-        # Arguments:
+        # Arguments
             y_true: the batch_wise labels
             y_pred: the batch_wise predictions
 
-        # Returns:
-            The total number of true positives seen this epoch at the completion of the batch.
+        # Returns
+            The total number of true positives seen this epoch at the
+                completion of the batch.
         """
 
         # Slice the positive score

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -127,8 +127,8 @@ def test_TruePositives():
 
     # Test the thresholding
     tp = metrics.TruePositives()
-    result = tp(y_true, y_pred)
-    assert K.eval(result) == 2.0
+    tp(y_true, y_pred)
+    assert K.eval(tp.state) == 2.0
 
     tp.reset_states()
     tp.threshold = K.variable(value=0.5)

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -130,24 +130,29 @@ def test_TruePositives():
     result = tp(y_true, y_pred)
     assert K.eval(result) == 2.0
 
-    tp = metrics.TruePositives(0.5)
+    tp.reset_states()
+    tp.threshold = K.variable(value=0.5)
     result = tp(y_true, y_pred)
     assert K.eval(result) == 2.0
 
-    tp = metrics.TruePositives(0.0)
+    tp.reset_states()
+    tp.threshold = K.variable(value=0.0)
     result = tp(y_true, y_pred)
     assert K.eval(result) == 5.0
 
-    tp = metrics.TruePositives(1.0)
+    tp.reset_states()
+    tp.threshold = K.variable(value=1.0)
     result = tp(y_true, y_pred)
     assert K.eval(result) == 0.0
 
-    tp = metrics.TruePositives(0.6)
+    tp.reset_states()
+    tp.threshold = K.variable(value=0.6)
     result = tp(y_true, y_pred)
     assert K.eval(result) == 1.0
 
     # Test the state
-    tp = metrics.TruePositives()
+    tp.reset_states()
+    tp.threshold = K.variable(value=0.5)
     repeats = np.random.randint(2, 10)
 
     for _ in range(repeats):

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -69,6 +69,13 @@ def test_invalid_get():
         metrics.get(5)
 
 
+def test_reset_states():
+    # Test each stateful metric has implemented reset_states
+    for metric in all_stateful_metrics:
+        metric.reset_states()
+    metrics.reset_stateful_metrics(all_metrics + all_stateful_metrics)
+
+
 def test_get_stateful_metrics():
     # Case 1: No metrics
     metric_lst = None

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -158,7 +158,7 @@ def test_TruePositives():
     for _ in range(repeats):
         K.eval(tp(y_true, y_pred))
 
-    assert K.eval(tp.state)  == 2.0 * repeats
+    assert K.eval(tp.state) == 2.0 * repeats
     tp.reset_states()  # Reset with internal method
     assert K.eval(tp.state) == 0.0
 

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -116,7 +116,36 @@ def test_get_stateful_metrics():
 
 
 def test_TruePositives():
-    pass
+    # Create dummy data
+    y_true = np.array([[0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0],
+                       [1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0]]).T
+
+    y_pred = np.array([[0.3, 0.9, 0.8, 0.7, 0.5, 1.0, 0.5, 1.0, 0.8, 0.4],
+                       [0.7, 0.1, 0.2, 0.3, 0.5, 0.0, 0.5, 0.0, 0.2, 0.6]]).T
+    y_true = K.variable(y_true)
+    y_pred = K.variable(y_pred)
+
+    # Test the thresholding
+    tp = metrics.TruePositives()
+    result = tp(y_true, y_pred)
+    assert K.eval(result) == 2.0
+
+    tp = metrics.TruePositives(0.5)
+    result = tp(y_true, y_pred)
+    assert K.eval(result) == 2.0
+
+    tp = metrics.TruePositives(0.0)
+    result = tp(y_true, y_pred)
+    assert K.eval(result) == 5.0
+
+    tp = metrics.TruePositives(1.0)
+    result = tp(y_true, y_pred)
+    assert K.eval(result) == 0.0
+
+    tp = metrics.TruePositives(0.6)
+    result = tp(y_true, y_pred)
+    assert K.eval(result) == 1.0
+
 
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason="keras cntk backend does not support top_k yet")

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -146,6 +146,24 @@ def test_TruePositives():
     result = tp(y_true, y_pred)
     assert K.eval(result) == 1.0
 
+    # Test the state
+    tp = metrics.TruePositives()
+    repeats = np.random.randint(2, 10)
+
+    for _ in range(repeats):
+        result = K.eval(tp(y_true, y_pred))
+        state =  K.eval(tp.state)
+        assert result == state
+
+    assert result == 2.0 * repeats
+    tp.reset_states()  # Reset with internal method
+    assert K.eval(tp.state) == 0.0
+
+    result = K.eval(tp(y_true, y_pred))
+    assert result == 2.0
+    metrics.reset_stateful_metrics([tp])  # Reset with helper function
+    assert K.eval(tp.state) == 0.0
+
 
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason="keras cntk backend does not support top_k yet")

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -72,6 +72,7 @@ def test_invalid_get():
 def test_reset_states():
     # Test each stateful metric has implemented reset_states
     for metric in all_stateful_metrics:
+        assert isinstance(metric, metrics.StatefulMetric)
         metric.reset_states()
     metrics.reset_stateful_metrics(all_metrics + all_stateful_metrics)
 

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -72,16 +72,7 @@ def test_invalid_get():
 def test_stateful_metric_inheritance():
     for metric in all_stateful_metrics:
         assert isinstance(metric, metrics.StatefulMetric)
-
-
-def test_reset_states():
-    for metric in all_stateful_metrics:
         assert hasattr(metric, "reset_states")
-        metric.reset_states()
-
-
-def test_reset_stateful_metrics():
-    metrics.reset_stateful_metrics(all_metrics + all_stateful_metrics)
 
 
 def test_get_stateful_metrics():

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -25,6 +25,10 @@ all_sparse_metrics = [
     metrics.sparse_categorical_crossentropy,
 ]
 
+all_stateful_metrics = [
+    metrics.TruePositives()
+]
+
 
 def test_metrics():
     y_a = K.variable(np.random.random((6, 7)))
@@ -63,6 +67,37 @@ def test_invalid_get():
 
     with pytest.raises(ValueError):
         metrics.get(5)
+
+
+def test_get_stateful_metrics():
+    # Case 1: No metrics
+    metric_lst = None
+    stateful_metrics, stateful_metric_names = metrics.get_stateful_metrics(metric_lst)
+    assert stateful_metrics == []
+    assert stateful_metric_names == []
+
+    metric_lst = []
+    stateful_metrics, stateful_metric_names = metrics.get_stateful_metrics(metric_lst)
+    assert stateful_metrics == []
+    assert stateful_metric_names == []
+
+    # Case 2: Only non-Stateful Metrics
+    metric_lst = all_metrics
+    stateful_metrics, stateful_metric_names = metrics.get_stateful_metrics(metric_lst)
+    assert stateful_metrics == []
+    assert stateful_metric_names == []
+
+    # Case 3: Only Stateful Metrics
+    metric_lst = all_stateful_metrics
+    stateful_metrics, stateful_metric_names = metrics.get_stateful_metrics(metric_lst)
+    assert stateful_metrics == all_stateful_metrics
+    assert stateful_metric_names == [metrics.serialize(m) for m in all_stateful_metrics]
+
+    # Case 4: Mixture of non-Stateful and Stateful Metrics
+    metric_lst = all_metrics + all_stateful_metrics
+    stateful_metrics, stateful_metric_names = metrics.get_stateful_metrics(metric_lst)
+    assert stateful_metrics == all_stateful_metrics
+    assert stateful_metric_names == [metrics.serialize(m) for m in all_stateful_metrics]
 
 
 @pytest.mark.skipif((K.backend() == 'cntk'),

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -75,9 +75,12 @@ def test_stateful_metric_inheritance():
 
 
 def test_reset_states():
-    # Test each stateful metric has implemented reset_states
     for metric in all_stateful_metrics:
+        assert hasattr(metric, "reset_states")
         metric.reset_states()
+
+
+def test_reset_stateful_metrics():
     metrics.reset_stateful_metrics(all_metrics + all_stateful_metrics)
 
 
@@ -113,7 +116,7 @@ def test_get_stateful_metrics():
 
 
 def test_TruePositives():
-
+    pass
 
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason="keras cntk backend does not support top_k yet")

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -69,10 +69,14 @@ def test_invalid_get():
         metrics.get(5)
 
 
+def test_stateful_metric_inheritance():
+    for metric in all_stateful_metrics:
+        assert isinstance(metric, metrics.StatefulMetric)
+
+
 def test_reset_states():
     # Test each stateful metric has implemented reset_states
     for metric in all_stateful_metrics:
-        assert isinstance(metric, metrics.StatefulMetric)
         metric.reset_states()
     metrics.reset_stateful_metrics(all_metrics + all_stateful_metrics)
 
@@ -106,6 +110,9 @@ def test_get_stateful_metrics():
     stateful_metrics, stateful_metric_names = metrics.get_stateful_metrics(metric_lst)
     assert stateful_metrics == all_stateful_metrics
     assert stateful_metric_names == [metrics.serialize(m) for m in all_stateful_metrics]
+
+
+def test_TruePositives():
 
 
 @pytest.mark.skipif((K.backend() == 'cntk'),

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -127,28 +127,28 @@ def test_TruePositives():
 
     # Test the thresholding
     tp = metrics.TruePositives()
-    tp(y_true, y_pred)
+    K.eval(tp(y_true, y_pred))
     assert K.eval(tp.state) == 2.0
 
     tp.reset_states()
     tp.threshold = K.variable(value=0.5)
-    result = tp(y_true, y_pred)
-    assert K.eval(result) == 2.0
+    K.eval(tp(y_true, y_pred))
+    assert K.eval(tp.state) == 2.0
 
     tp.reset_states()
     tp.threshold = K.variable(value=0.0)
-    result = tp(y_true, y_pred)
-    assert K.eval(result) == 5.0
+    K.eval(tp(y_true, y_pred))
+    assert K.eval(tp.state) == 5.0
 
     tp.reset_states()
     tp.threshold = K.variable(value=1.0)
-    result = tp(y_true, y_pred)
-    assert K.eval(result) == 0.0
+    K.eval(tp(y_true, y_pred))
+    assert K.eval(tp.state) == 0.0
 
     tp.reset_states()
     tp.threshold = K.variable(value=0.6)
-    result = tp(y_true, y_pred)
-    assert K.eval(result) == 1.0
+    K.eval(tp(y_true, y_pred))
+    assert K.eval(tp.state) == 1.0
 
     # Test the state
     tp.reset_states()
@@ -156,16 +156,14 @@ def test_TruePositives():
     repeats = np.random.randint(2, 10)
 
     for _ in range(repeats):
-        result = K.eval(tp(y_true, y_pred))
-        state =  K.eval(tp.state)
-        assert result == state
+        K.eval(tp(y_true, y_pred))
 
-    assert result == 2.0 * repeats
+    assert K.eval(tp.state)  == 2.0 * repeats
     tp.reset_states()  # Reset with internal method
     assert K.eval(tp.state) == 0.0
 
-    result = K.eval(tp(y_true, y_pred))
-    assert result == 2.0
+    K.eval(tp(y_true, y_pred))
+    assert K.eval(tp.state) == 2.0
     metrics.reset_stateful_metrics([tp])  # Reset with helper function
     assert K.eval(tp.state) == 0.0
 


### PR DESCRIPTION
This is a follow up on issue: https://github.com/keras-team/keras/issues/8657.

In this PR we introduce a Stateful (Global) Metrics base class and a single example - True Positives. Instead of computing the metric in batch wise averages, we directly store the state inside the metric and use the value of the state.

Note: Tests to come, I just wanted feedback on the scaffolding - I'm expecting a lot of feedback/revisions. The default metrics test  (https://github.com/keras-team/keras/blob/master/tests/keras/metrics_test.py) does not make sense for this metric as the state is a single number, and it should not return an array tensor - even for a misshaped input.
