### PR TITLE
[docs] more details for adagrad/delta, clarifying usage of rho

### DIFF
--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -274,10 +274,12 @@ class RMSprop(Optimizer):
 
 
 class Adagrad(Optimizer):
-    """Adagrad optimizer. Adagrad is a gradient-based optimizer
-    with parameter-specific learning rates, which are adapted relative
-    to how frequently a parameter gets updated during training. The more
-    updates a parameter receives, the smaller the updates.
+    """Adagrad optimizer.
+
+    Adagrad is an optimizer with parameter-specific learning rates,
+    which are adapted relative to how frequently a parameter gets
+    updated during training. The more updates a parameter receives,
+    the smaller the updates.
 
     It is recommended to leave the parameters of this optimizer
     at their default values.
@@ -338,8 +340,11 @@ class Adagrad(Optimizer):
 class Adadelta(Optimizer):
     """Adadelta optimizer. Adadelta is a more robust extension of Adagrad
     that adapts learning rates based on a moving window of gradient updates,
-    instead of accumulating all past gradients. Using Adadelta, you don't
-    even have to choose an initial learning rate.
+    instead of accumulating all past gradients. This way, Adadelta continues
+    learning even when many updates have been done. Compared to Adagrad, in the
+    original version of Adadelta you don't have to set an initial learning
+    rate. In this version, initial learning rate and decay factor can
+    be set, as in most other Keras optimizers.
 
     It is recommended to leave the parameters of this optimizer
     at their default values.

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -274,13 +274,16 @@ class RMSprop(Optimizer):
 
 
 class Adagrad(Optimizer):
-    """Adagrad optimizer.
+    """Adagrad optimizer. Adagrad is a gradient-based optimizer
+    with parameter-specific learning rates, which are adapted relative
+    to how frequently a parameter gets updated during training. The more
+    updates a parameter receives, the smaller the updates.
 
     It is recommended to leave the parameters of this optimizer
     at their default values.
 
     # Arguments
-        lr: float >= 0. Learning rate.
+        lr: float >= 0. Initial learning rate.
         epsilon: float >= 0. If `None`, defaults to `K.epsilon()`.
         decay: float >= 0. Learning rate decay over each update.
 
@@ -333,17 +336,21 @@ class Adagrad(Optimizer):
 
 
 class Adadelta(Optimizer):
-    """Adadelta optimizer.
+    """Adadelta optimizer. Adadelta is a more robust extension of Adagrad
+    that adapts learning rates based on a moving window of gradient updates,
+    instead of accumulating all past gradients. Using Adadelta, you don't
+    even have to choose an initial learning rate.
 
     It is recommended to leave the parameters of this optimizer
     at their default values.
 
     # Arguments
-        lr: float >= 0. Learning rate.
+        lr: float >= 0. Initial learning rate, defaults to 1.
             It is recommended to leave it at the default value.
-        rho: float >= 0.
+        rho: float >= 0. Adadelta decay factor, corresponding to fraction of
+            gradient to keep at each time step.
         epsilon: float >= 0. Fuzz factor. If `None`, defaults to `K.epsilon()`.
-        decay: float >= 0. Learning rate decay over each update.
+        decay: float >= 0. Initial learning rate decay.
 
     # References
         - [Adadelta - an adaptive learning rate method](http://arxiv.org/abs/1212.5701)

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -338,7 +338,9 @@ class Adagrad(Optimizer):
 
 
 class Adadelta(Optimizer):
-    """Adadelta optimizer. Adadelta is a more robust extension of Adagrad
+    """Adadelta optimizer.
+
+    Adadelta is a more robust extension of Adagrad
     that adapts learning rates based on a moving window of gradient updates,
     instead of accumulating all past gradients. This way, Adadelta continues
     learning even when many updates have been done. Compared to Adagrad, in the


### PR DESCRIPTION
@fchollet I've added a bit more info on adaptive optimizers.

If I remember correctly, `lr` and `decay` do not appear in the original Adadelta paper. One could argue that one benefit of Adadelta over Adagrad is that you _don't_ have to set `lr`. It's set to `lr=1` by default anyway.

Shall we remove those parameters altogether? I can do a follow-up PR. 