### PR TITLE
make stateful_metric_names a property

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -545,6 +545,12 @@ def _standardize_weights(y, sample_weight=None, class_weight=None,
 class Model(Container):
     """The `Model` class adds training & evaluation routines to a `Container`.
     """
+    @property
+    def stateful_metric_names(self):
+        if hasattr(self, '_stateful_metric_names'):
+            return self._stateful_metric_names
+        else:
+            return []
 
     def compile(self, optimizer, loss=None, metrics=None, loss_weights=None,
                 sample_weight_mode=None, weighted_metrics=None,
@@ -852,7 +858,7 @@ class Model(Container):
         nested_metrics = _collect_metrics(metrics, self.output_names)
         nested_weighted_metrics = _collect_metrics(weighted_metrics, self.output_names)
         self.metrics_updates = []
-        self.stateful_metric_names = []
+        self._stateful_metric_names = []
         with K.name_scope('metrics'):
             for i in range(len(self.outputs)):
                 if i in skip_target_indices:
@@ -913,7 +919,7 @@ class Model(Container):
                                                                mask=masks[i])
 
                         # Append to self.metrics_names, self.metric_tensors,
-                        # self.stateful_metric_names
+                        # self._stateful_metric_names
                         if len(self.output_names) > 1:
                             metric_name = self.output_names[i] + '_' + metric_name
                         # Dedupe name
@@ -928,7 +934,7 @@ class Model(Container):
                         # Keep track of state updates created by
                         # stateful metrics (i.e. metrics layers).
                         if isinstance(metric_fn, Layer):
-                            self.stateful_metric_names.append(metric_name)
+                            self._stateful_metric_names.append(metric_name)
                             self.metrics_updates += metric_fn.updates
 
                 handle_metrics(output_metrics)

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -2,6 +2,7 @@ import pytest
 import json
 import numpy as np
 from numpy.testing import assert_allclose
+import os
 
 from keras.layers import Dense, Dropout, Conv2D, InputLayer
 from keras import layers
@@ -331,6 +332,23 @@ def test_multi_input_layer():
     input_b_np = np.random.random((10, 32))
     fn_outputs = fn([input_a_np, input_b_np])
     assert [x.shape for x in fn_outputs] == [(10, 64), (10, 5)]
+
+
+@keras_test
+def test_predict_with_json():
+    weight_path = 'weight_test_predict.h5'
+    inp = Input([10])
+    k = Dense(10)(inp)
+
+    mod = Model(inp, k)
+    mod.compile('sgd', 'mse', metrics=['acc'])
+    mod.fit(np.ones([10, 10]), np.ones([10, 10]), batch_size=10)
+
+    mod.save_weights(weight_path, overwrite=True)
+    mod = model_from_json(mod.to_json())
+    mod.load_weights(weight_path)
+    mod.predict(np.ones([10, 10]), verbose=1)
+    os.remove(weight_path)
 
 
 @keras_test


### PR DESCRIPTION
Fix https://github.com/keras-team/keras/issues/9394

Otherwise, one needs to compile the Model before calling predict on it which wasn't required before. 
A simple condition on the Progbar would break the style in this area so I added a property.
Quick snippet to reproduce.
```python
import numpy as np

from keras import Input, Model
from keras.layers import Dense
from keras.models import model_from_json

inp = Input([30])
k = Dense(10)(inp)

mod = Model(inp, k)
mod.compile('sgd', 'mse', metrics=['acc'])
mod.fit(np.ones([40, 30]), np.ones([40, 10]), batch_size=10)

mod.save_weights('w.hdf5', overwrite=True)
mod = model_from_json(mod.to_json())
mod.load_weights('w.hdf5')
mod.predict(np.ones([40, 30]), verbose=1)
```