### PR TITLE
Fix dilated convolution for CNTK backend.

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1515,27 +1515,17 @@ def conv2d(x, kernel, strides=(1, 1), padding='valid',
     x = _preprocess_conv2d_input(x, data_format)
     kernel = _preprocess_conv2d_kernel(kernel, data_format)
     padding = _preprocess_border_mode(padding)
-    if dilation_rate == (1, 1):
-        strides = (1,) + strides
-        x = C.convolution(
-            kernel,
-            x,
-            strides,
-            auto_padding=[
-                False,
-                padding,
-                padding])
-    else:
-        assert dilation_rate[0] == dilation_rate[1]
-        assert strides == (1, 1), 'Invalid strides for dilated convolution'
-        x = C.convolution(
-            kernel,
-            x,
-            strides=dilation_rate[0],
-            auto_padding=[
-                False,
-                padding,
-                padding])
+
+    if dev.type() == 0 and dilation_rate != (1, 1):
+        raise ValueError('Dilated convolution on CPU is not supported by CNTK backend. ' +
+                         'Please set dilation_rate with (1, 1).')
+
+    x = C.convolution(kernel,
+                      x,
+                      strides,
+                      auto_padding=[False, padding, padding],
+                      dilation=dilation_rate)
+
     return _postprocess_conv2d_output(x, data_format)
 
 

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -135,7 +135,7 @@ def test_averagepooling_1d():
 
 @keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason="cntk does not support dilated conv")
+                    reason="cntk only supports dilated conv on GPU")
 def test_convolution_2d():
     num_samples = 2
     filters = 2


### PR DESCRIPTION
### Summary
2D Dilated convolution gives wrong output for CNTK backend:
```
from keras.layers import Input, Conv2D
from keras.models import Model
import numpy as np

inputs = Input(shape=(10, 10, 1))
m = Conv2D(1, kernel_size=(3, 3), padding='valid', dilation_rate=(2, 2))(inputs)
model = Model(inputs=inputs, outputs=m)
model.summary()

x = np.random.random((1, 10, 10, 1)).astype(np.float32)
y = model.predict(x)
print("y.shape = " + str(y.shape))
```
output is:
```
_________________________________________________________________
Layer (type)                 Output Shape              Param #
=================================================================
input_1 (InputLayer)         (None, 10, 10, 1)         0
_________________________________________________________________
conv2d_1 (Conv2D)            (None, 6, 6, 1)           10
=================================================================
Total params: 10
Trainable params: 10
Non-trainable params: 0
_________________________________________________________________
y.shape = (1, 4, 4, 1)
```
The output shape should be ```(None, 6, 6, 1)``` according keras shape inference, but it's ```(1, 4, 4, 1)``` after evaluation. This is because it passed ```dilation_rate``` to ```strides``` by mistake at CNTK backend when ```dilation > 2```. 

### How to test this fix
There is ```test_convolution_2d``` in ```convolutional_test.py```, but I still skip it due to CNTK only supports dilated convolution on GPU, but CI doesn't have GPU node. I run the following code with TF backend(CPU or GPU) and CNTK backend(GPU), they gives the same output.
Test code:
```
from keras.layers import Input, Conv2D
from keras.models import Model
from keras.initializers import Constant
import numpy as np

kernel = np.arange(9).reshape((3, 3, 1, 1))
print(kernel.shape)

inputs = Input(shape=(10, 10, 1))
m = Conv2D(1, kernel_size=(3,3), padding='valid', dilation_rate=(2, 2), kernel_initializer=Constant(kernel))(inputs)
model = Model(inputs=inputs, outputs=m)
model.summary()


x = np.arange(100).reshape((1, 10, 10, 1)).astype(np.float32) 
y = model.predict(x)

print(np.squeeze(y))
print(y.shape)
```
Output:
```
(3, 3, 1, 1)
_________________________________________________________________
Layer (type)                 Output Shape              Param #
=================================================================
input_1 (InputLayer)         (None, 10, 10, 1)         0
_________________________________________________________________
conv2d_1 (Conv2D)            (None, 6, 6, 1)           10
=================================================================
Total params: 10
Trainable params: 10
Non-trainable params: 0
_________________________________________________________________
[[1164. 1200. 1236. 1272. 1308. 1344.]
 [1524. 1560. 1596. 1632. 1668. 1704.]
 [1884. 1920. 1956. 1992. 2028. 2064.]
 [2244. 2280. 2316. 2352. 2388. 2424.]
 [2604. 2640. 2676. 2712. 2748. 2784.]
 [2964. 3000. 3036. 3072. 3108. 3144.]]
(1, 6, 6, 1)
```

Meanwhile, I found a CNTK dilated conv bug if number of channel > 1(need confirm from CNTK guys), I reported to https://github.com/Microsoft/CNTK/issues/3371. But I think it doesn't have effect of the code structure at Keras.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
