### PR TITLE
remove sentence about usage of rmsprop for RNN 

### DIFF
--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -224,9 +224,6 @@ class RMSprop(Optimizer):
     at their default values
     (except the learning rate, which can be freely tuned).
 
-    This optimizer is usually a good choice for recurrent
-    neural networks.
-
     # Arguments
         lr: float >= 0. Learning rate.
         rho: float >= 0.


### PR DESCRIPTION
### Summary
RMSprop is used for CNN and RNN.
So following sentence isn't proper description.

### Related Issues
https://github.com/keras-team/keras/issues/12460

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
