### PR TITLE
Remove word “shuffled” from comments in examples

### DIFF
--- a/examples/antirectifier.py
+++ b/examples/antirectifier.py
@@ -64,7 +64,7 @@ batch_size = 128
 num_classes = 10
 epochs = 40
 
-# the data, shuffled and split between train and test sets
+# the data, split between train and test sets
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
 x_train = x_train.reshape(60000, 784)

--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -21,7 +21,7 @@ num_predictions = 20
 save_dir = os.path.join(os.getcwd(), 'saved_models')
 model_name = 'keras_cifar10_trained_model.h5'
 
-# The data, shuffled and split between train and test sets:
+# The data, split between train and test sets:
 (x_train, y_train), (x_test, y_test) = cifar10.load_data()
 print('x_train shape:', x_train.shape)
 print(x_train.shape[0], 'train samples')

--- a/examples/cifar10_cnn_tfaugment2d.py
+++ b/examples/cifar10_cnn_tfaugment2d.py
@@ -112,7 +112,7 @@ num_predictions = 20
 save_dir = '/tmp/saved_models'
 model_name = 'keras_cifar10_trained_model.h5'
 
-# The data, shuffled and split between train and test sets:
+# The data, split between train and test sets:
 (x_train, y_train), (x_test, y_test) = cifar10.load_data()
 print('x_train shape:', x_train.shape)
 print(x_train.shape[0], 'train samples')

--- a/examples/mnist_cnn.py
+++ b/examples/mnist_cnn.py
@@ -20,7 +20,7 @@ epochs = 12
 # input image dimensions
 img_rows, img_cols = 28, 28
 
-# the data, shuffled and split between train and test sets
+# the data, split between train and test sets
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
 if K.image_data_format() == 'channels_first':

--- a/examples/mnist_hierarchical_rnn.py
+++ b/examples/mnist_hierarchical_rnn.py
@@ -47,7 +47,7 @@ epochs = 5
 row_hidden = 128
 col_hidden = 128
 
-# The data, shuffled and split between train and test sets.
+# The data, split between train and test sets.
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
 # Reshapes data to 4D for Hierarchical RNN.

--- a/examples/mnist_irnn.py
+++ b/examples/mnist_irnn.py
@@ -31,7 +31,7 @@ hidden_units = 100
 learning_rate = 1e-6
 clip_norm = 1.0
 
-# the data, shuffled and split between train and test sets
+# the data, split between train and test sets
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
 x_train = x_train.reshape(x_train.shape[0], -1, 1)

--- a/examples/mnist_mlp.py
+++ b/examples/mnist_mlp.py
@@ -17,7 +17,7 @@ batch_size = 128
 num_classes = 10
 epochs = 20
 
-# the data, shuffled and split between train and test sets
+# the data, split between train and test sets
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
 x_train = x_train.reshape(60000, 784)

--- a/examples/mnist_siamese.py
+++ b/examples/mnist_siamese.py
@@ -91,7 +91,7 @@ def accuracy(y_true, y_pred):
     return K.mean(K.equal(y_true, K.cast(y_pred < 0.5, y_true.dtype)))
 
 
-# the data, shuffled and split between train and test sets
+# the data, split between train and test sets
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
 x_train = x_train.astype('float32')
 x_test = x_test.astype('float32')

--- a/examples/mnist_swwae.py
+++ b/examples/mnist_swwae.py
@@ -107,7 +107,7 @@ K.set_image_data_format('channels_first')
 # input image dimensions
 img_rows, img_cols = 28, 28
 
-# the data, shuffled and split between train and test sets
+# the data, split between train and test sets
 (x_train, _), (x_test, _) = mnist.load_data()
 
 x_train = x_train.reshape(x_train.shape[0], 1, img_rows, img_cols)

--- a/examples/mnist_transfer_cnn.py
+++ b/examples/mnist_transfer_cnn.py
@@ -71,7 +71,7 @@ def train_model(model, train, test, num_classes):
     print('Test accuracy:', score[1])
 
 
-# the data, shuffled and split between train and test sets
+# the data, split between train and test sets
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
 # create two datasets one with digits below 5 and one with 5 and above


### PR DESCRIPTION
`cifar10.load_data()` and `mnist.load_data()` do not shuffle the datasets. This PR fixes the comments accordingly.

On another note, currently the dataset shuffling is not consistent:
- `boston_housing` and `reuters` allocate the train and test examples randomly;
- `imdb` shuffles the training and test sets separately;
- all other datasets, such as `mnist` and `cifar10`, do not shuffle anything.