### PR TITLE
Stateful metrics for Precision, Recall, and F-Beta Scores

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -64,8 +64,10 @@ class Precision(Layer):
     def __init__(self, name='precision', **kwargs):
         super(Precision, self).__init__(name=name, **kwargs)
         self.stateful = True
-        self.true_positives = K.variable(value=0, dtype='float32', name='true_positives')
-        self.predicted_positives = K.variable(value=0, dtype='float32', name='predicted_positives')
+        self.true_positives = K.variable(value=0, dtype='float32',
+                                         name='true_positives')
+        self.predicted_positives = K.variable(value=0, dtype='float32',
+                                              name='predicted_positives')
 
     def reset_states(self):
         K.set_value(self.true_positives, 0)
@@ -77,9 +79,11 @@ class Precision(Layer):
         correct_preds = K.cast(K.equal(y_pred, y_true), 'float32')
         true_pos = K.cast(K.sum(correct_preds * y_true), 'float32')
         predicted_pos = K.cast(K.sum(K.round(K.clip(y_pred, 0, 1))), 'float32')
-        updates = [K.update_add(self.true_positives, true_pos), K.update_add(self.predicted_positives, predicted_pos)]
+        updates = [K.update_add(self.true_positives, true_pos),
+                   K.update_add(self.predicted_positives, predicted_pos)]
         self.add_update(updates, inputs=[y_true, y_pred])
-        return (self.true_positives * 1) / ((K.epsilon() + self.predicted_positives) * 1)
+        return (self.true_positives * 1) / \
+               ((K.epsilon() + self.predicted_positives) * 1)
 
 
 class Recall(Layer):
@@ -92,8 +96,10 @@ class Recall(Layer):
     def __init__(self, name='recall', **kwargs):
         super(Recall, self).__init__(name=name, **kwargs)
         self.stateful = True
-        self.true_positives = K.variable(value=0, dtype='float32', name='true_positives')
-        self.actual_positives = K.variable(value=0, dtype='float32', name='actual_positives')
+        self.true_positives = K.variable(value=0, dtype='float32',
+                                         name='true_positives')
+        self.actual_positives = K.variable(value=0, dtype='float32',
+                                           name='actual_positives')
 
     def reset_states(self):
         K.set_value(self.true_positives, 0)
@@ -105,9 +111,11 @@ class Recall(Layer):
         correct_preds = K.cast(K.equal(y_pred, y_true), 'float32')
         true_pos = K.cast(K.sum(correct_preds * y_true), 'float32')
         actual_pos = K.cast(K.sum(K.round(K.clip(y_true, 0, 1))), 'float32')
-        updates = [K.update_add(self.true_positives, true_pos), K.update_add(self.actual_positives, actual_pos)]
+        updates = [K.update_add(self.true_positives, true_pos),
+                   K.update_add(self.actual_positives, actual_pos)]
         self.add_update(updates, inputs=[y_true, y_pred])
-        return (self.true_positives * 1) / ((self.actual_positives + K.epsilon()) * 1)
+        return (self.true_positives * 1) / \
+               ((self.actual_positives + K.epsilon()) * 1)
 
 
 class FBetaScore(Layer):
@@ -131,9 +139,12 @@ class FBetaScore(Layer):
         super(FBetaScore, self).__init__(name=name, **kwargs)
         self.beta = beta
         self.stateful = True
-        self.true_positives = K.variable(value=0, dtype='float32', name='true_positives')
-        self.false_positives = K.variable(value=0, dtype='float32', name='false_positives')
-        self.false_negatives = K.variable(value=0, dtype='float32', name='false_negatives')
+        self.true_positives = K.variable(value=0, dtype='float32',
+                                         name='true_positives')
+        self.false_positives = K.variable(value=0, dtype='float32',
+                                          name='false_positives')
+        self.false_negatives = K.variable(value=0, dtype='float32',
+                                          name='false_negatives')
 
     def reset_states(self):
         K.set_value(self.true_positives, 0)
