### PR TITLE
Avoid deprecated getargspec

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -73,6 +73,7 @@ from keras import layers
 from keras.layers import advanced_activations
 from keras.layers import noise
 from keras.layers import wrappers
+from keras.utils import generic_utils
 from keras import initializers
 from keras import optimizers
 from keras import callbacks
@@ -347,9 +348,9 @@ ROOT = 'http://keras.io/'
 def get_function_signature(function, method=True):
     wrapped = getattr(function, '_original_function', None)
     if wrapped is None:
-        signature = inspect.getargspec(function)
+        signature = generic_utils.getargspec(function)
     else:
-        signature = inspect.getargspec(wrapped)
+        signature = generic_utils.getargspec(wrapped)
     defaults = signature.defaults
     if method:
         args = signature.args[1:]

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -4,10 +4,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import inspect
-
 from .. import backend
 from .. import utils
+from ..utils import generic_utils
+
 from keras_preprocessing import image
 
 random_rotation = image.random_rotation
@@ -25,7 +25,7 @@ load_img = image.load_img
 def array_to_img(x, data_format=None, scale=True, dtype=None):
     if data_format is None:
         data_format = backend.image_data_format()
-    if 'dtype' in inspect.getargspec(image.array_to_img).args:
+    if 'dtype' in generic_utils.getargspec(image.array_to_img).args:
         if dtype is None:
             dtype = backend.floatx()
         return image.array_to_img(x,
@@ -40,7 +40,7 @@ def array_to_img(x, data_format=None, scale=True, dtype=None):
 def img_to_array(img, data_format=None, dtype=None):
     if data_format is None:
         data_format = backend.image_data_format()
-    if 'dtype' in inspect.getargspec(image.img_to_array).args:
+    if 'dtype' in generic_utils.getargspec(image.img_to_array).args:
         if dtype is None:
             dtype = backend.floatx()
         return image.img_to_array(img, data_format=data_format, dtype=dtype)
@@ -142,7 +142,7 @@ class DirectoryIterator(image.DirectoryIterator, Iterator):
         if data_format is None:
             data_format = backend.image_data_format()
         kwargs = {}
-        if 'dtype' in inspect.getargspec(
+        if 'dtype' in generic_utils.getargspec(
                 image.ImageDataGenerator.__init__).args:
             if dtype is None:
                 dtype = backend.floatx()
@@ -210,7 +210,7 @@ class NumpyArrayIterator(image.NumpyArrayIterator, Iterator):
         if data_format is None:
             data_format = backend.image_data_format()
         kwargs = {}
-        if 'dtype' in inspect.getargspec(
+        if 'dtype' in generic_utils.getargspec(
                 image.NumpyArrayIterator.__init__).args:
             if dtype is None:
                 dtype = backend.floatx()
@@ -436,7 +436,7 @@ class ImageDataGenerator(image.ImageDataGenerator):
         if data_format is None:
             data_format = backend.image_data_format()
         kwargs = {}
-        if 'dtype' in inspect.getargspec(
+        if 'dtype' in generic_utils.getargspec(
                 image.ImageDataGenerator.__init__).args:
             if dtype is None:
                 dtype = backend.floatx()

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -245,7 +245,7 @@ def getargspec(fn):
     """ python2/python3 compatible getargspec.
 
     Calls `getfullargspec` and assigns args, varargs,
-    varkw, and defautls to a python 2/3 compatible `ArgSpec`.
+    varkw, and defaults to a python 2/3 compatible `ArgSpec`.
     The parameter name 'varkw' is changed to 'keywords' to fit the
     `ArgSpec` struct.
 

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -242,16 +242,19 @@ def func_load(code, defaults=None, closure=None, globs=None):
 
 
 def getargspec(fn):
-    """A python3 version of getargspec.
+    """ python2/python3 compatible getargspec.
+
     Calls `getfullargspec` and assigns args, varargs,
-    varkw, and defaults to a python 2/3 compatible `ArgSpec`.
+    varkw, and defautls to a python 2/3 compatible `ArgSpec`.
     The parameter name 'varkw' is changed to 'keywords' to fit the
     `ArgSpec` struct.
-    Args:
-      fn: the target function to inspect.
-    Returns:
-      An ArgSpec with args, varargs, keywords, and defaults parameters
-      from FullArgSpec.
+
+    # Arguments
+        fn: the target function to inspect.
+
+    # Returns
+        An ArgSpec with args, varargs, keywords, and defaults parameters
+        from FullArgSpec.
     """
     if sys.version_info < (3,):
         arg_spec = inspect.getargspec(fn)

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -240,6 +240,29 @@ def func_load(code, defaults=None, closure=None, globs=None):
                                      argdefs=defaults,
                                      closure=closure)
 
+def getargspec(fn):
+    """A python3 version of getargspec.
+    Calls `getfullargspec` and assigns args, varargs,
+    varkw, and defaults to a python 2/3 compatible `ArgSpec`.
+    The parameter name 'varkw' is changed to 'keywords' to fit the
+    `ArgSpec` struct.
+    Args:
+      fn: the target function to inspect.
+    Returns:
+      An ArgSpec with args, varargs, keywords, and defaults parameters
+      from FullArgSpec.
+    """
+    if sys.version_info < (3,):
+        arg_spec = inspect.getargspec(fn)
+    else:
+        full_arg_spec = inspect.getfullargspec(fn)
+        arg_spec = inspect.ArgSpec(
+            args=full_arg_spec.args,
+            varargs=full_arg_spec.varargs,
+            keywords=full_arg_spec.varkw,
+            defaults=full_arg_spec.defaults)
+    return arg_spec
+
 
 def has_arg(fn, name, accept_all=False):
     """Checks if a callable accepts a given keyword argument.

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -240,6 +240,7 @@ def func_load(code, defaults=None, closure=None, globs=None):
                                      argdefs=defaults,
                                      closure=closure)
 
+
 def getargspec(fn):
     """A python3 version of getargspec.
     Calls `getfullargspec` and assigns args, varargs,

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -242,7 +242,7 @@ def func_load(code, defaults=None, closure=None, globs=None):
 
 
 def getargspec(fn):
-    """ python2/python3 compatible getargspec.
+    """Python 2/3 compatible `getargspec`.
 
     Calls `getfullargspec` and assigns args, varargs,
     varkw, and defaults to a python 2/3 compatible `ArgSpec`.


### PR DESCRIPTION
### Summary
We should use an getargspec instead of deprecated getagspec.

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
