### PR TITLE
Fix __call__ for Bidirectional wrapper

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -275,6 +275,7 @@ class Bidirectional(Wrapper):
         self.supports_masking = True
         self._trainable = True
         super(Bidirectional, self).__init__(layer, **kwargs)
+        self.input_spec = [InputSpec(ndim=3)]
 
     @property
     def trainable(self):
@@ -313,6 +314,51 @@ class Bidirectional(Wrapper):
             return [output_shape] + state_shape + copy.copy(state_shape)
         return output_shape
 
+    def __call__(self, inputs, initial_state=None, **kwargs):
+        # Not supporting constants now
+        inputs, initial_state, _ = self.forward_layer._standardize_args(
+            inputs, initial_state, None)
+
+        if initial_state is None:
+            return super(Bidirectional, self).__call__(inputs, **kwargs)
+
+        # Check if `initial_state` can be splitted into half
+        num_states = len(initial_state)
+        if num_states % 2 > 0:
+            raise ValueError(
+                'When passing `initial_state` to a Bidirectional RNN, the state '
+                'should be a list containing the states of the underlying RNNs. '
+                'Found: ' + str(initial_state))
+
+        # Applies the same workaround as in `RNN.__call__`, without handling constants
+        kwargs['initial_state'] = initial_state
+        additional_inputs = initial_state
+        additional_specs = [InputSpec(shape=K.int_shape(state))
+                            for state in initial_state]
+        self.forward_layer.state_spec = additional_specs[:num_states // 2]
+        self.backward_layer.state_spec = additional_specs[num_states // 2:]
+
+        is_keras_tensor = hasattr(additional_inputs[0], '_keras_history')
+        for tensor in additional_inputs:
+            if hasattr(tensor, '_keras_history') != is_keras_tensor:
+                raise ValueError('The initial state of a Bidirectional'
+                                 ' layer cannot be specified with a mix of'
+                                 ' Keras tensors and non-Keras tensors')
+
+        if is_keras_tensor:
+            # Compute the full input spec, including state
+            full_input = [inputs] + additional_inputs
+            full_input_spec = self.input_spec + additional_specs
+
+            # Perform the call with temporarily replaced input_spec
+            original_input_spec = self.input_spec
+            self.input_spec = full_input_spec
+            output = super(Bidirectional, self).__call__(full_input, **kwargs)
+            self.input_spec = original_input_spec
+            return output
+        else:
+            return super(Bidirectional, self).__call__(inputs, **kwargs)
+
     def call(self, inputs, training=None, mask=None, initial_state=None):
         kwargs = {}
         if has_arg(self.layer.call, 'training'):
@@ -321,11 +367,6 @@ class Bidirectional(Wrapper):
             kwargs['mask'] = mask
 
         if initial_state is not None and has_arg(self.layer.call, 'initial_state'):
-            if not isinstance(initial_state, list):
-                raise ValueError(
-                    'When passing `initial_state` to a Bidirectional RNN, the state '
-                    'should be a list containing the states of the underlying RNNs. '
-                    'Found: ' + str(initial_state))
             forward_state = initial_state[:len(initial_state) // 2]
             backward_state = initial_state[len(initial_state) // 2:]
             y = self.forward_layer.call(inputs, initial_state=forward_state, **kwargs)


### PR DESCRIPTION
Fix a bug in model topology when `initial_state` is provided to the `Bidirectional` wrapper. `initial_state` should be handled in a same way as in `RNN.__call__`.

```python
input1 = Input(shape=(None, 5))
input2 = Input(shape=(None, 5))
states = Bidirectional(GRU(2, return_state=True))(input1)[1:]
out = Bidirectional(GRU(2, return_sequences=True))(input2, initial_state=states)
model = Model([input1, input2], out)
print(model.layers)
model.summary()
```
Outputs:
```
[<keras.engine.topology.InputLayer object at 0x117d760f0>, <keras.layers.wrappers.Bidirectional object at 0x117ec5550>]
_________________________________________________________________
Layer (type)                 Output Shape              Param #
=================================================================
input_2 (InputLayer)         (None, None, 5)           0
_________________________________________________________________
bidirectional_2 (Bidirection (None, None, 4)           96
=================================================================
Total params: 96
Trainable params: 96
Non-trainable params: 0
_________________________________________________________________

```
This PR basically copies `RNN.__call__` into `Bidirectional.__call__`, but without the lines handling `constants`.

Also modifies `wrappers_test.test_Bidirectional_state_reuse` to cover this use case.