### PR TITLE
Merge test environments for PEP8 and DOC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,9 @@ cache:
 matrix:
     include:
         - python: 2.7
-          env: KERAS_BACKEND=tensorflow TEST_MODE=PEP8
-        - python: 2.7
           env: KERAS_BACKEND=tensorflow TEST_MODE=INTEGRATION_TESTS
         - python: 3.6
-          env: KERAS_BACKEND=tensorflow TEST_MODE=DOC
+          env: KERAS_BACKEND=tensorflow TEST_MODE=PEP8_DOC
         - python: 2.7
           env: KERAS_BACKEND=tensorflow
         - python: 3.6
@@ -51,7 +49,7 @@ install:
   - export LD_LIBRARY_PATH=$HOME/miniconda/envs/test-environment/lib/:$LD_LIBRARY_PATH
 
   # install PIL for preprocessing tests (they are integration tests).
-  - if [[ "$TEST_MODE" == "INTEGRATION_TESTS" ]] || [[ "$TEST_MODE" == "PEP8" ]]; then
+  - if [[ "$TEST_MODE" == "INTEGRATION_TESTS" ]] || [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
       if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         conda install pil;
       else
@@ -108,9 +106,8 @@ script:
   - echo -e "Running tests with the following config:\n$(cat ~/.keras/keras.json)"
   - if [[ "$TEST_MODE" == "INTEGRATION_TESTS" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/integration_tests;
-    elif [[ "$TEST_MODE" == "PEP8" ]]; then
+    elif [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0;
-    elif [[ "$TEST_MODE" == "DOC" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/test_documentation.py;
     else
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --ignore=tests/keras/legacy/layers_test.py --cov-config .coveragerc --cov=keras tests/;


### PR DESCRIPTION
This PR merges test environments for `PEP8` and `DOC`. In my humble opinion, I think the current build matrix may be a bit waste of resources, because the two tests usually take 3~4 mins and the initialization of environments (`conda create`, `pip install`, ...) consumes at least 2 mins.