### PR TITLE
Add the Precision, Recall and F1 Score metrics in callbacks.py

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -248,12 +248,13 @@ class BaseLogger(Callback):
                         logs[k] = self.totals[k] / self.seen
                         
 class BinaryClassificationMetrics(Callback):
-    def on_train_begin(self, logs={}):
+    def on_train_begin(self, logs=None):
         self.val_precisions = []
         self.val_f1s = []
         self.val_recalls = []
         
-    def on_epoch_end(self, epoch, logs={}):
+    def on_epoch_end(self, epoch, logs=None):
+        model = self.model
         val_predict = (np.asarray(self.model.predict(self.validation_data[0]))).round()
         val_targ = self.validation_data[1]
         _val_precision = np.dot(val_targ, val_predict)/sum(val_predict)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 import os
 import csv
 import six
-import sklearn
 
 import numpy as np
 import time
@@ -21,7 +20,6 @@ from collections import Iterable
 from .utils.generic_utils import Progbar
 from . import backend as K
 from .engine.training_utils import standardize_input_data
-from sklearn.metrics import confusion_matrix, f1_score, precision_score, recall_score
 
 try:
     import requests
@@ -249,42 +247,23 @@ class BaseLogger(Callback):
                     else:
                         logs[k] = self.totals[k] / self.seen
                         
-class Precision(Callback):
+class BinaryClassificationMetrics(Callback):
     def on_train_begin(self, logs={}):
         self.val_precisions = []
-        
-    def on_epoch_end(self, epoch, logs={}):
-        val_predict = (np.asarray(self.model.predict(self.validation_data[0]))).round()
-        val_targ = self.validation_data[1]
-        _val_precision = precision_score(val_targ, val_predict)
-        self.val_precisions.append(_val_precision)
-        print(" - val_precision: " + str(_val_precision))
-        return  
-                        
-class Recall(Callback):
-    def on_train_begin(self, logs={}):
+        self.val_f1s = []
         self.val_recalls = []
         
     def on_epoch_end(self, epoch, logs={}):
         val_predict = (np.asarray(self.model.predict(self.validation_data[0]))).round()
         val_targ = self.validation_data[1]
-        _val_recall = recall_score(val_targ, val_predict)
+        _val_precision = np.dot(val_targ, val_predict)/sum(val_predict)
+        _val_recall = np.dot(val_targ, val_predict)/sum(val_targ)
+        _val_f1 = (2*_val_precision*_val_recall)/(_val_precision + _val_recall)
+        self.val_precisions.append(_val_precision)
         self.val_recalls.append(_val_recall)
-        print(" - val_recall: " + str(_val_recall))
-        return 
-                        
-
-class F1Score(Callback):
-    def on_train_begin(self, logs={}):
-        self.val_f1s = []
-        
-    def on_epoch_end(self, epoch, logs={}):
-        val_predict = (np.asarray(self.model.predict(self.validation_data[0]))).round()
-        val_targ = self.validation_data[1]
-        _val_f1 = f1_score(val_targ, val_predict)
         self.val_f1s.append(_val_f1)
-        print(" - val_f1: " + str(_val_f1))
-        return 
+        print(“ — val_f1: %f — val_precision: %f — val_recall %f” %(_val_f1, _val_precision, _val_recall))
+        return  
 
 class TerminateOnNaN(Callback):
     """Callback that terminates training when a NaN loss is encountered.

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -213,7 +213,7 @@ class BaseLogger(Callback):
             All others will be averaged in `on_epoch_end`.
     """
 
-    def __init__(self, stateful_metrics=None):
+    def __init__(self, stateful_metrics=['binary_precision', 'binary_recall', 'binary_f1_score']):
         if stateful_metrics:
             self.stateful_metrics = set(stateful_metrics)
         else:

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -254,9 +254,9 @@ class BinaryClassificationMetrics(Callback):
         self.val_recalls = []
         
     def on_epoch_end(self, epoch, logs=None):
-        model = self.model
-        val_predict = (np.asarray(self.model.predict(self.validation_data[0]))).round()
-        val_targ = self.validation_data[1]
+        logs = logs or {}
+        val_predict = (np.asarray(self.model.predict(self.model.validation_data[0]))).round()
+        val_targ = self.model.validation_data[1]
         _val_precision = np.dot(val_targ, val_predict)/sum(val_predict)
         _val_recall = np.dot(val_targ, val_predict)/sum(val_targ)
         _val_f1 = (2*_val_precision*_val_recall)/(_val_precision + _val_recall)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -245,26 +245,7 @@ class BaseLogger(Callback):
                     if k in self.stateful_metrics:
                         logs[k] = self.totals[k]
                     else:
