### PR TITLE
Support seamless load/save of models and weights (incl. checkpoints) to Google Storage

### DIFF
--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -1089,6 +1089,7 @@ class Network(Layer):
         from ..models import save_model
         save_model(self, filepath, overwrite, include_optimizer)
 
+    @saving.parse_save_to_external_resource
     def save_weights(self, filepath, overwrite=True):
         """Dumps all layer weights to a HDF5 file.
 
@@ -1121,6 +1122,7 @@ class Network(Layer):
             saving.save_weights_to_hdf5_group(f, self.layers)
             f.flush()
 
+    @saving.parse_load_from_external_resource
     def load_weights(self, filepath, by_name=False,
                      skip_mismatch=False, reshape=False):
         """Loads all layer weights from a HDF5 save file.

--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -1089,7 +1089,7 @@ class Network(Layer):
         from ..models import save_model
         save_model(self, filepath, overwrite, include_optimizer)
 
-    @saving.parse_save_to_external_resource
+    @saving.allow_write_to_gcs
     def save_weights(self, filepath, overwrite=True):
         """Dumps all layer weights to a HDF5 file.
 
@@ -1122,7 +1122,7 @@ class Network(Layer):
             saving.save_weights_to_hdf5_group(f, self.layers)
             f.flush()
 
-    @saving.parse_load_from_external_resource
+    @saving.allow_read_from_gcs
     def load_weights(self, filepath, by_name=False,
                      skip_mismatch=False, reshape=False):
         """Loads all layer weights from a HDF5 save file.

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -10,6 +10,7 @@ import json
 import yaml
 import inspect
 import warnings
+import tempfile
 from six.moves import zip
 
 from .. import backend as K
@@ -359,7 +360,7 @@ def parse_save_to_external_resource(save_function):
     "gs://".
     """
     def save_wrapper(obj, filepath, overwrite=True, *args, **kwargs):
-        if filepath.startswith('gs://'):
+        if isinstance(filepath, basestring) and filepath.startswith('gs://'):
             tmp_filepath = os.path.join(tempfile.gettempdir(),
                                         os.path.basename(filepath))
             save_function(obj, tmp_filepath, True, *args, **kwargs)
@@ -369,6 +370,7 @@ def parse_save_to_external_resource(save_function):
                 os.remove(tmp_filepath)
         else:
             save_function(obj, filepath, *args, **kwargs)
+
     return save_wrapper
 
 
@@ -446,7 +448,7 @@ def parse_load_from_external_resource(load_function):
     def load_wrapper(*args, **kwargs):
         filepath, _args, _kwargs = extract_named_arg(
             load_function, 'filepath', args, kwargs)
-        if filepath.startswith('gs://'):
+        if isinstance(filepath, basestring) and filepath.startswith('gs://'):
             tmp_filepath = os.path.join(tempfile.gettempdir(),
                                         os.path.basename(filepath))
             _google_storage_transfer(filepath, tmp_filepath)
@@ -457,6 +459,7 @@ def parse_load_from_external_resource(load_function):
                 os.remove(tmp_filepath)
             return res
         return load_function(*args, **kwargs)
+
     return load_wrapper
 
 

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -346,7 +346,7 @@ def _deserialize_model(h5dict, custom_objects=None, compile=True):
 def _google_storage_transfer(source_filepath, target_filepath, overwrite=True):
     """Transfers file to/from Google Cloud Storage"""
     if tf_file_io is None:
-        raise ImportError('Google Storage file transfer requires tensorflow.')
+        raise ImportError('Google Cloud Storage file transfer requires tensorflow.')
     if not overwrite and tf_file_io.file_exists(target_filepath):
         proceed = ask_to_proceed_with_overwrite(target_filepath)
         if not proceed:
@@ -361,11 +361,9 @@ def _is_google_storage_location(filepath):
     return isinstance(filepath, string_types) and filepath.startswith('gs://')
 
 
-def parse_save_to_external_resource(save_function):
+def allow_write_to_gcs(save_function):
     """Function decorator that parses `filepath` argument to the `save_function`
