### PR TITLE
#11383 Making backend_tests pass PEP8 test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -22,8 +22,7 @@ pep8ignore=* E402 \
            * W503 \
            keras/backend/cntk_backend.py E501 \
            keras/backend/tensorflow_backend.py E501 \
-           keras/backend/theano_backend.py E501 \
-           tests/keras/backend/backend_test.py E501
+           keras/backend/theano_backend.py E501
 
 # Enable line length testing with maximum line length of 85
 pep8maxlinelength = 85

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1,19 +1,20 @@
-import pytest
-from numpy.testing import assert_allclose
-import numpy as np
-import scipy.sparse as sparse
 import warnings
+
+import numpy as np
+import pytest
+import reference_operations as KNP
+import scipy.sparse as sparse
+from numpy.testing import assert_allclose
 
 from keras import backend as K
 from keras.backend import floatx, set_floatx, variable
 from keras.utils.conv_utils import convert_kernel
-import reference_operations as KNP
-
 
 BACKENDS = []  # Holds a list of all available back-ends
 
 try:
     from keras.backend import cntk_backend as KC
+
     BACKENDS.append(KC)
 except ImportError:
     KC = None
@@ -21,6 +22,7 @@ except ImportError:
 
 try:
     from keras.backend import tensorflow_backend as KTF
+
     BACKENDS.append(KTF)
 except ImportError:
     KTF = None
@@ -28,13 +30,14 @@ except ImportError:
 
 try:
     from keras.backend import theano_backend as KTH
+
     BACKENDS.append(KTH)
 except ImportError:
     KTH = None
     warnings.warn('Could not import the Theano backend')
 
-
-WITH_NP = [KTH if K.backend() == 'theano' else KC if K.backend() == 'cntk' else KTF, KNP]
+WITH_NP = [KTH if K.backend() == 'theano' else KC if K.backend() == 'cntk' else KTF,
+           KNP]
 
 
 def check_dtype(var, dtype):
@@ -67,7 +70,8 @@ def parse_shape_or_val(shape_or_val):
         return shape_or_val, np.random.random(shape_or_val).astype(np.float32) - 0.5
 
 
-def assert_list_pairwise(z_list, shape=True, allclose=True, itself=False, atol=1e-05):
+def assert_list_pairwise(z_list,
+                         shape=True, allclose=True, itself=False, atol=1e-05):
     for (z1, z2) in zip(z_list[1:], z_list[:-1]):
         if shape:
             assert z1.shape == z2.shape
@@ -85,7 +89,8 @@ def assert_list_keras_shape(t_list, z_list):
                     assert t._keras_shape[i] == z.shape[i]
 
 
-def check_single_tensor_operation(function_name, x_shape_or_val, backend_list, **kwargs):
+def check_single_tensor_operation(function_name, x_shape_or_val, backend_list,
+                                  **kwargs):
     shape_or_val = kwargs.pop('shape_or_val', True)
     assert_value_equality = kwargs.pop('assert_value_equality', True)
     cntk_dynamicity = kwargs.pop('cntk_dynamicity', False)
@@ -186,16 +191,20 @@ class TestBackend(object):
         check_single_tensor_operation('eye', 3, WITH_NP, shape_or_val=False)
 
     def test_ones(self):
-        check_single_tensor_operation('ones', (3, 5, 10, 8), WITH_NP, shape_or_val=False)
+        check_single_tensor_operation('ones', (3, 5, 10, 8),
+                                      WITH_NP, shape_or_val=False)
 
     def test_zeros(self):
-        check_single_tensor_operation('zeros', (3, 5, 10, 8), WITH_NP, shape_or_val=False)
+        check_single_tensor_operation('zeros', (3, 5, 10, 8),
+                                      WITH_NP, shape_or_val=False)
 
     def test_ones_like(self):
-        check_single_tensor_operation('ones_like', (3, 5, 10, 8), WITH_NP, shape_or_val=True)
+        check_single_tensor_operation('ones_like', (3, 5, 10, 8),
+                                      WITH_NP, shape_or_val=True)
 
     def test_zeros_like(self):
-        check_single_tensor_operation('zeros_like', (3, 5, 10, 8), WITH_NP, shape_or_val=True)
+        check_single_tensor_operation('zeros_like', (3, 5, 10, 8),
+                                      WITH_NP, shape_or_val=True)
 
     def test_linear_operations(self):
         check_two_tensor_operation('dot', (4, 2), (2, 4), WITH_NP)
@@ -220,10 +229,12 @@ class TestBackend(object):
     def test_random_variables(self):
         check_single_tensor_operation('random_uniform_variable', (2, 3), WITH_NP,
                                       low=0., high=1.,
-                                      shape_or_val=False, assert_value_equality=False)
+                                      shape_or_val=False,
+                                      assert_value_equality=False)
         check_single_tensor_operation('random_normal_variable', (2, 3), WITH_NP,
                                       mean=0., scale=1.,
-                                      shape_or_val=False, assert_value_equality=False)
+                                      shape_or_val=False,
+                                      assert_value_equality=False)
 
     @pytest.mark.skipif(K.backend() != 'tensorflow', reason='Not supported.')
     def test_batch_dot_shape(self):
@@ -274,7 +285,7 @@ class TestBackend(object):
 
         y = K.flatten(x)
         if hasattr(y, '_keras_shape'):
-            assert y._keras_shape == (None, )
+            assert y._keras_shape == (None,)
 
     def test_repeat_elements(self):
         reps = 3
@@ -341,7 +352,8 @@ class TestBackend(object):
             if function_name == 'get_value':
                 assert_list_pairwise(v_list)
             else:
-                assert_list_pairwise(v_list, shape=False, allclose=False, itself=True)
+                assert_list_pairwise(v_list,
+                                     shape=False, allclose=False, itself=True)
 
         # print_tensor
         check_single_tensor_operation('print_tensor', (), WITH_NP)
@@ -360,7 +372,8 @@ class TestBackend(object):
 
         check_single_tensor_operation('mean', (4, 2), WITH_NP)
         check_single_tensor_operation('mean', (4, 2), WITH_NP, axis=1, keepdims=True)
