### PR TITLE
Class activation maps using resnet50, inception-resnet-v2, and nasnet model

### DIFF
--- a/examples/class_activation_maps.py
+++ b/examples/class_activation_maps.py
@@ -3,7 +3,6 @@
 import numpy as np
 import cv2
 import matplotlib.pyplot as plt
-import argparse
 
 from keras.models import Model
 
@@ -14,17 +13,8 @@ from keras.layers import UpSampling2D, Conv2D
 
 
 N_CLASSES = 1000
-
-# python main.py dog.png resnet
-parser = argparse.ArgumentParser(
-    description='Class Activation Mapping with Keras.')
-parser.add_argument('input_image_file', metavar='image', type=str,
-                    help='Input image file path.')
-parser.add_argument('base_network', metavar='base', type=str,
-                    default="resnet50",
-                    help='Base network model for Class Activation Mapping.')
-
-args = parser.parse_args()
+INPUT_IMG_FILE = "dog.jpg"
+BASE_NETWORK = "resnet"
 
 
 class _Backend(object):
@@ -111,13 +101,13 @@ def postprocess(preds, cams, top_k=1):
 
 
 if __name__ == "__main__":
-
+    
     # 1. create keras-cam model
-    if args.base_network == "resnet":
+    if BASE_NETWORK == "resnet":
         cam_builder = BackendResNet50()
-    elif args.base_network == "nasnet":
+    elif BASE_NETWORK == "nasnet":
         cam_builder = BackendNASNetLarge()
-    elif args.base_network == "inception":
+    elif BASE_NETWORK == "inception":
         cam_builder = BackendInceptionResNetV2()
     else:
         raise ValueError(
@@ -125,7 +115,7 @@ if __name__ == "__main__":
 
     # 2. load image
     imgs, original_img, original_size = cam_builder.load_img(
-        args.input_image_file)
+        INPUT_IMG_FILE)
 
     # 3. run model
     preds, cams = cam_builder.predict(imgs)

--- a/examples/class_activation_maps.py
+++ b/examples/class_activation_maps.py
@@ -10,14 +10,22 @@ import keras.applications.resnet50 as resnet
 from keras.layers import UpSampling2D, Conv2D
 
 
-N_CLASSES = 1000
-INPUT_IMG_FILE = "dog.jpg"
+# Please set an appropriate image file
+INPUT_IMG_FILE = "dog.jpg" 
+
+################################################################
+# The following parameters can be changed to other models 
+# that use global average pooling.
+# e.g.) InceptionResnetV2 / NASNetLarge
 NETWORK_INPUT_SIZE = 224
 MODEL_CLASS = resnet.ResNet50
 PREPROCESS_FN = resnet.preprocess_input
 LAST_CONV_LAYER = "activation_49"
 PRED_LAYER = "fc1000"
+################################################################
 
+# number of imagenet classes
+N_CLASSES = 1000
 
 
 def load_img(fname, input_size, preprocess_fn):

--- a/examples/class_activation_maps.py
+++ b/examples/class_activation_maps.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     elif args.base_network == "inception":
         cam_builder = BackendInceptionResNetV2()
     else:
-        pass
+        raise ValueError("The base network should be one of resnet, nasnet, or inception.")
         
 
     # 2. load image

--- a/examples/class_activation_maps.py
+++ b/examples/class_activation_maps.py
@@ -7,89 +7,47 @@ import matplotlib.pyplot as plt
 from keras.models import Model
 
 import keras.applications.resnet50 as resnet
-import keras.applications.inception_resnet_v2 as inception
-import keras.applications.nasnet as nasnet
 from keras.layers import UpSampling2D, Conv2D
 
 
 N_CLASSES = 1000
 INPUT_IMG_FILE = "dog.jpg"
