### PR TITLE
fix TimeseriesGenerator's glitch mentioned in #9778

### DIFF
--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -326,9 +326,15 @@ class TimeseriesGenerator(Sequence):
         self.reverse = reverse
         self.batch_size = batch_size
 
+        if self.start_index > self.end_index:
+            raise ValueError('`start_index+length=%i > end_index=%i` '
+                             'is disallowed, as no part of the sequence '
+                             'would be left to be used as current step.'
+                             % (self.start_index, self.end_index))
+
     def __len__(self):
         return int(np.ceil(
-            (self.end_index - self.start_index) /
+            (self.end_index - self.start_index + 1) /
             (self.batch_size * self.stride)))
 
     def _empty_batch(self, num_rows):
@@ -341,11 +347,11 @@ class TimeseriesGenerator(Sequence):
     def __getitem__(self, index):
         if self.shuffle:
             rows = np.random.randint(
-                self.start_index, self.end_index, size=self.batch_size)
+                self.start_index, self.end_index + 1, size=self.batch_size)
         else:
             i = self.start_index + self.batch_size * self.stride * index
             rows = np.arange(i, min(i + self.batch_size *
-                                    self.stride, self.end_index), self.stride)
+                                    self.stride, self.end_index + 1), self.stride)
 
         samples, targets = self._empty_batch(len(rows))
         for j, row in enumerate(rows):

--- a/tests/keras/preprocessing/sequence_test.py
+++ b/tests/keras/preprocessing/sequence_test.py
@@ -1,5 +1,7 @@
+from math import ceil
+
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_raises
 
 import pytest
 
@@ -152,7 +154,7 @@ def test_TimeseriesGenerator():
                                    length=10, sampling_rate=2,
                                    start_index=10, end_index=30,
                                    batch_size=2)
-    assert len(data_gen) == 5
+    assert len(data_gen) == 6
     assert (np.allclose(data_gen[0][0],
                         np.array([[[10], [12], [14], [16], [18]],
                                   [[11], [13], [15], [17], [19]]])))
@@ -165,12 +167,75 @@ def test_TimeseriesGenerator():
                                    length=10, sampling_rate=2,
                                    start_index=10, end_index=30,
                                    batch_size=2)
-
-    assert len(data_gen) == 5
+    assert len(data_gen) == 6
     assert np.allclose(data_gen[0][0], np.array(
         [np.array(data[10:19:2]), np.array(data[11:20:2])]))
     assert (np.allclose(data_gen[0][1],
                         np.array([targets[20], targets[21]])))
+
+    with assert_raises(ValueError) as context:
+        TimeseriesGenerator(data, targets, length=50)
+    error = str(context.exception)
+    assert '`start_index+length=50 > end_index=49` is disallowed' in error
+
+
+def test_TimeSeriesGenerator_doesnt_miss_any_sample():
+    x = np.array([[i] for i in range(10)])
+
+    for length in range(3, 10):
+        g = TimeseriesGenerator(x, x,
+                                length=length,
+                                batch_size=1)
+        expected = max(0, len(x) - length)
+        actual = len(g)
+
+        assert expected == actual
+
+        if len(g) > 0:
+            # All elements in range(length, 10) should be used as current step
+            expected = np.arange(length, 10).reshape(-1, 1)
+
+            y = np.concatenate([g[ix][1] for ix in range(len(g))], axis=0)
+            assert_allclose(y, expected)
+
+    x = np.array([[i] for i in range(23)])
+
+    strides = (1, 1, 5, 7, 3, 5, 3)
+    lengths = (3, 3, 4, 3, 1, 3, 7)
+    batch_sizes = (6, 6, 6, 5, 6, 6, 6)
+    shuffles = (False, True, True, False, False, False, False)
+
+    for stride, length, batch_size, shuffle in zip(strides,
+                                                   lengths,
+                                                   batch_sizes,
+                                                   shuffles):
+        g = TimeseriesGenerator(x, x,
+                                length=length,
+                                sampling_rate=1,
+                                stride=stride,
+                                start_index=0,
+                                end_index=None,
+                                shuffle=shuffle,
+                                reverse=False,
+                                batch_size=batch_size)
+        if shuffle:
+            # all batches have the same size when shuffle is True.
+            expected_sequences = ceil(
+                (23 - length) / float(batch_size * stride)) * batch_size
+        else:
+            # last batch will be different if `(samples - length) / stride`
+            # is not a multiple of `batch_size`.
+            expected_sequences = ceil((23 - length) / float(stride))
+
+        expected_batches = ceil(expected_sequences / float(batch_size))
+
+        y = [g[ix][1] for ix in range(len(g))]
+
+        actual_sequences = sum(len(_y) for _y in y)
+        actual_batches = len(y)
+
+        assert expected_sequences == actual_sequences
+        assert expected_batches == actual_batches
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes the `TimeseriesGenerator`'s glitch that was mentioned in #9778, where the last sample wasn't being included in the generated series.  
It also adds a validation step in `__init__` to prevent this non-informative error:

```py
>>> x = np.arange(10)
>>> g = TimeseriesGenerator(x, x, 10, batch_size=1)
>>> print(len(g))
ValueError: __len__() should return >= 0
```