### PR TITLE
Suppressed the warnings about updating to keras 2 in the legacy tests.

### DIFF
--- a/tests/keras/legacy/conftest.py
+++ b/tests/keras/legacy/conftest.py
@@ -1,0 +1,12 @@
+import warnings
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_session_after_test():
+    """This wrapper runs for all the tests in the legacy directory (recursively).
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', message=r'(.+) Keras 2 ',
+                                category=UserWarning)
+        yield


### PR DESCRIPTION
### Summary

We currently get a lot of warnings related to updating to the keras 2 API in the test suite. To make the logs easier to read, I suggest that we remove those.

### Related Issues

### PR Overview

This conftest will only affect the tests in the `legacy` directory. The filter is not perfect, but it takes care of most of the messages which we don't care about.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
