### PR TITLE
Added a test to ensure that the module name is always valid in the docs.

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -92,7 +92,6 @@ def clean_module_name(name):
         name = name.replace('keras_applications', 'keras.applications')
     if name.startswith('keras_preprocessing'):
         name = name.replace('keras_preprocessing', 'keras.preprocessing')
-    assert name[:6] == 'keras.', 'Invalid module name: %s' % name
     return name
 
 

--- a/tests/docs/test_doc_auto_generation.py
+++ b/tests/docs/test_doc_auto_generation.py
@@ -395,5 +395,22 @@ def test_docs_in_custom_destination_dir(tmpdir):
     assert os.listdir(os.path.join(tmpdir, 'examples'))
 
 
+def test_module_name():
+    for page in autogen.PAGES:
+        list_of_classes = autogen.read_page_data(page, 'classes')
+        for element in list_of_classes:
+            if isinstance(element, (list, tuple)):
+                cls = element[0]
+            else:
+                cls = element
+            signature = autogen.get_class_signature(cls)
+            assert signature.startswith('keras.')
+
+        list_of_functions = autogen.read_page_data(page, 'functions')
+        for function_ in list_of_functions:
+            signature = autogen.get_function_signature(function_)
+            assert signature.startswith('keras.')
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

I'm currently working on a refactoring of the `autogen.py`. The goal is to sanetize it and make it easily usable from keras-contrib. Since I want to make small PRs, this one may not look useful, but it's actually a necessary addition of test to ensure that I don't break things during the refactoring.

### Related Issues

https://github.com/keras-team/keras-contrib/issues/412

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
