### PR TITLE
Reduce separable conv tests

### DIFF
--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -323,6 +323,8 @@ def test_separable_conv_2d():
                         continue
                     if dilation_rate != (1, 1) and strides != (1, 1):
                         continue
+                    if dilation_rate != (1, 1) and multiplier == dilation_rate[0]:
+                        continue
                     if dilation_rate != (1, 1) and K.backend() == 'cntk':
                         continue
 


### PR DESCRIPTION
This PR reduces test combinations (18 -> 12 cases) of hyper-parameters in `test_separable_conv_2d`, which has always been presented in the slowest 20 tests. Note that the combinations are from `('valid', (1, 1), 1, (1, 1))` to `('same', (1, 1), 2, (1, 2))`). Also, this PR must not change the test coverages:

|   | [Before](https://travis-ci.org/keras-team/keras/builds/396224893) |
|:-:|---|
| Python 2.7 + TF | 90.73% |
| Python 3.6 + TF | 90.63% |
| Python 2.7 + TH | 88.24% |
| Python 3.6 + TH | 88.19% |
| Python 2.7 + C | 88.08% |
| Python 3.6 + C | 88.03% |