### PR TITLE
Make Dot documentation inline with Concatenate

### DIFF
--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -408,7 +408,7 @@ class Concatenate(_Merge):
 class Dot(_Merge):
     """Layer that computes a dot product between samples in two tensors.
 
-    E.g. if applied to two tensors `a` and `b` of shape `(batch_size, n)`,
+    E.g. if applied to a list of two tensors `a` and `b` of shape `(batch_size, n)`,
     the output will be a tensor of shape `(batch_size, 1)`
     where each entry `i` will be the dot product between
     `a[i]` and `b[i]`.


### PR DESCRIPTION
> E.g. if applied to two tensors `a` and `b` of shape `(batch_size, n)`,

The old text suggest to me and fellow students 2 arguments instead of 1 list argument containing 2 tensors

so make it explicit adding `list of ` similar as `Concatenate` does.

> E.g. if applied to list of two tensors `a` and `b` of shape `(batch_size, n)`,