### PR TITLE
Tf 2: fix optimizer weights naming collision issue

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -13,6 +13,7 @@ import tempfile
 from six.moves import zip
 from six import string_types
 from functools import wraps
+
 import numpy as np
 
 from .. import backend as K

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -192,7 +192,8 @@ class SGD(Optimizer):
                                                       K.dtype(self.decay))))
         # momentum
         shapes = [K.int_shape(p) for p in params]
-        moments = [K.zeros(shape) for shape in shapes]
+        moments = [K.zeros(shape, name='moment_' + str(i))
+                   for (i, shape) in enumerate(shapes)]
         self.weights = [self.iterations] + moments
         for p, g, m in zip(params, grads, moments):
             v = self.momentum * m - lr * g  # velocity
@@ -257,7 +258,10 @@ class RMSprop(Optimizer):
     @K.symbolic
     def get_updates(self, loss, params):
         grads = self.get_gradients(loss, params)
-        accumulators = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+        accumulators = [K.zeros(K.int_shape(p),
+                        dtype=K.dtype(p),
+                        name='accumulator_' + str(i))
+                        for (i, p) in enumerate(params)]
         self.weights = accumulators
         self.updates = [K.update_add(self.iterations, 1)]
 
@@ -325,7 +329,8 @@ class Adagrad(Optimizer):
     def get_updates(self, loss, params):
         grads = self.get_gradients(loss, params)
         shapes = [K.int_shape(p) for p in params]
-        accumulators = [K.zeros(shape) for shape in shapes]
+        accumulators = [K.zeros(shape, name='accumulator_' + str(i))
+                        for (i, shape) in enumerate(shapes)]
         self.weights = accumulators
         self.updates = [K.update_add(self.iterations, 1)]
 
@@ -399,8 +404,10 @@ class Adadelta(Optimizer):
     def get_updates(self, loss, params):
         grads = self.get_gradients(loss, params)
         shapes = [K.int_shape(p) for p in params]
-        accumulators = [K.zeros(shape) for shape in shapes]
-        delta_accumulators = [K.zeros(shape) for shape in shapes]
+        accumulators = [K.zeros(shape, name='accumulator_' + str(i))
+                        for (i, shape) in enumerate(shapes)]
+        delta_accumulators = [K.zeros(shape, name='delta_accumulator_' + str(i))
+                        for (i, shape) in enumerate(shapes)]
         self.weights = accumulators + delta_accumulators
         self.updates = [K.update_add(self.iterations, 1)]
 
@@ -490,12 +497,22 @@ class Adam(Optimizer):
         lr_t = lr * (K.sqrt(1. - K.pow(self.beta_2, t)) /
                      (1. - K.pow(self.beta_1, t)))
 
-        ms = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
-        vs = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+        ms = [K.zeros(K.int_shape(p),
+              dtype=K.dtype(p),
+              name='m_' + str(i))
+              for (i, p) in enumerate(params)]
+        vs = [K.zeros(K.int_shape(p),
+              dtype=K.dtype(p),
+              name='v_' + str(i))
+              for (i, p) in enumerate(params)]
+
         if self.amsgrad:
-            vhats = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+            vhats = [K.zeros(K.int_shape(p),
+                dtype=K.dtype(p),
+                name='vhat_' + str(i))
+                for (i, p) in enumerate(params)]
         else:
-            vhats = [K.zeros(1) for _ in params]
+            vhats = [K.zeros(1, name='vhat_' + str(i)) for i in range(len(params))]
         self.weights = [self.iterations] + ms + vs + vhats
 
         for p, g, m, v, vhat in zip(params, grads, ms, vs, vhats):
@@ -578,9 +595,11 @@ class Adamax(Optimizer):
 
         shapes = [K.int_shape(p) for p in params]
         # zero init of 1st moment
-        ms = [K.zeros(shape) for shape in shapes]
+        ms = [K.zeros(shape, name='m_' + str(i))
+              for (i, shape) in enumerate(shapes)]
         # zero init of exponentially weighted infinity norm
-        us = [K.zeros(shape) for shape in shapes]
+        us = [K.zeros(shape, name='u_' + str(i))
+              for (i, shape) in enumerate(shapes)]
         self.weights = [self.iterations] + ms + us
 
         for p, g, m, u in zip(params, grads, ms, us):
