### PR TITLE
Add missing to_list to multi_gpu_utils

### DIFF
--- a/keras/utils/multi_gpu_utils.py
+++ b/keras/utils/multi_gpu_utils.py
@@ -9,6 +9,7 @@ from .. import backend as K
 from ..layers.core import Lambda
 from ..engine.training import Model
 from ..models import clone_model
+from ..utils.generic_utils import to_list
 
 
 def _get_available_devices():


### PR DESCRIPTION
### Summary
Add missing import ```to_list``` to ```multi_gpu_utils.py```.

### Related Issues
#10792

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
