### PR TITLE
Fix spelling mistake in SELU docs

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -58,7 +58,7 @@ def selu(x):
     """Scaled Exponential Linear Unit (SELU).
 
     SELU is equal to: `scale * elu(x, alpha)`, where alpha and scale
-    are pre-defined constants. The values of `alpha` and `scale` are
+    are predefined constants. The values of `alpha` and `scale` are
     chosen so that the mean and variance of the inputs are preserved
     between two consecutive layers as long as the weights are initialized
     correctly (see `lecun_normal` initialization) and the number of inputs


### PR DESCRIPTION
### Summary
Fixed a spelling mistake in SELU documentation in activations.py. (pre-defined --> predefined)

### Related Issues
None

### PR Overview
Fix spelling error in docs.

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
