### PR TITLE
Add missing raise for ValueError at Embedding compute_output_shape

### DIFF
--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -122,13 +122,13 @@ class Embedding(Layer):
             else:
                 in_lens = [self.input_length]
             if len(in_lens) != len(input_shape) - 1:
-                ValueError('"input_length" is %s, but received input has shape %s' %
-                           (str(self.input_length), str(input_shape)))
+                raise ValueError('"input_length" is %s, but received input has shape %s' %
+                                 (str(self.input_length), str(input_shape)))
             else:
                 for i, (s1, s2) in enumerate(zip(in_lens, input_shape[1:])):
                     if s1 is not None and s2 is not None and s1 != s2:
-                        ValueError('"input_length" is %s, but received input has shape %s' %
-                                   (str(self.input_length), str(input_shape)))
+                        raise ValueError('"input_length" is %s, but received input has shape %s' %
+                                         (str(self.input_length), str(input_shape)))
                     elif s1 is None:
                         in_lens[i] = s2
             return (input_shape[0],) + tuple(in_lens) + (self.output_dim,)

--- a/tests/keras/layers/embeddings_test.py
+++ b/tests/keras/layers/embeddings_test.py
@@ -1,6 +1,7 @@
 import pytest
 from keras.utils.test_utils import layer_test, keras_test
 from keras.layers.embeddings import Embedding
+from keras.models import Sequential
 import keras.backend as K
 
 
@@ -27,6 +28,26 @@ def test_embedding():
                input_shape=(3, 2, 5),
                input_dtype='int32',
                expected_output_dtype=K.floatx())
+
+
+@keras_test
+def test_embedding_invalid():
+
+    # len(input_length) should be equal to len(input_shape) - 1
+    with pytest.raises(ValueError):
+        model = Sequential([Embedding(
+            input_dim=10,
+            output_dim=4,
+            input_length=2,
+            input_shape=(3, 4, 5))])
+
+    # input_length should be equal to input_shape[1:]
+    with pytest.raises(ValueError):
+        model = Sequential([Embedding(
+            input_dim=10,
+            output_dim=4,
+            input_length=2,
+            input_shape=(3, 5))])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary
Reported at https://github.com/keras-team/keras/issues/10895#issuecomment-417957421 . If users don't set ```input_length``` for ```Embedding``` layer correctly, it should throw exception. Otherwise, the downstream layers compute shape incorrect and throw confused exception.

### Related Issues
https://github.com/keras-team/keras/issues/10895#issuecomment-417957421

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
