### PR TITLE
Fixed the rerun flags which were flipped for flaky tests.

### DIFF
--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -125,7 +125,7 @@ def test_weighted_masked_objective():
 
 
 # TODO: resolve flakyness issue. Tracked with #11560
-@flaky(rerun_filter=lambda err, *args: not issubclass(err[0], AssertionError))
+@flaky(rerun_filter=lambda err, *args: issubclass(err[0], AssertionError))
 def test_model_methods():
     a = Input(shape=(3,), name='input_a')
     b = Input(shape=(3,), name='input_b')

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -123,7 +123,7 @@ def test_sparse_top_k_categorical_accuracy(y_pred, y_true):
 
 # TODO: resolve flakyness issue. Tracked with #11064
 @pytest.mark.parametrize('metrics_mode', ['list', 'dict'])
-@flaky(rerun_filter=lambda err, *args: not issubclass(err[0], AssertionError))
+@flaky(rerun_filter=lambda err, *args: issubclass(err[0], AssertionError))
 def test_stateful_metrics(metrics_mode):
     np.random.seed(1334)
 

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -213,7 +213,7 @@ def test_generator_enqueuer_threadsafe():
 
 
 # TODO: resolve flakyness issue. Tracked with #11587
-@flaky(rerun_filter=lambda err, *args: not issubclass(err[0], StopIteration))
+@flaky(rerun_filter=lambda err, *args: issubclass(err[0], StopIteration))
 def test_generator_enqueuer_fail_threads():
     enqueuer = GeneratorEnqueuer(create_generator_from_sequence_threads(
         FaultSequence()), use_multiprocessing=False)
@@ -365,7 +365,7 @@ def create_finite_generator_from_sequence_pcs(ds):
 
 
 # TODO: resolve flakyness issue. Tracked with #11586
-@flaky(rerun_filter=lambda err, *args: not issubclass(err[0], AssertionError))
+@flaky(rerun_filter=lambda err, *args: issubclass(err[0], AssertionError))
 def test_finite_generator_enqueuer_threads():
     enqueuer = GeneratorEnqueuer(create_finite_generator_from_sequence_threads(
         DummySequence([3, 10, 10, 3])), use_multiprocessing=False)


### PR DESCRIPTION
### Summary

This is a mistake that I did in #11660. There is a filter to choose to rerun or not depending on the error. The flag returned by the filter should be True if we want the test to run again. 

### Related Issues

#11660

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
