### PR TITLE
Updated the check of empty array.

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -249,7 +249,7 @@ def _deserialize_model(h5dict, custom_objects=None, compile=True):
     for name in layer_names:
         layer_weights = model_weights_group[name]
         weight_names = layer_weights['weight_names']
-        if weight_names:
+        if weight_names.size > 0:
             filtered_layer_names.append(name)
 
     layer_names = filtered_layer_names

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -249,7 +249,7 @@ def _deserialize_model(h5dict, custom_objects=None, compile=True):
     for name in layer_names:
         layer_weights = model_weights_group[name]
         weight_names = layer_weights['weight_names']
-        if weight_names.size > 0:
+        if len(weight_names) > 0:
             filtered_layer_names.append(name)
 
     layer_names = filtered_layer_names


### PR DESCRIPTION
### Summary
We have a lot of warning on travis which go like this:
```
/home/travis/build/keras-team/keras/keras/engine/saving.py:252: DeprecationWarning: The truth value of an empty array is ambiguous. Returning False, but in future this will result in an error. Use `array.size > 0` to check that an array is not empty.
    if weight_names:
```

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
