### PR TITLE
Removed a useless check which can cause an infinite loop.

### DIFF
--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -975,9 +975,6 @@ class Network(Layer):
                     kwargs = input_data[3]
                 else:
                     raise ValueError('Improperly formatted model config.')
-                if inbound_layer_name not in created_layers:
-                    add_unprocessed_node(layer, node_data)
-                    return
                 inbound_layer = created_layers[inbound_layer_name]
                 if len(inbound_layer._inbound_nodes) <= inbound_node_index:
                     add_unprocessed_node(layer, node_data)


### PR DESCRIPTION
### Summary

Here, we check if `inbound_layer_name` is in `created_layers`. If it is not, we delay the task and come back at it later on.

The problem is, if  `inbound_layer_name` is NOT in `created_layers`, it will never be because we don't modify the `created_layers` (last time this variable was modified was at line 1019 when we called `process_layer`).

This is very dangerous because it can tranform a simple keras bug (`KeyError`) into an infinite loop. 

And no one likes to debug infinite loops.

### Related Issues

### PR Overview

The check is removed. A `KeyError` is much better and it will make the code simpler to understand.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
