### PR TITLE
fix TensorBoard callback for fixed tensor inputs

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -856,7 +856,7 @@ class TensorBoard(Callback):
 
         if self.embeddings_freq and self.embeddings_data is not None:
             self.embeddings_data = standardize_input_data(self.embeddings_data,
-                                                          model.input_names)
+                                                          model._feed_input_names)
 
             embeddings_layer_names = self.embeddings_layer_names
 
@@ -915,9 +915,9 @@ class TensorBoard(Callback):
             if epoch % self.histogram_freq == 0:
 
                 val_data = self.validation_data
-                tensors = (self.model.inputs +
-                           self.model.targets +
-                           self.model.sample_weights)
+                tensors = (self.model._feed_inputs +
+                           self.model._feed_targets +
+                           self.model._feed_sample_weights)
 
                 if self.model.uses_learning_phase:
                     tensors += [K.learning_phase()]
@@ -960,11 +960,9 @@ class TensorBoard(Callback):
                     step = min(self.batch_size, n_samples - i)
                     batch = slice(i, i + step)
 
-                    if type(self.model.input) == list:
-                        feed_dict = {_input: embeddings_data[idx][batch]
-                                     for idx, _input in enumerate(self.model.input)}
-                    else:
-                        feed_dict = {self.model.input: embeddings_data[0][batch]}
+                    feed_dict = {
+                        _input: embeddings_data[idx][batch]
+                        for idx, _input in enumerate(self.model._feed_inputs)}
 
                     feed_dict.update({self.batch_id: i, self.step: step})
 

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -689,7 +689,8 @@ def test_TensorBoard_multi_input_output(tmpdir):
 
     inp1 = Input((input_dim, input_dim))
     inp2 = Input((input_dim, input_dim))
-    inp_3d = add([inp1, inp2])
+    inp3 = Input(tensor=K.random_normal(K.shape(inp1)))  # see issue #11433
+    inp_3d = add([inp1, inp2, inp3])
     inp_2d = GlobalAveragePooling1D()(inp_3d)
     # test a layer with a list of output tensors
     inp_pair = Lambda(lambda x: x)([inp_3d, inp_2d])
@@ -698,7 +699,7 @@ def test_TensorBoard_multi_input_output(tmpdir):
     hidden = Dropout(0.1)(hidden)
     output1 = Dense(num_classes, activation='softmax')(hidden)
     output2 = Dense(num_classes, activation='softmax')(hidden)
-    model = Model(inputs=[inp1, inp2], outputs=[output1, output2])
+    model = Model(inputs=[inp1, inp2, inp3], outputs=[output1, output2])
     model.compile(loss='categorical_crossentropy',
                   optimizer='sgd',
                   metrics=['accuracy'])


### PR DESCRIPTION
* Fixed tensor inputs should not be feed into the model

* As ugly as it is to access internal _feed_X variables of Model,
  copy&pasting all of the logic seems worse

* Also see d046cea1a1d32372cdf27a1c947969c9d09bbde8 which implemented
  the logic on the Model side

### Related Issues
Resolves #11433, #10171
### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
