### PR TITLE
Update neural_style_transfer.py

### DIFF
--- a/examples/neural_style_transfer.py
+++ b/examples/neural_style_transfer.py
@@ -50,7 +50,8 @@ keeping the generated image close enough to the original one.
 '''
 
 from __future__ import print_function
-from keras.preprocessing.image import load_img, save_img, img_to_array
+from keras.preprocessing.image import load_img, img_to_array
+from cv2 import imwrite as save_img
 import numpy as np
 from scipy.optimize import fmin_l_bfgs_b
 import time


### PR DESCRIPTION
The scipy pkg cancelled the imsave function and save_img function is not defined in some version of Keras 2 (eg. AWS DL AMI v8.0).
Thus using the opencv-python PKG instead.