### PR TITLE
Made the test_random_normal faster

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1198,9 +1198,7 @@ class TestBackend(object):
 
             # test that random_normal also generates different values when used within a function
             r = K.random_normal((1,), mean=mean, stddev=std, seed=1337)
-            samples = [K.eval(r) for _ in range(60000)]
-            assert np.abs(np.mean(samples) - mean) < std * 0.015
-            assert np.abs(np.std(samples) - std) < std * 0.015
+            assert abs(K.eval(r)[0] - K.eval(r)[0]) > 0.015 * std
 
     def test_random_uniform(self):
         min_val = -1.


### PR DESCRIPTION
### Summary

After a bit of profiling with tensorflow, I found out why the `test_random_normal` was so slow. Calling eval 60000 times is really slow (99.9% of the call time). After a bit of search with git blame, I found out that this piece of code was added to solve #10594.

I propose here a new formulation of the test which stills solve #10594 while being much faster (on my laptop, with tensorflow cpu, the test goes from 20s to 0.05s).

### Related Issues

#10594

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
