### PR TITLE
Fix a couple of undefined name in the error string

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2079,8 +2079,8 @@ def switch(condition, then_expression, else_expression):
         raise ValueError('Rank of condition should be less'
                          ' than or equal to rank of then and'
                          ' else expressions. ndim(condition)=' +
-                         str(cond_ndim) + ', ndim(then_expression)'
-                         '=' + str(expr_ndim))
+                         str(ndim_cond) + ', ndim(then_expression)'
+                         '=' + str(ndim_expr))
     elif ndim_cond < ndim_expr:
         shape_expr = int_shape(then_expression)
         ndim_diff = ndim_expr - ndim_cond


### PR DESCRIPTION
This fix tries to fix a couple of issues in the error string of `def switch(..` where `cond_ndim` and `expr_ndim` are undefined, and should be replaced with `ndim_cond` and `ndim_expr`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>