### PR TITLE
Removing duplicated backend tests.

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -195,7 +195,7 @@ class TestBackend(object):
             K.set_learning_phase(2)
 
     def test_eye(self):
-        z_list = [k.eval(k.eye(3)) for k in BACKENDS]
+        z_list = [k.eval(k.eye(3)) for k in WITH_NP]
         assert_list_pairwise(z_list)
 
     def test_linear_operations(self):
@@ -242,23 +242,23 @@ class TestBackend(object):
         assert_allclose(K.eval(xy_batch_dot), np.ones((32, 1)) * 20, atol=1e-05)
 
     def test_shape_operations(self):
-        check_two_tensor_operation('concatenate', (4, 3), (4, 2), BACKENDS,
+        check_two_tensor_operation('concatenate', (4, 3), (4, 2), WITH_NP,
                                    axis=-1, concat_args=True)
 
         check_single_tensor_operation('reshape', (4, 2), WITH_NP, shape=(8, 1))
         check_single_tensor_operation('permute_dimensions', (4, 2, 3), BACKENDS,
                                       pattern=(2, 0, 1))
-        check_single_tensor_operation('repeat', (4, 1), BACKENDS, n=3)
-        check_single_tensor_operation('flatten', (4, 1), BACKENDS)
-        check_single_tensor_operation('batch_flatten', (20, 2, 5), BACKENDS,
+        check_single_tensor_operation('repeat', (4, 1), WITH_NP, n=3)
+        check_single_tensor_operation('flatten', (4, 1), WITH_NP)
+        check_single_tensor_operation('batch_flatten', (20, 2, 5), WITH_NP,
                                       cntk_dynamicity=True)
-        check_single_tensor_operation('expand_dims', (4, 3), BACKENDS, axis=-1)
-        check_single_tensor_operation('expand_dims', (4, 3, 2), BACKENDS, axis=1)
-        check_single_tensor_operation('squeeze', (4, 3, 1), BACKENDS, axis=2)
-        check_single_tensor_operation('squeeze', (4, 1, 1), BACKENDS, axis=1)
+        check_single_tensor_operation('expand_dims', (4, 3), WITH_NP, axis=-1)
+        check_single_tensor_operation('expand_dims', (4, 3, 2), WITH_NP, axis=1)
+        check_single_tensor_operation('squeeze', (4, 3, 1), WITH_NP, axis=2)
+        check_single_tensor_operation('squeeze', (4, 1, 1), WITH_NP, axis=1)
         check_composed_tensor_operations('reshape', {'shape': (4, 3, 1, 1)},
                                          'squeeze', {'axis': 2},
-                                         (4, 3, 1, 1), BACKENDS)
+                                         (4, 3, 1, 1), WITH_NP)
 
     def test_none_shape_operations(self):
         # Test shape inference when input
@@ -342,10 +342,10 @@ class TestBackend(object):
                 assert_list_pairwise(v_list, shape=False, allclose=False, itself=True)
 
         # print_tensor
-        check_single_tensor_operation('print_tensor', (), BACKENDS)
-        check_single_tensor_operation('print_tensor', (2,), BACKENDS)
-        check_single_tensor_operation('print_tensor', (4, 3), BACKENDS)
-        check_single_tensor_operation('print_tensor', (1, 2, 3), BACKENDS)
+        check_single_tensor_operation('print_tensor', (), WITH_NP)
+        check_single_tensor_operation('print_tensor', (2,), WITH_NP)
+        check_single_tensor_operation('print_tensor', (4, 3), WITH_NP)
+        check_single_tensor_operation('print_tensor', (1, 2, 3), WITH_NP)
 
     def test_elementwise_operations(self):
         check_single_tensor_operation('max', (4, 2), WITH_NP)

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -329,6 +329,10 @@ def clip(x, min_value, max_value):
     return np.clip(x, min_value, max_value)
 
 
+def concatenate(tensors, axis=-1):
+    return np.concatenate(tensors, axis)
+
+
 def reshape(x, shape):
     return np.reshape(x, shape)
 
@@ -337,8 +341,25 @@ def repeat_elements(x, rep, axis):
     return np.repeat(x, rep, axis=axis)
 
 
+def flatten(x):
+    return np.reshape(x, (-1,))
+
+
+def batch_flatten(x):
+    return np.reshape(x, (x.shape[0], -1))
+
+
 def eval(x):
     return x
+
+
+def print_tensor(x, message=''):
+    print(x, message)
+    return x
+
+
+def eye(size, dtype=None, name=None):
+    return np.eye(size, dtype=dtype)
 
 
 def variable(value, dtype=None, name=None, constraint=None):
@@ -386,3 +407,5 @@ exp = np.exp
 log = np.log
 round = np.round
 sign = np.sign
+expand_dims = np.expand_dims
+squeeze = np.squeeze

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -341,6 +341,12 @@ def repeat_elements(x, rep, axis):
     return np.repeat(x, rep, axis=axis)
 
 
+def repeat(x, n):
+    y = np.expand_dims(x, 1)
+    y = np.repeat(y, n, axis=1)
+    return y
+
+
 def flatten(x):
     return np.reshape(x, (-1,))
 


### PR DESCRIPTION
### Summary

Follow up on #10992.

We are trying with @taehoonlee to remove, for example, the dependencies on Theano and CNTK when running the travis TF build. That would save us quite a bit of time (downloading and installing backends is slow). 

At the same time, we remove tests which are run multiple times overall in the travis build matrix.

### Related Issues

#10972
#10956
#10930

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
