### PR TITLE
Added np.tile to reference_operations.py.

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -300,8 +300,8 @@ class TestBackend(object):
     def test_tile(self):
         shape = (3, 4)
         arr = np.arange(np.prod(shape)).reshape(shape)
-        check_single_tensor_operation('tile', arr, BACKENDS, n=[2, 1])
-        check_single_tensor_operation('tile', (2, 5), BACKENDS, n=[5, 2])
+        check_single_tensor_operation('tile', arr, WITH_NP, n=[2, 1])
+        check_single_tensor_operation('tile', (2, 5), WITH_NP, n=[5, 2])
 
         # test theano shape inference when
         # input shape has None entries

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -402,6 +402,10 @@ def repeat(x, n):
     return y
 
 
+def tile(x, n):
+    return np.tile(x, n)
+
+
 def arange(start, stop=None, step=1, dtype='int32'):
     return np.arange(start, stop, step, dtype)
 


### PR DESCRIPTION
### Summary

Comparing to numpy operations allow us to know which backend fails in case of unexpected result (let's say the theano backend changes, the failure will only happen in the theano build on travis when comparing to numpy), and have a good ground truth for tests. 

It's also good for documentation purposes, in case we wonder what the real definition of an op in the keras backend is.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
