### PR TITLE
Fixed NaN loss when given a mask with all zeros

### DIFF
--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -410,7 +410,7 @@ def weighted_masked_objective(fn):
             score_array *= mask
             #  the loss per batch should be proportional
             #  to the number of unmasked samples.
-            score_array /= K.mean(mask)
+            score_array /= K.mean(mask) + K.epsilon()
 
         # apply sample weighting
         if weights is not None:

--- a/tests/test_loss_masking.py
+++ b/tests/test_loss_masking.py
@@ -8,16 +8,28 @@ from keras import losses
 from keras import backend as K
 
 
+def create_masking_model():
+    model = Sequential()
+    model.add(Masking(mask_value=0, input_shape=(None, 1)))
+    model.add(TimeDistributed(Dense(1, kernel_initializer='one')))
+    model.compile(loss='mse', optimizer='sgd')
+    return model
+
+
 def test_masking():
     np.random.seed(1337)
     x = np.array([[[1], [1]],
                   [[0], [0]]])
-    model = Sequential()
-    model.add(Masking(mask_value=0, input_shape=(2, 1)))
-    model.add(TimeDistributed(Dense(1, kernel_initializer='one')))
-    model.compile(loss='mse', optimizer='sgd')
+    model = create_masking_model()
     y = np.array([[[1], [1]],
                   [[1], [1]]])
+    loss = model.train_on_batch(x, y)
+    assert loss == 0
+
+
+def test_masking_is_all_zeros():
+    x = y = np.array([[[0], [0]]])
+    model = create_masking_model()
     loss = model.train_on_batch(x, y)
     assert loss == 0
 


### PR DESCRIPTION
### Summary

Sometimes when operates on the masks of sequential/time-series data, there will be a small chance that all values in a mask are zeros (e.g. only several positions are chosen at random with a small rate for loss calculation). The epsilon term was added to avoid NaN loss.

### Related Issues

N/A

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
