### PR TITLE
Sync the callback API with new tf.keras API

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -33,17 +33,6 @@ _TEST = 'test'
 _PREDICT = 'predict'
 
 
-def make_logs(model, logs, outputs, mode, prefix=''):
-    """Computes logs for sending to `on_batch_end` methods."""
-    if mode in {_TRAIN, _TEST}:
-        if hasattr(model, 'metrics_names'):
-            for label, output in zip(model.metrics_names, outputs):
-                logs[prefix + label] = output
-    else:
-        logs['outputs'] = outputs
-    return logs
-
-
 class CallbackList(object):
     """Container abstracting a list of callbacks.
 
@@ -57,6 +46,8 @@ class CallbackList(object):
         callbacks = callbacks or []
         self.callbacks = [c for c in callbacks]
         self.queue_length = queue_length
+        self.params = {}
+        self.model = None
         self._reset_batch_timing()
 
     def _reset_batch_timing(self):
@@ -67,10 +58,12 @@ class CallbackList(object):
         self.callbacks.append(callback)
 
     def set_params(self, params):
+        self.params = params
         for callback in self.callbacks:
             callback.set_params(params)
 
     def set_model(self, model):
+        self.model = model
         for callback in self.callbacks:
             callback.set_model(model)
 

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -192,7 +192,7 @@ class CallbackList(object):
             logs: dict, metric results for this batch.
         """
         self._call_batch_hook(_TEST, 'end', batch, logs=logs)
-    
+
     def on_predict_batch_begin(self, batch, logs=None):
         """Calls the `on_predict_batch_begin` methods of its callbacks.
 
@@ -202,7 +202,7 @@ class CallbackList(object):
                 batch number and the size of the batch.
         """
         self._call_batch_hook(_PREDICT, 'begin', batch, logs=logs)
-    
+
     def on_predict_batch_end(self, batch, logs=None):
         """Calls the `on_predict_batch_end` methods of its callbacks.
 
@@ -351,7 +351,7 @@ class Callback(object):
 
         # Arguments
             batch: integer, index of batch within the current epoch.
-            logs: dict, has keys `batch` and `size` representing the current 
+            logs: dict, has keys `batch` and `size` representing the current
                 batch number and the size of the batch.
         """
         # For backwards compatibility
@@ -368,7 +368,7 @@ class Callback(object):
         """
         # For backwards compatibility
         self.on_batch_end(batch, logs=logs)
-    
+
     def on_test_batch_begin(self, batch, logs=None):
         """Called at the beginning of a batch in `evaluate` methods.
 
@@ -379,16 +379,16 @@ class Callback(object):
 
         # Arguments
             batch: integer, index of batch within the current epoch.
-            logs: dict, has keys `batch` and `size` representing the current 
+            logs: dict, has keys `batch` and `size` representing the current
                 batch number and the size of the batch.
         """
 
     def on_test_batch_end(self, batch, logs=None):
         """Called at the end of a batch in `evaluate` methods.
-        
+
         Also called at the end of a validation batch in the `fit` methods,
         if validation data is provided.
-        
+
         Subclasses should override for any actions to run.
 
         # Arguments
@@ -403,20 +403,20 @@ class Callback(object):
 
         # Arguments
             batch: integer, index of batch within the current epoch.
-            logs: dict, has keys `batch` and `size` representing the current 
+            logs: dict, has keys `batch` and `size` representing the current
                 batch number and the size of the batch.
         """
 
     def on_predict_batch_end(self, batch, logs=None):
         """Called at the end of a batch in `predict` methods.
