### PR TITLE
Generators now use same logic as Sequence

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -582,7 +582,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
                     yield inputs
         except Exception as e:
             self.stop()
-            six.raise_from(StopIteration(e), e)
+            six.reraise(*sys.exc_info())
 
     def _send_sequence(self):
         """Send current Sequence to all workers."""
@@ -756,12 +756,12 @@ class GeneratorEnqueuer(SequenceEnqueuer):
         except Exception as e:
             self.stop()
             if 'generator already executing' in str(e):
-                raise StopIteration(
+                raise RuntimeError(
                     "Your generator is NOT thread-safe."
                     "Keras requires a thread-safe generator when"
                     "`use_multiprocessing=False, workers > 1`."
                     "For more information see issue #1638.")
-            six.raise_from(StopIteration(e), e)
+            six.reraise(*sys.exc_info())
 
     def _send_generator(self):
         """Send current generator to all workers."""

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -703,7 +703,8 @@ class GeneratorEnqueuer(SequenceEnqueuer):
         if self.use_multiprocessing:
             self.executor_fn = lambda gens: mp.Pool(workers,
                                                     initializer=init_pool_generator,
-                                                    initargs=(gens, self.random_seed))
+                                                    initargs=(gens,
+                                                              self.random_seed))
         else:
             # We do not need the init since it's threads.
             self.executor_fn = lambda _: ThreadPool(workers)

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -13,6 +13,7 @@ import tarfile
 import threading
 import time
 import traceback
+import warnings
 import zipfile
 from abc import abstractmethod
 from contextlib import closing
@@ -606,6 +607,37 @@ class OrderedEnqueuer(SequenceEnqueuer):
         _SHARED_SEQUENCES[self.uid] = None
 
 
+# Global variables to be shared across processes
+_SHARED_GENERATOR = {}
+# We use a Value to provide unique id to different processes.
+_GENERATOR_COUNTER = None
+
+
+def init_pool_generator(gens, random_seed=None):
+    global _SHARED_GENERATOR
+    _SHARED_GENERATOR = gens
+
+    if random_seed is not None:
+        ident = mp.current_process().ident
+        np.random.seed(random_seed + ident)
+
+
+def next_sample(uid):
+    """Get the next value from the generator `uid`.
+
+    To allow multiple generators to be used at the same time, we use `uid` to
+    get a specific one. A single generator would cause the validation to
+    overwrite the training generator.
+
+    # Arguments
+        uid: int, Sequence identifier
+
+    # Returns
+        The next value of generator `uid`.
+    """
+    return six.next(_SHARED_GENERATOR[uid])
+
+
 class GeneratorEnqueuer(SequenceEnqueuer):
     """Builds a queue out of a data generator.
 
@@ -624,143 +656,81 @@ class GeneratorEnqueuer(SequenceEnqueuer):
 
     def __init__(self, generator,
                  use_multiprocessing=False,
-                 wait_time=0.05,
-                 seed=None):
-        self.wait_time = wait_time
-        self._generator = generator
-        if os.name is 'nt' and use_multiprocessing is True:
-            # On Windows, avoid **SYSTEMATIC** error in `multiprocessing`:
-            # `TypeError: can't pickle generator objects`
-            # => Suggest multithreading instead of multiprocessing on Windows
-            raise ValueError('Using a generator with `use_multiprocessing=True`'
-                             ' is not supported on Windows (no marshalling of'
-                             ' generators across process boundaries). Instead,'
-                             ' use single thread/process or multithreading.')
-        else:
-            self._use_multiprocessing = use_multiprocessing
-        self._threads = []
-        self._stop_event = None
-        self._manager = None
-        self.queue = None
-        self.seed = seed
+                 wait_time=None,
+                 random_seed=None):
+        self.generator = generator
+        self.use_multiprocessing = use_multiprocessing
+        self.random_seed = random_seed
+        if wait_time is not None:
+            warnings.warn('`wait_time` is not used anymore.',
+                          DeprecationWarning)
 
-    def _data_generator_task(self):
-        if self._use_multiprocessing is False:
-            while not self._stop_event.is_set():
-                with self.genlock:
-                    try:
-                        if (self.queue is not None and
-                                self.queue.qsize() < self.max_queue_size):
-                            # On all OSes, avoid **SYSTEMATIC** error
-                            # in multithreading mode:
-                            # `ValueError: generator already executing`
-                            # => Serialize calls to
-                            # infinite iterator/generator's next() function
-                            generator_output = next(self._generator)
-                            self.queue.put((True, generator_output))
-                        else:
-                            time.sleep(self.wait_time)
-                    except StopIteration:
-                        break
-                    except Exception as e:
-                        # Can't pickle tracebacks.
-                        # As a compromise, print the traceback and
-                        # pickle None instead.
-                        if not hasattr(e, '__traceback__'):
-                            setattr(e, '__traceback__', sys.exc_info()[2])
-                        self.queue.put((False, e))
-                        self._stop_event.set()
-                        break
+        global _GENERATOR_COUNTER
+        if _GENERATOR_COUNTER is None:
+            try:
+                _GENERATOR_COUNTER = mp.Value('i', 0)
+            except OSError:
+                # In this case the OS does not allow us to use
+                # multiprocessing. We resort to an int
+                # for enqueuer indexing.
+                _GENERATOR_COUNTER = 0
+
+        if isinstance(_GENERATOR_COUNTER, int):
+            self.uid = _GENERATOR_COUNTER
+            _GENERATOR_COUNTER += 1
         else:
-            while not self._stop_event.is_set():
-                try:
-                    if (self.queue is not None and
-                            self.queue.qsize() < self.max_queue_size):
-                        generator_output = next(self._generator)
-                        self.queue.put((True, generator_output))
-                    else:
-                        time.sleep(self.wait_time)
-                except StopIteration:
-                    break
-                except Exception as e:
-                    # Can't pickle tracebacks.
-                    # As a compromise, print the traceback and pickle None instead.
-                    traceback.print_exc()
-                    setattr(e, '__traceback__', None)
-                    self.queue.put((False, e))
-                    self._stop_event.set()
-                    break
+            # Doing Multiprocessing.Value += x is not process-safe.
+            with _GENERATOR_COUNTER.get_lock():
+                self.uid = _GENERATOR_COUNTER.value
+                _GENERATOR_COUNTER.value += 1
+
+        self.workers = 0
+        self.executor_fn = None
+        self.queue = None
+        self.run_thread = None
+        self.stop_signal = None
+
+    def is_running(self):
+        return self.stop_signal is not None and not self.stop_signal.is_set()
 
     def start(self, workers=1, max_queue_size=10):
-        """Kicks off threads which add data from the generator into the queue.
+        """Start the handler's workers.
 
         # Arguments
             workers: number of worker threads
             max_queue_size: queue size
-                (when full, threads could block on `put()`)
+                (when full, workers could block on `put()`)
         """
