### PR TITLE
This makes Keras compatible with Tensorflow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='Keras',
                         'six>=1.9.0',
                         'pyyaml',
                         'h5py',
-                        'keras_applications==1.0.4',
+                        'keras_applications>=1.0.4',
                         'keras_preprocessing==1.0.2'],
       extras_require={
           'visualize': ['pydot>=1.2.4'],


### PR DESCRIPTION
### Summary
This may be intentional, but the Keras setup.py install requires 'keras_applications==1.0.4',

see: https://github.com/keras-team/keras/blob/master/setup.py#L40

keras-applications version 1.0.5 is out (and is auto-installed when you install tensorflow==1.11.0rc0 because it requires >=1.0.5).

The issue appears when installing keras and tensorflow with pipenv which can't create a lock file because of incompatible requirements:

`Could not find a version that matches keras-applications==1.0.4,>=1.0.5`

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
