### PR TITLE
Batch Normalization should squeeze mean/var/beta/gama tensors when calling tf.nn.fused_batch_norm

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1881,15 +1881,17 @@ def batch_normalization(x, mean, var, beta, gamma, axis=-1, epsilon=1e-3):
         if tf_data_format == 'NHWC' or tf_data_format == 'NCHW' and _has_nchw_support():
             # The mean / var / beta / gamma may be processed by broadcast
             # so it may have extra axes with 1, it is not needed and should be removed
-            mean = tf.squeeze(mean)
-            var = tf.squeeze(var)
+            if ndim(mean) > 1:
+                mean = tf.squeeze(mean)
+            if ndim(var) > 1:
+                var = tf.squeeze(var)
             if beta is None:
                 beta = zeros_like(mean)
-            else:
+            elif ndim(beta) > 1:
                 beta = tf.squeeze(beta)
             if gamma is None:
                 gamma = ones_like(mean)
-            else:
+            elif ndim(gamma) > 1:
                 gamma = tf.squeeze(gamma)
             y, _, _ = tf.nn.fused_batch_norm(
                 x,

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1879,10 +1879,18 @@ def batch_normalization(x, mean, var, beta, gamma, axis=-1, epsilon=1e-3):
             tf_data_format = None
 
         if tf_data_format == 'NHWC' or tf_data_format == 'NCHW' and _has_nchw_support():
+            # The mean / var / beta / gamma may be processed by broadcast
+            # so it may have extra axes with 1, it is not needed and should be removed
+            mean = tf.squeeze(mean)
+            var = tf.squeeze(var)
             if beta is None:
                 beta = zeros_like(mean)
+            else:
+                beta = tf.squeeze(beta)
             if gamma is None:
                 gamma = ones_like(mean)
+            else:
+                gamma = tf.squeeze(gamma)
             y, _, _ = tf.nn.fused_batch_norm(
                 x,
                 gamma,


### PR DESCRIPTION
### Summary
```BatchNormalization``` layer, mean/var/beta/gama tensors may be [broadcast](https://github.com/keras-team/keras/blob/master/keras/layers/normalization.py#L140). 
```
input = Input(shape=(3, 1001, 1001), dtype='float32')
x = Conv2D(filters=64, kernel_size=(3, 3), strides=1, padding='same')(input)
x = BatchNormalization(axis=1)(x)
```
In the above example, as you set ```axis=1```, the mean/var/beta/gama tensors would be reshaped as [1,64,1,1]. For TF backend, it will try to call the optimized ```tf.nn.fused_batch_norm``` if possible. But ```tf.nn.fused_batch_norm``` only accept mean/var/beta/gama as 1 dimension tensor, we need to squeeze them ahead.
Actually we have did same preprocessing for [CNTK backend](https://github.com/keras-team/keras/blob/master/keras/backend/cntk_backend.py#L1070).

Note: This bug should only happened when TF-GPU as backend, since TF-CPU FusedBatchNorm doesn't support NCHW format, and it will fall back to the default ```tf.nn.batch_normalization```.   

### Related Issues
https://github.com/keras-team/keras/issues/10648

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
