### PR TITLE
Allow project specific config files in Keras

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -12,14 +12,15 @@ from .common import cast_to_floatx
 from .common import image_data_format
 from .common import set_image_data_format
 
-# Obtain Keras base dir path: either ~/.keras or /tmp.
-_keras_base_dir = os.path.expanduser('~')
-if not os.access(_keras_base_dir, os.W_OK):
-    _keras_base_dir = '/tmp'
-_keras_dir = os.path.join(_keras_base_dir, '.keras')
-
-if os.environ.get('KERAS_HOME') is not None:
+# Set Keras base dir path given KERAS_HOME env variable, if applicable.
+# Otherwise either ~/.keras or /tmp.
+if 'KERAS_HOME' in os.environ:
     _keras_dir = os.environ.get('KERAS_HOME')
+else:
+    _keras_base_dir = os.path.expanduser('~')
+    if not os.access(_keras_base_dir, os.W_OK):
+        _keras_base_dir = '/tmp'
+    _keras_dir = os.path.join(_keras_base_dir, '.keras')
 
 # Default backend: TensorFlow.
 _BACKEND = 'tensorflow'

--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -18,6 +18,9 @@ if not os.access(_keras_base_dir, os.W_OK):
     _keras_base_dir = '/tmp'
 _keras_dir = os.path.join(_keras_base_dir, '.keras')
 
+if os.environ.get('KERAS_HOME') is not None:
+    _keras_dir = os.environ.get('KERAS_HOME')
+
 # Default backend: TensorFlow.
 _BACKEND = 'tensorflow'
 


### PR DESCRIPTION
This **minor** change would make it possible to point to a custom location of the `keras.json` config file by changing the dedicated `KERAS_HOME` env variable or launching your application like:
```
env KERAS_HOME=<path to custom folder containing keras.json> python keras_app.py
```

This is necessary to maintain keras config on a per-project basis, e.g. one project prefers the theano backend, and another project prefers the tensorflow backend in certain deployment environments. 