### PR TITLE
Added missing engine parameter.

### DIFF
--- a/keras/applications/__init__.py
+++ b/keras/applications/__init__.py
@@ -12,6 +12,7 @@ import keras_applications
 
 keras_applications.set_keras_submodules(
     backend=backend,
+    engine=engine,
     layers=layers,
     models=models,
     utils=utils)


### PR DESCRIPTION
### Summary

This fixes the error "TypeError: set_keras_submodules() missing 1 required positional argument: 'engine'".

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
