### PR TITLE
avoid url error exception

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -220,10 +220,10 @@ def get_file(fname,
         try:
             try:
                 urlretrieve(origin, fpath, dl_progress)
-            except URLError as e:
-                raise Exception(error_msg.format(origin, e.errno, e.reason))
             except HTTPError as e:
                 raise Exception(error_msg.format(origin, e.code, e.msg))
+            except URLError as e:
+                raise Exception(error_msg.format(origin, e.errno, e.reason))
         except (Exception, KeyboardInterrupt):
             if os.path.exists(fpath):
                 os.remove(fpath)


### PR DESCRIPTION
### Summary
To Avoid falling into url error exception, I changed the order of exceptions.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)


in
```python
from urllib.error import URLError, HTTPError
try:
    raise URLError(reason="test")
except URLError as e:
    print("URL_Error")
    pass
except HTTPError as e:
    print("HTTP Error")
    pass
try:
    raise HTTPError(url="example.com", code=200, msg="test", hdrs=None, fp=None)
except URLError as e:
   print("URL_Error")
   pass
except HTTPError as e:
   print("HTTP Error")
   pass
```

out
```python
URL_Error
URL_Error
```

I found that this code couldn't catch the HTTPError.
Because URLError is a subclass of HTTPError.

in
```python
issubclass(HTTPError, URLError)
```

out
```python
True
```

so, it should be changed order.