### PR TITLE
Add support for passthrough arguments to NumpyArrayIterator

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -1129,7 +1129,7 @@ class NumpyArrayIterator(Iterator):
                                      'Found a pair with: len(x[0]) = %s, len(x[?]) = %s' %
                                      (len(x), len(xx)))
         else:
-            x_misc = None
+            x_misc = []
 
         if y is not None and len(x) != len(y):
             raise ValueError('`x` (images tensor) and `y` (labels) '
@@ -1143,14 +1143,12 @@ class NumpyArrayIterator(Iterator):
             split_idx = int(len(x) * image_data_generator._validation_split)
             if subset == 'validation':
                 x = x[:split_idx]
-                if x_misc is not None:
-                    x_misc = [np.asarray(xx[:split_idx]) for xx in x_misc]
+                x_misc = [np.asarray(xx[:split_idx]) for xx in x_misc]
                 if y is not None:
                     y = y[:split_idx]
             else:
                 x = x[split_idx:]
-                if x_misc is not None:
-                    x_misc = [np.asarray(xx[split_idx:]) for xx in x_misc]
+                x_misc = [np.asarray(xx[split_idx:]) for xx in x_misc]
                 if y is not None:
                     y = y[split_idx:]
         if data_format is None:
@@ -1197,14 +1195,11 @@ class NumpyArrayIterator(Iterator):
                                                                   hash=np.random.randint(1e4),
                                                                   format=self.save_format)
                 img.save(os.path.join(self.save_to_dir, fname))
-        if self.x_misc is not None:
-            batch_x_miscs = [xx[index_array] for xx in self.x_misc]
-            output = ([batch_x] + batch_x_miscs,)
-        else:
-            output = (batch_x,)
-        if self.y is not None:
-            batch_y = self.y[index_array]
-            output += (batch_y,)
+        batch_x_miscs = [xx[index_array] for xx in self.x_misc]
+        output = (batch_x if batch_x_miscs == [] else [batch_x] + batch_x_miscs,)
+        if self.y is None:
+            return output[0]
+        output += (self.y[index_array],)
         return output
 
     def next(self):

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -71,6 +71,15 @@ class TestImage(object):
                 assert list(y) != [0, 1, 2]
                 break
 
+            # Test without y
+            for x in generator.flow(images, None,
+                                       shuffle=True, save_to_dir=str(tmpdir),
+                                       batch_size=3):
+                assert type(x) is np.ndarray
+                assert x.shape == images[:3].shape
+                # Check that the sequence is shuffled.
+                break
+            
             # Test with a single miscellaneous input data array
             dsize = images.shape[0]
             x_misc1 = np.random.random(dsize)
@@ -94,6 +103,22 @@ class TestImage(object):
                 assert (x[2] == x_misc2[(i * 2):((i + 1) * 2)]).all()
                 if i == 2:
                     break
+
+            # Test cases with `y = None`
+            x = generator.flow(images, None, batch_size=3).next()
+            assert type(x) is np.ndarray
+            assert x.shape == images[:3].shape
+            x = generator.flow((images, x_misc1), None,
+                               batch_size=3, shuffle=False).next()
+            assert type(x) is list
+            assert x[0].shape == images[:3].shape
+            assert (x[1] == x_misc1[:3]).all()
+            x = generator.flow((images, [x_misc1, x_misc2]), None,
+                               batch_size=3, shuffle=False).next()
+            assert type(x) is list
+            assert x[0].shape == images[:3].shape
+            assert (x[1] == x_misc1[:3]).all()
+            assert (x[2] == x_misc2[:3]).all()
 
             # Test some failure cases:
             x_misc_err = np.random.random((dsize + 1, 3, 3))

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -71,6 +71,41 @@ class TestImage(object):
                 assert list(y) != [0, 1, 2]
                 break
 
