### PR TITLE
Raise ValueError when merge_mode is unknown in Bidirectional#call

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -540,7 +540,7 @@ class Bidirectional(Wrapper):
         elif self.merge_mode is None:
             output = [y, y_rev]
         else:
-            raise ValueError('Unrecognized merge_mode ' + self.merge_mode)
+					raise ValueError('Unrecognized value for argument merge_mode: %s' % (self.merge_mode))
 
         # Properly set learning phase
         if (getattr(y, '_uses_learning_phase', False) or

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -539,6 +539,8 @@ class Bidirectional(Wrapper):
             output = y * y_rev
         elif self.merge_mode is None:
             output = [y, y_rev]
+        else:
+            raise ValueError('Unrecognized merge_mode ' + self.merge_mode)
 
         # Properly set learning phase
         if (getattr(y, '_uses_learning_phase', False) or

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -540,7 +540,7 @@ class Bidirectional(Wrapper):
         elif self.merge_mode is None:
             output = [y, y_rev]
         else:
-					raise ValueError('Unrecognized value for argument merge_mode: %s' % (self.merge_mode))
+            raise ValueError('Unrecognized value for argument merge_mode: %s' % (self.merge_mode))
 
         # Properly set learning phase
         if (getattr(y, '_uses_learning_phase', False) or


### PR DESCRIPTION
### Summary
In Bidirectional#call , when the merge_mode is unknown, currently there is no error.
We should raise error so that user becomes aware of the missing value.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
