### PR TITLE
Make InputLayer support masking

### DIFF
--- a/keras/engine/input_layer.py
+++ b/keras/engine/input_layer.py
@@ -42,6 +42,7 @@ class InputLayer(Layer):
         self.trainable = False
         self.built = True
         self.sparse = sparse
+        self.supports_masking = True
 
         if input_shape and batch_input_shape:
             raise ValueError('Only provide the input_shape OR '

--- a/tests/keras/layers/core_test.py
+++ b/tests/keras/layers/core_test.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 
 from keras import backend as K
 from keras import layers
-from keras.models import Model
+from keras.models import Model, Sequential
 from keras.utils.test_utils import layer_test
 from keras.utils.test_utils import keras_test
 from keras import regularizers
@@ -341,6 +341,31 @@ def test_activity_regularization():
     model_config = model.get_config()
     model = Model.from_config(model_config)
     model.compile('rmsprop', 'mse')
+
+
+@keras_test
+def test_sequential_as_downstream_of_masking_layer():
+
+    input = layers.Input(shape=(3, 4))
+    x = layers.Masking(mask_value=0., input_shape=(3, 4))(input)
+    s = Sequential()
+    s.add(layers.Dense(5, input_shape=(4,)))
+    s.add(layers.Activation('relu'))
+    x = layers.wrappers.TimeDistributed(s)(x)
+    model = Model(inputs=input, outputs=x)
+    model.compile(optimizer='rmsprop', loss='mse')
+    model_input = np.random.randint(low=1, high=5, size=(10, 3, 4))
+    for i in range(4):
+        model_input[i, i:, :] = 0.
+    model.fit(model_input,
+        np.random.random((10, 3, 5)), epochs=1, batch_size=6)
+
+    mask_outputs = [model.layers[1].compute_mask(model.layers[1].input)]
+    mask_outputs += [model.layers[2].compute_mask(model.layers[2].input, mask_outputs[-1])]
+    func = K.function([model.input], mask_outputs)
+    mask_outputs_val = func([model_input])
+    assert np.array_equal(mask_outputs_val[0], np.any(model_input, axis=-1))
+    assert np.array_equal(mask_outputs_val[1], np.any(model_input, axis=-1))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary
```Sequential``` add ```InputLayer``` automatically if users don't assign. We ```Sequential``` was placed as downstream of ```Masking``` layer(#10763), it would throw exception due to ```InputLayer``` doesn't support masking.
I think ```InputLayer``` should support masking and it can use the default ```compute_mask``` function in base layer(just carry over the input mask). 

### Related Issues
#10763

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
