### PR TITLE
Improve tests by designating dtype of sample data

### DIFF
--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -27,7 +27,7 @@ def to_categorical(y, num_classes=None):
     if not num_classes:
         num_classes = np.max(y) + 1
     n = y.shape[0]
-    categorical = np.zeros((n, num_classes))
+    categorical = np.zeros((n, num_classes), dtype=np.float32)
     categorical[np.arange(n), y] = 1
     output_shape = input_shape + (num_classes,)
     categorical = np.reshape(categorical, output_shape)

--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -28,13 +28,13 @@ def get_test_data(num_train=1000, num_test=500, input_shape=(10,),
     samples = num_train + num_test
     if classification:
         y = np.random.randint(0, num_classes, size=(samples,))
-        X = np.zeros((samples,) + input_shape)
+        X = np.zeros((samples,) + input_shape, dtype=np.float32)
         for i in range(samples):
             X[i] = np.random.normal(loc=y[i], scale=0.7, size=input_shape)
     else:
         y_loc = np.random.random((samples,))
-        X = np.zeros((samples,) + input_shape)
-        y = np.zeros((samples,) + output_shape)
+        X = np.zeros((samples,) + input_shape, dtype=np.float32)
+        y = np.zeros((samples,) + output_shape, dtype=np.float32)
         for i in range(samples):
             X[i] = np.random.normal(loc=y_loc[i], scale=0.7, size=input_shape)
             y[i] = np.random.normal(loc=y_loc[i], scale=0.7, size=output_shape)


### PR DESCRIPTION
This PR improve tests by designating dtype of sample data. This PR can significantly reduce warning messages (`/home/taehoonlee/.conda/envs/taehoonlee/lib/python2.7/site-packages/cntk/core.py:361: UserWarning: your data is of type "float64", but your input variable (uid "Input103") expects "<type 'numpy.float32'>"`), and may bring slight speed improvements.