### PR TITLE
Fix preprocess_input not working with int arrays

### DIFF
--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -38,6 +38,8 @@ def _preprocess_numpy_input(x, data_format, mode):
     # Returns
         Preprocessed Numpy array.
     """
+    x = x.astype(K.floatx())
+
     if mode == 'tf':
         x /= 127.5
         x -= 1.

--- a/tests/keras/applications/imagenet_utils_test.py
+++ b/tests/keras/applications/imagenet_utils_test.py
@@ -8,23 +8,35 @@ from keras.layers import Input, Lambda
 
 
 def test_preprocess_input():
-    # Test image batch
+    # Test image batch with float and int image input
     x = np.random.uniform(0, 255, (2, 10, 10, 3))
+    xint = x.astype('int32')
     assert utils.preprocess_input(x).shape == x.shape
+    assert utils.preprocess_input(xint).shape == xint.shape
 
     out1 = utils.preprocess_input(x, 'channels_last')
+    out1int = utils.preprocess_input(xint, 'channels_last')
     out2 = utils.preprocess_input(np.transpose(x, (0, 3, 1, 2)),
                                   'channels_first')
+    out2int = utils.preprocess_input(np.transpose(xint, (0, 3, 1, 2)),
+                                     'channels_first')
     assert_allclose(out1, out2.transpose(0, 2, 3, 1))
+    assert_allclose(out1int, out2int.transpose(0, 2, 3, 1))
 
     # Test single image
     x = np.random.uniform(0, 255, (10, 10, 3))
+    xint = x.astype('int32')
     assert utils.preprocess_input(x).shape == x.shape
+    assert utils.preprocess_input(xint).shape == xint.shape
 
     out1 = utils.preprocess_input(x, 'channels_last')
+    out1int = utils.preprocess_input(xint, 'channels_last')
     out2 = utils.preprocess_input(np.transpose(x, (2, 0, 1)),
                                   'channels_first')
+    out2int = utils.preprocess_input(np.transpose(xint, (2, 0, 1)),
+                                     'channels_first')
     assert_allclose(out1, out2.transpose(1, 2, 0))
+    assert_allclose(out1int, out2int.transpose(1, 2, 0))
 
 
 def test_preprocess_input_symbolic():


### PR DESCRIPTION
`preprocess_input()` throws an exception if used with NumPy arrays containing `int`s (which, to me, seems like a completely reasonable thing to do when processing images). This is a simple one line contribution that fixes the problem. I also added some tests that illustrate the problem.