### PR TITLE
updated inconsistent docs of dense layer

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -772,9 +772,6 @@ class Dense(Layer):
     created by the layer, and `bias` is a bias vector created by the layer
     (only applicable if `use_bias` is `True`).
 
-    Note: if the input to the layer has a rank greater than 2, then
-    it is flattened prior to the initial dot product with `kernel`.
-
     # Example
 
     ```python


### PR DESCRIPTION
The Dense layer docs were inconsistent with actual functionality. That is, the docs were stating that Dense flattens the input before the first dot product, but this is not the case.

This PR fixes this inconsistency in the least intrusive way possible (by updating the docs).

See #9813 for more details.