### PR TITLE
Simplify identity initializer with zero padding

### DIFF
--- a/keras/initializers.py
+++ b/keras/initializers.py
@@ -283,20 +283,7 @@ class Identity(Initializer):
             raise ValueError(
                 'Identity matrix initializer can only be used for 2D matrices.')
 
-        if shape[0] == shape[1]:
-            return self.gain * np.identity(shape[0])
-        elif shape[0] > shape[1]:
-            return self.gain * np.concatenate(
-                [np.identity(shape[1]),
-                 np.zeros((shape[0] - shape[1], shape[1]))],
-                axis=0
-            )
-        else:
-            return self.gain * np.concatenate(
-                [np.identity(shape[0]),
-                 np.zeros((shape[0], shape[1] - shape[0]))],
-                axis=1
-            )
+        return self.gain * np.eye(shape[0], shape[1])
 
     def get_config(self):
         return {


### PR DESCRIPTION
### Summary

This PR is a follow-up of #11887. The zero-padding for non-square identity matrices is the default behavior of `np.eye`.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
