### PR TITLE
Fix code examples in multiple_gpu missing after the document is generated

### DIFF
--- a/keras/utils/multi_gpu_utils.py
+++ b/keras/utils/multi_gpu_utils.py
@@ -59,7 +59,9 @@ def multi_gpu_model(model, gpus=None, cpu_merge=True, cpu_relocation=False):
         A Keras `Model` instance which can be used just like the initial
         `model` argument, but which distributes its workload on multiple GPUs.
 
-    # Example 1 - Training models with weights merge on CPU
+    # Examples
+
+    **Training models with weights merge on CPU.**
 
     ```python
         import tensorflow as tf
@@ -100,7 +102,7 @@ def multi_gpu_model(model, gpus=None, cpu_merge=True, cpu_relocation=False):
         model.save('my_model.h5')
     ```
 
-    # Example 2 - Training models with weights merge on CPU using cpu_relocation
+    **Training models with weights merge on CPU using cpu_relocation.**
 
     ```python
          ..
@@ -117,7 +119,7 @@ def multi_gpu_model(model, gpus=None, cpu_merge=True, cpu_relocation=False):
          ..
     ```
 
-    # Example 3 - Training models with weights merge on GPU (recommended for NV-link)
+    **Training models with weights merge on GPU (recommended for NV-link).**
 
     ```python
          ..


### PR DESCRIPTION
### Summary
It seems code blocks in `multiple_gpu.py` ([Link][1]) are missing after the document is generated.
<img width="590" alt="image" src="https://user-images.githubusercontent.com/1214890/46583351-f4a0a600-ca55-11e8-8701-87c392c5aabc.png"> 

[1]: https://keras.io/utils/#multi_gpu_model
### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)