### PR TITLE
Add an advanced activation layer for ReLU

### DIFF
--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -257,3 +257,35 @@ class Softmax(Layer):
 
     def compute_output_shape(self, input_shape):
         return input_shape
+
+
+class ReLU(Layer):
+    """Rectified Linear Unit activation function.
+
+    # Input shape
+        Arbitrary. Use the keyword argument `input_shape`
+        (tuple of integers, does not include the samples axis)
+        when using this layer as the first layer in a model.
+
+    # Output shape
+        Same shape as the input.
+
+    # Arguments
+        max_value: Float, the maximum output value.
+    """
+
+    def __init__(self, max_value=None, **kwargs):
+        super(ReLU, self).__init__(**kwargs)
+        self.supports_masking = True
+        self.max_value = max_value
+
+    def call(self, inputs):
+        return activations.relu(inputs, max_value=self.max_value)
+
+    def get_config(self):
+        config = {'max_value': self.max_value}
+        base_config = super(ReLU, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    def compute_output_shape(self, input_shape):
+        return input_shape

--- a/tests/keras/layers/advanced_activations_test.py
+++ b/tests/keras/layers/advanced_activations_test.py
@@ -43,5 +43,12 @@ def test_softmax():
                    input_shape=(2, 3, 4))
 
 
+@keras_test
+def test_relu():
+    for max_value in [None, 1., 6.]:
+        layer_test(layers.ReLU, kwargs={'max_value': max_value},
+                   input_shape=(2, 3, 4))
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
The ReLU `max_value` argument can not be used currently in a layer, except a custom layer or inside a Lambda layer. Hence, similarly to LeakyReLU or for example [Softmax](https://github.com/keras-team/keras/pull/8841) this PR adds an advanced activation layer for ReLU-N, implementing a capped ReLU.

The default value for `max_value` is set to `None` meaning normal ReLU. A typical value 6.0 is included in the tests.