### PR TITLE
fix a bug in VAE example, "vae = vae.load_weights" to "vae.load_weights", because load_weights doesn't return anything

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -192,7 +192,7 @@ if __name__ == '__main__':
                show_shapes=True)
 
     if args.weights:
-        vae = vae.load_weights(args.weights)
+        vae.load_weights(args.weights)
     else:
         # train the autoencoder
         vae.fit(x_train,


### PR DESCRIPTION
### Summary
fix a bug in VAE example, "vae = vae.load_weights" to "vae.load_weights", because load_weights doesn't return anything
### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
