### PR TITLE
Add subclass CustomCSVLogger to enable tracking additional data.

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -13,6 +13,7 @@ import time
 import json
 import warnings
 import io
+import inspect
 
 from collections import deque
 from collections import OrderedDict

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1521,7 +1521,7 @@ class CustomCSVLogger(CSVLogger):
             and `model` (type Model).
     """
 
-    def __init__(self, additional_columns, **kwargs):
+    def __init__(self, additional_columns={}, **kwargs):
         super(CustomCSVLogger, self).__init__(**kwargs)
         self.epoch_start = None
         self.additional_columns = additional_columns

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -852,8 +852,8 @@ def test_CustomCSVLogger(tmpdir):
     model = make_model()
     dict_columns = {'seconds': None, 'learning_rate': get_learning_rate}
     cbks = [callbacks.CustomCSVLogger(filepath,
-                                separator=sep,
-                                additional_columns=dict_columns)]
+                                      separator=sep,
+                                      additional_columns=dict_columns)]
     model.fit(X_train, y_train, batch_size=batch_size,
               validation_data=(X_test, y_test), callbacks=cbks, epochs=3)
 

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -857,6 +857,7 @@ def test_CustomCSVLogger(tmpdir):
     model.fit(X_train, y_train, batch_size=batch_size,
               validation_data=(X_test, y_test), callbacks=cbks, epochs=3)
 
+    import re
     with open(filepath) as csvfile:
         list_lines = csvfile.readlines()
         for line in list_lines:

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -826,6 +826,51 @@ def test_CSVLogger(tmpdir):
     assert not tmpdir.listdir()
 
 
+def test_CustomCSVLogger(tmpdir):
+    np.random.seed(1337)
+    filepath = str(tmpdir / 'log_custom.tsv')
+    sep = '\t'
+
+    (X_train, y_train), (X_test, y_test) = get_data_callbacks()
+    y_test = np_utils.to_categorical(y_test)
+    y_train = np_utils.to_categorical(y_train)
+
+    def make_model():
+        np.random.seed(1337)
+        model = Sequential()
+        model.add(Dense(num_hidden, input_dim=input_dim, activation='relu'))
+        model.add(Dense(num_classes, activation='softmax'))
+
+        model.compile(loss='categorical_crossentropy',
+                      optimizer=optimizers.SGD(lr=0.1),
+                      metrics=['accuracy'])
+        return model
+
+    def get_learning_rate(epoch=None, model=None):
+        return np.round(float(K.get_value(model.optimizer.lr)), 5)
+
+    model = make_model()
+    dict_columns = {'seconds': None, 'learning_rate': get_learning_rate}
+    cbks = [callbacks.CustomCSVLogger(filepath,
+                                separator=sep,
+                                additional_columns=dict_columns)]
+    model.fit(X_train, y_train, batch_size=batch_size,
+              validation_data=(X_test, y_test), callbacks=cbks, epochs=3)
+
+    with open(filepath) as csvfile:
+        list_lines = csvfile.readlines()
+        for line in list_lines:
+            assert line.count(sep) == 6
+        assert len(list_lines) == 4
+        output = " ".join(list_lines)
+        assert len(re.findall('seconds', output)) == 1
+        assert len(re.findall('learning_rate', output)) == 1
+        assert list_lines[1].split(sep)[2] == '0.1'
+
+    os.remove(filepath)
+    assert not tmpdir.listdir()
+
+
 @pytest.mark.parametrize('update_freq', ['batch', 'epoch', 9])
 def test_TensorBoard(tmpdir, update_freq):
     np.random.seed(np.random.randint(1, 1e7))

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -851,7 +851,7 @@ def test_CustomCSVLogger(tmpdir):
 
     model = make_model()
     dict_columns = {'seconds': None, 'learning_rate': get_learning_rate}
-    cbks = [callbacks.CustomCSVLogger(filepath,
+    cbks = [callbacks.CustomCSVLogger(filename=filepath,
                                       separator=sep,
                                       additional_columns=dict_columns)]
     model.fit(X_train, y_train, batch_size=batch_size,


### PR DESCRIPTION
### Summary
This is an updated PR, following feedback from, and replacing, #12266, in case the discussed feature is useful for others, too.

I use this PR for my own models: Enable inclusion of additional data columns in the csv file from callback `CSVLogger` by introducing a subclass `CustomCSVLogger`. For example, a researcher might want to add the seconds per epoch, an identifier (same for every epoch) and the learning rate of each epoch (especially useful when using a learning rate scheduler):

```
    import numpy as np
    from keras import backend as K

    def get_learning_rate(epoch=None, model=None):
        return np.round(float(K.get_value(model.optimizer.lr)), 5)

    custom_csv_logger = CustomCSVLogger('training.log',
        additional_columns={'seconds': None, 'learning_rate': get_learning_rate})
    model.fit(X_train, Y_train, callbacks=[custom_csv_logger])
```

Parameter `additional_columns`: dictionary with key-value pairs, such that key is the name of the column to add to the csv file. If key is 'seconds' then the value is ignored and the number of seconds per epoch will be printed in the respective column 'seconds'. For other keys the value has to be a callable which must have the following two keyword arguments: `epoch` (type integer) and `model` (type Model).


### Related Issues
- current PR follows feedback from, and replaces, #12266 
- current PR includes feature "ability to add static values to output file" from #4157 


### PR Overview
- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)


### Further details
- I have included unit tests at `keras/tests/keras/test_callbacks.py`, which are all passing.
- I have included documentation and a code example at `keras/keras/callbacks.py`
- All code changes that I did are in the above two py-files.
- This PR takes my [API Design Review suggestion](https://docs.google.com/document/d/1oU-x3l7wcZYmuk1bopnxMBs1YMyfSjQvX15k4Yn5hdA/edit#heading=h.5ojovhmssrde) a little bit further, and is a bit more clear, I believe. The latter suggestion was posted in the respective [GoogleGroup](https://groups.google.com/forum/#!topic/keras-users/lFARnrJdEcs) and had just 1 positive comment, but no further discussion.

Looking forward to feedback and improvement suggestions.