### PR TITLE
Hide progress bars of pip and conda on travis to make the logs faster to load.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,19 +41,19 @@ install:
 
   - travis_retry conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - travis_retry pip install --only-binary=numpy,scipy,pandas numpy nose scipy h5py theano pytest pytest-pep8 pandas
-  - pip install keras_applications keras_preprocessing
+  - travis_retry pip install --only-binary=numpy,scipy,pandas numpy nose scipy h5py theano pytest pytest-pep8 pandas --progress-bar off
+  - pip install keras_applications keras_preprocessing --progress-bar off
 
   # set library path
   - export LD_LIBRARY_PATH=$HOME/miniconda/envs/test-environment/lib/:$LD_LIBRARY_PATH
 
     # install pydot for visualization tests
-  - travis_retry conda install $MKL pydot graphviz $PIL
+  - travis_retry conda install -q $MKL pydot graphviz $PIL
 
-  - pip install -e .[tests]
+  - pip install -e .[tests] --progress-bar off
 
   # install TensorFlow (CPU version).
-  - pip install tensorflow==1.9
+  - pip install tensorflow==1.9 --progress-bar off
   
   # install cntk
   - if [[ "$KERAS_BACKEND" == "cntk" ]] || [[ "$TEST_MODE" == "PEP8_DOC" ]]; then


### PR DESCRIPTION
### Summary

Travis logs the state of the progress bar each time the progress bar is updated, making the logs big, taking a few seconds to open, and hard to read in a text editor. 

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
