### PR TITLE
Add tokeniser serialisation

### DIFF
--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -10,3 +10,4 @@ text_to_word_sequence = text.text_to_word_sequence
 one_hot = text.one_hot
 hashing_trick = text.hashing_trick
 Tokenizer = text.Tokenizer
+tokenizer_from_json = text.tokenizer_from_json


### PR DESCRIPTION
### Summary

Tokeniser serialisation was added to `keras_preprocessing` [1], but it was not linked here, so one could not import it from `keras.preprocessing.text`, one had to use `keras_preprocessing.text`.

[1] https://github.com/keras-team/keras-preprocessing/pull/29

### Related Issues

#11697

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
