### PR TITLE
Fix batch_dot with axis=None for 2D tensors #9847

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1141,7 +1141,9 @@ def batch_dot(x, y, axes=None):
     else:
         diff = 0
     if ndim(x) == 2 and ndim(y) == 2:
-        if axes[0] == axes[1]:
+        if axes is None:
+            out = tf.reduce_sum(tf.multiply(x, y), 1)
+        elif axes[0] == axes[1]:
             out = tf.reduce_sum(tf.multiply(x, y), axes[0])
         else:
             out = tf.reduce_sum(tf.multiply(tf.transpose(x, [1, 0]), y), axes[1])


### PR DESCRIPTION
See this issue: https://github.com/keras-team/keras/issues/9847

I created a quick fix that, for 2D tensors, defaults to doing the dot product on the axis index 1 if no axes arguments is provided. From the documentation I gather that this is logical considering how batch_dot() is typically used. Now batch_dotting two 2D-tensors with same shapes results, by default, in a new tensor with the same batch dimension, but the second dimension reduced to 1.

The example case given in the issue still throws error (because in that case the dimensions of the tensors are not compatible with the default behavior I provided), but the error user gets is now more informative.