### PR TITLE
 Added the mode "bilinear" in the upscaling2D layer.

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1169,7 +1169,7 @@ def resize_images(x, height_factor, width_factor, data_format, interpolation='ne
         else:
             raise ValueError('CNTK Backend: Invalid data_format:', data_format)
     else:
-        raise NotImplementedError
+        raise NotImplementedError('CNTK only supports `nearest` interpolation.')
 
 
 def resize_volumes(x, depth_factor, height_factor, width_factor, data_format):

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1167,7 +1167,7 @@ def resize_images(x, height_factor, width_factor, data_format, interpolation='ne
             output = repeat_elements(output, width_factor, axis=2)
             return output
         else:
-            raise ValueError('CNTK Backend: Invalid data_format:', data_format)
+            raise ValueError('CNTK Backend: Invalid data_format: %s' % data_format)
     else:
         raise NotImplementedError('CNTK only supports `nearest` interpolation.')
 
@@ -1184,7 +1184,7 @@ def resize_volumes(x, depth_factor, height_factor, width_factor, data_format):
         output = repeat_elements(output, width_factor, axis=3)
         return output
     else:
-        raise ValueError('CNTK Backend: Invalid data_format:', data_format)
+        raise ValueError('CNTK Backend: Invalid data_format: %s' % data_format)
 
 
 def repeat_elements(x, rep, axis):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1978,8 +1978,8 @@ def resize_images(x, height_factor, width_factor, data_format, interpolation='ne
     # Raises
         ValueError: if `data_format` is neither `"channels_last"` or `"channels_first"`.
     """
+    original_shape = int_shape(x)
     if data_format == 'channels_first':
-        original_shape = int_shape(x)
         new_shape = tf.shape(x)[2:]
         new_shape *= tf.constant(np.array([height_factor, width_factor]).astype('int32'))
         x = permute_dimensions(x, [0, 2, 3, 1])
@@ -1988,16 +1988,22 @@ def resize_images(x, height_factor, width_factor, data_format, interpolation='ne
         elif interpolation == 'bilinear':
             x = tf.image.resize_bilinear(x, new_shape)
         else:
-            raise ValueError('interpolation should be one of "nearest" or "bilinear".')
+            raise ValueError('interpolation should be one '
+                             'of "nearest" or "bilinear".')
         x = permute_dimensions(x, [0, 3, 1, 2])
         x.set_shape((None, None, original_shape[2] * height_factor if original_shape[2] is not None else None,
                      original_shape[3] * width_factor if original_shape[3] is not None else None))
         return x
     elif data_format == 'channels_last':
-        original_shape = int_shape(x)
         new_shape = tf.shape(x)[1:3]
         new_shape *= tf.constant(np.array([height_factor, width_factor]).astype('int32'))
-        x = tf.image.resize_nearest_neighbor(x, new_shape)
+        if interpolation == 'nearest':
+            x = tf.image.resize_nearest_neighbor(x, new_shape)
+        elif interpolation == 'bilinear':
+            x = tf.image.resize_bilinear(x, new_shape)
+        else:
+            raise ValueError('interpolation should be one '
+                             'of "nearest" or "bilinear".')
         x.set_shape((None, original_shape[1] * height_factor if original_shape[1] is not None else None,
                      original_shape[2] * width_factor if original_shape[2] is not None else None, None))
         return x

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1962,7 +1962,11 @@ def permute_dimensions(x, pattern):
     return tf.transpose(x, perm=pattern)
 
 
-def resize_images(x, height_factor, width_factor, data_format, interpolation='nearest'):
+def resize_images(x,
+                  height_factor,
+                  width_factor,
+                  data_format,
+                  interpolation='nearest'):
     """Resizes the images contained in a 4D tensor.
 
     # Arguments
@@ -1978,37 +1982,40 @@ def resize_images(x, height_factor, width_factor, data_format, interpolation='ne
     # Raises
         ValueError: if `data_format` is neither `"channels_last"` or `"channels_first"`.
     """
-    original_shape = int_shape(x)
     if data_format == 'channels_first':
-        new_shape = tf.shape(x)[2:]
-        new_shape *= tf.constant(np.array([height_factor, width_factor]).astype('int32'))
-        x = permute_dimensions(x, [0, 2, 3, 1])
-        if interpolation == 'nearest':
-            x = tf.image.resize_nearest_neighbor(x, new_shape)
-        elif interpolation == 'bilinear':
-            x = tf.image.resize_bilinear(x, new_shape)
-        else:
-            raise ValueError('interpolation should be one '
-                             'of "nearest" or "bilinear".')
-        x = permute_dimensions(x, [0, 3, 1, 2])
-        x.set_shape((None, None, original_shape[2] * height_factor if original_shape[2] is not None else None,
-                     original_shape[3] * width_factor if original_shape[3] is not None else None))
-        return x
-    elif data_format == 'channels_last':
-        new_shape = tf.shape(x)[1:3]
-        new_shape *= tf.constant(np.array([height_factor, width_factor]).astype('int32'))
-        if interpolation == 'nearest':
-            x = tf.image.resize_nearest_neighbor(x, new_shape)
-        elif interpolation == 'bilinear':
-            x = tf.image.resize_bilinear(x, new_shape)
-        else:
-            raise ValueError('interpolation should be one '
-                             'of "nearest" or "bilinear".')
-        x.set_shape((None, original_shape[1] * height_factor if original_shape[1] is not None else None,
-                     original_shape[2] * width_factor if original_shape[2] is not None else None, None))
-        return x
+        rows, cols = 2, 3
     else:
-        raise ValueError('Unknown data_format: ' + str(data_format))
+        rows, cols = 1, 2
+
+    original_shape = int_shape(x)
+    new_shape = tf.shape(x)[rows:cols + 1]
+    new_shape *= tf.constant(np.array([height_factor, width_factor], dtype='int32'))
+
+    if data_format == 'channels_first':
+        x = permute_dimensions(x, [0, 2, 3, 1])
+    if interpolation == 'nearest':
+        x = tf.image.resize_nearest_neighbor(x, new_shape)
+    elif interpolation == 'bilinear':
+        x = tf.image.resize_bilinear(x, new_shape)
+    else:
+        raise ValueError('interpolation should be one '
+                         'of "nearest" or "bilinear".')
+    if data_format == 'channels_first':
+        x = permute_dimensions(x, [0, 3, 1, 2])
+
+    if original_shape[rows] is None:
+        new_height = None
+    else:
+        new_height = original_shape[rows] * height_factor
+
+    if original_shape[cols] is None:
+        new_width = None
+    else:
+        new_width = original_shape[cols] * width_factor
+
+    output_shape = (None, new_height, new_width, None)
+    x.set_shape(transpose_shape(output_shape, data_format, spatial_axes=(1, 2)))
+    return x
 
 
 def resize_volumes(x, depth_factor, height_factor, width_factor, data_format):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -19,7 +19,6 @@ try:
 except ImportError:
     from theano.sandbox.softsign import softsign as T_softsign
 
-import warnings
 import numpy as np
 from .common import floatx
 from .common import epsilon

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1940,7 +1940,8 @@ class UpSampling2D(Layer):
         self.size = conv_utils.normalize_tuple(size, 2, 'size')
         self.input_spec = InputSpec(ndim=4)
         if interpolation not in ['nearest', 'bilinear']:
-            raise ValueError('interpolation should be one of "nearest" or "bilinear".')
+            raise ValueError('interpolation should be one '
+                             'of "nearest" or "bilinear".')
         self.interpolation = interpolation
 
     def compute_output_shape(self, input_shape):

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1917,6 +1917,8 @@ class UpSampling2D(Layer):
             Keras config file at `~/.keras/keras.json`.
             If you never set it, then it will be "channels_last".
         interpolation: A string, one of `nearest` or `bilinear`.
+            Note that CNTK does not support yet the `bilinear` upscaling
+            and that with Theano, only `size=(2, 2)` is possible.
 
     # Input shape
         4D tensor with shape:

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1323,6 +1323,23 @@ class TestBackend(object):
             K.resize_images(K.variable(xval), 2, 2,
                             data_format='channels_middle')
 
+    @staticmethod
+    def _helper_bilinear(height_factor, width_factor):
+        x_shape = (2, 3, 4, 5)
+        for data_format in ['channels_first', 'channels_last']:
+            check_single_tensor_operation('resize_images', x_shape,
+                                          [KTF, KTH],
+                                          height_factor=height_factor,
+                                          width_factor=width_factor,
+                                          data_format=data_format,
+                                          interpolation='bilinear')
+
+    @pytest.mark.skipif(K.backend() == 'cntk', reason='Not supported.')
+    def test_resize_images_bilinear(self):
+        self._helper_bilinear(2, 2)
+        with pytest.raises(NotImplementedError):
+            self._helper_bilinear(4, 4)
+
     def test_resize_volumes(self):
         for data_format in ['channels_first', 'channels_last']:
             shape = (5, 5, 5)

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1324,21 +1324,21 @@ class TestBackend(object):
                             data_format='channels_middle')
 
     @staticmethod
-    def _helper_bilinear(height_factor, width_factor):
+    def _helper_bilinear(data_format, height_factor, width_factor):
         x_shape = (2, 3, 4, 5)
-        for data_format in ['channels_first', 'channels_last']:
-            check_single_tensor_operation('resize_images', x_shape,
-                                          [KTF, KTH],
-                                          height_factor=height_factor,
-                                          width_factor=width_factor,
-                                          data_format=data_format,
-                                          interpolation='bilinear')
+        check_single_tensor_operation('resize_images', x_shape,
+                                      [KTF, KTH],
+                                      height_factor=height_factor,
+                                      width_factor=width_factor,
+                                      data_format=data_format,
+                                      interpolation='bilinear')
 
     @pytest.mark.skipif(K.backend() == 'cntk', reason='Not supported.')
-    def test_resize_images_bilinear(self):
-        self._helper_bilinear(2, 2)
+    @pytest.mark.parametrize('data_format', ['channels_first', 'channels_last'])
+    def test_resize_images_bilinear(self, data_format):
+        self._helper_bilinear(data_format, 2, 2)
         with pytest.raises(NotImplementedError):
-            self._helper_bilinear(4, 4)
+            self._helper_bilinear(data_format, 4, 4)
 
     def test_resize_volumes(self):
         for data_format in ['channels_first', 'channels_last']:

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -880,7 +880,9 @@ def test_upsampling_2d_bilinear():
 
         # basic test
         layer_test(convolutional.UpSampling2D,
-                   kwargs={'size': (2, 2), 'data_format': data_format, 'interpolation': 'bilinear'},
+                   kwargs={'size': (2, 2),
+                           'data_format': data_format,
+                           'interpolation': 'bilinear'},
                    input_shape=inputs.shape)
 
         for length_row in [2]:

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -864,41 +864,42 @@ def test_upsampling_2d():
 
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='cntk does not support it yet')
-def test_upsampling_2d_bilinear():
+@pytest.mark.parametrize('data_format',
+                         ['channels_first', 'channels_last'])
+def test_upsampling_2d_bilinear(data_format):
     num_samples = 2
     stack_size = 2
     input_num_row = 11
     input_num_col = 12
 
-    for data_format in ['channels_first', 'channels_last']:
-        if data_format == 'channels_first':
-            inputs = np.random.rand(num_samples, stack_size, input_num_row,
-                                    input_num_col)
-        else:  # tf
-            inputs = np.random.rand(num_samples, input_num_row, input_num_col,
-                                    stack_size)
+    if data_format == 'channels_first':
+        inputs = np.random.rand(num_samples, stack_size, input_num_row,
+                                input_num_col)
+    else:  # tf
+        inputs = np.random.rand(num_samples, input_num_row, input_num_col,
+                                stack_size)
 
-        # basic test
-        layer_test(convolutional.UpSampling2D,
-                   kwargs={'size': (2, 2),
-                           'data_format': data_format,
-                           'interpolation': 'bilinear'},
-                   input_shape=inputs.shape)
+    # basic test
+    layer_test(convolutional.UpSampling2D,
+               kwargs={'size': (2, 2),
+                       'data_format': data_format,
+                       'interpolation': 'bilinear'},
+               input_shape=inputs.shape)
 
-        for length_row in [2]:
-            for length_col in [2, 3]:
-                layer = convolutional.UpSampling2D(
-                    size=(length_row, length_col),
-                    data_format=data_format)
-                layer.build(inputs.shape)
-                outputs = layer(K.variable(inputs))
-                np_output = K.eval(outputs)
-                if data_format == 'channels_first':
-                    assert np_output.shape[2] == length_row * input_num_row
-                    assert np_output.shape[3] == length_col * input_num_col
-                else:  # tf
-                    assert np_output.shape[1] == length_row * input_num_row
-                    assert np_output.shape[2] == length_col * input_num_col
+    for length_row in [2]:
+        for length_col in [2, 3]:
+            layer = convolutional.UpSampling2D(
+                size=(length_row, length_col),
+                data_format=data_format)
+            layer.build(inputs.shape)
+            outputs = layer(K.variable(inputs))
+            np_output = K.eval(outputs)
+            if data_format == 'channels_first':
+                assert np_output.shape[2] == length_row * input_num_row
+                assert np_output.shape[3] == length_col * input_num_col
+            else:  # tf
+                assert np_output.shape[1] == length_row * input_num_row
+                assert np_output.shape[2] == length_col * input_num_col
 
 
 @pytest.mark.skipif((K.backend() == 'cntk'),

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -863,7 +863,7 @@ def test_upsampling_2d():
 
 
 @pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason="cntk does not support it yet")
+                    reason='cntk does not support it yet')
 def test_upsampling_2d_bilinear():
     num_samples = 2
     stack_size = 2


### PR DESCRIPTION
### Summary

Thanks @ahundt for your work. I was able to get Theano working and be compatible with what was doing tensorflow, but only for (2, 2) upscaling. Other factors like (4, 4) show different results for the theano's implementation and the tensorflow's implementation. 
I also couldn't figure out how to use other factors like (3, 2) with theano. Which is why, with the Theano backend, for implementation and backend compatibility reasons, only (2, 2) is implemented.

### Related Issues

See @ahundt 's PR: #9303

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