-        check_single_tensor_operation('mean', (4, 2, 3), WITH_NP, axis=-1, keepdims=True)
+        check_single_tensor_operation('mean', (4, 2, 3),
+                                      WITH_NP, axis=-1, keepdims=True)
         check_single_tensor_operation('mean', (4, 2, 3), WITH_NP, axis=[1, -1])
 
         check_single_tensor_operation('var', (4, 2), WITH_NP)
@@ -373,7 +386,8 @@ class TestBackend(object):
         # check_single_tensor_operation('std', (4, 2, 3), BACKENDS, axis=[1, -1])
 
         check_single_tensor_operation('logsumexp', (4, 2), WITH_NP)
-        check_single_tensor_operation('logsumexp', (4, 2), WITH_NP, axis=1, keepdims=True)
+        check_single_tensor_operation('logsumexp', (4, 2),
+                                      WITH_NP, axis=1, keepdims=True)
         check_single_tensor_operation('logsumexp', (4, 2, 3), WITH_NP, axis=[1, -1])
 
         check_single_tensor_operation('prod', (4, 2), WITH_NP)
@@ -611,11 +625,14 @@ class TestBackend(object):
 
         kwargs_list = [
             {'go_backwards': False, 'mask': None},
-            {'go_backwards': False, 'mask': None, 'unroll': True, 'input_length': timesteps},
+            {'go_backwards': False, 'mask': None, 'unroll': True,
+             'input_length': timesteps},
             {'go_backwards': True, 'mask': None},
-            {'go_backwards': True, 'mask': None, 'unroll': True, 'input_length': timesteps},
+            {'go_backwards': True, 'mask': None, 'unroll': True,
+             'input_length': timesteps},
             {'go_backwards': False, 'mask': mask_k},
-            {'go_backwards': False, 'mask': mask_k, 'unroll': True, 'input_length': timesteps},
+            {'go_backwards': False, 'mask': mask_k, 'unroll': True,
+             'input_length': timesteps},
         ]
 
         for (i, kwargs) in enumerate(kwargs_list):
@@ -645,7 +662,8 @@ class TestBackend(object):
                 assert_allclose(y1, y2, atol=1e-05)
                 assert_allclose(h1, h2, atol=1e-05)
             else:
-                assert_allclose(last_output_list[i - 1], last_output_list[i], atol=1e-05)
+                assert_allclose(last_output_list[i - 1], last_output_list[i],
+                                atol=1e-05)
                 assert_allclose(outputs_list[i - 1], outputs_list[i], atol=1e-05)
                 assert_allclose(state_list[i - 1], state_list[i], atol=1e-05)
 
@@ -681,11 +699,14 @@ class TestBackend(object):
 
         kwargs_list = [
             {'go_backwards': False, 'mask': None},
-            {'go_backwards': False, 'mask': None, 'unroll': True, 'input_length': timesteps},
+            {'go_backwards': False, 'mask': None, 'unroll': True,
+             'input_length': timesteps},
             {'go_backwards': True, 'mask': None},
-            {'go_backwards': True, 'mask': None, 'unroll': True, 'input_length': timesteps},
+            {'go_backwards': True, 'mask': None, 'unroll': True,
+             'input_length': timesteps},
             {'go_backwards': False, 'mask': mask_k},
-            {'go_backwards': False, 'mask': mask_k, 'unroll': True, 'input_length': timesteps},
+            {'go_backwards': False, 'mask': mask_k, 'unroll': True,
+             'input_length': timesteps},
         ]
 
         for (i, kwargs) in enumerate(kwargs_list):
@@ -720,7 +741,8 @@ class TestBackend(object):
                 assert_allclose(h11, h21, atol=1e-05)
                 assert_allclose(h12, h22, atol=1e-05)
             else:
-                assert_allclose(last_output_list[i - 1], last_output_list[i], atol=1e-05)
+                assert_allclose(last_output_list[i - 1], last_output_list[i],
+                                atol=1e-05)
                 assert_allclose(outputs_list[i - 1], outputs_list[i], atol=1e-05)
                 assert_allclose(state_list[i - 1][0], state_list[i][0], atol=1e-05)
                 assert_allclose(state_list[i - 1][1], state_list[i][1], atol=1e-05)
@@ -761,8 +783,10 @@ class TestBackend(object):
         output_dim = 3
         timesteps = 6
 
-        input_val = np.random.random((num_samples, timesteps, input_dim)).astype(np.float32)
-        init_state_val = np.random.random((num_samples, output_dim)).astype(np.float32)
+        input_val = np.random.random(
+            (num_samples, timesteps, input_dim)).astype(np.float32)
+        init_state_val = np.random.random(
+            (num_samples, output_dim)).astype(np.float32)
         W_i_val = np.random.random((input_dim, output_dim)).astype(np.float32)
         W_o_val = np.random.random((output_dim, output_dim)).astype(np.float32)
         np_mask = np.random.randint(2, size=(num_samples, timesteps))
@@ -792,11 +816,14 @@ class TestBackend(object):
 
             kwargs_list = [
                 {'go_backwards': False, 'mask': None},
-                {'go_backwards': False, 'mask': None, 'unroll': True, 'input_length': timesteps},
+                {'go_backwards': False, 'mask': None, 'unroll': True,
+                 'input_length': timesteps},
                 {'go_backwards': True, 'mask': None},
-                {'go_backwards': True, 'mask': None, 'unroll': True, 'input_length': timesteps},
+                {'go_backwards': True, 'mask': None, 'unroll': True,
+                 'input_length': timesteps},
                 {'go_backwards': False, 'mask': mask},
-                {'go_backwards': False, 'mask': mask, 'unroll': True, 'input_length': timesteps},
+                {'go_backwards': False, 'mask': mask, 'unroll': True,
+                 'input_length': timesteps},
             ]
 
             for (i, kwargs) in enumerate(kwargs_list):
