### PR TITLE
Add callback class to reduce lr with early stopping

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1131,25 +1131,26 @@ class ReduceLROnPlateau(Callback):
     def in_cooldown(self):
         return self.cooldown_counter > 0
 
+
 class ReduceLRWithEarlyStopping(ReduceLROnPlateau):
-    def __init__(self, *args,**kwargs):
+    def __init__(self, *args, **kwargs):
         super(ReduceLRWithEarlyStopping, self).__init__(*args, **kwargs)
         self.stopped_epoch = 0
-        
+
     def on_epoch_end(self, epoch, logs=None):
         super(ReduceLRWithEarlyStopping, self).on_epoch_end(epoch, logs)
         old_lr = float(K.get_value(self.model.optimizer.lr))
         if self.wait >= self.patience and old_lr <= self.min_lr:
-            #early stop training
+            # Stop training early
             self.stopped_epoch = epoch
             self.model.stop_training = True
-    
+
     def on_train_end(self, logs=None):
         super(ReduceLRWithEarlyStopping, self).on_epoch_end(logs)
         if self.stopped_epoch > 0 and self.verbose > 0:
             print('Epoch %05d: early stopping' % (self.stopped_epoch + 1))
-            
-            
+    
+     
 class CSVLogger(Callback):
     """Callback that streams epoch results to a csv file.
 

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1131,7 +1131,25 @@ class ReduceLROnPlateau(Callback):
     def in_cooldown(self):
         return self.cooldown_counter > 0
 
-
+class ReduceLRWithEarlyStopping(ReduceLROnPlateau):
+    def __init__(self, *args,**kwargs):
+        super(ReduceLRWithEarlyStopping, self).__init__(*args, **kwargs)
+        self.stopped_epoch = 0
+        
+    def on_epoch_end(self, epoch, logs=None):
+        super(ReduceLRWithEarlyStopping, self).on_epoch_end(epoch, logs)
+        old_lr = float(K.get_value(self.model.optimizer.lr))
+        if self.wait >= self.patience and old_lr <= self.min_lr:
+            #early stop training
+            self.stopped_epoch = epoch
+            self.model.stop_training = True
+    
+    def on_train_end(self, logs=None):
+        super(ReduceLRWithEarlyStopping, self).on_epoch_end(logs)
+        if self.stopped_epoch > 0 and self.verbose > 0:
+            print('Epoch %05d: early stopping' % (self.stopped_epoch + 1))
+            
+            
 class CSVLogger(Callback):
     """Callback that streams epoch results to a csv file.
 


### PR DESCRIPTION
### Summary
I found myself needing to create a custom callback that reduces LR on plateau but also stops training early when the lr has reached the specified minimum and the patience interval has elapsed. I felt it was generic enough to be useful to other folks so I decided to submit a PR.

Its pretty bare-bones and does not implement the restore-best-weights feature of the early stopping callback, but I felt it was better to submit the version that I've used and let others decide on what features to add.

Apologies for not documenting the code (and not following any relevant coding standards), feel free to comment any changes that might be necessary to make this better.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
