### PR TITLE
Made the backend tests faster by using the numpy backend in the test_switch.

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -885,7 +885,7 @@ class TestBackend(object):
         # scalar
         val = np.random.random()
         z_list = []
-        for k in BACKENDS:
+        for k in WITH_NP:
             x = k.variable(val)
             x = k.switch(k.greater_equal(x, 0.5), x * 0.1, x * 0.2)
             z_list.append(k.eval(x))
@@ -898,7 +898,7 @@ class TestBackend(object):
         for s in shapes:
             z_list = []
             arrays = list(map(np.random.random, s))
-            for k in BACKENDS:
+            for k in WITH_NP:
                 x, then_expr, else_expr = map(k.variable, arrays)
                 cond = k.greater_equal(x, 0.5)
                 z_list.append(k.eval(k.switch(cond, then_expr, else_expr)))

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -200,6 +200,13 @@ def relu(x, alpha=0., max_value=None):
     return y
 
 
+def switch(condition, then_expression, else_expression):
+    cond_float = condition.astype(floatx())
+    while cond_float.ndim < then_expression.ndim:
+        cond_float = cond_float[..., None]
+    return cond_float * then_expression + (1 - cond_float) * else_expression
+
+
 def softplus(x):
     return np.log(1. + np.exp(x))
 


### PR DESCRIPTION
### Summary

Follow up on #11061 
We want to avoid to duplicate backends tests.

@taehoonlee

### Related Issues

#11051
#11037
#10972
#10956
#10930

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
