### PR TITLE
Draw input layers even when added implicitly

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -61,7 +61,7 @@ def model_to_dot(model,
     if isinstance(model, Sequential):
         if not model.built:
             model.build()
-    layers = model.layers
+    layers = model._layers
 
     # Create graph nodes.
     for layer in layers:

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -108,6 +108,10 @@ def model_to_dot(model,
             if node_key in model._network_nodes:
                 for inbound_layer in node.inbound_layers:
                     inbound_layer_id = str(id(inbound_layer))
+                    # Make sure that both nodes exist before connecting them with
+                    # an edge, as add_edge would otherwise create any missing node.
+                    assert dot.get_node(inbound_layer_id)
+                    assert dot.get_node(layer_id)
                     dot.add_edge(pydot.Edge(inbound_layer_id, layer_id))
     return dot
 

--- a/tests/keras/utils/vis_utils_test.py
+++ b/tests/keras/utils/vis_utils_test.py
@@ -4,6 +4,7 @@ import sys
 import numpy as np
 from keras.layers import Conv2D
 from keras.layers import Dense
+from keras.layers import Embedding
 from keras.layers import Flatten
 from keras.layers import LSTM
 from keras.layers import TimeDistributed
@@ -24,6 +25,17 @@ def test_plot_model():
     model.add(TimeDistributed(Dense(5, name='dense2')))
     vis_utils.plot_model(model, to_file='model2.png', show_shapes=True)
     os.remove('model2.png')
+
+
+def test_plot_sequential_embedding():
+    """Fixes #11376"""
+    model = Sequential()
+    model.add(Embedding(10000, 256, input_length=400, name='embed'))
+    vis_utils.plot_model(model,
+                         to_file='model1.png',
+                         show_shapes=True,
+                         show_layer_names=True)
+    os.remove('model1.png')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

The `_layers` attribute, unlike `layers`, contains any `InputLayer` that gets implicitly added when adding an `Embedding` as the first layer. This means that the next loop starting at https://github.com/keras-team/keras/blob/590aa832680641218b233b22fa8b3bd7fdc0287e/keras/utils/vis_utils.py#L66-L67 will create a node for those implicit `InputLayer`s, which will prevent the final loop starting at https://github.com/keras-team/keras/blob/590aa832680641218b233b22fa8b3bd7fdc0287e/keras/utils/vis_utils.py#L103-L104 from creating an edge to a non-existing node.

### Related Issues

Closes https://github.com/keras-team/keras/issues/11376.

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
