### PR TITLE
Fix memory issue in tensorflow backend's batch_dot

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1221,34 +1221,141 @@ def batch_dot(x, y, axes=None):
                          ' with axes=' + str(axes) + '. x.shape[%d] != '
                          'y.shape[%d] (%d != %d).' % (axes[0], axes[1], d1, d2))
 
-    # bring the dimensions to be reduced to axis 1
-    if a0 != 1:
-        pattern = list(range(x_ndim))
-        for i in range(a0, 1, -1):
-            pattern[i] = pattern[i - 1]
-        pattern[1] = a0
-        x = permute_dimensions(x, pattern)
-    if a1 != 1:
-        pattern = list(range(y_ndim))
-        for i in range(a1, 1, -1):
-            pattern[i] = pattern[i - 1]
-        pattern[1] = a1
-        y = permute_dimensions(y, pattern)
 
-    # reshape to closest broadcastable shape
-    x_shape = tf.shape(x)
-    y_shape = tf.shape(y)
+    # There are 2 ways to perform theano's batched_tensordot in tensorflow:
+    # 1) Elementwise multiplication followed by tf.reduce_sum. This requires
+    # more memory but works with partial shape information.
+    # 2) Using tf.matmul. This is more efficient but all dimensions except
+    # batch size should be known for input with rank > 3.
 
-    new_x_shape = tf.concat([x_shape, tf.ones_like(y_shape[2:])], 0)
-    new_y_shape = tf.concat([y_shape[:2], tf.ones_like(x_shape[2:]), y_shape[2:]], 0)
+    if x_ndim > 3:
+        if None in x_shape[1:]:
+            x_matmullabe = False
+        else:
+            x_matmullabe = True
+    else:
+        x_matmullabe = True
+    
+    if y_ndim > 3:
+        if None in y_shape[1:]:
+            y_matmullabe = False
+        else:
+            y_matmullabe = True
+    else:
+        y_matmullabe = True
+    
+    if x_matmullabe and y_matmullabe:
+        use_matmul = True
+    else:
+        use_matmul = False
 
-    x = reshape(x, new_x_shape)
-    y = reshape(y, new_y_shape)
+    if use_matmul:
+        # backup ndims. Need them later.
+        orig_x_ndim = x_ndim
+        orig_y_ndim = y_ndim
 
-    result = tf.reduce_sum(x * y, 1)
+        # if rank is 2, expand to 3.
+        if x_ndim == 2:
+            x = tf.expand_dims(x, 1)
+            a0 += 1
+            x_ndim += 1
+        if y_ndim == 2:
+            y = tf.expand_dims(y, 2)
+            y_ndim += 1
 
