### PR TITLE
Fix image_ocr.py example ValueError

### DIFF
--- a/examples/image_ocr.py
+++ b/examples/image_ocr.py
@@ -212,7 +212,7 @@ class TextImageGenerator(keras.callbacks.Callback):
         self.Y_len = [0] * self.num_words
 
         # monogram file is sorted by frequency in english speech
-        with codecs.open(self.monogram_file, mode='rt', encoding='utf-8') as f:
+        with codecs.open(self.monogram_file, mode='r', encoding='utf-8') as f:
             for line in f:
                 if len(tmp_string_list) == int(self.num_words * mono_fraction):
                     break
@@ -221,7 +221,7 @@ class TextImageGenerator(keras.callbacks.Callback):
                     tmp_string_list.append(word)
 
         # bigram file contains common word pairings in english speech
-        with codecs.open(self.bigram_file, mode='rt', encoding='utf-8') as f:
+        with codecs.open(self.bigram_file, mode='r', encoding='utf-8') as f:
             lines = f.readlines()
             for line in lines:
                 if len(tmp_string_list) == self.num_words:


### PR DESCRIPTION
Python 3.6.3, Linux.
Fix this error:
```
Traceback (most recent call last):
  File "image_ocr.py", line 503, in <module>
    train(run_name, 0, 20, 128)
  File "image_ocr.py", line 498, in train
    initial_epoch=start_epoch)
  File "/home/oleg/.pyenv/versions/3.6.3/lib/python3.6/site-packages/keras/legacy/interfaces.py", line 91, in wrapper
    return func(*args, **kwargs)
  File "/home/oleg/.pyenv/versions/3.6.3/lib/python3.6/site-packages/keras/engine/training.py", line 2141, in fit_generator
    callbacks.on_train_begin()
  File "/home/oleg/.pyenv/versions/3.6.3/lib/python3.6/site-packages/keras/callbacks.py", line 130, in on_train_begin
    callback.on_train_begin(logs)
  File "image_ocr.py", line 312, in on_train_begin
    self.build_word_list(16000, 4, 1)
  File "image_ocr.py", line 215, in build_word_list
    with codecs.open(self.monogram_file, mode='rt', encoding='utf-8') as f:
  File "/home/oleg/.pyenv/versions/3.6.3/lib/python3.6/codecs.py", line 895, in open
    file = builtins.open(filename, mode, buffering)
ValueError: can't have text and binary mode at once
```
Tested on 3.6.3 and 2.7.13