### PR TITLE
Split Generators tests from Sequence tests

### DIFF
--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -7,13 +7,11 @@ import tarfile
 import threading
 import zipfile
 from itertools import cycle
-import multiprocessing as mp
 import numpy as np
 import pytest
 import six
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.request import pathname2url
-import warnings
 
 from flaky import flaky
 
@@ -24,6 +22,7 @@ from keras.utils.data_utils import _hash_file
 from keras.utils.data_utils import get_file
 from keras.utils.data_utils import validate_file
 from keras import backend as K
+from tests.test_multiprocessing import use_spawn
 
 pytestmark = pytest.mark.skipif(
     six.PY2 and 'TRAVIS_PYTHON_VERSION' in os.environ,
@@ -36,22 +35,6 @@ skip_generators = pytest.mark.skipif(K.backend() in {'tensorflow', 'cntk'} and
 if sys.version_info < (3,):
     def next(x):
         return x.next()
-
-
-def use_spawn(func):
-    """Decorator to test both Unix (fork) and Windows (spawn)"""
-
-    @six.wraps(func)
-    def wrapper(*args, **kwargs):
-        if sys.version_info > (3, 4):
-            mp.set_start_method('spawn', force=True)
-            out = func(*args, **kwargs)
-            mp.set_start_method('fork', force=True)
-        else:
-            out = func(*args, **kwargs)
-        return out
-
-    return wrapper
 
 
 @pytest.fixture

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,16 +1,42 @@
 from __future__ import print_function
+
+import multiprocessing as mp
 import os
+import sys
 import threading
 import pytest
 import numpy as np
+import six
+
 from keras.models import Sequential
 from keras.layers.core import Dense
 from keras.utils import Sequence
 from keras import backend as K
 
 pytestmark = pytest.mark.skipif(
-    K.backend() in {'tensorflow', 'cntk'} and 'TRAVIS_PYTHON_VERSION' in os.environ,
+    six.PY2 and 'TRAVIS_PYTHON_VERSION' in os.environ,
     reason='Temporarily disabled until the use_multiprocessing problem is solved')
+
+skip_generators = pytest.mark.skipif(K.backend() in {'tensorflow', 'cntk'} and
+                                     'TRAVIS_PYTHON_VERSION' in os.environ,
+                                     reason='Generators do not work with `spawn`.')
+
+
+def use_spawn(func):
+    """Decorator to test both Unix (fork) and Windows (spawn)"""
+
+    @six.wraps(func)
+    def wrapper(*args, **kwargs):
+        if sys.version_info > (3, 4):
+            mp.set_start_method('spawn', force=True)
+            out = func(*args, **kwargs)
+            mp.set_start_method('fork', force=True)
+        else:
+            out = func(*args, **kwargs)
+        return out
+
+    return wrapper
+
 
 STEPS_PER_EPOCH = 100
 STEPS = 100
@@ -66,6 +92,7 @@ def in_tmpdir(tmpdir):
     assert not tmpdir.listdir()
 
 
+@skip_generators
 def test_multiprocessing_training():
     arr_data = np.random.randint(0, 256, (50, 2))
     arr_labels = np.random.randint(0, 2, 50)
@@ -90,7 +117,7 @@ def test_multiprocessing_training():
 
     # Build a NN
     model = Sequential()
-    model.add(Dense(1, input_shape=(2, )))
+    model.add(Dense(1, input_shape=(2,)))
     model.compile(loss='mse', optimizer='adadelta')
 
     # - Produce data on 4 worker processes, consume on main process:
@@ -218,22 +245,6 @@ def test_multiprocessing_training():
                         workers=0,
                         use_multiprocessing=False)
 
-    # - For Sequence
-    model.fit_generator(DummySequence(),
-                        steps_per_epoch=STEPS_PER_EPOCH,
-                        validation_data=custom_generator(True),
-                        validation_steps=1,
-                        max_queue_size=10,
-                        workers=0,
-                        use_multiprocessing=True)
-    model.fit_generator(DummySequence(),
-                        steps_per_epoch=STEPS_PER_EPOCH,
-                        validation_data=custom_generator(True),
-                        validation_steps=1,
-                        max_queue_size=10,
-                        workers=0,
-                        use_multiprocessing=False)
-
     # Test invalid use cases
     @threadsafe_generator
     def invalid_generator():
@@ -273,7 +284,24 @@ def test_multiprocessing_training():
                             workers=1,
                             use_multiprocessing=False)
 
