### PR TITLE
Updated docstring for LSTM layer - Specifying order of outputs

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -293,7 +293,8 @@ class RNN(Layer):
     # Output shape
         - if `return_state`: a list of tensors. The first tensor is
             the output. The remaining tensors are the last states,
-            each with shape `(batch_size, units)`.
+            each with shape `(batch_size, units)`. For example, the number of
+            state tensors is 1 (for RNN and GRU) or 2 (for LSTM).
         - if `return_sequences`: 3D tensor with shape
             `(batch_size, timesteps, units)`.
         - else, 2D tensor with shape `(batch_size, units)`.

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -2096,7 +2096,8 @@ class LSTM(RNN):
         return_sequences: Boolean. Whether to return the last output
             in the output sequence, or the full sequence.
         return_state: Boolean. Whether to return the last state
-            in addition to the output.
+            in addition to the output. The returned elements of the
+            states list are the hidden state and the cell state, respectively.
         go_backwards: Boolean (default False).
             If True, process the input sequence backwards and return the
             reversed sequence.


### PR DESCRIPTION
### Summary

When using the LSTM layer with `return_state = True` the last states are returned in addition to the output of the layer. However, it is not clear from the documentation what is the order of the returned states (hidden state vs. cell state). For example, in:
`output, state_1, state_2 = LSTM(100, return_state=True)(x)`
I would like to know which of state_1\2 is the last hidden state and which one is the cell state.

### PR Overview
Following the code I'm pretty sure I got the order right - [hidden state, cell state]. However if you decide to include this change it would be nice for another set of eyes to make sure the order is correct.

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
