### PR TITLE
Add missing named arguments in ImageDataGenerator in examples

### DIFF
--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -83,11 +83,21 @@ else:
         featurewise_std_normalization=False,  # divide inputs by std of the dataset
         samplewise_std_normalization=False,  # divide each input by its std
         zca_whitening=False,  # apply ZCA whitening
+        zca_epsilon=1e-06,  # epsilon for ZCA whitening
         rotation_range=0,  # randomly rotate images in the range (degrees, 0 to 180)
         width_shift_range=0.1,  # randomly shift images horizontally (fraction of total width)
         height_shift_range=0.1,  # randomly shift images vertically (fraction of total height)
+        shear_range=0.,  # set range for random shear
+        zoom_range=0.,  # set range for random zoom
+        channel_shift_range=0.,  # set range for random channel shifts
+        fill_mode='nearest',  # set mode for filling points outside the input boundaries
+        cval=0.,  # value used for fill_mode = "constant"
         horizontal_flip=True,  # randomly flip images
-        vertical_flip=False)  # randomly flip images
+        vertical_flip=False,  # randomly flip images
+        rescale=None,  # set rescaling factor (applied before any other transformation)
+        preprocessing_function=None,  # set function that will be applied on each input
+        data_format=None,  # image data format, either "channels_first" or "channels_last"
+        validation_split=0.0)  # fraction of images reserved for validation (strictly between 0 and 1)
 
     # Compute quantities required for feature-wise normalization
     # (std, mean, and principal components if ZCA whitening is applied).

--- a/examples/cifar10_cnn_capsule.py
+++ b/examples/cifar10_cnn_capsule.py
@@ -204,11 +204,21 @@ else:
         featurewise_std_normalization=False,  # divide inputs by dataset std
         samplewise_std_normalization=False,  # divide each input by its std
         zca_whitening=False,  # apply ZCA whitening
+        zca_epsilon=1e-06,  # epsilon for ZCA whitening
         rotation_range=0,  # randomly rotate images in 0 to 180 degrees
         width_shift_range=0.1,  # randomly shift images horizontally
         height_shift_range=0.1,  # randomly shift images vertically
+        shear_range=0.,  # set range for random shear
+        zoom_range=0.,  # set range for random zoom
+        channel_shift_range=0.,  # set range for random channel shifts
+        fill_mode='nearest',  # set mode for filling points outside the input boundaries
+        cval=0.,  # value used for fill_mode = "constant"
         horizontal_flip=True,  # randomly flip images
-        vertical_flip=False)  # randomly flip images
+        vertical_flip=False,  # randomly flip images
+        rescale=None,  # set rescaling factor (applied before any other transformation)
+        preprocessing_function=None,  # set function that will be applied on each input
+        data_format=None,  # image data format, either "channels_first" or "channels_last"
+        validation_split=0.0)  # fraction of images reserved for validation (strictly between 0 and 1)
 
     # Compute quantities required for feature-wise normalization
     # (std, mean, and principal components if ZCA whitening is applied).

--- a/examples/cifar10_resnet.py
+++ b/examples/cifar10_resnet.py
@@ -384,16 +384,36 @@ else:
         samplewise_std_normalization=False,
         # apply ZCA whitening
         zca_whitening=False,
+        # epsilon for ZCA whitening
+        zca_epsilon=1e-06,
         # randomly rotate images in the range (deg 0 to 180)
         rotation_range=0,
         # randomly shift images horizontally
         width_shift_range=0.1,
         # randomly shift images vertically
         height_shift_range=0.1,
+        # set range for random shear
+        shear_range=0.,
+        # set range for random zoom
+        zoom_range=0.,
+        # set range for random channel shifts
+        channel_shift_range=0.,
+        # set mode for filling points outside the input boundaries
+        fill_mode='nearest',
+        # value used for fill_mode = "constant"
+        cval=0.,
         # randomly flip images
         horizontal_flip=True,
         # randomly flip images
-        vertical_flip=False)
+        vertical_flip=False,
+        # set rescaling factor (applied before any other transformation)
+        rescale=None,
+        # set function that will be applied on each input
+        preprocessing_function=None,
+        # image data format, either "channels_first" or "channels_last"
+        data_format=None,
+        # fraction of images reserved for validation (strictly between 0 and 1)
+        validation_split=0.0)
 
     # Compute quantities required for featurewise normalization
     # (std, mean, and principal components if ZCA whitening is applied).


### PR DESCRIPTION
Usage of `ImageDataGenerator` in the example codes was not up to date with the latest version.
This PR adds missing named arguments of `ImageDataGenerator` and pass them with their default values. 