### PR TITLE
Fix the timeout error on Travis

### DIFF
--- a/.travis/install_cntk.sh
+++ b/.travis/install_cntk.sh
@@ -1,5 +1,5 @@
 set -e
-pip install cntk
+pip install cntk==2.5.1
 
 # open mpi is needed for cntk
 rm -rf ~/mpi


### PR DESCRIPTION
### Summary

The timeout error has occurred a month ago, and CNTK released the new version 2.6 in 2018-09-17 (see [notes](https://github.com/Microsoft/CNTK/releases)). This PR is a simple try to fix the timeout error on Travis. We don't know the exact reason, thus I just assumed that the new CNTK suffers from memory leaks.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
