### PR TITLE
Fix in_top_k tests to include CNTK [Test fails]

### DIFF
--- a/keras/backend/numpy_backend.py
+++ b/keras/backend/numpy_backend.py
@@ -316,6 +316,12 @@ def l2_normalize(x, axis=-1):
     return x / np.sqrt(y)
 
 
+def in_top_k(predictions, targets, k):
+    top_k = np.argsort(-predictions)[:, :k]
+    targets = targets.reshape(-1, 1)
+    return np.any(targets == top_k, axis=-1)
+
+
 def binary_crossentropy(target, output, from_logits=False):
     if not from_logits:
         output = np.clip(output, 1e-7, 1 - 1e-7)

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1159,7 +1159,7 @@ class TestBackend(object):
         for k in range(num_classes + 1):
             z_list = [b.eval(b.in_top_k(b.variable(predictions, dtype='float32'),
                                         b.variable(targets, dtype='int32'), k))
-                      for b in [KTH, KTF]]
+                      for b in WITH_NP]
             assert_list_pairwise(z_list)
 
         # Identical prediction test case:
@@ -1174,7 +1174,7 @@ class TestBackend(object):
         for k in range(1, num_classes + 1):
             z_list = [b.eval(b.in_top_k(b.variable(predictions, dtype='float32'),
                                         b.variable(targets, dtype='int32'), k))
-                      for b in [KTH, KTF]]
+                                        for b in WITH_NP]
             assert_list_pairwise(z_list)
 
     @pytest.mark.parametrize('op,input_shape,kernel_shape,padding,data_format', [

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1156,7 +1156,7 @@ class TestBackend(object):
 
         # (k == 0 or k > num_classes) does not raise an error
         # but just return an unmeaningful tensor.
-        for k in range(num_classes + 1):
+        for k in range(1, num_classes + 1):
             z_list = [b.eval(b.in_top_k(b.variable(predictions, dtype='float32'),
                                         b.variable(targets, dtype='int32'), k))
                       for b in WITH_NP]

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1146,7 +1146,7 @@ class TestBackend(object):
         check_single_tensor_operation('l2_normalize', (4, 3), WITH_NP, axis=-1)
         check_single_tensor_operation('l2_normalize', (4, 3), WITH_NP, axis=1)
 
-    @pytest.mark.skipif(K.backend() == 'cntk', reason='Specific to CNTK.')
+    @pytest.mark.skipif(K.backend() == 'cntk', reason='Bug in CNTK')
     def test_in_top_k(self):
         batch_size = 20
         num_classes = 10

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1146,7 +1146,7 @@ class TestBackend(object):
         check_single_tensor_operation('l2_normalize', (4, 3), WITH_NP, axis=-1)
         check_single_tensor_operation('l2_normalize', (4, 3), WITH_NP, axis=1)
 
-    @pytest.mark.skipif(K.backend() != 'cntk', reason='Specific to CNTK.')
+    @pytest.mark.skipif(K.backend() == 'cntk', reason='Specific to CNTK.')
     def test_in_top_k(self):
         batch_size = 20
         num_classes = 10

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1174,7 +1174,7 @@ class TestBackend(object):
         for k in range(1, num_classes + 1):
             z_list = [b.eval(b.in_top_k(b.variable(predictions, dtype='float32'),
                                         b.variable(targets, dtype='int32'), k))
-                                        for b in WITH_NP]
+                      for b in WITH_NP]
             assert_list_pairwise(z_list)
 
     @pytest.mark.parametrize('op,input_shape,kernel_shape,padding,data_format', [

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1146,6 +1146,7 @@ class TestBackend(object):
         check_single_tensor_operation('l2_normalize', (4, 3), WITH_NP, axis=-1)
         check_single_tensor_operation('l2_normalize', (4, 3), WITH_NP, axis=1)
 
+    @pytest.mark.skipif(K.backend() != 'cntk', reason='Specific to CNTK.')
     def test_in_top_k(self):
         batch_size = 20
         num_classes = 10


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Tests for `K.in_top_k` were written to compare results between Theano and TF backends thus skipping CNTK altogether. The PR creates an equivalent function in numpy backend and compares the result of the backend being tested to it, allowing all the backends to be tested independently.

The fixed tests reveal #12335 

### Related Issues
#12335
### PR Overview

- [N] This PR requires new unit tests [y/n] (make sure tests are included)
- [N] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [Y] This PR is backwards compatible [y/n]
- [N] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
