### PR TITLE
Cleaning the keras.layers namespace.

### DIFF
--- a/docs/structure.py
+++ b/docs/structure.py
@@ -241,6 +241,7 @@ PAGES = [
             layers.Multiply,
             layers.Average,
             layers.Maximum,
+            layers.Minimum,
             layers.Concatenate,
             layers.Dot,
         ],
@@ -250,6 +251,7 @@ PAGES = [
             layers.multiply,
             layers.average,
             layers.maximum,
+            layers.minimum,
             layers.concatenate,
             layers.dot,
         ]

--- a/keras/layers/__init__.py
+++ b/keras/layers/__init__.py
@@ -1,24 +1,128 @@
 from __future__ import absolute_import
 
-from ..utils.generic_utils import deserialize_keras_object
 from ..engine.base_layer import Layer
 from ..engine import Input
-from ..engine import InputLayer
-from ..engine.base_layer import InputSpec
-from .merge import *
-from .core import *
-from .convolutional import *
-from .pooling import *
-from .local import *
-from .recurrent import *
-from .cudnn_recurrent import *
-from .normalization import *
-from .embeddings import *
-from .noise import *
-from .advanced_activations import *
-from .wrappers import *
-from .convolutional_recurrent import *
-from ..legacy.layers import *
+
+from .merge import Add
+from .merge import Subtract
+from .merge import Multiply
+from .merge import Average
+from .merge import Maximum
+from .merge import Minimum
+from .merge import Concatenate
+from .merge import Dot
+from .merge import add
+from .merge import subtract
+from .merge import multiply
+from .merge import average
+from .merge import maximum
+from .merge import minimum
+from .merge import concatenate
+from .merge import dot
+
+from .core import Dense
+from .core import Activation
+from .core import Dropout
+from .core import Flatten
+from .core import Reshape
+from .core import Permute
+from .core import RepeatVector
+from .core import Lambda
+from .core import ActivityRegularization
+from .core import Masking
+from .core import SpatialDropout1D
+from .core import SpatialDropout2D
+from .core import SpatialDropout3D
+
+from .convolutional import Conv1D
+from .convolutional import Conv2D
+from .convolutional import SeparableConv1D
+from .convolutional import SeparableConv2D
+from .convolutional import DepthwiseConv2D
+from .convolutional import Conv2DTranspose
+from .convolutional import Conv3D
+from .convolutional import Conv3DTranspose
+from .convolutional import Cropping1D
+from .convolutional import Cropping2D
+from .convolutional import Cropping3D
+from .convolutional import UpSampling1D
+from .convolutional import UpSampling2D
+from .convolutional import UpSampling3D
+from .convolutional import ZeroPadding1D
+from .convolutional import ZeroPadding2D
+from .convolutional import ZeroPadding3D
+
+from .pooling import MaxPooling1D
+from .pooling import MaxPooling2D
+from .pooling import MaxPooling3D
+from .pooling import AveragePooling1D
+from .pooling import AveragePooling2D
+from .pooling import AveragePooling3D
+from .pooling import GlobalMaxPooling1D
+from .pooling import GlobalAveragePooling1D
+from .pooling import GlobalMaxPooling2D
+from .pooling import GlobalAveragePooling2D
+from .pooling import GlobalMaxPooling3D
+from .pooling import GlobalAveragePooling3D
+
+from .local import LocallyConnected1D
+from .local import LocallyConnected2D
+
+from .recurrent import RNN
+from .recurrent import SimpleRNN
+from .recurrent import GRU
+from .recurrent import LSTM
+from .recurrent import SimpleRNNCell
+from .recurrent import GRUCell
+from .recurrent import LSTMCell
+
+from .cudnn_recurrent import CuDNNGRU
+from .cudnn_recurrent import CuDNNLSTM
+
+from .normalization import BatchNormalization
+
+from .embeddings import Embedding
+
+from .noise import GaussianNoise
+from .noise import GaussianDropout
+from .noise import AlphaDropout
+
+from .advanced_activations import LeakyReLU
+from .advanced_activations import PReLU
+from .advanced_activations import ELU
+from .advanced_activations import ThresholdedReLU
+from .advanced_activations import Softmax
+from .advanced_activations import ReLU
+
+from .wrappers import Bidirectional
+from .wrappers import TimeDistributed
+
+from .convolutional_recurrent import ConvLSTM2D
+
+# Legacy imports
+from ..legacy.layers import MaxoutDense
+from ..legacy.layers import Highway
+from ..legacy.layers import AtrousConvolution1D
+from ..legacy.layers import AtrousConvolution2D
+from ..legacy.layers import Recurrent
+from ..legacy.layers import ConvRecurrent2D
+from .pooling import MaxPool1D
+from .pooling import MaxPool2D
+from .pooling import MaxPool3D
+from .pooling import AvgPool1D
+from .pooling import AvgPool2D
+from .pooling import AvgPool3D
+from .pooling import GlobalAvgPool1D
+from .pooling import GlobalAvgPool2D
+from .pooling import GlobalAvgPool3D
+from .pooling import GlobalMaxPool1D
+from .pooling import GlobalMaxPool2D
+from .pooling import GlobalMaxPool3D
+from .convolutional import Convolution1D
+from .convolutional import Convolution2D
+from .convolutional import Convolution3D
+from .convolutional import Deconvolution2D
+from .convolutional import Deconvolution3D
 
 
 def serialize(layer):
@@ -49,6 +153,11 @@ def deserialize(config, custom_objects=None):
     globs = globals()  # All layers.
     globs['Model'] = models.Model
     globs['Sequential'] = models.Sequential
+    from keras.engine.input_layer import InputLayer
+    globs['InputLayer'] = InputLayer
+    from .recurrent import StackedRNNCells
+    globs['StackedRNNCells'] = StackedRNNCells
+    from ..utils.generic_utils import deserialize_keras_object
     return deserialize_keras_object(config,
                                     module_objects=globs,
                                     custom_objects=custom_objects,

--- a/keras/layers/cudnn_recurrent.py
+++ b/keras/layers/cudnn_recurrent.py
@@ -9,7 +9,7 @@ from .. import initializers
 from .. import regularizers
 from .. import constraints
 from .recurrent import RNN
-from ..layers import InputSpec
+from keras.engine.base_layer import InputSpec
 
 from collections import namedtuple
 

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -2,7 +2,8 @@ import pytest
 import json
 import numpy as np
 
-from keras.layers import Dense, Dropout, Conv2D, InputLayer
+from keras.layers import Dense, Dropout, Conv2D
+from keras.engine.input_layer import InputLayer
 from keras import layers
 from keras.engine import Input, Layer, saving, get_source_inputs
 from keras.models import Model, Sequential

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -13,7 +13,8 @@ from keras.models import Model, Sequential
 from keras.layers import Dense, Lambda, RepeatVector, TimeDistributed
 from keras.layers import Bidirectional, GRU, LSTM, CuDNNGRU, CuDNNLSTM
 from keras.layers import Conv2D, Flatten
-from keras.layers import Input, InputLayer
+from keras.layers import Input
+from keras.engine.input_layer import InputLayer
 from keras.initializers import Constant
 from keras import optimizers
 from keras import losses


### PR DESCRIPTION
### Summary
This PR is to clean the keras.layers namespace. This namespace have *a lot* of python objects in it which we don't want the users to access.

### Related Issues
#11992

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n] (I hope)
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
