### PR TITLE
Update the RNN cell API to be explicit about output_size.

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1436,7 +1436,7 @@ def rnn(step_function, inputs, initial_states,
             for o, p in zip(new_states, place_holders):
                 n_s.append(o.replace_placeholders({p: o.output}))
             if len(n_s) > 0:
-                new_output = n_s[0]
+                new_output = n_s[-1]
             return new_output, n_s
 
         final_output, final_states = _recurrence(rnn_inputs, states, mask)

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -54,36 +54,56 @@ class StackedRNNCells(Layer):
                                  '`state_size` attribute. '
                                  'received cells:', cells)
         self.cells = cells
+        # reverse_state_order determines whether the state size will be in a
+        # reverse order of the cells' state. User might want to set this to True
+        # to keep the existing behavior. This is only useful when use
+        # RNN(return_state=True since the state will be returned as the same
+        # order of state_size.
+        self.reverse_state_order = kwargs.pop('reverse_state_order', False)
+        if self.reverse_state_order:
+            warnings.warn('reverse_state_order=True in StackedRNNCells will '
+                          'soon be deprecated. Please update the code to '
+                          'work with the natural order of states if you '
+                          'reply on the RNN states, '
+                          'eg RNN(return_state=True).')
         super(StackedRNNCells, self).__init__(**kwargs)
 
     @property
     def state_size(self):
-        # States are a flat list
-        # in reverse order of the cell stack.
-        # This allows to preserve the requirement
-        # `stack.state_size[0] == output_dim`.
-        # e.g. states of a 2-layer LSTM would be
-        # `[h2, c2, h1, c1]`
+        # States are a flat list of the individual cell state size.
+        # e.g. states of a 2-layer LSTM would be `[h1, c1, h2, c2]`.
         # (assuming one LSTM has states [h, c])
+        # In the case of reverse_state_order=True, the state_size will be
+        # [h2, c2, h1, c1].
         state_size = []
-        for cell in self.cells[::-1]:
+        for cell in self.cells[::-1] if self.reverse_state_order else self.cells:
             if hasattr(cell.state_size, '__len__'):
                 state_size += list(cell.state_size)
             else:
                 state_size.append(cell.state_size)
         return tuple(state_size)
 
+    @property
+    def output_size(self):
+        if getattr(self.cells[-1], 'output_size', None) is not None:
+            return self.cells[-1].output_size
+        if hasattr(self.cells[-1].state_size, '__len__'):
+            return self.cells[-1].state_size[0]
+        else:
+            return self.cells[-1].state_size
+
     def call(self, inputs, states, constants=None, **kwargs):
         # Recover per-cell states.
         nested_states = []
-        for cell in self.cells[::-1]:
+        for cell in self.cells[::-1] if self.reverse_state_order else self.cells:
             if hasattr(cell.state_size, '__len__'):
                 nested_states.append(states[:len(cell.state_size)])
                 states = states[len(cell.state_size):]
             else:
                 nested_states.append([states[0]])
                 states = states[1:]
-        nested_states = nested_states[::-1]
+        if self.reverse_state_order:
+            nested_states = nested_states[::-1]
 
         # Call the cells in order and store the returned states.
         new_nested_states = []
@@ -98,10 +118,12 @@ class StackedRNNCells(Layer):
 
         # Format the new states as a flat list
         # in reverse cell order.
-        states = []
-        for cell_states in new_nested_states[::-1]:
-            states += cell_states
-        return inputs, states
+        new_states = []
+        if self.reverse_state_order:
+            new_nested_states = new_nested_states[::-1]
+        for cell_states in new_nested_states:
+            new_states += cell_states
+        return inputs, new_states
 
     def build(self, input_shape):
         if isinstance(input_shape, list):
@@ -113,7 +135,9 @@ class StackedRNNCells(Layer):
                     cell.build([input_shape] + constants_shape)
                 else:
                     cell.build(input_shape)
-            if hasattr(cell.state_size, '__len__'):
+            if getattr(cell, 'output_size', None) is not None:
+                output_dim = cell.output_size
+            elif hasattr(cell.state_size, '__len__'):
                 output_dim = cell.state_size[0]
             else:
                 output_dim = cell.state_size
@@ -223,9 +247,12 @@ class RNN(Layer):
                 the size of the recurrent state
                 (which should be the same as the size of the cell output).
                 This can also be a list/tuple of integers
