### PR TITLE
Update Dense Layer documentation in core.py

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -793,8 +793,8 @@ class Dense(Layer):
     created by the layer, and `bias` is a bias vector created by the layer
     (only applicable if `use_bias` is `True`).
 
-    Note: if the input to the layer has a rank greater than 2, then
-    it is flattened prior to the initial dot product with `kernel`.
+    Note: The input has to be of rank 2. Use the TimeDistributed wrapper
+          for inputs with rank greater than 2.
 
     # Example
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -794,6 +794,7 @@ class Dense(Layer):
     (only applicable if `use_bias` is `True`).
 
     Note: The input has to be of rank 2. Use the TimeDistributed wrapper
+        or add a Flatten layer before the Dense layer
         for inputs with rank greater than 2.
 
     # Example

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -794,7 +794,7 @@ class Dense(Layer):
     (only applicable if `use_bias` is `True`).
 
     Note: The input has to be of rank 2. Use the TimeDistributed wrapper
-          for inputs with rank greater than 2.
+        for inputs with rank greater than 2.
 
     # Example
 


### PR DESCRIPTION
### Summary
I have changed the documentation for the Dense layer in core.py (in the layers folder). I have specified
that the Dense layer only takes 2-d input and users need to use the TimeDistributed wrapper or add a Flatten layer before the Dense layer for 3-d inputs.

### Related Issues
[This issue](https://github.com/keras-team/keras/issues/10736)

### PR Overview
Update docs for Dense in core.py

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