+            # Test with a single miscellaneous input data array
+            dsize = images.shape[0]
+            x_misc1 = np.random.random(dsize)
+
+            for i, (x, y) in enumerate(generator.flow((images, x_misc1),
+                                                      np.arange(dsize),
+                                                      shuffle=False, batch_size=2)):
+                assert x[0].shape == images[:2].shape
+                assert (x[1] == x_misc1[((i*2) % dsize):(((i+1)*2) % dsize)]).all()
+                if i == 2:
+                    break
+
+            # Test with two miscellaneous inputs
+            x_misc2 = np.random.random((dsize, 3, 3))
+
+            for i, (x, y) in enumerate(generator.flow((images, [x_misc1, x_misc2]),
+                                                      np.arange(dsize),
+                                                      shuffle=False, batch_size=2)):
+                assert x[0].shape == images[:2].shape
+                assert (x[1] == x_misc1[((i*2) % dsize):(((i+1)*2) % dsize)]).all()
+                assert (x[2] == x_misc2[((i*2) % dsize):(((i+1)*2) % dsize)]).all()
+                if i == 2:
+                    break
+
+            # Test some failure cases:
+            x_misc_err = np.random.random((dsize+1, 3, 3))
+
+            with pytest.raises(ValueError) as e_info:
+                generator.flow((images, x_misc_err), np.arange(dsize), batch_size=3)
+            assert str(e_info.value).find('All of the arrays in') != -1
+
+            with pytest.raises(ValueError) as e_info:
+                generator.flow((images, x_misc1), np.arange(dsize+1), batch_size=3)
+            assert str(e_info.value).find('`x` (images tensor) and `y` (labels) ') != -1
+
             # Test `flow` behavior as Sequence
             seq = generator.flow(images, np.arange(images.shape[0]),
                                  shuffle=False, save_to_dir=str(tmpdir),

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -73,13 +73,13 @@ class TestImage(object):
 
             # Test without y
             for x in generator.flow(images, None,
-                                       shuffle=True, save_to_dir=str(tmpdir),
-                                       batch_size=3):
+                                    shuffle=True, save_to_dir=str(tmpdir),
+                                    batch_size=3):
                 assert type(x) is np.ndarray
                 assert x.shape == images[:3].shape
                 # Check that the sequence is shuffled.
                 break
-            
+
             # Test with a single miscellaneous input data array
             dsize = images.shape[0]
             x_misc1 = np.random.random(dsize)

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -79,7 +79,7 @@ class TestImage(object):
                                                       np.arange(dsize),
                                                       shuffle=False, batch_size=2)):
                 assert x[0].shape == images[:2].shape
-                assert (x[1] == x_misc1[((i*2) % dsize):(((i+1)*2) % dsize)]).all()
+                assert (x[1] == x_misc1[(i * 2):((i + 1) * 2)]).all()
                 if i == 2:
                     break
 
@@ -90,20 +90,20 @@ class TestImage(object):
                                                       np.arange(dsize),
                                                       shuffle=False, batch_size=2)):
                 assert x[0].shape == images[:2].shape
-                assert (x[1] == x_misc1[((i*2) % dsize):(((i+1)*2) % dsize)]).all()
-                assert (x[2] == x_misc2[((i*2) % dsize):(((i+1)*2) % dsize)]).all()
+                assert (x[1] == x_misc1[(i * 2):((i + 1) * 2)]).all()
+                assert (x[2] == x_misc2[(i * 2):((i + 1) * 2)]).all()
                 if i == 2:
                     break
 
             # Test some failure cases:
-            x_misc_err = np.random.random((dsize+1, 3, 3))
+            x_misc_err = np.random.random((dsize + 1, 3, 3))
 
             with pytest.raises(ValueError) as e_info:
                 generator.flow((images, x_misc_err), np.arange(dsize), batch_size=3)
             assert str(e_info.value).find('All of the arrays in') != -1
 
             with pytest.raises(ValueError) as e_info:
-                generator.flow((images, x_misc1), np.arange(dsize+1), batch_size=3)
+                generator.flow((images, x_misc1), np.arange(dsize + 1), batch_size=3)
             assert str(e_info.value).find('`x` (images tensor) and `y` (labels) ') != -1
 
             # Test `flow` behavior as Sequence


### PR DESCRIPTION
There have been some requests for more flexible behaviour for the ImageGenerator (see for example issue #9877). This pull request takes a step towards that direction (although it doesn't yet solve the problem in the issue I linked).

I add a support for multiple input arguments in NumpyArrayIterator (and thus, the flow() function). It now accepts following syntax: `flow((image_data, [other_data1, other_data2]), ...)`. The image_data part gets processed as before and the optional other_data arguments get passed through along with the image data without manipulations. This makes it possible to use flow() to feed a model multiple miscellaneous data arguments while still using the Keras image augmentations for the image data.

No old behaviour gets modified. All the modified functions can still be used as before by just leaving the additional arguments out.