### PR TITLE
Cached the theano compilation directory on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: required
 dist: trusty
 language: python
+cache:
+  directories:
+    - $HOME/.theano
 matrix:
     include:
         - python: 2.7


### PR DESCRIPTION
### Summary

It would make sense for us to cache the compilation directory of Theano. I enabled travis on my fork of keras to check the speedups. 

The benefits can be really big. I get a 6 minutes speedup for one of the Theano builds.
Only one theano build out of the two get the speed benefit of the cache. Which is strange (and it is not the same build all the time so it's weird). If someone wants to help me figure out why it would be nice. Here is the branch where I tested the cache:
https://github.com/gabrieldemarmiesse/keras/commits/theano_cache

We can merge this PR and get a 6 minutes speedup on a theano build, but it'd be nice to figure out this weird behavior in the travis cache first. 

### Related Issues

### PR Overview

Code taken from the .travis.yml from Theano:
https://github.com/Theano/Theano/blob/master/.travis.yml

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
