### PR TITLE
Consolidate functionality of ThresholdedReLU and LeakyReLU layers into ReLU layer

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -106,20 +106,26 @@ def softsign(x):
     return K.softsign(x)
 
 
-def relu(x, alpha=0., max_value=None):
+def relu(x, alpha=0., max_value=None, threshold=0.):
     """Rectified Linear Unit.
+
+    With default values, it returns element-wise `max(x, 0)`.
+
+    Otherwise, it follows:
+    `f(x) = max_value` for `x >= max_value`,
+    `f(x) = x` for `threshold <= x < max_value`,
+    `f(x) = alpha * (x - threshold)` otherwise.
 
     # Arguments
         x: Input tensor.
-        alpha: Slope of the negative part. Defaults to zero.
-        max_value: Maximum value for the output.
+        alpha: float. Slope of the negative part. Defaults to zero.
+        max_value: float. Saturation threshold.
+        threshold: float. Threshold value for thresholded activation.
 
     # Returns
-        The (leaky) rectified linear unit activation: `x` if `x > 0`,
-        `alpha * x` if `x < 0`. If `max_value` is defined, the result
-        is truncated to this value.
+        A tensor.
     """
-    return K.relu(x, alpha=alpha, max_value=max_value)
+    return K.relu(x, alpha=alpha, max_value=max_value, threshold=threshold)
 
 
 def tanh(x):

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1767,14 +1767,25 @@ def pool3d(x, pool_size, strides=(1, 1, 1), padding='valid',
     return _postprocess_conv3d_output(x, data_format)
 
 
-def relu(x, alpha=0., max_value=None):
+def relu(x, alpha=0., max_value=None, threshold=0.):
+
     if alpha != 0.:
-        negative_part = C.relu(-x)
-    x = C.relu(x)
+        if threshold != 0.:
+            negative_part = C.relu(-x + threshold)
+        else:
+            negative_part = C.relu(-x)
+
+    if threshold != 0.:
+        x = x * C.greater(x, threshold)
+    else:
+        x = C.relu(x)
+
     if max_value is not None:
         x = C.clip(x, 0.0, max_value)
+
     if alpha != 0.:
         x -= alpha * negative_part
+
     return x
 
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3148,30 +3148,55 @@ def in_test_phase(x, alt, training=None):
 
 # NN OPERATIONS
 
-def relu(x, alpha=0., max_value=None):
+def relu(x, alpha=0., max_value=None, threshold=0.):
     """Rectified linear unit.
 
     With default values, it returns element-wise `max(x, 0)`.
 
+    Otherwise, it follows:
+    `f(x) = max_value` for `x >= max_value`,
+    `f(x) = x` for `threshold <= x < max_value`,
+    `f(x) = alpha * (x - threshold)` otherwise.
+
     # Arguments
         x: A tensor or variable.
         alpha: A scalar, slope of negative section (default=`0.`).
-        max_value: Saturation threshold.
+        max_value: float. Saturation threshold.
+        threshold: float. Threshold value for thresholded activation.
 
     # Returns
         A tensor.
     """
-    if alpha == 0 and max_value == 6:
-        return tf.nn.relu6(x)
 
     if alpha != 0.:
-        x = tf.nn.leaky_relu(x, alpha)
+        if max_value is None and threshold == 0.:
+            return tf.nn.leaky_relu(x, alpha=alpha)
+
+        if threshold != 0.:
+            negative_part = tf.nn.relu(-x + threshold)
+        else:
+            negative_part = tf.nn.relu(-x)
+
+    clip_max = max_value is not None
+
+    if threshold != 0:
+        # computes x for x > threshold else 0
+        x = x * tf.cast(tf.greater(x, threshold), floatx())
+    elif max_value == 6:
+        # if no threshold, then can use nn.relu6 native TF op for performance
+        x = tf.nn.relu6(x)
+        clip_max = False
     else:
         x = tf.nn.relu(x)
 
-    if max_value is not None:
+    if clip_max:
         max_value = _to_tensor(max_value, x.dtype.base_dtype)
-        x = tf.minimum(x, max_value)
+        zero = _to_tensor(0., x.dtype.base_dtype)
+        x = tf.clip_by_value(x, zero, max_value)
+
+    if alpha != 0:
+        alpha = _to_tensor(alpha, x.dtype.base_dtype)
+        x -= alpha * negative_part
     return x
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1707,11 +1707,26 @@ def elu(x, alpha=1.0):
     return T.nnet.elu(x, alpha)
 
 
-def relu(x, alpha=0., max_value=None):
+def relu(x, alpha=0., max_value=None, threshold=0.):
     _assert_has_capability(T.nnet, 'relu')
-    x = T.nnet.relu(x, alpha)
+
+    if alpha != 0.:
+        if threshold != 0.:
+            negative_part = T.nnet.relu(-x + threshold)
+        else:
+            negative_part = T.nnet.relu(-x)
+
+    if threshold != 0.:
+        x = x * T.cast(T.gt(x, threshold), floatx())
+    else:
+        x = T.nnet.relu(x)
+
     if max_value is not None:
-        x = T.minimum(x, max_value)
+        x = T.clip(x, 0.0, max_value)
+
+    if alpha != 0.:
+        x -= alpha * negative_part
+
     return x
 
 

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -965,8 +965,24 @@ class TestBackend(object):
         with pytest.raises(ValueError):
             z = K.dropout(K.variable(val), level=-0.5)
 
+    @pytest.mark.parametrize('alpha,max_value,threshold', [
+        (0.0, None, 0.0),  # standard relu
+        (0.1, None, 0.0),  # set alpha only
+        (0.0, 5.0, 0.0),   # set max_value only
+        (0.0, None, 0.8),  # set threshold only
+        (0.1, 5.0, 0.0),   # set alpha and max_value
+        (0.1, None, 0.8),  # set alpha and threshold
+        (0.0, 5.0, 0.8),   # set max_value and threshold
+        (0.1, 5.0, 0.8),   # set all
+        (0.1, 0.0, 0.8),   # max_value is zero
+        (0.1, 5.0, -2.8),  # threshold is negative
+        (0.1, 9.0, 0.8),   # max_value > 6
+    ])
+    def test_relu(self, alpha, max_value, threshold):
+        check_single_tensor_operation('relu', (4, 2), WITH_NP, alpha=alpha,
+                                      max_value=max_value, threshold=threshold)
+
     def test_nn_operations(self):
-        check_single_tensor_operation('relu', (4, 2), WITH_NP, alpha=0.1, max_value=0.5)
         check_single_tensor_operation('softplus', (4, 10), WITH_NP)
         check_single_tensor_operation('elu', (4, 10), WITH_NP, alpha=0.5)
 

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -226,10 +226,11 @@ def in_test_phase(x, alt, training=None):
     return in_train_phase(alt, x, training=training)
 
 
-def relu(x, alpha=0., max_value=None):
-    y = x * (x > 0) + alpha * x * (x < 0)
+def relu(x, alpha=0., max_value=None, threshold=0.):
+    y = x * (x >= threshold)
     if max_value is not None:
-        y = np.minimum(y, max_value)
+        y = np.clip(y, 0.0, max_value)
+    y += alpha * (x - threshold) * (x < threshold)
     return y
 
 

--- a/tests/keras/layers/advanced_activations_test.py
+++ b/tests/keras/layers/advanced_activations_test.py
@@ -37,8 +37,20 @@ def test_softmax():
 
 
 def test_relu():
-    for max_value in [None, 1., 6.]:
-        layer_test(layers.ReLU, kwargs={'max_value': max_value},
+    layer_test(layers.ReLU,
+               kwargs={'max_value': 10,
+                       'negative_slope': 0.2,
+                       'threshold': 3.0},
+               input_shape=(2, 3, 4))
+
+    # max_value of ReLU layer cannot be negative value
+    with pytest.raises(ValueError):
+        layer_test(layers.ReLU, kwargs={'max_value': -2.0},
+                   input_shape=(2, 3, 4))
+
+    # negative_slope of ReLU layer cannot be negative value
+    with pytest.raises(ValueError):
+        layer_test(layers.ReLU, kwargs={'negative_slope': -2.0},
                    input_shape=(2, 3, 4))
 
 


### PR DESCRIPTION
This PR refers https://github.com/tensorflow/tensorflow/commit/0cf2c612e5e6ff8c5026011e8186056801def747 to consolidate functionality of ```ThresholdedReLU``` and ```LeakyReLU``` layers into ```ReLU``` layer. Then users can use all functionalities in a single layer, and it's also make ```keras``` and ```tf.keras``` API fully compatible.

### Summary

### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
