### PR TITLE
Convolutional layer supports float64 dtype after tensorflow 1.8.0

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -15,6 +15,7 @@ from tensorflow.core.protobuf import config_pb2
 from collections import defaultdict
 
 import numpy as np
+from distutils.version import StrictVersion
 import os
 
 from .common import floatx
@@ -3400,7 +3401,9 @@ def _preprocess_conv1d_input(x, data_format):
     # Returns
         A tensor.
     """
-    if dtype(x) == 'float64':
+    # tensorflow doesn't support float64 for conv layer before 1.8.0
+    if (dtype(x) == 'float64'
+            and StrictVersion(tf.__version__) < StrictVersion('1.8.0')):
         x = tf.cast(x, 'float32')
     tf_data_format = 'NWC'  # to pass TF Conv2dNative operations
     if data_format == 'channels_first':
@@ -3421,7 +3424,9 @@ def _preprocess_conv2d_input(x, data_format):
     # Returns
         A tensor.
     """
-    if dtype(x) == 'float64':
+    # tensorflow doesn't support float64 for conv layer before 1.8.0
+    if (dtype(x) == 'float64'
+            and StrictVersion(tf.__version__) < StrictVersion('1.8.0')):
         x = tf.cast(x, 'float32')
     tf_data_format = 'NHWC'
     if data_format == 'channels_first':
@@ -3442,7 +3447,9 @@ def _preprocess_conv3d_input(x, data_format):
     # Returns
         A tensor.
     """
-    if dtype(x) == 'float64':
+    # tensorflow doesn't support float64 for conv layer before 1.8.0
+    if (dtype(x) == 'float64'
+            and StrictVersion(tf.__version__) < StrictVersion('1.8.0')):
         x = tf.cast(x, 'float32')
     tf_data_format = 'NDHWC'
     if data_format == 'channels_first':

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -1062,7 +1062,7 @@ def test_cropping_3d():
 
 @keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason="cntk does not work with float64")
+                    reason='CNTK does not support float64')
 @pytest.mark.parametrize(
     'input_shape,conv_class',
     [((2, 4, 2), convolutional.Conv1D),

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -1060,5 +1060,28 @@ def test_cropping_3d():
         layer = convolutional.Cropping3D(cropping=lambda x: x)
 
 
+@keras_test
+@pytest.mark.skipif((K.backend() == 'cntk'),
+                    reason="cntk does not work with float64")
+@pytest.mark.parametrize(
+    'input_shape,conv_class',
+    [((2, 4, 2), convolutional.Conv1D),
+     ((2, 4, 4, 2), convolutional.Conv2D),
+     ((2, 4, 4, 4, 2), convolutional.Conv3D)]
+)
+def test_conv_float64(input_shape, conv_class):
+    kernel_size = 3
+    strides = 1
+    filters = 3
+    K.set_floatx('float64')
+    layer_test(conv_class,
+               kwargs={'filters': filters,
+                       'kernel_size': kernel_size,
+                       'padding': 'valid',
+                       'strides': strides},
+               input_shape=input_shape)
+    K.set_floatx('float32')
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
### Summary

Relax cast to `float32` in `_preprocess_conv*d_input` after `tensorflow` version >= 1.8.0

### Related Issues

#10964 

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
