### PR TITLE
update doc links for tensorboard/embeddings

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -669,7 +669,7 @@ class LearningRateScheduler(Callback):
 class TensorBoard(Callback):
     """TensorBoard basic visualizations.
 
-    [TensorBoard](https://www.tensorflow.org/get_started/summaries_and_tensorboard)
+    [TensorBoard](https://www.tensorflow.org/guide/summaries_and_tensorboard)
     is a visualization tool provided with TensorFlow.
 
     This callback writes a log for TensorBoard, which allows
@@ -711,14 +711,14 @@ class TensorBoard(Callback):
             None or empty list all the embedding layer will be watched.
         embeddings_metadata: a dictionary which maps layer name to a file name
             in which metadata for this embedding layer is saved. See the
-            [details](https://www.tensorflow.org/how_tos/embedding_viz/#metadata_optional)
+            [details](https://www.tensorflow.org/guide/embedding#metadata)
             about metadata files format. In case if the same metadata file is
             used for all embedding layers, string can be passed.
         embeddings_data: data to be embedded at layers specified in
             `embeddings_layer_names`. Numpy array (if the model has a single
             input) or list of Numpy arrays (if the model has multiple inputs).
             Learn [more about embeddings](
-            https://www.tensorflow.org/programmers_guide/embedding).
+            https://www.tensorflow.org/guide/embedding).
         update_freq: `'batch'` or `'epoch'` or integer. When using `'batch'`, writes
             the losses and metrics to TensorBoard after each batch. The same
             applies for `'epoch'`. If using an integer, let's say `10000`,


### PR DESCRIPTION
### Summary

This PR updates the links for the [Tensboard Callback](https://keras.io/callbacks/#tensorboard) documentation as they have changed and some don't redirect properly.

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
