### PR TITLE
Fix ImageDataGenerator preprocessing_function

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -907,7 +907,8 @@ class NumpyArrayIterator(Iterator):
                            dtype=K.floatx())
         for i, j in enumerate(index_array):
             x = self.x[j]
-            if self.image_data_generator.preprocessing_function: x = self.image_data_generator.preprocessing_function(x)
+            if self.image_data_generator.preprocessing_function:
+                x = self.image_data_generator.preprocessing_function(x)
             x = self.image_data_generator.random_transform(x.astype(K.floatx()))
             x = self.image_data_generator.standardize(x)
             batch_x[i] = x
@@ -1147,7 +1148,8 @@ class DirectoryIterator(Iterator):
                            grayscale=grayscale,
                            target_size=None,
                            interpolation=self.interpolation)
-            if self.image_data_generator.preprocessing_function: img = self.image_data_generator.preprocessing_function(img)
+            if self.image_data_generator.preprocessing_function:
+                img = self.image_data_generator.preprocessing_function(img)
             if self.target_size is not None:
                 width_height_tuple = (self.target_size[1], self.target_size[0])
                 if img.size != width_height_tuple:

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -555,8 +555,6 @@ class ImageDataGenerator(object):
         # Returns
             The inputs, normalized.
         """
-        if self.preprocessing_function:
-            x = self.preprocessing_function(x)
         if self.rescale:
             x *= self.rescale
         if self.samplewise_center:
@@ -909,6 +907,7 @@ class NumpyArrayIterator(Iterator):
                            dtype=K.floatx())
         for i, j in enumerate(index_array):
             x = self.x[j]
+            if self.image_data_generator.preprocessing_function: x = self.image_data_generator.preprocessing_function(x)
             x = self.image_data_generator.random_transform(x.astype(K.floatx()))
             x = self.image_data_generator.standardize(x)
             batch_x[i] = x
@@ -1146,8 +1145,20 @@ class DirectoryIterator(Iterator):
             fname = self.filenames[j]
             img = load_img(os.path.join(self.directory, fname),
                            grayscale=grayscale,
-                           target_size=self.target_size,
+                           target_size=None,
                            interpolation=self.interpolation)
+            if self.image_data_generator.preprocessing_function: img = self.image_data_generator.preprocessing_function(img)
+            if self.target_size is not None:
+                width_height_tuple = (self.target_size[1], self.target_size[0])
+                if img.size != width_height_tuple:
+                    if self.interpolation not in _PIL_INTERPOLATION_METHODS:
+                        raise ValueError(
+                            'Invalid interpolation method {} specified. Supported '
+                            'methods are {}'.format(
+                                self.interpolation,
+                                ", ".join(_PIL_INTERPOLATION_METHODS.keys())))
+                    resample = _PIL_INTERPOLATION_METHODS[self.interpolation]
+                    img = img.resize(width_height_tuple, resample)
             x = img_to_array(img, data_format=self.data_format)
             x = self.image_data_generator.random_transform(x)
             x = self.image_data_generator.standardize(x)

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -203,6 +203,30 @@ class TestImage(object):
         x1, y1 = dir_seq[5]
         with pytest.raises(ValueError):
             x1, y1 = dir_seq[9]
+        
+        # Test Preprocessing before load_img
+        def preprocess_test(img):
+            return img.resize((1,1))
+
+        generator = image.ImageDataGenerator(preprocessing_function=preprocess_test)
+        dir_seq = generator.flow_from_directory(str(tmpdir),
+                                                target_size=(26, 26),
+                                                color_mode='rgb',
+                                                batch_size=1,
+                                                class_mode='categorical')
+        
+        gen_x1, gen_y1 = dir_seq[1]
+
+        test_x1 = image.load_img(os.path.join(dir_seq.directory, dir_seq.filenames[1]),
+                                    grayscale=False)
+        test_x1 = preprocess_test(test_x1)
+        test_x1 = test_x1.resize((26,26))
+        test_x1 = image.img_to_array(test_x1)
+        test_x1 = dir_seq.image_data_generator.random_transform(test_x1)
+        test_x1 = dir_seq.image_data_generator.standardize(test_x1)
+
+        assert gen_x1.shape[1:] == test_x1.shape
+
 
     def test_directory_iterator_class_mode_input(self, tmpdir):
         tmpdir.join('class-1').mkdir()

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -206,7 +206,7 @@ class TestImage(object):
         
         # Test Preprocessing before resize
         def preprocess_test(img):
-            return img.resize((1,1))
+            return img.resize((1, 1))
 
         generator = image.ImageDataGenerator(preprocessing_function=preprocess_test)
         dir_seq = generator.flow_from_directory(str(tmpdir),
@@ -214,19 +214,18 @@ class TestImage(object):
                                                 color_mode='rgb',
                                                 batch_size=1,
                                                 class_mode='categorical')
-        
+
         gen_x1, gen_y1 = dir_seq[1]
 
         test_x1 = image.load_img(os.path.join(dir_seq.directory, dir_seq.filenames[1]),
-                                    grayscale=False)
+                                 grayscale=False)
         test_x1 = preprocess_test(test_x1)
-        test_x1 = test_x1.resize((26,26))
+        test_x1 = test_x1.resize((26, 26))
         test_x1 = image.img_to_array(test_x1)
         test_x1 = dir_seq.image_data_generator.random_transform(test_x1)
         test_x1 = dir_seq.image_data_generator.standardize(test_x1)
 
         assert gen_x1.shape[1:] == test_x1.shape
-
 
     def test_directory_iterator_class_mode_input(self, tmpdir):
         tmpdir.join('class-1').mkdir()

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -204,7 +204,7 @@ class TestImage(object):
         with pytest.raises(ValueError):
             x1, y1 = dir_seq[9]
         
-        # Test Preprocessing before load_img
+        # Test Preprocessing before resize
         def preprocess_test(img):
             return img.resize((1,1))
 

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -203,7 +203,7 @@ class TestImage(object):
         x1, y1 = dir_seq[5]
         with pytest.raises(ValueError):
             x1, y1 = dir_seq[9]
-        
+
         # Test Preprocessing before resize
         def preprocess_test(img):
             return img.resize((1, 1))


### PR DESCRIPTION
preprocessing_function must run before any other modification on image (by documentation)

by [issue](https://github.com/keras-team/keras/issues/9049)
Discussed on [keras-user-googlegroup](https://groups.google.com/forum/#!topic/keras-users/rjqLkpKIiH4), I suggested preprocessing function's option parameter for executing before resize.
But It must run before any modification according to documentation. [](url)