### PR TITLE
fit/evaluate_generator supporting native tensors

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2212,7 +2212,11 @@ class Model(Container):
                                          str(generator_output))
                     # build batch logs
                     batch_logs = {}
-                    if isinstance(x, list):
+                    if x is None or len(x) == 0:
+                        # Handle data tensors support when no input given
+                        # step-size = 1 for data tensors
+                        batch_size = 1
+                    elif isinstance(x, list):
                         batch_size = x[0].shape[0]
                     elif isinstance(x, dict):
                         batch_size = list(x.values())[0].shape[0]
@@ -2399,7 +2403,11 @@ class Model(Container):
                     outs = [outs]
                 outs_per_batch.append(outs)
 
-                if isinstance(x, list):
+                if x is None or len(x) == 0:
+                    # Handle data tensors support when no input given
+                    # step-size = 1 for data tensors
+                    batch_size = 1
+                elif isinstance(x, list):
                     batch_size = x[0].shape[0]
                 elif isinstance(x, dict):
                     batch_size = list(x.values())[0].shape[0]

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -867,6 +867,20 @@ def test_model_with_external_loss():
             out = model.fit(None, None, epochs=1, batch_size=10)
         out = model.fit(None, None, epochs=1, steps_per_epoch=1)
 
+        # define a generator to produce x=None and y=None
+        def data_tensors_generator():
+            while True:
+                yield (None, None)
+
+        generator = data_tensors_generator()
+
+        # test fit_generator for framework-native data tensors
+        out = model.fit_generator(generator, epochs=1,
+                                  steps_per_epoch=3)
+
+        # test evaluate_generator for framework-native data tensors
+        out = model.evaluate_generator(generator, steps=3)
+
         # test fit with validation data
         with pytest.raises(ValueError):
             out = model.fit(None, None,


### PR DESCRIPTION
Currently, `fit/evaluate_generator` don't support this case without this fix.
But framework-native data tensors are already supported by `_fit_loop` and `_test_loop`.

Signed-off-by: CUI Wei <ghostplant@qq.com>