@@ -968,15 +995,15 @@ class TestBackend(object):
     @pytest.mark.parametrize('alpha,max_value,threshold', [
         (0.0, None, 0.0),  # standard relu
         (0.1, None, 0.0),  # set alpha only
-        (0.0, 5.0, 0.0),   # set max_value only
+        (0.0, 5.0, 0.0),  # set max_value only
         (0.0, None, 0.8),  # set threshold only
-        (0.1, 5.0, 0.0),   # set alpha and max_value
+        (0.1, 5.0, 0.0),  # set alpha and max_value
         (0.1, None, 0.8),  # set alpha and threshold
-        (0.0, 5.0, 0.8),   # set max_value and threshold
-        (0.1, 5.0, 0.8),   # set all
-        (0.1, 0.0, 0.8),   # max_value is zero
+        (0.0, 5.0, 0.8),  # set max_value and threshold
+        (0.1, 5.0, 0.8),  # set all
+        (0.1, 0.0, 0.8),  # max_value is zero
         (0.1, 5.0, -2.8),  # threshold is negative
-        (0.1, 9.0, 0.8),   # max_value > 6
+        (0.1, 9.0, 0.8),  # max_value > 6
     ])
     def test_relu(self, alpha, max_value, threshold):
         check_single_tensor_operation('relu', (4, 2), WITH_NP, alpha=alpha,
@@ -994,21 +1021,28 @@ class TestBackend(object):
         check_single_tensor_operation('softmax', (4, 5, 3), WITH_NP, axis=1)
         check_single_tensor_operation('softmax', (4, 5, 3, 10), WITH_NP, axis=2)
 
-        check_two_tensor_operation('binary_crossentropy', (4, 2), (4, 2), WITH_NP, from_logits=True)
+        check_two_tensor_operation('binary_crossentropy', (4, 2), (4, 2),
+                                   WITH_NP, from_logits=True)
         # cross_entropy call require the label is a valid probability distribution,
         # otherwise it is garbage in garbage out...
-        # due to the algo difference, we can't guarantee CNTK has the same result on the garbage input.
+        # due to the algo difference, we can't guarantee CNTK has the same result
+        # on the garbage input.
         # so create a separate test case for valid label input
         if K.backend() != 'cntk':
-            check_two_tensor_operation('categorical_crossentropy', (4, 2), (4, 2), WITH_NP, from_logits=True)
+            check_two_tensor_operation('categorical_crossentropy', (4, 2), (4, 2),
+                                       WITH_NP, from_logits=True)
         xval = np.asarray([[0.26157712, 0.0432167], [-0.43380741, 0.30559841],
-                           [0.20225059, -0.38956559], [-0.13805378, 0.08506755]], dtype=np.float32)
+                           [0.20225059, -0.38956559], [-0.13805378, 0.08506755]],
+                          dtype=np.float32)
         yval = np.asarray([[0.46221867, 0.53778133], [0.51228984, 0.48771016],
-                           [0.64916514, 0.35083486], [0.47028078, 0.52971922]], dtype=np.float32)
-        check_two_tensor_operation('categorical_crossentropy', yval, xval,
-                                   WITH_NP, cntk_two_dynamicity=True, from_logits=True)
-        check_two_tensor_operation('binary_crossentropy', (4, 2), (4, 2), WITH_NP, from_logits=False)
-        check_two_tensor_operation('categorical_crossentropy', (4, 2), (4, 2), WITH_NP, from_logits=False)
+                           [0.64916514, 0.35083486], [0.47028078, 0.52971922]],
+                          dtype=np.float32)
+        check_two_tensor_operation('categorical_crossentropy', yval, xval, WITH_NP,
+                                   cntk_two_dynamicity=True, from_logits=True)
+        check_two_tensor_operation('binary_crossentropy', (4, 2), (4, 2),
+                                   WITH_NP, from_logits=False)
+        check_two_tensor_operation('categorical_crossentropy', (4, 2), (4, 2),
+                                   WITH_NP, from_logits=False)
 
         check_single_tensor_operation('l2_normalize', (4, 3), WITH_NP, axis=-1)
         check_single_tensor_operation('l2_normalize', (4, 3), WITH_NP, axis=1)
@@ -1021,7 +1055,8 @@ class TestBackend(object):
         predictions = np.random.random((batch_size, num_classes)).astype('float32')
         targets = np.random.randint(num_classes, size=batch_size, dtype='int32')
 
