### PR TITLE
Add depthwise conv2d for Theano and CNTK

### DIFF
--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -65,6 +65,7 @@ from ..layers import BatchNormalization
 from ..layers import GlobalAveragePooling2D
 from ..layers import GlobalMaxPooling2D
 from ..layers import Conv2D
+from ..layers import DepthwiseConv2D
 from .. import initializers
 from .. import regularizers
 from .. import constraints
@@ -97,204 +98,6 @@ def preprocess_input(x):
     return imagenet_utils.preprocess_input(x, mode='tf')
 
 
-class DepthwiseConv2D(Conv2D):
-    """Depthwise separable 2D convolution.
-
-    Depthwise Separable convolutions consists in performing
-    just the first step in a depthwise spatial convolution
-    (which acts on each input channel separately).
-    The `depth_multiplier` argument controls how many
-    output channels are generated per input channel in the depthwise step.
-
-    # Arguments
-        kernel_size: An integer or tuple/list of 2 integers, specifying the
-            width and height of the 2D convolution window.
-            Can be a single integer to specify the same value for
-            all spatial dimensions.
-        strides: An integer or tuple/list of 2 integers,
-            specifying the strides of the convolution along the width and height.
-            Can be a single integer to specify the same value for
-            all spatial dimensions.
-            Specifying any stride value != 1 is incompatible with specifying
-            any `dilation_rate` value != 1.
-        padding: one of `'valid'` or `'same'` (case-insensitive).
-        depth_multiplier: The number of depthwise convolution output channels
-            for each input channel.
-            The total number of depthwise convolution output
-            channels will be equal to `filters_in * depth_multiplier`.
-        data_format: A string,
-            one of `channels_last` (default) or `channels_first`.
-            The ordering of the dimensions in the inputs.
-            `channels_last` corresponds to inputs with shape
-            `(batch, height, width, channels)` while `channels_first`
-            corresponds to inputs with shape
-            `(batch, channels, height, width)`.
-            It defaults to the `image_data_format` value found in your
-            Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be 'channels_last'.
-        activation: Activation function to use
-            (see [activations](../activations.md)).
-            If you don't specify anything, no activation is applied
-            (ie. 'linear' activation: `a(x) = x`).
-        use_bias: Boolean, whether the layer uses a bias vector.
-        depthwise_initializer: Initializer for the depthwise kernel matrix
-            (see [initializers](../initializers.md)).
-        bias_initializer: Initializer for the bias vector
-            (see [initializers](../initializers.md)).
-        depthwise_regularizer: Regularizer function applied to
-            the depthwise kernel matrix
-            (see [regularizer](../regularizers.md)).
-        bias_regularizer: Regularizer function applied to the bias vector
-            (see [regularizer](../regularizers.md)).
-        activity_regularizer: Regularizer function applied to
-            the output of the layer (its 'activation').
-            (see [regularizer](../regularizers.md)).
-        depthwise_constraint: Constraint function applied to
-            the depthwise kernel matrix
-            (see [constraints](../constraints.md)).
-        bias_constraint: Constraint function applied to the bias vector
-            (see [constraints](../constraints.md)).
-
-    # Input shape
-        4D tensor with shape:
-        `[batch, channels, rows, cols]` if data_format='channels_first'
-        or 4D tensor with shape:
-        `[batch, rows, cols, channels]` if data_format='channels_last'.
-
-    # Output shape
-        4D tensor with shape:
-        `[batch, filters, new_rows, new_cols]` if data_format='channels_first'
-        or 4D tensor with shape:
-        `[batch, new_rows, new_cols, filters]` if data_format='channels_last'.
-        `rows` and `cols` values might have changed due to padding.
-    """
-
-    def __init__(self,
-                 kernel_size,
-                 strides=(1, 1),
-                 padding='valid',
-                 depth_multiplier=1,
-                 data_format=None,
-                 activation=None,
-                 use_bias=True,
-                 depthwise_initializer='glorot_uniform',
-                 bias_initializer='zeros',
-                 depthwise_regularizer=None,
-                 bias_regularizer=None,
-                 activity_regularizer=None,
-                 depthwise_constraint=None,
-                 bias_constraint=None,
-                 **kwargs):
-        super(DepthwiseConv2D, self).__init__(
-            filters=None,
-            kernel_size=kernel_size,
-            strides=strides,
-            padding=padding,
-            data_format=data_format,
-            activation=activation,
-            use_bias=use_bias,
-            bias_regularizer=bias_regularizer,
-            activity_regularizer=activity_regularizer,
-            bias_constraint=bias_constraint,
-            **kwargs)
-        self.depth_multiplier = depth_multiplier
-        self.depthwise_initializer = initializers.get(depthwise_initializer)
-        self.depthwise_regularizer = regularizers.get(depthwise_regularizer)
-        self.depthwise_constraint = constraints.get(depthwise_constraint)
-        self.bias_initializer = initializers.get(bias_initializer)
-
-    def build(self, input_shape):
-        if len(input_shape) < 4:
-            raise ValueError('Inputs to `DepthwiseConv2D` should have rank 4. '
-                             'Received input shape:', str(input_shape))
-        if self.data_format == 'channels_first':
-            channel_axis = 1
-        else:
-            channel_axis = 3
-        if input_shape[channel_axis] is None:
-            raise ValueError('The channel dimension of the inputs to '
-                             '`DepthwiseConv2D` '
-                             'should be defined. Found `None`.')
-        input_dim = int(input_shape[channel_axis])
-        depthwise_kernel_shape = (self.kernel_size[0],
-                                  self.kernel_size[1],
-                                  input_dim,
-                                  self.depth_multiplier)
-
-        self.depthwise_kernel = self.add_weight(
-            shape=depthwise_kernel_shape,
-            initializer=self.depthwise_initializer,
-            name='depthwise_kernel',
-            regularizer=self.depthwise_regularizer,
-            constraint=self.depthwise_constraint)
-
-        if self.use_bias:
-            self.bias = self.add_weight(shape=(input_dim * self.depth_multiplier,),
-                                        initializer=self.bias_initializer,
-                                        name='bias',
-                                        regularizer=self.bias_regularizer,
-                                        constraint=self.bias_constraint)
-        else:
-            self.bias = None
-        # Set input spec.
-        self.input_spec = InputSpec(ndim=4, axes={channel_axis: input_dim})
-        self.built = True
-
-    def call(self, inputs, training=None):
-        outputs = K.depthwise_conv2d(
-            inputs,
-            self.depthwise_kernel,
-            strides=self.strides,
-            padding=self.padding,
-            dilation_rate=self.dilation_rate,
-            data_format=self.data_format)
-
-        if self.bias:
-            outputs = K.bias_add(
-                outputs,
-                self.bias,
-                data_format=self.data_format)
-
-        if self.activation is not None:
-            return self.activation(outputs)
-
-        return outputs
-
-    def compute_output_shape(self, input_shape):
-        if self.data_format == 'channels_first':
-            rows = input_shape[2]
-            cols = input_shape[3]
-            out_filters = input_shape[1] * self.depth_multiplier
-        elif self.data_format == 'channels_last':
-            rows = input_shape[1]
-            cols = input_shape[2]
-            out_filters = input_shape[3] * self.depth_multiplier
-
-        rows = conv_utils.conv_output_length(rows, self.kernel_size[0],
-                                             self.padding,
-                                             self.strides[0])
-        cols = conv_utils.conv_output_length(cols, self.kernel_size[1],
-                                             self.padding,
-                                             self.strides[1])
-
-        if self.data_format == 'channels_first':
-            return (input_shape[0], out_filters, rows, cols)
-        elif self.data_format == 'channels_last':
-            return (input_shape[0], rows, cols, out_filters)
-
-    def get_config(self):
-        config = super(DepthwiseConv2D, self).get_config()
-        config.pop('filters')
-        config.pop('kernel_initializer')
-        config.pop('kernel_regularizer')
-        config.pop('kernel_constraint')
-        config['depth_multiplier'] = self.depth_multiplier
-        config['depthwise_initializer'] = initializers.serialize(self.depthwise_initializer)
-        config['depthwise_regularizer'] = regularizers.serialize(self.depthwise_regularizer)
-        config['depthwise_constraint'] = constraints.serialize(self.depthwise_constraint)
-        return config
-
-
 def MobileNet(input_shape=None,
               alpha=1.0,
               depth_multiplier=1,
@@ -306,18 +109,11 @@ def MobileNet(input_shape=None,
               classes=1000):
     """Instantiates the MobileNet architecture.
 
-    Note that only TensorFlow is supported for now,
-    therefore it only works with the data format
-    `image_data_format='channels_last'` in your Keras config
-    at `~/.keras/keras.json`.
-
     To load a MobileNet model via `load_model`, import the custom
-    objects `relu6` and `DepthwiseConv2D` and pass them to the
-    `custom_objects` parameter.
+    objects `relu6` and pass them to the `custom_objects` parameter.
     E.g.
     model = load_model('mobilenet.h5', custom_objects={
-                       'relu6': mobilenet.relu6,
-                       'DepthwiseConv2D': mobilenet.DepthwiseConv2D})
+                       'relu6': mobilenet.relu6})
 
     # Arguments
         input_shape: optional shape tuple, only to be specified
@@ -370,11 +166,6 @@ def MobileNet(input_shape=None,
         RuntimeError: If attempting to run this model with a
             backend that does not support separable convolutions.
     """
-
-    if K.backend() != 'tensorflow':
-        raise RuntimeError('Only TensorFlow backend is currently supported, '
-                           'as other backends do not support '
-                           'depthwise convolution.')
 
     if not (weights in {'imagenet', None} or os.path.exists(weights)):
         raise ValueError('The `weights` argument should be either '

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1517,7 +1517,33 @@ def separable_conv2d(x, depthwise_kernel, pointwise_kernel, strides=(1, 1),
 
 def depthwise_conv2d(x, depthwise_kernel, strides=(1, 1), padding='valid',
                      data_format=None, dilation_rate=(1, 1)):
-    raise NotImplementedError
+    if data_format is None:
+        data_format = image_data_format()
+    if data_format not in {'channels_first', 'channels_last'}:
+        raise ValueError('Unknown data_format ' + str(data_format))
+
+    x = _preprocess_conv2d_input(x, data_format)
+    depthwise_kernel = _preprocess_conv2d_kernel(depthwise_kernel, data_format)
+    depthwise_kernel = C.reshape(C.transpose(depthwise_kernel, (1, 0, 2, 3)),
+                                 (-1, 1) + depthwise_kernel.shape[2:])
+    padding = _preprocess_border_mode(padding)
+    if dilation_rate == (1, 1):
+        strides = (1,) + strides
+        x = C.convolution(depthwise_kernel, x,
+                          strides=strides,
+                          auto_padding=[False, padding, padding],
+                          groups=x.shape[0])
+    else:
+        if dilation_rate[0] != dilation_rate[1]:
+            raise ValueError('CNTK Backend: non-square dilation_rate is '
+                             'not supported.')
+        if strides != (1, 1):
+            raise ValueError('Invalid strides for dilated convolution')
+        x = C.convolution(depthwise_kernel, x,
+                          strides=dilation_rate[0],
+                          auto_padding=[False, padding, padding],
+                          groups=x.shape[0])
+    return _postprocess_conv2d_output(x, data_format)
 
 
 def conv3d(x, kernel, strides=(1, 1, 1), padding='valid',

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1987,7 +1987,60 @@ def separable_conv2d(x, depthwise_kernel, pointwise_kernel, strides=(1, 1),
 
 def depthwise_conv2d(x, depthwise_kernel, strides=(1, 1), padding='valid',
                      data_format=None, dilation_rate=(1, 1)):
-    raise NotImplementedError
+    """2D convolution with separable filters.
+
+    # Arguments
+        x: input tensor
+        depthwise_kernel: convolution kernel for the depthwise convolution.
+        strides: strides tuple (length 2).
+        padding: string, `"same"` or `"valid"`.
+        data_format: string, `"channels_last"` or `"channels_first"`.
+        dilation_rate: tuple of integers,
+            dilation rates for the separable convolution.
+
+    # Returns
+        Output tensor.
+
+    # Raises
+        ValueError: if `data_format` is neither `"channels_last"` or `"channels_first"`.
+    """
+    if data_format is None:
+        data_format = image_data_format()
+    if data_format not in {'channels_first', 'channels_last'}:
+        raise ValueError('Unknown data_format ', data_format)
+
+    if hasattr(x, '_keras_shape'):
+        image_shape = _preprocess_conv2d_image_shape(int_shape(x), data_format)
+    else:
+        image_shape = None
+    if hasattr(depthwise_kernel, '_keras_shape'):
+        depthwise_kernel_shape = depthwise_kernel._keras_shape
+    else:
+        # Will only work if `kernel` is a shared variable.
+        depthwise_kernel_shape = depthwise_kernel.eval().shape
+    depthwise_kernel_shape = _preprocess_conv2d_filter_shape(depthwise_kernel_shape, data_format)
+
+    x = _preprocess_conv2d_input(x, data_format)
+    depthwise_kernel = _preprocess_conv2d_kernel(depthwise_kernel, data_format)
+    th_padding = _preprocess_padding(padding)
+
+    input_depth = depthwise_kernel_shape[1]
+    output_depth = depthwise_kernel_shape[0]
+    depthwise_kernel_shape = (input_depth * output_depth, 1) + depthwise_kernel_shape[2:]
+    depthwise_kernel = depthwise_kernel.dimshuffle((1, 0, 2, 3))
+    depthwise_kernel = reshape(depthwise_kernel, depthwise_kernel_shape)
+    depthwise_kernel = depthwise_kernel[:, :, ::-1, ::-1]
+
+    conv_out = T.nnet.conv2d(x, depthwise_kernel,
+                             border_mode=th_padding,
+                             subsample=strides,
+                             input_shape=image_shape,
+                             filter_shape=depthwise_kernel_shape,
+                             filter_dilation=dilation_rate,
+                             num_groups=input_depth)
+    conv_out = _postprocess_conv2d_output(conv_out, x, padding,
+                                          depthwise_kernel_shape, strides, data_format)
+    return conv_out
 
 
 def conv3d(x, kernel, strides=(1, 1, 1),

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1511,6 +1511,203 @@ class SeparableConv2D(_SeparableConv):
             **kwargs)
 
 
+class DepthwiseConv2D(Conv2D):
+    """Depthwise separable 2D convolution.
+
+    Depthwise Separable convolutions consists in performing
+    just the first step in a depthwise spatial convolution
+    (which acts on each input channel separately).
+    The `depth_multiplier` argument controls how many
+    output channels are generated per input channel in the depthwise step.
+
+    # Arguments
+        kernel_size: An integer or tuple/list of 2 integers, specifying the
+            width and height of the 2D convolution window.
+            Can be a single integer to specify the same value for
+            all spatial dimensions.
+        strides: An integer or tuple/list of 2 integers,
+            specifying the strides of the convolution along the width and height.
+            Can be a single integer to specify the same value for
+            all spatial dimensions.
+            Specifying any stride value != 1 is incompatible with specifying
+            any `dilation_rate` value != 1.
+        padding: one of `'valid'` or `'same'` (case-insensitive).
+        depth_multiplier: The number of depthwise convolution output channels
+            for each input channel.
+            The total number of depthwise convolution output
+            channels will be equal to `filters_in * depth_multiplier`.
+        data_format: A string,
+            one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs.
+            `channels_last` corresponds to inputs with shape
+            `(batch, height, width, channels)` while `channels_first`
+            corresponds to inputs with shape
+            `(batch, channels, height, width)`.
+            It defaults to the `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be 'channels_last'.
+        activation: Activation function to use
+            (see [activations](../activations.md)).
+            If you don't specify anything, no activation is applied
+            (ie. 'linear' activation: `a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        depthwise_initializer: Initializer for the depthwise kernel matrix
+            (see [initializers](../initializers.md)).
+        bias_initializer: Initializer for the bias vector
+            (see [initializers](../initializers.md)).
+        depthwise_regularizer: Regularizer function applied to
+            the depthwise kernel matrix
+            (see [regularizer](../regularizers.md)).
+        bias_regularizer: Regularizer function applied to the bias vector
+            (see [regularizer](../regularizers.md)).
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its 'activation').
+            (see [regularizer](../regularizers.md)).
+        depthwise_constraint: Constraint function applied to
+            the depthwise kernel matrix
+            (see [constraints](../constraints.md)).
+        bias_constraint: Constraint function applied to the bias vector
+            (see [constraints](../constraints.md)).
+
+    # Input shape
+        4D tensor with shape:
+        `[batch, channels, rows, cols]` if data_format='channels_first'
+        or 4D tensor with shape:
+        `[batch, rows, cols, channels]` if data_format='channels_last'.
+
+    # Output shape
+        4D tensor with shape:
+        `[batch, filters, new_rows, new_cols]` if data_format='channels_first'
+        or 4D tensor with shape:
+        `[batch, new_rows, new_cols, filters]` if data_format='channels_last'.
+        `rows` and `cols` values might have changed due to padding.
+    """
+
+    def __init__(self,
+                 kernel_size,
+                 strides=(1, 1),
+                 padding='valid',
+                 depth_multiplier=1,
+                 data_format=None,
+                 activation=None,
+                 use_bias=True,
+                 depthwise_initializer='glorot_uniform',
+                 bias_initializer='zeros',
+                 depthwise_regularizer=None,
+                 bias_regularizer=None,
+                 activity_regularizer=None,
+                 depthwise_constraint=None,
+                 bias_constraint=None,
+                 **kwargs):
+        super(DepthwiseConv2D, self).__init__(
+            filters=None,
+            kernel_size=kernel_size,
+            strides=strides,
+            padding=padding,
+            data_format=data_format,
+            activation=activation,
+            use_bias=use_bias,
+            bias_regularizer=bias_regularizer,
+            activity_regularizer=activity_regularizer,
+            bias_constraint=bias_constraint,
+            **kwargs)
+        self.depth_multiplier = depth_multiplier
+        self.depthwise_initializer = initializers.get(depthwise_initializer)
+        self.depthwise_regularizer = regularizers.get(depthwise_regularizer)
+        self.depthwise_constraint = constraints.get(depthwise_constraint)
+        self.bias_initializer = initializers.get(bias_initializer)
+
+    def build(self, input_shape):
+        if len(input_shape) < 4:
+            raise ValueError('Inputs to `DepthwiseConv2D` should have rank 4. '
+                             'Received input shape:', str(input_shape))
+        if self.data_format == 'channels_first':
+            channel_axis = 1
+        else:
+            channel_axis = 3
+        if input_shape[channel_axis] is None:
+            raise ValueError('The channel dimension of the inputs to '
+                             '`DepthwiseConv2D` '
+                             'should be defined. Found `None`.')
+        input_dim = int(input_shape[channel_axis])
+        depthwise_kernel_shape = (self.kernel_size[0],
+                                  self.kernel_size[1],
+                                  input_dim,
+                                  self.depth_multiplier)
+
+        self.depthwise_kernel = self.add_weight(
+            shape=depthwise_kernel_shape,
+            initializer=self.depthwise_initializer,
+            name='depthwise_kernel',
+            regularizer=self.depthwise_regularizer,
+            constraint=self.depthwise_constraint)
+
+        if self.use_bias:
+            self.bias = self.add_weight(shape=(input_dim * self.depth_multiplier,),
+                                        initializer=self.bias_initializer,
+                                        name='bias',
+                                        regularizer=self.bias_regularizer,
+                                        constraint=self.bias_constraint)
+        else:
+            self.bias = None
+        # Set input spec.
+        self.input_spec = InputSpec(ndim=4, axes={channel_axis: input_dim})
+        self.built = True
+
+    def call(self, inputs, training=None):
+        outputs = K.depthwise_conv2d(
+            inputs,
+            self.depthwise_kernel,
+            strides=self.strides,
+            padding=self.padding,
+            dilation_rate=self.dilation_rate,
+            data_format=self.data_format)
+
+        if self.bias:
+            outputs = K.bias_add(
+                outputs,
+                self.bias,
+                data_format=self.data_format)
+
+        if self.activation is not None:
+            return self.activation(outputs)
+
+        return outputs
+
+    def compute_output_shape(self, input_shape):
+        if self.data_format == 'channels_first':
+            rows = input_shape[2]
+            cols = input_shape[3]
+            out_filters = input_shape[1] * self.depth_multiplier
+        elif self.data_format == 'channels_last':
+            rows = input_shape[1]
+            cols = input_shape[2]
+            out_filters = input_shape[3] * self.depth_multiplier
+
+        rows = conv_utils.conv_output_length(rows, self.kernel_size[0],
+                                             self.padding,
+                                             self.strides[0])
+        cols = conv_utils.conv_output_length(cols, self.kernel_size[1],
+                                             self.padding,
+                                             self.strides[1])
+        if self.data_format == 'channels_first':
+            return (input_shape[0], out_filters, rows, cols)
+        elif self.data_format == 'channels_last':
+            return (input_shape[0], rows, cols, out_filters)
+
+    def get_config(self):
+        config = super(DepthwiseConv2D, self).get_config()
+        config.pop('filters')
+        config.pop('kernel_initializer')
+        config.pop('kernel_regularizer')
+        config.pop('kernel_constraint')
+        config['depth_multiplier'] = self.depth_multiplier
+        config['depthwise_initializer'] = initializers.serialize(self.depthwise_initializer)
+        config['depthwise_regularizer'] = regularizers.serialize(self.depthwise_regularizer)
+        config['depthwise_constraint'] = constraints.serialize(self.depthwise_constraint)
+        return config
+
+
 class UpSampling1D(Layer):
     """Upsampling layer for 1D inputs.
 

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -137,8 +137,6 @@ def test_inceptionresnetv2():
     _test_app_pooling(app, last_dim)
 
 
-@pytest.mark.skipif((K.backend() != 'tensorflow'),
-                    reason='MobileNets are supported only on TensorFlow')
 def test_mobilenet():
     app = applications.MobileNet
     last_dim = 1024

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -844,27 +844,31 @@ class TestBackend(object):
             with pytest.raises(ValueError):
                 k.conv3d(k.variable(xval), k.variable(kernel_val), data_format='channels_middle')
 
-    @pytest.mark.parametrize('k', [KTF], ids=['TensorFlow'])
-    def test_depthwise_conv_2d(self, k):
-        for data_format in ['channels_first', 'channels_last']:
-            x_shape = (4, 4)
-            if data_format == 'channels_first':
-                input_shape = (2, 3) + x_shape
-            elif data_format == 'channels_last':
-                input_shape = (2,) + x_shape + (3,)
-            kernel_shape = (3, 3, 3, 2)
+    def test_depthwise_conv_2d(self):
+        # TF kernel shape: (rows, cols, input_depth, depth_multiplier)
+        # channels_first input shape: (n, input_depth, rows, cols)
+        for input_shape in [(2, 3, 4, 5), (2, 3, 5, 6)]:
+            for kernel_shape in [(2, 2, 3, 4), (4, 3, 3, 4)]:
+                check_two_tensor_operation('depthwise_conv2d',
+                                           input_shape, kernel_shape,
+                                           BACKENDS, cntk_dynamicity=True,
+                                           data_format='channels_first')
 
-            x_val = np.ones(input_shape)
-            kernel_val = np.arange(np.prod(kernel_shape)).reshape(kernel_shape)
-            z = k.eval(k.depthwise_conv2d(k.variable(x_val), k.variable(kernel_val),
-                                          data_format=data_format))
+        input_shape = (1, 6, 5, 3)
+        kernel_shape = (3, 3, 3, 2)
+        check_two_tensor_operation('depthwise_conv2d',
+                                   input_shape, kernel_shape,
+                                   BACKENDS, cntk_dynamicity=True,
+                                   data_format='channels_last')
 
-            for z_i in np.split(z, 6, axis=1 if data_format == 'channels_first' else -1):
-                assert_allclose(z_i, z_i[0] * np.ones_like(z_i))
-
+        xval = np.random.random(input_shape)
+        kernel_val = np.random.random(kernel_shape) - 0.5
         # Test invalid use cases
-        with pytest.raises(ValueError):
-            k.depthwise_conv2d(k.variable(x_val), k.variable(kernel_val), data_format='channels_middle')
+        for k in BACKENDS:
+            with pytest.raises(ValueError):
+                k.depthwise_conv2d(k.variable(xval),
+                                   k.variable(kernel_val),
+                                   data_format='channels_middle')
 
     def test_pool2d(self):
         check_single_tensor_operation('pool2d', (5, 10, 12, 3),

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -331,6 +331,50 @@ def test_separable_conv_2d():
 
 
 @keras_test
+def test_depthwise_conv_2d():
+    num_samples = 2
+    stack_size = 3
+    num_row = 7
+    num_col = 6
+
+    for padding in _convolution_paddings:
+        for strides in [(1, 1), (2, 2)]:
+            for multiplier in [1, 2]:
+                if padding == 'same' and strides != (1, 1):
+                    continue
+
+                layer_test(convolutional.DepthwiseConv2D,
+                           kwargs={'kernel_size': (3, 3),
+                                   'padding': padding,
+                                   'strides': strides,
+                                   'depth_multiplier': multiplier},
+                           input_shape=(num_samples,
+                                        num_row,
+                                        num_col,
+                                        stack_size))
+
+    layer_test(convolutional.DepthwiseConv2D,
+               kwargs={'kernel_size': 3,
+                       'padding': padding,
+                       'data_format': 'channels_first',
+                       'activation': None,
+                       'depthwise_regularizer': 'l2',
+                       'bias_regularizer': 'l2',
+                       'activity_regularizer': 'l2',
+                       'depthwise_constraint': 'unit_norm',
+                       'strides': strides,
+                       'depth_multiplier': multiplier},
+               input_shape=(num_samples, stack_size, num_row, num_col))
+
+    # Test invalid use case
+    with pytest.raises(ValueError):
+        Sequential([convolutional.DepthwiseConv2D(
+            kernel_size=3,
+            padding=padding,
+            batch_input_shape=(None, None, 5, None))])
+
+
+@keras_test
 def test_globalpooling_1d():
     layer_test(pooling.GlobalMaxPooling1D,
                input_shape=(3, 4, 5))


### PR DESCRIPTION
This PR enables `DepthwiseConv2D`, initially designed for TensorFlow only, to work on Theano and CNTK. This PR includes the following:
- moving `class DepthwiseConv2D` from `keras/applications/mobilenet.py` to `keras/layers/convolutional.py` without modification,
- adding `depthwise_conv2d` for Theano and CNTK,
- revising `test_depthwise_conv_2d` in `backend_test.py` with respect to existing backend test styles,
- adding `test_depthwise_conv_2d` in `convolutional_test.py`.