### PR TITLE
docs: fix typo

### DIFF
--- a/docs/templates/visualization.md
+++ b/docs/templates/visualization.md
@@ -20,7 +20,7 @@ You can also directly obtain the `pydot.Graph` object and render it yourself,
 for example to show it in an ipython notebook :
 ```python
 from IPython.display import SVG
-from keras.utils import model_to_dot
+from keras.utils.vis_utils import model_to_dot
 
 SVG(model_to_dot(model).create(prog='dot', format='svg'))
 ```


### PR DESCRIPTION
* Fixes typo in documentation.

### Summary
Fixes typo with function import as `from keras.utils import model_to_dot` is no longer available.
### Related Issues
N/A.

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
