### PR TITLE
add reset_uids to cntk backend

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2737,7 +2737,6 @@ class LambdaFunc(C.ops.functions.UserFunction):
 def reset_uids():
     global _UID_PREFIXES
     _UID_PREFIXES = defaultdict(int)
-    return _UID_PREFIXES
 
 def to_dense(tensor):
     raise NotImplementedError

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2735,8 +2735,9 @@ class LambdaFunc(C.ops.functions.UserFunction):
 
 
 def reset_uids():
-    raise NotImplementedError
-
+    global _UID_PREFIXES
+    _UID_PREFIXES = defaultdict(int)
+    return _UID_PREFIXES
 
 def to_dense(tensor):
     raise NotImplementedError

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2738,6 +2738,7 @@ def reset_uids():
     global _UID_PREFIXES
     _UID_PREFIXES = defaultdict(int)
 
+
 def to_dense(tensor):
     raise NotImplementedError
 

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -553,6 +553,13 @@ class TestBackend(object):
         check_two_tensor_operation('maximum', (4, 2), (4, 2), WITH_NP)
         check_two_tensor_operation('minimum', (4, 2), (4, 2), WITH_NP)
 
+    # assumes first uid will always be the same
+    def test_reset_uids(self):
+        first = K.get_uid()
+        K.get_uid()
+        K.reset_uids()
+        assert K.get_uid() == first
+
     @pytest.mark.skipif(K.backend() == 'cntk', reason='cntk does not support '
                                                       'cumsum and cumprod yet')
     def test_cumsum_cumprod(self):


### PR DESCRIPTION
### Summary
Implements reset_uids in cntk, just resets _UID_PREFIXES dictionary. 
Added simple test.
### Related Issues
#12161
### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
