### PR TITLE
Revise initializers for depthwise and pointwise kernels

### DIFF
--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -246,10 +246,11 @@ class Layer(object):
         initializer = initializers.get(initializer)
         if dtype is None:
             dtype = K.floatx()
-        weight = K.variable(initializer(shape),
-                            dtype=dtype,
-                            name=name,
-                            constraint=constraint)
+        if ('depthwise' in name) or ('pointwise' in name):
+            w = initializer(shape[0], base_shape=shape[1])
+        else:
+            w = initializer(shape)
+        weight = K.variable(w, dtype=dtype, name=name, constraint=constraint)
         if regularizer is not None:
             with K.name_scope('weight_regularizer'):
                 self.add_loss(regularizer(weight))

--- a/keras/initializers.py
+++ b/keras/initializers.py
@@ -15,7 +15,7 @@ class Initializer(object):
     """Initializer base class: all initializers inherit from this class.
     """
 
-    def __call__(self, shape, dtype=None):
+    def __call__(self, shape, dtype=None, base_shape=None):
         raise NotImplementedError
 
     def get_config(self):
@@ -34,7 +34,7 @@ class Zeros(Initializer):
     """Initializer that generates tensors initialized to 0.
     """
 
-    def __call__(self, shape, dtype=None):
+    def __call__(self, shape, dtype=None, base_shape=None):
         return K.constant(0, shape=shape, dtype=dtype)
 
 
@@ -42,7 +42,7 @@ class Ones(Initializer):
     """Initializer that generates tensors initialized to 1.
     """
 
-    def __call__(self, shape, dtype=None):
+    def __call__(self, shape, dtype=None, base_shape=None):
         return K.constant(1, shape=shape, dtype=dtype)
 
 
@@ -56,7 +56,7 @@ class Constant(Initializer):
     def __init__(self, value=0):
         self.value = value
 
-    def __call__(self, shape, dtype=None):
+    def __call__(self, shape, dtype=None, base_shape=None):
         return K.constant(self.value, shape=shape, dtype=dtype)
 
     def get_config(self):
@@ -79,7 +79,7 @@ class RandomNormal(Initializer):
         self.stddev = stddev
         self.seed = seed
 
-    def __call__(self, shape, dtype=None):
+    def __call__(self, shape, dtype=None, base_shape=None):
         return K.random_normal(shape, self.mean, self.stddev,
                                dtype=dtype, seed=self.seed)
 
@@ -107,7 +107,7 @@ class RandomUniform(Initializer):
         self.maxval = maxval
         self.seed = seed
 
-    def __call__(self, shape, dtype=None):
+    def __call__(self, shape, dtype=None, base_shape=None):
         return K.random_uniform(shape, self.minval, self.maxval,
                                 dtype=dtype, seed=self.seed)
 
@@ -140,7 +140,7 @@ class TruncatedNormal(Initializer):
         self.stddev = stddev
         self.seed = seed
 
-    def __call__(self, shape, dtype=None):
+    def __call__(self, shape, dtype=None, base_shape=None):
         return K.truncated_normal(shape, self.mean, self.stddev,
                                   dtype=dtype, seed=self.seed)
 
@@ -198,8 +198,11 @@ class VarianceScaling(Initializer):
         self.distribution = distribution
         self.seed = seed
 
-    def __call__(self, shape, dtype=None):
-        fan_in, fan_out = _compute_fans(shape)
+    def __call__(self, shape, dtype=None, base_shape=None):
+        if base_shape is not None:
+            fan_in, fan_out = _compute_fans(base_shape)
+        else:
+            fan_in, fan_out = _compute_fans(shape)
         scale = self.scale
         if self.mode == 'fan_in':
             scale /= max(1., fan_in)
@@ -242,7 +245,7 @@ class Orthogonal(Initializer):
         self.gain = gain
         self.seed = seed
 
-    def __call__(self, shape, dtype=None):
+    def __call__(self, shape, dtype=None, base_shape=None):
         num_rows = 1
         for dim in shape[:-1]:
             num_rows *= dim
@@ -278,7 +281,7 @@ class Identity(Initializer):
     def __init__(self, gain=1.):
         self.gain = gain
 
-    def __call__(self, shape, dtype=None):
+    def __call__(self, shape, dtype=None, base_shape=None):
         if len(shape) != 2:
             raise ValueError(
                 'Identity matrix initializer can only be used for 2D matrices.')

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1339,15 +1339,16 @@ class _SeparableConv(_Conv):
         depthwise_kernel_shape = self.kernel_size + depthwise_kernel_shape
         pointwise_kernel_shape = (self.depth_multiplier * input_dim, self.filters)
         pointwise_kernel_shape = (1,) * self.rank + pointwise_kernel_shape
