### PR TITLE
Removed some unused variables and fixed a formatting error.

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -270,7 +270,7 @@ def placeholder(
         raise ValueError('CNTK backend: creating placeholder with '
                          '%d dimension is not supported, at least '
                          '%d dimensions are needed.'
-                         % (len(cntk_shape, dynamic_axis_num)))
+                         % (len(cntk_shape), dynamic_axis_num))
 
     if name is None:
         name = ''

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -224,7 +224,7 @@ def get_file(fname,
                 raise Exception(error_msg.format(origin, e.errno, e.reason))
             except HTTPError as e:
                 raise Exception(error_msg.format(origin, e.code, e.msg))
-        except (Exception, KeyboardInterrupt) as e:
+        except (Exception, KeyboardInterrupt):
             if os.path.exists(fpath):
                 os.remove(fpath)
             raise

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -102,7 +102,6 @@ def model_to_dot(model,
 
     # Connect nodes with edges.
     for layer in layers:
-        layer_id = str(id(layer))
         for i, node in enumerate(layer._inbound_nodes):
             node_key = layer.name + '_ib-' + str(i)
             if node_key in model._network_nodes:

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -102,12 +102,12 @@ def model_to_dot(model,
 
     # Connect nodes with edges.
     for layer in layers:
+        layer_id = str(id(layer))
         for i, node in enumerate(layer._inbound_nodes):
             node_key = layer.name + '_ib-' + str(i)
             if node_key in model._network_nodes:
                 for inbound_layer in node.inbound_layers:
                     inbound_layer_id = str(id(inbound_layer))
-                    layer_id = str(id(layer))
                     dot.add_edge(pydot.Edge(inbound_layer_id, layer_id))
     return dot
 


### PR DESCRIPTION
### Summary
The exception `e` isn't used and `layer_id` is redefined later.
Also when the ValueError was raised, one would get the following error instead:

```
TypeError: len() takes exactly one argument (2 given)
```
### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