-    and saves the file to the inferred external resource.
-
-    Currently, Google Storage (GS) is supported for filepath:s starting with
+    and saves the file to Google Cloud Storage (GCS) if filepath starts with
     "gs://".
     """
     @wraps(save_function)
@@ -385,11 +383,9 @@ def parse_save_to_external_resource(save_function):
     return save_wrapper
 
 
-def parse_load_from_external_resource(load_function):
+def allow_read_from_gcs(load_function):
     """Function decorator that parses `filepath` argument to the `load_function`
-    and loads the file from the inferred external resource.
-
-    Currently, Google Storage (GS) is supported for filepath:s starting with
+    and loads the file from Google Cloud Storage (GCS) if filepath starts with
     "gs://"
     """
     def extract_named_arg(f, name, args, kwargs):
@@ -422,7 +418,7 @@ def parse_load_from_external_resource(load_function):
     return load_wrapper
 
 
-@parse_save_to_external_resource
+@allow_write_to_gcs
 def save_model(model, filepath, overwrite=True, include_optimizer=True):
     """Save a model to a HDF5 file.
 
@@ -475,7 +471,7 @@ def save_model(model, filepath, overwrite=True, include_optimizer=True):
             h5dict.close()
 
 
-@parse_load_from_external_resource
+@allow_read_from_gcs
 def load_model(filepath, custom_objects=None, compile=True):
     """Loads a model saved via `save_model`.
 

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -12,6 +12,7 @@ import inspect
 import warnings
 import tempfile
 from six.moves import zip
+from functools import wraps
 
 from .. import backend as K
 from .. import optimizers
@@ -359,6 +360,7 @@ def parse_save_to_external_resource(save_function):
     Currently, Google Storage (GS) is supported for filepath:s starting with
     "gs://".
     """
