### PR TITLE
Removed the tests of each layer with the sequential model.

### DIFF
--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -119,17 +119,12 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
 
     # check with the functional API
     model = Model(x, y)
-    _layer_in_model_test(model)
+    actual_output = _layer_in_model_test(model)
 
-    # test as first layer in Sequential API
+    # test instantiation from layer config
     layer_config = layer.get_config()
     layer_config['batch_input_shape'] = input_shape
     layer = layer.__class__.from_config(layer_config)
-
-    # check with the sequential API
-    model = Sequential()
-    model.add(layer)
-    actual_output = _layer_in_model_test(model)
 
     # for further checks in the caller function
     return actual_output


### PR DESCRIPTION
### Summary

This PR is a follow up on #11098 .

Build speedups:

| build | before | after |
|-------|--------|-------|
|    TF 2.7   |    13m    |   10m 4s    | 
|    TF 3.6   |     12m 29s   |    9m 51s   |
|    TH 2.7   |    10m 13s    |    9m 23s   | 
|    TH 3.6   |    11m 50s    |    10m 19s   | 
|    CNTK 2.7   |    6m10s    |    6m 36s   | 
|    CNTK 3.6   |    6m 34s    |    6m 51s   | 

Currently we have 2 types of models (`Sequential`, `Model`) and 25+ types of layers.
In the tests, we test each type of layer in each type of model.
But `Sequential` derives from `Model`, so in fact, if layers work in `Model` they're expected to work in `Sequential`. 

The effect of this PR is that it halves the running time of the layer tests in all backends (see the logs).

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
