### PR TITLE
EarlyStopping: restore model weights corresponding to best value of monitored quantity

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -456,9 +456,7 @@ class ModelCheckpoint(Callback):
 
 
 class EarlyStopping(Callback):
-    """Stop training when a monitored quantity has stopped improving and
-       restore the model weights from the epoch with the best value
-       of the monitored quantity.
+    """Stop training when a monitored quantity has stopped improving.
 
     # Arguments
         monitor: quantity to be monitored.
@@ -479,6 +477,10 @@ class EarlyStopping(Callback):
         baseline: Baseline value for the monitored quantity to reach.
             Training will stop if the model doesn't show improvement
             over the baseline.
+        restore_best_weights: whether to restore model weights from
+            the epoch with the best value of the monitored quantity.
+            If False, the model weights obtained at the last step of
+            training are used.
     """
 
     def __init__(self,
@@ -487,7 +489,8 @@ class EarlyStopping(Callback):
                  patience=0,
                  verbose=0,
                  mode='auto',
-                 baseline=None):
+                 baseline=None,
+                 restore_best_weights=False):
         super(EarlyStopping, self).__init__()
 
         self.monitor = monitor
@@ -497,7 +500,8 @@ class EarlyStopping(Callback):
         self.min_delta = min_delta
         self.wait = 0
         self.stopped_epoch = 0
-        self.good_weights = None
+        self.restore_best_weights = restore_best_weights
+        self.best_weights = None
 
         if mode not in ['auto', 'min', 'max']:
             warnings.warn('EarlyStopping mode %s is unknown, '
@@ -541,13 +545,17 @@ class EarlyStopping(Callback):
         if self.monitor_op(current - self.min_delta, self.best):
             self.best = current
             self.wait = 0
-            self.good_weights = self.model.get_weights()
+            if self.restore_best_weights:
+                self.best_weights = self.model.get_weights()
         else:
             self.wait += 1
             if self.wait >= self.patience:
                 self.stopped_epoch = epoch
                 self.model.stop_training = True
-                self.model.set_weights(self.good_weights)
+                if self.restore_best_weights:
+                    if self.verbose > 0:
+                        print("Restoring model weights from the end of the best epoch")
+                    self.model.set_weights(self.best_weights)
 
     def on_train_end(self, logs=None):
         if self.stopped_epoch > 0 and self.verbose > 0:

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -456,7 +456,9 @@ class ModelCheckpoint(Callback):
 
 
 class EarlyStopping(Callback):
-    """Stop training when a monitored quantity has stopped improving.
+    """Stop training when a monitored quantity has stopped improving and
+       restore the model weights from the epoch with the best value
+       of the monitored quantity.
 
     # Arguments
         monitor: quantity to be monitored.
@@ -495,6 +497,7 @@ class EarlyStopping(Callback):
         self.min_delta = min_delta
         self.wait = 0
         self.stopped_epoch = 0
+        self.good_weights = None
 
         if mode not in ['auto', 'min', 'max']:
             warnings.warn('EarlyStopping mode %s is unknown, '
@@ -538,11 +541,13 @@ class EarlyStopping(Callback):
         if self.monitor_op(current - self.min_delta, self.best):
             self.best = current
             self.wait = 0
+            self.good_weights = self.model.get_weights()
         else:
             self.wait += 1
             if self.wait >= self.patience:
                 self.stopped_epoch = epoch
                 self.model.stop_training = True
+                self.model.set_weights(self.good_weights)
 
     def on_train_end(self, logs=None):
         if self.stopped_epoch > 0 and self.verbose > 0:

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -267,6 +267,12 @@ def test_EarlyStopping_patience():
         def __init__(self):
             self.stop_training = False
 
+        def get_weights(self):
+            return []
+
+        def set_weights(self, weights):
+            pass
+
     early_stop = callbacks.EarlyStopping(monitor='val_loss', patience=2)
     early_stop.model = DummyModel()
 
@@ -292,6 +298,12 @@ def test_EarlyStopping_baseline():
         def __init__(self):
             self.stop_training = False
 
+        def get_weights(self):
+            return []
+
+        def set_weights(self, weights):
+            pass
+
     def baseline_tester(acc_levels):
         early_stop = callbacks.EarlyStopping(monitor='val_acc', baseline=0.75, patience=2)
         early_stop.model = DummyModel()
@@ -313,6 +325,44 @@ def test_EarlyStopping_baseline():
     assert baseline_met == 4
     # Baseline was not met by second epoch and should stop
     assert baseline_not_met == 2
+
+
+@keras_test
+def test_EarlyStopping_final_weights():
+    class DummyModel(object):
+        def __init__(self):
+            self.stop_training = False
+            self.weights = -1
+
+        def get_weights(self):
+            return self.weights
+
+        def set_weights(self, weights):
+            self.weights = weights
+
+        def set_weight_to_epoch(self, epoch):
+            self.weights = epoch
+
+    early_stop = callbacks.EarlyStopping(monitor='val_loss', patience=2)
+    early_stop.model = DummyModel()
+
+    losses = [0.2, 0.15, 0.1, 0.11, 0.12]
+
+    # The best configuration is in the epoch 2 (loss = 0.1000).
+
+    epochs_trained = 0
+    early_stop.on_train_begin()
+
+    for epoch in range(len(losses)):
+        epochs_trained += 1
+        early_stop.model.set_weight_to_epoch(epoch=epoch)
+        early_stop.on_epoch_end(epoch, logs={'val_loss': losses[epoch]})
+
+        if early_stop.model.stop_training:
+            break
+
+    # the weight has to be "2" (we're using the epoch here as weight)
+    assert early_stop.model.get_weights() == 2
 
 
 @keras_test


### PR DESCRIPTION
### Summary

The current implementation of EarlyStopping monitors a user-specified quantity, and stops training after [patience] epochs have passed since the last best value of the monitored quantity.

In the **current** implementation, the final model weights are those at the end of the patience period.

In the **proposed** implementation, the final model weights are those from the epoch with the best value of the monitored quantity, in agreement with the original paper [1] as well as [2].

The proposed implementation includes an additional test case (test_EarlyStopping_final_weights) in test_callbacks.py; it also makes two existing test cases (test_EarlyStopping_patience and test_EarlyStopping_baseline) compatible with the proposed implementation.

[1]
Advances in Neural Information Processing Systems 2", San Mateo, California, 1990, pages 630-637
[2]
Prechelt L. (2012) Early Stopping — But When?. In: Montavon G., Orr G.B., Müller KR. (eds) Neural Networks: Tricks of the Trade. Lecture Notes in Computer Science, vol 7700. Springer, Berlin, Heidelberg

### Related Issues
None

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
