### PR TITLE
Removed unnecessary newline in docs

### DIFF
--- a/docs/templates/models/about-keras-models.md
+++ b/docs/templates/models/about-keras-models.md
@@ -7,7 +7,6 @@ These models have a number of methods and attributes in common:
 - `model.layers` is a flattened list of the layers comprising the model.
 - `model.inputs` is the list of input tensors of the model.
 - `model.outputs` is the list of output tensors of the model.
-
 - `model.summary()` prints a summary representation of your model. Shortcut for [utils.print_summary](/utils/#print_summary)
 - `model.get_config()` returns a dictionary containing the configuration of the model. The model can be reinstantiated from its config via:
 


### PR DESCRIPTION
It was causing a non-uniform display in chrome.
![doc](https://user-images.githubusercontent.com/33203398/41852360-7928fc6a-78a8-11e8-95cb-2bf2e8189cad.JPG)
`model.outputs` and `model.summary()` lines appear in larger font size.
