### PR TITLE
Fix Issue #11384 - Explaining how to load external backends in the documentation

### DIFF
--- a/docs/templates/backend.md
+++ b/docs/templates/backend.md
@@ -45,6 +45,22 @@ KERAS_BACKEND=tensorflow python -c "from keras import backend"
 Using TensorFlow backend.
 ```
 
+In keras it is possible to load more backends than `"tensorflow"`, `"theano"`, and `"cntk"`. keras can use external backends as well, and this can be performed by changing the `keras.json` configuration file, and the `"backend"` setting. Suppose you have a python file called mxnet_backend.py that you wanted to use as your external backend. The `keras.json` configuration file would be changed as follows:
+
+```
+{
+    "image_data_format": "channels_last",
+    "epsilon": 1e-07,
+    "floatx": "float32",
+    "backend": "mxnet_backend"
+}
+```
+An external backend must be validated in order to be used, a valid backend is one that meets the following required entries:
+```python
+required_entries = ['placeholder', 'variable', 'function']
+```
+If an external backend is not valid due to missing a required entry, an error will be logged notifying which entry/entries are missing.
+
 ----
 
 ## keras.json details
@@ -69,22 +85,6 @@ You can change these settings by editing `$HOME/.keras/keras.json`.
 * `epsilon`: Float, a numeric fuzzing constant used to avoid dividing by zero in some operations.
 * `floatx`: String, `"float16"`, `"float32"`, or `"float64"`. Default float precision.
 * `backend`: String, `"tensorflow"`, `"theano"`, or `"cntk"`.
-
-In keras it is possible to load more backends than `"tensorflow"`, `"theano"`, and `"cntk"`. keras can use external backends as well, and this can be performed by changing the `keras.json` configuration file, and the `"backend"` setting. Suppose you have a python file called mxnet_backend.py that you wanted to use as your external backend. The `keras.json` configuration file would be changed as follows:
-
-```
-{
-    "image_data_format": "channels_last",
-    "epsilon": 1e-07,
-    "floatx": "float32",
-    "backend": "mxnet_backend"
-}
-```
-An external backend must be validated in order to be used, a valid backend is one that meets the following required entries:
-```python
-required_entries = ['placeholder', 'variable', 'function']
-```
-If an external backend is not valid due to missing a required entry, an error will be logged notifying which entry/entries are missing.
 
 ----
 

--- a/docs/templates/backend.md
+++ b/docs/templates/backend.md
@@ -70,6 +70,22 @@ You can change these settings by editing `$HOME/.keras/keras.json`.
 * `floatx`: String, `"float16"`, `"float32"`, or `"float64"`. Default float precision.
 * `backend`: String, `"tensorflow"`, `"theano"`, or `"cntk"`.
 
+In keras it is possible to load more backends than `"tensorflow"`, `"theano"`, and `"cntk"`. This can be performed by changing the `keras.json` configuration file, and the `"backend"` setting. Suppose you have a python file called mxnet_backend.py, changing `keras.json` would be as follows:
+
+```
+{
+    "image_data_format": "channels_last",
+    "epsilon": 1e-07,
+    "floatx": "float32",
+    "backend": "mxnet_backend"
+}
+```
+In order to add an external backend, it must be validated. A valid external backend must have the following required entires: 
+```python
+required_entries = ['placeholder', 'variable', 'function']
+```
+
+
 ----
 
 ## Using the abstract Keras backend to write new code

--- a/docs/templates/backend.md
+++ b/docs/templates/backend.md
@@ -80,11 +80,11 @@ In keras it is possible to load more backends than `"tensorflow"`, `"theano"`, a
     "backend": "mxnet_backend"
 }
 ```
-In order to add an external backend, it must be validated. A valid external backend must have the following required entires: 
+In order to add an external backend, it must be validated. A valid external backend must have the following required entries: 
 ```python
 required_entries = ['placeholder', 'variable', 'function']
 ```
-
+If an external backend is not valid due to missing a required entry, an error will be logged notifying which entry/entries are missing.
 
 ----
 

--- a/docs/templates/backend.md
+++ b/docs/templates/backend.md
@@ -45,20 +45,18 @@ KERAS_BACKEND=tensorflow python -c "from keras import backend"
 Using TensorFlow backend.
 ```
 
-In keras it is possible to load more backends than `"tensorflow"`, `"theano"`, and `"cntk"`. keras can use external backends as well, and this can be performed by changing the `keras.json` configuration file, and the `"backend"` setting. Suppose you have a python file called mxnet_backend.py that you wanted to use as your external backend. The `keras.json` configuration file would be changed as follows:
+In Keras it is possible to load more backends than `"tensorflow"`, `"theano"`, and `"cntk"`. Keras can use external backends as well, and this can be performed by changing the `keras.json` configuration file, and the `"backend"` setting. Suppose you have a Python module called `my_module` that you wanted to use as your external backend. The `keras.json` configuration file would be changed as follows:
 
 ```
 {
     "image_data_format": "channels_last",
     "epsilon": 1e-07,
     "floatx": "float32",
-    "backend": "mxnet_backend"
+    "backend": "my_package.my_module"
 }
 ```
-An external backend must be validated in order to be used, a valid backend is one that meets the following required entries:
-```python
-required_entries = ['placeholder', 'variable', 'function']
-```
+An external backend must be validated in order to be used, a valid backend must have the following functions: `placeholder`, `variable` and `function`.
+
 If an external backend is not valid due to missing a required entry, an error will be logged notifying which entry/entries are missing.
 
 ----

--- a/docs/templates/backend.md
+++ b/docs/templates/backend.md
@@ -70,7 +70,7 @@ You can change these settings by editing `$HOME/.keras/keras.json`.
 * `floatx`: String, `"float16"`, `"float32"`, or `"float64"`. Default float precision.
 * `backend`: String, `"tensorflow"`, `"theano"`, or `"cntk"`.
 
-In keras it is possible to load more backends than `"tensorflow"`, `"theano"`, and `"cntk"`. This can be performed by changing the `keras.json` configuration file, and the `"backend"` setting. Suppose you have a python file called mxnet_backend.py, changing `keras.json` would be as follows:
+In keras it is possible to load more backends than `"tensorflow"`, `"theano"`, and `"cntk"`. keras can use external backends as well, and this can be performed by changing the `keras.json` configuration file, and the `"backend"` setting. Suppose you have a python file called mxnet_backend.py that you wanted to use as your external backend. The `keras.json` configuration file would be changed as follows:
 
 ```
 {
@@ -80,7 +80,7 @@ In keras it is possible to load more backends than `"tensorflow"`, `"theano"`, a
     "backend": "mxnet_backend"
 }
 ```
-In order to add an external backend, it must be validated. A valid external backend must have the following required entries: 
+An external backend must be validated in order to be used, a valid backend is one that meets the following required entries:
 ```python
 required_entries = ['placeholder', 'variable', 'function']
 ```


### PR DESCRIPTION
### Summary
Created additional documentation for the "Switching from one backend to another" section of the documentation, including an example of an edited keras.json configuration file.

### Related Issues
Solves issue #11384 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
