### PR TITLE
Fix `in_test_phase` of CNTK and Add its tests

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -88,15 +88,8 @@ def in_train_phase(x, alt, training=None):
         return result
 
 
-def in_test_phase(x, alt):
-    global _LEARNING_PHASE
-    # Similar as in_train_phase, use element_select as workaround.
-    if callable(x) and isinstance(x, C.cntk_py.Function) is False:
-        x = x()
-    if callable(alt) and isinstance(alt, C.cntk_py.Function) is False:
-        alt = alt()
-
-    return C.element_select(learning_phase(), x, alt)
+def in_test_phase(x, alt, training=None):
+    return in_train_phase(alt, x, training=training)
 
 
 def _convert_string_dtype(dtype):

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1763,6 +1763,15 @@ class TestBackend(object):
         for training in [True, False]:
             check_two_tensor_operation('in_train_phase', (3, 3), (2, 2), [KTH, KTF],
                                        training=training)
+            check_two_tensor_operation('in_train_phase', (2, 3), (2, 3), BACKENDS,
+                                       training=training)
+
+    def test_in_test_phase(self):
+        for training in [True, False]:
+            check_two_tensor_operation('in_test_phase', (3, 3), (2, 2), [KTH, KTF],
+                                       training=training)
+            check_two_tensor_operation('in_test_phase', (2, 3), (2, 3), BACKENDS,
+                                       training=training)
 
     def test_setfloatx_incorrect_values(self):
         # Keep track of the old value


### PR DESCRIPTION
This PR fixes `in_test_phase` of CNTK in accordance with Theano and TensorFlow backends. Additionally, the PR adds tests for `in_train_phase` and `in_test_phase`, which will cover the following missing lines:
```
keras/backend/cntk_backend.py              1478    193    87%   94-99
```