### PR TITLE
Remove deprecated property model.model from saving

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -292,10 +292,7 @@ def load_model(filepath, custom_objects=None, compile=True):
             # Set optimizer weights.
             if 'optimizer_weights' in f:
                 # Build train function (to get weight updates).
-                if model.__class__.__name__ == 'Sequential':
-                    model.model._make_train_function()
-                else:
-                    model._make_train_function()
+                model._make_train_function()
                 optimizer_weights_group = f['optimizer_weights']
                 optimizer_weight_names = [
                     n.decode('utf8') for n in


### PR DESCRIPTION
Description:

Following the PR request (https://github.com/keras-team/keras/pull/10256) I raised form my work github, I thought it would be useful to cleanup the last occurrence of the deprecated ``model.model`` in the code base.

See:
``grep -rnw . -e "model.model"``
``
./examples/cifar10_resnet.py:342:# Prepare model model saving directory.
./keras/engine/saving.py:296:                    model.model._make_train_function()
``