### PR TITLE
Ensured line length in keras/backend/tensorflow_backend.py was below 85 characters.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -255,7 +255,8 @@ def _is_current_explicit_device(device_type):
         device_type: A string containing `GPU` or `CPU` (case-insensitive).
 
     # Returns
-        A boolean indicating if the current device scope is explicitly set on the device type.
+        A boolean indicating if the current device scope is explicitly set on the
+        device type.
 
     # Raises
         ValueError: If the `device_type` string indicates an unsupported device.
@@ -282,8 +283,9 @@ def _get_available_gpus():
 def _has_nchw_support():
     """Check whether the current scope supports NCHW ops.
 
-    TensorFlow does not support NCHW on CPU. Therefore we check if we are not explicitly put on
-    CPU, and have GPUs available. In this case there will be soft-placing on the GPU device.
+    TensorFlow does not support NCHW on CPU. Therefore we check if we are not
+    explicitly put on CPU, and have GPUs available. In this case there will be
+    soft-placing on the GPU device.
 
     # Returns
         bool: if the current scope device placement would support nchw
@@ -453,19 +455,23 @@ def is_keras_tensor(x):
         >>> K.is_keras_tensor(np_var) # A numpy array is not a symbolic tensor.
         ValueError
         >>> k_var = tf.placeholder('float32', shape=(1,1))
-        >>> K.is_keras_tensor(k_var) # A variable indirectly created outside of keras is not a Keras tensor.
+        >>> K.is_keras_tensor(k_var) # A variable indirectly created outside of
+                                     # keras is not a Keras tensor.
         False
         >>> keras_var = K.variable(np_var)
-        >>> K.is_keras_tensor(keras_var)  # A variable created with the keras backend is not a Keras tensor.
+        >>> K.is_keras_tensor(keras_var)  # A variable created with the keras
+                                          # backend is not a Keras tensor.
         False
         >>> keras_placeholder = K.placeholder(shape=(2, 4, 5))
-        >>> K.is_keras_tensor(keras_placeholder)  # A placeholder is not a Keras tensor.
+        >>> K.is_keras_tensor(keras_placeholder)  # A placeholder is not a Keras
+                                                  # tensor.
         False
         >>> keras_input = Input([10])
         >>> K.is_keras_tensor(keras_input) # An Input is a Keras tensor.
         True
         >>> keras_layer_output = Dense(10)(keras_input)
-        >>> K.is_keras_tensor(keras_layer_output) # Any Keras layer output is a Keras tensor.
+        >>> K.is_keras_tensor(keras_layer_output) # Any Keras layer output is a
+                                                  # Keras tensor.
         True
     ```
     """
@@ -1901,9 +1907,11 @@ def batch_normalization(x, mean, var, beta, gamma, axis=-1, epsilon=1e-3):
         else:
             tf_data_format = None
 
-        if tf_data_format == 'NHWC' or tf_data_format == 'NCHW' and _has_nchw_support():
+        if (tf_data_format == 'NHWC' or tf_data_format == 'NCHW'
+            and _has_nchw_support()):
             # The mean / var / beta / gamma may be processed by broadcast
-            # so it may have extra axes with 1, it is not needed and should be removed
+            # so it may have extra axes with 1, it is not needed and should be
+            # removed
             if ndim(mean) > 1:
                 mean = tf.reshape(mean, [-1])
             if ndim(var) > 1:
