### PR TITLE
Fixing HDF5Matrix `.dtype` and `.shape` properties

### DIFF
--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -58,6 +58,12 @@ class HDF5Matrix(object):
         else:
             self.end = end
         self.normalizer = normalizer
+        if self.normalizer is not None:
+            first_val = self.normalizer(self.data[0:1])
+        else:
+            first_val = self.data[0:1]
+        self._base_shape = first_val.shape[1:]
+        self._base_dtype = first_val.dtype
 
     def __len__(self):
         return self.end - self.start
@@ -101,7 +107,7 @@ class HDF5Matrix(object):
         # Returns
             A numpy-style shape tuple.
         """
-        return (self.end - self.start,) + self.data.shape[1:]
+        return (self.end - self.start,) + self._base_shape
 
     @property
     def dtype(self):
@@ -110,7 +116,7 @@ class HDF5Matrix(object):
         # Returns
             A numpy dtype string.
         """
-        return self.data.dtype
+        return self._base_dtype
 
     @property
     def ndim(self):

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -103,12 +103,12 @@ def test_io_utils(in_tmpdir):
     normalizer = lambda x: x + 1
     normalized_X_train = HDF5Matrix(h5_path, 'my_data', start=0, end=150, normalizer=normalizer)
     assert np.isclose(normalized_X_train[0][0], X_train[0][0] + 1)
-    
+
     # test resizing normalizer
     normalizer_rs = lambda x: x[:, ::2]
     normalized_rs_X_train = HDF5Matrix(h5_path, 'my_data', start=0, end=150, normalizer=normalizer_rs)
     assert (normalized_rs_X_train.shape[1] == 5)
-    
+
     # test dtype changing normalizer
     normalizer_dtype = lambda x: x.astype(np.uint8)
     normalized_dtype_X_train = HDF5Matrix(h5_path, 'my_data', start=0, end=150, normalizer=normalizer_dtype)

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -103,6 +103,16 @@ def test_io_utils(in_tmpdir):
     normalizer = lambda x: x + 1
     normalized_X_train = HDF5Matrix(h5_path, 'my_data', start=0, end=150, normalizer=normalizer)
     assert np.isclose(normalized_X_train[0][0], X_train[0][0] + 1)
+    
+    # test resizing normalizer
+    normalizer_rs = lambda x: x[:, ::2]
+    normalized_rs_X_train = HDF5Matrix(h5_path, 'my_data', start=0, end=150, normalizer=normalizer_rs)
+    assert (normalized_rs_X_train.shape[1] == 5)
+    
+    # test dtype changing normalizer
+    normalizer_dtype = lambda x: x.astype(np.uint8)
+    normalized_dtype_X_train = HDF5Matrix(h5_path, 'my_data', start=0, end=150, normalizer=normalizer_dtype)
+    assert (normalized_dtype_X_train.dtype == np.uint8)
 
     os.remove(h5_path)
 


### PR DESCRIPTION
### Summary

Adding code to the initialization function of `HDF5Matrix` so that `.dtype` and `.shape` reflect the actual values returned by the normalizer. This is particularly important because the `model.fit` function looks at the shape to determine if the code can be run and if there are changes to shape (random cropping, downsampling, edge removal, ...) performed in the normalizer these are not currently reflected in the `.shape` property. The dtype mismatch currently does not cause any issues (that I know of) but should also be adjusted as well. 

### Related Issues
https://github.com/keras-team/keras/issues/8304

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
