### PR TITLE
Fix PEP8 pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,7 +14,6 @@ norecursedirs= build
 
 pep8ignore=* E402 \
            * E731 \
-           setup.py E501 \
            docs/autogen.py E501 \
            docs/__init__.py E501 \
            examples/addition_rnn.py E501 \
@@ -194,4 +193,4 @@ pep8ignore=* E402 \
            tests/keras/wrappers/scikit_learn_test.py E501
 
 # Enable line length testing with maximum line length of 85
-+pep8maxlinelength = 85
+pep8maxlinelength = 85


### PR DESCRIPTION
### Summary
Fix a typo in pytest.ini that makes`pep8maxlinelength = 85` not working.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [X] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
