### PR TITLE
Fix `fit_generator` for `workers=0`

### DIFF
--- a/keras/engine/training_generator.py
+++ b/keras/engine/training_generator.py
@@ -124,7 +124,8 @@ def fit_generator(model,
             elif val_gen:
                 val_data = validation_data
                 if isinstance(val_data, Sequence):
-                    val_enqueuer_gen = iter_sequence_infinite(generator)
+                    val_enqueuer_gen = iter_sequence_infinite(val_data)
+                    validation_steps = validation_steps or len(val_data)
                 else:
                     val_enqueuer_gen = val_data
             else:

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -468,6 +468,19 @@ def test_model_methods():
     assert trained_batches == list(range(12)) * 5
     assert len(val_seq.logs) == 12 * 5
 
+    # test for workers = 0
+    trained_epochs = []
+    trained_batches = []
+    val_seq = RandomSequence(4)
+    out = model.fit_generator(generator=RandomSequence(3),
+                              epochs=5,
+                              validation_data=val_seq,
+                              callbacks=[tracker_cb],
+                              workers=0)
+    assert trained_epochs == [0, 1, 2, 3, 4]
+    assert trained_batches == list(range(12)) * 5
+    assert len(val_seq.logs) == 12 * 5
+
     # fit_generator will throw an exception
     # if steps is unspecified for regular generator
     with pytest.raises(ValueError):


### PR DESCRIPTION
### Summary
This PR provides fix for `engine.training_generator.fit_generator` when `workers=0`.
It used train data for validation and ignored `len(val_data)` when `val_data` was instance of `keras.Sequence`

### Related Issues
[#10855](https://github.com/keras-team/keras/issues/10855)

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
