### PR TITLE
Used the numpy backend to check pooling operations correctness.

### DIFF
--- a/keras/backend/numpy_backend.py
+++ b/keras/backend/numpy_backend.py
@@ -7,6 +7,7 @@ import numpy as np
 import scipy.signal as signal
 import scipy as sp
 from keras.backend import floatx
+from keras.backend import normalize_data_format
 from keras.utils.generic_utils import transpose_shape
 from keras.utils import to_categorical
 
@@ -117,7 +118,8 @@ conv2d_transpose = conv_transpose
 conv3d_transpose = conv_transpose
 
 
-def pool(x, pool_size, strides, padding, data_format, pool_mode):
+def pool(x, pool_size, strides, padding='valid', data_format=None, pool_mode='max'):
+    data_format = normalize_data_format(data_format)
     if data_format == 'channels_last':
         if x.ndim == 3:
             x = np.transpose(x, (0, 2, 1))

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1399,9 +1399,10 @@ class TestBackend(object):
             'pool3d', (5, 9, 11, 5, 3), WITH_NP, cntk_dynamicity=True,
             pool_size=(2, 3, 2), strides=(1, 1, 1), padding='valid')
 
-        check_single_tensor_operation(
-            'pool3d', (2, 6, 6, 6, 3), WITH_NP,
-            pool_size=(3, 3, 3), strides=(1, 1, 1), padding='same', pool_mode='avg')
+        if K.backend() != 'cntk':
+            check_single_tensor_operation(
+                'pool3d', (2, 6, 6, 6, 3), WITH_NP,
+                pool_size=(3, 3, 3), strides=(1, 1, 1), padding='same', pool_mode='avg')
 
     def test_random_normal(self):
         # test standard normal as well as a normal with a different set of parameters

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1402,7 +1402,8 @@ class TestBackend(object):
         if K.backend() != 'cntk':
             check_single_tensor_operation(
                 'pool3d', (2, 6, 6, 6, 3), WITH_NP,
-                pool_size=(3, 3, 3), strides=(1, 1, 1), padding='same', pool_mode='avg')
+                pool_size=(3, 3, 3), strides=(1, 1, 1), padding='same',
+                pool_mode='avg')
 
     def test_random_normal(self):
         # test standard normal as well as a normal with a different set of parameters

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1360,51 +1360,6 @@ class TestBackend(object):
                 padding=padding, data_format=data_format))
         assert_allclose(y1, y2, atol=1e-05)
 
-    def test_legacy_pool2d(self):
-        check_single_tensor_operation(
-            'pool2d', (5, 10, 12, 3), WITH_NP, cntk_dynamicity=True,
-            pool_size=(2, 2), strides=(1, 1), padding='valid')
-
-        check_single_tensor_operation(
-            'pool2d', (5, 9, 11, 3), WITH_NP, cntk_dynamicity=True,
-            pool_size=(2, 2), strides=(1, 1), padding='valid')
-
-        check_single_tensor_operation(
-            'pool2d', (5, 9, 11, 3), WITH_NP, cntk_dynamicity=True,
-            pool_size=(2, 2), strides=(1, 1), pool_mode='avg')
-
-        check_single_tensor_operation(
-            'pool2d', (5, 9, 11, 3), WITH_NP, cntk_dynamicity=True,
-            pool_size=(2, 3), strides=(1, 1), padding='valid')
-
-        check_single_tensor_operation(
-            'pool2d', (2, 7, 7, 5), WITH_NP, cntk_dynamicity=True,
-            pool_size=(3, 3), strides=(1, 1),
-            padding='same', pool_mode='avg')
-
-    def test_legacy_pool3d(self):
-        check_single_tensor_operation(
-            'pool3d', (5, 10, 12, 5, 3), WITH_NP, cntk_dynamicity=True,
-            pool_size=(2, 2, 2), strides=(1, 1, 1), padding='valid')
-
-        check_single_tensor_operation(
-            'pool3d', (5, 9, 11, 5, 3), WITH_NP, cntk_dynamicity=True,
-            pool_size=(2, 2, 2), strides=(1, 1, 1), padding='valid')
-
-        check_single_tensor_operation(
-            'pool3d', (5, 9, 11, 5, 3), WITH_NP, cntk_dynamicity=True,
-            pool_size=(2, 2, 2), strides=(1, 1, 1), pool_mode='avg')
-
-        check_single_tensor_operation(
-            'pool3d', (5, 9, 11, 5, 3), WITH_NP, cntk_dynamicity=True,
-            pool_size=(2, 3, 2), strides=(1, 1, 1), padding='valid')
-
-        if K.backend() != 'cntk':
-            check_single_tensor_operation(
-                'pool3d', (2, 6, 6, 6, 3), WITH_NP,
-                pool_size=(3, 3, 3), strides=(1, 1, 1), padding='same',
-                pool_mode='avg')
-
     def test_random_normal(self):
         # test standard normal as well as a normal with a different set of parameters
         for mean, std in [(0., 1.), (-10., 5.)]:

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1249,6 +1249,8 @@ class TestBackend(object):
              'valid', 'channels_last', 'avg'),
             ('pool2d', (3, 6, 7, 3), (3, 3), (1, 1),
              'same', 'channels_last', 'max'),
