### PR TITLE
Replace keras.engine.topology.Layer with keras.layers.Layer in the API

### DIFF
--- a/docs/templates/layers/writing-your-own-keras-layers.md
+++ b/docs/templates/layers/writing-your-own-keras-layers.md
@@ -10,7 +10,7 @@ Here is the skeleton of a Keras layer, **as of Keras 2.0** (if you have an older
 
 ```python
 from keras import backend as K
-from keras.engine.topology import Layer
+from keras.layers import Layer
 
 class MyLayer(Layer):
 
@@ -37,7 +37,7 @@ It is also possible to define Keras layers which have multiple input tensors and
 
 ```python
 from keras import backend as K
-from keras.engine.topology import Layer
+from keras.layers import Layer
 
 class MyLayer(Layer):
 


### PR DESCRIPTION
### Summary
I suggest that keras.engine should not be part of the official Keras API.
Since `keras.layers.Layer` is the same as `keras.engine.topology.Layer`, it would be simpler to just point the API to the former.
In fact, tf.keras does not have `tensorflow.keras.engine`.

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [y] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
