### PR TITLE
Static Learning Phase ignored on CNTK

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -25,6 +25,7 @@ if dev.type() == 0:
 # A learning phase is a bool tensor used to run Keras models in
 # either train mode (learning_phase == 1) or test mode (learning_phase == 0).
 _LEARNING_PHASE = C.constant(shape=(), dtype=np.float32, value=1.0, name='_keras_learning_phase')
+_DYNAMIC_LEARNING_PHASE = True
 _UID_PREFIXES = defaultdict(int)
 
 # cntk doesn't support gradient as symbolic op, to hook up with keras model,
@@ -54,17 +55,17 @@ def learning_phase():
 
 
 def set_learning_phase(value):
-    global _LEARNING_PHASE
+    global _LEARNING_PHASE, _DYNAMIC_LEARNING_PHASE
     if value not in {0, 1}:
         raise ValueError('CNTK Backend: Set learning phase '
                          'with value %s is not supported, '
                          'expected 0 or 1.' % value)
     v = np.asarray(value)
     _LEARNING_PHASE.value = v
+    _DYNAMIC_LEARNING_PHASE = False
 
 
 def in_train_phase(x, alt, training=None):
-    global _LEARNING_PHASE
     if training is None:
         training = learning_phase()
         uses_learning_phase = True

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -25,7 +25,7 @@ if dev.type() == 0:
 # A learning phase is a bool tensor used to run Keras models in
 # either train mode (learning_phase == 1) or test mode (learning_phase == 0).
 _LEARNING_PHASE = C.constant(shape=(), dtype=np.float32, value=1.0, name='_keras_learning_phase')
-_DYNAMIC_LEARNING_PHASE = True
+_LEARNING_PHASE.is_dynamic = True
 _UID_PREFIXES = defaultdict(int)
 
 # cntk doesn't support gradient as symbolic op, to hook up with keras model,
@@ -55,14 +55,14 @@ def learning_phase():
 
 
 def set_learning_phase(value):
-    global _LEARNING_PHASE, _DYNAMIC_LEARNING_PHASE
+    global _LEARNING_PHASE
     if value not in {0, 1}:
         raise ValueError('CNTK Backend: Set learning phase '
                          'with value %s is not supported, '
                          'expected 0 or 1.' % value)
     v = np.asarray(value)
     _LEARNING_PHASE.value = v
-    _DYNAMIC_LEARNING_PHASE = False
+    _LEARNING_PHASE.is_dynamic = False
 
 
 def in_train_phase(x, alt, training=None):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -23,6 +23,7 @@ from ..utils.generic_utils import Progbar
 from .. import callbacks as cbks
 from ..legacy import interfaces
 
+
 def _is_dynamic_lp():
     lp = K.learning_phase()
     if K.backend() == 'cntk':
@@ -33,6 +34,7 @@ def _is_dynamic_lp():
         return lp.is_dynamic
     else:
         return not isinstance(lp, int)
