### PR TITLE
Add static shape inference for theano concatenate and all operations

### DIFF
--- a/tests/keras/layers/merge_test.py
+++ b/tests/keras/layers/merge_test.py
@@ -288,5 +288,16 @@ def test_merge_broadcast():
         K.ndim = k_ndim
 
 
+@keras_test
+def test_masking_concatenate():
+    input1 = layers.Input(shape=(6,))
+    input2 = layers.Input(shape=(6,))
+    x1 = layers.Embedding(10, 5, input_length=6, mask_zero=True)(input1)
+    x2 = layers.Embedding(10, 5, input_length=6, mask_zero=True)(input2)
+    x = layers.concatenate([x1, x2])
+    x = layers.wrappers.TimeDistributed(layers.Dense(3, activation='softmax'))(x)
+    models.Model(inputs=[input1, input2], outputs=[x])
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
### Summary
Run the following code with theano backend:
```
from keras.layers import Input, Embedding, Dense
from keras.layers.wrappers import TimeDistributed
from keras.layers.merge import concatenate
from keras.models import Model

input1 = Input(shape=(20,))
input2 = Input(shape=(20,))
x1 = Embedding(10000, 10, input_length=20, mask_zero=True)(input1)
x2 = Embedding(10000, 10, input_length=20, mask_zero=True)(input2)
x = concatenate([x1, x2])
x = TimeDistributed(Dense(8, activation='softmax'))(x)
model = Model(inputs=[input1, input2], outputs=[x])
```
```TimeDistributed._get_shape_tuple``` throws exceptions due to theano ```K.int_shape``` return ```None```.
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "keras/engine/base_layer.py", line 458, in __call__
    output_mask = self.compute_mask(inputs, previous_mask)
  File "keras/layers/wrappers.py", line 300, in compute_mask
    inner_mask_shape = self._get_shape_tuple((-1,), mask, 2)
  File "keras/layers/wrappers.py", line 184, in _get_shape_tuple
    int_shape = K.int_shape(tensor)[start_idx:]
TypeError: 'NoneType' object has no attribute '__getitem__'
```
This is because theano ```K.concatenate``` and ```K.all``` operations don't have static shape inference. Added them in this PR.

### Related Issues
#10726 

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
