### PR TITLE
Add LR for Tensorboard in LearningRateScheduler

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -637,6 +637,10 @@ class LearningRateScheduler(Callback):
             print('\nEpoch %05d: LearningRateScheduler setting learning '
                   'rate to %s.' % (epoch + 1, lr))
 
+    def on_epoch_end(self, epoch, logs=None):
+        logs = logs or {}
+        logs['lr'] = K.get_value(self.model.optimizer.lr)
+
 
 class TensorBoard(Callback):
     """TensorBoard basic visualizations.


### PR DESCRIPTION
### Summary
Add learning rate in LearningRateScheduler's log. 

This is already done for the callback `ReduceLROnPlateau`, which is similar. The enables Tensorboard to display the learning rate. Changes done are identical to the implementation of `ReduceLROnPlateau`.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
