### PR TITLE
#9642 Add kwarg and documentation for dilation_rate to SeparableConvs

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1492,7 +1492,7 @@ class SeparableConv2D(_SeparableConv):
                  strides=(1, 1),
                  padding='valid',
                  data_format=None,
-                 dilation_rate=(1,1),
+                 dilation_rate=(1, 1),
                  depth_multiplier=1,
                  activation=None,
                  use_bias=True,

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1081,6 +1081,12 @@ class _SeparableConv(_Conv):
             It defaults to the `image_data_format` value found in your
             Keras config file at `~/.keras/keras.json`.
             If you never set it, then it will be "channels_last".
+        dilation_rate: an integer or tuple/list of n integers, specifying
+            the dilation rate to use for dilated convolution.
+            Can be a single integer to specify the same value for
+            all spatial dimensions.
+            Currently, specifying any `dilation_rate` value != 1 is
+            incompatible with specifying any stride value != 1.
         depth_multiplier: The number of depthwise convolution output channels
             for each input channel.
             The total number of depthwise convolution output
@@ -1136,6 +1142,7 @@ class _SeparableConv(_Conv):
                  strides=1,
                  padding='valid',
                  data_format=None,
+                 dilation_rate=1,
                  depth_multiplier=1,
                  activation=None,
                  use_bias=True,
@@ -1157,6 +1164,7 @@ class _SeparableConv(_Conv):
             strides=strides,
             padding=padding,
             data_format=data_format,
+            dilation_rate=dilation_rate,
             activation=activation,
             use_bias=use_bias,
             bias_regularizer=bias_regularizer,
@@ -1290,6 +1298,10 @@ class SeparableConv1D(_SeparableConv):
             It defaults to the `image_data_format` value found in your
             Keras config file at `~/.keras/keras.json`.
             If you never set it, then it will be "channels_last".
+        dilation_rate: An integer or tuple/list of a single integer, specifying
+            the dilation rate to use for dilated convolution.
+            Currently, specifying any `dilation_rate` value != 1 is
+            incompatible with specifying any `strides` value != 1.
         depth_multiplier: The number of depthwise convolution output channels
             for each input channel.
             The total number of depthwise convolution output
@@ -1344,6 +1356,7 @@ class SeparableConv1D(_SeparableConv):
                  strides=1,
                  padding='valid',
                  data_format=None,
+                 dilation_rate=1,
                  depth_multiplier=1,
                  activation=None,
                  use_bias=True,
@@ -1365,6 +1378,7 @@ class SeparableConv1D(_SeparableConv):
             strides=strides,
             padding=padding,
             data_format=data_format,
+            dilation_rate=dilation_rate,
             depth_multiplier=depth_multiplier,
             activation=activation,
             use_bias=use_bias,
@@ -1419,6 +1433,10 @@ class SeparableConv2D(_SeparableConv):
             It defaults to the `image_data_format` value found in your
             Keras config file at `~/.keras/keras.json`.
             If you never set it, then it will be "channels_last".
+        dilation_rate: An integer or tuple/list of 2 integers, specifying
+            the dilation rate to use for dilated convolution.
+            Currently, specifying any `dilation_rate` value != 1 is
+            incompatible with specifying any `strides` value != 1.
         depth_multiplier: The number of depthwise convolution output channels
             for each input channel.
             The total number of depthwise convolution output
@@ -1474,6 +1492,7 @@ class SeparableConv2D(_SeparableConv):
                  strides=(1, 1),
                  padding='valid',
                  data_format=None,
+                 dilation_rate=(1,1),
                  depth_multiplier=1,
                  activation=None,
                  use_bias=True,
@@ -1495,6 +1514,7 @@ class SeparableConv2D(_SeparableConv):
             strides=strides,
             padding=padding,
             data_format=data_format,
+            dilation_rate=dilation_rate,
             depth_multiplier=depth_multiplier,
             activation=activation,
             use_bias=use_bias,


### PR DESCRIPTION
See this issue: https://github.com/keras-team/keras/issues/9642

The documentation did not include dilation_rate for separable convolutions because it was not included as one of the keyword arguments. Instead dilation_rate got passed to _Conv() through **kwargs. I added dilation_rate explicitly to the keyword arguments of _SeparableConv, SeparableConv1D and SeparableConv2D so that the documentation can be generated correctly. The functionality of all these classes should be unchanged.