### PR TITLE
Added MarkDown formatting to examples/mnist_cnn.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,11 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Convolutional NN on MNIST: examples/mnist_cnn.md
+  - TensorFlow Dataset API: examples/mnist_dataset_api.md
+  - Denoising autoencoder: examples/mnist_denoising_autoencoder.md
+  - Hierarchical RNN: examples/mnist_hierarchical_rnn.md
+  - Recurrent NN initialization: examples/mnist_irnn.md
+  - Simple deep NN: examples/mnist_mlp.md
+  - Knowledge Transfer: examples/mnist_net2net.md
+  - Siamese MLP: examples/mnist_siamese.md

--- a/examples/mnist_cnn.py
+++ b/examples/mnist_cnn.py
@@ -1,5 +1,5 @@
 '''
-#Trains a simple convnet on the MNIST dataset.
+# Trains a simple convnet on the MNIST dataset.
 
 Gets to 99.25% test accuracy after 12 epochs
 (there is still a lot of margin for parameter tuning).

--- a/examples/mnist_cnn.py
+++ b/examples/mnist_cnn.py
@@ -1,4 +1,5 @@
-'''Trains a simple convnet on the MNIST dataset.
+'''
+#Trains a simple convnet on the MNIST dataset.
 
 Gets to 99.25% test accuracy after 12 epochs
 (there is still a lot of margin for parameter tuning).


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
This PR adds Markdown formatting to `examples/mnist_cnn.py`.
Result:
![mnist_cnn1](https://user-images.githubusercontent.com/3424796/54070221-2ca25400-4255-11e9-8666-12f205e59a6c.png)
![mnist_cnn2](https://user-images.githubusercontent.com/3424796/54070222-2ca25400-4255-11e9-8af7-433a544f20f5.png)

### Related Issues
#12219 
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
