### PR TITLE
Fix TF error for SeparableConv1D when strides > 1

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3416,10 +3416,10 @@ def separable_conv1d(x, depthwise_kernel, pointwise_kernel, strides=1,
     padding = _preprocess_padding(padding)
     if tf_data_format == 'NHWC':
         spatial_start_dim = 1
-        strides = (1, 1) + strides + (1,)
+        strides = (1,) + strides * 2 + (1,)
     else:
         spatial_start_dim = 2
-        strides = (1, 1, 1) + strides
+        strides = (1, 1) + strides * 2
     x = tf.expand_dims(x, spatial_start_dim)
     depthwise_kernel = tf.expand_dims(depthwise_kernel, 0)
     pointwise_kernel = tf.expand_dims(pointwise_kernel, 0)

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -238,21 +238,22 @@ def test_separable_conv_1d():
     num_step = 9
 
     for padding in _convolution_paddings:
-        for multiplier in [1, 2]:
-            for dilation_rate in [1, 2]:
-                if padding == 'same':
-                    continue
-                if dilation_rate != 1:
-                    continue
+        for strides in [1, 2]:
+            for multiplier in [1, 2]:
+                for dilation_rate in [1, 2]:
+                    if padding == 'same' and strides != 1:
+                        continue
+                    if dilation_rate != 1 and strides != 1:
+                        continue
 
-                layer_test(convolutional.SeparableConv1D,
-                           kwargs={'filters': filters,
-                                   'kernel_size': 3,
-                                   'padding': padding,
-                                   'strides': 1,
-                                   'depth_multiplier': multiplier,
-                                   'dilation_rate': dilation_rate},
-                           input_shape=(num_samples, num_step, stack_size))
+                    layer_test(convolutional.SeparableConv1D,
+                               kwargs={'filters': filters,
+                                       'kernel_size': 3,
+                                       'padding': padding,
+                                       'strides': strides,
+                                       'depth_multiplier': multiplier,
+                                       'dilation_rate': dilation_rate},
+                               input_shape=(num_samples, num_step, stack_size))
 
     layer_test(convolutional.SeparableConv1D,
                kwargs={'filters': filters,


### PR DESCRIPTION
The current implementation leads to an error from Tensorflow, when using SeparableConv1D with strides > 1, as shown below. (The error is raised after building the model, i.e. when evaluating or training.)

```
InvalidArgumentError (see above for traceback): Current implementation only supports equal length strides in the row and column dimensions.
	 [[Node: separable_conv1d_4/separable_conv2d/depthwise = DepthwiseConv2dNative[T=DT_FLOAT, data_format="NHWC", dilations=[1, 1, 1, 1], padding="VALID", strides=[1, 1, 2, 1], _device="/job:localhost/replica:0/task:0/device:GPU:0"](separable_conv1d_4/ExpandDims, separable_conv1d_4/ExpandDims_1)]]
```

The fix is to make strides the same for the height and width dimensions. For Conv1D, the height dimension will stay at 1.