### PR TITLE
Simplify with from six.moves import input

### DIFF
--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import numpy as np
 from collections import defaultdict
 
-from six.moves import input as get_input
+import six
 try:
     import h5py
 except ImportError:
@@ -141,10 +141,11 @@ def ask_to_proceed_with_overwrite(filepath):
     # Returns
         True if we can proceed with overwrite, False otherwise.
     """
-    overwrite = get_input('[WARNING] %s already exists - overwrite? '
-                          '[y/n]' % (filepath)).strip().lower()
+    overwrite = six.moves.input('[WARNING] %s already exists - overwrite? '
+                                '[y/n]' % (filepath)).strip().lower()
     while overwrite not in ('y', 'n'):
-        overwrite = get_input('Enter "y" (overwrite) or "n" (cancel).').lower()
+        overwrite = six.moves.input('Enter "y" (overwrite) or "n" '
+                                    '(cancel).').strip().lower()
     if overwrite == 'n':
         return False
     print('[TIP] Next time specify overwrite=True!')

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import numpy as np
 from collections import defaultdict
 
-from six.moves import input
+from six.moves import input as get_input
 try:
     import h5py
 except ImportError:
@@ -141,10 +141,10 @@ def ask_to_proceed_with_overwrite(filepath):
     # Returns
         True if we can proceed with overwrite, False otherwise.
     """
-    overwrite = input('[WARNING] %s already exists - overwrite? '
-                      '[y/n]' % (filepath)).strip().lower()
+    overwrite = get_input('[WARNING] %s already exists - overwrite? '
+                          '[y/n]' % (filepath)).strip().lower()
     while overwrite not in ('y', 'n'):
-        overwrite = input('Enter "y" (overwrite) or "n" (cancel).').lower()
+        overwrite = get_input('Enter "y" (overwrite) or "n" (cancel).').lower()
     if overwrite == 'n':
         return False
     print('[TIP] Next time specify overwrite=True!')

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -144,7 +144,7 @@ def ask_to_proceed_with_overwrite(filepath):
     overwrite = input('[WARNING] %s already exists - overwrite? '
                       '[y/n]' % (filepath)).strip().lower()
     while overwrite not in ('y', 'n'):
-        overwrite = get_input('Enter "y" (overwrite) or "n" (cancel).').lower()
+        overwrite = input('Enter "y" (overwrite) or "n" (cancel).').lower()
     if overwrite == 'n':
         return False
     print('[TIP] Next time specify overwrite=True!')

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -4,9 +4,9 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import sys
 from collections import defaultdict
 
+from six.moves import input
 try:
     import h5py
 except ImportError:
@@ -141,13 +141,10 @@ def ask_to_proceed_with_overwrite(filepath):
     # Returns
         True if we can proceed with overwrite, False otherwise.
     """
-    get_input = input
-    if sys.version_info[:2] <= (2, 7):
-        get_input = raw_input
-    overwrite = get_input('[WARNING] %s already exists - overwrite? '
-                          '[y/n]' % (filepath))
-    while overwrite not in ['y', 'n']:
-        overwrite = get_input('Enter "y" (overwrite) or "n" (cancel).')
+    overwrite = input('[WARNING] %s already exists - overwrite? '
+                      '[y/n]' % (filepath)).strip().lower()
+    while overwrite not in ('y', 'n'):
+        overwrite = get_input('Enter "y" (overwrite) or "n" (cancel).').lower()
     if overwrite == 'n':
         return False
     print('[TIP] Next time specify overwrite=True!')

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -8,7 +8,7 @@ from keras.layers import Dense
 from keras.utils.io_utils import HDF5Matrix
 from keras.utils.io_utils import ask_to_proceed_with_overwrite
 import numpy as np
-from six.moves import input
+import six
 import warnings
 import h5py
 try:
@@ -107,20 +107,12 @@ def test_io_utils(in_tmpdir):
 
 
 def test_ask_to_proceed_with_overwrite():
-    if sys.version_info[:2] <= (2, 7):
-        with patch('__builtin__.input') as mock:
-            mock.return_value = 'y'
-            assert ask_to_proceed_with_overwrite('/tmp/not_exists')
+    with patch('six.moves.input') as mock:
+        mock.return_value = 'y'
+        assert ask_to_proceed_with_overwrite('/tmp/not_exists')
 
-            mock.return_value = 'n'
-            assert not ask_to_proceed_with_overwrite('/tmp/not_exists')
-    else:
-        with patch('builtins.input') as mock:
-            mock.return_value = 'y'
-            assert ask_to_proceed_with_overwrite('/tmp/not_exists')
-
-            mock.return_value = 'n'
-            assert not ask_to_proceed_with_overwrite('/tmp/not_exists')
+        mock.return_value = 'n'
+        assert not ask_to_proceed_with_overwrite('/tmp/not_exists')
 
 
 if __name__ == '__main__':

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -8,7 +8,7 @@ from keras.layers import Dense
 from keras.utils.io_utils import HDF5Matrix
 from keras.utils.io_utils import ask_to_proceed_with_overwrite
 import numpy as np
-from six.moves import input
+from six.moves import input as get_input
 import warnings
 import h5py
 try:
@@ -107,7 +107,7 @@ def test_io_utils(in_tmpdir):
 
 
 def test_ask_to_proceed_with_overwrite():
-    with patch('input') as mock:
+    with patch('get_input') as mock:
         mock.return_value = 'y'
         assert ask_to_proceed_with_overwrite('/tmp/not_exists')
 

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -107,7 +107,7 @@ def test_io_utils(in_tmpdir):
 
 def test_ask_to_proceed_with_overwrite():
     if sys.version_info[:2] <= (2, 7):
-        with patch('__builtin__.raw_input') as mock:
+        with patch('__builtin__.input') as mock:
             mock.return_value = 'y'
             assert ask_to_proceed_with_overwrite('/tmp/not_exists')
 

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -8,6 +8,7 @@ from keras.layers import Dense
 from keras.utils.io_utils import HDF5Matrix
 from keras.utils.io_utils import ask_to_proceed_with_overwrite
 import numpy as np
+from six.moves import input
 import warnings
 import h5py
 try:

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -8,7 +8,7 @@ from keras.layers import Dense
 from keras.utils.io_utils import HDF5Matrix
 from keras.utils.io_utils import ask_to_proceed_with_overwrite
 import numpy as np
-from six.moves import input as get_input
+import six
 import warnings
 import h5py
 try:
@@ -107,7 +107,7 @@ def test_io_utils(in_tmpdir):
 
 
 def test_ask_to_proceed_with_overwrite():
-    with patch('get_input') as mock:
+    with patch('six.moves.input') as mock:
         mock.return_value = 'y'
         assert ask_to_proceed_with_overwrite('/tmp/not_exists')
 

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -8,7 +8,7 @@ from keras.layers import Dense
 from keras.utils.io_utils import HDF5Matrix
 from keras.utils.io_utils import ask_to_proceed_with_overwrite
 import numpy as np
-import six
+from six.moves import input
 import warnings
 import h5py
 try:
@@ -107,7 +107,7 @@ def test_io_utils(in_tmpdir):
 
 
 def test_ask_to_proceed_with_overwrite():
-    with patch('six.moves.input') as mock:
+    with patch('input') as mock:
         mock.return_value = 'y'
         assert ask_to_proceed_with_overwrite('/tmp/not_exists')
 


### PR DESCRIPTION
[Use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection)

Also deal gracefully with uppercase input and text with leading or trailing whitespace.