### PR TITLE
Fix bug for save nested models with shared parameters.

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -684,10 +684,11 @@ def preprocess_weights_for_loading(layer, weights,
         weights = convert_nested_bidirectional(weights)
     if layer.__class__.__name__ == 'TimeDistributed':
         weights = convert_nested_time_distributed(weights)
-    elif layer.__class__.__name__ in ['Model', 'Sequential']:
-        weights = convert_nested_model(weights)
 
     if original_keras_version == '1':
+        if layer.__class__.__name__ in ['Model', 'Sequential']:
+            weights = convert_nested_model(weights)
+
         if layer.__class__.__name__ == 'TimeDistributed':
             weights = preprocess_weights_for_loading(layer.layer,
                                                      weights,


### PR DESCRIPTION
### Summary
Problem loading models that have nested models with shared parameters. It is common to find this type of architecture in Siamese networks or triplets.

The problem occurs when once the network has been saved, it is tried to load again.

The problem is that you are trying to load multiple times the weights of the same model that is shared.

### Related Issues
https://github.com/keras-team/keras/issues/10428
https://github.com/experiencor/keras-yolo2/issues/358
https://github.com/keras-team/keras/issues/9562

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
