### PR TITLE
Added an error message for undefined shape on NASNet.

### DIFF
--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -158,6 +158,12 @@ def NASNet(input_shape=None,
         raise ValueError('If using `weights` as ImageNet with `include_top` '
                          'as true, `classes` should be 1000')
 
+    if isinstance(input_shape, tuple) and None in input_shape:
+        raise ValueError('When specifying the input shape of a NASNet,'
+                         'all dimensions must be defined by an integer.'
+                         '`None` is not a valid value here, but you have '
+                         'set `input_shape=' + str(input_shape) + '`.')
+
     if default_size is None:
         default_size = 331
 

--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -163,9 +163,9 @@ def NASNet(input_shape=None,
             weights == 'imagenet'):
         raise ValueError('When specifying the input shape of a NASNet'
                          ' and loading `ImageNet` weights, '
-                         'all dimensions must be defined by an integer. '
-                         '`None` is not a valid value here, but you have '
-                         'set `input_shape=' + str(input_shape) + '`.')
+                         'the input_shape argument must be static '
+                         '(no None entries). Got: `input_shape='
+                         + str(input_shape) + '`.')
 
     if default_size is None:
         default_size = 331

--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -158,9 +158,12 @@ def NASNet(input_shape=None,
         raise ValueError('If using `weights` as ImageNet with `include_top` '
                          'as true, `classes` should be 1000')
 
-    if isinstance(input_shape, tuple) and None in input_shape:
-        raise ValueError('When specifying the input shape of a NASNet,'
-                         'all dimensions must be defined by an integer.'
+    if (isinstance(input_shape, tuple) and
+            None in input_shape and
+            weights == 'imagenet'):
+        raise ValueError('When specifying the input shape of a NASNet'
+                         ' and loading `ImageNet` weights, '
+                         'all dimensions must be defined by an integer. '
                          '`None` is not a valid value here, but you have '
                          'set `input_shape=' + str(input_shape) + '`.')
 


### PR DESCRIPTION
Follow up from the #9865 .

This error message appears when doing things like:

```python
from keras.applications import NASNetMobile
NASNetMobile(input_shape=(None, None, 3))
```