### PR TITLE
Updating old method to prevent test failure in the future

### DIFF
--- a/keras/utils/conv_utils.py
+++ b/keras/utils/conv_utils.py
@@ -79,7 +79,7 @@ def convert_kernel(kernel):
     slices = [slice(None, None, -1) for _ in range(kernel.ndim)]
     no_flip = (slice(None, None), slice(None, None))
     slices[-2:] = no_flip
-    return np.copy(kernel[slices])
+    return np.copy(kernel[tuple(slices)])
 
 
 def conv_output_length(input_length, filter_size,


### PR DESCRIPTION
### Summary
When running tests, this appeared in the output: 
```src/keras/utils/conv_utils.py:82: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.```

### PR Overview

This PR is created to fix that error. 

- [ ] This PR requires new unit tests [n] (make sure tests are included)
- [ ] This PR requires to update the documentation [n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y]
- [ ] This PR changes the current API [n] (all API changes need to be approved by fchollet)