-        # (k == 0 or k > num_classes) does not raise an error but just return an unmeaningful tensor.
+        # (k == 0 or k > num_classes) does not raise an error
+        # but just return an unmeaningful tensor.
         for k in range(num_classes + 1):
             z_list = [b.eval(b.in_top_k(b.variable(predictions, dtype='float32'),
                                         b.variable(targets, dtype='int32'), k))
@@ -1032,7 +1067,8 @@ class TestBackend(object):
         # randomly set half of the predictions to an identical value
         num_identical = num_classes // 2
         for i in range(batch_size):
-            idx_identical = np.random.choice(num_classes, size=num_identical, replace=False)
+            idx_identical = np.random.choice(num_classes,
+                                             size=num_identical, replace=False)
             predictions[i, idx_identical] = predictions[i, 0]
         targets = np.zeros(batch_size, dtype='int32')
 
@@ -1077,14 +1113,19 @@ class TestBackend(object):
 
     @pytest.mark.skipif((K.backend() == 'cntk' and K.dev.type() == 0),
                         reason='cntk only supports dilated conv on GPU')
-    @pytest.mark.parametrize('op,input_shape,kernel_shape,padding,data_format,dilation_rate', [
-        ('conv1d', (2, 8, 3), (4, 3, 2), 'valid', 'channels_last', 2),
-        ('conv1d', (2, 3, 8), (4, 3, 2), 'valid', 'channels_first', 2),
-        ('conv2d', (2, 8, 9, 3), (3, 3, 3, 2), 'same', 'channels_last', (2, 2)),
-        ('conv2d', (2, 3, 9, 8), (4, 3, 3, 4), 'valid', 'channels_first', (2, 2)),
-        ('conv3d', (2, 5, 4, 6, 3), (2, 2, 3, 3, 4), 'valid', 'channels_last', (2, 2, 2)),
-        ('conv3d', (2, 3, 5, 4, 6), (2, 2, 3, 3, 4), 'same', 'channels_first', (2, 2, 2)),
-    ])
+    @pytest.mark.parametrize(
+        'op,input_shape,kernel_shape,padding,data_format,dilation_rate', [
+            ('conv1d', (2, 8, 3), (4, 3, 2), 'valid', 'channels_last', 2),
+            ('conv1d', (2, 3, 8), (4, 3, 2), 'valid', 'channels_first', 2),
+            ('conv2d', (2, 8, 9, 3), (3, 3, 3, 2),
+             'same', 'channels_last', (2, 2)),
+            ('conv2d', (2, 3, 9, 8), (4, 3, 3, 4),
+             'valid', 'channels_first', (2, 2)),
+            ('conv3d', (2, 5, 4, 6, 3), (2, 2, 3, 3, 4),
+             'valid', 'channels_last', (2, 2, 2)),
+            ('conv3d', (2, 3, 5, 4, 6), (2, 2, 3, 3, 4),
+             'same', 'channels_first', (2, 2, 2)),
+        ])
     def test_dilated_conv(self, op, input_shape, kernel_shape, padding,
                           data_format, dilation_rate):
         check_two_tensor_operation(
@@ -1095,14 +1136,16 @@ class TestBackend(object):
     @pytest.mark.skipif((K.backend() == 'cntk' and K.dev.type() == 0),
                         reason='cntk only supports dilated conv transpose on GPU')
     @pytest.mark.parametrize(
-        'op,input_shape,kernel_shape,output_shape,padding,data_format,dilation_rate', [
+        'op,input_shape,kernel_shape,output_shape,padding,data_format,dilation_rate',
+        [
             ('conv2d_transpose', (2, 5, 6, 3), (3, 3, 2, 3), (2, 5, 6, 2),
              'same', 'channels_last', (2, 2)),
             ('conv2d_transpose', (2, 3, 8, 9), (3, 3, 2, 3), (2, 2, 8, 9),
              'same', 'channels_first', (2, 2)),
         ])
-    def test_dilated_conv_transpose(self, op, input_shape, kernel_shape, output_shape,
-                                    padding, data_format, dilation_rate):
+    def test_dilated_conv_transpose(self, op, input_shape, kernel_shape,
+                                    output_shape, padding, data_format,
+                                    dilation_rate):
         check_two_tensor_operation(
             op, input_shape, kernel_shape, WITH_NP, output_shape=output_shape,
             padding=padding, data_format=data_format, dilation_rate=dilation_rate,
@@ -1114,23 +1157,34 @@ class TestBackend(object):
         ('depthwise_conv2d', (1, 6, 5, 3), (3, 4, 3, 2), 'valid', 'channels_last'),
         ('depthwise_conv2d', (1, 7, 6, 3), (3, 3, 3, 4), 'same', 'channels_last'),
     ])
-    def test_depthwise_conv(self, op, input_shape, kernel_shape, padding, data_format):
+    def test_depthwise_conv(self, op, input_shape, kernel_shape,
+                            padding, data_format):
         check_two_tensor_operation(
             op, input_shape, kernel_shape, WITH_NP,
             padding=padding, data_format=data_format,
             cntk_dynamicity=True)
 
-    @pytest.mark.parametrize('op,input_shape,pool_size,strides,padding,data_format,pool_mode', [
-        ('pool2d', (2, 3, 7, 7), (3, 3), (1, 1), 'same', 'channels_first', 'avg'),
-        ('pool2d', (3, 3, 8, 5), (2, 3), (1, 1), 'valid', 'channels_first', 'max'),
-        ('pool2d', (2, 9, 5, 3), (3, 2), (1, 1), 'valid', 'channels_last', 'avg'),
-        ('pool2d', (3, 6, 7, 3), (3, 3), (1, 1), 'same', 'channels_last', 'max'),
-        ('pool3d', (2, 3, 7, 7, 7), (3, 3, 3), (1, 1, 1), 'same', 'channels_first', 'avg'),
-        ('pool3d', (3, 3, 8, 5, 9), (2, 3, 2), (1, 1, 1), 'valid', 'channels_first', 'max'),
-        ('pool3d', (2, 8, 9, 5, 3), (3, 2, 3), (1, 1, 1), 'valid', 'channels_last', 'avg'),
-        ('pool3d', (3, 5, 6, 7, 3), (3, 3, 3), (1, 1, 1), 'same', 'channels_last', 'max'),
-    ])
-    def test_pool(self, op, input_shape, pool_size, strides, padding, data_format, pool_mode):
+    @pytest.mark.parametrize(
+        'op,input_shape,pool_size,strides,padding,data_format,pool_mode', [
+            ('pool2d', (2, 3, 7, 7), (3, 3), (1, 1),
+             'same', 'channels_first', 'avg'),
+            ('pool2d', (3, 3, 8, 5), (2, 3), (1, 1),
+             'valid', 'channels_first', 'max'),
+            ('pool2d', (2, 9, 5, 3), (3, 2), (1, 1),
+             'valid', 'channels_last', 'avg'),
+            ('pool2d', (3, 6, 7, 3), (3, 3), (1, 1),
+             'same', 'channels_last', 'max'),
+            ('pool3d', (2, 3, 7, 7, 7), (3, 3, 3), (1, 1, 1),
+             'same', 'channels_first', 'avg'),
+            ('pool3d', (3, 3, 8, 5, 9), (2, 3, 2), (1, 1, 1),
+             'valid', 'channels_first', 'max'),
+            ('pool3d', (2, 8, 9, 5, 3), (3, 2, 3), (1, 1, 1),
+             'valid', 'channels_last', 'avg'),
+            ('pool3d', (3, 5, 6, 7, 3), (3, 3, 3), (1, 1, 1),
+             'same', 'channels_last', 'max'),
+        ])
+    def test_pool(self, op, input_shape, pool_size, strides,
+                  padding, data_format, pool_mode):
         check_single_tensor_operation(
             op, input_shape, WITH_NP,
             pool_size=pool_size, strides=strides,
@@ -1151,9 +1205,10 @@ class TestBackend(object):
         # TF kernel shape: (rows, cols, input_depth, depth)
         # channels_first input shape: (n, input_depth, rows, cols)
         for (input_shape, kernel_shape, data_format) in [
-                ((2, 3, 4, 5), (2, 2, 3, 4), 'channels_first'),
-                ((2, 3, 5, 6), (4, 3, 3, 4), 'channels_first'),
-                ((1, 6, 5, 3), (3, 3, 3, 2), 'channels_last')]:
+            ((2, 3, 4, 5), (2, 2, 3, 4), 'channels_first'),
+            ((2, 3, 5, 6), (4, 3, 3, 4), 'channels_first'),
+            ((1, 6, 5, 3), (3, 3, 3, 2), 'channels_last')
+        ]:
             check_two_tensor_operation('conv2d', input_shape, kernel_shape,
                                        BACKENDS, cntk_dynamicity=True,
                                        data_format=data_format)
@@ -1162,9 +1217,10 @@ class TestBackend(object):
         # TF kernel shape: (rows, cols, input_depth, depth_multiplier)
         # channels_first input shape: (n, input_depth, rows, cols)
         for (input_shape, kernel_shape, data_format) in [
-                ((2, 3, 4, 5), (2, 2, 3, 4), 'channels_first'),
-                ((2, 3, 5, 6), (4, 3, 3, 4), 'channels_first'),
-                ((1, 6, 5, 3), (3, 3, 3, 2), 'channels_last')]:
+            ((2, 3, 4, 5), (2, 2, 3, 4), 'channels_first'),
+            ((2, 3, 5, 6), (4, 3, 3, 4), 'channels_first'),
+            ((1, 6, 5, 3), (3, 3, 3, 2), 'channels_last')
+        ]:
             check_two_tensor_operation('depthwise_conv2d',
                                        input_shape, kernel_shape,
                                        BACKENDS, cntk_dynamicity=True,
@@ -1176,26 +1232,32 @@ class TestBackend(object):
         # TH kernel shape: (depth, input_depth, x, y, z)
         # TF kernel shape: (x, y, z, input_depth, depth)
         for (input_shape, kernel_shape, data_format) in [
-                ((2, 3, 4, 5, 4), (2, 2, 2, 3, 4), 'channels_first'),
-                ((2, 3, 5, 4, 6), (3, 2, 4, 3, 4), 'channels_first'),
-                ((1, 2, 2, 2, 1), (2, 2, 2, 1, 1), 'channels_last')]:
+            ((2, 3, 4, 5, 4), (2, 2, 2, 3, 4), 'channels_first'),
+            ((2, 3, 5, 4, 6), (3, 2, 4, 3, 4), 'channels_first'),
+            ((1, 2, 2, 2, 1), (2, 2, 2, 1, 1), 'channels_last')
+        ]:
             check_two_tensor_operation('conv3d', input_shape, kernel_shape,
                                        BACKENDS, cntk_dynamicity=True,
                                        data_format=data_format)
 
-    @pytest.mark.parametrize('op,input_shape,kernel_shape,depth_multiplier,padding,data_format', [
-        ('separable_conv1d', (2, 8, 2), (3,), 1, 'same', 'channels_last'),
-        ('separable_conv1d', (1, 8, 2), (3,), 2, 'valid', 'channels_last'),
-        ('separable_conv2d', (2, 3, 4, 5), (3, 3), 1, 'same', 'channels_first'),
-        ('separable_conv2d', (2, 3, 5, 6), (4, 3), 2, 'valid', 'channels_first'),
-        ('separable_conv2d', (1, 6, 5, 3), (3, 4), 1, 'valid', 'channels_last'),
-        ('separable_conv2d', (1, 7, 6, 3), (3, 3), 2, 'same', 'channels_last'),
-    ])
-    def test_separable_conv(self, op, input_shape, kernel_shape, depth_multiplier, padding, data_format):
-        input_depth = input_shape[1] if data_format == 'channels_first' else input_shape[-1]
+    @pytest.mark.parametrize(
+        'op,input_shape,kernel_shape,depth_multiplier,padding,data_format', [
+            ('separable_conv1d', (2, 8, 2), (3,), 1, 'same', 'channels_last'),
+            ('separable_conv1d', (1, 8, 2), (3,), 2, 'valid', 'channels_last'),
+            ('separable_conv2d', (2, 3, 4, 5), (3, 3), 1, 'same', 'channels_first'),
+            ('separable_conv2d', (2, 3, 5, 6), (4, 3), 2, 'valid', 'channels_first'),
+            ('separable_conv2d', (1, 6, 5, 3), (3, 4), 1, 'valid', 'channels_last'),
+            ('separable_conv2d', (1, 7, 6, 3), (3, 3), 2, 'same', 'channels_last'),
+        ])
+    def test_separable_conv(self, op, input_shape, kernel_shape, depth_multiplier,
+                            padding, data_format):
+        input_depth = \
+            input_shape[1] if data_format == 'channels_first' else input_shape[-1]
         _, x = parse_shape_or_val(input_shape)
-        _, depthwise = parse_shape_or_val(kernel_shape + (input_depth, depth_multiplier))
-        _, pointwise = parse_shape_or_val((1,) * len(kernel_shape) + (input_depth * depth_multiplier, 7))
+        _, depthwise = parse_shape_or_val(kernel_shape +
+                                          (input_depth, depth_multiplier))
+        _, pointwise = parse_shape_or_val((1,) * len(kernel_shape) +
+                                          (input_depth * depth_multiplier, 7))
         y1 = KNP.separable_conv(x, depthwise, pointwise,
                                 padding=padding, data_format=data_format)
         if K.backend() == 'cntk':
@@ -1211,56 +1273,59 @@ class TestBackend(object):
         assert_allclose(y1, y2, atol=1e-05)
 
     def legacy_test_pool2d(self):
-        check_single_tensor_operation('pool2d', (5, 10, 12, 3),
-                                      BACKENDS, cntk_dynamicity=True,
-                                      pool_size=(2, 2), strides=(1, 1), padding='valid')
+        check_single_tensor_operation(
+            'pool2d', (5, 10, 12, 3), BACKENDS, cntk_dynamicity=True,
+            pool_size=(2, 2), strides=(1, 1), padding='valid')
 
-        check_single_tensor_operation('pool2d', (5, 9, 11, 3),
-                                      BACKENDS, cntk_dynamicity=True,
-                                      pool_size=(2, 2), strides=(1, 1), padding='valid')
+        check_single_tensor_operation(
+            'pool2d', (5, 9, 11, 3), BACKENDS, cntk_dynamicity=True,
+            pool_size=(2, 2), strides=(1, 1), padding='valid')
 
-        check_single_tensor_operation('pool2d', (5, 9, 11, 3),
-                                      BACKENDS, cntk_dynamicity=True,
-                                      pool_size=(2, 2), strides=(1, 1), pool_mode='avg')
+        check_single_tensor_operation(
+            'pool2d', (5, 9, 11, 3), BACKENDS, cntk_dynamicity=True,
+            pool_size=(2, 2), strides=(1, 1), pool_mode='avg')
 
-        check_single_tensor_operation('pool2d', (5, 9, 11, 3),
-                                      BACKENDS, cntk_dynamicity=True,
-                                      pool_size=(2, 3), strides=(1, 1), padding='valid')
+        check_single_tensor_operation(
+            'pool2d', (5, 9, 11, 3), BACKENDS, cntk_dynamicity=True,
+            pool_size=(2, 3), strides=(1, 1), padding='valid')
 
-        check_single_tensor_operation('pool2d', (2, 7, 7, 5),
-                                      BACKENDS, cntk_dynamicity=True,
-                                      pool_size=(3, 3), strides=(1, 1),
-                                      padding='same', pool_mode='avg')
+        check_single_tensor_operation(
+            'pool2d', (2, 7, 7, 5), BACKENDS, cntk_dynamicity=True,
+            pool_size=(3, 3), strides=(1, 1),
+            padding='same', pool_mode='avg')
 
     def legacy_test_pool3d(self):
-        check_single_tensor_operation('pool3d', (5, 10, 12, 5, 3),
-                                      BACKENDS, cntk_dynamicity=True,
-                                      pool_size=(2, 2, 2), strides=(1, 1, 1), padding='valid')
+        check_single_tensor_operation(
+            'pool3d', (5, 10, 12, 5, 3), BACKENDS, cntk_dynamicity=True,
+            pool_size=(2, 2, 2), strides=(1, 1, 1), padding='valid')
 
-        check_single_tensor_operation('pool3d', (5, 9, 11, 5, 3),
-                                      BACKENDS, cntk_dynamicity=True,
-                                      pool_size=(2, 2, 2), strides=(1, 1, 1), padding='valid')
+        check_single_tensor_operation(
+            'pool3d', (5, 9, 11, 5, 3), BACKENDS, cntk_dynamicity=True,
+            pool_size=(2, 2, 2), strides=(1, 1, 1), padding='valid')
 
-        check_single_tensor_operation('pool3d', (5, 9, 11, 5, 3),
-                                      BACKENDS, cntk_dynamicity=True,
-                                      pool_size=(2, 2, 2), strides=(1, 1, 1), pool_mode='avg')
+        check_single_tensor_operation(
+            'pool3d', (5, 9, 11, 5, 3), BACKENDS, cntk_dynamicity=True,
+            pool_size=(2, 2, 2), strides=(1, 1, 1), pool_mode='avg')
 
-        check_single_tensor_operation('pool3d', (5, 9, 11, 5, 3),
-                                      BACKENDS, cntk_dynamicity=True,
-                                      pool_size=(2, 3, 2), strides=(1, 1, 1), padding='valid')
+        check_single_tensor_operation(
+            'pool3d', (5, 9, 11, 5, 3), BACKENDS, cntk_dynamicity=True,
+            pool_size=(2, 3, 2), strides=(1, 1, 1), padding='valid')
 
-        check_single_tensor_operation('pool3d', (2, 6, 6, 6, 3), [KTH, KTF], pool_size=(3, 3, 3),
-                                      strides=(1, 1, 1), padding='same', pool_mode='avg')
+        check_single_tensor_operation(
+            'pool3d', (2, 6, 6, 6, 3), [KTH, KTF],
+            pool_size=(3, 3, 3), strides=(1, 1, 1), padding='same', pool_mode='avg')
 
     def test_random_normal(self):
         # test standard normal as well as a normal with a different set of parameters
         for mean, std in [(0., 1.), (-10., 5.)]:
-            rand = K.eval(K.random_normal((300, 200), mean=mean, stddev=std, seed=1337))
+            rand = K.eval(K.random_normal((300, 200),
+                                          mean=mean, stddev=std, seed=1337))
             assert rand.shape == (300, 200)
             assert np.abs(np.mean(rand) - mean) < std * 0.015
             assert np.abs(np.std(rand) - std) < std * 0.015
 
-            # test that random_normal also generates different values when used within a function
+            # test that random_normal also generates different values when used
+            # within a function
             r = K.random_normal((10, 10), mean=mean, stddev=std, seed=1337)
             samples = np.array([K.eval(r) for _ in range(200)])
             assert np.abs(np.mean(samples) - mean) < std * 0.015
@@ -1300,7 +1365,8 @@ class TestBackend(object):
         std = 1.
         min_val = -2.
         max_val = 2.
-        rand = K.eval(K.truncated_normal((300, 200), mean=mean, stddev=std, seed=1337))
+        rand = K.eval(K.truncated_normal((300, 200),
+                                         mean=mean, stddev=std, seed=1337))
         assert rand.shape == (300, 200)
         assert np.abs(np.mean(rand) - mean) < 0.015
         assert np.max(rand) <= max_val
@@ -1351,7 +1417,8 @@ class TestBackend(object):
                                    strides=(2, 2), dilation_rate=(1, 2))
 
     def test_pooling_invalid_use(self):
