### PR TITLE
Fix examples/mnist_net2net.py type of list keys was float

### DIFF
--- a/examples/mnist_net2net.py
+++ b/examples/mnist_net2net.py
@@ -208,7 +208,7 @@ def deeper2net_conv2d(teacher_w):
     kh, kw, num_channel, filters = teacher_w.shape
     student_w = np.zeros_like(teacher_w)
     for i in range(filters):
-        student_w[(kh - 1) / 2, (kw - 1) / 2, i, i] = 1.
+        student_w[(kh - 1) // 2, (kw - 1) // 2, i, i] = 1.
     student_b = np.zeros(filters)
     return student_w, student_b
 


### PR DESCRIPTION
I tried to run `examples/mnist_net2net.py` and I got an error in my env.  
The error is similer to [this thread](https://stackoverflow.com/questions/34952651/only-integers-slices-ellipsis-numpy-newaxis-none-and-intege) and I fixed it.  

## error occured
```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-2-c38539c7e5b8> in <module>()
    385 # run the experiments
    386 net2wider_experiment()
--> 387 net2deeper_experiment()

<ipython-input-2-c38539c7e5b8> in net2deeper_experiment()
    375                               x_test, y_test,
    376                               init='net2deeper',
--> 377                               epochs=epochs)
    378 
    379 

<ipython-input-2-c38539c7e5b8> in make_deeper_student_model(teacher_model, x_train, y_train, x_test, y_test, init, epochs)
    301     if init == 'net2deeper':
    302         prev_w, _ = model.get_layer('conv2').get_weights()
--> 303         new_weights = deeper2net_conv2d(prev_w)
    304         model.add(Conv2D(64, 3, padding='same',
    305                          name='conv2-deeper', weights=new_weights))

<ipython-input-2-c38539c7e5b8> in deeper2net_conv2d(teacher_w)
    196     student_w = np.zeros_like(teacher_w)
    197     for i in range(filters):
--> 198         student_w[(kh - 1) / 2, (kw - 1) / 2, i, i] = 1.
    199     student_b = np.zeros(filters)
    200     return student_w, student_b

IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```

## my environment
```
# python -V
Python 3.6.2
# pip freeze | grep Keras
Keras==2.0.9
# pip freeze | grep numpy
numpy==1.13.3
```