### PR TITLE
Make keras.wrappers.scikit_learn accessible without extra import

### DIFF
--- a/keras/wrappers/__init__.py
+++ b/keras/wrappers/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from . import scikit_learn


### PR DESCRIPTION
### Summary
Currently it is necessary to `import keras.wrapper.scikit_learn` before using it:

```python
import keras
import keras.wrappers.scikit_learn
clf = keras.wrappers.scikit_learn.KerasClassifier(...)
```

In contrast, tf.keras allows this:

```python
from tensorflow import keras
clf = keras.wrappers.scikit_learn.KerasClassifier(...)
```

For consistency, and to make code a bit easier to port from one Keras implementation to another, I suggest adding `from . import scikit_learn` in  `keras/wrappers/__init__.py`

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
