### PR TITLE
Use MobileNet model with undefined shape

### DIFF
--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -219,10 +219,15 @@ def MobileNet(input_shape=None,
                              '`0.25`, `0.50`, `0.75` or `1.0` only.')
 
         if rows != cols or rows not in [128, 160, 192, 224]:
-            raise ValueError('If imagenet weights are being loaded, '
-                             'input must have a static square shape (one of '
-                             '(128,128), (160,160), (192,192), or (224, 224)).'
-                             ' Input shape provided = %s' % (input_shape,))
+            if rows is None:
+                rows = 224
+                warnings.warn('The MobileNet shape is undefined.'
+                              ' Weights with input shape (224, 224) will be loaded.')
+            else:
+                raise ValueError('If imagenet weights are being loaded, '
+                                 'input must have a static square shape (one of '
+                                 '(128,128), (160,160), (192,192), or (224, 224)).'
+                                 ' Input shape provided = %s' % (input_shape,))
 
     if K.image_data_format() != 'channels_last':
         warnings.warn('The MobileNet family of models is only available '
@@ -451,7 +456,8 @@ def _depthwise_conv_block(inputs, pointwise_conv_filters, alpha,
                         strides=strides,
                         use_bias=False,
                         name='conv_dw_%d' % block_id)(x)
-    x = BatchNormalization(axis=channel_axis, name='conv_dw_%d_bn' % block_id)(x)
+    x = BatchNormalization(
+        axis=channel_axis, name='conv_dw_%d_bn' % block_id)(x)
     x = Activation(relu6, name='conv_dw_%d_relu' % block_id)(x)
 
     x = Conv2D(pointwise_conv_filters, (1, 1),
@@ -459,5 +465,6 @@ def _depthwise_conv_block(inputs, pointwise_conv_filters, alpha,
                use_bias=False,
                strides=(1, 1),
                name='conv_pw_%d' % block_id)(x)
-    x = BatchNormalization(axis=channel_axis, name='conv_pw_%d_bn' % block_id)(x)
+    x = BatchNormalization(
+        axis=channel_axis, name='conv_pw_%d_bn' % block_id)(x)
     return Activation(relu6, name='conv_pw_%d_relu' % block_id)(x)

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -221,12 +221,12 @@ def MobileNet(input_shape=None,
         if rows != cols or rows not in [128, 160, 192, 224]:
             if rows is None:
                 rows = 224
-                warnings.warn('The MobileNet shape is undefined.'
-                              ' Weights with input shape (224, 224) will be loaded.')
+                warnings.warn('MobileNet shape is undefined.'
+                              ' Weights for input shape (224, 224) will be loaded.')
             else:
                 raise ValueError('If imagenet weights are being loaded, '
                                  'input must have a static square shape (one of '
-                                 '(128,128), (160,160), (192,192), or (224, 224)).'
+                                 '(128, 128), (160, 160), (192, 192), or (224, 224)).'
                                  ' Input shape provided = %s' % (input_shape,))
 
     if K.image_data_format() != 'channels_last':


### PR DESCRIPTION
There is a problem to use MobileNet as feature extractor because it is only able to get input with static shape. If we use this code:
```
model = MobileNet(include_top=False, weights='imagenet')
```
it throws ValueError:
```
ValueError: If imagenet weights are being loaded, input must have a static square shape (one of (128,128), (160,160), (192,192), or (224, 224)). Input shape provided = (None, None, 3)
```
But another application model(such as ResNet50 etc) are able to get undefined shape.
As the solution of the problem I offer to use as default weights that were trained with input_shape (224,224) and warn about it.