### PR TITLE
Fixed tuple TypeError for nets with axis list.

### DIFF
--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -76,7 +76,10 @@ class BatchNormalization(Layer):
                  **kwargs):
         super(BatchNormalization, self).__init__(**kwargs)
         self.supports_masking = True
-        self.axis = unpack_singleton(axis)
+        if type(axis) == list:
+            self.axis = unpack_singleton(axis)
+        else:
+            self.axis = axis
         self.momentum = momentum
         self.epsilon = epsilon
         self.center = center

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -10,6 +10,7 @@ from .. import initializers
 from .. import regularizers
 from .. import constraints
 from .. import backend as K
+from ..utils.generic_utils import unpack_singleton
 from ..legacy import interfaces
 
 
@@ -75,7 +76,7 @@ class BatchNormalization(Layer):
                  **kwargs):
         super(BatchNormalization, self).__init__(**kwargs)
         self.supports_masking = True
-        self.axis = axis
+        self.axis = unpack_singleton(axis)
         self.momentum = momentum
         self.epsilon = epsilon
         self.center = center

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -12,7 +12,7 @@ from keras.engine.saving import preprocess_weights_for_loading
 from keras.models import Model, Sequential
 from keras.layers import Dense, Lambda, RepeatVector, TimeDistributed
 from keras.layers import Bidirectional, GRU, LSTM, CuDNNGRU, CuDNNLSTM
-from keras.layers import Conv2D, Flatten
+from keras.layers import Conv2D, Flatten, BatchNormalization
 from keras.layers import Input, InputLayer
 from keras.initializers import Constant
 from keras import optimizers
@@ -777,6 +777,23 @@ def test_saving_overwrite_option_gcs():
                 assert_allclose(w, new_w)
 
         file_io_proxy.delete_file(gcs_filepath)  # cleanup
+
+
+def test_saving_loading_batchnormalization_axis():
+    model = Sequential()
+    model.add(BatchNormalization(axis=1, input_shape=(4, 4, 4)))
+
+    fp, fname = tempfile.mkstemp('.h5')
+    os.close(fp)
+    del fp
+
+    model.save(fname)
+    del model
+
+    loaded_model = load_model(fname)
+    del loaded_model
+
+    os.remove(fname)
 
 
 @pytest.mark.parametrize('implementation', [1, 2], ids=['impl1', 'impl2'])


### PR DESCRIPTION
Encountered .h5 file where the layer axis was saved as 1-length list of int rather than a simple int.
Fixed the following exception:
Traceback (most recent call last):
  File "c:\python36\lib\site-packages\mmdnn\conversion\keras\keras2_parser.py", line 104, in __init__
    from keras.applications.mobilenet import relu6
ImportError: cannot import name 'relu6'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Python36\Scripts\mmconvert-script.py", line 11, in <module>
    load_entry_point('mmdnn==0.2.3', 'console_scripts', 'mmconvert')()
  File "c:\python36\lib\site-packages\mmdnn\conversion\_script\convert.py", line 102, in _main
    ret = convertToIR._convert(ir_args)
  File "c:\python36\lib\site-packages\mmdnn\conversion\_script\convertToIR.py", line 46, in _convert
    parser = Keras2Parser(model)
  File "c:\python36\lib\site-packages\mmdnn\conversion\keras\keras2_parser.py", line 120, in __init__
    'DepthwiseConv2D': layers.DepthwiseConv2D
  File "c:\python36\lib\site-packages\keras\engine\saving.py", line 419, in load_model
    model = _deserialize_model(f, custom_objects, compile)
  File "c:\python36\lib\site-packages\keras\engine\saving.py", line 225, in _deserialize_model
    model = model_from_config(model_config, custom_objects=custom_objects)
  File "c:\python36\lib\site-packages\keras\engine\saving.py", line 458, in model_from_config
    return deserialize(config, custom_objects=custom_objects)
  File "c:\python36\lib\site-packages\keras\layers\__init__.py", line 55, in deserialize
    printable_module_name='layer')
  File "c:\python36\lib\site-packages\keras\utils\generic_utils.py", line 147, in deserialize_keras_object
    list(custom_objects.items())))
  File "c:\python36\lib\site-packages\keras\engine\network.py", line 1033, in from_config
    process_node(layer, node_data)
  File "c:\python36\lib\site-packages\keras\engine\network.py", line 991, in process_node
    layer(unpack_singleton(input_tensors), **kwargs)
  File "c:\python36\lib\site-packages\keras\engine\base_layer.py", line 432, in __call__
    self.build(unpack_singleton(input_shapes))
  File "c:\python36\lib\site-packages\keras\layers\normalization.py", line 95, in build
    dim = input_shape[self.axis]
TypeError: tuple indices must be integers or slices, not list

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
