### PR TITLE
adds uniform_zoom to ImageDataGenerator

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -269,6 +269,7 @@ class ImageDataGenerator(image.ImageDataGenerator):
             (Shear angle in counter-clockwise direction in degrees)
         zoom_range: Float or [lower, upper]. Range for random zoom.
             If a float, `[lower, upper] = [1-zoom_range, 1+zoom_range]`.
+        uniform_zoom: Boolean. Apply same zoom amount on both axes.
         channel_shift_range: Float. Range for random channel shifts.
         fill_mode: One of {"constant", "nearest", "reflect" or "wrap"}.
             Default is 'nearest'.
@@ -423,6 +424,7 @@ class ImageDataGenerator(image.ImageDataGenerator):
                  brightness_range=None,
                  shear_range=0.,
                  zoom_range=0.,
+                 uniform_zoom=False,
                  channel_shift_range=0.,
                  fill_mode='nearest',
                  cval=0.,
@@ -454,6 +456,7 @@ class ImageDataGenerator(image.ImageDataGenerator):
             brightness_range=brightness_range,
             shear_range=shear_range,
             zoom_range=zoom_range,
+            uniform_zoom=False,
             channel_shift_range=channel_shift_range,
             fill_mode=fill_mode,
             cval=cval,


### PR DESCRIPTION
### Summary

This modification gives the user the ability to define, if the zoom transformation should be the same on the xy axes or seperate for each axis. 

Hope this is the right way to suggest such change. Sorry if not, but I never did this before :)

### Related Issues
This are additional changes for keras-team/keras-preprocessing#44

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