@@ -665,8 +684,10 @@ class Nadam(Optimizer):
         self.updates.append((self.m_schedule, m_schedule_new))
 
         shapes = [K.int_shape(p) for p in params]
-        ms = [K.zeros(shape) for shape in shapes]
-        vs = [K.zeros(shape) for shape in shapes]
+        ms = [K.zeros(shape, name='m_' + str(i))
+              for (i, shape) in enumerate(shapes)]
+        vs = [K.zeros(shape, name='v_' + str(i))
+              for (i, shape) in enumerate(shapes)]
 
         self.weights = [self.iterations] + ms + vs
 

--- a/keras/utils/multi_gpu_utils.py
+++ b/keras/utils/multi_gpu_utils.py
@@ -13,7 +13,7 @@ from ..utils.generic_utils import to_list
 
 
 def _get_available_devices():
-    return [x.name for x in K.tensorflow_backend._get_available_gpus()]
+    return K.tensorflow_backend._get_available_gpus()
 
 
 def _normalize_device_name(name):

--- a/keras/utils/multi_gpu_utils.py
+++ b/keras/utils/multi_gpu_utils.py
@@ -13,7 +13,7 @@ from ..utils.generic_utils import to_list
 
 
 def _get_available_devices():
-    return K.tensorflow_backend._get_available_gpus()
+    return [x.name for x in K.get_session().list_devices()]
 
 
 def _normalize_device_name(name):
@@ -153,7 +153,7 @@ def multi_gpu_model(model, gpus=None, cpu_merge=True, cpu_relocation=False):
     if not gpus:
         # Using all visible GPUs when not specifying `gpus`
         # e.g. CUDA_VISIBLE_DEVICES=0,2 python keras_mgpu.py
-        gpus = len(available_devices)
+        gpus = len([x for x in available_devices if 'gpu' in x])
 
     if isinstance(gpus, (list, tuple)):
         if len(gpus) <= 1:

--- a/keras/utils/multi_gpu_utils.py
+++ b/keras/utils/multi_gpu_utils.py
@@ -13,7 +13,7 @@ from ..utils.generic_utils import to_list
 
 
 def _get_available_devices():
-    return [x.name for x in K.get_session().list_devices()]
+    return [x.name for x in K.tensorflow_backend._get_available_gpus()]
 
 
 def _normalize_device_name(name):
@@ -153,7 +153,7 @@ def multi_gpu_model(model, gpus=None, cpu_merge=True, cpu_relocation=False):
     if not gpus:
         # Using all visible GPUs when not specifying `gpus`
         # e.g. CUDA_VISIBLE_DEVICES=0,2 python keras_mgpu.py
-        gpus = len([x for x in available_devices if 'gpu' in x])
+        gpus = len(available_devices)
 
     if isinstance(gpus, (list, tuple)):
         if len(gpus) <= 1:

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -10,7 +10,6 @@ from keras.layers.core import Dense, Activation, Lambda
 from keras.utils.np_utils import to_categorical
 from keras import backend as K
 import tempfile
-import os
 
 
 num_classes = 2
@@ -74,7 +73,6 @@ def _test_optimizer(optimizer, target=0.75):
     _, fname = tempfile.mkstemp('.h5')
     model.save(fname)
     model2 = load_model(fname)
-    os.remove(fname)
 
     for w1, w2 in zip(model.get_weights(), model2.get_weights()):
         assert_allclose(w1, w2)

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -81,7 +81,7 @@ def _test_optimizer(optimizer, target=0.75):
 @pytest.mark.skipif((K.backend() != 'tensorflow'),
                     reason="Only Tensorflow raises a "
                            "ValueError if the gradient is null.")
-def test_no_grad(tmpdir):
+def test_no_grad():
     inp = Input([3])
     x = Dense(10)(inp)
     x = Lambda(


### PR DESCRIPTION

### Summary

* Since variables dont have global scope in TF 2, they do not have unique names. This has to be taken into account when saving weights. 

* Provided names for all keras optimizer weights (though this is not required for `optimizer_tests` to pass, the fix in `saving.py` should do)


### Related Issues

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
