### PR TITLE
Typo

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1906,7 +1906,7 @@ class LSTMCell(Layer):
 
 
 class LSTM(RNN):
-    """Long-Short Term Memory layer - Hochreiter 1997.
+    """Long Short-Term Memory layer - Hochreiter 1997.
 
     # Arguments
         units: Positive integer, dimensionality of the output space.


### PR DESCRIPTION
Minor typo from "Long-Short Term Memory" to "Long Short-Term Memory"