### PR TITLE
General stateful metrics fixes

### DIFF
--- a/docs/templates/metrics.md
+++ b/docs/templates/metrics.md
@@ -19,7 +19,7 @@ model.compile(loss='mean_squared_error',
 
 A metric function is similar to a [loss function](/losses), except that the results from evaluating a metric are not used when training the model.
 
-You can either pass the name of an existing metric, or pass a Theano/TensorFlow symbolic function (see [Custom metrics](#custom-metrics)).
+You can either pass the name of an existing metric, or pass a function or layer (see [Custom metrics](#custom-metrics)).
 
 #### Arguments
   - __y_true__: True labels. Theano/TensorFlow tensor.
@@ -40,9 +40,21 @@ You can either pass the name of an existing metric, or pass a Theano/TensorFlow 
 
 ## Custom metrics
 
-Custom metrics can be passed at the compilation step. The
-function would need to take `(y_true, y_pred)` as arguments and return
-a single tensor value.
+Custom metrics can be passed at the compilation step.
+They can be either a Theano/TensorFlow symbolic function that is computed
+for each batch independently and is averaged across batches,
+or a Layer providing a stateful function that is computed incrementally
+across batches and is not averaged in Keras itself.
+
+Stateful layers are useful for metrics that are not independent across
+batches - for example precision, recall or AUC.
+
+### Symbolic functions
+
+The
+Theano/TensorFlow symbolic function
+would need to take `(y_true, y_pred)` as arguments and return
+a single tensor value representing the metrics value for that batch.
 
 ```python
 import keras.backend as K
@@ -53,4 +65,59 @@ def mean_pred(y_true, y_pred):
 model.compile(optimizer='rmsprop',
               loss='binary_crossentropy',
               metrics=['accuracy', mean_pred])
+```
+
+### Stateful metrics
+
+The stateful Layer would need to take `(y_true, y_pred)` as arguments
+(when used as a callable)
+and return a single tensor value representing the metrics value up to
+this batch.  The layer state is reset (using the `reset_states`
+method) at the beginning of each epoch or evaluation run (e.g. for
+validation after each epoch).
+
+The layer needs to have the `stateful` attribute set, and should
+register an update using its `add_update` method when called.
+
+Please see the "Writing your own Keras layers" section for details
+on stateful layers.
+
+```python
+class BinaryTruePositives(keras.layers.Layer):
+    """Stateful Metric to count the total true positives over all batches.
+
+    Assumes predictions and targets of shape `(samples, 1)`.
+
+    # Arguments
+        name: String, name for the metric.
+    """
+
+    def __init__(self, name='true_positives', **kwargs):
+        super(BinaryTruePositives, self).__init__(name=name, **kwargs)
+        self.stateful = True
+        self.true_positives = K.variable(value=0, dtype='int32')
+
+    def reset_states(self):
+        K.set_value(self.true_positives, 0)
+
+    def __call__(self, y_true, y_pred):
+        """Computes the number of true positives in a batch.
+
+        # Arguments
+            y_true: Tensor, batch_wise labels
+            y_pred: Tensor, batch_wise predictions
+
+        # Returns
+            The total number of true positives seen this epoch at the
+                completion of the batch.
+        """
+        y_true = K.cast(y_true, 'int32')
+        y_pred = K.cast(K.round(y_pred), 'int32')
+        correct_preds = K.cast(K.equal(y_pred, y_true), 'int32')
+        true_pos = K.cast(K.sum(correct_preds * y_true), 'int32')
+        current_true_pos = self.true_positives * 1
+        self.add_update(K.update_add(self.true_positives,
+                                     true_pos),
+                        inputs=[y_true, y_pred])
+        return current_true_pos + true_pos
 ```

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2427,7 +2427,7 @@ class Model(Container):
                     averages.append(np.average([out[i] for out in all_outs],
                                                weights=batch_sizes))
                 else:
-                    averages.append(all_outs[-1][i])
+                    averages.append(float(all_outs[-1][i]))
             return averages
 
     @interfaces.legacy_generator_methods_support

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1398,7 +1398,7 @@ class Model(Container):
                             outs.append(0.)
                     for i, batch_out in enumerate(batch_outs):
                         if i in stateful_metric_indices:
-                            outs[i] = batch_out
+                            outs[i] = float(batch_out)
                         else:
                             outs[i] += batch_out
                 else:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -927,7 +927,7 @@ class Model(Container):
 
                         # Keep track of state updates created by
                         # stateful metrics (i.e. metrics layers).
-                        if isinstance(metric_fn, Layer):
+                        if isinstance(metric_fn, Layer) and metric_fn.stateful:
                             self.stateful_metric_names.append(metric_name)
                             self.metrics_updates += metric_fn.updates
 
@@ -1175,7 +1175,7 @@ class Model(Container):
         for epoch in range(initial_epoch, epochs):
             # Reset stateful metrics
             for m in self.metrics:
-                if isinstance(m, Layer):
+                if isinstance(m, Layer) and m.stateful:
                     m.reset_states()
             callbacks.on_epoch_begin(epoch)
             epoch_logs = {}
@@ -1364,7 +1364,7 @@ class Model(Container):
 
         if hasattr(self, 'metrics'):
             for m in self.metrics:
-                if isinstance(m, Layer):
+                if isinstance(m, Layer) and m.stateful:
                     m.reset_states()
             stateful_metric_indices = [
                 i for i, name in enumerate(self.metrics_names)

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -337,7 +337,7 @@ class Progbar(object):
                     self._values[k][0] += v * (current - self._seen_so_far)
                     self._values[k][1] += (current - self._seen_so_far)
             else:
-                self._values[k] = v
+                self._values[k] = [v, 1]
         self._seen_so_far = current
 
         now = time.time()

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -337,6 +337,9 @@ class Progbar(object):
                     self._values[k][0] += v * (current - self._seen_so_far)
                     self._values[k][1] += (current - self._seen_so_far)
             else:
+                # Stateful metrics output a numeric value.  This representation
+                # means "take an average from a single value" but keeps the
+                # numeric formatting.
                 self._values[k] = [v, 1]
         self._seen_so_far = current
 

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -123,6 +123,7 @@ def test_stateful_metrics():
 
         def __init__(self, name='true_positives', **kwargs):
             super(BinaryTruePositives, self).__init__(name=name, **kwargs)
+            self.stateful = True
             self.true_positives = K.variable(value=0, dtype='int32')
 
         def reset_states(self):

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -116,8 +116,6 @@ def test_stateful_metrics():
         Assumes predictions and targets of shape `(samples, 1)`.
 
         # Arguments
-            threshold: Float, lower limit on prediction value that counts as a
-                positive class prediction.
             name: String, name for the metric.
         """
 

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -188,6 +188,23 @@ def test_stateful_metrics():
     np.testing.assert_allclose(val_outs[2], ref_true_pos(val_y, val_preds), atol=1e-5)
     np.testing.assert_allclose(val_outs[2], history.history['val_true_positives'][-1], atol=1e-5)
 
+    # Test with generators
+    gen = [(np.array([x0]), np.array([y0])) for x0, y0 in zip(x, y)]
+    val_gen = [(np.array([x0]), np.array([y0])) for x0, y0 in zip(val_x, val_y)]
+    history = model.fit_generator(iter(gen), epochs=1, steps_per_epoch=samples,
+                                  validation_data=iter(val_gen), validation_steps=val_samples)
+    outs = model.evaluate_generator(iter(gen), steps=samples)
+    preds = model.predict_generator(iter(gen), steps=samples)
+
+    # Test correctness of the metric re ref_true_pos()
+    np.testing.assert_allclose(outs[2], ref_true_pos(y, preds), atol=1e-5)
+
+    # Test correctness of the validation metric computation
+    val_preds = model.predict_generator(iter(val_gen), steps=val_samples)
+    val_outs = model.evaluate_generator(iter(val_gen), steps=val_samples)
+    np.testing.assert_allclose(val_outs[2], ref_true_pos(val_y, val_preds), atol=1e-5)
+    np.testing.assert_allclose(val_outs[2], history.history['val_true_positives'][-1], atol=1e-5)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -163,11 +163,16 @@ def test_stateful_metrics():
                   loss='binary_crossentropy',
                   metrics=['acc', metric_fn])
 
-    # Test fit, evaluate
     samples = 1000
     x = np.random.random((samples, 2))
     y = np.random.randint(2, size=(samples, 1))
-    model.fit(x, y, epochs=1, batch_size=10)
+
+    val_samples = 10
+    val_x = np.random.random((val_samples, 2))
+    val_y = np.random.randint(2, size=(val_samples, 1))
+
+    # Test fit and evaluate
+    history = model.fit(x, y, validation_data=(val_x, val_y), epochs=1, batch_size=10)
     outs = model.evaluate(x, y, batch_size=10)
     preds = model.predict(x)
 
@@ -176,6 +181,12 @@ def test_stateful_metrics():
 
     # Test correctness (e.g. updates should have been run)
     np.testing.assert_allclose(outs[2], ref_true_pos(y, preds), atol=1e-5)
+
+    # Test correctness of the validation metric computation
+    val_preds = model.predict(val_x)
+    val_outs = model.evaluate(val_x, val_y, batch_size=10)
+    np.testing.assert_allclose(val_outs[2], ref_true_pos(val_y, val_preds), atol=1e-5)
+    np.testing.assert_allclose(val_outs[2], history.history['val_true_positives'][-1], atol=1e-5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This implements a variety of stateful metrics improvements I noted in #9253 .

  * Require stateful metrics layers to be actually stateful: It seems a bit confusing to me that the Layer of a stateful metric doesn't need to have the stateful attribute set - with the assumption that all Layer metrics will be stateful, and behaving statefully even without this attribute. Is that a good assumption to make for the future?

  *  Prevent stateful metrics to leak np.floats to the History object: When logging normal metrics, they are added in _*_loop() to 0., making them float. This doesn't happen with stateful metrics (they are assigned directly), so they are np.float32. This is annoying if you e.g. want to serialize the history object to JSON after training, which used to work fine before.

  *  Progbar: Format stateful metrics values as floats alike other metrics:  In progress bar (verbose=1), stateful metric values aren't formatted as %.4f but %s. This is messy with many metrics, but also sometimes one \b too many is printed (didn't find out why) and the progress bar jumps a line upwards (overwriting earlier content)

  * Most importantly, fit_generator() and evaluate_generator() now support stateful metrics.

  * I wrote some documentation.