### PR TITLE
Remove legacy environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,12 +63,6 @@ install:
   # Remove the current backend from the coverage exclusion.
   - sed -i "\/keras\/backend\/${KERAS_BACKEND}_backend.py/d" .coveragerc
 
-  # detect whether core files are changed or not
-  - export CORE_CHANGED=False;
-  - for entry in `git diff --name-only HEAD~1`; do if [[ "$entry" == "keras/backend/"* ]] || [[ "$entry" == "keras/engine/"* ]] || [[ "$entry" == "keras/layers/"* ]]; then export CORE_CHANGED=True; fi; done
-  - export APP_CHANGED=False;
-  - for entry in `git diff --name-only HEAD~1`; do if [[ "$entry" == "keras/applications/"* ]]; then export APP_CHANGED=True; fi; done
-
   # install mkdocs
   - pip install mkdocs --progress-bar off
 

--- a/tests/integration_tests/applications_test.py
+++ b/tests/integration_tests/applications_test.py
@@ -6,12 +6,6 @@ from keras import applications
 from keras import backend as K
 
 
-pytestmark = pytest.mark.skipif(
-    os.environ.get('CORE_CHANGED', 'True') == 'False' and
-    os.environ.get('APP_CHANGED', 'True') == 'False',
-    reason='Runs only when the relevant files have been modified.')
-
-
 MODEL_LIST = [
     (applications.ResNet50, 2048),
     (applications.VGG16, 512),


### PR DESCRIPTION
### Summary

This PR remove legacy environment variables: `CORE_CHANGED`, `APP_CHANGED`. The reason why they were proposed is to skip the unit tests for applications because the app tests are too heavy to test every time Travis is triggered. But now, the app tests have been performing in another repository since `keras-applications` was decoupled. Thus, the related stuffs are no longer needed.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
