### PR TITLE
Added pull request templates.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/a--bug-fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/a--bug-fix.md
@@ -1,0 +1,19 @@
+---
+name: a) Bug fix
+about: Select this if you're fixing a bug in Keras.
+
+---
+
+<!--
+Please make sure you've read and understood our contributing guidelines;
+https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
+-->
+
+**- What bug I fixed**
+
+This pull request fixes #issue_number_here .
+
+**- How I fixed it**
+
+**- How you can verify it**
+<!-- You need a good justification for not including tests for the bug you fixed. -->

--- a/.github/PULL_REQUEST_TEMPLATE/a--bug-fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/a--bug-fix.md
@@ -1,7 +1,7 @@
 ---
 name: a) Bug fix
 about: Select this if you're fixing a bug in Keras.
-
+labels: bugfix
 ---
 
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE/b--new-feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/b--new-feature.md
@@ -1,0 +1,27 @@
+---
+name: b) New feature
+about: Select this if you're adding a new feature to Keras.
+
+---
+
+<!--
+Please make sure you've read and understood our contributing guidelines;
+https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
+-->
+
+This pull request closes #issue_number_here .
+
+**- What I did**
+
+**- How I did it**
+
+**- How to verify it**
+<!-- 
+You need a good justification for not 
+including tests for the new feature you added. 
+-->
+
+
+- [ ] I updated the docs.
+
+This pull request adds a new feature to Keras. @fchollet, could you please take a look at it?

--- a/.github/PULL_REQUEST_TEMPLATE/b--new-feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/b--new-feature.md
@@ -1,7 +1,8 @@
 ---
 name: b) New feature
 about: Select this if you're adding a new feature to Keras.
-
+labels: feature
+assignees: fchollet
 ---
 
 <!--

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+<!--
+Please make sure you've read and understood our contributing guidelines;
+https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
+-->
+
 ### Summary
 
 ### Related Issues


### PR DESCRIPTION
### Summary

We often see PRs without the keyword fixes #{issue_number} and PRs without unit tests. That's an issue.

### Related Issues

### PR Overview

I propose PR templates with some decent defaults. I based this on moby/moby PR template which I think is quite good. I hope it makes us more productive.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
