### PR TITLE
replace generic_utils.getargspec with inspect.getargspec

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -73,7 +73,6 @@ from keras import layers
 from keras.layers import advanced_activations
 from keras.layers import noise
 from keras.layers import wrappers
-from keras.utils import generic_utils
 from keras import initializers
 from keras import optimizers
 from keras import callbacks
@@ -353,9 +352,9 @@ ROOT = 'http://keras.io/'
 def get_function_signature(function, method=True):
     wrapped = getattr(function, '_original_function', None)
     if wrapped is None:
-        signature = generic_utils.getargspec(function)
+        signature = inspect.getargspec(function)
     else:
-        signature = generic_utils.getargspec(wrapped)
+        signature = inspect.getargspec(wrapped)
     defaults = signature.defaults
     if method:
         args = signature.args[1:]


### PR DESCRIPTION
### Summary
autogen.py isn't working because the latest version of keras in PyPI hasn't generic_utils method.
When the latest version of keras in PyPI is updated, I will add an new pull request.

### Related Issues
reference: https://github.com/keras-team/keras/pull/11463

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
