### PR TITLE
Added MarkDown formatting to examples/cifar10_cnn_tfaugment2d.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -73,3 +73,4 @@ nav:
   - Baby MemNN: examples/babi_memnn.md
   - CIFAR-10 CNN: examples/cifar10_cnn.md
   - CIFAR-10 CNN-Capsule: examples/cifar10_cnn_capsule.md
+  - CIFAR-10 CNN with augmentation (TF): examples/cifar10_cnn_tfaugment2d.md

--- a/examples/cifar10_cnn_tfaugment2d.py
+++ b/examples/cifar10_cnn_tfaugment2d.py
@@ -1,34 +1,36 @@
-'''Train a simple deep CNN on the CIFAR10 small images dataset.
+'''
+#Train a simple deep CNN on the CIFAR10 small images dataset using augmentation.
 
-Using Tensorflow internal augmentation APIs by replacing ImageGenerator with
+Using TensorFlow internal augmentation APIs by replacing ImageGenerator with
 an embedded AugmentLayer using LambdaLayer, which is faster on GPU.
 
-# Benchmark of `ImageGenerator` vs `AugmentLayer` both using augmentation 2D:
+** Benchmark of `ImageGenerator`(IG) vs `AugmentLayer`(AL) both using augmentation
+2D:**
+
 (backend = Tensorflow-GPU, Nvidia Tesla P100-SXM2)
 
+Epoch no. | IG %Accuracy   | IG Performance | AL %Accuracy  | AL Performance
+---------:|---------------:|---------------:|--------------:|--------------:
+1         | 44.84          | 15 ms/step     | 45.54         | 358 us/step
+2         | 52.34          |  8 ms/step     | 50.55         | 285 us/step
+8         | 65.45          |  8 ms/step     | 65.59         | 281 us/step
+25        | 76.74          |  8 ms/step     | 76.17         | 280 us/step
+100       | 78.81          |  8 ms/step     | 78.70         | 285 us/step
+
 Settings: horizontal_flip = True
-----------------------------------------------------------------------------
-Epoch     | ImageGenerator | ImageGenerator | AugmentLayer  | Augment Layer
-Number    | %Accuracy      | Performance    | %Accuracy     | Performance
-----------------------------------------------------------------------------
-1         | 44.84          | 15ms/step      | 45.54         | 358us/step
-2         | 52.34          |  8ms/step      | 50.55         | 285us/step
-8         | 65.45          |  8ms/step      | 65.59         | 281us/step
-25        | 76.74          |  8ms/step      | 76.17         | 280us/step
-100       | 78.81          |  8ms/step      | 78.70         | 285us/step
----------------------------------------------------------------------------
+
+
+Epoch no. | IG %Accuracy   | IG Performance | AL %Accuracy  | AL Performance
+---------:|---------------:|---------------:|--------------:|--------------:
+1         | 43.46          | 15 ms/step     | 42.21         | 334 us/step
+2         | 48.95          | 11 ms/step     | 48.06         | 282 us/step
+8         | 63.59          | 11 ms/step     | 61.35         | 290 us/step
+25        | 72.25          | 12 ms/step     | 71.08         | 287 us/step
+100       | 76.35          | 11 ms/step     | 74.62         | 286 us/step
 
 Settings: rotation = 30.0
-----------------------------------------------------------------------------
-Epoch     | ImageGenerator | ImageGenerator | AugmentLayer  | Augment Layer
-Number    | %Accuracy      | Performance    | %Accuracy     | Performance
-----------------------------------------------------------------------------
-1         | 43.46          | 15ms/step      | 42.21         | 334us/step
-2         | 48.95          | 11ms/step      | 48.06         | 282us/step
-8         | 63.59          | 11ms/step      | 61.35         | 290us/step
-25        | 72.25          | 12ms/step      | 71.08         | 287us/step
-100       | 76.35          | 11ms/step      | 74.62         | 286us/step
----------------------------------------------------------------------------
+
+
 (Corner process and rotation precision by `ImageGenerator` and `AugmentLayer`
 are slightly different.)
 '''


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
This PR adds MarkDown formatting to ```examples/cifar10_cnn_tfaugment2d.py```.

Result:
![cifar10_cnn_tfaugment2d1](https://user-images.githubusercontent.com/3424796/52510423-cb567900-2bf3-11e9-9e4c-faa9c26fb33c.png)
![cifar10_cnn_tfaugment2d2](https://user-images.githubusercontent.com/3424796/52510422-cb567900-2bf3-11e9-9691-a933fdbdd2d9.png)

Unfortunately, according to [this](https://www.mkdocs.org/user-guide/writing-your-docs/), it seems that table cells cannot span multiple lines in MarkDown. In addition, the PEP8 tests fail with long lines so I tried to make it concise but clear.
The 'Settings: ' lines were moved under the tables because this way they'll be close to the tables the settings refer to and act similar to a caption. If the lines were above the tables, there was a big gap between the table header and the setting description.
Finally, the 'Benchmark ...' line was changed from a heading to regular bold text as the long line was showing in the sidebar on the left.

If this formatting is undesirable, another option would be to keep the old formatting for the tables and wrap them in code blocks.

### Related Issues
https://github.com/keras-team/keras/issues/12219
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