+    # - For Sequence
+    model.fit_generator(DummySequence(),
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        validation_data=DummySequence(),
+                        validation_steps=1,
+                        max_queue_size=10,
+                        workers=0,
+                        use_multiprocessing=True)
+    model.fit_generator(DummySequence(),
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        validation_data=DummySequence(),
+                        validation_steps=1,
+                        max_queue_size=10,
+                        workers=0,
+                        use_multiprocessing=False)
 
+
+@skip_generators
 def test_multiprocessing_training_from_file(in_tmpdir):
     arr_data = np.random.randint(0, 256, (50, 2))
     arr_labels = np.random.randint(0, 2, 50)
@@ -297,7 +325,7 @@ def test_multiprocessing_training_from_file(in_tmpdir):
 
     # Build a NN
     model = Sequential()
-    model.add(Dense(1, input_shape=(2, )))
+    model.add(Dense(1, input_shape=(2,)))
     model.compile(loss='mse', optimizer='adadelta')
 
     # - Produce data on 4 worker processes, consume on main process:
@@ -325,17 +353,6 @@ def test_multiprocessing_training_from_file(in_tmpdir):
                             workers=WORKERS,
                             use_multiprocessing=True)
 
-    # - Produce data on 4 worker threads, consume on main thread:
-    #   - All worker threads share the SAME generator
-    model.fit_generator(custom_generator(),
-                        steps_per_epoch=STEPS_PER_EPOCH,
-                        epochs=1,
-                        verbose=1,
-                        validation_steps=None,
-                        max_queue_size=10,
-                        workers=WORKERS,
-                        use_multiprocessing=False)
-
     # - Produce data on 1 worker process, consume on main process:
     #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
@@ -360,6 +377,59 @@ def test_multiprocessing_training_from_file(in_tmpdir):
                             max_queue_size=10,
                             workers=1,
                             use_multiprocessing=True)
+
+    # - Produce data on 1 worker thread, consume on main thread:
+    #   - Worker thread is the only thread running the generator
+
+    # - Produce and consume data without a queue on main thread
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    model.fit_generator(custom_generator(),
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        epochs=1,
+                        verbose=1,
+                        validation_steps=None,
+                        max_queue_size=10,
+                        workers=0,
+                        use_multiprocessing=True)
+
+    os.remove('data.npz')
+
+
+def test_multithreading_from_file():
+    arr_data = np.random.randint(0, 256, (50, 2))
+    arr_labels = np.random.randint(0, 2, 50)
+    np.savez('data_threads.npz', **{'data': arr_data, 'labels': arr_labels})
+
+    @threadsafe_generator
+    def custom_generator():
+        batch_size = 10
+        n_samples = 50
+
+        arr = np.load('data_threads.npz')
+
+        while True:
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr['data'][start: end]
+            y = arr['labels'][start: end]
+            yield X, y
+
+    # Build a NN
+    model = Sequential()
+    model.add(Dense(1, input_shape=(2,)))
+    model.compile(loss='mse', optimizer='adadelta')
+
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
+    model.fit_generator(custom_generator(),
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        epochs=1,
+                        verbose=1,
+                        validation_steps=None,
+                        max_queue_size=10,
+                        workers=WORKERS,
+                        use_multiprocessing=False)
 
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
@@ -381,19 +451,12 @@ def test_multiprocessing_training_from_file(in_tmpdir):
                         validation_steps=None,
                         max_queue_size=10,
                         workers=0,
