### PR TITLE
Added a global timeout for the test suite.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,7 @@ addopts=-v
 # Do not run tests in the build folder
 norecursedirs= build
 
-# Running all tests should take lass than 12 minutes.
+# Running all tests should take less than 12 minutes.
 # Otherwise, something went wrong.
 timeout = 720
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,10 @@ addopts=-v
 # Do not run tests in the build folder
 norecursedirs= build
 
+# Running all tests should take lass than 12 minutes.
+# Otherwise, something went wrong.
+timeout = 720
+
 # PEP-8 The following are ignored:
 # E501 line too long (82 > 79 characters)
 # E402 module level import not at top of file - temporary measure to continue adding ros python packaged in sys.path


### PR DESCRIPTION
### Summary

The stalling build is a big issue. We need tools to be able to debug it.
I believe we should merge this into master and wait until we have the timeout issue again to see a stacktrace.

### Related Issues

### PR Overview

If the test suite is taking more than 12 minutes to run, stop the run and give a stacktrace.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
