### PR TITLE
Fix tensorflow_backend  deprecation warning

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3148,7 +3148,7 @@ def l2_normalize(x, axis=None):
     # Returns
         A tensor.
     """
-    return tf.nn.l2_normalize(x, dim=axis)
+    return tf.nn.l2_normalize(x, axis=axis)
 
 
 def in_top_k(predictions, targets, k):


### PR DESCRIPTION
WARNING:tensorflow:From .../lib/python3.6/site-packages/keras/backend/tensorflow_backend.py:3148: calling l2_normalize (from tensorflow.python.ops.nn_impl) with dim is deprecated and will be removed in a future version.
Instructions for updating:
dim is deprecated, use axis instead