### PR TITLE
Use Python logging instead of printing

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import
 from __future__ import print_function
-import os
-import json
-import sys
+
 import importlib
+import json
+import logging
+import os
+import sys
+
 from .common import epsilon
 from .common import floatx
 from .common import set_epsilon
@@ -12,6 +15,8 @@ from .common import cast_to_floatx
 from .common import image_data_format
 from .common import set_image_data_format
 from .common import normalize_data_format
+
+_logger = logging.getLogger(__name__)
 
 # Set Keras base dir path given KERAS_HOME env variable, if applicable.
 # Otherwise either ~/.keras or /tmp.
@@ -79,13 +84,13 @@ if 'KERAS_BACKEND' in os.environ:
 
 # Import backend functions.
 if _BACKEND == 'cntk':
-    sys.stderr.write('Using CNTK backend\n')
+    _logger.info('Using CNTK backend')
     from .cntk_backend import *
 elif _BACKEND == 'theano':
-    sys.stderr.write('Using Theano backend.\n')
+    _logger.info('Using Theano backend')
     from .theano_backend import *
 elif _BACKEND == 'tensorflow':
-    sys.stderr.write('Using TensorFlow backend.\n')
+    _logger.info('Using TensorFlow backend')
     from .tensorflow_backend import *
 else:
     # Try and load external backend.
@@ -97,15 +102,15 @@ else:
         required_entries = ['placeholder', 'variable', 'function']
         for e in required_entries:
             if e not in entries:
-                raise ValueError('Invalid backend. Missing required entry : ' + e)
+                raise ValueError('Invalid backend. Missing required entry: ' + e)
         namespace = globals()
         for k, v in entries.items():
             # Make sure we don't override any entries from common, such as epsilon.
             if k not in namespace:
                 namespace[k] = v
-        sys.stderr.write('Using ' + _BACKEND + ' backend.\n')
+        _logger.info('Using %s backend', _BACKEND)
     except ImportError:
-        raise ValueError('Unable to import backend : ' + str(_BACKEND))
+        raise ValueError('Unable to import backend: ' + str(_BACKEND))
 
 
 def backend():

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2,23 +2,25 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from collections import defaultdict
+from contextlib import contextmanager
+import logging
+import warnings
+
 import cntk as C
 import numpy as np
+
 from .common import floatx
 from .common import epsilon
 from .common import image_data_format
 from .common import normalize_data_format
 from ..utils.generic_utils import transpose_shape
-from collections import defaultdict
-from contextlib import contextmanager
-import warnings
 
-
+_logger = logging.getLogger(__name__)
 C.set_global_option('align_axis', 1)
 
 b_any = any
 py_slice = slice
-
 
 dev = C.device.use_default_device()
 if dev.type() == 0:
@@ -2705,7 +2707,7 @@ class LambdaFunc(C.ops.functions.UserFunction):
     def __init__(self,
                  arg,
                  when=lambda arg: True,
-                 execute=lambda arg: print(arg),
+                 execute=lambda arg: _logger.info(arg),
                  name=''):
         self.when = when
         self.execute = execute

--- a/keras/backend/numpy_backend.py
+++ b/keras/backend/numpy_backend.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import numpy as np
 import scipy.signal as signal
 import scipy as sp
+
 from keras.backend import floatx
 from keras.utils.generic_utils import transpose_shape
 from keras.utils import to_categorical

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2,6 +2,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from collections import defaultdict
+from distutils.version import StrictVersion
+import os
+
+import numpy as np
 import tensorflow as tf
 from tensorflow.python.framework import ops as tf_ops
 from tensorflow.python.training import moving_averages
@@ -12,18 +17,11 @@ from tensorflow.python.ops import ctc_ops as ctc
 from tensorflow.python.client import device_lib
 from tensorflow.core.protobuf import config_pb2
 
-from collections import defaultdict
-
-import numpy as np
-from distutils.version import StrictVersion
-import os
-
 from .common import floatx
 from .common import epsilon
 from .common import normalize_data_format
 from ..utils.generic_utils import transpose_shape
 from ..utils.generic_utils import has_arg
-
 # Legacy functions
 from .common import set_image_dim_ordering
 from .common import image_dim_ordering

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -4,6 +4,8 @@ from __future__ import print_function
 
 from collections import defaultdict
 from contextlib import contextmanager
+
+import numpy as np
 import theano
 from theano import tensor as T
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
@@ -19,7 +21,6 @@ try:
 except ImportError:
     from theano.sandbox.softsign import softsign as T_softsign
 
-import numpy as np
 from .common import floatx
 from .common import epsilon
 from .common import normalize_data_format
@@ -32,7 +33,6 @@ py_all = all
 py_any = any
 py_sum = sum
 py_slice = slice
-
 
 # INTERNAL UTILS
 theano.config.floatX = floatx()

