### PR TITLE
Add class_name method to Layer.

### DIFF
--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -122,7 +122,7 @@ class Layer(object):
                 raise TypeError('Keyword argument not understood:', kwarg)
         name = kwargs.get('name')
         if not name:
-            prefix = self.__class__.__name__
+            prefix = self.class_name()
             name = _to_snake_case(prefix) + '_' + str(K.get_uid(prefix))
         self.name = name
 
@@ -153,6 +153,11 @@ class Layer(object):
             self._initial_weights = kwargs['weights']
         else:
             self._initial_weights = None
+
+    def class_name(self):
+        """Returns the name of this class.
+        """
+        return self.__class__.__name__
 
     @staticmethod
     def _node_key(layer, node_index):
@@ -1128,7 +1133,7 @@ class Layer(object):
                 (in which case its weights aren't yet defined).
         """
         if not self.built:
-            if self.__class__.__name__ == 'Sequential':
+            if self.class_name() == 'Sequential':
                 self.build()
             else:
                 raise RuntimeError('You tried to call `count_params` on ' +

--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -103,7 +103,7 @@ class Network(Layer):
 
         # Handle `name` argument.
         if not name:
-            prefix = self.__class__.__name__.lower()
+            prefix = self.class_name().lower()
             name = prefix + '_' + str(K.get_uid(prefix))
         self.name = name
 
@@ -156,7 +156,7 @@ class Network(Layer):
         for x in self.inputs:
             # Check that x has appropriate `_keras_history` metadata.
             if not hasattr(x, '_keras_history'):
-                cls_name = self.__class__.__name__
+                cls_name = self.class_name()
                 raise ValueError('Input tensors to a ' + cls_name + ' ' +
                                  'must come from `tf.layers.Input`. '
                                  'Received: ' + str(x) +
@@ -166,7 +166,7 @@ class Network(Layer):
         if (len(layer._inbound_nodes) > 1 or
                 (layer._inbound_nodes and
                  layer._inbound_nodes[0].inbound_layers)):
-            cls_name = self.__class__.__name__
+            cls_name = self.class_name()
             warnings.warn(cls_name + ' inputs must come from '
                           '`tf.layers.Input` '
                           '(thus holding past layer metadata), '
@@ -184,7 +184,7 @@ class Network(Layer):
                           str(x.name))
         for x in self.outputs:
             if not hasattr(x, '_keras_history'):
-                cls_name = self.__class__.__name__
+                cls_name = self.class_name()
                 raise ValueError('Output tensors to a ' + cls_name +
                                  ' must be '
                                  'the output of a TensorFlow `Layer` '
@@ -287,7 +287,7 @@ class Network(Layer):
                     'Input {} (0-based) originates '
                     'from layer type `{}`.'.format(inputs,
                                                    i,
-                                                   layer.__class__.__name__))
+                                                   layer.class_name()))
             self.input_names.append(layer.name)
             if layer.is_placeholder:
                 self._feed_inputs.append(layer.input)
@@ -867,7 +867,7 @@ class Network(Layer):
         # serialize and save the layers in layer_configs
         layer_configs = []
         for layer in self.layers:  # From the earliest layers on.
-            layer_class_name = layer.__class__.__name__
+            layer_class_name = layer.class_name()
             layer_config = layer.get_config()
             filtered_inbound_nodes = []
             for original_node_index, node in enumerate(layer._inbound_nodes):
@@ -1189,7 +1189,7 @@ class Network(Layer):
 
         config = self.get_config()
         model_config = {
-            'class_name': self.__class__.__name__,
+            'class_name': self.class_name(),
             'config': config,
             'keras_version': keras_version,
             'backend': K.backend()

--- a/keras/engine/sequential.py
+++ b/keras/engine/sequential.py
@@ -279,7 +279,7 @@ class Sequential(Model):
         config = []
         for layer in self.layers:
             config.append({
-                'class_name': layer.__class__.__name__,
+                'class_name': layer.class_name(),
                 'config': layer.get_config()
             })
         return copy.deepcopy(config)

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -566,7 +566,7 @@ class Model(Network):
             whether to build the model's graph in inference mode (False), training
             mode (True), or using the Keras learning phase (None).
         """
-        if self.__class__.__name__ == 'Sequential':
+        if self.class_name() == 'Sequential':
             # Note: we can't test whether the model
             # is `Sequential` via `isinstance`
             # since `Sequential` depends on `Model`.


### PR DESCRIPTION
This PR adds a `class_name` method to Layer.

The idea of this method is that people can override it in custom layers. This can be useful to add module names as a prefix to the layer names to avoid naming collisions.

For example, we have similar layers in [`keras-retinanet`](https://github.com/fizyr/keras-retinanet`) and [`keras-maskrcnn`](https://github.com/fizyr/keras-maskrcnn). Currently we named them slightly different to avoid collision (`UpsampleLike`, which upsamples to a given tensors shape and `Upsample` which upsamples to a given shape).

If possible, we would like to "name" them `keras_retinanet.layers.Upsample` and `keras_maskrcnn.layers.Upsample` in `custom_objects`. Using the method from this PR we can override the name used by Keras to store the layers.