### PR TITLE
Default dtype made floatx() instead of np.float32

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -420,14 +420,12 @@ def random_uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
 
 def random_uniform_variable(shape, low, high,
                             dtype=None, name=None, seed=None):
-    if dtype is None:
-        dtype = floatx()
     if seed is None:
         # ensure that randomness is conditioned by the Numpy RNG
         seed = np.random.randint(10e3)
 
     if dtype is None:
-        dtype = np.float32
+        dtype = floatx()
     else:
         dtype = _convert_string_dtype(dtype)
 
@@ -452,13 +450,11 @@ def random_normal_variable(
         dtype=None,
         name=None,
         seed=None):
-    if dtype is None:
-        dtype = floatx()
     if seed is None:
         # ensure that randomness is conditioned by the Numpy RNG
         seed = np.random.randint(10e7)
     if dtype is None:
-        dtype = np.float32
+        dtype = floatx()
     else:
         dtype = _convert_string_dtype(dtype)
 
@@ -497,7 +493,7 @@ def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
     if seed is None:
         seed = np.random.randint(1, 10e6)
     if dtype is None:
-        dtype = np.float32
+        dtype = floatx()
     else:
         dtype = _convert_string_dtype(dtype)
 

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -386,7 +386,7 @@ def random_binomial(shape, p=0.0, dtype=None, seed=None):
         # ensure that randomness is conditioned by the Numpy RNG
         seed = np.random.randint(10e7)
     if dtype is None:
-        dtype = np.float32
+        dtype = floatx()
     else:
         dtype = _convert_string_dtype(dtype)
 

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -181,7 +181,7 @@ def variable(value, dtype=None, name=None, constraint=None):
         value = value.astype(dtype)
 
     # TODO: remove the conversion when cntk supports int32, int64
-    # https://docs.microsoft.com/en-us/python/api/cntk.variables.parameter
+    # https://www.cntk.ai/pythondocs/cntk.variables.html#cntk.variables.Parameter
     dtype = 'float32' if 'int' in str(dtype) else dtype
 
     v = C.parameter(shape=shape,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
- dtype for `random_uniform`, `random_normal_variable`, `truncated_normal` will default to `floatx()` instead of `np.float32`
- Replacing an obsolete link in comment
### Related Issues

### PR Overview

- [N] This PR requires new unit tests [y/n] (make sure tests are included)
- [N] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [Y] This PR is backwards compatible [y/n]
- [N] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
