### PR TITLE
Exclude the numpy backend when reporting coverages

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -20,6 +20,7 @@ omit =
     keras/layers/cudnn_recurrent.py
     keras/legacy/*
     keras/utils/multi_gpu_utils.py
+    keras/backend/numpy_backend.py
     keras/backend/theano_backend.py
     keras/backend/tensorflow_backend.py
     keras/backend/cntk_backend.py


### PR DESCRIPTION
### Summary

This PR excludes he numpy backend when reporting coverages. This affects only calculating test coverages.

### Related Issues

#10802
#10801
#9942
#9568
#9223

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
