### PR TITLE
 Fix nested sequential deferred build

### DIFF
--- a/keras/engine/sequential.py
+++ b/keras/engine/sequential.py
@@ -149,8 +149,6 @@ class Sequential(Model):
                     first_layer = layer.layers[0]
                     while isinstance(first_layer, (Model, Sequential)):
                         first_layer = first_layer.layers[0]
-                    batch_shape = first_layer.batch_input_shape
-                    dtype = first_layer.dtype
 
                 if hasattr(first_layer, 'batch_input_shape'):
                     batch_shape = first_layer.batch_input_shape

--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -430,7 +430,7 @@ def test_nested_sequential_deferred_build():
 
     model = keras.models.Sequential()
     model.add(inner_model)
-    model.add(Dense(5))
+    model.add(keras.layers.Dense(5))
     model.compile('sgd', 'mse')
 
     assert inner_model.built is False

--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -422,5 +422,45 @@ def test_sequential_deferred_build():
     assert len(new_model.weights) == 4
 
 
+@keras_test
+def test_nested_sequential_deferred_build():
+    inner_model = keras.models.Sequential()
+    inner_model.add(keras.layers.Dense(3))
+    inner_model.add(keras.layers.Dense(3))
+
+    model = keras.models.Sequential()
+    model.add(inner_model)
+    model.add(Dense(5))
+    model.compile('sgd', 'mse')
+
+    assert inner_model.built is False
+    assert len(inner_model.layers) == 2
+    assert len(inner_model.weights) == 0
+    assert model.built is False
+    assert len(model.layers) == 2
+    assert len(model.weights) == 0
+
+    model.train_on_batch(
+        np.random.random((2, 4)), np.random.random((2, 5)))
+
+    assert inner_model.built is True
+    assert len(inner_model.layers) == 2
+    assert len(inner_model.weights) == 4
+    assert model.built is True
+    assert len(model.layers) == 2
+    assert len(model.weights) == 6
+
+    config = model.get_config()
+    new_model = keras.models.Sequential.from_config(config)
+    assert new_model.built is True
+    assert len(new_model.layers) == 2
+    assert len(new_model.weights) == 6
+
+    new_inner_model = new_model.layers[0]
+    assert new_inner_model.built is True
+    assert len(new_inner_model.layers) == 2
+    assert len(new_inner_model.weights) == 4
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
### Summary
When adding a `Sequential` (without `input_shape`) to another `Sequential`, the `add()` operation fails:

```python
inner = Sequential([Dense(5), Dense(5)])
model = Sequential()
model.add(inner)
```
```
keras/engine/sequential.py in add(self, layer)
    150                     while isinstance(first_layer, (Model, Sequential)):
    151                         first_layer = first_layer.layers[0]
--> 152                     batch_shape = first_layer.batch_input_shape
    153                     dtype = first_layer.dtype
    154

AttributeError: 'Dense' object has no attribute 'batch_input_shape'
```

Fix it by removing the duplicated lines causing this error. A unit test is also added for this case.

### Related Issues
None

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
