### PR TITLE
Speed up backend tests

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -195,12 +195,11 @@ class TestBackend(object):
             K.set_learning_phase(2)
 
     def test_eye(self):
-        z_list = [k.eval(k.eye(3)) for k in WITH_NP]
-        assert_list_pairwise(z_list)
+        check_single_tensor_operation('eye', 3, WITH_NP, shape_or_val=False)
 
     def test_linear_operations(self):
-        check_two_tensor_operation('dot', (4, 2), (2, 4), BACKENDS)
-        check_two_tensor_operation('dot', (4, 2), (5, 2, 3), BACKENDS)
+        check_two_tensor_operation('dot', (4, 2), (2, 4), WITH_NP)
+        check_two_tensor_operation('dot', (4, 2), (5, 2, 3), WITH_NP)
 
         check_two_tensor_operation('batch_dot', (4, 2, 3), (4, 5, 3),
                                    BACKENDS, cntk_two_dynamicity=True, axes=(2, 2))
@@ -213,15 +212,16 @@ class TestBackend(object):
         check_two_tensor_operation('batch_dot', (32, 20), (32, 20),
                                    BACKENDS, cntk_two_dynamicity=True, axes=(1, 1))
 
-        check_single_tensor_operation('transpose', (4, 2), BACKENDS)
-        check_single_tensor_operation('reverse', (4, 3, 2), BACKENDS, axes=1)
-        check_single_tensor_operation('reverse', (4, 3, 2), [KTH, KTF], axes=(1, 2))
+        check_single_tensor_operation('transpose', (4, 2), WITH_NP)
+        check_single_tensor_operation('reverse', (4, 3, 2), WITH_NP, axes=1)
+        if K.backend() != 'cntk':
+            check_single_tensor_operation('reverse', (4, 3, 2), WITH_NP, axes=(1, 2))
 
     def test_random_variables(self):
