### PR TITLE
Removed unused function in autogen.py

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -418,13 +418,6 @@ def clean_module_name(name):
     return name
 
 
-def class_to_docs_link(cls):
-    module_name = clean_module_name(cls.__module__)
-    module_name = module_name[6:]
-    link = ROOT + module_name.replace('.', '/') + '#' + cls.__name__.lower()
-    return link
-
-
 def class_to_source_link(cls):
     module_name = clean_module_name(cls.__module__)
     path = module_name.replace('.', '/')


### PR DESCRIPTION
### Summary

This function isn't called or mentioned anywhere else in keras. We should remove it.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
