### PR TITLE
Improve datatype dict recognition

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -49,6 +49,8 @@ def _standardize_input_data(data, names, shapes=None,
     # Raises
         ValueError: in case of improperly formatted user-provided data.
     """
+    if data.shape == (1,1): 
+        if isinstance(data[0][0], dict): data = data[0][0]
     if not names:
         if data is not None and hasattr(data, '__len__') and len(data):
             raise ValueError('Error when checking model ' +


### PR DESCRIPTION
In my case of communication between a custom gym environment, utilizing an dict-observation space: `spaces.Dict()`, these additional lines where necessary, otherwise the model would not be able to distribute multiple separate inputs to separate networks (using a setup as described in "Multi-input and multi-output models" in "https://keras.io/getting-started/functional-api-guide/") 

Regarding the custom openai-gym environment I use, the relevant things are shown here: https://gist.github.com/bklebel/913d8f155e6ed23f8a35fba989c70140
Sadly, gym seems to pack the dict into arrays, so I need to unpack it again. As I could not find the place where gym packs it, I changed it on the other side. 

In case I missed something (preventing the packing), and this can be solved more elegant, I would be pleased to know. Possibly this is rather a problem of gym than of keras...