### PR TITLE
Fix check equality between static shape and dynamic shape in test

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1204,7 +1204,7 @@ def spatial_3d_padding(x, padding=((1, 1), (1, 1), (1, 1)), data_format=None):
                                   x._keras_shape[1] + padding[0][0] + padding[0][1],
                                   x._keras_shape[2] + padding[1][0] + padding[1][1],
                                   x._keras_shape[3] + padding[2][0] + padding[2][1],
-                                  x._keras_shape[4] )
+                                  x._keras_shape[4])
         y._keras_shape = output_keras_shape
     return y
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1144,7 +1144,18 @@ def spatial_2d_padding(x, padding=((1, 1), (1, 1)), data_format=None):
                    py_slice(left_pad, input_shape[2] + left_pad),
                    py_slice(None))
     y = T.set_subtensor(output[indices], x)
-    y._keras_shape = output_shape
+    if hasattr(x, '_keras_shape'):
+        if data_format == 'channels_first':
+            output_keras_shape = (x._keras_shape[0],
+                                  x._keras_shape[1],
+                                  x._keras_shape[2] + top_pad + bottom_pad,
+                                  x._keras_shape[3] + left_pad + right_pad)
+        else:
+            output_keras_shape = (x._keras_shape[0],
+                                  x._keras_shape[1] + top_pad + bottom_pad,
+                                  x._keras_shape[2] + left_pad + right_pad,
+                                  x._keras_shape[3])
+        y._keras_shape = output_keras_shape
     return y
 
 
@@ -1180,7 +1191,22 @@ def spatial_3d_padding(x, padding=((1, 1), (1, 1), (1, 1)), data_format=None):
                    py_slice(padding[1][0], input_shape[2] + padding[1][0]),
                    py_slice(padding[2][0], input_shape[3] + padding[2][0]),
                    py_slice(None))
-    return T.set_subtensor(output[indices], x)
+    y = T.set_subtensor(output[indices], x)
+    if hasattr(x, '_keras_shape'):
+        if data_format == 'channels_first':
+            output_keras_shape = (x._keras_shape[0],
+                                  x._keras_shape[1],
+                                  x._keras_shape[2] + padding[0][0] + padding[0][1],
+                                  x._keras_shape[3] + padding[1][0] + padding[1][1],
+                                  x._keras_shape[4] + padding[2][0] + padding[2][1])
+        else:
+            output_keras_shape = (x._keras_shape[0],
+                                  x._keras_shape[1] + padding[0][0] + padding[0][1],
+                                  x._keras_shape[2] + padding[1][0] + padding[1][1],
+                                  x._keras_shape[3] + padding[2][0] + padding[2][1],
+                                  x._keras_shape[4] )
+        y._keras_shape = output_keras_shape
+    return y
 
 
 def stack(x, axis=0):

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -92,7 +92,9 @@ def assert_list_with_ref(z_list, ref):
 def assert_list_keras_shape(t_list, z_list):
     for t, z in zip(t_list, z_list):
         if hasattr(t, '_keras_shape') and len(t._keras_shape) > 1:
-            assert t._keras_shape == z.shape
+            for i, s in enumerate(t._keras_shape):
+                if s:
+                    assert t._keras_shape[i] == z.shape[i]
 
 
 @keras_test


### PR DESCRIPTION
### Summary
At ```backend_test.py```, we would like to check the equality between static keras shape and dynamic shape. However, we actually don't trigger this check by mistake in the existing code. See my inline comments for detail.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
