### PR TITLE
Add data_format support for *Pooling1D layers

### DIFF
--- a/keras/layers/pooling.py
+++ b/keras/layers/pooling.py
@@ -17,39 +17,51 @@ class _Pooling1D(Layer):
     """
 
     def __init__(self, pool_size=2, strides=None,
-                 padding='valid', **kwargs):
+                 padding='valid', data_format=None, **kwargs):
         super(_Pooling1D, self).__init__(**kwargs)
         if strides is None:
             strides = pool_size
         self.pool_size = conv_utils.normalize_tuple(pool_size, 1, 'pool_size')
         self.strides = conv_utils.normalize_tuple(strides, 1, 'strides')
         self.padding = conv_utils.normalize_padding(padding)
+        self.data_format = K.normalize_data_format(data_format)
         self.input_spec = InputSpec(ndim=3)
 
     def compute_output_shape(self, input_shape):
-        length = conv_utils.conv_output_length(input_shape[1],
+        if self.data_format == 'channels_first':
+            steps = input_shape[2]
+            features = input_shape[1]
+        else:
+            steps = input_shape[1]
+            features = input_shape[2]
+        length = conv_utils.conv_output_length(steps,
                                                self.pool_size[0],
                                                self.padding,
                                                self.strides[0])
-        return (input_shape[0], length, input_shape[2])
+        if self.data_format == 'channels_first':
+            return (input_shape[0], features, length)
+        else:
+            return (input_shape[0], length, features)
 
     def _pooling_function(self, inputs, pool_size, strides,
                           padding, data_format):
         raise NotImplementedError
 
     def call(self, inputs):
-        inputs = K.expand_dims(inputs, 2)   # add dummy last dimension
+        dummy_axis = 2 if self.data_format == 'channels_last' else 3
+        inputs = K.expand_dims(inputs, dummy_axis)   # add dummy last dimension
         output = self._pooling_function(inputs=inputs,
                                         pool_size=self.pool_size + (1,),
                                         strides=self.strides + (1,),
                                         padding=self.padding,
-                                        data_format='channels_last')
-        return K.squeeze(output, 2)  # remove dummy last dimension
+                                        data_format=self.data_format)
+        return K.squeeze(output, dummy_axis)  # remove dummy last dimension
 
     def get_config(self):
         config = {'strides': self.strides,
                   'pool_size': self.pool_size,
-                  'padding': self.padding}
+                  'padding': self.padding,
+                  'data_format': self.data_format}
         base_config = super(_Pooling1D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
@@ -63,19 +75,40 @@ class MaxPooling1D(_Pooling1D):
             E.g. 2 will halve the input.
             If None, it will default to `pool_size`.
         padding: One of `"valid"` or `"same"` (case-insensitive).
+        data_format: A string,
+            one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs.
+            `channels_last` corresponds to inputs with shape
+            `(batch, steps, features)` while `channels_first`
+            corresponds to inputs with shape
+            `(batch, features, steps)`.
+            It defaults to the `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "channels_last".
 
     # Input shape
-        3D tensor with shape: `(batch_size, steps, features)`.
+        - If `data_format='channels_last'`:
+            3D tensor with shape:
+            `(batch_size, steps, features)`
+        - If `data_format='channels_first'`:
+            3D tensor with shape:
+            `(batch_size, features, steps)`
 
     # Output shape
-        3D tensor with shape: `(batch_size, downsampled_steps, features)`.
+        - If `data_format='channels_last'`:
+            3D tensor with shape:
+            `(batch_size, downsampled_steps, features)`
+        - If `data_format='channels_first'`:
+            3D tensor with shape:
+            `(batch_size, features, downsampled_steps)`
     """
 
     @interfaces.legacy_pooling1d_support
     def __init__(self, pool_size=2, strides=None,
-                 padding='valid', **kwargs):
+                 padding='valid', data_format=None, **kwargs):
         super(MaxPooling1D, self).__init__(pool_size, strides,
-                                           padding, **kwargs)
+                                           padding, data_format,
+                                           **kwargs)
 
     def _pooling_function(self, inputs, pool_size, strides,
                           padding, data_format):
