### PR TITLE
Bump TF version to 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
   - pip install -e .[tests] --progress-bar off
 
   # install TensorFlow (CPU version).
-  - pip install tensorflow==1.11 --progress-bar off
+  - pip install tensorflow==1.12 --progress-bar off
 
   # install cntk
   - if [[ "$KERAS_BACKEND" == "cntk" ]] || [[ "$TEST_MODE" == "PEP8_DOC" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
   - pip install -e .[tests] --progress-bar off
 
   # install TensorFlow (CPU version).
-  - pip install tensorflow==1.9 --progress-bar off
+  - pip install tensorflow==1.11 --progress-bar off
 
   # install cntk
   - if [[ "$KERAS_BACKEND" == "cntk" ]] || [[ "$TEST_MODE" == "PEP8_DOC" ]]; then


### PR DESCRIPTION
### Summary

Retry for https://github.com/keras-team/keras/pull/11672

Having some trouble with `ctc_decode_beam_search`: I've explored the computed values by Tensorflow `gen_ctc_ops.ctc_beam_search_decoder` and the returned `log_probabilities` are different between 1.10 and 1.11. Investigating on this atm.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