-                        use_multiprocessing=True)
-    model.fit_generator(custom_generator(),
-                        steps_per_epoch=STEPS_PER_EPOCH,
-                        epochs=1,
-                        verbose=1,
-                        validation_steps=None,
-                        max_queue_size=10,
-                        workers=0,
                         use_multiprocessing=False)
 
-    os.remove('data.npz')
+    os.remove('data_threads.npz')
 
 
+@skip_generators
 def test_multiprocessing_predicting():
     arr_data = np.random.randint(0, 256, (50, 2))
 
@@ -411,7 +474,7 @@ def test_multiprocessing_predicting():
 
     # Build a NN
     model = Sequential()
-    model.add(Dense(1, input_shape=(2, )))
+    model.add(Dense(1, input_shape=(2,)))
     model.compile(loss='mse', optimizer='adadelta')
 
     # - Produce data on 4 worker processes, consume on main process:
@@ -433,14 +496,6 @@ def test_multiprocessing_predicting():
                                 workers=WORKERS,
                                 use_multiprocessing=True)
 
-    # - Produce data on 4 worker threads, consume on main thread:
-    #   - All worker threads share the SAME generator
-    model.predict_generator(custom_generator(),
-                            steps=STEPS,
-                            max_queue_size=10,
-                            workers=WORKERS,
-                            use_multiprocessing=False)
-
     # - Produce data on 1 worker process, consume on main process:
     #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
@@ -460,6 +515,43 @@ def test_multiprocessing_predicting():
                                 workers=1,
                                 use_multiprocessing=True)
 
+    # - Main thread runs the generator without a queue
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    model.predict_generator(custom_generator(),
+                            steps=STEPS,
+                            max_queue_size=10,
+                            workers=0,
+                            use_multiprocessing=True)
+
+
+def test_multithreading_predicting():
+    arr_data = np.random.randint(0, 256, (50, 2))
+
+    @threadsafe_generator
+    def custom_generator():
+        batch_size = 10
+        n_samples = 50
+
+        while True:
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr_data[start: end]
+            yield X
+
+    # Build a NN
+    model = Sequential()
+    model.add(Dense(1, input_shape=(2,)))
+    model.compile(loss='mse', optimizer='adadelta')
+
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
+    model.predict_generator(custom_generator(),
+                            steps=STEPS,
+                            max_queue_size=10,
+                            workers=WORKERS,
+                            use_multiprocessing=False)
+
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     model.predict_generator(custom_generator(),
@@ -474,14 +566,10 @@ def test_multiprocessing_predicting():
                             steps=STEPS,
                             max_queue_size=10,
                             workers=0,
-                            use_multiprocessing=True)
-    model.predict_generator(custom_generator(),
-                            steps=STEPS,
-                            max_queue_size=10,
-                            workers=0,
                             use_multiprocessing=False)
 
 
+@skip_generators
 def test_multiprocessing_evaluating():
     arr_data = np.random.randint(0, 256, (50, 2))
     arr_labels = np.random.randint(0, 2, 50)
@@ -501,7 +589,7 @@ def test_multiprocessing_evaluating():
 
     # Build a NN
     model = Sequential()
-    model.add(Dense(1, input_shape=(2, )))
+    model.add(Dense(1, input_shape=(2,)))
     model.compile(loss='mse', optimizer='adadelta')
 
     # - Produce data on 4 worker processes, consume on main process:
@@ -524,14 +612,6 @@ def test_multiprocessing_evaluating():
                                  workers=WORKERS,
                                  use_multiprocessing=True)
 
-    # - Produce data on 4 worker threads, consume on main thread:
-    #   - All worker threads share the SAME generator
-    model.evaluate_generator(custom_generator(),
-                             steps=STEPS,
-                             max_queue_size=10,
-                             workers=WORKERS,
-                             use_multiprocessing=False)
-
     # - Produce data on 1 worker process, consume on main process:
     #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
@@ -551,6 +631,45 @@ def test_multiprocessing_evaluating():
                                  workers=1,
                                  use_multiprocessing=True)
 