@@ -93,19 +126,40 @@ class AveragePooling1D(_Pooling1D):
             E.g. 2 will halve the input.
             If None, it will default to `pool_size`.
         padding: One of `"valid"` or `"same"` (case-insensitive).
+        data_format: A string,
+            one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs.
+            `channels_last` corresponds to inputs with shape
+            `(batch, steps, features)` while `channels_first`
+            corresponds to inputs with shape
+            `(batch, features, steps)`.
+            It defaults to the `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "channels_last".
 
     # Input shape
-        3D tensor with shape: `(batch_size, steps, features)`.
+        - If `data_format='channels_last'`:
+            3D tensor with shape:
+            `(batch_size, steps, features)`
+        - If `data_format='channels_first'`:
+            3D tensor with shape:
+            `(batch_size, features, steps)`
 
     # Output shape
-        3D tensor with shape: `(batch_size, downsampled_steps, features)`.
+        - If `data_format='channels_last'`:
+            3D tensor with shape:
+            `(batch_size, downsampled_steps, features)`
+        - If `data_format='channels_first'`:
+            3D tensor with shape:
+            `(batch_size, features, downsampled_steps)`
     """
 
     @interfaces.legacy_pooling1d_support
     def __init__(self, pool_size=2, strides=None,
-                 padding='valid', **kwargs):
+                 padding='valid', data_format=None, **kwargs):
         super(AveragePooling1D, self).__init__(pool_size, strides,
-                                               padding, **kwargs)
+                                               padding, data_format,
+                                               **kwargs)
 
     def _pooling_function(self, inputs, pool_size, strides,
                           padding, data_format):
@@ -440,42 +494,70 @@ class _GlobalPooling1D(Layer):
     """Abstract class for different global pooling 1D layers.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, data_format=None, **kwargs):
         super(_GlobalPooling1D, self).__init__(**kwargs)
         self.input_spec = InputSpec(ndim=3)
+        self.data_format = K.normalize_data_format(data_format)
 
     def compute_output_shape(self, input_shape):
-        return (input_shape[0], input_shape[2])
+        if self.data_format == 'channels_first':
+            return (input_shape[0], input_shape[1])
+        else:
+            return (input_shape[0], input_shape[2])
 
     def call(self, inputs):
         raise NotImplementedError
+
+    def get_config(self):
+        config = {'data_format': self.data_format}
+        base_config = super(_GlobalPooling1D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
 
 
 class GlobalAveragePooling1D(_GlobalPooling1D):
     """Global average pooling operation for temporal data.
 
+    # Arguments
+        data_format: A string,
+            one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs.
+            `channels_last` corresponds to inputs with shape
+            `(batch, steps, features)` while `channels_first`
+            corresponds to inputs with shape
+            `(batch, features, steps)`.
+            It defaults to the `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "channels_last".
+
     # Input shape
-        3D tensor with shape: `(batch_size, steps, features)`.
+        - If `data_format='channels_last'`:
+            3D tensor with shape:
+            `(batch_size, steps, features)`
+        - If `data_format='channels_first'`:
+            3D tensor with shape:
+            `(batch_size, features, steps)`
 
     # Output shape
         2D tensor with shape:
         `(batch_size, features)`
     """
 
-    def __init__(self, **kwargs):
-        super(GlobalAveragePooling1D, self).__init__(**kwargs)
+    def __init__(self, data_format=None, **kwargs):
+        super(GlobalAveragePooling1D, self).__init__(data_format,
+                                                     **kwargs)
         self.supports_masking = True
 
     def call(self, inputs, mask=None):
+        steps_axis = 1 if self.data_format == 'channels_last' else 2
         if mask is not None:
             mask = K.cast(mask, K.floatx())
             input_shape = K.int_shape(inputs)
-            broadcast_shape = [-1, input_shape[1], 1]
+            broadcast_shape = [-1, input_shape[steps_axis], 1]
             mask = K.reshape(mask, broadcast_shape)
             inputs *= mask
-            return K.sum(inputs, axis=1) / K.sum(mask, axis=1)
+            return K.sum(inputs, axis=steps_axis) / K.sum(mask, axis=steps_axis)
         else:
-            return K.mean(inputs, axis=1)
+            return K.mean(inputs, axis=steps_axis)
 
     def compute_mask(self, inputs, mask=None):
         return None
@@ -484,8 +566,25 @@ class GlobalAveragePooling1D(_GlobalPooling1D):
 class GlobalMaxPooling1D(_GlobalPooling1D):
     """Global max pooling operation for temporal data.
 
