### PR TITLE
allow saving weights directly to a binary stream

### DIFF
--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -1105,7 +1105,7 @@ class Network(Layer):
         # Arguments
             filepath: one of the following:
             - string, path where to save the model, or
-            - h5py.File object where to save the model
+            - h5py.Group object where to save the model
             overwrite: Whether to silently overwrite any existing file at the
                 target location, or provide the user with a manual prompt.
 
@@ -1152,7 +1152,7 @@ class Network(Layer):
         # Arguments
             filepath: one of the following:
             - string, path to the saved model, or
-            - h5py.File object from which to load the model
+            - h5py.Group object from which to load the model
             by_name: Boolean, whether to load weights by name
                 or by topological order.
             skip_mismatch: Boolean, whether to skip loading of layers

--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -1105,7 +1105,7 @@ class Network(Layer):
         # Arguments
             filepath: one of the following:
             - string, path where to save the model, or
-            - h5py.Group object where to save the model
+            - h5py.File or h5py.Group object where to save the model
             overwrite: Whether to silently overwrite any existing file at the
                 target location, or provide the user with a manual prompt.
 
@@ -1129,9 +1129,12 @@ class Network(Layer):
 
         try:
             saving.save_weights_to_hdf5_group(f, self.layers)
+
+            if isinstance(f, h5py.File):  # f could also be a h5py.Group object
+                f.flush()
         finally:
             if opened_new_file:
-                f.flush()
+                f.close()
 
     def load_weights(self, filepath, by_name=False,
                      skip_mismatch=False, reshape=False):
@@ -1152,7 +1155,7 @@ class Network(Layer):
         # Arguments
             filepath: one of the following:
             - string, path to the saved model, or
-            - h5py.Group object from which to load the model
+            - h5py.File or h5py.Group object from which to load the model
             by_name: Boolean, whether to load weights by name
                 or by topological order.
             skip_mismatch: Boolean, whether to skip loading of layers

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -441,14 +441,20 @@ def test_loading_weights_by_name_skip_mismatch():
 
 
 def test_weight_saving_to_pre_created_h5py_file():
-    inputs = Input(shape=(3,))
-    x = Dense(2)(inputs)
-    outputs = Dense(3)(x)
 
-    model = Model(inputs, outputs)
-    model.compile(loss=losses.MSE,
-                  optimizer=optimizers.Adam(),
-                  metrics=[metrics.categorical_accuracy])
+    def create_untrained_model():
+        inputs = Input(shape=(3,))
+        x = Dense(2)(inputs)
+        outputs = Dense(3)(x)
+
+        model = Model(inputs, outputs)
+        model.compile(loss=losses.MSE,
+                      optimizer=optimizers.Adam(),
+                      metrics=[metrics.categorical_accuracy])
+
+        return model
+
+    model = create_untrained_model()
     x = np.random.random((1, 3))
     y = np.random.random((1, 3))
     model.train_on_batch(x, y)
@@ -457,35 +463,47 @@ def test_weight_saving_to_pre_created_h5py_file():
     _, fname = tempfile.mkstemp('.h5')
     with h5py.File(fname, mode='r+') as h5file:
         model.save_weights(h5file)
-        model.load_weights(h5file)
-        out2 = model.predict(x)
+
+        loaded_model = create_untrained_model()
+        loaded_model.load_weights(h5file)
+        out2 = loaded_model.predict(x)
     assert_allclose(out, out2, atol=1e-05)
 
     # test non-default options in h5
     with h5py.File('does not matter', driver='core',
                    backing_store=False) as h5file:
         model.save_weights(h5file)
-        model.load_weights(h5file)
-        out2 = model.predict(x)
+
+        loaded_model = create_untrained_model()
+        loaded_model.load_weights(h5file)
+        out2 = loaded_model.predict(x)
     assert_allclose(out, out2, atol=1e-05)
 
     with h5py.File(fname, mode='r+') as h5file:
         g = h5file.create_group('weights')
         model.save_weights(g)
-        model.load_weights(g)
-        out2 = model.predict(x)
+
+        loaded_model = create_untrained_model()
+        loaded_model.load_weights(g)
+        out2 = loaded_model.predict(x)
     assert_allclose(out, out2, atol=1e-05)
 
 
 def test_weight_saving_to_binary_stream():
-    inputs = Input(shape=(3,))
-    x = Dense(2)(inputs)
-    outputs = Dense(3)(x)
 
-    model = Model(inputs, outputs)
-    model.compile(loss=losses.MSE,
-                  optimizer=optimizers.Adam(),
-                  metrics=[metrics.categorical_accuracy])
+    def create_untrained_model():
+        inputs = Input(shape=(3,))
+        x = Dense(2)(inputs)
+        outputs = Dense(3)(x)
+
+        model = Model(inputs, outputs)
+        model.compile(loss=losses.MSE,
+                      optimizer=optimizers.Adam(),
+                      metrics=[metrics.categorical_accuracy])
+
+        return model
+
+    model = create_untrained_model()
     x = np.random.random((1, 3))
     y = np.random.random((1, 3))
     model.train_on_batch(x, y)
@@ -494,15 +512,16 @@ def test_weight_saving_to_binary_stream():
     _, fname = tempfile.mkstemp('.h5')
     with h5py.File(fname, mode='r+') as h5file:
         model.save_weights(h5file)
-        model.load_weights(h5file)
-        out2 = model.predict(x)
+
+        loaded_model = create_untrained_model()
+        loaded_model.load_weights(h5file)
+        out2 = loaded_model.predict(x)
     assert_allclose(out, out2, atol=1e-05)
 
     # Save the model to an in-memory-only h5 file.
     with h5py.File('does not matter', driver='core',
                    backing_store=False) as h5file:
         model.save_weights(h5file)
-        h5file.flush()  # Very important! Otherwise you get all zeroes below.
         binary_data = h5file.fid.get_file_image()
 
         # Make sure the binary data is correct by saving it to a file manually
@@ -512,8 +531,9 @@ def test_weight_saving_to_binary_stream():
 
     # Load the manually-saved binary data, and make sure the model is intact.
     with h5py.File(fname, mode='r') as h5file:
-        model.load_weights(h5file)
-        out2 = model.predict(x)
+        loaded_model = create_untrained_model()
+        loaded_model.load_weights(h5file)
+        out2 = loaded_model.predict(x)
 
     assert_allclose(out, out2, atol=1e-05)
 


### PR DESCRIPTION
### Summary
The `load_weights` and `save_weights` functions of a keras `Model` only support weight serialization straight to a file on disk. The change allows saving model weights to memory-mapped files that do not have a physical presence on disk, and extraction of the serialized weights data as a raw binary stream.

The same functionality has recently been added for the `save_model` and `load_model` functions, see https://github.com/keras-team/keras/pull/9789. This pr closely parallels this implementation, as well as the testing strategy.

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
