### PR TITLE
Fix docstring of layer.Embedding to properly render arguments

### DIFF
--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -35,30 +35,30 @@ class Embedding(Layer):
     ```
 
     # Arguments
-      input_dim: int > 0. Size of the vocabulary,
-          i.e. maximum integer index + 1.
-      output_dim: int >= 0. Dimension of the dense embedding.
-      embeddings_initializer: Initializer for the `embeddings` matrix
-          (see [initializers](../initializers.md)).
-      embeddings_regularizer: Regularizer function applied to
-          the `embeddings` matrix
-          (see [regularizer](../regularizers.md)).
-      embeddings_constraint: Constraint function applied to
-          the `embeddings` matrix
-          (see [constraints](../constraints.md)).
-      mask_zero: Whether or not the input value 0 is a special "padding"
-          value that should be masked out.
-          This is useful when using [recurrent layers](recurrent.md)
-          which may take variable length input.
-          If this is `True` then all subsequent layers
-          in the model need to support masking or an exception will be raised.
-          If mask_zero is set to True, as a consequence, index 0 cannot be
-          used in the vocabulary (input_dim should equal size of
-          vocabulary + 1).
-      input_length: Length of input sequences, when it is constant.
-          This argument is required if you are going to connect
-          `Flatten` then `Dense` layers upstream
-          (without it, the shape of the dense outputs cannot be computed).
+        input_dim: int > 0. Size of the vocabulary,
+            i.e. maximum integer index + 1.
+        output_dim: int >= 0. Dimension of the dense embedding.
+        embeddings_initializer: Initializer for the `embeddings` matrix
+            (see [initializers](../initializers.md)).
+        embeddings_regularizer: Regularizer function applied to
+            the `embeddings` matrix
+            (see [regularizer](../regularizers.md)).
+        embeddings_constraint: Constraint function applied to
+            the `embeddings` matrix
+            (see [constraints](../constraints.md)).
+        mask_zero: Whether or not the input value 0 is a special "padding"
+            value that should be masked out.
+            This is useful when using [recurrent layers](recurrent.md)
+            which may take variable length input.
+            If this is `True` then all subsequent layers
+            in the model need to support masking or an exception will be raised.
+            If mask_zero is set to True, as a consequence, index 0 cannot be
+            used in the vocabulary (input_dim should equal size of
+            vocabulary + 1).
+        input_length: Length of input sequences, when it is constant.
+            This argument is required if you are going to connect
+            `Flatten` then `Dense` layers upstream
+            (without it, the shape of the dense outputs cannot be computed).
 
     # Input shape
         2D tensor with shape: `(batch_size, sequence_length)`.


### PR DESCRIPTION
The individual arguments in the **Embedding** | **Arguments** section of https://keras.io/layers/embeddings/ are not rendered as a list. This appears to be due to formatting within the docstring, which is adjusted in this PR.

Prior to this change:
![image](https://user-images.githubusercontent.com/634688/41515390-bcdb10b0-727c-11e8-9551-24314945de6d.png)
