### PR TITLE
Enabled the use of the numpy backend on legacy_conv tests.

### DIFF
--- a/keras/backend/numpy_backend.py
+++ b/keras/backend/numpy_backend.py
@@ -39,7 +39,15 @@ def normalize_conv(func):
                 for j in range(w.shape[2 + i] - 1):
                     w = np.insert(w, 2 * j + 1, 0, axis=2 + i)
 
+        strides = kwargs.pop('strides', 1)
+        if isinstance(strides, int):
+            strides = [1, 1] + [strides] * (x.ndim - 2)
+
         y = func(x, w, **kwargs)
+
+        slices = tuple(slice(None, None, stride) for stride in strides)
+
+        y = y[slices]
 
         if kwargs['data_format'] == 'channels_last':
             if y.ndim == 3:
@@ -55,7 +63,7 @@ def normalize_conv(func):
 
 
 @normalize_conv
-def conv(x, w, padding, data_format):
+def conv(x, w, padding='valid', data_format=None):
     y = []
     for i in range(x.shape[0]):
         _y = []
@@ -70,7 +78,7 @@ def conv(x, w, padding, data_format):
 
 
 @normalize_conv
-def depthwise_conv(x, w, padding, data_format):
+def depthwise_conv(x, w, padding='valid', data_format=None):
     y = []
     for i in range(x.shape[0]):
         _y = []

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1278,7 +1278,7 @@ class TestBackend(object):
         kernel_shape = (3, 2, 3)
         for strides in [1, 2]:
             check_two_tensor_operation('conv1d', input_shape, kernel_shape,
-                                       BACKENDS, cntk_dynamicity=True,
+                                       WITH_NP, cntk_dynamicity=True,
                                        strides=strides,
                                        data_format='channels_last')
 
@@ -1291,7 +1291,7 @@ class TestBackend(object):
             ((1, 6, 5, 3), (3, 3, 3, 2), 'channels_last')
         ]:
             check_two_tensor_operation('conv2d', input_shape, kernel_shape,
-                                       BACKENDS, cntk_dynamicity=True,
+                                       WITH_NP, cntk_dynamicity=True,
                                        data_format=data_format)
 
     def test_legacy_depthwise_conv_2d(self):
@@ -1304,7 +1304,7 @@ class TestBackend(object):
         ]:
             check_two_tensor_operation('depthwise_conv2d',
                                        input_shape, kernel_shape,
-                                       BACKENDS, cntk_dynamicity=True,
+                                       WITH_NP, cntk_dynamicity=True,
                                        data_format=data_format)
 
     def test_legacy_conv3d(self):
@@ -1318,7 +1318,7 @@ class TestBackend(object):
             ((1, 2, 2, 2, 1), (2, 2, 2, 1, 1), 'channels_last')
         ]:
             check_two_tensor_operation('conv3d', input_shape, kernel_shape,
-                                       BACKENDS, cntk_dynamicity=True,
+                                       WITH_NP, cntk_dynamicity=True,
                                        data_format=data_format)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Summary
The handling of the `strides` argument was missing. As well as the default values for `padding` and `data_format`.
### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
