### PR TITLE
Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,22 @@ cache:
     - $HOME/.theano
 matrix:
     include:
-        - python: 2.7
-          env: KERAS_BACKEND=tensorflow TEST_MODE=INTEGRATION_TESTS PIL=Pil
+        - python: 3.7
+          env: KERAS_BACKEND=tensorflow TEST_MODE=INTEGRATION_TESTS PIL=Pillow
         - python: 3.7
           env: KERAS_BACKEND=tensorflow TEST_MODE=PEP8_DOC PIL=Pillow
+        - python: 3.7
+          env: KERAS_BACKEND=tensorflow TEST_MODE=API
         - python: 2.7
           env: KERAS_BACKEND=tensorflow
         - python: 3.7
           env: KERAS_BACKEND=tensorflow
         - python: 2.7
-          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile MKL="mkl mkl-service"
+          env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile MKL="mkl mkl-service" RUN_ONLY_BACKEND_TESTS=1
         - python: 3.7
           env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile MKL="mkl mkl-service"
         - python: 2.7
-          env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
+          env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore RUN_ONLY_BACKEND_TESTS=1
         - python: 3.7
           env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
 install:
@@ -41,8 +43,8 @@ install:
 
   - travis_retry conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  # TODO: remove the freeze of the numpy version once the next theano version is out on pypi.
-  - travis_retry pip install --only-binary=numpy,scipy,pandas numpy==1.15.4 nose scipy h5py theano pytest pytest-pep8 pandas --progress-bar off
+
+  - travis_retry pip install --only-binary=numpy,scipy,pandas numpy nose scipy h5py theano pytest pytest-pep8 pandas --progress-bar off
   - pip install keras_applications keras_preprocessing --progress-bar off
 
   # set library path
@@ -57,7 +59,7 @@ install:
   - pip install tensorflow==1.13.1 --progress-bar off
 
   # install cntk
