### PR TITLE
Added intersection over union metric for bbox

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -53,8 +53,68 @@ def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):
                   axis=-1)
 
 
+
+def iou_metric_bbox(y_true, y_pred):
+    # iou loss for bounding box prediction
+    # input must be as [x1, x2, y1, y2]
+
+    # AOG = Area of Groundtruth box
+    AG = K.abs(K.transpose(y_true)[1] - K.transpose(y_true)[0] + 1) * K.abs(K.transpose
+                                                                             (y_true)[3] - K.transpose(y_true)[2] + 1)
+
+    # AOP = Area of Predicted box
+    AP = K.abs(K.transpose(y_pred)[1] - K.transpose(y_pred)[0] + 1) * K.abs(K.transpose
+                                                                             (y_pred)[3] - K.transpose(y_pred)[2] + 1)
+
+    # overlaps are the co-ordinates of intersection box
+    area_0 = K.maximum(K.transpose(y_true)[0], K.transpose(y_pred)[0])
+    area_1 = K.minimum(K.transpose(y_true)[1], K.transpose(y_pred)[1])
+    area_2 = K.maximum(K.transpose(y_true)[2], K.transpose(y_pred)[2])
+    area_3 = K.minimum(K.transpose(y_true)[3], K.transpose(y_pred)[3])
+
+    # intersection area
+    intersection = (area_1 -area_0 + 1) * (area_3 - area_2 + 1)
+
+    # area of union of both boxes
+    union = AG + AP - intersection
+
+    # iou calculation
+    iou = intersection / union
+
+    #avoiding divide by zero
+    if union == 0:
+        union = 0.0001
+
+    # bounding values of iou to (0,1)
+    iou = K.clip(iou, 0.0 + K.epsilon(), 1.0 - K.epsilon())
+
+    return (iou)
+
+
+def iou_bbox(y_true, y_pred):
+    num_images = K.int_shape(y_pred)[-1]
+    # print(y_pred.shape)
+    if y_pred.shape[1] != 4:
+        raise Exception(
+            'BBox metric takes columns in the format. (x1,x2,y1,y2).'
+            'Target shape should have 4 values in column. No of columns found: {} .Please consider changing metric function for this problem.'.format(
+                y_pred.shape[1]))
+    if y_true.shape[1] != 4:
+        raise Exception(
+            'BBox metric takes columns in the format. (x1,x2,y1,y2).'
+            'Source shape should have 4 values in column. No of columns found: {} .Please consider changing metric function for this problem.'.format(
+                y_pred.shape[1]))
+    # initialize a variable to store total IoU in
+    total_iou = K.variable(0)
+    # iterate over labels to calculate IoU for
+    for label in range(num_images):
+        total_iou = total_iou + iou_metric_bbox(y_true, y_pred)
+    # divide total IoU by number of labels to get mean IoU
+    return total_iou / num_images
+
 # Aliases
 
+intersection_over_union_bbox = bbox = iou_bbox
 mse = MSE = mean_squared_error
 mae = MAE = mean_absolute_error
 mape = MAPE = mean_absolute_percentage_error


### PR DESCRIPTION
Bounding Box should be in the format x1,x2,y1,y2. x1,y1 left upper corner of the box in the image and x2,y2 be the right  lower corner of the box in the image. This metric is very useful as it can be used in many object localization tasks.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
