### PR TITLE
Fix Dense layer bias_add bug when ndim > 2.

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -884,7 +884,7 @@ class Dense(Layer):
     def call(self, inputs):
         output = K.dot(inputs, self.kernel)
         if self.use_bias:
-            output = K.bias_add(output, self.bias)
+            output = K.bias_add(output, self.bias, data_format="channels_last")
         if self.activation is not None:
             output = self.activation(output)
         return output

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -884,7 +884,7 @@ class Dense(Layer):
     def call(self, inputs):
         output = K.dot(inputs, self.kernel)
         if self.use_bias:
-            output = K.bias_add(output, self.bias, data_format="channels_last")
+            output = K.bias_add(output, self.bias, data_format='channels_last')
         if self.activation is not None:
             output = self.activation(output)
         return output


### PR DESCRIPTION
This fix https://github.com/keras-team/keras/issues/10530 .
When input ndim > 2, Dense layer should add bias to the last dim, so we should always set  ```data_format``` with ```channels_last``` when calling ```K.bias_add```. This is different from other layers such as CNN or RNN, which is determinated by keras configuration.