@@ -159,7 +170,9 @@ class FBetaScore(Layer):
                    K.update_add(self.false_negatives, fn)]
         self.add_update(updates, inputs=[y_true, y_pred])
 
-        return ((1 + self.beta ** 2) * self.true_positives) / (((1 + self.beta ** 2) * self.true_positives + K.epsilon()) + (self.beta ** 2) * self.false_negatives + self.false_positives)
+        return ((1 + self.beta ** 2) * self.true_positives) / \
+               (((1 + self.beta ** 2) * self.true_positives + K.epsilon()) +
+                (self.beta ** 2) * self.false_negatives + self.false_positives)
 
 
 # Aliases

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import six
 from . import backend as K
+from .engine.base_layer import Layer
 from .losses import mean_squared_error
 from .losses import mean_absolute_error
 from .losses import mean_absolute_percentage_error
@@ -53,6 +54,35 @@ def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):
                   axis=-1)
 
 
+class Precision(Layer):
+    """Precision metric.
+        Computes a stateful representation of precision,
+        a metric for multi-label classification of
+        how many selected items are relevant.
+        """
+
+    def __init__(self, name='precision', **kwargs):
+        super(Precision, self).__init__(name=name, **kwargs)
+        self.stateful = True
+        self.true_positives = K.variable(value=0, dtype='float32', name='true_positives')
+        self.predicted_positives = K.variable(value=0, dtype='float32', name='predicted_positives')
+
+    def reset_states(self):
+        K.set_value(self.true_positives, 0)
+        K.set_value(self.predicted_positives, 0)
+
+    def __call__(self, y_true, y_pred):
+        y_true = K.cast(y_true, 'float32')
+        y_pred = K.cast(K.round(y_pred), 'float32')
+        correct_preds = K.cast(K.equal(y_pred, y_true), 'float32')
+        true_pos = K.cast(K.sum(correct_preds * y_true), 'float32')
+        predicted_pos = K.cast(K.sum(K.round(K.clip(y_pred, 0, 1))), 'float32')
+        updates = [K.update_add(self.true_positives, true_pos), K.update_add(self.predicted_positives, predicted_pos)]
+        self.add_update(updates, inputs=[y_true, y_pred])
+        precision = (self.true_positives * 1) / ((K.epsilon() + self.predicted_positives) * 1)
+        return precision
+
+
 # Aliases
 
 mse = MSE = mean_squared_error
@@ -60,6 +90,7 @@ mae = MAE = mean_absolute_error
 mape = MAPE = mean_absolute_percentage_error
 msle = MSLE = mean_squared_logarithmic_error
 cosine = cosine_proximity
+precision = Precision()
 
 
 def serialize(metric):

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -64,26 +64,26 @@ class Precision(Layer):
     def __init__(self, name='precision', **kwargs):
         super(Precision, self).__init__(name=name, **kwargs)
         self.stateful = True
