### PR TITLE
move relu6 function from mobilenet.py  into activations.py

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -72,6 +72,10 @@ def relu(x, alpha=0., max_value=None):
     return K.relu(x, alpha=alpha, max_value=max_value)
 
 
+def relu6(x):
+    return K.relu(x, max_value=6)
+
+
 def tanh(x):
     return K.tanh(x)
 

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -83,10 +83,6 @@ from .. import backend as K
 BASE_WEIGHT_PATH = 'https://github.com/fchollet/deep-learning-models/releases/download/v0.6/'
 
 
-def relu6(x):
-    return K.relu(x, max_value=6)
-
-
 def preprocess_input(x):
     """Preprocesses a numpy array encoding a batch of images.
 
@@ -110,11 +106,9 @@ def MobileNet(input_shape=None,
               classes=1000):
     """Instantiates the MobileNet architecture.
 
-    To load a MobileNet model via `load_model`, import the custom
-    objects `relu6` and pass them to the `custom_objects` parameter.
+    To load a MobileNet model via `load_model`
     E.g.
-    model = load_model('mobilenet.h5', custom_objects={
-                       'relu6': mobilenet.relu6})
+    model = load_model('mobilenet.h5')
 
     # Arguments
         input_shape: optional shape tuple, only to be specified


### PR DESCRIPTION
relu6 function is used by MobileNet V1 and V2 and Tensorflow is already implemented [tf.nn.relu6](https://www.tensorflow.org/api_docs/python/tf/nn/relu6)