### PR TITLE
Fix #12213 by mentioning what output shape multiple means in docs

### DIFF
--- a/docs/templates/models/about-keras-models.md
+++ b/docs/templates/models/about-keras-models.md
@@ -7,7 +7,7 @@ These models have a number of methods and attributes in common:
 - `model.layers` is a flattened list of the layers comprising the model.
 - `model.inputs` is the list of input tensors of the model.
 - `model.outputs` is the list of output tensors of the model.
-- `model.summary()` prints a summary representation of your model. Shortcut for [utils.print_summary](/utils/#print_summary)
+- `model.summary()` prints a summary representation of your model. For layers with multiple outputs, `multiple` is displayed instead of each individual output's shape due to size limitations. Shortcut for [utils.print_summary](/utils/#print_summary)
 - `model.get_config()` returns a dictionary containing the configuration of the model. The model can be reinstantiated from its config via:
 
 ```python

--- a/docs/templates/models/about-keras-models.md
+++ b/docs/templates/models/about-keras-models.md
@@ -7,7 +7,7 @@ These models have a number of methods and attributes in common:
 - `model.layers` is a flattened list of the layers comprising the model.
 - `model.inputs` is the list of input tensors of the model.
 - `model.outputs` is the list of output tensors of the model.
-- `model.summary()` prints a summary representation of your model. For layers with multiple outputs, `multiple` is displayed instead of each individual output's shape due to size limitations. Shortcut for [utils.print_summary](/utils/#print_summary)
+- `model.summary()` prints a summary representation of your model. For layers with multiple outputs, `multiple` is displayed instead of each individual output shape due to size limitations. Shortcut for [utils.print_summary](/utils/#print_summary)
 - `model.get_config()` returns a dictionary containing the configuration of the model. The model can be reinstantiated from its config via:
 
 ```python


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Mention what output shape "multiple" actually means in model.summary()

### Fixes #12213 

### Mention that output shape is displayed as "multiple" if a layer has multiple outputs due to size limitations.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
