### PR TITLE
[BUG] Bug in adadelta optimizer's learning rate

### DIFF
--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -410,8 +410,8 @@ class Adadelta(Optimizer):
             self.updates.append(K.update(a, new_a))
 
             # use the new accumulator and the *old* delta_accumulator
-            update = g * K.sqrt(d_a + self.epsilon) / K.sqrt(new_a + self.epsilon)
-            new_p = p - lr * update
+            update = lr * g * K.sqrt(d_a + self.epsilon) / K.sqrt(new_a + self.epsilon)
+            new_p = p - update
 
             # Apply constraints.
             if getattr(p, 'constraint', None) is not None:


### PR DESCRIPTION
The learning rate is not part of the original AdaDelta algorithm. If we want to add it as a parameter, it should be considered as part of the `update` variable in order to accumulate it into the `delta_accumulators` variable, if not, when it reaches a local minimum it starts bouncing and no total convergence is achieved.

I.e. we should add the actual update in the numerator of the LR adjustment



