### PR TITLE
Allow NumpyArrayIterator to accept non-Image Array

### DIFF
--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -174,6 +174,15 @@ class TestImage(object):
         x = np.random.random((32, 1, 4, 4))
         generator.fit(x)
 
+    def test_numpy_index_array_generator(self):
+        x = np.random.random((32, 784))
+        y = np.random.random((32, 10))
+        generator = image.NumpyArrayIterator(x, y, batch_size=16)
+        for i in range(2):
+            x_batch, y_batch = next(generator)
+            assert x_batch.shape == (16, 784)
+            assert y_batch.shape == (16, 10)
+
     def test_directory_iterator(self, tmpdir):
         num_classes = 2
 


### PR DESCRIPTION
NumpyArrayIterator is expected to conditionally performance image check and 4D-image transformation.

This fix enables the following usage:

```sh
from keras.preprocessing.image import NumpyArrayIterator

x_train = np.random.random((60000, 784))
y_train = np.random.random((60000, 10))
datagen = NumpyArrayIterator(x_train, y_train, batch_size=32)
model.fit_generator(datagen, epochs=4)
```
Signed-off-by: CUI Wei <ghostplant@qq.com>