### PR TITLE
Fix bug in sparse_top_k_categorical_accuracy

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -45,7 +45,8 @@ def top_k_categorical_accuracy(y_true, y_pred, k=5):
 
 
 def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):
-    return K.mean(K.in_top_k(y_pred, K.cast(K.max(y_true, axis=-1), 'int32'), k),
+    # If the shape of y_true is (num_samples, 1), flatten to (num_samples,)
+    return K.mean(K.in_top_k(y_pred, K.cast(K.flatten(y_true), 'int32'), k),
                   axis=-1)
 
 

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -96,26 +96,15 @@ def test_top_k_categorical_accuracy():
 
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='CNTK backend does not support top_k yet')
-def test_sparse_top_k_categorical_accuracy():
+@pytest.mark.parametrize('y_pred, y_true', [
     # Test correctness if the shape of y_true is (num_samples, 1)
-    y_pred = K.variable(np.array([[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]))
-    y_true = K.variable(np.array([[1], [0]]))
-    success_result = K.eval(
-        metrics.sparse_top_k_categorical_accuracy(y_true, y_pred, k=3))
-
-    assert success_result == 1
-    partial_result = K.eval(
-        metrics.sparse_top_k_categorical_accuracy(y_true, y_pred, k=2))
-
-    assert partial_result == 0.5
-    failure_result = K.eval(
-        metrics.sparse_top_k_categorical_accuracy(y_true, y_pred, k=1))
-
-    assert failure_result == 0
-
+    (np.array([[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]), np.array([[1], [0]])),
     # Test correctness if the shape of y_true is (num_samples,)
-    y_pred = K.variable(np.array([[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]))
-    y_true = K.variable(np.array([1, 0]))
+    (np.array([[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]), np.array([1, 0])),
+])
+def test_sparse_top_k_categorical_accuracy(y_pred, y_true):
+    y_pred = K.variable(y_pred)
+    y_true = K.variable(y_true)
     success_result = K.eval(
         metrics.sparse_top_k_categorical_accuracy(y_true, y_pred, k=3))
 

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -97,8 +97,25 @@ def test_top_k_categorical_accuracy():
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='CNTK backend does not support top_k yet')
 def test_sparse_top_k_categorical_accuracy():
+    # Test correctness if the shape of y_true is (num_samples, 1)
     y_pred = K.variable(np.array([[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]))
     y_true = K.variable(np.array([[1], [0]]))
+    success_result = K.eval(
+        metrics.sparse_top_k_categorical_accuracy(y_true, y_pred, k=3))
+
+    assert success_result == 1
+    partial_result = K.eval(
+        metrics.sparse_top_k_categorical_accuracy(y_true, y_pred, k=2))
+
+    assert partial_result == 0.5
+    failure_result = K.eval(
+        metrics.sparse_top_k_categorical_accuracy(y_true, y_pred, k=1))
+
+    assert failure_result == 0
+
+    # Test correctness if the shape of y_true is (num_samples,)
+    y_pred = K.variable(np.array([[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]))
+    y_true = K.variable(np.array([1, 0]))
     success_result = K.eval(
         metrics.sparse_top_k_categorical_accuracy(y_true, y_pred, k=3))
 


### PR DESCRIPTION
### Summary
For the input of ```sparse_top_k_categorical_accuracy```, the shape of ```y_true``` can be ```(num_samples, 1)``` or ```(num_samples,)```.
* Train with Numpy array, the shape of ```y_true``` is ```(num_samples, 1)```. Because ```y_true``` is feed with a placeholder which is generated according the shape of ```y_pred```.
* Train with TensorFlow dataset API, the shape of ```y_true``` is _usually_ ```(num_samples,)``` according your input.

https://github.com/tensorflow/tensorflow/issues/22190 has reported a relevant bug.
#11100 has fixed this issue for ```sparse_categorical_accuracy```, this PR add the same fix for ```sparse_top_k_categorical_accuracy```.

### Related Issues
#11100
https://github.com/tensorflow/tensorflow/issues/22190
https://github.com/tensorflow/tensorflow/pull/22392

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
