### PR TITLE
Added Markdown formatting to examples/imdb_lstm.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -82,4 +82,6 @@ nav:
   - Image OCR: examples/image_ocr.md
   - Bidirectional LSTM: examples/imdb_bidirectional_lstm.md
   - 1D CNN for text classification: examples/imdb_cnn.md
-  - Sentiment classification LSTM: examples/imdb_cnn_lstm.md
+  - Sentiment classification CNN-LSTM: examples/imdb_cnn_lstm.md
+  - Fasttext for text classification: examples/imdb_fasttext.md
+  - Sentiment classification LSTM: examples/imdb_lstm.md

--- a/examples/imdb_fasttext.py
+++ b/examples/imdb_fasttext.py
@@ -1,13 +1,18 @@
-'''This example demonstrates the use of fasttext for text classification
+'''
+#This example demonstrates the use of fasttext for text classification
 
 Based on Joulin et al's paper:
 
-Bags of Tricks for Efficient Text Classification
-https://arxiv.org/abs/1607.01759
+[Bags of Tricks for Efficient Text Classification
+](https://arxiv.org/abs/1607.01759)
 
 Results on IMDB datasets with uni and bi-gram embeddings:
-    Uni-gram: 0.8813 test accuracy after 5 epochs. 8s/epoch on i7 cpu.
-    Bi-gram : 0.9056 test accuracy after 5 epochs. 2s/epoch on GTx 980M gpu.
+
+Embedding|Accuracy, 5 epochs|Speed (s/epoch)|Hardware
+:--------|-----------------:|----:|:-------
+Uni-gram |            0.8813|    8|i7 CPU
+Bi-gram  |            0.9056|    2|GTx 980M GPU
+
 '''
 
 from __future__ import print_function

--- a/examples/imdb_lstm.py
+++ b/examples/imdb_lstm.py
@@ -1,9 +1,10 @@
-'''Trains an LSTM model on the IMDB sentiment classification task.
+'''
+#Trains an LSTM model on the IMDB sentiment classification task.
 
 The dataset is actually too small for LSTM to be of any advantage
 compared to simpler, much faster methods such as TF-IDF + LogReg.
 
-# Notes
+**Notes**
 
 - RNNs are tricky. Choice of batch size is important,
 choice of loss and optimizer is critical, etc.
@@ -11,6 +12,7 @@ Some configurations won't converge.
 
 - LSTM loss decrease patterns during training can be quite different
 from what you see with CNNs/MLPs/etc.
+
 '''
 from __future__ import print_function
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
This PR adds Markdown formatting to ```examples/imdb_lstm.py```.
Result:
![imdb_lstm1](https://user-images.githubusercontent.com/3424796/53106098-3ffdb180-352a-11e9-950c-2c86f87cf49a.png)
![imdb_lstm2](https://user-images.githubusercontent.com/3424796/53106099-3ffdb180-352a-11e9-9983-997aa01735bb.png)
### Related Issues
#12219 
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
