### PR TITLE
Fix typo in siamese example

### DIFF
--- a/examples/mnist_siamese.py
+++ b/examples/mnist_siamese.py
@@ -43,9 +43,9 @@ def contrastive_loss(y_true, y_pred):
     http://yann.lecun.com/exdb/publis/pdf/hadsell-chopra-lecun-06.pdf
     '''
     margin = 1
-    sqaure_pred = K.square(y_pred)
+    square_pred = K.square(y_pred)
     margin_square = K.square(K.maximum(margin - y_pred, 0))
-    return K.mean(y_true * sqaure_pred + (1 - y_true) * margin_square)
+    return K.mean(y_true * square_pred + (1 - y_true) * margin_square)
 
 
 def create_pairs(x, digit_indices):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
I've noticed a typo in `mnist_siamese.py` example (variable `sqaure_pred` -> `square_pred`)
### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
