### PR TITLE
Fix documentation rendering issue

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -101,7 +101,7 @@ def class_to_source_link(cls):
 
 def code_snippet(snippet):
     result = '```python\n'
-    result += snippet + '\n'
+    result += snippet.encode('unicode_escape').decode('utf8') + '\n'
     result += '```\n'
     return result
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
`\n` and `\t` was being rendered as actual newline and tabs in documentation ([see here](https://keras.io/preprocessing/text/)) of `keras.preprocessing.text`. This PR fixes it.

### Related Issues
[#146 in keras-preprocessing](https://github.com/keras-team/keras-preprocessing/issues/146)
### PR Overview

- [N] This PR requires new unit tests [y/n] (make sure tests are included)
- [Y] This PR ~requires~ is an to update the documentation [y/n] (make sure the docs are up-to-date)
- [Y] This PR is backwards compatible [y/n]
- [Y] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
