### PR TITLE
ModelCheckpoint: print previous best

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -447,8 +447,8 @@ class ModelCheckpoint(Callback):
                             self.model.save(filepath, overwrite=True)
                     else:
                         if self.verbose > 0:
-                            print('\nEpoch %05d: %s did not improve' %
-                                  (epoch + 1, self.monitor))
+                            print('\nEpoch %05d: %s did not improve from %0.5f' %
+                                  (epoch + 1, self.monitor, self.best))
             else:
                 if self.verbose > 0:
                     print('\nEpoch %05d: saving model to %s' % (epoch + 1, filepath))


### PR DESCRIPTION
Before:
```
Epoch 00010: val_acc did not improve
```

After:
```
Epoch 00010: val_acc did not improve from 0.54000
```

Now matching
```
Epoch 00002: val_acc improved from 0.39000 to 0.54000, saving model to /tmp/model.h5
```

This way, when the output is scrolled out of the buffer, one can still see the current best model