### PR TITLE
Fix shape mismatch in `rnn()` of tensorflow_backend

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2736,7 +2736,10 @@ def rnn(step_function, inputs, initial_states,
                 tiled_mask_t = tf.tile(mask_t,
                                        tf.stack([1, tf.shape(output)[1]]))
                 output = tf.where(tiled_mask_t, output, states[0])
-                new_states = [tf.where(tiled_mask_t, new_states[i], states[i]) for i in range(len(states))]
+                new_states = [
+                    tf.where(tf.tile(mask_t, tf.stack([1, tf.shape(new_states[i])[1]])),
+                             new_states[i], states[i]) for i in range(len(states))
+                ]
                 output_ta_t = output_ta_t.write(time, output)
                 return (time + 1, output_ta_t) + tuple(new_states)
         else:

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -569,7 +569,8 @@ class TestBackend(object):
         ]
 
         for (i, kwargs) in enumerate(kwargs_list):
-            last_y1, y1, h1 = reference_operations.rnn(x, [wi, wh, None], h0, **kwargs)
+            last_y1, y1, [h1, _] = reference_operations.rnn(
+                x, [wi, wh, None, None, None, None], [h0, None], **kwargs)
             last_y2, y2, h2 = K.rnn(rnn_fn, x_k, h0_k, **kwargs)
 
             assert len(h2) == 1
@@ -599,6 +600,93 @@ class TestBackend(object):
                 assert_allclose(outputs_list[i - 1], outputs_list[i], atol=1e-05)
                 assert_allclose(state_list[i - 1], state_list[i], atol=1e-05)
 
+    def test_rnn_additional_states(self):
+        # implement a simple RNN with an additional state
+        # whose shape is different from that of the output
+        num_samples = 4
+        input_dim = 5
+        output_dim = 3
+        state_dim = 7
+        timesteps = 6
+
+        _, x = parse_shape_or_val((num_samples, timesteps, input_dim))
+        _, h0 = parse_shape_or_val((num_samples, output_dim))
+        _, s0 = parse_shape_or_val((num_samples, state_dim))
+        _, wi = parse_shape_or_val((input_dim, output_dim))
+        _, wh = parse_shape_or_val((output_dim, output_dim))
+        _, ws = parse_shape_or_val((state_dim, output_dim))
+        _, wxs = parse_shape_or_val((input_dim, state_dim))
+        _, wss = parse_shape_or_val((state_dim, state_dim))
+        mask = np.random.randint(2, size=(num_samples, timesteps))
+
+        x_k = K.variable(x)
+        hs0_k = [K.variable(h0), K.variable(s0)]
+        wi_k = K.variable(wi)
+        wh_k = K.variable(wh)
+        ws_k = K.variable(ws)
+        wxs_k = K.variable(wxs)
+        wss_k = K.variable(wss)
+        mask_k = K.variable(mask)
+
+        def rnn_fn(x_k, hs_k):
+            assert len(hs_k) == 2
+            h_k1, s_k1 = hs_k
+            y_k = K.dot(x_k, wi_k) + K.dot(h_k1, wh_k) + K.dot(s_k1, ws_k)
+            s_k = K.dot(x_k, wxs_k) + K.dot(s_k1, wss_k)
+            return y_k, [y_k, s_k]
+
+        # test default setup
+        last_output_list = []
+        outputs_list = []
+        state_list = []
+
+        kwargs_list = [
+            {'go_backwards': False, 'mask': None},
+            {'go_backwards': False, 'mask': None, 'unroll': True, 'input_length': timesteps},
+            {'go_backwards': True, 'mask': None},
+            {'go_backwards': True, 'mask': None, 'unroll': True, 'input_length': timesteps},
+            {'go_backwards': False, 'mask': mask_k},
+            {'go_backwards': False, 'mask': mask_k, 'unroll': True, 'input_length': timesteps},
+        ]
+
+        for (i, kwargs) in enumerate(kwargs_list):
+            last_y1, y1, [h1, s1] = reference_operations.rnn(
+                x, [wi, wh, None, ws, wxs, wss], [h0, s0], **kwargs)
+            last_y2, y2, hs2 = K.rnn(rnn_fn, x_k, hs0_k, **kwargs)
+
+            assert len(hs2) == 2
+            last_y2 = K.eval(last_y2)
+            y2 = K.eval(y2)
+            h1 = h1[:, -1]
+            s1 = s1[:, -1]
+            h2 = K.eval(hs2[0])
+            s2 = K.eval(hs2[1])
+
+            if kwargs['mask'] is not None:
+                last_y1 = last_y1 * np.expand_dims(mask[:, -1], -1)
+                last_y2 = last_y2 * np.expand_dims(mask[:, -1], -1)
+                y1 = y1 * np.expand_dims(mask, -1)
+                y2 = y2 * np.expand_dims(mask, -1)
+                h1 = h1 * np.expand_dims(mask[:, -1], -1)
+                h2 = h2 * np.expand_dims(mask[:, -1], -1)
+                s1 = s1 * np.expand_dims(mask[:, -1], -1)
+                s2 = s2 * np.expand_dims(mask[:, -1], -1)
+
+            last_output_list.append(last_y2)
+            outputs_list.append(y2)
+            state_list.append([h2, s2])
+
+            if i % 2 == 0:
+                assert_allclose(last_y1, last_y2, atol=1e-05)
+                assert_allclose(y1, y2, atol=1e-05)
+                assert_allclose(h1, h2, atol=1e-05)
+                assert_allclose(s1, s2, atol=1e-05)
+            else:
+                assert_allclose(last_output_list[i - 1], last_output_list[i], atol=1e-05)
+                assert_allclose(outputs_list[i - 1], outputs_list[i], atol=1e-05)
+                for state_i1, state_i in zip(state_list[i - 1], state_list[i]):
+                    assert_allclose(state_i1, state_i, atol=1e-05)
+
     def test_rnn_no_states(self):
         # implement a simple RNN without states
         input_dim = 8
