### PR TITLE
Allow user to specify `hash_function` in `one_hot`

### DIFF
--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -58,6 +58,7 @@ def text_to_word_sequence(text,
 
 
 def one_hot(text, n,
+            hash_function=None,
             filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n',
             lower=True,
             split=' '):
@@ -69,6 +70,9 @@ def one_hot(text, n,
     # Arguments
         text: Input text (string).
         n: Dimension of the hashing space.
+        hash_function:  if `None` uses python `hash` function, can be 'md5' or
+            any function that takes in input a string and returns a int. See
+            hashing_trick for more informtion.
         filters: Sequence of characters to filter out.
         lower: Whether to convert the input to lowercase.
         split: Sentence split marker (string).
@@ -77,7 +81,7 @@ def one_hot(text, n,
         A list of integer word indices (unicity non-guaranteed).
     """
     return hashing_trick(text, n,
-                         hash_function=hash,
+                         hash_function=hash_function,
                          filters=filters,
                          lower=lower,
                          split=split)


### PR DESCRIPTION
This is a shallow PR that allows passing the `hash_function` argument from `one_hot`. This ensures that users can use a stable hash function for one_hot, and can fix issues like #9500. It does, however, also eliminate what seems to be the only purpose for the function. 

After inspecting the API, I that there's no difference between typing `one_hot(data, n)` and `hashing_trick(data, n)`, since the built in `hash` is indeed the default `hash_function` for `hashing_trick` as well as for `one_hot`.

I'm not here to propose breaking changes, but after writing this it seems like `one_hot` has little to offer except a friendlier name. 