-    if ndim(result) == 1:
-        result = tf.expand_dims(result, -1)
+        # bring x's dimension to be reduced to last axis.
+        if a0 != x_ndim - 1:
+            pattern = list(range(x_ndim))
+            for i in range(a0, x_ndim - 1):
+                pattern[i] = pattern[i + 1]
+            pattern[-1] = a0
+            x = tf.transpose(x, pattern)
+
+        # bring y's dimension to be reduced to axis 1.
+        if a1 != 1:
+            pattern = list(range(y_ndim))
+            for i in range(a1, 1, -1):
+                pattern[i] = pattern[i- 1]
+            pattern[1] = a1
+            y = tf.transpose(y, pattern)
+
+        # normalize both inputs to rank 3.
+        if x_ndim > 3:
+            # squash middle dimensions of x.
+            x_shape = list(int_shape(x))
+            x_mid_dims = x_shape[1:-1]
+            x_squashed_dim = np.prod(x_mid_dims)
+            if x_batch_size is None:
+                x_batch_size = -1
+            x = tf.reshape(x, [x_batch_size, x_squashed_dim, x_shape[-1]])
+            x_squashed = True
+        else:
+            x_squashed = False
+        if y_ndim > 3:
+            # squash trailing dimensions of y
+            y_shape = list(int_shape(y))
+            y_trail_dims = y_shape[2:]
+            y_squashed_dim = np.prod(y_trail_dims)
+            if y_batch_size is None:
+                y_batch_size = -1
+            y = tf.reshape(y, [y_batch_size, y_shape[1], y_squashed_dim])
+            y_squashed = True
+        else:
+            y_squashed = False
+
+        result = tf.matmul(x, y)
+
+        # if inputs were squashed, we have to reshape the matmul output.
+        output_shape = list(int_shape(result))
+        do_reshape = False
+        if x_squashed:
+            output_shape = [output_shape[0]] + x_mid_dims + [output_shape[-1]]
+            do_reshape = True
+        if y_squashed:
+            output_shape = output_shape[:-1] + y_trail_dims
+            do_reshape = True
+
+        if do_reshape:
+            if output_shape[0] is None:
+                output_shape[0] = -1
+            result = tf.reshape(result, output_shape)
+
+        # if the inputs were originally rank 2, we remove the added 1 dim.
+        if orig_x_ndim == 2:
+            result = tf.squeeze(result, 1)
+        elif orig_y_ndim == 2:
+            result = tf.squeeze(result, -1)
+    else:
+        
+        # bring the dimension to be reduced to axis 1.
+        if a0 != 1:
+            pattern = list(range(x_ndim))
+            for i in range(a0, 1, -1):
+                pattern[i] = pattern[i - 1]
+            pattern[1] = a0
+            x = tf.transpose(x, pattern)
+
+        if a1 != 1:
+            pattern = list(range(y_ndim))
+            for i in range(a1, 1, -1):
+                pattern[i] = pattern[i - 1]
+            pattern[1] = a1
+            y = tf.transpose(y, pattern)
+
+        # reshape to closest broadcastable shape.
+        x_shape = tf.shape(x)
+        y_shape = tf.shape(y)
+
+        new_x_shape = tf.concat([x_shape, tf.ones_like(y_shape[2:])], 0)
+        new_y_shape = tf.concat([y_shape[:2], tf.ones_like(x_shape[2:]), y_shape[2:]], 0)
+
+        x = reshape(x, new_x_shape)
+        y = reshape(y, new_y_shape)
+
+        result = tf.reduce_sum(x * y, 1)
+
+        if ndim(result) == 1:
+            result = tf.expand_dims(result, -1)
 
     return result
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1221,7 +1221,6 @@ def batch_dot(x, y, axes=None):
                          ' with axes=' + str(axes) + '. x.shape[%d] != '
                          'y.shape[%d] (%d != %d).' % (axes[0], axes[1], d1, d2))
 
-
     # There are 2 ways to perform theano's batched_tensordot in tensorflow:
     # 1) Elementwise multiplication followed by tf.reduce_sum. This requires
     # more memory but works with partial shape information.
@@ -1235,7 +1234,7 @@ def batch_dot(x, y, axes=None):
             x_matmullabe = True
     else:
         x_matmullabe = True
-    
+
     if y_ndim > 3:
         if None in y_shape[1:]:
             y_matmullabe = False
@@ -1243,7 +1242,7 @@ def batch_dot(x, y, axes=None):
             y_matmullabe = True
     else:
         y_matmullabe = True
-    
+
     if x_matmullabe and y_matmullabe:
         use_matmul = True
     else:
@@ -1275,7 +1274,7 @@ def batch_dot(x, y, axes=None):
         if a1 != 1:
             pattern = list(range(y_ndim))
             for i in range(a1, 1, -1):
-                pattern[i] = pattern[i- 1]
+                pattern[i] = pattern[i - 1]
             pattern[1] = a1
             y = tf.transpose(y, pattern)
 
@@ -1326,7 +1325,7 @@ def batch_dot(x, y, axes=None):
         elif orig_y_ndim == 2:
             result = tf.squeeze(result, -1)
     else:
