### PR TITLE
Removed useless function call in autogen.py

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -69,7 +69,7 @@ def get_class_signature(cls):
         # in case the class inherits from object and does not
         # define __init__
         class_signature = "{clean_module_name}.{cls_name}()".format(
-            clean_module_name=clean_module_name(cls.__module__),
+            clean_module_name=cls.__module__,
             cls_name=cls.__name__
         )
     return post_process_signature(class_signature)
@@ -96,7 +96,7 @@ def clean_module_name(name):
 
 
 def class_to_source_link(cls):
-    module_name = clean_module_name(cls.__module__)
+    module_name = cls.__module__
     path = module_name.replace('.', '/')
     path += '.py'
     line = inspect.getsourcelines(cls)[-1]

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -96,7 +96,7 @@ def clean_module_name(name):
 
 
 def class_to_source_link(cls):
-    module_name = cls.__module__
+    module_name = clean_module_name(cls.__module__)
     path = module_name.replace('.', '/')
     path += '.py'
     line = inspect.getsourcelines(cls)[-1]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

There is no need for this `clean_module_name` here because it's already done earlier in `get_function_signature`. You can check that this is true because the tests here is still passing:  

https://github.com/keras-team/keras/blob/de36e0426d4f01216653979af4beb0481a1b2735/tests/docs/test_doc_auto_generation.py#L398

### Related Issues
https://github.com/keras-team/keras-contrib/issues/412
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
