### PR TITLE
Remove deprecated imsave method in neural style transfer example

### DIFF
--- a/examples/conv_filter_visualization.py
+++ b/examples/conv_filter_visualization.py
@@ -6,9 +6,9 @@ Results example: http://i.imgur.com/4nj4KjN.jpg
 '''
 from __future__ import print_function
 
-from scipy.misc import imsave
 import numpy as np
 import time
+from keras.preprocessing.image import save_img
 from keras.applications import vgg16
 from keras import backend as K
 
@@ -39,6 +39,7 @@ def deprocess_image(x):
         x = x.transpose((1, 2, 0))
     x = np.clip(x, 0, 255).astype('uint8')
     return x
+
 
 # build the VGG16 network with ImageNet weights
 model = vgg16.VGG16(weights='imagenet', include_top=False)
@@ -132,4 +133,4 @@ for i in range(n):
                          (img_height + margin) * j: (img_height + margin) * j + img_height, :] = img
 
 # save the result to disk
-imsave('stitched_filters_%dx%d.png' % (n, n), stitched_filters)
+save_img('stitched_filters_%dx%d.png' % (n, n), stitched_filters)

--- a/examples/deep_dream.py
+++ b/examples/deep_dream.py
@@ -67,7 +67,6 @@ def deprocess_image(x):
     x = np.clip(x, 0, 255).astype('uint8')
     return x
 
-
 K.set_learning_phase(0)
 
 # Build the InceptionV3 network with our placeholder.
@@ -84,8 +83,7 @@ layer_dict = dict([(layer.name, layer) for layer in model.layers])
 loss = K.variable(0.)
 for layer_name in settings['features']:
     # Add the L2 norm of the features of a layer to the loss.
-    assert layer_name in layer_dict.keys(), 'Layer ' + layer_name + \
-        ' not found in model.'
+    assert layer_name in layer_dict.keys(), 'Layer ' + layer_name + ' not found in model.'
     coeff = settings['features'][layer_name]
     x = layer_dict[layer_name].output
     # We avoid border artifacts by only involving non-border pixels in the loss.

--- a/examples/deep_dream.py
+++ b/examples/deep_dream.py
@@ -11,7 +11,7 @@ python deep_dream.py img/mypic.jpg results/dream
 '''
 from __future__ import print_function
 
-from keras.preprocessing.image import load_img, img_to_array
+from keras.preprocessing.image import load_img, save_img, img_to_array
 import numpy as np
 import scipy
 import argparse
@@ -67,6 +67,7 @@ def deprocess_image(x):
     x = np.clip(x, 0, 255).astype('uint8')
     return x
 
+
 K.set_learning_phase(0)
 
 # Build the InceptionV3 network with our placeholder.
@@ -83,7 +84,8 @@ layer_dict = dict([(layer.name, layer) for layer in model.layers])
 loss = K.variable(0.)
 for layer_name in settings['features']:
     # Add the L2 norm of the features of a layer to the loss.
-    assert layer_name in layer_dict.keys(), 'Layer ' + layer_name + ' not found in model.'
+    assert layer_name in layer_dict.keys(), 'Layer ' + layer_name + \
+        ' not found in model.'
     coeff = settings['features'][layer_name]
     x = layer_dict[layer_name].output
     # We avoid border artifacts by only involving non-border pixels in the loss.
@@ -133,11 +135,6 @@ def gradient_ascent(x, iterations, step, max_loss=None):
         print('..Loss value at', i, ':', loss_value)
         x += step * grad_values
     return x
