### PR TITLE
Added MarkDown formatting to examples/cifar10_cnn_capsule.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,3 +72,4 @@ nav:
   - Baby RNN: examples/babi_rnn.md
   - Baby MemNN: examples/babi_memnn.md
   - CIFAR-10 CNN: examples/cifar10_cnn.md
+  - CIFAR-10 CNN-Capsule: examples/cifar10_cnn_capsule.md

--- a/examples/cifar10_cnn_capsule.py
+++ b/examples/cifar10_cnn_capsule.py
@@ -1,4 +1,5 @@
-"""Train a simple CNN-Capsule Network on the CIFAR10 small images dataset.
+"""
+#Train a simple CNN-Capsule Network on the CIFAR10 small images dataset.
 
 Without Data Augmentation:
 It gets to 75% validation accuracy in 10 epochs,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
This PR adds markdown formatting to ```examples/cifar10_cnn_capsule.py```.
Result:
![cifar10_cnn_capsule1](https://user-images.githubusercontent.com/3424796/52479096-65400680-2b9f-11e9-93c3-9bb1ded46a25.png)
![cifar10_cnn_capsule2](https://user-images.githubusercontent.com/3424796/52479095-65400680-2b9f-11e9-9276-f82c79434169.png)
### Related Issues
https://github.com/keras-team/keras/issues/12219
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
