### PR TITLE
Update keras docs link in breadcrumbs.html

### DIFF
--- a/docs/theme/breadcrumbs.html
+++ b/docs/theme/breadcrumbs.html
@@ -14,7 +14,7 @@
     <li class="wy-breadcrumbs-aside">
       {%- block repo %}
       {% if page and page.edit_url %}
-        <a href="{{ page.edit_url }}"
+        <a href="https://github.com/keras-team/keras/tree/master/docs"
         {%- if config.repo_name|lower == 'github' %}
           class="icon icon-github"
         {%- elif config.repo_name|lower == 'bitbucket' %}


### PR DESCRIPTION
### Summary
I have changed the hyperlink url  at the top right of this [keras docs page](https://keras.io) (Edit on GitHub) from https://github.com/keras-team/keras/edit/master/docs/index.md to https://github.com/keras-team/keras/tree/master/docs, so that it leads to the keras docs on GitHub. (it was giving a 404 error before)

### Related Issues
[This issue](https://github.com/keras-team/keras/issues/11816)

### PR Overview
Changed url for hyperlink in breadcrumbs.html for the keras.io homepage to the correct one.

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
