### PR TITLE
Gracefully handle legacy Sequential configs

### DIFF
--- a/keras/engine/sequential.py
+++ b/keras/engine/sequential.py
@@ -292,7 +292,6 @@ class Sequential(Model):
             build_input_shape = config.get('build_input_shape')
             layer_configs = config['layers']
         else:  # legacy config file
-            warnings.warn('Using a legacy config file.')
             name = build_input_shape = None
             layer_configs = config
         model = cls(name=name)

--- a/keras/engine/sequential.py
+++ b/keras/engine/sequential.py
@@ -291,6 +291,10 @@ class Sequential(Model):
             name = config['name']
             build_input_shape = config.get('build_input_shape')
             layer_configs = config['layers']
+        else:  # legacy config file
+            warnings.warn('Using a legacy config file.')
+            name = build_input_shape = None
+            layer_configs = config
         model = cls(name=name)
         for conf in layer_configs:
             layer = layer_module.deserialize(conf,


### PR DESCRIPTION
### Summary

In a recent change to Keras (#11133) incorporated in 2.2.3, `name` was added to the Sequential config. From the release notes:

> **Breaking Changes**
> Modify the return value of Sequential.get_config(). Previously, the return value was a list of the config dictionaries of the layers of the model. Now, the return value is a dictionary with keys layers, name, and an optional key build_input_shape. The old config is equivalent to new_config['layers']. This makes the output of get_config consistent across all model classes.

However, Keras now raises an `UnboundLocalError` exception whenever loading a legacy configuration file. In `from_config`, `name` can be undefined if this variable is not present in the config, and in line 298 of the modified file, is used by `model = cls(name=name)`.

I modified the code such that legacy configs still load, but throws a warning. Maybe a different behavior is desired, but Keras, in my opinion, shouldn't crash like this (especially without any warnings).

### Related Issues

#11133 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
