### PR TITLE
Add validation_split to fit_generator #3900

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -7,10 +7,12 @@ import hashlib
 import multiprocessing
 import os
 import random
+import math
 import shutil
 import sys
 import tarfile
 import threading
+import tempfile
 import time
 import traceback
 import zipfile
@@ -239,6 +241,51 @@ def get_file(fname,
         _extract_archive(fpath, datadir, archive_format)
 
     return fpath
+
+
+def _copy_symlinks(files, src_dir, dst_dir):
+    for i in files:
+        base_file_name = os.path.basename(i)
+        src_file_path = os.path.join(src_dir, base_file_name)
+        dst_file_path = os.path.join(dst_dir, base_file_name)
+        src_file_path = os.path.abspath(src_file_path)
+        dst_file_path = os.path.abspath(dst_file_path)
+        os.symlink(src_file_path, dst_file_path)
+
+def train_valid_split(original_dir, validation_split=0.1):
+    if not os.path.isdir(original_dir):
+        raise NotADirectoryError
+    tmp_dir = tempfile.TemporaryDirectory()
+    train_dir = os.path.join(tmp_dir.name, 'train')
+    valid_dir = os.path.join(tmp_dir.name, 'validation')
+
+    # make subdirs in train tmp and valid tmp
+    for root, dirs, files in os.walk(original_dir):
+        if root == original_dir:
+            continue
+        sub_dir_name = os.path.basename(root)
+        train_sub_dir_path = os.path.join(train_dir, sub_dir_name)
+        valid_sub_dir_path = os.path.join(valid_dir, sub_dir_name)
+        if not os.path.exists(train_sub_dir_path):
+            os.makedirs(train_sub_dir_path)
+        if not os.path.exists(valid_sub_dir_path):
+            os.makedirs(valid_sub_dir_path)
+
+    # distribute symlinks to train_tmp, test_tmp
+    for root, dirs, files in os.walk(original_dir):
+        if root == original_dir:
+            continue
+        sub_dir_name = os.path.basename(root)
+        train_sub_dir_path = os.path.join(train_dir, sub_dir_name)
+        valid_sub_dir_path = os.path.join(valid_dir, sub_dir_name)
+        files = [os.path.join(root, f) for f in files]
+        random.shuffle(files)
+        valid_idx = math.ceil(validation_split * len(files))
+        train_files = files[valid_idx:]
+        valid_files = files[:valid_idx]
+        _copy_symlinks(train_files, root, train_sub_dir_path)
+        _copy_symlinks(valid_files, root, valid_sub_dir_path)
+    return train_dir, valid_dir
 
 
 def _hash_file(fpath, algorithm='sha256', chunk_size=65535):

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -285,7 +285,7 @@ def train_valid_split(original_dir, validation_split=0.1):
         valid_files = files[:valid_idx]
         _copy_symlinks(train_files, root, train_sub_dir_path)
         _copy_symlinks(valid_files, root, valid_sub_dir_path)
-    return train_dir, valid_dir
+    return tmp_dir, train_dir, valid_dir
 
 
 def _hash_file(fpath, algorithm='sha256', chunk_size=65535):


### PR DESCRIPTION
This is an alternative solution for adding validation_split to fit_generator(#3900 ).
I made utility which can split train and validation from original_dir with validation_split argument.

I'd like to get your feedback.
If it is not fit keras API,  please close.

usage
```python
train_dir, val_dir = keras.utils.data_utils.train_valid_split(original_dir, validation_split=0.1)
# all data in train_dir which are alias to original_data.
# and train_dir is a temporary directory.

train_datagen = ImageDataGenerator(
        rescale=1./255,
        shear_range=0.2,
        zoom_range=0.2,
        horizontal_flip=True)

val_datagen = ImageDataGenerator(rescale=1./255)

train_generator = train_datagen.flow_from_directory(
        train_dir,
        target_size=(150, 150),
        batch_size=32,
        class_mode='binary')

val_generator = val_datagen.flow_from_directory(
       val_dir,
        target_size=(150, 150),
        batch_size=32,
        class_mode='binary')
```