+    # Arguments
+        data_format: A string,
+            one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs.
+            `channels_last` corresponds to inputs with shape
+            `(batch, steps, features)` while `channels_first`
+            corresponds to inputs with shape
+            `(batch, features, steps)`.
+            It defaults to the `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "channels_last".
+
     # Input shape
-        3D tensor with shape: `(batch_size, steps, features)`.
+        - If `data_format='channels_last'`:
+            3D tensor with shape:
+            `(batch_size, steps, features)`
+        - If `data_format='channels_first'`:
+            3D tensor with shape:
+            `(batch_size, features, steps)`
 
     # Output shape
         2D tensor with shape:
@@ -493,7 +592,8 @@ class GlobalMaxPooling1D(_GlobalPooling1D):
     """
 
     def call(self, inputs):
-        return K.max(inputs, axis=1)
+        steps_axis = 1 if self.data_format == 'channels_last' else 2
+        return K.max(inputs, axis=steps_axis)
 
 
 class _GlobalPooling2D(Layer):

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -117,20 +117,24 @@ def test_conv_1d():
 def test_maxpooling_1d():
     for padding in ['valid', 'same']:
         for stride in [1, 2]:
-            layer_test(convolutional.MaxPooling1D,
-                       kwargs={'strides': stride,
-                               'padding': padding},
-                       input_shape=(3, 5, 4))
+            for data_format in ['channels_first', 'channels_last']:
+                layer_test(convolutional.MaxPooling1D,
+                           kwargs={'strides': stride,
+                                   'padding': padding,
+                                   'data_format': data_format},
+                           input_shape=(3, 5, 4))
 
 
 @keras_test
 def test_averagepooling_1d():
     for padding in ['valid', 'same']:
         for stride in [1, 2]:
-            layer_test(convolutional.AveragePooling1D,
-                       kwargs={'strides': stride,
-                               'padding': padding},
-                       input_shape=(3, 5, 4))
+            for data_format in ['channels_first', 'channels_last']:
+                layer_test(convolutional.AveragePooling1D,
+                           kwargs={'strides': stride,
+                                   'padding': padding,
+                                   'data_format': data_format},
+                           input_shape=(3, 5, 4))
 
 
 @keras_test
@@ -408,10 +412,13 @@ def test_depthwise_conv_2d():
 
 @keras_test
 def test_globalpooling_1d():
-    layer_test(pooling.GlobalMaxPooling1D,
-               input_shape=(3, 4, 5))
-    layer_test(pooling.GlobalAveragePooling1D,
-               input_shape=(3, 4, 5))
+    for data_format in ['channels_first', 'channels_last']:
+        layer_test(pooling.GlobalMaxPooling1D,
+                   kwargs={'data_format': data_format},
+                   input_shape=(3, 4, 5))
+        layer_test(pooling.GlobalAveragePooling1D,
+                   kwargs={'data_format': data_format},
+                   input_shape=(3, 4, 5))
 
 
 @keras_test


### PR DESCRIPTION
### Summary
Adds `data_format` support for `*Pooling1D layers`. Details in #10960 

### Related Issues
Problem brought up in #10570 
Design review in #10960

### PR Overview
- [ ] This PR requires new unit tests [y/**n**] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/**n**] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [**y**/n]
- [x] This PR changes the current API [**y**/n] (all API changes need to be approved by fchollet)
