### PR TITLE
Fix `pool_2d` of Theano for backend compatibility

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -2171,14 +2171,10 @@ def pool2d(x, pool_size, strides=(1, 1), padding='valid',
                                 pad=pad,
                                 mode='max')
     elif pool_mode == 'avg':
-        if padding == 'same':
-            th_avg_pool_mode = 'average_inc_pad'
-        elif padding == 'valid':
-            th_avg_pool_mode = 'average_exc_pad'
         pool_out = pool.pool_2d(x, ws=pool_size, stride=strides,
                                 ignore_border=True,
                                 pad=pad,
-                                mode=th_avg_pool_mode)
+                                mode='average_exc_pad')
     else:
         raise ValueError('Invalid pooling mode:', pool_mode)
     if padding == 'same':

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -933,6 +933,11 @@ class TestBackend(object):
                                       BACKENDS, cntk_dynamicity=True,
                                       pool_size=(2, 3), strides=(1, 1), padding='valid')
 
+        check_single_tensor_operation('pool2d', (2, 7, 7, 5),
+                                      BACKENDS, cntk_dynamicity=True,
+                                      pool_size=(3, 3), strides=(1, 1),
+                                      padding='same', pool_mode='avg')
+
     def test_pool3d(self):
         check_single_tensor_operation('pool3d', (5, 10, 12, 5, 3),
                                       BACKENDS, cntk_dynamicity=True,


### PR DESCRIPTION
As discussed in #9457, there is the discrepancy in `InceptionV3`. The difference began from `branch_pool = AveragePooling2D((3, 3), strides=(1, 1), padding='same')(x)` in `inception_v3.py`. This PR fixes `pool_2d` of Theano in order to compute averages excluding borders when `padding='same'`, which is the same behaviour over CNTK and TensorFlow:
```bash
 $ cat test_pool2d.py 
import numpy as np
from numpy.testing import assert_allclose
from keras.backend import cntk_backend as KC
from keras.backend import tensorflow_backend as KTF
from keras.backend import theano_backend as KTH

x = np.random.random((1, 35, 35, 192)).astype(np.float32)
kwargs = {'pool_size': (3, 3), 'strides': (1, 1), 'padding': 'same', 'pool_mode': 'avg'}

xc = KC.placeholder(x.shape)
yc = KC.function([xc], [KC.pool2d(xc, **kwargs)])([x])[0]
ytf = KTF.eval(KTF.pool2d(KTF.variable(x), **kwargs))
yth = KTH.eval(KTH.pool2d(KTH.variable(x), **kwargs))

assert_allclose(yc, ytf, atol=1e-5)
assert_allclose(ytf, yth, atol=1e-5)

 $ python test_pool2d.py
Using TensorFlow backend.
Selected GPU[1] Tesla P100-PCIE-16GB as the process wide default device.
Traceback (most recent call last):
  File "test_pool2d.py", line 16, in <module>
    assert_allclose(ytf, yth, atol=1e-5)
  File "/home/taehoonlee/.conda/envs/taehoonlee/lib/python2.7/site-packages/numpy/testing/nose_tools/utils.py", line 1396, in assert_allclose
    verbose=verbose, header=header, equal_nan=equal_nan)
  File "/home/taehoonlee/.conda/envs/taehoonlee/lib/python2.7/site-packages/numpy/testing/nose_tools/utils.py", line 779, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Not equal to tolerance rtol=1e-07, atol=1e-05

(mismatch 11.1020408163%)
 x: array([[[[0.362999, 0.588966, 0.687862, ..., 0.154685, 0.633186,
          0.427167],
         [0.330889, 0.661694, 0.556173, ..., 0.199553, 0.656043,...
 y: array([[[[0.161333, 0.261763, 0.305717, ..., 0.068749, 0.281416,
          0.189852],
         [0.220593, 0.44113 , 0.370782, ..., 0.133035, 0.437362,...
```

With this PR, `InceptionV3` is now able to produce the same results over CNTK and TensorFlow.
```bash
 $ KERAS_BACKEND=cntk python test_inception.py 
Using CNTK backend
Selected GPU[0] Tesla P100-PCIE-16GB as the process wide default device.
('Predicted:', [(u'n02123045', u'tabby', 0.0965918), (u'n04325704', u'stole', 0.096036375), (u'n02124075', u'Egyptian_cat', 0.06516922)])

 $ KERAS_BACKEND=tensorflow python test_inception.py 
Using TensorFlow backend.
('Predicted:', [(u'n02123045', u'tabby', 0.098742), (u'n04325704', u'stole', 0.092110544), (u'n02124075', u'Egyptian_cat', 0.065612644)])

 $ KERAS_BACKEND=theano python test_inception.py 
Using Theano backend.
('Predicted:', [(u'n02123045', u'tabby', 0.13581793), (u'n02124075', u'Egyptian_cat', 0.08953164), (u'n02123159', u'tiger_cat', 0.06193132)])

 $ git checkout fix_pool2d
Switched to branch 'fix_pool2d'

 $ KERAS_BACKEND=theano python test_inception.py 
Using Theano backend.
('Predicted:', [(u'n02123045', u'tabby', 0.09874197), (u'n04325704', u'stole', 0.09211039), (u'n02124075', u'Egyptian_cat', 0.06561278)])
```