### PR TITLE
Remove duplicate normalize_data_format

### DIFF
--- a/keras/layers/pooling.py
+++ b/keras/layers/pooling.py
@@ -121,7 +121,6 @@ class _Pooling2D(Layer):
     def __init__(self, pool_size=(2, 2), strides=None, padding='valid',
                  data_format=None, **kwargs):
         super(_Pooling2D, self).__init__(**kwargs)
-        data_format = conv_utils.normalize_data_format(data_format)
         if strides is None:
             strides = pool_size
         self.pool_size = conv_utils.normalize_tuple(pool_size, 2, 'pool_size')


### PR DESCRIPTION
### Summary
`normalize_data_format` was being called twice in `_Pooling2D`

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
