### PR TITLE
Added MarkDown formatting to examples/antirectifier.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
 - Contributing: contributing.md
 - Examples:
   - Addition RNN: examples/addition_rnn.md
+  - Custom layer - antirectifier: examples/antirectifier.md
   - Baby RNN: examples/babi_rnn.md
   - Baby MemNN: examples/babi_memnn.md
   - CIFAR-10 CNN: examples/cifar10_cnn.md

--- a/examples/antirectifier.py
+++ b/examples/antirectifier.py
@@ -1,4 +1,5 @@
-'''The example demonstrates how to write custom layers for Keras.
+'''
+#This example demonstrates how to write custom layers for Keras.
 
 We build a custom activation layer called 'Antirectifier',
 which modifies the shape of the tensor that passes through it.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
This PR adds Markdown formatting to ```examples/antirectifier.py```.
Result:
![antirectifier1](https://user-images.githubusercontent.com/3424796/52917384-a2fd0780-32e2-11e9-9c96-3e87e4a89b08.png)
![antirectifier2](https://user-images.githubusercontent.com/3424796/52917383-a2fd0780-32e2-11e9-851b-fc714d405b41.png)
### Related Issues
https://github.com/keras-team/keras/issues/12219
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
