### PR TITLE
Updated the check of empty array in the constraints tests.

### DIFF
--- a/tests/keras/constraints_test.py
+++ b/tests/keras/constraints_test.py
@@ -71,8 +71,8 @@ def test_min_max_norm():
         normed = norm_instance(K.variable(array))
         value = K.eval(normed)
         l2 = np.sqrt(np.sum(np.square(value), axis=0))
-        assert not l2[l2 < m]
-        assert not l2[l2 > m * 2 + 1e-5]
+        assert l2[l2 < m].size == 0
+        assert l2[l2 > m * 2 + 1e-5].size == 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

We have many warnings looking like this: 
```
tests/keras/constraints_test.py:75
  /home/travis/build/keras-team/keras/tests/keras/constraints_test.py:75: DeprecationWarning: The truth value of an empty array is ambiguous. Returning False, but in future this will result in an error. Use `array.size > 0` to check that an array is not empty.
    assert not l2[l2 > m * 2 + 1e-5]
```

This PR fixes this problem.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
