### PR TITLE
Support tuple/list as axis argument in BatchNormalizatio` layer

### DIFF
--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -75,7 +75,10 @@ class BatchNormalization(Layer):
                  **kwargs):
         super(BatchNormalization, self).__init__(**kwargs)
         self.supports_masking = True
-        self.axis = axis
+        if isinstance(axis, list):
+            self.axis = axis[:]
+        else:
+            self.axis = axis
         self.momentum = momentum
         self.epsilon = epsilon
         self.center = center

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -77,6 +77,8 @@ class BatchNormalization(Layer):
         self.supports_masking = True
         if isinstance(axis, list):
             self.axis = axis[:]
+        elif isinstance(axis, tuple):
+            self.axis = list(axis)[:]
         else:
             self.axis = axis
         self.momentum = momentum

--- a/tests/keras/layers/normalization_test.py
+++ b/tests/keras/layers/normalization_test.py
@@ -34,6 +34,16 @@ def test_basic_batchnorm():
                        'moving_mean_initializer': 'zeros',
                        'moving_variance_initializer': 'ones'},
                input_shape=(3, 4, 2, 4))
+    layer_test(normalization.BatchNormalization,
+               kwargs={'momentum': 0.9,
+                       'epsilon': 0.1,
+                       'axis': (1)},
+               input_shape=(1, 4, 1))
+    layer_test(normalization.BatchNormalization,
+               kwargs={'momentum': 0.9,
+                       'epsilon': 0.1,
+                       'axis': [1]},
+               input_shape=(1, 4, 1))
     if K.backend() != 'theano':
         layer_test(normalization.BatchNormalization,
                    kwargs={'momentum': 0.9,


### PR DESCRIPTION
### Summary
This PR add support tuple/list as `axis` argument in `BatchNormalization` layer, as implemented in `tf.keras.layers.BatchNormalization`
### Related Issues
This PR solves issue https://github.com/keras-team/keras/issues/12126
### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
