### PR TITLE
Delete misleading comment about Dense input flattening

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -794,9 +794,6 @@ class Dense(Layer):
     created by the layer, and `bias` is a bias vector created by the layer
     (only applicable if `use_bias` is `True`).
 
-    Note: if the input to the layer has a rank greater than 2, then
-    it is flattened prior to the initial dot product with `kernel`.
-
     # Example
 
     ```python


### PR DESCRIPTION
From this comment it sounds like there is an implicit
`Flatten` layer before the dot product with `kernel`.

However, this seems misleading to me, as the output
shape of this layer is the same as the input shape
with the last dimension replaced by `units`. This
is also mentioned further down in the comment, so
I propose just deleting this comment about the
flattening.

Alternatively, we could replace it by a comment that
says something about the dot product only being done
along the last dimension.