### PR TITLE
Load model callbacks

### DIFF
--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -820,6 +820,7 @@ def test_preprocess_weights_for_loading_gru_incompatible():
                           'GRU(reset_after=True) is not compatible with '
                           'GRU(reset_after=False)')
 
+
 @patch('keras.optimizers.Optimizer.set_weights')
 @patch('keras.backend.batch_set_value')
 def test_load_callbacks(set_weights, set_value):


### PR DESCRIPTION
### Summary
Call set_model on callbacks during load_model

The load_model function builds the model from the saved object, and
implicitly sets the model in the backed when the weights are set.

Callbacks that require set_model to be called before the model is
set on the backend can fail to operate on loaded models as a result.

This commit adds the ability to pass callbacks to the load_model function.### Summary

### Related Issues
Fixes #11279
### PR Overview

- [ Y ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ N ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ Y ] This PR is backwards compatible [y/n]
- [ Y ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