-                (one size per state). In this case, the first entry
-                (`state_size[0]`) should be the same as
-                the size of the cell output.
+                (one size per state).
+            - a `output_size` attribute. This can be a single integer or a
+                TensorShape, which represent the shape of the output. For
+                backward compatible reason, if this attribute is not available
+                for the cell, the value will be inferred by the first element
+                of the `state_size`.
             It is also possible for `cell` to be a list of RNN cell instances,
             in which cases the cells get stacked on after the other in the RNN,
             implementing an efficient stacked RNN.
@@ -414,7 +441,11 @@ class RNN(Layer):
             state_size = self.cell.state_size
         else:
             state_size = [self.cell.state_size]
-        output_dim = state_size[0]
+
+        if getattr(self.cell, 'output_size', None) is not None:
+            output_dim = self.cell.output_size
+        else:
+            output_dim = state_size[0]
 
         if self.return_sequences:
             output_shape = (input_shape[0], input_shape[1], output_dim)
@@ -827,6 +858,7 @@ class SimpleRNNCell(Layer):
         self.dropout = min(1., max(0., dropout))
         self.recurrent_dropout = min(1., max(0., recurrent_dropout))
         self.state_size = self.units
+        self.output_size = self.units
         self._dropout_mask = None
         self._recurrent_dropout_mask = None
 
@@ -1220,6 +1252,7 @@ class GRUCell(Layer):
         self.implementation = implementation
         self.reset_after = reset_after
         self.state_size = self.units
+        self.output_size = self.units
         self._dropout_mask = None
         self._recurrent_dropout_mask = None
 
@@ -1795,6 +1828,7 @@ class LSTMCell(Layer):
         self.recurrent_dropout = min(1., max(0., recurrent_dropout))
         self.implementation = implementation
         self.state_size = (self.units, self.units)
+        self.output_size = self.units
         self._dropout_mask = None
         self._recurrent_dropout_mask = None
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -57,15 +57,15 @@ class StackedRNNCells(Layer):
         # reverse_state_order determines whether the state size will be in a
         # reverse order of the cells' state. User might want to set this to True
         # to keep the existing behavior. This is only useful when use
-        # RNN(return_state=True since the state will be returned as the same
+        # RNN(return_state=True) since the state will be returned as the same
         # order of state_size.
         self.reverse_state_order = kwargs.pop('reverse_state_order', False)
         if self.reverse_state_order:
-            warnings.warn('reverse_state_order=True in StackedRNNCells will '
-                          'soon be deprecated. Please update the code to '
+            warnings.warn('`reverse_state_order=True` in `StackedRNNCells` '
+                          'will soon be deprecated. Please update the code to '
                           'work with the natural order of states if you '
                           'reply on the RNN states, '
-                          'eg RNN(return_state=True).')
+                          'eg `RNN(return_state=True)`.')
         super(StackedRNNCells, self).__init__(**kwargs)
 
     @property

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -57,7 +57,7 @@ class StackedRNNCells(Layer):
         # reverse_state_order determines whether the state size will be in a
         # reverse order of the cells' state. User might want to set this to True
         # to keep the existing behavior. This is only useful when use
-        # RNN(return_state=True) since the state will be returned as the same
+        # `RNN(return_state=True)` since the state will be returned as the same
         # order of state_size.
         self.reverse_state_order = kwargs.pop('reverse_state_order', False)
         if self.reverse_state_order:
@@ -74,7 +74,7 @@ class StackedRNNCells(Layer):
         # e.g. states of a 2-layer LSTM would be `[h1, c1, h2, c2]`.
         # (assuming one LSTM has states [h, c])
         # In the case of reverse_state_order=True, the state_size will be
-        # [h2, c2, h1, c1].
+        # `[h2, c2, h1, c1]`.
         state_size = []
         for cell in self.cells[::-1] if self.reverse_state_order else self.cells:
             if hasattr(cell.state_size, '__len__'):

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -950,7 +950,7 @@ def test_inconsistent_output_state_size():
     assert cell.state_size == state_size
     init_state = layer.get_initial_state(x)
     assert len(init_state) == 1
-    assert init_state[0].get_shape().as_list() == [None, state_size]
+    assert K.int_shape(init_state[0]) == (None, state_size)
 
     model = keras.models.Model(x, y)
     model.compile(optimizer='rmsprop', loss='mse')

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -499,7 +499,7 @@ def test_minimal_rnn_cell_non_layer_multiple_states():
              MinimalRNNCell(16, 8),
              MinimalRNNCell(32, 16)]
     layer = recurrent.RNN(cells)
