### PR TITLE
TF Batch Normalization should use FusedBatchNorm when axis = -1

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1872,9 +1872,9 @@ def batch_normalization(x, mean, var, beta, gamma, axis=-1, epsilon=1e-3):
     """
     if ndim(x) == 4:
         # The CPU implementation of FusedBatchNorm only support NHWC
-        if axis == 1:
+        if axis == 1 or axis == -3:
             tf_data_format = 'NCHW'
-        elif axis == 3:
+        elif axis == 3 or axis == -1:
             tf_data_format = 'NHWC'
         else:
             tf_data_format = None


### PR DESCRIPTION
### Summary
When applying ```BatchNormalization``` to ```Conv2D```, TF backend try to use ```FusedBatchNorm``` for optimization(when ```axis=1``` and ```axis=3```), we should cover their equivalent condition(```axis=-3``` and ```axis=-1```) as well. Since the default value for axis is -1, it's common case that users don't set axis explicitly, then they won't get optimized code route before this fix.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
