### PR TITLE
Added MarkDown formatting to examples/lstm_stateful.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -85,3 +85,6 @@ nav:
   - Sentiment classification CNN-LSTM: examples/imdb_cnn_lstm.md
   - Fasttext for text classification: examples/imdb_fasttext.md
   - Sentiment classification LSTM: examples/imdb_lstm.md
+  - Sequence to sequence - training: examples/lstm_seq2seq.md
+  - Sequence to sequence - prediction: examples/lstm_seq2seq_restore.md
+  - Stateful LSTM: examples/lstm_stateful.md

--- a/examples/lstm_seq2seq.py
+++ b/examples/lstm_seq2seq.py
@@ -1,4 +1,5 @@
-'''Sequence to sequence example in Keras (character-level).
+'''
+#Sequence to sequence example in Keras (character-level).
 
 This script demonstrates how to implement a basic character-level
 sequence-to-sequence model. We apply it to translating
@@ -7,7 +8,7 @@ character-by-character. Note that it is fairly unusual to
 do character-level machine translation, as word-level
 models are more common in this domain.
 
-# Summary of the algorithm
+**Summary of the algorithm**
 
 - We start with input sequences from a domain (e.g. English sentences)
     and corresponding target sequences from another domain
@@ -32,21 +33,21 @@ models are more common in this domain.
     - Repeat until we generate the end-of-sequence character or we
         hit the character limit.
 
-# Data download
+**Data download**
 
