### PR TITLE
Dynamic Batch Sizes

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -97,7 +97,8 @@ class Model(Network):
 
         # Raises
             ValueError: In case of invalid arguments for
-                `optimizer`, `loss`, `metrics`, `sample_weight_mode`, or `check_array_lengths`
+                `optimizer`, `loss`, `metrics`, `sample_weight_mode`,
+                 or `check_array_lengths`
         """
         self.optimizer = optimizers.get(optimizer)
         self.loss = loss or []

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -99,6 +99,9 @@ class Model(Network):
             ValueError: In case of invalid arguments for
                 `optimizer`, `loss`, `metrics`, `sample_weight_mode`,
                  or `check_array_lengths`
+            NotImplementedError: If `check_array_lengths` is set to True on
+                 the CNTK backend, as CNTK does not support multiple dynamic
+                 axes at present.
         """
         self.optimizer = optimizers.get(optimizer)
         self.loss = loss or []

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -41,7 +41,7 @@ class Model(Network):
                 sample_weight_mode=None,
                 weighted_metrics=None,
                 target_tensors=None,
-                check_array_lengths=False,
+                check_array_lengths=True,
                 **kwargs):
         """Configures the model for training.
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -89,7 +89,7 @@ class Model(Network):
                 and output tensors have a matching batch size for each batch.
                 If you would like to skip this check and allow variable batch
                 sizes among input/output tensors, this parameter can be set
-                to True.
+                to False.
             **kwargs: When using the Theano/CNTK backends, these arguments
                 are passed into `K.function`.
                 When using the TensorFlow backend,

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -41,6 +41,7 @@ class Model(Network):
                 sample_weight_mode=None,
                 weighted_metrics=None,
                 target_tensors=None,
+                check_array_lengths=False,
                 **kwargs):
         """Configures the model for training.
 
@@ -84,6 +85,11 @@ class Model(Network):
                 can specify them via the `target_tensors` argument. It can be
                 a single tensor (for a single-output model), a list of tensors,
                 or a dict mapping output names to target tensors.
+            check_array_lengths: By default, Keras will ensure that all input
+                and output tensors have a matching batch size for each batch.
+                If you would like to skip this check and allow variable batch
+                sizes among input/output tensors, this parameter can be set
+                to True.
             **kwargs: When using the Theano/CNTK backends, these arguments
                 are passed into `K.function`.
                 When using the TensorFlow backend,
@@ -91,7 +97,7 @@ class Model(Network):
 
         # Raises
             ValueError: In case of invalid arguments for
-                `optimizer`, `loss`, `metrics` or `sample_weight_mode`.
+                `optimizer`, `loss`, `metrics`, `sample_weight_mode`, or `check_array_lengths`
         """
         self.optimizer = optimizers.get(optimizer)
         self.loss = loss or []
@@ -99,6 +105,7 @@ class Model(Network):
         self.loss_weights = loss_weights
         self.sample_weight_mode = sample_weight_mode
         self.weighted_metrics = weighted_metrics
+        self.check_array_lengths = check_array_lengths
 
         if not self.built:
             # Model is not compilable because
@@ -644,7 +651,6 @@ class Model(Network):
                                y=None,
                                sample_weight=None,
                                class_weight=None,
-                               check_array_lengths=True,
                                batch_size=None):
         all_inputs = []
         if not self.built:
@@ -801,7 +807,7 @@ class Model(Network):
                     feed_sample_weight_modes)
             ]
             # Check that all arrays have the same length.
-            if check_array_lengths:
+            if self.check_array_lengths:
                 check_array_length_consistency(x, y, sample_weights)
             if self._is_graph_network:
                 # Additional checks to avoid users mistakenly

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -116,7 +116,6 @@ class Model(Network):
                                       'batch sizes. Please set '
                                       'check_array_lengths=True when compiling.')
 
-        
         if not self.built:
             # Model is not compilable because
             # it does not know its number of inputs

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -108,6 +108,12 @@ class Model(Network):
         self.weighted_metrics = weighted_metrics
         self.check_array_lengths = check_array_lengths
 
+        if not self.check_array_lengths and K.backend() == 'cntk':
+            raise NotImplementedError('CNTK backend does not support dynamic '
+                                      'batch sizes. Please set '
+                                      'check_array_lengths=True when compiling.')
+
+        
         if not self.built:
             # Model is not compilable because
             # it does not know its number of inputs

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -1607,7 +1607,9 @@ def test_dynamic_batch_size():
     def dot_prod(inp):
         return K.dot(inp[0], K.transpose(inp[1]))
 
-    output = keras.layers.Lambda(dot_prod)([x1, x2])
+    # output shape is (None, None)
+    output = keras.layers.Lambda(
+        dot_prod, output_shape=(None,))([x1, x2])
 
     model = keras.models.Model(inputs=[input1, input2],
                                outputs=output)

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -324,8 +324,7 @@ def test_model_methods():
         return K.mean(K.pow(y_true - y_pred, 2))
 
     model.compile(optimizer, loss, metrics=[mse],
-                  sample_weight_mode=None,
-                  check_array_lengths=True)
+                  sample_weight_mode=None)
 
     out = model.train_on_batch([input_a_np, input_b_np],
                                [output_a_np, output_b_np])

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -1597,6 +1597,8 @@ def test_sample_weights():
     assert np.allclose(weights, expected)
 
 
+@pytest.mark.skipif((K.backend() == 'cntk'),
+                    reason='cntk does not support dynamic batch sizes yet')
 def test_dynamic_batch_size():
     input1 = keras.layers.Input((10,))
     input2 = keras.layers.Input((10,))

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -1613,7 +1613,7 @@ def test_dynamic_batch_size():
                                outputs=output)
 
     numpy_in1, numpy_in2, numpy_targ = map(np.zeros,
-                                           [(20,10), (10,10), (20,10)])
+                                           [(20, 10), (10, 10), (20, 10)])
 
     pred = model.predict_on_batch([numpy_in1, numpy_in2])
     assert pred.shape == (20, 10)
@@ -1621,9 +1621,10 @@ def test_dynamic_batch_size():
     assert pred.shape == (5, 6)
     model.compile(loss='mse', optimizer='adam', check_array_lengths=False)
     model.train_on_batch([numpy_in1, numpy_in2], numpy_targ)
-    model.train_on_batch([numpy_in1[:3, ...], numpy_in2[:7, ...]], numpy_targ[:3, :7])
-    
-    
+    model.train_on_batch([numpy_in1[:3, ...],
+                          numpy_in2[:7, ...]],
+                         numpy_targ[:3, :7])
+
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
### Summary

Attempt to support dynamic batch sizes by giving API access to the `check_array_lengths` parameter. See https://github.com/keras-team/keras/issues/11993.

`model.predict` already works with dynamic batch sizes, but this PR makes training work too via:

`model.compile( ... , check_array_lengths=False)`

### Related Issues

https://github.com/keras-team/keras/issues/11993

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [n] This PR is backwards compatible [y/n]
- [y] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

PR is not backwards compatible because it doesn't work on the CNTK backend. I don't think CNTK supports multiple dynamic axes, which arise frequently in code enabled by this PR.
