### PR TITLE
Fix doc generation

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -117,8 +117,8 @@ def count_leading_spaces(s):
 def process_list_block(docstring, starting_point, section_end,
                        leading_spaces, marker):
     ending_point = docstring.find('\n\n', starting_point)
-    block = docstring[starting_point:(None if ending_point == -1 else
-                                      ending_point - 1)]
+    block = docstring[starting_point:(ending_point - 1 if ending_point > -1 else
+                                      section_end)]
     # Place marker for later reinjection.
     docstring_slice = docstring[starting_point:section_end].replace(block, marker)
     docstring = (docstring[:starting_point]

--- a/tests/test_doc_auto_generation.py
+++ b/tests/test_doc_auto_generation.py
@@ -362,5 +362,30 @@ def test_doc_multiple_sections_code():
     assert 'def dot(x, y):' in generated
 
 
+test_doc_with_arguments_as_last_block = {
+    'doc': """Base class for recurrent layers.
+
+    # Arguments
+        return_sequences: Boolean. Whether to return the last output
+            in the output sequence, or the full sequence.
+        return_state: Boolean. Whether to return the last state
+            in addition to the output.
+    """,
+    'result': '''Base class for recurrent layers.
+
+__Arguments__
+
+- __return_sequences__: Boolean. Whether to return the last output
+    in the output sequence, or the full sequence.
+- __return_state__: Boolean. Whether to return the last state
+    in addition to the output.
+'''}
+
+
+def test_doc_list_with_argument_as_last_block():
+    docstring = autogen.process_docstring(test_doc_with_arguments_as_last_block['doc'])
+    assert markdown(docstring) == markdown(test_doc_with_arguments_as_last_block['result'])
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
### Summary

Fix display bug in the docs. When Arguments is the last section of a docstring, it generally doesn't display the bullet points of the function arguments properly. This PR fixes this bug.

### Related Issues

https://github.com/keras-team/keras/issues/11673
https://github.com/keras-team/keras/issues/12006

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
