### PR TITLE
Refactoring: Made an abstract class for all the cropping layers.

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -2368,7 +2368,8 @@ class _Cropping(Layer):
         return tuple(output_shape)
 
     def get_config(self):
-        config = {'cropping': self.cropping,
+        config = {'rank': self.rank,
+                  'cropping': self.cropping,
                   'data_format': self.data_format}
         base_config = super(_Cropping, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -2406,6 +2407,7 @@ class Cropping1D(_Cropping):
 
     def get_config(self):
         base_config = super(Cropping1D, self).get_config()
+        base_config.pop('rank')
         base_config.pop('data_format')
         return base_config
 
@@ -2497,6 +2499,11 @@ class Cropping2D(_Cropping):
                                          data_format,
                                          **kwargs)
 
+    def get_config(self):
+        config = super(Cropping2D, self).get_config()
+        config.pop('rank')
+        return config
+
 
 class Cropping3D(_Cropping):
     """Cropping layer for 3D data (e.g. spatial or spatio-temporal).
@@ -2570,6 +2577,11 @@ class Cropping3D(_Cropping):
                                          normalized_cropping,
                                          data_format,
                                          **kwargs)
+
+    def get_config(self):
+        config = super(Cropping3D, self).get_config()
+        config.pop('rank')
+        return config
 
 
 # Aliases

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -2314,8 +2314,6 @@ class _Cropping(Layer):
     """Abstract nD copping layer (private, used as implementation base).
 
     # Arguments
-        rank: An integer, the rank of the cropping,
-            e.g. "2" for Cropping2D.
         cropping: A tuple of tuples of 2 ints.
         data_format: A string,
             one of `"channels_last"` or `"channels_first"`.
@@ -2329,15 +2327,15 @@ class _Cropping(Layer):
             For Cropping1D, the data format is always `"channels_last"`.
     """
 
-    def __init__(self, rank,
-                 cropping,
+    def __init__(self, cropping,
                  data_format=None,
                  **kwargs):
         super(_Cropping, self).__init__(**kwargs)
-        self.rank = rank
+        # self.rank is 1 for Cropping1D, 2 for Cropping2D...
+        self.rank = len(cropping)
         self.cropping = cropping
         self.data_format = K.normalize_data_format(data_format)
-        self.input_spec = InputSpec(ndim=2 + rank)
+        self.input_spec = InputSpec(ndim=2 + self.rank)
 
     def call(self, inputs):
         slices_dims = []
@@ -2367,8 +2365,7 @@ class _Cropping(Layer):
         return tuple(output_shape)
 
     def get_config(self):
-        config = {'rank': self.rank,
-                  'cropping': self.cropping,
+        config = {'cropping': self.cropping,
                   'data_format': self.data_format}
         base_config = super(_Cropping, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -2395,14 +2392,12 @@ class Cropping1D(_Cropping):
 
     def __init__(self, cropping=(1, 1), **kwargs):
         normalized_cropping = (conv_utils.normalize_tuple(cropping, 2, 'cropping'),)
-        super(Cropping1D, self).__init__(1,
-                                         normalized_cropping,
+        super(Cropping1D, self).__init__(normalized_cropping,
                                          'channels_last',
                                          **kwargs)
 
     def get_config(self):
         base_config = super(Cropping1D, self).get_config()
-        base_config.pop('rank')
         base_config.pop('data_format')
         base_config['cropping'] = base_config['cropping'][0]
         return base_config
@@ -2486,15 +2481,9 @@ class Cropping2D(_Cropping):
                              'or a tuple of 2 tuples of 2 ints '
                              '((top_crop, bottom_crop), (left_crop, right_crop)). '
                              'Found: ' + str(cropping))
-        super(Cropping2D, self).__init__(2,
-                                         normalized_cropping,
+        super(Cropping2D, self).__init__(normalized_cropping,
                                          data_format,
                                          **kwargs)
-
-    def get_config(self):
-        config = super(Cropping2D, self).get_config()
-        config.pop('rank')
-        return config
 
 
 class Cropping3D(_Cropping):
@@ -2565,15 +2554,9 @@ class Cropping3D(_Cropping):
                              ' (left_dim2_crop, right_dim2_crop),'
                              ' (left_dim3_crop, right_dim2_crop)). '
                              'Found: ' + str(cropping))
-        super(Cropping3D, self).__init__(3,
-                                         normalized_cropping,
+        super(Cropping3D, self).__init__(normalized_cropping,
                                          data_format,
                                          **kwargs)
-
-    def get_config(self):
-        config = super(Cropping3D, self).get_config()
-        config.pop('rank')
-        return config
 
 
 # Aliases

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -2316,8 +2316,7 @@ class _Cropping(Layer):
     # Arguments
         rank: An integer, the rank of the cropping,
             e.g. "2" for Cropping2D.
-        cropping: A tuple of tuples of 2 ints. For Cropping1D,
-            it is just a tuple of two ints.
+        cropping: A tuple of tuples of 2 ints.
         data_format: A string,
             one of `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs.
@@ -2342,7 +2341,7 @@ class _Cropping(Layer):
 
     def call(self, inputs):
         slices_dims = []
-        for start, end in self._normalized_cropping:
+        for start, end in self.cropping:
             if end == 0:
                 end = None
             else:
@@ -2356,7 +2355,7 @@ class _Cropping(Layer):
         return inputs[slices]
 
     def compute_output_shape(self, input_shape):
-        cropping_all_dims = ((0, 0),) + self._normalized_cropping + ((0, 0),)
+        cropping_all_dims = ((0, 0),) + self.cropping + ((0, 0),)
         spatial_axes = list(range(1, 1 + self.rank))
         cropping_all_dims = transpose_shape(cropping_all_dims,
                                             self.data_format,
@@ -2373,10 +2372,6 @@ class _Cropping(Layer):
                   'data_format': self.data_format}
         base_config = super(_Cropping, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
-
-    @property
-    def _normalized_cropping(self):
-        return self.cropping
 
 
 class Cropping1D(_Cropping):
@@ -2399,7 +2394,7 @@ class Cropping1D(_Cropping):
     """
 
     def __init__(self, cropping=(1, 1), **kwargs):
-        normalized_cropping = conv_utils.normalize_tuple(cropping, 2, 'cropping')
+        normalized_cropping = (conv_utils.normalize_tuple(cropping, 2, 'cropping'),)
         super(Cropping1D, self).__init__(1,
                                          normalized_cropping,
                                          'channels_last',
@@ -2409,11 +2404,8 @@ class Cropping1D(_Cropping):
         base_config = super(Cropping1D, self).get_config()
         base_config.pop('rank')
         base_config.pop('data_format')
+        base_config['cropping'] = base_config['cropping'][0]
         return base_config
-
-    @property
-    def _normalized_cropping(self):
-        return self.cropping,
 
 
 class Cropping2D(_Cropping):


### PR DESCRIPTION
### Summary

Following up on @Dref360 's comment in #10865.
It allows us to regroup the methods of those classes. Now `Cropping1D`, `Cropping2D` and `Cropping3D` only implement the `__init__()` method.

### Related Issues

### PR Overview

Things to note:

- Now the `Cropping1D` layer will get an `data_format` attribute. This attribute will always have the value `'channels_last'`. Maybe this can be considered as an API change.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
