### PR TITLE
Provide Compatibliy for default Softmax axis

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2955,7 +2955,16 @@ def softmax(x, axis=-1):
 
     # Returns
         A tensor.
+
+    # Raises
+        AttributeError: if using unsupported axia attribution.
     """
+    if tf.VERSION < '1.5.0':
+        if axis != -1:
+            raise AttributeError('axis is not supported by current'
+                                 'tensorflow, please upgrade tensorflow'
+                                 'backend to >= 1.5.0')
+        return tf.nn.softmax(x)
     return tf.nn.softmax(x, axis=axis)
 
 


### PR DESCRIPTION
This fix is to provide compatibility for original Keras backend interface.

NOTE: TF1.5 is using CUDA9 and CUDNN7 by default while most machines
keep CUDA8 and CUDNN6.

Keras cannot launch TF<=1.4 correct that makes all models fail, e.g: 
https://github.com/keras-team/keras/issues/9621

Signed-off-by: CUI Wei <ghostplant@qq.com>
