### PR TITLE
Don't create dead-lock threadpool by default.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1958,7 +1958,7 @@ class Model(Container):
                       validation_steps=None,
                       class_weight=None,
                       max_queue_size=10,
-                      workers=1,
+                      workers=0,
                       use_multiprocessing=False,
                       shuffle=True,
                       initial_epoch=0):

--- a/keras/models.py
+++ b/keras/models.py
@@ -1152,7 +1152,7 @@ class Sequential(Model):
                       validation_steps=None,
                       class_weight=None,
                       max_queue_size=10,
-                      workers=1,
+                      workers=0,
                       use_multiprocessing=False,
                       shuffle=True,
                       initial_epoch=0):


### PR DESCRIPTION
Don't create dead-lock threadpool by default.

Inception_V3 and Resnet50 have very-high possibility of dead-lock on quit when workers = 1 by default.

Signed-off-by: CUI Wei <ghostplant@qq.com>