### PR TITLE
Removing boolean checks on python values for clipping

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -870,8 +870,16 @@ def pow(x, a):
 
 
 def clip(x, min_value, max_value):
-    if max_value is not None and max_value < min_value:
-        max_value = min_value
+    """Element-wise value clipping.
+
+    # Arguments
+        x: Tensor or variable.
+        min_value: Python float, integer or tensor/variable.
+        max_value: Python float, integer or tensor/variable.
+
+    # Returns
+        A tensor.
+    """
     if max_value is None:
         max_value = np.inf
     if min_value is None:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1552,14 +1552,12 @@ def clip(x, min_value, max_value):
 
     # Arguments
         x: Tensor or variable.
-        min_value: Python float or integer.
-        max_value: Python float or integer.
+        min_value: Python float, integer or tensor/variable.
+        max_value: Python float, integer or tensor/variable.
 
     # Returns
         A tensor.
     """
-    if max_value is not None and max_value < min_value:
-        max_value = min_value
     if max_value is None:
         max_value = np.inf
     min_value = _to_tensor(min_value, x.dtype.base_dtype)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -636,8 +636,16 @@ def pow(x, a):
 
 
 def clip(x, min_value, max_value):
-    if max_value is not None and max_value < min_value:
-        max_value = min_value
+    """Element-wise value clipping.
+
+    # Arguments
+        x: Tensor or variable.
+        min_value: Python float, integer or tensor/variable.
+        max_value: Python float, integer or tensor/variable.
+
+    # Returns
+        A tensor.
+    """
     if max_value is None:
         max_value = np.inf
     return T.clip(x, min_value, max_value)

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1834,14 +1834,12 @@ class TestBackend(object):
                 K.variable('', dtype='unsupported')
 
     def test_clip_with_tensors(self):
-        # Create tensor
-        import keras
+        # Create tensors
         x_placeholder = K.placeholder(ndim=0)
-        y = keras.layers.Input(shape=(1,))
-		# y_placeholder = KTF.placeholder(shape=())
+        y_placeholder = K.placeholder(shape=())
         # Check correct values
-        clip_ = K.clip(y, x_placeholder + 1.0, x_placeholder - 1.0)
-        assert isinstance(clip_, type(y))
+        clip_ = K.clip(y_placeholder, x_placeholder + 1.0, x_placeholder - 1.0)
+        assert isinstance(clip_, type(x_placeholder))
 
 
 if __name__ == '__main__':

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1833,6 +1833,16 @@ class TestBackend(object):
             with pytest.raises(TypeError):
                 K.variable('', dtype='unsupported')
 
+    def test_clip_with_tensors(self):
+        # Create tensor
+        import keras
+        x_placeholder = K.placeholder(ndim=0)
+        y = keras.layers.Input(shape=(1,))
+		# y_placeholder = KTF.placeholder(shape=())
+        # Check correct values
+        clip_ = K.clip(y, x_placeholder + 1.0, x_placeholder - 1.0)
+        assert isinstance(clip_, type(y))
+
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
These don't work if you want to use a tensor or variable as an argument for the clipping terms.