@@ -616,8 +704,8 @@ class TestBackend(object):
             y_k = K.dot(x_k, wi_k)
             return y_k, []
 
-        last_y1, y1, h1 = reference_operations.rnn(x, [wi, None, None], None,
-                                                   go_backwards=False, mask=None)
+        last_y1, y1, [h1, _] = reference_operations.rnn(
+            x, [wi, None, None, None, None, None], [None, None], go_backwards=False, mask=None)
         last_y2, y2, h2 = K.rnn(rnn_fn, x_k, [],
                                 go_backwards=False, mask=None)
 

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -599,6 +599,82 @@ class TestBackend(object):
                 assert_allclose(outputs_list[i - 1], outputs_list[i], atol=1e-05)
                 assert_allclose(state_list[i - 1], state_list[i], atol=1e-05)
 
+    def test_rnn_additional_states(self):
+        # implement a simple RNN with an additional state
+        # whose shape is different from that of the output
+        num_samples = 4
+        input_dim = 5
+        output_dim = 3
+        timesteps = 6
+
+        _, x = parse_shape_or_val((num_samples, timesteps, input_dim))
+        _, h0 = parse_shape_or_val((num_samples, output_dim))
+        _, wi = parse_shape_or_val((input_dim, output_dim))
+        _, wh = parse_shape_or_val((output_dim, output_dim))
+        mask = np.random.randint(2, size=(num_samples, timesteps))
+
+        x_k = K.variable(x)
+        h0_k = [K.variable(h0), K.variable(np.concatenate([h0, h0], axis=-1))]
+        wi_k = K.variable(wi)
+        wh_k = K.variable(wh)
+        mask_k = K.variable(mask)
+
+        def rnn_fn(x_k, h_k):
+            assert len(h_k) == 2
+            y_k = K.dot(x_k, wi_k) + K.dot(h_k[0], wh_k)
+            return y_k, [y_k, K.concatenate([y_k, y_k], axis=-1)]
+
+        # test default setup
+        last_output_list = []
+        outputs_list = []
+        state_list = []
+
+        kwargs_list = [
+            {'go_backwards': False, 'mask': None},
+            {'go_backwards': False, 'mask': None, 'unroll': True, 'input_length': timesteps},
+            {'go_backwards': True, 'mask': None},
+            {'go_backwards': True, 'mask': None, 'unroll': True, 'input_length': timesteps},
+            {'go_backwards': False, 'mask': mask_k},
+            {'go_backwards': False, 'mask': mask_k, 'unroll': True, 'input_length': timesteps},
+        ]
+
+        for (i, kwargs) in enumerate(kwargs_list):
+            last_y1, y1, h1 = reference_operations.rnn(x, [wi, wh, None], h0, **kwargs)
+            last_y2, y2, h2 = K.rnn(rnn_fn, x_k, h0_k, **kwargs)
+
+            assert len(h2) == 2
+            last_y2 = K.eval(last_y2)
+            y2 = K.eval(y2)
+            h11 = h1[:, -1]
+            h12 = np.concatenate([h1[:, -1], h1[:, -1]], axis=-1)
+            h21 = K.eval(h2[0])
+            h22 = K.eval(h2[1])
+
+            if kwargs['mask'] is not None:
+                last_y1 = last_y1 * np.expand_dims(mask[:, -1], -1)
+                last_y2 = last_y2 * np.expand_dims(mask[:, -1], -1)
+                y1 = y1 * np.expand_dims(mask, -1)
+                y2 = y2 * np.expand_dims(mask, -1)
+                h11 = h11 * np.expand_dims(mask[:, -1], -1)
+                h21 = h21 * np.expand_dims(mask[:, -1], -1)
+                h12 = h12 * np.expand_dims(mask[:, -1], -1)
+                h22 = h22 * np.expand_dims(mask[:, -1], -1)
+
+            last_output_list.append(last_y2)
+            outputs_list.append(y2)
+            state_list.append((h21, h22))
+
+            if i % 2 == 0:
+                assert_allclose(last_y1, last_y2, atol=1e-05)
+                assert_allclose(y1, y2, atol=1e-05)
+                assert_allclose(h11, h21, atol=1e-05)
+                assert_allclose(h12, h22, atol=1e-05)
+            else:
+                assert_allclose(last_output_list[i - 1], last_output_list[i], atol=1e-05)
+                assert_allclose(outputs_list[i - 1], outputs_list[i], atol=1e-05)
+                assert_allclose(state_list[i - 1][0], state_list[i][0], atol=1e-05)
+                assert_allclose(state_list[i - 1][1], state_list[i][1], atol=1e-05)
+
     def test_rnn_no_states(self):
         # implement a simple RNN without states
         input_dim = 8

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -126,8 +126,13 @@ def pool(x, pool_size, strides, padding, data_format, pool_mode):
 
 
 def rnn(x, w, init, go_backwards=False, mask=None, unroll=False, input_length=None):
