### PR TITLE
Update top_k_categorical_accuracy to handle 3 dim

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -44,7 +44,10 @@ def sparse_categorical_accuracy(y_true, y_pred):
 
 
 def top_k_categorical_accuracy(y_true, y_pred, k=5):
-    return K.mean(K.in_top_k(y_pred, K.argmax(y_true, axis=-1), k), axis=-1)
+    number_of_categories = K.int_shape(y_true)[-1]
+    return K.mean(K.in_top_k(K.reshape(y_pred, (-1, number_of_categories)),
+                  K.argmax(K.reshape(y_true, (-1, number_of_categories)),
+                           axis=-1), k), axis=-1)
 
 
 def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -83,8 +83,24 @@ def test_invalid_get():
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='CNTK backend does not support top_k yet')
 def test_top_k_categorical_accuracy():
+    # 2d tests - shape: (batch_size, number_of_categories)
     y_pred = K.variable(np.array([[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]))
     y_true = K.variable(np.array([[0, 1, 0], [1, 0, 0]]))
+    success_result = K.eval(metrics.top_k_categorical_accuracy(y_true, y_pred,
+                                                               k=3))
+    assert success_result == 1
+    partial_result = K.eval(metrics.top_k_categorical_accuracy(y_true, y_pred,
+                                                               k=2))
+    assert partial_result == 0.5
+    failure_result = K.eval(metrics.top_k_categorical_accuracy(y_true, y_pred,
+                                                               k=1))
+    assert failure_result == 0
+
+    # 3d tests - example shape: (batch_size, sequence_size, number_of_categories)
+    y_pred = K.variable(np.array([[[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]],
+                                  [[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]]))
+    y_true = K.variable(np.array([[[0, 1, 0], [1, 0, 0]],
+                                  [[0, 1, 0], [1, 0, 0]]]))
     success_result = K.eval(metrics.top_k_categorical_accuracy(y_true, y_pred,
                                                                k=3))
     assert success_result == 1


### PR DESCRIPTION
### Summary
Currently, `top_k_categorical_accuracy` only works with 2 dimentional data : **(batch_size, categories)**
This PR improves `top_k_categorical_accuracy` such that it handles 3 dimentional data such as sequence with shape: **(batch_size, sequence_size, categories)** by first converting the data to shape: **(-1, categories)**

### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
