### PR TITLE
Better UX for __iter__

### DIFF
--- a/keras/engine/training_generator.py
+++ b/keras/engine/training_generator.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import warnings
 import numpy as np
 
+from .training_utils import iter_sequence_infinite
 from .. import backend as K
 from ..utils.data_utils import Sequence
 from ..utils.data_utils import GeneratorEnqueuer
@@ -121,7 +122,7 @@ def fit_generator(model,
             elif val_gen:
                 val_data = validation_data
                 if isinstance(val_data, Sequence):
-                    val_enqueuer_gen = iter(val_data)
+                    val_enqueuer_gen = iter_sequence_infinite(generator)
                 else:
                     val_enqueuer_gen = val_data
             else:
@@ -160,7 +161,7 @@ def fit_generator(model,
             output_generator = enqueuer.get()
         else:
             if is_sequence:
-                output_generator = iter(generator)
+                output_generator = iter_sequence_infinite(generator)
             else:
                 output_generator = generator
 
@@ -315,7 +316,7 @@ def evaluate_generator(model, generator,
             output_generator = enqueuer.get()
         else:
             if is_sequence:
-                output_generator = iter(generator)
+                output_generator = iter_sequence_infinite(generator)
             else:
                 output_generator = generator
 
@@ -420,7 +421,7 @@ def predict_generator(model, generator,
             output_generator = enqueuer.get()
         else:
             if is_sequence:
-                output_generator = iter(generator)
+                output_generator = iter_sequence_infinite(generator)
             else:
                 output_generator = generator
 

--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -575,3 +575,17 @@ def check_num_samples(ins,
     if hasattr(ins[0], 'shape'):
         return int(ins[0].shape[0])
     return None  # Edge case where ins == [static_learning_phase]
+
+
+def iter_sequence_infinite(seq):
+    """Iterate indefinitely over a Sequence.
+
+    # Arguments
+        seq: Sequence object
+
+    # Returns
+        Generator yielding batches.
+    """
+    while True:
+        for item in seq:
+            yield item

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -368,10 +368,9 @@ class Sequence(object):
         pass
 
     def __iter__(self):
-        """Create an infinite generator that iterate over the Sequence."""
-        while True:
-            for item in (self[i] for i in range(len(self))):
-                yield item
+        """Create a generator that iterate over the Sequence."""
+        for item in (self[i] for i in range(len(self))):
+            yield item
 
 
 # Global variables to be shared across processes


### PR DESCRIPTION
### Summary
We recently added __iter__ to Sequence. And while at the time making it infinite made sense. It's a bad UX. This PR makes __iter__ more friendly by **not** being infinite and add a function to be used when we need it to be infinite (when workers=0)
### Related Issues
https://github.com/keras-team/keras-preprocessing/issues/45
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
