### PR TITLE
Converted the print calls in the backend package initialization into Python logging calls

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import os
 import json
-import sys
+import logging
 import importlib
 from .common import epsilon
 from .common import floatx
@@ -12,6 +12,9 @@ from .common import cast_to_floatx
 from .common import image_data_format
 from .common import set_image_data_format
 from .common import normalize_data_format
+
+# Setup logging
+logger = logging.getLogger(__name__)
 
 # Set Keras base dir path given KERAS_HOME env variable, if applicable.
 # Otherwise either ~/.keras or /tmp.
@@ -79,13 +82,13 @@ if 'KERAS_BACKEND' in os.environ:
 
 # Import backend functions.
 if _BACKEND == 'cntk':
-    sys.stderr.write('Using CNTK backend\n')
+    logger.debug('Using CNTK backend')
     from .cntk_backend import *
 elif _BACKEND == 'theano':
-    sys.stderr.write('Using Theano backend.\n')
+    logger.debug('Using Theano backend')
     from .theano_backend import *
 elif _BACKEND == 'tensorflow':
-    sys.stderr.write('Using TensorFlow backend.\n')
+    logger.debug('Using TensorFlow backend')
     from .tensorflow_backend import *
 else:
     # Try and load external backend.
@@ -103,7 +106,7 @@ else:
             # Make sure we don't override any entries from common, such as epsilon.
             if k not in namespace:
                 namespace[k] = v
-        sys.stderr.write('Using ' + _BACKEND + ' backend.\n')
+        logger.debug('Using ' + _BACKEND + ' backend')
     except ImportError:
         raise ValueError('Unable to import backend : ' + str(_BACKEND))
 


### PR DESCRIPTION
### Summary

This pull request moves from printing on stderr the "Using X backend" message to sending it to the Python logging module in the backend package `__init__.py` file.

The log level for these messages has been set to "debug" as if everything works as expected there is no need to inform about which backend is used. On the other hand, I understand that maintainers might want to elevate this specific message to an "info".

### Related Issues

#1406 
#11332 

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