-BASE_NETWORK = "resnet"
+NETWORK_INPUT_SIZE = 224
+MODEL_CLASS = resnet.ResNet50
+PREPROCESS_FN = resnet.preprocess_input
+LAST_CONV_LAYER = "activation_49"
+PRED_LAYER = "fc1000"
 
 
-class _Backend(object):
-    def __init__(self,
-                 input_size,
-                 last_conv_layer,
-                 pred_layer,
-                 preprocess_fn,
-                 model_class):
-        self.input_size = input_size
-        self.preprocess_fn = preprocess_fn
-        self.cam_model = self._create_cam_model(
-            model_class, last_conv_layer, pred_layer)
 
-    def load_img(self, fname):
-        original_img = cv2.imread(fname)[:, :, ::-1]
-        original_size = (original_img.shape[1], original_img.shape[0])
-        img = cv2.resize(original_img, (self.input_size, self.input_size))
-        imgs = np.expand_dims(self.preprocess_fn(img), axis=0)
-        return imgs, original_img, original_size
-
-    def predict(self, imgs):
-        preds, cams = self.cam_model.predict(imgs)
-        return preds, cams
-
-    def _create_cam_model(self, model_class, last_conv_layer, pred_layer):
-        model = model_class(input_shape=(self.input_size, self.input_size, 3))
-
-        final_params = model.get_layer(pred_layer).get_weights()
-        final_params = (final_params[0].reshape(
-            1, 1, -1, N_CLASSES), final_params[1])
-
-        last_conv_output = model.get_layer(last_conv_layer).output
-        x = UpSampling2D(size=(32, 32), interpolation="bilinear")(
-            last_conv_output)
-        x = Conv2D(filters=N_CLASSES, kernel_size=(
-            1, 1), name="predictions_2")(x)
-
-        cam_model = Model(inputs=model.input,
-                          outputs=[model.output, x])
-        cam_model.get_layer("predictions_2").set_weights(final_params)
-        return cam_model
+def load_img(fname, input_size, preprocess_fn):
+    original_img = cv2.imread(fname)[:, :, ::-1]
+    original_size = (original_img.shape[1], original_img.shape[0])
+    img = cv2.resize(original_img, (input_size, input_size))
+    imgs = np.expand_dims(preprocess_fn(img), axis=0)
+    return imgs, original_img, original_size
 
 
-class BackendInceptionResNetV2(_Backend):
-    def __init__(self):
-        super(
-            BackendInceptionResNetV2,
-            self).__init__(
-            input_size=299,
-            last_conv_layer="conv_7b_ac",
-            pred_layer="predictions",
-            preprocess_fn=inception.preprocess_input,
-            model_class=inception.InceptionResNetV2)
+def get_cam_model(model_class,
+                  input_size=224,
+                  last_conv_layer="activation_49",
+                  pred_layer="fc1000"):
+    model = model_class(input_shape=(input_size, input_size, 3))
 
+    final_params = model.get_layer(pred_layer).get_weights()
+    final_params = (final_params[0].reshape(
+        1, 1, -1, N_CLASSES), final_params[1])
 
-class BackendResNet50(_Backend):
-    def __init__(self):
-        super(BackendResNet50, self).__init__(input_size=224,
-                                              last_conv_layer="activation_49",
-                                              pred_layer="fc1000",
-                                              preprocess_fn=resnet.preprocess_input,
-                                              model_class=resnet.ResNet50)
+    last_conv_output = model.get_layer(last_conv_layer).output
+    x = UpSampling2D(size=(32, 32), interpolation="bilinear")(
+        last_conv_output)
+    x = Conv2D(filters=N_CLASSES, kernel_size=(
+        1, 1), name="predictions_2")(x)
 
-
-class BackendNASNetLarge(_Backend):
-    def __init__(self):
-        super(
-            BackendNASNetLarge,
-            self).__init__(
-            input_size=331,
-            last_conv_layer="activation_260",
-            pred_layer="predictions",
-            preprocess_fn=nasnet.preprocess_input,
-            model_class=nasnet.NASNetLarge)
+    cam_model = Model(inputs=model.input,
+                      outputs=[model.output, x])
+    cam_model.get_layer("predictions_2").set_weights(final_params)
+    return cam_model
 
 
 def postprocess(preds, cams, top_k=1):
