### PR TITLE
GlobalAveragePooling1D supports masking

### DIFF
--- a/keras/layers/pooling.py
+++ b/keras/layers/pooling.py
@@ -469,8 +469,9 @@ class GlobalAveragePooling1D(_GlobalPooling1D):
     def call(self, inputs, mask=None):
         if mask is not None:
             mask = K.cast(mask, K.floatx())
-            mask = K.repeat(mask, K.int_shape(inputs)[-1])
-            mask = K.permute_dimensions(mask, [0, 2, 1])
+            input_shape = K.shape(inputs)
+            broadcast_shape = [input_shape[0], input_shape[1], 1]
+            mask = K.reshape(mask, broadcast_shape)
             inputs *= mask
             return K.sum(inputs, axis=1) / K.sum(mask, axis=1)
         else:

--- a/keras/layers/pooling.py
+++ b/keras/layers/pooling.py
@@ -462,8 +462,22 @@ class GlobalAveragePooling1D(_GlobalPooling1D):
         `(batch_size, features)`
     """
 
-    def call(self, inputs):
-        return K.mean(inputs, axis=1)
+    def __init__(self, **kwargs):
+        super(GlobalAveragePooling1D, self).__init__(**kwargs)
+        self.supports_masking = True
+
+    def call(self, inputs, mask=None):
+        if mask is not None:
+            mask = K.cast(mask, K.floatx())
+            mask = K.repeat(mask, K.int_shape(inputs)[-1])
+            mask = K.permute_dimensions(mask, [0, 2, 1])
+            inputs *= mask
+            return K.sum(inputs, axis=1) / K.sum(mask, axis=1)
+        else:
+            return K.mean(inputs, axis=1)
+
+    def compute_mask(self, inputs, mask=None):
+        return None
 
 
 class GlobalMaxPooling1D(_GlobalPooling1D):

--- a/keras/layers/pooling.py
+++ b/keras/layers/pooling.py
@@ -469,8 +469,8 @@ class GlobalAveragePooling1D(_GlobalPooling1D):
     def call(self, inputs, mask=None):
         if mask is not None:
             mask = K.cast(mask, K.floatx())
-            input_shape = K.shape(inputs)
-            broadcast_shape = [input_shape[0], input_shape[1], 1]
+            input_shape = K.int_shape(inputs)
+            broadcast_shape = [-1, input_shape[1], 1]
             mask = K.reshape(mask, broadcast_shape)
             inputs *= mask
             return K.sum(inputs, axis=1) / K.sum(mask, axis=1)

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -7,6 +7,7 @@ from keras.utils.test_utils import keras_test
 from keras import backend as K
 from keras.layers import convolutional
 from keras.layers import pooling
+from keras.layers import Masking
 from keras.models import Sequential
 
 
@@ -412,6 +413,20 @@ def test_globalpooling_1d():
                input_shape=(3, 4, 5))
     layer_test(pooling.GlobalAveragePooling1D,
                input_shape=(3, 4, 5))
+
+
+@keras_test
+def test_globalpooling_1d_supports_masking():
+    # Test GlobalAveragePooling1D supports masking
+    model = Sequential()
+    model.add(Masking(mask_value=0., input_shape=(3, 4)))
+    model.add(pooling.GlobalAveragePooling1D())
+    model.compile(loss='mae', optimizer='adam')
+
+    model_input = np.random.randint(low=1, high=5, size=(2, 3, 4))
+    model_input[0, 1:, :] = 0
+    output = model.predict(model_input)
+    assert np.array_equal(output[0], model_input[0, 0, :])
 
 
 @keras_test


### PR DESCRIPTION
### Summary
```GlobalAveragePooling1D``` can follow ```Embedding``` layer to get an embedding representation of a sentence by adding words representation together(refer #10895). It's necessary to make ```GlobalAveragePooling1D``` support masking as the sentences are very likely to be padding with zero.

### Related Issues
#10895 

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
