### PR TITLE
Fix bug in BatchNorm when channel=1

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1905,17 +1905,17 @@ def batch_normalization(x, mean, var, beta, gamma, axis=-1, epsilon=1e-3):
             # The mean / var / beta / gamma may be processed by broadcast
             # so it may have extra axes with 1, it is not needed and should be removed
             if ndim(mean) > 1:
-                mean = tf.squeeze(mean)
+                mean = tf.reshape(mean, (-1))
             if ndim(var) > 1:
-                var = tf.squeeze(var)
+                var = tf.reshape(var, (-1))
             if beta is None:
                 beta = zeros_like(mean)
             elif ndim(beta) > 1:
-                beta = tf.squeeze(beta)
+                beta = tf.reshape(beta, (-1))
             if gamma is None:
                 gamma = ones_like(mean)
             elif ndim(gamma) > 1:
-                gamma = tf.squeeze(gamma)
+                gamma = tf.reshape(gamma, (-1))
             y, _, _ = tf.nn.fused_batch_norm(
                 x,
                 gamma,

--- a/tests/keras/layers/normalization_test.py
+++ b/tests/keras/layers/normalization_test.py
@@ -28,7 +28,7 @@ def test_basic_batchnorm():
                kwargs={'momentum': 0.9,
                        'epsilon': 0.1,
                        'axis': 1},
-               input_shape=(3, 4, 2))
+               input_shape=(1, 4, 1))
     layer_test(normalization.BatchNormalization,
                kwargs={'gamma_initializer': 'ones',
                        'beta_initializer': 'ones',


### PR DESCRIPTION
### Summary
When channel=1 and we call `squeeze` the tensors become scalars. This is not accepted by Tensorflow. This is an issue only on GPU.
### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
