### PR TITLE
allow non-square weights to initialize with identity initializer

### DIFF
--- a/keras/initializers.py
+++ b/keras/initializers.py
@@ -266,7 +266,8 @@ class Orthogonal(Initializer):
 class Identity(Initializer):
     """Initializer that generates the identity matrix.
 
-    Only use for square 2D matrices.
+    Only use for 2D matrices. If long side of matrix is multiple of short side,
+    identity matrices are concatenated along the long side.
 
     # Arguments
         gain: Multiplicative factor to apply to the identity matrix.
@@ -276,11 +277,20 @@ class Identity(Initializer):
         self.gain = gain
 
     def __call__(self, shape, dtype=None):
-        if len(shape) != 2 or shape[0] != shape[1]:
-            raise ValueError('Identity matrix initializer can only be used '
-                             'for 2D square matrices.')
-        else:
+        if len(shape) != 2:
+            raise ValueError('Identity matrix initializer can only be used for 2D matrices.')
+
+        if max(shape) % min(shape) != 0:
+            raise ValueError('Long side should be multiple of short side.')
+
+        if shape[0] == shape[1]:
             return self.gain * np.identity(shape[0])
+        elif shape[0] > shape[1]:
+            return self.gain * np.concatenate(
+                [np.identity(shape[1])] * (shape[0] // shape[1]), axis=0)
+        else:
+            return self.gain * np.concatenate(
+                [np.identity(shape[0])] * (shape[1] // shape[0]), axis=1)
 
     def get_config(self):
         return {

--- a/tests/keras/initializers_test.py
+++ b/tests/keras/initializers_test.py
@@ -104,9 +104,10 @@ def test_orthogonal(tensor_shape):
             target_mean=0.)
 
 
-@pytest.mark.parametrize('tensor_shape', [(100, 100), (1, 2, 3, 4)], ids=['FC', 'CONV'])
+@pytest.mark.parametrize('tensor_shape', [(100, 100), (10, 20), (30, 80), (1, 2, 3, 4)],
+                         ids=['FC', 'RNN', 'RNN_INVALID', 'CONV'])
 def test_identity(tensor_shape):
-    if len(tensor_shape) > 2:
+    if len(tensor_shape) > 2 or max(tensor_shape) % min(tensor_shape) != 0:
         with pytest.raises(ValueError):
             _runner(initializers.identity(), tensor_shape,
                     target_mean=1. / tensor_shape[0], target_max=1.)

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -896,5 +896,16 @@ def test_rnn_cell_with_constants_layer_passing_initial_state():
     assert_allclose(y_np, y_np_3, atol=1e-4)
 
 
+@rnn_test
+def test_rnn_cell_identity_initializer(layer_class):
+    inputs = Input(shape=(timesteps, embedding_dim))
+    layer = layer_class(units, recurrent_initializer='identity')
+    layer(inputs)
+    recurrent_kernel = layer.get_weights()[1]
+    num_kernels = recurrent_kernel.shape[1] // recurrent_kernel.shape[0]
+    assert np.array_equal(recurrent_kernel,
+                          np.concatenate([np.identity(units)] * num_kernels, axis=1))
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
### Summary

Recurrent kernels of RNN cells are concatenated to speedup, therefore shape of its weights are no longer square and can't be initialized with identity initializer. Here we relax identity initializer for this case.

### Related Issues
#10893 

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
