### PR TITLE
Add list_pictures function path

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -23,3 +23,4 @@ ImageDataGenerator = image.ImageDataGenerator
 Iterator = image.Iterator
 NumpyArrayIterator = image.NumpyArrayIterator
 DirectoryIterator = image.DirectoryIterator
+list_pictures = image.list_pictures


### PR DESCRIPTION
When I used `from keras.preprocessing.image import list_pictures` I got this error:
```python
from keras.preprocessing.image import list_pictures
Using TensorFlow backend.
Traceback (most recent call last):
  File "<input>", line 1, in <module>
ImportError: cannot import name 'list_pictures'
```
Because list_pictures function was forgotten, I added it.