### PR TITLE
 Import fails in Windows service because of stderr

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -79,13 +79,16 @@ if 'KERAS_BACKEND' in os.environ:
 
 # Import backend functions.
 if _BACKEND == 'cntk':
-    sys.stderr.write('Using CNTK backend\n')
+    if sys.stderr is not None:
+        sys.stderr.write('Using CNTK backend\n')
     from .cntk_backend import *
 elif _BACKEND == 'theano':
-    sys.stderr.write('Using Theano backend.\n')
+    if sys.stderr is not None:
+        sys.stderr.write('Using Theano backend.\n')
     from .theano_backend import *
 elif _BACKEND == 'tensorflow':
-    sys.stderr.write('Using TensorFlow backend.\n')
+    if sys.stderr is not None:
+        sys.stderr.write('Using TensorFlow backend.\n')
     from .tensorflow_backend import *
 else:
     # Try and load external backend.
@@ -103,7 +106,8 @@ else:
             # Make sure we don't override any entries from common, such as epsilon.
             if k not in namespace:
                 namespace[k] = v
-        sys.stderr.write('Using ' + _BACKEND + ' backend.\n')
+        if sys.stderr is not None:
+            sys.stderr.write('Using ' + _BACKEND + ' backend.\n')
     except ImportError:
         raise ValueError('Unable to import backend : ' + str(_BACKEND))
 


### PR DESCRIPTION
### Summary
There are no stderr and stdout in Windows service, so any attempt to write to it fails:
```
    sys.stderr.write('Using TensorFlow backend.\n')
AttributeError: 'NoneType' object has no attribute 'write' 
```
So in my opinion the library must be more careful when printing unavoidable messages.

### Related Issues
#1406 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