-        try:
-            self.max_queue_size = max_queue_size
-            if self._use_multiprocessing:
-                self._manager = mp.Manager()
-                self.queue = self._manager.Queue(maxsize=max_queue_size)
-                self._stop_event = mp.Event()
-            else:
-                # On all OSes, avoid **SYSTEMATIC** error in multithreading mode:
-                # `ValueError: generator already executing`
-                # => Serialize calls to infinite iterator/generator's next() function
-                self.genlock = threading.Lock()
-                self.queue = queue.Queue(maxsize=max_queue_size)
-                self._stop_event = threading.Event()
+        if self.use_multiprocessing:
+            self.executor_fn = lambda gens: mp.Pool(workers,
+                                                    initializer=init_pool_generator,
+                                                    initargs=(gens,))
+        else:
+            # We do not need the init since it's threads.
+            self.executor_fn = lambda _: ThreadPool(workers)
+        self.workers = workers
+        self.queue = queue.Queue(max_queue_size)
+        self.stop_signal = threading.Event()
+        self.run_thread = threading.Thread(target=self._run)
+        self.run_thread.daemon = True
+        self.run_thread.start()
 
-            for _ in range(workers):
-                if self._use_multiprocessing:
-                    # Reset random seed else all children processes
-                    # share the same seed
-                    np.random.seed(self.seed)
-                    thread = mp.Process(target=self._data_generator_task)
-                    thread.daemon = True
-                    if self.seed is not None:
-                        self.seed += 1
-                else:
-                    thread = threading.Thread(target=self._data_generator_task)
-                self._threads.append(thread)
-                thread.start()
-        except:
-            self.stop()
-            raise
+    def _wait_queue(self):
+        """Wait for the queue to be empty."""
+        while True:
+            time.sleep(0.1)
+            if self.queue.unfinished_tasks == 0 or self.stop_signal.is_set():
+                return
 