@@ -100,25 +58,19 @@ def postprocess(preds, cams, top_k=1):
     return class_activation_map
 
 
-# 1. create keras-cam model
-if BASE_NETWORK == "resnet":
-    cam_builder = BackendResNet50()
-elif BASE_NETWORK == "nasnet":
-    cam_builder = BackendNASNetLarge()
-elif BASE_NETWORK == "inception":
-    cam_builder = BackendInceptionResNetV2()
-else:
-    raise ValueError(
-        "The base network should be one of resnet, nasnet, or inception.")
+# 1. load image
+imgs, original_img, original_size = load_img(INPUT_IMG_FILE,
+                                             input_size=NETWORK_INPUT_SIZE,
+                                             preprocess_fn=resnet.preprocess_input)
 
-# 2. load image
-imgs, original_img, original_size = cam_builder.load_img(
-    INPUT_IMG_FILE)
+# 2. prediction
+model = get_cam_model(resnet.ResNet50,
+                      NETWORK_INPUT_SIZE,
+                      LAST_CONV_LAYER,
+                      PRED_LAYER)
+preds, cams = model.predict(imgs)
 
-# 3. run model
-preds, cams = cam_builder.predict(imgs)
-
-# 4. postprocessing
+# 4. post processing
 class_activation_map = postprocess(preds, cams)
 
 # 5. plot image+cam to original size

--- a/examples/class_activation_maps.py
+++ b/examples/class_activation_maps.py
@@ -100,31 +100,29 @@ def postprocess(preds, cams, top_k=1):
     return class_activation_map
 
 
-if __name__ == "__main__":
-    
-    # 1. create keras-cam model
-    if BASE_NETWORK == "resnet":
-        cam_builder = BackendResNet50()
-    elif BASE_NETWORK == "nasnet":
-        cam_builder = BackendNASNetLarge()
-    elif BASE_NETWORK == "inception":
-        cam_builder = BackendInceptionResNetV2()
-    else:
-        raise ValueError(
-            "The base network should be one of resnet, nasnet, or inception.")
+# 1. create keras-cam model
+if BASE_NETWORK == "resnet":
+    cam_builder = BackendResNet50()
+elif BASE_NETWORK == "nasnet":
+    cam_builder = BackendNASNetLarge()
+elif BASE_NETWORK == "inception":
+    cam_builder = BackendInceptionResNetV2()
+else:
+    raise ValueError(
+        "The base network should be one of resnet, nasnet, or inception.")
 
-    # 2. load image
-    imgs, original_img, original_size = cam_builder.load_img(
-        INPUT_IMG_FILE)
+# 2. load image
+imgs, original_img, original_size = cam_builder.load_img(
+    INPUT_IMG_FILE)
 
-    # 3. run model
-    preds, cams = cam_builder.predict(imgs)
+# 3. run model
+preds, cams = cam_builder.predict(imgs)
 
-    # 4. postprocessing
-    class_activation_map = postprocess(preds, cams)
+# 4. postprocessing
+class_activation_map = postprocess(preds, cams)
 
-    # 5. plot image+cam to original size
-    plt.imshow(original_img, alpha=0.5)
-    plt.imshow(cv2.resize(class_activation_map,
-                          original_size), cmap='jet', alpha=0.5)
-    plt.show()
+# 5. plot image+cam to original size
+plt.imshow(original_img, alpha=0.5)
+plt.imshow(cv2.resize(class_activation_map,
+                      original_size), cmap='jet', alpha=0.5)
+plt.show()

--- a/examples/class_activation_maps.py
+++ b/examples/class_activation_maps.py
@@ -3,6 +3,7 @@
 import numpy as np
 import cv2
 import matplotlib.pyplot as plt
+import argparse
 
 from keras.models import Model
 from keras.applications.resnet50 import ResNet50, preprocess_input as resnet_preprocess
@@ -12,6 +13,16 @@ from keras.layers import UpSampling2D, Conv2D
 
 
 N_CLASSES = 1000
