### PR TITLE
Fix default data_format for Conv1D

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -272,13 +272,15 @@ class Conv1D(_Conv):
             should not violate the temporal order. See
             [WaveNet: A Generative Model for Raw Audio, section 2.1](https://arxiv.org/abs/1609.03499).
         data_format: A string,
-            one of `"channels_last"` (default) or `"channels_first"`.
+            one of `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs.
             `"channels_last"` corresponds to inputs with shape
             `(batch, steps, channels)`
-            (default format for temporal data in Keras)
             while `"channels_first"` corresponds to inputs
             with shape `(batch, channels, steps)`.
+            It defaults to the `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "channels_last".
         dilation_rate: an integer or tuple/list of a single integer, specifying
             the dilation rate to use for dilated convolution.
             Currently, specifying any `dilation_rate` value != 1 is
@@ -318,7 +320,7 @@ class Conv1D(_Conv):
                  kernel_size,
                  strides=1,
                  padding='valid',
-                 data_format='channels_last',
+                 data_format=None,
                  dilation_rate=1,
                  activation=None,
                  use_bias=True,
@@ -331,7 +333,7 @@ class Conv1D(_Conv):
                  bias_constraint=None,
                  **kwargs):
         if padding == 'causal':
-            if data_format != 'channels_last':
+            if K.normalize_data_format(data_format) != 'channels_last':
                 raise ValueError('When using causal padding in `Conv1D`, '
                                  '`data_format` must be "channels_last" '
                                  '(temporal data).')

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -24,7 +24,8 @@ else:
     [
         # Causal
         ({'filters': 1, 'kernel_size': 2, 'dilation_rate': 1, 'padding': 'causal',
-          'kernel_initializer': 'ones', 'use_bias': False},
+          'kernel_initializer': 'ones', 'data_format': 'channels_last',
+          'use_bias': False},
          4, [[[0], [1], [3], [5]]]),
         # Non-causal
         ({'filters': 1, 'kernel_size': 2, 'dilation_rate': 1, 'padding': 'valid',
@@ -32,7 +33,8 @@ else:
          4, [[[1], [3], [5]]]),
         # Causal dilated with larger kernel size
         ({'filters': 1, 'kernel_size': 3, 'dilation_rate': 2, 'padding': 'causal',
-          'kernel_initializer': 'ones', 'use_bias': False},
+          'kernel_initializer': 'ones',  'data_format': 'channels_last',
+          'use_bias': False},
          10, np.float32([[[0], [1], [2], [4], [6], [9], [12], [15], [18], [21]]])),
     ]
 )


### PR DESCRIPTION
### Summary
The default ```data_format``` for ```Conv1D``` should be decided by Keras config at ```~/.keras/keras.json```, so it should be ```None``` in the constructor. I also checked all other convolution layers, they are correctly set with ```None```.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
