### PR TITLE
Fixed the NASNet issue.

### DIFF
--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -86,10 +86,9 @@ def NASNet(input_shape=None,
     at `~/.keras/keras.json`.
 
     # Arguments
-        input_shape: Optional shape tuple, only to be specified
-            if `include_top` is False (otherwise the input shape
-            has to be `(331, 331, 3)` for NASNetLarge or
-            `(224, 224, 3)` for NASNetMobile
+        input_shape: Optional shape tuple, the input shape
+            is by default `(331, 331, 3)` for NASNetLarge and
+            `(224, 224, 3)` for NASNetMobile.
             It should have exactly 3 inputs channels,
             and width and height should be no smaller than 32.
             E.g. `(224, 224, 3)` would be one valid value.

--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -167,7 +167,7 @@ def NASNet(input_shape=None,
                                       default_size=default_size,
                                       min_size=32,
                                       data_format=K.image_data_format(),
-                                      require_flatten=include_top,
+                                      require_flatten=False,
                                       weights=weights)
 
     if K.image_data_format() != 'channels_last':

--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -167,7 +167,7 @@ def NASNet(input_shape=None,
                                       default_size=default_size,
                                       min_size=32,
                                       data_format=K.image_data_format(),
-                                      require_flatten=include_top or weights,
+                                      require_flatten=include_top,
                                       weights=weights)
 
     if K.image_data_format() != 'channels_last':


### PR DESCRIPTION
This fixes the bug reported in #9812 .

To reproduce the bug:
```python
from keras.applications import NASNetLarge
NASNetLarge(include_top=False, input_shape=(512,512,3))
```

We get this traceback:
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-f0280447738f> in <module>()
----> 1 NASNetLarge(include_top=False, input_shape=(512,512,3))

/mnt/c/Users/yolo/Desktop/projects/keras/keras/applications/nasnet.py in NASNetLarge(input_shape, include_top, weights, input_tensor, pooling, classes)
    364                   pooling=pooling,
    365                   classes=classes,
--> 366                   default_size=331)
    367
    368

/mnt/c/Users/yolo/Desktop/projects/keras/keras/applications/nasnet.py in NASNet(input_shape, penultimate_filters, num_blocks, stem_block_filters, skip_reduction, filter_multiplier, include_top, weights, input_tensor, pooling, classes, default_size)
    169                                       data_format=K.image_data_format(),
    170                                       require_flatten=include_top or weights,
--> 171                                       weights=weights)
    172
    173     if K.image_data_format() != 'channels_last':

/mnt/c/Users/yolo/Desktop/projects/keras/keras/applications/imagenet_utils.py in _obtain_input_shape(input_shape, default_size, min_size, data_format, require_flatten, weights)
    269                                  'and loading `imagenet` weights, '
    270                                  '`input_shape` should be ' +
--> 271                                  str(default_shape) + '.')
    272         return default_shape
    273     if input_shape:

ValueError: When setting`include_top=True` and loading `imagenet` weights, `input_shape` should be (331, 331, 3).
```

Should I add a test to the PR or is it overkill?