### PR TITLE
Added note to manually install h5py where needed

### DIFF
--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -606,17 +606,16 @@ K.set_session(sess)
 
 ### How can I install HDF5 or h5py to save my models in Keras?
 
-In order to save your Keras models as hdf5 files, e.g. via `keras.callbacks.ModelCheckpoint`, you need to install the h5py Python package. The exact steps may varry depending on your operating system. For many systems a simple
-
-```
-pip install h5py
-```
-
-is sufficient. For Debian based unix distributions you will need to do
+In order to save your Keras models as hdf5 files, e.g. via `keras.callbacks.ModelCheckpoint`, Keras uses the h5py Python package. They are a dependency of Keras and should be installed by default. On Debian based distributions you will have to additionally install
 
 ```
 sudo apt-get install libhdf5-serial-dev
-pip install h5py
 ```
 
-When in doubt, you can always check the official h5py installation instructions here: http://docs.h5py.org/en/latest/build.html
+If you are unsure if h5py is installed you can open a Python shell and load the module via
+
+```
+import h5py
+```
+
+If it imports without error it is installed ortherwise you can find detaild installation instructions here: http://docs.h5py.org/en/latest/build.html

--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -19,6 +19,7 @@
 - [How can I use HDF5 inputs with Keras?](#how-can-i-use-hdf5-inputs-with-keras)
 - [Where is the Keras configuration file stored?](#where-is-the-keras-configuration-file-stored)
 - [How can I obtain reproducible results using Keras during development?](#how-can-i-obtain-reproducible-results-using-keras-during-development)
+- [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras)
 
 ---
 
@@ -137,8 +138,6 @@ Below are some common definitions that are necessary to know and understand to c
 
 *It is not recommended to use pickle or cPickle to save a Keras model.*
 
-Note: To use this you have to `pip install h5py` manually.
-
 You can use `model.save(filepath)` to save a Keras model into a single HDF5 file which will contain:
 
 - the architecture of the model, allowing to re-create the model
@@ -149,6 +148,8 @@ You can use `model.save(filepath)` to save a Keras model into a single HDF5 file
 You can then use `keras.models.load_model(filepath)` to reinstantiate your model.
 `load_model` will also take care of compiling the model using the saved training configuration
 (unless the model was never compiled in the first place).
+
+Please also see [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) for instructions on how to install `h5py`.
 
 Example:
 
@@ -195,8 +196,6 @@ Note: To use this you have to `pip install h5py` manually.
 
 If you need to save the **weights of a model**, you can do so in HDF5 with the code below.
 
-Note that you will first need to install HDF5 and the Python library h5py, which do not come bundled with Keras.
-
 ```python
 model.save_weights('my_model_weights.h5')
 ```
@@ -212,6 +211,8 @@ If you need to load weights into a *different* architecture (with some layers in
 ```python
 model.load_weights('my_model_weights.h5', by_name=True)
 ```
+
+Please also see [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) for instructions on how to install `h5py`.
 
 For example:
 
@@ -519,6 +520,8 @@ with h5py.File('input/file.hdf5', 'r') as f:
     model.predict(x_data)
 ```
 
+Please also see [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) for instructions on how to install `h5py`.
+
 ---
 
 ### Where is the Keras configuration file stored?
@@ -602,3 +605,20 @@ K.set_session(sess)
 
 # Rest of code follows ...
 ```
+
+### How can I install HDF5 or h5py to save my models in Keras?
+
+In order to save your Keras models as hdf5 files, e.g. via `keras.callbacks.ModelCheckpoint`, you need to install the h5py Python package. The exact steps may varry depending on your operating system. For many systems a simple
+
+```
+pip install h5py
+```
+
+is sufficient. For Debian based unix distributions you will need to do
+
+```
+sudo apt-get install libhdf5-serial-dev
+pip install h5py
+```
+
+When in doubt, you can always check the official h5py installation instructions here: http://docs.h5py.org/en/latest/build.html

--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -137,6 +137,8 @@ Below are some common definitions that are necessary to know and understand to c
 
 *It is not recommended to use pickle or cPickle to save a Keras model.*
 
+Note: To use this you have to `pip install h5py` manually.
+
 You can use `model.save(filepath)` to save a Keras model into a single HDF5 file which will contain:
 
 - the architecture of the model, allowing to re-create the model
@@ -188,6 +190,8 @@ model = model_from_yaml(yaml_string)
 ```
 
 #### Saving/loading only a model's weights
+
+Note: To use this you have to `pip install h5py` manually.
 
 If you need to save the **weights of a model**, you can do so in HDF5 with the code below.
 

--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -606,16 +606,21 @@ K.set_session(sess)
 
 ### How can I install HDF5 or h5py to save my models in Keras?
 
-In order to save your Keras models as hdf5 files, e.g. via `keras.callbacks.ModelCheckpoint`, Keras uses the h5py Python package. They are a dependency of Keras and should be installed by default. On Debian based distributions you will have to additionally install
+In order to save your Keras models as HDF5 files, e.g. via
+`keras.callbacks.ModelCheckpoint`, Keras uses the h5py Python package. It is
+ a dependency of Keras and should be installed by default. On Debian-based
+ distributions, you will have to additionally install `libhdf5`:
 
 ```
 sudo apt-get install libhdf5-serial-dev
 ```
 
-If you are unsure if h5py is installed you can open a Python shell and load the module via
+If you are unsure if h5py is installed you can open a Python shell and load the
+module via
 
 ```
 import h5py
 ```
 
-If it imports without error it is installed ortherwise you can find detaild installation instructions here: http://docs.h5py.org/en/latest/build.html
+If it imports without error it is installed ortherwise you can find detaild
+installation instructions here: http://docs.h5py.org/en/latest/build.html

--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -192,8 +192,6 @@ model = model_from_yaml(yaml_string)
 
 #### Saving/loading only a model's weights
 
-Note: To use this you have to `pip install h5py` manually.
-
 If you need to save the **weights of a model**, you can do so in HDF5 with the code below.
 
 ```python

--- a/docs/templates/models/about-keras-models.md
+++ b/docs/templates/models/about-keras-models.md
@@ -32,4 +32,4 @@ model = model_from_yaml(yaml_string)
 - `model.save_weights(filepath)`: saves the weights of the model as a HDF5 file.
 - `model.load_weights(filepath, by_name=False)`: loads the weights of the model from a HDF5 file (created by `save_weights`). By default, the architecture is expected to be unchanged. To load weights into a different architecture (with some layers in common), use `by_name=True` to load only those layers with the same name.
 
-Note: Please also see [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) in the FAQ for instructions on how to install `h5py`.
+Note: Please also see [How can I install HDF5 or h5py to save my models in Keras?](/getting-started/faq/#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) in the FAQ for instructions on how to install `h5py`.

--- a/docs/templates/models/about-keras-models.md
+++ b/docs/templates/models/about-keras-models.md
@@ -29,5 +29,5 @@ from keras.models import model_from_yaml
 yaml_string = model.to_yaml()
 model = model_from_yaml(yaml_string)
 ```
-- `model.save_weights(filepath)`: saves the weights of the model as a HDF5 file.
-- `model.load_weights(filepath, by_name=False)`: loads the weights of the model from a HDF5 file (created by `save_weights`). By default, the architecture is expected to be unchanged. To load weights into a different architecture (with some layers in common), use `by_name=True` to load only those layers with the same name.
+- `model.save_weights(filepath)`: saves the weights of the model as a HDF5 file. This requires manual `pip install h5py`.
+- `model.load_weights(filepath, by_name=False)`: loads the weights of the model from a HDF5 file (created by `save_weights`). By default, the architecture is expected to be unchanged. To load weights into a different architecture (with some layers in common), use `by_name=True` to load only those layers with the same name. This requires manual `pip install h5py`.

--- a/docs/templates/models/about-keras-models.md
+++ b/docs/templates/models/about-keras-models.md
@@ -29,5 +29,7 @@ from keras.models import model_from_yaml
 yaml_string = model.to_yaml()
 model = model_from_yaml(yaml_string)
 ```
-- `model.save_weights(filepath)`: saves the weights of the model as a HDF5 file. This requires manual `pip install h5py`.
-- `model.load_weights(filepath, by_name=False)`: loads the weights of the model from a HDF5 file (created by `save_weights`). By default, the architecture is expected to be unchanged. To load weights into a different architecture (with some layers in common), use `by_name=True` to load only those layers with the same name. This requires manual `pip install h5py`.
+- `model.save_weights(filepath)`: saves the weights of the model as a HDF5 file.
+- `model.load_weights(filepath, by_name=False)`: loads the weights of the model from a HDF5 file (created by `save_weights`). By default, the architecture is expected to be unchanged. To load weights into a different architecture (with some layers in common), use `by_name=True` to load only those layers with the same name.
+
+Note: Please also see [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) in the FAQ for instructions on how to install `h5py`.

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -369,7 +369,7 @@ class ModelCheckpoint(Callback):
     then the model checkpoints will be saved with the epoch number and
     the validation loss in the filename.
 
-    Note: This function requires you to `pip install h5py` manually.
+    Note: Please also see [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) in the FAQ for instructions on how to install `h5py`.
 
     # Arguments
         filepath: string, path to save the model file.

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -369,6 +369,8 @@ class ModelCheckpoint(Callback):
     then the model checkpoints will be saved with the epoch number and
     the validation loss in the filename.
 
+    Note: This function requires you to `pip install h5py` manually.
+
     # Arguments
         filepath: string, path to save the model file.
         monitor: quantity to monitor.

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -369,8 +369,6 @@ class ModelCheckpoint(Callback):
     then the model checkpoints will be saved with the epoch number and
     the validation loss in the filename.
 
-    Note: Please also see [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) in the FAQ for instructions on how to install `h5py`.
-
     # Arguments
         filepath: string, path to save the model file.
         monitor: quantity to monitor.

--- a/keras/models.py
+++ b/keras/models.py
@@ -36,7 +36,8 @@ def save_model(model, filepath, overwrite=True, include_optimizer=True):
     """Save a model to a HDF5 file.
 
     Note: Please also see
-    [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras)
+    [How can I install HDF5 or h5py to save my models in Keras?](
+        #how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras)
     in the FAQ for instructions on how to install `h5py`.
 
     The saved model contains:
@@ -769,7 +770,8 @@ class Sequential(Model):
         """Saves the weights of a model.
 
         Note: Please also see
-        [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras)
+        [How can I install HDF5 or h5py to save my models in Keras?](
+            #how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras)
         in the FAQ for instructions on how to install `h5py`.
         """
 

--- a/keras/models.py
+++ b/keras/models.py
@@ -35,7 +35,7 @@ except ImportError:
 def save_model(model, filepath, overwrite=True, include_optimizer=True):
     """Save a model to a HDF5 file.
 
-    Note: This function requires you to `pip install h5py` manually.
+    Note: Please also see [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) in the FAQ for instructions on how to install `h5py`.
 
     The saved model contains:
         - the model's configuration (topology)
@@ -766,7 +766,7 @@ class Sequential(Model):
     def save_weights(self, filepath, overwrite=True):
         """Saves the weights of a model.
 
-        Note: This function requires you to `pip install h5py` manually.
+        Note: Please also see [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) in the FAQ for instructions on how to install `h5py`.
         
         """
 

--- a/keras/models.py
+++ b/keras/models.py
@@ -35,6 +35,8 @@ except ImportError:
 def save_model(model, filepath, overwrite=True, include_optimizer=True):
     """Save a model to a HDF5 file.
 
+    Note: This function requires you to `pip install h5py` manually.
+
     The saved model contains:
         - the model's configuration (topology)
         - the model's weights
@@ -762,6 +764,12 @@ class Sequential(Model):
                 topology.load_weights_from_hdf5_group(f, layers, reshape=reshape)
 
     def save_weights(self, filepath, overwrite=True):
+        """Saves the weights of a model.
+
+        Note: This function requires you to `pip install h5py` manually.
+        
+        """
+
         if h5py is None:
             raise ImportError('`save_weights` requires h5py.')
         # If file exists and should not be overwritten:

--- a/keras/models.py
+++ b/keras/models.py
@@ -35,7 +35,9 @@ except ImportError:
 def save_model(model, filepath, overwrite=True, include_optimizer=True):
     """Save a model to a HDF5 file.
 
-    Note: Please also see [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) in the FAQ for instructions on how to install `h5py`.
+    Note: Please also see 
+    [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) 
+    in the FAQ for instructions on how to install `h5py`.
 
     The saved model contains:
         - the model's configuration (topology)
@@ -766,8 +768,9 @@ class Sequential(Model):
     def save_weights(self, filepath, overwrite=True):
         """Saves the weights of a model.
 
-        Note: Please also see [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) in the FAQ for instructions on how to install `h5py`.
-        
+        Note: Please also see 
+        [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) 
+        in the FAQ for instructions on how to install `h5py`.
         """
 
         if h5py is None:

--- a/keras/models.py
+++ b/keras/models.py
@@ -37,6 +37,7 @@ def save_model(model, filepath, overwrite=True, include_optimizer=True):
 
     Note: Please also see
     [How can I install HDF5 or h5py to save my models in Keras?](
+        /getting-started/faq/
         #how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras)
     in the FAQ for instructions on how to install `h5py`.
 
@@ -771,7 +772,8 @@ class Sequential(Model):
 
         Note: Please also see
         [How can I install HDF5 or h5py to save my models in Keras?](
-            #how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras)
+        /getting-started/faq/
+        #how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras)
         in the FAQ for instructions on how to install `h5py`.
         """
 

--- a/keras/models.py
+++ b/keras/models.py
@@ -35,8 +35,8 @@ except ImportError:
 def save_model(model, filepath, overwrite=True, include_optimizer=True):
     """Save a model to a HDF5 file.
 
-    Note: Please also see 
-    [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) 
+    Note: Please also see
+    [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras)
     in the FAQ for instructions on how to install `h5py`.
 
     The saved model contains:
@@ -768,8 +768,8 @@ class Sequential(Model):
     def save_weights(self, filepath, overwrite=True):
         """Saves the weights of a model.
 
-        Note: Please also see 
-        [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras) 
+        Note: Please also see
+        [How can I install HDF5 or h5py to save my models in Keras?](#how-can-i-install-HDF5-or-h5py-to-save-my-models-in-Keras)
         in the FAQ for instructions on how to install `h5py`.
         """
 


### PR DESCRIPTION
h5py is a latent dependency of Keras when saving to hdf5. Unfortunately it is not actively tracked as dependency by Keras. From the discussion at #9822 the result was that the best way to address this is to update the docs and make it clear that this dependency exists.

This is to prevent situations where one assumes that using e.g. `keras.callbacks.ModelCheckpoint` will work and then trains an expensive model for an hour just to find it crashing due to such an unforeseeable, yet preventable problem.