### PR TITLE
Add missing verbose opt for evaluate_generator

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2282,7 +2282,8 @@ class Model(Container):
     def evaluate_generator(self, generator, steps=None,
                            max_queue_size=10,
                            workers=1,
-                           use_multiprocessing=False):
+                           use_multiprocessing=False,
+                           verbose=0):
         """Evaluates the model on a data generator.
 
         The generator should return the same kind of data
@@ -2310,6 +2311,7 @@ class Model(Container):
                 non picklable arguments to the generator
                 as they can't be passed
                 easily to children processes.
+            verbose: verbosity mode, 0 or 1.
 
         # Returns
             Scalar test loss (if the model has a single output and no metrics)
@@ -2372,6 +2374,9 @@ class Model(Container):
                 else:
                     output_generator = generator
 
+            if verbose == 1:
+                progbar = Progbar(target=steps)
+
             while steps_done < steps:
                 generator_output = next(output_generator)
                 if not hasattr(generator_output, '__len__'):
@@ -2406,6 +2411,8 @@ class Model(Container):
 
                 steps_done += 1
                 batch_sizes.append(batch_size)
+                if verbose == 1:
+                    progbar.update(steps_done)
 
         finally:
             if enqueuer is not None:

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -288,6 +288,9 @@ def test_model_methods():
     out = model.evaluate([input_a_np, input_b_np], [output_a_np, output_b_np], batch_size=4)
     out = model.predict([input_a_np, input_b_np], batch_size=4)
 
+    # enable verbose for evaluate_generator
+    out = model.evaluate_generator(gen_data(4), steps=3, verbose=1)
+
     # empty batch
     with pytest.raises(ValueError):
         def gen_data():


### PR DESCRIPTION
`evaluate_generator` misses `verbose` support while `evaluate` doesn't.

Used for partial enhancement for fit/evaluate/predict API upgrade.

Signed-off-by: CUI Wei <ghostplant@qq.com>