### PR TITLE
Show time spent in the warning of slow progress

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -118,7 +118,8 @@ class CallbackList(object):
         if (self._delta_t_batch > 0. and
            (delta_t_median > 0.95 * self._delta_t_batch and delta_t_median > 0.1)):
             warnings.warn('Method on_batch_end() is slow compared '
-                          'to the batch update (%f) spending (%d). Check your callbacks.'
+                          'to the batch update (%f) spending (%d).'
+                          ' Check your callbacks.'
                           % (delta_t_median, self._delta_t_batch))
 
     def on_train_begin(self, logs=None):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -118,8 +118,8 @@ class CallbackList(object):
         if (self._delta_t_batch > 0. and
            (delta_t_median > 0.95 * self._delta_t_batch and delta_t_median > 0.1)):
             warnings.warn('Method on_batch_end() is slow compared '
-                          'to the batch update (%f). Check your callbacks.'
-                          % delta_t_median)
+                          'to the batch update (%f) spending (%d). Check your callbacks.'
+                          % (delta_t_median, self._delta_t_batch))
 
     def on_train_begin(self, logs=None):
         """Called at the beginning of training.

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -117,9 +117,9 @@ class CallbackList(object):
         delta_t_median = np.median(self._delta_ts_batch_end)
         if (self._delta_t_batch > 0. and
            (delta_t_median > 0.95 * self._delta_t_batch and delta_t_median > 0.1)):
-            warnings.warn('Method on_batch_end() is slow compared '
-                          'to the batch update (%f) spending (%d).'
-                          ' Check your callbacks.'
+            warnings.warn('In your callbacks, method `on_batch_end()` '
+                          'is slow compared to a model step '
+                          '(%f vs %f). Check your callbacks.'
                           % (delta_t_median, self._delta_t_batch))
 
     def on_train_begin(self, logs=None):


### PR DESCRIPTION
In the warning message of on_batch_end, display the time spent for the batch.
This would give more clue to the user.

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
