### PR TITLE
Always create a tf variable.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -699,10 +699,7 @@ def zeros(shape, dtype=None, name=None):
     if dtype is None:
         dtype = floatx()
     tf_dtype = tf.as_dtype(dtype)
-    v = tf.zeros(shape=shape, dtype=tf_dtype, name=name)
-    if py_all(v.get_shape().as_list()):
-        return variable(v, dtype=dtype, name=name)
-    return v
+    return tf.zeros(shape=shape, dtype=tf_dtype, name=name)
 
 
 def ones(shape, dtype=None, name=None):
@@ -731,10 +728,7 @@ def ones(shape, dtype=None, name=None):
     if dtype is None:
         dtype = floatx()
     tf_dtype = tf.as_dtype(dtype)
-    v = tf.ones(shape=shape, dtype=tf_dtype, name=name)
-    if py_all(v.get_shape().as_list()):
-        return variable(v, dtype=dtype, name=name)
-    return v
+    return tf.ones(shape=shape, dtype=tf_dtype, name=name)
 
 
 def eye(size, dtype=None, name=None):


### PR DESCRIPTION
This PR changes `keras.backend.ones` and `keras.backend.zeros` (using the Tensorflow backend) slightly to allow for creation of variables inside loops, such as `tf.map_fn` as shown below:

```python
import keras
import tensorflow as tf

def succeeds(x):
    """
    Creates tensorflow.ones tensor, which works.
    """
    x = tf.ones((100,))
    return x

def fails(x):
    """
    Creates keras.backend.ones tensor, which fails.
    """
    x = keras.backend.ones((100,))
    return x

elems = keras.backend.zeros((1, 100))

# this call works
y = tf.map_fn(succeeds, elems=elems)

# this call doesn't
y = tf.map_fn(fails, elems=elems)
```

On `master`, this code crashes on the second call to `tf.map_fn` with the following error:

```
Using TensorFlow backend.
Traceback (most recent call last):
  File "test.py", line 18, in <module>
    y = tf.map_fn(fails, elems=elems)
  File "/usr/lib/python3.7/site-packages/tensorflow/python/ops/functional_ops.py", line 459, in map_fn
    maximum_iterations=n)
  File "/usr/lib/python3.7/site-packages/tensorflow/python/ops/control_flow_ops.py", line 3232, in while_loop
    return_same_structure)
  File "/usr/lib/python3.7/site-packages/tensorflow/python/ops/control_flow_ops.py", line 2952, in BuildLoop
    pred, body, original_loop_vars, loop_vars, shape_invariants)
  File "/usr/lib/python3.7/site-packages/tensorflow/python/ops/control_flow_ops.py", line 2887, in _BuildLoop
    body_result = body(*packed_vars_for_body)
  File "/usr/lib/python3.7/site-packages/tensorflow/python/ops/control_flow_ops.py", line 3201, in <lambda>
    body = lambda i, lv: (i + 1, orig_body(*lv))
  File "/usr/lib/python3.7/site-packages/tensorflow/python/ops/functional_ops.py", line 448, in compute
    packed_fn_values = fn(packed_values)
  File "test.py", line 9, in fails
    x = keras.backend.ones((100,))
  File "/home/hgaiser/.local/lib/python3.7/site-packages/keras/backend/tensorflow_backend.py", line 734, in ones
    return variable(v, dtype=dtype, name=name)
  File "/home/hgaiser/.local/lib/python3.7/site-packages/keras/backend/tensorflow_backend.py", line 400, in variable
    v = tf.Variable(value, dtype=tf.as_dtype(dtype), name=name)
  File "/usr/lib/python3.7/site-packages/tensorflow/python/ops/variables.py", line 259, in __init__
    constraint=constraint)
  File "/usr/lib/python3.7/site-packages/tensorflow/python/ops/variables.py", line 387, in _init_from_args
    "initializer." % name)
ValueError: Initializer for variable map_1/while/Variable/ is from inside a control-flow construct, such as a loop or conditional. When creating a variable inside a loop or conditional, use a lambda as the initializer.
```

This PR makes a minor adjustment to always return either `tf.ones` or `tf.zeros`. Apparently `keras.backend.variable`'s cannot be created inside "control-flow constructs" such as `tf.map_fn`. 