### PR TITLE
Added MarkDown formatting to examples/cifar10_resnet.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -74,3 +74,4 @@ nav:
   - CIFAR-10 CNN: examples/cifar10_cnn.md
   - CIFAR-10 CNN-Capsule: examples/cifar10_cnn_capsule.md
   - CIFAR-10 CNN with augmentation (TF): examples/cifar10_cnn_tfaugment2d.md
+  - CIFAR-10 ResNet: examples/cifar10_resnet.md

--- a/examples/cifar10_resnet.py
+++ b/examples/cifar10_resnet.py
@@ -8,6 +8,29 @@ ResNet v1:
 ResNet v2:
 [Identity Mappings in Deep Residual Networks
 ](https://arxiv.org/pdf/1603.05027.pdf)
+
+
+Model|n|200-epoch accuracy|Original paper accuracy |sec/epoch GTX1080Ti
+:------------|--:|-------:|-----------------------:|---:
+ResNet20   v1|  3| 92.16 %|                 91.25 %|35
+ResNet32   v1|  5| 92.46 %|                 92.49 %|50
+ResNet44   v1|  7| 92.50 %|                 92.83 %|70
+ResNet56   v1|  9| 92.71 %|                 93.03 %|90
+ResNet110  v1| 18| 92.65 %|            93.39+-.16 %|165
+ResNet164  v1| 27|     - %|                 94.07 %|  -
+ResNet1001 v1|N/A|     - %|                 92.39 %|  -
+
+&nbsp;
+
+Model|n|200-epoch accuracy|Original paper accuracy |sec/epoch GTX1080Ti
+:------------|--:|-------:|-----------------------:|---:
+ResNet20   v2|  2|     - %|                     - %|---
+ResNet32   v2|N/A| NA    %|            NA         %| NA
+ResNet44   v2|N/A| NA    %|            NA         %| NA
+ResNet56   v2|  6| 93.01 %|            NA         %|100
+ResNet110  v2| 12| 93.15 %|            93.63      %|180
+ResNet164  v2| 18|     - %|            94.54      %|  -
+ResNet1001 v2|111|     - %|            95.08+-.14 %|  -
 """
 
 from __future__ import print_function

--- a/examples/cifar10_resnet.py
+++ b/examples/cifar10_resnet.py
@@ -1,12 +1,13 @@
-"""Trains a ResNet on the CIFAR10 dataset.
+"""
+#Trains a ResNet on the CIFAR10 dataset.
 
-ResNet v1
-[a] Deep Residual Learning for Image Recognition
-https://arxiv.org/pdf/1512.03385.pdf
+ResNet v1:
+[Deep Residual Learning for Image Recognition
+](https://arxiv.org/pdf/1512.03385.pdf)
 
-ResNet v2
-[b] Identity Mappings in Deep Residual Networks
-https://arxiv.org/pdf/1603.05027.pdf
+ResNet v2:
+[Identity Mappings in Deep Residual Networks
+](https://arxiv.org/pdf/1603.05027.pdf)
 """
 
 from __future__ import print_function


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
This PR adds MarkDown formatting to ```examples/cifar10_resnet.py```.
Result:
![cifar10_resnet1](https://user-images.githubusercontent.com/3424796/52522299-41ea8980-2c7b-11e9-84ef-c6f1b28238de.png)
![cifar10_resnet2](https://user-images.githubusercontent.com/3424796/52522298-41ea8980-2c7b-11e9-9884-b1c468944acf.png)

### Related Issues
https://github.com/keras-team/keras/issues/12219
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
