### PR TITLE
Skipped the training tests when the layer has the same behavior at training and testing time.

### DIFF
--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -102,9 +102,11 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
             _output = recovered_model.predict(input_data)
             assert_allclose(_output, actual_output, rtol=1e-3)
 
-        # test training mode (e.g. useful for dropout tests)
-        model.compile('rmsprop', 'mse')
-        model.train_on_batch(input_data, actual_output)
+        # test training mode (e.g. useful when the layer has a
+        # different behavior at training and testing time).
+        if has_arg(layer.call, 'training'):
+            model.compile('rmsprop', 'mse')
+            model.train_on_batch(input_data, actual_output)
         return actual_output
 
     # test in functional API


### PR DESCRIPTION
### Summary

We can't expect an error at this point in the code if a layer has the same behavior at training and testing time since we already called `model.predict` just before. The idea came from @fchollet 's comment in this issue: #8990

### Related Issues

### PR Overview

This PR is pretty simple. With a small test on my pc with tf-cpu, the time for `test_dense` go from 5s to 1.3s.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