-        self.true_positives = K.variable(value=0, dtype='float32',
+        self.true_positives = K.variable(value=0.0, dtype='float32',
                                          name='true_positives')
-        self.predicted_positives = K.variable(value=0, dtype='float32',
+        self.predicted_positives = K.variable(value=0.0, dtype='float32',
                                               name='predicted_positives')
 
     def reset_states(self):
-        K.set_value(self.true_positives, 0)
-        K.set_value(self.predicted_positives, 0)
+        K.set_value(self.true_positives, 0.0)
+        K.set_value(self.predicted_positives, 0.0)
 
     def __call__(self, y_true, y_pred):
         y_true = K.cast(y_true, 'float32')
         y_pred = K.cast(K.round(y_pred), 'float32')
         correct_preds = K.cast(K.equal(y_pred, y_true), 'float32')
         true_pos = K.cast(K.sum(correct_preds * y_true), 'float32')
-        predicted_pos = K.cast(K.sum(K.round(K.clip(y_pred, 0, 1))), 'float32')
+        predicted_pos = K.cast(K.sum(K.round(K.clip(y_pred, 0.0, 1.0))), 'float32')
         updates = [K.update_add(self.true_positives, true_pos),
                    K.update_add(self.predicted_positives, predicted_pos)]
         self.add_update(updates, inputs=[y_true, y_pred])
-        return (self.true_positives * 1) / \
-               ((K.epsilon() + self.predicted_positives) * 1)
+        return (self.true_positives * 1.0) / \
+               ((K.epsilon() + self.predicted_positives) * 1.0)
 
 
 class Recall(Layer):
@@ -96,26 +96,26 @@ class Recall(Layer):
     def __init__(self, name='recall', **kwargs):
         super(Recall, self).__init__(name=name, **kwargs)
         self.stateful = True
-        self.true_positives = K.variable(value=0, dtype='float32',
+        self.true_positives = K.variable(value=0.0, dtype='float32',
                                          name='true_positives')
-        self.actual_positives = K.variable(value=0, dtype='float32',
+        self.actual_positives = K.variable(value=0.0, dtype='float32',
                                            name='actual_positives')
 
     def reset_states(self):
-        K.set_value(self.true_positives, 0)
-        K.set_value(self.actual_positives, 0)
+        K.set_value(self.true_positives, 0.0)
+        K.set_value(self.actual_positives, 0.0)
 
     def __call__(self, y_true, y_pred):
         y_true = K.cast(y_true, 'float32')
         y_pred = K.cast(K.round(y_pred), 'float32')
         correct_preds = K.cast(K.equal(y_pred, y_true), 'float32')
         true_pos = K.cast(K.sum(correct_preds * y_true), 'float32')
-        actual_pos = K.cast(K.sum(K.round(K.clip(y_true, 0, 1))), 'float32')
+        actual_pos = K.cast(K.sum(K.round(K.clip(y_true, 0.0, 1.0))), 'float32')
         updates = [K.update_add(self.true_positives, true_pos),
                    K.update_add(self.actual_positives, actual_pos)]
         self.add_update(updates, inputs=[y_true, y_pred])
-        return (self.true_positives * 1) / \
-               ((self.actual_positives + K.epsilon()) * 1)
+        return (self.true_positives * 1.0) / \
+               ((self.actual_positives + K.epsilon()) * 1.0)
 
 
 class FBetaScore(Layer):
@@ -139,27 +139,27 @@ class FBetaScore(Layer):
         super(FBetaScore, self).__init__(name=name, **kwargs)
         self.beta = beta
         self.stateful = True
-        self.true_positives = K.variable(value=0, dtype='float32',
+        self.true_positives = K.variable(value=0.0, dtype='float32',
                                          name='true_positives')
-        self.false_positives = K.variable(value=0, dtype='float32',
+        self.false_positives = K.variable(value=0.0, dtype='float32',
                                           name='false_positives')
-        self.false_negatives = K.variable(value=0, dtype='float32',
+        self.false_negatives = K.variable(value=0.0, dtype='float32',
                                           name='false_negatives')
 
     def reset_states(self):
-        K.set_value(self.true_positives, 0)
-        K.set_value(self.false_positives, 0)
-        K.set_value(self.false_negatives, 0)
+        K.set_value(self.true_positives, 0.0)
+        K.set_value(self.false_positives, 0.0)
+        K.set_value(self.false_negatives, 0.0)
 
     def __call__(self, y_true, y_pred):
         y_true = K.cast(y_true, 'float32')
         y_pred = K.cast(K.round(y_pred), 'float32')
 
-        y_pred_pos = K.round(K.clip(y_pred, 0, 1))
-        y_pred_neg = 1 - y_pred_pos
+        y_pred_pos = K.round(K.clip(y_pred, 0.0, 1.0))
+        y_pred_neg = 1.0 - y_pred_pos
 
-        y_pos = K.round(K.clip(y_true, 0, 1))
-        y_neg = 1 - y_pos
+        y_pos = K.round(K.clip(y_true, 0.0, 1.0))
+        y_neg = 1.0 - y_pos
 
         tp = K.cast(K.sum(y_pos * y_pred_pos), 'float32')
         fp = K.cast(K.sum(y_neg * y_pred_pos), 'float32')
@@ -170,8 +170,8 @@ class FBetaScore(Layer):
                    K.update_add(self.false_negatives, fn)]
         self.add_update(updates, inputs=[y_true, y_pred])
 
-        return ((1 + self.beta ** 2) * self.true_positives) / \
-               (((1 + self.beta ** 2) * self.true_positives + K.epsilon()) +
+        return ((1.0 + self.beta ** 2) * self.true_positives) / \
+               (((1.0 + self.beta ** 2) * self.true_positives + K.epsilon()) +
                 (self.beta ** 2) * self.false_negatives + self.false_positives)
 
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -110,6 +110,58 @@ class Recall(Layer):
         return (self.true_positives * 1) / ((self.actual_positives + K.epsilon()) * 1)
 
 
+class FBetaScore(Layer):
+    """Computes the F score.
+    The F score is the weighted harmonic mean of precision and recall.
+    This is useful for multi-label classification, where input samples can be
+    classified as sets of labels. By only using accuracy (precision) a model
+    would achieve a perfect score by simply assigning every class to every
+    input. In order to avoid this, a metric should penalize incorrect class
+    assignments as well (recall). The F-beta score (ranged from 0.0 to 1.0)
+    computes this, as a weighted mean of the proportion of correct class
+    assignments vs. the proportion of incorrect class assignments.
+    With beta = 1, this is equivalent to a F-measure. With beta < 1, assigning
+    correct classes becomes more important, and with beta > 1 the metric is
+    instead weighted towards penalizing incorrect class assignments.
+    """
+
+    def __init__(self, name='fbeta_score', beta=1, **kwargs):
+        if beta < 0:
+            raise ValueError('The lowest choosable beta is zero (only precision).')
+        super(FBetaScore, self).__init__(name=name, **kwargs)
+        self.beta = beta
+        self.stateful = True
+        self.true_positives = K.variable(value=0, dtype='float32', name='true_positives')
+        self.false_positives = K.variable(value=0, dtype='float32', name='false_positives')
+        self.false_negatives = K.variable(value=0, dtype='float32', name='false_negatives')
+
+    def reset_states(self):
+        K.set_value(self.true_positives, 0)
+        K.set_value(self.false_positives, 0)
+        K.set_value(self.false_negatives, 0)
+
+    def __call__(self, y_true, y_pred):
+        y_true = K.cast(y_true, 'float32')
+        y_pred = K.cast(K.round(y_pred), 'float32')
+
+        y_pred_pos = K.round(K.clip(y_pred, 0, 1))
+        y_pred_neg = 1 - y_pred_pos
+
+        y_pos = K.round(K.clip(y_true, 0, 1))
+        y_neg = 1 - y_pos
+
+        tp = K.cast(K.sum(y_pos * y_pred_pos), 'float32')
+        fp = K.cast(K.sum(y_neg * y_pred_pos), 'float32')
+        fn = K.cast(K.sum(y_pos * y_pred_neg), 'float32')
+
+        updates = [K.update_add(self.true_positives, tp),
+                   K.update_add(self.false_positives, fp),
+                   K.update_add(self.false_negatives, fn)]
+        self.add_update(updates, inputs=[y_true, y_pred])
+
+        return ((1 + self.beta ** 2) * self.true_positives) / (((1 + self.beta ** 2) * self.true_positives + K.epsilon()) + (self.beta ** 2) * self.false_negatives + self.false_positives)
+
+
 # Aliases
 
 mse = MSE = mean_squared_error
@@ -119,6 +171,7 @@ msle = MSLE = mean_squared_logarithmic_error
 cosine = cosine_proximity
 precision = Precision()
 recall = Recall()
+f1 = fscore = f1score = fmeasure = FBetaScore(name='f1_score', beta=1)
 
 
 def serialize(metric):

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -258,11 +258,11 @@ def test_precision(metrics_mode):
                       loss='binary_crossentropy',
                       metrics={'out': ['acc', metric_fn]})
 
-    samples = 1000
+    samples = 10000
     x = np.random.random((samples, 2))
     y = np.random.randint(low=0, high=2, size=(samples, 1))
 
-    val_samples = 10
+    val_samples = 1000
     val_x = np.random.random((val_samples, 2))
     val_y = np.random.randint(low=0, high=2, size=(val_samples, 1))
 
@@ -278,15 +278,13 @@ def test_precision(metrics_mode):
         return tp / (tp + fp)
 
     # Test correctness (e.g. updates should have been run)
-    np.testing.assert_allclose(outs[2], ref_precision(y, preds), atol=1e-3)
+    np.testing.assert_allclose(outs[2], ref_precision(y, preds), atol=1e-2)
 
     # Test correctness of the validation metric computation
     val_preds = model.predict(val_x)
     val_outs = model.evaluate(val_x, val_y, batch_size=10)
-    print('val_outs:')
-    print(val_outs)
-    assert_allclose(val_outs[2], ref_precision(val_y, val_preds), atol=1e-3)
-    assert_allclose(val_outs[2], history.history['val_precision'][-1], atol=1e-3)
+    assert_allclose(val_outs[2], ref_precision(val_y, val_preds), atol=1e-2)
+    assert_allclose(val_outs[2], history.history['val_precision'][-1], atol=1e-2)
 
 
 @pytest.mark.parametrize('metrics_mode', ['list', 'dict'])
@@ -311,11 +309,11 @@ def test_recall(metrics_mode):
                       loss='binary_crossentropy',
                       metrics={'out': ['acc', metric_fn]})
 
-    samples = 1000
+    samples = 10000
     x = np.random.random((samples, 2))
     y = np.random.randint(low=0, high=2, size=(samples, 1))
 
-    val_samples = 10
+    val_samples = 1000
     val_x = np.random.random((val_samples, 2))
     val_y = np.random.randint(low=0, high=2, size=(val_samples, 1))
 
@@ -336,8 +334,6 @@ def test_recall(metrics_mode):
     # Test correctness of the validation metric computation
     val_preds = model.predict(val_x)
     val_outs = model.evaluate(val_x, val_y, batch_size=10)
-    print('val_outs:')
-    print(val_outs)
     assert_allclose(val_outs[2], ref_recall(val_y, val_preds), atol=1e-2)
     assert_allclose(val_outs[2], history.history['val_recall'][-1], atol=1e-2)
 
@@ -364,11 +360,11 @@ def test_f1(metrics_mode):
                       loss='binary_crossentropy',
                       metrics={'out': ['acc', metric_fn]})
 
-    samples = 1000
+    samples = 10000
     x = np.random.random((samples, 2))
     y = np.random.randint(low=0, high=2, size=(samples, 1))
 
-    val_samples = 10
+    val_samples = 1000
     val_x = np.random.random((val_samples, 2))
     val_y = np.random.randint(low=0, high=2, size=(val_samples, 1))
 
@@ -390,8 +386,6 @@ def test_f1(metrics_mode):
     # Test correctness of the validation metric computation
     val_preds = model.predict(val_x)
     val_outs = model.evaluate(val_x, val_y, batch_size=10)
-    print('val_outs:')
-    print(val_outs)
     assert_allclose(val_outs[2], ref_f1(val_y, val_preds), atol=1e-2)
     assert_allclose(val_outs[2], history.history['val_f1_score'][-1], atol=1e-2)
 

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -242,14 +242,19 @@ def test_precision(metrics_mode):
     outputs = keras.layers.Dense(1, activation='sigmoid', name='out')(inputs)
     model = keras.Model(inputs, outputs)
 
+    metric_fn = metrics.Precision()
+    config = metrics.serialize(metric_fn)
+    metric_fn = metrics.deserialize(
+        config, custom_objects={'precision': metrics.Precision()})
+
     if metrics_mode == 'list':
         model.compile(optimizer='sgd',
                       loss='binary_crossentropy',
-                      metrics=['acc', 'precision'])
+                      metrics=['acc', metric_fn])
     elif metrics_mode == 'dict':
         model.compile(optimizer='sgd',
                       loss='binary_crossentropy',
-                      metrics={'out': ['acc', 'precision']})
+                      metrics={'out': ['acc', metric_fn]})
 
     samples = 1000
     x = np.random.random((samples, 2))
@@ -290,14 +295,19 @@ def test_recall(metrics_mode):
     outputs = keras.layers.Dense(1, activation='sigmoid', name='out')(inputs)
     model = keras.Model(inputs, outputs)
 
+    metric_fn = metrics.Recall()
+    config = metrics.serialize(metric_fn)
+    metric_fn = metrics.deserialize(
+        config, custom_objects={'recall': metrics.Recall()})
+
     if metrics_mode == 'list':
         model.compile(optimizer='sgd',
                       loss='binary_crossentropy',
-                      metrics=['acc', 'recall'])
+                      metrics=['acc', metric_fn])
     elif metrics_mode == 'dict':
         model.compile(optimizer='sgd',
                       loss='binary_crossentropy',
-                      metrics={'out': ['acc', 'recall']})
+                      metrics={'out': ['acc', metric_fn]})
 
     samples = 1000
     x = np.random.random((samples, 2))
