### PR TITLE
Handle `mask` in `TimeDistributed` wrapper.

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -867,13 +867,12 @@ def concatenate(tensors, axis=-1):
 
 def reshape(x, shape):
     y = T.reshape(x, shape)
-    if _is_explicit_shape(shape):
-        shape = tuple(x if x != -1 else None for x in shape)
-        y._keras_shape = shape
-        if hasattr(x, '_uses_learning_phase'):
-            y._uses_learning_phase = x._uses_learning_phase
-        else:
-            y._uses_learning_phase = False
+    shape = tuple(x if isinstance(x, int) and x > 0 else None for x in shape)
+    y._keras_shape = shape
+    if hasattr(x, '_uses_learning_phase'):
+        y._uses_learning_phase = x._uses_learning_phase
+    else:
+        y._uses_learning_phase = False
     return y
 
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -61,8 +61,6 @@ class Masking(Layer):
 
     def compute_mask(self, inputs, mask=None):
         output_mask = K.any(K.not_equal(inputs, self.mask_value), axis=-1)
-        if hasattr(inputs, '_keras_shape'):
-            output_mask._keras_shape = inputs._keras_shape[:-1]
         return output_mask
 
     def call(self, inputs):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -60,7 +60,10 @@ class Masking(Layer):
         self.mask_value = mask_value
 
     def compute_mask(self, inputs, mask=None):
