### PR TITLE
Created a dummy 'variable' function in the numpy backend to replace the `BACKEND` variable.

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -388,55 +388,47 @@ class TestBackend(object):
         check_single_tensor_operation('print_tensor', (1, 2, 3), BACKENDS)
 
     def test_elementwise_operations(self):
-        check_single_tensor_operation('max', (4, 2), BACKENDS)
-        check_single_tensor_operation('max', (4, 2), BACKENDS, axis=1, keepdims=True)
+        check_single_tensor_operation('max', (4, 2), WITH_NP)
+        check_single_tensor_operation('max', (4, 2), WITH_NP, axis=1, keepdims=True)
 
-        check_single_tensor_operation('min', (4, 2), BACKENDS)
-        check_single_tensor_operation('min', (4, 2), BACKENDS, axis=1, keepdims=True)
-        check_single_tensor_operation('min', (4, 2, 3), BACKENDS, axis=[1, -1])
+        check_single_tensor_operation('min', (4, 2), WITH_NP)
+        check_single_tensor_operation('min', (4, 2), WITH_NP, axis=1, keepdims=True)
+        check_single_tensor_operation('min', (4, 2, 3), WITH_NP, axis=[1, -1])
 
-        check_single_tensor_operation('mean', (4, 2), BACKENDS)
-        check_single_tensor_operation('mean', (4, 2), BACKENDS, axis=1, keepdims=True)
-        check_single_tensor_operation('mean', (4, 2, 3), BACKENDS, axis=-1, keepdims=True)
-        check_single_tensor_operation('mean', (4, 2, 3), BACKENDS, axis=[1, -1])
+        check_single_tensor_operation('mean', (4, 2), WITH_NP)
+        check_single_tensor_operation('mean', (4, 2), WITH_NP, axis=1, keepdims=True)
+        check_single_tensor_operation('mean', (4, 2, 3), WITH_NP, axis=-1, keepdims=True)
+        check_single_tensor_operation('mean', (4, 2, 3), WITH_NP, axis=[1, -1])
 
-        check_single_tensor_operation('std', (4, 2), BACKENDS)
-        check_single_tensor_operation('std', (4, 2), BACKENDS, axis=1, keepdims=True)
+        check_single_tensor_operation('std', (4, 2), WITH_NP)
+        check_single_tensor_operation('std', (4, 2), WITH_NP, axis=1, keepdims=True)
         # check_single_tensor_operation('std', (4, 2, 3), BACKENDS, axis=[1, -1])
 
-        check_single_tensor_operation('prod', (4, 2), BACKENDS)
-        check_single_tensor_operation('prod', (4, 2), BACKENDS, axis=1, keepdims=True)
-        check_single_tensor_operation('prod', (4, 2, 3), BACKENDS, axis=[1, -1])
+        check_single_tensor_operation('prod', (4, 2), WITH_NP)
+        check_single_tensor_operation('prod', (4, 2), WITH_NP, axis=1, keepdims=True)
+        check_single_tensor_operation('prod', (4, 2, 3), WITH_NP, axis=[1, -1])
 
-        # cntk does not support cumsum and cumprod yet
-        check_single_tensor_operation('cumsum', (4, 2), [KTF, KTH])
-        check_single_tensor_operation('cumsum', (4, 2), [KTF, KTH], axis=1)
+        check_single_tensor_operation('any', (4, 2), WITH_NP)
+        check_single_tensor_operation('any', (4, 2), WITH_NP, axis=1, keepdims=True)
 
-        check_single_tensor_operation('cumprod', (4, 2), [KTF, KTH])
-        check_single_tensor_operation('cumprod', (4, 2), [KTF, KTH], axis=1)
+        check_single_tensor_operation('all', (4, 2), WITH_NP)
+        check_single_tensor_operation('all', (4, 2), WITH_NP, axis=1, keepdims=True)
 
-        check_single_tensor_operation('any', (4, 2), BACKENDS)
-        check_single_tensor_operation('any', (4, 2), BACKENDS, axis=1, keepdims=True)
+        check_single_tensor_operation('argmax', (4, 2), WITH_NP)
+        check_single_tensor_operation('argmax', (4, 2), WITH_NP, axis=1)
 
-        check_single_tensor_operation('all', (4, 2), BACKENDS)
-        check_single_tensor_operation('all', (4, 2), BACKENDS, axis=1, keepdims=True)
+        check_single_tensor_operation('argmin', (4, 2), WITH_NP)
+        check_single_tensor_operation('argmin', (4, 2), WITH_NP, axis=1)
 
-        check_single_tensor_operation('argmax', (4, 2), BACKENDS)
-        check_single_tensor_operation('argmax', (4, 2), BACKENDS, axis=1)
-
-        check_single_tensor_operation('argmin', (4, 2), BACKENDS)
-        check_single_tensor_operation('argmin', (4, 2), BACKENDS, axis=1)
-
-        check_single_tensor_operation('square', (4, 2), BACKENDS)
-        check_single_tensor_operation('abs', (4, 2), BACKENDS)
-        check_single_tensor_operation('sqrt', (4, 2), BACKENDS)
+        check_single_tensor_operation('square', (4, 2), WITH_NP)
+        check_single_tensor_operation('abs', (4, 2), WITH_NP)
+        check_single_tensor_operation('sqrt', (4, 2), WITH_NP)
         check_single_tensor_operation('exp', (4, 2), BACKENDS)
