### PR TITLE
update install_requires: h5py>=2.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='Keras',
                         'scipy>=0.14',
                         'six>=1.9.0',
                         'pyyaml',
-                        'h5py',
+                        'h5py>=2.8',
                         'keras_applications>=1.0.6',
                         'keras_preprocessing>=1.0.5'],
       extras_require={


### PR DESCRIPTION
### Summary

when update from older python environment, and the h5py version  is below 2.8. `import keras` may cause error like this:

>  /Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [n] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)