### PR TITLE
Set input_spec to full_input_spec when initial state provided

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -564,11 +564,8 @@ class RNN(Layer):
             # Compute the full input spec, including state and constants
             full_input = [inputs] + additional_inputs
             full_input_spec = self.input_spec + additional_specs
-            # Perform the call with temporarily replaced input_spec
-            original_input_spec = self.input_spec
             self.input_spec = full_input_spec
             output = super(RNN, self).__call__(full_input, **kwargs)
-            self.input_spec = original_input_spec
             return output
         else:
             return super(RNN, self).__call__(inputs, **kwargs)


### PR DESCRIPTION
This PR provides fix for reset_states() failure in a stateful network with initial_states set and training in batch https://github.com/keras-team/keras/issues/11148
