### PR TITLE
Clarify expected label formats for crossentropy losses

### DIFF
--- a/docs/templates/losses.md
+++ b/docs/templates/losses.md
@@ -36,10 +36,5 @@ from keras.utils import to_categorical
 categorical_labels = to_categorical(int_labels, num_classes=None)
 ```
 
-When using the `sparse_categorical_crossentropy` loss, your targets should be *integer targets*. If you have categorical targets, you could either use `categorical_crossentropy`, or convert your targets to integer targets:
-
-```python
-import numpy as np
-
-integer_labels = np.argmax(categorical_labels, axis=1)
-```
+When using the `sparse_categorical_crossentropy` loss, your targets should be *integer targets*.
+If you have categorical targets, you should use `categorical_crossentropy`.

--- a/docs/templates/losses.md
+++ b/docs/templates/losses.md
@@ -35,3 +35,11 @@ from keras.utils import to_categorical
 
 categorical_labels = to_categorical(int_labels, num_classes=None)
 ```
+
+When using the `sparse_categorical_crossentropy` loss, your targets should be *integer targets*. If you have categorical targets, you could either use `categorical_crossentropy`, or convert your targets to integer targets:
+
+```python
+import numpy as np
+
+integer_labels = np.argmax(categorical_labels, axis=1)
+```


### PR DESCRIPTION
### Summary

Adds more clarification as to what label format/shape the two categorical loss functions are expecting. The difference has bit me before.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
