### PR TITLE
Default type to floatx()

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -528,12 +528,16 @@ def eye(size, dtype=None, name=None):
 
 def zeros_like(x, dtype=None, name=None):
     name = name or ''
-    return C.zeros_like(x, name)
+    if dtype is None:
+        dtype = floatx()
+    return C.cast(C.zeros_like(x, name), dtype)
 
 
 def ones_like(x, dtype=None, name=None):
     name = name or ''
-    return C.ones_like(x, name)
+    if dtype is None:
+        dtype = floatx()
+    return C.cast(C.ones_like(x, name), dtype)
 
 
 def count_params(x):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -808,6 +808,9 @@ def zeros_like(x, dtype=None, name=None):
     ```
     {{np_implementation}}
     """
+    if dtype is None:
+        dtype = floatx()
+    tf_dtype = tf.as_dtype(dtype)
     return tf.zeros_like(x, dtype=dtype, name=name)
 
 
@@ -834,6 +837,9 @@ def ones_like(x, dtype=None, name=None):
     ```
     {{np_implementation}}
     """
+    if dtype is None:
+        dtype = floatx()
+    tf_dtype = tf.as_dtype(dtype)
     return tf.ones_like(x, dtype=dtype, name=name)
 
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -810,7 +810,6 @@ def zeros_like(x, dtype=None, name=None):
     """
     if dtype is None:
         dtype = floatx()
-    tf_dtype = tf.as_dtype(dtype)
     return tf.zeros_like(x, dtype=dtype, name=name)
 
 
@@ -839,7 +838,6 @@ def ones_like(x, dtype=None, name=None):
     """
     if dtype is None:
         dtype = floatx()
-    tf_dtype = tf.as_dtype(dtype)
     return tf.ones_like(x, dtype=dtype, name=name)
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -334,10 +334,14 @@ def eye(size, dtype=None, name=None):
 
 
 def ones_like(x, dtype=None, name=None):
+    if dtype is None:
+        dtype = floatx()
     return T.ones_like(x, dtype=dtype)
 
 
 def zeros_like(x, dtype=None, name=None):
+    if dtype is None:
+        dtype = floatx()
     return T.zeros_like(x, dtype=dtype)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Default to floatx() type when dtype argument is not provided
### Related Issues

### PR Overview

- [N] This PR requires new unit tests [y/n] (make sure tests are included)
- [Y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [Y] This PR is backwards compatible [y/n]
- [N] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