+
+# python main.py dog.png resnet
+parser = argparse.ArgumentParser(description='Class Activation Mapping with Keras.')
+parser.add_argument('input_image_file', metavar='image', type=str,
+                    help='Input image file path.')
+parser.add_argument('base_network', metavar='base', type=str,
+                    default="resnet50",
+                    help='Base network model for Class Activation Mapping.')
+
+args = parser.parse_args()
 
 
 class _Backend(object):
@@ -90,10 +101,18 @@ def postprocess(preds, cams, top_k=1):
 if __name__ == "__main__":
     
     # 1. create keras-cam model
-    cam_builder = BackendResNet50()
+    if args.base_network == "resnet":
+        cam_builder = BackendResNet50()
+    elif args.base_network == "nasnet":
+        cam_builder = BackendNASNetLarge()
+    elif args.base_network == "inception":
+        cam_builder = BackendInceptionResNetV2()
+    else:
+        pass
+        
 
     # 2. load image
-    imgs, original_img, original_size = cam_builder.load_img("dog.png")
+    imgs, original_img, original_size = cam_builder.load_img(args.input_image_file)
     
     # 3. run model
     preds, cams = cam_builder.predict(imgs)

--- a/examples/class_activation_maps.py
+++ b/examples/class_activation_maps.py
@@ -6,9 +6,13 @@ import matplotlib.pyplot as plt
 import argparse
 
 from keras.models import Model
-from keras.applications.resnet50 import ResNet50, preprocess_input as resnet_preprocess
-from keras.applications.inception_resnet_v2 import InceptionResNetV2, preprocess_input as inception_resnet_preprocess
-from keras.applications.nasnet import NASNetLarge, preprocess_input as nasnet_preprocess
+from keras.applications.resnet50 import ResNet50, preprocess_input \
+    as resnet_preprocess
+from keras.applications.inception_resnet_v2 \
+    import InceptionResNetV2, preprocess_input \
+    as inception_resnet_preprocess
+from keras.applications.nasnet import NASNetLarge, preprocess_input \
+    as nasnet_preprocess
 from keras.layers import UpSampling2D, Conv2D
 
 

