### PR TITLE
Reduced the size of the numpy arrays used in the tests.

### DIFF
--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -169,7 +169,7 @@ def create_generator_from_sequence_pcs(ds):
 
 def test_generator_enqueuer_threads():
     enqueuer = GeneratorEnqueuer(create_generator_from_sequence_threads(
-        DummySequence([3, 200, 200, 3])), use_multiprocessing=False)
+        DummySequence([3, 10, 10, 3])), use_multiprocessing=False)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
     acc = []
@@ -187,7 +187,7 @@ def test_generator_enqueuer_threads():
 
 def test_generator_enqueuer_processes():
     enqueuer = GeneratorEnqueuer(create_generator_from_sequence_pcs(
-        DummySequence([3, 200, 200, 3])), use_multiprocessing=True)
+        DummySequence([3, 10, 10, 3])), use_multiprocessing=True)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
     acc = []
@@ -200,7 +200,7 @@ def test_generator_enqueuer_processes():
 
 def test_generator_enqueuer_threadsafe():
     enqueuer = GeneratorEnqueuer(create_generator_from_sequence_pcs(
-        DummySequence([3, 200, 200, 3])), use_multiprocessing=False)
+        DummySequence([3, 10, 10, 3])), use_multiprocessing=False)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
     with pytest.raises(RuntimeError) as e:
@@ -228,7 +228,7 @@ def test_generator_enqueuer_fail_processes():
 
 
 def test_ordered_enqueuer_threads():
-    enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]),
+    enqueuer = OrderedEnqueuer(DummySequence([3, 10, 10, 3]),
                                use_multiprocessing=False)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
@@ -241,7 +241,7 @@ def test_ordered_enqueuer_threads():
 
 
 def test_ordered_enqueuer_threads_not_ordered():
-    enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]),
+    enqueuer = OrderedEnqueuer(DummySequence([3, 10, 10, 3]),
                                use_multiprocessing=False,
                                shuffle=True)
     enqueuer.start(3, 10)
@@ -256,7 +256,7 @@ def test_ordered_enqueuer_threads_not_ordered():
 
 @use_spawn
 def test_ordered_enqueuer_processes():
-    enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]),
+    enqueuer = OrderedEnqueuer(DummySequence([3, 10, 10, 3]),
                                use_multiprocessing=True)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
@@ -278,7 +278,7 @@ def test_ordered_enqueuer_fail_threads():
 
 @use_spawn
 def test_on_epoch_end_processes():
-    enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]),
+    enqueuer = OrderedEnqueuer(DummySequence([3, 10, 10, 3]),
                                use_multiprocessing=True)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
@@ -292,9 +292,9 @@ def test_on_epoch_end_processes():
 
 @use_spawn
 def test_context_switch():
-    enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]),
+    enqueuer = OrderedEnqueuer(DummySequence([3, 10, 10, 3]),
                                use_multiprocessing=True)
-    enqueuer2 = OrderedEnqueuer(DummySequence([3, 200, 200, 3], value=15),
+    enqueuer2 = OrderedEnqueuer(DummySequence([3, 10, 10, 3], value=15),
                                 use_multiprocessing=True)
     enqueuer.start(3, 10)
     enqueuer2.start(3, 10)
@@ -324,7 +324,7 @@ def test_context_switch():
 
 
 def test_on_epoch_end_threads():
-    enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]),
+    enqueuer = OrderedEnqueuer(DummySequence([3, 10, 10, 3]),
                                use_multiprocessing=False)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
@@ -361,7 +361,7 @@ def create_finite_generator_from_sequence_pcs(ds):
 
 def test_finite_generator_enqueuer_threads():
     enqueuer = GeneratorEnqueuer(create_finite_generator_from_sequence_threads(
-        DummySequence([3, 200, 200, 3])), use_multiprocessing=False)
+        DummySequence([3, 10, 10, 3])), use_multiprocessing=False)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
     acc = []
@@ -373,7 +373,7 @@ def test_finite_generator_enqueuer_threads():
 
 def test_finite_generator_enqueuer_processes():
     enqueuer = GeneratorEnqueuer(create_finite_generator_from_sequence_pcs(
-        DummySequence([3, 200, 200, 3])), use_multiprocessing=True)
+        DummySequence([3, 10, 10, 3])), use_multiprocessing=True)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
     acc = []


### PR DESCRIPTION
### Summary

This may mitigate the OOM issue, (maybe not), but there is no reason to use big numpy arrays in the tests.

### Related Issues

#11461 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
