### PR TITLE
Optimizer - set_weights : check weights length

### DIFF
--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -106,6 +106,11 @@ class Optimizer(object):
             ValueError: in case of incompatible weight shapes.
         """
         params = self.weights
+        if len(params) != len(weights):
+            raise ValueError('Length of the specified weight list (' +
+                             str(len(weights)) +
+                             ') does not match the number of weights ' +
+                             'of the optimizer (' + str(len(params)) + ')')
         weight_value_tuples = []
         param_values = K.batch_get_value(params)
         for pv, p, w in zip(param_values, params, weights):


### PR DESCRIPTION
This PR fixes a little inconsistency that I encountered using Keras, described below :
```python
model = Model(...)
model.compile(...)
optimizer_weights = model.optimizer.get_weights()
# value is [], as optimizer.get_updates has not been called yet
model._make_train_function()
# Now optimizer has proper weights
model.optimzier.set_weights(optimizer_weights)
# Runs without error, but has no effect
len(model.optimizer.get_weights()) == len(optimizer_weights)
# Obviously not, which is counterintuitive
```

It is my first PR, I apologize in advance if the format is not correct.
Thank you