### PR TITLE
Fit and transform sequences of words

### DIFF
--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -172,20 +172,26 @@ class Tokenizer(object):
 
     def fit_on_texts(self, texts):
         """Updates internal vocabulary based on a list of texts.
+        In the case where texts contains lists, we assume each entry of the lists
+        to be a token.
 
         Required before using `texts_to_sequences` or `texts_to_matrix`.
 
         # Arguments
             texts: can be a list of strings,
-                or a generator of strings (for memory-efficiency)
+                a generator of strings (for memory-efficiency),
+                or a list of list of strings.
         """
         self.document_count = 0
         for text in texts:
             self.document_count += 1
-            seq = text if self.char_level else text_to_word_sequence(text,
-                                                                     self.filters,
-                                                                     self.lower,
-                                                                     self.split)
+            if self.char_level or isinstance(text, list):
+                seq = text
+            else:
+                seq = text_to_word_sequence(text,
+                                            self.filters,
+                                            self.lower,
+                                            self.split)
             for w in seq:
                 if w in self.word_counts:
                     self.word_counts[w] += 1
@@ -251,22 +257,27 @@ class Tokenizer(object):
 
     def texts_to_sequences_generator(self, texts):
         """Transforms each text in texts in a sequence of integers.
+        Each item in texts can also be a list, in which we assume each item of that list
+        to be a token.
 
         Only top "num_words" most frequent words will be taken into account.
         Only words known by the tokenizer will be taken into account.
 
         # Arguments
-            texts: A list of texts (strings).
+            texts: A list of texts (strings), or a list of lists containing strings.
 
         # Yields
             Yields individual sequences.
         """
         num_words = self.num_words
         for text in texts:
-            seq = text if self.char_level else text_to_word_sequence(text,
-                                                                     self.filters,
-                                                                     self.lower,
-                                                                     self.split)
+            if self.char_level or isinstance(text, list):
+                seq = text
+            else:
+                seq = text_to_word_sequence(text,
+                                            self.filters,
+                                            self.lower,
+                                            self.split)
             vect = []
             for w in seq:
                 i = self.word_index.get(w)

--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -182,7 +182,6 @@ class Tokenizer(object):
                 a generator of strings (for memory-efficiency),
                 or a list of list of strings.
         """
-        self.document_count = 0
         for text in texts:
             self.document_count += 1
             if self.char_level or isinstance(text, list):

--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -169,6 +169,7 @@ class Tokenizer(object):
         self.document_count = 0
         self.char_level = char_level
         self.oov_token = oov_token
+        self.index_docs = {}
 
     def fit_on_texts(self, texts):
         """Updates internal vocabulary based on a list of texts.
@@ -213,7 +214,6 @@ class Tokenizer(object):
             if i is None:
                 self.word_index[self.oov_token] = len(self.word_index) + 1
 
-        self.index_docs = {}
         for w, c in list(self.word_docs.items()):
             self.index_docs[self.word_index[w]] = c
 
@@ -227,8 +227,7 @@ class Tokenizer(object):
             sequences: A list of sequence.
                 A "sequence" is a list of integer word indices.
         """
-        self.document_count = len(sequences)
-        self.index_docs = {}
+        self.document_count += len(sequences)
         for seq in sequences:
             seq = set(seq)
             for i in seq:

--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -254,15 +254,15 @@ class Tokenizer(object):
         return res
 
     def texts_to_sequences_generator(self, texts):
-        """Transforms each text in texts in a sequence of integers.
-        Each item in texts can also be a list, in which we assume each item of that list
+        """Transforms each text in `texts` in a sequence of integers.
+        Each item in texts can also be a list, in which case we assume each item of that list
         to be a token.
 
         Only top "num_words" most frequent words will be taken into account.
         Only words known by the tokenizer will be taken into account.
 
         # Arguments
-            texts: A list of texts (strings), or a list of lists containing strings.
+            texts: A list of texts (strings).
 
         # Yields
             Yields individual sequences.

--- a/tests/keras/preprocessing/text_test.py
+++ b/tests/keras/preprocessing/text_test.py
@@ -49,6 +49,25 @@ def test_tokenizer():
         matrix = tokenizer.texts_to_matrix(texts, mode)
 
 
+def test_sequential_fit():
+    texts = ['The cat sat on the mat.',
+             'The dog sat on the log.',
+             'Dogs and cats living together.']
+    word_sequences = [
+        ['The', 'cat', 'is', 'dumb'],
+        ['The', 'dog', 'is', 'nice']
+    ]
+
+    tokenizer = Tokenizer()
+    tokenizer.fit_on_texts(texts)
+    tokenizer.fit_on_texts(word_sequences)
+
+    assert tokenizer.document_count == 5
+
+    tokenizer.texts_to_matrix(texts)
+    tokenizer.texts_to_matrix(word_sequences)
+
+
 def test_text_to_word_sequence():
     text = 'hello! ? world!'
     assert text_to_word_sequence(text) == ['hello', 'world']

--- a/tests/keras/preprocessing/text_test.py
+++ b/tests/keras/preprocessing/text_test.py
@@ -54,8 +54,8 @@ def test_sequential_fit():
              'The dog sat on the log.',
              'Dogs and cats living together.']
     word_sequences = [
-        ['The', 'cat', 'is', 'dumb'],
-        ['The', 'dog', 'is', 'nice']
+        ['The', 'cat', 'is', 'sitting'],
+        ['The', 'dog', 'is', 'standing']
     ]
 
     tokenizer = Tokenizer()


### PR DESCRIPTION
Dear keras-community,

I've encountered a use-case where I in my data have a columns of text, and a column consisting of lists of texts. Something like this:

```Python
col1 = ['long text here', 'other long text here']
col2 = [['tags', 'in', 'here'], ['tags', 'tags', 'tags']]
```
Ideally I could use the same tokenizer, but this is currently a hassle. This PR implements

1. The ability to call `fit_on_texts`, and `texts_to_x` with list of lists as arguments. Assuming each inner list to consist of tokens.
2. Allow you to run `fit` multiple times.

This PR does not break the current API, but I'm open to reworking it based on your feedback. Let me know.
