### PR TITLE
Change BN layer to use moving mean/var if frozen

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -323,6 +323,9 @@ def is_sparse(tensor):
 
 
 def int_shape(x):
+    if type(x) in {int, float}:
+        return ()
+
     if hasattr(x, '_keras_shape'):
         return x._keras_shape
 

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -69,7 +69,7 @@ def in_train_phase(x, alt, training=None):
         training = learning_phase()
         uses_learning_phase = True
     else:
-        uses_learning_phase = False
+        uses_learning_phase = getattr(training, '_uses_learning_phase', False)
 
     # CNTK currently don't support cond op, so here we use
     # element_select approach as workaround. It may have

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2865,7 +2865,7 @@ def in_train_phase(x, alt, training=None):
         training = learning_phase()
         uses_learning_phase = True
     else:
-        uses_learning_phase = False
+        uses_learning_phase = getattr(training, '_uses_learning_phase', False)
 
     if training is 1 or training is True:
         if callable(x):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1496,7 +1496,7 @@ def in_train_phase(x, alt, training=None):
         training = learning_phase()
         uses_learning_phase = True
     else:
-        uses_learning_phase = False
+        uses_learning_phase = getattr(training, '_uses_learning_phase', False)
 
     if training is 1 or training is True:
         if callable(x):

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -190,7 +190,8 @@ class BatchNormalization(Layer):
             return normalize_inference()
         elif training is None:
             # If it's undefined then if trainable tensor is on respect learning phase else set to false
-            training = K.switch(self._trainable_tensor, K.cast(K.learning_phase(), 'int32'), K.constant(0, dtype='int32'))
+            training = K.switch(self._trainable_tensor, K.cast(K.learning_phase(), 'int32'),
+                                K.constant(0, dtype='int32'))
             training._uses_learning_phase = True
 
         # If the learning is either dynamic, or set to training:

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -92,12 +92,13 @@ class BatchNormalization(Layer):
 
     @property
     def trainable(self):
+        # Use cached value to avoid unnecessary get_value() calls
         return self._trainable
 
     @trainable.setter
     def trainable(self, trainable):
         trainable = bool(trainable)
-        # Speed it up by avoiding unnecessary set_value() calls
+        # Change when different to avoid unnecessary set_value() calls
         if self._trainable != trainable:
             self._trainable = trainable
             K.set_value(self._trainable_tensor, 1 if trainable else 0)

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -72,6 +72,8 @@ class BatchNormalization(Layer):
                  beta_constraint=None,
                  gamma_constraint=None,
                  **kwargs):
+        self._trainable = True
+        self._trainable_tensor = K.variable(1, dtype='int32', name='trainable')
         super(BatchNormalization, self).__init__(**kwargs)
         self.supports_masking = True
         self.axis = axis
@@ -87,6 +89,18 @@ class BatchNormalization(Layer):
         self.gamma_regularizer = regularizers.get(gamma_regularizer)
         self.beta_constraint = constraints.get(beta_constraint)
         self.gamma_constraint = constraints.get(gamma_constraint)
+
+    @property
+    def trainable(self):
+        return self._trainable
+
+    @trainable.setter
+    def trainable(self, trainable):
+        trainable = bool(trainable)
+        # Speed it up by avoiding unnecessary set_value() calls
+        if self._trainable != trainable:
+            self._trainable = trainable
+            K.set_value(self._trainable_tensor, 1 if trainable else 0)
 
     def build(self, input_shape):
         dim = input_shape[self.axis]
@@ -171,9 +185,13 @@ class BatchNormalization(Layer):
                     self.gamma,
                     epsilon=self.epsilon)
 
-        # If the learning phase is *static* and set to inference:
         if training in {0, False}:
+            # If the learning phase is *static* and set to inference:
             return normalize_inference()
+        elif training is None:
+            # If it's undefined then if trainable tensor is on respect learning phase else set to false
+            training = K.switch(self._trainable_tensor, K.cast(K.learning_phase(), 'int32'), K.constant(0, dtype='int32'))
+            training._uses_learning_phase = True
 
         # If the learning is either dynamic, or set to training:
         normed_training, mean, variance = K.normalize_batch_in_training(

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -73,7 +73,7 @@ class BatchNormalization(Layer):
                  gamma_constraint=None,
                  **kwargs):
         self._trainable = True
