### PR TITLE
Remove named argument from LearningRateScheduler

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -625,7 +625,7 @@ class LearningRateScheduler(Callback):
             raise ValueError('Optimizer must have a "lr" attribute.')
         lr = float(K.get_value(self.model.optimizer.lr))
         try:  # new API
-            lr = self.schedule(epoch, lr=lr)
+            lr = self.schedule(epoch, lr)
         except TypeError:  # old API for backward compatibility
             lr = self.schedule(epoch)
         if not isinstance(lr, (float, np.float32, np.float64)):


### PR DESCRIPTION
The schedule function for the LearningRateScheduler callback assumes that the learning rate argument is called lr. This should either be reflected by the documentation, as it is not right now, or this super simple PR should be applied.