-        check_single_tensor_operation('random_uniform_variable', (2, 3), BACKENDS,
+        check_single_tensor_operation('random_uniform_variable', (2, 3), WITH_NP,
                                       low=0., high=1.,
                                       shape_or_val=False, assert_value_equality=False)
-        check_single_tensor_operation('random_normal_variable', (2, 3), BACKENDS,
+        check_single_tensor_operation('random_normal_variable', (2, 3), WITH_NP,
                                       mean=0., scale=1.,
                                       shape_or_val=False, assert_value_equality=False)
 
@@ -246,7 +246,7 @@ class TestBackend(object):
                                    axis=-1, concat_args=True)
 
         check_single_tensor_operation('reshape', (4, 2), WITH_NP, shape=(8, 1))
-        check_single_tensor_operation('permute_dimensions', (4, 2, 3), BACKENDS,
+        check_single_tensor_operation('permute_dimensions', (4, 2, 3), WITH_NP,
                                       pattern=(2, 0, 1))
         check_single_tensor_operation('repeat', (4, 1), WITH_NP, n=3)
         check_single_tensor_operation('flatten', (4, 1), WITH_NP)
@@ -1260,7 +1260,7 @@ class TestBackend(object):
             elif data_format == 'channels_last':
                 x_shape = (2,) + shape + (3,)
             check_single_tensor_operation('resize_images', x_shape,
-                                          BACKENDS, cntk_dynamicity=True,
+                                          WITH_NP, cntk_dynamicity=True,
                                           height_factor=2,
                                           width_factor=2,
                                           data_format=data_format)
@@ -1296,7 +1296,7 @@ class TestBackend(object):
             elif data_format == 'channels_last':
                 x_shape = (2,) + shape + (3,)
             check_single_tensor_operation('resize_volumes', x_shape,
-                                          BACKENDS, cntk_dynamicity=True,
+                                          WITH_NP, cntk_dynamicity=True,
                                           depth_factor=2,
                                           height_factor=2,
                                           width_factor=2,
@@ -1367,7 +1367,7 @@ class TestBackend(object):
                     x_shape = (1,) + shape + (4,)
                 bias_shape = (4,)
                 check_two_tensor_operation('bias_add', x_shape, bias_shape,
-                                           BACKENDS, cntk_dynamicity=True,
+                                           WITH_NP, cntk_dynamicity=True,
                                            data_format=data_format)
 
             if data_format == 'channels_first':
@@ -1375,7 +1375,7 @@ class TestBackend(object):
             else:
                 x_shape = (20, 10, 6)
             check_two_tensor_operation('bias_add', x_shape, (10, 6),
-                                       BACKENDS, cntk_dynamicity=True,
+                                       WITH_NP, cntk_dynamicity=True,
                                        data_format=data_format)
 
         # Test invalid use cases

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -413,8 +413,7 @@ def transpose(x):
 
 def reverse(x, axes):
     if isinstance(axes, int):
-        axes = (axes,)
-    axes = list(axes)
+        axes = [axes]
     for a in axes:
         x = np.flip(x, a)
     return x
@@ -460,7 +459,7 @@ def minimum(x, y):
 
 
 def random_uniform_variable(shape, low, high, dtype=None, name=None, seed=None):
-    return np.random.random(shape).astype(dtype)
+    return (high - low) * np.random.random(shape).astype(dtype) + low
 
 
 def random_normal_variable(shape, mean, scale, dtype=None, name=None, seed=None):

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -142,6 +142,18 @@ pool2d = pool
 pool3d = pool
 
 
+def bias_add(x, y, data_format):
+    if data_format == 'channels_first':
+        if y.ndim > 1:
+            y = np.reshape(y, y.shape[::-1])
+        for _ in range(x.ndim - y.ndim - 1):
+            y = np.expand_dims(y, -1)
+    else:
+        for _ in range(x.ndim - y.ndim - 1):
+            y = np.expand_dims(y, 0)
+    return x + y
+
+
 def rnn(x, w, init, go_backwards=False, mask=None, unroll=False, input_length=None):
     w_i, w_h, w_o = w
     h = []
@@ -334,6 +346,10 @@ def concatenate(tensors, axis=-1):
     return np.concatenate(tensors, axis)
 
 
+def permute_dimensions(x, pattern):
+    return np.transpose(x, pattern)
+
+
 def reshape(x, shape):
     return np.reshape(x, shape)
 
@@ -387,6 +403,23 @@ def eye(size, dtype=None, name=None):
     return np.eye(size, dtype=dtype)
 
 
+def dot(x, y):
+    return np.dot(x, y)
+
+
+def transpose(x):
+    return np.transpose(x)
+
+
+def reverse(x, axes):
+    if isinstance(axes, int):
+        axes = (axes,)
+    axes = list(axes)
+    for a in axes:
+        x = np.flip(x, a)
+    return x
+
+
 def variable(value, dtype=None, name=None, constraint=None):
     if constraint is not None:
         raise TypeError("Constraint must be None when "
@@ -424,6 +457,36 @@ def maximum(x, y):
 
 def minimum(x, y):
     return np.minimum(x, y)
+
+
+def random_uniform_variable(shape, low, high, dtype=None, name=None, seed=None):
+    return np.random.random(shape).astype(dtype)
+
+
+def random_normal_variable(shape, mean, scale, dtype=None, name=None, seed=None):
+    return scale * np.random.randn(*shape).astype(dtype) + mean
+
+
+def resize_images(x, height_factor, width_factor, data_format):
+    if data_format == 'channels_first':
+        x = repeat_elements(x, height_factor, axis=2)
+        x = repeat_elements(x, width_factor, axis=3)
+    elif data_format == 'channels_last':
+        x = repeat_elements(x, height_factor, axis=1)
+        x = repeat_elements(x, width_factor, axis=2)
+    return x
+
+
+def resize_volumes(x, depth_factor, height_factor, width_factor, data_format):
+    if data_format == 'channels_first':
+        x = repeat_elements(x, depth_factor, axis=2)
+        x = repeat_elements(x, height_factor, axis=3)
+        x = repeat_elements(x, width_factor, axis=4)
+    elif data_format == 'channels_last':
+        x = repeat_elements(x, depth_factor, axis=1)
+        x = repeat_elements(x, height_factor, axis=2)
+        x = repeat_elements(x, width_factor, axis=3)
+    return x
 
 
 square = np.square


### PR DESCRIPTION
### Summary

This PR speeds up backend tests by removing redundant backend tests. The targets, which always been included in the slowest 20 test durations, are `test_linear_operations`, `test_resize_images`, `test_resize_volumes`, and `test_bias_add`.

### Related Issues

#11037
#10972
#10956
#10930

cc @gabrieldemarmiesse 