@@ -338,14 +348,19 @@ def test_f1(metrics_mode):
     outputs = keras.layers.Dense(1, activation='sigmoid', name='out')(inputs)
     model = keras.Model(inputs, outputs)
 
+    metric_fn = metrics.f1
+    config = metrics.serialize(metric_fn)
+    metric_fn = metrics.deserialize(
+        config, custom_objects={'f1': metrics.f1})
+
     if metrics_mode == 'list':
         model.compile(optimizer='sgd',
                       loss='binary_crossentropy',
-                      metrics=['acc', 'f1'])
+                      metrics=['acc', metric_fn])
     elif metrics_mode == 'dict':
         model.compile(optimizer='sgd',
                       loss='binary_crossentropy',
-                      metrics={'out': ['acc', 'f1']})
+                      metrics={'out': ['acc', metric_fn]})
 
     samples = 1000
     x = np.random.random((samples, 2))

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -330,5 +330,54 @@ def test_recall(metrics_mode):
     assert_allclose(val_outs[2], history.history['val_recall'][-1], atol=1e-2)
 
 
+@pytest.mark.parametrize('metrics_mode', ['list', 'dict'])
+@flaky(rerun_filter=lambda err, *args: issubclass(err[0], AssertionError))
+def test_f1(metrics_mode):
+    np.random.seed(47)
+    inputs = keras.Input(shape=(2,))
+    outputs = keras.layers.Dense(1, activation='sigmoid', name='out')(inputs)
+    model = keras.Model(inputs, outputs)
+
+    if metrics_mode == 'list':
+        model.compile(optimizer='sgd',
+                      loss='binary_crossentropy',
+                      metrics=['acc', 'f1'])
+    elif metrics_mode == 'dict':
+        model.compile(optimizer='sgd',
+                      loss='binary_crossentropy',
+                      metrics={'out': ['acc', 'f1']})
+
+    samples = 1000
+    x = np.random.random((samples, 2))
+    y = np.random.randint(low=0, high=2, size=(samples, 1))
+
+    val_samples = 10
+    val_x = np.random.random((val_samples, 2))
+    val_y = np.random.randint(low=0, high=2, size=(val_samples, 1))
+
+    # Test fit and evaluate
+    history = model.fit(x, y, validation_data=(val_x, val_y),
+                        epochs=1, batch_size=10)
+    outs = model.evaluate(x, y, batch_size=10)
+    preds = model.predict(x)
+
+    def ref_f1(y_true, y_pred):
+        tp = np.sum(np.logical_and(y_pred >= 0.5, y_true == 1))
+        fp = np.sum(np.logical_and(y_pred >= 0.5, y_true == 0))
+        fn = np.sum(np.logical_and(y_pred < 0.5, y_true == 1))
+        return 2 * tp / (2 * tp + fn + fp)
+
+    # Test correctness (e.g. updates should have been run)
+    np.testing.assert_allclose(outs[2], ref_f1(y, preds), atol=1e-2)
+
+    # Test correctness of the validation metric computation
+    val_preds = model.predict(val_x)
+    val_outs = model.evaluate(val_x, val_y, batch_size=10)
+    print('val_outs:')
+    print(val_outs)
+    assert_allclose(val_outs[2], ref_f1(val_y, val_preds), atol=1e-2)
+    assert_allclose(val_outs[2], history.history['val_f1_score'][-1], atol=1e-2)
+
+
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -282,5 +282,53 @@ def test_precision(metrics_mode):
     assert_allclose(val_outs[2], history.history['val_precision'][-1], atol=1e-3)
 
 
