### PR TITLE
corrected batch norm implementation in cntk and documentation in tensorflow

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1085,7 +1085,7 @@ def batch_normalization(x, mean, var, beta, gamma, axis=-1, epsilon=1e-3):
     elif ndim(beta) == ndim(x) and shape(beta)[0] == 1:
         beta = _reshape_dummy_dim(beta, [0])
 
-    return (x - mean) / (C.sqrt(var) + epsilon) * gamma + beta
+    return (x - mean) / C.sqrt(var + epsilon) * gamma + beta
 
 
 def concatenate(tensors, axis=-1):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1854,7 +1854,7 @@ def batch_normalization(x, mean, var, beta, gamma, axis=-1, epsilon=1e-3):
     """Applies batch normalization on x given mean, var, beta and gamma.
 
     I.e. returns:
-    `output = (x - mean) / (sqrt(var) + epsilon) * gamma + beta`
+    `output = (x - mean) / sqrt(var + epsilon) * gamma + beta`
 
     # Arguments
         x: Input tensor or variable.


### PR DESCRIPTION
I corrected the documentation in tensorflow backend and the implementation in cntk backend, as to how the epsilon is used. This relates to this question: https://stackoverflow.com/questions/50830891/recreating-keras-model-in-numpy

Basically BN was used as (x-mean)/(sqrt(var) + eps) whereas it should have been used as  (x-mean)/sqrt(var + eps).

Also this line seems to confirm that its used the way I have described above:
https://github.com/tensorflow/tensorflow/blob/r1.8/tensorflow/python/ops/nn_impl.py#L830