### PR TITLE
Enable Xception to work on Theano and CNTK

### DIFF
--- a/keras/applications/xception.py
+++ b/keras/applications/xception.py
@@ -9,9 +9,6 @@ the VGG16 and ResNet models (299x299 instead of 224x224),
 and that the input preprocessing function
 is also different (same as Inception V3).
 
-Also do note that this model is only available for the TensorFlow backend,
-due to its reliance on `SeparableConvolution` layers.
-
 # Reference
 
 - [Xception: Deep Learning with Depthwise Separable Convolutions](https://arxiv.org/abs/1610.02357)
@@ -53,10 +50,8 @@ def Xception(include_top=True, weights='imagenet',
              classes=1000):
     """Instantiates the Xception architecture.
 
-    Optionally loads weights pre-trained
-    on ImageNet. This model is available for TensorFlow only,
-    and can only be used with inputs following the TensorFlow
-    data format `(width, height, channels)`.
+    Optionally loads weights pre-trained on ImageNet. This model can
+    only be used with the data format `(width, height, channels)`.
     You should set `image_data_format='channels_last'` in your Keras config
     located at ~/.keras/keras.json.
 
@@ -110,9 +105,6 @@ def Xception(include_top=True, weights='imagenet',
         raise ValueError('If using `weights` as imagenet with `include_top`'
                          ' as true, `classes` should be 1000')
 
-    if K.backend() != 'tensorflow':
-        raise RuntimeError('The Xception model is only available with '
-                           'the TensorFlow backend.')
     if K.image_data_format() != 'channels_last':
         warnings.warn('The Xception model is only available for the '
                       'input data format "channels_last" '

--- a/keras/applications/xception.py
+++ b/keras/applications/xception.py
@@ -34,6 +34,7 @@ from ..layers import GlobalAveragePooling2D
 from ..layers import GlobalMaxPooling2D
 from ..engine.topology import get_source_inputs
 from ..utils.data_utils import get_file
+from ..utils import layer_utils
 from .. import backend as K
 from . import imagenet_utils
 from .imagenet_utils import decode_predictions
@@ -253,6 +254,8 @@ def Xception(include_top=True, weights='imagenet',
                                     cache_subdir='models',
                                     file_hash='b0042744bf5b25fce3cb969f33bebb97')
         model.load_weights(weights_path)
+        if K.backend() == 'theano':
+            layer_utils.convert_all_kernels_in_model(model)
     elif weights is not None:
         model.load_weights(weights)
 

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -108,8 +108,6 @@ def test_vgg():
     _test_app_pooling(app, last_dim)
 
 
-@pytest.mark.skipif((K.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
 def test_xception():
     app = applications.Xception
     last_dim = 2048


### PR DESCRIPTION
This PR enables Xception to work on Theano and CNTK. As `separable_conv2d` of Theano is added by #10003, users are now able to use Xception on all the backends.