### PR TITLE
Typos: cond_ndim --> ndim_cond, expr_ndim --> ndim_expr

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2079,8 +2079,8 @@ def switch(condition, then_expression, else_expression):
         raise ValueError('Rank of condition should be less'
                          ' than or equal to rank of then and'
                          ' else expressions. ndim(condition)=' +
-                         str(cond_ndim) + ', ndim(then_expression)'
-                         '=' + str(expr_ndim))
+                         str(ndim_cond) + ', ndim(then_expression)'
+                         '=' + str(ndim_expr))
     elif ndim_cond < ndim_expr:
         shape_expr = int_shape(then_expression)
         ndim_diff = ndim_expr - ndim_cond


### PR DESCRIPTION
flake8 testing of https://github.com/keras-team/keras

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./keras/backend/cntk_backend.py:2082:30: F821 undefined name 'cond_ndim'
                         str(cond_ndim) + ', ndim(then_expression)'
                             ^
./keras/backend/cntk_backend.py:2083:36: F821 undefined name 'expr_ndim'
                         '=' + str(expr_ndim))
                                   ^
```