### PR TITLE
Fixed InputLayer display in print_summary()

### DIFF
--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -159,7 +159,7 @@ def print_summary(model, line_length=None, positions=None, print_fn=None):
                 fields = ['', '', '', connections[i]]
                 print_row(fields, positions)
 
-    layers = model.layers
+    layers = model._layers
     for i in range(len(layers)):
         if sequential_like:
             print_layer_summary(layers[i])


### PR DESCRIPTION
### Summary
The print_summary() function does not display the input layer of Sequential models correctly. 
The reason is using model.layers instead of model._layers.

### Related Issues
https://github.com/keras-team/keras/issues/10638 — the same problem in model_to_dot() fixed

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
