### PR TITLE
Removing mkl from travis to speed up the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
     fi
 
     # install pydot for visualization tests
-  - travis_retry conda install mkl mkl-service pydot graphviz $PIL
+  - travis_retry conda install pydot graphviz $PIL
 
   - pip install -e .[tests]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,13 @@ install:
       fi
     fi
 
+    # install mkl only for Theano.
+    - if [[ "$KERAS_BACKEND" == "theano" ]]; then
+        export MKL="mkl mkl-service";
+      fi
+
     # install pydot for visualization tests
-  - travis_retry conda install pydot graphviz $PIL
+  - travis_retry conda install $MKL pydot graphviz $PIL
 
   - pip install -e .[tests]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,10 @@ install:
       fi
     fi
 
-    # install mkl only for Theano.
-    - if [[ "$KERAS_BACKEND" == "theano" ]]; then
-        export MKL="mkl mkl-service";
-      fi
+  # install mkl only for Theano.
+  - if [[ "$KERAS_BACKEND" == "theano" ]]; then
+      export MKL="mkl mkl-service";
+    fi
 
     # install pydot for visualization tests
   - travis_retry conda install $MKL pydot graphviz $PIL


### PR DESCRIPTION
### Summary

We do operations on very small tensors in the tests, so mkl might not provide a speed benefit. 

Mkl takes 40 seconds to install, so let's see how much we can save by avoiding it.

So MKL has been removed in all builds except theano, and we save ~40s each time we don't install it.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
