### PR TITLE
Reduce the flakyness of builds with `travis_retry`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest pandas
+  - travis_retry conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest pandas
   - source activate test-environment
-  - pip install --only-binary=numpy,scipy numpy nose scipy matplotlib h5py theano
+  - travis_retry pip install --only-binary=numpy,scipy numpy nose scipy matplotlib h5py theano
   - pip install keras_applications keras_preprocessing
   - conda install mkl mkl-service
 


### PR DESCRIPTION
### Summary
It happens sometimes that a build fails because of timeouts or https errors. Forcing us to often re-triggering the whole build by closing and opening again the PR.
See: [this build](https://travis-ci.org/keras-team/keras/builds/420060113?utm_source=github_status&utm_medium=notification)
and [this build](https://travis-ci.org/keras-team/keras/builds/414613797?utm_source=github_status&utm_medium=notification)


Keras is not the only repo facing this issue with travis. This is why travis made a script for that. See [the docs for reference](https://docs.travis-ci.com/user/common-build-problems/#timeouts-installing-dependencies)
### Related Issues

### PR Overview

See those examples for usage: 

https://github.com/scikit-fuzzy/scikit-fuzzy/blob/master/.travis.yml

https://github.com/pyoceans/python-seawater/blob/master/.travis.yml

https://github.com/blink1073/scilab2py/blob/master/.travis.yml

I only added `travis_retry` for the commands which have the most stuff being downloaded.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
