### PR TITLE
Add document generation test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,10 +69,6 @@ install:
   - export APP_CHANGED=False;
   - for entry in `git diff --name-only HEAD~1`; do if [[ "$entry" == "keras/applications/"* ]]; then export APP_CHANGED=True; fi; done
 
-  # set utf-8
-  - export LC_ALL=C.UTF-8;
-  - export LANG=C.UTF-8;
-
   # install mkdocs
   - pip install mkdocs --progress-bar off
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
 
   # install TensorFlow (CPU version).
   - pip install tensorflow==1.9 --progress-bar off
-  
+
   # install cntk
   - if [[ "$KERAS_BACKEND" == "cntk" ]] || [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
       ./.travis/install_cntk.sh;
@@ -69,6 +69,9 @@ install:
   - export APP_CHANGED=False;
   - for entry in `git diff --name-only HEAD~1`; do if [[ "$entry" == "keras/applications/"* ]]; then export APP_CHANGED=True; fi; done
 
+  # set utf-8
+  - export LC_ALL=C.UTF-8;
+  - export LANG=C.UTF-8;
 
 # command to run tests
 script:
@@ -83,7 +86,7 @@ script:
   - if [[ "$TEST_MODE" == "INTEGRATION_TESTS" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/integration_tests;
     elif [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
-      PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0 && py.test tests/test_documentation.py;
+      PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0 && py.test tests/test_documentation.py && cd docs && python autogen.py;
     else
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --ignore=tests/keras/legacy/layers_test.py --cov-config .coveragerc --cov=keras tests/;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ install:
 
   # install cntk
   - if [[ "$KERAS_BACKEND" == "cntk" ]] || [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
-      ./.travis/install_cntk.sh;
     fi
 
   # Remove the current backend from the coverage exclusion.
@@ -73,7 +72,7 @@ install:
   - export LC_ALL=C.UTF-8;
   - export LANG=C.UTF-8;
 
-  # install TensorFlow (CPU version).
+  # install mkdocs
   - pip install mkdocs --progress-bar off
 
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ install:
 
   # install cntk
   - if [[ "$KERAS_BACKEND" == "cntk" ]] || [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
+      ./.travis/install_cntk.sh;
     fi
 
   # Remove the current backend from the coverage exclusion.

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   - export LD_LIBRARY_PATH=$HOME/miniconda/envs/test-environment/lib/:$LD_LIBRARY_PATH
 
     # install pydot for visualization tests
-  - travis_retry conda install -q $MKL pydot graphviz $PIL mkdocs
+  - travis_retry conda install -q $MKL pydot graphviz $PIL
 
   - pip install -e .[tests] --progress-bar off
 
@@ -72,6 +72,9 @@ install:
   # set utf-8
   - export LC_ALL=C.UTF-8;
   - export LANG=C.UTF-8;
+
+  # install TensorFlow (CPU version).
+  - pip install mkdocs --progress-bar off
 
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   - export LD_LIBRARY_PATH=$HOME/miniconda/envs/test-environment/lib/:$LD_LIBRARY_PATH
 
     # install pydot for visualization tests
-  - travis_retry conda install -q $MKL pydot graphviz $PIL
+  - travis_retry conda install -q $MKL pydot graphviz $PIL mkdocs
 
   - pip install -e .[tests] --progress-bar off
 
@@ -86,7 +86,7 @@ script:
   - if [[ "$TEST_MODE" == "INTEGRATION_TESTS" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/integration_tests;
     elif [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
-      PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0 && py.test tests/test_documentation.py && cd docs && python autogen.py;
+      PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0 && py.test tests/test_documentation.py && cd docs && python autogen.py && mkdocs build;
     else
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --ignore=tests/keras/legacy/layers_test.py --cov-config .coveragerc --cov=keras tests/;
     fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,7 +57,9 @@ RUN conda install -y python=${python_version} && \
       pyyaml \
       scikit-learn \
       six \
-      theano && \
+      theano \
+      mkdocs \
+      && \
     git clone git://github.com/keras-team/keras.git /src && pip install -e /src[tests] && \
     pip install git+git://github.com/keras-team/keras.git && \
     conda clean -yt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,6 +64,9 @@ RUN conda install -y python=${python_version} && \
 
 ADD theanorc /home/keras/.theanorc
 
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
 ENV PYTHONPATH='/src/:$PYTHONPATH'
 
 WORKDIR /src


### PR DESCRIPTION
### Summary
We should try to build the docs in travis to catch document generation errors.

### Related Issues
https://github.com/keras-team/keras/pull/11880

### PR Overview
- Add UTF-8 and mkdocs in Dockerfile, travis.yml
- Test `python autogen.py && mkdocs build`