### PR TITLE
Tensorflow batchnorm float16 support

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -510,6 +510,10 @@ def cast(x, dtype):
     return x
 
 
+def cast_like(x, y):
+    return None if x is None else cast(x, dtype(y))
+
+
 def dot(x, y):
     if len(x.shape) > 2 or len(y.shape) > 2:
         y_shape = int_shape(y)

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -777,7 +777,12 @@ def zeros_like(x, dtype=None, name=None):
                [ 0.,  0.,  0.]], dtype=float32)
     ```
     """
-    return tf.zeros_like(x, dtype=dtype, name=name)
+    dtype = dtype or x.dtype.base_dtype.name
+    tf_dtype = tf.as_dtype(dtype)
+    v = tf.zeros_like(x, dtype=dtype, name=name)
+    if py_all(v.get_shape().as_list()):
+        return variable(v, dtype=dtype, name=name)
+    return v
 
 
 def ones_like(x, dtype=None, name=None):
@@ -944,7 +949,28 @@ def cast(x, dtype):
         <tf.Tensor 'Cast_2:0' shape=(2, 3) dtype=float16>
     ```
     """
-    return tf.cast(x, dtype)
+    return (
+        None
+        if x is None
+        else (
+            x
+            if x.dtype.base_dtype.name == dtype
+            else tf.cast(x, dtype)))
+
+
+def cast_like(x, y):
+    """Casts a tensor to the type of another tensor and returns it
+
+    You can cast a Keras variable but it still returns a Keras tensor.
+
+    # Arguments
+        x: Keras tensor (or variable) to be cast
+        y: Keras tensor with the target dtype
+
+    # Returns
+        x cast to the dtype of y. None if x is None
+    """
+    return None if x is None else cast(x, dtype(y))
 
 
 # UPDATES OPS

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -360,7 +360,17 @@ def count_params(x):
 
 
 def cast(x, dtype):
-    return T.cast(x, dtype)
+    return (
+        None
+        if x is None
+        else (
+            x
+            if x.dtype == dtype
+            else T.cast(x, dtype)))
+
+
+def cast_like(x, y):
+    return None if x is None else cast(x, dtype(y))
 
 
 # UPDATES OPS

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -410,7 +410,7 @@ class Layer(object):
         initializer = initializers.get(initializer)
         if dtype is None:
             dtype = K.floatx()
-        weight = K.variable(initializer(shape),
+        weight = K.variable(initializer(shape, dtype=dtype),
                             dtype=dtype,
                             name=name,
                             constraint=constraint)

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -845,7 +845,7 @@ class Model(Container):
             # Add regularization penalties
             # and other layer-specific losses.
             for loss_tensor in self.losses:
-                total_loss += loss_tensor
+                total_loss += K.cast_like(loss_tensor, total_loss)
 
         # List of same size as output_names.
         # contains tuples (metrics for output, names of metrics).

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -99,9 +99,14 @@ class BatchNormalization(Layer):
                                     axes={self.axis: dim})
         shape = (dim,)
 
+        weight_dtype = (
+            'float32'
+            if K.backend() == 'tensorflow' and K.floatx() == 'float16'
+            else None)
         if self.scale:
             self.gamma = self.add_weight(shape=shape,
                                          name='gamma',
+                                         dtype=weight_dtype,
                                          initializer=self.gamma_initializer,
                                          regularizer=self.gamma_regularizer,
                                          constraint=self.gamma_constraint)
@@ -110,6 +115,7 @@ class BatchNormalization(Layer):
         if self.center:
             self.beta = self.add_weight(shape=shape,
                                         name='beta',
+                                        dtype=weight_dtype,
                                         initializer=self.beta_initializer,
                                         regularizer=self.beta_regularizer,
                                         constraint=self.beta_constraint)
@@ -118,11 +124,13 @@ class BatchNormalization(Layer):
         self.moving_mean = self.add_weight(
             shape=shape,
             name='moving_mean',
+            dtype=weight_dtype,
             initializer=self.moving_mean_initializer,
             trainable=False)
         self.moving_variance = self.add_weight(
             shape=shape,
             name='moving_variance',
+            dtype=weight_dtype,
             initializer=self.moving_variance_initializer,
             trainable=False)
         self.built = True
@@ -183,7 +191,7 @@ class BatchNormalization(Layer):
         if K.backend() != 'cntk':
             sample_size = K.prod([K.shape(inputs)[axis]
                                   for axis in reduction_axes])
-            sample_size = K.cast(sample_size, dtype=K.dtype(inputs))
+            sample_size = K.cast_like(sample_size, variance)
 
             # sample variance - unbiased estimator of population variance
             variance *= sample_size / (sample_size - (1.0 + self.epsilon))

--- a/tests/keras/layers/normalization_test.py
+++ b/tests/keras/layers/normalization_test.py
@@ -14,9 +14,22 @@ input_2 = np.zeros(10)
 input_3 = np.ones((10))
 input_shapes = [np.ones((10, 10)), np.ones((10, 10, 10))]
 
+floatx_variations = ['float32', 'float16'] if K.backend() == 'tensorflow' else ['float32']
 
+@pytest.yield_fixture(autouse=True)
+def restore_floatx():
+    prev_floatx = K.floatx()
+    prev_epsilon = K.epsilon()
+    yield
+    K.set_floatx(prev_floatx)
+    K.set_epsilon(prev_epsilon)
+
+@pytest.mark.parametrize("floatx", floatx_variations)
 @keras_test
-def test_basic_batchnorm():
+def test_basic_batchnorm(floatx):
+    K.set_floatx(floatx)
+    if floatx == 'float16':
+        K.set_epsilon(1e-04)
     layer_test(normalization.BatchNormalization,
                kwargs={'momentum': 0.9,
                        'epsilon': 0.1,
@@ -44,8 +57,12 @@ def test_basic_batchnorm():
                    input_shape=(3, 4, 2, 4))
 
 
+@pytest.mark.parametrize("floatx", floatx_variations)
 @keras_test
-def test_batchnorm_correctness_1d():
+def test_batchnorm_correctness_1d(floatx):
+    K.set_floatx(floatx)
+    if floatx == 'float16':
+        K.set_epsilon(1e-04)
     model = Sequential()
     norm = normalization.BatchNormalization(input_shape=(10,), momentum=0.8)
     model.add(norm)
@@ -62,8 +79,12 @@ def test_batchnorm_correctness_1d():
     assert_allclose(out.std(), 1.0, atol=1e-1)
 
 
+@pytest.mark.parametrize("floatx", floatx_variations)
 @keras_test
-def test_batchnorm_correctness_2d():
+def test_batchnorm_correctness_2d(floatx):
+    K.set_floatx(floatx)
+    if floatx == 'float16':
+        K.set_epsilon(1e-04)
     model = Sequential()
     norm = normalization.BatchNormalization(axis=1, input_shape=(10, 6), momentum=0.8)
     model.add(norm)
@@ -80,8 +101,12 @@ def test_batchnorm_correctness_2d():
     assert_allclose(out.std(axis=(0, 2)), 1.0, atol=1.1e-1)
 
 
+@pytest.mark.parametrize("floatx", floatx_variations)
 @keras_test
-def test_batchnorm_training_argument():
+def test_batchnorm_training_argument(floatx):
+    K.set_floatx(floatx)
+    if floatx == 'float16':
+        K.set_epsilon(1e-04)
     bn1 = normalization.BatchNormalization(input_shape=(10,))
     x1 = Input(shape=(10,))
     y1 = bn1(x1, training=True)
@@ -105,8 +130,12 @@ def test_batchnorm_training_argument():
     assert not bn2.updates
 
 
+@pytest.mark.parametrize("floatx", floatx_variations)
 @keras_test
-def test_batchnorm_mode_twice():
+def test_batchnorm_mode_twice(floatx):
+    K.set_floatx(floatx)
+    if floatx == 'float16':
+        K.set_epsilon(1e-04)
     # This is a regression test for issue #4881 with the old
     # batch normalization functions in the Theano backend.
     model = Sequential()
@@ -119,8 +148,12 @@ def test_batchnorm_mode_twice():
     model.predict(x)
 
 
+@pytest.mark.parametrize("floatx", floatx_variations)
 @keras_test
-def test_batchnorm_convnet():
+def test_batchnorm_convnet(floatx):
+    K.set_floatx(floatx)
+    if floatx == 'float16':
+        K.set_epsilon(1e-04)
     model = Sequential()
     norm = normalization.BatchNormalization(axis=1, input_shape=(3, 4, 4), momentum=0.8)
     model.add(norm)
@@ -137,10 +170,14 @@ def test_batchnorm_convnet():
     assert_allclose(np.std(out, axis=(0, 2, 3)), 1.0, atol=1e-1)
 
 
+@pytest.mark.parametrize("floatx", floatx_variations)
 @keras_test
 @pytest.mark.skipif((K.backend() == 'theano'),
                     reason='Bug with theano backend')
-def test_batchnorm_convnet_no_center_no_scale():
+def test_batchnorm_convnet_no_center_no_scale(floatx):
+    K.set_floatx(floatx)
+    if floatx == 'float16':
+        K.set_epsilon(1e-04)
     model = Sequential()
     norm = normalization.BatchNormalization(axis=-1, center=False, scale=False,
                                             input_shape=(3, 4, 4), momentum=0.8)
@@ -156,8 +193,12 @@ def test_batchnorm_convnet_no_center_no_scale():
     assert_allclose(np.std(out, axis=(0, 2, 3)), 1.0, atol=1e-1)
 
 
+@pytest.mark.parametrize("floatx", floatx_variations)
 @keras_test
-def test_shared_batchnorm():
+def test_shared_batchnorm(floatx):
+    K.set_floatx(floatx)
+    if floatx == 'float16':
+        K.set_epsilon(1e-04)
     '''Test that a BN layer can be shared
     across different data streams.
     '''
@@ -184,8 +225,12 @@ def test_shared_batchnorm():
     new_model.train_on_batch(x, x)
 
 
+@pytest.mark.parametrize("floatx", floatx_variations)
 @keras_test
-def test_that_trainable_disables_updates():
+def test_that_trainable_disables_updates(floatx):
+    K.set_floatx(floatx)
+    if floatx == 'float16':
+        K.set_epsilon(1e-04)
     val_a = np.random.random((10, 4))
     val_out = np.random.random((10, 4))
 
@@ -224,4 +269,4 @@ def test_that_trainable_disables_updates():
 
 
 if __name__ == '__main__':
-    pytest.main([__file__])
+    pytest.main([__file__, '-x'])

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -31,7 +31,15 @@ def _test_optimizer(optimizer, target=0.75):
     model = Sequential()
     model.add(Dense(10, input_shape=(x_train.shape[1],)))
     model.add(Activation('relu'))
+    # We cast to float16 to test the situation where weights have a different
+    # dtype than floatx(), such as a BatchNormalization layer with float32
+    # weights when floatx() is float16.
+    prev_floatx = K.floatx()
+    K.set_floatx('float16')
+    model.add(Lambda(lambda x: K.cast(x, K.floatx())))
     model.add(Dense(y_train.shape[1]))
+    K.set_floatx(prev_floatx)
+    model.add(Lambda(lambda x: K.cast(x, K.floatx())))
     model.add(Activation('softmax'))
     model.compile(loss='categorical_crossentropy',
                   optimizer=optimizer,


### PR DESCRIPTION
This adds support for properly using the Tensorflow fused_batchnorm API (passing in float32 values for scale and offset). And when Tensorflow is the backend, it follows NVIDIA's recommendation of storing weights in float32, performing the weight updates in float32, and performing aggregations in float32.