### PR TITLE
Best to set self.built=True at the end of build()

### DIFF
--- a/docs/templates/layers/writing-your-own-keras-layers.md
+++ b/docs/templates/layers/writing-your-own-keras-layers.md
@@ -4,7 +4,7 @@ For simple, stateless custom operations, you are probably better off using `laye
 
 Here is the skeleton of a Keras layer, **as of Keras 2.0** (if you have an older version, please upgrade). There are only three methods you need to implement:
 
-- `build(input_shape)`: this is where you will define your weights. This method must set `self.built = True`, which can be done by calling `super([Layer], self).build()`.
+- `build(input_shape)`: this is where you will define your weights. This method must set `self.built = True` at the end, which can be done by calling `super([Layer], self).build()`.
 - `call(x)`: this is where the layer's logic lives. Unless you want your layer to support masking, you only have to care about the first argument passed to `call`: the input tensor.
 - `compute_output_shape(input_shape)`: in case your layer modifies the shape of its input, you should specify here the shape transformation logic. This allows Keras to do automatic shape inference.
 
@@ -25,7 +25,7 @@ class MyLayer(Layer):
                                       shape=(input_shape[1], self.output_dim),
                                       initializer='uniform',
                                       trainable=True)
-        super(MyLayer, self).build(input_shape)  # Be sure to call this somewhere!
+        super(MyLayer, self).build(input_shape)  # Be sure to call this at the end
 
     def call(self, x):
         return K.dot(x, self.kernel)


### PR DESCRIPTION
When using Keras on TensorFlow (in graph mode), via `tf.keras`, then calling `self.add_weight()` fails if `self.built==True`, so it is best to encourage users to set `self.built=True` at the *end* of their `build()` method, rather than just "somewhere".