### PR TITLE
Conv2DTranspose supports dilation

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2186,7 +2186,7 @@ def in_top_k(predictions, targets, k):
 
 
 def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
-                     padding='valid', data_format=None):
+                     padding='valid', data_format=None, dilation_rate=(1, 1)):
     data_format = normalize_data_format(data_format)
 
     x = _preprocess_conv2d_input(x, data_format)
@@ -2208,7 +2208,8 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
             False,
             padding,
             padding],
-        output_shape=output_shape)
+        output_shape=output_shape,
+        dilation=dilation_rate)
     return _postprocess_conv2d_output(x, data_format)
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -2134,7 +2134,7 @@ def conv2d(x, kernel, strides=(1, 1), padding='valid',
 
 
 def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
-                     padding='valid', data_format=None):
+                     padding='valid', data_format=None, dilation_rate=(1, 1)):
     """2D deconvolution (transposed convolution).
 
     # Arguments
@@ -2144,7 +2144,8 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
         padding: string, "same" or "valid".
         data_format: "channels_last" or "channels_first".
             Whether to use Theano or TensorFlow data format
-        in inputs/kernels/outputs.
+            in inputs/kernels/outputs.
+        dilation_rate: tuple of 2 integers.
 
     # Raises
         ValueError: if using an even kernel size with padding 'same'.
@@ -2177,7 +2178,8 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
                                                         kshp=kernel_shape,
                                                         subsample=strides,
                                                         border_mode=th_padding,
-                                                        filter_flip=not flip_filters)
+                                                        filter_flip=not flip_filters,
+                                                        filter_dilation=dilation_rate)
     conv_out = op(kernel, x, output_shape[2:])
     conv_out = _postprocess_conv2d_output(conv_out, x, padding,
                                           kernel_shape, strides, data_format)

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -731,6 +731,7 @@ class Conv2DTranspose(Conv2D):
                  padding='valid',
                  output_padding=None,
                  data_format=None,
+                 dilation_rate=(1, 1),
                  activation=None,
                  use_bias=True,
                  kernel_initializer='glorot_uniform',
@@ -747,6 +748,7 @@ class Conv2DTranspose(Conv2D):
             strides=strides,
             padding=padding,
             data_format=data_format,
+            dilation_rate=dilation_rate,
             activation=activation,
             use_bias=use_bias,
             kernel_initializer=kernel_initializer,
@@ -820,11 +822,13 @@ class Conv2DTranspose(Conv2D):
         out_height = conv_utils.deconv_length(height,
                                               stride_h, kernel_h,
                                               self.padding,
-                                              out_pad_h)
+                                              out_pad_h,
+                                              self.dilation_rate[0])
         out_width = conv_utils.deconv_length(width,
                                              stride_w, kernel_w,
                                              self.padding,
-                                             out_pad_w)
+                                             out_pad_w,
+                                             self.dilation_rate[1])
         if self.data_format == 'channels_first':
             output_shape = (batch_size, self.filters, out_height, out_width)
         else:
@@ -836,7 +840,8 @@ class Conv2DTranspose(Conv2D):
             output_shape,
             self.strides,
             padding=self.padding,
-            data_format=self.data_format)
+            data_format=self.data_format,
+            dilation_rate=self.dilation_rate)
 
         if self.use_bias:
             outputs = K.bias_add(
@@ -867,17 +872,18 @@ class Conv2DTranspose(Conv2D):
                                                         stride_h,
                                                         kernel_h,
                                                         self.padding,
-                                                        out_pad_h)
+                                                        out_pad_h,
+                                                        self.dilation_rate[0])
         output_shape[w_axis] = conv_utils.deconv_length(output_shape[w_axis],
                                                         stride_w,
                                                         kernel_w,
                                                         self.padding,
-                                                        out_pad_w)
+                                                        out_pad_w,
+                                                        self.dilation_rate[1])
         return tuple(output_shape)
 
     def get_config(self):
         config = super(Conv2DTranspose, self).get_config()
-        config.pop('dilation_rate')
         config['output_padding'] = self.output_padding
         return config
 

--- a/keras/utils/conv_utils.py
+++ b/keras/utils/conv_utils.py
@@ -135,7 +135,8 @@ def conv_input_length(output_length, filter_size, padding, stride):
     return (output_length - 1) * stride - 2 * pad + filter_size
 
 
-def deconv_length(dim_size, stride_size, kernel_size, padding, output_padding, dilation=1):
+def deconv_length(dim_size, stride_size, kernel_size, padding,
+                  output_padding, dilation=1):
     """Determines output length of a transposed convolution given input length.
 
     # Arguments

--- a/keras/utils/conv_utils.py
+++ b/keras/utils/conv_utils.py
@@ -135,7 +135,7 @@ def conv_input_length(output_length, filter_size, padding, stride):
     return (output_length - 1) * stride - 2 * pad + filter_size
 
 
