### PR TITLE
Remove unnecessary Flatten layer from mnist_acgan

### DIFF
--- a/examples/mnist_acgan.py
+++ b/examples/mnist_acgan.py
@@ -32,7 +32,7 @@ from six.moves import range
 
 from keras.datasets import mnist
 from keras import layers
-from keras.layers import Input, Dense, Reshape, Flatten, Embedding, Dropout
+from keras.layers import Input, Dense, Flatten, Reshape, Embedding, Dropout
 from keras.layers import BatchNormalization
 from keras.layers.advanced_activations import LeakyReLU
 from keras.layers.convolutional import Conv2DTranspose, Conv2D
@@ -76,8 +76,8 @@ def build_generator(latent_size):
     # this will be our label
     image_class = Input(shape=(1,), dtype='int32')
 
-    cls = Flatten()(Embedding(num_classes, latent_size,
-                              embeddings_initializer='glorot_normal')(image_class))
+    cls = Embedding(num_classes, latent_size,
+                    embeddings_initializer='glorot_normal')(image_class)
 
     # hadamard product between z-space and a class conditional embedding
     h = layers.multiply([latent, cls])


### PR DESCRIPTION
### Summary
mnist_acgan example: Remove unnecessary flatten layer in generator.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