--- a/examples/class_activation_maps.py
+++ b/examples/class_activation_maps.py
@@ -1,0 +1,108 @@
+#-*- coding: utf-8 -*-
+
+import numpy as np
+import cv2
+import matplotlib.pyplot as plt
+
+from keras.models import Model
+from keras.applications.resnet50 import ResNet50, preprocess_input as resnet_preprocess
+from keras.applications.inception_resnet_v2 import InceptionResNetV2, preprocess_input as inception_resnet_preprocess
+from keras.applications.nasnet import NASNetLarge, preprocess_input as nasnet_preprocess
+from keras.layers import UpSampling2D, Conv2D
+
+
+N_CLASSES = 1000
+
+
+class _Backend(object):
+    def __init__(self,
+                 input_size,
+                 last_conv_layer,
+                 pred_layer,
+                 preprocess_fn,
+                 model_class):
+        self.input_size = input_size
+        self.preprocess_fn = preprocess_fn
+        self.cam_model = self._create_cam_model(model_class, last_conv_layer, pred_layer)
+
+    def load_img(self, fname):
+        original_img = cv2.imread(fname)[:,:,::-1]
+        original_size = (original_img.shape[1], original_img.shape[0])
+        img = cv2.resize(original_img, (self.input_size, self.input_size))
+        imgs = np.expand_dims(self.preprocess_fn(img), axis=0)
+        return imgs, original_img, original_size
+    
+    def predict(self, imgs):
+        preds, cams = self.cam_model.predict(imgs)
+        return preds, cams
+
+    def _create_cam_model(self, model_class, last_conv_layer, pred_layer):
+        model = model_class(input_shape=(self.input_size,self.input_size,3))
+        
+        final_params = model.get_layer(pred_layer).get_weights()
+        final_params = (final_params[0].reshape(1, 1, -1, N_CLASSES), final_params[1])
+        
+        last_conv_output = model.get_layer(last_conv_layer).output
+        x = UpSampling2D(size=(32, 32), interpolation="bilinear")(last_conv_output)
+        x = Conv2D(filters=N_CLASSES, kernel_size = (1,1), name="predictions_2")(x)
+         
+        cam_model = Model(inputs=model.input,
+                         outputs=[model.output, x])
+        cam_model.get_layer("predictions_2").set_weights(final_params)
+        return cam_model
+
+
+
+class BackendInceptionResNetV2(_Backend):
+    def __init__(self):
+        super(BackendInceptionResNetV2, self).__init__(input_size=299,
+                                                       last_conv_layer="conv_7b_ac",
+                                                       pred_layer = "predictions",
+                                                       preprocess_fn = inception_resnet_preprocess,
+                                                       model_class = InceptionResNetV2)
+    
+class BackendResNet50(_Backend):
+    def __init__(self):
+        super(BackendResNet50, self).__init__(input_size=224,
+                                              last_conv_layer="activation_49",
+                                              pred_layer = "fc1000",
+                                              preprocess_fn = resnet_preprocess,
+                                              model_class = ResNet50)
+        
+
+class BackendNASNetLarge(_Backend):
+    def __init__(self):
+        super(BackendNASNetLarge, self).__init__(input_size=331,
+                                                 last_conv_layer="activation_260",
+                                                 pred_layer = "predictions",
+                                                 preprocess_fn = nasnet_preprocess,
+                                                 model_class = NASNetLarge)
+        
+        
+def postprocess(preds, cams, top_k=1):
+    idxes = np.argsort(preds[0])[-top_k:]
+    class_activation_map = np.zeros_like(cams[0,:,:,0])
+    for i in idxes:
+        class_activation_map += cams[0, :,:,i]
+    return class_activation_map
+    
+
+if __name__ == "__main__":
+    
+    # 1. create keras-cam model
+    cam_builder = BackendResNet50()
+
+    # 2. load image
+    imgs, original_img, original_size = cam_builder.load_img("dog.png")
+    
+    # 3. run model
+    preds, cams = cam_builder.predict(imgs)
+
+    # 4. postprocessing
+    class_activation_map = postprocess(preds, cams)
+
+    # 5. plot image+cam to original size
+    plt.imshow(original_img, alpha=0.5)
+    plt.imshow(cv2.resize(class_activation_map, original_size), cmap='jet', alpha=0.5)
+    plt.show()
+

--- a/examples/class_activation_maps.py
+++ b/examples/class_activation_maps.py
@@ -11,10 +11,10 @@ from keras.layers import UpSampling2D, Conv2D
 
 
 # Please set an appropriate image file
-INPUT_IMG_FILE = "dog.jpg" 
+INPUT_IMG_FILE = "dog.jpg"
 
 ################################################################
-# The following parameters can be changed to other models 
+# The following parameters can be changed to other models
 # that use global average pooling.
 # e.g.) InceptionResnetV2 / NASNetLarge
 NETWORK_INPUT_SIZE = 224

--- a/examples/class_activation_maps.py
+++ b/examples/class_activation_maps.py
@@ -6,13 +6,10 @@ import matplotlib.pyplot as plt
 import argparse
 
 from keras.models import Model
-from keras.applications.resnet50 import ResNet50, preprocess_input \
-    as resnet_preprocess
-from keras.applications.inception_resnet_v2 \
-    import InceptionResNetV2, preprocess_input \
-    as inception_resnet_preprocess
-from keras.applications.nasnet import NASNetLarge, preprocess_input \
-    as nasnet_preprocess
+
+import keras.applications.resnet50 as resnet
+import keras.applications.inception_resnet_v2 as inception
+import keras.applications.nasnet as nasnet
 from keras.layers import UpSampling2D, Conv2D
 
 
@@ -80,8 +77,8 @@ class BackendInceptionResNetV2(_Backend):
             input_size=299,
             last_conv_layer="conv_7b_ac",
             pred_layer="predictions",
