### PR TITLE
Use RandomState instead of global random seed in Orthogonal initializer

### DIFF
--- a/keras/initializers.py
+++ b/keras/initializers.py
@@ -249,8 +249,10 @@ class Orthogonal(Initializer):
         num_cols = shape[-1]
         flat_shape = (num_rows, num_cols)
         if self.seed is not None:
-            np.random.seed(self.seed)
-        a = np.random.normal(0.0, 1.0, flat_shape)
+            random_state = np.random.RandomState(self.seed)
+            a = random_state.normal(0.0, 1.0, flat_shape)
+        else:
+            a = np.random.normal(0.0, 1.0, flat_shape)
         u, _, v = np.linalg.svd(a, full_matrices=False)
         # Pick the one with the correct shape.
         q = u if u.shape == flat_shape else v


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
`np.random.seed` modifies global seed that other packages or programs where Keras is being imported into have access to. This may lead to confusion and errors.  

### Related Issues

### PR Overview
It looks like seeding random globally is not required in Orthogonal initializer. 
Using `np.random.RandomState` instead of global `np.random.seed` to generate normal distribution. 


- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)