### PR TITLE
 Fix HDF5Matrix issue when working in conjunction with TimeSeriesGenerator

### DIFF
--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -83,7 +83,7 @@ class HDF5Matrix(object):
                 idx = (self.start + key).tolist()
             else:
                 raise IndexError
-        elif isinstance(key, (list, xrange)):
+        elif isinstance(key, (list, six.moves.range)):
             if max(key) + self.start < self.end:
                 idx = [x + self.start for x in key]
             else:

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -83,7 +83,7 @@ class HDF5Matrix(object):
                 idx = (self.start + key).tolist()
             else:
                 raise IndexError
-        elif isinstance(key, list):
+        elif isinstance(key, (list, xrange)):
             if max(key) + self.start < self.end:
                 idx = [x + self.start for x in key]
             else:

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -86,9 +86,9 @@ class HDF5Matrix(object):
         else:
             # Assume list/iterable
             if max(key) + self.start < self.end:
-                   idx = [x + self.start for x in key]
+                idx = [x + self.start for x in key]
             else:
-                  raise IndexError
+                raise IndexError
         if self.normalizer is not None:
             return self.normalizer(self.data[idx])
         else:

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -83,13 +83,12 @@ class HDF5Matrix(object):
                 idx = (self.start + key).tolist()
             else:
                 raise IndexError
-        elif isinstance(key, (list, six.moves.range)):
-            if max(key) + self.start < self.end:
-                idx = [x + self.start for x in key]
-            else:
-                raise IndexError
         else:
-            raise IndexError
+            # Assume list/iterable
+            if max(key) + self.start < self.end:
+                   idx = [x + self.start for x in key]
+            else:
+                  raise IndexError
         if self.normalizer is not None:
             return self.normalizer(self.data[idx])
         else:

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -90,7 +90,7 @@ def test_io_utils(in_tmpdir):
     with pytest.raises(IndexError):
         X_train[[1000, 1001]]
     with pytest.raises(IndexError):
-        X_train[[xrange(1000, 1001)]]
+        X_train[six.moves.range(1000, 1001)]
     with pytest.raises(IndexError):
         X_train[np.array([1000])]
     with pytest.raises(IndexError):

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -90,6 +90,8 @@ def test_io_utils(in_tmpdir):
     with pytest.raises(IndexError):
         X_train[[1000, 1001]]
     with pytest.raises(IndexError):
+        X_train[[xrange(1000, 1001)]]
+    with pytest.raises(IndexError):
         X_train[np.array([1000])]
     with pytest.raises(IndexError):
         X_train[None]

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -93,7 +93,7 @@ def test_io_utils(in_tmpdir):
         X_train[six.moves.range(1000, 1001)]
     with pytest.raises(IndexError):
         X_train[np.array([1000])]
-    with pytest.raises(IndexError):
+    with pytest.raises(TypeError):
         X_train[None]
     assert (X_train[0] == X_train[:1][0]).all()
     assert (X_train[[0, 1]] == X_train[:2]).all()


### PR DESCRIPTION
The TimeSeriesGenerator uses xrange through six which caused an IndexError when using HDF5Matrix.