### PR TITLE
fix TensorBoard callback with unit test

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -786,8 +786,12 @@ class TensorBoard(Callback):
                         tf.summary.image(mapped_weight_name, w_img)
 
                 if hasattr(layer, 'output'):
-                    tf.summary.histogram('{}_out'.format(layer.name),
-                                         layer.output)
+                    if isinstance(layer.output, list):
+                        for i, output in enumerate(layer.output):
+                            tf.summary.histogram('{}_out_{}'.format(layer.name, i), output)
+                    else:
+                        tf.summary.histogram('{}_out'.format(layer.name),
+                                             layer.output)
         self.merged = tf.summary.merge_all()
 
         if self.write_graph:


### PR DESCRIPTION
There's a bug with `TensorBoard` with `histogram_freq>0` and a layer which produces a list of output tensors with different ranks (e.g., an rnn layer with `return_sequences=True` and `return_states=True`). In this situation, the callback attempts to get the mean on the `output` without validating whether it is a tensor or not, which will lead to an error. This pr aims to solve this problem by taking the mean of each output separately. 



BTW, here's another issue which I didn't solve in this pr but want to discuss. Currently `TensorBoard` can not get the output histograms from layers with multiple outputs: It doesn't check the `get_output_at` of those layers in that case, and the 'output' does not exist in those layers. 
Because the same layer can be reused in different models and then not all the outputs of that layer belong to the current model. Is there any efficient way to know if the output at node `i` is part of one model or not?