### PR TITLE
Update docstring in imagenet_utils.py

### DIFF
--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -152,13 +152,16 @@ def preprocess_input(x, data_format=None, mode='caffe'):
     # Arguments
         x: Input Numpy or symbolic tensor, 3D or 4D.
         data_format: Data format of the image tensor/array.
-        mode: One of "caffe", "tf".
+        mode: One of "caffe", "tf" or "torch".
             - caffe: will convert the images from RGB to BGR,
                 then will zero-center each color channel with
                 respect to the ImageNet dataset,
                 without scaling.
             - tf: will scale pixels between -1 and 1,
                 sample-wise.
+            - torch: will scale pixels between 0 and 1 and then
+                will normalize each channel with respect to the
+                ImageNet dataset.
 
     # Returns
         Preprocessed tensor or Numpy array.


### PR DESCRIPTION
I noticed that the "torch" preprocessing mode is missing from the docstring of the preprocess_input method even though the two methods (_preprocess_numpy_input and _preprocess_symbolic_input) that it uses to do the preprocessing have support for it.