-
-
-def save_img(img, fname):
-    pil_img = deprocess_image(np.copy(img))
-    scipy.misc.imsave(fname, pil_img)
 
 
 """Process:
@@ -192,4 +189,4 @@ for shape in successive_shapes:
     img += lost_detail
     shrunk_original_img = resize_img(original_img, shape)
 
-save_img(img, fname=result_prefix + '.png')
+save_img(result_prefix + '.png', deprocess_image(np.copy(img)))

--- a/examples/neural_doodle.py
+++ b/examples/neural_doodle.py
@@ -47,12 +47,11 @@ import time
 import argparse
 import numpy as np
 from scipy.optimize import fmin_l_bfgs_b
-from scipy.misc import imread, imsave
 
 from keras import backend as K
 from keras.layers import Input, AveragePooling2D
 from keras.models import Model
-from keras.preprocessing.image import load_img, img_to_array
+from keras.preprocessing.image import load_img, save_img, img_to_array
 from keras.applications import vgg19
 
 # Command line arguments
@@ -83,7 +82,7 @@ use_content_img = content_img_path is not None
 num_labels = args.nlabels
 num_colors = 3  # RGB
 # determine image sizes based on target_mask
-ref_img = imread(target_mask_path)
+ref_img = img_to_array(load_img(target_mask_path))
 img_nrows, img_ncols = ref_img.shape[:2]
 
 total_variation_weight = 50.
@@ -164,6 +163,7 @@ def load_mask_labels():
 
     return (np.expand_dims(style_mask, axis=0),
             np.expand_dims(target_mask, axis=0))
+
 
 # Create tensor variables for images
 if K.image_data_format() == 'channels_first':
@@ -284,6 +284,7 @@ def total_variation_loss(x):
                      x[:, :img_nrows - 1, 1:, :])
     return K.sum(K.pow(a + b, 1.25))
 
+
 # Overall loss is the weighted sum of content_loss, style_loss and tv_loss
 # Each individual loss uses features from image/mask models.
 loss = K.variable(0)
@@ -347,6 +348,7 @@ class Evaluator(object):
         self.grad_values = None
         return grad_values
 
+
 evaluator = Evaluator()
 
 # Generate images by iterative optimization
@@ -364,7 +366,7 @@ for i in range(50):
     # save current generated image
     img = deprocess_image(x.copy())
     fname = target_img_prefix + '_at_iteration_%d.png' % i
-    imsave(fname, img)
+    save_img(fname, img)
     end_time = time.time()
     print('Image saved as', fname)
     print('Iteration %d completed in %ds' % (i, end_time - start_time))

--- a/examples/neural_doodle.py
+++ b/examples/neural_doodle.py
@@ -348,7 +348,6 @@ class Evaluator(object):
         self.grad_values = None
         return grad_values
 
-
 evaluator = Evaluator()
 
 # Generate images by iterative optimization

--- a/examples/neural_style_transfer.py
+++ b/examples/neural_style_transfer.py
@@ -51,7 +51,7 @@ keeping the generated image close enough to the original one.
 
 from __future__ import print_function
 from keras.preprocessing.image import load_img, img_to_array
-from scipy.misc import imsave
+import imageio
 import numpy as np
 from scipy.optimize import fmin_l_bfgs_b
 import time
@@ -284,7 +284,7 @@ for i in range(iterations):
     # save current generated image
     img = deprocess_image(x.copy())
     fname = result_prefix + '_at_iteration_%d.png' % i
-    imsave(fname, img)
+    imageio.imwrite(fname, img)
     end_time = time.time()
     print('Image saved as', fname)
     print('Iteration %d completed in %ds' % (i, end_time - start_time))

--- a/examples/neural_style_transfer.py
+++ b/examples/neural_style_transfer.py
@@ -50,8 +50,7 @@ keeping the generated image close enough to the original one.
 '''
 
 from __future__ import print_function
-from keras.preprocessing.image import load_img, img_to_array
-import imageio
+from keras.preprocessing.image import load_img, save_img, img_to_array
 import numpy as np
 from scipy.optimize import fmin_l_bfgs_b
 import time
@@ -284,7 +283,7 @@ for i in range(iterations):
     # save current generated image
     img = deprocess_image(x.copy())
     fname = result_prefix + '_at_iteration_%d.png' % i
-    imageio.imwrite(fname, img)
+    save_img(fname, img)
     end_time = time.time()
     print('Image saved as', fname)
     print('Iteration %d completed in %ds' % (i, end_time - start_time))

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -375,6 +375,7 @@ def save_img(path,
             If a file object was used instead of a filename, this
             parameter should always be used.
         scale: Whether to rescale image values to be within [0, 255].
+        **kwargs: Additional keyword arguments passed to PIL.Image.save(). 
     """
     img = array_to_img(x, data_format=data_format, scale=scale)
     img.save(path, format=file_format, **kwargs)

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -375,7 +375,7 @@ def save_img(path,
             If a file object was used instead of a filename, this
             parameter should always be used.
         scale: Whether to rescale image values to be within [0, 255].
-        **kwargs: Additional keyword arguments passed to PIL.Image.save(). 
+        **kwargs: Additional keyword arguments passed to PIL.Image.save().
     """
     img = array_to_img(x, data_format=data_format, scale=scale)
     img.save(path, format=file_format, **kwargs)

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -358,6 +358,17 @@ def img_to_array(img, data_format=None):
     return x
 
 
+def save_img(path, x):
+    """Save an image stored as a Numpy Array to a path or file object.
+
+    # Arguments
+        path: Path or file object
+        x: Input Numpy Array
+    """
+    img = pil_image.fromarray(x)
+    img.save(path)
+
+
 def load_img(path, grayscale=False, target_size=None,
              interpolation='nearest'):
     """Loads an image into PIL format.

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -358,14 +358,16 @@ def img_to_array(img, data_format=None):
     return x
 
 
-def save_img(path, x):
+def save_img(path, x, data_format=None, scale=True):
     """Save an image stored as a Numpy Array to a path or file object.
 
     # Arguments
-        path: Path or file object
-        x: Input Numpy Array
+        path: Path or file object.
+        x: Numpy array.
+        data_format: Image data format.
+        scale: Whether to rescale image values to be within [0, 255].
     """
-    img = pil_image.fromarray(x)
+    img = array_to_img(x, data_format=data_format, scale=scale)
     img.save(path)
 
 

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -358,17 +358,26 @@ def img_to_array(img, data_format=None):
     return x
 
 
-def save_img(path, x, data_format=None, scale=True):
-    """Save an image stored as a Numpy Array to a path or file object.
+def save_img(path, 
+             x, 
+             data_format=None, 
+             file_format=None, 
+             scale=True, **kwargs):
+    """Save an image stored as a Numpy array to a path or file object.
 
     # Arguments
         path: Path or file object.
         x: Numpy array.
-        data_format: Image data format.
+        data_format: Image data format.  One of {"channels_first" or "channels_last"}.  
+            Default is 'channels_last'.
+        file_format: Optional file format override.  If omitted, the
+            format to use is determined from the filename extension.
+            If a file object was used instead of a filename, this
+            parameter should always be used.
         scale: Whether to rescale image values to be within [0, 255].
     """
     img = array_to_img(x, data_format=data_format, scale=scale)
-    img.save(path)
+    img.save(path, format=file_format, **kwargs)
 
 
 def load_img(path, grayscale=False, target_size=None,

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -358,17 +358,17 @@ def img_to_array(img, data_format=None):
     return x
 
 
-def save_img(path, 
-             x, 
-             data_format=None, 
-             file_format=None, 
+def save_img(path,
+             x,
+             data_format=None,
+             file_format=None,
              scale=True, **kwargs):
     """Save an image stored as a Numpy array to a path or file object.
 
     # Arguments
         path: Path or file object.
         x: Numpy array.
-        data_format: Image data format.  One of {"channels_first" or "channels_last"}.  
+        data_format: Image data format.  One of {"channels_first" or "channels_last"}.
             Default is 'channels_last'.
         file_format: Optional file format override.  If omitted, the
             format to use is determined from the filename extension.


### PR DESCRIPTION
While attempting to run the neural style transfer example, the imsave method failed.  According to https://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.imsave.html#scipy.misc.imsave  
`scipy.misc.imsave` is deprecated and `imageio.imwrite` should be used.  After making this change the script runs successfully.  