### PR TITLE
Let utils.to_categorical support different dtypes.

### DIFF
--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import numpy as np
 
 
-def to_categorical(y, num_classes=None):
+def to_categorical(y, num_classes=None, dtype='float32'):
     """Converts a class vector (integers) to binary class matrix.
 
     E.g. for use with categorical_crossentropy.
@@ -15,6 +15,8 @@ def to_categorical(y, num_classes=None):
         y: class vector to be converted into a matrix
             (integers from 0 to num_classes).
         num_classes: total number of classes.
+        dtype: The data type expected by the input, as a string
+            (`float32`, `float64`, `int32`...)
 
     # Returns
         A binary matrix representation of the input. The classes axis
@@ -28,7 +30,7 @@ def to_categorical(y, num_classes=None):
     if not num_classes:
         num_classes = np.max(y) + 1
     n = y.shape[0]
-    categorical = np.zeros((n, num_classes), dtype=np.float32)
+    categorical = np.zeros((n, num_classes), dtype=dtype)
     categorical[np.arange(n), y] = 1
     output_shape = input_shape + (num_classes,)
     categorical = np.reshape(categorical, output_shape)


### PR DESCRIPTION
### Summary

Currently the returned data type of utils.to_categorical is hardcoded. This PR makes it customizable.

### Related Issues

#9262

### PR Overview

- [ n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ y ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y ] This PR is backwards compatible [y/n]
- [ y ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
