### PR TITLE
Add missing doc

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -164,6 +164,7 @@ PAGES = [
         'classes': [
             layers.Conv1D,
             layers.Conv2D,
+            layers.SeparableConv1D,
             layers.SeparableConv2D,
             layers.Conv2DTranspose,
             layers.Conv3D,


### PR DESCRIPTION
`SeparableConv1D` was missing from the documentation. This PR adds it. 