### PR TITLE
Update wording in "LearningRateScheduler"

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -634,7 +634,7 @@ class LearningRateScheduler(Callback):
                              'should be float.')
         K.set_value(self.model.optimizer.lr, lr)
         if self.verbose > 0:
-            print('\nEpoch %05d: LearningRateScheduler reducing learning '
+            print('\nEpoch %05d: LearningRateScheduler setting learning '
                   'rate to %s.' % (epoch + 1, lr))
 
 


### PR DESCRIPTION
### Summary
In light of SuperConvergence [1], the user might want to increase the learning rate during training so saying 'reducing' is no longer appropriate.
[1]: https://arxiv.org/abs/1708.07120

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
