### PR TITLE
Add zero-mean weight constraint

### DIFF
--- a/keras/constraints.py
+++ b/keras/constraints.py
@@ -144,6 +144,36 @@ class MinMaxNorm(Constraint):
                 'rate': self.rate,
                 'axis': self.axis}
 
+class ZeroMean(Constraint):
+    """ ZeroMean weight constraint.
+
+    Constraints the weights incident to each hidden unit
+    to have zero mean.
+
+    # Arguments
+        axis: integer, axis along which to calculate weight norms.
+            For instance, in a `Dense` layer the weight matrix
+            has shape `(input_dim, output_dim)`,
+            set `axis` to `0` to constrain each weight vector
+            of length `(input_dim,)`.
+            In a `Conv2D` layer with `data_format="channels_last"`,
+            the weight tensor has shape
+            `(rows, cols, input_depth, output_depth)`,
+            set `axis` to `[0, 1]`
+            to constrain the weights of each filter tensor of size
+            `(rows, cols,)`.
+    """
+    def __init__(self, axis=0):
+        self.axis = axis
+
+    def __call__(self, w):
+        mean = K.mean(w, axis=self.axis, keepdims=True)
+        w -= mean
+        return w
+
+    def get_config(self):
+        return  {'axis' : self.axis}
+
 
 # Aliases.
 
@@ -151,6 +181,7 @@ max_norm = MaxNorm
 non_neg = NonNeg
 unit_norm = UnitNorm
 min_max_norm = MinMaxNorm
+zero_mean = ZeroMean
 
 
 # Legacy aliases.

--- a/keras/constraints.py
+++ b/keras/constraints.py
@@ -144,6 +144,7 @@ class MinMaxNorm(Constraint):
                 'rate': self.rate,
                 'axis': self.axis}
 
+
 class ZeroMean(Constraint):
     """ ZeroMean weight constraint.
 
@@ -172,7 +173,7 @@ class ZeroMean(Constraint):
         return w
 
     def get_config(self):
-        return  {'axis' : self.axis}
+        return {'axis': self.axis}
 
 
 # Aliases.


### PR DESCRIPTION
I needed this constraint for my own application and thought it can be useful for others. 

- When treating audio signals directly from the waveform, with `Conv1D` for example, we can enforce a zero-mean constraint on each filter by passing `kernel_constraint=ZeroMean(axis=0)`. In this way we get closer to a filterbank.
- Similarly, it can be applied with `Conv2D` using `kernel_constraint=ZeroMean(axis=[0,1])` (if `data_format="channels_last"`) to zero-mean each spatial filter (depth not included).  

I think it's a pretty general constraint and I'm sure their are other useful uses which I didn't think of. 