-            preprocess_fn=inception_resnet_preprocess,
-            model_class=InceptionResNetV2)
+            preprocess_fn=inception.preprocess_input,
+            model_class=inception.InceptionResNetV2)
 
 
 class BackendResNet50(_Backend):
@@ -89,8 +86,8 @@ class BackendResNet50(_Backend):
         super(BackendResNet50, self).__init__(input_size=224,
                                               last_conv_layer="activation_49",
                                               pred_layer="fc1000",
-                                              preprocess_fn=resnet_preprocess,
-                                              model_class=ResNet50)
+                                              preprocess_fn=resnet.preprocess_input,
+                                              model_class=resnet.ResNet50)
 
 
 class BackendNASNetLarge(_Backend):
@@ -101,8 +98,8 @@ class BackendNASNetLarge(_Backend):
             input_size=331,
             last_conv_layer="activation_260",
             pred_layer="predictions",
-            preprocess_fn=nasnet_preprocess,
-            model_class=NASNetLarge)
+            preprocess_fn=nasnet.preprocess_input,
+            model_class=nasnet.NASNetLarge)
 
 
 def postprocess(preds, cams, top_k=1):

--- a/examples/class_activation_maps.py
+++ b/examples/class_activation_maps.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 import numpy as np
 import cv2
@@ -15,7 +15,8 @@ from keras.layers import UpSampling2D, Conv2D
 N_CLASSES = 1000
 
 # python main.py dog.png resnet
-parser = argparse.ArgumentParser(description='Class Activation Mapping with Keras.')
+parser = argparse.ArgumentParser(
+    description='Class Activation Mapping with Keras.')
 parser.add_argument('input_image_file', metavar='image', type=str,
                     help='Input image file path.')
 parser.add_argument('base_network', metavar='base', type=str,
@@ -34,72 +35,82 @@ class _Backend(object):
                  model_class):
         self.input_size = input_size
         self.preprocess_fn = preprocess_fn
-        self.cam_model = self._create_cam_model(model_class, last_conv_layer, pred_layer)
+        self.cam_model = self._create_cam_model(
+            model_class, last_conv_layer, pred_layer)
 
     def load_img(self, fname):
-        original_img = cv2.imread(fname)[:,:,::-1]
+        original_img = cv2.imread(fname)[:, :, ::-1]
         original_size = (original_img.shape[1], original_img.shape[0])
         img = cv2.resize(original_img, (self.input_size, self.input_size))
         imgs = np.expand_dims(self.preprocess_fn(img), axis=0)
         return imgs, original_img, original_size
-    
+
     def predict(self, imgs):
         preds, cams = self.cam_model.predict(imgs)
         return preds, cams
 
     def _create_cam_model(self, model_class, last_conv_layer, pred_layer):
-        model = model_class(input_shape=(self.input_size,self.input_size,3))
-        
+        model = model_class(input_shape=(self.input_size, self.input_size, 3))
+
         final_params = model.get_layer(pred_layer).get_weights()
-        final_params = (final_params[0].reshape(1, 1, -1, N_CLASSES), final_params[1])
-        
+        final_params = (final_params[0].reshape(
+            1, 1, -1, N_CLASSES), final_params[1])
+
         last_conv_output = model.get_layer(last_conv_layer).output
-        x = UpSampling2D(size=(32, 32), interpolation="bilinear")(last_conv_output)
-        x = Conv2D(filters=N_CLASSES, kernel_size = (1,1), name="predictions_2")(x)
-         
+        x = UpSampling2D(size=(32, 32), interpolation="bilinear")(
+            last_conv_output)
+        x = Conv2D(filters=N_CLASSES, kernel_size=(
+            1, 1), name="predictions_2")(x)
+
         cam_model = Model(inputs=model.input,
-                         outputs=[model.output, x])
+                          outputs=[model.output, x])
         cam_model.get_layer("predictions_2").set_weights(final_params)
         return cam_model
 
 
-
 class BackendInceptionResNetV2(_Backend):
     def __init__(self):
