### PR TITLE
Move package installation on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - travis_retry conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest pandas
+  - travis_retry conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - travis_retry pip install --only-binary=numpy,scipy numpy nose scipy matplotlib h5py theano
+  - travis_retry pip install --only-binary=numpy,scipy,pandas numpy nose scipy matplotlib h5py theano pytest pytest-pep8 pandas
   - pip install keras_applications keras_preprocessing
   - conda install mkl mkl-service
 


### PR DESCRIPTION
This PR moves package installation on Travis. Especially, the installation of `pytest pandas` has been moved to `pip` from `conda`. The `conda create` requires too much time (60+ secs) in [Keras](https://travis-ci.org/keras-team/keras/builds/429078096) while less time (<10 secs) in [TensorNets](https://travis-ci.org/taehoonlee/tensornets/builds/426029804).