### PR TITLE
Add saving tests

### DIFF
--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -312,20 +312,25 @@ def test_loading_weights_by_name_and_reshape():
     model.add(Conv2D(2, (1, 1), input_shape=(1, 1, 1), use_bias=False, name='rick'))
     model.add(Flatten())
     model.add(Dense(3, name='morty'))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError,
+                       match=r'.* expects [0-9]+ .* but the saved .* [0-9]+ .*'):
         model.load_weights(fname)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError,
+                       match=r'.* expects [0-9]+ .* but the saved .* [0-9]+ .*'):
         model.load_weights(fname, by_name=True)
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning,
+                      match=r'Skipping loading .* due to mismatch .*'):
         model.load_weights(fname, by_name=True, skip_mismatch=True)
 
     # delete and recreate model with `filters=10`
     del(model)
     model = Sequential()
     model.add(Conv2D(10, (1, 1), input_shape=(1, 1, 1), name='rick'))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError,
+                       match=r'.* has shape .* but the saved .* shape .*'):
         model.load_weights(fname, by_name=True)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError,
+                       match=r'.* load .* [0-9]+ layers into .* [0-9]+ layers.'):
         model.load_weights(fname)
 
     os.remove(fname)

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -296,7 +296,6 @@ def test_loading_weights_by_name_and_reshape():
         model.load_weights(fname, by_name=False, reshape=False)
     model.load_weights(fname, by_name=False, reshape=True)
     model.load_weights(fname, by_name=True, reshape=True)
-    os.remove(fname)
 
     out2 = model.predict(x)
     assert_allclose(np.squeeze(out), np.squeeze(out2), atol=1e-05)
@@ -306,6 +305,30 @@ def test_loading_weights_by_name_and_reshape():
             # only compare layers that have weights, skipping Flatten()
             if old_weights[i]:
                 assert_allclose(old_weights[i][j], new_weights[j], atol=1e-05)
+
+    # delete and recreate model with `use_bias=False`
+    del(model)
+    model = Sequential()
+    model.add(Conv2D(2, (1, 1), input_shape=(1, 1, 1), use_bias=False, name='rick'))
+    model.add(Flatten())
+    model.add(Dense(3, name='morty'))
+    with pytest.raises(ValueError):
+        model.load_weights(fname)
+    with pytest.raises(ValueError):
+        model.load_weights(fname, by_name=True)
+    with pytest.warns(UserWarning):
+        model.load_weights(fname, by_name=True, skip_mismatch=True)
+
+    # delete and recreate model with `filters=10`
+    del(model)
+    model = Sequential()
+    model.add(Conv2D(10, (1, 1), input_shape=(1, 1, 1), name='rick'))
+    with pytest.raises(ValueError):
+        model.load_weights(fname, by_name=True)
+    with pytest.raises(ValueError):
+        model.load_weights(fname)
+
+    os.remove(fname)
 
 
 @keras_test


### PR DESCRIPTION
This PR add saving tests for weights mismatch cases. This PR will make CI cover the following:
```
keras/engine/saving.py                      366     69    81%  ..., 898, 918, 956, 960, 988-994, 1012
```

|   | [Before](https://travis-ci.org/keras-team/keras/builds/396224893) |
|:-:|---|
| Python 2.7 + TF | 90.73% |
| Python 3.6 + TF | 90.63% |
| Python 2.7 + TH | 88.24% |
| Python 3.6 + TH | 88.19% |
| Python 2.7 + C | 88.08% |
| Python 3.6 + C | 88.03% |