### PR TITLE
add warning about validation_split

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -997,6 +997,9 @@ class Model(Network):
                     'If your data is in the form of symbolic tensors, '
                     'you cannot use `validation_split`.')
             do_validation = True
+            warnings.warn('Validation data is selected from the last samples '
+                          'in the `x` and `y` data provided, before shuffling.',
+                          category=Warning)
             if hasattr(x[0], 'shape'):
                 split_at = int(int(x[0].shape[0]) * (1. - validation_split))
             else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Adding a warning describing the way validation data is selected when `model.fit` is run with `validation_split`.
The fact that `validation_split` simply selects the last examples from the data set is not obvious and displaying this warning would surely save plenty of time anyone who may assume otherwise as well as serve as a reminder to those who might not have considered it an issue.

### Related Issues

### PR Overview

- [x] This PR requires new unit tests [n] (make sure tests are included)
- [x] This PR requires to update the documentation [n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y]
- [x] This PR changes the current API [n] (all API changes need to be approved by fchollet)
