### PR TITLE
Added MarkDown formatting to examples/lstm_seq2seq_restore.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -85,3 +85,6 @@ nav:
   - Sentiment classification CNN-LSTM: examples/imdb_cnn_lstm.md
   - Fasttext for text classification: examples/imdb_fasttext.md
   - Sentiment classification LSTM: examples/imdb_lstm.md
+  - Sequence to sequence - training: examples/lstm_seq2seq.md
+  - Sequence to sequence - prediction: examples/lstm_seq2seq_restore.md
+  - Stateful LSTM: examples/lstm_stateful.md

--- a/examples/lstm_seq2seq.py
+++ b/examples/lstm_seq2seq.py
@@ -1,4 +1,5 @@
-'''Sequence to sequence example in Keras (character-level).
+'''
+#Sequence to sequence example in Keras (character-level).
 
 This script demonstrates how to implement a basic character-level
 sequence-to-sequence model. We apply it to translating
@@ -7,7 +8,7 @@ character-by-character. Note that it is fairly unusual to
 do character-level machine translation, as word-level
 models are more common in this domain.
 
-# Summary of the algorithm
+**Summary of the algorithm**
 
 - We start with input sequences from a domain (e.g. English sentences)
     and corresponding target sequences from another domain
@@ -32,21 +33,21 @@ models are more common in this domain.
     - Repeat until we generate the end-of-sequence character or we
         hit the character limit.
 
-# Data download
+**Data download**
 
-English to French sentence pairs.
-http://www.manythings.org/anki/fra-eng.zip
+[English to French sentence pairs.
+](http://www.manythings.org/anki/fra-eng.zip)
 
-Lots of neat sentence pairs datasets can be found at:
-http://www.manythings.org/anki/
+[Lots of neat sentence pairs datasets.
+](http://www.manythings.org/anki/)
 
-# References
+**References**
 
-- Sequence to Sequence Learning with Neural Networks
-    https://arxiv.org/abs/1409.3215
-- Learning Phrase Representations using
+- [Sequence to Sequence Learning with Neural Networks
+   ](https://arxiv.org/abs/1409.3215)
+- [Learning Phrase Representations using
     RNN Encoder-Decoder for Statistical Machine Translation
-    https://arxiv.org/abs/1406.1078
+    ](https://arxiv.org/abs/1406.1078)
 '''
 from __future__ import print_function
 

--- a/examples/lstm_seq2seq_restore.py
+++ b/examples/lstm_seq2seq_restore.py
@@ -1,12 +1,13 @@
-'''Restore a character-level sequence to sequence model from disk and use it
-to generate predictions.
+'''
+#Restore a character-level sequence to sequence model from to generate predictions.
 
-This script loads the s2s.h5 model saved by lstm_seq2seq.py and generates
-sequences from it.  It assumes that no changes have been made (for example:
-latent_dim is unchanged, and the input data and model architecture are unchanged).
+This script loads the ```s2s.h5``` model saved by [lstm_seq2seq.py
+](/examples/lstm_seq2seq/) and generates sequences from it. It assumes
+that no changes have been made (for example: ```latent_dim``` is unchanged,
+and the input data and model architecture are unchanged).
 
-See lstm_seq2seq.py for more details on the model architecture and how
-it is trained.
+See [lstm_seq2seq.py](/examples/lstm_seq2seq/) for more details on the
+model architecture and how it is trained.
 '''
 from __future__ import print_function
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
This PR adds Markdown formatting to ```examples/lstm_seq2seq_restore.py```.
The links refer to the documentation page for ```examples/lstm_seq2seq.py```.
Result:
![lstm_seq2seq2_restore1](https://user-images.githubusercontent.com/3424796/53178584-04c2b780-35ea-11e9-96a1-ab58aa8a94b5.png)
![lstm_seq2seq2_restore2](https://user-images.githubusercontent.com/3424796/53178585-04c2b780-35ea-11e9-8645-52f7ad27d2b0.png)
### Related Issues
#12219 
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
