### PR TITLE
Add warnings when trying to compute metrics for an unknown layer

### DIFF
--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -322,6 +322,10 @@ def collect_metrics(metrics, output_names):
         return [copy.copy(metrics) for _ in output_names]
     elif isinstance(metrics, dict):
         nested_metrics = []
+        if not set(metrics.keys()).issubset(set(output_names)):
+            unknown_output_names = list(set(metrics.keys()) - set(output_names))
+            warnings.warn('Invalid layer name for metric computations: '
+                          '{}'.format(unknown_output_names))
         for name in output_names:
             output_metrics = metrics.get(name, [])
             output_metrics = to_list(output_metrics)

--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -325,7 +325,8 @@ def collect_metrics(metrics, output_names):
         if not set(metrics.keys()).issubset(set(output_names)):
             unknown_output_names = list(set(metrics.keys()) - set(output_names))
             warnings.warn('Invalid layer name for metric computations: '
-                          '{}'.format(unknown_output_names))
+                          '{}. Available names are {}.'
+                          .format(unknown_output_names, output_names))
         for name in output_names:
             output_metrics = metrics.get(name, [])
             output_metrics = to_list(output_metrics)

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -734,6 +734,29 @@ def test_check_bad_shape():
     assert 'targets to have the same shape' in str(exc)
 
 
+@pytest.mark.parametrize('input_metrics,expected_output', [
+    (None, [[], []]),
+    (['mse', 'mae'], [['mse', 'mae'], ['mse', 'mae']]),
+    ({'layer_1': 'mae', 'layer_2': 'mse'}, [['mae'], ['mse']]),
+])
+def test_collect_metrics(input_metrics, expected_output):
+    output_names = ['layer_1', 'layer_2']
+
+    output_metrics = training_utils.collect_metrics(input_metrics,
+                                                    output_names)
+    assert output_metrics == expected_output
+
+
+def test_collect_metrics_with_invalid_metrics_format():
+    with pytest.raises(TypeError):
+        training_utils.collect_metrics({'a', 'set', 'type'}, [])
+
+
+def test_collect_metrics_with_invalid_layer_name():
+    with pytest.warns(Warning):
+        training_utils.collect_metrics({'unknown_layer': 'mse'}, ['layer_1'])
+
+
 @pytest.mark.skipif(K.backend() != 'tensorflow',
                     reason='Requires TensorFlow backend')
 def test_model_with_input_feed_tensor():

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -753,8 +753,11 @@ def test_collect_metrics_with_invalid_metrics_format():
 
 
 def test_collect_metrics_with_invalid_layer_name():
-    with pytest.warns(Warning):
+    with pytest.warns(Warning) as w:
         training_utils.collect_metrics({'unknown_layer': 'mse'}, ['layer_1'])
+
+    warning_raised = all(['unknown_layer' in str(w_.message) for w_ in w])
+    assert warning_raised, 'Warning was raised for unknown_layer'
 
 
 @pytest.mark.skipif(K.backend() != 'tensorflow',


### PR DESCRIPTION
### Summary

When giving unknown layer name in `metrics` to `model.compile`, will raise a warning instead of saying silent.

### Related Issues

fixes #12068 

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
