### PR TITLE
Avoiding hardcoding paths when generating examples in the docs.

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -336,19 +336,20 @@ def get_module_docstring(filepath):
     return docstring, co.co_firstlineno
 
 
-def copy_examples():
+def copy_examples(examples_dir, destination_dir):
     """Copy the examples directory in the documentation.
 
     Prettify files by extracting the docstrings written in Markdown.
     """
-    pathlib.Path('sources/examples').mkdir(exist_ok=True)
-    for file in os.listdir('../examples'):
+    pathlib.Path(destination_dir).mkdir(exist_ok=True)
+    for file in os.listdir(examples_dir):
         if not file.endswith('.py'):
             continue
-        docstring, starting_line = get_module_docstring('../examples/' + file)
-        destination_file = 'sources/examples/' + file[:-2] + 'md'
+        module_path = os.path.join(examples_dir, file)
+        docstring, starting_line = get_module_docstring(module_path)
+        destination_file = os.path.join(destination_dir, file[:-2] + 'md')
         with open(destination_file, 'w+') as f_out, \
-                open('../examples/' + file, 'r+') as f_in:
+                open(os.path.join(examples_dir , file), 'r+') as f_in:
 
             f_out.write(docstring + '\n\n')
 
@@ -458,7 +459,8 @@ def generate():
 
     shutil.copyfile(os.path.join(keras_dir, 'CONTRIBUTING.md'),
                     os.path.join(sources_dir, 'contributing.md'))
-    copy_examples()
+    copy_examples(os.path.join(keras_dir, 'examples'),
+                  os.path.join(sources_dir, 'examples'))
 
 
 if __name__ == '__main__':

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -349,7 +349,7 @@ def copy_examples(examples_dir, destination_dir):
         docstring, starting_line = get_module_docstring(module_path)
         destination_file = os.path.join(destination_dir, file[:-2] + 'md')
         with open(destination_file, 'w+') as f_out, \
-                open(os.path.join(examples_dir , file), 'r+') as f_in:
+                open(os.path.join(examples_dir, file), 'r+') as f_in:
 
             f_out.write(docstring + '\n\n')
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

In the function `copy_examples` of `autogen.py`, the paths were hardcoded. Using relative paths will allow us more flexibility, so the ability to run the script in tests and also in the future, use this autogen.py in keras-contrib.

### Related Issues

https://github.com/keras-team/keras-contrib/issues/412

### PR Overview

The source and destination can now be specified at runtime.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
