### PR TITLE
fixed sampling from z_log_var in vae deconv example

### DIFF
--- a/examples/variational_autoencoder_deconv.py
+++ b/examples/variational_autoencoder_deconv.py
@@ -63,7 +63,7 @@ def sampling(args):
     z_mean, z_log_var = args
     epsilon = K.random_normal(shape=(K.shape(z_mean)[0], latent_dim),
                               mean=0., stddev=epsilon_std)
-    return z_mean + K.exp(z_log_var) * epsilon
+    return z_mean + K.exp(0.5*z_log_var) * epsilon
 
 # note that "output_shape" isn't necessary with the TensorFlow backend
 # so you could write `Lambda(sampling)([z_mean, z_log_var])`


### PR DESCRIPTION
In https://arxiv.org/abs/1312.6114 they are sampling with the std not the var. exp(0.5*log(std^2)= std
If there is a reason to sample with the var let me know please :+1: 
Indeed I wonder why it still worked well, hope I am not missing something