### PR TITLE
add verbose=0

### DIFF
--- a/examples/lstm_text_generation.py
+++ b/examples/lstm_text_generation.py
@@ -109,4 +109,5 @@ print_callback = LambdaCallback(on_epoch_end=on_epoch_end)
 model.fit(x, y,
           batch_size=128,
           epochs=60,
-          callbacks=[print_callback])
+          callbacks=[print_callback],
+          verbose=0)


### PR DESCRIPTION
If `verbose=0` is not added, we get the following error.

`AttributeError: 'ProgbarLogger' object has no attribute 'log_values'`

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
