### PR TITLE
Added the Swish activation (a better ReLU proposed by Google)

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -122,6 +122,12 @@ def relu(x, alpha=0., max_value=None):
     return K.relu(x, alpha=alpha, max_value=max_value)
 
 
+def swish(x):
+    """Swish activation function.
+    """
+    return x * K.sigmoid(x)
+
+
 def tanh(x):
     """Hyperbolic tangent activation function.
     """

--- a/tests/keras/activations_test.py
+++ b/tests/keras/activations_test.py
@@ -17,7 +17,7 @@ def get_standard_values():
 def test_serialization():
     all_activations = ['softmax', 'relu', 'elu', 'tanh',
                        'sigmoid', 'hard_sigmoid', 'linear',
-                       'softplus', 'softsign', 'selu']
+                       'softplus', 'softsign', 'selu', 'swish']
     for name in all_activations:
         fn = activations.get(name)
         ref_fn = getattr(activations, name)
@@ -214,6 +214,14 @@ def test_linear():
     for x in xs:
         assert(x == activations.linear(x))
 
+
+def test_swish():
+    x = K.placeholder(ndim=2)
+    f = K.function([x], [activations.swish(x)])
+
+    test_values = get_standard_values()
+    result = f([test_values])[0]
+    assert_allclose(result, test_values, rtol=1e-05)
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/activations_test.py
+++ b/tests/keras/activations_test.py
@@ -218,7 +218,7 @@ def test_linear():
 def test_swish():
     def ref_swish(x):
         if x >= 0:
-            return x * (1 / (1 + np.exp(-1)))
+            return x * (1 / (1 + np.exp(-x)))
         else:
             z = np.exp(x)
             return x * (z / (1 + z))

--- a/tests/keras/activations_test.py
+++ b/tests/keras/activations_test.py
@@ -216,12 +216,21 @@ def test_linear():
 
 
 def test_swish():
+    def ref_swish(x):
+        if x >= 0:
+            return x * (1 / (1 + np.exp(-1)))
+        else:
+            z = np.exp(x)
+            return x * (z / (1 + z))
+    swish = np.vectorize(ref_swish)
+
     x = K.placeholder(ndim=2)
     f = K.function([x], [activations.swish(x)])
 
     test_values = get_standard_values()
     result = f([test_values])[0]
-    assert_allclose(result, test_values, rtol=1e-05)
+    expected = swish(test_values)
+    assert_allclose(result, expected, rtol=1e-05)
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
I recently read a [paper that was published in 2017](https://arxiv.org/abs/1710.05941) that detailed a better activation function for deeper networks than the widely used ReLUs.

The results in the paper showed 

> Simply replacing ReLUs with Swish units improves top-1 classification accuracy on ImageNet by 0.9% for Mobile NASNet-A and 0.6% for Inception-ResNet-v2. The simplicity of Swish and its similarity to ReLU make it easy for practitioners to replace ReLUs with Swish units in any neural network.

# The Key Things
**Don't use on shallow networks** as there may be an actual noticeable accuracy loss.
This activation is used to improve *deeper networks*.