### PR TITLE
Added Markdown formatting to examples/imdb_cnn_lstm.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -77,7 +77,9 @@ nav:
   - CIFAR-10 CNN with augmentation (TF): examples/cifar10_cnn_tfaugment2d.md
   - CIFAR-10 ResNet: examples/cifar10_resnet.md
   - Convolution filter visualization: examples/conv_filter_visualization.md
+  - Convolutional LSTM: examples/conv_lstm.md
+  - Deep Dream: examples/deep_dream.md
   - Image OCR: examples/image_ocr.md
   - Bidirectional LSTM: examples/imdb_bidirectional_lstm.md
   - 1D CNN for text classification: examples/imdb_cnn.md
-  - Convolutional LSTM: examples/conv_lstm.md
+  - Sentiment classification LSTM: examples/imdb_cnn_lstm.md

--- a/examples/deep_dream.py
+++ b/examples/deep_dream.py
@@ -1,11 +1,12 @@
-'''Deep Dreaming in Keras.
+'''
+#Deep Dreaming in Keras.
 
 Run the script with:
-```
+```python
 python deep_dream.py path_to_your_base_image.jpg prefix_for_results
 ```
 e.g.:
-```
+```python
 python deep_dream.py img/mypic.jpg results/dream
 ```
 '''

--- a/examples/imdb_cnn_lstm.py
+++ b/examples/imdb_cnn_lstm.py
@@ -1,7 +1,7 @@
-'''Train a recurrent convolutional network on the IMDB sentiment
-classification task.
+'''
+#Train a recurrent convolutional network on the IMDB sentiment classification task.
 
-Gets to 0.8498 test accuracy after 2 epochs. 41s/epoch on K520 GPU.
+Gets to 0.8498 test accuracy after 2 epochs. 41 s/epoch on K520 GPU.
 '''
 from __future__ import print_function
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
This PR adds Markdown formatting to ```examples/imdb_cnn_lstm.py```.
Result:
![imdb_cnn_lstm1](https://user-images.githubusercontent.com/3424796/53010014-ac968480-3434-11e9-855d-97141c5366de.png)
![imdb_cnn_lstm2](https://user-images.githubusercontent.com/3424796/53010012-ac968480-3434-11e9-94fa-7874a229b8b0.png)
### Related Issues
#12219 
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
