### PR TITLE
fixed RemoteMonitor: Json to handle np.float32 and np.int32 types

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -550,7 +550,7 @@ class RemoteMonitor(Callback):
         if isinstance(v, (np.float16, np.float32)):
             send[k] = np.float64(v)
         elif isinstance(v, (np.int16, np.int32)):
-            send[k] = np.float64(v)
+            send[k] = np.int64(v)
         try:
             requests.post(self.root + self.path,
                           {self.field: json.dumps(send)},

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -546,11 +546,10 @@ class RemoteMonitor(Callback):
         send = {}
         send['epoch'] = epoch
         for k, v in logs.items():
-            send[k] = v
-        if isinstance(v, (np.float16, np.float32)):
-            send[k] = np.float64(v)
-        elif isinstance(v, (np.int16, np.int32)):
-            send[k] = np.int64(v)
+            if isinstance(v, (np.ndarray, np.generic)):
+                send[k] = v.item()
+            else:
+                send[k] = v
         try:
             requests.post(self.root + self.path,
                           {self.field: json.dumps(send)},

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -913,7 +913,7 @@ class ReduceLROnPlateau(Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
-        logs['lr'] = float(K.get_value(self.model.optimizer.lr))
+        logs['lr'] = K.get_value(self.model.optimizer.lr)
         current = logs.get(self.monitor)
         if current is None:
             warnings.warn(

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -89,8 +89,8 @@ class CallbackList(object):
         self._delta_ts_batch_begin.append(time.time() - t_before_callbacks)
         delta_t_median = np.median(self._delta_ts_batch_begin)
         if (self._delta_t_batch > 0. and
-           delta_t_median > 0.95 * self._delta_t_batch and
-           delta_t_median > 0.1):
+            delta_t_median > 0.95 * self._delta_t_batch and
+            delta_t_median > 0.1):
             warnings.warn('Method on_batch_begin() is slow compared '
                           'to the batch update (%f). Check your callbacks.'
                           % delta_t_median)
@@ -113,7 +113,7 @@ class CallbackList(object):
         self._delta_ts_batch_end.append(time.time() - t_before_callbacks)
         delta_t_median = np.median(self._delta_ts_batch_end)
         if (self._delta_t_batch > 0. and
-           (delta_t_median > 0.95 * self._delta_t_batch and delta_t_median > 0.1)):
+            (delta_t_median > 0.95 * self._delta_t_batch and delta_t_median > 0.1)):
             warnings.warn('Method on_batch_end() is slow compared '
                           'to the batch update (%f). Check your callbacks.'
                           % delta_t_median)
@@ -547,6 +547,10 @@ class RemoteMonitor(Callback):
         send['epoch'] = epoch
         for k, v in logs.items():
             send[k] = v
+        if isinstance(v, (np.float16, np.float32)):
+            send[k] = np.float64(v)
+        elif isinstance(v, (np.int16, np.int32)):
+            send[k] = np.float64(v)
         try:
             requests.post(self.root + self.path,
                           {self.field: json.dumps(send)},
@@ -899,7 +903,7 @@ class ReduceLROnPlateau(Callback):
                           RuntimeWarning)
             self.mode = 'auto'
         if (self.mode == 'min' or
-           (self.mode == 'auto' and 'acc' not in self.monitor)):
+            (self.mode == 'auto' and 'acc' not in self.monitor)):
             self.monitor_op = lambda a, b: np.less(a, b - self.epsilon)
             self.best = np.Inf
         else:

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -89,8 +89,8 @@ class CallbackList(object):
         self._delta_ts_batch_begin.append(time.time() - t_before_callbacks)
         delta_t_median = np.median(self._delta_ts_batch_begin)
         if (self._delta_t_batch > 0. and
-            delta_t_median > 0.95 * self._delta_t_batch and
-            delta_t_median > 0.1):
+           delta_t_median > 0.95 * self._delta_t_batch and
+           delta_t_median > 0.1):
             warnings.warn('Method on_batch_begin() is slow compared '
                           'to the batch update (%f). Check your callbacks.'
                           % delta_t_median)
@@ -113,7 +113,7 @@ class CallbackList(object):
         self._delta_ts_batch_end.append(time.time() - t_before_callbacks)
         delta_t_median = np.median(self._delta_ts_batch_end)
         if (self._delta_t_batch > 0. and
-            (delta_t_median > 0.95 * self._delta_t_batch and delta_t_median > 0.1)):
+           (delta_t_median > 0.95 * self._delta_t_batch and delta_t_median > 0.1)):
             warnings.warn('Method on_batch_end() is slow compared '
                           'to the batch update (%f). Check your callbacks.'
                           % delta_t_median)
@@ -903,7 +903,7 @@ class ReduceLROnPlateau(Callback):
                           RuntimeWarning)
             self.mode = 'auto'
         if (self.mode == 'min' or
-            (self.mode == 'auto' and 'acc' not in self.monitor)):
+           (self.mode == 'auto' and 'acc' not in self.monitor)):
             self.monitor_op = lambda a, b: np.less(a, b - self.epsilon)
             self.best = np.Inf
         else:

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -913,7 +913,7 @@ class ReduceLROnPlateau(Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
-        logs['lr'] = K.get_value(self.model.optimizer.lr)
+        logs['lr'] = float(K.get_value(self.model.optimizer.lr))
         current = logs.get(self.monitor)
         if current is None:
             warnings.warn(


### PR DESCRIPTION
Previously lr log had dtype numpy.float32 which throws JSON serializable error if used along with Remote monitor callback.Fixed it by casting it to float.