### PR TITLE
Fix signature of functions and methods in generated docs

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -115,7 +115,7 @@ EXCLUDE = {
 PAGES = [
     {
         'page': 'models/sequential.md',
-        'functions': [
+        'methods': [
             models.Sequential.compile,
             models.Sequential.fit,
             models.Sequential.evaluate,
@@ -131,7 +131,7 @@ PAGES = [
     },
     {
         'page': 'models/model.md',
-        'functions': [
+        'methods': [
             models.Model.compile,
             models.Model.fit,
             models.Model.evaluate,
@@ -370,10 +370,6 @@ def get_function_signature(function, method=True):
         signature = st[:-2] + ')'
     else:
         signature = st + ')'
-
-    if not method:
-        # Prepend the module name.
-        signature = clean_module_name(function.__module__) + '.' + signature
     return post_process_signature(signature)
 
 
@@ -597,9 +593,6 @@ def render_function(function, method=True):
     if method:
         signature = signature.replace(
             clean_module_name(function.__module__) + '.', '')
-    else:
-        signature = signature.replace(
-            clean_module_name(function.__module__) + '.', '', 1)
     subblocks.append('### ' + function.__name__ + '\n')
     subblocks.append(code_snippet(signature))
     docstring = function.__doc__
@@ -609,7 +602,7 @@ def render_function(function, method=True):
 
 
 def read_page_data(page_data, type):
-    assert type in ['classes', 'functions']
+    assert type in ['classes', 'functions', 'methods']
     data = page_data.get(type, [])
     for module in page_data.get('all_module_{}'.format(type), []):
         module_data = []
@@ -664,11 +657,16 @@ if __name__ == '__main__':
                     [render_function(method, method=True) for method in methods]))
             blocks.append('\n'.join(subblocks))
 
+        methods = read_page_data(page_data, 'methods')
+
+        for method in methods:
+            blocks.append(render_function(method, method=True))
+
         functions = read_page_data(page_data, 'functions')
 
         for function in functions:
             blocks.append(render_function(function, method=False))
-
+        
         if not blocks:
             raise RuntimeError('Found no content for page ' +
                                page_data['page'])

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -666,7 +666,7 @@ if __name__ == '__main__':
 
         for function in functions:
             blocks.append(render_function(function, method=False))
-            
+
         if not blocks:
             raise RuntimeError('Found no content for page ' +
                                page_data['page'])

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -666,7 +666,7 @@ if __name__ == '__main__':
 
         for function in functions:
             blocks.append(render_function(function, method=False))
-        
+            
         if not blocks:
             raise RuntimeError('Found no content for page ' +
                                page_data['page'])


### PR DESCRIPTION
### Summary
This PR resolves two issues:
1) The `get_function_signature` in `autogen.py` duplicates module name for non-method functions. For example, it returns `keras.preprocessing.sequence.keras.preprocessing.sequence.pad_sequences` instead of `keras.preprocessing.sequence.pad_sequences`.

2) Method functions and non-method functions should be distinguished from each other. Since, the module name of non-method functions should be included in the signature in the docs (like `keras.preprocessing.sequence.pad_sequences(...)`) whereas for the methods of classes it should not be included (like `compile(...)` for `Sequential` class). Therefore, a new `'methods'` key is introduced to make this distinction.

Note that I temporary resolved the first issue by a merged PR (#10664); however that PR did not address the underlying problem.

### Related Issues
#10658 
#10662 
### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
