### PR TITLE
Fix documentation for Masking layer

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -40,8 +40,8 @@ class Masking(Layer):
 
     Consider a Numpy data array `x` of shape `(samples, timesteps, features)`,
     to be fed to an LSTM layer.
-    You want to mask sample #0 timestep #3 and sample #2 timestep #5 because you
-    lack features for these sample timesteps. You can:
+    You want to mask sample #0 at timestep #3, and sample #2 at timestep #5,
+    because you lack features for these sample timesteps. You can do:
 
         - set `x[0, 3, :] = 0.` and `x[2, 5, :] = 0.`
         - insert a `Masking` layer with `mask_value=0.` before the LSTM layer:

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -29,10 +29,9 @@ from ..legacy import interfaces
 class Masking(Layer):
     """Masks a sequence by using a mask value to skip timesteps.
 
-    For each timestep in the input tensor (dimension #1 in the tensor),
-    if all values in the input tensor at that timestep
-    are equal to `mask_value`, then the timestep will be masked (skipped)
-    in all downstream layers (as long as they support masking).
+    If all features for a given sample timestep are equal to `mask_value`,
+    then the sample timestep will be masked (skipped) in all downstream layers
+    (as long as they support masking).
 
     If any downstream layer does not support masking yet receives such
     an input mask, an exception will be raised.
@@ -41,10 +40,10 @@ class Masking(Layer):
 
     Consider a Numpy data array `x` of shape `(samples, timesteps, features)`,
     to be fed to an LSTM layer.
-    You want to mask timestep #3 and #5 because you lack data for
-    these timesteps. You can:
+    You want to mask sample #0 timestep #3 and sample #2 timestep #5 because you
+    lack features for these sample timesteps. You can:
 
-        - set `x[:, 3, :] = 0.` and `x[:, 5, :] = 0.`
+        - set `x[0, 3, :] = 0.` and `x[2, 5, :] = 0.`
         - insert a `Masking` layer with `mask_value=0.` before the LSTM layer:
 
     ```python


### PR DESCRIPTION
### Summary

This PR updates the documentation for the `Masking` layer to reflect the fact that the `Masking` layer works when all values for a given sample and timestep are the mask_value. Previously the description led you to believe that all values for a given timestep had to be the mask_value (across all samples).

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
