### PR TITLE
multiple input lambda doc example

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -592,10 +592,21 @@ class Lambda(Layer):
         model.add(Lambda(antirectifier,
                          output_shape=antirectifier_output_shape))
     ```
+    ```python
+        # add a layer that returns the hadamard product
+        # of the two input tensors
+
+        def hadamard_product(tensors):
+            return tensors[0]*tensors[1]
+
+        x1 = Dense(32, activation="relu", input_dim=3)(input_1)
+        x2 = Dense(32, activation="relu", input_dim=3)(input_2)
+        x = Lambda(hadamard_product)([x1, x2])
+    ```
 
     # Arguments
         function: The function to be evaluated.
-            Takes input tensor as first argument.
+            Takes input tensor or list of tensors as first argument.
         output_shape: Expected output shape from function.
             Only relevant when using Theano.
             Can be a tuple or function.

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -609,7 +609,8 @@ class Lambda(Layer):
 
         x1 = Dense(32)(input_1)
         x2 = Dense(32)(input_2)
-        x, _ = Lambda(hadamard_product_sum, hadamard_product_sum_output_shape)([x1, x2])
+        layer = Lambda(hadamard_product_sum, hadamard_product_sum_output_shape)
+        x_hadamard, x_sum = layer([x1, x2])
     ```
 
     # Arguments

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -594,14 +594,22 @@ class Lambda(Layer):
     ```
     ```python
         # add a layer that returns the hadamard product
-        # of the two input tensors
+        # and sum of it from two input tensors
 
-        def hadamard_product(tensors):
-            return tensors[0]*tensors[1]
+        def hadamard_product_sum(tensors):
+            out1 = tensors[0] * tensors[1]
+            out2 = K.sum(out1, axis=-1)
+            return [out1, out2]
 
-        x1 = Dense(32, activation="relu", input_dim=3)(input_1)
-        x2 = Dense(32, activation="relu", input_dim=3)(input_2)
-        x = Lambda(hadamard_product)([x1, x2])
+        def hadamard_product_sum_output_shape(input_shapes):
+            shape1 = list(input_shapes[0])
+            shape2 = list(input_shapes[1])
+            assert shape1 == shape2  # else hadamard product isn't possible
+            return [tuple(shape1), tuple(shape2[:-1])]
+
+        x1 = Dense(32)(input_1)
+        x2 = Dense(32)(input_2)
+        x, _ = Lambda(hadamard_product_sum, hadamard_product_sum_output_shape)([x1, x2])
     ```
 
     # Arguments


### PR DESCRIPTION
### Summary
[DOCS]
To showcase multiple inputs for `Lambda` layer, added an example to the docstrings, small changes to the parameter description. I also made a [gist](https://gist.github.com/greed2411/f1d11d4152ebc8011391a79c9b5edd4c) if you want to see the clean and working example of the code I've added.

### Related Issues
Solves #11020 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

Other:
Failed to build the appropriate docs from docstrings using `mkdocs`. I apologise for that, I followed the instructions over [here](https://github.com/keras-team/keras/tree/master/docs), still couldn't do it, I followed the steps in installing and running the server, but both markdowns and the static websites didn't reflect the changes.