### PR TITLE
Update Conv1D input_shape description

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -249,10 +249,10 @@ class Conv1D(_Conv):
     it is applied to the outputs as well.
 
     When using this layer as the first layer in a model,
-    provide an `input_shape` argument
-    (tuple of integers or `None`, e.g.
-    `(10, 128)` for sequences of 10 vectors of 128-dimensional vectors,
-    or `(None, 128)` for variable-length sequences of 128-dimensional vectors.
+    provide an `input_shape` argument (tuple of integers or `None`, does not
+    include the sample axis), e.g. `input_shape=(10, 128)` for time series
+    sequences of 10 time steps with 128 features per step, or
+    `(None, 128)` for variable-length sequences with 128 features per step.
 
     # Arguments
         filters: Integer, the dimensionality of the output space

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -250,7 +250,7 @@ class Conv1D(_Conv):
 
     When using this layer as the first layer in a model,
     provide an `input_shape` argument (tuple of integers or `None`, does not
-    include the sample axis), e.g. `input_shape=(10, 128)` for time series
+    include the batch axis), e.g. `input_shape=(10, 128)` for time series
     sequences of 10 time steps with 128 features per step in
     `data_format="channels_last"`, or `(None, 128)` for variable-length
     sequences with 128 features per step.
@@ -376,7 +376,7 @@ class Conv2D(_Conv):
 
     When using this layer as the first layer in a model,
     provide the keyword argument `input_shape`
-    (tuple of integers, does not include the sample axis),
+    (tuple of integers, does not include the batch axis),
     e.g. `input_shape=(128, 128, 3)` for 128x128 RGB pictures
     in `data_format="channels_last"`.
 
@@ -507,7 +507,7 @@ class Conv3D(_Conv):
 
     When using this layer as the first layer in a model,
     provide the keyword argument `input_shape`
-    (tuple of integers, does not include the sample axis),
+    (tuple of integers, does not include the batch axis),
     e.g. `input_shape=(128, 128, 128, 1)` for 128x128x128 volumes
     with a single channel,
     in `data_format="channels_last"`.
@@ -637,7 +637,7 @@ class Conv2DTranspose(Conv2D):
 
     When using this layer as the first layer in a model,
     provide the keyword argument `input_shape`
-    (tuple of integers, does not include the sample axis),
+    (tuple of integers, does not include the batch axis),
     e.g. `input_shape=(128, 128, 3)` for 128x128 RGB pictures
     in `data_format="channels_last"`.
 
@@ -910,7 +910,7 @@ class Conv3DTranspose(Conv3D):
 
     When using this layer as the first layer in a model,
     provide the keyword argument `input_shape`
-    (tuple of integers, does not include the sample axis),
+    (tuple of integers, does not include the batch axis),
     e.g. `input_shape=(128, 128, 128, 3)` for a 128x128x128 volume with 3 channels
     if `data_format="channels_last"`.
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -251,8 +251,9 @@ class Conv1D(_Conv):
     When using this layer as the first layer in a model,
     provide an `input_shape` argument (tuple of integers or `None`, does not
     include the sample axis), e.g. `input_shape=(10, 128)` for time series
-    sequences of 10 time steps with 128 features per step, or
-    `(None, 128)` for variable-length sequences with 128 features per step.
+    sequences of 10 time steps with 128 features per step in
+    `data_format="channels_last"`, or `(None, 128)` for variable-length
+    sequences with 128 features per step.
 
     # Arguments
         filters: Integer, the dimensionality of the output space


### PR DESCRIPTION
### Summary

This PR updates the `input_shape` description for `Conv1D`. It adds a reference to the sample axis not being included, states which axis corresponds to the steps dimension and which corresponds to the channels dimension in the given example, and specifies the `data_format` in the given example. 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
