### PR TITLE
Fix comment in pow function

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1538,7 +1538,7 @@ def pow(x, a):
 
     # Arguments
         x: Tensor or variable.
-        a: Python integer.
+        a: Python integer or float.
 
     # Returns
         A tensor.


### PR DESCRIPTION
We can use both interger or float for pow operation.
This pow operation comes from math_ops.py in tensorflow:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/math_ops.py#L548-L571