### PR TITLE
Splitted the convolutional recurrent tests.

### DIFF
--- a/tests/keras/layers/convolutional_recurrent_test.py
+++ b/tests/keras/layers/convolutional_recurrent_test.py
@@ -8,16 +8,18 @@ from keras.layers import convolutional_recurrent, Input
 from keras.utils.test_utils import layer_test
 from keras import regularizers
 
+num_row = 3
+num_col = 3
+filters = 2
+num_samples = 1
+input_channel = 2
+input_num_row = 5
+input_num_col = 5
+sequence_len = 2
+
 
 def test_convolutional_recurrent():
-    num_row = 3
-    num_col = 3
-    filters = 2
-    num_samples = 1
-    input_channel = 2
-    input_num_row = 5
-    input_num_col = 5
-    sequence_len = 2
+
     for data_format in ['channels_first', 'channels_last']:
 
         if data_format == 'channels_first':
@@ -59,97 +61,101 @@ def test_convolutional_recurrent():
                                         'padding': 'valid'},
                                 input_shape=inputs.shape)
 
-            # No need to check following tests for both data formats
-            if data_format == 'channels_first' or return_sequences:
-                continue
 
-            # Tests for statefulness
-            model = Sequential()
-            kwargs = {'data_format': data_format,
-                      'return_sequences': return_sequences,
-                      'filters': filters,
-                      'kernel_size': (num_row, num_col),
-                      'stateful': True,
-                      'batch_input_shape': inputs.shape,
-                      'padding': 'same'}
-            layer = convolutional_recurrent.ConvLSTM2D(**kwargs)
+def test_convolutional_recurrent_statefulness():
 
-            model.add(layer)
-            model.compile(optimizer='sgd', loss='mse')
-            out1 = model.predict(np.ones_like(inputs))
+    data_format = 'channels_last'
+    return_sequences = False
+    inputs = np.random.rand(num_samples, sequence_len,
+                            input_num_row, input_num_col,
+                            input_channel)
+    # Tests for statefulness
+    model = Sequential()
+    kwargs = {'data_format': data_format,
+              'return_sequences': return_sequences,
+              'filters': filters,
+              'kernel_size': (num_row, num_col),
+              'stateful': True,
+              'batch_input_shape': inputs.shape,
+              'padding': 'same'}
+    layer = convolutional_recurrent.ConvLSTM2D(**kwargs)
 
-            # train once so that the states change
-            model.train_on_batch(np.ones_like(inputs),
-                                 np.random.random(out1.shape))
-            out2 = model.predict(np.ones_like(inputs))
+    model.add(layer)
+    model.compile(optimizer='sgd', loss='mse')
+    out1 = model.predict(np.ones_like(inputs))
 
-            # if the state is not reset, output should be different
-            assert(out1.max() != out2.max())
+    # train once so that the states change
+    model.train_on_batch(np.ones_like(inputs),
+                         np.random.random(out1.shape))
+    out2 = model.predict(np.ones_like(inputs))
 
-            # check that output changes after states are reset
-            # (even though the model itself didn't change)
-            layer.reset_states()
-            out3 = model.predict(np.ones_like(inputs))
-            assert(out2.max() != out3.max())
+    # if the state is not reset, output should be different
+    assert(out1.max() != out2.max())
 
-            # check that container-level reset_states() works
-            model.reset_states()
-            out4 = model.predict(np.ones_like(inputs))
-            assert_allclose(out3, out4, atol=1e-5)
+    # check that output changes after states are reset
+    # (even though the model itself didn't change)
+    layer.reset_states()
+    out3 = model.predict(np.ones_like(inputs))
+    assert(out2.max() != out3.max())
 
-            # check that the call to `predict` updated the states
-            out5 = model.predict(np.ones_like(inputs))
-            assert(out4.max() != out5.max())
+    # check that container-level reset_states() works
+    model.reset_states()
+    out4 = model.predict(np.ones_like(inputs))
+    assert_allclose(out3, out4, atol=1e-5)
 
-            # cntk doesn't support eval convolution with static
-            # variable, will enable it later
-            if K.backend() != 'cntk':
-                # check regularizers
-                kwargs = {'data_format': data_format,
-                          'return_sequences': return_sequences,
-                          'kernel_size': (num_row, num_col),
-                          'stateful': True,
-                          'filters': filters,
-                          'batch_input_shape': inputs.shape,
-                          'kernel_regularizer': regularizers.L1L2(l1=0.01),
-                          'recurrent_regularizer': regularizers.L1L2(l1=0.01),
-                          'bias_regularizer': 'l2',
-                          'activity_regularizer': 'l2',
-                          'kernel_constraint': 'max_norm',
-                          'recurrent_constraint': 'max_norm',
-                          'bias_constraint': 'max_norm',
-                          'padding': 'same'}
+    # check that the call to `predict` updated the states
+    out5 = model.predict(np.ones_like(inputs))
+    assert(out4.max() != out5.max())
 
