### PR TITLE
Add Precision & Recall "Stateful" Metrics

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -83,7 +83,7 @@ class Recall(Layer):
         '''
         # Batch
         if self.label_encoding == 'one_hot':
-           y_true, y_pred = _one_hot_to_binary(y_true, y_pred)
+            y_true, y_pred = _one_hot_to_binary(y_true, y_pred)
 
         true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
         total_positives = K.sum(K.round(K.clip(y_true, 0, 1)))
@@ -135,7 +135,7 @@ class Precision(Layer):
         '''
         # Batch
         if self.label_encoding == 'one_hot':
-           y_true, y_pred = _one_hot_to_binary(y_true, y_pred)
+            y_true, y_pred = _one_hot_to_binary(y_true, y_pred)
 
         true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
         pred_positives = K.sum(K.round(K.clip(y_pred, 0, 1)))
@@ -165,7 +165,7 @@ def _one_hot_to_binary(y_true, y_pred):
         y_true: Tensor, batch_wise labels (binary encoded).
         y_pred: Tensor,  batch_wise predictions (binary encoded).
     '''
-    return y_true[...,1], y_pred[...,1]
+    return y_true[..., 1], y_pred[..., 1]
 
 
 # Aliases

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import six
 from . import backend as K
+from .engine import Layer
 from .losses import mean_squared_error
 from .losses import mean_absolute_error
 from .losses import mean_absolute_percentage_error
@@ -45,6 +46,126 @@ def top_k_categorical_accuracy(y_true, y_pred, k=5):
 
 def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):
     return K.mean(K.in_top_k(y_pred, K.cast(K.max(y_true, axis=-1), 'int32'), k), axis=-1)
+
+
+# Stateful Metrics
+
+class Recall(Layer):
+    '''Compute recall over all batches.
+
+    # Arguments
+        name: String, name for the metric.
+        label_encoding: String, 'binary' or 'one_hot', label encoding format.
+    '''
+
+    def __init__(self, name='recall', label_encoding='binary'):
+        super(Recall, self).__init__(name=name)
+        self.true_positives = K.variable(value=0, dtype='float32')
+        self.total_positives = K.variable(value=0, dtype='float32')
+
+        if label_encoding not in ['binary', 'one_hot']:
+            raise ValueError('Label encoding must be "binary" or "one_hot"')
+        self.label_encoding = label_encoding
+
+    def reset_states(self):
+        K.set_value(self.true_positives, 0.0)
+        K.set_value(self.total_positives, 0.0)
+
+    def __call__(self, y_true, y_pred):
+        '''Update recall computation.
+
+        # Arguments
+            y_true: Tensor, batch_wise labels
+            y_pred: Tensor, batch_wise predictions
+
+        # Returns
+            Overall recall for the epoch at the completion of the batch.
+        '''
+        # Batch
+        if self.label_encoding == 'one_hot':
+           y_true, y_pred = _one_hot_to_binary(y_true, y_pred)
+
+        true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
+        total_positives = K.sum(K.round(K.clip(y_true, 0, 1)))
+
+        # Current
+        current_true_positives = self.true_positives * 1
+        current_total_positives = self.total_positives * 1
+
+        # Updates
+        updates = [K.update_add(self.true_positives, true_positives),
+                   K.update_add(self.total_positives, total_positives)]
+        self.add_update(updates, inputs=[y_true, y_pred])
+
+        # Compute recall
+        return (current_true_positives + true_positives) / \
+               (current_total_positives + total_positives + K.epsilon())
+
+
+class Precision(Layer):
+    '''Compute precision over all batches.
+
+    # Arguments
+        name: String, name for the metric.
+        label_encoding: String, 'binary' or 'one_hot', label encoding format.
+    '''
+
+    def __init__(self, name='precision', label_encoding='binary'):
+        super(Precision, self).__init__(name=name)
+        self.true_positives = K.variable(value=0, dtype='float32')
+        self.pred_positives = K.variable(value=0, dtype='float32')
+
+        if label_encoding not in ['binary', 'one_hot']:
+            raise ValueError('Label encoding must be "binary" or "one_hot"')
+        self.label_encoding = label_encoding
+
+    def reset_states(self):
+        K.set_value(self.true_positives, 0.0)
+        K.set_value(self.pred_positives, 0.0)
+
+    def __call__(self, y_true, y_pred):
+        '''Update precision computation.
+
+        # Arguments
+            y_true: Tensor, batch_wise labels
+            y_pred: Tensor, batch_wise predictions
+
+        # Returns
+            Overall precision for the epoch at the completion of the batch.
+        '''
+        # Batch
+        if self.label_encoding == 'one_hot':
+           y_true, y_pred = _one_hot_to_binary(y_true, y_pred)
+
+        true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
+        pred_positives = K.sum(K.round(K.clip(y_pred, 0, 1)))
+
+        # Current
+        current_true_positives = self.true_positives * 1
+        current_pred_positives = self.pred_positives * 1
+
+        # Updates
+        updates = [K.update_add(self.true_positives, true_positives),
+                   K.update_add(self.pred_positives, pred_positives)]
+        self.add_update(updates, inputs=[y_true, y_pred])
+
+        # Compute recall
+        return (current_true_positives + true_positives) / \
+               (current_pred_positives + pred_positives + K.epsilon())
+
+
+def _one_hot_to_binary(y_true, y_pred):
+    '''Convert one hot encoded labels and predictions to binary encoding.
+
+    #  Arguments:
+        y_true: Tensor, batch_wise labels (one hot encoded).
+        y_pred: Tensor, batch_wise predictions (one hot encoded).
+
+    # Returns:
+        y_true: Tensor, batch_wise labels (binary encoded).
+        y_pred: Tensor,  batch_wise predictions (binary encoded).
+    '''
+    return y_true[...,1], y_pred[...,1]
 
 
 # Aliases

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -195,8 +195,8 @@ def test_stateful_metrics():
     model.compile(optimizer='sgd',
                   loss='categorical_crossentropy',
                   metrics=['acc',
-                           metrics.Recall(label_encoding="one_hot"),
-                           metrics.Precision(label_encoding="one_hot")])
+                           metrics.Recall(),
+                           metrics.Precision()])
 
     y = keras.utils.to_categorical(y, 2)
     model.fit(x, y, epochs=1, batch_size=10)

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -160,7 +160,10 @@ def test_stateful_metrics():
     model = keras.Model(inputs, outputs)
     model.compile(optimizer='sgd',
                   loss='binary_crossentropy',
-                  metrics=['acc', metrics.Recall(), metrics.Precision(), metric_fn])
+                  metrics=['acc',
+                           metrics.Recall(),
+                           metrics.Precision(),
+                           metric_fn])
 
     # Test fit, evaluate
     samples = 1000


### PR DESCRIPTION
Back in release 1.2.2 batchwise metrics for ``precision`` and ``recall`` were built into Keras. They were subsequently deprecated because batchwise metrics were inaccurate and were overall confusing ux.

In release 2.1.4, stateful metrics are now supported. This enables us to write stateful, globally accurate, metrics that **do not** batch average. 

I have provided implementations for ``precision`` and ``recall`` that work with both ``binary`` encoding (as per release 1.2.2) in addition to ``one_hot`` encoding for better ux (for people who always use one hot encoding even if only 2 classes... like me). It defaults to ``binary`` for consistency with release 1.2.2.

Before implementing: ``AUC``, ``Confusion Matrix`` (``FP``, ``FN``, ``TP``, ``TN``) and potentially the rest of https://www.tensorflow.org/api_docs/python/tf/metrics, I wanted feedback on the first 2 metrics.

The implementations of ``precision`` and ``recall`` were adapted from ``BinaryTruePositives`` inside ``metrics_test.py``. 