-        super(BackendInceptionResNetV2, self).__init__(input_size=299,
-                                                       last_conv_layer="conv_7b_ac",
-                                                       pred_layer = "predictions",
-                                                       preprocess_fn = inception_resnet_preprocess,
-                                                       model_class = InceptionResNetV2)
-    
+        super(
+            BackendInceptionResNetV2,
+            self).__init__(
+            input_size=299,
+            last_conv_layer="conv_7b_ac",
+            pred_layer="predictions",
+            preprocess_fn=inception_resnet_preprocess,
+            model_class=InceptionResNetV2)
+
+
 class BackendResNet50(_Backend):
     def __init__(self):
         super(BackendResNet50, self).__init__(input_size=224,
                                               last_conv_layer="activation_49",
-                                              pred_layer = "fc1000",
-                                              preprocess_fn = resnet_preprocess,
-                                              model_class = ResNet50)
-        
+                                              pred_layer="fc1000",
+                                              preprocess_fn=resnet_preprocess,
+                                              model_class=ResNet50)
+
 
 class BackendNASNetLarge(_Backend):
     def __init__(self):
-        super(BackendNASNetLarge, self).__init__(input_size=331,
-                                                 last_conv_layer="activation_260",
-                                                 pred_layer = "predictions",
-                                                 preprocess_fn = nasnet_preprocess,
-                                                 model_class = NASNetLarge)
-        
-        
+        super(
+            BackendNASNetLarge,
+            self).__init__(
+            input_size=331,
+            last_conv_layer="activation_260",
+            pred_layer="predictions",
+            preprocess_fn=nasnet_preprocess,
+            model_class=NASNetLarge)
+
+
 def postprocess(preds, cams, top_k=1):
     idxes = np.argsort(preds[0])[-top_k:]
-    class_activation_map = np.zeros_like(cams[0,:,:,0])
+    class_activation_map = np.zeros_like(cams[0, :, :, 0])
     for i in idxes:
-        class_activation_map += cams[0, :,:,i]
+        class_activation_map += cams[0, :, :, i]
     return class_activation_map
-    
+
 
 if __name__ == "__main__":
-    
+
     # 1. create keras-cam model
     if args.base_network == "resnet":
         cam_builder = BackendResNet50()
@@ -108,12 +119,13 @@ if __name__ == "__main__":
     elif args.base_network == "inception":
         cam_builder = BackendInceptionResNetV2()
     else:
-        raise ValueError("The base network should be one of resnet, nasnet, or inception.")
-        
+        raise ValueError(
+            "The base network should be one of resnet, nasnet, or inception.")
 
     # 2. load image
-    imgs, original_img, original_size = cam_builder.load_img(args.input_image_file)
-    
+    imgs, original_img, original_size = cam_builder.load_img(
+        args.input_image_file)
+
     # 3. run model
     preds, cams = cam_builder.predict(imgs)
 
@@ -122,6 +134,6 @@ if __name__ == "__main__":
 
     # 5. plot image+cam to original size
     plt.imshow(original_img, alpha=0.5)
-    plt.imshow(cv2.resize(class_activation_map, original_size), cmap='jet', alpha=0.5)
+    plt.imshow(cv2.resize(class_activation_map,
+                          original_size), cmap='jet', alpha=0.5)
     plt.show()
-


### PR DESCRIPTION
### Summary

Class activation mapping implementation using resnet50, inception-resnet-v2, and nasnet model. 
I implemented it using only the imagenet weight provided by keras.

Sample images are shown below.

* resnet50
    * ![resnet](https://user-images.githubusercontent.com/7403396/49650218-de6f9000-fa6e-11e8-9514-077fc7107862.png)

* inception-resnet-v2
    * ![inception](https://user-images.githubusercontent.com/7403396/49650227-e3344400-fa6e-11e8-9d13-8bea5fd3e642.png)

* nasnet 
    * ![nasnet](https://user-images.githubusercontent.com/7403396/49650232-e5969e00-fa6e-11e8-8b70-7a36e6c07459.png)


### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
