### PR TITLE
[Request for contributions] implement get_reachable_from_inputs

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2574,14 +2574,11 @@ def backward_pass(outputs):
 
 
 def link_to_inputs(node):
-    try:
-        assert node._keras_done
+    if hasattr(node, '_keras_done'):
         return []
-    except AttributeError:
+    else:
         children = get_children(node)
         for child in children:
-            if child is None:
-                raise IndexError
             add_link(child, node)
         node._keras_done = True
         return children
@@ -2595,11 +2592,9 @@ def add_link(from_tensor, to_tensor):
 
 
 def get_children(node):
-    from cntk.ops.functions import Function
-    from cntk.variables import Variable
-    if isinstance(node, Function):
+    if isinstance(node, C.ops.functions.Function):
         return node.inputs  # Wrong way to do it.
-    elif isinstance(node, Variable):
+    elif isinstance(node, C.variables.Variable):
         if node.is_output:
             return [node.owner]  # Ok but only special case.
         else:

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2565,11 +2565,6 @@ def get_reachable_from_inputs(inputs, targets=None):
 
 
 def backward_pass(outputs):
-    if outputs is None:
-        raise NotImplementedError(
-            'It is not possible to give no'
-            'outputs to `get_reachable_from_inputs` when using '
-            'the CNTK backend.')
     queue = outputs[:]
     while queue:
         x = queue.pop()
@@ -2606,7 +2601,7 @@ def get_children(node):
         return node.inputs  # Wrong way to do it.
     elif isinstance(node, Variable):
         if node.is_output:
-            return [node.owner] # Ok but only special case.
+            return [node.owner]  # Ok but only special case.
         else:
             return []
     raise NotImplementedError

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 
 import cntk as C
-from cntk.logging.graph import depth_first_search
 import numpy as np
 from .common import floatx
 from .common import epsilon
@@ -2420,35 +2419,6 @@ def _reshape_batch(x, shape):
         return C.user_function(ReshapeBatch(x, shape[1:]))
 
 
-def get_ancestor(x):
-    raise NotImplementedError
-
-
-def visitor(x):
-    try:
-        assert x._keras_done
-        return False
-    except:
-        for ancestor in get_ancestor(x):
-            if hasattr(ancestor, '_keras_forward_ptrs'):
-                ancestor._keras_forward_ptrs.add(x)
-            else:
-                ancestor._keras_forward_ptrs = {x}
-
-        x._keras_done = True
-        return False
-
-
-def get_reachable_from_inputs(inputs, targets=None):
-    if targets is None:
-        raise NotImplementedError('It is not possible to use '
-                                  '`get_reachable_from_inputs` with the CNTK'
-                                  ' backend without specifying target tensors to'
-                                  ' reach.')
-    for target in targets:
-        depth_first_search(target, visitor)
-
-
 def _get_cntk_version():
     version = C.__version__
     if version.endswith('+'):
@@ -2581,3 +2551,32 @@ class LambdaFunc(C.ops.functions.UserFunction):
 
     def backward(self, state, root_gradients):
         return root_gradients
+
+
+def get_ancestor(x):
+    raise NotImplementedError
+
+
+def visitor(x):
+    try:
+        assert x._keras_done
+        return False
+    except:
+        for ancestor in get_ancestor(x):
+            if hasattr(ancestor, '_keras_forward_ptrs'):
+                ancestor._keras_forward_ptrs.add(x)
+            else:
+                ancestor._keras_forward_ptrs = {x}
+
+        x._keras_done = True
+        return False
+
+
+def get_reachable_from_inputs(inputs, targets=None):
+    if targets is None:
+        raise NotImplementedError('It is not possible to use '
+                                  '`get_reachable_from_inputs` with the CNTK'
+                                  ' backend without specifying target tensors to'
+                                  ' reach.')
+    for target in targets:
+        depth_first_search(target, visitor)

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2553,30 +2553,10 @@ class LambdaFunc(C.ops.functions.UserFunction):
         return root_gradients
 
 