-        return K.any(K.not_equal(inputs, self.mask_value), axis=-1)
+        output_mask = K.any(K.not_equal(inputs, self.mask_value), axis=-1)
+        if hasattr(inputs, '_keras_shape'):
+            output_mask._keras_shape = inputs._keras_shape[:-1]
+        return output_mask
 
     def call(self, inputs):
         boolean_mask = K.any(K.not_equal(inputs, self.mask_value),

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -110,8 +110,6 @@ class Embedding(Layer):
         if not self.mask_zero:
             return None
         output_mask = K.not_equal(inputs, 0)
-        if hasattr(inputs, '_keras_shape'):
-            output_mask._keras_shape = inputs._keras_shape
         return output_mask
 
     def compute_output_shape(self, input_shape):

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -109,8 +109,10 @@ class Embedding(Layer):
     def compute_mask(self, inputs, mask=None):
         if not self.mask_zero:
             return None
-        else:
-            return K.not_equal(inputs, 0)
+        output_mask = K.not_equal(inputs, 0)
+        if hasattr(inputs, '_keras_shape'):
+            output_mask._keras_shape = inputs._keras_shape
+        return output_mask
 
     def compute_output_shape(self, input_shape):
         if self.input_length is None:

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -93,6 +93,7 @@ class Embedding(Layer):
         self.activity_regularizer = regularizers.get(activity_regularizer)
         self.embeddings_constraint = constraints.get(embeddings_constraint)
         self.mask_zero = mask_zero
+        self.supports_masking = mask_zero
         self.input_length = input_length
 
     def build(self, input_shape):

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -162,7 +162,7 @@ class TimeDistributed(Wrapper):
 
     def _get_shape_tuple(self, init_tuple, tensor, start_idx, int_shape=None):
         """Finds non-specific dimensions in the static shapes
-        and replaces them by the corresponding dynamic shapes of the tensor. 
+        and replaces them by the corresponding dynamic shapes of the tensor.
 
         # Arguments
             init_tuple: a tuple, the first part of the output shape
@@ -170,13 +170,13 @@ class TimeDistributed(Wrapper):
                 as the last part of the output shape
             start_idx: int, which indicate the first dimension to take from
                 the static shape of the tensor
-            int_shape: an alternative static shape to take as the last part 
+            int_shape: an alternative static shape to take as the last part
                 of the output shape
 
         # Returns
-            The new int_shape with the first part from init_tuple 
-            and the last part from either `int_shape` (if provided) 
-            or K.int_shape(tensor), where every `None` is replaced by 
+            The new int_shape with the first part from init_tuple
+            and the last part from either `int_shape` (if provided)
+            or K.int_shape(tensor), where every `None` is replaced by
             the corresponding dimension from K.shape(tensor)
         """
         # replace all None in int_shape by K.shape
@@ -269,7 +269,7 @@ class TimeDistributed(Wrapper):
         based on the inputs, mask, and the inner layer.
 
         If batch size is specified:
-        Simply return the input `mask`. (An rnn-based implementation with 
+        Simply return the input `mask`. (An rnn-based implementation with
         more than one rnn inputs is required but not supported in Keras yet.)
 
         Otherwise we call `compute_mask` of the inner layer at each time step.
@@ -281,7 +281,7 @@ class TimeDistributed(Wrapper):
         Reduce the input_mask to 2 dimensions and return it.
         Otherwise (both the output mask and the input mask are `None`):
         (E.g., `mask` is not used at all)
-        Return `None`.         
+        Return `None`.
 
         # Arguments
             inputs: Tensor

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -160,6 +160,37 @@ class TimeDistributed(Wrapper):
         super(TimeDistributed, self).__init__(layer, **kwargs)
         self.supports_masking = True
 
+    def _get_shape_tuple(self, init_tuple, tensor, start_idx, int_shape=None):
+        """Finds non-specific dimensions in the static shapes
+        and replaces them by the corresponding dynamic shapes of the tensor. 
+
+        # Arguments
+            init_tuple: a tuple, the first part of the output shape
+            tensor: the tensor from which to get the (static and dynamic) shapes
+                as the last part of the output shape
+            start_idx: int, which indicate the first dimension to take from
+                the static shape of the tensor
+            int_shape: an alternative static shape to take as the last part 
+                of the output shape
+
+        # Returns
+            The new int_shape with the first part from init_tuple 
+            and the last part from either `int_shape` (if provided) 
+            or K.int_shape(tensor), where every `None` is replaced by 
+            the corresponding dimension from K.shape(tensor)
+        """
+        # replace all None in int_shape by K.shape
+        if int_shape is None:
+            int_shape = K.int_shape(tensor)[start_idx:]
+        if not any(not s for s in int_shape):
+            return init_tuple + int_shape
+        tensor_shape = K.shape(tensor)
+        int_shape = list(int_shape)
+        for i, s in enumerate(int_shape):
+            if not s:
+                int_shape[i] = tensor_shape[start_idx + i]
+        return init_tuple + tuple(int_shape)
+
     def build(self, input_shape):
         assert len(input_shape) >= 3
         self.input_spec = InputSpec(shape=input_shape)
@@ -201,24 +232,10 @@ class TimeDistributed(Wrapper):
             # No batch size specified, therefore the layer will be able
             # to process batches of any size.
             # We can go with reshape-based implementation for performance.
-
-            def get_shape_tuple(tensor, start_idx, init_tuple, int_shape=None):
-                # replace all None in int_shape by K.shape
-                if int_shape is None:
-                    int_shape = K.int_shape(tensor)[start_idx:]
-                if not any(not s for s in int_shape):
-                    return init_tuple + int_shape
-                tensor_shape = K.shape(tensor)
-                int_shape = list(int_shape)
-                for i, s in enumerate(int_shape):
-                    if not s:
-                        int_shape[i] = tensor_shape[start_idx + i]
-                return init_tuple + tuple(int_shape)
-
             input_length = input_shape[1]
             if not input_length:
                 input_length = K.shape(inputs)[1]
-            inner_input_shape = get_shape_tuple(inputs, 2, (-1,))
+            inner_input_shape = self._get_shape_tuple((-1,), inputs, 2)
             # Shape: (num_samples * timesteps, ...). And track the
             # transformation in self._input_map.
             input_uid = object_list_uid(inputs)
@@ -226,14 +243,15 @@ class TimeDistributed(Wrapper):
             self._input_map[input_uid] = inputs
             # (num_samples * timesteps, ...)
             if has_arg(self.layer.call, 'mask') and mask is not None:
-                inner_mask_shape = get_shape_tuple(mask, 2, (-1,))
+                inner_mask_shape = self._get_shape_tuple((-1,), mask, 2)
                 kwargs['mask'] = K.reshape(mask, inner_mask_shape)
             y = self.layer.call(inputs, **kwargs)
             if hasattr(y, '_uses_learning_phase'):
                 uses_learning_phase = y._uses_learning_phase
             # Shape: (num_samples, timesteps, ...)
             output_shape = self.compute_output_shape(input_shape)
-            output_shape = get_shape_tuple(y, 1, (-1, input_length), output_shape[2:])
+            output_shape = self._get_shape_tuple(
+                (-1, input_length), y, 1, output_shape[2:])
             y = K.reshape(y, output_shape)
 
         # Apply activity regularizer if any:
@@ -247,29 +265,39 @@ class TimeDistributed(Wrapper):
         return y
 
     def compute_mask(self, inputs, mask=None):
+        """Computes an output mask tensor for Embedding layer
+        based on the inputs, mask, and the inner layer.
+
+        If batch size is specified:
+        Simply return the input `mask`. (An rnn-based implementation with 
+        more than one rnn inputs is required but not supported in Keras yet.)
+
+        Otherwise we call `compute_mask` of the inner layer at each time step.
+        If the output mask at each time step is not `None`:
+        (E.g., inner layer is Masking or RNN)
+        Concatenate all of them and return the concatenation.
+        If the output mask at each time step is `None` and the input mask is not `None`:
+        (E.g., inner layer is Dense)
+        Reduce the input_mask to 2 dimensions and return it.
+        Otherwise (both the output mask and the input mask are `None`):
+        (E.g., `mask` is not used at all)
+        Return `None`.         
+
+        # Arguments
+            inputs: Tensor
+            mask: Tensor
+        # Returns
+            None or a tensor
+        """
         # cases need to call the layer.compute_mask when input_mask is None:
         # Masking layer and Embedding layer with mask_zero
-
-        def get_shape_tuple(tensor, start_idx, init_tuple, int_shape=None):
-            # replace all None in int_shape by K.shape
-            if int_shape is None:
-                int_shape = K.int_shape(tensor)[start_idx:]
-            if not any(not s for s in int_shape):
-                return init_tuple + int_shape
-            tensor_shape = K.shape(tensor)
-            int_shape = list(int_shape)
-            for i, s in enumerate(int_shape):
-                if not s:
-                    int_shape[i] = tensor_shape[start_idx + i]
-            return init_tuple + tuple(int_shape)
-
         input_shape = K.int_shape(inputs)
         if input_shape[0]:
             # batch size matters, we currently do not handle mask explicitly
             return mask
         inner_mask = mask
         if inner_mask is not None:
-            inner_mask_shape = get_shape_tuple(mask, 2, (-1,))
+            inner_mask_shape = self._get_shape_tuple((-1,), mask, 2)
             inner_mask = K.reshape(inner_mask, inner_mask_shape)
         input_uid = object_list_uid(inputs)
         inner_inputs = self._input_map[input_uid]
@@ -277,7 +305,8 @@ class TimeDistributed(Wrapper):
         if output_mask is None:
             if mask is None:
                 return None
-            # input_mask is not None, and output_mask is None: we should return a not-None mask
+            # input_mask is not None, and output_mask is None:
+            # we should return a not-None mask
             output_mask = mask
             for _ in range(2, len(K.int_shape(mask))):
                 output_mask = K.any(output_mask, axis=-1)
@@ -288,14 +317,14 @@ class TimeDistributed(Wrapper):
                 input_length = K.shape(inputs)[1]
             output_mask_int_shape = K.int_shape(output_mask)
             if output_mask_int_shape is None:
-                # if the output_mask does not have `_keras_shape`,
+                # if the output_mask does not have a static shape,
                 # its shape must be the same as mask's
                 if mask is not None:
                     output_mask_int_shape = K.int_shape(mask)
                 else:
                     output_mask_int_shape = K.compute_output_shape(input_shape)[:-1]
-            output_mask_shape = get_shape_tuple(output_mask, 1, (-1, input_length),
-                                                output_mask_int_shape[1:])
+            output_mask_shape = self._get_shape_tuple(
+                (-1, input_length), output_mask, 1, output_mask_int_shape[1:])
             output_mask = K.reshape(output_mask, output_mask_shape)
         return output_mask
 

--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -159,7 +159,7 @@ def test_TimeDistributed_trainable():
 @keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='Unknown timestamps for RNN not supported in CNTK.')
-def test_TimeDistributed_with_mask_and_unspecified_shape():
+def test_TimeDistributed_with_masked_embedding_and_unspecified_shape():
     # test with unspecified shape and Embeddings with mask_zero
     model = Sequential()
     model.add(wrappers.TimeDistributed(layers.Embedding(5, 6, mask_zero=True),
@@ -188,7 +188,7 @@ def test_TimeDistributed_with_mask_and_unspecified_shape():
 
 
 @keras_test
-def test_TimeDistributed_with_mask_and_unspecified_shape():
+def test_TimeDistributed_with_masking_layer():
     # test with Masking layer
     model = Sequential()
     model.add(wrappers.TimeDistributed(layers.Masking(mask_value=0.,),

--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -157,6 +157,35 @@ def test_TimeDistributed_trainable():
 
 
 @keras_test
+def test_TimeDistributed_with_mask_and_unspecified_shape():
+    # test with TimeDistributed layers with Embeddings and mask
+    model = Sequential()
+    model.add(wrappers.TimeDistributed(layers.Embedding(5, 6, mask_zero=True),
+                                       input_shape=(None, None)))  # N by t_1 by t_2 by 6
+    model.add(wrappers.TimeDistributed(layers.SimpleRNN(7, return_sequences=True)))
+    model.add(wrappers.TimeDistributed(layers.SimpleRNN(8, return_sequences=False)))
+    model.add(layers.SimpleRNN(1, return_sequences=False))
+    model.compile(optimizer='rmsprop', loss='mse')
+    model_input = np.random.randint(low=1, high=5, size=(10, 3, 4), dtype='int32')
+    for i in range(4):
+        model_input[i, i:, i:] = 0
+    model.fit(model_input,
+              np.random.random((10, 1)), epochs=1, batch_size=10)
+    mask_outputs = [model.layers[0].compute_mask(model.input)]
+    for layer in model.layers[1:]:
+        mask_outputs.append(layer.compute_mask(layer.input, mask_outputs[-1]))
+    func = K.function([model.input], mask_outputs[:-1])
+    mask_outputs_val = func([model_input])
+    ref_mask_val_0 = model_input > 0         # embedding layer
+    ref_mask_val_1 = ref_mask_val_0          # first RNN layer
+    ref_mask_val_2 = np.any(ref_mask_val_1, axis=-1)     # second RNN layer
+    ref_mask_val = [ref_mask_val_0, ref_mask_val_1, ref_mask_val_2]
+    for i in range(3):
+        assert np.array_equal(mask_outputs_val[i], ref_mask_val[i])
+    assert mask_outputs[-1] is None  # final layer
+
+
+@keras_test
 def test_regularizers():
     model = Sequential()
     model.add(wrappers.TimeDistributed(

--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -157,6 +157,8 @@ def test_TimeDistributed_trainable():
 
 
 @keras_test
+@pytest.mark.skipif((K.backend() == 'cntk'),
+                    reason='Unknown timestamps for RNN not supported in CNTK.')
 def test_TimeDistributed_with_mask_and_unspecified_shape():
     # test with unspecified shape and Embeddings with mask_zero
     model = Sequential()
@@ -184,6 +186,9 @@ def test_TimeDistributed_with_mask_and_unspecified_shape():
         assert np.array_equal(mask_outputs_val[i], ref_mask_val[i])
     assert mask_outputs[-1] is None  # final layer
 
+
+@keras_test
+def test_TimeDistributed_with_mask_and_unspecified_shape():
     # test with Masking layer
     model = Sequential()
     model.add(wrappers.TimeDistributed(layers.Masking(mask_value=0.,),


### PR DESCRIPTION
This PR aims to add proper support of `mask` in `TimeDistributed` wrapper layer. Several previous PRs have raised questions about this or have attempted to solve it, but I didn't find any perfect solution so far. I may not be able to have a perfect one either but am willing to improve it. The most frequent usage of such layers with masking support might be a hierarchical RNN on a sentence with words with characters, or a paragraph with sentences with words. (E.g., models like [this](https://github.com/keras-team/keras/blob/master/examples/mnist_hierarchical_rnn.py)).

Here are the main ideas/purposes of this pr:

1) For layers like `TimeDistributed(Embedding(..., mask_zero=True))` or `TimeDistributed(Masking(...))`, the layer should call `compute_mask()` at each time step and stack them.
2) For layers like `TimeDistributed(LSTM(...))`, the `input_mask` should be split and fed into the `LSTM` layer at each time step. And if the `output_shape` changes (e.g., `return_sequences=False` in `LSTM`), the `output_mask` of the `TimeDistributed` layer should also change correspondingly.
3) The `TimeDistributed` layer should support, e.g., `input_shape=(None, None)`. For example, the number of words in a sentence and the number of characters in a word can be different from sample to sample. Currently the `TimeDistributed` can only support one unspecified input dimension.

Here are some details of this PR to discuss, which might have better solutions:
1) `K.int_shape()` may not be available for some `mask` with `Theano` backend, especially when the inner layer is `Embedding` or `Masking`. This is because `_keras_shape` is not set in lots of operations in `theano_backend` if the tensor shape is not changed. I manually create the `_keras_shape` in `compute_mask` of these two layers.
2) When `input_shape[0] is not None` in `TimeDistributed` layer, we need to use `K.rnn()` to dynamically call the inner layer. Because `K.rnn()` can only take 1 tensor input but we need to feed both `input` and `mask`, I didn't do anything in this situation. Probably we can pass all `mask` as constants to `K.rnn()` but I was expecting better solutions.
3) If there's `None` from the output of `K.int_shape`, we need to replace it by the output from `K.shape`, so that `reshape` can be correctly called.
