### PR TITLE
Add tests to batch_dot

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -385,6 +385,12 @@ class TestBackend(object):
                                    BACKENDS, cntk_two_dynamicity=True, axes=1)
         check_two_tensor_operation('batch_dot', (32, 20), (32, 20),
                                    BACKENDS, cntk_two_dynamicity=True, axes=(1, 1))
+        check_two_tensor_operation('batch_dot', (32, 20), (32, 20),
+                                   BACKENDS, cntk_two_dynamicity=True, axes=0)
+        check_two_tensor_operation('batch_dot', (32, 20), (32, 20),
+                                   BACKENDS, cntk_two_dynamicity=True, axes=None)
+        check_two_tensor_operation('batch_dot', (32, 20, 10), (32, 20, 10),
+                                   BACKENDS, cntk_two_dynamicity=True, axes=([1, 2], [1, 2]))
 
         check_single_tensor_operation('transpose', (4, 2), BACKENDS)
         check_single_tensor_operation('reverse', (4, 3, 2), BACKENDS, axes=1)


### PR DESCRIPTION
See this issue: https://github.com/keras-team/keras/issues/9862

I added three tests to test the backend.batch_dot() function. They all yield inconsistent behaviour on Theano and Tensorflow backends. I have not tested on CNTK backend because I don't have it running on my machine.

The first test throws error on Theano but not on Tensorflow because Theano does not allow summing over the 0th index in batch_dot while Tensorflow does. The second test throws indexing error on Tensorflow (see this issue: https://github.com/keras-team/keras/issues/9847) and the same error as the first test on Theano. However, there might be some tensor shapes for which the second test works on Theano but not on Tensorflow, but I couldn't think of one immediately. The third test yields tensors of different shapes on the two backends.

I am not sure what is the intended behaviour of batch_dot() in these cases I have illustrated so I couldn't add tests to test_batch_dot_shape(). Perhaps the documentation should be updated to indicate the desired behaviour more clearly so that the functionality could be compared to that.

@farizrahman4u 
