### PR TITLE
Update causal Conv1D doc : uses zero padding #8751

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -265,9 +265,11 @@ class Conv1D(_Conv):
             `"same"` results in padding the input such that
             the output has the same length as the original input.
             `"causal"` results in causal (dilated) convolutions, e.g. output[t]
-            does not depend on input[t+1:]. Useful when modeling temporal data
-            where the model should not violate the temporal order.
-            See [WaveNet: A Generative Model for Raw Audio, section 2.1](https://arxiv.org/abs/1609.03499).
+            does not depend on input[t+1:]. A zero padding is used such that
+            the output has the same length as the original input.
+            Useful when modeling temporal data where the model
+            should not violate the temporal order. See
+            [WaveNet: A Generative Model for Raw Audio, section 2.1](https://arxiv.org/abs/1609.03499).
         data_format: A string,
             one of `"channels_last"` (default) or `"channels_first"`.
             The ordering of the dimensions in the inputs.

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -264,8 +264,9 @@ class Conv1D(_Conv):
             `"valid"` means "no padding".
             `"same"` results in padding the input such that
             the output has the same length as the original input.
-            `"causal"` results in causal (dilated) convolutions, e.g. output[t]
-            does not depend on input[t+1:]. A zero padding is used such that
+            `"causal"` results in causal (dilated) convolutions,
+            e.g. `output[t]` does not depend on `input[t + 1:]`.
+            A zero padding is used such that
             the output has the same length as the original input.
             Useful when modeling temporal data where the model
             should not violate the temporal order. See


### PR DESCRIPTION
### Summary

Update  Conv1D documentation about causal padding : it uses zero padding.

### Related Issues

See issue #8751

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
