### PR TITLE
add installing pydot

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,6 +52,7 @@ RUN conda install -y python=${python_version} && \
       notebook \
       Pillow \
       pandas \
+      pydot \
       pygpu \
       pyyaml \
       scikit-learn \


### PR DESCRIPTION
### Summary

### 
In Dockerrfile, we should add an pydot module.

**test before install pydot**
```
keras@cef4fc61682d:/Users/admin/program/private/oss/other/keras$ pytest tests/keras/utils/vis_utils_test.py
========================================================================================================= test session starts =========================================================================================================
platform linux -- Python 3.6.3, pytest-3.7.1, py-1.5.4, pluggy-0.7.1 -- /opt/conda/bin/python
cachedir: .pytest_cache
rootdir: /Users/admin/program/private/oss/other/keras, inifile: pytest.ini
plugins: xdist-1.22.5, pep8-1.0.6, forked-0.2, cov-2.5.1
[gw0] linux Python 3.6.3 cwd: /Users/admin/program/private/oss/other/keras
[gw1] linux Python 3.6.3 cwd: /Users/admin/program/private/oss/other/keras
[gw0] Python 3.6.3 |Anaconda, Inc.| (default, Oct 13 2017, 12:02:49)  -- [GCC 7.2.0]
[gw1] Python 3.6.3 |Anaconda, Inc.| (default, Oct 13 2017, 12:02:49)  -- [GCC 7.2.0]
gw0 [1] / gw1 [1]
scheduling tests via LoadScheduling

tests/keras/utils/vis_utils_test.py::test_plot_model
[gw0] [100%] FAILED tests/keras/utils/vis_utils_test.py::test_plot_model

============================================================================================================== FAILURES ===============================================================================================================
___________________________________________________________________________________________________________ test_plot_model ___________________________________________________________________________________________________________
[gw0] linux -- Python 3.6.3 /opt/conda/bin/python

    def test_plot_model():
        model = Sequential()
        model.add(Conv2D(2, kernel_size=(2, 3), input_shape=(3, 5, 5), name='conv'))
        model.add(Flatten(name='flat'))
        model.add(Dense(5, name='dense1'))
>       vis_utils.plot_model(model, to_file='model1.png', show_layer_names=False)

tests/keras/utils/vis_utils_test.py:19:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
keras/utils/vis_utils.py:132: in plot_model
    dot = model_to_dot(model, show_shapes, show_layer_names, rankdir)
keras/utils/vis_utils.py:55: in model_to_dot
    _check_pydot()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def _check_pydot():
        """Raise errors if `pydot` or GraphViz unavailable."""
        if pydot is None:
            raise ImportError(
>               'Failed to import `pydot`. '
                'Please install `pydot`. '
                'For example with `pip install pydot`.')
E           ImportError: Failed to import `pydot`. Please install `pydot`. For example with `pip install pydot`.

keras/utils/vis_utils.py:20: ImportError
====================================================================================================== slowest 20 test durations ======================================================================================================
0.09s call     tests/keras/utils/vis_utils_test.py::test_plot_model
0.00s setup    tests/keras/utils/vis_utils_test.py::test_plot_model
0.00s teardown tests/keras/utils/vis_utils_test.py::test_plot_model
====================================================================================================== 1 failed in 6.85 seconds =======================================================================================================
```
**test after install pydot**
```
keras@cef4fc61682d:/Users/admin/program/private/oss/other/keras$ pytest tests/keras/utils/vis_utils_test.py
========================================================================================================= test session starts =========================================================================================================
platform linux -- Python 3.6.3, pytest-3.7.1, py-1.5.4, pluggy-0.7.1 -- /opt/conda/bin/python
cachedir: .pytest_cache
rootdir: /Users/admin/program/private/oss/other/keras, inifile: pytest.ini
plugins: xdist-1.22.5, pep8-1.0.6, forked-0.2, cov-2.5.1
[gw0] linux Python 3.6.3 cwd: /Users/admin/program/private/oss/other/keras
[gw1] linux Python 3.6.3 cwd: /Users/admin/program/private/oss/other/keras
[gw0] Python 3.6.3 |Anaconda, Inc.| (default, Oct 13 2017, 12:02:49)  -- [GCC 7.2.0]
[gw1] Python 3.6.3 |Anaconda, Inc.| (default, Oct 13 2017, 12:02:49)  -- [GCC 7.2.0]
gw0 [1] / gw1 [1]
scheduling tests via LoadScheduling

tests/keras/utils/vis_utils_test.py::test_plot_model
[gw0] [100%] PASSED tests/keras/utils/vis_utils_test.py::test_plot_model

============================================ slowest 20 test durations ============================================
0.63s call     tests/keras/utils/vis_utils_test.py::test_plot_model
0.00s teardown tests/keras/utils/vis_utils_test.py::test_plot_model
0.00s setup    tests/keras/utils/vis_utils_test.py::test_plot_model
============================================ 1 passed in 7.77 seconds =============================================
```
### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
