### PR TITLE
Make `tile` consistent over all the backends

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -843,11 +843,9 @@ def tile(x, n):
 
     shape = int_shape(x)
     num_dynamic_axis = _get_dynamic_axis_num(x)
-    # Padding the axis
-    if len(n) < len(shape):
+    if len(n) < len(shape):  # Padding the axis
         n = tuple([1 for _ in range(len(shape) - len(n))]) + n
-
-    if len(n) != len(shape):
+    elif len(n) != len(shape):
         raise NotImplementedError
 
     i = num_dynamic_axis

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2385,9 +2385,31 @@ def tile(x, n):
 
     # Returns
         A tiled tensor.
+
+    # Example
+    ```python
+        >>> from keras import backend as K
+        >>> kvar = K.variable(np.random.random((2, 3)))
+        >>> kvar_tile = K.tile(K.eye(2), (2, 3))
+        >>> K.eval(kvar_tile)
+        array([[1., 0., 1., 0., 1., 0.],
+               [0., 1., 0., 1., 0., 1.],
+               [1., 0., 1., 0., 1., 0.],
+               [0., 1., 0., 1., 0., 1.]], dtype=float32)
+    ```
+    {{np_implementation}}
     """
     if isinstance(n, int):
-        n = [n]
+        n = (n,)
+    elif isinstance(n, list):
+        n = tuple(n)
+
+    shape = int_shape(x)
+    if len(n) < len(shape):  # Padding the axis
+        n = tuple([1 for _ in range(len(shape) - len(n))]) + n
+    elif len(n) != len(shape):
+        raise NotImplementedError
+
     return tf.tile(x, n)
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1061,16 +1061,17 @@ def tile(x, n):
     elif isinstance(n, list):
         n = tuple(n)
 
+    y = T.tile(x, n)
     shape = int_shape(x)
-    if len(n) < len(shape):  # Padding the axis
+    if shape is None:
+        return y
+    elif len(n) < len(shape):  # Padding the axis
         n = tuple([1 for _ in range(len(shape) - len(n))]) + n
+        y._keras_shape = tuple([None if a is None else a * b
+                                for (a, b) in zip(shape, n)])
+        return y
     elif len(n) != len(shape):
         raise NotImplementedError
-
-    y = T.tile(x, n)
-    y._keras_shape = tuple([None if a is None else a * b
-                            for (a, b) in zip(shape, n)])
-    return y
 
 
 def flatten(x):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1067,11 +1067,12 @@ def tile(x, n):
         return y
     elif len(n) < len(shape):  # Padding the axis
         n = tuple([1 for _ in range(len(shape) - len(n))]) + n
-        y._keras_shape = tuple([None if a is None else a * b
-                                for (a, b) in zip(shape, n)])
-        return y
     elif len(n) != len(shape):
         raise NotImplementedError
+
+    y._keras_shape = tuple([None if a is None else a * b
+                            for (a, b) in zip(shape, n)])
+    return y
 
 
 def flatten(x):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -101,16 +101,6 @@ def to_dense(tensor):
         return tensor
 
 
-def _is_explicit_shape(shape):
-    if hasattr(shape, '__iter__'):
-        for x in shape:
-            if x is not None:
-                if not isinstance(x, int):
-                    return False
-        return True
-    return False
-
-
 NAME_SCOPE_STACK = []
 
 
@@ -1066,33 +1056,20 @@ def arange(start, stop=None, step=1, dtype='int32'):
 
 
 def tile(x, n):
+    if isinstance(n, int):
+        n = (n,)
+    elif isinstance(n, list):
+        n = tuple(n)
+
+    shape = int_shape(x)
+    if len(n) < len(shape):  # Padding the axis
+        n = tuple([1 for _ in range(len(shape) - len(n))]) + n
+    elif len(n) != len(shape):
+        raise NotImplementedError
+
     y = T.tile(x, n)
-    if hasattr(x, '_keras_shape'):
-        if _is_explicit_shape(n):
-            output_shape = x._keras_shape[:-len(n)]
-            for i, j in zip(x._keras_shape, n):
-                if i is None:
-                    output_shape += (None,)
-                else:
-                    output_shape += (i * j,)
-        elif isinstance(n, int):
-            output_shape = x._keras_shape[:-1]
-            if x._keras_shape[-1] is None:
-                output_shape += (None,)
-            else:
-                output_shape += (x._keras_shape[-1] * n,)
-        else:
-            # symbolic n
-            if n.ndim == 0:
-                # n is a scalar
-                output_shape = x._keras_shape[:-1] + (None,)
-            elif hasattr(n, '_keras_shape'):
-                # n is a vector
-                n_size = n._keras_shape[0]
-                output_shape = x._keras_shape[:-n_size] + (None,) * n_size
-            else:
-                output_shape = (None,) * x.ndim
-        y._keras_shape = output_shape
+    y._keras_shape = tuple([None if a is None else a * b
+                            for (a, b) in zip(shape, n)])
     return y
 
 

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -428,10 +428,11 @@ class TestBackend(object):
                     assert y._keras_shape == K.int_shape(y)
 
     def test_tile(self):
-        shape = (3, 4)
-        arr = np.arange(np.prod(shape)).reshape(shape)
-        check_single_tensor_operation('tile', arr, WITH_NP, n=[2, 1])
-        check_single_tensor_operation('tile', (2, 5), WITH_NP, n=[5, 2])
+        check_single_tensor_operation('tile', (3, 4), WITH_NP, n=2)
+        check_single_tensor_operation('tile', (3, 4), WITH_NP, n=(2, 1))
+        check_single_tensor_operation('tile', (3, 4, 5), WITH_NP, n=2)
+        check_single_tensor_operation('tile', (3, 4, 5), WITH_NP, n=(1, 2))
+        check_single_tensor_operation('tile', (3, 4, 5), WITH_NP, n=(3, 1, 2))
 
         # test theano shape inference when
         # input shape has None entries


### PR DESCRIPTION
### Summary

Currently, the behaviors of `tile` in all the backends are different. This PR makes `tile` consistent over all the backends (including NumPy backend).