### PR TITLE
fixed callback warning error

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -91,8 +91,8 @@ class CallbackList(object):
            delta_t_median > 0.1):
             warnings.warn(
                 'Method (%s) is slow compared '
-                'to the batch update (%f). Check your callbacks.', hook_name,
-                delta_t_median)
+                'to the batch update (%f). Check your callbacks.'
+                % (hook_name, delta_t_median), RuntimeWarning)
         if hook == 'begin':
             self._t_enter_batch = time.time()
 


### PR DESCRIPTION
### Summary
Fixed the callback warning error from #12069 
It was caused by wrong use of the formatting: used "," instead of "%" to concatenate string and its variable 

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
