### PR TITLE
Fix dtype designation for `variable` of CNTK and Add its tests

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -156,9 +156,14 @@ def variable(value, dtype=None, name=None, constraint=None):
     shape = value.shape if hasattr(value, 'shape') else ()
     if hasattr(value, 'dtype') and value.dtype != dtype and len(shape) > 0:
         value = value.astype(dtype)
-    # cntk will init type based on the value type
+
+    # TODO: remove the conversion when cntk supports int32, int64
+    # https://docs.microsoft.com/en-us/python/api/cntk.variables.parameter
+    dtype = 'float32' if 'int' in str(dtype) else dtype
+
     v = C.parameter(shape=shape,
                     init=value,
+                    dtype=dtype,
                     name=_prepare_name(name, 'variable'))
     v._keras_shape = v.shape
     v._uses_learning_phase = False

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1807,6 +1807,15 @@ class TestBackend(object):
         # Restore old value
         set_floatx(old_floatx)
 
+    def test_dtype(self):
+        assert K.dtype(K.variable(1, dtype='float64')) == 'float64'
+        assert K.dtype(K.variable(1, dtype='float32')) == 'float32'
+        if K.backend() == 'cntk':
+            with pytest.raises(ValueError):
+                K.variable(1, dtype='float16')
+        else:
+            assert K.dtype(K.variable(1, dtype='float16')) == 'float16'
+
     def test_variable_support_bool_dtype(self):
         # Github issue: 7819
         if K.backend() == 'tensorflow':


### PR DESCRIPTION
This PR fixes dtype designation for `variable` of CNTK. Without putting `dtype` into `C.parameter`, CNTK always creates a float32 tensor (see [official docs](https://docs.microsoft.com/en-us/python/api/cntk.variables.parameter?view=cntk-py-2.5)).

Additionally, the PR adds tests for `dtype`, which will cover the following missing lines (`_convert_dtype_string`):
```
keras/backend/cntk_backend.py              1478    193    87%   117-120
```