@@ -2001,7 +2009,8 @@ def resize_images(x,
         A tensor.
 
     # Raises
-        ValueError: if `data_format` is neither `"channels_last"` or `"channels_first"`.
+        ValueError: if `data_format` is neither `"channels_last"` or
+            `"channels_first"`.
     """
     if data_format == 'channels_first':
         rows, cols = 2, 3
@@ -2053,7 +2062,8 @@ def resize_volumes(x, depth_factor, height_factor, width_factor, data_format):
         A tensor.
 
     # Raises
-        ValueError: if `data_format` is neither `"channels_last"` or `"channels_first"`.
+        ValueError: if `data_format` is neither `"channels_last"` or
+            `"channels_first"`.
     """
     if data_format == 'channels_first':
         output = repeat_elements(x, depth_factor, axis=2)
@@ -2272,7 +2282,8 @@ def spatial_2d_padding(x, padding=((1, 1), (1, 1)), data_format=None):
         A padded 4D tensor.
 
     # Raises
-        ValueError: if `data_format` is neither `"channels_last"` or `"channels_first"`.
+        ValueError: if `data_format` is neither `"channels_last"` or
+            `"channels_first"`.
     """
     assert len(padding) == 2
     assert len(padding[0]) == 2
@@ -2307,7 +2318,8 @@ def spatial_3d_padding(x, padding=((1, 1), (1, 1), (1, 1)), data_format=None):
         A padded 5D tensor.
 
     # Raises
-        ValueError: if `data_format` is neither `"channels_last"` or `"channels_first"`.
+        ValueError: if `data_format` is neither `"channels_last"` or
+            `"channels_first"`.
 
     """
     assert len(padding) == 3
@@ -2705,11 +2717,12 @@ class Function(object):
             # callable generated by Session._make_callable_from_options accepts
             # `run_metadata` keyword argument since TF 1.10
             if (self.run_metadata and
-                    StrictVersion(tf.__version__.split('-')[0]) < StrictVersion('1.10.0')):
+                    StrictVersion(tf.__version__.split('-')[0]) <
+                        StrictVersion('1.10.0')):
                 if py_any(is_tensor(x) for x in inputs):
                     raise ValueError(
-                        'In order to feed symbolic tensors to a Keras model and set '
-                        '`run_metadata`, you need tensorflow 1.10 or higher.')
+                        'In order to feed symbolic tensors to a Keras model and '
+                        'set `run_metadata`, you need tensorflow 1.10 or higher.')
                 return self._legacy_call(inputs)
 
             return self._call(inputs)
@@ -2738,8 +2751,10 @@ def function(inputs, outputs, updates=None, **kwargs):
     """
     if kwargs:
         for key in kwargs:
-            if not (has_arg(tf.Session.run, key, True) or has_arg(Function.__init__, key, True)):
-                msg = 'Invalid argument "%s" passed to K.function with TensorFlow backend' % key
+            if not (has_arg(tf.Session.run, key, True) or
+                        has_arg(Function.__init__, key, True)):
+                msg = ('Invalid argument "%s" passed to K.function with '
+                       'TensorFlow backend' % key)
                 raise ValueError(msg)
     return Function(inputs, outputs, updates=updates, **kwargs)
 
@@ -2973,7 +2988,8 @@ def rnn(step_function, inputs, initial_states,
                                        tf.stack([1, tf.shape(output)[1]]))
                 output = tf.where(tiled_mask_t, output, states[0])
                 new_states = [
-                    tf.where(tf.tile(mask_t, tf.stack([1, tf.shape(new_states[i])[1]])),
+                    tf.where(tf.tile(mask_t,
+                                     tf.stack([1, tf.shape(new_states[i])[1]])),
                              new_states[i], states[i]) for i in range(len(states))
                 ]
                 output_ta_t = output_ta_t.write(time, output)
@@ -3077,7 +3093,9 @@ def switch(condition, then_expression, else_expression):
             condition = tf.reshape(condition, cond_shape)
             expr_shape = tf.shape(then_expression)
             shape_diff = expr_shape - cond_shape
-            tile_shape = tf.where(shape_diff > 0, expr_shape, tf.ones_like(expr_shape))
+            tile_shape = tf.where(shape_diff > 0,
+                                  expr_shape,
+                                  tf.ones_like(expr_shape))
             condition = tf.tile(condition, tile_shape)
         x = tf.where(condition, then_expression, else_expression)
     return x
@@ -3958,7 +3976,8 @@ def pool2d(x, pool_size, strides=(1, 1),
         A tensor, result of 2D pooling.
 
     # Raises
-        ValueError: if `data_format` is neither `"channels_last"` or `"channels_first"`.
+        ValueError: if `data_format` is neither `"channels_last"` or
+            `"channels_first"`.
         ValueError: if `pool_mode` is neither `"max"` or `"avg"`.
     """
     data_format = normalize_data_format(data_format)