-def get_ancestor(x):
-    raise NotImplementedError
-
-
-def visitor(x):
-    try:
-        assert x._keras_done
-        return False
-    except:
-        for ancestor in get_ancestor(x):
-            if hasattr(ancestor, '_keras_forward_ptrs'):
-                ancestor._keras_forward_ptrs.add(x)
-            else:
-                ancestor._keras_forward_ptrs = {x}
-
-        x._keras_done = True
-        return False
-
-
 def get_reachable_from_inputs(inputs, targets=None):
     if targets is None:
         raise NotImplementedError('It is not possible to use '
                                   '`get_reachable_from_inputs` with the CNTK'
                                   ' backend without specifying target tensors to'
                                   ' reach.')
-    for target in targets:
-        depth_first_search(target, visitor)
+    raise NotImplementedError

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -4441,6 +4441,9 @@ def get_reachable_from_inputs(inputs, targets=None):
 
     # Returns
         A set of tensors reachable from the inputs (includes the inputs themselves).
+
+    # Raises
+        TypeError: If one of the nodes in the graph isn't known.
     """
     reachable = set(inputs)
     if targets is not None:
@@ -4451,7 +4454,6 @@ def get_reachable_from_inputs(inputs, targets=None):
         x = queue.pop()
         if isinstance(x, tf_ops.Operation):
             outputs = x.outputs[:] or []
-            #outputs += x._control_outputs  # pylint: disable=protected-access
         elif isinstance(x, variables.Variable):
             outputs = [x.op]
         elif tensor_util.is_tensor(x):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -2850,4 +2850,4 @@ def get_reachable_from_inputs(inputs, targets=None):
                                   ' backend without specifying target tensors to'
                                   ' reach.')
 
-    return graph.variables(inputs, targets) + graph.list_of_nodes(inputs, targets)
+    raise NotImplementedError

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -11,6 +11,7 @@ from theano.tensor.signal import pool
 from theano.printing import Print
 from theano.ifelse import ifelse
 from theano.gof import graph
+from theano.gof.graph import Variable, Apply
 try:
     import theano.sparse as th_sparse_module
 except ImportError:
@@ -2864,14 +2865,11 @@ def backward_pass(outputs):
 
 
 def link_to_inputs(node):
-    try:
-        assert node._keras_done
+    if hasattr(node, '_keras_done'):
         return []
-    except AttributeError:
+    else:
         children = get_children(node)
         for child in children:
-            if child is None:
-                raise IndexError
             add_link(child, node)
         node._keras_done = True
         return children
@@ -2885,7 +2883,6 @@ def add_link(from_tensor, to_tensor):
 
 
 def get_children(node):
-    from theano.gof.graph import Variable, Apply
     if isinstance(node, Variable):
         if node.owner is None:
             # Placeholder

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -10,6 +10,7 @@ from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 from theano.tensor.signal import pool
 from theano.printing import Print
 from theano.ifelse import ifelse
+from theano.gof import graph
 try:
     import theano.sparse as th_sparse_module
 except ImportError:
@@ -2840,3 +2841,13 @@ def local_conv2d(inputs, kernel, kernel_size, strides, output_shape, data_format
                          (output_row, output_col, -1, filters))
         output = permute_dimensions(output, (2, 0, 1, 3))
     return output
+
+
+def get_reachable_from_inputs(inputs, targets=None):
+    if targets is None:
+        raise NotImplementedError('It is not possible to use '
+                                  '`get_reachable_from_inputs` with the Theano'
+                                  ' backend without specifying target tensors to'
+                                  ' reach.')
+
+    return graph.variables(inputs, targets) + graph.list_of_nodes(inputs, targets)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -2850,4 +2850,73 @@ def get_reachable_from_inputs(inputs, targets=None):
                                   ' backend without specifying target tensors to'
                                   ' reach.')
 
-    raise NotImplementedError
+    backward_pass(targets)
+    return get_reachable_from_inputs_with_ptrs(inputs, targets)
+
+
+def backward_pass(outputs):
+    if outputs is None:
+        raise NotImplementedError(
+            'It is not possible to give no'
+            'outputs to `get_reachable_from_inputs` when using '
+            'the Theano backend.')
+    queue = outputs[:]
+    while queue:
+        x = queue.pop()
+        inputs = link_to_inputs(x)
+        for input_ in inputs:
+            queue.insert(0, input_)
+
+
+def link_to_inputs(node):
+    try:
+        assert node._keras_done
+        return []
+    except AttributeError:
+        children = get_children(node)
+        for child in children:
+            if child is None:
+                raise IndexError
+            add_link(child, node)
+        node._keras_done = True
+        return children
+
+
+def add_link(from_tensor, to_tensor):
+    if hasattr(from_tensor, '_keras_forward_ptrs'):
+        from_tensor._keras_forward_ptrs.add(to_tensor)
+    else:
+        from_tensor._keras_forward_ptrs = {to_tensor}
+
+
+def get_children(node):
+    from theano.gof.graph import Variable, Apply
+    if isinstance(node, Variable):
+        if node.owner is None:
+            # Placeholder
+            return []
+        else:
+            return [node.owner]
+    elif isinstance(node, Apply):
+        return node.inputs
+    else:
+        raise NotImplementedError
+
+
+def get_reachable_from_inputs_with_ptrs(inputs, targets=None):
+    reachable = set(inputs)
+    if targets:
+        targets = set(targets)
+    queue = inputs[:]
+
+    while queue:
+        x = queue.pop()
+        outputs = x._keras_forward_ptrs
+        for y in outputs:
+            if y not in reachable:
+                reachable.add(y)
+                queue.insert(0, y)
+
+        if targets and targets.issubset(reachable):
+            return reachable
+    return reachable

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -2855,11 +2855,6 @@ def get_reachable_from_inputs(inputs, targets=None):
 
 
 def backward_pass(outputs):
-    if outputs is None:
-        raise NotImplementedError(
-            'It is not possible to give no'
-            'outputs to `get_reachable_from_inputs` when using '
-            'the Theano backend.')
     queue = outputs[:]
     while queue:
         x = queue.pop()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 # Configuration of py.test
 [pytest]
 addopts=-v
-        -n 2
+        -n 1
         --durations=20
 
 # Do not run tests in the build folder

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 # Configuration of py.test
 [pytest]
 addopts=-v
-        -n 1
+        -n 2
         --durations=20
 
 # Do not run tests in the build folder

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1905,7 +1905,6 @@ class TestBackend(object):
             with pytest.raises(TypeError):
                 K.variable('', dtype='unsupported')
 
-    @keras_test
     @pytest.mark.skipif((K.backend() != 'tensorflow'),
                         reason='Only Tensorflow exposes pointers to '
                                'the next nodes and operations.')
@@ -1918,7 +1917,6 @@ class TestBackend(object):
             for tensor in branch:
                 assert tensor in nodes
 
-    @keras_test
     def test_get_reachable_from_inputs_1(self):
         branches = get_dummy_graph()
         branch_a, branch_b = branches[:2]
@@ -1930,7 +1928,6 @@ class TestBackend(object):
         for tensor in branch_b:
             assert tensor not in nodes
 
-    @keras_test
     def test_get_reachable_from_inputs_2(self):
         branches = get_dummy_graph()
         branch_a, branch_b = branches[:2]


### PR DESCRIPTION
### Summary

Hello, this PR implements the function `get_reachable_from_inputs` as described in this ticket: https://github.com/keras-team/keras/projects/1#card-9317506

### Related Issues

https://github.com/keras-team/keras/projects/1#card-9317506
#11777

### PR Overview

* Tests were added

* Tensorflow backend is working (implementation taken from tf.keras)

* Theano backend is working if there are target tensors. This is because Theano tensors have only pointers to previous tensors, not the next ones. So we can't do the same as in the tensorflow implementation. We have to start from the outputs, come back (like the backpropagation), add pointers, and then we can do the same algorithm as in the tensorflow backend.

* I didn't manage to get the CNTK backend to work as I didn't find a way to get children or parents nodes from CNTK functions and variables. @souptc, help would be very much welcome. Thank you in advance. 

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