-    assert layer.cell.state_size == (32, 32, 16, 16, 8, 8)
+    assert layer.cell.state_size == (8, 8, 16, 16, 32, 32)
     y = layer(x)
     model = keras.models.Model(x, y)
     model.compile(optimizer='rmsprop', loss='mse')
@@ -677,6 +677,19 @@ def test_stacked_rnn_compute_output_shape():
     cells = [recurrent.LSTMCell(3),
              recurrent.LSTMCell(6)]
     layer = recurrent.RNN(cells, return_state=True, return_sequences=True)
+    output_shape = layer.compute_output_shape((None, timesteps, embedding_dim))
+    expected_output_shape = [(None, timesteps, 6),
+                             (None, 3),
+                             (None, 3),
+                             (None, 6),
+                             (None, 6)]
+    assert output_shape == expected_output_shape
+
+    # Test reverse_state_order = True for stacked cell.
+    stacked_cell = recurrent.StackedRNNCells(
+        cells, reverse_state_order=True)
+    layer = recurrent.RNN(
+        stacked_cell, return_state=True, return_sequences=True)
     output_shape = layer.compute_output_shape((None, timesteps, embedding_dim))
     expected_output_shape = [(None, timesteps, 6),
                              (None, 6),
@@ -905,6 +918,46 @@ def test_rnn_cell_identity_initializer(layer_class):
     num_kernels = recurrent_kernel.shape[1] // recurrent_kernel.shape[0]
     assert np.array_equal(recurrent_kernel,
                           np.concatenate([np.identity(units)] * num_kernels, axis=1))
+
+
+@keras_test
+def test_inconsistent_output_state_size():
+
+    class PlusOneRNNCell(keras.layers.Layer):
+        """Add one to the input and state.
+
+        This cell is used for testing state_size and output_size."""
+
+        def __init__(self, num_unit, **kwargs):
+            self.state_size = num_unit
+            super(PlusOneRNNCell, self).__init__(**kwargs)
+
+        def build(self, input_shape):
+            self.output_size = input_shape[-1]
+
+        def call(self, inputs, states):
+            return inputs + 1, [states[0] + 1]
+
+    batch = 32
+    time_step = 4
+    state_size = 5
+    input_size = 6
+    cell = PlusOneRNNCell(state_size)
+    x = keras.Input((None, input_size))
+    layer = recurrent.RNN(cell)
+    y = layer(x)
+
+    assert cell.state_size == state_size
+    init_state = layer.get_initial_state(x)
+    assert len(init_state) == 1
+    assert init_state[0].get_shape().as_list() == [None, state_size]
+
+    model = keras.models.Model(x, y)
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(
+        np.zeros((batch, time_step, input_size)),
+        np.zeros((batch, input_size)))
+    assert model.output_shape == (None, input_size)
 
 
 if __name__ == '__main__':

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -921,6 +921,7 @@ def test_rnn_cell_identity_initializer(layer_class):
 
 
 @keras_test
+@pytest.mark.skipif((K.backend() in ['cntk']), reason='Not supported.')
 def test_inconsistent_output_state_size():
 
     class PlusOneRNNCell(keras.layers.Layer):
@@ -950,7 +951,9 @@ def test_inconsistent_output_state_size():
     assert cell.state_size == state_size
     init_state = layer.get_initial_state(x)
     assert len(init_state) == 1
-    assert K.int_shape(init_state[0]) == (None, state_size)
+    if K.backend() != 'theano':
+        # theano does not support static shape inference.
+        assert K.int_shape(init_state[0]) == (None, state_size)
 
     model = keras.models.Model(x, y)
     model.compile(optimizer='rmsprop', loss='mse')

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -921,7 +921,7 @@ def test_rnn_cell_identity_initializer(layer_class):
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() in ['cntk']), reason='Not supported.')
+@pytest.mark.skipif(K.backend() == 'cntk', reason='Not supported.')
 def test_inconsistent_output_state_size():
 
     class PlusOneRNNCell(keras.layers.Layer):


### PR DESCRIPTION
The existing contract of state_size[0] to be output size is bit
weird and might cause unnecessary contrain for supporting higher
dimension input/output/states. Adding explicit output_size to cell
so that the contract is not inferred by state_size anymore.

For backward compat reason, if a cell does not implement
output_size, the state_size[0] will be used as output_size.

The stackedRNNCells is also updated to by default return natural
order state_size as the cells' state, instead of reverse order.
For any user who rely on the states of the RNN, eg
RNN(return_state=True), please add the extra param
reverse_state_order=True while constructing the StackedRNNCells.

### Summary

### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
