### PR TITLE
Added Markdown formatting to examples/mnist_dataset_api.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,11 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Convolutional NN on MNIST: examples/mnist_cnn.md
+  - TensorFlow Dataset API: examples/mnist_dataset_api.md
+  - Denoising autoencoder: examples/mnist_denoising_autoencoder.md
+  - Hierarchical RNN: examples/mnist_hierarchical_rnn.md
+  - Recurrent NN initialization: examples/mnist_irnn.md
+  - Simple deep NN: examples/mnist_mlp.md
+  - Knowledge Transfer: examples/mnist_net2net.md
+  - Siamese MLP: examples/mnist_siamese.md

--- a/examples/mnist_cnn.py
+++ b/examples/mnist_cnn.py
@@ -1,4 +1,5 @@
-'''Trains a simple convnet on the MNIST dataset.
+'''
+#Trains a simple convnet on the MNIST dataset.
 
 Gets to 99.25% test accuracy after 12 epochs
 (there is still a lot of margin for parameter tuning).

--- a/examples/mnist_dataset_api.py
+++ b/examples/mnist_dataset_api.py
@@ -1,5 +1,5 @@
 '''
-#MNIST classification with TensorFlow's Dataset API.
+# MNIST classification with TensorFlow's Dataset API.
 
 Introduced in TensorFlow 1.3, the Dataset API is now the
 standard method for loading data into TensorFlow models.

--- a/examples/mnist_dataset_api.py
+++ b/examples/mnist_dataset_api.py
@@ -1,20 +1,22 @@
-'''MNIST classification with TensorFlow's Dataset API.
+'''
+#MNIST classification with TensorFlow's Dataset API.
 
 Introduced in TensorFlow 1.3, the Dataset API is now the
 standard method for loading data into TensorFlow models.
 A Dataset is a sequence of elements, which are themselves
-composed of tf.Tensor components. For more details, see:
-https://www.tensorflow.org/programmers_guide/datasets
+composed of `tf.Tensor` components. For more details, see
+[Tensorflow's dataset API guide
+](https://www.tensorflow.org/programmers_guide/datasets)
 
 To use this with Keras, we make a dataset out of elements
 of the form (input batch, output batch). From there, we
 create a one-shot iterator and a graph node corresponding
-to its get_next() method. Its components are then provided
-to the network's Input layer and the Model.compile() method,
+to its `get_next()` method. Its components are then provided
+to the network's Input layer and the `Model.compile()` method,
 respectively.
 
 This example is intended to closely follow the
-mnist_tfrecord.py example.
+`mnist_tfrecord.py` example.
 '''
 import numpy as np
 import os


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
This PR adds Markdown formatting to `examples/mnist_dataset_api.py`.
Result:
![mnist_dataset_api1](https://user-images.githubusercontent.com/3424796/54070246-7b4fee00-4255-11e9-8805-91ace1754772.png)
![mnist_dataset_api2](https://user-images.githubusercontent.com/3424796/54070247-7b4fee00-4255-11e9-9a74-a205b962db54.png)


### Related Issues
#12219 
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
