### PR TITLE
Fix h5py error "Unable to create attribute (object header message is too large)"

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -34,7 +34,7 @@ def _serialize_model(model, f, include_optimizer=True):
 
     # Arguments
         model: Keras model instance to be serialized.
-        f: keras.utils.hdf5.HD5Dict instance.
+        f: keras.utils.io_utils.HD5Dict instance.
         include_optimizer: If True, serialize optimizer's state together.
 
     """

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -219,7 +219,7 @@ class H5Dict(object):
                 dataset[()] = val
             else:
                 dataset[:] = val
-        if isinstance(val, list):
+        elif isinstance(val, list):
             # Check that no item in `data` is larger than `HDF5_OBJECT_HEADER_LIMIT`
             # because in that case even chunking the array would not make the saving
             # possible.

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -183,7 +183,7 @@ def test_h5dict_groups():
         group3['y'] = [b'efg', b'hij', b'klmn']
 
         group4 = group3['group4']
-        array = np.random.random((3, 4, 5))
+        array = np.random.random((4, 5, 512))
         group4['z'] = array
 
         f.close()

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -150,7 +150,7 @@ def test_h5dict_attrs():
         f['y'] = [b'efg', b'hij', b'klmn']
 
         # ndarray
-        array = np.random.random((3, 4, 5))
+        array = np.random.random((4, 5, 512))
         f['z'] = array
 
         f.close()


### PR DESCRIPTION
### Summary

Fixes a minor bug introduced by https://github.com/keras-team/keras/commit/9a4c5d8f10667e571c23f1b2f2e0397a85368bea: The `H5Dict` object tried to save (large) `numpy` objects without the `dataset` interface from `h5py`. This produced the error ` Unable to create attribute (object header message is too large)`

### Related Issues

https://github.com/keras-team/keras/issues/11104
https://github.com/Skuldur/Classical-Piano-Composer/issues/8

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