+    # - Produce and consume data without a queue on main thread
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    model.evaluate_generator(custom_generator(),
+                             steps=STEPS,
+                             max_queue_size=10,
+                             workers=0,
+                             use_multiprocessing=True)
+
+
+def test_multithreading_evaluating():
+    arr_data = np.random.randint(0, 256, (50, 2))
+    arr_labels = np.random.randint(0, 2, 50)
+
+    @threadsafe_generator
+    def custom_generator():
+        batch_size = 10
+        n_samples = 50
+
+        while True:
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr_data[start: end]
+            y = arr_labels[start: end]
+            yield X, y
+
+    # Build a NN
+    model = Sequential()
+    model.add(Dense(1, input_shape=(2,)))
+    model.compile(loss='mse', optimizer='adadelta')
+
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
+    model.evaluate_generator(custom_generator(),
+                             steps=STEPS,
+                             max_queue_size=10,
+                             workers=WORKERS,
+                             use_multiprocessing=False)
+
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     model.evaluate_generator(custom_generator(),
@@ -565,14 +684,10 @@ def test_multiprocessing_evaluating():
                              steps=STEPS,
                              max_queue_size=10,
                              workers=0,
-                             use_multiprocessing=True)
-    model.evaluate_generator(custom_generator(),
-                             steps=STEPS,
-                             max_queue_size=10,
-                             workers=0,
                              use_multiprocessing=False)
 
 
+@skip_generators
 def test_multiprocessing_fit_error():
     arr_data = np.random.randint(0, 256, (50, 2))
     arr_labels = np.random.randint(0, 2, 50)
@@ -593,7 +708,7 @@ def test_multiprocessing_fit_error():
         raise RuntimeError
 
     model = Sequential()
-    model.add(Dense(1, input_shape=(2, )))
+    model.add(Dense(1, input_shape=(2,)))
     model.compile(loss='mse', optimizer='adadelta')
 
     samples = batch_size * (good_batches + 1)
@@ -621,17 +736,6 @@ def test_multiprocessing_fit_error():
                                 workers=WORKERS,
                                 use_multiprocessing=True)
 
-    # - Produce data on 4 worker threads, consume on main thread:
-    #   - All worker threads share the SAME generator
-    #   - Make sure `RuntimeError` exception bubbles up
-    with pytest.raises(RuntimeError):
-        model.fit_generator(custom_generator(),
-                            steps_per_epoch=samples,
-                            validation_steps=None,
-                            max_queue_size=10,
-                            workers=WORKERS,
-                            use_multiprocessing=False)
-
     # - Produce data on 1 worker process, consume on main process:
     #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
@@ -655,6 +759,53 @@ def test_multiprocessing_fit_error():
                                 workers=1,
                                 use_multiprocessing=True)
 
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    #   - Make sure `RuntimeError` exception bubbles up
+    with pytest.raises(RuntimeError):
+        model.fit_generator(custom_generator(),
+                            steps_per_epoch=samples,
+                            validation_steps=None,
+                            max_queue_size=10,
+                            workers=0,
+                            use_multiprocessing=True)
+
+
+def test_multithreading_fit_error():
+    arr_data = np.random.randint(0, 256, (50, 2))
+    arr_labels = np.random.randint(0, 2, 50)
+    batch_size = 10
+    n_samples = 50
+    good_batches = 3
+
+    @threadsafe_generator
+    def custom_generator(use_weights=False):
+        """Raises an exception after a few good batches"""
+        for i in range(good_batches):
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr_data[start: end]
+            y = arr_labels[start: end]
+            yield X, y
+        raise RuntimeError
+
+    model = Sequential()
+    model.add(Dense(1, input_shape=(2,)))
+    model.compile(loss='mse', optimizer='adadelta')
+
+    samples = batch_size * (good_batches + 1)
+
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
+    #   - Make sure `RuntimeError` exception bubbles up
+    with pytest.raises(RuntimeError):
+        model.fit_generator(custom_generator(),
+                            steps_per_epoch=samples,
+                            validation_steps=None,
+                            max_queue_size=10,
+                            workers=WORKERS,
+                            use_multiprocessing=False)
+
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     #   - Make sure `RuntimeError` exception bubbles up
@@ -675,16 +826,10 @@ def test_multiprocessing_fit_error():
                             validation_steps=None,
                             max_queue_size=10,
                             workers=0,
