### PR TITLE
docs/scikit-learn-api: fix source file link

### DIFF
--- a/docs/templates/scikit-learn-api.md
+++ b/docs/templates/scikit-learn-api.md
@@ -1,6 +1,6 @@
 # Wrappers for the Scikit-Learn API
 
-You can use `Sequential` Keras models (single-input only) as part of your Scikit-Learn workflow via the wrappers found at `keras.wrappers.scikit_learn.py`.
+You can use `Sequential` Keras models (single-input only) as part of your Scikit-Learn workflow via the wrappers found at [keras.wrappers.scikit_learn](/keras/wrappers/scikit_learn.py).
 
 There are two wrappers available:
 


### PR DESCRIPTION
keras.wrappers.scikit_learn link should be working at least in github, not sure if mkdocs could correctly resolve the source code file link