### PR TITLE
RNN.call should get initial state from full input spec

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -551,6 +551,14 @@ class RNN(Layer):
         # note that the .build() method of subclasses MUST define
         # self.input_spec and self.state_spec with complete input shapes.
         if isinstance(inputs, list):
+            # get initial_state from full input spec
+            # as they could be copied to multiple GPU.
+            if self._num_constants is None:
+                initial_state = inputs[1:]
+            else:
+                initial_state = inputs[1:-self._num_constants]
+            if len(initial_state) == 0:
+                initial_state = None
             inputs = inputs[0]
         if initial_state is not None:
             pass

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -496,10 +496,27 @@ class Bidirectional(Wrapper):
             kwargs['constants'] = constants
 
         if initial_state is not None and has_arg(self.layer.call, 'initial_state'):
-            forward_state = initial_state[:len(initial_state) // 2]
-            backward_state = initial_state[len(initial_state) // 2:]
-            y = self.forward_layer.call(inputs, initial_state=forward_state, **kwargs)
-            y_rev = self.backward_layer.call(inputs, initial_state=backward_state, **kwargs)
+            forward_inputs = [inputs[0]]
+            backward_inputs = [inputs[0]]
+            pivot = len(initial_state) // 2 + 1
+            # add forward initial state
+            forward_state = inputs[1:pivot]
+            forward_inputs += forward_state
+            if self._num_constants is None:
+                # add backward initial state
+                backward_state = inputs[pivot:]
+                backward_inputs += backward_state
+            else:
+                # add backward initial state
+                backward_state = inputs[pivot:-self._num_constants]
+                backward_inputs += backward_state
+                # add constants for forward and backward layers
+                forward_inputs += inputs[-self._num_constants:]
+                backward_inputs += inputs[-self._num_constants:]
+            y = self.forward_layer.call(forward_inputs,
+                                        initial_state=forward_state, **kwargs)
+            y_rev = self.backward_layer.call(backward_inputs,
+                                             initial_state=backward_state, **kwargs)
         else:
             y = self.forward_layer.call(inputs, **kwargs)
             y_rev = self.backward_layer.call(inputs, **kwargs)

--- a/tests/keras/utils/multi_gpu_test.py
+++ b/tests/keras/utils/multi_gpu_test.py
@@ -272,5 +272,19 @@ def multi_gpu_application_folder_generator_benchmark():
         print('%d gpus training:' % i, total_time)
 
 
+@keras_test
+def test_multi_gpu_with_multi_input_layers():
+    inputs = keras.Input((4, 3))
+    init_state = keras.Input((3,))
+    outputs = keras.layers.SimpleRNN(
+        3, return_sequences=True)(inputs, initial_state=init_state)
+    x = [np.random.randn(2, 4, 3), np.random.randn(2, 3)]
+    y = np.random.randn(2, 4, 3)
+    model = keras.models.Model([inputs, init_state], outputs)
+    parallel_model = multi_gpu_model(model, 2)
+    parallel_model.compile(loss='mean_squared_error', optimizer='adam')
+    parallel_model.train_on_batch(x, y)
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
### Summary
This PR fix a critical bug in ```RNN``` which reported at #9449 and #10830 .

In ```RNN.call```, if ```initial_state``` is a tensor that was returned by a Keras layer, we should get ```initial_state``` from full input spec(including training data, state and constants) which was generated at ```RNN.__call__```, as it could be copied to multiple GPUs. Otherwise, it would use the original ```initial_states``` which is not be sliced according the number of GPUs.
BTW, I have also check ```CuDNNRNN```, it use the correct way, so we don't need to modify it.

I run the following test code in a machine with 2 GPUs, it works well after this fix.
```
import numpy as np
import keras
from keras import layers as L
from keras.models import Sequential, Model
from keras.utils.multi_gpu_utils import multi_gpu_model

x = L.Input((4,3))
init_state = L.Input((3,))
y = L.SimpleRNN(3,return_sequences=True)(x,initial_state=init_state)
_x = [np.random.randn(2,4,3),np.random.randn(2,3)]
_y = np.random.randn(2,4,3)
m = Model([x,init_state],y)
m2 = multi_gpu_model(m,2)
m2.compile(loss='mean_squared_error',optimizer='adam')
m2.train_on_batch(_x,_y)
```

### Related Issues
#9449
#10830
 
### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
