### PR TITLE
Add exceptions for `batch_dot`

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -545,6 +545,10 @@ def batch_dot(x, y, axes=None):
     if axes is None:
         # behaves like tf.batch_matmul as default
         axes = [len(x_shape) - 1, len(y_shape) - 2]
+    if b_any([isinstance(a, (list, tuple)) for a in axes]):
+        raise ValueError('Multiple target dimensions are not supported. ' +
+                         'Expected: None, int, (int, int), ' +
+                         'Provided: ' + str(axes))
 
     if len(x_shape) == 2 and len(y_shape) == 2:
         if axes[0] == axes[1]:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -25,6 +25,7 @@ from .common import set_image_dim_ordering
 from .common import image_dim_ordering
 
 py_all = all
+py_any = any
 py_sum = sum
 
 # INTERNAL UTILS
@@ -1135,6 +1136,10 @@ def batch_dot(x, y, axes=None):
     if axes is None:
         # behaves like tf.batch_matmul as default
         axes = [x_ndim - 1, y_ndim - 2]
+    if py_any([isinstance(a, (list, tuple)) for a in axes]):
+        raise ValueError('Multiple target dimensions are not supported. ' +
+                         'Expected: None, int, (int, int), ' +
+                         'Provided: ' + str(axes))
     if x_ndim > y_ndim:
         diff = x_ndim - y_ndim
         y = tf.reshape(y, tf.concat([tf.shape(y), [1] * (diff)], axis=0))

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -26,6 +26,7 @@ from ..utils.generic_utils import has_arg
 from .common import set_image_dim_ordering, image_dim_ordering
 
 py_all = all
+py_any = any
 py_sum = sum
 
 
@@ -451,6 +452,10 @@ def batch_dot(x, y, axes=None):
     if axes is None:
         # behaves like tf.batch_matmul as default
         axes = [x.ndim - 1, y.ndim - 2]
+    if py_any([isinstance(a, (list, tuple)) for a in axes]):
+        raise ValueError('Multiple target dimensions are not supported. ' +
+                         'Expected: None, int, (int, int), ' +
+                         'Provided: ' + str(axes))
     if isinstance(axes, tuple):
         axes = list(axes)
 


### PR DESCRIPTION
This PR adds exceptions for `batch_dot` described in #9872. It is meaningless to perform `batch_dot` on n-dimensional tensors (`n>=3`).