### PR TITLE
Fix clone_model

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -139,7 +139,8 @@ def _clone_functional_model(model, input_tensors=None):
                         layer(computed_tensor, **kwargs))
                     output_masks = to_list(
                         layer.compute_mask(computed_tensor,
-                                           computed_mask))
+                                           computed_mask)) \
+                        if layer.supports_masking else [None] * len(output_tensors)
                     computed_tensors = [computed_tensor]
                     computed_masks = [computed_mask]
                 else:
@@ -152,7 +153,8 @@ def _clone_functional_model(model, input_tensors=None):
                         layer(computed_tensors, **kwargs))
                     output_masks = to_list(
                         layer.compute_mask(computed_tensors,
-                                           computed_masks))
+                                           computed_masks)) \
+                        if layer.supports_masking else [None] * len(output_tensors)
                 # Update tensor_map.
                 for x, y, mask in zip(reference_output_tensors,
                                       output_tensors,

--- a/keras/models.py
+++ b/keras/models.py
@@ -137,10 +137,12 @@ def _clone_functional_model(model, input_tensors=None):
                             kwargs['mask'] = computed_mask
                     output_tensors = to_list(
                         layer(computed_tensor, **kwargs))
-                    output_masks = to_list(
-                        layer.compute_mask(computed_tensor,
-                                           computed_mask)) \
-                        if layer.supports_masking else [None] * len(output_tensors)
+                    if layer.supports_masking:
+                        output_masks = to_list(
+                            layer.compute_mask(computed_tensor,
+                                               computed_mask))
+                    else:
+                        output_masks = [None] * len(output_tensors)
                     computed_tensors = [computed_tensor]
                     computed_masks = [computed_mask]
                 else:
@@ -151,10 +153,12 @@ def _clone_functional_model(model, input_tensors=None):
                             kwargs['mask'] = computed_masks
                     output_tensors = to_list(
                         layer(computed_tensors, **kwargs))
-                    output_masks = to_list(
-                        layer.compute_mask(computed_tensors,
-                                           computed_masks)) \
-                        if layer.supports_masking else [None] * len(output_tensors)
+                    if layer.supports_masking:
+                        output_masks = to_list(
+                            layer.compute_mask(computed_tensors,
+                                               computed_masks))
+                    else:
+                        output_masks = [None] * len(output_tensors)
                 # Update tensor_map.
                 for x, y, mask in zip(reference_output_tensors,
                                       output_tensors,

--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -342,7 +342,7 @@ def test_clone_functional_model():
 def test_clone_functional_model_with_multi_outputs():
     input_layer = keras.Input(shape=(4,))
 
-    # Layer with single input and multiply outputs
+    # Layer with single input and multiple outputs
     layer1 = keras.layers.Lambda(lambda x: [x + 1, x],
                                  lambda shapes: [shapes, shapes])
     x_a, x_b = layer1(input_layer)
@@ -354,7 +354,7 @@ def test_clone_functional_model_with_multi_outputs():
         def compute_output_shape(self, input_shape):
             return [input_shape[1], input_shape[0]]
 
-    # Layer with multiply inputs and outputs
+    # Layer with multiple inputs and outputs
     x_a, x_b = SwapLayer()([x_a, x_b])
     model = keras.Model(inputs=[input_layer], outputs=[x_a, x_b])
     new_model = keras.models.clone_model(model)

--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -343,7 +343,8 @@ def test_clone_functional_model_with_multi_outputs():
     input_layer = keras.Input(shape=(4,))
 
     # Layer with single input and multiply outputs
-    layer1 = keras.layers.Lambda(lambda x: [x + 1, x], lambda shapes: [shapes, shapes])
+    layer1 = keras.layers.Lambda(lambda x: [x + 1, x],
+                                 lambda shapes: [shapes, shapes])
     x_a, x_b = layer1(input_layer)
 
     class SwapLayer(keras.layers.Layer):

--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -343,15 +343,15 @@ def test_clone_functional_model_with_multi_outputs():
     input_layer = keras.Input(shape=(4,))
 
     # Layer with single input and multiply outputs
-    x_a, x_b = keras.layers.Lambda(lambda x: [x + 1, x])(input_layer)
+    layer1 = keras.layers.Lambda(lambda x: [x + 1, x], lambda shapes: [shapes, shapes])
+    x_a, x_b = layer1(input_layer)
 
     class SwapLayer(keras.layers.Layer):
         def call(self, inputs, **kwargs):
             return [inputs[1], inputs[0]]
 
         def compute_output_shape(self, input_shape):
-            x, y = input_shape
-            return [(y[0], y[1:]), (x[0], x[1:])]
+            return [input_shape[1], input_shape[0]]
 
     # Layer with multiply inputs and outputs
     x_a, x_b = SwapLayer()([x_a, x_b])


### PR DESCRIPTION
### Summary

Try to fix a bug inside `keras.models._clone_functional_model`, which can cause an error when clone a model containing a layer with 2 or more outputs

I'm not sure whether or not the issue needs a new unit test.. In fact I faced it when I'm using `multi_gpu_model` as mentioned in my earlier issue，so maybe it's a better idea to do some more test on 
`multi_gpu_model` instead (but I have no idea about that...)

### Related Issues

https://github.com/keras-team/keras/issues/12202

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
