### PR TITLE
[wip] Add `reach` parameter in EarlyStop callback.

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -476,6 +476,9 @@ class EarlyStopping(Callback):
         baseline: Baseline value for the monitored quantity to reach.
             Training will stop if the model doesn't show improvement
             over the baseline.
+        reach: Lower bound value for the monitored quantity to reach.
+            Training can be stopped only after
+            lower bound is reached.
     """
 
     def __init__(self,
@@ -484,11 +487,13 @@ class EarlyStopping(Callback):
                  patience=0,
                  verbose=0,
                  mode='auto',
+                 reach=None,
                  baseline=None):
         super(EarlyStopping, self).__init__()
 
         self.monitor = monitor
         self.baseline = baseline
+        self.reach = reach
         self.patience = patience
         self.verbose = verbose
         self.min_delta = min_delta
@@ -534,7 +539,9 @@ class EarlyStopping(Callback):
                 (self.monitor, ','.join(list(logs.keys()))), RuntimeWarning
             )
             return
-        if self.monitor_op(current - self.min_delta, self.best):
+        if self.reach is not None and self.monitor_op(self.reach, current):
+            pass
+        elif self.monitor_op(current - self.min_delta, self.best):
             self.best = current
             self.wait = 0
         else:

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -316,6 +316,33 @@ def test_EarlyStopping_baseline():
 
 
 @keras_test
+def test_EarlyStopping_reach():
+    class DummyModel(object):
+        def __init__(self):
+            self.stop_training = False
+
+    def reach_tester(acc_levels):
+        early_stop = callbacks.EarlyStopping(monitor='val_acc', reach=0.75)
+        early_stop.model = DummyModel()
+        epochs_trained = 0
+        early_stop.on_train_begin()
+        for epoch in range(len(acc_levels)):
+            epochs_trained += 1
+            early_stop.on_epoch_end(epoch, logs={'val_acc': acc_levels[epoch]})
+            if early_stop.model.stop_training:
+                break
+        return epochs_trained
+
+    acc_levels = [0.76, 0.76, 0.76, 0.76]
+    reach_met_early = reach_tester(acc_levels)
+    acc_levels = [0.55, 0.55, 0.81, 0.81]
+    reach_met_late = reach_tester(acc_levels)
+
+    assert reach_met_early == 2
+    assert reach_met_late == 4
+
+
+@keras_test
 def test_LearningRateScheduler():
     np.random.seed(1337)
     (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,


### PR DESCRIPTION
This way you can check improvements only _after_ a specific lower bound is reached.
```
keras.callbacks.EarlyStopping(monitor='val_acc', min_delta=0.001, patience=30, reach=0.95)
```