### PR TITLE
Used pytest's autouse to get rid of the @keras_test decorator.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from keras import backend as K
 
 @pytest.fixture(autouse=True)
 def clear_session_after_test():
-    print("dododod")
     yield
     if K.backend() == 'tensorflow' or K.backend() == 'cntk':
         K.clear_session()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+from keras import backend as K
+
+
+@pytest.fixture(autouse=True)
+def clear_session_after_test():
+    print("dododod")
+    yield
+    if K.backend() == 'tensorflow' or K.backend() == 'cntk':
+        K.clear_session()

--- a/tests/integration_tests/applications_test.py
+++ b/tests/integration_tests/applications_test.py
@@ -2,7 +2,6 @@ import pytest
 import random
 import os
 from multiprocessing import Process, Queue
-from keras.utils.test_utils import keras_test
 from keras import applications
 from keras import backend as K
 
@@ -57,13 +56,11 @@ def _get_output_shape(model_fn):
         return model.output_shape
 
 
-@keras_test
 def _test_application_basic(app, last_dim=1000):
     output_shape = _get_output_shape(lambda: app(weights=None))
     assert output_shape == (None, last_dim)
 
 
-@keras_test
 def _test_application_notop(app, last_dim):
     output_shape = _get_output_shape(
         lambda: app(weights=None, include_top=False))

--- a/tests/integration_tests/test_image_data_tasks.py
+++ b/tests/integration_tests/test_image_data_tasks.py
@@ -2,13 +2,12 @@ from __future__ import print_function
 import numpy as np
 import pytest
 
-from keras.utils.test_utils import get_test_data, keras_test
+from keras.utils.test_utils import get_test_data
 from keras.models import Sequential
 from keras import layers
 from keras.utils.np_utils import to_categorical
 
 
-@keras_test
 def test_image_classification():
     np.random.seed(1337)
     input_shape = (16, 16, 3)

--- a/tests/integration_tests/test_temporal_data_tasks.py
+++ b/tests/integration_tests/test_temporal_data_tasks.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 import string
 
-from keras.utils.test_utils import get_test_data, keras_test
+from keras.utils.test_utils import get_test_data
 from keras.utils.np_utils import to_categorical
 from keras.models import Sequential
 from keras import layers, optimizers
@@ -11,7 +11,6 @@ import keras.backend as K
 import keras
 
 
-@keras_test
 def test_temporal_classification():
     '''
     Classify temporal sequences of float numbers
@@ -44,7 +43,6 @@ def test_temporal_classification():
     model = Sequential.from_config(config)
 
 
-@keras_test
 def test_temporal_classification_functional():
     '''
     Classify temporal sequences of float numbers
@@ -74,7 +72,6 @@ def test_temporal_classification_functional():
     assert(history.history['acc'][-1] >= 0.8)
 
 
-@keras_test
 def test_temporal_regression():
     '''
     Predict float numbers (regression) based on sequences
@@ -95,7 +92,6 @@ def test_temporal_regression():
     assert(history.history['loss'][-1] < 1.)
 
 
-@keras_test
 def test_3d_to_3d():
     '''
     Apply a same Dense layer for each element of time dimension of the input
@@ -119,7 +115,6 @@ def test_3d_to_3d():
     assert(history.history['loss'][-1] < 1.)
 
 
-@keras_test
 def test_stacked_lstm_char_prediction():
     '''
     Learn alphabetical char sequence with stacked LSTM.
@@ -173,7 +168,6 @@ def test_stacked_lstm_char_prediction():
     assert(generated == alphabet)
 
 
-@keras_test
 def test_masked_temporal():
     '''
     Confirm that even with masking on both inputs and outputs, cross-entropies are
@@ -212,7 +206,6 @@ def test_masked_temporal():
 
 
 @pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TF backend')
-@keras_test
 def test_embedding_with_clipnorm():
     model = Sequential()
     model.add(layers.Embedding(input_dim=1, output_dim=1))

--- a/tests/integration_tests/test_tensorflow_integration.py
+++ b/tests/integration_tests/test_tensorflow_integration.py
@@ -6,12 +6,10 @@ import pytest
 import keras
 from keras import layers
 from keras.utils.test_utils import get_test_data
-from keras.utils.test_utils import keras_test
 
 
 @pytest.mark.skipif(keras.backend.backend() != 'tensorflow',
                     reason='Requires TF backend')
-@keras_test
 def test_tf_optimizer():
     import tensorflow as tf
 

--- a/tests/integration_tests/test_vector_data_tasks.py
+++ b/tests/integration_tests/test_vector_data_tasks.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import pytest
 
-from keras.utils.test_utils import get_test_data, keras_test
+from keras.utils.test_utils import get_test_data
 from keras.models import Sequential
 from keras import layers
 import keras
@@ -10,7 +10,6 @@ from keras.utils.np_utils import to_categorical
 num_classes = 2
 
 
-@keras_test
 def test_vector_classification():
     '''
     Classify random float vectors into 2 classes with logistic regression
@@ -43,7 +42,6 @@ def test_vector_classification():
     model = Sequential.from_config(config)
 
 
-@keras_test
 def test_vector_classification_functional():
     (x_train, y_train), (x_test, y_test) = get_test_data(num_train=500,
                                                          num_test=200,
@@ -66,7 +64,6 @@ def test_vector_classification_functional():
     assert(history.history['val_acc'][-1] > 0.8)
 
 
-@keras_test
 def test_vector_regression():
     '''
     Perform float data prediction (regression) using 2 layer MLP

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -3,7 +3,6 @@ from numpy.testing import assert_allclose
 import numpy as np
 import scipy.sparse as sparse
 import warnings
-from keras.utils.test_utils import keras_test
 
 from keras import backend as K
 from keras.backend import floatx, set_floatx, variable
@@ -101,7 +100,6 @@ def assert_list_keras_shape(t_list, z_list):
                     assert t._keras_shape[i] == z.shape[i]
 
 
-@keras_test
 def check_single_tensor_operation(function_name, x_shape_or_val, backend_list, **kwargs):
     shape_or_val = kwargs.pop('shape_or_val', True)
     assert_value_equality = kwargs.pop('assert_value_equality', True)
