### PR TITLE
Add `conv_transpose` into reference operations

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1060,7 +1060,7 @@ class TestBackend(object):
                             padding, data_format):
         check_two_tensor_operation(
             op, input_shape, kernel_shape, WITH_NP,
-            output_shape=output_shape,padding=padding, data_format=data_format,
+            output_shape=output_shape, padding=padding, data_format=data_format,
             cntk_dynamicity=True)
 
     @pytest.mark.skipif((K.backend() == 'cntk' and K.dev.type() == 0),

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -37,21 +37,6 @@ except ImportError:
 WITH_NP = [KTH if K.backend() == 'theano' else KC if K.backend() == 'cntk' else KTF, KNP]
 
 
-# CNTK only supports dilated convolution on GPU
-def get_dilated_conv_backends():
-    backend_list = []
-    if KTF is not None:
-        backend_list.append(KTF)
-    if KTH is not None:
-        backend_list.append(KTH)
-    if KC is not None and KC.dev.type() == 1:
-        backend_list.append(KC)
-    return backend_list
-
-
-DILATED_CONV_BACKENDS = get_dilated_conv_backends()
-
-
 def check_dtype(var, dtype):
     if K._BACKEND == 'theano':
         assert var.dtype == dtype
@@ -1064,6 +1049,20 @@ class TestBackend(object):
             padding=padding, data_format=data_format,
             cntk_dynamicity=True)
 
+    @pytest.mark.parametrize(
+        'op,input_shape,kernel_shape,output_shape,padding,data_format', [
+            ('conv2d_transpose', (2, 5, 6, 3), (3, 3, 2, 3), (2, 5, 6, 2),
+             'same', 'channels_last'),
+            ('conv2d_transpose', (2, 3, 8, 9), (3, 3, 2, 3), (2, 2, 8, 9),
+             'same', 'channels_first'),
+        ])
+    def test_conv_transpose(self, op, input_shape, kernel_shape, output_shape,
+                            padding, data_format):
+        check_two_tensor_operation(
+            op, input_shape, kernel_shape, WITH_NP,
+            output_shape=output_shape,padding=padding, data_format=data_format,
+            cntk_dynamicity=True)
+
     @pytest.mark.skipif((K.backend() == 'cntk' and K.dev.type() == 0),
                         reason='cntk only supports dilated conv on GPU')
     @pytest.mark.parametrize('op,input_shape,kernel_shape,padding,data_format,dilation_rate', [
@@ -1090,10 +1089,10 @@ class TestBackend(object):
             ('conv2d_transpose', (2, 3, 8, 9), (3, 3, 2, 3), (2, 2, 8, 9),
              'same', 'channels_first', (2, 2)),
         ])
-    def test_conv_transpose_dilation(self, op, input_shape, kernel_shape, output_shape,
-                                     padding, data_format, dilation_rate):
+    def test_dilated_conv_transpose(self, op, input_shape, kernel_shape, output_shape,
+                                    padding, data_format, dilation_rate):
         check_two_tensor_operation(
-            op, input_shape, kernel_shape, DILATED_CONV_BACKENDS, output_shape=output_shape,
+            op, input_shape, kernel_shape, WITH_NP, output_shape=output_shape,
             padding=padding, data_format=data_format, dilation_rate=dilation_rate,
             cntk_dynamicity=True)
 

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -87,12 +87,32 @@ def separable_conv(x, w1, w2, padding, data_format):
     return conv(x2, w2, padding=padding, data_format=data_format)
 
 
+def conv_transpose(x, w, output_shape, padding, data_format, dilation_rate=1):
+    if x.ndim == 4:
+        w = np.fliplr(np.flipud(w))
+        w = np.transpose(w, (0, 1, 3, 2))
+    else:
+        w = np.flip(np.fliplr(np.flipud(w)), axis=2)
+        w = np.transpose(w, (0, 1, 2, 4, 3))
+
+    if isinstance(dilation_rate, int):
+        dilation_rate = (dilation_rate,) * (x.ndim - 2)
+    for (i, d) in enumerate(dilation_rate):
+        if d > 1:
+            for j in range(w.shape[i] - 1):
+                w = np.insert(w, 2 * j + 1, 0, axis=i)
+
+    return conv(x, w, padding=padding, data_format=data_format)
+
+
 conv1d = conv
 conv2d = conv
 conv3d = conv
 depthwise_conv2d = depthwise_conv
 separable_conv1d = separable_conv
 separable_conv2d = separable_conv
+conv2d_transpose = conv_transpose
+conv3d_transpose = conv_transpose
 
 
 def pool(x, pool_size, strides, padding, data_format, pool_mode):


### PR DESCRIPTION
This PR adds `conv_transpose` and `dilated_conv_transpose`  into numpy reference operations so that we can reduce CI build time.