### PR TITLE
Tensorboard histograms with generators

### DIFF
--- a/keras/engine/training_arrays.py
+++ b/keras/engine/training_arrays.py
@@ -429,19 +429,15 @@ def test_loop(model, f, ins,
             batch_logs = {'batch': step, 'size': 1}
             callbacks._call_batch_hook('test', 'begin', step, batch_logs)
             batch_outs = f(ins)
-            if isinstance(batch_outs, list):
-                if step == 0:
-                    for _ in enumerate(batch_outs):
-                        outs.append(0.)
-                for i, batch_out in enumerate(batch_outs):
-                    if i in stateful_metric_indices:
-                        outs[i] = float(batch_out)
-                    else:
-                        outs[i] += batch_out
-            else:
-                if step == 0:
+            batch_outs = to_list(batch_outs)
+            if step == 0:
+                for _ in enumerate(batch_outs):
                     outs.append(0.)
-                outs[0] += batch_outs
+            for i, batch_out in enumerate(batch_outs):
+                if i in stateful_metric_indices:
+                    outs[i] = float(batch_out)
+                else:
+                    outs[i] += batch_out
 
             if hasattr(model, 'metrics_names'):
                 for l, o in zip(model.metrics_names, batch_outs):

--- a/keras/engine/training_generator.py
+++ b/keras/engine/training_generator.py
@@ -147,8 +147,8 @@ def fit_generator(model,
                 if model.uses_learning_phase and not isinstance(K.learning_phase(),
                                                                 int):
                     val_data += [0.]
-                for cbk in callbacks:
-                    cbk.validation_data = val_data
+            for cbk in callbacks:
+                cbk.validation_data = val_data
 
         if workers > 0:
             if use_sequence_api:

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -954,16 +954,16 @@ def test_TensorBoard_histogram_freq_must_have_validation_data(tmpdir):
                                                         write_grads=False))
     assert 'validation_data must be provided' in str(raised_exception.value)
 
-    # fit generator with validation data generator should raise ValueError if
-    # histogram_freq > 0
-    with pytest.raises(ValueError) as raised_exception:
-        model.fit_generator(train_generator, len(X_train), epochs=2,
-                            validation_data=validation_generator,
-                            validation_steps=1,
-                            callbacks=callbacks_factory(histogram_freq=1,
-                                                        write_images=False,
-                                                        write_grads=False))
-    assert 'validation_data must be provided' in str(raised_exception.value)
+    model.fit_generator(train_generator,
+                        len(X_train), epochs=2,
+                        validation_data=validation_generator,
+                        validation_steps=1,
+                        callbacks=callbacks_factory(histogram_freq=1,
+                                                    write_images=False,
+                                                    write_grads=False))
+    assert os.path.isdir(filepath)
+    shutil.rmtree(filepath)
+    assert not tmpdir.listdir()
 
 
 def test_TensorBoard_multi_input_output(tmpdir):


### PR DESCRIPTION
### Summary
With tf.keras callbacks in place, I simply imported the ideas implemented by David and Hermansje in their previous PRs (#10108 and #10513).

The `Tensorboard` callback will now add the histogram computing operation to `model#test_function#fetches` if necessary. The operation runs with the other updates and the result is stored. The callback will retrieve it at the end of each validation batch and pass it along to the writer.

Two improvements are:
- `histogram_freq>0` will now be compatible with validation_data coming from a generator
- The epoch will be a little faster because a second feed-forward won't be performed onto the validation data

Necessary changes:
- A property `fetched` as added to `Function`, containing a dictionary which maps the fetches to their fetched results
- Only the first batch of an epoch is used to compute the histograms (currently, histograms are computed for each batch but only the last one is saved)
- `histogram_freq>0` still requires validation data, so `cbk.validation_data = val_data` had to be performed regardless if the data is a tuple of `ndarrays` or an iterator/sequence (currently, it is only performed for the former)

### Related Issues
#10108, #10513, #11957 maybe?

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
