### PR TITLE
Update Dockerfile to fix error introduced by #11011

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN conda install -y python=${python_version} && \
     pip install --upgrade pip && \
     pip install \
       sklearn_pandas \
-      tensorflow-gpu && \
+      tensorflow-gpu \
       cntk-gpu && \
     conda install \
       bcolz \


### PR DESCRIPTION
### Summary
As `cntk-gpu` is being installed via the continuation of previous `pip install...` comand, `&&` at the end ends the command, Which calls `cntk-gpu` instaed
### Related Issues
#11011 
### PR Overview

- [ n] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
