### PR TITLE
The argument bias_initializer was not used in _SeparableConv. 

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1285,6 +1285,7 @@ class _SeparableConv(_Conv):
             dilation_rate=dilation_rate,
             activation=activation,
             use_bias=use_bias,
+            bias_initializer=bias_initializer,
             bias_regularizer=bias_regularizer,
             activity_regularizer=activity_regularizer,
             bias_constraint=bias_constraint,


### PR DESCRIPTION
### Summary

I think it was meant to be passed it to the `__init__` of the parent class.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
