### PR TITLE
bug fix: can't use code blocks in multiple sections in docstrings.

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -448,12 +448,16 @@ def count_leading_spaces(s):
         return 0
 
 
-def process_list_block(docstring, starting_point, leading_spaces, marker):
+def process_list_block(docstring, starting_point, section_end,
+                       leading_spaces, marker):
     ending_point = docstring.find('\n\n', starting_point)
     block = docstring[starting_point:(None if ending_point == -1 else
                                       ending_point - 1)]
     # Place marker for later reinjection.
-    docstring = docstring.replace(block, marker)
+    docstring_slice = docstring[starting_point:section_end].replace(block, marker)
+    docstring = (docstring[:starting_point]
+                 + docstring_slice
+                 + docstring[section_end:])
     lines = block.split('\n')
     # Remove the computed number of leading white spaces from each line.
     lines = [re.sub('^' + ' ' * leading_spaces, '', line) for line in lines]
@@ -536,12 +540,20 @@ def process_docstring(docstring):
         anchor = section_idx.group(2)
         leading_spaces = len(section_idx.group(1))
         shift += section_idx.end()
+        next_section_idx = re.search(section_regex, docstring[shift:])
+        if next_section_idx is None:
+            section_end = -1
+        else:
+            section_end = shift + next_section_idx.start()
         marker = '$' + anchor.replace(' ', '_') + '$'
         docstring, content = process_list_block(docstring,
                                                 shift,
+                                                section_end,
                                                 leading_spaces,
                                                 marker)
         sections[marker] = content
+        # `docstring` has changed, so we can't use `next_section_idx` anymore
+        # we have to recompute it
         section_idx = re.search(section_regex, docstring[shift:])
 
     # Format docstring section titles.

--- a/tests/test_doc_auto_generation.py
+++ b/tests/test_doc_auto_generation.py
@@ -330,5 +330,78 @@ def test_doc_lists():
     assert docstring == test_doc1['result']
 
 
