### PR TITLE
Add `depthconv_conv2d` tests

### DIFF
--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -4,7 +4,6 @@ import os
 from multiprocessing import Process, Queue
 from keras.utils.test_utils import keras_test
 from keras.utils.test_utils import layer_test
-from keras.utils.generic_utils import CustomObjectScope
 from keras.models import Sequential
 from keras import applications
 from keras import backend as K
@@ -168,55 +167,6 @@ def test_nasnet():
     _test_application_notop(app, last_dim)
     _test_application_variable_input_channels(app, last_dim)
     _test_app_pooling(app, last_dim)
-
-
-@pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TF backend')
-@keras_test
-def test_depthwise_conv_2d():
-    _convolution_paddings = ['valid', 'same']
-    num_samples = 2
-    stack_size = 3
-    num_row = 7
-    num_col = 6
-
-    with CustomObjectScope(
-        {'relu6': applications.mobilenet.relu6,
-         'DepthwiseConv2D': applications.mobilenet.DepthwiseConv2D}):
-        for padding in _convolution_paddings:
-            for strides in [(1, 1), (2, 2)]:
-                for multiplier in [1, 2]:
-                    if padding == 'same' and strides != (1, 1):
-                        continue
-
-                    layer_test(applications.mobilenet.DepthwiseConv2D,
-                               kwargs={'kernel_size': (3, 3),
-                                       'padding': padding,
-                                       'strides': strides,
-                                       'depth_multiplier': multiplier},
-                               input_shape=(num_samples,
-                                            num_row,
-                                            num_col,
-                                            stack_size))
-
-        layer_test(applications.mobilenet.DepthwiseConv2D,
-                   kwargs={'kernel_size': 3,
-                           'padding': padding,
-                           'data_format': 'channels_first',
-                           'activation': None,
-                           'depthwise_regularizer': 'l2',
-                           'bias_regularizer': 'l2',
-                           'activity_regularizer': 'l2',
-                           'depthwise_constraint': 'unit_norm',
-                           'strides': strides,
-                           'depth_multiplier': multiplier},
-                   input_shape=(num_samples, stack_size, num_row, num_col))
-
-        # Test invalid use case
-        with pytest.raises(ValueError):
-            Sequential([applications.mobilenet.DepthwiseConv2D(
-                kernel_size=3,
-                padding=padding,
-                batch_input_shape=(None, None, 5, None))])
 
 
 if __name__ == '__main__':

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -844,6 +844,28 @@ class TestBackend(object):
             with pytest.raises(ValueError):
                 k.conv3d(k.variable(xval), k.variable(kernel_val), data_format='channels_middle')
 
+    @pytest.mark.parametrize('k', [KTF], ids=['TensorFlow'])
+    def test_depthwise_conv_2d(self, k):
+        for data_format in ['channels_first', 'channels_last']:
+            x_shape = (4, 4)
+            if data_format == 'channels_first':
+                input_shape = (2, 3) + x_shape
+            elif data_format == 'channels_last':
+                input_shape = (2,) + x_shape + (3,)
+            kernel_shape = (3, 3, 3, 2)
+
+            x_val = np.ones(input_shape)
+            kernel_val = np.arange(np.prod(kernel_shape)).reshape(kernel_shape)
+            z = k.eval(k.depthwise_conv2d(k.variable(x_val), k.variable(kernel_val),
+                                          data_format=data_format))
+
+            for z_i in np.split(z, 6, axis=1 if data_format == 'channels_first' else -1):
+                assert_allclose(z_i, z_i[0] * np.ones_like(z_i))
+
+        # Test invalid use cases
+        with pytest.raises(ValueError):
+            k.depthwise_conv2d(k.variable(x_val), k.variable(kernel_val), data_format='channels_middle')
+
     def test_pool2d(self):
         check_single_tensor_operation('pool2d', (5, 10, 12, 3),
                                       BACKENDS, cntk_dynamicity=True,

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -4,8 +4,6 @@ from numpy.testing import assert_allclose
 
 from keras.utils.test_utils import layer_test
 from keras.utils.test_utils import keras_test
-from keras.utils.generic_utils import CustomObjectScope
-from keras import applications
 from keras import backend as K
 from keras.engine.topology import InputLayer
 from keras.layers import convolutional
@@ -934,56 +932,6 @@ def test_cropping_3d():
         layer = convolutional.Cropping3D(cropping=((1, 1),))
     with pytest.raises(ValueError):
         layer = convolutional.Cropping3D(cropping=lambda x: x)
-
-
-@pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TF backend')
-@keras_test
-def test_depthwise_conv_2d():
-    _convolution_paddings = ['valid', 'same']
-    num_samples = 2
-    stack_size = 3
-    num_row = 7
-    num_col = 6
-
-    with CustomObjectScope(
-        {'relu6': applications.mobilenet.relu6,
-         'DepthwiseConv2D': applications.mobilenet.DepthwiseConv2D}):
-        for padding in _convolution_paddings:
-            for strides in [(1, 1), (2, 2)]:
-                for multiplier in [1, 2]:
-                    if padding == 'same' and strides != (1, 1):
-                        continue
-
-                    layer_test(applications.mobilenet.DepthwiseConv2D,
-                               kwargs={'kernel_size': (3, 3),
-                                       'padding': padding,
-                                       'strides': strides,
-                                       'depth_multiplier': multiplier},
-                               input_shape=(num_samples,
-                                            num_row,
-                                            num_col,
-                                            stack_size))
-
-        layer_test(applications.mobilenet.DepthwiseConv2D,
-                   kwargs={'kernel_size': 3,
-                           'padding': padding,
-                           'data_format': 'channels_first',
-                           'activation': None,
-                           'depthwise_regularizer': 'l2',
-                           'bias_regularizer': 'l2',
-                           'activity_regularizer': 'l2',
-                           'depthwise_constraint': 'unit_norm',
-                           'strides': strides,
-                           'depth_multiplier': multiplier},
-                   input_shape=(num_samples, stack_size, num_row, num_col))
-
-        # Test invalid use case
-        with pytest.raises(ValueError):
-            Sequential([applications.mobilenet.DepthwiseConv2D(
-                kernel_size=3,
-                padding=padding,
-                batch_input_shape=(None, None, 5, None))])
-
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
This PR adds `depthconv_conv2d` tests by immigrating existing codes from "applications_test.py" to "convolutional_test.py". As the "application_test.py" begins to run conditionally, regular tests can not hit `depthconv_conv2d` (lines 3503-3522 in keras/backend/tensorflow_backend.py, see [one](https://travis-ci.org/keras-team/keras/jobs/334191656) of the recent builds).