### PR TITLE
Update mkdocs config

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -9,7 +9,7 @@ site_description: 'Documentation for Keras, the Python Deep Learning library.'
 dev_addr: '0.0.0.0:8000'
 google_analytics: ['UA-61785484-1', 'keras.io']
 
-pages:
+nav:
 - Home: index.md
 - Why use Keras: why-use-keras.md
 - Getting started:


### PR DESCRIPTION
### Summary

This PR updates the Keras `mkdocs.yml` configuration file to use `nav` instead of `pages` (the use of `pages` was [depreciated in the MkDocs Version 1.0 release](https://www.mkdocs.org/about/release-notes/#version-10-2018-08-03)). This will prevent the following warning message
```
WARNING -  Config value: 'pages'. Warning: The 'pages' configuration option has been deprecated and will be removed in a future release of MkDocs. Use 'nav' instead.
```
from being output when building the documentation. 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