-    def is_running(self):
-        return self._stop_event is not None and not self._stop_event.is_set()
-
-    def stop(self, timeout=None):
-        """Stops running threads and wait for them to exit, if necessary.
-
-        Should be called by the same thread which called `start()`.
-
-        # Arguments
-            timeout: maximum time to wait on `thread.join()`.
-        """
-        if self.is_running():
-            self._stop_event.set()
-
-        for thread in self._threads:
-            if self._use_multiprocessing:
-                if thread.is_alive():
-                    thread.terminate()
-            else:
-                # The thread.is_alive() test is subject to a race condition:
-                # the thread could terminate right after the test and before the
-                # join, rendering this test meaningless -> Call thread.join()
-                # always, which is ok no matter what the status of the thread.
-                thread.join(timeout)
-
-        if self._manager:
-            self._manager.shutdown()
-
-        self._threads = []
-        self._stop_event = None
-        self.queue = None
+    def _run(self):
+        """Submits request to the executor and queue the `Future` objects."""
+        self._send_generator()  # Share the initial sequence
+        with closing(self.executor_fn(_SHARED_GENERATOR)) as executor:
+            while True:
+                if self.stop_signal.is_set():
+                    return
+                self.queue.put(
+                    executor.apply_async(next_sample, (self.uid,)), block=True)
 
     def get(self):
         """Creates a generator to extract data from the queue.
@@ -772,25 +742,39 @@ class GeneratorEnqueuer(SequenceEnqueuer):
             `(inputs, targets)` or
             `(inputs, targets, sample_weights)`.
         """
-        while self.is_running():
-            if not self.queue.empty():
-                success, value = self.queue.get()
-                # Rethrow any exceptions found in the queue
-                if not success:
-                    six.reraise(value.__class__, value, value.__traceback__)
-                # Yield regular values
-                if value is not None:
-                    yield value
-            else:
-                all_finished = all([not thread.is_alive()
-                                    for thread in self._threads])
-                if all_finished and self.queue.empty():
-                    raise StopIteration()
-                else:
-                    time.sleep(self.wait_time)
+        try:
+            while self.is_running():
+                inputs = self.queue.get(block=True).get()
+                self.queue.task_done()
+                if inputs is not None:
+                    yield inputs
+        except Exception as e:
+            self.stop()
+            if 'generator already executing' in e.message:
+                raise StopIteration(
+                    "Your generator is NOT thread-safe."
+                    "Keras requires a thread-safe generator when"
+                    "`use_multiprocessing=False, workers > 1`."
+                    "For more information see issue #1638.")
+            six.raise_from(StopIteration(e), e)
 
-        # Make sure to rethrow the first exception in the queue, if any
-        while not self.queue.empty():
-            success, value = self.queue.get()
-            if not success:
-                six.reraise(value.__class__, value, value.__traceback__)
+    def _send_generator(self):
+        """Send current generator to all workers."""
+        # For new processes that may spawn
+        _SHARED_GENERATOR[self.uid] = self.generator
+
+    def stop(self, timeout=None):
+        """Stops running threads and wait for them to exit, if necessary.
+
+        Should be called by the same thread which called `start()`.
+
+        # Arguments
+            timeout: maximum time to wait on `thread.join()`
+        """
+        self.stop_signal.set()
+        with self.queue.mutex:
+            self.queue.queue.clear()
+            self.queue.unfinished_tasks = 0
+            self.queue.not_full.notify()
+        self.run_thread.join(timeout)
+        _SHARED_GENERATOR[self.uid] = None

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -293,6 +293,7 @@ def test_model_methods():
 
     # test starting from non-zero initial epoch for generator too
     trained_epochs = []
+
     @threadsafe_generator
     def gen_data(batch_sz):
         while True:

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 import numpy as np
 import pandas as pd
@@ -35,6 +37,36 @@ class RandomSequence(Sequence):
 
     def on_epoch_end(self):
         pass
+
+
+class threadsafe_iter:
+    """Takes an iterator/generator and makes it thread-safe by
+    serializing call to the `next` method of given iterator/generator.
+    """
+
+    def __init__(self, it):
+        self.it = it
+        self.lock = threading.Lock()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self.next()
+
+    def next(self):
+        with self.lock:
+            return next(self.it)
+
+
+def threadsafe_generator(f):
+    """A decorator that takes a generator function and makes it thread-safe.
+    """
+
+    def g(*a, **kw):
+        return threadsafe_iter(f(*a, **kw))
+
+    return g
 
 
 @keras_test
