### PR TITLE
Fixing minor bug in pretrained_word_embeddings example

### DIFF
--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -101,7 +101,7 @@ y_val = labels[-num_validation_samples:]
 print('Preparing embedding matrix.')
 
 # prepare embedding matrix
-num_words = min(MAX_NUM_WORDS, len(word_index))
+num_words = min(MAX_NUM_WORDS, len(word_index) + 1)
 embedding_matrix = np.zeros((num_words, EMBEDDING_DIM))
 for word, i in word_index.items():
     if i >= MAX_NUM_WORDS:


### PR DESCRIPTION
tokenizer.word_index starts from index 1, so we need to account for one additional index when getting num_words. This example using 20_newsgroup dataset works with or without this fix but I think it is good to update the code as people may reuse it for other datasets.

Why does this example work?
If MAX_NUM_WORDS is set to a value greater than  len(word_index) [17405] eg. 175K embedding_vector we get for index 17405 is None. So we do not try to set embedding_matrix for this index
```embedding_matrix[i] = embedding_vector```

If there exists an embedding_vector for the word at the last index in word_index dict, we will see index out of bounds error.