### PR TITLE
Add relu6

### DIFF
--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 from keras_applications import mobilenet
 
+relu6 = mobilenet.relu6
 MobileNet = mobilenet.MobileNet
 decode_predictions = mobilenet.decode_predictions
 preprocess_input = mobilenet.preprocess_input

--- a/keras/applications/mobilenetv2.py
+++ b/keras/applications/mobilenetv2.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 from keras_applications import mobilenet_v2
 
+relu6 = mobilenet_v2.relu6
 MobileNetV2 = mobilenet_v2.MobileNetV2
 decode_predictions = mobilenet_v2.decode_predictions
 preprocess_input = mobilenet_v2.preprocess_input


### PR DESCRIPTION
Trained MobileNet models couldn't be loaded the same way as before, as suggested in the docs:
```
model = load_model('mobilenet_v2.h5', custom_objects={
                   'relu6': mobilenetv2.relu6})
```
Added `relu6` to fix the error. If this doesn't look good then I think we should change the docs.