### PR TITLE
Exclude CNTK legacy codes when reporting coverages

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =
+    pragma: no cover
     os.remove
     except ImportError
     # Don't complain if tests don't hit defensive assertion code:

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2031,7 +2031,7 @@ def temporal_padding(x, padding=(1, 1)):
     return pad(x, [padding], 'channels_last', num_dynamic_axis)
 
 
-def _padding(x, pattern, axis):
+def _padding(x, pattern, axis):  # pragma: no cover
     base_shape = x.shape
     if b_any([dim < 0 for dim in base_shape]):
         raise ValueError('CNTK Backend: padding input tensor with '
@@ -2062,7 +2062,7 @@ def pad(x, pad_info, data_format, num_dynamic_axis):
         if num_dynamic_axis == 0:
             pattern = [[0, 0]] + pattern
         return C.pad(x, pattern=pattern)
-    else:
+    else:  # pragma: no cover
         for (a, p) in enumerate(pad_info):
             x = _padding(x, p,
                          a + (1 if num_dynamic_axis == 0 else 0) +


### PR DESCRIPTION
This PR excludes CNTK legacy codes when reporting coverages (the `_padding` is for the old versions that don't have `C.pad`). This affects only calculating test coverages.