@@ -261,7 +293,7 @@ def test_model_methods():
 
     # test starting from non-zero initial epoch for generator too
     trained_epochs = []
-
+    @threadsafe_generator
     def gen_data(batch_sz):
         while True:
             yield ([np.random.random((batch_sz, 3)),
@@ -307,6 +339,7 @@ def test_model_methods():
 
     # empty batch
     with pytest.raises(ValueError):
+        @threadsafe_generator
         def gen_data():
             while True:
                 yield (np.asarray([]), np.asarray([]))
@@ -434,6 +467,7 @@ def test_model_methods():
     # fit_generator will throw an exception
     # if steps is unspecified for regular generator
     with pytest.raises(ValueError):
+        @threadsafe_generator
         def gen_data():
             while True:
                 yield (np.asarray([]), np.asarray([]))
@@ -445,12 +479,12 @@ def test_model_methods():
     # Check if generator is only accessed an expected number of times
     gen_counters = [0, 0]
 
+    @threadsafe_generator
     def gen_data(i):
         while True:
             gen_counters[i] += 1
             yield ([np.random.random((1, 3)), np.random.random((1, 3))],
                    [np.random.random((1, 4)), np.random.random((1, 3))])
-
     out = model.fit_generator(generator=gen_data(0), epochs=3,
                               steps_per_epoch=2,
                               validation_data=gen_data(1),
@@ -460,7 +494,9 @@ def test_model_methods():
 
     # Need range check here as filling
     # of the queue depends on sleep in the enqueuers
-    assert 6 <= gen_counters[0] <= 8
+    max_train = 3 * 2 + 2 * 2
+    min_train = 2 * 3
+    assert min_train <= gen_counters[0] <= max_train
     # 12 = (epoch * workers * validation steps * max_queue_size)
     assert 3 <= gen_counters[1] <= 12
 
@@ -537,6 +573,7 @@ def test_warnings():
     model.compile(optimizer, loss, metrics=[], loss_weights=loss_weights,
                   sample_weight_mode=None)
 
+    @threadsafe_generator
     def gen_data(batch_sz):
         while True:
             yield ([np.random.random((batch_sz, 3)),
@@ -915,6 +952,7 @@ def test_model_with_external_loss():
         out = model.fit(None, None, epochs=1, steps_per_epoch=1)
 
         # define a generator to produce x=None and y=None
+        @threadsafe_generator
         def data_tensors_generator():
             while True:
                 yield (None, None)

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -212,8 +212,10 @@ def test_stateful_metrics(metrics_mode):
     # Test correctness of the validation metric computation
     val_preds = model.predict_generator(iter(val_gen), steps=val_samples, workers=0)
     val_outs = model.evaluate_generator(iter(val_gen), steps=val_samples, workers=0)
-    np.testing.assert_allclose(val_outs[2], ref_true_pos(val_y, val_preds), atol=1e-5)
-    np.testing.assert_allclose(val_outs[2], history.history['val_true_positives'][-1],
+    np.testing.assert_allclose(val_outs[2], ref_true_pos(val_y, val_preds),
+                               atol=1e-5)
+    np.testing.assert_allclose(val_outs[2],
+                               history.history['val_true_positives'][-1],
                                atol=1e-5)
 
 

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -198,15 +198,15 @@ def test_stateful_metrics(metrics_mode):
     val_gen = [(np.array([x0]), np.array([y0])) for x0, y0 in zip(val_x, val_y)]
     history = model.fit_generator(iter(gen), epochs=1, steps_per_epoch=samples,
                                   validation_data=iter(val_gen), validation_steps=val_samples)
-    outs = model.evaluate_generator(iter(gen), steps=samples)
-    preds = model.predict_generator(iter(gen), steps=samples)
+    outs = model.evaluate_generator(iter(gen), steps=samples, workers=0)
+    preds = model.predict_generator(iter(gen), steps=samples, workers=0)
 
     # Test correctness of the metric re ref_true_pos()
     np.testing.assert_allclose(outs[2], ref_true_pos(y, preds), atol=1e-5)
 
     # Test correctness of the validation metric computation
-    val_preds = model.predict_generator(iter(val_gen), steps=val_samples)
-    val_outs = model.evaluate_generator(iter(val_gen), steps=val_samples)
+    val_preds = model.predict_generator(iter(val_gen), steps=val_samples, workers=0)
+    val_outs = model.evaluate_generator(iter(val_gen), steps=val_samples, workers=0)
     np.testing.assert_allclose(val_outs[2], ref_true_pos(val_y, val_preds), atol=1e-5)
     np.testing.assert_allclose(val_outs[2], history.history['val_true_positives'][-1], atol=1e-5)
 

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -180,7 +180,6 @@ def test_generator_enqueuer_threads():
     enqueuer.stop()
 
 
-@use_spawn
 def test_generator_enqueuer_processes():
     enqueuer = GeneratorEnqueuer(create_generator_from_sequence_pcs(
         DummySequence([3, 200, 200, 3])), use_multiprocessing=True)
@@ -201,7 +200,7 @@ def test_generator_enqueuer_threadsafe():
     gen_output = enqueuer.get()
     with pytest.raises(StopIteration) as e:
         [next(gen_output) for _ in range(10)]
-    assert 'thread-safe' in e.value.message
+    assert 'thread-safe' in str(e.value)
     enqueuer.stop()
 
 
@@ -367,7 +366,6 @@ def test_finite_generator_enqueuer_threads():
     enqueuer.stop()
 
 
-@use_spawn
 def test_finite_generator_enqueuer_processes():
     enqueuer = GeneratorEnqueuer(create_finite_generator_from_sequence_pcs(
         DummySequence([3, 200, 200, 3])), use_multiprocessing=True)

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -198,7 +198,7 @@ def test_generator_enqueuer_threadsafe():
         DummySequence([3, 200, 200, 3])), use_multiprocessing=False)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
-    with pytest.raises(StopIteration) as e:
+    with pytest.raises(RuntimeError) as e:
         [next(gen_output) for _ in range(10)]
     assert 'thread-safe' in str(e.value)
     enqueuer.stop()
@@ -209,7 +209,7 @@ def test_generator_enqueuer_fail_threads():
         FaultSequence()), use_multiprocessing=False)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
-    with pytest.raises(StopIteration):
+    with pytest.raises(IndexError):
         next(gen_output)
 
 
@@ -218,7 +218,7 @@ def test_generator_enqueuer_fail_processes():
         FaultSequence()), use_multiprocessing=True)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