-                        logs[k] = self.totals[k] / self.seen
-                        
-class BinaryClassificationMetrics(Callback):
-    def on_train_begin(self, logs=None):
-        self.val_precisions = []
-        self.val_f1s = []
-        self.val_recalls = []
-        
-    def on_epoch_end(self, epoch, logs=None):
-        logs = logs or {}
-        val_predict = (np.asarray(self.model.predict(self.model.validation_data[0]))).round()
-        val_targ = self.model.validation_data[1]
-        _val_precision = np.dot(val_targ, val_predict)/sum(val_predict)
-        _val_recall = np.dot(val_targ, val_predict)/sum(val_targ)
-        _val_f1 = (2*_val_precision*_val_recall)/(_val_precision + _val_recall)
-        self.val_precisions.append(_val_precision)
-        self.val_recalls.append(_val_recall)
-        self.val_f1s.append(_val_f1)
-        print(" — val_f1: %f — val_precision: %f — val_recall %f" %(_val_f1, _val_precision, _val_recall))
-        return  
+                        logs[k] = self.totals[k] / self.seen           
 
 class TerminateOnNaN(Callback):
     """Callback that terminates training when a NaN loss is encountered.

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import os
 import csv
 import six
+import sklearn
 
 import numpy as np
 import time
@@ -20,6 +21,7 @@ from collections import Iterable
 from .utils.generic_utils import Progbar
 from . import backend as K
 from .engine.training_utils import standardize_input_data
+from sklearn.metrics import confusion_matrix, f1_score, precision_score, recall_score
 
 try:
     import requests
@@ -246,7 +248,43 @@ class BaseLogger(Callback):
                         logs[k] = self.totals[k]
                     else:
                         logs[k] = self.totals[k] / self.seen
+                        
+class Precision(Callback):
+    def on_train_begin(self, logs={}):
+        self.val_precisions = []
+        
+    def on_epoch_end(self, epoch, logs={}):
+        val_predict = (np.asarray(self.model.predict(self.validation_data[0]))).round()
+        val_targ = self.validation_data[1]
+        _val_precision = precision_score(val_targ, val_predict)
+        self.val_precisions.append(_val_precision)
+        print(" - val_precision: " + str(_val_precision))
+        return  
+                        
+class Recall(Callback):
+    def on_train_begin(self, logs={}):
+        self.val_recalls = []
+        
+    def on_epoch_end(self, epoch, logs={}):
+        val_predict = (np.asarray(self.model.predict(self.validation_data[0]))).round()
+        val_targ = self.validation_data[1]
+        _val_recall = recall_score(val_targ, val_predict)
+        self.val_recalls.append(_val_recall)
+        print(" - val_recall: " + str(_val_recall))
+        return 
+                        
 
+class F1Score(Callback):
+    def on_train_begin(self, logs={}):
+        self.val_f1s = []
+        
+    def on_epoch_end(self, epoch, logs={}):
+        val_predict = (np.asarray(self.model.predict(self.validation_data[0]))).round()
+        val_targ = self.validation_data[1]
+        _val_f1 = f1_score(val_targ, val_predict)
+        self.val_f1s.append(_val_f1)
+        print(" - val_f1: " + str(_val_f1))
+        return 
 
 class TerminateOnNaN(Callback):
     """Callback that terminates training when a NaN loss is encountered.

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -213,9 +213,9 @@ class BaseLogger(Callback):
             All others will be averaged in `on_epoch_end`.
     """
 
-    def __init__(self, stateful_metrics=['binary_precision', 'binary_recall', 'binary_f1_score']):
+    def __init__(self, stateful_metrics=None):
         if stateful_metrics:
-            self.stateful_metrics = set(stateful_metrics)
+            self.stateful_metrics = set(['binary_precision', 'binary_recall', 'binary_f1_score'])
         else:
             self.stateful_metrics = set()
 
@@ -286,7 +286,7 @@ class ProgbarLogger(Callback):
         else:
             raise ValueError('Unknown `count_mode`: ' + str(count_mode))
         if stateful_metrics:
-            self.stateful_metrics = set(stateful_metrics)
+            self.stateful_metrics = set(['binary_precision', 'binary_recall', 'binary_f1_score'])
         else:
             self.stateful_metrics = set()
 

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -262,7 +262,7 @@ class BinaryClassificationMetrics(Callback):
         self.val_precisions.append(_val_precision)
         self.val_recalls.append(_val_recall)
         self.val_f1s.append(_val_f1)
-        print(“ — val_f1: %f — val_precision: %f — val_recall %f” %(_val_f1, _val_precision, _val_recall))
+        print(" — val_f1: %f — val_precision: %f — val_recall %f" %(_val_f1, _val_precision, _val_recall))
         return  
 
 class TerminateOnNaN(Callback):

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -53,10 +53,10 @@ def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):
                   axis=-1)
 
 def binary_precision(y_true, y_pred):
-    return K.dot(y_true, y_pred)/K.sum(y_pred)
+    return K.sum(y_true * y_pred, axis=-1, keepdims=True)/K.sum(y_pred)
 
 def binary_recall(y_true, y_pred):
-    return K.dot(y_true, y_pred)/K.sum(y_true)
+    return K.sum(y_true * y_pred, axis=-1, keepdims=True)/K.sum(y_true)
 
 def binary_f1_score(y_true, y_pred):
     p = binary_precision(y_true, y_pred)

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -52,6 +52,16 @@ def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):
     return K.mean(K.in_top_k(y_pred, K.cast(K.flatten(y_true), 'int32'), k),
                   axis=-1)
 
+def binary_precision(y_true, y_pred):
+    return K.dot(y_true, y_pred)/K.sum(pred)
+
+def binary_recall(y_true, y_pred):
+    return K.dot(y_true, y_pred)/K.sum(y_true)
+
+def binary_f1_score(y_true, y_pred):
+    p = binary_precision(y_true, y_pred)
+    r = binary_recall(y_true, y_pred)
+    return 2 * p * r/(p + r)
 
 # Aliases
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -53,7 +53,7 @@ def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):
                   axis=-1)
 
 def binary_precision(y_true, y_pred):
-    return K.dot(y_true, y_pred)/K.sum(pred)
+    return K.dot(y_true, y_pred)/K.sum(y_pred)
 
 def binary_recall(y_true, y_pred):
     return K.dot(y_true, y_pred)/K.sum(y_true)


### PR DESCRIPTION
### Summary
Add precision, recall and f1 score metrics for binary classification.

### Related Issues
[This issue](https://github.com/keras-team/keras/issues/11846)

### PR Overview
Added precision, recall and f1 score metrics for binary classification in callbacks.py.

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
