### PR TITLE
Callback value can now be raw float

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -939,7 +939,7 @@ class TensorBoard(Callback):
                 continue
             summary = tf.Summary()
             summary_value = summary.value.add()
-            summary_value.simple_value = value.item()
+            summary_value.simple_value = value if isinstance(value, float) else value.item()
             summary_value.tag = name
             self.writer.add_summary(summary, epoch)
         self.writer.flush()


### PR DESCRIPTION
Had no errors when I was using [`fit`](https://keras.io/models/sequential/#fit), moving to [`flow_from_directory`](https://keras.io/preprocessing/image/#flow_from_directory) and [`fit_generator`](https://keras.io/models/sequential/#fit_generator) and I got this error:

```
Using TensorFlow backend.
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/opt/venvs/tflow3.6/lib/python3.5/site-packages/ml_glaucoma/__main__.py", line 88, in <module>
    }[command])(**kwargs)
  File "/opt/venvs/tflow3.6/lib/python3.5/site-packages/ml_glaucoma/CNN/bmes_cnn.py", line 235, in run
    model.fit_generator(train_seq, validation_data=valid_seq, epochs=epochs, callbacks=callbacks, verbose=1)
  File "/opt/venvs/tflow3.6/lib/python3.5/site-packages/keras/legacy/interfaces.py", line 91, in wrapper
    return func(*args, **kwargs)
  File "/opt/venvs/tflow3.6/lib/python3.5/site-packages/keras/engine/training.py", line 1426, in fit_generator
    initial_epoch=initial_epoch)
  File "/opt/venvs/tflow3.6/lib/python3.5/site-packages/keras/engine/training_generator.py", line 229, in fit_generator
    callbacks.on_epoch_end(epoch, epoch_logs)
  File "/opt/venvs/tflow3.6/lib/python3.5/site-packages/keras/callbacks.py", line 77, in on_epoch_end
    callback.on_epoch_end(epoch, logs)
  File "/opt/venvs/tflow3.6/lib/python3.5/site-packages/keras/callbacks.py", line 942, in on_epoch_end
    summary_value.simple_value = value.item()
AttributeError: 'float' object has no attribute 'item'
```

Made this minor edit, and now my callbacks work fine.