### PR TITLE
Make `sample_weights` and `class_weights` multiplicative.

### DIFF
--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -432,7 +432,8 @@ def standardize_weights(y,
     """Performs sample weight validation and standardization.
 
     Everything gets normalized to a single sample-wise (or timestep-wise)
-    weight array.
+    weight array. If both `sample_weights` and `class_weights` are provided,
+    the weights are multiplied together.
 
     # Arguments
         y: Numpy array of model targets to be weighted.
@@ -478,10 +479,6 @@ def standardize_weights(y,
                              'sample-wise weights, make sure your '
                              'sample_weight array is 1D.')
 
-    if sample_weight is not None and class_weight is not None:
-        warnings.warn('Found both `sample_weight` and `class_weight`: '
-                      '`class_weight` argument will be ignored.')
-
     if sample_weight is not None:
         if len(sample_weight.shape) > len(y.shape):
             raise ValueError('Found a sample_weight with shape' +
@@ -495,22 +492,24 @@ def standardize_weights(y,
                              ' for an input with shape ' +
                              str(y.shape) + '. '
                              'sample_weight cannot be broadcast.')
-        return sample_weight
-    elif isinstance(class_weight, dict):
+
+    class_sample_weight = None
+    if isinstance(class_weight, dict):
         if len(y.shape) > 2:
             raise ValueError('`class_weight` not supported for '
                              '3+ dimensional targets.')
-        if y.shape[1] > 1:
-            y_classes = np.argmax(y, axis=1)
-        elif y.shape[1] == 1:
-            y_classes = np.reshape(y, y.shape[0])
+        if len(y.shape) == 2:
+            if y.shape[1] > 1:
+                y_classes = np.argmax(y, axis=1)
+            elif y.shape[1] == 1:
+                y_classes = np.reshape(y, y.shape[0])
         else:
             y_classes = y
 
-        weights = np.asarray([class_weight[cls] for cls in y_classes
-                              if cls in class_weight])
+        class_sample_weight = np.asarray(
+            [class_weight[cls] for cls in y_classes if cls in class_weight])
 
-        if len(weights) != len(y_classes):
+        if len(class_sample_weight) != len(y_classes):
             # subtract the sets to pick all missing classes
             existing_classes = set(y_classes)
             existing_class_weight = set(class_weight.keys())
@@ -519,12 +518,19 @@ def standardize_weights(y,
                              ' The classes %s exist in the data but not in '
                              '`class_weight`.'
                              % (existing_classes - existing_class_weight))
-        return weights
+
+    if sample_weight is not None and class_sample_weight is not None:
+        return sample_weight * class_sample_weight
+    if sample_weight is not None:
+        return sample_weight
+    if class_sample_weight is not None:
+        return class_sample_weight
+
+    # Everything has weight 1 by default.
+    if sample_weight_mode is None:
+        return np.ones((y.shape[0],), dtype=K.floatx())
     else:
-        if sample_weight_mode is None:
-            return np.ones((y.shape[0],), dtype=K.floatx())
-        else:
-            return np.ones((y.shape[0], y.shape[1]), dtype=K.floatx())
+        return np.ones((y.shape[0], y.shape[1]), dtype=K.floatx())
 
 
 def check_num_samples(ins,

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -1575,5 +1575,25 @@ def test_dynamic_set_inputs():
     assert preds4.shape == (1, 19)
 
 
+def test_sample_weights():
+    y = np.array([0, 1, 0, 0, 2])
+    sample_weights = np.array([0.5, 1., 1., 0., 2.])
+    class_weights = {0: 0.5, 1: 1., 2: 1.5}
+
+    # Only `sample_weights`.
+    weights = training_utils.standardize_weights(y, sample_weights)
+    assert np.allclose(weights, sample_weights)
+
+    # Only `class_weights`.
+    weights = training_utils.standardize_weights(y, class_weight=class_weights)
+    assert np.allclose(weights, np.array([0.5, 1., 0.5, 0.5, 1.5]))
+
+    # Both 'sample_weights` and 'class_weights`.
+    weights = training_utils.standardize_weights(y, sample_weights,
+                                                 class_weights)
+    expected = sample_weights * np.array([0.5, 1., 0.5, 0.5, 1.5])
+    assert np.allclose(weights, expected)
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
### Summary

This is an item to sync Keras with a pending change in tf.Keras

Previously `class_weights` was ignored with a logging warning if
`sample_weights` was also provided.

### Related Issues

### PR Overview

- [ y] This PR requires new unit tests [y/n] (make sure tests are included)
- [ y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
