### PR TITLE
Update python wheel of CNTK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,8 @@ install:
   # install TensorFlow (CPU version).
   - pip install tensorflow
   
-  # install cntk
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      pip install https://cntk.ai/PythonWheel/CPU-Only/cntk-2.3.1-cp27-cp27mu-linux_x86_64.whl;
-    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
-      pip install https://cntk.ai/PythonWheel/CPU-Only/cntk-2.3.1-cp36-cp36m-linux_x86_64.whl;
-    fi
+  # install cntk (as of the CNTK 2.5 release, users can now install CNTK via PyPI)
+  - pip install cntk
 
   # install pydot for visualization tests
   - conda install pydot graphviz


### PR DESCRIPTION
This PR updates python wheel of CNTK. As of the CNTK 2.5 release, users can now install CNTK via PyPI (see [the official docs](https://docs.microsoft.com/en-us/cognitive-toolkit/setup-linux-python?tabs=cntkpy25#installing-cntk-for-python-on-linux)).