### PR TITLE
Random seed option before shuffling

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -541,6 +541,9 @@ class OrderedEnqueuer(SequenceEnqueuer):
         """Submits request to the executor and queue the `Future` objects."""
         sequence = list(range(len(self.sequence)))
         self._send_sequence()  # Share the initial sequence
+        if self.sequence.seed is not None:
+            random.seed(self.sequence.seed)
+            print(self.sequence.seed)
         while True:
             if self.shuffle:
                 random.shuffle(sequence)

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -542,8 +542,10 @@ class OrderedEnqueuer(SequenceEnqueuer):
         """Submits request to the executor and queue the `Future` objects."""
         sequence = list(range(len(self.sequence)))
         self._send_sequence()  # Share the initial sequence
+        # Set random seed so the following shuffling
+        # is deterministic when a seed has been specified
         if self.seed is not None:
-            random.seed(self.seed)  # Set random seed so the following shuffling is deterministic when a seed has been specified.  
+            random.seed(self.seed)    
         while True:
             if self.shuffle:
                 random.shuffle(sequence)

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -478,7 +478,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
                  shuffle=False):
         self.sequence = sequence
         self.use_multiprocessing = use_multiprocessing
-		self.seed = self.sequence.seed
+        self.seed = self.sequence.seed
 
         global _SEQUENCE_COUNTER
         if _SEQUENCE_COUNTER is None:

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -543,7 +543,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
         sequence = list(range(len(self.sequence)))
         self._send_sequence()  # Share the initial sequence
         if self.seed is not None:
-            random.seed(self.seed)	# Set random seed so the following shuffling is deterministic when a seed has been specified. 
+            random.seed(self.seed)  # Set random seed so the following shuffling is deterministic when a seed has been specified.  
         while True:
             if self.shuffle:
                 random.shuffle(sequence)

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -543,7 +543,6 @@ class OrderedEnqueuer(SequenceEnqueuer):
         self._send_sequence()  # Share the initial sequence
         if self.sequence.seed is not None:
             random.seed(self.sequence.seed)
-            print(self.sequence.seed)
         while True:
             if self.shuffle:
                 random.shuffle(sequence)

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -478,6 +478,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
                  shuffle=False):
         self.sequence = sequence
         self.use_multiprocessing = use_multiprocessing
+		self.seed = self.sequence.seed
 
         global _SEQUENCE_COUNTER
         if _SEQUENCE_COUNTER is None:
@@ -541,8 +542,8 @@ class OrderedEnqueuer(SequenceEnqueuer):
         """Submits request to the executor and queue the `Future` objects."""
         sequence = list(range(len(self.sequence)))
         self._send_sequence()  # Share the initial sequence
-        if self.sequence.seed is not None:
-            random.seed(self.sequence.seed)
+        if self.seed is not None:
+            random.seed(self.seed)	# Set random seed so the following shuffling is deterministic when a seed has been specified. 
         while True:
             if self.shuffle:
                 random.shuffle(sequence)


### PR DESCRIPTION
Have added the option for specifying random seed before shuffling the generated data. This is useful for the function "fit_generator" to produce the consistent sequence of data when a seed is given in the function "flow_from_dictionary".

This change is to fix the issue [#10169](https://github.com/keras-team/keras/issues/10169)