### PR TITLE
Added Markdown formatting to examples/mnist_net2net.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,11 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Convolutional NN on MNIST: examples/mnist_cnn.md
+  - TensorFlow Dataset API: examples/mnist_dataset_api.md
+  - Denoising autoencoder: examples/mnist_denoising_autoencoder.md
+  - Hierarchical RNN: examples/mnist_hierarchical_rnn.md
+  - Recurrent NN initialization: examples/mnist_irnn.md
+  - Simple deep NN: examples/mnist_mlp.md
+  - Knowledge Transfer: examples/mnist_net2net.md
+  - Siamese MLP: examples/mnist_siamese.md

--- a/examples/mnist_cnn.py
+++ b/examples/mnist_cnn.py
@@ -1,4 +1,5 @@
-'''Trains a simple convnet on the MNIST dataset.
+'''
+#Trains a simple convnet on the MNIST dataset.
 
 Gets to 99.25% test accuracy after 12 epochs
 (there is still a lot of margin for parameter tuning).

--- a/examples/mnist_dataset_api.py
+++ b/examples/mnist_dataset_api.py
@@ -1,20 +1,22 @@
-'''MNIST classification with TensorFlow's Dataset API.
+'''
+#MNIST classification with TensorFlow's Dataset API.
 
 Introduced in TensorFlow 1.3, the Dataset API is now the
 standard method for loading data into TensorFlow models.
 A Dataset is a sequence of elements, which are themselves
