### PR TITLE
Use with to ensure no resource leak in get_word_index()

### DIFF
--- a/keras/datasets/reuters.py
+++ b/keras/datasets/reuters.py
@@ -101,7 +101,5 @@ def get_word_index(path='reuters_word_index.json'):
         path,
         origin='https://s3.amazonaws.com/text-datasets/reuters_word_index.json',
         file_hash='4d44cc38712099c9e383dc6e5f11a921')
-    f = open(path)
-    data = json.load(f)
-    f.close()
-    return data
+    with open(path) as f:
+        return json.load(f)


### PR DESCRIPTION
### Summary

Use the `with` context manager to ensure no resource leak in `get_word_index()`.

### Related Issues

None.

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
