### PR TITLE
Grouped conda installations together to speed up the travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
     fi
 
     # install pydot for visualization tests
-  - conda install mkl mkl-service pydot graphviz $PIL
+  - travis_retry conda install mkl mkl-service pydot graphviz $PIL
 
   - pip install -e .[tests]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ install:
   - source activate test-environment
   - travis_retry pip install --only-binary=numpy,scipy numpy nose scipy matplotlib h5py theano
   - pip install keras_applications keras_preprocessing
-  - conda install mkl mkl-service
 
   # set library path
   - export LD_LIBRARY_PATH=$HOME/miniconda/envs/test-environment/lib/:$LD_LIBRARY_PATH
@@ -53,11 +52,14 @@ install:
   # install PIL for preprocessing tests (they are integration tests).
   - if [[ "$TEST_MODE" == "INTEGRATION_TESTS" ]] || [[ "$TEST_MODE" == "PEP8" ]]; then
       if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-        conda install pil;
+        export PIL=Pil;
       else
-        conda install Pillow;
+        export PIL=Pillow;
       fi
     fi
+
+    # install pydot for visualization tests
+  - conda install mkl mkl-service pydot graphviz $PIL
 
   - pip install -e .[tests]
 
@@ -66,9 +68,6 @@ install:
   
   # install cntk
   - pip install cntk
-
-  # install pydot for visualization tests
-  - conda install pydot graphviz
 
   # exclude different backends to measure a coverage for the designated backend only
   - if [[ "$KERAS_BACKEND" != "tensorflow" ]]; then


### PR DESCRIPTION
### Summary

Master:
* Installation of mkl and mkl-services: 10.10s
* installation of Pil/Pillow: 11s
* installation of pydot graphvis: 21s
#### total: 43s

proposed:
* grouped installation of  mkl ,mkl-services Pil/Pillow pydot graphvis: 24.8s.

We can save ~18s on all travis jobs.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
