### PR TITLE
DOC: Add Conv3DTranspose class to autogen.py.

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -174,6 +174,7 @@ PAGES = [
             layers.SeparableConv2D,
             layers.Conv2DTranspose,
             layers.Conv3D,
+            layers.Conv3DTranspose,
             layers.Cropping1D,
             layers.Cropping2D,
             layers.Cropping3D,


### PR DESCRIPTION
### Summary
Not sure if it was intentionally left out, but `Conv3DTranspose` is not showing up in the docs at: https://keras.io/layers/convolutional/ 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
