### PR TITLE
Update tensorflow_backend.py

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1905,17 +1905,17 @@ def batch_normalization(x, mean, var, beta, gamma, axis=-1, epsilon=1e-3):
             # The mean / var / beta / gamma may be processed by broadcast
             # so it may have extra axes with 1, it is not needed and should be removed
             if ndim(mean) > 1:
-                mean = tf.reshape(mean, (-1))
+                mean = tf.reshape(mean, [-1])
             if ndim(var) > 1:
-                var = tf.reshape(var, (-1))
+                var = tf.reshape(var, [-1])
             if beta is None:
                 beta = zeros_like(mean)
             elif ndim(beta) > 1:
-                beta = tf.reshape(beta, (-1))
+                beta = tf.reshape(beta, [-1])
             if gamma is None:
                 gamma = ones_like(mean)
             elif ndim(gamma) > 1:
-                gamma = tf.reshape(gamma, (-1))
+                gamma = tf.reshape(gamma, [-1])
             y, _, _ = tf.nn.fused_batch_norm(
                 x,
                 gamma,


### PR DESCRIPTION
From line 1907 - 1918: when call tf.reshape(x, shape), (*before*)shape=(-1) will raise ValueError: Shape must be rank 1 but is rank 0 ...
I think (-1) in python refers to the Rank-0 shape, though [-1] or (-1,) refers to the Rank-1 shape instead.

It was also strange that it only raised error when 'image_data_format' was set to 'channels_first', not 'channels_last'.

Test case:

from keras.layers import Conv2D, ZeroPadding2D
from keras.layers.normalization import BatchNormalization
from keras import backend as K
K.set_image_data_format('channels_first')

X_input = Input((3, 96, 96))
X = ZeroPadding2D((3, 3))(X_input)
X = Conv2D(64, (7, 7), strides=(2, 2))(X)
X = BatchNormalization(axis=1)(X)  # raise error at this line
...

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