-  - if [[ "$KERAS_BACKEND" == "cntk" ]] || [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
+  - if [[ "$KERAS_BACKEND" == "cntk" ]] || [[ "$TEST_MODE" == "PEP8_DOC" ]] || [[ "$TEST_MODE" == "API" ]]; then
       ./.travis/install_cntk.sh;
     fi
 
@@ -66,6 +68,9 @@ install:
 
   # install mkdocs
   - pip install mkdocs --progress-bar off
+
+  # install pyux
+  - pip install pyux
 
 # command to run tests
 script:
@@ -80,7 +85,11 @@ script:
   - if [[ "$TEST_MODE" == "INTEGRATION_TESTS" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/integration_tests;
     elif [[ "$TEST_MODE" == "PEP8_DOC" ]]; then
-      PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0 && py.test tests/test_documentation.py && cd docs && python autogen.py && mkdocs build;
+      PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0 && py.test tests/docs;
+    elif [[ "$TEST_MODE" == "API" ]]; then
+      PYTHONPATH=$PWD:$PYTHONPATH pip install git+git://www.github.com/keras-team/keras.git && python update_api.py && pip install -e .[tests] --progress-bar off && py.test tests/test_api.py;
+    elif [[ "$RUN_ONLY_BACKEND_TESTS" == "1" ]]; then
+      PYTHONPATH=$PWD:$PYTHONPATH py.test  tests/keras/backend/;
     else
-      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/test_documentation.py --ignore=tests/keras/legacy/layers_test.py --cov-config .coveragerc --cov=keras tests/;
+      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --ignore=tests/docs --ignore=tests/keras/legacy/layers_test.py --ignore=tests/test_api.py --cov-config .coveragerc --cov=keras tests/;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,19 @@ matrix:
     include:
         - python: 2.7
           env: KERAS_BACKEND=tensorflow TEST_MODE=INTEGRATION_TESTS PIL=Pil
-        - python: 3.6
+        - python: 3.7
           env: KERAS_BACKEND=tensorflow TEST_MODE=PEP8_DOC PIL=Pillow
         - python: 2.7
           env: KERAS_BACKEND=tensorflow
-        - python: 3.6
+        - python: 3.7
           env: KERAS_BACKEND=tensorflow
         - python: 2.7
           env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile MKL="mkl mkl-service"
-        - python: 3.6
+        - python: 3.7
           env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile MKL="mkl mkl-service"
         - python: 2.7
           env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
-        - python: 3.6
+        - python: 3.7
           env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
 install:
   # code below is taken from http://conda.pydata.org/docs/travis.html
@@ -54,7 +54,7 @@ install:
   - pip install -e .[tests] --progress-bar off
 
   # install TensorFlow (CPU version).
-  - pip install tensorflow==1.12 --progress-bar off
+  - pip install tensorflow==1.13.1 --progress-bar off
 
   # install cntk
   - if [[ "$KERAS_BACKEND" == "cntk" ]] || [[ "$TEST_MODE" == "PEP8_DOC" ]]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,9 +71,9 @@ Here's a quick guide to submitting your improvements:
     - You will need to install the test requirements as well: `pip install -e .[tests]`.
 
 6. Make sure all tests are passing:
-    - with the Theano backend, on Python 2.7 and Python 3.6. Make sure you have the development version of Theano.
-    - with the TensorFlow backend, on Python 2.7 and Python 3.6. Make sure you have the development version of TensorFlow.
-    - with the CNTK backend, on Python 2.7 and Python 3.6. Make sure you have the development version of CNTK.
+    - with the Theano backend, on Python 2.7 and Python 3.7. Make sure you have the development version of Theano.
+    - with the TensorFlow backend, on Python 2.7 and Python 3.7. Make sure you have the development version of TensorFlow.
+    - with the CNTK backend, on Python 2.7 and Python 3.7. Make sure you have the development version of CNTK.
 
 7. We use PEP8 syntax conventions, but we aren't dogmatic when it comes to line length. Make sure your lines stay reasonably sized, though. To make your life easier, we recommend running a PEP8 linter:
     - Install PEP8 packages: `pip install pep8 pytest-pep8 autopep8`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Keras is compatible with: __Python 2.7-3.6__.
 
 - __User friendliness.__ Keras is an API designed for human beings, not machines. It puts user experience front and center. Keras follows best practices for reducing cognitive load: it offers consistent & simple APIs, it minimizes the number of user actions required for common use cases, and it provides clear and actionable feedback upon user error.
 
-- __Modularity.__ A model is understood as a sequence or a graph of standalone, fully-configurable modules that can be plugged together with as few restrictions as possible. In particular, neural layers, cost functions, optimizers, initialization schemes, activation functions, regularization schemes are all standalone modules that you can combine to create new models.
+- __Modularity.__ A model is understood as a sequence or a graph of standalone, fully configurable modules that can be plugged together with as few restrictions as possible. In particular, neural layers, cost functions, optimizers, initialization schemes, activation functions, regularization schemes are all standalone modules that you can combine to create new models.
 
 - __Easy extensibility.__ New modules are simple to add (as new classes and functions), and existing modules provide ample examples. To be able to easily create new modules allows for total expressiveness, making Keras suitable for advanced research.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use Keras if you need a deep learning library that:
 
 Read the documentation at [Keras.io](https://keras.io).
 
-Keras is compatible with: __Python 2.7-3.6__.
+Keras is compatible with: __Python 2.7-3.7__.
 
 
 ------------------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG cuda_version=9.0
+ARG cuda_version=10.0
 ARG cudnn_version=7
 FROM nvidia/cuda:${cuda_version}-cudnn${cudnn_version}-devel
 
@@ -35,7 +35,7 @@ RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
 
 USER $NB_USER
 
-ARG python_version=3.6
+ARG python_version=3.7
 
 RUN conda config --append channels conda-forge
 RUN conda install -y python=${python_version} && \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,8 +6,8 @@ GPU?=0
 DOCKER_FILE=Dockerfile
 DOCKER=GPU=$(GPU) nvidia-docker
 BACKEND=tensorflow
-PYTHON_VERSION?=3.6
-CUDA_VERSION?=9.0
+PYTHON_VERSION?=3.7
+CUDA_VERSION?=10.0
 CUDNN_VERSION?=7
 TEST=tests/
 SRC?=$(shell dirname `pwd`)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ Read the documentation at: https://keras.io/
 For a detailed overview of what makes Keras special, see:
 https://keras.io/why-use-keras/
 
-Keras is compatible with Python 2.7-3.6
+Keras is compatible with Python 2.7-3.7
 and is distributed under the MIT license.
 '''
 
@@ -59,7 +59,7 @@ setup(name='Keras',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
           'Topic :: Software Development :: Libraries',
           'Topic :: Software Development :: Libraries :: Python Modules'
       ],


### PR DESCRIPTION
### Summary
TensorFlow 1.13 has added support for Python 3.7 and CUDA 10, so I've updated the documentation and the Travis config to include support for 3.7.

### Related Issues
#11690 

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