+    @wraps(save_function)
     def save_wrapper(obj, filepath, overwrite=True, *args, **kwargs):
         if isinstance(filepath, basestring) and filepath.startswith('gs://'):
             tmp_filepath = os.path.join(tempfile.gettempdir(),
@@ -445,6 +447,7 @@ def parse_load_from_external_resource(load_function):
         else:
             raise ValueError('function {} has no argument {}'.format(f, name))
 
+    @wraps(load_function)
     def load_wrapper(*args, **kwargs):
         filepath, _args, _kwargs = extract_named_arg(
             load_function, 'filepath', args, kwargs)

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -347,9 +347,10 @@ def _google_storage_transfer(source_filepath, target_filepath, overwrite=True):
     """Transfers file to/from Google Cloud Storage"""
     if tf_file_io is None:
         raise ImportError('Google Storage file transfer requires tensorflow.')
-    if not overwrite:
-        if tf_file_io.file_exists(target_filepath):
-            raise IOError('Object {} already exists.'.format(target_filepath))
+    if not overwrite and tf_file_io.file_exists(target_filepath):
+        proceed = ask_to_proceed_with_overwrite(target_filepath)
+        if not proceed:
+            return
     with tf_file_io.FileIO(source_filepath, mode='r') as source_f:
         with tf_file_io.FileIO(target_filepath, mode='w') as target_f:
             target_f.write(source_f.read())
@@ -378,7 +379,8 @@ def parse_save_to_external_resource(save_function):
             finally:
                 os.remove(tmp_filepath)
         else:
-            save_function(obj, filepath, *args, **kwargs)
+
+            save_function(obj, filepath, overwrite, *args, **kwargs)
 
     return save_wrapper
 

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -351,8 +351,8 @@ def _google_storage_transfer(source_filepath, target_filepath, overwrite=True):
         proceed = ask_to_proceed_with_overwrite(target_filepath)
         if not proceed:
             return
-    with tf_file_io.FileIO(source_filepath, mode='r') as source_f:
-        with tf_file_io.FileIO(target_filepath, mode='w') as target_f:
+    with tf_file_io.FileIO(source_filepath, mode='rb') as source_f:
+        with tf_file_io.FileIO(target_filepath, mode='wb') as target_f:
             target_f.write(source_f.read())
 
 

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -363,7 +363,7 @@ def _is_gcs_location(filepath):
 
 def allow_write_to_gcs(save_function):
     """Function decorator that parses `filepath` argument to the `save_function`
-    and saves the file to Google Cloud Storage (GCS) if filepath starts with
+    and saves the file to Google Cloud Storage (GCS) if `filepath` starts with
     "gs://".
     """
     @wraps(save_function)
@@ -377,7 +377,6 @@ def allow_write_to_gcs(save_function):
             finally:
                 os.remove(tmp_filepath)
         else:
-
             save_function(obj, filepath, overwrite, *args, **kwargs)
 
     return save_wrapper
@@ -385,7 +384,7 @@ def allow_write_to_gcs(save_function):
 
 def allow_read_from_gcs(load_function):
     """Function decorator that parses `filepath` argument to the `load_function`
-    and loads the file from Google Cloud Storage (GCS) if filepath starts with
+    and loads the file from Google Cloud Storage (GCS) if `filepath` starts with
     "gs://"
     """
     def extract_named_arg(f, name, args, kwargs):

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-import numpy as np
 import os
 import json
 import yaml
@@ -14,6 +13,8 @@ import tempfile
 from six.moves import zip
 from six import string_types
 from functools import wraps
+
+import numpy as np
 
 from .. import backend as K
 from .. import optimizers

--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -134,24 +134,24 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
 class tf_file_io_proxy(object):
     """Context manager for mock patching `tensorflow.python.lib.io.file_io` in tests.
 
-    The main purpose of this class is to be able to tests model saving/loading
-    to/from Google Cloud Storage, for witch the tensorflow `file_io` package is used.
+    The purpose of this class is to be able to tests model saving/loading to/from
+    Google Cloud Storage, for witch the tensorflow `file_io` package is used.
 
     If a `bucket_name` is provided, either as an input argument or by setting the
     environment variable GCS_TEST_BUCKET, *NO mocking* will be done and files will be
     transferred to the real GCS bucket. For this to work, valid Google application
-    credentials must be available for the python process, see:
+    credentials must be available, see:
         https://cloud.google.com/video-intelligence/docs/common/auth
     for further details.
 
     If a `bucket_name` is not provided, an identifier of the import of the file_io
     module to mock must be provided, using the `file_io_module` argument.
-    NOTE that only a subsets of the module is mocked and that the same Exceptions
+    NOTE that only part of the module is mocked and that the same Exceptions
     are not raised in mock implementation.
 
-    Since the bucket name can be provided using an environment variable it is
-    recommended to use method `get_filepath(filename)` in test cases to make them
-    compatible with and without a real GCS bucket during testing. See example below.
+    Since the bucket name can be provided using an environment variable, it is
+    recommended to use method `get_filepath(filename)` in tests to make them
+    pass with and without a real GCS bucket during testing. See example below.
 
     Arguments:
         file_io_module: String identifier of the file_io module import to patch. E.g
@@ -269,7 +269,7 @@ class tf_file_io_proxy(object):
             os.remove(filename)
 
     def assert_exists(self, filepath):
-        """Convenience method to verfiy that a file exists after writing."""
+        """Convenience method for verifying that a file exists after writing."""
         self._check_started()
         if not self.file_exists(filepath):
             raise AssertionError('{} does not exist'.format(filepath))

--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -6,8 +6,6 @@ from __future__ import print_function
 import os
 from io import BytesIO
 
-from mock import patch, Mock, MagicMock
-
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -19,6 +17,11 @@ try:
     from tensorflow.python.lib.io import file_io as tf_file_io
 except ImportError:
     tf_file_io = None
+
+try:
+    from unittest.mock import patch, Mock, MagicMock
+except:
+    from mock import patch, Mock, MagicMock
 
 
 def get_test_data(num_train=1000, num_test=500, input_shape=(10,),

--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -146,6 +146,8 @@ class tf_file_io_proxy(object):
 
     If a `bucket_name` is not provided, an identifier of the import of the file_io
     module to mock must be provided, using the `file_io_module` argument.
+    NOTE that only a subsets of the module is mocked and that the same Exceptions
+    are not raised in mock implementation.
 
     Since the bucket name can be provided using an environment variable it is
     recommended to use method `get_filepath(filename)` in test cases to make them
@@ -196,7 +198,7 @@ class tf_file_io_proxy(object):
             try:
                 # check that bucket exists and is accessible
                 tf_file_io.is_directory(self.bucket_path)
-            except Exception:  # TODO
+            except:
                 raise IOError(
                     'could not access provided bucket {}'.format(self.bucket_path))
             self.mock_gcs = False
@@ -229,7 +231,7 @@ class tf_file_io_proxy(object):
             mock_fio.__enter__ = Mock(return_value=mock_fio)
             if mode == 'rb':
                 if filepath not in self.local_objects:
-                    raise IOError('TODO')
+                    raise IOError('{} does not exist'.format(filepath))
                 self.local_objects[filepath].seek(0)
                 mock_fio.read = self.local_objects[filepath].read
             elif mode == 'wb':

--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -227,17 +227,17 @@ class tf_file_io_proxy(object):
         if filepath.startswith(self._gcp_prefix):
             mock_fio = MagicMock()
             mock_fio.__enter__ = Mock(return_value=mock_fio)
-            if mode == 'r':
+            if mode == 'rb':
                 if filepath not in self.local_objects:
                     raise IOError('TODO')
                 self.local_objects[filepath].seek(0)
                 mock_fio.read = self.local_objects[filepath].read
-            elif mode == 'w':
+            elif mode == 'wb':
                 self.local_objects[filepath] = BytesIO()
                 mock_fio.write = self.local_objects[filepath].write
             else:
                 raise ValueError(
-                    '{} only supports wrapping of FileIO for `mode` "r" or "w"')
+                    '{} only supports wrapping of FileIO for `mode` "rb" or "wb"')
             return mock_fio
 
         return open(filepath, mode)

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -698,6 +698,22 @@ def test_saving_constant_initializer_with_numpy():
     os.remove(fname)
 
 
+def test_save_load_weights_gcs():
+    model = Sequential()
+    model.add(Dense(2, input_shape=(3,)))
+    org_weights = model.get_weights()
+
+    with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
+        gcp_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        model.save_weights(gcp_filepath)
+        model.set_weights([np.random.random(w.shape) for w in org_weights])
+        for w, org_w in zip(model.get_weights(), org_weights):
+            assert not (w == org_w).all()
+        model.load_weights(gcp_filepath)
+        for w, org_w in zip(model.get_weights(), org_weights):
+            assert_allclose(w, org_w)
+
+
 def test_saving_overwrite_option():
     model = Sequential()
     model.add(Dense(2, input_shape=(3,)))

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -53,7 +53,7 @@ def test_sequential_model_saving():
     os.remove(fname)
 
     with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
-        gcs_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        gcs_filepath = file_io_proxy.get_filepath(filename=fname)
         save_model(model, gcs_filepath)
         file_io_proxy.assert_exists(gcs_filepath)
         new_model_gcs = load_model(gcs_filepath)
@@ -95,7 +95,7 @@ def test_sequential_model_saving_2():
     os.remove(fname)
 
     with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
-        gcs_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        gcs_filepath = file_io_proxy.get_filepath(filename=fname)
         save_model(model, gcs_filepath)
         file_io_proxy.assert_exists(gcs_filepath)
         new_model_gcs = load_model(gcs_filepath, **load_kwargs)
@@ -126,7 +126,7 @@ def test_functional_model_saving():
     os.remove(fname)
 
     with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
-        gcs_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        gcs_filepath = file_io_proxy.get_filepath(filename=fname)
         save_model(model, gcs_filepath)
         file_io_proxy.assert_exists(gcs_filepath)
         new_model_gcs = load_model(gcs_filepath)
@@ -704,7 +704,10 @@ def test_save_load_weights_gcs():
     org_weights = model.get_weights()
 
     with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
-        gcs_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        gcs_filepath = file_io_proxy.get_filepath(
+            filename='test_save_load_weights_gcs.h5')
+        # we should not use same filename in several tests to allow for parallel
+        # execution
         model.save_weights(gcs_filepath)
         model.set_weights([np.random.random(w.shape) for w in org_weights])
         for w, org_w in zip(model.get_weights(), org_weights):
@@ -712,6 +715,8 @@ def test_save_load_weights_gcs():
         model.load_weights(gcs_filepath)
         for w, org_w in zip(model.get_weights(), org_weights):
             assert_allclose(w, org_w)
+
+        file_io_proxy.delete_file(gcs_filepath)  # cleanup
 
 
 def test_saving_overwrite_option():
@@ -749,7 +754,10 @@ def test_saving_overwrite_option_gcs():
     new_weights = [np.random.random(w.shape) for w in org_weights]
 
     with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
-        gcs_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        gcs_filepath = file_io_proxy.get_filepath(
+            filename='test_saving_overwrite_option_gcs.h5')
+        # we should not use same filename in several tests to allow for parallel
+        # execution
         save_model(model, gcs_filepath)
         model.set_weights(new_weights)
 

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+
 import pytest
 import os
 import h5py
@@ -5,6 +7,8 @@ import tempfile
 import numpy as np
 from numpy.testing import assert_allclose
 from numpy.testing import assert_raises
+
+from mock import patch, Mock, MagicMock
 
 from keras import backend as K
 from keras.engine.saving import preprocess_weights_for_loading
@@ -24,6 +28,94 @@ skipif_no_tf_gpu = pytest.mark.skipif(
     (K.backend() != 'tensorflow' or
      not K.tensorflow_backend._get_available_gpus()),
     reason='Requires TensorFlow backend and a GPU')
+
+
+class GCPTestProxy(object):
+
+    _gcp_prefix = 'gs://'
+
+    def __init__(self, file_io_module=None, bucket_name=None):
+        if bucket_name is None:
+            bucket_name = os.environ.get('GCP_TEST_BUCKET', None)
+        if bucket_name is None:
+            # will mock gcp locally for tests
+            self.bucket_name = 'mock_bucket'
+            self.mock_gcp = True
+            self.objects = {}
+        else:
+            # will use real bucket for tests
+            if bucket_name.startswith(self._gcp_prefix):
+                bucket_name = bucket_name[len(self._gcp_prefix):]
+            # TODO check that bucket exists and is accessible
+            self.bucket_name = bucket_name
+            self.mock_gcp = False
+            self.objects = None
+
+        if file_io_module is None:
+            raise ValueError(
+                'The tensorflow file_io module to proxy must be provided')
+        self.file_io_module = file_io_module
+        self.patched_file_io = None
+        self.entered = False
+
+    def get_bucket_path(self):
+        return self._gcp_prefix + self.bucket_name
+
+    def _complete_gcp_filepath(self, filepath):
+        # assert filepath.startswith(self._gcp_prefix + '{bucket_name}/')
+        return filepath.format(bucket_name=self.bucket_name)
+
+    def FileIO(self, filepath, mode):
+        if filepath.startswith(self._gcp_prefix):
+            filepath = self._complete_gcp_filepath(filepath)
+            if not self.mock_gcp:
+                return self.patched_file_io.get_original().FileIO(filepath, mode)
+
+            mock_fio = MagicMock()
+            mock_fio.__enter__ = Mock(return_value=mock_fio)
+            if mode == 'r':
+                if filepath not in self.objects:
+                    raise IOError('TODO')
+                self.objects[filepath].seek(0)
+                mock_fio.read = self.objects[filepath].read
+            elif mode == 'w':
+                self.objects[filepath] = BytesIO()
+                mock_fio.write = self.objects[filepath].write
+            else:
+                raise ValueError(
+                    '{} only supports wrapping of FileIO for `mode` "r" or "w"')
+            return mock_fio
+        else:
+            return open(filepath, mode)
+
+    def file_exists(self, filepath):
+        if filepath.startswith(self._gcp_prefix):
+            filepath = self._complete_gcp_filepath(filepath)
+            if not self.mock_gcp:
+                self.patched_file_io.get_original().file_exists(filepath)
+            return filepath in self.objects
+        else:
+            os.path.exists(filepath)
+
+    def assert_exists(self, filepath):
+        if not self.entered:
+            raise RuntimeError('TODO')
+        if not self.patched_file_io.new.file_exists(filepath):
+            raise AssertionError('TODO')
+
+    def __enter__(self):
+        mock_module = Mock()
+        mock_module.FileIO = self.FileIO
+        mock_module.file_exists = self.file_exists
+        patched_file_io = patch(self.file_io_module, new=mock_module)
+        self.patched_file_io = patched_file_io
+        self.patched_file_io.start()
+        self.entered = True
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.patched_file_io.stop()
+        self.entered = False
 
 
 def test_sequential_model_saving():
@@ -46,8 +138,17 @@ def test_sequential_model_saving():
     new_model = load_model(fname)
     os.remove(fname)
 
+    with GCPTestProxy(file_io_module='keras.engine.saving.tf_file_io') as gcp_proxy:
+        gcp_filepath = 'gs://{bucket_name}/model.h5'
+        save_model(model, gcp_filepath)
+        gcp_proxy.assert_exists(gcp_filepath)
+        new_model_gcp = load_model(gcp_filepath)
+
     out2 = new_model.predict(x)
     assert_allclose(out, out2, atol=1e-05)
+
+    out3 = new_model_gcp.predict(x)
+    assert_allclose(out, out3, atol=1e-05)
 
     # test that new updates are the same with both models
     x = np.random.random((1, 3))

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -4,6 +4,7 @@ import os
 import h5py
 import tempfile
 import numpy as np
+from mock import mock
 from numpy.testing import assert_allclose
 from numpy.testing import assert_raises
 
@@ -53,6 +54,7 @@ def test_sequential_model_saving():
         save_model(model, gcp_filepath)
         file_io_proxy.assert_exists(gcp_filepath)
         new_model_gcp = load_model(gcp_filepath)
+        file_io_proxy.delete_file(gcp_filepath)  # cleanup
 
     x2 = np.random.random((1, 3))
     y2 = np.random.random((1, 3, 3))
@@ -94,6 +96,7 @@ def test_sequential_model_saving_2():
         save_model(model, gcp_filepath)
         file_io_proxy.assert_exists(gcp_filepath)
         new_model_gcp = load_model(gcp_filepath, **load_kwargs)
+        file_io_proxy.delete_file(gcp_filepath)  # cleanup
 
     for new_model in [new_model_disk, new_model_gcp]:
         new_out = new_model.predict(x)
@@ -112,16 +115,23 @@ def test_functional_model_saving():
     x = np.random.random((1, 3))
     y = np.random.random((1, 3))
     model.train_on_batch(x, y)
-
     out = model.predict(x)
+
     _, fname = tempfile.mkstemp('.h5')
     save_model(model, fname)
-
-    model = load_model(fname)
+    new_model_disk = load_model(fname)
     os.remove(fname)
 
-    out2 = model.predict(x)
-    assert_allclose(out, out2, atol=1e-05)
+    with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
+        gcp_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        save_model(model, gcp_filepath)
+        file_io_proxy.assert_exists(gcp_filepath)
+        new_model_gcp = load_model(gcp_filepath)
+        file_io_proxy.delete_file(gcp_filepath)  # cleanup
+
+    for new_model in [new_model_disk, new_model_gcp]:
+        new_out = new_model.predict(x)
+        assert_allclose(out, new_out, atol=1e-05)
 
 
 def test_model_saving_to_pre_created_h5py_file():
@@ -683,6 +693,63 @@ def test_saving_constant_initializer_with_numpy():
     save_model(model, fname)
     model = load_model(fname)
     os.remove(fname)
+
+
+def test_saving_overwrite_option():
+    model = Sequential()
+    model.add(Dense(2, input_shape=(3,)))
+    org_weights = model.get_weights()
+    new_weights = [np.random.random(w.shape) for w in org_weights]
+
+    _, fname = tempfile.mkstemp('.h5')
+    save_model(model, fname)
+    model.set_weights(new_weights)
+
+    with mock.patch('keras.engine.saving.ask_to_proceed_with_overwrite') as ask:
+        ask.return_value = False
+        save_model(model, fname, overwrite=False)
+        ask.assert_called_once()
+        new_model = load_model(fname)
+        for w, org_w in zip(new_model.get_weights(), org_weights):
+            assert_allclose(w, org_w)
+
+        ask.return_value = True
+        save_model(model, fname, overwrite=False)
+        assert ask.call_count == 2
+        new_model = load_model(fname)
+        for w, new_w in zip(new_model.get_weights(), new_weights):
+            assert_allclose(w, new_w)
+
+    os.remove(fname)
+
+
+def test_saving_overwrite_option_gcs():
+    model = Sequential()
+    model.add(Dense(2, input_shape=(3,)))
+    org_weights = model.get_weights()
+    new_weights = [np.random.random(w.shape) for w in org_weights]
+
+    with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
+        gcp_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        save_model(model, gcp_filepath)
+        model.set_weights(new_weights)
+
+        with mock.patch('keras.engine.saving.ask_to_proceed_with_overwrite') as ask:
+            ask.return_value = False
+            save_model(model, gcp_filepath, overwrite=False)
+            ask.assert_called_once()
+            new_model = load_model(gcp_filepath)
+            for w, org_w in zip(new_model.get_weights(), org_weights):
+                assert_allclose(w, org_w)
+
+            ask.return_value = True
+            save_model(model, gcp_filepath, overwrite=False)
+            assert ask.call_count == 2
+            new_model = load_model(gcp_filepath)
+            for w, new_w in zip(new_model.get_weights(), new_weights):
+                assert_allclose(w, new_w)
+
+        file_io_proxy.delete_file(gcp_filepath)  # cleanup
 
 
 @pytest.mark.parametrize('implementation', [1, 2], ids=['impl1', 'impl2'])

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -53,18 +53,18 @@ def test_sequential_model_saving():
     os.remove(fname)
 
     with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
-        gcp_filepath = file_io_proxy.get_filepath(filename='model.h5')
-        save_model(model, gcp_filepath)
-        file_io_proxy.assert_exists(gcp_filepath)
-        new_model_gcp = load_model(gcp_filepath)
-        file_io_proxy.delete_file(gcp_filepath)  # cleanup
+        gcs_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        save_model(model, gcs_filepath)
+        file_io_proxy.assert_exists(gcs_filepath)
+        new_model_gcs = load_model(gcs_filepath)
+        file_io_proxy.delete_file(gcs_filepath)  # cleanup
 
     x2 = np.random.random((1, 3))
     y2 = np.random.random((1, 3, 3))
     model.train_on_batch(x2, y2)
     out_2 = model.predict(x2)
 
-    for new_model in [new_model_disk, new_model_gcp]:
+    for new_model in [new_model_disk, new_model_gcs]:
         new_out = new_model.predict(x)
         assert_allclose(out, new_out, atol=1e-05)
         # test that new updates are the same with both models
@@ -95,13 +95,13 @@ def test_sequential_model_saving_2():
     os.remove(fname)
 
     with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
-        gcp_filepath = file_io_proxy.get_filepath(filename='model.h5')
-        save_model(model, gcp_filepath)
-        file_io_proxy.assert_exists(gcp_filepath)
-        new_model_gcp = load_model(gcp_filepath, **load_kwargs)
-        file_io_proxy.delete_file(gcp_filepath)  # cleanup
+        gcs_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        save_model(model, gcs_filepath)
+        file_io_proxy.assert_exists(gcs_filepath)
+        new_model_gcs = load_model(gcs_filepath, **load_kwargs)
+        file_io_proxy.delete_file(gcs_filepath)  # cleanup
 
-    for new_model in [new_model_disk, new_model_gcp]:
+    for new_model in [new_model_disk, new_model_gcs]:
         new_out = new_model.predict(x)
         assert_allclose(out, new_out, atol=1e-05)
 
@@ -126,13 +126,13 @@ def test_functional_model_saving():
     os.remove(fname)
 
     with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
-        gcp_filepath = file_io_proxy.get_filepath(filename='model.h5')
-        save_model(model, gcp_filepath)
-        file_io_proxy.assert_exists(gcp_filepath)
-        new_model_gcp = load_model(gcp_filepath)
-        file_io_proxy.delete_file(gcp_filepath)  # cleanup
+        gcs_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        save_model(model, gcs_filepath)
+        file_io_proxy.assert_exists(gcs_filepath)
+        new_model_gcs = load_model(gcs_filepath)
+        file_io_proxy.delete_file(gcs_filepath)  # cleanup
 
-    for new_model in [new_model_disk, new_model_gcp]:
+    for new_model in [new_model_disk, new_model_gcs]:
         new_out = new_model.predict(x)
         assert_allclose(out, new_out, atol=1e-05)
 
@@ -704,12 +704,12 @@ def test_save_load_weights_gcs():
     org_weights = model.get_weights()
 
     with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
-        gcp_filepath = file_io_proxy.get_filepath(filename='model.h5')
-        model.save_weights(gcp_filepath)
+        gcs_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        model.save_weights(gcs_filepath)
         model.set_weights([np.random.random(w.shape) for w in org_weights])
         for w, org_w in zip(model.get_weights(), org_weights):
             assert not (w == org_w).all()
-        model.load_weights(gcp_filepath)
+        model.load_weights(gcs_filepath)
         for w, org_w in zip(model.get_weights(), org_weights):
             assert_allclose(w, org_w)
 
@@ -749,26 +749,26 @@ def test_saving_overwrite_option_gcs():
     new_weights = [np.random.random(w.shape) for w in org_weights]
 
     with tf_file_io_proxy('keras.engine.saving.tf_file_io') as file_io_proxy:
-        gcp_filepath = file_io_proxy.get_filepath(filename='model.h5')
-        save_model(model, gcp_filepath)
+        gcs_filepath = file_io_proxy.get_filepath(filename='model.h5')
+        save_model(model, gcs_filepath)
         model.set_weights(new_weights)
 
         with patch('keras.engine.saving.ask_to_proceed_with_overwrite') as ask:
             ask.return_value = False
-            save_model(model, gcp_filepath, overwrite=False)
+            save_model(model, gcs_filepath, overwrite=False)
             ask.assert_called_once()
-            new_model = load_model(gcp_filepath)
+            new_model = load_model(gcs_filepath)
             for w, org_w in zip(new_model.get_weights(), org_weights):
                 assert_allclose(w, org_w)
 
             ask.return_value = True
-            save_model(model, gcp_filepath, overwrite=False)
+            save_model(model, gcs_filepath, overwrite=False)
             assert ask.call_count == 2
-            new_model = load_model(gcp_filepath)
+            new_model = load_model(gcs_filepath)
             for w, new_w in zip(new_model.get_weights(), new_weights):
                 assert_allclose(w, new_w)
 
-        file_io_proxy.delete_file(gcp_filepath)  # cleanup
+        file_io_proxy.delete_file(gcs_filepath)  # cleanup
 
 
 @pytest.mark.parametrize('implementation', [1, 2], ids=['impl1', 'impl2'])

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -4,7 +4,6 @@ import os
 import h5py
 import tempfile
 import numpy as np
-from mock import mock
 from numpy.testing import assert_allclose
 from numpy.testing import assert_raises
 
@@ -21,6 +20,10 @@ from keras import losses
 from keras import metrics
 from keras.models import save_model, load_model
 from keras.utils.test_utils import tf_file_io_proxy
+try:
+    from unittest.mock import patch
+except:
+    from mock import patch
 
 
 skipif_no_tf_gpu = pytest.mark.skipif(
@@ -705,7 +708,7 @@ def test_saving_overwrite_option():
     save_model(model, fname)
     model.set_weights(new_weights)
 
-    with mock.patch('keras.engine.saving.ask_to_proceed_with_overwrite') as ask:
+    with patch('keras.engine.saving.ask_to_proceed_with_overwrite') as ask:
         ask.return_value = False
         save_model(model, fname, overwrite=False)
         ask.assert_called_once()
@@ -734,7 +737,7 @@ def test_saving_overwrite_option_gcs():
         save_model(model, gcp_filepath)
         model.set_weights(new_weights)
 
-        with mock.patch('keras.engine.saving.ask_to_proceed_with_overwrite') as ask:
+        with patch('keras.engine.saving.ask_to_proceed_with_overwrite') as ask:
             ask.return_value = False
             save_model(model, gcp_filepath, overwrite=False)
             ask.assert_called_once()


### PR DESCRIPTION
### Summary
This addition makes it possible to provide a Google Storage (bucket) path as the `filename` arguments of model/weights loading and saving methods.

This solution should be extendable for other external resources such as AWS S3 etc.

### Related Issues
This automatically solves: https://github.com/keras-team/keras/issues/7935
(related: https://github.com/keras-team/keras/issues/9343)

### PR Overview
- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
