### PR TITLE
Exclude cudnn layers when reporting coverages

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,4 +15,5 @@ show_missing = True
 omit =
     keras/applications/*
     keras/datasets/*
+    keras/layers/cudnn_recurrent.py
     keras/legacy/*


### PR DESCRIPTION
This PR excludes cudnn related codes that can not be reached during CI tests. This affects only calculating test coverages.