### PR TITLE
Fix DeprecationWarning: invalid escape sequence in examples and tests

### DIFF
--- a/examples/babi_memnn.py
+++ b/examples/babi_memnn.py
@@ -34,7 +34,7 @@ def tokenize(sent):
     >>> tokenize('Bob dropped the apple. Where is the apple?')
     ['Bob', 'dropped', 'the', 'apple', '.', 'Where', 'is', 'the', 'apple', '?']
     '''
-    return [x.strip() for x in re.split('(\W+)?', sent) if x.strip()]
+    return [x.strip() for x in re.split(r'(\W+)?', sent) if x.strip()]
 
 
 def parse_stories(lines, only_supporting=False):

--- a/examples/babi_rnn.py
+++ b/examples/babi_rnn.py
@@ -78,7 +78,7 @@ def tokenize(sent):
     >>> tokenize('Bob dropped the apple. Where is the apple?')
     ['Bob', 'dropped', 'the', 'apple', '.', 'Where', 'is', 'the', 'apple', '?']
     '''
-    return [x.strip() for x in re.split('(\W+)?', sent) if x.strip()]
+    return [x.strip() for x in re.split(r'(\W+)?', sent) if x.strip()]
 
 
 def parse_stories(lines, only_supporting=False):

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -1130,12 +1130,12 @@ def test_target_tensors():
     # multi-output, not enough target tensors when `target_tensors` is not a dict
     with pytest.raises(ValueError,
                        match='When passing a list as `target_tensors`, it should '
-                             'have one entry per model output. The model has \d '
+                             'have one entry per model output. The model has \\d '
                              'outputs, but you passed target_tensors='):
         model.compile(optimizer='rmsprop', loss='mse',
                       target_tensors=[target_a])
     with pytest.raises(ValueError,
-                       match='The model has \d outputs, but you passed a single '
+                       match='The model has \\d outputs, but you passed a single '
                              'tensor as `target_tensors`. Expected a list or '
                              'a dict of tensors.'):
         model.compile(optimizer='rmsprop', loss='mse',


### PR DESCRIPTION
### Summary

Fixes `DeprecationWarning: invalid escape sequence` in examples and tests.

### Related Issues

None.

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
