### PR TITLE
Numpy ndarray should be serialized as Python list.

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -79,8 +79,7 @@ def save_model(model, filepath, overwrite=True, include_optimizer=True):
         # if obj is any numpy type
         if type(obj).__module__ == np.__name__:
             if isinstance(obj, np.ndarray):
-                return {'type': type(obj),
-                        'value': obj.tolist()}
+                return obj.tolist()
             else:
                 return obj.item()
 

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -12,6 +12,7 @@ from keras.models import Model, Sequential
 from keras.layers import Dense, Lambda, RepeatVector, TimeDistributed, Bidirectional, GRU, LSTM, CuDNNGRU, CuDNNLSTM
 from keras.layers import Conv2D, Flatten
 from keras.layers import Input, InputLayer
+from keras.initializers import Constant
 from keras import optimizers
 from keras import losses
 from keras import metrics
@@ -638,6 +639,22 @@ def test_saving_recurrent_layer_without_bias():
     model.save(fname)
 
     loaded_model = load_model(fname)
+    os.remove(fname)
+
+
+@keras_test
+def test_saving_constant_initializer_with_numpy():
+    """
+    Test saving and loading model of constant initializer with numpy ndarray as input.
+    """
+    model = Sequential()
+    model.add(Dense(2, input_shape=(3,), kernel_initializer=Constant(np.ones((3, 2)))))
+    model.add(Dense(3))
+    model.compile(loss='mse', optimizer='sgd', metrics=['acc'])
+
+    _, fname = tempfile.mkstemp('.h5')
+    save_model(model, fname)
+    model = load_model(fname)
     os.remove(fname)
 
 

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -644,8 +644,7 @@ def test_saving_recurrent_layer_without_bias():
 
 @keras_test
 def test_saving_constant_initializer_with_numpy():
-    """
-    Test saving and loading model of constant initializer with numpy ndarray as input.
+    """Test saving and loading model of constant initializer with numpy ndarray as input.
     """
     model = Sequential()
     model.add(Dense(2, input_shape=(3,), kernel_initializer=Constant(np.ones((3, 2)))))


### PR DESCRIPTION
### Summary
If there is numpy ndarray in a layer config, for example, set ```Constant(np.zeros(2,3))``` as the initializer, the internal representation should be Tensor in backend(not discriminate numpy ndarray or Python list). When serializing it to JSON format, it should be regards as normal Python list. Otherwise, it will throw exception when deserialization(Refer #10718), since ```from_config``` doesn't know(doesn't need) how to deserialize numpy ndarray if there are extra message header.

Note: I have verify this fix works well for #10718.

### Related Issues
#10718 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
