### PR TITLE
create new DeviceSlice layer for multi-GPU workloads

### DIFF
--- a/keras/layers/__init__.py
+++ b/keras/layers/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from ..utils.generic_utils import deserialize_keras_object
+from ..utils.training_utils import DeviceSlice
 from ..engine import Layer
 from ..engine import Input
 from ..engine import InputLayer

--- a/keras/utils/__init__.py
+++ b/keras/utils/__init__.py
@@ -22,4 +22,5 @@ from .layer_utils import print_summary
 from .vis_utils import plot_model
 from .np_utils import to_categorical
 from .np_utils import normalize
+from .training_utils import DeviceSlice
 from .training_utils import multi_gpu_model


### PR DESCRIPTION
Fixes #8764.

The multi_gpu_model() currently creates a Lambda layer referencing the function
get_slice() which in-turn references a bunch of Tensorflow functions.
Serializing this function (e.g. by copy.deepcopy) will also try to serialize
the entire tensorflow module import.

Instead of using a Lambda layer, create a new custom layer called DeviceSlice
using the code from get_slice() for the DeviceSlice.call function.

---

I'm not sure about the `DeviceSlice` class name. I used "Device" in the name because figure it could be used for more than just GPUs, as a way of dividing work among a variety of offload device targets (GPUs, TPUs, Xeon Phis, whatever).

 I'm also not sure where the `DeviceSlice` class should be put. For now I left it in `keras.utils.training_utils`, but that probably isn't the best place for it.

Let me know what changes need to happen for this to be mergable, as I'm currently forced to build my own keras fork in order to use `multi_gpu_model()`