### PR TITLE
Set some layers explicitly non-trainable (https://github.com/keras-team/keras/issues/10328)

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -103,6 +103,7 @@ class Dropout(Layer):
         self.noise_shape = noise_shape
         self.seed = seed
         self.supports_masking = True
+        self.trainable = False
 
     def _get_noise_shape(self, inputs):
         if self.noise_shape is None:
@@ -350,6 +351,7 @@ class Reshape(Layer):
     def __init__(self, target_shape, **kwargs):
         super(Reshape, self).__init__(**kwargs)
         self.target_shape = tuple(target_shape)
+        self.trainable = False
 
     def _fix_unknown_dimension(self, input_shape, output_shape):
         """Finds and replaces a missing dimension in an output shape.
@@ -445,6 +447,7 @@ class Permute(Layer):
         super(Permute, self).__init__(**kwargs)
         self.dims = tuple(dims)
         self.input_spec = InputSpec(ndim=len(self.dims) + 1)
+        self.trainable = False
 
     def compute_output_shape(self, input_shape):
         input_shape = list(input_shape)
@@ -498,6 +501,7 @@ class Flatten(Layer):
         super(Flatten, self).__init__(**kwargs)
         self.input_spec = InputSpec(min_ndim=3)
         self.data_format = conv_utils.normalize_data_format(data_format)
+        self.trainable = False
 
     def compute_output_shape(self, input_shape):
         if not all(input_shape[1:]):

--- a/keras/layers/pooling.py
+++ b/keras/layers/pooling.py
@@ -25,6 +25,7 @@ class _Pooling1D(Layer):
         self.strides = conv_utils.normalize_tuple(strides, 1, 'strides')
         self.padding = conv_utils.normalize_padding(padding)
         self.input_spec = InputSpec(ndim=3)
+        self.trainable = False
 
     def compute_output_shape(self, input_shape):
         length = conv_utils.conv_output_length(input_shape[1],
@@ -129,6 +130,7 @@ class _Pooling2D(Layer):
         self.padding = conv_utils.normalize_padding(padding)
         self.data_format = conv_utils.normalize_data_format(data_format)
         self.input_spec = InputSpec(ndim=4)
+        self.trainable = False
 
     def compute_output_shape(self, input_shape):
         if self.data_format == 'channels_first':
@@ -290,6 +292,7 @@ class _Pooling3D(Layer):
         self.padding = conv_utils.normalize_padding(padding)
         self.data_format = conv_utils.normalize_data_format(data_format)
         self.input_spec = InputSpec(ndim=5)
+        self.trainable = False
 
     def compute_output_shape(self, input_shape):
         if self.data_format == 'channels_first':


### PR DESCRIPTION
This small commit sets `trainable = False` in many layers that don't have any trainable parameters. See issue https://github.com/keras-team/keras/issues/10328. There might also be other layers where this should be done, but I changed the ones I could easily find. The layers affected by this commit are:
* `_PoolingXD`, where X=1,2,3
* `Dropout`
* `Reshape`
* `Flatten`

I didn't add new tests because the changes are pretty trivial. If you disagree with me, please tell and I will add some.