### PR TITLE
Convert h5py Dataset to np.array before preprocess_weights_for_loading

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -3370,7 +3370,7 @@ def load_weights_from_hdf5_group(f, layers, reshape=False):
     for k, name in enumerate(layer_names):
         g = f[name]
         weight_names = _load_attributes_from_hdf5_group(g, 'weight_names')
-        weight_values = [g[weight_name] for weight_name in weight_names]
+        weight_values = [np.asarray(g[weight_name]) for weight_name in weight_names]
         layer = filtered_layers[k]
         symbolic_weights = layer.weights
         weight_values = preprocess_weights_for_loading(layer,
@@ -3438,7 +3438,7 @@ def load_weights_from_hdf5_group_by_name(f, layers, skip_mismatch=False,
     for k, name in enumerate(layer_names):
         g = f[name]
         weight_names = _load_attributes_from_hdf5_group(g, 'weight_names')
-        weight_values = [g[weight_name] for weight_name in weight_names]
+        weight_values = [np.asarray(g[weight_name]) for weight_name in weight_names]
 
         for layer in index.get(name, []):
             symbolic_weights = layer.weights


### PR DESCRIPTION
In `load_weights_from_hdf5_group` and `load_weights_from_hdf5_group_by_name`, the following line:
```python
weight_values = [g[weight_name] for weight_name in weight_names]
```
generates a list of h5py datasets (`g[weight_name]` points to the h5py `Dataset` created in `save_weights_to_hdf5_group`).

However, the expected input data type for `preprocess_weights_for_loading` is a list of numpy arrays, as stated in the docstring. The unit tests for `preprocess_weights_for_loading` also assume the input/output to be lists of numpy arrays (which is why the tests fail to detect [the error reported](https://github.com/keras-team/keras/pull/9112#issuecomment-372988910) in PR #9112).

Also, if some of the weights are converted in `preprocess_weights_for_loading`, the returned list could be a mix of h5py datasets and numpy arrays, which might not be a desirable behavior.

This PR applies `np.asarray` to the h5py datasets (earlier, since `np.asarray` is applied to them in `K.batch_set_value` anyway) to resolve the above issues.