### PR TITLE
Remove Sequential.model deprecation warning

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -61,7 +61,7 @@ def model_to_dot(model,
     if isinstance(model, Sequential):
         if not model.built:
             model.build()
-        model = model.model
+        model = model
     layers = model.layers
 
     # Create graph nodes.

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -61,7 +61,6 @@ def model_to_dot(model,
     if isinstance(model, Sequential):
         if not model.built:
             model.build()
-        model = model
     layers = model.layers
 
     # Create graph nodes.


### PR DESCRIPTION
Description:

``Sequential.model`` has a deprecation warning. This removes said warning:

``"UserWarning: `Sequential.model` is deprecated. `Sequential` is a subclass of `Model`, you can just use your `Sequential` instance directly."``

This is more important for ``tf.keras`` because it does not implement the deprecated ``.model`` property. It actually raises an exception (https://github.com/tensorflow/tensorflow/issues/18908)

Unfortunately I do not have open source approval (yet) to submit this to TensorFlow also...