### PR TITLE
(1,1) tuple instead of None will crash AveragePooling2D (#9241)

### DIFF
--- a/keras/layers/pooling.py
+++ b/keras/layers/pooling.py
@@ -266,6 +266,8 @@ class AveragePooling2D(_Pooling2D):
     @interfaces.legacy_pooling2d_support
     def __init__(self, pool_size=(2, 2), strides=None, padding='valid',
                  data_format=None, **kwargs):
+        if pool_size==(1,1):
+            pool_size=None
         super(AveragePooling2D, self).__init__(pool_size, strides, padding,
                                                data_format, **kwargs)
 

--- a/keras/layers/pooling.py
+++ b/keras/layers/pooling.py
@@ -266,8 +266,8 @@ class AveragePooling2D(_Pooling2D):
     @interfaces.legacy_pooling2d_support
     def __init__(self, pool_size=(2, 2), strides=None, padding='valid',
                  data_format=None, **kwargs):
-        if pool_size==(1,1):
-            pool_size=None
+        if pool_size == (1, 1):
+            pool_size = None
         super(AveragePooling2D, self).__init__(pool_size, strides, padding,
                                                data_format, **kwargs)
 

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -400,9 +400,9 @@ def test_averagepooling_2d():
                        'data_format': 'channels_first'},
                input_shape=(3, 4, 5, 6))
     layer_test(convolutional.AveragePooling2D,
-               kwargs={'strides': None,
+               kwargs={'strides': (1, 1),
                        'padding': 'valid',
-                       'pool_size': (2, 2),
+                       'pool_size': None,
                        'data_format': 'channels_first'},
                input_shape=(3, 4, 5, 6))
 

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -402,6 +402,12 @@ def test_averagepooling_2d():
     layer_test(convolutional.AveragePooling2D,
                kwargs={'strides': (1, 1),
                        'padding': 'valid',
+                       'pool_size': (1, 1),
+                       'data_format': 'channels_first'},
+               input_shape=(3, 4, 5, 6))
+    layer_test(convolutional.AveragePooling2D,
+               kwargs={'strides': (1, 1),
+                       'padding': 'valid',
                        'pool_size': None,
                        'data_format': 'channels_first'},
                input_shape=(3, 4, 5, 6))

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -399,6 +399,12 @@ def test_averagepooling_2d():
                        'pool_size': (2, 2),
                        'data_format': 'channels_first'},
                input_shape=(3, 4, 5, 6))
+    layer_test(convolutional.AveragePooling2D,
+               kwargs={'strides': None,
+                       'padding': 'valid',
+                       'pool_size': (2, 2),
+                       'data_format': 'channels_first'},
+               input_shape=(3, 4, 5, 6))
 
 
 @keras_test


### PR DESCRIPTION
(1,1) tuple caused a kernel crash in iPython running Python 3 and Keras.