### PR TITLE
Adds height_shift_range to preprocessing.image doc and adds support for indentation in auto-generated doc

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -452,6 +452,26 @@ def count_leading_spaces(s):
         return 0
 
 
+def process_list_block(docstring, anchor, marker):
+    anchor_pos = docstring.find(anchor)
+    starting_point = anchor_pos + len(anchor) + 1
+    block = ""
+    if anchor_pos > -1:
+        block = docstring[starting_point:docstring.find("\n\n", starting_point)]
+        # Place marker for later reinjection.
+        docstring = docstring.replace(block, marker)
+        # White spaces to be removed in order to correctly align the block.
+        whitespace_n = re.search("[^\s]", block).start()
+        # Remove the computed number of leading white spaces from each line.
+        lines = [re.sub('^' + ' ' * whitespace_n, '', line) for line in block.split('\n')]
+        # Format docstring lists
+        top_level_regex = r'^([^\s\\\(]+):(.*)'
+        top_level_replacement = r'- __\1__:\2'
+        lines = [re.sub(top_level_regex, top_level_replacement, line) for line in lines]
+        block = '\n'.join(lines)
+    return docstring, block
+
+
 def process_docstring(docstring):
     # First, extract code blocks and process them.
     code_blocks = []
@@ -491,18 +511,22 @@ def process_docstring(docstring):
             code_blocks.append(snippet)
             tmp = tmp[index:]
 
+    # Format docstring lists.
+    docstring, arguments = process_list_block(docstring, "# Arguments", "$ARGUMENTS$")
+    docstring, returns = process_list_block(docstring, "# Returns", "$RETURNS$")
+
     # Format docstring section titles.
     docstring = re.sub(r'\n(\s+)# (.*)\n',
                        r'\n\1__\2__\n\n',
-                       docstring)
-    # Format docstring lists.
-    docstring = re.sub(r'    ([^\s\\\(]+):(.*)\n',
-                       r'    - __\1__:\2\n',
                        docstring)
 
     # Strip all leading spaces.
     lines = docstring.split('\n')
     docstring = '\n'.join([line.lstrip(' ') for line in lines])
+
+    # Reinject arguments and returns blocks.
+    docstring = docstring.replace("$ARGUMENTS$", arguments)
+    docstring = docstring.replace("$RETURNS$", returns)
 
     # Reinject code blocks.
     for i, code_block in enumerate(code_blocks):

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -455,14 +455,24 @@ class ImageDataGenerator(object):
         zca_whitening: Boolean. Apply ZCA whitening.
         rotation_range: Int. Degree range for random rotations.
         width_shift_range: Float, 1-D array-like or int
-            float: fraction of total width, if < 1, or pixels if >= 1.
-            1-D array-like: random elements from the array.
-            int: integer number of pixels from interval
+            - float: fraction of total width, if < 1, or pixels if >= 1.
+            - 1-D array-like: random elements from the array.
+            - int: integer number of pixels from interval
                 `(-width_shift_range, +width_shift_range)`
-            With `width_shift_range=2` possible values
+            - With `width_shift_range=2` possible values
                 are integers `[-1, 0, +1]`,
             same as with `width_shift_range=[-1, 0, +1]`,
             while with `width_shift_range=1.0` possible values are floats in
+            the interval [-1.0, +1.0).
+        height_shift_range: Float, 1-D array-like or int
+            - float: fraction of total height, if < 1, or pixels if >= 1.
+            - 1-D array-like: random elements from the array.
+            - int: integer number of pixels from interval
+                `(-height_shift_range, +height_shift_range)`
+            - With `height_shift_range=2` possible values
+                are integers `[-1, 0, +1]`,
+            same as with `height_shift_range=[-1, 0, +1]`,
+            while with `height_shift_range=1.0` possible values are floats in
             the interval [-1.0, +1.0).
         shear_range: Float. Shear Intensity
             (Shear angle in counter-clockwise direction in degrees)
@@ -473,10 +483,10 @@ class ImageDataGenerator(object):
             Default is 'nearest'.
             Points outside the boundaries of the input are filled
             according to the given mode:
-            'constant': kkkkkkkk|abcd|kkkkkkkk (cval=k)
-            'nearest':  aaaaaaaa|abcd|dddddddd
-            'reflect':  abcddcba|abcd|dcbaabcd
-            'wrap':  abcdabcd|abcd|abcdabcd
+            - 'constant': kkkkkkkk|abcd|kkkkkkkk (cval=k)
+            - 'nearest':  aaaaaaaa|abcd|dddddddd
+            - 'reflect':  abcddcba|abcd|dcbaabcd
+            - 'wrap':  abcdabcd|abcd|abcdabcd
         cval: Float or Int.
             Value used for points outside the boundaries
             when `fill_mode = "constant"`.
@@ -725,7 +735,6 @@ class ImageDataGenerator(object):
                 without any modifications.
                 Can be used to feed the model miscellaneous data
                 along with the images.
-
                 In case of grayscale data, the channels axis of the image array
                 should have value 1, and in case
                 of RGB data, it should have value 3.
@@ -812,7 +821,7 @@ class ImageDataGenerator(object):
                     "sparse" will be 1D integer labels,
                 - "input" will be images identical
                     to input images (mainly used to work with autoencoders).
-                If None, no labels are returned
+                - If None, no labels are returned
                 (the generator will only yield batches of image data,
                 which is useful to use with `model.predict_generator()`,
                 `model.evaluate_generator()`, etc.).


### PR DESCRIPTION
This should:

1. Fix the small "*problem*" introduced in 3b444513b52cf05e7d40f2ffdb7ab7283bb2ce06 (the height_shift_range completely disappeared from the doc)
2. Almost completely solve the problem with indentation in auto-generated doc. I noticed that many times the doc written in the code uses sublists that are not rendered properly (see images below for a before and after comparison)
![one](https://user-images.githubusercontent.com/4191058/39999363-3bdf88a0-5789-11e8-9c8b-d9c1dc07244f.png)
![three](https://user-images.githubusercontent.com/4191058/39999364-3bfef410-5789-11e8-9afd-5e617daacf67.png)
![two](https://user-images.githubusercontent.com/4191058/39999365-3c1e7df8-5789-11e8-98b5-980a83a3b8da.png)


