### PR TITLE
Add description on depth in model comparison table

### DIFF
--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -188,6 +188,8 @@ model = InceptionV3(input_tensor=input_tensor, weights='imagenet', include_top=T
 
 The top-1 and top-5 accuracy refers to the model's performance on the ImageNet validation dataset.
 
+Depth refers to the topological depth of the network. This includes activation layers, batch normalization layers etc.
+
 -----
 
 


### PR DESCRIPTION
### Summary

The depth field in the model comparison table is ambiguous.

The PR adds a sentence to specify that it refers to the topological depth of network, or the underlying `keras.engine.network` (mentioned in #7837).

Note that novice developers may be confused as the depth is just slightly different from `len(model.layers)`.

<img width="869" alt="screen shot 2019-01-08 at 6 43 53 pm" src="https://user-images.githubusercontent.com/23400562/50822597-71089500-1375-11e9-91bd-14c79c7c33fd.png">

### Related Issues

#7837

### PR Overview

- [ ] This PR requires new unit tests [n]
- [ ] This PR requires to update the documentation [n?]
- [ ] This PR is backwards compatible [n]
- [ ] This PR changes the current API [n]