### PR TITLE
Fix use_bias in some convolutional layers

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -807,7 +807,7 @@ class Conv2DTranspose(Conv2D):
             padding=self.padding,
             data_format=self.data_format)
 
-        if self.bias:
+        if self.use_bias:
             outputs = K.bias_add(
                 outputs,
                 self.bias,
@@ -1034,7 +1034,7 @@ class Conv3DTranspose(Conv3D):
                                      padding=self.padding,
                                      data_format=self.data_format)
 
-        if self.bias:
+        if self.use_bias:
             outputs = K.bias_add(
                 outputs,
                 self.bias,
@@ -1278,7 +1278,7 @@ class _SeparableConv(_Conv):
                 padding=self.padding,
                 dilation_rate=self.dilation_rate)
 
-        if self.bias:
+        if self.use_bias:
             outputs = K.bias_add(
                 outputs,
                 self.bias,
@@ -1737,7 +1737,7 @@ class DepthwiseConv2D(Conv2D):
             dilation_rate=self.dilation_rate,
             data_format=self.data_format)
 
-        if self.bias:
+        if self.use_bias:
             outputs = K.bias_add(
                 outputs,
                 self.bias,

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -226,6 +226,7 @@ def test_conv2d_transpose():
         model = Sequential([convolutional.Conv2DTranspose(filters=filters,
                                                           kernel_size=3,
                                                           padding=padding,
+                                                          use_bias=true,
                                                           batch_input_shape=(None, None, 5, None))])
 
 
@@ -269,6 +270,7 @@ def test_separable_conv_1d():
                        'pointwise_constraint': 'unit_norm',
                        'depthwise_constraint': 'unit_norm',
                        'strides': 1,
+                       'use_bias': True,
                        'depth_multiplier': multiplier},
                input_shape=(num_samples, stack_size, num_step))
 
@@ -364,6 +366,7 @@ def test_depthwise_conv_2d():
                        'bias_regularizer': 'l2',
                        'activity_regularizer': 'l2',
                        'depthwise_constraint': 'unit_norm',
+                       'use_bias': True,
                        'strides': strides,
                        'depth_multiplier': multiplier},
                input_shape=(num_samples, stack_size, num_row, num_col))
@@ -521,6 +524,7 @@ def test_conv3d_transpose():
                        'activity_regularizer': 'l2',
                        'kernel_constraint': 'max_norm',
                        'bias_constraint': 'max_norm',
+                       'use_bias': True,
                        'strides': strides},
                input_shape=(None, stack_size, num_depth, num_row, num_col),
                fixed_batch_size=True)

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -226,7 +226,7 @@ def test_conv2d_transpose():
         model = Sequential([convolutional.Conv2DTranspose(filters=filters,
                                                           kernel_size=3,
                                                           padding=padding,
-                                                          use_bias=true,
+                                                          use_bias=True,
                                                           batch_input_shape=(None, None, 5, None))])
 
 


### PR DESCRIPTION
replace condition `if self.bias` with `if self.use_bias` in DepthConv2D, Conv2DTranspose, Conv3DTranspose, SeparableConv. self.bias is tensor and using that as bool will result in an error