### PR TITLE
Added MarkDown formatting to examples/imdb_fasttext.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -82,4 +82,6 @@ nav:
   - Image OCR: examples/image_ocr.md
   - Bidirectional LSTM: examples/imdb_bidirectional_lstm.md
   - 1D CNN for text classification: examples/imdb_cnn.md
-  - Sentiment classification LSTM: examples/imdb_cnn_lstm.md
+  - Sentiment classification CNN-LSTM: examples/imdb_cnn_lstm.md
+  - Fasttext for text classification: examples/imdb_fasttext.md
+  - Sentiment classification LSTM: examples/imdb_lstm.md

--- a/examples/imdb_fasttext.py
+++ b/examples/imdb_fasttext.py
@@ -1,13 +1,18 @@
-'''This example demonstrates the use of fasttext for text classification
+'''
+#This example demonstrates the use of fasttext for text classification
 
 Based on Joulin et al's paper:
 
-Bags of Tricks for Efficient Text Classification
-https://arxiv.org/abs/1607.01759
+[Bags of Tricks for Efficient Text Classification
+](https://arxiv.org/abs/1607.01759)
 
 Results on IMDB datasets with uni and bi-gram embeddings:
-    Uni-gram: 0.8813 test accuracy after 5 epochs. 8s/epoch on i7 cpu.
-    Bi-gram : 0.9056 test accuracy after 5 epochs. 2s/epoch on GTx 980M gpu.
+
+Embedding|Accuracy, 5 epochs|Speed (s/epoch)|Hardware
+:--------|-----------------:|----:|:-------
+Uni-gram |            0.8813|    8|i7 CPU
+Bi-gram  |            0.9056|    2|GTx 980M GPU
+
 '''
 
 from __future__ import print_function


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
This PR adds Markdown formatting to ```examples/imdb_fasttext.py```.
In addition, it renames the example description for ```examples/imdb_cnn_lstm.py``` to be more distinguishable from the coming description of ```examples/imdb_lstm.py```.
Result:
![imdb_fasttext1](https://user-images.githubusercontent.com/3424796/53105907-e09fa180-3529-11e9-9ce8-0e0cb6af1b72.png)
![imdb_fasttext2](https://user-images.githubusercontent.com/3424796/53105909-e09fa180-3529-11e9-9257-bc5d7988687f.png)
### Related Issues
#12219
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
