### PR TITLE
Errors while Loading  Model

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -531,9 +531,10 @@ def load_model(filepath, custom_objects=None, compile=True):
         raise ImportError('`load_model` requires h5py.')
     model = None
     opened_new_file = not isinstance(filepath, h5py.Group)
-    h5dict = H5Dict(filepath, 'r')
+    h5dict = H5Dict(filepath, 'a')
     try:
-        model = _deserialize_model(h5dict, custom_objects, compile)
+        model = _deserialize_model(h5dict, custom_objects, compile) 
+    except AttributeError: pass
     finally:
         if opened_new_file:
             h5dict.close()


### PR DESCRIPTION
### Summary
Running on Python 3.6 on MacOS

If a model file doesn't exist, I was having this error thrown:

Unable to create group (no write intent on file)

The fix for this is explained here: 
https://stackoverflow.com/questions/15192874/i-cant-read-data-back-in-using-h5py-unable-to-create-group


I then had an error with:

'Group' object has no attribute 'decode'

According to https://stackoverflow.com/questions/28583565/str-object-has-no-attribute-decode-python-3-error

This error was generated due to decoding a string that is already in UTF-8 and is safe to ignore.

This patch fixes both of these things.

### Related Issues

https://github.com/keras-team/keras/issues/6005
https://github.com/keras-team/keras/issues/12195

### PR Overview
- [ Dunno] This PR requires new unit tests [y/n] (make sure tests are included)
- [No ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ Dunno] This PR is backwards compatible [y/n]
- [No ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
