### PR TITLE
also set intra_op_parallelism_threads

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -186,6 +186,7 @@ def get_session():
             else:
                 num_thread = int(os.environ.get('OMP_NUM_THREADS'))
                 config = tf.ConfigProto(intra_op_parallelism_threads=num_thread,
+                                        inter_op_parallelism_threads=num_thread,
                                         allow_soft_placement=True)
             _SESSION = tf.Session(config=config)
         session = _SESSION

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -2074,11 +2074,11 @@ class TestBackend(object):
         assert np.allclose(K.eval(K.clip(x, min_value, max_value)),
                            np.asarray([-5., -4., 0., 4., 9.], dtype=np.float32))
 
-    def test_session_parallelism_settings(self, monkeypatch):
+    def test_tensorflow_session_parallelism_settings(self, monkeypatch):
         for threads in [0, 1, 4]:
-            K.clear_session()
+            KTF.clear_session()
             monkeypatch.setenv('OMP_NUM_THREADS', str(threads))
-            cfg = K.get_session()._config
+            cfg = KTF.get_session()._config
             assert cfg.intra_op_parallelism_threads == threads
             assert cfg.inter_op_parallelism_threads == threads
 

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -2074,11 +2074,13 @@ class TestBackend(object):
         assert np.allclose(K.eval(K.clip(x, min_value, max_value)),
                            np.asarray([-5., -4., 0., 4., 9.], dtype=np.float32))
 
+    @pytest.mark.skipif(K.backend() != 'tensorflow',
+                        reason='This test is for tensorflow parallelism.')
     def test_tensorflow_session_parallelism_settings(self, monkeypatch):
         for threads in [0, 1, 4]:
-            KTF.clear_session()
+            K.clear_session()
             monkeypatch.setenv('OMP_NUM_THREADS', str(threads))
-            cfg = KTF.get_session()._config
+            cfg = K.get_session()._config
             assert cfg.intra_op_parallelism_threads == threads
             assert cfg.inter_op_parallelism_threads == threads
 

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -2074,6 +2074,13 @@ class TestBackend(object):
         assert np.allclose(K.eval(K.clip(x, min_value, max_value)),
                            np.asarray([-5., -4., 0., 4., 9.], dtype=np.float32))
 
+    def test_session_parallelism_settings(self, monkeypatch):
+        for threads in [0, 1, 4]:
+            K.clear_session()
+            monkeypatch.setenv('OMP_NUM_THREADS', str(threads))
+            cfg = K.get_session()._config
+            assert cfg.intra_op_parallelism_threads == threads
+            assert cfg.inter_op_parallelism_threads == threads
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Conveniently, keras uses`os.environ.get('OMP_NUM_THREADS')` to set `intra_op_parallelism_threads`.  I think it would be useful to also set `inter_op_parallelism_threads` using this variable.

This is convenient because e.g. you can set `OMP_NUM_THREADS=1` and keras will use no multithreading.


### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
