### PR TITLE
Add `dilated_conv` into reference operations

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1054,11 +1054,12 @@ class TestBackend(object):
         ('conv3d', (2, 5, 4, 6, 3), (2, 2, 3, 3, 4), 'valid', 'channels_last', (2, 2, 2)),
         ('conv3d', (2, 3, 5, 4, 6), (2, 2, 3, 3, 4), 'same', 'channels_first', (2, 2, 2)),
     ])
-    def test_conv_dilation(self, op, input_shape, kernel_shape, padding,
-                           data_format, dilation_rate):
+    def test_dilated_conv(self, op, input_shape, kernel_shape, padding,
+                          data_format, dilation_rate):
         check_two_tensor_operation(
-            op, input_shape, kernel_shape, DILATED_CONV_BACKENDS, padding=padding,
-            data_format=data_format, dilation_rate=dilation_rate, cntk_dynamicity=True)
+            op, input_shape, kernel_shape, WITH_NP,
+            padding=padding, data_format=data_format,
+            dilation_rate=dilation_rate, cntk_dynamicity=True)
 
     @pytest.mark.skipif((K.backend() == 'cntk' and K.dev.type() == 0),
                         reason='cntk only supports dilated conv transpose on GPU')

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -29,6 +29,14 @@ def normalize_conv(func):
             if kwargs['data_format'] == 'channels_last':
                 x = np.transpose(x, (0, 4, 1, 2, 3))
 
+        dilation_rate = kwargs.pop('dilation_rate', 1)
+        if isinstance(dilation_rate, int):
+            dilation_rate = (dilation_rate,) * (x.ndim - 2)
+        for (i, d) in enumerate(dilation_rate):
+            if d > 1:
+                for j in range(w.shape[2 + i] - 1):
+                    w = np.insert(w, 2 * j + 1, 0, axis=2 + i)
+
         y = func(x, w, **kwargs)
 
         if kwargs['data_format'] == 'channels_last':


### PR DESCRIPTION
This PR adds `dilated_conv` into numpy reference operations so that we can reduce CI build time.