--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -4,13 +4,18 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-import numpy as np
-import json
-import yaml
-import warnings
 import copy
+import json
 import os
+import warnings
+
+try:
+    import h5py
+except ImportError:
+    h5py = None
+import numpy as np
 from six.moves import zip
+import yaml
 
 from . import saving
 from .base_layer import Layer
@@ -25,11 +30,6 @@ from ..utils.generic_utils import to_list
 from ..utils.generic_utils import object_list_uid
 from ..utils.generic_utils import unpack_singleton
 from ..legacy import interfaces
-
-try:
-    import h5py
-except ImportError:
-    h5py = None
 
 
 class Network(Layer):

--- a/keras/engine/training_arrays.py
+++ b/keras/engine/training_arrays.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import logging
+
 import numpy as np
 from scipy.sparse import issparse
 
@@ -16,6 +18,8 @@ from ..utils.generic_utils import Progbar
 from ..utils.generic_utils import slice_arrays
 from ..utils.generic_utils import to_list
 from ..utils.generic_utils import unpack_singleton
+
+_logger = logging.getLogger(__name__)
 
 
 def fit_loop(model, fit_function, fit_inputs,
@@ -71,8 +75,8 @@ def fit_loop(model, fit_function, fit_inputs,
         do_validation = True
         if (verbose and fit_inputs and
            hasattr(fit_inputs[0], 'shape') and hasattr(val_inputs[0], 'shape')):
-            print('Train on %d samples, validate on %d samples' %
-                  (fit_inputs[0].shape[0], val_inputs[0].shape[0]))
+            _logger.info('Train on %d samples, validate on %d samples',
+                         fit_inputs[0].shape[0], val_inputs[0].shape[0])
     if validation_steps:
         do_validation = True
         if steps_per_epoch is None:

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 from .. import backend
 from .. import utils
 from ..utils import generic_utils
-
 from keras_preprocessing import image
 
 random_rotation = image.random_rotation

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -3,8 +3,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from abc import abstractmethod
+from contextlib import closing
 import hashlib
+import logging
 import multiprocessing as mp
+from multiprocessing.pool import ThreadPool
 import os
 import random
 import shutil
@@ -14,9 +18,6 @@ import threading
 import time
 import warnings
 import zipfile
-from abc import abstractmethod
-from contextlib import closing
-from multiprocessing.pool import ThreadPool
 
 import numpy as np
 import six
@@ -30,6 +31,8 @@ except ImportError:
     import Queue as queue
 
 from ..utils.generic_utils import Progbar
+
+_logger = logging.getLogger(__name__)
 
 if sys.version_info[0] == 2:
     def urlretrieve(url, filename, reporthook=None, data=None):
@@ -195,16 +198,17 @@ def get_file(fname,
         # File found; verify integrity if a hash was provided.
         if file_hash is not None:
             if not validate_file(fpath, file_hash, algorithm=hash_algorithm):
-                print('A local file was found, but it seems to be '
-                      'incomplete or outdated because the ' + hash_algorithm +
-                      ' file hash does not match the original value of ' +
-                      file_hash + ' so we will re-download the data.')
+                _logger.info('A local file was found, but it seems to be '
+                             'incomplete or outdated because the %s file hash '
+                             'does not match the original value of %s so we '
+                             'will re-download the data.', hash_algorithm,
+                             file_hash)
                 download = True
     else:
         download = True
 
     if download:
-        print('Downloading data from', origin)
+        _logger.info('Downloading data from %s', origin)
 
         class ProgressTracker(object):
             # Maintain progbar for the lifetime of download.

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -3,23 +3,23 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import numpy as np
 from collections import defaultdict
+import logging
 import sys
+if sys.version_info[0] == 3:
+    import pickle
+else:
+    import cPickle as pickle
 
-
-import six
 try:
     import h5py
     HDF5_OBJECT_HEADER_LIMIT = 64512
 except ImportError:
     h5py = None
+import numpy as np
+import six
 
-
-if sys.version_info[0] == 3:
-    import pickle
-else:
-    import cPickle as pickle
+_logger = logging.getLogger(__name__)
 
 
 class HDF5Matrix(object):
@@ -162,7 +162,7 @@ def ask_to_proceed_with_overwrite(filepath):
                                     '(cancel).').strip().lower()
     if overwrite == 'n':
         return False
-    print('[TIP] Next time specify overwrite=True!')
+    _logger.info('[TIP] Next time specify overwrite=True!')
     return True
 
 

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -4,9 +4,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import numpy as np
+
 from .conv_utils import convert_kernel
 from .. import backend as K
-import numpy as np
 
 
 def count_params(weights):


### PR DESCRIPTION
### Summary

This PR uses the `logging` package instead of the built-in function `print` to report events. This is the standard practice in Python libraries.
See https://docs.python-guide.org/writing/logging/#or-print for the reasons.

### Related Issues

#7777 and #9272 (duplicate).

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)