-    with pytest.raises(StopIteration):
+    with pytest.raises(IndexError):
         next(gen_output)
 
 
@@ -267,7 +267,7 @@ def test_ordered_enqueuer_fail_threads():
     enqueuer = OrderedEnqueuer(FaultSequence(), use_multiprocessing=False)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
-    with pytest.raises(StopIteration):
+    with pytest.raises(IndexError):
         next(gen_output)
 
 
@@ -339,7 +339,7 @@ def test_ordered_enqueuer_fail_processes():
     enqueuer = OrderedEnqueuer(FaultSequence(), use_multiprocessing=True)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
-    with pytest.raises(StopIteration):
+    with pytest.raises(IndexError):
         next(gen_output)
 
 

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -607,7 +607,7 @@ def test_multiprocessing_fit_error():
     #     exception and does not attempt to run the generator.
     #   - On other platforms, make sure `RuntimeError` exception bubbles up
     if os.name is 'nt':
-        with pytest.raises(StopIteration):
+        with pytest.raises(RuntimeError):
             model.fit_generator(custom_generator(),
                                 steps_per_epoch=samples,
                                 validation_steps=None,
@@ -615,7 +615,7 @@ def test_multiprocessing_fit_error():
                                 workers=WORKERS,
                                 use_multiprocessing=True)
     else:
