### PR TITLE
Documentation: Fix typo: sk_params are passed to build_fn, not to sk_params, right?

### DIFF
--- a/docs/templates/scikit-learn-api.md
+++ b/docs/templates/scikit-learn-api.md
@@ -35,7 +35,7 @@ fitting (predicting) parameters are selected in the following order:
 
 1. Values passed to the dictionary arguments of
 `fit`, `predict`, `predict_proba`, and `score` methods
-2. Values passed to `sk_params`
+2. Values passed to `build_fn`
 3. The default values of the `keras.models.Sequential`
 `fit`, `predict`, `predict_proba` and `score` methods
 


### PR DESCRIPTION
### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
