### PR TITLE
Added get_value, count_params, int_shape and get_variable_shape to reference_operations.py

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -331,19 +331,20 @@ class TestBackend(object):
             y = K.gather(x, indices)
             assert y._keras_shape == (5, 6, 3, 4)
 
-    def test_value_manipulation(self):
+    @pytest.mark.parametrize('function_name',
+                             ['get_value', 'count_params',
+                              'int_shape', 'get_variable_shape'])
+    def test_value_manipulation(self, function_name):
         val = np.random.random((4, 2))
-        for function_name in ['get_value', 'count_params',
-                              'int_shape', 'get_variable_shape']:
-            v_list = [getattr(k, function_name)(k.variable(val))
-                      for k in BACKENDS]
+        v_list = [getattr(k, function_name)(k.variable(val))
+                  for k in WITH_NP]
 
-            if function_name == 'get_value':
-                assert_list_pairwise(v_list)
-            else:
-                assert_list_pairwise(v_list, shape=False, allclose=False, itself=True)
+        if function_name == 'get_value':
+            assert_list_pairwise(v_list)
+        else:
+            assert_list_pairwise(v_list, shape=False, allclose=False, itself=True)
 
-        # print_tensor
+    def test_print_tensor(self):
         check_single_tensor_operation('print_tensor', (), WITH_NP)
         check_single_tensor_operation('print_tensor', (2,), WITH_NP)
         check_single_tensor_operation('print_tensor', (4, 3), WITH_NP)

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -451,6 +451,22 @@ def eval(x):
     return x
 
 
+def get_value(x):
+    return x
+
+
+def count_params(x):
+    return x.size
+
+
+def int_shape(x):
+    return x.shape
+
+
+def get_variable_shape(x):
+    return int_shape(x)
+
+
 def dtype(x):
     return x.dtype.name
 


### PR DESCRIPTION
### Summary

Added the four functions and adapted the backend tests accordingly.

Also made 5 tests instead of one for more focused error reporting.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