+@pytest.mark.parametrize('metrics_mode', ['list', 'dict'])
+@flaky(rerun_filter=lambda err, *args: issubclass(err[0], AssertionError))
+def test_recall(metrics_mode):
+    np.random.seed(47)
+    inputs = keras.Input(shape=(2,))
+    outputs = keras.layers.Dense(1, activation='sigmoid', name='out')(inputs)
+    model = keras.Model(inputs, outputs)
+
+    if metrics_mode == 'list':
+        model.compile(optimizer='sgd',
+                      loss='binary_crossentropy',
+                      metrics=['acc', 'recall'])
+    elif metrics_mode == 'dict':
+        model.compile(optimizer='sgd',
+                      loss='binary_crossentropy',
+                      metrics={'out': ['acc', 'recall']})
+
+    samples = 1000
+    x = np.random.random((samples, 2))
+    y = np.random.randint(low=0, high=2, size=(samples, 1))
+
+    val_samples = 10
+    val_x = np.random.random((val_samples, 2))
+    val_y = np.random.randint(low=0, high=2, size=(val_samples, 1))
+
+    # Test fit and evaluate
+    history = model.fit(x, y, validation_data=(val_x, val_y),
+                        epochs=1, batch_size=10)
+    outs = model.evaluate(x, y, batch_size=10)
+    preds = model.predict(x)
+
+    def ref_recall(y_true, y_pred):
+        tp = np.sum(np.logical_and(y_pred >= 0.5, y_true == 1))
+        fn = np.sum(np.logical_and(y_pred < 0.5, y_true == 1))
+        return tp / (tp + fn)
+
+    # Test correctness (e.g. updates should have been run)
+    np.testing.assert_allclose(outs[2], ref_recall(y, preds), atol=1e-2)
+
+    # Test correctness of the validation metric computation
+    val_preds = model.predict(val_x)
+    val_outs = model.evaluate(val_x, val_y, batch_size=10)
+    print('val_outs:')
+    print(val_outs)
+    assert_allclose(val_outs[2], ref_recall(val_y, val_preds), atol=1e-2)
+    assert_allclose(val_outs[2], history.history['val_recall'][-1], atol=1e-2)
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
### Summary
This PR adds 3 stateful metrics - precision, recall, and fbeta score. 

### Related Issues
#8657 

### PR Overview

- [y ] This PR requires new unit tests [y/n] (make sure tests are included)
- [n ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y ] This PR is backwards compatible [y/n]
- [y ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)