### PR TITLE
Allow dynamic backends in _need_convert_kernel

### DIFF
--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -143,7 +143,7 @@ def NASNet(input_shape=None,
         RuntimeError: If attempting to run this model with a
             backend that does not support separable convolutions.
     '''
-    if K.backend() != 'tensorflow':
+    if K.backend() in ['cntk', 'theano']:
         raise RuntimeError('Only TensorFlow backend is currently supported, '
                            'as other backends do not support '
                            'separable convolution.')

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -815,7 +815,15 @@ def _need_convert_kernel(original_backend):
     uses_correlation = {'tensorflow': True,
                         'theano': False,
                         'cntk': True}
-    return uses_correlation[original_backend] != uses_correlation[K.backend()]
+    if original_backend not in uses_correlation:
+        # no way of knowing for external backend, so don't convert
+        return False
+    try:
+        current_uses_correlation = uses_correlation[K.backend()]
+    except KeyError:
+        # External backends can report this with K.uses_correlation
+        current_uses_correlation = K.uses_correlation()
+    return uses_correlation[original_backend] != current_uses_correlation
 
 
 def load_weights_from_hdf5_group(f, layers, reshape=False):

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -816,13 +816,13 @@ def _need_convert_kernel(original_backend):
                         'theano': False,
                         'cntk': True}
     if original_backend not in uses_correlation:
-        # no way of knowing for external backend, so don't convert
+        # By default, do not convert the kernels if the original backend is unknown
         return False
-    try:
+    if K.backend() in uses_correlation:
         current_uses_correlation = uses_correlation[K.backend()]
-    except KeyError:
-        # External backends can report this with K.uses_correlation
-        current_uses_correlation = K.uses_correlation()
+    else:
+        # Assume unknown backends use correlation
+        current_uses_correlation = True
     return uses_correlation[original_backend] != current_uses_correlation
 
 


### PR DESCRIPTION
Allow dynamic backends to work in `_need_convert_kernel` by defining `K.uses_correlation()`.

Also don't assume that dynamic backends won't support separable convolutions.