### PR TITLE
adding check for check_array_lengths

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -801,7 +801,8 @@ class Model(Network):
                     feed_sample_weight_modes)
             ]
             # Check that all arrays have the same length.
-            check_array_length_consistency(x, y, sample_weights)
+            if check_array_lengths:
+                check_array_length_consistency(x, y, sample_weights)
             if self._is_graph_network:
                 # Additional checks to avoid users mistakenly
                 # using improper loss fns.


### PR DESCRIPTION
### Summary
This PR implements a check for existing `check_array_lengths` kwarg for `model._standardize_user_data`. Models can therefore avoid checking input lengths (i.e., asserting a consistent batch size across multiple inputs) by inheriting from Model:

```python
from keras.models import Model

class NoCheckModel(Model):
    def _standardize_user_data(self, *args, **kwargs):
        kwargs['check_array_lengths'] = False
        return super(NoCheckModel, self)._standardize_user_data(*args, **kwargs)
```

### Related Issues
#11545

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
