### PR TITLE
[WIP] Made the overriding of 'compute_output_shape' optional when subclassing a keras layer.

### DIFF
--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -593,6 +593,19 @@ class Layer(object):
         # Returns
             An input shape tuple.
         """
+        # With TensorFlow or CNTK, we can infer the output shape directly:
+        if K.backend() in ('tensorflow', 'cntk'):
+            if isinstance(input_shape, list):
+                xs = [K.placeholder(shape=shape) for shape in input_shape]
+                x = self.call(xs)
+            else:
+                x = K.placeholder(shape=input_shape)
+                x = self.call(x)
+            if isinstance(x, list):
+                return [K.int_shape(x_elem) for x_elem in x]
+            else:
+                return K.int_shape(x)
+        # Otherwise, we default to the input shape.
         return input_shape
 
     def compute_mask(self, inputs, mask=None):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -648,29 +648,18 @@ class Lambda(Layer):
             self._output_shape = output_shape
 
     def compute_output_shape(self, input_shape):
+
         if self._output_shape is None:
-            # With TensorFlow or CNTK, we can infer the output shape directly:
-            if K.backend() in ('tensorflow', 'cntk'):
-                if isinstance(input_shape, list):
-                    xs = [K.placeholder(shape=shape) for shape in input_shape]
-                    x = self.call(xs)
-                else:
-                    x = K.placeholder(shape=input_shape)
-                    x = self.call(x)
-                if isinstance(x, list):
-                    return [K.int_shape(x_elem) for x_elem in x]
-                else:
-                    return K.int_shape(x)
-            # Otherwise, we default to the input shape.
-            warnings.warn('`output_shape` argument not specified for layer {} '
-                          'and cannot be automatically inferred '
-                          'with the Theano backend. '
-                          'Defaulting to output shape `{}` '
-                          '(same as input shape). '
-                          'If the expected output shape is different, '
-                          'specify it via the `output_shape` argument.'
-                          .format(self.name, input_shape))
-            return input_shape
+            if K.backend() == 'theano':
+                warnings.warn('`output_shape` argument not specified for layer {} '
+                              'and cannot be automatically inferred '
+                              'with the Theano backend. '
+                              'Defaulting to output shape `{}` '
+                              '(same as input shape). '
+                              'If the expected output shape is different, '
+                              'specify it via the `output_shape` argument.'
+                              .format(self.name, input_shape))
+            return super(Lambda, self).compute_output_shape(input_shape)
         elif isinstance(self._output_shape, (tuple, list)):
             if isinstance(input_shape, list):
                 num_samples = input_shape[0][0]


### PR DESCRIPTION
# This PR is not ready yet. I'm just making it to have the travis build.

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
