### PR TITLE
Model.compile() requires a loss argument

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -55,7 +55,7 @@ kl_loss = - 0.5 * K.sum(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axi
 vae_loss = K.mean(xent_loss + kl_loss)
 
 vae.add_loss(vae_loss)
-vae.compile(optimizer='rmsprop')
+vae.compile(optimizer='rmsprop', loss='')
 vae.summary()
 
 


### PR DESCRIPTION
The change in [`examples/variational_autoencoder.py`](https://github.com/keras-team/keras/blob/master/examples/variational_autoencoder.py) was introduced in

https://github.com/keras-team/keras/commit/10b46cbdc47f7164cd92209077939a7f7882b3c0

It is missing a `loss` argument.

Here is where Model.compile() is defined:

https://github.com/keras-team/keras/blob/d9f26a92f4fdc1f1e170a4203a7c13abf3af86e8/keras/models.py#L758

