### PR TITLE
Remove irrelevant code

### DIFF
--- a/keras/engine/training_arrays.py
+++ b/keras/engine/training_arrays.py
@@ -157,7 +157,6 @@ def fit_loop(model, f, ins,
 
             if do_validation:
                 val_outs = test_loop(model, val_f, val_ins,
-                                     batch_size=batch_size,
                                      steps=validation_steps,
                                      verbose=0)
                 if not isinstance(val_outs, list):


### PR DESCRIPTION
`batch_size` is always `None` , because `steps_per_epoch` and `batch_size` are mutually exclusive.
Passing `batch_size` seems irrelevant as `None` is its default value in `test_loop`