### PR TITLE
Skipping tests when py2 on other backends than tensorflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ script:
     elif [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0 && py.test tests/test_documentation.py && cd docs && python autogen.py && mkdocs build;
     elif [[ "RUN_ONLY_BACKEND_TESTS" == "1" ]]; then
-      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/keras/backend/
+      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/keras/backend/;
     else
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --ignore=tests/keras/legacy/layers_test.py --cov-config .coveragerc --cov=keras tests/;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ matrix:
         - python: 3.6
           env: KERAS_BACKEND=tensorflow
         - python: 2.7
-          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile MKL="mkl mkl-service"
+          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile MKL="mkl mkl-service" RUN_ONLY_BACKEND_TESTS=1
         - python: 3.6
           env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile MKL="mkl mkl-service"
         - python: 2.7
-          env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
+          env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore RUN_ONLY_BACKEND_TESTS=1
         - python: 3.6
           env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
 install:
@@ -81,6 +81,8 @@ script:
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/integration_tests;
     elif [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0 && py.test tests/test_documentation.py && cd docs && python autogen.py && mkdocs build;
+    elif [[ "RUN_ONLY_BACKEND_TESTS" == "1" ]]; then
+      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/keras/backend/
     else
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --ignore=tests/keras/legacy/layers_test.py --cov-config .coveragerc --cov=keras tests/;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ script:
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/integration_tests;
     elif [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0 && py.test tests/test_documentation.py && cd docs && python autogen.py && mkdocs build;
-    elif [[ "RUN_ONLY_BACKEND_TESTS" == "1" ]]; then
+    elif [[ "$RUN_ONLY_BACKEND_TESTS" == "1" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/keras/backend/;
     else
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --ignore=tests/keras/legacy/layers_test.py --cov-config .coveragerc --cov=keras tests/;

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ script:
     elif [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0 && py.test tests/test_documentation.py && cd docs && python autogen.py && mkdocs build;
     elif [[ "$RUN_ONLY_BACKEND_TESTS" == "1" ]]; then
-      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/keras/backend/;
+      PYTHONPATH=$PWD:$PYTHONPATH py.test  tests/keras/backend/;
     else
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --ignore=tests/keras/legacy/layers_test.py --cov-config .coveragerc --cov=keras tests/;
     fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

I believe that we should cover the entier codebase with tests for both python 2 and python 3. But this is overkill to run all tests with all backends on python2. 

### Related Issues

### PR Overview

Now theano with python 2 runs only the backend tests and cntk with python 2 runs only the backend tests.

We save 4 minutes in the theano build and 1 minute in the cntk build.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
