### PR TITLE
Using shutil rather than copying the tree manually in autogen.py

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -369,15 +369,7 @@ def generate():
         shutil.rmtree('sources')
 
     print('Populating sources directory with templates.')
-    for subdir, dirs, fnames in os.walk('templates'):
-        for fname in fnames:
-            new_subdir = subdir.replace('templates', 'sources')
-            if not os.path.exists(new_subdir):
-                os.makedirs(new_subdir)
-            if fname[-3:] == '.md':
-                fpath = os.path.join(subdir, fname)
-                new_fpath = fpath.replace('templates', 'sources')
-                shutil.copy(fpath, new_fpath)
+    shutil.copytree('templates', 'sources')
 
     readme = read_file('../README.md')
     index = read_file('templates/index.md')


### PR DESCRIPTION
### Summary

In autogen.py, we copy template into sources and then work on it. But we copy the tree manually. `shutil` has a function for this purpose.

### Related Issues

### PR Overview

 In the loop, we copy only markdown files. But all the files in `templates` are markdown files so it's fine.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