-composed of tf.Tensor components. For more details, see:
-https://www.tensorflow.org/programmers_guide/datasets
+composed of `tf.Tensor` components. For more details, see
+[Tensorflow's dataset API guide
+](https://www.tensorflow.org/programmers_guide/datasets)
 
 To use this with Keras, we make a dataset out of elements
 of the form (input batch, output batch). From there, we
 create a one-shot iterator and a graph node corresponding
-to its get_next() method. Its components are then provided
-to the network's Input layer and the Model.compile() method,
+to its `get_next()` method. Its components are then provided
+to the network's Input layer and the `Model.compile()` method,
 respectively.
 
 This example is intended to closely follow the
-mnist_tfrecord.py example.
+`mnist_tfrecord.py` example.
 '''
 import numpy as np
 import os

--- a/examples/mnist_denoising_autoencoder.py
+++ b/examples/mnist_denoising_autoencoder.py
@@ -1,4 +1,5 @@
-'''Trains a denoising autoencoder on MNIST dataset.
+'''
+#Trains a denoising autoencoder on MNIST dataset.
 
 Denoising is one of the classic applications of autoencoders.
 The denoising process removes unwanted noise that corrupted the

--- a/examples/mnist_hierarchical_rnn.py
+++ b/examples/mnist_hierarchical_rnn.py
@@ -1,4 +1,5 @@
-"""Example of using Hierarchical RNN (HRNN) to classify MNIST digits.
+"""
+#Example of using Hierarchical RNN (HRNN) to classify MNIST digits.
 
 HRNNs can learn across multiple levels
 of temporal hierarchy over a complex sequence.
@@ -10,16 +11,19 @@ such vectors (encoded by the first layer) into a document vector.
 This document vector is considered to preserve both
 the word-level and sentence-level structure of the context.
 
-# References
+**References**
 
-- [A Hierarchical Neural Autoencoder for Paragraphs and Documents]
-    (https://arxiv.org/abs/1506.01057)
+- [A Hierarchical Neural Autoencoder for Paragraphs and Documents
+    ](https://arxiv.org/abs/1506.01057)
+
     Encodes paragraphs and documents with HRNN.
     Results have shown that HRNN outperforms standard
     RNNs and may play some role in more sophisticated generation tasks like
     summarization or question answering.
-- [Hierarchical recurrent neural network for skeleton based action recognition]
-    (http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=7298714)
+
+- [Hierarchical recurrent neural network for skeleton based action recognition
+    ](http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=7298714)
+
     Achieved state-of-the-art results on
     skeleton based action recognition with 3 levels
     of bidirectional HRNN combined with fully connected layers.

--- a/examples/mnist_irnn.py
+++ b/examples/mnist_irnn.py
@@ -1,10 +1,11 @@
-'''This is a reproduction of the IRNN experiment
-with pixel-by-pixel sequential MNIST in
-"A Simple Way to Initialize Recurrent Networks of Rectified Linear Units"
-by Quoc V. Le, Navdeep Jaitly, Geoffrey E. Hinton
+'''
+#Recurrent neural network initialization
 
-arxiv:1504.00941v2 [cs.NE] 7 Apr 2015
-http://arxiv.org/pdf/1504.00941v2.pdf
+This is a reproduction of the IRNN experiment
+with pixel-by-pixel sequential MNIST in
+["A Simple Way to Initialize Recurrent Networks of Rectified Linear Units"
+](http://arxiv.org/pdf/1504.00941v2.pdf) by Quoc V. Le, Navdeep Jaitly,
+Geoffrey E. Hinton
 
 Optimizer is replaced with RMSprop which yields more stable and steady
 improvement.

--- a/examples/mnist_mlp.py
+++ b/examples/mnist_mlp.py
@@ -1,4 +1,5 @@
-'''Trains a simple deep NN on the MNIST dataset.
+'''
+#Train a simple deep NN on the MNIST dataset.
 
 Gets to 98.40% test accuracy after 20 epochs
 (there is *a lot* of margin for parameter tuning).

--- a/examples/mnist_net2net.py
+++ b/examples/mnist_net2net.py
@@ -1,5 +1,5 @@
 '''
-#Knowledge transfer with Net2Net
+# Knowledge transfer with Net2Net
 This is an implementation of Net2Net experiment with MNIST in
 ['Net2Net: Accelerating Learning via Knowledge Transfer'
 ](http://arxiv.org/abs/1511.05641)

--- a/examples/mnist_net2net.py
+++ b/examples/mnist_net2net.py
@@ -1,49 +1,49 @@
-'''This is an implementation of Net2Net experiment with MNIST in
-'Net2Net: Accelerating Learning via Knowledge Transfer'
+'''
+#Knowledge transfer with Net2Net
+This is an implementation of Net2Net experiment with MNIST in
+['Net2Net: Accelerating Learning via Knowledge Transfer'
+](http://arxiv.org/abs/1511.05641)
 by Tianqi Chen, Ian Goodfellow, and Jonathon Shlens
 
-arXiv:1511.05641v4 [cs.LG] 23 Apr 2016
-http://arxiv.org/abs/1511.05641
-
-# Notes
+**Notes**
 
 - What:
-  + Net2Net is a group of methods to transfer knowledge from a teacher neural
-    net to a student net,so that the student net can be trained faster than
-    from scratch.
-  + The paper discussed two specific methods of Net2Net, i.e. Net2WiderNet
-    and Net2DeeperNet.
-  + Net2WiderNet replaces a model with an equivalent wider model that has
-    more units in each hidden layer.
-  + Net2DeeperNet replaces a model with an equivalent deeper model.
-  + Both are based on the idea of 'function-preserving transformations of
-    neural nets'.
+    * Net2Net is a group of methods to transfer knowledge from a teacher neural
+      net to a student net,so that the student net can be trained faster than
+      from scratch.
+    * The paper discussed two specific methods of Net2Net, i.e. Net2WiderNet
+      and Net2DeeperNet.
+    * Net2WiderNet replaces a model with an equivalent wider model that has
+      more units in each hidden layer.
+    * Net2DeeperNet replaces a model with an equivalent deeper model.
+    * Both are based on the idea of 'function-preserving transformations of
+      neural nets'.
 - Why:
-  + Enable fast exploration of multiple neural nets in experimentation and
-    design process,by creating a series of wider and deeper models with
-    transferable knowledge.
-  + Enable 'lifelong learning system' by gradually adjusting model complexity
-    to data availability,and reusing transferable knowledge.
+    * Enable fast exploration of multiple neural nets in experimentation and
+      design process,by creating a series of wider and deeper models with
+      transferable knowledge.
+    * Enable 'lifelong learning system' by gradually adjusting model complexity
+      to data availability,and reusing transferable knowledge.
 
-# Experiments
+**Experiments**
 
 - Teacher model: a basic CNN model trained on MNIST for 3 epochs.
 - Net2WiderNet experiment:
-  + Student model has a wider Conv2D layer and a wider FC layer.
-  + Comparison of 'random-padding' vs 'net2wider' weight initialization.
-  + With both methods, after 1 epoch, student model should perform as well as
-    teacher model, but 'net2wider' is slightly better.
+    * Student model has a wider Conv2D layer and a wider FC layer.
+    * Comparison of 'random-padding' vs 'net2wider' weight initialization.
+    * With both methods, after 1 epoch, student model should perform as well as
+      teacher model, but 'net2wider' is slightly better.
 - Net2DeeperNet experiment:
-  + Student model has an extra Conv2D layer and an extra FC layer.
-  + Comparison of 'random-init' vs 'net2deeper' weight initialization.
-  + After 1 epoch, performance of 'net2deeper' is better than 'random-init'.
+    * Student model has an extra Conv2D layer and an extra FC layer.
+    * Comparison of 'random-init' vs 'net2deeper' weight initialization.
+    * After 1 epoch, performance of 'net2deeper' is better than 'random-init'.
 - Hyper-parameters:
-  + SGD with momentum=0.9 is used for training teacher and student models.
-  + Learning rate adjustment: it's suggested to reduce learning rate
-    to 1/10 for student model.
-  + Addition of noise in 'net2wider' is used to break weight symmetry
-    and thus enable full capacity of student models. It is optional
-    when a Dropout layer is used.
+    * SGD with momentum=0.9 is used for training teacher and student models.
+    * Learning rate adjustment: it's suggested to reduce learning rate
+      to 1/10 for student model.
+    * Addition of noise in 'net2wider' is used to break weight symmetry
+      and thus enable full capacity of student models. It is optional
+      when a Dropout layer is used.
 
 # Results
 
@@ -51,16 +51,15 @@ http://arxiv.org/abs/1511.05641
 - Running on GPU GeForce GTX Titan X Maxwell
 - Performance Comparisons - validation loss values during first 3 epochs:
 
-Teacher model ...
-(0) teacher_model:             0.0537   0.0354   0.0356
 
-Experiment of Net2WiderNet ...
-(1) wider_random_pad:          0.0320   0.0317   0.0289
-(2) wider_net2wider:           0.0271   0.0274   0.0270
+ Experiment | Initialization | Epoch 1 | Epoch 2 |Epoch 3
+:------------|:-----------------|-----:|-----:|-----:
+Teacher model|-                 |0.0537|0.0354|0.0356
+Net2WiderNet |wider_random_pad  |0.0320|0.0317|0.0289
+Net2WiderNet |wider_net2wider   |0.0271|0.0274|0.0270
+Net2DeeperNet|deeper_random_init|0.0682|0.0506|0.0468
+Net2DeeperNet|deeper_net2deeper |0.0292|0.0294|0.0286
 
-Experiment of Net2DeeperNet ...
-(3) deeper_random_init:        0.0682   0.0506   0.0468
-(4) deeper_net2deeper:         0.0292   0.0294   0.0286
 '''
 
 from __future__ import print_function

--- a/examples/mnist_net2net.py
+++ b/examples/mnist_net2net.py
@@ -51,7 +51,6 @@ by Tianqi Chen, Ian Goodfellow, and Jonathon Shlens
 - Running on GPU GeForce GTX Titan X Maxwell
 - Performance Comparisons - validation loss values during first 3 epochs:
 
-
  Experiment | Initialization | Epoch 1 | Epoch 2 |Epoch 3
 :------------|:-----------------|-----:|-----:|-----:
 Teacher model|-                 |0.0537|0.0354|0.0356


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Added Markdown formatting to `examples/mnist_net2net.py`.
Result:
![mnist_net2net1](https://user-images.githubusercontent.com/3424796/54070302-0f21ba00-4256-11e9-8787-287d9795515a.png)
![mnist_net2net2](https://user-images.githubusercontent.com/3424796/54070303-0f21ba00-4256-11e9-834b-7e3a01d659b4.png)

### Related Issues
#12219
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
