### PR TITLE
Add exceptions for `fit_loop`

### DIFF
--- a/keras/engine/training_arrays.py
+++ b/keras/engine/training_arrays.py
@@ -76,6 +76,11 @@ def fit_loop(model, f, ins,
                              'when doing step-wise '
                              'training, i.e. `steps_per_epoch` '
                              'must be set.')
+    elif do_validation:
+        if steps_per_epoch:
+            raise ValueError('Must specify `validation_steps` '
+                             'to perform validation '
+                             'when doing step-wise training.')
 
     num_train_samples = check_num_samples(ins,
                                           batch_size=batch_size,


### PR DESCRIPTION
In the method `model.fit()`, if validation data(`validation_data` or` validation_split`) and `steps_per_epoch` are specified without `validation_steps`, it runs into an error.  

This is because `fit_loop` runs `test_loop` with `batch_size=None` (due to `batch_size` and `steps_per_epoch` being mutually exclusive), which in turn tries to make batches for validation with `batch_size=None` , and causes an error. 

Below is a simple test case that shows the problem.

```
import numpy as np
from keras import layers
from keras.models import Sequential

X = np.arange(100)
y = np.arange(100)

model = Sequential()
model.add(layers.Dense(8, input_shape=(1,), activation="relu"))
model.add(layers.Dense(1))
model.compile(loss="mse", optimizer="rmsprop", metrics=["mae"])

history = model.fit(X, y, epochs=1, validation_split=0.1, steps_per_epoch=1)
```

This PR adds an exception for the case described above. 