-        
+
         Subclasses should override for any actions to run.
 
         # Arguments
             batch: integer, index of batch within the current epoch.
             logs: dict, metric results for this batch.
         """
-    
+
     def on_train_begin(self, logs=None):
         """Called at the beginning of training.
 

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -257,7 +257,10 @@ class BaseLogger(Callback):
     """
 
     def __init__(self, stateful_metrics=None):
-        self.stateful_metrics = set(stateful_metrics or [])
+        if stateful_metrics:
+            self.stateful_metrics = set(stateful_metrics)
+        else:
+            self.stateful_metrics = set()
 
     def on_epoch_begin(self, epoch, logs=None):
         self.seen = 0
@@ -317,7 +320,8 @@ class ProgbarLogger(Callback):
         ValueError: In case of invalid `count_mode`.
     """
 
-    def __init__(self, count_mode='samples', stateful_metrics=None):
+    def __init__(self, count_mode='samples',
+                 stateful_metrics=None):
         super(ProgbarLogger, self).__init__()
         if count_mode == 'samples':
             self.use_steps = False
@@ -325,7 +329,10 @@ class ProgbarLogger(Callback):
             self.use_steps = True
         else:
             raise ValueError('Unknown `count_mode`: ' + str(count_mode))
-        self.stateful_metrics = set(stateful_metrics or [])
+        if stateful_metrics:
+            self.stateful_metrics = set(stateful_metrics)
+        else:
+            self.stateful_metrics = set()
 
     def on_train_begin(self, logs=None):
         self.verbose = self.params['verbose']
@@ -624,7 +631,7 @@ class RemoteMonitor(Callback):
             The field is used only if the payload is sent within a form
             (i.e. send_as_json is set to False).
         headers: Dictionary; optional custom HTTP headers.
-        send_as_json: Boolean; whether the request should be sent as
+        send_as_json: Boolean; whether the request should be send as
             application/json.
     """
 
@@ -644,7 +651,8 @@ class RemoteMonitor(Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         if requests is None:
-            raise ImportError('RemoteMonitor requires the `requests` library.')
+            raise ImportError('RemoteMonitor requires '
+                              'the `requests` library.')
         logs = logs or {}
         send = {}
         send['epoch'] = epoch
@@ -1090,7 +1098,8 @@ class ReduceLROnPlateau(Callback):
 
         self.monitor = monitor
         if factor >= 1.0:
-            raise ValueError('ReduceLROnPlateau does not support a factor >= 1.0.')
+            raise ValueError('ReduceLROnPlateau '
+                             'does not support a factor >= 1.0.')
         if 'epsilon' in kwargs:
             min_delta = kwargs.pop('epsilon')
             warnings.warn('`epsilon` argument is deprecated and '

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -62,7 +62,7 @@ class CallbackList(object):
         """Helper function for all batch_{begin | end} methods."""
         # only train mode is supported for now
         if mode != 'train':
-            return
+            raise NotImplementedError
 
         hook_name = 'on_{mode}_batch_{hook}'.format(mode=mode, hook=hook)
         if hook == 'end':
@@ -90,14 +90,16 @@ class CallbackList(object):
     def _call_begin_hook(self, mode):
         """Helper function for on_{train|test|predict}_begin methods."""
         # only train mode is supported for now
-        if mode == 'train':
-            self.on_train_begin()
+        if mode != 'train':
+            raise NotImplementedError
+        self.on_train_begin()
 
     def _call_end_hook(self, mode):
         """Helper function for on_{train|test|predict}_end methods."""
         # only train mode is supported for now
-        if mode == 'train':
-            self.on_train_end()
+        if mode != 'train':
+            raise NotImplementedError
+        self.on_train_end()
 
     def on_epoch_begin(self, epoch, logs=None, mode='train'):
         """Called at the start of an epoch.
@@ -108,10 +110,11 @@ class CallbackList(object):
             mode: one of 'train'/'test'/'predict'
         """
         # only train mode is supported for now
-        if mode == 'train':
-            logs = logs or {}
-            for callback in self.callbacks:
-                callback.on_epoch_begin(epoch, logs)
+        if mode != 'train':
+            raise NotImplementedError
+        logs = logs or {}
+        for callback in self.callbacks:
+            callback.on_epoch_begin(epoch, logs)
         self._reset_batch_timing()
 
     def on_epoch_end(self, epoch, logs=None, mode='train'):
@@ -123,10 +126,11 @@ class CallbackList(object):
             mode: one of 'train'/'test'/'predict'
         """
         # only train mode is supported for now
