### PR TITLE
Added more info about categorical_crossentropy

### DIFF
--- a/docs/templates/losses.md
+++ b/docs/templates/losses.md
@@ -38,3 +38,5 @@ categorical_labels = to_categorical(int_labels, num_classes=None)
 
 When using the `sparse_categorical_crossentropy` loss, your targets should be *integer targets*.
 If you have categorical targets, you should use `categorical_crossentropy`.
+
+`categorical_crossentropy` is another term for [multi-class log loss](http://wiki.fast.ai/index.php/Log_Loss). 


### PR DESCRIPTION
`categorical_crossentropy`  is another term for multiclass log loss. Which seems to be necessary information about `categorical_crossentropy` as `sklearn` has it as `log_loss` hence its beneficial for people migrating from `sklearn` and other people who learned it as `log_loss`.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