-    w_i, w_h, w_o = w
+    # Test these recurrent equations:
+    # h_t = w_o( x_{t} w_i + h_{t-1} w_h + s_{t-1} w_s )
+    # s_t = x_{t} w_xs + s_{t-1} w_ss
+    w_i, w_h, w_o, w_s, w_xs, w_ss = w
+    h_init, s_init = init
     h = []
+    s = []
     o = []
 
     if go_backwards:
@@ -145,20 +150,48 @@ def rnn(x, w, init, go_backwards=False, mask=None, unroll=False, input_length=No
         h_t = np.dot(x[:, t], w_i)
 
         if w_h is not None:
-            prev = h[i - 1] if i > 0 else init
-            h_t1 = np.dot(prev, w_h)
+            h_prev = h[i - 1] if i > 0 else h_init
+            h_t1 = np.dot(h_prev, w_h)
             if np_mask is not None:
-                h_t1[np_mask[:, t] == 0] = prev[np_mask[:, t] == 0]
+                h_t1[np_mask[:, t] == 0] = h_prev[np_mask[:, t] == 0]
         else:
             h_t1 = 0
-
-        o_t = h_t + h_t1
-        if w_o is not None:
-            o_t = np.dot(o_t, w_o)
-        o.append(o_t)
+        if w_s is not None:
+            s_prev = s[i - 1] if i > 0 else s_init
+            s_t1 = np.dot(s_prev, w_s)
+            if np_mask is not None:
+                s_t1 = s_t1 * np_mask[:, t].reshape(-1, 1)
+        else:
+            s_t1 = 0
 
         if np_mask is not None:
             h_t = h_t * np_mask[:, t].reshape(-1, 1)
-        h.append(h_t + h_t1)
+        h_t = h_t + h_t1 + s_t1
+        h.append(h_t)
 
-    return o[-1], np.stack(o, axis=1), np.stack(h, axis=1)
+        if w_o is not None:
+            o_t = np.dot(h_t, w_o)
+        else:
+            o_t = h_t
+        o.append(o_t)
+
+        if w_xs is not None:
+            s_t = np.dot(x[:, t], w_xs)
+            if np_mask is not None:
+                s_t = s_t * np_mask[:, t].reshape(-1, 1)
+            if w_ss is not None:
+                s_prev = s[i - 1] if i > 0 else s_init
+                s_t1 = np.dot(s_prev, w_ss)
+                if np_mask is not None:
+                    s_t1[np_mask[:, t] == 0] = s_prev[np_mask[:, t] == 0]
+            else:
+                s_t1 = 0
+            s_t = s_t + s_t1
+            s.append(s_t)
+
+    if w_xs is None:
+        stacked_s = None
+    else:
+        stacked_s = np.stack(s, axis=1)
+
+    return o[-1], np.stack(o, axis=1), [np.stack(h, axis=1), stacked_s]


### PR DESCRIPTION
Fix the shape mismatch in `rnn()` with `not unroll` and `mask is not None` of the Tensorflow backend.

Problem: If the rnn cell has any (recurrent) `states[i]` whose shape is different from that of the `output` (`states[0]`), there will raise an `ValueError` when updating that state.

Reason: This is because the `tiled_mask_t` is not updated correctly for each `states[i]` but instead is simply copied from that of the `output` (`states[0]`).

Solution: Tile the `mask_t` with the correct shape of each `states[i]`. Notice that in a similar situation with `unroll is True`, the `tiled_mask_t` is handled correctly.