### PR TITLE
Conv1D and Conv3D supporting dilated conv for CNTK backend

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1494,14 +1494,17 @@ def conv1d(x, kernel, strides=1, padding='valid',
         kernel = C.swapaxes(kernel, 0, 2)
 
     padding = _preprocess_border_mode(padding)
-    strides = [strides]
+
+    if dev.type() == 0 and dilation_rate != 1:
+        raise ValueError('Dilated convolution on CPU is not supported by CNTK backend. ' +
+                         'Please set dilation_rate with 1.')
+
     x = C.convolution(
         kernel,
         x,
-        strides=tuple(strides),
-        auto_padding=[
-            False,
-            padding])
+        strides=strides,
+        auto_padding=[False, padding],
+        dilation=dilation_rate)
 
     if data_format == 'channels_last':
         x = C.swapaxes(x, 0, 1)
@@ -1649,17 +1652,18 @@ def conv3d(x, kernel, strides=(1, 1, 1), padding='valid',
     x = _preprocess_conv3d_input(x, data_format)
     kernel = _preprocess_conv3d_kernel(kernel, data_format)
     padding = _preprocess_border_mode(padding)
-    strides = strides + (strides[0],)
+
+    if dev.type() == 0 and dilation_rate != (1, 1, 1):
+        raise ValueError('Dilated convolution on CPU is not supported by CNTK backend. ' +
+                         'Please set dilation_rate with (1, 1, 1).')
 
     x = C.convolution(
         kernel,
         x,
         strides,
-        auto_padding=[
-            False,
-            padding,
-            padding,
-            padding])
+        auto_padding=[False, padding, padding, padding],
+        dilation=dilation_rate)
+
     return _postprocess_conv3d_output(x, data_format)
 
 

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1496,8 +1496,8 @@ def conv1d(x, kernel, strides=1, padding='valid',
     padding = _preprocess_border_mode(padding)
 
     if dev.type() == 0 and dilation_rate != 1:
-        raise ValueError('Dilated convolution on CPU is not supported by CNTK backend. ' +
-                         'Please set dilation_rate with 1.')
+        raise ValueError('Dilated convolution on CPU is not supported by CNTK backend. '
+                         'Please set `dilation_rate` to 1. You passed: %s' % (dilation_rate,))
 
     x = C.convolution(
         kernel,
@@ -1520,8 +1520,9 @@ def conv2d(x, kernel, strides=(1, 1), padding='valid',
     padding = _preprocess_border_mode(padding)
 
     if dev.type() == 0 and dilation_rate != (1, 1):
-        raise ValueError('Dilated convolution on CPU is not supported by CNTK backend. ' +
-                         'Please set dilation_rate with (1, 1).')
+        raise ValueError('Dilated convolution on CPU is not supported by CNTK backend. '
+                         'Please set `dilation_rate` to (1, 1).'
+                         'You passed: %s' % (dilation_rate,))
 
     x = C.convolution(kernel,
                       x,
@@ -1654,8 +1655,9 @@ def conv3d(x, kernel, strides=(1, 1, 1), padding='valid',
     padding = _preprocess_border_mode(padding)
 
     if dev.type() == 0 and dilation_rate != (1, 1, 1):
-        raise ValueError('Dilated convolution on CPU is not supported by CNTK backend. ' +
-                         'Please set dilation_rate with (1, 1, 1).')
+        raise ValueError('Dilated convolution on CPU is not supported by CNTK backend. '
+                         'Please set `dilation_rate` to (1, 1, 1).'
+                         'You passed: %s' % (dilation_rate,))
 
     x = C.convolution(
         kernel,

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1521,7 +1521,7 @@ def conv2d(x, kernel, strides=(1, 1), padding='valid',
 
     if dev.type() == 0 and dilation_rate != (1, 1):
         raise ValueError('Dilated convolution on CPU is not supported by CNTK backend. '
-                         'Please set `dilation_rate` to (1, 1).'
+                         'Please set `dilation_rate` to (1, 1). '
                          'You passed: %s' % (dilation_rate,))
 
     x = C.convolution(kernel,
@@ -1656,7 +1656,7 @@ def conv3d(x, kernel, strides=(1, 1, 1), padding='valid',
 
     if dev.type() == 0 and dilation_rate != (1, 1, 1):
         raise ValueError('Dilated convolution on CPU is not supported by CNTK backend. '
-                         'Please set `dilation_rate` to (1, 1, 1).'
+                         'Please set `dilation_rate` to (1, 1, 1). '
                          'You passed: %s' % (dilation_rate,))
 
     x = C.convolution(

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -20,7 +20,7 @@ else:
 
 @keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason="cntk only support dilated conv on GPU")
+                    reason='cntk only support dilated conv on GPU')
 def test_causal_dilated_conv():
     # Causal:
     layer_test(convolutional.Conv1D,

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -20,7 +20,7 @@ else:
 
 @keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason="cntk does not support dilated conv")
+                    reason="cntk only support dilated conv on GPU")
 def test_causal_dilated_conv():
     # Causal:
     layer_test(convolutional.Conv1D,
@@ -98,12 +98,14 @@ def test_conv_1d():
                        input_shape=(batch_size, steps, input_dim))
 
     # Test dilation
-    layer_test(convolutional.Conv1D,
-               kwargs={'filters': filters,
-                       'kernel_size': kernel_size,
-                       'padding': padding,
-                       'dilation_rate': 2},
-               input_shape=(batch_size, steps, input_dim))
+    if K.backend() != 'cntk':
+        # cntk only support dilated conv on GPU
+        layer_test(convolutional.Conv1D,
+                   kwargs={'filters': filters,
+                           'kernel_size': kernel_size,
+                           'padding': padding,
+                           'dilation_rate': 2},
+                   input_shape=(batch_size, steps, input_dim))
 
     # Test channels_first
     layer_test(convolutional.Conv1D,
@@ -138,8 +140,6 @@ def test_averagepooling_1d():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason="cntk only supports dilated conv on GPU")
 def test_convolution_2d():
     num_samples = 2
     filters = 2
@@ -176,12 +176,14 @@ def test_convolution_2d():
                input_shape=(num_samples, num_row, num_col, stack_size))
 
     # Test dilation
-    layer_test(convolutional.Conv2D,
-               kwargs={'filters': filters,
-                       'kernel_size': kernel_size,
-                       'padding': padding,
-                       'dilation_rate': (2, 2)},
-               input_shape=(num_samples, num_row, num_col, stack_size))
+    if K.backend() != 'cntk':
+        # cntk only support dilated conv on GPU
+        layer_test(convolutional.Conv2D,
+                   kwargs={'filters': filters,
+                           'kernel_size': kernel_size,
+                           'padding': padding,
+                           'dilation_rate': (2, 2)},
+                   input_shape=(num_samples, num_row, num_col, stack_size))
 
     # Test invalid use case
     with pytest.raises(ValueError):


### PR DESCRIPTION
### Summary
Following #10967, this PR makes ```dilation_rate``` take effect for ```Conv1D``` and ```Conv3D``` for CNTK backend.

### How to test
There is ```test_causal_dilated_conv``` in ```convolutional_test.py```, existing code can't pass when I run against CNTK backend. It's passed after this fix when I run on a node with 2 GPUs. I still keep this test ignored since Travis CI doesn't have GPU node. Another check is to run the following code again TF backend(CPU or GPU) and CNTK backend(GPU), they produce sam result.
```
from keras.layers import Input, Conv1D, Conv2D, Conv3D
from keras.models import Model
from keras.initializers import Constant
import numpy as np

# Test dilated convolution 1D
kernel = np.array([2, 3, 5]).reshape((3, 1, 1))
print(kernel.shape)

inputs = Input(shape=(10, 1))
m = Conv1D(1, kernel_size=3, padding='valid', dilation_rate=2, kernel_initializer=Constant(kernel))(inputs)
model = Model(inputs=inputs, outputs=m)
model.summary()

x = np.arange(10).reshape((1, 10, 1)).astype(np.float32) 
y = model.predict(x)

print(np.squeeze(y))
print(y.shape)

# Test dilated convolution 3D
kernel = np.arange(27).reshape((3, 3, 3, 1, 1))
print(kernel.shape)

inputs = Input(shape=(10, 10, 10, 1))
m = Conv3D(1, kernel_size=3, padding='valid', dilation_rate=(2, 3, 2), kernel_initializer=Constant(kernel))(inputs)
model = Model(inputs=inputs, outputs=m)
model.summary()

x = np.arange(1000).reshape((1, 10, 10, 10, 1)).astype(np.float32) 
y = model.predict(x)

print(np.squeeze(y))
print(y.shape)
```

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