-        with pytest.raises(StopIteration):
+        with pytest.raises(RuntimeError):
             model.fit_generator(custom_generator(),
                                 steps_per_epoch=samples,
                                 validation_steps=None,
@@ -626,7 +626,7 @@ def test_multiprocessing_fit_error():
     # - Produce data on 4 worker threads, consume on main thread:
     #   - All worker threads share the SAME generator
     #   - Make sure `RuntimeError` exception bubbles up
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError):
         model.fit_generator(custom_generator(),
                             steps_per_epoch=samples,
                             validation_steps=None,
@@ -641,7 +641,7 @@ def test_multiprocessing_fit_error():
     #     exception and does not attempt to run the generator.
     #   - On other platforms, make sure `RuntimeError` exception bubbles up
     if os.name is 'nt':
-        with pytest.raises(StopIteration):
+        with pytest.raises(RuntimeError):
             model.fit_generator(custom_generator(),
                                 steps_per_epoch=samples,
                                 validation_steps=None,
@@ -649,7 +649,7 @@ def test_multiprocessing_fit_error():
                                 workers=1,
                                 use_multiprocessing=True)
     else:
-        with pytest.raises(StopIteration):
+        with pytest.raises(RuntimeError):
             model.fit_generator(custom_generator(),
                                 steps_per_epoch=samples,
                                 validation_steps=None,
@@ -660,7 +660,7 @@ def test_multiprocessing_fit_error():
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     #   - Make sure `RuntimeError` exception bubbles up
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError):
         model.fit_generator(custom_generator(),
                             steps_per_epoch=samples,
                             validation_steps=None,
@@ -725,7 +725,7 @@ def test_multiprocessing_evaluate_error():
                                      workers=WORKERS,
                                      use_multiprocessing=True)
     else:
-        with pytest.raises(StopIteration):
+        with pytest.raises(RuntimeError):
             model.evaluate_generator(custom_generator(),
                                      steps=good_batches * WORKERS + 1,
                                      max_queue_size=10,
@@ -735,7 +735,7 @@ def test_multiprocessing_evaluate_error():
     # - Produce data on 4 worker threads, consume on main thread:
     #   - All worker threads share the SAME generator
     #   - Make sure `RuntimeError` exception bubbles up
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError):
         model.evaluate_generator(custom_generator(),
                                  steps=good_batches * WORKERS + 1,
                                  max_queue_size=10,
@@ -749,14 +749,14 @@ def test_multiprocessing_evaluate_error():
     #     exception and does not attempt to run the generator.
     #   - On other platforms, make sure `RuntimeError` exception bubbles up
     if os.name is 'nt':
-        with pytest.raises(StopIteration):
+        with pytest.raises(RuntimeError):
             model.evaluate_generator(custom_generator(),
                                      steps=good_batches + 1,
                                      max_queue_size=10,
                                      workers=1,
                                      use_multiprocessing=True)
     else:
-        with pytest.raises(StopIteration):
+        with pytest.raises(RuntimeError):
             model.evaluate_generator(custom_generator(),
                                      steps=good_batches + 1,
                                      max_queue_size=10,
@@ -766,7 +766,7 @@ def test_multiprocessing_evaluate_error():
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     #   - Make sure `RuntimeError` exception bubbles up
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError):
         model.evaluate_generator(custom_generator(),
                                  steps=good_batches + 1,
                                  max_queue_size=10,
@@ -827,7 +827,7 @@ def test_multiprocessing_predict_error():
                                     workers=WORKERS,
                                     use_multiprocessing=True)
     else:
-        with pytest.raises(StopIteration):
+        with pytest.raises(RuntimeError):
             model.predict_generator(custom_generator(),
                                     steps=good_batches * WORKERS + 1,
                                     max_queue_size=10,
@@ -837,7 +837,7 @@ def test_multiprocessing_predict_error():
     # - Produce data on 4 worker threads, consume on main thread:
     #   - All worker threads share the SAME generator
     #   - Make sure `RuntimeError` exception bubbles up
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError):
         model.predict_generator(custom_generator(),
                                 steps=good_batches * WORKERS + 1,
                                 max_queue_size=10,
@@ -851,14 +851,14 @@ def test_multiprocessing_predict_error():
     #     exception and does not attempt to run the generator.
     #   - On other platforms, make sure `RuntimeError` exception bubbles up
     if os.name is 'nt':
-        with pytest.raises(StopIteration):
+        with pytest.raises(RuntimeError):
             model.predict_generator(custom_generator(),
                                     steps=good_batches + 1,
                                     max_queue_size=10,
                                     workers=1,
                                     use_multiprocessing=True)
     else:
-        with pytest.raises(StopIteration):
+        with pytest.raises(RuntimeError):
             model.predict_generator(custom_generator(),
                                     steps=good_batches + 1,
                                     max_queue_size=10,
@@ -868,7 +868,7 @@ def test_multiprocessing_predict_error():
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     #   - Make sure `RuntimeError` exception bubbles up
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError):
         model.predict_generator(custom_generator(),
                                 steps=good_batches + 1,
                                 max_queue_size=10,


### PR DESCRIPTION
### Summary
Update the GeneratorEnqueuer logic to follow the Ordered Enqueuer (We could merge them later on)
* Remove the Lock and adds a new error message when use_multiprocessing=False.
* The exceptions raised are now similar between a Generator and a Sequence. (StopIteration)
* wait_time is now deprecated.

### Related Issues
https://github.com/keras-team/keras/pull/8662#discussion_r210682836

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

cc @datumbox @de-vri-es 