### PR TITLE
fix sparse categorical acc

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -32,9 +32,8 @@ def categorical_accuracy(y_true, y_pred):
                           K.argmax(y_pred, axis=-1)),
                   K.floatx())
 
-
 def sparse_categorical_accuracy(y_true, y_pred):
-    return K.cast(K.equal(K.max(y_true, axis=-1),
+    return K.cast(K.equal(y_true,
                           K.cast(K.argmax(y_pred, axis=-1), K.floatx())),
                   K.floatx())
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -34,6 +34,7 @@ def categorical_accuracy(y_true, y_pred):
 
 
 def sparse_categorical_accuracy(y_true, y_pred):
+    # flatten y_true in case it's in shape (num_samples, 1) instead of (num_samples,)
     return K.cast(K.equal(K.flatten(y_true),
                           K.cast(K.argmax(y_pred, axis=-1), K.floatx())),
                   K.floatx())

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -32,6 +32,7 @@ def categorical_accuracy(y_true, y_pred):
                           K.argmax(y_pred, axis=-1)),
                   K.floatx())
 
+
 def sparse_categorical_accuracy(y_true, y_pred):
     return K.cast(K.equal(K.flatten(y_true),
                           K.cast(K.argmax(y_pred, axis=-1), K.floatx())),

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -33,7 +33,7 @@ def categorical_accuracy(y_true, y_pred):
                   K.floatx())
 
 def sparse_categorical_accuracy(y_true, y_pred):
-    return K.cast(K.equal(y_true,
+    return K.cast(K.equal(K.flatten(y_true),
                           K.cast(K.argmax(y_pred, axis=-1), K.floatx())),
                   K.floatx())
 

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -46,15 +46,18 @@ def test_sparse_metrics():
         y_b = K.variable(np.random.random((6, 7)), dtype=K.floatx())
         assert K.eval(metric(y_a, y_b)).shape == (6,)
 
+
 @keras_test
 def test_sparse_categorical_accuracy_correctness():
     y_a = K.variable(np.random.randint(0, 7, (6,)), dtype=K.floatx())
     y_b = K.variable(np.random.random((6, 7)), dtype=K.floatx())
     # use one_hot embedding to convert sparse labels to equivalent dense labels
-    y_a_dense_labels = K.cast(K.one_hot(K.cast(y_a, dtype='int32'), num_classes=7), dtype=K.floatx())
+    y_a_dense_labels = K.cast(K.one_hot(K.cast(y_a, dtype='int32'), num_classes=7),
+                              dtype=K.floatx())
     sparse_categorical_acc = metrics.sparse_categorical_accuracy(y_a, y_b)
     categorical_acc = metrics.categorical_accuracy(y_a_dense_labels, y_b)
     assert np.allclose(K.eval(sparse_categorical_acc), K.eval(categorical_acc))
+
 
 def test_serialize():
     '''This is a mock 'round trip' of serialize and deserialize.

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -46,6 +46,15 @@ def test_sparse_metrics():
         y_b = K.variable(np.random.random((6, 7)), dtype=K.floatx())
         assert K.eval(metric(y_a, y_b)).shape == (6,)
 
+@keras_test
+def test_sparse_categorical_accuracy_correctness():
+    y_a = K.variable(np.random.randint(0, 7, (6,)), dtype=K.floatx())
+    y_b = K.variable(np.random.random((6, 7)), dtype=K.floatx())
+    # use one_hot embedding to convert sparse labels to equivalent dense labels
+    y_a_dense_labels = K.cast(K.one_hot(K.cast(y_a, dtype='int32'), num_classes=7), dtype=K.floatx())
+    sparse_categorical_acc = metrics.sparse_categorical_accuracy(y_a, y_b)
+    categorical_acc = metrics.categorical_accuracy(y_a_dense_labels, y_b)
+    assert np.allclose(K.eval(sparse_categorical_acc), K.eval(categorical_acc))
 
 def test_serialize():
     '''This is a mock 'round trip' of serialize and deserialize.


### PR DESCRIPTION
### Summary

1. sparse categorical acc should have the same result as categorical acc.

For example, with 3 classes, given `sparse_true_label = [0, 1, 1]`, it's equivalent in categorical labels is `dense_true_label = [[1, 0, 0], [0, 1, 0], [0, 1, 0]]`. With the same predictions 
```
pred = [[0.7, 0.2, 0.1], 
[0.1, 0.1, 0.8], 
[0.2, 0.6, 0.2]]
```
They should produce the same acc which is `[1, 0 ,1]`

2. Not sure why `max` is used, but it should directly compare with `y_true`
3. Added unit test to test correctness


### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y] (make sure tests are included)
- [ ] This PR requires to update the documentation [n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y]
- [ ] This PR changes the current API [n] (all API changes need to be approved by fchollet)
