### PR TITLE
Add Bicubic Interpolation

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2091,7 +2091,7 @@ def resize_images(x,
         height_factor: Positive integer.
         width_factor: Positive integer.
         data_format: string, `"channels_last"` or `"channels_first"`.
-        interpolation: A string, one of `nearest` or `bilinear`.
+        interpolation: A string, one of `nearest`, `bilinear`, or `bicubic`.
 
     # Returns
         A tensor.
@@ -2115,9 +2115,11 @@ def resize_images(x,
         x = tf.image.resize_nearest_neighbor(x, new_shape)
     elif interpolation == 'bilinear':
         x = tf.image.resize_bilinear(x, new_shape)
+    elif interpolation == 'bicubic':
+        x = tf.image.resize_bicubic(x, new_shape)
     else:
         raise ValueError('interpolation should be one '
-                         'of "nearest" or "bilinear".')
+                         'of "nearest", "bilinear", or "bicubic".')
     if data_format == 'channels_first':
         x = permute_dimensions(x, [0, 3, 1, 2])
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1009,10 +1009,10 @@ def resize_images(x,
             output._keras_shape[axis_2] *= width_factor
             output._keras_shape = tuple(output._keras_shape)
     elif interpolation == 'bicubic':
-        output = resize_images(x, 
-                               height_factor, 
-                               width_factor, 
-                               data_format, 
+        output = resize_images(x,
+                               height_factor,
+                               width_factor,
+                               data_format,
                                interpolation='nearest')
     else:
         raise ValueError('interpolation should be one of "nearest" or "bilinear".')

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1008,6 +1008,8 @@ def resize_images(x,
             output._keras_shape[axis_1] *= height_factor
             output._keras_shape[axis_2] *= width_factor
             output._keras_shape = tuple(output._keras_shape)
+    elif interpolation == 'bicubic':
+        resize_images(x, height_factor, width_factor, data_format, interpolation='nearest')
     else:
         raise ValueError('interpolation should be one of "nearest" or "bilinear".')
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1009,7 +1009,11 @@ def resize_images(x,
             output._keras_shape[axis_2] *= width_factor
             output._keras_shape = tuple(output._keras_shape)
     elif interpolation == 'bicubic':
-        resize_images(x, height_factor, width_factor, data_format, interpolation='nearest')
+        output = resize_images(x, 
+                               height_factor, 
+                               width_factor, 
+                               data_format, 
+                               interpolation='nearest')
     else:
         raise ValueError('interpolation should be one of "nearest" or "bilinear".')
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1990,7 +1990,7 @@ class UpSampling2D(_UpSampling):
             It defaults to the `image_data_format` value found in your
             Keras config file at `~/.keras/keras.json`.
             If you never set it, then it will be "channels_last".
-        interpolation: A string, one of `nearest` or `bilinear`.
+        interpolation: A string, one of `nearest`, `bilinear`, or `bicubic`.
             Note that CNTK does not support yet the `bilinear` upscaling
             and that with Theano, only `size=(2, 2)` is possible.
 
@@ -2014,9 +2014,9 @@ class UpSampling2D(_UpSampling):
                  **kwargs):
         normalized_size = conv_utils.normalize_tuple(size, 2, 'size')
         super(UpSampling2D, self).__init__(normalized_size, data_format, **kwargs)
-        if interpolation not in ['nearest', 'bilinear']:
+        if interpolation not in ['nearest', 'bilinear', 'bicubic']:
             raise ValueError('interpolation should be one '
-                             'of "nearest" or "bilinear".')
+                             'of "nearest", "bilinear", or "bicubic".')
         self.interpolation = interpolation
 
     def call(self, inputs):

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1316,12 +1316,29 @@ class TestBackend(object):
                                       data_format=data_format,
                                       interpolation='bilinear')
 
+    @staticmethod
+    def _helper_bicubic(data_format, height_factor, width_factor):
+        x_shape = (2, 3, 4, 5)
+        check_single_tensor_operation('resize_images', x_shape,
+                                      [KTF, KTH],
+                                      height_factor=height_factor,
+                                      width_factor=width_factor,
+                                      data_format=data_format,
+                                      interpolation='bicubic')
+
     @pytest.mark.skipif(K.backend() == 'cntk', reason='Not supported.')
     @pytest.mark.parametrize('data_format', ['channels_first', 'channels_last'])
     def test_resize_images_bilinear(self, data_format):
         self._helper_bilinear(data_format, 2, 2)
         with pytest.raises(NotImplementedError):
             self._helper_bilinear(data_format, 4, 4)
+
+    @pytest.mark.skipif(K.backend() == 'cntk', reason='Not supported.')
+    @pytest.mark.parametrize('data_format', ['channels_first', 'channels_last'])
+    def test_resize_images_bicubic(self, data_format):
+        self._helper_bicubic(data_format, 2, 2)
+        with pytest.raises(NotImplementedError):
+            self._helper_bicubic(data_format, 4, 4)
 
     def test_resize_volumes(self):
         for data_format in ['channels_first', 'channels_last']:

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1433,7 +1433,7 @@ class TestBackend(object):
     def _helper_bicubic(data_format, height_factor, width_factor):
         x_shape = (2, 3, 4, 5)
         check_single_tensor_operation('resize_images', x_shape,
-                                      [KTF, KTH],
+                                      [KTF],
                                       height_factor=height_factor,
                                       width_factor=width_factor,
                                       data_format=data_format,

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1446,7 +1446,8 @@ class TestBackend(object):
         with pytest.raises(NotImplementedError):
             self._helper_bilinear(data_format, 4, 4)
 
-    @pytest.mark.skipif(K.backend() == 'cntk', reason='Not supported.')
+    @pytest.mark.skipif(K.backend() != 'tensorflow',
+                        reason='Specific to Tensorflow.')
     @pytest.mark.parametrize('data_format', ['channels_first', 'channels_last'])
     def test_resize_images_bicubic(self, data_format):
         self._helper_bicubic(data_format, 2, 2)

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -908,8 +908,8 @@ def test_upsampling_2d_bilinear(data_format):
                 assert np_output.shape[2] == length_col * input_num_col
 
 
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason='cntk does not support it yet')
+@pytest.mark.skipif(K.backend() != 'tensorflow',
+                    reason='Specific to Tensorflow.')
 @pytest.mark.parametrize('data_format',
                          ['channels_first', 'channels_last'])
 def test_upsampling_2d_bicubic(data_format):
@@ -946,7 +946,6 @@ def test_upsampling_2d_bicubic(data_format):
             else:  # tf
                 assert np_output.shape[1] == length_row * input_num_row
                 assert np_output.shape[2] == length_col * input_num_col
-
 
 
 @pytest.mark.skipif((K.backend() == 'cntk'),

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -909,6 +909,47 @@ def test_upsampling_2d_bilinear(data_format):
 
 
 @pytest.mark.skipif((K.backend() == 'cntk'),
+                    reason='cntk does not support it yet')
+@pytest.mark.parametrize('data_format',
+                         ['channels_first', 'channels_last'])
+def test_upsampling_2d_bicubic(data_format):
+    num_samples = 2
+    stack_size = 2
+    input_num_row = 11
+    input_num_col = 12
+
+    if data_format == 'channels_first':
+        inputs = np.random.rand(num_samples, stack_size, input_num_row,
+                                input_num_col)
+    else:  # tf
+        inputs = np.random.rand(num_samples, input_num_row, input_num_col,
+                                stack_size)
+
+    # basic test
+    layer_test(convolutional.UpSampling2D,
+               kwargs={'size': (2, 2),
+                       'data_format': data_format,
+                       'interpolation': 'bicubic'},
+               input_shape=inputs.shape)
+
+    for length_row in [2]:
+        for length_col in [2, 3]:
+            layer = convolutional.UpSampling2D(
+                size=(length_row, length_col),
+                data_format=data_format)
+            layer.build(inputs.shape)
+            outputs = layer(K.variable(inputs))
+            np_output = K.eval(outputs)
+            if data_format == 'channels_first':
+                assert np_output.shape[2] == length_row * input_num_row
+                assert np_output.shape[3] == length_col * input_num_col
+            else:  # tf
+                assert np_output.shape[1] == length_row * input_num_row
+                assert np_output.shape[2] == length_col * input_num_col
+
+
+
+@pytest.mark.skipif((K.backend() == 'cntk'),
                     reason="cntk does not support it yet")
 def test_upsampling_3d():
     num_samples = 2


### PR DESCRIPTION
### Summary
Adds Bicubic interpolation to the Keras backend.
`K.resize_images(x, height_factor, width_factor, data_format, interpolation='bicubic') `

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
