### PR TITLE
Add a to_ordinal util function

### DIFF
--- a/keras/utils/__init__.py
+++ b/keras/utils/__init__.py
@@ -23,5 +23,6 @@ from .layer_utils import get_source_inputs
 from .layer_utils import print_summary
 from .vis_utils import plot_model
 from .np_utils import to_categorical
+from .np_utils import to_ordinal
 from .np_utils import normalize
 from .multi_gpu_utils import multi_gpu_model

--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -55,6 +55,36 @@ def to_categorical(y, num_classes=None, dtype='float32'):
     return categorical
 
 
+def to_ordinal(y, num_classes=None):
+    """Converts a class vector (integers representing ordinal values) to multi-hot binary class matrix.
+
+    E.g. for use with binary_crossentropy.
+
+    # Arguments
+        y: class vector to be converted into a matrix
+            (integers from 0 to num_classes).
+        num_classes: total number of classes.
+
+    # Returns
+        A binary matrix representation of the input. The classes axis
+        is placed last.
+    """
+    y = np.array(y, dtype='int')
+    input_shape = y.shape
+    if input_shape and input_shape[-1] == 1 and len(input_shape) > 1:
+        input_shape = tuple(input_shape[:-1])
+    y = y.ravel()
+    if not num_classes:
+        num_classes = np.max(y) + 1
+    n = y.shape[0]
+    ordinal = np.zeros((n, num_classes - 1), dtype=np.float32)
+    for i, yi in enumerate(y):
+        ordinal[i, :yi] = 1
+    output_shape = input_shape + (num_classes - 1,)
+    ordinal = np.reshape(ordinal, output_shape)
+    return ordinal
+
+
 def normalize(x, axis=-1, order=2):
     """Normalizes a Numpy array.
 

--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -55,7 +55,7 @@ def to_categorical(y, num_classes=None, dtype='float32'):
     return categorical
 
 
-def to_ordinal(y, num_classes=None):
+def to_ordinal(y, num_classes=None, dtype='float32'):
     """Converts a class vector (integers representing ordinal values) to multi-hot binary class matrix.
 
     E.g. for use with binary_crossentropy.
@@ -68,6 +68,23 @@ def to_ordinal(y, num_classes=None):
     # Returns
         A binary matrix representation of the input. The classes axis
         is placed last.
+
+    # Example
+
+    ```python
+    # Consider an array of 5 labels out of a set of 3 classes {0, 1, 2}:
+    > labels
+    array([0, 2, 1, 2, 0])
+    # `to_ordinal` converts this into a matrix with as many
+    # columns are there are classes, minus one, because the
+    # first class is represented by a zero vector.
+    > to_categorical(labels)
+    array([[ 0.,  0.],
+           [ 1.,  1.],
+           [ 1.,  0.],
+           [ 1.,  1.],
+           [ 0.,  0.]], dtype=float32)
+    ```
     """
     y = np.array(y, dtype='int')
     input_shape = y.shape
@@ -77,7 +94,7 @@ def to_ordinal(y, num_classes=None):
     if not num_classes:
         num_classes = np.max(y) + 1
     n = y.shape[0]
-    ordinal = np.zeros((n, num_classes - 1), dtype=np.float32)
+    ordinal = np.zeros((n, num_classes - 1), dtype=dtype)
     for i, yi in enumerate(y):
         ordinal[i, :yi] = 1
     output_shape = input_shape + (num_classes - 1,)

--- a/tests/keras/utils/np_utils_test.py
+++ b/tests/keras/utils/np_utils_test.py
@@ -2,7 +2,7 @@
 """
 import numpy as np
 import pytest
-from keras.utils import to_categorical
+from keras.utils import to_categorical, to_ordinal
 
 
 def test_to_categorical():
@@ -27,6 +27,28 @@ def test_to_categorical():
         assert np.all(one_hot.sum(axis=-1) == 1)
         # Get original labels back from one hots
         assert np.all(np.argmax(one_hot, -1).reshape(label.shape) == label)
+
+
+def test_to_ordinal():
+    num_classes = 5
+    shapes = [(1,), (3,), (4, 3), (5, 4, 3), (3, 1), (3, 2, 1)]
+    expected_shapes = [(1, num_classes - 1),
+                       (3, num_classes - 1),
+                       (4, 3, num_classes - 1),
+                       (5, 4, 3, num_classes - 1),
+                       (3, num_classes - 1),
+                       (3, 2, num_classes - 1)]
+    labels = [np.random.randint(0, num_classes, shape) for shape in shapes]
+    multi_hots = [to_ordinal(label, num_classes) for label in labels]
+    for label, multi_hot, expected_shape in zip(labels,
+                                                multi_hots,
+                                                expected_shapes):
+        # Check shape
+        assert multi_hot.shape == expected_shape
+        # Make sure there are only 0s and 1s
+        assert np.array_equal(multi_hot, multi_hot.astype(bool))
+        # Get original labels back from multi hot
+        assert np.all(multi_hot.sum(axis=-1).reshape(label.shape) == label)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

This PR adds a to_ordinal function for multi-hot encoding ordinal values, as most (I think ?) neural network libraries lack ordinal values support and often use standard one-hot encoding which loose the ordering information of the target classes.

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date) - docs not yet updated
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
