### PR TITLE
Keep input types with Lambda layers

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -22,7 +22,6 @@ from ..utils.generic_utils import func_dump
 from ..utils.generic_utils import func_load
 from ..utils.generic_utils import deserialize_keras_object
 from ..utils.generic_utils import has_arg
-from ..utils import conv_utils
 from ..legacy import interfaces
 
 
@@ -644,6 +643,7 @@ class Lambda(Layer):
                  mask=None, arguments=None, **kwargs):
         super(Lambda, self).__init__(**kwargs)
         self.function = function
+        self.input_dtypes = None
         self.arguments = arguments if arguments else {}
         if mask is not None:
             self.supports_masking = True
@@ -664,10 +664,11 @@ class Lambda(Layer):
             # With TensorFlow or CNTK, we can infer the output shape directly:
             if K.backend() in ('tensorflow', 'cntk'):
                 if isinstance(input_shape, list):
-                    xs = [K.placeholder(shape=shape) for shape in input_shape]
+                    xs = [K.placeholder(shape=shape, dtype=dtype)
+                          for shape, dtype in zip(input_shape, self.input_dtypes)]
                     x = self.call(xs)
                 else:
-                    x = K.placeholder(shape=input_shape)
+                    x = K.placeholder(shape=input_shape, dtype=self.input_dtypes)
                     x = self.call(x)
                 if isinstance(x, list):
                     return [K.int_shape(x_elem) for x_elem in x]
@@ -703,6 +704,10 @@ class Lambda(Layer):
         arguments = self.arguments
         if has_arg(self.function, 'mask'):
             arguments['mask'] = mask
+        if isinstance(inputs, list):
+            self.input_dtypes = [K.dtype(x) for x in inputs]
+        else:
+            self.input_dtypes = K.dtype(inputs)
         return self.function(inputs, **arguments)
 
     def compute_mask(self, inputs, mask=None):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -643,7 +643,7 @@ class Lambda(Layer):
                  mask=None, arguments=None, **kwargs):
         super(Lambda, self).__init__(**kwargs)
         self.function = function
-        self.input_dtypes = None
+        self._input_dtypes = None
         self.arguments = arguments if arguments else {}
         if mask is not None:
             self.supports_masking = True
@@ -665,10 +665,10 @@ class Lambda(Layer):
             if K.backend() in ('tensorflow', 'cntk'):
                 if isinstance(input_shape, list):
                     xs = [K.placeholder(shape=shape, dtype=dtype)
-                          for shape, dtype in zip(input_shape, self.input_dtypes)]
+                          for shape, dtype in zip(input_shape, self._input_dtypes)]
                     x = self.call(xs)
                 else:
-                    x = K.placeholder(shape=input_shape, dtype=self.input_dtypes)
+                    x = K.placeholder(shape=input_shape, dtype=self._input_dtypes)
                     x = self.call(x)
                 if isinstance(x, list):
                     return [K.int_shape(x_elem) for x_elem in x]
@@ -705,9 +705,9 @@ class Lambda(Layer):
         if has_arg(self.function, 'mask'):
             arguments['mask'] = mask
         if isinstance(inputs, list):
-            self.input_dtypes = [K.dtype(x) for x in inputs]
+            self._input_dtypes = [K.dtype(x) for x in inputs]
         else:
-            self.input_dtypes = K.dtype(inputs)
+            self._input_dtypes = K.dtype(inputs)
         return self.function(inputs, **arguments)
 
     def compute_mask(self, inputs, mask=None):

--- a/tests/keras/layers/core_test.py
+++ b/tests/keras/layers/core_test.py
@@ -244,14 +244,14 @@ def test_lambda():
 
     def test_dtypes():
         def func(x):
-            if K.dtype(x) != 'int32':
-                raise TypeError('x dtype is not int32, it is', K.dtype(x))
+            if K.dtype(x) != 'float16':
+                raise TypeError('x dtype is not float16, it is', K.dtype(x))
             return x
 
-        i = layers.Input(shape=(3, 2, 1), dtype='int32')
+        i = layers.Input(shape=(3, 2, 1), dtype='float16')
         o = layers.Lambda(func)
         _ = o(i)
-        assert o.input_dtypes == 'int32'
+        assert o.input_dtypes == 'float16'
     test_dtypes()
 
     # test serialization with function

--- a/tests/keras/layers/core_test.py
+++ b/tests/keras/layers/core_test.py
@@ -242,6 +242,18 @@ def test_lambda():
 
     test_multiple_outputs_no_mask()
 
+    def test_dtypes():
+        def func(x):
+            if K.dtype(x) != 'int32':
+                raise TypeError('x dtype is not int32, it is', K.dtype(x))
+            return x
+
+        i = layers.Input(shape=(3, 2, 1), dtype='int32')
+        o = layers.Lambda(func)
+        _ = o(i)
+        assert o.input_dtypes == 'int32'
+    test_dtypes()
+
     # test serialization with function
     def f(x):
         return x + 1

--- a/tests/keras/layers/core_test.py
+++ b/tests/keras/layers/core_test.py
@@ -251,7 +251,7 @@ def test_lambda():
         i = layers.Input(shape=(3, 2, 1), dtype='float16')
         o = layers.Lambda(func)
         _ = o(i)
-        assert o.input_dtypes == 'float16'
+        assert o._input_dtypes == 'float16'
     test_dtypes()
 
     # test serialization with function


### PR DESCRIPTION
### Summary
When computing the output shape, we create a dummy placeholder, but the dtype is not carried.

### Related Issues
Fixes #12121

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