-def deconv_length(dim_size, stride_size, kernel_size, padding, output_padding):
+def deconv_length(dim_size, stride_size, kernel_size, padding, output_padding, dilation=1):
     """Determines output length of a transposed convolution given input length.
 
     # Arguments
@@ -146,6 +146,7 @@ def deconv_length(dim_size, stride_size, kernel_size, padding, output_padding):
         padding: One of `"same"`, `"valid"`, `"full"`.
         output_padding: Integer, amount of padding along the output dimension,
             Can be set to `None` in which case the output length is inferred.
+        dilation: dilation rate, integer.
 
     # Returns
         The output length (integer).
@@ -153,6 +154,9 @@ def deconv_length(dim_size, stride_size, kernel_size, padding, output_padding):
     assert padding in {'same', 'valid', 'full'}
     if dim_size is None:
         return None
+
+    # Get the dilated kernel size
+    kernel_size = kernel_size + (kernel_size - 1) * (dilation - 1)
 
     # Infer length if output padding is None, else compute the exact length
     if output_padding is None:

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -164,7 +164,7 @@ def test_convolution_2d_channels_last():
 
 @keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason="cntk only supports dilated conv on GPU")
+                    reason='cntk only supports dilated conv on GPU')
 def test_convolution_2d_dilation():
     num_samples = 2
     filters = 2
@@ -221,6 +221,25 @@ def test_conv2d_transpose(padding, out_padding, strides):
                        'output_padding': out_padding,
                        'strides': strides,
                        'data_format': 'channels_last'},
+               input_shape=(num_samples, num_row, num_col, stack_size),
+               fixed_batch_size=True)
+
+
+@keras_test
+@pytest.mark.skipif((K.backend() == 'cntk'),
+                    reason='cntk only supports dilated conv transpose on GPU')
+def test_conv2d_transpose_dilation():
+    num_samples = 2
+    stack_size = 3
+    num_row = 5
+    num_col = 6
+
+    layer_test(convolutional.Conv2DTranspose,
+               kwargs={'filters': 2,
+                       'kernel_size': 3,
+                       'padding': 'same',
+                       'data_format': 'channels_last',
+                       'dilation_rate': (2, 2)},
                input_shape=(num_samples, num_row, num_col, stack_size),
                fixed_batch_size=True)
 

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -229,10 +229,6 @@ def test_conv2d_transpose(padding, out_padding, strides):
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='cntk only supports dilated conv transpose on GPU')
 def test_conv2d_transpose_dilation():
-    num_samples = 2
-    stack_size = 3
-    num_row = 5
-    num_col = 6
 
     layer_test(convolutional.Conv2DTranspose,
                kwargs={'filters': 2,
@@ -240,8 +236,24 @@ def test_conv2d_transpose_dilation():
                        'padding': 'same',
                        'data_format': 'channels_last',
                        'dilation_rate': (2, 2)},
-               input_shape=(num_samples, num_row, num_col, stack_size),
-               fixed_batch_size=True)
+               input_shape=(2, 5, 6, 3))
+
+    # Check dilated conv transpose returns expected output
+    input_data = np.arange(48).reshape((1, 4, 4, 3)).astype(np.float32)
+    expected_output = np.float32([[192, 228, 192, 228],
+                                  [336, 372, 336, 372],
+                                  [192, 228, 192, 228],
+                                  [336, 372, 336, 372]]).reshape((1, 4, 4, 1))
+
+    layer_test(convolutional.Conv2DTranspose,
+               input_data=input_data,
+               kwargs={'filters': 1,
+                       'kernel_size': 3,
+                       'padding': 'same',
+                       'data_format': 'channels_last',
+                       'dilation_rate': (2, 2),
+                       'kernel_initializer': 'ones'},
+               expected_output=expected_output)
 
 
 @keras_test


### PR DESCRIPTION
### Summary
I saw the requirements for dilated transposed convolution at several places(https://github.com/keras-team/keras/issues/8159, https://github.com/tensorflow/tensorflow/issues/21598). This PR makes ```Conv2DTranspose``` supports dilation for all backends.

### How to test
Except the unit test I added, I also run the following test. As dilated transposed convolution is equivalent to standard transposed convolution with upsampled kernels with effective size ```kernel_size + (kernel_size - 1) * (dilation_rate - 1)``` , produced by inserting ```dilation_rate - 1``` zeros along consecutive elements across the kernel' spatial dimensions. The following code verify these two scenarios that give the same output:
* kernel_size = 2, dilation_rate = 2
* kernel_size = 3, kernel is built from the above kernel and insert zeros along consecutive elements.

```
from keras.layers import Input, Conv2DTranspose
from keras.models import Model
from keras.initializers import Constant
import numpy as np

kernel = np.arange(24).reshape((2, 2, 2, 3))

inputs = Input(shape=(5, 6, 3))
m = Conv2DTranspose(2, kernel_size=2, padding='same', dilation_rate=2, kernel_initializer=Constant(kernel))(inputs)
model = Model(inputs=inputs, outputs=m)
model.summary()

x = np.arange(180).reshape((2, 5, 6, 3)).astype(np.float32)
y = model.predict(x)

print(np.squeeze(y))
print(y.shape)

print("--------------------------------------------------")

kernel = np.arange(24).reshape((2, 2, 2, 3))

# Insert zeros along consecutive elements across the kernel' spatial dimensions
k = np.zeros((3, 3, 2, 3))
k[0, 0, :, :] = kernel[0, 0, :, :]
k[0, 2, :, :] = kernel[0, 1, :, :]
k[2, 0, :, :] = kernel[1, 0, :, :]
k[2, 2, :, :] = kernel[1, 1, :, :]
kernel = k

inputs = Input(shape=(5, 6, 3))
m = Conv2DTranspose(2, kernel_size=3, padding='same', kernel_initializer=Constant(kernel))(inputs)
model = Model(inputs=inputs, outputs=m)
model.summary()

x = np.arange(180).reshape((2, 5, 6, 3)).astype(np.float32)
y = model.predict(x)

print(np.squeeze(y))
print(y.shape)
```

### Related Issues
https://github.com/keras-team/keras/issues/8159
https://github.com/tensorflow/tensorflow/issues/21598

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