@@ -4004,7 +4023,8 @@ def pool3d(x, pool_size, strides=(1, 1, 1), padding='valid',
         A tensor, result of 3D pooling.
 
     # Raises
-        ValueError: if `data_format` is neither `"channels_last"` or `"channels_first"`.
+        ValueError: if `data_format` is neither `"channels_last"` or
+            `"channels_first"`.
         ValueError: if `pool_mode` is neither `"max"` or `"avg"`.
     """
     data_format = normalize_data_format(data_format)
@@ -4055,8 +4075,8 @@ def bias_add(x, bias, data_format=None):
     data_format = normalize_data_format(data_format)
     bias_shape = int_shape(bias)
     if len(bias_shape) != 1 and len(bias_shape) != ndim(x) - 1:
-        raise ValueError('Unexpected bias dimensions %d, expect to be 1 or %d dimensions'
-                         % (len(bias_shape), ndim(x)))
+        raise ValueError('Unexpected bias dimensions %d, expect to be 1 or %d '
+                         'dimensions' % (len(bias_shape), ndim(x)))
     if ndim(x) == 5:
         if len(bias_shape) == 1:
             new_shape = (1, 1, 1, 1, bias_shape[0])
@@ -4220,13 +4240,17 @@ def ctc_label_dense_to_sparse(labels, label_lengths):
     label_ind = tf.boolean_mask(label_array, dense_mask)
 
     batch_array = tf.transpose(tf.reshape(tf.tile(tf.range(label_shape[0]),
-                                                  max_num_labels_tns), reverse(label_shape, 0)))
+                                                  max_num_labels_tns),
+                                          reverse(label_shape, 0)))
     batch_ind = tf.boolean_mask(batch_array, dense_mask)
-    indices = tf.transpose(tf.reshape(concatenate([batch_ind, label_ind], axis=0), [2, -1]))
+    indices = tf.transpose(tf.reshape(concatenate([batch_ind, label_ind], axis=0),
+                                      [2, -1]))
 
     vals_sparse = tf.gather_nd(labels, indices)
 
-    return tf.SparseTensor(tf.to_int64(indices), vals_sparse, tf.to_int64(label_shape))
+    return tf.SparseTensor(tf.to_int64(indices),
+                           vals_sparse,
+                           tf.to_int64(label_shape))
 
 
 def ctc_batch_cost(y_true, y_pred, input_length, label_length):
@@ -4299,7 +4323,10 @@ def ctc_decode(y_pred, input_length, greedy=True, beam_width=100,
             sequence_length=input_length, beam_width=beam_width,
             top_paths=top_paths)
 
-    decoded_dense = [tf.sparse_to_dense(st.indices, st.dense_shape, st.values, default_value=-1)
+    decoded_dense = [tf.sparse_to_dense(st.indices,
+                                        st.dense_shape,
+                                        st.values,
+                                        default_value=-1)
                      for st in decoded]
     return (decoded_dense, log_prob)
 
@@ -4367,7 +4394,8 @@ def local_conv1d(inputs, kernel, kernel_size, strides, data_format=None):
         data_format: the data format, channels_first or channels_last
 
     # Returns
-        the tensor after 1d conv with un-shared weights, with shape (batch_size, output_length, filters)
+        the tensor after 1d conv with un-shared weights, with shape (batch_size,
+        output_length, filters)
 
     # Raises
         ValueError: If `data_format` is neither
@@ -4391,7 +4419,12 @@ def local_conv1d(inputs, kernel, kernel_size, strides, data_format=None):
     return permute_dimensions(output, (1, 0, 2))
 
 
-def local_conv2d(inputs, kernel, kernel_size, strides, output_shape, data_format=None):
+def local_conv2d(inputs,
+                 kernel,
+                 kernel_size,
+                 strides,
+                 output_shape,
+                 data_format=None):
     """Apply 2D conv with un-shared weights.
 
     # Arguments

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,7 +21,6 @@ pep8ignore=* E402 \
            * E731 \
            * W503 \
            keras/backend/cntk_backend.py E501 \
-           keras/backend/tensorflow_backend.py E501 \
            keras/backend/theano_backend.py E501
 
 # Enable line length testing with maximum line length of 85


### PR DESCRIPTION
### Summary

Made sure all lines in the keras/backend/tensorflow_backend.py were less than 85 
characters in length and removed corresponding exception from pytest.ini.

### Related Issues

This was done to address Issue #11383.

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
