### PR TITLE
Add spatial dropout and 3D global pooling to docs

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -158,6 +158,9 @@ PAGES = [
             layers.Lambda,
             layers.ActivityRegularization,
             layers.Masking,
+            layers.SpatialDropout1D,
+            layers.SpatialDropout2D,
+            layers.SpatialDropout3D,
         ],
     },
     {

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -196,6 +196,8 @@ PAGES = [
             layers.GlobalAveragePooling1D,
             layers.GlobalMaxPooling2D,
             layers.GlobalAveragePooling2D,
+            layers.GlobalMaxPooling3D,
+            layers.GlobalAveragePooling3D,
         ],
     },
     {


### PR DESCRIPTION
Maybe there's a reason these layers were left out, but I think it doesn't hurt to let the world know. I went through all layers, those two sets are the only ones that were missing.