### PR TITLE
Fix multi-output Siamese networks in multi_gpu_model

### DIFF
--- a/keras/utils/multi_gpu_utils.py
+++ b/keras/utils/multi_gpu_utils.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from collections import Counter
-
 from ..layers.merge import concatenate
 from .. import backend as K
 from ..layers.core import Lambda
@@ -234,7 +232,12 @@ def multi_gpu_model(model, gpus=None, cpu_merge=True, cpu_relocation=False):
                     all_outputs[o].append(outputs[o])
 
     # Deduplicate output names to handle Siamese networks.
-    occurrences = Counter(model.output_names)
+    occurrences = {}
+    for n in model.output_names:
+        if n not in occurrences:
+            occurrences[n] = 1
+        else:
+            occurrences[n] += 1
     conflict_counter = {n: 0 for n, count in occurrences.items() if count > 1}
     output_names = []
     for n in model.output_names:

--- a/keras/utils/multi_gpu_utils.py
+++ b/keras/utils/multi_gpu_utils.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from collections import Counter
+
 from ..layers.merge import concatenate
 from .. import backend as K
 from ..layers.core import Lambda
@@ -231,10 +233,20 @@ def multi_gpu_model(model, gpus=None, cpu_merge=True, cpu_relocation=False):
                 for o in range(len(outputs)):
                     all_outputs[o].append(outputs[o])
 
+    # Deduplicate output names to handle Siamese networks.
+    occurrences = Counter(model.output_names)
+    conflict_counter = {n: 0 for n, count in occurrences.items() if count > 1}
+    output_names = []
+    for n in model.output_names:
+        if n in conflict_counter:
+            conflict_counter[n] += 1
+            n += '_%d' % conflict_counter[n]
+        output_names.append(n)
+
     # Merge outputs under expected scope.
     with tf.device('/cpu:0' if cpu_merge else '/gpu:%d' % target_gpu_ids[0]):
         merged = []
-        for name, outputs in zip(model.output_names, all_outputs):
+        for name, outputs in zip(output_names, all_outputs):
             merged.append(concatenate(outputs,
                                       axis=0, name=name))
         return Model(model.inputs, merged)


### PR DESCRIPTION
### Summary
Passing a multi-output Siamese network through `multi_gpu_model()` can lead to `ValueError` exception when both values of the nested model are returned. 

Code:
```python
from keras.models import Sequential, Model
from keras.layers import Input, Dense, Add

input_shape = (3,)

nested_model = Sequential([
    Dense(32, input_shape=input_shape),
    Dense(1)
], name='nested')

input1 = Input(input_shape)
input2 = Input(input_shape)

score1 = nested_model(input1)
score2 = nested_model(input2)
score_sum = Add()([score1, score2])

siamese = Model(inputs=[input1, input2], outputs=[score_sum, score1, score2], name='siamese')

from keras.utils import multi_gpu_model
parallel_siamese = multi_gpu_model(siamese, gpus=2)
``` 

Output:
```
>>> parallel_siamese = multi_gpu_model(siamese, gpus=2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/keras/utils/multi_gpu_utils.py", line 240, in multi_gpu_model
    return Model(model.inputs, merged)
  File "/usr/local/lib/python2.7/dist-packages/keras/legacy/interfaces.py", line 91, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/network.py", line 93, in __init__
    self._init_graph_network(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/network.py", line 237, in _init_graph_network
    self.inputs, self.outputs)
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/network.py", line 1442, in _map_graph_network
    ' times in the model. '
ValueError: The name "nested" is used 2 times in the model. All layer names should be unique.
```

The problem is caused by [line 237](https://github.com/keras-team/keras/blob/master/keras/utils/multi_gpu_utils.py#L237) on current implementation of `multi_gpu_model()`. The values of `model.output_names` can be non-unique and thus we get ValueError exceptions. The PR handles this case by choosing unique names for the outputs that have conflicts. 

Example: In the above snippet the `siamese.output_names` has value `['add_1', 'nested', 'nested']`. To avoid duplicate layer names the proposed code will update `parallel_siamese.output_names` value to `['add_1', 'nested_1', 'nested_2']`. 

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
