### PR TITLE
Support merge_repeated in K.ctc_decode() beam search.

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2762,7 +2762,8 @@ def ctc_batch_cost(y_true, y_pred, input_length, label_length):
     raise NotImplementedError
 
 
-def ctc_decode(y_pred, input_length, greedy=True, beam_width=100, top_paths=1):
+def ctc_decode(y_pred, input_length, greedy=True, beam_width=100, top_paths=1,
+               merge_repeated=False):
     raise NotImplementedError
 
 

--- a/keras/backend/numpy_backend.py
+++ b/keras/backend/numpy_backend.py
@@ -707,7 +707,8 @@ def one_hot(indices, num_classes):
     return to_categorical(indices, num_classes)
 
 
-def ctc_decode(y_pred, input_length, greedy=True, beam_width=100, top_paths=1):
+def ctc_decode(y_pred, input_length, greedy=True, beam_width=100, top_paths=1,
+               merge_repeated=False):
     num_samples = y_pred.shape[0]
     num_classes = y_pred.shape[-1]
     log_prob = np.zeros((num_samples, 1))

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -4513,20 +4513,20 @@ def ctc_decode(y_pred, input_length, greedy=True, beam_width=100,
             containing the prediction, or output of the softmax.
         input_length: tensor `(samples, )` containing the sequence length for
             each batch item in `y_pred`.
-        greedy: perform much faster best-path search if `true`.
+        greedy: perform much faster best-path search if `True`.
             This does not use a dictionary.
-        beam_width: if `greedy` is `false`: a beam search decoder will be used
+        beam_width: if `greedy` is `False`: a beam search decoder will be used
             with a beam of this width.
-        top_paths: if `greedy` is `false`,
+        top_paths: if `greedy` is `False`,
             how many of the most probable paths will be returned.
-        merge_repeated: if `greedy` is `false`,
+        merge_repeated: if `greedy` is `False`,
             merge repeated classes in the output beams.
 
     # Returns
         Tuple:
-            List: if `greedy` is `true`, returns a list of one element that
+            List: if `greedy` is `True`, returns a list of one element that
                 contains the decoded sequence.
-                If `false`, returns the `top_paths` most probable
+                If `False`, returns the `top_paths` most probable
                 decoded sequences.
                 Important: blank labels are returned as `-1`.
             Tensor `(top_paths, )` that contains

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -4502,7 +4502,7 @@ def ctc_batch_cost(y_true, y_pred, input_length, label_length):
 
 
 def ctc_decode(y_pred, input_length, greedy=True, beam_width=100,
-               top_paths=1):
+               top_paths=1, merge_repeated=False):
     """Decodes the output of a softmax.
 
     Can use either greedy search (also known as best path)
@@ -4519,6 +4519,8 @@ def ctc_decode(y_pred, input_length, greedy=True, beam_width=100,
             with a beam of this width.
         top_paths: if `greedy` is `false`,
             how many of the most probable paths will be returned.
+        merge_repeated: if `greedy` is `false`,
+            merge repeated classes in the output beams.
 
     # Returns
         Tuple:
@@ -4541,7 +4543,7 @@ def ctc_decode(y_pred, input_length, greedy=True, beam_width=100,
         (decoded, log_prob) = ctc.ctc_beam_search_decoder(
             inputs=y_pred,
             sequence_length=input_length, beam_width=beam_width,
-            top_paths=top_paths, merge_repeated=False)
+            top_paths=top_paths, merge_repeated=merge_repeated)
 
     decoded_dense = []
     for st in decoded:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -4547,10 +4547,7 @@ def ctc_decode(y_pred, input_length, greedy=True, beam_width=100,
 
     decoded_dense = []
     for st in decoded:
-        dense_tensor = tf.sparse_to_dense(st.indices,
-                                          st.dense_shape,
-                                          st.values,
-                                          default_value=-1)
+        dense_tensor = tf.sparse.to_dense(st, default_value=-1)
         decoded_dense.append(dense_tensor)
     return (decoded_dense, log_prob)
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -2944,5 +2944,6 @@ def ctc_label_dense_to_sparse(labels, label_lengths):
     raise NotImplementedError
 
 
-def ctc_decode(y_pred, input_length, greedy=True, beam_width=100, top_paths=1):
+def ctc_decode(y_pred, input_length, greedy=True, beam_width=100, top_paths=1,
+               merge_repeated=False):
     raise NotImplementedError

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1844,6 +1844,43 @@ class TestBackend(object):
 
         assert np.allclose(log_prob_truth, log_prob_pred)
 
+    @pytest.mark.skipif(K.backend() != 'tensorflow',
+                        reason='Beam search is only implemented with '
+                               'the TensorFlow backend.')
+    def test_ctc_decode_beam_search_no_merge(self):
+        # A simple CTC probability map with some repeating characters,
+        # shape(batch, input_width, char_count)
+        # Without merging should be decoded as: "AABB", with merging as: "AB".
+        input_prob = np.array([
+            [  # blank, A ,B
+                [0, 0, 1],  # blank
+                [1, 0, 0],  # A
+                [0, 0, 1],  # blank
+                [1, 0, 0],  # A
+                [0, 1, 0],  # B
+                [0, 0, 1],  # blank
+                [0, 1, 0]  # B
+            ]
+        ])
+        input_len = np.array(input_prob.shape[0] * [input_prob.shape[1]])
+
+        def decode(merge_repeated):
+            input_prob_tensor = K.placeholder(shape=(None, None, None),
+                                              dtype='float32')
+            input_len_tensor = K.placeholder(shape=(None), dtype='int64')
+            paths_tensors, _ = K.ctc_decode(input_prob_tensor, input_len_tensor,
+                                            greedy=False, beam_width=1, top_paths=1,
+                                            merge_repeated=merge_repeated)
+            decode_func = K.function([input_prob_tensor, input_len_tensor],
+                                     paths_tensors)
+            paths = decode_func([input_prob, input_len])
+            return paths
+
+        # merged: A B
+        assert np.allclose(decode(merge_repeated=True), [np.array([[0, 1]])])
+        # not merged: A A B B
+        assert np.allclose(decode(merge_repeated=False), [np.array([[0, 0, 1, 1]])])
+
     def test_one_hot(self):
         input_length = 10
         num_classes = 20


### PR DESCRIPTION
### Summary

It allows CTC beam search to disable merging repeated adjacent symbols even if they are separated by a blank symbol and behave consistently with greedy search. `K.ctc_decode()` has a new argument `merge_repeated=False` (instead of hard-coded constant) which is passed to TF. A test is included.

In addition it upgrades deprecated usage of `tf.sparse_to_dense()` in `K.ctc_decode()` (TF was warning about it) and fixes some doc strings (proper case of boolean values) there.

There's a separate test, since we needed different data and to make the whole test as obvious as possible. Possibly we could craft such data that both tests can be merged and parametrized.

### Related Issues

-  #12238 K.ctc_decode() does not pass merge_repeated
  - + older duplicate: #10852 ctc_decode returns inconsistent result when greedy=False
-  #12240 K.ctc_decode() beam search: tf.sparse_to_dense is deprecated

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
  - YES, added `test_ctc_decode_beam_search_no_merge()`
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
  - YES, doc of `K.ctc_decode()` is updated
- [x] This PR is backwards compatible [y/n]
  - YES, the default value of `merge_repeated=False` is the same as the previously hard-coded one
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
  - YES, it just add one more optional argument `merge_repeated` to `K.ctc_decode()`
