### PR TITLE
Fix function 'get_file()' is inconsistent with keras backend when 'KERAS_HOME' is not `~/.keras`

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -170,7 +170,10 @@ def get_file(fname,
         Path to the downloaded file
     """  # noqa
     if cache_dir is None:
-        cache_dir = os.path.join(os.path.expanduser('~'), '.keras')
+        if 'KERAS_HOME' in os.environ:
+            cache_dir = os.environ.get('KERAS_HOME')
+        else:
+            cache_dir = os.path.join(os.path.expanduser('~'), '.keras')
     if md5_hash is not None and file_hash is None:
         file_hash = md5_hash
         hash_algorithm = 'md5'

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -87,7 +87,8 @@ def test_data_utils(in_tmpdir):
 
     path = get_file(dirname, origin, untar=True)
     filepath = path + '.tar.gz'
-    assert os.path.dirname(os.path.dirname(os.path.abspath(filepath))) == os.path.dirname(K._config_path)
+    assert os.path.dirname(os.path.dirname(os.path.abspath(filepath))) \
+           == os.path.dirname(K._config_path)
     os.remove(filepath)
 
     _keras_home = os.path.join(os.path.abspath('.'), '.keras')
@@ -97,7 +98,8 @@ def test_data_utils(in_tmpdir):
     reload_module(K)
     path = get_file(dirname, origin, untar=True)
     filepath = path + '.tar.gz'
-    assert os.path.dirname(os.path.dirname(os.path.abspath(filepath))) == os.path.dirname(K._config_path)
+    assert os.path.dirname(os.path.dirname(os.path.abspath(filepath))) \
+           == os.path.dirname(K._config_path)
     os.environ.pop('KERAS_HOME')
     shutil.rmtree(_keras_home)
     reload_module(K)

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -88,7 +88,7 @@ def test_data_utils(in_tmpdir):
     path = get_file(dirname, origin, untar=True)
     filepath = path + '.tar.gz'
     assert os.path.dirname(os.path.dirname(os.path.abspath(filepath))) \
-           == os.path.dirname(K._config_path)
+        == os.path.dirname(K._config_path)
     os.remove(filepath)
 
     _keras_home = os.path.join(os.path.abspath('.'), '.keras')
@@ -99,7 +99,7 @@ def test_data_utils(in_tmpdir):
     path = get_file(dirname, origin, untar=True)
     filepath = path + '.tar.gz'
     assert os.path.dirname(os.path.dirname(os.path.abspath(filepath))) \
-           == os.path.dirname(K._config_path)
+        == os.path.dirname(K._config_path)
     os.environ.pop('KERAS_HOME')
     shutil.rmtree(_keras_home)
     reload_module(K)

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -5,6 +5,7 @@ import time
 import sys
 import tarfile
 import threading
+import shutil
 import zipfile
 from itertools import cycle
 import multiprocessing as mp
@@ -13,6 +14,7 @@ import pytest
 import six
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.request import pathname2url
+from six.moves import reload_module
 
 from flaky import flaky
 
@@ -85,6 +87,23 @@ def test_data_utils(in_tmpdir):
 
     path = get_file(dirname, origin, untar=True)
     filepath = path + '.tar.gz'
+    assert os.path.dirname(os.path.dirname(os.path.abspath(filepath))) == os.path.dirname(K._config_path)
+    os.remove(filepath)
+
+    _keras_home = os.path.join(os.path.abspath('.'), '.keras')
+    if not os.path.exists(_keras_home):
+        os.makedirs(_keras_home)
+    os.environ['KERAS_HOME'] = _keras_home
+    reload_module(K)
+    path = get_file(dirname, origin, untar=True)
+    filepath = path + '.tar.gz'
+    assert os.path.dirname(os.path.dirname(os.path.abspath(filepath))) == os.path.dirname(K._config_path)
+    os.environ.pop('KERAS_HOME')
+    shutil.rmtree(_keras_home)
+    reload_module(K)
+
+    path = get_file(dirname, origin, untar=True)
+    filepath = path + '.tar.gz'
     hashval_sha256 = _hash_file(filepath)
     hashval_md5 = _hash_file(filepath, algorithm='md5')
     path = get_file(dirname, origin, md5_hash=hashval_md5, untar=True)
@@ -106,6 +125,7 @@ def test_data_utils(in_tmpdir):
     assert validate_file(path, hashval_md5)
 
     os.remove(path)
+    os.remove(os.path.join(os.path.dirname(path), 'test.txt'))
     os.remove('test.txt')
     os.remove('test.zip')
 

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -87,8 +87,8 @@ def test_data_utils(in_tmpdir):
 
     path = get_file(dirname, origin, untar=True)
     filepath = path + '.tar.gz'
-    assert os.path.dirname(os.path.dirname(os.path.abspath(filepath))) \
-        == os.path.dirname(K._config_path)
+    data_keras_home = os.path.dirname(os.path.dirname(os.path.abspath(filepath)))
+    assert data_keras_home == os.path.dirname(K._config_path)
     os.remove(filepath)
 
     _keras_home = os.path.join(os.path.abspath('.'), '.keras')
@@ -98,8 +98,8 @@ def test_data_utils(in_tmpdir):
     reload_module(K)
     path = get_file(dirname, origin, untar=True)
     filepath = path + '.tar.gz'
-    assert os.path.dirname(os.path.dirname(os.path.abspath(filepath))) \
-        == os.path.dirname(K._config_path)
+    data_keras_home = os.path.dirname(os.path.dirname(os.path.abspath(filepath)))
+    assert data_keras_home == os.path.dirname(K._config_path)
     os.environ.pop('KERAS_HOME')
     shutil.rmtree(_keras_home)
     reload_module(K)


### PR DESCRIPTION
### Summary
the default value(None) for param `cache_dir` in function `get_file()` is inconsistent with keras backend when 'KERAS_HOME' is not `~/.keras`.
when we set `KERAS_HOME` and `KERAS_HOME` is not `~/.keras`, models and datasets will still be in `~/.keras`(when the cache_dir is default value) while the config file `keras.json` in `KERAS_HOME`.
The config file `keras.json`, models and datasets should be in the same folder by default

bug fix the unit test `test_data_utils ()` in `tests/keras/utils/data_utils_test.py` where the cache_dir remain extracted-file `test.txt`(which should be removed at last) when `untar` is `True`

### Related Issues
This applies the fix in issue [#11923](https://github.com/keras-team/keras/issues/11923)

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
