### PR TITLE
Raise warning if both class_weight and sample_weight given

### DIFF
--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -478,8 +478,8 @@ def standardize_weights(y,
                              'sample_weight array is 1D.')
 
     if sample_weight is not None and class_weight is not None:
-        warnings.warn('Found both sample_weight and class_weight - '
-                      'class_weight will be ignored')
+        warnings.warn('Found both `sample_weight` and `class_weight`: '
+                      '`class_weight` argument will be ignored.')
 
     if sample_weight is not None:
         if len(sample_weight.shape) > len(y.shape):

--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import copy
 import numpy as np
+import warnings
 
 from .. import backend as K
 from .. import losses
@@ -475,6 +476,10 @@ def standardize_weights(y,
                              'in compile(). If you just mean to use '
                              'sample-wise weights, make sure your '
                              'sample_weight array is 1D.')
+
+    if sample_weight is not None and class_weight is not None:
+        warnings.warn('Found both sample_weight and class_weight - '
+                      'class_weight will be ignored')
 
     if sample_weight is not None:
         if len(sample_weight.shape) > len(y.shape):


### PR DESCRIPTION
### Summary
As discussed in past issues it would be beneficial to raise a warning, informing the user that class_weight is ignored in case both sample_weight and class_weight are given.

### Related Issues
#497
#504

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [X] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
