### PR TITLE
Ignore PEP8 W503

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,9 +11,11 @@ norecursedirs= build
 # E501 line too long (82 > 79 characters)
 # E402 module level import not at top of file - temporary measure to continue adding ros python packaged in sys.path
 # E731 do not assign a lambda expression, use a def
+# W503 line break occurred before a binary operator
 
 pep8ignore=* E402 \
            * E731 \
+           * W503 \
            keras/callbacks.py E501 \
            keras/constraints.py E501 \
            keras/metrics.py E501 \


### PR DESCRIPTION
### Summary

As suggest in [pep-8](https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator), we should ignore `W503` to allow breaking line before a binary operator and improve readability.

### Related Issues

#10975 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
