### PR TITLE
Non training Batch Norm operator has bad performance for it running into tensorflow's non fused batch norm API

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1062,7 +1062,7 @@ def _moments(x, axes=None, shift=None, keep_dims=False):
     return mean, variance
 
 
-def batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
+def batch_normalization(x, mean, var, beta, gamma, axis, epsilon=1e-3):
     # The mean / var / beta / gamma may be processed by broadcast
     # so it may have an extra batch axis with 1, it is not needed
     # in cntk, need to remove those dummy axis.

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1062,7 +1062,7 @@ def _moments(x, axes=None, shift=None, keep_dims=False):
     return mean, variance
 
 
-def batch_normalization(x, mean, var, beta, gamma, axis, epsilon=1e-3):
+def batch_normalization(x, mean, var, beta, gamma, axis=-1, epsilon=1e-3):
     # The mean / var / beta / gamma may be processed by broadcast
     # so it may have an extra batch axis with 1, it is not needed
     # in cntk, need to remove those dummy axis.

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1867,14 +1867,13 @@ def batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
         A tensor.
     """
     if ndim(x) == 4:
+        #The CPU implementation of FusedBatchNorm only support NHWC
         if len(mean.shape) == 1:
             tf_data_format = 'NHWC'
-        elif (len(mean.shape) == 4 and mean.shape[0] == 1 and 
-                mean.shape[2] == 1 and mean.shape[3] == 1):
-            tf_data_format = 'NCHW'
         else:
             tf_data_format = None
-        if tf_data_format is not None:
+        if (tf_data_format is not None and 
+                beta is not None and gamma is not None):
             y, _, _ = tf.nn.fused_batch_norm(
                 x,
                 gamma,

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1867,12 +1867,12 @@ def batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
         A tensor.
     """
     if ndim(x) == 4:
-        #The CPU implementation of FusedBatchNorm only support NHWC
+        # The CPU implementation of FusedBatchNorm only support NHWC
         if len(mean.shape) == 1:
             tf_data_format = 'NHWC'
         else:
             tf_data_format = None
-        if (tf_data_format is not None and 
+        if (tf_data_format is not None and
                 beta is not None and gamma is not None):
             y, _, _ = tf.nn.fused_batch_norm(
                 x,
@@ -1883,9 +1883,9 @@ def batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
                 variance=var,
                 data_format=tf_data_format,
                 is_training=False
-                )
+            )
             return y
-    #default
+    # default
     return tf.nn.batch_normalization(x, mean, var, beta, gamma, epsilon)
 
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1866,6 +1866,27 @@ def batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
     # Returns
         A tensor.
     """
+    if ndim(x) == 4:
+        if len(mean.shape) == 1:
+            tf_data_format = 'NHWC'
+        elif (len(mean.shape) == 4 and mean.shape[0] == 1 and 
+                mean.shape[2] == 1 and mean.shape[3] == 1):
+            tf_data_format = 'NCHW'
+        else:
+            tf_data_format = None
+        if tf_data_format is not None:
+            y, _, _ = tf.nn.fused_batch_norm(
+                x,
+                gamma,
+                beta,
+                epsilon=epsilon,
+                mean=mean,
+                variance=var,
+                data_format=tf_data_format,
+                is_training=False
+                )
+            return y
+    #default
     return tf.nn.batch_normalization(x, mean, var, beta, gamma, epsilon)
 
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1849,7 +1849,7 @@ def normalize_batch_in_training(x, gamma, beta,
                                                           epsilon=epsilon)
 
 
-def batch_normalization(x, mean, var, beta, gamma, axis, epsilon=1e-3):
+def batch_normalization(x, mean, var, beta, gamma, axis=-1, epsilon=1e-3):
     """Applies batch normalization on x given mean, var, beta and gamma.
 
     I.e. returns:
@@ -1862,7 +1862,7 @@ def batch_normalization(x, mean, var, beta, gamma, axis, epsilon=1e-3):
         beta: Tensor with which to center the input.
         gamma: Tensor by which to scale the input.
         axis: Integer, the axis that should be normalized.
-                (typically the features axis).
+            (typically the features axis).
         epsilon: Fuzz factor.
 
     # Returns
@@ -1877,7 +1877,7 @@ def batch_normalization(x, mean, var, beta, gamma, axis, epsilon=1e-3):
         else:
             tf_data_format = None
 
-        if ((tf_data_format == 'NHWC') or (tf_data_format == 'NCHW' and _has_nchw_support())):
+        if tf_data_format == 'NHWC' or tf_data_format == 'NCHW' and _has_nchw_support():
             if beta is None:
                 beta = zeros_like(mean)
             if gamma is None:

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -730,7 +730,7 @@ def normalize_batch_in_training(x, gamma, beta,
     return normed, mean, T.inv(stdinv ** 2)
 
 
-def batch_normalization(x, mean, var, beta, gamma, axis, epsilon=1e-3):
+def batch_normalization(x, mean, var, beta, gamma, axis=-1, epsilon=1e-3):
     """Apply batch normalization on x given mean, var, beta and gamma.
     """
     # TODO remove this if statement when Theano without

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -730,7 +730,7 @@ def normalize_batch_in_training(x, gamma, beta,
     return normed, mean, T.inv(stdinv ** 2)
 
 
-def batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
+def batch_normalization(x, mean, var, beta, gamma, axis, epsilon=1e-3):
     """Apply batch normalization on x given mean, var, beta and gamma.
     """
     # TODO remove this if statement when Theano without

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -161,6 +161,7 @@ class BatchNormalization(Layer):
                     broadcast_moving_variance,
                     broadcast_beta,
                     broadcast_gamma,
+                    self.axis,
                     epsilon=self.epsilon)
             else:
                 return K.batch_normalization(
@@ -169,6 +170,7 @@ class BatchNormalization(Layer):
                     self.moving_variance,
                     self.beta,
                     self.gamma,
+                    self.axis,
                     epsilon=self.epsilon)
 
         # If the learning phase is *static* and set to inference:

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -161,7 +161,7 @@ class BatchNormalization(Layer):
                     broadcast_moving_variance,
                     broadcast_beta,
                     broadcast_gamma,
-                    self.axis,
+                    axis=self.axis,
                     epsilon=self.epsilon)
             else:
                 return K.batch_normalization(
@@ -170,7 +170,7 @@ class BatchNormalization(Layer):
                     self.moving_variance,
                     self.beta,
                     self.gamma,
-                    self.axis,
+                    axis=self.axis,
                     epsilon=self.epsilon)
 
         # If the learning phase is *static* and set to inference:


### PR DESCRIPTION
In current Keras code with Tensorflow as it’s backend, the non-training batch norm operator/layer will finally run into Tensorflow’s old non-fused batch norm API (tf.nn.batch_normalization), which result in bad performance in both CPU and GPU.

http://github.com/keras-team/keras/issues/10058

Test result:
 test env: with Tensorflow(commit a543d9471047ca3f6881c87105fcbe2cdff9207d Date:   Thu May 10 17:43:30 2018, local build), python3.4, centos7.4
 test cases:
      "pytest  ./tests/keras/layers/normalization_test.py"  <all passed>
      "pytest  ./tests"      <keep same result as without this PR's modification>
