### PR TITLE
Exclude multi-gpu utils when reporting coverages

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,3 +17,4 @@ omit =
     keras/datasets/*
     keras/layers/cudnn_recurrent.py
     keras/legacy/*
+    keras/utils/multi_gpu_utils.py


### PR DESCRIPTION
This PR excludes multi-gpu utils that can not be reached during CI tests. This affects only calculating test coverages.