@@ -130,7 +128,6 @@ def check_single_tensor_operation(function_name, x_shape_or_val, backend_list, *
     assert_list_keras_shape(t_list, z_list)
 
 
-@keras_test
 def check_two_tensor_operation(function_name, x_shape_or_val,
                                y_shape_or_val, backend_list, **kwargs):
     concat_args = kwargs.pop('concat_args', False)
@@ -168,7 +165,6 @@ def check_two_tensor_operation(function_name, x_shape_or_val,
     assert_list_keras_shape(t_list, z_list)
 
 
-@keras_test
 def check_composed_tensor_operations(first_function_name, first_function_args,
                                      second_function_name, second_function_args,
                                      input_shape, backend_list):

--- a/tests/keras/constraints_test.py
+++ b/tests/keras/constraints_test.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_allclose
 
 from keras import backend as K
 from keras import constraints
-from keras.utils.test_utils import keras_test
 
 
 def get_test_values():
@@ -30,7 +29,6 @@ def test_serialization():
         assert fn.__class__ == ref_fn.__class__
 
 
-@keras_test
 def test_max_norm():
     array = get_example_array()
     for m in get_test_values():
@@ -50,14 +48,12 @@ def test_max_norm():
     assert_allclose(x_normed_actual, x_normed_target, rtol=1e-05)
 
 
-@keras_test
 def test_non_neg():
     non_neg_instance = constraints.non_neg()
     normed = non_neg_instance(K.variable(get_example_array()))
     assert(np.all(np.min(K.eval(normed), axis=1) == 0.))
 
 
-@keras_test
 def test_unit_norm():
     unit_norm_instance = constraints.unit_norm()
     normalized = unit_norm_instance(K.variable(get_example_array()))
@@ -68,7 +64,6 @@ def test_unit_norm():
     assert(np.abs(largest_difference) < 10e-5)
 
 
-@keras_test
 def test_min_max_norm():
     array = get_example_array()
     for m in get_test_values():

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -8,7 +8,6 @@ from keras.engine import Input, Layer, saving, get_source_inputs
 from keras.models import Model, Sequential
 from keras import backend as K
 from keras.models import model_from_json, model_from_yaml
-from keras.utils.test_utils import keras_test
 from keras.initializers import Constant
 
 
@@ -18,7 +17,6 @@ skipif_no_tf_gpu = pytest.mark.skipif(
     reason='Requires TensorFlow backend and a GPU')
 
 
-@keras_test
 def test_get_updates_for():
     a = Input(shape=(2,))
     dense_layer = Dense(1)
@@ -29,7 +27,6 @@ def test_get_updates_for():
     assert dense_layer.get_updates_for(None) == [1]
 
 
-@keras_test
 def test_get_losses_for():
     a = Input(shape=(2,))
     dense_layer = Dense(1)
@@ -40,7 +37,6 @@ def test_get_losses_for():
     assert dense_layer.get_losses_for(None) == [1]
 
 
-@keras_test
 def test_trainable_weights():
     a = Input(shape=(2,))
     b = Dense(1)(a)
@@ -153,7 +149,6 @@ def test_learning_phase():
     assert fn_outputs_no_dp[1].sum() != fn_outputs_dp[1].sum()
 
 
-@keras_test
 def test_layer_call_arguments():
     # Test the ability to pass and serialize arguments to `call`.
     inp = layers.Input(shape=(2,))
@@ -173,7 +168,6 @@ def test_layer_call_arguments():
     assert not model.uses_learning_phase
 
 
-@keras_test
 def test_node_construction():
     ####################################################
     # test basics
@@ -256,7 +250,6 @@ def test_node_construction():
     assert dense.get_output_mask_at(1) is None
 
 
-@keras_test
 def test_multi_input_layer():
     ####################################################
     # test multi-input layer
@@ -323,7 +316,6 @@ def test_multi_input_layer():
     assert [x.shape for x in fn_outputs] == [(10, 64), (10, 5)]
 
 
-@keras_test
 def test_recursion():
     ####################################################
     # test recursion
@@ -503,7 +495,6 @@ def test_recursion():
         Dense(2)(x)
 
 
-@keras_test
 def test_load_layers():
     from keras.layers import ConvLSTM2D, TimeDistributed
     from keras.layers import Bidirectional, Conv2D, Input
@@ -583,7 +574,6 @@ def convert_weights(layer, weights):
     return weights
 
 
-@keras_test
 @pytest.mark.parametrize("layer", [
     layers.GRU(2, input_shape=[3, 5]),
     layers.LSTM(2, input_shape=[3, 5]),
@@ -602,7 +592,6 @@ def test_preprocess_weights_for_loading(layer):
                 for (x, y) in zip(weights1, weights2)])
 
 
-@keras_test
 @pytest.mark.parametrize("layer", [
     layers.Conv2D(2, (3, 3), input_shape=[5, 5, 3]),
     layers.Conv2DTranspose(2, (5, 5),
@@ -619,7 +608,6 @@ def test_preprocess_weights_for_loading_for_model(layer):
                 for (x, y) in zip(weights1, weights2)])
 
 
-@keras_test
 @pytest.mark.parametrize('layer_class,args', [
     (layers.GRU, {'units': 2, 'input_shape': [3, 5]}),
     (layers.GRU, {'units': 2, 'input_shape': [3, 5], 'reset_after': True}),
@@ -638,7 +626,6 @@ def test_preprocess_weights_for_loading_rnn_should_be_idempotent(layer_class, ar
     assert all([np.allclose(x, y, 1e-5) for (x, y) in zip(weights1, weights2)])
 
 
-@keras_test
 @pytest.mark.parametrize('layer_class,args', [
     (layers.CuDNNGRU, {'units': 2, 'input_shape': [3, 5]}),
     (layers.CuDNNLSTM, {'units': 2, 'input_shape': [3, 5]}),
@@ -649,7 +636,6 @@ def test_preprocess_weights_for_loading_cudnn_rnn_should_be_idempotent(layer_cla
     test_preprocess_weights_for_loading_rnn_should_be_idempotent(layer_class, args)
 
 
-@keras_test
 def test_recursion_with_bn_and_loss():
     model1 = Sequential([
         layers.Dense(5, input_dim=5, activity_regularizer='l1'),
@@ -676,7 +662,6 @@ def test_recursion_with_bn_and_loss():
     model2.fit(x, y, verbose=0, epochs=1)
 
 
-@keras_test
 def test_activity_regularization_with_model_composition():
 
     def reg(x):
@@ -699,7 +684,6 @@ def test_activity_regularization_with_model_composition():
     assert loss == 4
 
 
-@keras_test
 def test_shared_layer_depth_is_correct():
     # Basic outline here: we have a shared embedding layer, and two inputs that
     # go through different depths of computation in the graph before
@@ -728,7 +712,6 @@ def test_shared_layer_depth_is_correct():
     assert input1_depth == input2_depth
 
 
-@keras_test
 def test_layer_sharing_at_heterogeneous_depth():
     x_val = np.random.random((10, 5))
 
@@ -750,7 +733,6 @@ def test_layer_sharing_at_heterogeneous_depth():
     np.testing.assert_allclose(output_val, output_val_2, atol=1e-6)
 
 
-@keras_test
 def test_layer_sharing_at_heterogeneous_depth_with_concat():
     input_shape = (16, 9, 3)
     input_layer = Input(shape=input_shape)
@@ -778,7 +760,6 @@ def test_layer_sharing_at_heterogeneous_depth_with_concat():
     np.testing.assert_allclose(output_val, output_val_2, atol=1e-6)
 
 
-@keras_test
 def test_multi_output_mask():
     """Fixes #7589"""
     class TestMultiOutputLayer(Layer):
@@ -808,7 +789,6 @@ def test_multi_output_mask():
     assert K.int_shape(z)[1:] == (16, 16, 3)
 
 
-@keras_test
 def test_constant_initializer_with_numpy():
     model = Sequential()
     model.add(Dense(2, input_shape=(3,),

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -17,7 +17,6 @@ from keras.utils.generic_utils import slice_arrays
 from keras.models import Sequential
 from keras import backend as K
 from keras.utils import Sequence
-from keras.utils.test_utils import keras_test
 from keras.callbacks import LambdaCallback
 
 
@@ -71,7 +70,6 @@ def threadsafe_generator(f):
     return g
 
 
-@keras_test
 def test_check_array_length_consistency():
     training_utils.check_array_length_consistency(None, None, None)
     a_np = np.random.random((4, 3, 3))
@@ -93,7 +91,6 @@ def test_check_array_length_consistency():
         training_utils.check_array_length_consistency([a_np], None, [b_np])
 
 
-@keras_test
 def testslice_arrays():
     input_a = np.random.random((10, 3))
     slice_arrays(None)
@@ -114,7 +111,6 @@ def testslice_arrays():
     slice_arrays(input_a, stop=2)
 
 
-@keras_test
 def test_weighted_masked_objective():
     a = Input(shape=(3,), name='input_a')
 
@@ -127,7 +123,6 @@ def test_weighted_masked_objective():
     weighted_function(a, a, None)
 
 
-@keras_test
 def test_model_methods():
     a = Input(shape=(3,), name='input_a')
     b = Input(shape=(3,), name='input_b')
@@ -565,7 +560,6 @@ def test_model_methods():
 
 @pytest.mark.skipif(sys.version_info < (3,),
                     reason='Cannot catch warnings in python 2')
-@keras_test
 def test_warnings():
     a = Input(shape=(3,), name='input_a')
     b = Input(shape=(3,), name='input_b')
@@ -607,7 +601,6 @@ def test_warnings():
         'A warning was raised for Sequence.')
 
 
-@keras_test
 def test_sparse_inputs_targets():
     test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
     test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 5)]
@@ -625,7 +618,6 @@ def test_sparse_inputs_targets():
 
 @pytest.mark.skipif(K.backend() != 'tensorflow',
                     reason='sparse operations supported only by TensorFlow')
-@keras_test
 def test_sparse_placeholder_fit():
     test_inputs = [sparse.random(6, 3, density=0.25).tocsr() for _ in range(2)]
     test_outputs = [sparse.random(6, i, density=0.25).tocsr() for i in range(3, 5)]
@@ -641,7 +633,6 @@ def test_sparse_placeholder_fit():
     model.evaluate(test_inputs, test_outputs, batch_size=2)
 
 
-@keras_test
 def test_trainable_argument():
     x = np.random.random((5, 3))
     y = np.random.random((5, 2))
@@ -665,7 +656,6 @@ def test_trainable_argument():
     assert_allclose(out, out_2)
 
 
-@keras_test
 def test_with_list_as_targets():
     model = Sequential()
     model.add(Dense(1, input_dim=3, trainable=False))
@@ -676,7 +666,6 @@ def test_with_list_as_targets():
     model.train_on_batch(x, y)
 
 
-@keras_test
 def test_check_not_failing():
     a = np.random.random((2, 1, 3))
     training_utils.check_loss_and_target_compatibility(
@@ -685,7 +674,6 @@ def test_check_not_failing():
         [a], [losses.categorical_crossentropy], [(2, None, 3)])
 
 
-@keras_test
 def test_check_last_is_one():
     a = np.random.random((2, 3, 1))
     with pytest.raises(ValueError) as exc:
@@ -695,7 +683,6 @@ def test_check_last_is_one():
     assert 'You are passing a target array' in str(exc)
 
 
-@keras_test
 def test_check_bad_shape():
     a = np.random.random((2, 3, 5))
     with pytest.raises(ValueError) as exc:
@@ -707,7 +694,6 @@ def test_check_bad_shape():
 
 @pytest.mark.skipif(K.backend() != 'tensorflow',
                     reason='Requires TensorFlow backend')
-@keras_test
 def test_model_with_input_feed_tensor():
     """We test building a model with a TF variable as input.
     We should be able to call fit, evaluate, predict,
@@ -849,7 +835,6 @@ def test_model_with_input_feed_tensor():
     assert out.shape == (10 * 3, 4)
 
 
-@keras_test
 def test_model_with_partial_loss():
     a = Input(shape=(3,), name='input_a')
     a_2 = Dense(4, name='dense_1')(a)
@@ -891,7 +876,6 @@ def test_model_with_partial_loss():
     out = model.evaluate(input_a_np, [output_a_np])
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='cntk does not support external loss yet')
 def test_model_with_external_loss():
@@ -1045,7 +1029,6 @@ def test_model_with_external_loss():
         assert out[1].shape == (10 * 3, 4)
 
 
-@keras_test
 def test_target_tensors():
     # single-output, as list
     model = keras.models.Sequential()
@@ -1123,7 +1106,6 @@ def test_target_tensors():
                          sample_weight={'dense_a': np.random.random((10,))})
 
 
-@keras_test
 def test_model_custom_target_tensors():
     a = Input(shape=(3,), name='input_a')
     b = Input(shape=(3,), name='input_b')
@@ -1187,7 +1169,6 @@ def test_model_custom_target_tensors():
 
 @pytest.mark.skipif(sys.version_info < (3,),
                     reason='Cannot catch warnings in python 2')
-@keras_test
 def test_trainable_weights_count_consistency():
     """Tests the trainable weights consistency check of Model.
 
@@ -1230,7 +1211,6 @@ def test_trainable_weights_count_consistency():
         'Warning raised even when .compile() is called after modifying .trainable')
 
 
-@keras_test
 def test_pandas_dataframe():
     input_a = Input(shape=(3,), name='input_a')
     input_b = Input(shape=(3,), name='input_b')
@@ -1310,7 +1290,6 @@ def test_pandas_dataframe():
                           [output_a_df, output_b_df])
 
 
-@keras_test
 @pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TensorFlow')
 @pytest.mark.skipif((K.backend() == 'tensorflow' and
                      not hasattr(K.get_session(),
@@ -1339,7 +1318,6 @@ def test_training_and_eval_methods_on_symbolic_tensors_single_io():
               validation_data=(inputs, targets), validation_steps=2)
 
 
-@keras_test
 @pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TensorFlow')
 @pytest.mark.skipif((K.backend() == 'tensorflow' and
                      not hasattr(K.get_session(),
@@ -1437,7 +1415,6 @@ def test_training_and_eval_methods_on_symbolic_tensors_multi_io():
     model.test_on_batch([input_a_tf, input_b_tf], [output_d_tf, output_e_tf])
 
 
-@keras_test
 def test_model_with_crossentropy_losses_channels_first():
     """Tests use of all crossentropy losses with `channels_first`.
 
@@ -1520,7 +1497,6 @@ def test_model_with_crossentropy_losses_channels_first():
                                           'channels_first and channels_last.'))
 
 
-@keras_test
 def test_dynamic_set_inputs():
     model = Sequential()
     model.add(Dense(16, input_dim=32))

--- a/tests/keras/layers/advanced_activations_test.py
+++ b/tests/keras/layers/advanced_activations_test.py
@@ -1,49 +1,41 @@
 import pytest
 from keras.utils.test_utils import layer_test
-from keras.utils.test_utils import keras_test
 from keras import layers
 
 
-@keras_test
 def test_leaky_relu():
     for alpha in [0., .5, -1.]:
         layer_test(layers.LeakyReLU, kwargs={'alpha': alpha},
                    input_shape=(2, 3, 4))
 
 
-@keras_test
 def test_prelu():
     layer_test(layers.PReLU, kwargs={},
                input_shape=(2, 3, 4))
 
 
-@keras_test
 def test_prelu_share():
     layer_test(layers.PReLU, kwargs={'shared_axes': 1},
                input_shape=(2, 3, 4))
 
 
-@keras_test
 def test_elu():
     for alpha in [0., .5, -1.]:
         layer_test(layers.ELU, kwargs={'alpha': alpha},
                    input_shape=(2, 3, 4))
 
 
-@keras_test
 def test_thresholded_relu():
     layer_test(layers.ThresholdedReLU, kwargs={'theta': 0.5},
                input_shape=(2, 3, 4))
 
 
-@keras_test
 def test_softmax():
     for axis in [1, -1]:
         layer_test(layers.Softmax, kwargs={'axis': axis},
                    input_shape=(2, 3, 4))
 
 
-@keras_test
 def test_relu():
     for max_value in [None, 1., 6.]:
         layer_test(layers.ReLU, kwargs={'max_value': max_value},

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -3,7 +3,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from keras.utils.test_utils import layer_test
-from keras.utils.test_utils import keras_test
 from keras import backend as K
 from keras.layers import convolutional
 from keras.models import Sequential
@@ -16,7 +15,6 @@ else:
     _convolution_paddings = ['valid', 'same']
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk' and K.dev.type() == 0),
                     reason='cntk only support dilated conv on GPU')
 @pytest.mark.parametrize(
@@ -43,7 +41,6 @@ def test_causal_dilated_conv(layer_kwargs, input_length, expected_output):
                kwargs=layer_kwargs, expected_output=expected_output)
 
 
-@keras_test
 @pytest.mark.parametrize(
     'padding,strides',
     [(padding, strides)
@@ -78,7 +75,6 @@ def test_conv_1d(padding, strides):
                input_shape=(batch_size, steps, input_dim))
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk' and K.dev.type() == 0),
                     reason='cntk only support dilated conv on GPU')
 def test_conv_1d_dilation():
@@ -97,7 +93,6 @@ def test_conv_1d_dilation():
                input_shape=(batch_size, steps, input_dim))
 
 
-@keras_test
 def test_conv_1d_channels_first():
     batch_size = 2
     steps = 8
@@ -112,7 +107,6 @@ def test_conv_1d_channels_first():
                input_shape=(batch_size, input_dim, steps))
 
 
-@keras_test
 @pytest.mark.parametrize(
     'strides,padding',
     [(strides, padding)
@@ -137,7 +131,6 @@ def test_convolution_2d(strides, padding):
                input_shape=(num_samples, stack_size, num_row, num_col))
 
 
-@keras_test
 def test_convolution_2d_channels_last():
     num_samples = 2
     filters = 2
@@ -162,7 +155,6 @@ def test_convolution_2d_channels_last():
                input_shape=(num_samples, num_row, num_col, stack_size))
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk' and K.dev.type() == 0),
                     reason='cntk only supports dilated conv on GPU')
 def test_convolution_2d_dilation():
@@ -182,7 +174,6 @@ def test_convolution_2d_dilation():
                input_shape=(num_samples, num_row, num_col, stack_size))
 
 
-@keras_test
 def test_convolution_2d_invalid():
     filters = 2
     padding = _convolution_paddings[-1]
@@ -194,7 +185,6 @@ def test_convolution_2d_invalid():
             batch_input_shape=(None, None, 5, None))])
 
 
-@keras_test
 @pytest.mark.parametrize(
     'padding,out_padding,strides',
     [(padding, out_padding, strides)
@@ -222,7 +212,6 @@ def test_conv2d_transpose(padding, out_padding, strides):
                fixed_batch_size=True)
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk' and K.dev.type() == 0),
                     reason='cntk only supports dilated conv transpose on GPU')
 def test_conv2d_transpose_dilation():
@@ -253,7 +242,6 @@ def test_conv2d_transpose_dilation():
                expected_output=expected_output)
 
 
-@keras_test
 def test_conv2d_transpose_channels_first():
     num_samples = 2
     filters = 2
@@ -279,7 +267,6 @@ def test_conv2d_transpose_channels_first():
                fixed_batch_size=True)
 
 
-@keras_test
 def test_conv2d_transpose_invalid():
     filters = 2
     stack_size = 3
@@ -316,7 +303,6 @@ def test_conv2d_transpose_invalid():
             batch_input_shape=(None, num_row, num_col, stack_size))])
 
 
-@keras_test
 @pytest.mark.parametrize(
     'padding,strides,multiplier,dilation_rate',
     [(padding, strides, multiplier, dilation_rate)
@@ -344,7 +330,6 @@ def test_separable_conv_1d(padding, strides, multiplier, dilation_rate):
                input_shape=(num_samples, num_step, stack_size))
 
 
-@keras_test
 def test_separable_conv_1d_additional_args():
     num_samples = 2
     filters = 6
@@ -371,7 +356,6 @@ def test_separable_conv_1d_additional_args():
                input_shape=(num_samples, stack_size, num_step))
 
 
-@keras_test
 def test_separable_conv_1d_invalid():
     filters = 6
     padding = 'valid'
@@ -381,7 +365,6 @@ def test_separable_conv_1d_invalid():
             batch_input_shape=(None, 5, None))])
 
 
-@keras_test
 @pytest.mark.parametrize(
     'padding,strides,multiplier,dilation_rate',
     [(padding, strides, multiplier, dilation_rate)
@@ -412,7 +395,6 @@ def test_separable_conv_2d(padding, strides, multiplier, dilation_rate):
         input_shape=(num_samples, num_row, num_col, stack_size))
 
 
-@keras_test
 def test_separable_conv_2d_additional_args():
     num_samples = 2
     filters = 6
@@ -440,7 +422,6 @@ def test_separable_conv_2d_additional_args():
                input_shape=(num_samples, stack_size, num_row, num_col))
 
 
-@keras_test
 def test_separable_conv_2d_invalid():
     filters = 6
     padding = 'valid'
@@ -450,7 +431,6 @@ def test_separable_conv_2d_invalid():
             batch_input_shape=(None, None, 5, None))])
 
 
-@keras_test
 @pytest.mark.parametrize(
     'padding,strides,multiplier',
     [(padding, strides, multiplier)
@@ -476,7 +456,6 @@ def test_depthwise_conv_2d(padding, strides, multiplier):
                             stack_size))
 
 
-@keras_test
 def test_depthwise_conv_2d_additional_args():
     num_samples = 2
     stack_size = 3
@@ -501,7 +480,6 @@ def test_depthwise_conv_2d_additional_args():
                input_shape=(num_samples, stack_size, num_row, num_col))
 
 
-@keras_test
 def test_depthwise_conv_2d_invalid():
     padding = 'valid'
     with pytest.raises(ValueError):
@@ -511,7 +489,6 @@ def test_depthwise_conv_2d_invalid():
             batch_input_shape=(None, None, 5, None))])
 
 
-@keras_test
 @pytest.mark.parametrize(
     'padding,strides',
     [(padding, strides)
@@ -538,7 +515,6 @@ def test_convolution_3d(padding, strides):
                             stack_size))
 
 
-@keras_test
 def test_convolution_3d_additional_args():
     num_samples = 2
     filters = 2
@@ -566,7 +542,6 @@ def test_convolution_3d_additional_args():
                             stack_size))
 
 
-@keras_test
 @pytest.mark.parametrize(
     'padding,out_padding,strides,data_format',
     [(padding, out_padding, strides, data_format)
@@ -596,7 +571,6 @@ def test_conv3d_transpose(padding, out_padding, strides, data_format):
         fixed_batch_size=True)
 
 
-@keras_test
 def test_conv3d_transpose_additional_args():
     filters = 2
     stack_size = 3
@@ -623,7 +597,6 @@ def test_conv3d_transpose_additional_args():
                fixed_batch_size=True)
 
 
-@keras_test
 def test_conv3d_transpose_invalid():
     filters = 2
     stack_size = 3
@@ -662,7 +635,6 @@ def test_conv3d_transpose_invalid():
             batch_input_shape=(None, num_depth, num_row, num_col, stack_size))])
 
 
-@keras_test
 def test_zero_padding_1d():
     num_samples = 2
     input_dim = 2
@@ -699,7 +671,6 @@ def test_zero_padding_1d():
     layer.get_config()
 
 
-@keras_test
 @pytest.mark.parametrize(
     'data_format,padding',
     [(data_format, padding)
@@ -722,7 +693,6 @@ def test_zero_padding_2d(data_format, padding):
                input_shape=inputs.shape)
 
 
-@keras_test
 def test_zero_padding_2d_correctness():
     num_samples = 2
     stack_size = 2
@@ -774,7 +744,6 @@ def test_zero_padding_2d_correctness():
             assert_allclose(np_output[:, :, 1:-2, 3:-4], 1.)
 
 
-@keras_test
 @pytest.mark.parametrize(
     'data_format,padding',
     [(data_format, padding)
@@ -796,7 +765,6 @@ def test_zero_padding_3d(data_format, padding):
                input_shape=inputs.shape)
 
 
-@keras_test
 def test_zero_padding_3d_correctness():
     num_samples = 2
     stack_size = 2
@@ -849,14 +817,12 @@ def test_zero_padding_3d_correctness():
             assert_allclose(np_output[:, :, 1:-2, 3:-4, 0:-2], 1.)
 
 
-@keras_test
 def test_upsampling_1d():
     layer_test(convolutional.UpSampling1D,
                kwargs={'size': 2},
                input_shape=(3, 5, 4))
 
 
-@keras_test
 def test_upsampling_2d():
     num_samples = 2
     stack_size = 2
@@ -997,7 +963,6 @@ def test_upsampling_3d():
                     assert_allclose(np_output, expected_out)
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason="cntk does not support slice to 0 dimension")
 def test_cropping_1d():
@@ -1142,7 +1107,6 @@ def test_cropping_3d():
         layer = convolutional.Cropping3D(cropping=lambda x: x)
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='CNTK does not support float64')
 @pytest.mark.parametrize(

--- a/tests/keras/layers/core_test.py
+++ b/tests/keras/layers/core_test.py
@@ -7,20 +7,17 @@ from keras import layers
 from keras.models import Model
 from keras.models import Sequential
 from keras.utils.test_utils import layer_test
-from keras.utils.test_utils import keras_test
 from keras import regularizers
 from keras import constraints
 from keras.layers import deserialize as deserialize_layer
 
 
-@keras_test
 def test_masking():
     layer_test(layers.Masking,
                kwargs={},
                input_shape=(3, 2, 3))
 
 
-@keras_test
 def test_dropout():
     layer_test(layers.Dropout,
                kwargs={'rate': 0.5},
@@ -61,7 +58,6 @@ def test_dropout():
                            input_shape=input_shape)
 
 
-@keras_test
 def test_activation():
     # with string argument
     layer_test(layers.Activation,
@@ -74,7 +70,6 @@ def test_activation():
                input_shape=(3, 2))
 
 
-@keras_test
 def test_reshape():
     layer_test(layers.Reshape,
                kwargs={'target_shape': (8, 1)},
@@ -93,14 +88,12 @@ def test_reshape():
                input_shape=(None, None, 4))
 
 
-@keras_test
 def test_permute():
     layer_test(layers.Permute,
                kwargs={'dims': (2, 1)},
                input_shape=(3, 2, 4))
 
 
-@keras_test
 def test_flatten():
 
     def test_4d():
@@ -161,14 +154,12 @@ def test_flatten():
     test_5d()
 
 
-@keras_test
 def test_repeat_vector():
     layer_test(layers.RepeatVector,
                kwargs={'n': 3},
                input_shape=(3, 2))
 
 
-@keras_test
 def test_lambda():
     layer_test(layers.Lambda,
                kwargs={'function': lambda x: x + 1},
@@ -285,7 +276,6 @@ def test_lambda():
     ld = deserialize_layer({'class_name': 'Lambda', 'config': config})
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'theano'),
                     reason="theano cannot compute "
                            "the output shape automatically.")
@@ -295,7 +285,6 @@ def test_lambda_output_shape():
                input_shape=(3, 2, 4))
 
 
-@keras_test
 def test_dense():
     layer_test(layers.Dense,
                kwargs={'units': 3},
@@ -329,7 +318,6 @@ def test_dense():
     assert len(layer.losses) == 2
 
 
-@keras_test
 def test_activity_regularization():
     layer = layers.ActivityRegularization(l1=0.01, l2=0.01)
 
@@ -348,7 +336,6 @@ def test_activity_regularization():
     model.compile('rmsprop', 'mse')
 
 
-@keras_test
 def test_sequential_as_downstream_of_masking_layer():
 
     inputs = layers.Input(shape=(3, 4))

--- a/tests/keras/layers/cudnn_recurrent_test.py
+++ b/tests/keras/layers/cudnn_recurrent_test.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_allclose
 import keras
 import keras.backend as K
 from keras.utils.test_utils import layer_test
-from keras.utils.test_utils import keras_test
 import time
 
 
@@ -14,7 +13,6 @@ skipif_no_tf_gpu = pytest.mark.skipif(
     reason='Requires TensorFlow backend and a GPU')
 
 
-@keras_test
 @skipif_no_tf_gpu
 def test_cudnn_rnn_canonical_to_params_lstm():
     units = 1
@@ -72,7 +70,6 @@ def test_cudnn_rnn_canonical_to_params_lstm():
     assert diff < 1e-8
 
 
-@keras_test
 @skipif_no_tf_gpu
 def test_cudnn_rnn_canonical_to_params_gru():
     units = 7
@@ -122,7 +119,6 @@ def test_cudnn_rnn_canonical_to_params_gru():
     assert diff < 1e-8
 
 
-@keras_test
 @pytest.mark.parametrize('rnn_type', ['lstm', 'gru'], ids=['LSTM', 'GRU'])
 @skipif_no_tf_gpu
 def test_cudnn_rnn_timing(rnn_type):
@@ -161,7 +157,6 @@ def test_cudnn_rnn_timing(rnn_type):
     assert speedup > 3
 
 
-@keras_test
 @skipif_no_tf_gpu
 def test_cudnn_rnn_basics():
     input_size = 10
@@ -189,7 +184,6 @@ def test_cudnn_rnn_basics():
                     input_shape=(num_samples, timesteps, input_size))
 
 
-@keras_test
 @skipif_no_tf_gpu
 def test_trainability():
     input_size = 10
@@ -210,7 +204,6 @@ def test_trainability():
         assert len(layer.non_trainable_weights) == 0
 
 
-@keras_test
 @skipif_no_tf_gpu
 def test_regularizer():
     input_size = 10
@@ -237,7 +230,6 @@ def test_regularizer():
         assert len(layer.get_losses_for(x)) == 1
 
 
-@keras_test
 @skipif_no_tf_gpu
 def test_return_state():
     input_size = 10
@@ -261,7 +253,6 @@ def test_return_state():
             keras.backend.eval(layer.states[0]), state, atol=1e-4)
 
 
-@keras_test
 @skipif_no_tf_gpu
 def test_specify_initial_state_keras_tensor():
     input_size = 10
@@ -290,7 +281,6 @@ def test_specify_initial_state_keras_tensor():
         model.fit([inputs] + initial_state, targets)
 
 
-@keras_test
 @skipif_no_tf_gpu
 def test_statefulness():
     input_size = 10
@@ -337,7 +327,6 @@ def test_statefulness():
         assert(out4.max() != out5.max())
 
 
-@keras_test
 @skipif_no_tf_gpu
 def test_cudnnrnn_bidirectional():
     rnn = keras.layers.CuDNNGRU

--- a/tests/keras/layers/embeddings_test.py
+++ b/tests/keras/layers/embeddings_test.py
@@ -1,11 +1,10 @@
 import pytest
-from keras.utils.test_utils import layer_test, keras_test
+from keras.utils.test_utils import layer_test
 from keras.layers.embeddings import Embedding
 from keras.models import Sequential
 import keras.backend as K
 
 
-@keras_test
 def test_embedding():
     layer_test(Embedding,
                kwargs={'output_dim': 4, 'input_dim': 10, 'input_length': 2},
@@ -30,7 +29,6 @@ def test_embedding():
                expected_output_dtype=K.floatx())
 
 
-@keras_test
 def test_embedding_invalid():
 
     # len(input_length) should be equal to len(input_shape) - 1

--- a/tests/keras/layers/local_test.py
+++ b/tests/keras/layers/local_test.py
@@ -1,11 +1,9 @@
 import pytest
 
 from keras.utils.test_utils import layer_test
-from keras.utils.test_utils import keras_test
 from keras.layers import local
 
 
-@keras_test
 def test_locallyconnected_1d():
     num_samples = 2
     num_steps = 8
@@ -26,7 +24,6 @@ def test_locallyconnected_1d():
                input_shape=(num_samples, num_steps, input_dim))
 
 
-@keras_test
 def test_locallyconnected_2d():
     num_samples = 5
     filters = 3

--- a/tests/keras/layers/merge_test.py
+++ b/tests/keras/layers/merge_test.py
@@ -5,11 +5,9 @@ from keras import layers
 from keras import models
 from keras import backend as K
 from keras.utils.test_utils import layer_test
-from keras.utils.test_utils import keras_test
 from keras.layers import merge
 
 
-@keras_test
 def test_merge_add():
     i1 = layers.Input(shape=(4, 5))
     i2 = layers.Input(shape=(4, 5))
@@ -42,7 +40,6 @@ def test_merge_add():
         add_layer.compute_mask([i1, i2, i3], [None, None])
 
 
-@keras_test
 def test_merge_subtract():
     i1 = layers.Input(shape=(4, 5))
     i2 = layers.Input(shape=(4, 5))
@@ -77,7 +74,6 @@ def test_merge_subtract():
         subtract_layer([i1])
 
 
-@keras_test
 def test_merge_multiply():
     i1 = layers.Input(shape=(4, 5))
     i2 = layers.Input(shape=(4, 5))
@@ -98,7 +94,6 @@ def test_merge_multiply():
     assert_allclose(out, x1 * x2 * x3, atol=1e-4)
 
 
-@keras_test
 def test_merge_average():
     i1 = layers.Input(shape=(4, 5))
     i2 = layers.Input(shape=(4, 5))
@@ -117,7 +112,6 @@ def test_merge_average():
     assert_allclose(out, 0.5 * (x1 + x2), atol=1e-4)
 
 
-@keras_test
 def test_merge_maximum():
     i1 = layers.Input(shape=(4, 5))
     i2 = layers.Input(shape=(4, 5))
@@ -136,7 +130,6 @@ def test_merge_maximum():
     assert_allclose(out, np.maximum(x1, x2), atol=1e-4)
 
 
-@keras_test
 def test_merge_minimum():
     i1 = layers.Input(shape=(4, 5))
     i2 = layers.Input(shape=(4, 5))
@@ -155,7 +148,6 @@ def test_merge_minimum():
     assert_allclose(out, np.minimum(x1, x2), atol=1e-4)
 
 
-@keras_test
 def test_merge_concatenate():
     i1 = layers.Input(shape=(None, 5))
     i2 = layers.Input(shape=(None, 5))
@@ -208,7 +200,6 @@ def test_merge_concatenate():
         concat_layer([i1])
 
 
-@keras_test
 def test_merge_dot():
     i1 = layers.Input(shape=(4,))
     i2 = layers.Input(shape=(4,))
@@ -238,7 +229,6 @@ def test_merge_dot():
     assert_allclose(out, expected, atol=1e-4)
 
 
-@keras_test
 def test_merge_broadcast():
     # shapes provided
     i1 = layers.Input(shape=(4, 5))
@@ -288,7 +278,6 @@ def test_merge_broadcast():
         K.ndim = k_ndim
 
 
-@keras_test
 def test_masking_concatenate():
     input1 = layers.Input(shape=(6,))
     input2 = layers.Input(shape=(6,))

--- a/tests/keras/layers/noise_test.py
+++ b/tests/keras/layers/noise_test.py
@@ -1,11 +1,9 @@
 import pytest
 from keras.utils.test_utils import layer_test
-from keras.utils.test_utils import keras_test
 from keras.layers import noise
 from keras import backend as K
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason="cntk does not support it yet")
 def test_GaussianNoise():
@@ -14,7 +12,6 @@ def test_GaussianNoise():
                input_shape=(3, 2, 3))
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason="cntk does not support it yet")
 def test_GaussianDropout():
@@ -23,7 +20,6 @@ def test_GaussianDropout():
                input_shape=(3, 2, 3))
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason="cntk does not support it yet")
 def test_AlphaDropout():

--- a/tests/keras/layers/normalization_test.py
+++ b/tests/keras/layers/normalization_test.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 
 from keras.layers import Input
 from keras import regularizers
-from keras.utils.test_utils import layer_test, keras_test
+from keras.utils.test_utils import layer_test
 from keras.layers import normalization
 from keras.models import Sequential, Model
 from keras import backend as K
@@ -16,7 +16,6 @@ input_4 = np.expand_dims(np.arange(10.), axis=1)
 input_shapes = [np.ones((10, 10)), np.ones((10, 10, 10))]
 
 
-@keras_test
 def test_basic_batchnorm():
     layer_test(normalization.BatchNormalization,
                kwargs={'momentum': 0.9,
@@ -45,7 +44,6 @@ def test_basic_batchnorm():
                    input_shape=(3, 4, 2, 4))
 
 
-@keras_test
 def test_batchnorm_correctness_1d():
     model = Sequential()
     norm = normalization.BatchNormalization(input_shape=(10,), momentum=0.8)
@@ -63,7 +61,6 @@ def test_batchnorm_correctness_1d():
     assert_allclose(out.std(), 1.0, atol=1e-1)
 
 
-@keras_test
 def test_batchnorm_correctness_2d():
     model = Sequential()
     norm = normalization.BatchNormalization(axis=1, input_shape=(10, 6),
@@ -82,7 +79,6 @@ def test_batchnorm_correctness_2d():
     assert_allclose(out.std(axis=(0, 2)), 1.0, atol=1.1e-1)
 
 
-@keras_test
 def test_batchnorm_training_argument():
     bn1 = normalization.BatchNormalization(input_shape=(10,))
     x1 = Input(shape=(10,))
@@ -107,7 +103,6 @@ def test_batchnorm_training_argument():
     assert not bn2.updates
 
 
-@keras_test
 def test_batchnorm_mode_twice():
     # This is a regression test for issue #4881 with the old
     # batch normalization functions in the Theano backend.
@@ -121,7 +116,6 @@ def test_batchnorm_mode_twice():
     model.predict(x)
 
 
-@keras_test
 def test_batchnorm_convnet():
     model = Sequential()
     norm = normalization.BatchNormalization(axis=1, input_shape=(3, 4, 4),
@@ -140,7 +134,6 @@ def test_batchnorm_convnet():
     assert_allclose(np.std(out, axis=(0, 2, 3)), 1.0, atol=1e-1)
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'theano'),
                     reason='Bug with theano backend')
 def test_batchnorm_convnet_no_center_no_scale():
@@ -159,7 +152,6 @@ def test_batchnorm_convnet_no_center_no_scale():
     assert_allclose(np.std(out, axis=(0, 2, 3)), 1.0, atol=1e-1)
 
 
-@keras_test
 def test_shared_batchnorm():
     '''Test that a BN layer can be shared
     across different data streams.
@@ -187,7 +179,6 @@ def test_shared_batchnorm():
     new_model.train_on_batch(x, x)
 
 
-@keras_test
 def test_that_trainable_disables_updates():
     val_a = np.random.random((10, 4))
     val_out = np.random.random((10, 4))
@@ -226,7 +217,6 @@ def test_that_trainable_disables_updates():
     assert_allclose(x1, x2, atol=1e-7)
 
 
-@keras_test
 def test_batchnorm_trainable():
     bn_mean = 0.5
     bn_std = 10.

--- a/tests/keras/layers/pooling_test.py
+++ b/tests/keras/layers/pooling_test.py
@@ -1,14 +1,13 @@
 import numpy as np
 import pytest
 
-from keras.utils.test_utils import keras_test, layer_test
+from keras.utils.test_utils import layer_test
 from keras.layers import pooling
 from keras.layers import Masking
 from keras.layers import convolutional
 from keras.models import Sequential
 
 
-@keras_test
 @pytest.mark.parametrize(
     'padding,stride,data_format',
     [(padding, stride, data_format)
@@ -24,7 +23,6 @@ def test_maxpooling_1d(padding, stride, data_format):
                input_shape=(3, 5, 4))
 
 
-@keras_test
 @pytest.mark.parametrize(
     'strides',
     [(1, 1), (2, 3)]
@@ -38,7 +36,6 @@ def test_maxpooling_2d(strides):
                input_shape=(3, 5, 6, 4))
 
 
-@keras_test
 @pytest.mark.parametrize(
     'strides,data_format,input_shape',
     [(2, None, (3, 11, 12, 10, 4)),
@@ -54,7 +51,6 @@ def test_maxpooling_3d(strides, data_format, input_shape):
                input_shape=input_shape)
 
 
-@keras_test
 @pytest.mark.parametrize(
     'padding,stride,data_format',
     [(padding, stride, data_format)
@@ -70,7 +66,6 @@ def test_averagepooling_1d(padding, stride, data_format):
                input_shape=(3, 5, 4))
 
 
-@keras_test
 @pytest.mark.parametrize(
     'strides,padding,data_format,input_shape',
     [((2, 2), 'same', None, (3, 5, 6, 4)),
@@ -86,7 +81,6 @@ def test_averagepooling_2d(strides, padding, data_format, input_shape):
                input_shape=input_shape)
 
 
-@keras_test
 @pytest.mark.parametrize(
     'strides,data_format,input_shape',
     [(2, None, (3, 11, 12, 10, 4)),
@@ -103,7 +97,6 @@ def test_averagepooling_3d(strides, data_format, input_shape):
                input_shape=input_shape)
 
 
-@keras_test
 @pytest.mark.parametrize(
     'data_format,pooling_class',
     [(data_format, pooling_class)
@@ -117,7 +110,6 @@ def test_globalpooling_1d(data_format, pooling_class):
                input_shape=(3, 4, 5))
 
 
-@keras_test
 def test_globalpooling_1d_supports_masking():
     # Test GlobalAveragePooling1D supports masking
     model = Sequential()
@@ -131,7 +123,6 @@ def test_globalpooling_1d_supports_masking():
     assert np.array_equal(output[0], model_input[0, 0, :])
 
 
-@keras_test
 @pytest.mark.parametrize(
     'data_format,pooling_class',
     [(data_format, pooling_class)
@@ -145,7 +136,6 @@ def test_globalpooling_2d(data_format, pooling_class):
                input_shape=(3, 4, 5, 6))
 
 
-@keras_test
 @pytest.mark.parametrize(
     'data_format,pooling_class',
     [(data_format, pooling_class)

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -18,7 +18,6 @@ num_samples, timesteps, embedding_dim, units = 2, 5, 4, 3
 embedding_num = 12
 
 
-@keras_test
 def rnn_test(f):
     """
     All the recurrent layers share the same interface,
@@ -32,7 +31,6 @@ def rnn_test(f):
     ])(f)
 
 
-@keras_test
 def rnn_cell_test(f):
     f = keras_test(f)
     return pytest.mark.parametrize('cell_class', [
@@ -239,7 +237,6 @@ def test_trainability(layer_class):
     assert len(layer.non_trainable_weights) == 0
 
 
-@keras_test
 def test_masking_layer():
     ''' This test based on a previously failing issue here:
     https://github.com/keras-team/keras/issues/1567
@@ -430,7 +427,6 @@ def test_state_reuse_with_dropout(layer_class):
     outputs = model.predict(inputs)
 
 
-@keras_test
 def test_minimal_rnn_cell_non_layer():
 
     class MinimalRNNCell(object):
@@ -466,7 +462,6 @@ def test_minimal_rnn_cell_non_layer():
     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
 
 
-@keras_test
 def test_minimal_rnn_cell_non_layer_multiple_states():
 
     class MinimalRNNCell(object):
@@ -506,7 +501,6 @@ def test_minimal_rnn_cell_non_layer_multiple_states():
     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
 
 
-@keras_test
 def test_minimal_rnn_cell_layer():
 
     class MinimalRNNCell(keras.layers.Layer):
@@ -632,7 +626,6 @@ def test_builtin_rnn_cell_layer(cell_class):
     assert_allclose(y_np, y_np_2, atol=1e-4)
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() in ['cntk', 'theano']),
                     reason='Not supported.')
 def test_stacked_rnn_dropout():
@@ -649,7 +642,6 @@ def test_stacked_rnn_dropout():
     model.train_on_batch(x_np, y_np)
 
 
-@keras_test
 def test_stacked_rnn_attributes():
     cells = [recurrent.LSTMCell(3),
              recurrent.LSTMCell(3, kernel_regularizer='l2')]
@@ -672,7 +664,6 @@ def test_stacked_rnn_attributes():
     assert layer.get_losses_for(x) == [y]
 
 
-@keras_test
 def test_stacked_rnn_compute_output_shape():
     cells = [recurrent.LSTMCell(3),
              recurrent.LSTMCell(6)]
@@ -711,7 +702,6 @@ def test_batch_size_equal_one(layer_class):
     model.train_on_batch(x, y)
 
 
-@keras_test
 def test_rnn_cell_with_constants_layer():
 
     class RNNCellWithConstants(keras.layers.Layer):
@@ -820,7 +810,6 @@ def test_rnn_cell_with_constants_layer():
     assert_allclose(y_np, y_np_2, atol=1e-4)
 
 
-@keras_test
 def test_rnn_cell_with_constants_layer_passing_initial_state():
 
     class RNNCellWithConstants(keras.layers.Layer):
@@ -920,7 +909,6 @@ def test_rnn_cell_identity_initializer(layer_class):
                           np.concatenate([np.identity(units)] * num_kernels, axis=1))
 
 
-@keras_test
 @pytest.mark.skipif(K.backend() == 'cntk', reason='Not supported.')
 def test_inconsistent_output_state_size():
 

--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 import copy
 from numpy.testing import assert_allclose
-from keras.utils.test_utils import keras_test
 from keras.utils import CustomObjectScope
 from keras.layers import wrappers, Input, Layer
 from keras.layers import RNN
@@ -12,7 +11,6 @@ from keras import backend as K
 from keras.utils.generic_utils import object_list_uid, to_list
 
 
-@keras_test
 def test_TimeDistributed():
     # first, test with Dense layer
     model = Sequential()
@@ -127,7 +125,6 @@ def test_TimeDistributed():
     assert K.int_shape(td._input_map[uid]) == (None, 2)
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='Flaky with CNTK backend')
 def test_TimeDistributed_learning_phase():
@@ -140,7 +137,6 @@ def test_TimeDistributed_learning_phase():
     assert_allclose(np.mean(y), 0., atol=1e-1, rtol=1e-1)
 
 
-@keras_test
 def test_TimeDistributed_trainable():
     # test layers that need learning_phase to be set
     x = Input(shape=(3, 2))
@@ -156,7 +152,6 @@ def test_TimeDistributed_trainable():
     assert len(layer.trainable_weights) == 2
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='Unknown timestamps for RNN not supported in CNTK.')
 def test_TimeDistributed_with_masked_embedding_and_unspecified_shape():
@@ -188,7 +183,6 @@ def test_TimeDistributed_with_masked_embedding_and_unspecified_shape():
     assert mask_outputs[-1] is None  # final layer
 
 
-@keras_test
 def test_TimeDistributed_with_masking_layer():
     # test with Masking layer
     model = Sequential()
@@ -211,7 +205,6 @@ def test_TimeDistributed_with_masking_layer():
     assert np.array_equal(mask_outputs_val[1], np.any(model_input, axis=-1))
 
 
-@keras_test
 def test_regularizers():
     model = Sequential()
     model.add(wrappers.TimeDistributed(
@@ -231,7 +224,6 @@ def test_regularizers():
     assert len(model.losses) == 1
 
 
-@keras_test
 def test_Bidirectional():
     rnn = layers.SimpleRNN
     samples = 2
@@ -286,7 +278,6 @@ def test_Bidirectional():
         model.fit(x, y, epochs=1, batch_size=1)
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='Unknown timestamps not supported in CNTK.')
 def test_Bidirectional_dynamic_timesteps():
@@ -311,7 +302,6 @@ def test_Bidirectional_dynamic_timesteps():
         model.fit(x, y, epochs=1, batch_size=1)
 
 
-@keras_test
 @pytest.mark.parametrize('merge_mode', ['sum', 'mul', 'ave', 'concat', None])
 def test_Bidirectional_merged_value(merge_mode):
     rnn = layers.LSTM
@@ -372,7 +362,6 @@ def test_Bidirectional_merged_value(merge_mode):
         assert_allclose(state_birnn, state_inner, atol=1e-5)
 
 
-@keras_test
 @pytest.mark.skipif(K.backend() == 'theano', reason='Not supported.')
 @pytest.mark.parametrize('merge_mode', ['sum', 'concat', None])
 def test_Bidirectional_dropout(merge_mode):
@@ -403,7 +392,6 @@ def test_Bidirectional_dropout(merge_mode):
         assert_allclose(x1, x2, atol=1e-5)
 
 
-@keras_test
 def test_Bidirectional_state_reuse():
     rnn = layers.LSTM
     samples = 2
@@ -431,7 +419,6 @@ def test_Bidirectional_state_reuse():
     outputs = model.predict(inputs)
 
 
-@keras_test
 def test_Bidirectional_with_constants():
     class RNNCellWithConstants(Layer):
         def __init__(self, units, **kwargs):
@@ -512,7 +499,6 @@ def test_Bidirectional_with_constants():
     assert_allclose(y_np, y_np_3, atol=1e-4)
 
 
-@keras_test
 def test_Bidirectional_with_constants_layer_passing_initial_state():
     class RNNCellWithConstants(Layer):
         def __init__(self, units, **kwargs):
@@ -603,7 +589,6 @@ def test_Bidirectional_with_constants_layer_passing_initial_state():
     assert_allclose(y_np, y_np_3, atol=1e-4)
 
 
-@keras_test
 def test_Bidirectional_trainable():
     # test layers that need learning_phase to be set
     x = Input(shape=(3, 2))
@@ -616,7 +601,6 @@ def test_Bidirectional_trainable():
     assert len(layer.trainable_weights) == 6
 
 
-@keras_test
 def test_Bidirectional_updates():
     x = Input(shape=(3, 2))
     layer = wrappers.Bidirectional(layers.SimpleRNN(3))
@@ -632,7 +616,6 @@ def test_Bidirectional_updates():
     assert len(layer.get_updates_for(x)) == 2
 
 
-@keras_test
 def test_Bidirectional_losses():
     x = Input(shape=(3, 2))
     layer = wrappers.Bidirectional(

--- a/tests/keras/legacy/interface_test.py
+++ b/tests/keras/legacy/interface_test.py
@@ -1,11 +1,9 @@
 import pytest
 import json
-from keras.utils.test_utils import keras_test
 import keras
 import numpy as np
 
 
-@keras_test
 def test_dense_legacy_interface():
     old_layer = keras.layers.Dense(input_dim=3, output_dim=2, name='d')
     new_layer = keras.layers.Dense(2, input_shape=(3,), name='d')
@@ -29,7 +27,6 @@ def test_dense_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_dropout_legacy_interface():
     old_layer = keras.layers.Dropout(p=3, name='drop')
     new_layer1 = keras.layers.Dropout(rate=3, name='drop')
@@ -38,7 +35,6 @@ def test_dropout_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer2.get_config())
 
 
-@keras_test
 def test_embedding_legacy_interface():
     old_layer = keras.layers.Embedding(4, 2, name='d')
     new_layer = keras.layers.Embedding(output_dim=2, input_dim=4, name='d')
@@ -59,7 +55,6 @@ def test_embedding_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_maxpooling1d_legacy_interface():
     old_layer = keras.layers.MaxPool1D(pool_length=2,
                                        border_mode='valid',
@@ -76,7 +71,6 @@ def test_maxpooling1d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_avgpooling1d_legacy_interface():
     old_layer = keras.layers.AvgPool1D(pool_length=2,
                                        border_mode='valid',
@@ -89,21 +83,18 @@ def test_avgpooling1d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_prelu_legacy_interface():
     old_layer = keras.layers.PReLU(init='zero', name='p')
     new_layer = keras.layers.PReLU('zero', name='p')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_gaussiannoise_legacy_interface():
     old_layer = keras.layers.GaussianNoise(sigma=0.5, name='gn')
     new_layer = keras.layers.GaussianNoise(stddev=0.5, name='gn')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_lstm_legacy_interface():
     old_layer = keras.layers.LSTM(input_shape=[3, 5], output_dim=2, name='d')
     new_layer = keras.layers.LSTM(2, input_shape=[3, 5], name='d')
@@ -179,7 +170,6 @@ def test_lstm_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_simplernn_legacy_interface():
     old_layer = keras.layers.SimpleRNN(input_shape=[3, 5], output_dim=2, name='d')
     new_layer = keras.layers.SimpleRNN(2, input_shape=[3, 5], name='d')
@@ -204,7 +194,6 @@ def test_simplernn_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_gru_legacy_interface():
     old_layer = keras.layers.GRU(input_shape=[3, 5], output_dim=2, name='d')
     new_layer = keras.layers.GRU(2, input_shape=[3, 5], name='d')
@@ -231,7 +220,6 @@ def test_gru_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_gaussiandropout_legacy_interface():
     old_layer = keras.layers.GaussianDropout(p=0.6, name='drop')
     new_layer1 = keras.layers.GaussianDropout(rate=0.6, name='drop')
@@ -240,7 +228,6 @@ def test_gaussiandropout_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer2.get_config())
 
 
-@keras_test
 def test_maxpooling2d_legacy_interface():
     old_layer = keras.layers.MaxPooling2D(
         pool_size=(2, 2), border_mode='valid', name='maxpool2d')
@@ -273,7 +260,6 @@ def test_maxpooling2d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_avgpooling2d_legacy_interface():
     old_layer = keras.layers.AveragePooling2D(
         pool_size=(2, 2), border_mode='valid', name='avgpooling2d')
@@ -308,7 +294,6 @@ def test_avgpooling2d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_maxpooling3d_legacy_interface():
     old_layer = keras.layers.MaxPooling3D(
         pool_size=(2, 2, 2), border_mode='valid', name='maxpool3d')
@@ -343,7 +328,6 @@ def test_maxpooling3d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_avgpooling3d_legacy_interface():
     old_layer = keras.layers.AveragePooling3D(
         pool_size=(2, 2, 2), border_mode='valid', name='avgpooling3d')
@@ -379,7 +363,6 @@ def test_avgpooling3d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_global_maxpooling2d_legacy_interface():
     old_layer = keras.layers.GlobalMaxPooling2D(dim_ordering='tf',
                                                 name='global_maxpool2d')
@@ -399,7 +382,6 @@ def test_global_maxpooling2d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_global_avgpooling2d_legacy_interface():
     old_layer = keras.layers.GlobalAveragePooling2D(dim_ordering='tf',
                                                     name='global_avgpool2d')
@@ -419,7 +401,6 @@ def test_global_avgpooling2d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_global_maxpooling3d_legacy_interface():
     old_layer = keras.layers.GlobalMaxPooling3D(dim_ordering='tf',
                                                 name='global_maxpool3d')
@@ -439,7 +420,6 @@ def test_global_maxpooling3d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_global_avgpooling3d_legacy_interface():
     old_layer = keras.layers.GlobalAveragePooling3D(dim_ordering='tf',
                                                     name='global_avgpool3d')
@@ -459,7 +439,6 @@ def test_global_avgpooling3d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_upsampling1d_legacy_interface():
     old_layer = keras.layers.UpSampling1D(length=3, name='us1d')
     new_layer_1 = keras.layers.UpSampling1D(size=3, name='us1d')
@@ -468,7 +447,6 @@ def test_upsampling1d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer_2.get_config())
 
 
-@keras_test
 def test_upsampling2d_legacy_interface():
     old_layer = keras.layers.UpSampling2D((2, 2), dim_ordering='tf', name='us2d')
     new_layer = keras.layers.UpSampling2D((2, 2), data_format='channels_last',
@@ -476,7 +454,6 @@ def test_upsampling2d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_upsampling3d_legacy_interface():
     old_layer = keras.layers.UpSampling3D((2, 2, 2),
                                           dim_ordering='tf',
@@ -487,7 +464,6 @@ def test_upsampling3d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_conv2d_legacy_interface():
     old_layer = keras.layers.Convolution2D(5, 3, 3, name='conv')
     new_layer = keras.layers.Conv2D(5, (3, 3), name='conv')
@@ -524,7 +500,6 @@ def test_conv2d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_deconv2d_legacy_interface():
     old_layer = keras.layers.Deconvolution2D(5, 3, 3, (6, 7, 5), name='deconv')
     new_layer = keras.layers.Conv2DTranspose(5, (3, 3), name='deconv')
@@ -570,7 +545,6 @@ def test_deconv2d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_conv1d_legacy_interface():
     old_layer = keras.layers.Convolution1D(5,
                                            filter_length=3,
@@ -601,7 +575,6 @@ def test_conv1d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_separable_conv2d_legacy_interface():
     old_layer = keras.layers.SeparableConv2D(5, 3, 3, name='conv')
     new_layer = keras.layers.SeparableConv2D(5, (3, 3), name='conv')
@@ -641,7 +614,6 @@ def test_separable_conv2d_legacy_interface():
     assert old_config == new_config
 
 
-@keras_test
 def test_conv3d_legacy_interface():
     old_layer = keras.layers.Convolution3D(5, 3, 3, 4, name='conv')
     new_layer = keras.layers.Conv3D(5, (3, 3, 4), name='conv')
@@ -689,7 +661,6 @@ def test_conv3d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_convlstm2d_legacy_interface():
     old_layer = keras.layers.ConvLSTM2D(5, 3, 3, name='conv')
     new_layer = keras.layers.ConvLSTM2D(5, (3, 3), name='conv')
@@ -734,7 +705,6 @@ def test_convlstm2d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_batchnorm_legacy_interface():
     old_layer = keras.layers.BatchNormalization(mode=0, name='bn')
     new_layer = keras.layers.BatchNormalization(name='bn')
@@ -750,7 +720,6 @@ def test_batchnorm_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_atrousconv1d_legacy_interface():
     old_layer = keras.layers.AtrousConvolution1D(5, 3,
                                                  init='normal',
@@ -775,7 +744,6 @@ def test_atrousconv1d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_atrousconv2d_legacy_interface():
     old_layer = keras.layers.AtrousConvolution2D(
         5, 3, 3,
@@ -803,7 +771,6 @@ def test_atrousconv2d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_zeropadding2d_legacy_interface():
     old_layer = keras.layers.ZeroPadding2D(padding={'right_pad': 4,
                                                     'bottom_pad': 2,
@@ -817,7 +784,6 @@ def test_zeropadding2d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_zeropadding3d_legacy_interface():
     old_layer = keras.layers.ZeroPadding3D((2, 2, 2),
                                            dim_ordering='tf',
@@ -828,21 +794,18 @@ def test_zeropadding3d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_cropping2d_legacy_interface():
     old_layer = keras.layers.Cropping2D(dim_ordering='tf', name='c2d')
     new_layer = keras.layers.Cropping2D(data_format='channels_last', name='c2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_cropping3d_legacy_interface():
     old_layer = keras.layers.Cropping3D(dim_ordering='tf', name='c3d')
     new_layer = keras.layers.Cropping3D(data_format='channels_last', name='c3d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@keras_test
 def test_generator_methods_interface():
     def train_generator():
         x = np.random.randn(2, 2)
@@ -890,7 +853,6 @@ def test_spatialdropout1d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer_2.get_config())
 
 
-@keras_test
 def test_spatialdropout2d_legacy_interface():
     old_layer = keras.layers.SpatialDropout2D(p=0.5,
                                               dim_ordering='tf',
@@ -905,7 +867,6 @@ def test_spatialdropout2d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer_2.get_config())
 
 
-@keras_test
 def test_spatialdropout3d_legacy_interface():
     old_layer = keras.layers.SpatialDropout3D(p=0.5,
                                               dim_ordering='tf',
@@ -920,7 +881,6 @@ def test_spatialdropout3d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer_2.get_config())
 
 
-@keras_test
 def test_optimizer_get_updates_legacy_interface():
     for optimizer_cls in [keras.optimizers.RMSprop,
                           keras.optimizers.SGD,

--- a/tests/keras/legacy/layers_test.py
+++ b/tests/keras/legacy/layers_test.py
@@ -1,13 +1,11 @@
 import pytest
 
-from keras.utils.test_utils import keras_test
 from keras.utils.test_utils import layer_test
 from keras.legacy import layers as legacy_layers
 from keras import regularizers
 from keras import constraints
 
 
-@keras_test
 def test_highway():
     layer_test(legacy_layers.Highway,
                kwargs={},
@@ -22,7 +20,6 @@ def test_highway():
                input_shape=(3, 2))
 
 
-@keras_test
 def test_maxout_dense():
     layer_test(legacy_layers.MaxoutDense,
                kwargs={'output_dim': 3},

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -5,7 +5,6 @@ from numpy.testing import assert_allclose
 import keras
 from keras import metrics
 from keras import backend as K
-from keras.utils.test_utils import keras_test
 
 all_metrics = [
     metrics.binary_accuracy,
@@ -29,7 +28,6 @@ all_sparse_metrics = [
 ]
 
 
-@keras_test
 def test_metrics():
     y_a = K.variable(np.random.random((6, 7)))
     y_b = K.variable(np.random.random((6, 7)))
@@ -39,7 +37,6 @@ def test_metrics():
         assert K.eval(output).shape == (6,)
 
 
-@keras_test
 def test_sparse_metrics():
     for metric in all_sparse_metrics:
         y_a = K.variable(np.random.randint(0, 7, (6,)), dtype=K.floatx())
@@ -47,7 +44,6 @@ def test_sparse_metrics():
         assert K.eval(metric(y_a, y_b)).shape == (6,)
 
 
-@keras_test
 def test_sparse_categorical_accuracy_correctness():
     y_a = K.variable(np.random.randint(0, 7, (6,)), dtype=K.floatx())
     y_b = K.variable(np.random.random((6, 7)), dtype=K.floatx())
@@ -84,7 +80,6 @@ def test_invalid_get():
 
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='CNTK backend does not support top_k yet')
-@keras_test
 def test_top_k_categorical_accuracy():
     y_pred = K.variable(np.array([[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]))
     y_true = K.variable(np.array([[0, 1, 0], [1, 0, 0]]))
@@ -101,7 +96,6 @@ def test_top_k_categorical_accuracy():
 
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='CNTK backend does not support top_k yet')
-@keras_test
 def test_sparse_top_k_categorical_accuracy():
     y_pred = K.variable(np.array([[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]))
     y_true = K.variable(np.array([[1], [0]]))
@@ -119,7 +113,6 @@ def test_sparse_top_k_categorical_accuracy():
     assert failure_result == 0
 
 
-@keras_test
 @pytest.mark.parametrize('metrics_mode', ['list', 'dict'])
 def test_stateful_metrics(metrics_mode):
     np.random.seed(1334)

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -7,7 +7,6 @@ from keras.utils import test_utils
 from keras import optimizers, Input
 from keras.models import Sequential, Model
 from keras.layers.core import Dense, Activation, Lambda
-from keras.utils.test_utils import keras_test
 from keras.utils.np_utils import to_categorical
 from keras import backend as K
 
@@ -64,7 +63,6 @@ def _test_optimizer(optimizer, target=0.75):
     assert_allclose(bias, 2.)
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() != 'tensorflow'),
                     reason="Only Tensorflow raises a "
                            "ValueError if the gradient is null.")
@@ -80,66 +78,55 @@ def test_no_grad():
                 batch_size=10, epochs=10)
 
 
-@keras_test
 def test_sgd():
     sgd = optimizers.SGD(lr=0.01, momentum=0.9, nesterov=True)
     _test_optimizer(sgd)
 
 
-@keras_test
 def test_rmsprop():
     _test_optimizer(optimizers.RMSprop())
     _test_optimizer(optimizers.RMSprop(decay=1e-3))
 
 
-@keras_test
 def test_adagrad():
     _test_optimizer(optimizers.Adagrad())
     _test_optimizer(optimizers.Adagrad(decay=1e-3))
 
 
-@keras_test
 def test_adadelta():
     _test_optimizer(optimizers.Adadelta(), target=0.6)
     _test_optimizer(optimizers.Adadelta(decay=1e-3), target=0.6)
 
 
-@keras_test
 def test_adam():
     _test_optimizer(optimizers.Adam())
     _test_optimizer(optimizers.Adam(decay=1e-3))
 
 
-@keras_test
 def test_adamax():
     _test_optimizer(optimizers.Adamax())
     _test_optimizer(optimizers.Adamax(decay=1e-3))
 
 
-@keras_test
 def test_nadam():
     _test_optimizer(optimizers.Nadam())
 
 
-@keras_test
 def test_adam_amsgrad():
     _test_optimizer(optimizers.Adam(amsgrad=True))
     _test_optimizer(optimizers.Adam(amsgrad=True, decay=1e-3))
 
 
-@keras_test
 def test_clipnorm():
     sgd = optimizers.SGD(lr=0.01, momentum=0.9, clipnorm=0.5)
     _test_optimizer(sgd)
 
 
-@keras_test
 def test_clipvalue():
     sgd = optimizers.SGD(lr=0.01, momentum=0.9, clipvalue=0.5)
     _test_optimizer(sgd)
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() != 'tensorflow'),
                     reason='Requires TensorFlow backend')
 def test_tfoptimizer():

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -17,7 +17,6 @@ from keras.layers.pooling import MaxPooling2D
 from keras.layers.pooling import GlobalAveragePooling1D
 from keras.layers.pooling import GlobalAveragePooling2D
 from keras.utils.test_utils import get_test_data
-from keras.utils.test_utils import keras_test
 from keras import backend as K
 from keras.utils import np_utils
 try:
@@ -34,7 +33,6 @@ train_samples = 20
 test_samples = 20
 
 
-@keras_test
 def test_TerminateOnNaN():
     np.random.seed(1337)
     (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,
@@ -81,7 +79,6 @@ def test_TerminateOnNaN():
     assert loss[0] == np.inf or np.isnan(loss[0])
 
 
-@keras_test
 def test_stop_training_csv(tmpdir):
     np.random.seed(1337)
     fp = str(tmpdir / 'test.csv')
@@ -134,7 +131,6 @@ def test_stop_training_csv(tmpdir):
     os.remove(fp)
 
 
-@keras_test
 def test_ModelCheckpoint(tmpdir):
     np.random.seed(1337)
     filepath = str(tmpdir / 'checkpoint.h5')
@@ -211,7 +207,6 @@ def test_ModelCheckpoint(tmpdir):
     assert not tmpdir.listdir()
 
 
-@keras_test
 def test_EarlyStopping():
     np.random.seed(1337)
     (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,
@@ -242,7 +237,6 @@ def test_EarlyStopping():
                         validation_data=(X_test, y_test), callbacks=cbks, epochs=20)
 
 
-@keras_test
 def test_EarlyStopping_reuse():
     np.random.seed(1337)
     patience = 3
@@ -265,7 +259,6 @@ def test_EarlyStopping_reuse():
     assert len(hist.epoch) >= patience
 
 
-@keras_test
 def test_EarlyStopping_patience():
     class DummyModel(object):
         def __init__(self):
@@ -297,7 +290,6 @@ def test_EarlyStopping_patience():
     assert epochs_trained == 3
 
 
-@keras_test
 def test_EarlyStopping_baseline():
     class DummyModel(object):
         def __init__(self):
@@ -333,7 +325,6 @@ def test_EarlyStopping_baseline():
     assert baseline_not_met == 2
 
 
-@keras_test
 def test_EarlyStopping_final_weights():
     class DummyModel(object):
         def __init__(self):
@@ -370,7 +361,6 @@ def test_EarlyStopping_final_weights():
     assert early_stop.model.get_weights() == 4
 
 
-@keras_test
 def test_EarlyStopping_final_weights_when_restoring_model_weights():
     class DummyModel(object):
         def __init__(self):
@@ -411,7 +401,6 @@ def test_EarlyStopping_final_weights_when_restoring_model_weights():
     assert early_stop.model.get_weights() == 2
 
 
-@keras_test
 def test_LearningRateScheduler():
     np.random.seed(1337)
     (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,
@@ -434,7 +423,6 @@ def test_LearningRateScheduler():
     assert (float(K.get_value(model.optimizer.lr)) - 0.2) < K.epsilon()
 
 
-@keras_test
 def test_ReduceLROnPlateau():
     np.random.seed(1337)
     (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,
@@ -473,7 +461,6 @@ def test_ReduceLROnPlateau():
     assert_allclose(float(K.get_value(model.optimizer.lr)), 0.1, atol=K.epsilon())
 
 
-@keras_test
 def test_ReduceLROnPlateau_patience():
     class DummyOptimizer(object):
         def __init__(self):
@@ -498,7 +485,6 @@ def test_ReduceLROnPlateau_patience():
     assert all([lr == 1.0 for lr in lrs[:-1]]) and lrs[-1] < 1.0
 
 
-@keras_test
 def test_ReduceLROnPlateau_backwards_compatibility():
     import warnings
     with warnings.catch_warnings(record=True) as ws:
@@ -511,7 +497,6 @@ def test_ReduceLROnPlateau_backwards_compatibility():
     assert reduce_on_plateau.min_delta == 1e-13
 
 
-@keras_test
 def test_CSVLogger(tmpdir):
     np.random.seed(1337)
     filepath = str(tmpdir / 'log.tsv')
@@ -571,7 +556,6 @@ def test_CSVLogger(tmpdir):
     assert not tmpdir.listdir()
 
 
-@keras_test
 def test_TensorBoard(tmpdir):
     np.random.seed(np.random.randint(1, 1e7))
     filepath = str(tmpdir / 'logs')
@@ -659,7 +643,6 @@ def test_TensorBoard(tmpdir):
     assert not tmpdir.listdir()
 
 
-@keras_test
 @pytest.mark.skipif((K.backend() != 'tensorflow'),
                     reason='Requires TensorFlow backend')
 def test_TensorBoard_histogram_freq_must_have_validation_data(tmpdir):
@@ -734,7 +717,6 @@ def test_TensorBoard_histogram_freq_must_have_validation_data(tmpdir):
     assert 'validation_data must be provided' in str(raised_exception.value)
 
 
-@keras_test
 def test_TensorBoard_multi_input_output(tmpdir):
     np.random.seed(np.random.randint(1, 1e7))
     filepath = str(tmpdir / 'logs')
@@ -816,7 +798,6 @@ def test_TensorBoard_multi_input_output(tmpdir):
     assert not tmpdir.listdir()
 
 
-@keras_test
 def test_TensorBoard_convnet(tmpdir):
     np.random.seed(np.random.randint(1, 1e7))
     filepath = str(tmpdir / 'logs')
@@ -857,7 +838,6 @@ def test_TensorBoard_convnet(tmpdir):
     assert not tmpdir.listdir()
 
 
-@keras_test
 def test_TensorBoard_display_float_from_logs(tmpdir):
     filepath = str(tmpdir / 'logs')
 
@@ -891,7 +871,6 @@ def test_TensorBoard_display_float_from_logs(tmpdir):
     assert not tmpdir.listdir()
 
 
-@keras_test
 def test_CallbackValData():
     np.random.seed(1337)
     (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,
@@ -940,7 +919,6 @@ def test_CallbackValData():
     assert cbk.validation_data[2].shape == cbk2.validation_data[2].shape
 
 
-@keras_test
 def test_LambdaCallback():
     np.random.seed(1337)
     (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,
@@ -975,7 +953,6 @@ def test_LambdaCallback():
     assert not p.is_alive()
 
 
-@keras_test
 def test_TensorBoard_with_ReduceLROnPlateau(tmpdir):
     import shutil
     np.random.seed(np.random.randint(1, 1e7))
@@ -1013,7 +990,6 @@ def test_TensorBoard_with_ReduceLROnPlateau(tmpdir):
     assert not tmpdir.listdir()
 
 
-@keras_test
 def tests_RemoteMonitor():
     (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,
                                                          num_test=test_samples,
@@ -1035,7 +1011,6 @@ def tests_RemoteMonitor():
                   validation_data=(X_test, y_test), callbacks=cbks, epochs=1)
 
 
-@keras_test
 def tests_RemoteMonitorWithJsonPayload():
     (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,
                                                          num_test=test_samples,

--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -10,7 +10,7 @@ import keras
 from keras.models import Sequential
 from keras.layers import Dense, Activation
 from keras.utils import np_utils
-from keras.utils.test_utils import get_test_data, keras_test
+from keras.utils.test_utils import get_test_data
 from keras.models import model_from_json, model_from_yaml
 from keras import losses
 from keras.engine.training_utils import make_batches
@@ -34,7 +34,6 @@ def in_tmpdir(tmpdir):
     assert not tmpdir.listdir()
 
 
-@keras_test
 def test_sequential_pop():
     model = Sequential()
     model.add(Dense(num_hidden, input_dim=input_dim))
@@ -67,7 +66,6 @@ def _get_test_data():
     return (x_train, y_train), (x_test, y_test)
 
 
-@keras_test
 def test_sequential_fit_generator():
     (x_train, y_train), (x_test, y_test) = _get_test_data()
 
@@ -106,7 +104,6 @@ def test_sequential_fit_generator():
     model.evaluate(x_train, y_train)
 
 
-@keras_test
 def test_sequential(in_tmpdir):
     (x_train, y_train), (x_test, y_test) = _get_test_data()
 
@@ -182,7 +179,6 @@ def test_sequential(in_tmpdir):
     model_from_yaml(yaml_str)
 
 
-@keras_test
 def test_nested_sequential(in_tmpdir):
     (x_train, y_train), (x_test, y_test) = _get_test_data()
 
@@ -248,7 +244,6 @@ def test_nested_sequential(in_tmpdir):
     model_from_yaml(yaml_str)
 
 
-@keras_test
 def test_sequential_count_params():
     input_dim = 20
     num_units = 10
@@ -271,7 +266,6 @@ def test_sequential_count_params():
     assert(n == model.count_params())
 
 
-@keras_test
 def test_nested_sequential_trainability():
     input_dim = 20
     num_units = 10
@@ -291,7 +285,6 @@ def test_nested_sequential_trainability():
     assert len(model.trainable_weights) == 4
 
 
-@keras_test
 def test_rebuild_model():
     model = Sequential()
     model.add(Dense(128, input_shape=(784,)))
@@ -302,7 +295,6 @@ def test_rebuild_model():
     assert(model.get_layer(index=-1).output_shape == (None, 32))
 
 
-@keras_test
 def test_clone_functional_model():
     val_a = np.random.random((10, 4))
     val_b = np.random.random((10, 4))
@@ -347,7 +339,6 @@ def test_clone_functional_model():
     new_model.train_on_batch(None, val_out)
 
 
-@keras_test
 def test_clone_sequential_model():
     val_a = np.random.random((10, 4))
     val_out = np.random.random((10, 4))
@@ -382,7 +373,6 @@ def test_clone_sequential_model():
     new_model.train_on_batch(None, val_out)
 
 
-@keras_test
 def test_sequential_update_disabling():
     val_a = np.random.random((10, 4))
     val_out = np.random.random((10, 4))
@@ -410,7 +400,6 @@ def test_sequential_update_disabling():
     assert np.abs(np.sum(x1 - x2)) > 1e-5
 
 
-@keras_test
 def test_sequential_deferred_build():
     model = keras.models.Sequential()
     model.add(keras.layers.Dense(3))
@@ -437,7 +426,6 @@ def test_sequential_deferred_build():
     assert len(new_model.weights) == 4
 
 
-@keras_test
 def test_nested_sequential_deferred_build():
     inner_model = keras.models.Sequential()
     inner_model.add(keras.layers.Dense(3))

--- a/tests/keras/utils/generic_utils_test.py
+++ b/tests/keras/utils/generic_utils_test.py
@@ -7,12 +7,10 @@ from keras.utils.generic_utils import has_arg
 from keras.utils.generic_utils import Progbar
 from keras.utils.generic_utils import func_dump
 from keras.utils.generic_utils import func_load
-from keras.utils.test_utils import keras_test
 from keras import activations
 from keras import regularizers
 
 
-@keras_test
 def test_progbar():
     values_s = [None,
                 [['key1', 1], ['key2', 1e-4]],

--- a/tests/keras/utils/layer_utils_test.py
+++ b/tests/keras/utils/layer_utils_test.py
@@ -7,10 +7,8 @@ from keras.layers import Dense
 from keras.layers import Flatten
 from keras.models import Sequential
 from keras.utils import layer_utils
-from keras.utils.test_utils import keras_test
 
 
-@keras_test
 def test_convert_weights():
     def get_model(shape, data_format):
         model = Sequential()

--- a/tests/keras/utils/multi_gpu_test.py
+++ b/tests/keras/utils/multi_gpu_test.py
@@ -11,7 +11,6 @@ import pytest
 import time
 import tempfile
 import tensorflow as tf
-from keras.utils.test_utils import keras_test
 from keras.preprocessing.image import ImageDataGenerator
 
 
@@ -25,7 +24,6 @@ if K.backend() == 'tensorflow':
                                     reason='Requires 8 GPUs.')
 
 
-@keras_test
 def test_multi_gpu_simple_model():
     print('####### test simple model')
     num_samples = 1000
@@ -52,7 +50,6 @@ def test_multi_gpu_simple_model():
     parallel_model.fit(x, y, epochs=epochs)
 
 
-@keras_test
 def test_multi_gpu_multi_io_model():
     print('####### test multi-io model')
     num_samples = 1000
@@ -88,7 +85,6 @@ def test_multi_gpu_multi_io_model():
     parallel_model.fit([a_x, b_x], [a_y, b_y], epochs=epochs)
 
 
-@keras_test
 def test_multi_gpu_invalid_devices():
     input_shape = (1000, 10)
     model = keras.models.Sequential()
@@ -120,7 +116,6 @@ def test_multi_gpu_invalid_devices():
         parallel_model.fit(x, y, epochs=2)
 
 
-@keras_test
 def test_serialization():
     model = keras.models.Sequential()
     model.add(keras.layers.Dense(3,
@@ -272,7 +267,6 @@ def multi_gpu_application_folder_generator_benchmark():
         print('%d gpus training:' % i, total_time)
 
 
-@keras_test
 def test_multi_gpu_with_multi_input_layers():
     inputs = keras.Input((4, 3))
     init_state = keras.Input((3,))
@@ -286,7 +280,6 @@ def test_multi_gpu_with_multi_input_layers():
     parallel_model.train_on_batch(x, y)
 
 
-@keras_test
 def test_multi_gpu_with_siamese():
     input_shape = (3,)
     nested_model = keras.models.Sequential([

--- a/tests/test_dynamic_trainability.py
+++ b/tests/test_dynamic_trainability.py
@@ -2,12 +2,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 import pytest
 
-from keras.utils.test_utils import keras_test
 from keras.models import Model, Sequential
 from keras.layers import Dense, Input
 
 
-@keras_test
 def test_layer_trainability_switch():
     # with constructor argument, in Sequential
     model = Sequential()
@@ -38,7 +36,6 @@ def test_layer_trainability_switch():
     assert model.trainable_weights == []
 
 
-@keras_test
 def test_model_trainability_switch():
     # a non-trainable model has no trainable weights
     x = Input(shape=(1,))
@@ -54,7 +51,6 @@ def test_model_trainability_switch():
     assert model.trainable_weights == []
 
 
-@keras_test
 def test_nested_model_trainability():
     # a Sequential inside a Model
     inner_model = Sequential()

--- a/tests/test_loss_masking.py
+++ b/tests/test_loss_masking.py
@@ -4,12 +4,10 @@ import pytest
 from keras.models import Sequential
 from keras.engine.training_utils import weighted_masked_objective
 from keras.layers import TimeDistributed, Masking, Dense
-from keras.utils.test_utils import keras_test
 from keras import losses
 from keras import backend as K
 
 
-@keras_test
 def test_masking():
     np.random.seed(1337)
     x = np.array([[[1], [1]],
@@ -24,7 +22,6 @@ def test_masking():
     assert loss == 0
 
 
-@keras_test
 def test_loss_masking():
     weighted_loss = weighted_masked_objective(losses.get('mae'))
     shape = (3, 4, 2)

--- a/tests/test_loss_weighting.py
+++ b/tests/test_loss_weighting.py
@@ -8,7 +8,6 @@ from keras.utils.test_utils import get_test_data
 from keras.models import Sequential, Model
 from keras.layers import Dense, Activation, GRU, TimeDistributed, Input
 from keras.utils import np_utils
-from keras.utils.test_utils import keras_test
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
 
 num_classes = 10
@@ -73,7 +72,6 @@ def create_temporal_sequential_model():
     return model
 
 
-@keras_test
 def test_sequential_class_weights():
     model = create_sequential_model()
     model.compile(loss=loss, optimizer='rmsprop')
@@ -99,7 +97,6 @@ def test_sequential_class_weights():
     assert(score < standard_score_sequential)
 
 
-@keras_test
 def test_sequential_sample_weights():
     model = create_sequential_model()
     model.compile(loss=loss, optimizer='rmsprop')
@@ -123,7 +120,6 @@ def test_sequential_sample_weights():
     assert(score < standard_score_sequential)
 
 
-@keras_test
 def test_sequential_temporal_sample_weights():
     ((x_train, y_train), (x_test, y_test),
      (sample_weight, class_weight, test_ids)) = _get_test_data()
@@ -162,7 +158,6 @@ def test_sequential_temporal_sample_weights():
     assert(score < standard_score_sequential)
 
 
-@keras_test
 def test_weighted_metrics_with_sample_weight():
     decimal = decimal_precision[K.backend()]
 
@@ -207,7 +202,6 @@ def test_weighted_metrics_with_sample_weight():
     assert_almost_equal(loss_score, weighted_metric_score, decimal=decimal)
 
 
-@keras_test
 def test_weighted_metrics_with_no_sample_weight():
     decimal = decimal_precision[K.backend()]
 
@@ -244,7 +238,6 @@ def test_weighted_metrics_with_no_sample_weight():
     assert_almost_equal(loss_score, weighted_metric_score, decimal=decimal)
 
 
-@keras_test
 def test_weighted_metrics_with_weighted_accuracy_metric():
     model = create_sequential_model()
     model.compile(loss=loss, optimizer='rmsprop',
@@ -259,7 +252,6 @@ def test_weighted_metrics_with_weighted_accuracy_metric():
     assert history.history['acc'] != history.history['weighted_acc']
 
 
-@keras_test
 def test_weighted_metrics_with_multiple_outputs():
     decimal = decimal_precision[K.backend()]
 
@@ -289,7 +281,6 @@ def test_weighted_metrics_with_multiple_outputs():
     assert_almost_equal(unweighted_metric * weight, weighted_metric, decimal=decimal)
 
 
-@keras_test
 def test_class_weight_wrong_classes():
     model = create_sequential_model()
     model.compile(loss=loss, optimizer='rmsprop')

--- a/tests/test_model_pickling.py
+++ b/tests/test_model_pickling.py
@@ -13,7 +13,6 @@ from keras.layers import Input
 from keras import optimizers
 from keras import losses
 from keras import metrics
-from keras.utils.test_utils import keras_test
 
 if sys.version_info[0] == 3:
     import pickle
@@ -27,7 +26,6 @@ skipif_no_tf_gpu = pytest.mark.skipif(
     reason='Requires TensorFlow backend and a GPU')
 
 
-@keras_test
 def test_sequential_model_pickling():
     model = Sequential()
     model.add(Dense(2, input_shape=(3,)))
@@ -60,7 +58,6 @@ def test_sequential_model_pickling():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_sequential_model_pickling_2():
     # test with custom optimizer, loss
     custom_opt = optimizers.rmsprop
@@ -83,7 +80,6 @@ def test_sequential_model_pickling_2():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_functional_model_pickling():
     inputs = Input(shape=(3,))
     x = Dense(2)(inputs)
@@ -106,7 +102,6 @@ def test_functional_model_pickling():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_pickling_multiple_metrics_outputs():
     inputs = Input(shape=(5,))
     x = Dense(5)(inputs)
@@ -132,7 +127,6 @@ def test_pickling_multiple_metrics_outputs():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_pickling_without_compilation():
     """Test pickling model without compiling.
     """
@@ -143,7 +137,6 @@ def test_pickling_without_compilation():
     model = pickle.loads(pickle.dumps(model))
 
 
-@keras_test
 def test_pickling_right_after_compilation():
     model = Sequential()
     model.add(Dense(2, input_shape=(3,)))
@@ -154,7 +147,6 @@ def test_pickling_right_after_compilation():
     model = pickle.loads(pickle.dumps(model))
 
 
-@keras_test
 def test_pickling_unused_layers_is_ok():
     a = Input(shape=(256, 512, 6))
     b = Input(shape=(256, 512, 1))

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -17,7 +17,6 @@ from keras.initializers import Constant
 from keras import optimizers
 from keras import losses
 from keras import metrics
-from keras.utils.test_utils import keras_test
 from keras.models import save_model, load_model
 
 
@@ -27,7 +26,6 @@ skipif_no_tf_gpu = pytest.mark.skipif(
     reason='Requires TensorFlow backend and a GPU')
 
 
-@keras_test
 def test_sequential_model_saving():
     model = Sequential()
     model.add(Dense(2, input_shape=(3,)))
@@ -61,7 +59,6 @@ def test_sequential_model_saving():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_sequential_model_saving_2():
     # test with custom optimizer, loss
     custom_opt = optimizers.rmsprop
@@ -88,7 +85,6 @@ def test_sequential_model_saving_2():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_functional_model_saving():
     inputs = Input(shape=(3,))
     x = Dense(2)(inputs)
@@ -113,7 +109,6 @@ def test_functional_model_saving():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_model_saving_to_pre_created_h5py_file():
     inputs = Input(shape=(3,))
     x = Dense(2)(inputs)
@@ -151,7 +146,6 @@ def test_model_saving_to_pre_created_h5py_file():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_model_saving_to_binary_stream():
     inputs = Input(shape=(3,))
     x = Dense(2)(inputs)
@@ -193,7 +187,6 @@ def test_model_saving_to_binary_stream():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_saving_multiple_metrics_outputs():
     inputs = Input(shape=(5,))
     x = Dense(5)(inputs)
@@ -222,7 +215,6 @@ def test_saving_multiple_metrics_outputs():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_saving_without_compilation():
     """Test saving model without compiling.
     """
@@ -236,7 +228,6 @@ def test_saving_without_compilation():
     os.remove(fname)
 
 
-@keras_test
 def test_saving_right_after_compilation():
     model = Sequential()
     model.add(Dense(2, input_shape=(3,)))
@@ -250,7 +241,6 @@ def test_saving_right_after_compilation():
     os.remove(fname)
 
 
-@keras_test
 def test_saving_unused_layers_is_ok():
     a = Input(shape=(256, 512, 6))
     b = Input(shape=(256, 512, 1))
@@ -264,7 +254,6 @@ def test_saving_unused_layers_is_ok():
     os.remove(fname)
 
 
-@keras_test
 def test_loading_weights_by_name_and_reshape():
     """
     test loading model weights by name on:
@@ -346,7 +335,6 @@ def test_loading_weights_by_name_and_reshape():
     os.remove(fname)
 
 
-@keras_test
 def test_loading_weights_by_name_2():
     """
     test loading model weights by name on:
@@ -405,7 +393,6 @@ def test_loading_weights_by_name_2():
     assert_allclose(np.zeros_like(jessica[1]), jessica[1])  # biases init to 0
 
 
-@keras_test
 def test_loading_weights_by_name_skip_mismatch():
     """
     test skipping layers while loading model weights by name on:
@@ -458,7 +445,6 @@ def square_fn(x):
     return x * x
 
 
-@keras_test
 def test_saving_lambda_custom_objects():
     inputs = Input(shape=(3,))
     x = Lambda(lambda x: square_fn(x), output_shape=(3,))(inputs)
@@ -483,7 +469,6 @@ def test_saving_lambda_custom_objects():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_saving_lambda_numpy_array_arguments():
     mean = np.random.random((4, 2, 3))
     std = np.abs(np.random.random((4, 2, 3))) + 1e-5
@@ -503,7 +488,6 @@ def test_saving_lambda_numpy_array_arguments():
     assert_allclose(std, model.layers[1].arguments['std'])
 
 
-@keras_test
 def test_saving_custom_activation_function():
     x = Input(shape=(3,))
     output = Dense(3, activation=K.cos)(x)
@@ -527,7 +511,6 @@ def test_saving_custom_activation_function():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_saving_model_with_long_layer_names():
     # This layer name will make the `layers_name` HDF5 attribute blow
     # out of proportion. Note that it fits into the internal HDF5
@@ -570,7 +553,6 @@ def test_saving_model_with_long_layer_names():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_saving_model_with_long_weights_names():
     x = Input(shape=(2,), name='nested_model_input')
     f = x
@@ -616,7 +598,6 @@ def test_saving_model_with_long_weights_names():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@keras_test
 def test_saving_recurrent_layer_with_init_state():
     vector_size = 8
     input_length = 20
@@ -636,7 +617,6 @@ def test_saving_recurrent_layer_with_init_state():
     os.remove(fname)
 
 
-@keras_test
 def test_saving_recurrent_layer_without_bias():
     vector_size = 8
     input_length = 20
@@ -652,7 +632,6 @@ def test_saving_recurrent_layer_without_bias():
     os.remove(fname)
 
 
-@keras_test
 def test_saving_constant_initializer_with_numpy():
     """Test saving and loading model of constant initializer with numpy inputs.
     """
@@ -668,7 +647,6 @@ def test_saving_constant_initializer_with_numpy():
     os.remove(fname)
 
 
-@keras_test
 @pytest.mark.parametrize('implementation', [1, 2], ids=['impl1', 'impl2'])
 @pytest.mark.parametrize('bidirectional',
                          [False, True],
@@ -756,7 +734,6 @@ def _convert_model_weights(source_model, target_model):
     os.remove(fname)
 
 
-@keras_test
 @pytest.mark.parametrize('to_cudnn', [False, True], ids=['from_cudnn', 'to_cudnn'])
 @pytest.mark.parametrize('rnn_type', ['LSTM', 'GRU'], ids=['LSTM', 'GRU'])
 @skipif_no_tf_gpu

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -5,7 +5,6 @@ import pytest
 import numpy as np
 from keras.models import Sequential
 from keras.layers.core import Dense
-from keras.utils.test_utils import keras_test
 from keras.utils import Sequence
 from keras import backend as K
 
@@ -67,7 +66,6 @@ def in_tmpdir(tmpdir):
     assert not tmpdir.listdir()
 
 
-@keras_test
 def test_multiprocessing_training():
     arr_data = np.random.randint(0, 256, (50, 2))
     arr_labels = np.random.randint(0, 2, 50)
@@ -276,7 +274,6 @@ def test_multiprocessing_training():
                             use_multiprocessing=False)
 
 
-@keras_test
 def test_multiprocessing_training_from_file(in_tmpdir):
     arr_data = np.random.randint(0, 256, (50, 2))
     arr_labels = np.random.randint(0, 2, 50)
@@ -397,7 +394,6 @@ def test_multiprocessing_training_from_file(in_tmpdir):
     os.remove('data.npz')
 
 
-@keras_test
 def test_multiprocessing_predicting():
     arr_data = np.random.randint(0, 256, (50, 2))
 
@@ -486,7 +482,6 @@ def test_multiprocessing_predicting():
                             use_multiprocessing=False)
 
 
-@keras_test
 def test_multiprocessing_evaluating():
     arr_data = np.random.randint(0, 256, (50, 2))
     arr_labels = np.random.randint(0, 2, 50)
@@ -578,7 +573,6 @@ def test_multiprocessing_evaluating():
                              use_multiprocessing=False)
 
 
-@keras_test
 def test_multiprocessing_fit_error():
     arr_data = np.random.randint(0, 256, (50, 2))
     arr_labels = np.random.randint(0, 2, 50)
@@ -691,7 +685,6 @@ def test_multiprocessing_fit_error():
                             use_multiprocessing=False)
 
 
-@keras_test
 def test_multiprocessing_evaluate_error():
     arr_data = np.random.randint(0, 256, (50, 2))
     arr_labels = np.random.randint(0, 2, 50)
@@ -794,7 +787,6 @@ def test_multiprocessing_evaluate_error():
                                  use_multiprocessing=False)
 
 
-@keras_test
 def test_multiprocessing_predict_error():
     arr_data = np.random.randint(0, 256, (50, 2))
     good_batches = 3


### PR DESCRIPTION
### Summary

It's annoying to have to think about adding `@keras_test` all the time.
Using a `conftest.py` we can run a fixture for all the tests in the test suite. It doesn't seem to make the build take more time than before.

### Related Issues

### PR Overview

This PR has two parts:
* the `conftest.py`:
```python
import pytest
from keras import backend as K
@pytest.fixture(autouse=True)
def clear_session_after_test():
    yield
    if K.backend() == 'tensorflow' or K.backend() == 'cntk':
        K.clear_session()
```

* the removal of 300+ usages of `keras_test`.

If a reviewer wants me to split this PR, it's possible.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
