### PR TITLE
#10080 Convert CuDNN weights in nested Model.

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -477,8 +477,7 @@ def preprocess_weights_for_loading(layer, weights,
                                    original_keras_version=None,
                                    original_backend=None,
                                    reshape=False):
-    """Converts layers weights from Keras 1 format to Keras 2
-    and also weights of CuDNN layers in Keras 2.
+    """Converts layers weights from Keras 1 format to Keras 2 and also weights of CuDNN layers in Keras 2.
 
     # Arguments
         layer: Layer instance.
@@ -493,10 +492,12 @@ def preprocess_weights_for_loading(layer, weights,
         A list of weights values (Numpy arrays).
     """
     def convert_nested_bidirectional(weights):
-        """
-        Converts layers nested in `Bidirectional` wrapper by `preprocess_weights_for_loading()`.
-        :param weights: list of of numpy arrays
-        :return: converted list of of numpy arrays
+        """Converts layers nested in `Bidirectional` wrapper by `preprocess_weights_for_loading()`.
+
+        # Arguments
+            weights: List of weights values (Numpy arrays).
+        # Returns
+            A list of weights values (Numpy arrays).
         """
         num_weights_per_layer = len(weights) // 2
         forward_weights = preprocess_weights_for_loading(layer.forward_layer,
@@ -510,10 +511,12 @@ def preprocess_weights_for_loading(layer, weights,
         return forward_weights + backward_weights
 
     def convert_nested_model(weights):
-        """
-        Converts layers nested in `Model` or `Sequential` by `preprocess_weights_for_loading()`.
-        :param weights: list of of numpy arrays
-        :return: converted list of of numpy arrays
+        """Converts layers nested in `Model` or `Sequential` by `preprocess_weights_for_loading()`.
+        
+        # Arguments
+            weights: List of weights values (Numpy arrays).
+        # Returns
+            A list of weights values (Numpy arrays).
         """
         new_weights = []
         # trainable weights

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -512,7 +512,7 @@ def preprocess_weights_for_loading(layer, weights,
 
     def convert_nested_model(weights):
         """Converts layers nested in `Model` or `Sequential` by `preprocess_weights_for_loading()`.
-        
+
         # Arguments
             weights: List of weights values (Numpy arrays).
         # Returns

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -11,6 +11,11 @@ from keras.models import model_from_json, model_from_yaml
 from keras.utils.test_utils import keras_test
 
 
+skipif_no_tf_gpu = pytest.mark.skipif(
+    (K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+    reason='Requires TensorFlow backend and a GPU')
+
+
 @keras_test
 def test_get_updates_for():
     a = Input(shape=(2,))
@@ -630,8 +635,7 @@ def test_preprocess_weights_for_loading_rnn_should_be_idempotent(layer_class, la
     (layers.CuDNNGRU, {'units': 2, 'input_shape': [3, 5]}),
     (layers.CuDNNLSTM, {'units': 2, 'input_shape': [3, 5]}),
 ])
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_preprocess_weights_for_loading_cudnn_rnn_should_be_idempotent(layer_class, layer_args):
     test_preprocess_weights_for_loading_rnn_should_be_idempotent(layer_class, layer_args)
 

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -630,8 +630,8 @@ def test_preprocess_weights_for_loading_rnn_should_be_idempotent(layer_class, la
     (layers.CuDNNGRU, {'units': 2, 'input_shape': [3, 5]}),
     (layers.CuDNNLSTM, {'units': 2, 'input_shape': [3, 5]}),
 ])
-@pytest.mark.skipif((K.backend() != 'tensorflow'), reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not K.tensorflow_backend._get_available_gpus(), reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_preprocess_weights_for_loading_cudnn_rnn_should_be_idempotent(layer_class, layer_args):
     test_preprocess_weights_for_loading_rnn_should_be_idempotent(layer_class, layer_args)
 

--- a/tests/keras/layers/cudnn_recurrent_test.py
+++ b/tests/keras/layers/cudnn_recurrent_test.py
@@ -8,9 +8,13 @@ from keras.utils.test_utils import keras_test
 import time
 
 
+skipif_no_tf_gpu = pytest.mark.skipif(
+    (K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+    reason='Requires TensorFlow backend and a GPU')
+
+
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_cudnn_rnn_canonical_to_params_lstm():
     units = 1
     input_size = 1
@@ -68,8 +72,7 @@ def test_cudnn_rnn_canonical_to_params_lstm():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_cudnn_rnn_canonical_to_params_gru():
     units = 7
     input_size = 9
@@ -120,8 +123,7 @@ def test_cudnn_rnn_canonical_to_params_gru():
 
 @keras_test
 @pytest.mark.parametrize('rnn_type', ['lstm', 'gru'], ids=['LSTM', 'GRU'])
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_cudnn_rnn_timing(rnn_type):
     input_size = 1000
     timesteps = 60
@@ -159,8 +161,7 @@ def test_cudnn_rnn_timing(rnn_type):
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_cudnn_rnn_basics():
     input_size = 10
     timesteps = 6
@@ -188,8 +189,7 @@ def test_cudnn_rnn_basics():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_trainability():
     input_size = 10
     units = 2
@@ -210,8 +210,7 @@ def test_trainability():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_regularizer():
     input_size = 10
     timesteps = 6
@@ -238,8 +237,7 @@ def test_regularizer():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_return_state():
     input_size = 10
     timesteps = 6
@@ -263,8 +261,7 @@ def test_return_state():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_specify_initial_state_keras_tensor():
     input_size = 10
     timesteps = 6
@@ -293,8 +290,7 @@ def test_specify_initial_state_keras_tensor():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_statefulness():
     input_size = 10
     timesteps = 6
@@ -341,8 +337,7 @@ def test_statefulness():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_cudnnrnn_bidirectional():
     rnn = keras.layers.CuDNNGRU
     samples = 2

--- a/tests/keras/layers/cudnn_recurrent_test.py
+++ b/tests/keras/layers/cudnn_recurrent_test.py
@@ -2,16 +2,15 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import keras
+import keras.backend as K
 from keras.utils.test_utils import layer_test
 from keras.utils.test_utils import keras_test
 import time
 
 
 @keras_test
-@pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_cudnn_rnn_canonical_to_params_lstm():
     units = 1
     input_size = 1
@@ -69,10 +68,8 @@ def test_cudnn_rnn_canonical_to_params_lstm():
 
 
 @keras_test
-@pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_cudnn_rnn_canonical_to_params_gru():
     units = 7
     input_size = 9
@@ -123,10 +120,8 @@ def test_cudnn_rnn_canonical_to_params_gru():
 
 @keras_test
 @pytest.mark.parametrize('rnn_type', ['lstm', 'gru'], ids=['LSTM', 'GRU'])
-@pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_cudnn_rnn_timing(rnn_type):
     input_size = 1000
     timesteps = 60
@@ -164,10 +159,8 @@ def test_cudnn_rnn_timing(rnn_type):
 
 
 @keras_test
-@pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_cudnn_rnn_basics():
     input_size = 10
     timesteps = 6
@@ -195,10 +188,8 @@ def test_cudnn_rnn_basics():
 
 
 @keras_test
-@pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_trainability():
     input_size = 10
     units = 2
@@ -219,10 +210,8 @@ def test_trainability():
 
 
 @keras_test
-@pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_regularizer():
     input_size = 10
     timesteps = 6
@@ -249,10 +238,8 @@ def test_regularizer():
 
 
 @keras_test
-@pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_return_state():
     input_size = 10
     timesteps = 6
@@ -276,10 +263,8 @@ def test_return_state():
 
 
 @keras_test
-@pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_specify_initial_state_keras_tensor():
     input_size = 10
     timesteps = 6
@@ -308,10 +293,8 @@ def test_specify_initial_state_keras_tensor():
 
 
 @keras_test
-@pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_statefulness():
     input_size = 10
     timesteps = 6
@@ -358,10 +341,8 @@ def test_statefulness():
 
 
 @keras_test
-@pytest.mark.skipif((keras.backend.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not keras.backend.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_cudnnrnn_bidirectional():
     rnn = keras.layers.CuDNNGRU
     samples = 2

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -19,6 +19,11 @@ from keras.utils.test_utils import keras_test
 from keras.models import save_model, load_model
 
 
+skipif_no_tf_gpu = pytest.mark.skipif(
+    (K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+    reason='Requires TensorFlow backend and a GPU')
+
+
 @keras_test
 def test_sequential_model_saving():
     model = Sequential()
@@ -615,8 +620,7 @@ def test_saving_recurrent_layer_without_bias():
 @pytest.mark.parametrize('rnn_type', ['LSTM', 'GRU'], ids=['LSTM', 'GRU'])
 @pytest.mark.parametrize('model_nest_level', [1, 2], ids=['model_plain', 'model_nested'])
 @pytest.mark.parametrize('model_type', ['func', 'seq'], ids=['model_func', 'model_seq'])
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_load_weights_between_noncudnn_rnn(rnn_type, to_cudnn, bidirectional, implementation,
                                            model_nest_level, model_type):
     input_size = 10
@@ -688,8 +692,7 @@ def _make_nested_model(input_shape, layer, level=1, model_type='func'):
         return make_nested_seq_model(input_shape, layer, level)
 
 
-@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
-                    reason='Requires TensorFlow backend and a GPU')
+@skipif_no_tf_gpu
 def test_preprocess_weights_for_loading_gru_incompatible():
     """
     Loading weights between incompatible layers should fail fast with an exception.

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -615,10 +615,8 @@ def test_saving_recurrent_layer_without_bias():
 @pytest.mark.parametrize('rnn_type', ['LSTM', 'GRU'], ids=['LSTM', 'GRU'])
 @pytest.mark.parametrize('model_nest_level', [1, 2], ids=['model_plain', 'model_nested'])
 @pytest.mark.parametrize('model_type', ['func', 'seq'], ids=['model_func', 'model_seq'])
-@pytest.mark.skipif((K.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not K.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_load_weights_between_noncudnn_rnn(rnn_type, to_cudnn, bidirectional, implementation,
                                            model_nest_level, model_type):
     input_size = 10
@@ -690,10 +688,8 @@ def _make_nested_model(input_shape, layer, level=1, model_type='func'):
         return make_nested_seq_model(input_shape, layer, level)
 
 
-@pytest.mark.skipif((K.backend() != 'tensorflow'),
-                    reason='Requires TensorFlow backend')
-@pytest.mark.skipif(not K.tensorflow_backend._get_available_gpus(),
-                    reason='Requires GPU')
+@pytest.mark.skipif((K.backend() != 'tensorflow') or (not K.tensorflow_backend._get_available_gpus()),
+                    reason='Requires TensorFlow backend and a GPU')
 def test_preprocess_weights_for_loading_gru_incompatible():
     """
     Loading weights between incompatible layers should fail fast with an exception.


### PR DESCRIPTION
- similar problem to nesting in Bidirectional (#8860)
- ~quick fix: just copy/paste. I'll refactor it later~
- also convert biases from H5 Dataset to np.array for reshape() (#9662)
- [x] refactor duplicate code
- [x] add tests
  - nested models
  - various model types: Model, Sequential (not only Sequential)
    - [x] Model -> CuDNNGRU
    - [x] Sequential -> CuDNNGRU
    - [x] Model -> Model -> CuDNNGRU
    - ~Model -> Sequential -> CuDNNGRU~
    - ~Sequential -> Model -> CuDNNGRU~
    - [x] Sequential -> Sequential -> CuDNNGRU
  - [x] convert weights on model, not layer
  - [x] better just save model weights and load them back instead of calling `preprocess_weights_for_loading()` directly
- fixed `pytest.skipif` markers for requiring TensorFlow and GPU
  - It seems that pytest doesn't support short-circuit evaluation of subsequent markers. I can't understand how the tests passed until now.
- refactored duplicate `pytest.skipif` markers