### PR TITLE
Identity initializer with zero padding

### DIFF
--- a/keras/initializers.py
+++ b/keras/initializers.py
@@ -290,10 +290,20 @@ class Identity(Initializer):
             return self.gain * np.identity(shape[0])
         elif shape[0] > shape[1]:
             return self.gain * np.concatenate(
-                [np.identity(shape[1])] * (shape[0] // shape[1]), axis=0)
+                [
+                    np.identity(shape[1]),
+                    np.zeros(shape[0] - shape[1], shape[1])
+                ],
+                axis=0
+            )
         else:
             return self.gain * np.concatenate(
-                [np.identity(shape[0])] * (shape[1] // shape[0]), axis=1)
+                [
+                    np.identity(shape[0]),
+                    np.zeros(shape[0], shape[1] - shape[0])
+                ],
+                axis=1
+            )
 
     def get_config(self):
         return {

--- a/keras/initializers.py
+++ b/keras/initializers.py
@@ -268,8 +268,7 @@ class Identity(Initializer):
     """Initializer that generates the identity matrix.
 
     Only use for 2D matrices.
-    If the long side of the matrix is a multiple of the short side,
-    multiple identity matrices are concatenated along the long side.
+    If the desired matrix is not square, it pads 0s on the additional rows/columns
 
     # Arguments
         gain: Multiplicative factor to apply to the identity matrix.
@@ -282,9 +281,6 @@ class Identity(Initializer):
         if len(shape) != 2:
             raise ValueError(
                 'Identity matrix initializer can only be used for 2D matrices.')
-
-        if max(shape) % min(shape) != 0:
-            raise ValueError('Long side should be multiple of short side.')
 
         if shape[0] == shape[1]:
             return self.gain * np.identity(shape[0])

--- a/keras/initializers.py
+++ b/keras/initializers.py
@@ -292,7 +292,7 @@ class Identity(Initializer):
             return self.gain * np.concatenate(
                 [
                     np.identity(shape[1]),
-                    np.zeros(shape[0] - shape[1], shape[1])
+                    np.zeros((shape[0] - shape[1], shape[1]))
                 ],
                 axis=0
             )
@@ -300,7 +300,7 @@ class Identity(Initializer):
             return self.gain * np.concatenate(
                 [
                     np.identity(shape[0]),
-                    np.zeros(shape[0], shape[1] - shape[0])
+                    np.zeros((shape[0], shape[1] - shape[0]))
                 ],
                 axis=1
             )

--- a/tests/keras/initializers_test.py
+++ b/tests/keras/initializers_test.py
@@ -108,13 +108,14 @@ def test_orthogonal(tensor_shape):
                          [(100, 100), (10, 20), (30, 80), (1, 2, 3, 4)],
                          ids=['FC', 'RNN', 'RNN_INVALID', 'CONV'])
 def test_identity(tensor_shape):
+    target_mean = min(tensor_shape) / (tensor_shape[0] * tensor_shape[1])
     if len(tensor_shape) > 2 or max(tensor_shape) % min(tensor_shape) != 0:
         with pytest.raises(ValueError):
             _runner(initializers.identity(), tensor_shape,
-                    target_mean=1. / tensor_shape[0], target_max=1.)
+                    target_mean=target_mean, target_max=1.)
     else:
         _runner(initializers.identity(), tensor_shape,
-                target_mean=1. / tensor_shape[0], target_max=1.)
+                target_mean=target_mean, target_max=1.)
 
 
 @pytest.mark.parametrize('tensor_shape', [FC_SHAPE, CONV_SHAPE], ids=['FC', 'CONV'])

--- a/tests/keras/initializers_test.py
+++ b/tests/keras/initializers_test.py
@@ -109,7 +109,7 @@ def test_orthogonal(tensor_shape):
                          ids=['FC', 'RNN', 'RNN_INVALID', 'CONV'])
 def test_identity(tensor_shape):
     target_mean = min(tensor_shape) / (tensor_shape[0] * tensor_shape[1])
-    if len(tensor_shape) > 2 or max(tensor_shape) % min(tensor_shape) != 0:
+    if len(tensor_shape) > 2:
         with pytest.raises(ValueError):
             _runner(initializers.identity(), tensor_shape,
                     target_mean=target_mean, target_max=1.)


### PR DESCRIPTION
### Summary

This PR changes the behaviour of `initializers.Identity` to match Tensorflow's behaviour (pad with 0s if matrix is not square)

### Related Issues

#11774 

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included) -> tests have been updated but no new tests required
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
