### PR TITLE
Make H5Dict accept pathlib Paths.

### DIFF
--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -13,8 +13,10 @@ import six
 import h5py
 import tempfile
 try:
+    from pathlib import Path
     from unittest.mock import patch
 except:
+    from pathlib2 import Path
     from mock import patch
 
 
@@ -211,6 +213,22 @@ def test_H5Dict_groups():
         assert_allclose(group4['z'], array)
 
         f.close()
+    os.remove(h5_path)
+
+
+def test_H5Dict_accepts_pathlib_Path():
+    """GitHub issue: 11459"""
+    _, h5_path = tempfile.mkstemp('.h5')
+
+    f = H5Dict(Path(h5_path), mode='w')
+    f['x'] = 'abcd'
+    f.close()
+    del f
+
+    f = H5Dict(Path(h5_path), mode='r')
+    assert f['x'] == 'abcd'
+    f.close()
+
     os.remove(h5_path)
 
 


### PR DESCRIPTION
### Summary

The type checking done in the constructor of `H5Dict` restricts users to use strings to denote paths, but `Path` objects from `pathlib` (https://docs.python.org/3/library/pathlib.html) also make sense there.

### Related Issues

Closes https://github.com/keras-team/keras/issues/11459.

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