-        
+
         # bring the dimension to be reduced to axis 1.
         if a0 != 1:
             pattern = list(range(x_ndim))

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1346,7 +1346,9 @@ def batch_dot(x, y, axes=None):
         y_shape = tf.shape(y)
 
         new_x_shape = tf.concat([x_shape, tf.ones_like(y_shape[2:])], 0)
-        new_y_shape = tf.concat([y_shape[:2], tf.ones_like(x_shape[2:]), y_shape[2:]], 0)
+        new_y_shape = tf.concat([y_shape[:2],
+                                tf.ones_like(x_shape[2:]),
+                                y_shape[2:]], 0)
 
         x = reshape(x, new_x_shape)
         y = reshape(y, new_y_shape)

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1243,10 +1243,7 @@ def batch_dot(x, y, axes=None):
     else:
         y_matmullabe = True
 
-    if x_matmullabe and y_matmullabe:
-        use_matmul = True
-    else:
-        use_matmul = False
+    use_matmul = x_matmullabe and y_matmullabe
 
     if use_matmul:
         # backup ndims. Need them later.

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -292,7 +292,7 @@ class TestBackend(object):
             assert_allclose(f([x_np, y_np])[0], z_np, atol=1e-05)
 
             # test with placeholders (no shape info)
-            if K != KC:
+            if K.backend() != 'cntk':
                 x = K.placeholder(ndim=len(x_shape))
                 y = K.placeholder(ndim=len(y_shape))
                 z = K.batch_dot(x, y, axes)

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -291,6 +291,20 @@ class TestBackend(object):
 
             assert_allclose(f([x_np, y_np])[0], z_np, atol=1e-05)
 
+            # test with placeholders (no shape info)
+            x = K.placeholder(ndim=len(x_shape))
+            y = K.placeholder(ndim=len(y_shape))
+            z = K.batch_dot(x, y, axes)
+
+            z_shape = K.int_shape(z)
+            if z_shape is not None:
+                assert len(z_shape) == z_np.ndim
+                assert set(z_shape) <= set((None, 1))
+
+            f = K.function([x, y], [z])
+
+            assert_allclose(f([x_np, y_np])[0], z_np, atol=1e-05)
+
             # test with variables
             x = K.variable(x_np)
             y = K.variable(y_np)

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -292,18 +292,19 @@ class TestBackend(object):
             assert_allclose(f([x_np, y_np])[0], z_np, atol=1e-05)
 
             # test with placeholders (no shape info)
-            x = K.placeholder(ndim=len(x_shape))
-            y = K.placeholder(ndim=len(y_shape))
-            z = K.batch_dot(x, y, axes)
+            if K != KC:
+                x = K.placeholder(ndim=len(x_shape))
+                y = K.placeholder(ndim=len(y_shape))
+                z = K.batch_dot(x, y, axes)
 
-            z_shape = K.int_shape(z)
-            if z_shape is not None:
-                assert len(z_shape) == z_np.ndim
-                assert set(z_shape) <= set((None, 1))
+                z_shape = K.int_shape(z)
+                if z_shape is not None:
+                    assert len(z_shape) == z_np.ndim
+                    assert set(z_shape) <= set((None, 1))
 
-            f = K.function([x, y], [z])
+                f = K.function([x, y], [z])
 
-            assert_allclose(f([x_np, y_np])[0], z_np, atol=1e-05)
+                assert_allclose(f([x_np, y_np])[0], z_np, atol=1e-05)
 
             # test with variables
             x = K.variable(x_np)


### PR DESCRIPTION
### Summary
See #11665 

In this PR, `batch_dot` uses `tf.matmul` to avoid memory allocation that happens when doing an elem-wise multiplication, if enough shape information is available.

If required shape information is not available, we fall back to old elem-wise mul+`tf.reduce_sum` based implementation.



### PR Overview

- [y ] This PR requires new unit tests [y/n] (make sure tests are included)
- [n ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y ] This PR is backwards compatible [y/n]
- [n ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)


