### PR TITLE
Removed dead code in layer_test

### DIFF
--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -71,13 +71,6 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
     weights = layer.get_weights()
     layer.set_weights(weights)
 
-    # test and instantiation from weights
-    # Checking for empty weights array to avoid a problem where some
-    # legacy layers return bad values from get_weights()
-    if has_arg(layer_cls.__init__, 'weights') and len(weights):
-        kwargs['weights'] = weights
-        layer = layer_cls(**kwargs)
-
     expected_output_shape = layer.compute_output_shape(input_shape)
 
     def _layer_in_model_test(model):


### PR DESCRIPTION
### Summary

This condition is never hit in `layer_test`. I added an `assert False` and ran the test suite locally to check it.

I don't know what was intended with this check, but it seems that this should not be performed on each layer because it does not depend on the implementation of the layer.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