-        if mode == 'train':
-            logs = logs or {}
-            for callback in self.callbacks:
-                callback.on_epoch_end(epoch, logs)
+        if mode != 'train':
+            raise NotImplementedError
+        logs = logs or {}
+        for callback in self.callbacks:
+            callback.on_epoch_end(epoch, logs)
 
     def on_batch_begin(self, batch, logs=None):
         self._call_batch_hook('train', 'begin', batch, logs=logs)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -78,7 +78,8 @@ class CallbackList(object):
 
         delta_t_median = np.median(self._delta_ts[hook_name])
         if (self._delta_t_batch > 0. and
-            delta_t_median > 0.95 * self._delta_t_batch and delta_t_median > 0.1):
+           delta_t_median > 0.95 * self._delta_t_batch and
+           delta_t_median > 0.1):
             logging.warning(
                 'Method (%s) is slow compared '
                 'to the batch update (%f). Check your callbacks.', hook_name,
@@ -150,7 +151,7 @@ class CallbackList(object):
             logs: dictionary of logs.
         """
         self._call_batch_hook('train', 'end', batch, logs=logs)
-        
+
     def on_train_begin(self, logs=None):
         """Called at the beginning of training.
 
@@ -253,7 +254,7 @@ class BaseLogger(Callback):
 
     def __init__(self, stateful_metrics=None):
         self.stateful_metrics = set(stateful_metrics or [])
-        
+
     def on_epoch_begin(self, epoch, logs=None):
         self.seen = 0
         self.totals = {}
@@ -321,7 +322,7 @@ class ProgbarLogger(Callback):
         else:
             raise ValueError('Unknown `count_mode`: ' + str(count_mode))
         self.stateful_metrics = set(stateful_metrics or [])
-        
+
     def on_train_begin(self, logs=None):
         self.verbose = self.params['verbose']
         self.epochs = self.params['epochs']

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -125,35 +125,35 @@ class CallbackList(object):
     def on_batch_end(self, batch, logs=None):
         self._call_batch_hook(_TRAIN, 'end', batch, logs=logs)
 
-    def on_epoch_begin(self, epoch, logs=None, mode='train'):
+    def on_epoch_begin(self, epoch, logs=None):
         """Calls the `on_epoch_begin` methods of its callbacks.
+
+        This function should only be called during train mode.
 
         # Arguments
             epoch: integer, index of epoch.
             logs: dict, Currently no data is passed to this argument for this method
                 but that may change in the future.
-            mode: one of 'train'/'test'/'predict'
         """
-        if mode == _TRAIN:
-            logs = logs or {}
-            for callback in self.callbacks:
-                callback.on_epoch_begin(epoch, logs)
+        logs = logs or {}
+        for callback in self.callbacks:
+            callback.on_epoch_begin(epoch, logs)
         self._reset_batch_timing()
 
-    def on_epoch_end(self, epoch, logs=None, mode='train'):
+    def on_epoch_end(self, epoch, logs=None):
         """Calls the `on_epoch_end` methods of its callbacks.
+
+        This function should only be called during train mode.
 
         # Arguments
             epoch: integer, index of epoch.
             logs: dict, metric results for this training epoch, and for the
                 validation epoch if validation is performed. Validation result keys
                 are prefixed with `val_`.
-            mode: one of 'train'/'test'/'predict'
         """
-        if mode == _TRAIN:
-            logs = logs or {}
-            for callback in self.callbacks:
-                callback.on_epoch_end(epoch, logs)
+        logs = logs or {}
+        for callback in self.callbacks:
+            callback.on_epoch_end(epoch, logs)
 
     def on_train_batch_begin(self, batch, logs=None):
         """Calls the `on_train_batch_begin` methods of its callbacks.
@@ -319,29 +319,29 @@ class Callback(object):
     def on_batch_end(self, batch, logs=None):
         """A backwards compatibility alias for `on_train_batch_end`."""
 
-    def on_epoch_begin(self, epoch, logs=None, mode='train'):
+    def on_epoch_begin(self, epoch, logs=None):
         """Called at the start of an epoch.
 
-        Subclasses should override for any actions to run.
+        Subclasses should override for any actions to run. This function should only
+        be called during train mode.
 
         # Arguments
             epoch: integer, index of epoch.
             logs: dict, currently no data is passed to this argument for this method
                 but that may change in the future.
-            mode: one of 'train'/'test'/'predict'.
         """
 
-    def on_epoch_end(self, epoch, logs=None, mode='train'):
+    def on_epoch_end(self, epoch, logs=None):
         """Called at the end of an epoch.
 
-        Subclasses should override for any actions to run.
+        Subclasses should override for any actions to run. This function should only
+        be called during train mode.
 
         # Arguments
             epoch: integer, index of epoch.
             logs: dict, metric results for this training epoch, and for the
                 validation epoch if validation is performed. Validation result keys
                 are prefixed with `val_`.
-            mode: one of 'train'/'test'/'predict'.
         """
 
     def on_train_batch_begin(self, batch, logs=None):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -66,6 +66,8 @@ class CallbackList(object):
 
         hook_name = 'on_{mode}_batch_{hook}'.format(mode=mode, hook=hook)
         if hook == 'end':
+            if not hasattr(self, '_t_enter_batch'):
+                self._t_enter_batch = time.time()
             # batch is ending, calculate batch time
             self._delta_t_batch = time.time() - self._t_enter_batch
 

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -80,7 +80,7 @@ class CallbackList(object):
         if (self._delta_t_batch > 0. and
            delta_t_median > 0.95 * self._delta_t_batch and
            delta_t_median > 0.1):
-            logging.warning(
+            warnings.warn(
                 'Method (%s) is slow compared '
                 'to the batch update (%f). Check your callbacks.', hook_name,
                 delta_t_median)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -76,6 +76,8 @@ class CallbackList(object):
 
     def _call_batch_hook(self, mode, hook, batch, logs=None):
         """Helper function for all batch_{begin | end} methods."""
+        if not self.callbacks:
+            return
         hook_name = 'on_{mode}_batch_{hook}'.format(mode=mode, hook=hook)
         if hook == 'end':
             if not hasattr(self, '_t_enter_batch'):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -823,6 +823,12 @@ class Model(Network):
                                  str(x[0].shape[0]) + ' samples')
         return x, y, sample_weights
 
+    def _get_callback_model(self):
+        """Returns the Callback Model for this Model."""
+        if hasattr(self, 'callback_model') and self.callback_model:
+            return self.callback_model
+        return self
+
     def fit(self,
             x=None,
             y=None,
@@ -869,7 +875,8 @@ class Model(Network):
             verbose: Integer. 0, 1, or 2. Verbosity mode.
                 0 = silent, 1 = progress bar, 2 = one line per epoch.
             callbacks: List of `keras.callbacks.Callback` instances.
-                List of callbacks to apply during training.
+                List of callbacks to apply during training and validation
+                (if ).
                 See [callbacks](/callbacks).
             validation_split: Float between 0 and 1.
                 Fraction of the training data to be used as validation data.
@@ -1043,7 +1050,8 @@ class Model(Network):
                  batch_size=None,
                  verbose=1,
                  sample_weight=None,
-                 steps=None):
+                 steps=None,
+                 callbacks=None):
         """Returns the loss value & metrics values for the model in test mode.
 
         Computation is done in batches.
@@ -1082,6 +1090,9 @@ class Model(Network):
                 Total number of steps (batches of samples)
                 before declaring the evaluation round finished.
                 Ignored with the default value of `None`.
+            callbacks: List of `keras.callbacks.Callback` instances.
+                List of callbacks to apply during evaluation.
+                See [callbacks](/callbacks).
 
         # Returns
             Scalar test loss (if the model has a single output and no metrics)
@@ -1111,12 +1122,14 @@ class Model(Network):
         return training_arrays.test_loop(self, f, ins,
                                          batch_size=batch_size,
                                          verbose=verbose,
-                                         steps=steps)
+                                         steps=steps,
+                                         callbacks=callbacks)
 
     def predict(self, x,
                 batch_size=None,
                 verbose=0,
-                steps=None):
+                steps=None,
+                callbacks=None):
         """Generates output predictions for the input samples.
 
         Computation is done in batches.
@@ -1129,6 +1142,9 @@ class Model(Network):
             steps: Total number of steps (batches of samples)
                 before declaring the prediction round finished.
                 Ignored with the default value of `None`.
+            callbacks: List of `keras.callbacks.Callback` instances.
+                List of callbacks to apply during prediction.
+                See [callbacks](/callbacks).
 
         # Returns
             Numpy array(s) of predictions.
@@ -1167,7 +1183,8 @@ class Model(Network):
         return training_arrays.predict_loop(self, f, ins,
                                             batch_size=batch_size,
                                             verbose=verbose,
-                                            steps=steps)
+                                            steps=steps,
+                                            callbacks=callbacks)
 
     def train_on_batch(self, x, y,
                        sample_weight=None,
@@ -1421,6 +1438,7 @@ class Model(Network):
     @interfaces.legacy_generator_methods_support
     def evaluate_generator(self, generator,
                            steps=None,
+                           callbacks=None,
                            max_queue_size=10,
                            workers=1,
                            use_multiprocessing=False,
@@ -1440,6 +1458,9 @@ class Model(Network):
                 to yield from `generator` before stopping.
                 Optional for `Sequence`: if unspecified, will use
                 the `len(generator)` as a number of steps.
+            callbacks: List of `keras.callbacks.Callback` instances.
+                List of callbacks to apply during training.
+                See [callbacks](/callbacks).
             max_queue_size: maximum size for the generator queue
             workers: Integer. Maximum number of processes to spin up
                 when using process based threading.
@@ -1467,6 +1488,7 @@ class Model(Network):
         return training_generator.evaluate_generator(
             self, generator,
             steps=steps,
+            callbacks=callbacks,
             max_queue_size=max_queue_size,
             workers=workers,
             use_multiprocessing=use_multiprocessing,
@@ -1475,6 +1497,7 @@ class Model(Network):
     @interfaces.legacy_generator_methods_support
     def predict_generator(self, generator,
                           steps=None,
+                          callbacks=None,
                           max_queue_size=10,
                           workers=1,
                           use_multiprocessing=False,
@@ -1493,6 +1516,9 @@ class Model(Network):
                 to yield from `generator` before stopping.
                 Optional for `Sequence`: if unspecified, will use
                 the `len(generator)` as a number of steps.
+            callbacks: List of `keras.callbacks.Callback` instances.
+                List of callbacks to apply during training.
+                See [callbacks](/callbacks).
             max_queue_size: Maximum size for the generator queue.
             workers: Integer. Maximum number of processes to spin up
                 when using process based threading.
@@ -1517,6 +1543,7 @@ class Model(Network):
         return training_generator.predict_generator(
             self, generator,
             steps=steps,
+            callbacks=callbacks,
             max_queue_size=max_queue_size,
             workers=workers,
             use_multiprocessing=use_multiprocessing,

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose
 from csv import reader
 from csv import Sniffer
 import shutil
+from collections import defaultdict
 from keras import optimizers
 from keras import initializers
 from keras import callbacks
@@ -63,6 +64,175 @@ def get_data_callbacks(num_train=train_samples,
                          input_shape=input_shape,
                          classification=classification,
                          num_classes=num_classes)
+
+
+class Counter(callbacks.Callback):
+    """Counts the number of times each callback method was run.
+
+    # Arguments
+        method_counts: dict, contains the counts of time each callback method was
+            run.
+    """
+
+    def __init__(self):
+        self.method_counts = defaultdict(int)
+        methods_to_count = [
+            'on_batch_begin', 'on_batch_end', 'on_epoch_begin', 'on_epoch_end',
+            'on_train_batch_begin', 'on_train_batch_end',
+            'on_test_batch_begin', 'on_test_batch_end',
+            'on_predict_batch_begin', 'on_predict_batch_end',
+            'on_train_begin', 'on_train_end', 'on_predict_begin', 'on_predict_end',
+            'on_test_begin', 'on_test_end',
+        ]
+        for method_name in methods_to_count:
+            setattr(self, method_name,
+                    self.wrap_with_counts(method_name, getattr(self, method_name)))
+
+    def wrap_with_counts(self, method_name, method):
+
+        def _call_and_count(*args, **kwargs):
+            self.method_counts[method_name] += 1
+            return method(*args, **kwargs)
+
+        return _call_and_count
+
+
+class TestCallbackCounts(object):
+
+    def _check_counts(self, counter, expected_counts):
+        """Checks that the counts registered by `counter` are those expected."""
+        for method_name, expected_count in expected_counts.items():
+            count = counter.method_counts[method_name]
+            assert count == expected_count, \
+                'For method {}: expected {}, got: {}'.format(
+                    method_name, expected_count, count)
+
+    def _get_model(self):
+        layers = [
+            Dense(10, activation='relu', input_dim=input_dim),
+            Dense(num_classes, activation='softmax')
+        ]
+        model = Sequential(layers=layers)
+        model.compile(optimizer='adam', loss='binary_crossentropy')
+        return model
+
+    def test_callback_hooks_are_called_in_fit(self):
+        np.random.seed(1337)
+        (X_train, y_train), (X_test, y_test) = get_data_callbacks(num_train=10,
+                                                                  num_test=4)
+        y_train = np_utils.to_categorical(y_train)
+        y_test = np_utils.to_categorical(y_test)
+
+        model = self._get_model()
+        counter = Counter()
+        model.fit(X_train, y_train, validation_data=(X_test, y_test),
+                  batch_size=2, epochs=5, callbacks=[counter])
+
+        self._check_counts(
+            counter, {
+                'on_batch_begin': 25,
+                'on_batch_end': 25,
+                'on_epoch_begin': 5,
+                'on_epoch_end': 5,
+                'on_predict_batch_begin': 0,
+                'on_predict_batch_end': 0,
+                'on_predict_begin': 0,
+                'on_predict_end': 0,
+                'on_test_batch_begin': 10,
+                'on_test_batch_end': 10,
+                'on_test_begin': 5,
+                'on_test_end': 5,
+                'on_train_batch_begin': 25,
+                'on_train_batch_end': 25,
+                'on_train_begin': 1,
+                'on_train_end': 1,
+            })
+
+    def test_callback_hooks_are_called_in_evaluate(self):
+        np.random.seed(1337)
+        (_, _), (X_test, y_test) = get_data_callbacks(num_test=10)
+
+        y_test = np_utils.to_categorical(y_test)
+
+        model = self._get_model()
+        counter = Counter()
+        model.evaluate(X_test, y_test, batch_size=2, callbacks=[counter])
+        self._check_counts(
+            counter, {
+                'on_test_batch_begin': 5,
+                'on_test_batch_end': 5,
+                'on_test_begin': 1,
+                'on_test_end': 1,
+                'on_batch_begin': 0,
+                'on_batch_end': 0,
+                'on_epoch_begin': 0,
+                'on_epoch_end': 0,
+                'on_predict_batch_begin': 0,
+                'on_predict_batch_end': 0,
+                'on_predict_begin': 0,
+                'on_predict_end': 0,
+                'on_train_batch_begin': 0,
+                'on_train_batch_end': 0,
+                'on_train_begin': 0,
+                'on_train_end': 0,
+            })
+
+    def test_callback_hooks_are_called_in_predict(self):
+        np.random.seed(1337)
+        (_, _), (X_test, _) = get_data_callbacks(num_test=10)
+
+        model = self._get_model()
+        counter = Counter()
+        model.predict(X_test, batch_size=2, callbacks=[counter])
+        self._check_counts(
+            counter, {
+                'on_predict_batch_begin': 5,
+                'on_predict_batch_end': 5,
+                'on_predict_begin': 1,
+                'on_predict_end': 1,
+                'on_batch_begin': 0,
+                'on_batch_end': 0,
+                'on_epoch_begin': 0,
+                'on_epoch_end': 0,
+                'on_test_batch_begin': 0,
+                'on_test_batch_end': 0,
+                'on_test_begin': 0,
+                'on_test_end': 0,
+                'on_train_batch_begin': 0,
+                'on_train_batch_end': 0,
+                'on_train_begin': 0,
+                'on_train_end': 0,
+            })
+
+    def test_callback_list_methods(self):
+        counter = Counter()
+        callback_list = callbacks.CallbackList([counter])
+
+        batch = 0
+        callback_list.on_test_batch_begin(batch)
+        callback_list.on_test_batch_end(batch)
+        callback_list.on_predict_batch_begin(batch)
+        callback_list.on_predict_batch_end(batch)
+
+        self._check_counts(
+            counter, {
+                'on_test_batch_begin': 1,
+                'on_test_batch_end': 1,
+                'on_predict_batch_begin': 1,
+                'on_predict_batch_end': 1,
+                'on_predict_begin': 0,
+                'on_predict_end': 0,
+                'on_batch_begin': 0,
+                'on_batch_end': 0,
+                'on_epoch_begin': 0,
+                'on_epoch_end': 0,
+                'on_test_begin': 0,
+                'on_test_end': 0,
+                'on_train_batch_begin': 0,
+                'on_train_batch_end': 0,
+                'on_train_begin': 0,
+                'on_train_end': 0,
+            })
 
 
 def test_TerminateOnNaN():


### PR DESCRIPTION
### Summary
This PR syncs callback API with [the new `tf.keras` API](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/callbacks.py#L175).

Modifications:
- A new helper function, `_call_batch_hook`, has been introduced to handle batch-related callbacks methods in different modes (train/test/prediction).
- `on_batch_end` and `on_batch_begin` has been refactored to call `_call_batch_hook` instead.
- Methods `on_train_batch_begin` and `on_train_batch_end` have been introduced specifically for callbacks batch-related methods in training mode.

I have also done some small formatting and style fixes.

Further, I must mention that I think there is a small error in TF implementation: [in this line](https://github.com/tensorflow/tensorflow/blob/320dc4913f94a679790d90f5c577037276aa9599/tensorflow/python/keras/callbacks.py#L187) the `_t_enter_batch` attribute, which measure the batch processing time, is set at the beginning of the method. However, I think this is wrong (since in that case the execution time of `on_batch_begin` would also be included) and as it is [currently implemented in Keras](https://github.com/keras-team/keras/blob/7bee9a18d83899ce6dfd50c4883afc678139f4ad/keras/callbacks.py#L99), it must be done at the end of the method. So in this PR I would set this attribute at the end.

### Related Issues
#11771 

### PR Overview

- [?] This PR requires new unit tests [y/n] (make sure tests are included)
- [?] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [y] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