-        self._trainable_tensor = K.variable(1, dtype='int32', name='trainable')
+        self._trainable_tensor = K.variable(1, dtype='float32', name='trainable')
         super(BatchNormalization, self).__init__(**kwargs)
         self.supports_masking = True
         self.axis = axis
@@ -191,8 +191,8 @@ class BatchNormalization(Layer):
             return normalize_inference()
         elif training is None:
             # If it's undefined then if trainable tensor is on respect learning phase else set to false
-            training = K.switch(self._trainable_tensor, K.cast(K.learning_phase(), 'int32'),
-                                K.constant(0, dtype='int32'))
+            training = K.switch(self._trainable_tensor, K.cast(K.learning_phase(), 'float32'),
+                                K.constant(0, dtype='float32'))
             training._uses_learning_phase = True
 
         # If the learning is either dynamic, or set to training:

--- a/tests/keras/layers/normalization_test.py
+++ b/tests/keras/layers/normalization_test.py
@@ -231,9 +231,10 @@ def test_batchnorm_trainable():
 
     def get_model(bn_mean, bn_std):
         input = Input(shape=(1,))
-        x = normalization.BatchNormalization(center=False, scale=False)(input)
+        x = normalization.BatchNormalization()(input)
         model = Model(input, x)
-        model.set_weights([np.array([bn_mean]), np.array([bn_std**2])])
+        model.set_weights([np.array([1.]), np.array([0.]),
+                           np.array([bn_mean]), np.array([bn_std**2])])
         return model
 
     # Simulates training-mode with trainable layer. Should use mini-batch statistics.

--- a/tests/keras/layers/normalization_test.py
+++ b/tests/keras/layers/normalization_test.py
@@ -234,7 +234,7 @@ def test_batchnorm_trainable():
         x = normalization.BatchNormalization()(input)
         model = Model(input, x)
         model.set_weights([np.array([1.]), np.array([0.]),
-                           np.array([bn_mean]), np.array([bn_std**2])])
+                           np.array([bn_mean]), np.array([bn_std ** 2])])
         return model
 
     # Simulates training-mode with trainable layer. Should use mini-batch statistics.
@@ -243,7 +243,7 @@ def test_batchnorm_trainable():
     model.layers[1].trainable = True
     model.compile(loss='mse', optimizer='rmsprop')
     out = model.predict(input_4)
-    assert_allclose((input_4 - np.mean(input_4)) / np.std(input_4), out, atol=1e-4)
+    assert_allclose((input_4 - np.mean(input_4)) / np.std(input_4), out, atol=1e-3)
 
     # In all other cases we should use the moving mean and variance from BN.
     for lp, trainable in [(1, False), (0, True), (0, False)]:
@@ -252,7 +252,7 @@ def test_batchnorm_trainable():
         model.layers[1].trainable = trainable
         model.compile(loss='mse', optimizer='rmsprop')
         out = model.predict(input_4)
-        assert_allclose((input_4 - bn_mean) / bn_std, out, atol=1e-4)
+        assert_allclose((input_4 - bn_mean) / bn_std, out, atol=1e-3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
During fine-tuning, if a Batch Normalization layer is **frozen** it uses the mini-batch statistics. I believe this is incorrect and it can lead to reduced accuracy especially when we use Transfer learning. A better approach in this case would be to use the values of the moving mean and variance.

**Changes on this PR:**
In this PR I update the Batch Normalization layer to use the learned statistics if frozen during training. This is achieved by making the trainable flag part of the computational graph and by depending the behavior of the BN  not only on the learning_phase but also on the value of the trainable property. 

**Brief explanation:**
Assume we use one of the pre-trained CNNs of Keras and we want to fine-tune it. Unfortunately, we get no guarantees that the mean and variance of our new dataset inside the BN layers will be similar to the ones of the original dataset. As a result, if we fine-tune the top layers, their weights will be adjusted to the mean/variance of the new dataset. Nevertheless, during inference the top layers will receive data which are scaled using the mean/variance of the original dataset. This discrepancy can lead to reduced accuracy. 

I understand that this is a significant change that requires thorough review. To faciliate the situation I've documented why making such a change is important and provided detailed comparisons before and after applying the patch [on my blog](http://blog.datumbox.com/the-batch-normalization-layer-of-keras-is-broken/).