### PR TITLE
Travis was ignoring PEP8 failures. Now fixed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,8 +106,7 @@ script:
   - if [[ "$TEST_MODE" == "INTEGRATION_TESTS" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/integration_tests;
     elif [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
-      PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0;
-      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/test_documentation.py;
+      PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0 && py.test tests/test_documentation.py;
     else
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --ignore=tests/keras/legacy/layers_test.py --cov-config .coveragerc --cov=keras tests/;
     fi

--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -1250,8 +1250,10 @@ class Network(Layer):
         if not self.built:
             raise ValueError(
                 'This model has not yet been built. '
-                'Build the model first by calling build() or calling fit() with some data. '
-                'Or specify input_shape or batch_input_shape in the first layer for automatic build. ')
+                'Build the model first by calling build() '
+                'or calling fit() with some data. '
+                'Or specify input_shape or batch_input_shape '
+                'in the first layer for automatic build. ')
         return print_layer_summary(self,
                                    line_length=line_length,
                                    positions=positions,

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -540,7 +540,8 @@ class Bidirectional(Wrapper):
         elif self.merge_mode is None:
             output = [y, y_rev]
         else:
-            raise ValueError('Unrecognized value for argument merge_mode: %s' % (self.merge_mode))
+            raise ValueError('Unrecognized value for argument '
+                             'merge_mode: %s' % (self.merge_mode))
 
         # Properly set learning phase
         if (getattr(y, '_uses_learning_phase', False) or

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,10 +7,6 @@ addopts=-v
 # Do not run tests in the build folder
 norecursedirs= build
 
-# Running all tests should take less than 12 minutes.
-# Otherwise, something went wrong.
-timeout = 720
-
 # PEP-8 The following are ignored:
 # E501 line too long (82 > 79 characters)
 # E402 module level import not at top of file - temporary measure to continue adding ros python packaged in sys.path

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,10 @@ addopts=-v
 # Do not run tests in the build folder
 norecursedirs= build
 
+# Running all tests should take less than 12 minutes.
+# Otherwise, something went wrong.
+timeout = 720
+
 # PEP-8 The following are ignored:
 # E501 line too long (82 > 79 characters)
 # E402 module level import not at top of file - temporary measure to continue adding ros python packaged in sys.path


### PR DESCRIPTION
### Summary

Before, Travis was ignoring PEP8 failures. I think it was since #11163. My take on it is that travis only cares about the last exit code (with `$?` or something like that) after each instruction (at each `-` symbol). I think chaining the instructions with `&&` will solve the issue.

### Related Issues

#11163
#11258
#11254

### PR Overview

There is the fix of travis.yml and also fixing the pep8 errors which were merged into master since the apparition of the bug.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