+test_doc2 = {
+    'doc': """Multiplies 2 tensors (and/or variables) and returns a *tensor*.
+
+    When attempting to multiply a nD tensor
+    with a nD tensor, it reproduces the Theano behavior.
+    (e.g. `(2, 3) * (4, 3, 5) -> (2, 4, 5)`)
+
+    # Arguments
+        x: Tensor or variable.
+        y: Tensor or variable.
+
+    # Returns
+        A tensor, dot product of `x` and `y`.
+
+    # Examples
+    ```python
+        # Theano-like behavior example
+        >>> x = K.random_uniform_variable(shape=(2, 3), low=0, high=1)
+        >>> y = K.ones((4, 3, 5))
+        >>> xy = K.dot(x, y)
+        >>> K.int_shape(xy)
+        (2, 4, 5)
+    ```
+    
+    # Numpy implementation
+    ```python
+        def dot(x, y):
+            return dot(x, y)
+    ```
+    """,
+    'result': '''Multiplies 2 tensors (and/or variables) and returns a *tensor*.
+
+When attempting to multiply a nD tensor
+with a nD tensor, it reproduces the Theano behavior.
+(e.g. `(2, 3) * (4, 3, 5) -> (2, 4, 5)`)
+
+__Arguments__
+
+- __x__: Tensor or variable.
+- __y__: Tensor or variable.
+
+__Returns__
+
+A tensor, dot product of `x` and `y`.
+
+__Examples__
+
+```python
+# Theano-like behavior example
+>>> x = K.random_uniform_variable(shape=(2, 3), low=0, high=1)
+>>> y = K.ones((4, 3, 5))
+>>> xy = K.dot(x, y)
+>>> K.int_shape(xy)
+(2, 4, 5)
+```
+
+__Numpy implementation__
+
+```python
+def dot(x, y):
+    return dot(x, y)
+```
+'''}
+
+
+def test_doc_multiple_sections_code():
+    """ Checks that we can have code blocks in multiple sections."""
+    docstring = autogen.process_docstring(test_doc2['doc'])
+    with open('./dudu.txt', 'w+') as f:
+        f.write(docstring)
+    assert docstring == test_doc2['result']
+
+
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/test_doc_auto_generation.py
+++ b/tests/test_doc_auto_generation.py
@@ -345,7 +345,7 @@ dummy_docstring = """Multiplies 2 tensors (and/or variables) and returns a *tens
         >>> K.int_shape(xy)
         (2, 4, 5)
     ```
-    
+
     # Numpy implementation
     ```python
         def dot(x, y):

--- a/tests/test_doc_auto_generation.py
+++ b/tests/test_doc_auto_generation.py
@@ -330,19 +330,11 @@ def test_doc_lists():
     assert docstring == test_doc1['result']
 
 
-test_doc2 = {
-    'doc': """Multiplies 2 tensors (and/or variables) and returns a *tensor*.
+dummy_docstring = """Multiplies 2 tensors (and/or variables) and returns a *tensor*.
 
     When attempting to multiply a nD tensor
     with a nD tensor, it reproduces the Theano behavior.
     (e.g. `(2, 3) * (4, 3, 5) -> (2, 4, 5)`)
-
-    # Arguments
-        x: Tensor or variable.
-        y: Tensor or variable.
-
-    # Returns
-        A tensor, dot product of `x` and `y`.
 
     # Examples
     ```python
@@ -359,48 +351,14 @@ test_doc2 = {
         def dot(x, y):
             return dot(x, y)
     ```
-    """,
-    'result': '''Multiplies 2 tensors (and/or variables) and returns a *tensor*.
-
-When attempting to multiply a nD tensor
-with a nD tensor, it reproduces the Theano behavior.
-(e.g. `(2, 3) * (4, 3, 5) -> (2, 4, 5)`)
-
-__Arguments__
-
-- __x__: Tensor or variable.
-- __y__: Tensor or variable.
-
-__Returns__
-
-A tensor, dot product of `x` and `y`.
-
-__Examples__
-
-```python
-# Theano-like behavior example
->>> x = K.random_uniform_variable(shape=(2, 3), low=0, high=1)
->>> y = K.ones((4, 3, 5))
->>> xy = K.dot(x, y)
->>> K.int_shape(xy)
-(2, 4, 5)
-```
-
-__Numpy implementation__
-
-```python
-def dot(x, y):
-    return dot(x, y)
-```
-'''}
+    """
 
 
 def test_doc_multiple_sections_code():
     """ Checks that we can have code blocks in multiple sections."""
-    docstring = autogen.process_docstring(test_doc2['doc'])
-    with open('./dudu.txt', 'w+') as f:
-        f.write(docstring)
-    assert docstring == test_doc2['result']
+    generated = autogen.process_docstring(dummy_docstring)
+    assert '# Theano-like behavior example' in generated
+    assert 'def dot(x, y):' in generated
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

Having blocks of code in multiple sections of the same docstring breaks the rendering of the documentation. To see exactly what I mean, see the test which I added.

### Related Issues

### PR Overview

The problem came from this line:
https://github.com/keras-team/keras/blob/267ccbb4a76913680f4db6b400e05dea7aa84db7/docs/autogen.py#L456

Because the `replace` was used on the full docstring (not the slice of the docstring correnponding to the section being worked on), even code blocks which were in other sections were replaced.

So as the parser progressed, some code blocks were replaced multiple times, and the parser lost the content of the last blocks of code, because the parser only remember what it just replaced. 
See this line which does it: https://github.com/keras-team/keras/blob/267ccbb4a76913680f4db6b400e05dea7aa84db7/docs/autogen.py#L453

When we arrive at this line for the last code block, the code isn't there, only the marker. So the marker gets saved instead of `$CODE_BLOCK_%d`. 

Feel free to use a debugger to understand what I mean. I hope I was clear enough. I advise the reviewer to be very careful, as this PR can potentially break many pages in the docs. I checked most of them, but well... we never know.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
