### PR TITLE
Enable automatic shape inference when using Lambda layers and CNTK.

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -624,7 +624,7 @@ class Lambda(Layer):
 
     # Output shape
         Specified by `output_shape` argument
-        (or auto-inferred when using TensorFlow).
+        (or auto-inferred when using TensorFlow or CNTK).
     """
 
     @interfaces.legacy_lambda_support
@@ -649,8 +649,8 @@ class Lambda(Layer):
 
     def compute_output_shape(self, input_shape):
         if self._output_shape is None:
-            # With TensorFlow, we can infer the output shape directly:
-            if K.backend() == 'tensorflow':
+            # With TensorFlow or CNTK, we can infer the output shape directly:
+            if K.backend() in ('tensorflow', 'cntk'):
                 if isinstance(input_shape, list):
                     xs = [K.placeholder(shape=shape) for shape in input_shape]
                     x = self.call(xs)

--- a/tests/keras/layers/core_test.py
+++ b/tests/keras/layers/core_test.py
@@ -281,6 +281,16 @@ def test_lambda():
 
 
 @keras_test
+@pytest.mark.skipif((K.backend() == 'theano'),
+                    reason="theano cannot compute "
+                           "the output shape automatically.")
+def test_lambda_output_shape():
+    layer_test(layers.Lambda,
+               kwargs={'function': lambda x: K.mean(x, axis=-1)},
+               input_shape=(3, 2, 4))
+
+
+@keras_test
 def test_dense():
     layer_test(layers.Dense,
                kwargs={'units': 3},


### PR DESCRIPTION
### Summary
When using a Lambda layer and CNTK, the user have to give the function to compute the output shape. But CNTK can infer it (like Tensorflow). So it would make sense to do it for the user and make the API even cleaner.
### Related Issues

### PR Overview

#### Main changes
Some docs updates, as well as a test for checking that a lambda layer can handle a function which changes the shape of the input.

#### Fixing a tests that was not working as intended.
`test_sgd` was broken after my modification. Which was really strange. I investigated and the test was not working as intended. Let me explain:

The function `_test_no_grad` is supposed to test that a `ValueError` is raised when there is no gradient.
But only Tensorflow can detect this anomaly and raise the error. So why isn't this test skipped with other backends? The test was working on all backends but the `ValueError` was different (this is before my modification, result obtained on the master branch):

**Theano**
`ValueError: Error when checking target: expected lambda_1 to have shape (10,) but got array with shape (1,)`

**TensorFlow**
`ValueError: An operation has `None` for gradient. Please make sure that all of your ops have a gradient defined (i.e. are differentiable). Common ops without gradient: K.argmax, K.round, K.eval.`

**CNTK**
`ValueError: Error when checking target: expected lambda_1 to have shape (10,) but got array with shape (1,)`

So the test was passing for all backends! Because the person who made the test forgot to add the argument `output_shape` to the lambda layer.

The test have been fixed. Now everything is working as intended.

### End note:
Maybe `test_no_grad` should not exist at all? We are testing a TensorFlow feature. It would make more sense if this test was in the TensorFlow test suite and not in the Keras one.

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [y] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
