### PR TITLE
Fixed typo in training_utils.py

### DIFF
--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -21,7 +21,7 @@ def standardize_single_array(x):
         shape = K.int_shape(x)
         if shape is None or shape[0] is None:
             raise ValueError(
-                'When feeding symbolic tensors to a model, we expect the'
+                'When feeding symbolic tensors to a model, we expect the '
                 'tensors to have a static batch size. '
                 'Got tensor with shape: %s' % str(shape))
         return x


### PR DESCRIPTION
### Summary
The error message didn't have a space between words, so it looked like "we expect thetensors to have a static batch size." 
With this change we add a space between "the" and "tensors"
### Related Issues
N/A
### PR Overview
- [n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