-        # cntk return -85.1 for zero or negative number, not nan, so can't compare with other backend.
-        check_single_tensor_operation('log', (4, 2), [KTH, KTF])
+
         check_single_tensor_operation('round', (4, 2), BACKENDS)
         check_single_tensor_operation('sign', (4, 2), BACKENDS)
-        check_single_tensor_operation('pow', (4, 2), BACKENDS, a=3)
-        check_single_tensor_operation('clip', (4, 2), BACKENDS, min_value=0.4,
+        check_single_tensor_operation('pow', (4, 2), WITH_NP, a=3)
+        check_single_tensor_operation('clip', (4, 2), WITH_NP, min_value=0.4,
                                       max_value=0.6)
 
         # two-tensor ops
@@ -448,6 +440,22 @@ class TestBackend(object):
         check_two_tensor_operation('less_equal', (4, 2), (4, 2), BACKENDS)
         check_two_tensor_operation('maximum', (4, 2), (4, 2), BACKENDS)
         check_two_tensor_operation('minimum', (4, 2), (4, 2), BACKENDS)
+
+    @pytest.mark.skipif(K.backend() == 'cntk', reason='cntk does not support '
+                                                      'cumsum and cumprod yet')
+    def test_cumsum_cumprod(self):
+        check_single_tensor_operation('cumsum', (4, 2), WITH_NP)
+        check_single_tensor_operation('cumsum', (4, 2), WITH_NP, axis=1)
+
+        check_single_tensor_operation('cumprod', (4, 2), WITH_NP)
+        check_single_tensor_operation('cumprod', (4, 2), WITH_NP, axis=1)
+
+    @pytest.mark.skipif(K.backend() == 'cntk',
+                        reason='cntk return -85.1 for zero or '
+                               'negative number, not nan, so can\'t '
+                               'compare with other backend.')
+    def test_log(self):
+        check_single_tensor_operation('log', (4, 2), WITH_NP)
 
     # cntk doesn't support gradient in this way
     def test_gradient(self):

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -12,7 +12,7 @@ import reference_operations as KNP
 
 
 BACKENDS = []  # Holds a list of all available back-ends
-BACKEND_AND_NP = [K, KNP]
+WITH_NP = [K, KNP]
 
 try:
     from keras.backend import cntk_backend as KC
@@ -283,7 +283,7 @@ class TestBackend(object):
         check_two_tensor_operation('concatenate', (4, 3), (4, 2), BACKENDS,
                                    axis=-1, concat_args=True)
 
-        check_single_tensor_operation('reshape', (4, 2), BACKEND_AND_NP, shape=(8, 1))
+        check_single_tensor_operation('reshape', (4, 2), WITH_NP, shape=(8, 1))
         check_single_tensor_operation('permute_dimensions', (4, 2, 3), BACKENDS,
                                       pattern=(2, 0, 1))
         check_single_tensor_operation('repeat', (4, 1), BACKENDS, n=3)

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -12,6 +12,7 @@ import reference_operations as KNP
 
 
 BACKENDS = []  # Holds a list of all available back-ends
+BACKEND_AND_NP = [K, KNP]
 
 try:
     from keras.backend import cntk_backend as KC
@@ -282,7 +283,7 @@ class TestBackend(object):
         check_two_tensor_operation('concatenate', (4, 3), (4, 2), BACKENDS,
                                    axis=-1, concat_args=True)
 
-        check_single_tensor_operation('reshape', (4, 2), BACKENDS, shape=(8, 1))
+        check_single_tensor_operation('reshape', (4, 2), BACKEND_AND_NP, shape=(8, 1))
         check_single_tensor_operation('permute_dimensions', (4, 2, 3), BACKENDS,
                                       pattern=(2, 0, 1))
         check_single_tensor_operation('repeat', (4, 1), BACKENDS, n=3)

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -300,6 +300,17 @@ def clip(x, min_value, max_value):
     return np.clip(x, min_value, max_value)
 
 
+def reshape(x, shape):
+    return np.reshape(x, shape)
+
+
+def variable(value, dtype=None, name=None, constraint=None):
+    if constraint is not None:
+        raise TypeError("Constraint must be None when "
+                        "using the NumPy backend.")
+    return np.array(value, dtype)
+
+
 square = np.square
 abs = np.abs
 exp = np.exp


### PR DESCRIPTION
### Summary
@taehoonlee 

Allow me to propose an alternative to the `assert_value_with_ref` method for the numpy reference operations.
The limitation which I see with this approach is that it will be hard to track the progress of the removal of the other backends (I may be wrong, feel free to correct me it's possible I haven't read the code well enough).

I propose that we consider the numpy backend as a true backend for the tests (without gradients of course).
I created a new variable called `BACKEND_AND_NP` which is similar to `BACKENDS` and will hopefully replace it.

Once we manage to remove all occurences of `KC`, `KTF`, `KTH` and `BACKENDS`, we should be able to removed unnecessary installs of backends.

I made a small example here for the `reshape` backend function.

What are your thoughts on this?

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
