### PR TITLE
Remove an unnecessary activation in docs

### DIFF
--- a/docs/templates/optimizers.md
+++ b/docs/templates/optimizers.md
@@ -8,7 +8,6 @@ from keras import optimizers
 
 model = Sequential()
 model.add(Dense(64, kernel_initializer='uniform', input_shape=(10,)))
-model.add(Activation('tanh'))
 model.add(Activation('softmax'))
 
 sgd = optimizers.SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)


### PR DESCRIPTION
This PR removes an unnecessary activation in docs. The usage of `Activation('tanh')` followed by `Activation('softmax')` does not seem to be normal. In general cases, a `softmax` function takes unnormalized values.