-        for (input_shape, pool_size) in zip([(5, 10, 12, 3), (5, 10, 12, 6, 3)], [(2, 2), (2, 2, 2)]):
+        for (input_shape, pool_size) in zip([(5, 10, 12, 3), (5, 10, 12, 6, 3)],
+                                            [(2, 2), (2, 2, 2)]):
             x = K.variable(np.random.random(input_shape))
             if len(pool_size) == 2:
                 with pytest.raises(ValueError):
@@ -1511,12 +1578,12 @@ class TestBackend(object):
             xth = KTH.variable(x_val)
             xtf = KTF.variable(x_val)
             xc = KC.placeholder(x_shape)
-            zth, _, _ = KTH.normalize_batch_in_training(xth, None, None,
-                                                        reduction_axes='per-activation')
-            ztf, _, _ = KTF.normalize_batch_in_training(xtf, None, None,
-                                                        reduction_axes=[0, 1, 2, 3])
-            zc, _, _ = KC.normalize_batch_in_training(xc, None, None,
-                                                      reduction_axes=[0, 1, 2, 3])
+            zth, _, _ = KTH.normalize_batch_in_training(
+                xth, None, None, reduction_axes='per-activation')
+            ztf, _, _ = KTF.normalize_batch_in_training(
+                xtf, None, None, reduction_axes=[0, 1, 2, 3])
+            zc, _, _ = KC.normalize_batch_in_training(
+                xc, None, None, reduction_axes=[0, 1, 2, 3])
             zth = KTH.eval(zth)
             ztf = KTF.eval(ztf)
             zc = KC.function([xc], [zc])([x_val])[0]
