### PR TITLE
Fix undefined behaviour: preprocess_input copying/not copying the input arrays

### DIFF
--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -180,7 +180,6 @@ def preprocess_input(x, data_format=None, mode='caffe', copy=True):
     # Raises
         ValueError: In case of unknown `data_format` argument.
     """
-
     if data_format is None:
         data_format = K.image_data_format()
     if data_format not in {'channels_first', 'channels_last'}:

--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -18,7 +18,7 @@ CLASS_INDEX_PATH = 'https://s3.amazonaws.com/deep-learning-models/image-models/i
 _IMAGENET_MEAN = None
 
 
-def _preprocess_numpy_input(x, data_format, mode, copy=True):
+def _preprocess_numpy_input(x, data_format, mode):
     """Preprocesses a Numpy array encoding a batch of images.
 
     # Arguments
@@ -34,17 +34,12 @@ def _preprocess_numpy_input(x, data_format, mode, copy=True):
             - torch: will scale pixels between 0 and 1 and then
                 will normalize each channel with respect to the
                 ImageNet dataset.
-        copy: Whether to allocate a new array for the results or not.
-            If set to `False`, the results are copied over the input
-            array if their datatypes are compatible.
 
     # Returns
         Preprocessed Numpy array.
     """
     if not issubclass(x.dtype.type, np.floating):
-        x = x.astype(K.floatx(), copy=copy)
-    elif copy:
-        x = np.copy(x)
+        x = x.astype(K.floatx(), copy=False)
 
     if mode == 'tf':
         x /= 127.5
@@ -154,11 +149,14 @@ def _preprocess_symbolic_input(x, data_format, mode):
     return x
 
 
-def preprocess_input(x, data_format=None, mode='caffe', copy=True):
+def preprocess_input(x, data_format=None, mode='caffe'):
     """Preprocesses a tensor or Numpy array encoding a batch of images.
 
     # Arguments
         x: Input Numpy or symbolic tensor, 3D or 4D.
+            The preprocessed data is written over the input data
+            if the data types are compatible. To avoid this
+            behaviour, `numpy.copy(x)` can be used.
         data_format: Data format of the image tensor/array.
         mode: One of "caffe", "tf" or "torch".
             - caffe: will convert the images from RGB to BGR,
@@ -170,9 +168,6 @@ def preprocess_input(x, data_format=None, mode='caffe', copy=True):
             - torch: will scale pixels between 0 and 1 and then
                 will normalize each channel with respect to the
                 ImageNet dataset.
-        copy: Whether to allocate a new array for the results or not.
-            If set to `False`, the results are copied over the input
-            array if their datatypes are compatible.
 
     # Returns
         Preprocessed tensor or Numpy array.
@@ -186,8 +181,7 @@ def preprocess_input(x, data_format=None, mode='caffe', copy=True):
         raise ValueError('Unknown data_format ' + str(data_format))
 
     if isinstance(x, np.ndarray):
-        return _preprocess_numpy_input(x, data_format=data_format, mode=mode,
-                                       copy=copy)
+        return _preprocess_numpy_input(x, data_format=data_format, mode=mode)
     else:
         return _preprocess_symbolic_input(x, data_format=data_format,
                                           mode=mode)

--- a/tests/keras/applications/imagenet_utils_test.py
+++ b/tests/keras/applications/imagenet_utils_test.py
@@ -5,7 +5,6 @@ from numpy.testing import assert_allclose
 from keras.applications import imagenet_utils as utils
 from keras.models import Model
 from keras.layers import Input, Lambda
-import keras.backend as K
 
 
 def test_preprocess_input():

--- a/tests/keras/applications/imagenet_utils_test.py
+++ b/tests/keras/applications/imagenet_utils_test.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 from keras.applications import imagenet_utils as utils
 from keras.models import Model
 from keras.layers import Input, Lambda
+import keras.backend as K
 
 
 def test_preprocess_input():
@@ -37,6 +38,15 @@ def test_preprocess_input():
                                      'channels_first')
     assert_allclose(out1, out2.transpose(1, 2, 0))
     assert_allclose(out1int, out2int.transpose(1, 2, 0))
+
+    # Test copying option
+    x = np.random.uniform(0, 255, (2, 10, 10, 3))
+    x2 = utils.preprocess_input(x, copy=False)
+    assert x.max() == x2.max()
+
+    x = np.random.uniform(0, 255, (2, 10, 10, 3))
+    x2 = utils.preprocess_input(x, copy=True)
+    assert x.max() == x2.max()
 
 
 def test_preprocess_input_symbolic():

--- a/tests/keras/applications/imagenet_utils_test.py
+++ b/tests/keras/applications/imagenet_utils_test.py
@@ -45,7 +45,7 @@ def test_preprocess_input():
 
     x = np.random.uniform(0, 255, (2, 10, 10, 3))
     x2 = utils.preprocess_input(x, copy=True)
-    assert x.max() == x2.max()
+    assert x.max() != x2.max()
 
 
 def test_preprocess_input_symbolic():

--- a/tests/keras/applications/imagenet_utils_test.py
+++ b/tests/keras/applications/imagenet_utils_test.py
@@ -38,14 +38,21 @@ def test_preprocess_input():
     assert_allclose(out1, out2.transpose(1, 2, 0))
     assert_allclose(out1int, out2int.transpose(1, 2, 0))
 
-    # Test copying option
+    # Test that writing over the input data works predictably
+    for mode in ['torch', 'tf']:
+        x = np.random.uniform(0, 255, (2, 10, 10, 3))
+        xint = x.astype('int')
+        x2 = utils.preprocess_input(x, mode=mode)
+        xint2 = utils.preprocess_input(xint)
+        assert_allclose(x, x2)
+        assert xint.astype('float').max() != xint2.max()
+    # Caffe mode works differently from the others
     x = np.random.uniform(0, 255, (2, 10, 10, 3))
-    x2 = utils.preprocess_input(x, copy=False)
-    assert x.max() == x2.max()
-
-    x = np.random.uniform(0, 255, (2, 10, 10, 3))
-    x2 = utils.preprocess_input(x, copy=True)
-    assert x.max() != x2.max()
+    xint = x.astype('int')
+    x2 = utils.preprocess_input(x, data_format='channels_last', mode='caffe')
+    xint2 = utils.preprocess_input(xint)
+    assert_allclose(x, x2[..., ::-1])
+    assert xint.astype('float').max() != xint2.max()
 
 
 def test_preprocess_input_symbolic():


### PR DESCRIPTION
Before, `preprocess_input` would sometimes write over images it processed. Inadvertently, my commit (https://github.com/keras-team/keras/commit/84e168b5fa55933e02e767ff7c86fcc0232aecc6) from two days ago changed this so that instead of the previous behaviour, preprocess_input would always make a new copy of the input images to work with. This seems, to me, more intuitive behaviour.

This PR gives the user explicit control over the behaviour by introducing `copy` keyword argument to the relevant functions. This way, the earlier behaviour can be regained if the user so wishes. Also, it fixes my earlier commit so that the dtype of the input array is not changed unless necessary (i.e. when inputting other than float arrays).