### PR TITLE
Fix val_step in fit_generator with Sequence

### DIFF
--- a/keras/engine/training_generator.py
+++ b/keras/engine/training_generator.py
@@ -111,7 +111,7 @@ def fit_generator(model,
                 if isinstance(val_data, Sequence):
                     val_enqueuer = OrderedEnqueuer(val_data,
                                                    use_multiprocessing=use_multiprocessing)
-                    validation_steps = len(val_data)
+                    validation_steps = validation_steps or len(val_data)
                 else:
                     val_enqueuer = GeneratorEnqueuer(val_data,
                                                      use_multiprocessing=use_multiprocessing)


### PR DESCRIPTION
### Summary
The previous code was forcing the val_steps to len(val_seq). Not sure how to test this without breaking the "read-only"
### Related Issues
Fix #10944
### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
