### PR TITLE
Fixing a confusing URL faliure error message in get_file() exception …

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -216,7 +216,7 @@ def get_file(fname,
             else:
                 ProgressTracker.progbar.update(count * block_size)
 
-        error_msg = 'URL fetch failure on {}: {} -- {}'
+        error_msg = 'URL fetch failure on {} : {} -- {}'
         try:
             try:
                 urlretrieve(origin, fpath, dl_progress)


### PR DESCRIPTION
…handler

### Summary
The error message of the URL failure exception handler in get_file() is confusing because the link showed up by the error message is appended with ':' without splitting and therefore included in the link itself. It always leads to an "error 404" page when clicking on it, so I suggest to split it from the url by a simple space ' ' in order to get the meant web page when debugging the error resulting code.
### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
