### PR TITLE
Parametrizing the metrics tests to get one test per metric.

### DIFF
--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -28,20 +28,19 @@ all_sparse_metrics = [
 ]
 
 
-def test_metrics():
+@pytest.mark.parametrize('metric', all_metrics)
+def test_metrics(metric):
     y_a = K.variable(np.random.random((6, 7)))
     y_b = K.variable(np.random.random((6, 7)))
-    for metric in all_metrics:
-        output = metric(y_a, y_b)
-        print(metric.__name__)
-        assert K.eval(output).shape == (6,)
+    output = metric(y_a, y_b)
+    assert K.eval(output).shape == (6,)
 
 
-def test_sparse_metrics():
-    for metric in all_sparse_metrics:
-        y_a = K.variable(np.random.randint(0, 7, (6,)), dtype=K.floatx())
-        y_b = K.variable(np.random.random((6, 7)), dtype=K.floatx())
-        assert K.eval(metric(y_a, y_b)).shape == (6,)
+@pytest.mark.parametrize('metric', all_sparse_metrics)
+def test_sparse_metrics(metric):
+    y_a = K.variable(np.random.randint(0, 7, (6,)), dtype=K.floatx())
+    y_b = K.variable(np.random.random((6, 7)), dtype=K.floatx())
+    assert K.eval(metric(y_a, y_b)).shape == (6,)
 
 
 def test_sparse_categorical_accuracy_correctness():


### PR DESCRIPTION
### Summary

We can take advantage of pytest's error reporting when testing metrics to get one test per metric and have better insights in case of bugs.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
