### PR TITLE
Travis CI: reduce hardcoding of Python 3 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
   - pip install -e .[tests]
 
   # install TensorFlow (CPU version).
-  - pip install tensorflow
+  #- pip install tensorflow==1.7
   
   # install cntk
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,27 +3,24 @@ dist: trusty
 language: python
 matrix:
     include:
-        #- python: 2.7
-        #  env: KERAS_BACKEND=tensorflow TEST_MODE=PEP8
-        #- python: 2.7
-        #  env: KERAS_BACKEND=tensorflow TEST_MODE=INTEGRATION_TESTS
-        #- python: 3.6
-        #  env: KERAS_BACKEND=tensorflow TEST_MODE=DOC
-        #- python: 2.7
-        #  env: KERAS_BACKEND=tensorflow
-        #- python: 3.6
-        #  env: KERAS_BACKEND=tensorflow
+        - python: 2.7
+          env: KERAS_BACKEND=tensorflow TEST_MODE=PEP8
+        - python: 2.7
+          env: KERAS_BACKEND=tensorflow TEST_MODE=INTEGRATION_TESTS
+        - python: 3.6
+          env: KERAS_BACKEND=tensorflow TEST_MODE=DOC
+        - python: 2.7
+          env: KERAS_BACKEND=tensorflow
+        - python: 3.6
+          env: KERAS_BACKEND=tensorflow
         - python: 2.7
           env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
         - python: 3.6
           env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
-        - python: 3.7
-          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
-          dist: xenial  # required for Python 3.7
-        #- python: 2.7
-        #  env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
-        #- python: 3.6
-        #  env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
+        - python: 2.7
+          env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
+        - python: 3.6
+          env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
 install:
   # code below is taken from http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the
@@ -60,7 +57,7 @@ install:
   - pip install -e .[tests]
 
   # install TensorFlow (CPU version).
-  #- pip install tensorflow==1.7
+  - pip install tensorflow==1.7
   
   # install cntk
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
   - pip install -e .[tests]
 
   # install TensorFlow (CPU version).
-  - pip install tensorflow==1.7
+  - pip install tensorflow
   
   # install cntk
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
           env: KERAS_BACKEND=tensorflow
         - python: 3.6
           env: KERAS_BACKEND=tensorflow
+        - python: 3.7
+          env: KERAS_BACKEND=tensorflow
+          dist: xenial  # required for Python 3.7
         - python: 2.7
           env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
         - python: 3.6
@@ -50,7 +53,7 @@ install:
   # install PIL for preprocessing tests
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       conda install pil;
-    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
+    else
       conda install Pillow;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,27 +3,27 @@ dist: trusty
 language: python
 matrix:
     include:
+        #- python: 2.7
+        #  env: KERAS_BACKEND=tensorflow TEST_MODE=PEP8
+        #- python: 2.7
+        #  env: KERAS_BACKEND=tensorflow TEST_MODE=INTEGRATION_TESTS
+        #- python: 3.6
+        #  env: KERAS_BACKEND=tensorflow TEST_MODE=DOC
+        #- python: 2.7
+        #  env: KERAS_BACKEND=tensorflow
+        #- python: 3.6
+        #  env: KERAS_BACKEND=tensorflow
         - python: 2.7
-          env: KERAS_BACKEND=tensorflow TEST_MODE=PEP8
-        - python: 2.7
-          env: KERAS_BACKEND=tensorflow TEST_MODE=INTEGRATION_TESTS
+          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
         - python: 3.6
-          env: KERAS_BACKEND=tensorflow TEST_MODE=DOC
-        - python: 2.7
-          env: KERAS_BACKEND=tensorflow
-        - python: 3.6
-          env: KERAS_BACKEND=tensorflow
+          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
         - python: 3.7
-          env: KERAS_BACKEND=tensorflow
+          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
           dist: xenial  # required for Python 3.7
-        - python: 2.7
-          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
-        - python: 3.6
-          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
-        - python: 2.7
-          env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
-        - python: 3.6
-          env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
+        #- python: 2.7
+        #  env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
+        #- python: 3.6
+        #  env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
 install:
   # code below is taken from http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the


### PR DESCRIPTION
### Summary
Python 2.7 needs __pil__ but _all other_ currently supported versions of Python need __Pillow__ instead.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