-                            use_multiprocessing=True)
-    with pytest.raises(RuntimeError):
-        model.fit_generator(custom_generator(),
-                            steps_per_epoch=samples,
-                            validation_steps=None,
-                            max_queue_size=10,
-                            workers=0,
                             use_multiprocessing=False)
 
 
+@skip_generators
 def test_multiprocessing_evaluate_error():
     arr_data = np.random.randint(0, 256, (50, 2))
     arr_labels = np.random.randint(0, 2, 50)
@@ -705,7 +850,7 @@ def test_multiprocessing_evaluate_error():
         raise RuntimeError
 
     model = Sequential()
-    model.add(Dense(1, input_shape=(2, )))
+    model.add(Dense(1, input_shape=(2,)))
     model.compile(loss='mse', optimizer='adadelta')
 
     # - Produce data on 4 worker processes, consume on main process:
@@ -729,16 +874,6 @@ def test_multiprocessing_evaluate_error():
                                      workers=WORKERS,
                                      use_multiprocessing=True)
 
-    # - Produce data on 4 worker threads, consume on main thread:
-    #   - All worker threads share the SAME generator
-    #   - Make sure `RuntimeError` exception bubbles up
-    with pytest.raises(RuntimeError):
-        model.evaluate_generator(custom_generator(),
-                                 steps=good_batches * WORKERS + 1,
-                                 max_queue_size=10,
-                                 workers=WORKERS,
-                                 use_multiprocessing=False)
-
     # - Produce data on 1 worker process, consume on main process:
     #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
@@ -760,6 +895,50 @@ def test_multiprocessing_evaluate_error():
                                      workers=1,
                                      use_multiprocessing=True)
 
+    # - Produce and consume data without a queue on main thread
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    #   - Make sure `RuntimeError` exception bubbles up
+    with pytest.raises(RuntimeError):
+        model.evaluate_generator(custom_generator(),
+                                 steps=good_batches + 1,
+                                 max_queue_size=10,
+                                 workers=0,
+                                 use_multiprocessing=True)
+
+
+def test_multithreading_evaluate_error():
+    arr_data = np.random.randint(0, 256, (50, 2))
+    arr_labels = np.random.randint(0, 2, 50)
+    batch_size = 10
+    n_samples = 50
+    good_batches = 3
+
+    @threadsafe_generator
+    def custom_generator():
+        """Raises an exception after a few good batches"""
+        for i in range(good_batches):
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr_data[start: end]
+            y = arr_labels[start: end]
+            yield X, y
+        raise RuntimeError
+
+    model = Sequential()
+    model.add(Dense(1, input_shape=(2,)))
+    model.compile(loss='mse', optimizer='adadelta')
+
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
+    #   - Make sure `RuntimeError` exception bubbles up
+    with pytest.raises(RuntimeError):
+        model.evaluate_generator(custom_generator(),
+                                 steps=good_batches * WORKERS + 1,
+                                 max_queue_size=10,
+                                 workers=WORKERS,
+                                 use_multiprocessing=False)
+
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     #   - Make sure `RuntimeError` exception bubbles up
@@ -778,15 +957,10 @@ def test_multiprocessing_evaluate_error():
                                  steps=good_batches + 1,
                                  max_queue_size=10,
                                  workers=0,
-                                 use_multiprocessing=True)
-    with pytest.raises(RuntimeError):
-        model.evaluate_generator(custom_generator(),
-                                 steps=good_batches + 1,
-                                 max_queue_size=10,
-                                 workers=0,
                                  use_multiprocessing=False)
 
 
+@skip_generators
 def test_multiprocessing_predict_error():
     arr_data = np.random.randint(0, 256, (50, 2))
     good_batches = 3
@@ -806,7 +980,7 @@ def test_multiprocessing_predict_error():
         raise RuntimeError
 
     model = Sequential()
