### PR TITLE
import `pydot`, improve error messages about `pydot` and GraphViz, bump to `pydot >= 1.2.4`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ examples/img/*
 # test-related
 .coverage
 .cache
+.pytest_cache
 
 # developer environments
 .idea

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -5,19 +5,12 @@ from __future__ import print_function
 
 import os
 
+# `pydot` is an optional dependency,
+# see `extras_require` in `setup.py`.
 try:
-    # pydot-ng is a fork of pydot that is better maintained.
-    import pydot_ng as pydot
+    import pydot
 except ImportError:
-    # pydotplus is an improved version of pydot
-    try:
-        import pydotplus as pydot
-    except ImportError:
-        # Fall back on pydot if necessary.
-        try:
-            import pydot
-        except ImportError:
-            pydot = None
+    pydot = None
 
 
 def _check_pydot():

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -14,15 +14,21 @@ except ImportError:
 
 
 def _check_pydot():
+    """Raise errors if `pydot` or GraphViz unavailable."""
+    if pydot is None:
+        raise ImportError(
+            'Failed to import `pydot`. '
+            'Please install `pydot`. '
+            'For example with `pip install pydot`.')
     try:
         # Attempt to create an image of a blank graph
         # to check the pydot/graphviz installation.
         pydot.Dot.create(pydot.Dot())
-    except Exception:
-        # pydot raises a generic Exception here,
-        # so no specific class can be caught.
-        raise ImportError('Failed to import pydot. You must install pydot'
-                          ' and graphviz for `pydotprint` to work.')
+    except OSError:
+        raise OSError(
+            '`pydot` failed to call GraphViz.'
+            'Please install GraphViz (https://www.graphviz.org/) '
+            'and ensure that its executables are in the $PATH.')
 
 
 def model_to_dot(model,

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='Keras',
                         'pyyaml',
                         'h5py'],
       extras_require={
-          'visualize': ['pydot>=1.2.0'],
+          'visualize': ['pydot>=1.2.4'],
           'tests': ['pytest',
                     'pytest-pep8',
                     'pytest-xdist',


### PR DESCRIPTION
Following up on #7448 and #6398, bump to [`pydot >= 1.2.4`](https://pypi.org/project/pydot/#history), and `import pydot`, as required in `setup.py`. `pydot` is maintained at: https://github.com/erocarrera/pydot (currently, I am a maintainer).

Also, these changes improve the error messages, distinguishing between whether `pydot` isn't installed (if so indicating how to install it), or GraphViz executables (`dot`) cannot be found.

See also:
https://github.com/erocarrera/pydot/pull/152
#5313
https://github.com/erocarrera/pydot/blob/master/pydot.py#L1862-L1869