### PR TITLE
Fix several typos

### DIFF
--- a/examples/lstm_seq2seq.py
+++ b/examples/lstm_seq2seq.py
@@ -10,7 +10,7 @@ models are more common in this domain.
 # Summary of the algorithm
 
 - We start with input sequences from a domain (e.g. English sentences)
-    and correspding target sequences from another domain
+    and corresponding target sequences from another domain
     (e.g. French sentences).
 - An encoder LSTM turns input sequences to 2 state vectors
     (we keep the last LSTM state and discard the outputs).

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2736,7 +2736,7 @@ def rnn(step_function, inputs, initial_states,
                 states: List of tensors.
             Returns:
                 outputs: Tensor with shape (samples, ...) (no time dimension),
-                new_states: Tist of tensors, same length and shapes
+                new_states: List of tensors, same length and shapes
                     as 'states'.
         inputs: Tensor of temporal data of shape (samples, time, ...)
             (at least 3D).

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1323,7 +1323,7 @@ def rnn(step_function, inputs, initial_states,
                 states: List of tensors.
             Returns:
                 outputs: Tensor with shape (samples, ...) (no time dimension),
-                new_states: Tist of tensors, same length and shapes
+                new_states: List of tensors, same length and shapes
                     as 'states'.
         inputs: Tensor of temporal data of shape (samples, time, ...)
             (at least 3D).

--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -131,7 +131,7 @@ class Network(Layer):
         # Entries are unique. Includes input and output layers.
         self._layers = []
 
-        # Used only in conjonction with graph-networks
+        # Used only in conjunction with graph-networks
         self._outbound_nodes = []
         self._inbound_nodes = []
 
@@ -524,7 +524,7 @@ class Network(Layer):
                 or a single instance if the model has only one input.
         """
         if not self._is_graph_network:
-            # TODO: support it in subclassd networks after inputs are set.
+            # TODO: support it in subclassed networks after inputs are set.
             return None
 
         specs = []

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -833,7 +833,7 @@ def _need_convert_kernel(original_backend):
     The convolution operation is implemented differently in different backends.
     While TH implements convolution, TF and CNTK implement the correlation operation.
     So the channel axis needs to be flipped when we're loading TF weights onto a TH model,
-    or vice verca. However, there's no conversion required between TF and CNTK.
+    or vice versa. However, there's no conversion required between TF and CNTK.
 
     # Arguments
         original_backend: Keras backend the weights were trained with, as a string.


### PR DESCRIPTION
Just fixing several typos, the first three of which are visible in the keras.io documentation.