### PR TITLE
Network.to_json should handle numpy.ndarray correctly.

### DIFF
--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -1193,7 +1193,10 @@ class Network(Layer):
         def get_json_type(obj):
             # If obj is any numpy type
             if type(obj).__module__ == np.__name__:
-                return obj.item()
+                if isinstance(obj, np.ndarray):
+                    return obj.tolist()
+                else:
+                    return obj.item()
 
             # If obj is a python 'type'
             if type(obj).__name__ == type.__name__:

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -9,6 +9,7 @@ from keras.models import Model, Sequential
 from keras import backend as K
 from keras.models import model_from_json, model_from_yaml
 from keras.utils.test_utils import keras_test
+from keras.initializers import Constant
 
 
 skipif_no_tf_gpu = pytest.mark.skipif(
@@ -795,6 +796,20 @@ def test_multi_output_mask():
     z = ArbitraryMultiInputLayer()([x, y])
     _ = Model(inputs=input_layer, outputs=z)
     assert K.int_shape(z)[1:] == (16, 16, 3)
+
+
+@keras_test
+def test_constant_initializer_with_numpy():
+    model = Sequential()
+    model.add(Dense(2, input_shape=(3,), kernel_initializer=Constant(np.ones((3, 2)))))
+    model.add(Dense(3))
+    model.compile(loss='mse', optimizer='sgd', metrics=['acc'])
+
+    json_str = model.to_json()
+    model_from_json(json_str).summary()
+
+    yaml_str = model.to_yaml()
+    model_from_yaml(yaml_str).summary()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary
Similar as #10727, when we serialize a ```Network``` by ```to_json```, we should handle ```numpy.ndarray``` correctly if there is. For example: 
```
model = Sequential()
model.add(Dense(2, input_shape=(3,), kernel_initializer=Constant(np.ones((3, 2)))))
model.add(Dense(3))
model.compile(loss='mse', optimizer='sgd', metrics=['acc'])
model.to_json()
```
It throws the following error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "keras/engine/network.py", line 1205, in to_json
    return json.dumps(model_config, default=get_json_type, **kwargs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 250, in dumps
    sort_keys=sort_keys, **kw).encode(obj)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
  File "keras/engine/network.py", line 1196, in get_json_type
    return obj.item()
ValueError: can only convert an array of size 1 to a Python scalar
```

Note: ```tf.keras``` should have the same issue, will send a fix if this get approved.

### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
