### PR TITLE
Spelling and formatting in variational_autoencoder.py

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -33,7 +33,6 @@ import os
 # reparameterization trick
 # instead of sampling from Q(z|X), sample epsilon = N(0,I)
 # z = z_mean + sqrt(var) * epsilon
-
 def sampling(args):
     """Reparameterization trick by sampling from an isotropic unit Gaussian.
 
@@ -50,6 +49,7 @@ def sampling(args):
     # by default, random_normal has mean = 0 and std = 1.0
     epsilon = K.random_normal(shape=(batch, dim))
     return z_mean + K.exp(0.5 * z_log_var) * epsilon
+
 
 def plot_results(models,
                  data,

--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -2,14 +2,14 @@
 
 The VAE has a modular design. The encoder, decoder and VAE
 are 3 models that share weights. After training the VAE model,
-the encoder can be used to  generate latent vectors.
+the encoder can be used to generate latent vectors.
 The decoder can be used to generate MNIST digits by sampling the
-latent vector from a Gaussian distribution with mean=0 and std=1.
+latent vector from a Gaussian distribution with mean = 0 and std = 1.
 
 # Reference
 
 [1] Kingma, Diederik P., and Max Welling.
-"Auto-encoding variational bayes."
+"Auto-Encoding Variational Bayes."
 https://arxiv.org/abs/1312.6114
 '''
 
@@ -31,10 +31,11 @@ import os
 
 
 # reparameterization trick
-# instead of sampling from Q(z|X), sample eps = N(0,I)
-# z = z_mean + sqrt(var)*eps
+# instead of sampling from Q(z|X), sample epsilon = N(0,I)
+# z = z_mean + sqrt(var) * epsilon
+
 def sampling(args):
-    """Reparameterization trick by sampling fr an isotropic unit Gaussian.
+    """Reparameterization trick by sampling from an isotropic unit Gaussian.
 
     # Arguments
         args (tensor): mean and log of variance of Q(z|X)
@@ -46,7 +47,7 @@ def sampling(args):
     z_mean, z_log_var = args
     batch = K.shape(z_mean)[0]
     dim = K.int_shape(z_mean)[1]
-    # by default, random_normal has mean=0 and std=1.0
+    # by default, random_normal has mean = 0 and std = 1.0
     epsilon = K.random_normal(shape=(batch, dim))
     return z_mean + K.exp(0.5 * z_log_var) * epsilon
 
@@ -55,7 +56,7 @@ def plot_results(models,
                  data,
                  batch_size=128,
                  model_name="vae_mnist"):
-    """Plots labels and MNIST digits as function of 2-dim latent vector
+    """Plots labels and MNIST digits as function of 2D latent vector
 
     # Arguments
         models (tuple): encoder and decoder models
@@ -205,3 +206,4 @@ if __name__ == '__main__':
                  data,
                  batch_size=batch_size,
                  model_name="vae_mlp")
+

--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -51,12 +51,11 @@ def sampling(args):
     epsilon = K.random_normal(shape=(batch, dim))
     return z_mean + K.exp(0.5 * z_log_var) * epsilon
 
-
 def plot_results(models,
                  data,
                  batch_size=128,
                  model_name="vae_mnist"):
-    """Plots labels and MNIST digits as function of 2D latent vector
+    """Plots labels and MNIST digits as a function of the 2D latent vector
 
     # Arguments
         models (tuple): encoder and decoder models
@@ -206,4 +205,3 @@ if __name__ == '__main__':
                  data,
                  batch_size=batch_size,
                  model_name="vae_mlp")
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Small formatting and a mistake in variational_autoencoder.py
### Related Issues

### PR Overview

- [N ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [Y ] This PR is backwards compatible [y/n]
- [N ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
