### PR TITLE
Force update of Sequences for Windows

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -512,9 +512,11 @@ class OrderedEnqueuer(SequenceEnqueuer):
         """
         if self.use_multiprocessing:
             self.executor_fn = lambda seqs: multiprocessing.Pool(workers,
-                                                                 initializer=init_pool, initargs=(seqs,))
+                                                                 initializer=init_pool,
+                                                                 initargs=(seqs,))
         else:
-            self.executor_fn = lambda _: ThreadPool(workers)  # We do not need the init since it's threads.
+            # We do not need the init since it's threads.
+            self.executor_fn = lambda _: ThreadPool(workers)
         self.workers = workers
         self.queue = queue.Queue(max_queue_size)
         self.stop_signal = threading.Event()

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -373,6 +373,10 @@ _SHARED_SEQUENCES = {}
 _SEQUENCE_COUNTER = None
 
 
+def init_pool(seqs):
+    global _SHARED_SEQUENCES
+    _SHARED_SEQUENCES = seqs
+
 def get_index(uid, i):
     """Get the value from the Sequence `uid` at index `i`.
 
@@ -506,9 +510,10 @@ class OrderedEnqueuer(SequenceEnqueuer):
                 (when full, workers could block on `put()`)
         """
         if self.use_multiprocessing:
-            self.executor_fn = lambda: multiprocessing.Pool(workers)
+            self.executor_fn = lambda seqs: multiprocessing.Pool(workers,
+                                                                 initializer=init_pool, initargs=(seqs,))
         else:
-            self.executor_fn = lambda: ThreadPool(workers)
+            self.executor_fn = lambda _: ThreadPool(workers)  # We do not need the init since it's threads.
         self.workers = workers
         self.queue = queue.Queue(max_queue_size)
         self.stop_signal = threading.Event()
@@ -531,7 +536,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
             if self.shuffle:
                 random.shuffle(sequence)
 
-            with closing(self.executor_fn()) as executor:
+            with closing(self.executor_fn(_SHARED_SEQUENCES)) as executor:
                 for i in sequence:
                     if self.stop_signal.is_set():
                         return

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -377,6 +377,7 @@ def init_pool(seqs):
     global _SHARED_SEQUENCES
     _SHARED_SEQUENCES = seqs
 
+
 def get_index(uid, i):
     """Get the value from the Sequence `uid` at index `i`.
 

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -6,9 +6,10 @@ import tarfile
 import threading
 import zipfile
 from itertools import cycle
-
+import multiprocessing as mp
 import numpy as np
 import pytest
+import six
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.request import pathname2url
 
@@ -22,6 +23,19 @@ from keras.utils.data_utils import validate_file
 if sys.version_info < (3,):
     def next(x):
         return x.next()
+
+
+def use_spawn(func):
+    """Decorator to test both Unix (fork) and Windows (spawn)"""
+    @six.wraps(func)
+    def wrapper(*args,**kwargs):
+        out = func(*args,**kwargs)
+        if sys.version_info > (3,4):
+            mp.set_start_method('spawn', force=True)
+            func(*args, **kwargs)
+            mp.set_start_method('fork', force=True)
+        return out
+    return wrapper
 
 
 @pytest.fixture
@@ -219,6 +233,7 @@ def test_ordered_enqueuer_threads_not_ordered():
     enqueuer.stop()
 
 
+@use_spawn
 def test_ordered_enqueuer_processes():
     enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]), use_multiprocessing=True)
     enqueuer.start(3, 10)
@@ -237,7 +252,7 @@ def test_ordered_enqueuer_fail_threads():
     with pytest.raises(StopIteration):
         next(gen_output)
 
-
+@use_spawn
 def test_on_epoch_end_processes():
     enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]), use_multiprocessing=True)
     enqueuer.start(3, 10)
@@ -248,7 +263,7 @@ def test_on_epoch_end_processes():
     assert acc[100:] == list([k * 5 for k in range(100)]), "Order was not keep in GeneratorEnqueuer with processes"
     enqueuer.stop()
 
-
+@use_spawn
 def test_context_switch():
     enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]), use_multiprocessing=True)
     enqueuer2 = OrderedEnqueuer(DummySequence([3, 200, 200, 3], value=15), use_multiprocessing=True)
@@ -292,7 +307,7 @@ def test_on_epoch_end_threads():
     assert acc == list([k * 5 for k in range(100)]), "Order was not keep in GeneratorEnqueuer with processes"
     enqueuer.stop()
 
-
+@use_spawn
 def test_ordered_enqueuer_fail_processes():
     enqueuer = OrderedEnqueuer(FaultSequence(), use_multiprocessing=True)
     enqueuer.start(3, 10)

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -28,9 +28,9 @@ if sys.version_info < (3,):
 def use_spawn(func):
     """Decorator to test both Unix (fork) and Windows (spawn)"""
     @six.wraps(func)
-    def wrapper(*args,**kwargs):
-        out = func(*args,**kwargs)
-        if sys.version_info > (3,4):
+    def wrapper(*args, **kwargs):
+        out = func(*args, **kwargs)
+        if sys.version_info > (3, 4):
             mp.set_start_method('spawn', force=True)
             func(*args, **kwargs)
             mp.set_start_method('fork', force=True)
@@ -252,6 +252,7 @@ def test_ordered_enqueuer_fail_threads():
     with pytest.raises(StopIteration):
         next(gen_output)
 
+
 @use_spawn
 def test_on_epoch_end_processes():
     enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]), use_multiprocessing=True)
@@ -262,6 +263,7 @@ def test_on_epoch_end_processes():
         acc.append(next(gen_output)[0, 0, 0, 0])
     assert acc[100:] == list([k * 5 for k in range(100)]), "Order was not keep in GeneratorEnqueuer with processes"
     enqueuer.stop()
+
 
 @use_spawn
 def test_context_switch():
@@ -306,6 +308,7 @@ def test_on_epoch_end_threads():
         acc.append(next(gen_output)[0, 0, 0, 0])
     assert acc == list([k * 5 for k in range(100)]), "Order was not keep in GeneratorEnqueuer with processes"
     enqueuer.stop()
+
 
 @use_spawn
 def test_ordered_enqueuer_fail_processes():


### PR DESCRIPTION
Fix https://github.com/keras-team/keras/issues/9434

On Windows, there is no fork, only spawn so the shared variables are not shared.
This PR forces the update when we initialize any process. We use a Sequence only once per epoch so we do not need to update it constantly. 

Future : 
* Find a way to test multiprocessing with Windows.
* ` mp.set_start_method('spawn')` would mimic Windows behavior, but we cannot pickle generators on Windows so the test suite doesn't pass.

EDIT : Added a decorator to test *Ordered*Enqueuer for both Windoes and Unix.