### PR TITLE
Fix a bug to write no-need blank lines to each line of csv file on Windows

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1100,13 +1100,14 @@ class CSVLogger(Callback):
         super(CSVLogger, self).__init__()
 
     def on_train_begin(self, logs=None):
+        newline = '\n' if os.name == 'nt' else None
         if self.append:
             if os.path.exists(self.filename):
                 with open(self.filename, 'r' + self.file_flags) as f:
                     self.append_header = not bool(len(f.readline()))
-            self.csv_file = open(self.filename, 'a' + self.file_flags)
+            self.csv_file = open(self.filename, 'a' + self.file_flags, newline=newline)
         else:
-            self.csv_file = open(self.filename, 'w' + self.file_flags)
+            self.csv_file = open(self.filename, 'w' + self.file_flags, newline=newline)
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}


### PR DESCRIPTION
On Windows, `open` method writes line terminator of '\r\n' on default. ([When writing output to the stream, if newline is None, any '\n' characters written are translated to the system default line separator, os.linesep.](https://docs.python.org/3.3/library/functions.html#open))
But, we should use line terminator of '\n' on all platform. ([Do not use os.linesep as a line terminator when writing files opened in text mode](https://docs.python.org/3.3/library/os.html#os.linesep))

The default behavior of `open` method causes to add no-need blank lines to each line of csv file viewing by excel or csv library.
(`foo.csv` is generated by old `CSVLogger`)
```
In [1]: import csv

In [2]: with open('foo.csv', 'r') as f:
   ...:     reader = csv.reader(f)
   ...:     for row in reader:
   ...:         print(row)
   ...:
['epoch', 'acc', 'loss', 'val_acc', 'val_loss']
['', '', '', '', '']
['0', '0.92615', '0.244615294', '0.9675', '0.10786899']
['', '', '', '', '']
['1', '0.9689', '0.103249485', '0.9694', '0.092479979']
```

This PR remove this no-need blank lines.
(`bar.csv` is generated by `CSVLogger` of this PR)
```
In [3]: with open('bar.csv', 'r') as f:
   ...:     reader = csv.reader(f)
   ...:     for row in reader:
   ...:         print(row)
   ...:
['epoch', 'acc', 'loss', 'val_acc', 'val_loss']
['0', '0.9231166666666667', '0.24697612047990164', '0.9635', '0.11830915709584952']
['1', '0.9684666666348776', '0.1029080352028211', '0.9764', '0.0800724924955517']
```

I don't have environments of Unix and Mac OS, so I wrote code to effect only for Windows.
Please check behavior on other environments and write code for the environments.

Thank you.