### PR TITLE
Inlined nested function in layer_test

### DIFF
--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -97,6 +97,7 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
                                         actual_output_shape):
         if expected_dim is not None:
             assert expected_dim == actual_dim
+
     if expected_output is not None:
         assert_allclose(actual_output, expected_output, rtol=1e-3)
 

--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -80,32 +80,6 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
 
     expected_output_shape = layer.compute_output_shape(input_shape)
 
-    def _layer_in_model_test(model):
-        actual_output = model.predict(input_data)
-        actual_output_shape = actual_output.shape
-        for expected_dim, actual_dim in zip(expected_output_shape,
-                                            actual_output_shape):
-            if expected_dim is not None:
-                assert expected_dim == actual_dim
-        if expected_output is not None:
-            assert_allclose(actual_output, expected_output, rtol=1e-3)
-
-        # test serialization, weight setting at model level
-        model_config = model.get_config()
-        recovered_model = model.__class__.from_config(model_config)
-        if model.weights:
-            weights = model.get_weights()
-            recovered_model.set_weights(weights)
-            _output = recovered_model.predict(input_data)
-            assert_allclose(_output, actual_output, rtol=1e-3)
-
-        # test training mode (e.g. useful when the layer has a
-        # different behavior at training and testing time).
-        if has_arg(layer.call, 'training'):
-            model.compile('rmsprop', 'mse')
-            model.train_on_batch(input_data, actual_output)
-        return actual_output
-
     # test in functional API
     if fixed_batch_size:
         x = Input(batch_shape=input_shape, dtype=input_dtype)
@@ -116,7 +90,30 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
 
     # check with the functional API
     model = Model(x, y)
-    actual_output = _layer_in_model_test(model)
+
+    actual_output = model.predict(input_data)
+    actual_output_shape = actual_output.shape
+    for expected_dim, actual_dim in zip(expected_output_shape,
+                                        actual_output_shape):
+        if expected_dim is not None:
+            assert expected_dim == actual_dim
+    if expected_output is not None:
+        assert_allclose(actual_output, expected_output, rtol=1e-3)
+
+    # test serialization, weight setting at model level
+    model_config = model.get_config()
+    recovered_model = model.__class__.from_config(model_config)
+    if model.weights:
+        weights = model.get_weights()
+        recovered_model.set_weights(weights)
+        _output = recovered_model.predict(input_data)
+        assert_allclose(_output, actual_output, rtol=1e-3)
+
+    # test training mode (e.g. useful when the layer has a
+    # different behavior at training and testing time).
+    if has_arg(layer.call, 'training'):
+        model.compile('rmsprop', 'mse')
+        model.train_on_batch(input_data, actual_output)
 
     # test instantiation from layer config
     layer_config = layer.get_config()


### PR DESCRIPTION
### Summary
This piece of code was put in a inner function to be able to apply it on both `Sequential` and `Model`. But since `Sequential` is not tested in `layer_test` anymore, it's not useful to keep it in an inner function. It's harder to read.

### Related Issues

#10660
#11115

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
