### PR TITLE
Add better error message for model.summary()

### DIFF
--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -1240,10 +1240,10 @@ class Network(Layer):
         """
         if not self.built:
             raise ValueError(
-                'This model has never been called, thus its weights '
-                'have not yet been created, so no summary can be displayed. '
-                'Build the model first '
-                '(e.g. by calling it on some test data).')
+                'This model has not yet been built. '
+                'Build the model first by calling build() or calling fit() with some data. '
+                'Or specify input_shape or batch_input_shape in the first layer for automatic build. '
+                )
         return print_layer_summary(self,
                                    line_length=line_length,
                                    positions=positions,


### PR DESCRIPTION
Fixes #11217 

For detailed discussion consider referring to the issue #11217 

Overview:
In version 2.2.2 of keras building model without specifying `input_shape` or `batch_input_shape` is allowed but for such cases, the model will not be actually built implicitly and you need to build the model explicitly either by calling `model.build()` or else `model.fit()` on some data. If you call `model.summary()` before building the model it will give a "model not built" error but the possible solutions to such error are

1. Add `input_shape` or `batch_input_size` in the first layer
2. Call `model.build()` before `model.summary()`
3. Call `model.fit()` on some data before `model.summary()`

But the previous error message was only suggesting solution 3 which seems unintutive. 

So i have rewritten the error message to suggest all three possible solutions

Checklist

- [X] Build using `python setup.py build`