### PR TITLE
Fix different results over three backends for ResNet50 and MobileNet

### DIFF
--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -64,6 +64,7 @@ from ..layers import Reshape
 from ..layers import BatchNormalization
 from ..layers import GlobalAveragePooling2D
 from ..layers import GlobalMaxPooling2D
+from ..layers import ZeroPadding2D
 from ..layers import Conv2D
 from ..layers import DepthwiseConv2D
 from .. import initializers
@@ -381,11 +382,12 @@ def _conv_block(inputs, filters, alpha, kernel=(3, 3), strides=(1, 1)):
     """
     channel_axis = 1 if K.image_data_format() == 'channels_first' else -1
     filters = int(filters * alpha)
+    x = ZeroPadding2D(padding=(1, 1), name='conv1_pad')(inputs)
     x = Conv2D(filters, kernel,
-               padding='same',
+               padding='valid',
                use_bias=False,
                strides=strides,
-               name='conv1')(inputs)
+               name='conv1')(x)
     x = BatchNormalization(axis=channel_axis, name='conv1_bn')(x)
     return Activation(relu6, name='conv1_relu')(x)
 
@@ -442,12 +444,13 @@ def _depthwise_conv_block(inputs, pointwise_conv_filters, alpha,
     channel_axis = 1 if K.image_data_format() == 'channels_first' else -1
     pointwise_conv_filters = int(pointwise_conv_filters * alpha)
 
+    x = ZeroPadding2D(padding=(1, 1), name='conv_pad_%d' % block_id)(inputs)
     x = DepthwiseConv2D((3, 3),
-                        padding='same',
+                        padding='valid',
                         depth_multiplier=depth_multiplier,
                         strides=strides,
                         use_bias=False,
-                        name='conv_dw_%d' % block_id)(inputs)
+                        name='conv_dw_%d' % block_id)(x)
     x = BatchNormalization(axis=channel_axis, name='conv_dw_%d_bn' % block_id)(x)
     x = Activation(relu6, name='conv_dw_%d_relu' % block_id)(x)
 

--- a/keras/applications/resnet50.py
+++ b/keras/applications/resnet50.py
@@ -24,6 +24,7 @@ from ..layers import MaxPooling2D
 from ..layers import AveragePooling2D
 from ..layers import GlobalAveragePooling2D
 from ..layers import GlobalMaxPooling2D
+from ..layers import ZeroPadding2D
 from ..layers import BatchNormalization
 from ..models import Model
 from .. import backend as K
@@ -209,8 +210,8 @@ def ResNet50(include_top=True, weights='imagenet',
     else:
         bn_axis = 1
 
-    x = Conv2D(
-        64, (7, 7), strides=(2, 2), padding='same', name='conv1')(img_input)
+    x = ZeroPadding2D(padding=(3, 3), name='conv1_pad')(img_input)
+    x = Conv2D(64, (7, 7), strides=(2, 2), padding='valid', name='conv1')(x)
     x = BatchNormalization(axis=bn_axis, name='bn_conv1')(x)
     x = Activation('relu')(x)
     x = MaxPooling2D((3, 3), strides=(2, 2))(x)


### PR DESCRIPTION
As discussed in #9457, there are the discrepancies in `ResNet50` and `MobileNet`. The tests scripts are:
```python
import numpy as np
from keras.preprocessing import image
from keras.applications.mobilenet import decode_predictions

from keras.applications.mobilenet import MobileNet
from keras.applications.mobilenet import preprocess_input as p1
from keras.applications.resnet50 import ResNet50
from keras.applications.resnet50 import preprocess_input as p2

model1 = MobileNet(weights='imagenet')
model2 = ResNet50(weights='imagenet')

img = image.load_img('cat.png', target_size=(224, 224))
x = image.img_to_array(img)
x = np.expand_dims(x, axis=0)
x1 = p1(x.copy())
x2 = p2(x.copy())

print('Predicted:', decode_predictions(model1.predict(x1), top=3)[0])
print('Predicted:', decode_predictions(model2.predict(x2), top=3)[0])
```

The outputs of CNTK and Theano are:
```bash
 $ KERAS_BACKEND=cntk python test_mobilenet.py
Using CNTK backend
Selected GPU[0] Tesla P100-PCIE-16GB as the process wide default device.
('Predicted:', [(u'n02123159', u'tiger_cat', 0.25886607), (u'n02124075', u'Egyptian_cat', 0.14433344), (u'n02123045', u'tabby', 0.06473238)])
('Predicted:', [(u'n02124075', u'Egyptian_cat', 0.17055313), (u'n02123597', u'Siamese_cat', 0.11803201), (u'n03482405', u'hamper', 0.055440076)])

 $ KERAS_BACKEND=theano python test_mobilenet.py
Using Theano backend.
('Predicted:', [(u'n02123159', u'tiger_cat', 0.2602814), (u'n02124075', u'Egyptian_cat', 0.14234008), (u'n02123045', u'tabby', 0.06521355)])
('Predicted:', [(u'n02124075', u'Egyptian_cat', 0.17173238), (u'n02123597', u'Siamese_cat', 0.10258683), (u'n02130308', u'cheetah', 0.0565808)])
```

The problem is that TensorFlow differs as follows:
```bash
 $ KERAS_BACKEND=tensorflow python test_mobilenet.py
Using TensorFlow backend.
('Predicted:', [(u'n03482405', u'hamper', 0.21035317), (u'n02123159', u'tiger_cat', 0.113607496), (u'n04074963', u'remote_control', 0.09508652)])
('Predicted:', [(u'n02124075', u'Egyptian_cat', 0.116303556), (u'n02123597', u'Siamese_cat', 0.075559795), (u'n02130308', u'cheetah', 0.048775144)])
```

The main problem is from different padding behaviour of `Conv2D(filters, kernel, padding='same', strides=(2, 2))`. With explicit `ZeroPadding2D`, TensorFlow is able to show small numerical differences.
```bash
 $ git checkout fix_resnet_mobilenet
Switched to branch 'fix_resnet_mobilenet'
 $ KERAS_BACKEND=tensorflow python test_mobilenet.py
Using TensorFlow backend.
('Predicted:', [(u'n02123159', u'tiger_cat', 0.2602828), (u'n02124075', u'Egyptian_cat', 0.14233977), (u'n02123045', u'tabby', 0.0652139)])
('Predicted:', [(u'n02124075', u'Egyptian_cat', 0.17173262), (u'n02123597', u'Siamese_cat', 0.102586426), (u'n02130308', u'cheetah', 0.056580666)])
```