### PR TITLE
Allow to specify a _target_ value for the monitored quantity in EarlyStopping callback

### DIFF
--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -287,32 +287,53 @@ def test_EarlyStopping_patience():
 
 
 @keras_test
-def test_EarlyStopping_baseline():
+def test_EarlyStopping_baseline_met():
     class DummyModel(object):
         def __init__(self):
             self.stop_training = False
 
-    def baseline_tester(acc_levels):
-        early_stop = callbacks.EarlyStopping(monitor='val_acc', baseline=0.75, patience=2)
-        early_stop.model = DummyModel()
-        epochs_trained = 0
-        early_stop.on_train_begin()
-        for epoch in range(len(acc_levels)):
-            epochs_trained += 1
-            early_stop.on_epoch_end(epoch, logs={'val_acc': acc_levels[epoch]})
-            if early_stop.model.stop_training:
-                break
-        return epochs_trained
+    early_stop = callbacks.EarlyStopping(monitor='val_acc', baseline=0.75, patience=2)
+    early_stop.model = DummyModel()
 
-    acc_levels = [0.55, 0.76, 0.81, 0.81]
-    baseline_met = baseline_tester(acc_levels)
-    acc_levels = [0.55, 0.74, 0.81, 0.81]
-    baseline_not_met = baseline_tester(acc_levels)
+    accuracies = [0.55, 0.76, 0.81, 0.81]
+
+    epochs_trained = 0
+    early_stop.on_train_begin()
+
+    for epoch in range(len(accuracies)):
+        epochs_trained += 1
+        early_stop.on_epoch_end(epoch, logs={'val_acc': accuracies[epoch]})
+
+        if early_stop.model.stop_training:
+            break
 
     # All epochs should run because baseline was met in second epoch
-    assert baseline_met == 4
+    assert epochs_trained == 4
+
+
+@keras_test
+def test_EarlyStopping_baseline_not_met():
+    class DummyModel(object):
+        def __init__(self):
+            self.stop_training = False
+
+    early_stop = callbacks.EarlyStopping(monitor='val_acc', baseline=0.75, patience=2)
+    early_stop.model = DummyModel()
+
+    accuracies = [0.55, 0.74, 0.81, 0.81]
+
+    epochs_trained = 0
+    early_stop.on_train_begin()
+
+    for epoch in range(len(accuracies)):
+        epochs_trained += 1
+        early_stop.on_epoch_end(epoch, logs={'val_acc': accuracies[epoch]})
+
+        if early_stop.model.stop_training:
+            break
+
     # Baseline was not met by second epoch and should stop
-    assert baseline_not_met == 2
+    assert epochs_trained == 2
 
 
 @keras_test

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -337,6 +337,54 @@ def test_EarlyStopping_baseline_not_met():
 
 
 @keras_test
+def test_EarlyStopping_specified_accuracy_is_not_reached():
+    class DummyModel(object):
+        def __init__(self):
+            self.stop_training = False
+
+    early_stop = callbacks.EarlyStopping(monitor='val_acc', reach=0.90)
+    early_stop.model = DummyModel()
+
+    accuracies = [0.55, 0.81, 0.81, 0.81]
+
+    epochs_trained = 0
+    early_stop.on_train_begin()
+
+    for epoch in range(len(accuracies)):
+        epochs_trained += 1
+        early_stop.on_epoch_end(epoch, logs={'val_acc': accuracies[epoch]})
+
+        if early_stop.model.stop_training:
+            break
+
+    assert epochs_trained == 4
+
+
+@keras_test
+def test_EarlyStopping_specified_accuracy_is_reached():
+    class DummyModel(object):
+        def __init__(self):
+            self.stop_training = False
+
+    early_stop = callbacks.EarlyStopping(monitor='val_acc', reach=0.90)
+    early_stop.model = DummyModel()
+
+    accuracies = [0.80, 0.90, 0.90, 0.95]
+
+    epochs_trained = 0
+    early_stop.on_train_begin()
+
+    for epoch in range(len(accuracies)):
+        epochs_trained += 1
+        early_stop.on_epoch_end(epoch, logs={'val_acc': accuracies[epoch]})
+
+        if early_stop.model.stop_training:
+            break
+
+    assert epochs_trained == 3
+
+
+@keras_test
 def test_LearningRateScheduler():
     np.random.seed(1337)
     (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,


### PR DESCRIPTION
> As of 354bd35, EarlyStopping callback allows only to specify a baseline. That value is used to stop training when monitored quantity is worse than the baseline. To my understanding, what's missing is the ability to specify a value to reach for the monitored quantity before considering to stop training. Say you want to stop training if stable but you want to reach at least an accuracy of 95%. Right now you can't.

https://github.com/keras-team/keras/issues/10586