-    model.add(Dense(1, input_shape=(2, )))
+    model.add(Dense(1, input_shape=(2,)))
     model.compile(loss='mse', optimizer='adadelta')
 
     # - Produce data on 4 worker processes, consume on main process:
@@ -830,16 +1004,6 @@ def test_multiprocessing_predict_error():
                                     workers=WORKERS,
                                     use_multiprocessing=True)
 
-    # - Produce data on 4 worker threads, consume on main thread:
-    #   - All worker threads share the SAME generator
-    #   - Make sure `RuntimeError` exception bubbles up
-    with pytest.raises(RuntimeError):
-        model.predict_generator(custom_generator(),
-                                steps=good_batches * WORKERS + 1,
-                                max_queue_size=10,
-                                workers=WORKERS,
-                                use_multiprocessing=False)
-
     # - Produce data on 1 worker process, consume on main process:
     #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
@@ -861,6 +1025,48 @@ def test_multiprocessing_predict_error():
                                     workers=1,
                                     use_multiprocessing=True)
 
+    # - Produce and consume data without a queue on main thread
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    #   - Make sure `RuntimeError` exception bubbles up
+    with pytest.raises(RuntimeError):
+        model.predict_generator(custom_generator(),
+                                steps=good_batches + 1,
+                                max_queue_size=10,
+                                workers=0,
+                                use_multiprocessing=True)
+
+
+def test_multithreading_predict_error():
+    arr_data = np.random.randint(0, 256, (50, 2))
+    good_batches = 3
+
+    @threadsafe_generator
+    def custom_generator():
+        """Raises an exception after a few good batches"""
+        batch_size = 10
+        n_samples = 50
+
+        for i in range(good_batches):
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr_data[start: end]
+            yield X
+        raise RuntimeError
+
+    model = Sequential()
+    model.add(Dense(1, input_shape=(2,)))
+    model.compile(loss='mse', optimizer='adadelta')
+
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
+    #   - Make sure `RuntimeError` exception bubbles up
+    with pytest.raises(RuntimeError):
+        model.predict_generator(custom_generator(),
+                                steps=good_batches * WORKERS + 1,
+                                max_queue_size=10,
+                                workers=WORKERS,
+                                use_multiprocessing=False)
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     #   - Make sure `RuntimeError` exception bubbles up
@@ -874,12 +1080,6 @@ def test_multiprocessing_predict_error():
     # - Produce and consume data without a queue on main thread
     #   - Make sure the value of `use_multiprocessing` is ignored
     #   - Make sure `RuntimeError` exception bubbles up
-    with pytest.raises(RuntimeError):
-        model.predict_generator(custom_generator(),
-                                steps=good_batches + 1,
-                                max_queue_size=10,
-                                workers=0,
-                                use_multiprocessing=True)
     with pytest.raises(RuntimeError):
         model.predict_generator(custom_generator(),
                                 steps=good_batches + 1,

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -780,7 +780,7 @@ def test_multithreading_fit_error():
     good_batches = 3
 
     @threadsafe_generator
-    def custom_generator(use_weights=False):
+    def custom_generator():
         """Raises an exception after a few good batches"""
         for i in range(good_batches):
             batch_index = np.random.randint(0, n_samples - batch_size)

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -23,11 +23,13 @@ skip_generators = pytest.mark.skipif(K.backend() in {'tensorflow', 'cntk'} and
 
 
 def use_spawn(func):
-    """Decorator to test both Unix (fork) and Windows (spawn)"""
+    """Decorator which uses `spawn` when possible.
+    This is useful on Travis to avoid memory issues.
+    """
 
     @six.wraps(func)
     def wrapper(*args, **kwargs):
-        if sys.version_info > (3, 4):
+        if sys.version_info > (3, 4) and os.name != 'nt':
             mp.set_start_method('spawn', force=True)
             out = func(*args, **kwargs)
             mp.set_start_method('fork', force=True)


### PR DESCRIPTION
### Summary

We can now test the Sequence API on Python3. This PR aims at enabling those tests on Travis.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
