### PR TITLE
Removed completely the keras_test decorator.

### DIFF
--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -128,21 +128,3 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
 
     # for further checks in the caller function
     return actual_output
-
-
-def keras_test(func):
-    """Function wrapper to clean up after TensorFlow tests.
-
-    # Arguments
-        func: test function to clean up after.
-
-    # Returns
-        A function wrapping the input function.
-    """
-    @six.wraps(func)
-    def wrapper(*args, **kwargs):
-        output = func(*args, **kwargs)
-        if K.backend() == 'tensorflow' or K.backend() == 'cntk':
-            K.clear_session()
-        return output
-    return wrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,10 @@ from keras import backend as K
 
 @pytest.fixture(autouse=True)
 def clear_session_after_test():
+    """Test wrapper to clean up after TensorFlow and CNTK tests.
+
+    This wrapper runs for all the tests in the keras test suite.
+    """
     yield
     if K.backend() == 'tensorflow' or K.backend() == 'cntk':
         K.clear_session()

--- a/tests/keras/layers/convolutional_recurrent_test.py
+++ b/tests/keras/layers/convolutional_recurrent_test.py
@@ -6,7 +6,6 @@ from keras import backend as K
 from keras.models import Sequential, Model
 from keras.layers import convolutional_recurrent, Input
 from keras.utils.test_utils import layer_test
-from keras.utils.test_utils import keras_test
 from keras import regularizers
 
 num_row = 3
@@ -19,7 +18,6 @@ input_num_col = 5
 sequence_len = 2
 
 
-@keras_test
 def test_convolutional_recurrent():
 
     for data_format in ['channels_first', 'channels_last']:
@@ -64,7 +62,6 @@ def test_convolutional_recurrent():
                                 input_shape=inputs.shape)
 
 
-@keras_test
 def test_convolutional_recurrent_statefulness():
 
     data_format = 'channels_last'

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_allclose
 
 import keras
 from keras.utils.test_utils import layer_test
-from keras.utils.test_utils import keras_test
 from keras.layers import recurrent
 from keras.layers import embeddings
 from keras.models import Sequential
@@ -18,26 +17,16 @@ num_samples, timesteps, embedding_dim, units = 2, 5, 4, 3
 embedding_num = 12
 
 
-def rnn_test(f):
-    """
-    All the recurrent layers share the same interface,
-    so we can run through them with a single function.
-    """
-    f = keras_test(f)
-    return pytest.mark.parametrize('layer_class', [
-        recurrent.SimpleRNN,
-        recurrent.GRU,
-        recurrent.LSTM
-    ])(f)
+rnn_test = pytest.mark.parametrize('layer_class',
+                                   [recurrent.SimpleRNN,
+                                    recurrent.GRU,
+                                    recurrent.LSTM])
 
 
-def rnn_cell_test(f):
-    f = keras_test(f)
-    return pytest.mark.parametrize('cell_class', [
-        recurrent.SimpleRNNCell,
-        recurrent.GRUCell,
-        recurrent.LSTMCell
-    ])(f)
+rnn_cell_test = pytest.mark.parametrize('cell_class',
+                                        [recurrent.SimpleRNNCell,
+                                         recurrent.GRUCell,
+                                         recurrent.LSTMCell])
 
 
 @rnn_test


### PR DESCRIPTION
### Summary

We already have a test wrapper in a `conftest.py` so we don't need that decorator anymore.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
