### PR TITLE
Add mkl installation for all the envs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ matrix:
         - python: 3.6
           env: KERAS_BACKEND=tensorflow
         - python: 2.7
-          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile MKL="mkl mkl-service"
+          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
         - python: 3.6
-          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile MKL="mkl mkl-service"
+          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
         - python: 2.7
           env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
         - python: 3.6
@@ -48,7 +48,7 @@ install:
   - export LD_LIBRARY_PATH=$HOME/miniconda/envs/test-environment/lib/:$LD_LIBRARY_PATH
 
     # install pydot for visualization tests
-  - travis_retry conda install $MKL pydot graphviz $PIL
+  - travis_retry conda install mkl mkl-service pydot graphviz $PIL
 
   - pip install -e .[tests]
 


### PR DESCRIPTION
### Summary

Recently, the total build time has increased by about 20 minutes, especially after #11570 (see [the recent build times](https://travis-ci.org/keras-team/keras/builds)). I assumed that theano compiled with non-mkl BLAS was cached by the first env (`INTEGRATION_TESTS`) and the next envs (`KERAS_BACKEND=theano`) just uses the cache without recompiled with mkl. The theano tests were twice as slow as before #11570.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
