### PR TITLE
TensorBoard finds nested Embedding layers

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -784,11 +784,11 @@ class TensorBoard(Callback):
 
             embedding_layers = set()
             layers = model.layers[:]
-            while len(layers) > 0:
+            while layers:
                 layer = layers.pop(0)
                 if isinstance(layer, __import__(__name__).layers.Embedding):
                     embedding_layers.add(layer)
-                elif isinstance(layer, __import__(__name__).layers.Wrapper):
+                elif isinstance(layer, __import__(__name__).layers.TimeDistributed):
                     layers.append(layer.layer)
                 elif isinstance(layer, __import__(__name__).models.Model):
                         layers.extend(layer.layers)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -791,7 +791,7 @@ class TensorBoard(Callback):
                 elif isinstance(layer, __import__(__name__).layers.TimeDistributed):
                     layers.append(layer.layer)
                 elif isinstance(layer, __import__(__name__).models.Model):
-                        layers.extend(layer.layers)
+                    layers.extend(layer.layers)
 
             if not embeddings_layer_names:
                 embeddings = {layer.name: layer.weights[0]

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -663,6 +663,7 @@ def test_TensorBoard_convnet(tmpdir):
     shutil.rmtree(filepath)
     assert not tmpdir.listdir()
 
+
 @keras_test
 def test_TensorBoard_embedding(tmpdir):
     np.random.seed(np.random.randint(1, 1e7))
@@ -676,8 +677,8 @@ def test_TensorBoard_embedding(tmpdir):
 
     def data_gen(n_samples):
         while True:
-            data_X = np.random.randint(1, char_vocab_size+1,
-                size=(n_samples, words_per_sentence, chars_per_word))
+            data_X = np.random.randint(1, char_vocab_size + 1,
+                                       size=(n_samples, words_per_sentence, chars_per_word))
             data_Y = np.eye(num_classes)[np.random.choice(num_classes, n_samples)]
             yield data_X, data_Y
 

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -666,7 +666,6 @@ def test_TensorBoard_convnet(tmpdir):
 
 @keras_test
 def test_TensorBoard_embedding(tmpdir):
-    np.random.seed(np.random.randint(1, 1e7))
     filepath = str(tmpdir / 'logs')
 
     words_per_sentence = 10
@@ -676,10 +675,12 @@ def test_TensorBoard_embedding(tmpdir):
     rnn_size = 8
 
     def data_gen(n_samples):
+        np.random.seed(1337)
+        eye = np.eye(num_classes)
         while True:
             data_X = np.random.randint(1, char_vocab_size + 1,
                                        size=(n_samples, words_per_sentence, chars_per_word))
-            data_Y = np.eye(num_classes)[np.random.choice(num_classes, n_samples)]
+            data_Y = eye[np.random.choice(num_classes, n_samples)]
             yield data_X, data_Y
 
     # Embedding in a (nested) Model in a TimeDistributed

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -667,6 +667,7 @@ def test_TensorBoard_convnet(tmpdir):
 @keras_test
 def test_TensorBoard_embedding(tmpdir):
     filepath = str(tmpdir / 'logs')
+    np.random.seed(1337)
 
     words_per_sentence = 10
     chars_per_word = 5
@@ -675,7 +676,6 @@ def test_TensorBoard_embedding(tmpdir):
     rnn_size = 8
 
     def data_gen(n_samples):
-        np.random.seed(1337)
         eye = np.eye(num_classes)
         while True:
             data_X = np.random.randint(1, char_vocab_size + 1,
@@ -686,7 +686,7 @@ def test_TensorBoard_embedding(tmpdir):
     # Embedding in a (nested) Model in a TimeDistributed
     x = Input(shape=(words_per_sentence, chars_per_word,))
     nested_model = Sequential()
-    nested_model.add(Embedding(input_dim=char_vocab_size, output_dim=embed_size,
+    nested_model.add(Embedding(input_dim=char_vocab_size + 1, output_dim=embed_size,
                                input_length=chars_per_word, name='embedding_layer'))
     nested_model.add(GRU(rnn_size))
     y = TimeDistributed(nested_model)(x)

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -665,6 +665,8 @@ def test_TensorBoard_convnet(tmpdir):
 
 
 @keras_test
+@pytest.mark.skipif((K.backend() != 'tensorflow'),
+                    reason='Requires TensorFlow backend')
 def test_TensorBoard_embedding(tmpdir):
     filepath = str(tmpdir / 'logs')
     np.random.seed(1337)


### PR DESCRIPTION
Currently the TensorBoard callback does not allow visualization of nested Embedding layers, for example, in a Model (used as a layer) wrapped in a TimeDistributed layer. This PR allows the TensorBoard callback to find nested Embedding layers too, for visualization.