@@ -1557,8 +1624,10 @@ class TestBackend(object):
         k_inputs = K.variable(inputs, dtype="float32")
         k_input_lens = K.variable(input_lens, dtype="int32")
         k_label_lens = K.variable(label_lens, dtype="int32")
-        res = K.eval(K.ctc_batch_cost(k_labels, k_inputs, k_input_lens, k_label_lens))
-        assert_allclose(res[0, :] if K.backend() == 'theano' else res[:, 0], ref, atol=1e-05)
+        res = K.eval(K.ctc_batch_cost(k_labels, k_inputs, k_input_lens,
+                                      k_label_lens))
+        assert_allclose(res[0, :] if K.backend() == 'theano' else res[:, 0], ref,
+                        atol=1e-05)
 
         # test when batch_size = 1, that is, one sample only
         # get only first sample from above test case
@@ -1583,8 +1652,10 @@ class TestBackend(object):
         k_inputs = K.variable(inputs, dtype="float32")
         k_input_lens = K.variable(input_lens, dtype="int32")
         k_label_lens = K.variable(label_lens, dtype="int32")
-        res = K.eval(K.ctc_batch_cost(k_labels, k_inputs, k_input_lens, k_label_lens))
-        assert_allclose(res[0, :] if K.backend() == 'theano' else res[:, 0], ref, atol=1e-05)
+        res = K.eval(K.ctc_batch_cost(k_labels, k_inputs, k_input_lens,
+                                      k_label_lens))
+        assert_allclose(res[0, :] if K.backend() == 'theano' else res[:, 0], ref,
+                        atol=1e-05)
 
     @pytest.mark.skipif(K.backend() != 'tensorflow',
                         reason='Test adapted from tensorflow.')
