### PR TITLE
Fixed duplication of module name in signature of non-me…

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -369,10 +369,6 @@ def get_function_signature(function, method=True):
         signature = st[:-2] + ')'
     else:
         signature = st + ')'
-
-    if not method:
-        # Prepend the module name.
-        signature = clean_module_name(function.__module__) + '.' + signature
     return post_process_signature(signature)
 
 
@@ -591,8 +587,6 @@ def render_function(function, method=True):
     signature = get_function_signature(function, method=method)
     if method:
         signature = signature.replace(clean_module_name(function.__module__) + '.', '')
-    else:
-        signature = signature.replace(clean_module_name(function.__module__) + '.', '', 1)
     subblocks.append('### ' + function.__name__ + '\n')
     subblocks.append(code_snippet(signature))
     docstring = function.__doc__


### PR DESCRIPTION
…thod functions in autogen docs
### Summary
This PR fixes the real cause of duplicated module name in signature of non-method functions in auto-generated docs which was resolved by PR #10664. I did not address the underlying source of this issue in the mentioned PR. After inspecting the code further, I found out that in `get_function_signature()` function, the module name part of signature is wrongly duplicated for non-method functions like `pad_sequences` and returned. Note that this PR does not change the generated docs in any way since the previous PR has resolved the issue, though not by addressing the underlying cause.
### Related Issues
#10658 
#10662 
### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
