### PR TITLE
Update cuda & cudnn version for tensorflow 1.5

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-ARG cuda_version=8.0
-ARG cudnn_version=6
+ARG cuda_version=9.0
+ARG cudnn_version=7
 FROM nvidia/cuda:${cuda_version}-cudnn${cudnn_version}-devel
 
 ENV CONDA_DIR /opt/conda

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,8 +7,8 @@ DOCKER_FILE=Dockerfile
 DOCKER=GPU=$(GPU) nvidia-docker
 BACKEND=tensorflow
 PYTHON_VERSION?=3.6
-CUDA_VERSION?=8.0
-CUDNN_VERSION?=6
+CUDA_VERSION?=9.0
+CUDNN_VERSION?=7
 TEST=tests/
 SRC?=$(shell dirname `pwd`)
 


### PR DESCRIPTION
As Tensorflow 1.5 is no longer compatible with CUDA 8 and CUDNN 6, this PR just updates the CUDA and CUDNN versions in the Dockerfile and Makefile.