### PR TITLE
Add ResNet, ResNetV2, and ResNeXt variants

### DIFF
--- a/keras/applications/__init__.py
+++ b/keras/applications/__init__.py
@@ -42,4 +42,4 @@ from .densenet import DenseNet121, DenseNet169, DenseNet201
 from .nasnet import NASNetMobile, NASNetLarge
 from .resnet import ResNet101, ResNet152
 from .resnet_v2 import ResNet50V2, ResNet101V2, ResNet152V2
-from .resnext import ResNeXt50c32, ResNeXt101c32, ResNeXt101c64
+from .resnext import ResNeXt50, ResNeXt101

--- a/keras/applications/__init__.py
+++ b/keras/applications/__init__.py
@@ -40,3 +40,6 @@ from .mobilenet import MobileNet
 from .mobilenet_v2 import MobileNetV2
 from .densenet import DenseNet121, DenseNet169, DenseNet201
 from .nasnet import NASNetMobile, NASNetLarge
+from .resnet import ResNet101, ResNet152
+from .resnet_v2 import ResNet50V2, ResNet101V2, ResNet152V2
+from .resnext import ResNeXt50c32, ResNeXt101c32, ResNeXt101c64

--- a/keras/applications/resnet.py
+++ b/keras/applications/resnet.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+    from keras_applications import resnet
+except:
+    resnet = None
+from . import keras_modules_injection
+
+
+@keras_modules_injection
+def ResNet50(*args, **kwargs):
+    return resnet.ResNet50(*args, **kwargs)
+
+
+@keras_modules_injection
+def ResNet101(*args, **kwargs):
+    return resnet.ResNet101(*args, **kwargs)
+
+
+@keras_modules_injection
+def ResNet152(*args, **kwargs):
+    return resnet.ResNet152(*args, **kwargs)
+
+
+@keras_modules_injection
+def decode_predictions(*args, **kwargs):
+    return resnet.decode_predictions(*args, **kwargs)
+
+
+@keras_modules_injection
+def preprocess_input(*args, **kwargs):
+    return resnet.preprocess_input(*args, **kwargs)

--- a/keras/applications/resnet.py
+++ b/keras/applications/resnet.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from keras_applications import resnet
+try:
+    from keras_applications import resnet
+except:
+    resnet = None
 from . import keras_modules_injection
 
 

--- a/keras/applications/resnet.py
+++ b/keras/applications/resnet.py
@@ -2,10 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-try:
-    from keras_applications import resnet
-except:
-    resnet = None
+from keras_applications import resnet
 from . import keras_modules_injection
 
 

--- a/keras/applications/resnet_v2.py
+++ b/keras/applications/resnet_v2.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+    from keras_applications import resnet_v2
+except:
+    resnet_v2 = None
+from . import keras_modules_injection
+
+
+@keras_modules_injection
+def ResNet50V2(*args, **kwargs):
+    return resnet_v2.ResNet50V2(*args, **kwargs)
+
+
+@keras_modules_injection
+def ResNet101V2(*args, **kwargs):
+    return resnet_v2.ResNet101V2(*args, **kwargs)
+
+
+@keras_modules_injection
+def ResNet152V2(*args, **kwargs):
+    return resnet_v2.ResNet152V2(*args, **kwargs)
+
+
+@keras_modules_injection
+def decode_predictions(*args, **kwargs):
+    return resnet_v2.decode_predictions(*args, **kwargs)
+
+
+@keras_modules_injection
+def preprocess_input(*args, **kwargs):
+    return resnet_v2.preprocess_input(*args, **kwargs)

--- a/keras/applications/resnet_v2.py
+++ b/keras/applications/resnet_v2.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from keras_applications import resnet_v2
+try:
+    from keras_applications import resnet_v2
+except:
+    resnet_v2 = None
 from . import keras_modules_injection
 
 

--- a/keras/applications/resnet_v2.py
+++ b/keras/applications/resnet_v2.py
@@ -2,10 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-try:
-    from keras_applications import resnet_v2
-except:
-    resnet_v2 = None
+from keras_applications import resnet_v2
 from . import keras_modules_injection
 
 

--- a/keras/applications/resnext.py
+++ b/keras/applications/resnext.py
@@ -10,18 +10,13 @@ from . import keras_modules_injection
 
 
 @keras_modules_injection
-def ResNeXt50c32(*args, **kwargs):
-    return resnext.ResNeXt50c32(*args, **kwargs)
+def ResNeXt50(*args, **kwargs):
+    return resnext.ResNeXt50(*args, **kwargs)
 
 
 @keras_modules_injection
-def ResNeXt101c32(*args, **kwargs):
-    return resnext.ResNeXt101c32(*args, **kwargs)
-
-
-@keras_modules_injection
-def ResNeXt101c64(*args, **kwargs):
-    return resnext.ResNeXt101c64(*args, **kwargs)
+def ResNeXt101(*args, **kwargs):
+    return resnext.ResNeXt101(*args, **kwargs)
 
 
 @keras_modules_injection

--- a/keras/applications/resnext.py
+++ b/keras/applications/resnext.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+    from keras_applications import resnext
+except:
+    resnext = None
+from . import keras_modules_injection
+
+
+@keras_modules_injection
+def ResNeXt50c32(*args, **kwargs):
+    return resnext.ResNeXt50c32(*args, **kwargs)
+
+
+@keras_modules_injection
+def ResNeXt101c32(*args, **kwargs):
+    return resnext.ResNeXt101c32(*args, **kwargs)
+
+
+@keras_modules_injection
+def ResNeXt101c64(*args, **kwargs):
+    return resnext.ResNeXt101c64(*args, **kwargs)
+
+
+@keras_modules_injection
+def decode_predictions(*args, **kwargs):
+    return resnext.decode_predictions(*args, **kwargs)
+
+
+@keras_modules_injection
+def preprocess_input(*args, **kwargs):
+    return resnext.preprocess_input(*args, **kwargs)

--- a/keras/applications/resnext.py
+++ b/keras/applications/resnext.py
@@ -2,10 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-try:
-    from keras_applications import resnext
-except:
-    resnext = None
+from keras_applications import resnext
 from . import keras_modules_injection
 
 

--- a/keras/applications/resnext.py
+++ b/keras/applications/resnext.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from keras_applications import resnext
+try:
+    from keras_applications import resnext
+except:
+    resnext = None
 from . import keras_modules_injection
 
 


### PR DESCRIPTION
This PR adds declarations of ResNet, ResNetV2, and ResNeXt variants. In order to add new models into `keras-applications`,  we should first add those declarations into `keras`. Please refer to the cores (keras-team/keras-applications#26).