### PR TITLE
Fix duplicated argname: num_gpus === parts

### DIFF
--- a/keras/utils/multi_gpu_utils.py
+++ b/keras/utils/multi_gpu_utils.py
@@ -184,7 +184,7 @@ def multi_gpu_model(model, gpus=None, cpu_merge=True, cpu_relocation=False):
         batch_size = shape[:1]
         input_shape = shape[1:]
         step = batch_size // parts
-        if i == num_gpus - 1:
+        if i == parts - 1:
             size = batch_size - step * i
         else:
             size = step


### PR DESCRIPTION
`get_slice` should compute **last part** by given `parts` args, instead of external variable, though the values are same.

Signed-off-by: CUI Wei <ghostplant@qq.com>