### PR TITLE
Adding warning if dropout rate is outside the valid range

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -100,6 +100,8 @@ class Dropout(Layer):
     @interfaces.legacy_dropout_support
     def __init__(self, rate, noise_shape=None, seed=None, **kwargs):
         super(Dropout, self).__init__(**kwargs)
+        if (rate>=1) or (rate<0):
+            warnings.warn('`rate` should be between 0 and 1')
         self.rate = min(1., max(0., rate))
         self.noise_shape = noise_shape
         self.seed = seed

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -100,8 +100,8 @@ class Dropout(Layer):
     @interfaces.legacy_dropout_support
     def __init__(self, rate, noise_shape=None, seed=None, **kwargs):
         super(Dropout, self).__init__(**kwargs)
-        if (rate>=1) or (rate<0):
-            warnings.warn('`rate` should be between 0 and 1')
+        if (rate > 1) or (rate < 0):
+            warnings.warn('Dropout `rate` should be between 0 and 1')
         self.rate = min(1., max(0., rate))
         self.noise_shape = noise_shape
         self.seed = seed


### PR DESCRIPTION
### Summary

adding warning when rate value for dropout is out of valid range

### Related Issues

https://github.com/keras-team/keras/issues/10629

### PR Overview

- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
