### PR TITLE
Corrected 2D relicts in 3D function comments

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -2240,7 +2240,7 @@ class ZeroPadding3D(_ZeroPadding):
             - If int: the same symmetric padding
                 is applied to height and width.
             - If tuple of 3 ints:
-                interpreted as two different
+                interpreted as three different
                 symmetric padding values for height and width:
                 `(symmetric_dim1_pad, symmetric_dim2_pad, symmetric_dim3_pad)`.
             - If tuple of 3 tuples of 2 ints:
@@ -2496,7 +2496,7 @@ class Cropping3D(_Cropping):
             - If int: the same symmetric cropping
                 is applied to depth, height, and width.
             - If tuple of 3 ints:
-                interpreted as two different
+                interpreted as three different
                 symmetric cropping values for depth, height, and width:
                 `(symmetric_dim1_crop, symmetric_dim2_crop, symmetric_dim3_crop)`.
             - If tuple of 3 tuples of 2 ints:

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -2241,7 +2241,7 @@ class ZeroPadding3D(_ZeroPadding):
                 is applied to height and width.
             - If tuple of 3 ints:
                 interpreted as three different
-                symmetric padding values for height and width:
+                symmetric padding values for depth, height, and width:
                 `(symmetric_dim1_pad, symmetric_dim2_pad, symmetric_dim3_pad)`.
             - If tuple of 3 tuples of 2 ints:
                 interpreted as


### PR DESCRIPTION
In Cropping3D and ZeroPadding3D, the comments referred to "two" values, which for 3D functions must be "three".
### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
