### PR TITLE
RNN: properly set built flag to True

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -479,6 +479,7 @@ class RNN(Layer):
                                for dim in state_size]
         if self.stateful:
             self.reset_states()
+        self.built = True
 
     def get_initial_state(self, inputs):
         # build an all-zero tensor of shape (samples, output_dim)


### PR DESCRIPTION
RNN's self.built flag wasn't set after build(), causing it to be built again if used several times. This resulted in disconnected input errors on theano.