### PR TITLE
Correct parameters of Conv2D layer

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -486,7 +486,7 @@ class Flatten(Layer):
     ```python
         model = Sequential()
         model.add(Conv2D(64, 3, 3,
-                         border_mode='same',
+                         padding='same',
                          input_shape=(3, 32, 32)))
         # now: model.output_shape == (None, 64, 32, 32)
 


### PR DESCRIPTION
Changed border_mode='same' to padding='same' in the example to match it with the parameters of Conv2D.