### PR TITLE
Fixes type error in Sequence example

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -328,7 +328,7 @@ class Sequence(object):
                 self.batch_size = batch_size
 
             def __len__(self):
-                return np.ceil(len(self.x) / float(self.batch_size))
+                return int(np.ceil(len(self.x) / float(self.batch_size)))
 
             def __getitem__(self, idx):
                 batch_x = self.x[idx * self.batch_size:(idx + 1) * self.batch_size]


### PR DESCRIPTION
The method `__len__` returns a `numpy.float64` but the class' `__iter__` method expects it to return an integer, which is not obvious from the example alone.