-                layer = convolutional_recurrent.ConvLSTM2D(**kwargs)
-                layer.build(inputs.shape)
-                assert len(layer.losses) == 3
-                assert layer.activity_regularizer
-                output = layer(K.variable(np.ones(inputs.shape)))
-                assert len(layer.losses) == 4
-                K.eval(output)
+    # cntk doesn't support eval convolution with static
+    # variable, will enable it later
+    if K.backend() != 'cntk':
+        # check regularizers
+        kwargs = {'data_format': data_format,
+                  'return_sequences': return_sequences,
+                  'kernel_size': (num_row, num_col),
+                  'stateful': True,
+                  'filters': filters,
+                  'batch_input_shape': inputs.shape,
+                  'kernel_regularizer': regularizers.L1L2(l1=0.01),
+                  'recurrent_regularizer': regularizers.L1L2(l1=0.01),
+                  'bias_regularizer': 'l2',
+                  'activity_regularizer': 'l2',
+                  'kernel_constraint': 'max_norm',
+                  'recurrent_constraint': 'max_norm',
+                  'bias_constraint': 'max_norm',
+                  'padding': 'same'}
 
-            # check dropout
-            layer_test(convolutional_recurrent.ConvLSTM2D,
-                       kwargs={'data_format': data_format,
-                               'return_sequences': return_sequences,
-                               'filters': filters,
-                               'kernel_size': (num_row, num_col),
-                               'padding': 'same',
-                               'dropout': 0.1,
-                               'recurrent_dropout': 0.1},
-                       input_shape=inputs.shape)
+        layer = convolutional_recurrent.ConvLSTM2D(**kwargs)
+        layer.build(inputs.shape)
+        assert len(layer.losses) == 3
+        assert layer.activity_regularizer
+        output = layer(K.variable(np.ones(inputs.shape)))
+        assert len(layer.losses) == 4
+        K.eval(output)
 
-            # check state initialization
-            layer = convolutional_recurrent.ConvLSTM2D(
-                filters=filters, kernel_size=(num_row, num_col),
-                data_format=data_format, return_sequences=return_sequences)
-            layer.build(inputs.shape)
-            x = Input(batch_shape=inputs.shape)
-            initial_state = layer.get_initial_state(x)
-            y = layer(x, initial_state=initial_state)
-            model = Model(x, y)
-            assert (model.predict(inputs).shape ==
-                    layer.compute_output_shape(inputs.shape))
+    # check dropout
+    layer_test(convolutional_recurrent.ConvLSTM2D,
+               kwargs={'data_format': data_format,
+                       'return_sequences': return_sequences,
+                       'filters': filters,
+                       'kernel_size': (num_row, num_col),
+                       'padding': 'same',
+                       'dropout': 0.1,
+                       'recurrent_dropout': 0.1},
+               input_shape=inputs.shape)
+
+    # check state initialization
+    layer = convolutional_recurrent.ConvLSTM2D(
+        filters=filters, kernel_size=(num_row, num_col),
+        data_format=data_format, return_sequences=return_sequences)
+    layer.build(inputs.shape)
+    x = Input(batch_shape=inputs.shape)
+    initial_state = layer.get_initial_state(x)
+    y = layer(x, initial_state=initial_state)
+    model = Model(x, y)
+    assert (model.predict(inputs).shape ==
+            layer.compute_output_shape(inputs.shape))
 
 
 if __name__ == '__main__':

--- a/tests/keras/layers/convolutional_recurrent_test.py
+++ b/tests/keras/layers/convolutional_recurrent_test.py
@@ -6,6 +6,7 @@ from keras import backend as K
 from keras.models import Sequential, Model
 from keras.layers import convolutional_recurrent, Input
 from keras.utils.test_utils import layer_test
+from keras.utils.test_utils import keras_test
 from keras import regularizers
 
 num_row = 3
@@ -18,6 +19,7 @@ input_num_col = 5
 sequence_len = 2
 
 
+@keras_test
 def test_convolutional_recurrent():
 
     for data_format in ['channels_first', 'channels_last']:
@@ -62,6 +64,7 @@ def test_convolutional_recurrent():
                                 input_shape=inputs.shape)
 
 
+@keras_test
 def test_convolutional_recurrent_statefulness():
 
     data_format = 'channels_last'


### PR DESCRIPTION
### Summary

This will allow for more readable and informative tests. 150 lines for a test function is too much, even more because the are nested for loops.

The logic and behavior of the tests have not changed at all.

### Related Issues

### PR Overview

The git diff looks awful because of tabs, but the big piece of code hasn't changed. It just has less tabs than before.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
