### PR TITLE
Enable `variable_input_channels` test for `InceptionV3`

### DIFF
--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -124,11 +124,8 @@ def test_inceptionv3():
     last_dim = 2048
     _test_application_basic(app)
     _test_application_notop(app, last_dim)
+    _test_application_variable_input_channels(app, last_dim)
     _test_app_pooling(app, last_dim)
-
-    if K.backend() != 'cntk':
-        # CNTK does not support dynamic padding.
-        _test_application_variable_input_channels(app, last_dim)
 
 
 def test_inceptionresnetv2():


### PR DESCRIPTION
The `InceptionV3` is not associated with the dynamic padding; thus `_test_application_variable_input_channels` is available.