### PR TITLE
Tensorboard to get gradients only for trainable weights

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -792,7 +792,7 @@ class TensorBoard(Callback):
         if self.histogram_freq and self.merged is None:
             for layer in self.model.layers:
 
-                for weight in layer.weights:
+                for weight in layer.trainable_weights:
                     mapped_weight_name = weight.name.replace(':', '_')
                     tf.summary.histogram(mapped_weight_name, weight)
                     if self.write_grads:


### PR DESCRIPTION
### Summary
For certain operations like moving_mean, there will be no gradients. However the TensorBoard callback tries to calculate one and returns with the error 
"
ValueError: An operation has `None` for gradient. Please make sure that all of your ops have a gradient defined (i.e. are differentiable). Common ops without gradient: K.argmax, K.round, K.eval.
"
The fix for this is to explicitly want histograms and gradients to be computed for trainable weights only.

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)