-English to French sentence pairs.
-http://www.manythings.org/anki/fra-eng.zip
+[English to French sentence pairs.
+](http://www.manythings.org/anki/fra-eng.zip)
 
-Lots of neat sentence pairs datasets can be found at:
-http://www.manythings.org/anki/
+[Lots of neat sentence pairs datasets.
+](http://www.manythings.org/anki/)
 
-# References
+**References**
 
-- Sequence to Sequence Learning with Neural Networks
-    https://arxiv.org/abs/1409.3215
-- Learning Phrase Representations using
+- [Sequence to Sequence Learning with Neural Networks
+   ](https://arxiv.org/abs/1409.3215)
+- [Learning Phrase Representations using
     RNN Encoder-Decoder for Statistical Machine Translation
-    https://arxiv.org/abs/1406.1078
+    ](https://arxiv.org/abs/1406.1078)
 '''
 from __future__ import print_function
 

--- a/examples/lstm_seq2seq_restore.py
+++ b/examples/lstm_seq2seq_restore.py
@@ -1,12 +1,13 @@
-'''Restore a character-level sequence to sequence model from disk and use it
-to generate predictions.
+'''
+#Restore a character-level sequence to sequence model from to generate predictions.
 
-This script loads the s2s.h5 model saved by lstm_seq2seq.py and generates
-sequences from it.  It assumes that no changes have been made (for example:
-latent_dim is unchanged, and the input data and model architecture are unchanged).
+This script loads the ```s2s.h5``` model saved by [lstm_seq2seq.py
+](/examples/lstm_seq2seq/) and generates sequences from it. It assumes
+that no changes have been made (for example: ```latent_dim``` is unchanged,
+and the input data and model architecture are unchanged).
 
-See lstm_seq2seq.py for more details on the model architecture and how
-it is trained.
+See [lstm_seq2seq.py](/examples/lstm_seq2seq/) for more details on the
+model architecture and how it is trained.
 '''
 from __future__ import print_function
 

--- a/examples/lstm_stateful.py
+++ b/examples/lstm_stateful.py
@@ -1,38 +1,41 @@
-'''Example script showing how to use a stateful LSTM model
-and how its stateless counterpart performs.
+'''
+#How to use a stateful LSTM model, stateful vs stateless LSTM performance comparison
 
-More documentation about the Keras LSTM model can be found at
-https://keras.io/layers/recurrent/#lstm
+[More documentation about the Keras LSTM model
+](https://keras.io/layers/recurrent/#lstm)
 
 The models are trained on an input/output pair, where
 the input is a generated uniformly distributed
-random sequence of length = "input_len",
-and the output is a moving average of the input with window length = "tsteps".
-Both "input_len" and "tsteps" are defined in the "editable parameters" section.
+random sequence of length = ```input_len```,
+and the output is a moving average of the input with window length = ```tsteps```.
+Both ```input_len``` and ```tsteps``` are defined in the "editable parameters"
+section.
 
-A larger "tsteps" value means that the LSTM will need more memory
+A larger ```tsteps``` value means that the LSTM will need more memory
 to figure out the input-output relationship.
-This memory length is controlled by the "lahead" variable (more details below).
+This memory length is controlled by the ```lahead``` variable (more details below).
 
 The rest of the parameters are:
-- input_len: the length of the generated input sequence
-- lahead: the input sequence length that the LSTM
+
+- ```input_len```: the length of the generated input sequence
+- ```lahead```: the input sequence length that the LSTM
   is trained on for each output point
-- batch_size, epochs: same parameters as in the model.fit(...) function
+- ```batch_size```, ```epochs```: same parameters as in the ```model.fit(...)```
+  function
 
-When lahead > 1, the model input is preprocessed to a "rolling window view"
-of the data, with the window length = "lahead".
-This is similar to sklearn's "view_as_windows"
-with "window_shape" being a single number
-Ref: http://scikit-image.org/docs/0.10.x/api/skimage.util.html#view-as-windows
+When ```lahead > 1```, the model input is preprocessed to a "rolling window view"
+of the data, with the window length = ```lahead```.
+This is similar to sklearn's ```view_as_windows```
+with ```window_shape``` being a single number ([reference](
+http://scikit-image.org/docs/0.10.x/api/skimage.util.html#view-as-windows)).
 
-When lahead < tsteps, only the stateful LSTM converges because its
+When ```lahead < tsteps```, only the stateful LSTM converges because its
 statefulness allows it to see beyond the capability that lahead
 gave it to fit the n-point average. The stateless LSTM does not have
-this capability, and hence is limited by its "lahead" parameter,
+this capability, and hence is limited by its ```lahead``` parameter,
 which is not sufficient to see the n-point average.
 
-When lahead >= tsteps, both the stateful and stateless LSTM converge.
+When ```lahead >= tsteps```, both the stateful and stateless LSTM converge.
 '''
 from __future__ import print_function
 import numpy as np

--- a/examples/lstm_stateful.py
+++ b/examples/lstm_stateful.py
@@ -1,41 +1,40 @@
 '''
 #How to use a stateful LSTM model, stateful vs stateless LSTM performance comparison
 
-[More documentation about the Keras LSTM model
-](https://keras.io/layers/recurrent/#lstm)
+[More documentation about the Keras LSTM model](/layers/recurrent/#lstm)
 
 The models are trained on an input/output pair, where
 the input is a generated uniformly distributed
-random sequence of length = ```input_len```,
-and the output is a moving average of the input with window length = ```tsteps```.
-Both ```input_len``` and ```tsteps``` are defined in the "editable parameters"
+random sequence of length = `input_len`,
+and the output is a moving average of the input with window length = `tsteps`.
+Both `input_len` and `tsteps` are defined in the "editable parameters"
 section.
 
-A larger ```tsteps``` value means that the LSTM will need more memory
+A larger `tsteps` value means that the LSTM will need more memory
 to figure out the input-output relationship.
-This memory length is controlled by the ```lahead``` variable (more details below).
+This memory length is controlled by the `lahead` variable (more details below).
 
 The rest of the parameters are:
 
-- ```input_len```: the length of the generated input sequence
-- ```lahead```: the input sequence length that the LSTM
+- `input_len`: the length of the generated input sequence
+- `lahead`: the input sequence length that the LSTM
   is trained on for each output point
-- ```batch_size```, ```epochs```: same parameters as in the ```model.fit(...)```
+- `batch_size`, `epochs`: same parameters as in the `model.fit(...)`
   function
 
-When ```lahead > 1```, the model input is preprocessed to a "rolling window view"
-of the data, with the window length = ```lahead```.
-This is similar to sklearn's ```view_as_windows```
-with ```window_shape``` being a single number ([reference](
-http://scikit-image.org/docs/0.10.x/api/skimage.util.html#view-as-windows)).
+When `lahead > 1`, the model input is preprocessed to a "rolling window view"
+of the data, with the window length = `lahead`.
+This is similar to sklearn's `view_as_windows`
+with `window_shape` [being a single number.](
+http://scikit-image.org/docs/0.10.x/api/skimage.util.html#view-as-windows)
 
-When ```lahead < tsteps```, only the stateful LSTM converges because its
+When `lahead < tsteps`, only the stateful LSTM converges because its
 statefulness allows it to see beyond the capability that lahead
 gave it to fit the n-point average. The stateless LSTM does not have
-this capability, and hence is limited by its ```lahead``` parameter,
+this capability, and hence is limited by its `lahead` parameter,
 which is not sufficient to see the n-point average.
 
-When ```lahead >= tsteps```, both the stateful and stateless LSTM converge.
+When `lahead >= tsteps`, both the stateful and stateless LSTM converge.
 '''
 from __future__ import print_function
 import numpy as np


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
This PR adds Markdown formatting to ```examples/lstm_stateful.py```.
Result:
![lstm_stateful1](https://user-images.githubusercontent.com/3424796/53178681-3b98cd80-35ea-11e9-809a-9104c81dfb9f.png)
![lstm_stateful2](https://user-images.githubusercontent.com/3424796/53178682-3b98cd80-35ea-11e9-83a2-fbab3abd7254.png)
### Related Issues
#12219 
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
