### PR TITLE
Fix/test_multiprocessing.py and data_utils_test.py, increase test coverage

### DIFF
--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -10,6 +10,7 @@ import multiprocessing as mp
 import numpy as np
 import pytest
 import six
+from multiprocessing import set_start_method
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.request import pathname2url
 
@@ -21,9 +22,6 @@ from keras.utils.data_utils import get_file
 from keras.utils.data_utils import validate_file
 from keras import backend as K
 
-pytestmark = pytest.mark.skipif(
-    K.backend() == 'tensorflow',
-    reason='Temporarily disabled until the use_multiprocessing problem is solved')
 
 if sys.version_info < (3,):
     def next(x):
@@ -385,4 +383,5 @@ def test_finite_generator_enqueuer_processes():
 
 
 if __name__ == '__main__':
+    set_start_method('spawn', force=True)
     pytest.main([__file__])

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -7,10 +7,8 @@ from keras.models import Sequential
 from keras.layers.core import Dense
 from keras.utils import Sequence
 from keras import backend as K
+from multiprocessing import set_start_method
 
-pytestmark = pytest.mark.skipif(
-    K.backend() == 'tensorflow',
-    reason='Temporarily disabled until the use_multiprocessing problem is solved')
 
 STEPS_PER_EPOCH = 100
 STEPS = 100
@@ -889,4 +887,5 @@ def test_multiprocessing_predict_error():
 
 
 if __name__ == '__main__':
+    set_start_method('spawn', force=True)
     pytest.main([__file__])


### PR DESCRIPTION
### Summary
This PR is an attempt in order to increase code coverage and test again `ests/keras/utils/data_utils_test.py` and `tests/test_multiprocessing.py` with tensorflow backend.

### Related Issues
https://github.com/keras-team/keras/pull/10929, https://github.com/keras-team/keras/pull/10674
