### PR TITLE
Simplify documentation comment to conform to line-length convention

### DIFF
--- a/keras/backend/common.py
+++ b/keras/backend/common.py
@@ -111,7 +111,7 @@ def cast_to_floatx(x):
 
 
 def image_data_format():
-    """Returns the default image data format convention ('channels_first' or 'channels_last').
+    """Returns the default image data format convention.
 
     # Returns
         A string, either `'channels_first'` or `'channels_last'`

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,7 +21,6 @@ pep8ignore=* E402 \
            * E731 \
            * W503 \
            keras/backend/cntk_backend.py E501 \
-           keras/backend/common.py E501 \
            keras/backend/tensorflow_backend.py E501 \
            keras/backend/theano_backend.py E501 \
            tests/keras/backend/backend_test.py E501


### PR DESCRIPTION
### Summary

Simplify comment (removing redundant information) to conform to line-length convention.

### Related Issues

Part of #11391

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
