### PR TITLE
[RELNOTES] Allow symbolic tensors to be fed to models (with TF backend)

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -974,9 +974,13 @@ class Model(Network):
                 val_ins = val_x + val_y + val_sample_weights
 
         elif validation_split and 0. < validation_split < 1.:
+            if any(K.is_tensor(t) for t in x):
+                raise ValueError(
+                    'If your data is in the form of symbolic tensors, '
+                    'you cannot use `validation_split`.')
             do_validation = True
             if hasattr(x[0], 'shape'):
-                split_at = int(x[0].shape[0] * (1. - validation_split))
+                split_at = int(int(x[0].shape[0]) * (1. - validation_split))
             else:
                 split_at = int(len(x[0]) * (1. - validation_split))
             x, val_x = (slice_arrays(x, 0, split_at),

--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -11,6 +11,22 @@ from .. import backend as K
 from .. import losses
 
 
+def standardize_single_array(x):
+    if x is None:
+        return None
+    elif K.is_tensor(x):
+        shape = K.int_shape(x)
+        if shape is None or shape[0] is None:
+            raise ValueError(
+                'When feeding symbolic tensors to a model, we expect the'
+                'tensors to have a static batch size. '
+                'Got tensor with shape: %s' % str(shape))
+        return x
+    elif x.ndim == 1:
+        x = np.expand_dims(x, 1)
+    return x
+
+
 def standardize_input_data(data,
                            names,
                            shapes=None,
@@ -49,23 +65,29 @@ def standardize_input_data(data,
 
     if isinstance(data, dict):
         try:
-            data = [data[x].values if data[x].__class__.__name__ == 'DataFrame'
-                    else data[x] for x in names]
+            data = [
+                data[x].values
+                if data[x].__class__.__name__ == 'DataFrame' else data[x]
+                for x in names
+            ]
         except KeyError as e:
-            raise ValueError(
-                'No data provided for "' + e.args[0] + '". Need data '
-                'for each key in: ' + str(names))
+            raise ValueError('No data provided for "' + e.args[0] +
+                             '". Need data '
+                             'for each key in: ' + str(names))
     elif isinstance(data, list):
-        if len(names) == 1 and data and isinstance(data[0], (float, int)):
+        if isinstance(data[0], list):
+            data = [np.asarray(d) for d in data]
+        elif len(names) == 1 and isinstance(data[0], (float, int)):
             data = [np.asarray(data)]
         else:
-            data = [x.values if x.__class__.__name__ == 'DataFrame'
-                    else x for x in data]
+            data = [
+                x.values if x.__class__.__name__ == 'DataFrame'
+                else x for x in data
+            ]
     else:
         data = data.values if data.__class__.__name__ == 'DataFrame' else data
         data = [data]
-    data = [np.expand_dims(x, 1) if x is not None and x.ndim == 1
-            else x for x in data]
+    data = [standardize_single_array(x) for x in data]
 
     if len(data) != len(names):
         if data and hasattr(data[0], 'shape'):
@@ -81,20 +103,19 @@ def standardize_input_data(data,
                 'Error when checking model ' + exception_prefix +
                 ': you are passing a list as input to your model, '
                 'but the model expects a list of ' + str(len(names)) +
-                ' Numpy arrays instead. The list you passed was: ' +
-                str(data)[:200])
+                ' Numpy arrays instead. '
+                'The list you passed was: ' + str(data)[:200])
         elif len(data) == 1 and not hasattr(data[0], 'shape'):
-            raise TypeError(
-                'Error when checking model ' + exception_prefix +
-                ': data should be a Numpy array, or list/dict of '
-                'Numpy arrays. Found: ' + str(data)[:200] + '...')
+            raise TypeError('Error when checking model ' + exception_prefix +
+                            ': data should be a Numpy array, or list/dict of '
+                            'Numpy arrays. Found: ' + str(data)[:200] + '...')
         elif len(names) == 1:
             data = [np.asarray(data)]
 
     # Check shapes compatibility.
     if shapes:
         for i in range(len(names)):
-            if shapes[i] is not None:
+            if shapes[i] is not None and not K.is_tensor(data[i]):
                 data_shape = data[i].shape
                 shape = shapes[i]
                 if data[i].ndim != len(shape):
@@ -194,7 +215,7 @@ def check_array_length_consistency(inputs, targets, weights=None):
         if x is None:
             return {0}
         else:
-            return set([0 if y is None else y.shape[0] for y in x])
+            return set([0 if y is None else int(y.shape[0]) for y in x])
 
     set_x = set_of_lengths(inputs)
     set_y = set_of_lengths(targets)
@@ -532,15 +553,20 @@ def check_num_samples(ins,
     # Raises
         ValueError: In case of invalid arguments.
     """
-    if steps is not None:
-        num_samples = None
-        if batch_size is not None:
-            raise ValueError('If ' + steps_name +
-                             ' is set, the `batch_size` must be None.')
-    elif ins and hasattr(ins[0], 'shape'):
-        num_samples = ins[0].shape[0]
-    else:
-        raise ValueError('Either the input data should have '
-                         'a defined shape, or ' + steps_name +
-                         ' should be specified.')
-    return num_samples
+    if steps is not None and batch_size is not None:
+        raise ValueError(
+            'If ' + steps_name + ' is set, the `batch_size` must be None.')
+
+    if not ins or any(K.is_tensor(x) for x in ins):
+        if steps is None:
+            raise ValueError(
+                'If your data is in the form of symbolic tensors, '
+                'you should specify the `' + steps_name + '` argument '
+                '(instead of the `batch_size` argument, '
+                'because symbolic tensors are expected to produce '
+                'batches of input data).')
+        return None
+
+    if hasattr(ins[0], 'shape'):
+        return int(ins[0].shape[0])
+    return None  # Edge case where ins == [static_learning_phase]

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -1236,6 +1236,10 @@ def test_pandas_dataframe():
 
 @keras_test
 @pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TensorFlow')
+@pytest.mark.skipif((K.backend() == 'tensorflow' and
+                     not hasattr(K.get_session(),
+                                 '_make_callable_from_options')),
+                    reason='Requires TF 1.8 or higher')
 def test_training_and_eval_methods_on_symbolic_tensors_single_io():
     x = keras.layers.Input(shape=(3,), name='input')
     y = keras.layers.Dense(4, name='dense')(x)
@@ -1261,6 +1265,10 @@ def test_training_and_eval_methods_on_symbolic_tensors_single_io():
 
 @keras_test
 @pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TensorFlow')
+@pytest.mark.skipif((K.backend() == 'tensorflow' and
+                     not hasattr(K.get_session(),
+                                 '_make_callable_from_options')),
+                    reason='Requires TF 1.8 or higher')
 def test_training_and_eval_methods_on_symbolic_tensors_multi_io():
     a = keras.layers.Input(shape=(3,), name='input_a')
     b = keras.layers.Input(shape=(3,), name='input_b')

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -1234,5 +1234,124 @@ def test_pandas_dataframe():
                           [output_a_df, output_b_df])
 
 
+@keras_test
+@pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TensorFlow')
+def test_training_and_eval_methods_on_symbolic_tensors_single_io():
+    x = keras.layers.Input(shape=(3,), name='input')
+    y = keras.layers.Dense(4, name='dense')(x)
+    model = keras.Model(x, y)
+
+    optimizer = 'rmsprop'
+    loss = 'mse'
+    metrics = ['mae']
+    model.compile(optimizer, loss, metrics=metrics)
+
+    inputs = keras.backend.zeros(shape=(10, 3))
+    targets = keras.backend.zeros(shape=(10, 4))
+
+    model.fit(inputs, targets, epochs=1, steps_per_epoch=2, verbose=0)
+    model.evaluate(inputs, targets, steps=2, verbose=0)
+    model.predict(inputs, steps=2)
+    model.train_on_batch(inputs, targets)
+    model.test_on_batch(inputs, targets)
+    model.fit(inputs, targets,
+              epochs=1, steps_per_epoch=2, verbose=1,
+              validation_data=(inputs, targets), validation_steps=2)
+
+
+@keras_test
+@pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TensorFlow')
+def test_training_and_eval_methods_on_symbolic_tensors_multi_io():
+    a = keras.layers.Input(shape=(3,), name='input_a')
+    b = keras.layers.Input(shape=(3,), name='input_b')
+
+    dense = keras.layers.Dense(4, name='dense')
+    c = dense(a)
+    d = dense(b)
+    e = keras.layers.Dropout(0.5, name='dropout')(c)
+
+    model = keras.models.Model([a, b], [d, e])
+
+    optimizer = 'rmsprop'
+    loss = 'mse'
+    loss_weights = [1., 0.5]
+    metrics = ['mae']
+    model.compile(optimizer, loss, metrics=metrics, loss_weights=loss_weights)
+
+    input_a_tf = keras.backend.zeros(shape=(10, 3))
+    input_b_tf = keras.backend.zeros(shape=(10, 3))
+
+    output_d_tf = keras.backend.zeros(shape=(10, 4))
+    output_e_tf = keras.backend.zeros(shape=(10, 4))
+
+    model.fit(
+        [input_a_tf, input_b_tf], [output_d_tf, output_e_tf],
+        epochs=1,
+        steps_per_epoch=2,
+        verbose=0)
+    with pytest.raises(ValueError) as excinfo:
+        model.fit(
+            [input_a_tf, input_b_tf], [output_d_tf, output_e_tf],
+            epochs=1,
+            batch_size=5,
+            verbose=0)
+    assert 'should specify the `steps_per_epoch`' in str(excinfo.value)
+    model.train_on_batch([input_a_tf, input_b_tf], [output_d_tf, output_e_tf])
+
+    # Test with dictionary inputs
+    model.fit(
+        {'input_a': input_a_tf,
+         'input_b': input_b_tf},
+        {'dense': output_d_tf,
+         'dropout': output_e_tf},
+        epochs=1,
+        steps_per_epoch=2,
+        verbose=0)
+    model.fit(
+        {'input_a': input_a_tf,
+         'input_b': input_b_tf},
+        {'dense': output_d_tf,
+         'dropout': output_e_tf},
+        validation_data=({'input_a': input_a_tf,
+                          'input_b': input_b_tf},
+                         {'dense': output_d_tf,
+                          'dropout': output_e_tf}),
+        epochs=1,
+        steps_per_epoch=2,
+        validation_steps=2,
+        verbose=0)
+    model.train_on_batch(
+        {'input_a': input_a_tf,
+         'input_b': input_b_tf},
+        {'dense': output_d_tf,
+         'dropout': output_e_tf})
+
+    # Test with validation data
+    model.fit(
+        [input_a_tf, input_b_tf], [output_d_tf, output_e_tf],
+        validation_data=([input_a_tf, input_b_tf],
+                         [output_d_tf, output_e_tf]),
+        epochs=1,
+        steps_per_epoch=2,
+        validation_steps=2,
+        verbose=0)
+    # Test with validation split
+    with pytest.raises(ValueError) as excinfo:
+        model.fit(
+            [input_a_tf, input_b_tf], [output_d_tf, output_e_tf],
+            epochs=2,
+            steps_per_epoch=2,
+            verbose=0,
+            validation_split=0.2,
+            validation_steps=2)
+    assert 'you cannot use `validation_split`' in str(excinfo.value)
+
+    # Test evaluation / prediction methods
+    model.evaluate([input_a_tf, input_b_tf], [output_d_tf, output_e_tf],
+                   steps=2, verbose=0)
+    model.predict([input_a_tf, input_b_tf], steps=2)
+    model.test_on_batch([input_a_tf, input_b_tf], [output_d_tf, output_e_tf])
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Enables the API (with TF backend, TF>=1.8):

```python
model.fit(symbolic_input, symbolic_target, steps_per_epoch=100, epochs=10)
```

**Caveat**: inputs tensors must have a static batch size. This limitation does not exist in `tf.keras`. Lifting this limitation in multi-backend Keras is doable but fairly involved. First we need all backends to implement `placeholder_with_default`. That part is relatively straightforward (by using regular placeholders and feeding the default if a value is not provided, at the level of `K.function`), but will take a bit of work. Then we need to switch the sample weight placeholders to be placeholders with default values of 1.

CC @TimZaman @ahundt 