### PR TITLE
Make dirname configurable for all datasets.

### DIFF
--- a/keras/datasets/cifar10.py
+++ b/keras/datasets/cifar10.py
@@ -11,13 +11,15 @@ import numpy as np
 import os
 
 
-def load_data():
+def load_data(dirname='cifar-10-batches-py'):
     """Loads CIFAR10 dataset.
+
+    # Arguments
+        dirname: Name of the directory in which to untar the data.
 
     # Returns
         Tuple of Numpy arrays: `(x_train, y_train), (x_test, y_test)`.
     """
-    dirname = 'cifar-10-batches-py'
     origin = 'https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz'
     path = get_file(dirname, origin=origin, untar=True)
 

--- a/keras/datasets/cifar100.py
+++ b/keras/datasets/cifar100.py
@@ -11,10 +11,11 @@ import numpy as np
 import os
 
 
-def load_data(label_mode='fine'):
+def load_data(dirname='cifar-100-python', label_mode='fine'):
     """Loads CIFAR100 dataset.
 
     # Arguments
+        dirname: Name of the directory in which to untar the data.
         label_mode: one of "fine", "coarse".
 
     # Returns
@@ -26,7 +27,6 @@ def load_data(label_mode='fine'):
     if label_mode not in ['fine', 'coarse']:
         raise ValueError('`label_mode` must be one of `"fine"`, `"coarse"`.')
 
-    dirname = 'cifar-100-python'
     origin = 'https://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz'
     path = get_file(dirname, origin=origin, untar=True)
 

--- a/keras/datasets/fashion_mnist.py
+++ b/keras/datasets/fashion_mnist.py
@@ -11,13 +11,15 @@ from ..utils.data_utils import get_file
 import numpy as np
 
 
-def load_data():
+def load_data(dirname=os.path.join('datasets', 'fashion-mnist')):
     """Loads the Fashion-MNIST dataset.
+
+    # Arguments:
+        dirname: Name of the directory in which to unzip the data.
 
     # Returns
         Tuple of Numpy arrays: `(x_train, y_train), (x_test, y_test)`.
     """
-    dirname = os.path.join('datasets', 'fashion-mnist')
     base = 'http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/'
     files = ['train-labels-idx1-ubyte.gz', 'train-images-idx3-ubyte.gz',
              't10k-labels-idx1-ubyte.gz', 't10k-images-idx3-ubyte.gz']


### PR DESCRIPTION
### Summary

Some datasets use an intermediate folder in which to store the data after untarring/unzipping. The name of this folder was not configurable, unlike the other datasets, which prevented users from passing their own absolute paths unless they defined the appropriate symbolic links.

### Related Issues

Closes https://github.com/keras-team/keras/issues/11385.

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
