### PR TITLE
Add support for `constants` in Bidirectional wrapper

### DIFF
--- a/keras/layers/convolutional_recurrent.py
+++ b/keras/layers/convolutional_recurrent.py
@@ -11,6 +11,7 @@ from .. import initializers
 from .. import regularizers
 from .. import constraints
 from .recurrent import _generate_dropout_mask
+from .recurrent import _standardize_args
 
 import numpy as np
 import warnings
@@ -270,8 +271,8 @@ class ConvRNN2D(RNN):
             return [initial_state]
 
     def __call__(self, inputs, initial_state=None, constants=None, **kwargs):
-        inputs, initial_state, constants = self._standardize_args(
-            inputs, initial_state, constants)
+        inputs, initial_state, constants = _standardize_args(
+            inputs, initial_state, constants, self._num_constants)
 
         if initial_state is None and constants is None:
             return super(ConvRNN2D, self).__call__(inputs, **kwargs)

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -12,6 +12,8 @@ from ..engine.topology import _object_list_uid
 from ..utils.generic_utils import has_arg
 from .. import backend as K
 
+from . import recurrent
+
 
 class Wrapper(Layer):
     """Abstract wrapper base class.
@@ -316,8 +318,8 @@ class Bidirectional(Wrapper):
         return output_shape
 
     def __call__(self, inputs, initial_state=None, constants=None, **kwargs):
-        inputs, initial_state, constants = self._standardize_args(
-            inputs, initial_state, constants)
+        inputs, initial_state, constants = recurrent._standardize_args(
+            inputs, initial_state, constants, self._num_constants)
 
         if initial_state is None and constants is None:
             return super(Bidirectional, self).__call__(inputs, **kwargs)
@@ -433,48 +435,6 @@ class Bidirectional(Wrapper):
                 return output + states
             return [output] + states
         return output
-
-    def _standardize_args(self, inputs, initial_state, constants):
-        """Standardize `__call__` to a single list of tensor inputs.
-
-        This method is taken from `RNN` as it is.
-
-        When running a model loaded from file, the input tensors
-        `initial_state` and `constants` can be passed to `RNN.__call__` as part
-        of `inputs` instead of by the dedicated keyword arguments. This method
-        makes sure the arguments are separated and that `initial_state` and
-        `constants` are lists of tensors (or None).
-
-        # Arguments
-            inputs: tensor or list/tuple of tensors
-            initial_state: tensor or list of tensors or None
-            constants: tensor or list of tensors or None
-
-        # Returns
-            inputs: tensor
-            initial_state: list of tensors or None
-            constants: list of tensors or None
-        """
-        if isinstance(inputs, list):
-            assert initial_state is None and constants is None
-            if self._num_constants is not None:
-                constants = inputs[-self._num_constants:]
-                inputs = inputs[:-self._num_constants]
-            if len(inputs) > 1:
-                initial_state = inputs[1:]
-            inputs = inputs[0]
-
-        def to_list_or_none(x):
-            if x is None or isinstance(x, list):
-                return x
-            if isinstance(x, tuple):
-                return list(x)
-            return [x]
-
-        initial_state = to_list_or_none(initial_state)
-        constants = to_list_or_none(constants)
-
-        return inputs, initial_state, constants
 
     def reset_states(self):
         self.forward_layer.reset_states()

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -276,6 +276,7 @@ class Bidirectional(Wrapper):
         self._trainable = True
         super(Bidirectional, self).__init__(layer, **kwargs)
         self.input_spec = layer.input_spec
+        self._num_constants = None
 
     @property
     def trainable(self):
@@ -314,36 +315,45 @@ class Bidirectional(Wrapper):
             return [output_shape] + state_shape + copy.copy(state_shape)
         return output_shape
 
-    def __call__(self, inputs, initial_state=None, **kwargs):
-        if isinstance(inputs, list):
-            if len(inputs) > 1:
-                initial_state = inputs[1:]
-            inputs = inputs[0]
+    def __call__(self, inputs, initial_state=None, constants=None, **kwargs):
+        inputs, initial_state, constants = self._standardize_args(
+            inputs, initial_state, constants)
 
-        if initial_state is None:
+        if initial_state is None and constants is None:
             return super(Bidirectional, self).__call__(inputs, **kwargs)
 
-        # Standardize `initial_state` into list
-        if isinstance(initial_state, tuple):
-            initial_state = list(initial_state)
-        elif not isinstance(initial_state, list):
-            initial_state = [initial_state]
+        # Applies the same workaround as in `RNN.__call__`
+        additional_inputs = []
+        additional_specs = []
+        if initial_state is not None:
+            # Check if `initial_state` can be splitted into half
+            num_states = len(initial_state)
+            if num_states % 2 > 0:
+                raise ValueError(
+                    'When passing `initial_state` to a Bidirectional RNN, '
+                    'the state should be a list containing the states of '
+                    'the underlying RNNs. '
+                    'Found: ' + str(initial_state))
 
-        # Check if `initial_state` can be splitted into half
-        num_states = len(initial_state)
-        if num_states % 2 > 0:
-            raise ValueError(
-                'When passing `initial_state` to a Bidirectional RNN, the state '
-                'should be a list containing the states of the underlying RNNs. '
-                'Found: ' + str(initial_state))
+            kwargs['initial_state'] = initial_state
+            additional_inputs += initial_state
+            state_specs = [InputSpec(shape=K.int_shape(state))
+                           for state in initial_state]
+            self.forward_layer.state_spec = state_specs[:num_states // 2]
+            self.backward_layer.state_spec = state_specs[num_states // 2:]
+            additional_specs += state_specs
+        if constants is not None:
+            kwargs['constants'] = constants
+            additional_inputs += constants
+            constants_spec = [InputSpec(shape=K.int_shape(constant))
+                              for constant in constants]
+            self.forward_layer.constants_spec = constants_spec
+            self.backward_layer.constants_spec = constants_spec
+            additional_specs += constants_spec
 
-        # Applies the same workaround as in `RNN.__call__`, without handling constants
-        kwargs['initial_state'] = initial_state
-        additional_inputs = initial_state
-        additional_specs = [InputSpec(shape=K.int_shape(state))
-                            for state in initial_state]
-        self.forward_layer.state_spec = additional_specs[:num_states // 2]
-        self.backward_layer.state_spec = additional_specs[num_states // 2:]
+            self._num_constants = len(constants)
+            self.forward_layer._num_constants = self._num_constants
+            self.backward_layer._num_constants = self._num_constants
 
         is_keras_tensor = K.is_keras_tensor(additional_inputs[0])
         for tensor in additional_inputs:
@@ -368,12 +378,19 @@ class Bidirectional(Wrapper):
         else:
             return super(Bidirectional, self).__call__(inputs, **kwargs)
 
-    def call(self, inputs, training=None, mask=None, initial_state=None):
+    def call(self,
+             inputs,
+             mask=None,
+             training=None,
+             initial_state=None,
+             constants=None):
         kwargs = {}
         if has_arg(self.layer.call, 'training'):
             kwargs['training'] = training
         if has_arg(self.layer.call, 'mask'):
             kwargs['mask'] = mask
+        if has_arg(self.layer.call, 'constants'):
+            kwargs['constants'] = constants
 
         if initial_state is not None and has_arg(self.layer.call, 'initial_state'):
             forward_state = initial_state[:len(initial_state) // 2]
@@ -416,6 +433,48 @@ class Bidirectional(Wrapper):
                 return output + states
             return [output] + states
         return output
+
+    def _standardize_args(self, inputs, initial_state, constants):
+        """Standardize `__call__` to a single list of tensor inputs.
+
+        This method is taken from `RNN` as it is.
+
+        When running a model loaded from file, the input tensors
+        `initial_state` and `constants` can be passed to `RNN.__call__` as part
+        of `inputs` instead of by the dedicated keyword arguments. This method
+        makes sure the arguments are separated and that `initial_state` and
+        `constants` are lists of tensors (or None).
+
+        # Arguments
+            inputs: tensor or list/tuple of tensors
+            initial_state: tensor or list of tensors or None
+            constants: tensor or list of tensors or None
+
+        # Returns
+            inputs: tensor
+            initial_state: list of tensors or None
+            constants: list of tensors or None
+        """
+        if isinstance(inputs, list):
+            assert initial_state is None and constants is None
+            if self._num_constants is not None:
+                constants = inputs[-self._num_constants:]
+                inputs = inputs[:-self._num_constants]
+            if len(inputs) > 1:
+                initial_state = inputs[1:]
+            inputs = inputs[0]
+
+        def to_list_or_none(x):
+            if x is None or isinstance(x, list):
+                return x
+            if isinstance(x, tuple):
+                return list(x)
+            return [x]
+
+        initial_state = to_list_or_none(initial_state)
+        constants = to_list_or_none(constants)
+
+        return inputs, initial_state, constants
 
     def reset_states(self):
         self.forward_layer.reset_states()
@@ -473,5 +532,18 @@ class Bidirectional(Wrapper):
 
     def get_config(self):
         config = {'merge_mode': self.merge_mode}
+        if self._num_constants is not None:
+            config['num_constants'] = self._num_constants
+
         base_config = super(Bidirectional, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        from . import deserialize as deserialize_layer
+        rnn_layer = deserialize_layer(config.pop('layer'),
+                                      custom_objects=custom_objects)
+        num_constants = config.pop('num_constants', None)
+        layer = cls(rnn_layer, **config)
+        layer._num_constants = num_constants
+        return layer

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -490,11 +490,20 @@ class Bidirectional(Wrapper):
     def compute_mask(self, inputs, mask):
         if self.return_sequences:
             if not self.merge_mode:
-                return [mask, mask]
+                output_mask = [mask, mask]
             else:
-                return mask
+                output_mask = mask
         else:
-            return None
+            output_mask = [None, None] if not self.merge_mode else None
+
+        if self.return_state:
+            states = self.forward_layer.states
+            state_mask = [None for _ in states]
+            if isinstance(output_mask, list):
+                return output_mask + state_mask * 2
+            return [output_mask] + state_mask * 2
+
+        return output_mask
 
     @property
     def trainable_weights(self):

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -448,6 +448,8 @@ class Bidirectional(Wrapper):
         self.built = True
 
     def compute_mask(self, inputs, mask):
+        if isinstance(mask, list):
+            mask = mask[0]
         if self.return_sequences:
             if not self.merge_mode:
                 output_mask = [mask, mask]

--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -222,6 +222,15 @@ def test_Bidirectional():
         model.compile(loss='mse', optimizer='sgd')
         model.fit(x, y, epochs=1, batch_size=1)
 
+        # test with functional API with unknown length
+        inputs = Input((None, dim))
+        outputs = wrappers.Bidirectional(rnn(output_dim, dropout=dropout_rate,
+                                             recurrent_dropout=dropout_rate),
+                                         merge_mode=mode)(inputs)
+        model = Model(inputs, outputs)
+        model.compile(loss='mse', optimizer='sgd')
+        model.fit(x, y, epochs=1, batch_size=1)
+
         # Bidirectional and stateful
         inputs = Input(batch_shape=(1, timesteps, dim))
         outputs = wrappers.Bidirectional(rnn(output_dim, stateful=True),

--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -1,8 +1,11 @@
 import pytest
 import numpy as np
+import copy
 from numpy.testing import assert_allclose
 from keras.utils.test_utils import keras_test
-from keras.layers import wrappers, Input
+from keras.utils import CustomObjectScope
+from keras.layers import wrappers, Input, Layer
+from keras.layers import RNN
 from keras import layers
 from keras.models import Sequential, Model, model_from_json
 from keras import backend as K
@@ -342,6 +345,177 @@ def test_Bidirectional_state_reuse():
     inputs = [np.random.rand(samples, timesteps, dim),
               np.random.rand(samples, timesteps, dim)]
     outputs = model.predict(inputs)
+
+
+@keras_test
+def test_Bidirectional_with_constants():
+    class RNNCellWithConstants(Layer):
+        def __init__(self, units, **kwargs):
+            self.units = units
+            self.state_size = units
+            super(RNNCellWithConstants, self).__init__(**kwargs)
+
+        def build(self, input_shape):
+            if not isinstance(input_shape, list):
+                raise TypeError('expects constants shape')
+            [input_shape, constant_shape] = input_shape
+            # will (and should) raise if more than one constant passed
+
+            self.input_kernel = self.add_weight(
+                shape=(input_shape[-1], self.units),
+                initializer='uniform',
+                name='kernel')
+            self.recurrent_kernel = self.add_weight(
+                shape=(self.units, self.units),
+                initializer='uniform',
+                name='recurrent_kernel')
+            self.constant_kernel = self.add_weight(
+                shape=(constant_shape[-1], self.units),
+                initializer='uniform',
+                name='constant_kernel')
+            self.built = True
+
+        def call(self, inputs, states, constants):
+            [prev_output] = states
+            [constant] = constants
+            h_input = K.dot(inputs, self.input_kernel)
+            h_state = K.dot(prev_output, self.recurrent_kernel)
+            h_const = K.dot(constant, self.constant_kernel)
+            output = h_input + h_state + h_const
+            return output, [output]
+
+        def get_config(self):
+            config = {'units': self.units}
+            base_config = super(RNNCellWithConstants, self).get_config()
+            return dict(list(base_config.items()) + list(config.items()))
+
+    # Test basic case.
+    x = Input((None, 5))
+    c = Input((3,))
+    cell = RNNCellWithConstants(32)
+    custom_objects = {'RNNCellWithConstants': RNNCellWithConstants}
+    with CustomObjectScope(custom_objects):
+        layer = wrappers.Bidirectional(RNN(cell))
+    y = layer(x, constants=c)
+    model = Model([x, c], y)
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(
+        [np.zeros((6, 5, 5)), np.zeros((6, 3))],
+        np.zeros((6, 64))
+    )
+
+    # Test basic case serialization.
+    x_np = np.random.random((6, 5, 5))
+    c_np = np.random.random((6, 3))
+    y_np = model.predict([x_np, c_np])
+    weights = model.get_weights()
+    config = layer.get_config()
+    with CustomObjectScope(custom_objects):
+        layer = wrappers.Bidirectional.from_config(copy.deepcopy(config))
+    y = layer(x, constants=c)
+    model = Model([x, c], y)
+    model.set_weights(weights)
+    y_np_2 = model.predict([x_np, c_np])
+    assert_allclose(y_np, y_np_2, atol=1e-4)
+
+    # test flat list inputs
+    with CustomObjectScope(custom_objects):
+        layer = wrappers.Bidirectional.from_config(copy.deepcopy(config))
+    y = layer([x, c])
+    model = Model([x, c], y)
+    model.set_weights(weights)
+    y_np_3 = model.predict([x_np, c_np])
+    assert_allclose(y_np, y_np_3, atol=1e-4)
+
+
+@keras_test
+def test_Bidirectional_with_constants_layer_passing_initial_state():
+    class RNNCellWithConstants(Layer):
+        def __init__(self, units, **kwargs):
+            self.units = units
+            self.state_size = units
+            super(RNNCellWithConstants, self).__init__(**kwargs)
+
+        def build(self, input_shape):
+            if not isinstance(input_shape, list):
+                raise TypeError('expects constants shape')
+            [input_shape, constant_shape] = input_shape
+            # will (and should) raise if more than one constant passed
+
+            self.input_kernel = self.add_weight(
+                shape=(input_shape[-1], self.units),
+                initializer='uniform',
+                name='kernel')
+            self.recurrent_kernel = self.add_weight(
+                shape=(self.units, self.units),
+                initializer='uniform',
+                name='recurrent_kernel')
+            self.constant_kernel = self.add_weight(
+                shape=(constant_shape[-1], self.units),
+                initializer='uniform',
+                name='constant_kernel')
+            self.built = True
+
+        def call(self, inputs, states, constants):
+            [prev_output] = states
+            [constant] = constants
+            h_input = K.dot(inputs, self.input_kernel)
+            h_state = K.dot(prev_output, self.recurrent_kernel)
+            h_const = K.dot(constant, self.constant_kernel)
+            output = h_input + h_state + h_const
+            return output, [output]
+
+        def get_config(self):
+            config = {'units': self.units}
+            base_config = super(RNNCellWithConstants, self).get_config()
+            return dict(list(base_config.items()) + list(config.items()))
+
+    # Test basic case.
+    x = Input((None, 5))
+    c = Input((3,))
+    s_for = Input((32,))
+    s_bac = Input((32,))
+    cell = RNNCellWithConstants(32)
+    custom_objects = {'RNNCellWithConstants': RNNCellWithConstants}
+    with CustomObjectScope(custom_objects):
+        layer = wrappers.Bidirectional(RNN(cell))
+    y = layer(x, initial_state=[s_for, s_bac], constants=c)
+    model = Model([x, s_for, s_bac, c], y)
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(
+        [np.zeros((6, 5, 5)), np.zeros((6, 32)), np.zeros((6, 32)), np.zeros((6, 3))],
+        np.zeros((6, 64))
+    )
+
+    # Test basic case serialization.
+    x_np = np.random.random((6, 5, 5))
+    s_fw_np = np.random.random((6, 32))
+    s_bk_np = np.random.random((6, 32))
+    c_np = np.random.random((6, 3))
+    y_np = model.predict([x_np, s_fw_np, s_bk_np, c_np])
+    weights = model.get_weights()
+    config = layer.get_config()
+    with CustomObjectScope(custom_objects):
+        layer = wrappers.Bidirectional.from_config(copy.deepcopy(config))
+    y = layer(x, initial_state=[s_for, s_bac], constants=c)
+    model = Model([x, s_for, s_bac, c], y)
+    model.set_weights(weights)
+    y_np_2 = model.predict([x_np, s_fw_np, s_bk_np, c_np])
+    assert_allclose(y_np, y_np_2, atol=1e-4)
+
+    # verify that state is used
+    y_np_2_different_s = model.predict([x_np, s_fw_np + 10., s_bk_np + 10., c_np])
+    with pytest.raises(AssertionError):
+        assert_allclose(y_np, y_np_2_different_s, atol=1e-4)
+
+    # test flat list inputs
+    with CustomObjectScope(custom_objects):
+        layer = wrappers.Bidirectional.from_config(copy.deepcopy(config))
+    y = layer([x, s_for, s_bac, c])
+    model = Model([x, s_for, s_bac, c], y)
+    model.set_weights(weights)
+    y_np_3 = model.predict([x_np, s_fw_np, s_bk_np, c_np])
+    assert_allclose(y_np, y_np_3, atol=1e-4)
 
 
 @keras_test


### PR DESCRIPTION
Continuing #9248, this PR adds support for passing `constants` to Bidirectional wrapper for RNN.