### PR TITLE
Add issue template that redirect to KP

### DIFF
--- a/.github/ISSUE_TEMPLATE/d--keras-preprocessing-users.md
+++ b/.github/ISSUE_TEMPLATE/d--keras-preprocessing-users.md
@@ -1,0 +1,12 @@
+---
+name: a) `keras.preprocessing` users
+about: Select this if your issue is related to the `keras.preprocessing` module.
+
+---
+
+
+The [keras-preprocessing](https://github.com/keras-team/keras-preprocessing) module has been splitted from the main Keras repository.
+
+Please submit your issue using this [link](https://github.com/keras-team/keras-preprocessing/issues/new/choose).
+
+Thank you!

--- a/.github/ISSUE_TEMPLATE/d--keras-preprocessing-users.md
+++ b/.github/ISSUE_TEMPLATE/d--keras-preprocessing-users.md
@@ -1,11 +1,11 @@
 ---
-name: a) `keras.preprocessing` users
+name: d) `keras.preprocessing` users
 about: Select this if your issue is related to the `keras.preprocessing` module.
 
 ---
 
 
-The [keras-preprocessing](https://github.com/keras-team/keras-preprocessing) module has been splitted from the main Keras repository.
+The [keras.preprocessing](https://github.com/keras-team/keras-preprocessing) module has been splitted from the main Keras repository.
 
 Please submit your issue using this [link](https://github.com/keras-team/keras-preprocessing/issues/new/choose).
 

--- a/.github/ISSUE_TEMPLATE/e--keras-applications-users.md
+++ b/.github/ISSUE_TEMPLATE/e--keras-applications-users.md
@@ -1,0 +1,12 @@
+---
+name: e) `keras.applications` users
+about: Select this if your issue is related to the `keras.applications` module.
+
+---
+
+
+The [keras.applications](https://github.com/keras-team/keras-applications) module has been splitted from the main Keras repository.
+
+Please submit your issue using this [link](https://github.com/keras-team/keras-applications/issues/new/choose).
+
+Thank you!

--- a/.github/ISSUE_TEMPLATE/e--keras-applications-users.md
+++ b/.github/ISSUE_TEMPLATE/e--keras-applications-users.md
@@ -7,6 +7,6 @@ about: Select this if your issue is related to the `keras.applications` module.
 
 The [keras.applications](https://github.com/keras-team/keras-applications) module has been splitted from the main Keras repository.
 
-Please submit your issue using this [link](https://github.com/keras-team/keras-applications/issues/new/choose).
+Please submit your issue using this [link](https://github.com/keras-team/keras-applications/issues/new).
 
 Thank you!


### PR DESCRIPTION
### Summary
I'm not sure that this is the right way, feel free to comment.

Basically, we see a lot KP issues in the Keras issue tab. This is an attempt to fix this.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
