### PR TITLE
Added the gather operation in reference_operations.py.

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -316,9 +316,9 @@ class TestBackend(object):
         ref = np.arange(np.prod(shape)).reshape(shape)
         inds = [1, 3, 7, 9]
         t_list = [k.gather(k.variable(ref), k.variable(inds, dtype='int32'))
-                  for k in BACKENDS]
+                  for k in WITH_NP]
         z_list = [k.eval(k.gather(k.variable(ref), k.variable(inds, dtype='int32')))
-                  for k in BACKENDS]
+                  for k in WITH_NP]
 
         assert_list_pairwise(z_list)
         assert_list_keras_shape(t_list, z_list)

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -447,6 +447,10 @@ def batch_flatten(x):
     return np.reshape(x, (x.shape[0], -1))
 
 
+def gather(reference, indices):
+    return reference[indices]
+
+
 def eval(x):
     return x
 


### PR DESCRIPTION
### Summary

Added the gather operation in reference_operations.py. Thus making  the tests more indépendant and get a better error reporting in case of changes. Will allow to skip some backend installs in the future.

### Related Issues

#11068

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
