### PR TITLE
Adding GELU activation fuction

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -158,6 +158,15 @@ def hard_sigmoid(x):
     return K.hard_sigmoid(x)
 
 
+def gelu(x):
+    """Gaussian Error Linear Units (GELUs)
+    
+    GLUEs are nonconvex, nonmonotonic.
+    """
+    return K.gelu(x)
+
+
+
 def exponential(x):
     """Exponential (base e) activation function.
     """
@@ -211,3 +220,6 @@ def get(identifier):
     else:
         raise ValueError('Could not interpret '
                          'activation function identifier:', identifier)
+
+        
+      

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3614,7 +3614,7 @@ def hard_sigmoid(x):
     x = tf.clip_by_value(x, zero, one)
     return x
 
-def def gelu(x):
+def gelu(x):
     """Gaussian Error Linear Units (GELUs)
     
     GLUEs are nonconvex, nonmonotonic.

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3614,6 +3614,22 @@ def hard_sigmoid(x):
     x = tf.clip_by_value(x, zero, one)
     return x
 
+def def gelu(x):
+    """Gaussian Error Linear Units (GELUs)
+    
+    GLUEs are nonconvex, nonmonotonic.
+    
+    Arguments
+      x: Input tensor.
+    
+    References:
+      Gaussian Error Linear Units (GELUs), Hendrycks et. al, 2018.
+      
+    Links: 
+        [https://arxiv.org/pdf/1606.08415.pdf](https://arxiv.org/pdf/1606.08415.pdf)
+    """
+
+    return 0.5 * x * (1 + tf.tanh(tf.sqrt(2 / np.pi) * (x + 0.044715 * tf.pow(x, 3))))
 
 def tanh(x):
     """Element-wise tanh.

--- a/tests/keras/activations_test.py
+++ b/tests/keras/activations_test.py
@@ -171,7 +171,23 @@ def test_hard_sigmoid():
     expected = hard_sigmoid(test_values)
     assert_allclose(result, expected, rtol=1e-05)
 
+    
+def test_gelu():
+    """Test using a reference
+    """
+    def ref_gelu(x):
+        return 0.5 * x * (1 + np.tanh(np.sqrt(2 / np.pi) * (x + 0.044715 * np.pow(x, 3))))
+    gelu = np.vectorize(ref_gelu)
 
+    x = K.placeholder(ndim=2)
+    f = K.function([x], [activations.gelu(x)])
+    test_values = get_standard_values()
+    
+    result = f([test_values])[0]
+    expected = gelu(test_values)
+    assert_allclose(result, expected, rtol=1e-05)
+    
+    
 def test_relu():
     x = K.placeholder(ndim=2)
     f = K.function([x], [activations.relu(x)])


### PR DESCRIPTION
### Summary
New activation function which performs better than ReLU and ELU on several computer vision, NLP and speech tasks. The explanation is in more detail by authors in very recent paper (Nov 11, 2018) https://arxiv.org/abs/1606.08415

### Related Issues
No issues, it is an add-on in existing activation function list.

### PR Overview
Adding GELUs activation function they are non-convex and non-monotonic compared to ReLU or ELU.
Reference: Gaussian Error Linear Units (GELUs), Hendrycks et. al, 2018.
Link: https://arxiv.org/abs/1606.08415

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