@@ -1761,7 +1832,8 @@ class TestBackend(object):
 
             k_s_d = k.eval(k_s)
 
-            k_d = k.eval(k.concatenate([k.variable(x_dense_1), k.variable(x_dense_2)]))
+            k_d = k.eval(k.concatenate([k.variable(x_dense_1),
+                                        k.variable(x_dense_2)]))
 
             assert k_s_d.shape == k_d.shape
             assert_allclose(k_s_d, k_d, atol=1e-05)

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -72,7 +72,10 @@ def parse_shape_or_val(shape_or_val):
 
 
 def assert_list_pairwise(z_list,
-                         shape=True, allclose=True, itself=False, atol=1e-05):
+                         shape=True,
+                         allclose=True,
+                         itself=False,
+                         atol=1e-05):
     for (z1, z2) in zip(z_list[1:], z_list[:-1]):
         if shape:
             assert z1.shape == z2.shape
@@ -90,7 +93,9 @@ def assert_list_keras_shape(t_list, z_list):
                     assert t._keras_shape[i] == z.shape[i]
 
 
-def check_single_tensor_operation(function_name, x_shape_or_val, backend_list,
+def check_single_tensor_operation(function_name,
+                                  x_shape_or_val,
+                                  backend_list,
                                   **kwargs):
     shape_or_val = kwargs.pop('shape_or_val', True)
     assert_value_equality = kwargs.pop('assert_value_equality', True)
@@ -119,8 +124,11 @@ def check_single_tensor_operation(function_name, x_shape_or_val, backend_list,
     assert_list_keras_shape(t_list, z_list)
 
 
-def check_two_tensor_operation(function_name, x_shape_or_val,
-                               y_shape_or_val, backend_list, **kwargs):
+def check_two_tensor_operation(function_name,
+                               x_shape_or_val,
+                               y_shape_or_val,
+                               backend_list,
+                               **kwargs):
     concat_args = kwargs.pop('concat_args', False)
     cntk_dynamicity = kwargs.pop('cntk_dynamicity', False)
     cntk_two_dynamicity = kwargs.pop('cntk_two_dynamicity', False)
@@ -156,9 +164,12 @@ def check_two_tensor_operation(function_name, x_shape_or_val,
     assert_list_keras_shape(t_list, z_list)
 
 
-def check_composed_tensor_operations(first_function_name, first_function_args,
-                                     second_function_name, second_function_args,
-                                     input_shape, backend_list):
+def check_composed_tensor_operations(first_function_name,
+                                     first_function_args,
+                                     second_function_name,
+                                     second_function_args,
+                                     input_shape,
+                                     backend_list):
     val = np.random.random(input_shape) - 0.5
 
     z_list = []
@@ -996,15 +1007,15 @@ class TestBackend(object):
     @pytest.mark.parametrize('alpha,max_value,threshold', [
         (0.0, None, 0.0),  # standard relu
         (0.1, None, 0.0),  # set alpha only
-        (0.0, 5.0, 0.0),  # set max_value only
+        (0.0, 5.0, 0.0),   # set max_value only
         (0.0, None, 0.8),  # set threshold only
-        (0.1, 5.0, 0.0),  # set alpha and max_value
+        (0.1, 5.0, 0.0),   # set alpha and max_value
         (0.1, None, 0.8),  # set alpha and threshold
-        (0.0, 5.0, 0.8),  # set max_value and threshold
-        (0.1, 5.0, 0.8),  # set all
-        (0.1, 0.0, 0.8),  # max_value is zero
+        (0.0, 5.0, 0.8),   # set max_value and threshold
+        (0.1, 5.0, 0.8),   # set all
+        (0.1, 0.0, 0.8),   # max_value is zero
         (0.1, 5.0, -2.8),  # threshold is negative
-        (0.1, 9.0, 0.8),  # max_value > 6
+        (0.1, 9.0, 0.8),   # max_value > 6
     ])
     def test_relu(self, alpha, max_value, threshold):
         check_single_tensor_operation('relu', (4, 2), WITH_NP, alpha=alpha,
@@ -1105,8 +1116,13 @@ class TestBackend(object):
             ('conv2d_transpose', (2, 3, 8, 9), (3, 3, 2, 3), (2, 2, 8, 9),
              'same', 'channels_first'),
         ])
-    def test_conv_transpose(self, op, input_shape, kernel_shape, output_shape,
-                            padding, data_format):
+    def test_conv_transpose(self,
+                            op,
+                            input_shape,
+                            kernel_shape,
+                            output_shape,
+                            padding,
+                            data_format):
         check_two_tensor_operation(
             op, input_shape, kernel_shape, WITH_NP,
             output_shape=output_shape, padding=padding, data_format=data_format,
@@ -1127,8 +1143,13 @@ class TestBackend(object):
             ('conv3d', (2, 3, 5, 4, 6), (2, 2, 3, 3, 4),
              'same', 'channels_first', (2, 2, 2)),
         ])
-    def test_dilated_conv(self, op, input_shape, kernel_shape, padding,
-                          data_format, dilation_rate):
+    def test_dilated_conv(self,
+                          op,
+                          input_shape,
+                          kernel_shape,
+                          padding,
+                          data_format,
+                          dilation_rate):
         check_two_tensor_operation(
             op, input_shape, kernel_shape, WITH_NP,
             padding=padding, data_format=data_format,
@@ -1144,8 +1165,13 @@ class TestBackend(object):
             ('conv2d_transpose', (2, 3, 8, 9), (3, 3, 2, 3), (2, 2, 8, 9),
              'same', 'channels_first', (2, 2)),
         ])
