### PR TITLE
Doc Change: Change in shape for CIFAR Datasets

### DIFF
--- a/docs/templates/datasets.md
+++ b/docs/templates/datasets.md
@@ -14,7 +14,7 @@ from keras.datasets import cifar10
 
 - __Returns:__
     - 2 tuples:
-        - __x_train, x_test__: uint8 array of RGB image data with shape (num_samples, 32, 32, 3).
+        - __x_train, x_test__: uint8 array of RGB image data with shape (num_samples, 3, 32, 32) or (num_samples, 32, 32, 3) based on the `image_data_format` backend setting of either `channels_first` or `channels_last` respectively.
         - __y_train, y_test__: uint8 array of category labels (integers in range 0-9) with shape (num_samples,).
 
 
@@ -34,7 +34,7 @@ from keras.datasets import cifar100
 
 - __Returns:__
     - 2 tuples:
-        - __x_train, x_test__: uint8 array of RGB image data with shape (num_samples, 32, 32, 3).
+        - __x_train, x_test__: uint8 array of RGB image data with shape (num_samples, 3, 32, 32) or (num_samples, 32, 32, 3) based on the `image_data_format` backend setting of either `channels_first` or `channels_last` respectively.
         - __y_train, y_test__: uint8 array of category labels with shape (num_samples,).
 
 - __Arguments:__

--- a/docs/templates/datasets.md
+++ b/docs/templates/datasets.md
@@ -14,7 +14,7 @@ from keras.datasets import cifar10
 
 - __Returns:__
     - 2 tuples:
-        - __x_train, x_test__: uint8 array of RGB image data with shape (num_samples, 3, 32, 32).
+        - __x_train, x_test__: uint8 array of RGB image data with shape (num_samples, 32, 32, 3).
         - __y_train, y_test__: uint8 array of category labels (integers in range 0-9) with shape (num_samples,).
 
 
@@ -34,7 +34,7 @@ from keras.datasets import cifar100
 
 - __Returns:__
     - 2 tuples:
-        - __x_train, x_test__: uint8 array of RGB image data with shape (num_samples, 3, 32, 32).
+        - __x_train, x_test__: uint8 array of RGB image data with shape (num_samples, 32, 32, 3).
         - __y_train, y_test__: uint8 array of category labels with shape (num_samples,).
 
 - __Arguments:__


### PR DESCRIPTION
Both the CIFAR datasets have been updates now having the channel as the last dimension in the shape resulting in (num_samples, 32, 32, 3)

![](https://preview.ibb.co/dadE09/keras_shape.png)

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
