### PR TITLE
Decoupled the layers tests and the sequential tests.

### DIFF
--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -8,9 +8,21 @@ from numpy.testing import assert_allclose
 from keras import backend as K
 import keras
 from keras.models import Sequential
-from keras.layers import Dense, Activation
+from keras.layers import Dense
+from keras.layers import Activation
+from keras.layers import BatchNormalization
+from keras.layers import Conv2D
+from keras.layers import Conv3D
+from keras.layers import Dropout
+from keras.layers import ReLU
+from keras.layers import UpSampling3D
+from keras.layers import Lambda
+from keras.layers import SimpleRNN
+from keras.layers import Softmax
 from keras.utils import np_utils
 from keras.utils.test_utils import get_test_data, keras_test
+from keras.utils.test_utils import helper_test_simple_model
+from keras.utils.test_utils import generate_input_data
 from keras.models import model_from_json, model_from_yaml
 from keras import losses
 from keras.engine.training_utils import make_batches
@@ -471,6 +483,53 @@ def test_nested_sequential_deferred_build():
     assert new_inner_model.built is True
     assert len(new_inner_model.layers) == 2
     assert len(new_inner_model.weights) == 4
+
+
+@keras_test
+def test_sequential_1D():
+    input_shape = (4, 3, 5)
+    model = Sequential()
+    model.add(Dense(3, input_shape=input_shape[1:]))
+    model.add(Dropout(0.2))
+    model.add(ReLU())
+
+    input_data, _ = generate_input_data(input_shape)
+    helper_test_simple_model(model, input_data)
+
+
+@keras_test
+def test_sequential_2D():
+    input_shape = (4, 3, 5, 2)
+    model = Sequential()
+    model.add(Conv2D(2, (1, 3), padding='valid', input_shape=input_shape[1:]))
+    model.add(BatchNormalization())
+    model.add(Softmax())
+
+    input_data, _ = generate_input_data(input_shape)
+    helper_test_simple_model(model, input_data)
+
+
+@keras_test
+def test_sequential_3D():
+    input_shape = (4, 3, 5, 3, 2)
+    model = Sequential()
+    model.add(Conv3D(3, (1, 3, 2), padding='same', input_shape=input_shape[1:]))
+    model.add(UpSampling3D())
+    model.add(Lambda(lambda x: x * 2))
+
+    input_data, _ = generate_input_data(input_shape)
+    helper_test_simple_model(model, input_data)
+
+
+@keras_test
+def test_sequential_RNN():
+    input_shape = (4, 3, 5)
+    model = Sequential()
+    model.add(SimpleRNN(2, return_sequences=True, input_shape=input_shape[1:]))
+    model.add(SimpleRNN(3))
+
+    input_data, _ = generate_input_data(input_shape)
+    helper_test_simple_model(model, input_data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

Currently we have 2 types of models (`Sequential`, `Model`) and 25+ types of layers.
In the tests, we test each type of layer in each type of model.
But `Sequential` derives from `Model`, so in fact, if layers work in `Model` they're expected to work in `Sequential`. We need other types of tests for `Sequential`. Most of them already exist in `keras/tests/keras/test_sequential_model.py`, I just added a few which look like what we tested before.

The effect of this PR is that it halves the running time of the layer tests in all backends (see the logs).
For some reason, the theano tests are not faster with python 3.6 which is very strange (caching maybe?).

* TF 2.7 : 12m17s -> 10m28s
* TF 3.6 : 11m33s -> 9m25s
* TH 2.7 : 10m20s -> 10m32s
* TH 3.6 : 12m11s -> 10m28s
* CNTK 2.7 : 6m13s -> 6m36s
* CNTK 3.6 : 6m23s -> 6m11s

### Related Issues

#8990

### PR Overview

Quite some code was moved around in `test_utils.py`, but very few has changed. I wanted to be able to reuse the functions in `test_sequential_model.py`.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
