### PR TITLE
Speed up backend tests

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -108,6 +108,15 @@ def check_single_tensor_operation(function_name, x_shape_or_val, backend_list, *
     if shape_or_val:
         x_shape, x_val = parse_shape_or_val(x_shape_or_val)
 
+        # If we can take a NumPy output, it is efficient to compare the outputs
+        # from a single backend and NumPy.
+        z_np = reference_operations.basics(function_name, x_val, **kwargs)
+        if z_np is not None:
+            assert_value_with_ref = z_np
+            # Leave only the designated backend from the test list of backends.
+            backend_list = [k for k in backend_list
+                            if K.backend() == k.__name__.split('.')[-1][:-8]]
+
     t_list = []
     z_list = []
     for k in backend_list:

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -168,51 +168,141 @@ def rnn(x, w, init, go_backwards=False, mask=None, unroll=False, input_length=No
     return o[-1], np.stack(o, axis=1), np.stack(h, axis=1)
 
 
-def basics(function_name, x, **kwargs):
-    if function_name == 'relu':
-        y = x * (x > 0)
-        if kwargs.get('alpha', None):
-            y += kwargs.get('alpha') * x * (x < 0)
-        if kwargs.get('max_value', None):
-            y = np.minimum(y, kwargs.get('max_value'))
-        return y
-    elif function_name == 'softplus':
-        return np.log(1. + np.exp(x))
-    elif function_name == 'elu':
-        y = x * (x > 0)
-        if kwargs.get('alpha', None):
-            y += kwargs.get('alpha') * (np.exp(x) - 1.) * (x < 0)
-        return y
-    elif function_name == 'sigmoid':
-        return 1. / (1. + np.exp(-x))
-    elif function_name == 'hard_sigmoid':
-        y = 0.2 * x + 0.5
-        y = np.minimum(y, 1.)
-        y = np.maximum(y, 0.)
-        return y
-    elif function_name == 'tanh':
-        return np.tanh(x)
-    elif function_name == 'softmax':
-        axis = kwargs.get('axis', -1)
-        y = np.exp(x - np.max(x, axis, keepdims=True))
-        return y / np.sum(y, axis, keepdims=True)
-    elif function_name == 'l2_normalize':
-        axis = kwargs.get('axis', -1)
-        y = np.max(np.sum(x ** 2, axis, keepdims=True), axis, keepdims=True)
-        return x / np.sqrt(y)
+def relu(x, alpha=0., max_value=None):
+    y = x * (x > 0) + alpha * x * (x < 0)
+    if max_value is not None:
+        y = np.minimum(y, max_value)
+    return y
+
+
+def softplus(x):
+    return np.log(1. + np.exp(x))
+
+
+def elu(x, alpha=1.):
+    return x * (x > 0) + alpha * (np.exp(x) - 1.) * (x < 0)
+
+
+def sigmoid(x):
+    return 1. / (1. + np.exp(-x))
+
+
+def hard_sigmoid(x):
+    y = 0.2 * x + 0.5
+    y = np.minimum(y, 1.)
+    y = np.maximum(y, 0.)
+    return y
+
+
+def tanh(x):
+    return np.tanh(x)
+
+
+def softmax(x, axis=-1):
+    y = np.exp(x - np.max(x, axis, keepdims=True))
+    return y / np.sum(y, axis, keepdims=True)
+
+
+def l2_normalize(x, axis=-1):
+    y = np.max(np.sum(x ** 2, axis, keepdims=True), axis, keepdims=True)
+    return x / np.sqrt(y)
+
+
+def max(x, axis=None, keepdims=False):
+    if isinstance(axis, list):
+        for a in axis:
+            x = np.max(x, axis=a, keepdims=keepdims)
+        return x
     else:
-        try:
-            np_operation = getattr(np, function_name)
-            if 'axis' not in kwargs:
-                if function_name[:3] == 'arg':  # argmax, argmin
-                    kwargs['axis'] = -1
-                if function_name[:3] == 'cum':  # cumsum, cumprod
-                    kwargs['axis'] = 0
-            y = np_operation(x, **kwargs)
-            if function_name == 'sqrt':
-                y[np.isnan(y)] = 0.
-            return y
-        except:
-            if function_name == 'pow':
-                return np.power(x, kwargs['a'])
-            return None
+        return np.max(x, axis=axis, keepdims=keepdims)
+
+
+def min(x, axis=None, keepdims=False):
+    if isinstance(axis, list):
+        for a in axis:
+            x = np.min(x, axis=a, keepdims=keepdims)
+        return x
+    else:
+        return np.min(x, axis=axis, keepdims=keepdims)
+
+
+def mean(x, axis=None, keepdims=False):
+    if isinstance(axis, list):
+        for a in axis:
+            x = np.mean(x, axis=a, keepdims=keepdims)
+        return x
+    else:
+        return np.mean(x, axis=axis, keepdims=keepdims)
+
+
+def std(x, axis=None, keepdims=False):
+    if isinstance(axis, list):
+        for a in axis:
+            x = np.std(x, axis=a, keepdims=keepdims)
+        return x
+    else:
+        return np.std(x, axis=axis, keepdims=keepdims)
+
+
+def sum(x, axis=None, keepdims=False):
+    if isinstance(axis, list):
+        for a in axis:
+            x = np.sum(x, axis=a, keepdims=keepdims)
+        return x
+    else:
+        return np.sum(x, axis=axis, keepdims=keepdims)
+
+
+def prod(x, axis=None, keepdims=False):
+    if isinstance(axis, list):
+        for a in axis:
+            x = np.prod(x, axis=a, keepdims=keepdims)
+        return x
+    else:
+        return np.prod(x, axis=axis, keepdims=keepdims)
+
+
+def cumsum(x, axis=0):
+    return np.cumsum(x, axis=axis)
+
+
+def cumprod(x, axis=0):
+    return np.cumprod(x, axis=axis)
+
+
+def any(x, axis=None, keepdims=False):
+    return np.any(x, axis=axis, keepdims=keepdims)
+
+
+def all(x, axis=None, keepdims=False):
+    return np.all(x, axis=axis, keepdims=keepdims)
+
+
+def argmax(x, axis=-1):
+    return np.argmax(x, axis=axis)
+
+
+def argmin(x, axis=-1):
+    return np.argmin(x, axis=axis)
+
+
+def sqrt(x):
+    y = np.sqrt(x)
+    y[np.isnan(y)] = 0.
+    return y
+
+
+def pow(x, a=1.):
+    return np.power(x, a)
+
+
+def clip(x, min_value, max_value):
+    return np.clip(x, min_value, max_value)
+
+
+square = np.square
+abs = np.abs
+exp = np.exp
+log = np.log
+round = np.round
+sign = np.sign


### PR DESCRIPTION
This PR is a follow-up of #10930 and speeds up backend tests by removing redundant backend tests. Especially, `test_elementwise_operations` and `test_nn_operations` have always been included in the slowest 20 test durations. Thus, this PR defines a set of basic operations and calculates only a single backend output if an operation exists in the list of basic operations.