-    def test_dilated_conv_transpose(self, op, input_shape, kernel_shape,
-                                    output_shape, padding, data_format,
+    def test_dilated_conv_transpose(self,
+                                    op,
+                                    input_shape,
+                                    kernel_shape,
+                                    output_shape,
+                                    padding,
+                                    data_format,
                                     dilation_rate):
         check_two_tensor_operation(
             op, input_shape, kernel_shape, WITH_NP, output_shape=output_shape,
@@ -1158,8 +1184,12 @@ class TestBackend(object):
         ('depthwise_conv2d', (1, 6, 5, 3), (3, 4, 3, 2), 'valid', 'channels_last'),
         ('depthwise_conv2d', (1, 7, 6, 3), (3, 3, 3, 4), 'same', 'channels_last'),
     ])
-    def test_depthwise_conv(self, op, input_shape, kernel_shape,
-                            padding, data_format):
+    def test_depthwise_conv(self,
+                            op,
+                            input_shape,
+                            kernel_shape,
+                            padding,
+                            data_format):
         check_two_tensor_operation(
             op, input_shape, kernel_shape, WITH_NP,
             padding=padding, data_format=data_format,
@@ -1184,8 +1214,14 @@ class TestBackend(object):
             ('pool3d', (3, 5, 6, 7, 3), (3, 3, 3), (1, 1, 1),
              'same', 'channels_last', 'max'),
         ])
-    def test_pool(self, op, input_shape, pool_size, strides,
-                  padding, data_format, pool_mode):
+    def test_pool(self,
+                  op,
+                  input_shape,
+                  pool_size,
+                  strides,
+                  padding,
+                  data_format,
+                  pool_mode):
         check_single_tensor_operation(
             op, input_shape, WITH_NP,
             pool_size=pool_size, strides=strides,
@@ -1250,8 +1286,13 @@ class TestBackend(object):
             ('separable_conv2d', (1, 6, 5, 3), (3, 4), 1, 'valid', 'channels_last'),
             ('separable_conv2d', (1, 7, 6, 3), (3, 3), 2, 'same', 'channels_last'),
         ])
-    def test_separable_conv(self, op, input_shape, kernel_shape, depth_multiplier,
-                            padding, data_format):
+    def test_separable_conv(self,
+                            op,
+                            input_shape,
+                            kernel_shape,
+                            depth_multiplier,
+                            padding,
+                            data_format):
         if data_format == 'channels_first':
             input_depth = input_shape[1]
         else:

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1252,8 +1252,10 @@ class TestBackend(object):
         ])
     def test_separable_conv(self, op, input_shape, kernel_shape, depth_multiplier,
                             padding, data_format):
-        input_depth = \
-            input_shape[1] if data_format == 'channels_first' else input_shape[-1]
+        if data_format == 'channels_first':
+            input_depth = input_shape[1]
+        else:
+            input_depth = input_shape[-1]
         _, x = parse_shape_or_val(input_shape)
         _, depthwise = parse_shape_or_val(kernel_shape +
                                           (input_depth, depth_multiplier))


### PR DESCRIPTION
### Summary

The file with the [backend tests](https://github.com/keras-team/keras/blob/master/tests/keras/backend/backend_test.py) did not pass PEP8 tests due to long lines. This has been fixed.

While the PEP8 tests are now passing, there are 12 tests failing - but not due to changes introduced in this PR.

### Related Issues

Part of issue #11383

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [X] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