+
 
 def _standardize_input_data(data, names, shapes=None,
                             check_batch_axis=True,

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -24,14 +24,15 @@ from .. import callbacks as cbks
 from ..legacy import interfaces
 
 def _is_dynamic_lp():
+    lp = K.learning_phase()
     if K.backend() == 'cntk':
         # Ugly hack for CNTK because of the way Learning Phase
         # is implemented. Since it does not support static values
         # we use this variable to know if it was set statically
         # by the user.
-        return getattr(K, '_DYNAMIC_LEARNING_PHASE', True)
+        return lp.is_dynamic
     else:
-        return not isinstance(K.learning_phase(), int)
+        return not isinstance(lp, int)
 
 def _standardize_input_data(data, names, shapes=None,
                             check_batch_axis=True,

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -23,6 +23,15 @@ from ..utils.generic_utils import Progbar
 from .. import callbacks as cbks
 from ..legacy import interfaces
 
+def _is_dynamic_lp():
+    if K.backend() == 'cntk':
+        # Ugly hack for CNTK because of the way Learning Phase
+        # is implemented. Since it does not support static values
+        # we use this variable to know if it was set statically
+        # by the user.
+        return getattr(K, '_DYNAMIC_LEARNING_PHASE', True)
+    else:
+        return not isinstance(K.learning_phase(), int)
 
 def _standardize_input_data(data, names, shapes=None,
                             check_batch_axis=True,
@@ -982,7 +991,7 @@ class Model(Container):
         self._check_trainable_weights_consistency()
         if self.train_function is None:
             inputs = self._feed_inputs + self._feed_targets + self._feed_sample_weights
-            if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+            if self.uses_learning_phase and _is_dynamic_lp():
                 inputs += [K.learning_phase()]
 
             with K.name_scope('training'):
@@ -1003,7 +1012,7 @@ class Model(Container):
             raise RuntimeError('You must compile your model before using it.')
         if self.test_function is None:
             inputs = self._feed_inputs + self._feed_targets + self._feed_sample_weights
-            if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+            if self.uses_learning_phase and _is_dynamic_lp():
                 inputs += [K.learning_phase()]
             # Return loss and metrics, no gradient updates.
             # Does update the network states.
@@ -1017,7 +1026,7 @@ class Model(Container):
         if not hasattr(self, 'predict_function'):
             self.predict_function = None
         if self.predict_function is None:
-            if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+            if self.uses_learning_phase and _is_dynamic_lp():
                 inputs = self._feed_inputs + [K.learning_phase()]
             else:
                 inputs = self._feed_inputs
@@ -1648,7 +1657,7 @@ class Model(Container):
                 val_x, val_y,
                 sample_weight=val_sample_weight,
                 batch_size=batch_size)
-            if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+            if self.uses_learning_phase and _is_dynamic_lp():
                 val_ins = val_x + val_y + val_sample_weights + [0.]
             else:
                 val_ins = val_x + val_y + val_sample_weights
@@ -1664,18 +1673,18 @@ class Model(Container):
             sample_weights, val_sample_weights = (
                 _slice_arrays(sample_weights, 0, split_at),
                 _slice_arrays(sample_weights, split_at))
-            if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+            if self.uses_learning_phase and _is_dynamic_lp():
                 val_ins = val_x + val_y + val_sample_weights + [0.]
             else:
                 val_ins = val_x + val_y + val_sample_weights
 
         elif validation_steps:
             do_validation = True
-            if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+            if self.uses_learning_phase and _is_dynamic_lp():
                 val_ins = [0.]
 
         # Prepare input arrays and training function.
-        if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+        if self.uses_learning_phase and _is_dynamic_lp():
             ins = x + y + sample_weights + [1.]
         else:
             ins = x + y + sample_weights
@@ -1767,7 +1776,7 @@ class Model(Container):
             sample_weight=sample_weight,
             batch_size=batch_size)
         # Prepare inputs, delegate logic to `_test_loop`.
-        if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+        if self.uses_learning_phase and _is_dynamic_lp():
             ins = x + y + sample_weights + [0.]
         else:
             ins = x + y + sample_weights
@@ -1825,7 +1834,7 @@ class Model(Container):
                                  'Batch size: ' + str(batch_size) + '.')
 
         # Prepare inputs, delegate logic to `_predict_loop`.
-        if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+        if self.uses_learning_phase and _is_dynamic_lp():
             ins = x + [0.]
         else:
             ins = x
@@ -1875,7 +1884,7 @@ class Model(Container):
             x, y,
             sample_weight=sample_weight,
             class_weight=class_weight)
-        if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+        if self.uses_learning_phase and _is_dynamic_lp():
             ins = x + y + sample_weights + [1.]
         else:
             ins = x + y + sample_weights
@@ -1916,7 +1925,7 @@ class Model(Container):
         x, y, sample_weights = self._standardize_user_data(
             x, y,
             sample_weight=sample_weight)
-        if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+        if self.uses_learning_phase and _is_dynamic_lp():
             ins = x + y + sample_weights + [0.]
         else:
             ins = x + y + sample_weights
