### PR TITLE
Removed StackedRNNCells from docs.

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -203,7 +203,6 @@ PAGES = [
             layers.SimpleRNNCell,
             layers.GRUCell,
             layers.LSTMCell,
-            layers.StackedRNNCells,
             layers.CuDNNGRU,
             layers.CuDNNLSTM,
         ],


### PR DESCRIPTION
Hi!

From my undertanding, the keras framework should be in charge of using the class StackedRNNCells, not the user. The user just provides list of cells. 

So I might be wrong but I think it's misleading to display this class in the docs.
