### PR TITLE
Added MarkDown formatting to examples/image_ocr.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -76,3 +76,4 @@ nav:
   - CIFAR-10 CNN with augmentation (TF): examples/cifar10_cnn_tfaugment2d.md
   - CIFAR-10 ResNet: examples/cifar10_resnet.md
   - Convolution filter visualization: examples/conv_filter_visualization.md
+  - Image OCR: examples/image_ocr.md

--- a/examples/image_ocr.py
+++ b/examples/image_ocr.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-'''This example uses a convolutional stack followed by a recurrent stack
+'''
+# Optical character recognition
+This example uses a convolutional stack followed by a recurrent stack
 and a CTC logloss function to perform optical character recognition
 of generated text images. I have no evidence of whether it actually
 learns general shapes of text, or just is able to recognize all
@@ -17,17 +19,18 @@ the word list to include two words separated by a space.
 The table below shows normalized edit distance values. Theano uses
 a slightly different CTC implementation, hence the different results.
 
-            Norm. ED
 Epoch |   TF   |   TH
-------------------------
-    10   0.027   0.064
-    15   0.038   0.035
-    20   0.043   0.045
-    25   0.014   0.019
+-----:|-------:|-------:
+    10|  0.027 | 0.064
+    15|  0.038 | 0.035
+    20|  0.043 | 0.045
+    25|  0.014 | 0.019
 
-This requires cairo and editdistance packages:
+This requires ```cairo``` and ```editdistance``` packages:
+```python
 pip install cairocffi
 pip install editdistance
+```
 
 Created by Mike Henry
 https://github.com/mbhenry/


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->
### Summary
This PR adds Markdown formatting to ```examples/image_ocr.py```.
Result:
![image_ocr1](https://user-images.githubusercontent.com/3424796/52852421-71ccdd80-3110-11e9-829a-6b16334092fb.png)
![image_ocr2](https://user-images.githubusercontent.com/3424796/52852420-71ccdd80-3110-11e9-82c1-8dab3b01c1d5.png)
### Related Issues
https://github.com/keras-team/keras/issues/12219
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