+            ('pool2d', (3, 6, 7, 3), (3, 3), (2, 1),
+             'same', 'channels_last', 'max'),
             ('pool3d', (2, 3, 7, 7, 7), (3, 3, 3), (1, 1, 1),
              'same', 'channels_first', 'avg'),
             ('pool3d', (3, 3, 8, 5, 9), (2, 3, 2), (1, 1, 1),
@@ -1256,6 +1258,8 @@ class TestBackend(object):
             ('pool3d', (2, 8, 9, 5, 3), (3, 2, 3), (1, 1, 1),
              'valid', 'channels_last', 'avg'),
             ('pool3d', (3, 5, 6, 7, 3), (3, 3, 3), (1, 1, 1),
+             'same', 'channels_last', 'max'),
+            ('pool3d', (3, 5, 6, 7, 3), (3, 3, 3), (1, 2, 1),
              'same', 'channels_last', 'max'),
         ])
     def test_pool(self,

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1360,47 +1360,47 @@ class TestBackend(object):
                 padding=padding, data_format=data_format))
         assert_allclose(y1, y2, atol=1e-05)
 
-    def legacy_test_pool2d(self):
+    def test_legacy_pool2d(self):
         check_single_tensor_operation(
-            'pool2d', (5, 10, 12, 3), BACKENDS, cntk_dynamicity=True,
+            'pool2d', (5, 10, 12, 3), WITH_NP, cntk_dynamicity=True,
             pool_size=(2, 2), strides=(1, 1), padding='valid')
 
         check_single_tensor_operation(
-            'pool2d', (5, 9, 11, 3), BACKENDS, cntk_dynamicity=True,
+            'pool2d', (5, 9, 11, 3), WITH_NP, cntk_dynamicity=True,
             pool_size=(2, 2), strides=(1, 1), padding='valid')
 
         check_single_tensor_operation(
-            'pool2d', (5, 9, 11, 3), BACKENDS, cntk_dynamicity=True,
+            'pool2d', (5, 9, 11, 3), WITH_NP, cntk_dynamicity=True,
             pool_size=(2, 2), strides=(1, 1), pool_mode='avg')
 
         check_single_tensor_operation(
-            'pool2d', (5, 9, 11, 3), BACKENDS, cntk_dynamicity=True,
+            'pool2d', (5, 9, 11, 3), WITH_NP, cntk_dynamicity=True,
             pool_size=(2, 3), strides=(1, 1), padding='valid')
 
         check_single_tensor_operation(
-            'pool2d', (2, 7, 7, 5), BACKENDS, cntk_dynamicity=True,
+            'pool2d', (2, 7, 7, 5), WITH_NP, cntk_dynamicity=True,
             pool_size=(3, 3), strides=(1, 1),
             padding='same', pool_mode='avg')
 
-    def legacy_test_pool3d(self):
+    def test_legacy_pool3d(self):
         check_single_tensor_operation(
-            'pool3d', (5, 10, 12, 5, 3), BACKENDS, cntk_dynamicity=True,
+            'pool3d', (5, 10, 12, 5, 3), WITH_NP, cntk_dynamicity=True,
             pool_size=(2, 2, 2), strides=(1, 1, 1), padding='valid')
 
         check_single_tensor_operation(
-            'pool3d', (5, 9, 11, 5, 3), BACKENDS, cntk_dynamicity=True,
+            'pool3d', (5, 9, 11, 5, 3), WITH_NP, cntk_dynamicity=True,
             pool_size=(2, 2, 2), strides=(1, 1, 1), padding='valid')
 
         check_single_tensor_operation(
-            'pool3d', (5, 9, 11, 5, 3), BACKENDS, cntk_dynamicity=True,
+            'pool3d', (5, 9, 11, 5, 3), WITH_NP, cntk_dynamicity=True,
             pool_size=(2, 2, 2), strides=(1, 1, 1), pool_mode='avg')
 
         check_single_tensor_operation(
-            'pool3d', (5, 9, 11, 5, 3), BACKENDS, cntk_dynamicity=True,
+            'pool3d', (5, 9, 11, 5, 3), WITH_NP, cntk_dynamicity=True,
             pool_size=(2, 3, 2), strides=(1, 1, 1), padding='valid')
 
         check_single_tensor_operation(
-            'pool3d', (2, 6, 6, 6, 3), [KTH, KTF],
+            'pool3d', (2, 6, 6, 6, 3), WITH_NP,
             pool_size=(3, 3, 3), strides=(1, 1, 1), padding='same', pool_mode='avg')
 
     def test_random_normal(self):


### PR DESCRIPTION
### Summary
The default values were missing, and I also had to rename the test functions because they were not detected by pytest.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
