### PR TITLE
Temporary disabling of large TF tests to try to fix CI build timeout

### DIFF
--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -3,17 +3,16 @@ import random
 import os
 from multiprocessing import Process, Queue
 from keras.utils.test_utils import keras_test
-from keras.utils.test_utils import layer_test
-from keras.models import Sequential
 from keras import applications
 from keras import backend as K
 
 
 pytestmark = pytest.mark.skipif(
-    os.environ.get('CORE_CHANGED', 'True') == 'False' and
-    os.environ.get('APP_CHANGED', 'True') == 'False',
+    # Temporary disabling of large TF tests
+    K.backend() == 'tensorflow' or
+    (os.environ.get('CORE_CHANGED', 'True') == 'False' and
+     os.environ.get('APP_CHANGED', 'True') == 'False'),
     reason='Runs only when the relevant files have been modified.')
-
 
 DENSENET_LIST = [(applications.DenseNet121, 1024),
                  (applications.DenseNet169, 1664),

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -8,10 +8,8 @@ from keras import backend as K
 
 
 pytestmark = pytest.mark.skipif(
-    # Temporary disabling of large TF tests
-    K.backend() == 'tensorflow' or
-    (os.environ.get('CORE_CHANGED', 'True') == 'False' and
-     os.environ.get('APP_CHANGED', 'True') == 'False'),
+    os.environ.get('CORE_CHANGED', 'True') == 'False' and
+    os.environ.get('APP_CHANGED', 'True') == 'False',
     reason='Runs only when the relevant files have been modified.')
 
 DENSENET_LIST = [(applications.DenseNet121, 1024),

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -13,12 +13,17 @@ import six
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.request import pathname2url
 
+from keras import backend as K
 from keras.utils import GeneratorEnqueuer
 from keras.utils import OrderedEnqueuer
 from keras.utils import Sequence
 from keras.utils.data_utils import _hash_file
 from keras.utils.data_utils import get_file
 from keras.utils.data_utils import validate_file
+
+pytestmark = pytest.mark.skipif(
+    # Temporary disabling
+    K.backend() == 'tensorflow')
 
 if sys.version_info < (3,):
     def next(x):

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -22,8 +22,8 @@ from keras.utils.data_utils import get_file
 from keras.utils.data_utils import validate_file
 
 pytestmark = pytest.mark.skipif(
-    # Temporary disabling
-    K.backend() == 'tensorflow')
+    K.backend() == 'tensorflow',
+    reason='Temporary disabling to fix CI build')
 
 if sys.version_info < (3,):
     def next(x):


### PR DESCRIPTION
Re: comment in #10082:

> We haven't merged any PR where the CI build did not pass. So I don't think the recent failures are linked to any change on our end (at least not in isolation).
> My guess is that it may be that Travis made a change that resulted in builds timing out after ~20-25 min (exact timing is non-deterministic). TF tests have been taking that much time, or more, for a long time, but that only started being a problem a few days ago.
> This view is reinforced by the fact that the failures aren't completely deterministic, sometimes one of the two TF builds passes (when it happens to take less time).
> Proposed fix: temporarily disable very large TF tests to bring TF build time under 20 min.