### PR TITLE
Removed few redundant periods in the documentation

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -229,7 +229,7 @@ class RNN(Layer):
             It is also possible for `cell` to be a list of RNN cell instances,
             in which cases the cells get stacked on after the other in the RNN,
             implementing an efficient stacked RNN.
-        return_sequences: Boolean. Whether to return the last output.
+        return_sequences: Boolean. Whether to return the last output
             in the output sequence, or the full sequence.
         return_state: Boolean. Whether to return the last state
             in addition to the output.
@@ -983,7 +983,7 @@ class SimpleRNN(RNN):
         recurrent_dropout: Float between 0 and 1.
             Fraction of the units to drop for
             the linear transformation of the recurrent state.
-        return_sequences: Boolean. Whether to return the last output.
+        return_sequences: Boolean. Whether to return the last output
             in the output sequence, or the full sequence.
         return_state: Boolean. Whether to return the last state
             in addition to the output.
@@ -1528,7 +1528,7 @@ class GRU(RNN):
             batch them into fewer, larger operations. These modes will
             have different performance profiles on different hardware and
             for different applications.
-        return_sequences: Boolean. Whether to return the last output.
+        return_sequences: Boolean. Whether to return the last output
             in the output sequence, or the full sequence.
         return_state: Boolean. Whether to return the last state
             in addition to the output.
@@ -2054,7 +2054,7 @@ class LSTM(RNN):
             batch them into fewer, larger operations. These modes will
             have different performance profiles on different hardware and
             for different applications.
-        return_sequences: Boolean. Whether to return the last output.
+        return_sequences: Boolean. Whether to return the last output
             in the output sequence, or the full sequence.
         return_state: Boolean. Whether to return the last state
             in addition to the output.


### PR DESCRIPTION
There was an extra period in the middle of few sentences in the recurrent.py documentation.