+        base_kernel_shape = self.kernel_size + (input_dim, self.filters)
 
         self.depthwise_kernel = self.add_weight(
-            shape=depthwise_kernel_shape,
+            shape=(depthwise_kernel_shape, base_kernel_shape),
             initializer=self.depthwise_initializer,
             name='depthwise_kernel',
             regularizer=self.depthwise_regularizer,
             constraint=self.depthwise_constraint)
         self.pointwise_kernel = self.add_weight(
-            shape=pointwise_kernel_shape,
+            shape=(pointwise_kernel_shape, base_kernel_shape),
             initializer=self.pointwise_initializer,
             name='pointwise_kernel',
             regularizer=self.pointwise_regularizer,
@@ -1819,9 +1820,13 @@ class DepthwiseConv2D(Conv2D):
                                   self.kernel_size[1],
                                   input_dim,
                                   self.depth_multiplier)
+        base_kernel_shape = (self.kernel_size[0],
+                             self.kernel_size[1],
+                             input_dim,
+                             input_dim * self.depth_multiplier)
 
         self.depthwise_kernel = self.add_weight(
-            shape=depthwise_kernel_shape,
+            shape=(depthwise_kernel_shape, base_kernel_shape),
             initializer=self.depthwise_initializer,
             name='depthwise_kernel',
             regularizer=self.depthwise_regularizer,


### PR DESCRIPTION
This PR addresses #11773, the issue of initializers described in the "Requests for contributions". I checked the scales of initial weight values of three layers (`Conv2D`, `DepthwiseConv2D`, `SeparableConv2D`) with six initializers. I set the hyper-parameters of the 3 layers in order to have the same mapping: `(n, 32, 32, 64)` -> `(n, 28, 28, 128)`.

In results, the current implementation assigns the different scales of weight values if **a kernel is pointwise kernel or an initializer is fan_out**, as shown in the "as-is" figure. Thus, I proposed one of the possible solutions as this PR. The solution can make all the initiali values have the same scales, as shown in the "to-be" figure.

### Test codes

```python
import numpy as np
import matplotlib as mpl
import matplotlib.pyplot as plt

from keras.models import Model
from keras.layers import Input, Conv2D, SeparableConv2D, DepthwiseConv2D
from keras.initializers import VarianceScaling

f, axarr = plt.subplots(6, 4, figsize=(10, 10))

inputs = Input(shape=(32, 32, 64))
weights = []

for (i, init) in enumerate(['glorot_uniform', 'lecun_uniform',
                            'glorot_normal', 'he_normal', 'he_uniform',
                            VarianceScaling(mode='fan_out')]):
    x = [Conv2D(128, 5, kernel_initializer=init)(inputs),
         DepthwiseConv2D(5, depth_multiplier=2, depthwise_initializer=init)(inputs),
         SeparableConv2D(128, 5, depthwise_initializer=init, pointwise_initializer=init)(inputs)]
    models = [Model(inputs=inputs, outputs=_x) for _x in x]
    weights.append([model.get_weights() for model in models])
    axarr[i, 0].set_ylabel(init if isinstance(init, str) else 'fanout')
    axarr[i, 0].hist(weights[i][0][0].reshape(-1))
    axarr[i, 1].hist(weights[i][1][0].reshape(-1))
    axarr[i, 2].hist(weights[i][2][0].reshape(-1))
    axarr[i, 3].hist(weights[i][2][1].reshape(-1))
    
    if i == 0:
        axarr[i, 0].set_title("Conv2D\n(%s)" % list(weights[i][0][0].shape))
        axarr[i, 1].set_title("DepthwiseConv2D\n(%s)" % list(weights[i][1][0].shape))
        axarr[i, 2].set_title("Separable\nin SeparableConv2D\n(%s)" % list(weights[i][2][0].shape))
        axarr[i, 3].set_title("Pointwise\nin SeparableConv2D\n(%s)" % list(weights[i][2][1].shape))

plt.show()
```

### As-is

![before](https://user-images.githubusercontent.com/4445535/50809338-43f0be00-1346-11e9-87f1-efb9494448d4.png)

### To-be

![after](https://user-images.githubusercontent.com/4445535/50809341-46ebae80-1346-11e9-82e9-d9e2a308561f.png)