### PR TITLE
add `interfaces.generate_legacy_interface` to softmax

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -20,6 +20,7 @@ import os
 from .common import floatx, epsilon
 from .common import image_data_format
 from ..utils.generic_utils import has_arg
+from ..legacy import interfaces
 
 # Legacy functions
 from .common import set_image_dim_ordering
@@ -3135,6 +3136,7 @@ def elu(x, alpha=1.):
         return tf.where(x > 0, res, alpha * res)
 
 
+@interfaces.generate_legacy_interface(conversions=[('dim', 'axis')])
 def softmax(x, axis=-1):
     """Softmax of a tensor.
 


### PR DESCRIPTION
The Tensorflow before 1.5 still use the `dim` rather than `axis`, but there are a lot of project still use tf1.4 because of `CUDA8.0`. So I think it should add this change.

If there are any irregularities, please let me know.