### PR TITLE
Correction of wrong instructions

### DIFF
--- a/examples/imdb_fasttext.py
+++ b/examples/imdb_fasttext.py
@@ -26,8 +26,8 @@ def create_ngram_set(input_list, ngram_value=2):
     Extract a set of n-grams from a list of integers.
 
     >>> create_ngram_set([1, 4, 9, 4, 1, 4], ngram_value=2)
-    {(4, 9), (4, 1), (1, 4), (9, 4)}
-
+    {(1, 4), (4, 1), (4, 9), (9, 4)}
+    
     >>> create_ngram_set([1, 4, 9, 4, 1, 4], ngram_value=3)
     [(1, 4, 9), (4, 9, 4), (9, 4, 1), (4, 1, 4)]
     """


### PR DESCRIPTION
Correct the {(4, 9), (4, 1), (1, 4), (9, 4)} of the twenty-ninth rows to {(1, 4), (4, 1), (4, 9), (9, 4)}. Although this is a minor mistake, it may be a slip of the pen, but correcting it will help beginners understand.

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
