### PR TITLE
Add MarkDown formatting to examples/cifar10_cnn.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -71,3 +71,4 @@ nav:
   - Addition RNN: examples/addition_rnn.md
   - Baby RNN: examples/babi_rnn.md
   - Baby MemNN: examples/babi_memnn.md
+  - CIFAR-10 CNN: examples/cifar10_cnn.md

--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -1,4 +1,5 @@
-'''Train a simple deep CNN on the CIFAR10 small images dataset.
+'''
+#Train a simple deep CNN on the CIFAR10 small images dataset.
 
 It gets to 75% validation accuracy in 25 epochs, and 79% after 50 epochs.
 (it's still underfitting at that point, though).


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
This PR adds MarkDown formatting to ```examples/cifar10_cnn.py```.
Result:
![cifar_10_cnn1](https://user-images.githubusercontent.com/3424796/52439260-f9b05780-2b12-11e9-8aa1-49b2bf5a4ec1.png)
![cifar_10_cnn2](https://user-images.githubusercontent.com/3424796/52439261-fa48ee00-2b12-11e9-883b-4bba1e58ff99.png)
### Related Issues
https://github.com/keras-team/keras/issues/12219
### PR Overview
- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
