### PR TITLE
TimeDistributed._get_shape_tuple should work well in compute_mask

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -187,14 +187,15 @@ class TimeDistributed(Wrapper):
         if int_shape and not any(not s for s in int_shape):
             return init_tuple + int_shape
         tensor_shape = K.shape(tensor)
-        # replace all None in int_shape by K.shape
         if int_shape:
+            # replace all None in int_shape by K.shape
             int_shape = list(int_shape)
             for i, s in enumerate(int_shape):
                 if not s:
                     int_shape[i] = tensor_shape[start_idx + i]
             return init_tuple + tuple(int_shape)
         else:
+            # fully fall back to use K.shape
             if K.backend() == "tensorflow":
                 ts1 = K.stack(list(init_tuple))
                 ts2 = K.slice(tensor_shape, [start_idx], [-1])

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -193,9 +193,14 @@ class TimeDistributed(Wrapper):
             for i, s in enumerate(int_shape):
                 if not s:
                     int_shape[i] = tensor_shape[start_idx + i]
+            return init_tuple + tuple(int_shape)
         else:
-            int_shape = tensor_shape[start_idx:]
-        return init_tuple + tuple(int_shape)
+            if K.backend() == "tensorflow":
+                ts1 = K.stack(list(init_tuple))
+                ts2 = K.slice(tensor_shape, [start_idx], [-1])
+                return K.concatenate([ts1, ts2])
+            else:
+                return init_tuple + tuple(tensor_shape[start_idx:])
 
     def build(self, input_shape):
         assert len(input_shape) >= 3

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -182,12 +182,12 @@ class TimeDistributed(Wrapper):
         # get int_shape if available
         if int_shape is None:
             int_shape = K.int_shape(tensor)
-            if int_shape:
+            if int_shape is not None:
                 int_shape = int_shape[start_idx:]
-        if int_shape and not any(not s for s in int_shape):
+        if int_shape is not None and not any(not s for s in int_shape):
             return init_tuple + int_shape
         tensor_shape = K.shape(tensor)
-        if int_shape:
+        if int_shape is not None:
             # replace all None in int_shape by K.shape
             int_shape = list(int_shape)
             for i, s in enumerate(int_shape):

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -179,16 +179,22 @@ class TimeDistributed(Wrapper):
             or K.int_shape(tensor), where every `None` is replaced by
             the corresponding dimension from K.shape(tensor)
         """
-        # replace all None in int_shape by K.shape
+        # get int_shape if available
         if int_shape is None:
-            int_shape = K.int_shape(tensor)[start_idx:]
-        if not any(not s for s in int_shape):
+            int_shape = K.int_shape(tensor)
+            if int_shape:
+                int_shape = int_shape[start_idx:]
+        if int_shape and not any(not s for s in int_shape):
             return init_tuple + int_shape
         tensor_shape = K.shape(tensor)
-        int_shape = list(int_shape)
-        for i, s in enumerate(int_shape):
-            if not s:
-                int_shape[i] = tensor_shape[start_idx + i]
+        # replace all None in int_shape by K.shape
+        if int_shape:
+            int_shape = list(int_shape)
+            for i, s in enumerate(int_shape):
+                if not s:
+                    int_shape[i] = tensor_shape[start_idx + i]
+        else:
+            int_shape = tensor_shape[start_idx:]
         return init_tuple + tuple(int_shape)
 
     def build(self, input_shape):

--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -643,5 +643,19 @@ def test_Bidirectional_losses():
     assert len(layer.get_losses_for(x)) == 2
 
 
+@keras_test
+def test_TimeDistributed_with_mask_get_shape_tuple():
+    # TimeDistributed._get_shape_tuple should work well in compute_mask
+    # if it can't get static shape by K.int_shape
+    input1 = Input(shape=(4,))
+    input2 = Input(shape=(4,))
+    x1 = layers.Embedding(10, 3, input_length=4, mask_zero=True)(input1)
+    x2 = layers.Embedding(10, 3, input_length=4, mask_zero=True)(input2)
+    x = layers.concatenate([x1, x2])
+    x = wrappers.TimeDistributed(layers.Dense(3, activation='softmax'))(x)
+    model = Model(inputs=[input1, input2], outputs=[x])
+    model.summary()
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
### Summary
Run the following code with theano backend:
```
from keras.layers import Input, Embedding, Dense
from keras.layers.wrappers import TimeDistributed
from keras.layers.merge import concatenate
from keras.models import Model

input1 = Input(shape=(20,))
input2 = Input(shape=(20,))
x1 = Embedding(10000, 10, input_length=20, mask_zero=True)(input1)
x2 = Embedding(10000, 10, input_length=20, mask_zero=True)(input2)
x = concatenate([x1, x2])
x = TimeDistributed(Dense(8, activation='softmax'))(x)
model = Model(inputs=[input1, input2], outputs=[x])
```
```TimeDistributed._get_shape_tuple``` throws exceptions due to theano ```K.int_shape``` return ```None```. 
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "keras/engine/base_layer.py", line 458, in __call__
    output_mask = self.compute_mask(inputs, previous_mask)
  File "keras/layers/wrappers.py", line 300, in compute_mask
    inner_mask_shape = self._get_shape_tuple((-1,), mask, 2)
  File "keras/layers/wrappers.py", line 184, in _get_shape_tuple
    int_shape = K.int_shape(tensor)[start_idx:]
TypeError: 'NoneType' object has no attribute '__getitem__'
```
This is because mask values propagate along layers, many layers(theano backend) don't add ```_keras_shape``` to the output mask values, then ```K.int_shape(mask)``` returns ```None``` and caused exception. For tensorflow backend, if there is not ```_keras_shape``` for mask values, it calls ```tensor.get_shape``` to get static shape in most case, but it still not guaranteed, it's also possible to return ```None```.
The fix is: if ```K.int_shape``` return ```None```, we fall back to ```K.shape```.

### Related Issues
#10726 

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
