### PR TITLE
move relu6 function from mobilenet.py into activations.py

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -72,6 +72,10 @@ def relu(x, alpha=0., max_value=None):
     return K.relu(x, alpha=alpha, max_value=max_value)
 
 
+def relu6(x):
+    return K.relu(x, max_value=6)
+
+
 def tanh(x):
     return K.tanh(x)
 

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -388,7 +388,7 @@ def _conv_block(inputs, filters, alpha, kernel=(3, 3), strides=(1, 1)):
                strides=strides,
                name='conv1')(x)
     x = BatchNormalization(axis=channel_axis, name='conv1_bn')(x)
-    return Activation(relu6, name='conv1_relu')(x)
+    return Activation('relu6', name='conv1_relu')(x)
 
 
 def _depthwise_conv_block(inputs, pointwise_conv_filters, alpha,
@@ -452,7 +452,7 @@ def _depthwise_conv_block(inputs, pointwise_conv_filters, alpha,
                         name='conv_dw_%d' % block_id)(x)
     x = BatchNormalization(
         axis=channel_axis, name='conv_dw_%d_bn' % block_id)(x)
-    x = Activation(relu6, name='conv_dw_%d_relu' % block_id)(x)
+    x = Activation('relu6', name='conv_dw_%d_relu' % block_id)(x)
 
     x = Conv2D(pointwise_conv_filters, (1, 1),
                padding='same',
@@ -461,4 +461,4 @@ def _depthwise_conv_block(inputs, pointwise_conv_filters, alpha,
                name='conv_pw_%d' % block_id)(x)
     x = BatchNormalization(
         axis=channel_axis, name='conv_pw_%d_bn' % block_id)(x)
-    return Activation(relu6, name='conv_pw_%d_relu' % block_id)(x)
+    return Activation('relu6', name='conv_pw_%d_relu' % block_id)(x)

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -83,10 +83,6 @@ from .. import backend as K
 BASE_WEIGHT_PATH = 'https://github.com/fchollet/deep-learning-models/releases/download/v0.6/'
 
 
-def relu6(x):
-    return K.relu(x, max_value=6)
-
-
 def preprocess_input(x):
     """Preprocesses a numpy array encoding a batch of images.
 
@@ -110,11 +106,9 @@ def MobileNet(input_shape=None,
               classes=1000):
     """Instantiates the MobileNet architecture.
 
-    To load a MobileNet model via `load_model`, import the custom
-    objects `relu6` and pass them to the `custom_objects` parameter.
+    To load a MobileNet model via `load_model`
     E.g.
-    model = load_model('mobilenet.h5', custom_objects={
-                       'relu6': mobilenet.relu6})
+    model = load_model('mobilenet.h5')
 
     # Arguments
         input_shape: optional shape tuple, only to be specified


### PR DESCRIPTION
relu6 function is used by MobileNet V1 and V2 and Tensorflow is already implemented [tf.nn.relu6](https://www.tensorflow.org/api_docs/python/tf/nn/relu6)