### PR TITLE
Fix stdout messes in `on_epoch_end` with verbose=1

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1114,7 +1114,7 @@ class Model(Container):
                 count_mode = 'steps'
             else:
                 count_mode = 'samples'
-            callbacks += [cbks.ProgbarLogger(count_mode)]
+            callbacks = [cbks.ProgbarLogger(count_mode)] + callbacks
         callbacks = cbks.CallbackList(callbacks)
         out_labels = out_labels or []
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1114,7 +1114,7 @@ class Model(Container):
                 count_mode = 'steps'
             else:
                 count_mode = 'samples'
-            callbacks = [cbks.ProgbarLogger(count_mode)] + callbacks
+            callbacks.insert(1, cbks.ProgbarLogger(count_mode))
         callbacks = cbks.CallbackList(callbacks)
         out_labels = out_labels or []
 
@@ -2085,7 +2085,7 @@ class Model(Container):
         self.history = cbks.History()
         callbacks = [cbks.BaseLogger()] + (callbacks or []) + [self.history]
         if verbose:
-            callbacks += [cbks.ProgbarLogger(count_mode='steps')]
+            callbacks.insert(1, cbks.ProgbarLogger(count_mode='steps'))
         callbacks = cbks.CallbackList(callbacks)
 
         # it's possible to callback a different model than self:


### PR DESCRIPTION
This PR will try to fix such issue in `Projects-Improvements`:

> When callbacks print something to stdout in on_epoch_end, this messes with the output of the progress bar in verbosity mode 1. Could we fix it?

Test script I'm using:
```python
import numpy as np
from keras.models import Sequential
from keras.layers import Dense
from keras.callbacks import Callback


class TestCallback(Callback):
    def on_epoch_end(self, epoch, logs={}):
        print('on_epoch_end triggered')
        

train_x = np.random.rand(10000, 10)
train_y = np.random.rand(10000)

model = Sequential([
    Dense(128, input_dim=10),
    Dense(1),
])
model.compile('sgd', 'mse')
model.fit(
    train_x, train_y, batch_size=16, epochs=2,
    callbacks=[TestCallback()], verbose=1
)
```

## Result before this patch
```
Epoch 1/2
10000/10000 [==============================] - 4s 436us/step - loss: 0.0922ch_end triggered
Epoch 2/2
10000/10000 [==============================] - 2s 170us/step - loss: 0.0824ch_end triggered
```
In which stdout of `TestCallback` is messed. (`0.0824ch_end_triggered` stuff)

## Result after this patch
```
Epoch 1/2
10000/10000 [==============================] - 4s 418us/step - loss: 0.0910
on_epoch_end triggered
Epoch 2/2
10000/10000 [==============================] - 2s 157us/step - loss: 0.0836
on_epoch_end triggered
```
The stdout of `TestCallback` works well.


BTW, should I add my test script into keras' test cases? Is there any other cases I haven't noticed yet?