@@ -1937,7 +1946,7 @@ class Model(Container):
         """
         x = _standardize_input_data(x, self._feed_input_names,
                                     self._feed_input_shapes)
-        if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+        if self.uses_learning_phase and _is_dynamic_lp():
             ins = x + [0.]
         else:
             ins = x
@@ -2159,7 +2168,7 @@ class Model(Container):
                 val_x, val_y, val_sample_weights = self._standardize_user_data(
                     val_x, val_y, val_sample_weight)
                 val_data = val_x + val_y + val_sample_weights
-                if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+                if self.uses_learning_phase and _is_dynamic_lp():
                     val_data += [0.]
                 for cbk in callbacks:
                     cbk.validation_data = val_data

--- a/tests/keras/layers/normalization_test.py
+++ b/tests/keras/layers/normalization_test.py
@@ -12,6 +12,7 @@ from keras import backend as K
 input_1 = np.arange(10)
 input_2 = np.zeros(10)
 input_3 = np.ones((10))
+input_4 = np.expand_dims(np.arange(10.), axis=1)
 input_shapes = [np.ones((10, 10)), np.ones((10, 10, 10))]
 
 
@@ -221,6 +222,27 @@ def test_that_trainable_disables_updates():
     model.train_on_batch(val_a, val_out)
     x2 = model.predict(val_a)
     assert_allclose(x1, x2, atol=1e-7)
+
+
+@keras_test
+def test_batchnorm_trainable():
+    bn_mean = 0.5
+    bn_std = 10.
+
+    def get_model(bn_mean, bn_std):
+        input = Input(shape=(1,))
+        x = normalization.BatchNormalization()(input)
+        model = Model(input, x)
+        model.set_weights([np.array([1.]), np.array([0.]),
+                           np.array([bn_mean]), np.array([bn_std**2])])
+        return model
+
+    # Simulates training-mode with trainable layer. Should use mini-batch statistics.
+    K.set_learning_phase(1)
+    model = get_model(bn_mean, bn_std)
+    model.compile(loss='mse', optimizer='rmsprop')
+    out = model.predict(input_4)
+    assert_allclose((input_4 - np.mean(input_4)) / np.std(input_4), out, atol=1e-4)
 
 
 if __name__ == '__main__':

--- a/tests/keras/layers/normalization_test.py
+++ b/tests/keras/layers/normalization_test.py
@@ -243,6 +243,9 @@ def test_batchnorm_trainable():
     model.compile(loss='mse', optimizer='rmsprop')
     out = model.predict(input_4)
     assert_allclose((input_4 - np.mean(input_4)) / np.std(input_4), out, atol=1e-3)
+    if K.backend() == 'cntk':
+        # Reset the learning phase for next tests
+        K.learning_phase().is_dynamic = True
 
 
 if __name__ == '__main__':

--- a/tests/keras/layers/normalization_test.py
+++ b/tests/keras/layers/normalization_test.py
@@ -242,7 +242,7 @@ def test_batchnorm_trainable():
     model = get_model(bn_mean, bn_std)
     model.compile(loss='mse', optimizer='rmsprop')
     out = model.predict(input_4)
-    assert_allclose((input_4 - np.mean(input_4)) / np.std(input_4), out, atol=1e-4)
+    assert_allclose((input_4 - np.mean(input_4)) / np.std(input_4), out, atol=1e-3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
While working on a bigger PR for the behaviour of Learning Phase on BatchNormalization, I noticed that there is a bug on the CNTK backend that affects how it handles static learning phases. It seems that when the user sets a static learning_phase, it is ignored. I believe the bigger PR requires building a case and thorough discussion, so I decided to split the changes into 2 parts (I will soon document the problem on BN and submit another PR).

**What's the problem on CNTK:**
- The current implementation of learning_phase on CNTK requires it to [always be a tensor](https://github.com/keras-team/keras/blob/master/keras/backend/cntk_backend.py#L63); it can never be an integer even when it is set statically.
- Unfortunately multiple methods on [training.py](https://github.com/keras-team/keras/blob/master/keras/engine/training.py#L1828) check if `isinstance(K.learning_phase(), int)` to decide if the learning phase is static.
- Since the learning_phase on CNTK is never an integer, if the user sets `K.set_learning_phase(1)` it is ignored.

**Things to know about this PR:**
- On the first commit of this PR, I added a test which fails on the current master. The test shows that BatchNormalization operates in test-mode even when the user explicitly sets learning_phase to 1. After applying the patch all tests pass.
- This fix addresses the problem but it's not an elegant solution. If we don't like it, I'm happy to update or close the PR and someone else can provide a better solution.
- I have never worked with CNTK backend before. So I would really appreciate a thorough review from any of the people who wrote the CNTK backend (@taehoonlee, @fchollet, @souptc or @ozabluda)