### PR TITLE
Update Dockefile to fix PackageNotFoundError of conda

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,7 @@ USER $NB_USER
 
 ARG python_version=3.6
 
+RUN conda config --append channels conda-forge
 RUN conda install -y python=${python_version} && \
     pip install --upgrade pip && \
     pip install \
@@ -76,4 +77,3 @@ WORKDIR /src
 EXPOSE 8888
 
 CMD jupyter notebook --port=8888 --ip=0.0.0.0
-


### PR DESCRIPTION
### Summary
I tried `make build` to build docker image of keras.
I got an error like following. (on both macOS High Sierra and Ubuntu server 17.10 )

```
PackageNotFoundError: Packages missing in current channels:

  - mkdocs
````

I think it is because conda's default channel does not contain `mkdocs`.
I added the statement to add channel `conda-forge` in `Dockerfile` .

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
