### PR TITLE
Made the `compute_output_shape` method optional when making a custom layer with tensorflow or CNTK.

### DIFF
--- a/docs/templates/layers/writing-your-own-keras-layers.md
+++ b/docs/templates/layers/writing-your-own-keras-layers.md
@@ -6,7 +6,7 @@ Here is the skeleton of a Keras layer, **as of Keras 2.0** (if you have an older
 
 - `build(input_shape)`: this is where you will define your weights. This method must set `self.built = True` at the end, which can be done by calling `super([Layer], self).build()`.
 - `call(x)`: this is where the layer's logic lives. Unless you want your layer to support masking, you only have to care about the first argument passed to `call`: the input tensor.
-- `compute_output_shape(input_shape)`: in case your layer modifies the shape of its input, you should specify here the shape transformation logic. This allows Keras to do automatic shape inference.
+- `compute_output_shape(input_shape)`: in case your layer modifies the shape of its input, you should specify here the shape transformation logic. This allows Keras to do automatic shape inference. Note that this is only necessary when using the Theano backend as it cannot infer the shape automatically.
 
 ```python
 from keras import backend as K
@@ -30,6 +30,7 @@ class MyLayer(Layer):
     def call(self, x):
         return K.dot(x, self.kernel)
 
+	# Optional if you are using Tensorflow or CNTK
     def compute_output_shape(self, input_shape):
         return (input_shape[0], self.output_dim)
 ```

--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -593,6 +593,19 @@ class Layer(object):
         # Returns
             An input shape tuple.
         """
+        # With TensorFlow or CNTK, we can infer the output shape directly:
+        if K.backend() in ('tensorflow', 'cntk'):
+            if isinstance(input_shape, list):
+                xs = [K.placeholder(shape=shape) for shape in input_shape]
+                x = self.call(xs)
+            else:
+                x = K.placeholder(shape=input_shape)
+                x = self.call(x)
+            if isinstance(x, list):
+                return [K.int_shape(x_elem) for x_elem in x]
+            else:
+                return K.int_shape(x)
+        # Otherwise, we default to the input shape.
         return input_shape
 
     def compute_mask(self, inputs, mask=None):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -649,28 +649,17 @@ class Lambda(Layer):
 
     def compute_output_shape(self, input_shape):
         if self._output_shape is None:
-            # With TensorFlow or CNTK, we can infer the output shape directly:
-            if K.backend() in ('tensorflow', 'cntk'):
-                if isinstance(input_shape, list):
-                    xs = [K.placeholder(shape=shape) for shape in input_shape]
-                    x = self.call(xs)
-                else:
-                    x = K.placeholder(shape=input_shape)
-                    x = self.call(x)
-                if isinstance(x, list):
-                    return [K.int_shape(x_elem) for x_elem in x]
-                else:
-                    return K.int_shape(x)
-            # Otherwise, we default to the input shape.
-            warnings.warn('`output_shape` argument not specified for layer {} '
-                          'and cannot be automatically inferred '
-                          'with the Theano backend. '
-                          'Defaulting to output shape `{}` '
-                          '(same as input shape). '
-                          'If the expected output shape is different, '
-                          'specify it via the `output_shape` argument.'
-                          .format(self.name, input_shape))
-            return input_shape
+            if K.backend() == 'theano':
+                warnings.warn('`output_shape` argument not specified for layer {} '
+                              'and cannot be automatically inferred '
+                              'with the Theano backend. '
+                              'Defaulting to output shape `{}` '
+                              '(same as input shape). '
+                              'If the expected output shape is different, '
+                              'specify it via the `output_shape` argument.'
+                              .format(self.name, input_shape))
+            return super(Lambda, self).compute_output_shape(input_shape)
+
         elif isinstance(self._output_shape, (tuple, list)):
             if isinstance(input_shape, list):
                 num_samples = input_shape[0][0]


### PR DESCRIPTION
# Less typing! Cleaner API! Yay!

### Summary
When making a custom layer with Keras, users have to implement `compute_output_shape`.
But this is not always necessary as TensorFlow and CNTK are able to compute it for the user.
The goal of this PR is to make the implementation of this function optional (same as the `Lambda` layer).

### Related Issues

### PR Overview
* Moved the code from the `Lambda` layer to the `Layer` class.

* Two tests were added. 
* We could also do a test with multiple inputs. But it would require more changes to the `layer_test` function

#### Changes to the `layer_test` function:
* Supports testing custom layers
* Support testing layers with multiple outputs.

#### Breaking changes:

I think it's minor, but calling `super().compute_output_shape(x)` won't return x anymore (not all the time).
But this function was useless, I don't see why anyone would have used it (though, Ironically, it was in one of the tests).

Many users will benefits from this PR, and it can save a lot of code (and maths), so I believe that making those small breaking changes are worth it.


- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
