### PR TITLE
Suppress several warnings

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -33,6 +33,11 @@ try:
 except ImportError:
     tf_file_io = None
 
+try:
+    getargspec = inspect.getfullargspec
+except:  # getargspec() is deprecated since Python 3.0
+    getargspec = inspect.getargspec
+
 
 def _serialize_model(model, h5dict, include_optimizer=True):
     """Model serialization logic.
@@ -422,7 +427,7 @@ def allow_read_from_gcs(load_function):
         if name in kwargs:
             arg = kwargs.pop(name)
             return arg, args, kwargs
-        argnames = inspect.getargspec(f)[0]
+        argnames = getargspec(f)[0]
         for i, (argname, arg) in enumerate(zip(argnames, args)):
             if argname == name:
                 return arg, args[:i] + args[i + 1:], kwargs
@@ -587,7 +592,7 @@ def model_from_yaml(yaml_string, custom_objects=None):
     # Returns
         A Keras model instance (uncompiled).
     """
-    config = yaml.load(yaml_string)
+    config = yaml.load(yaml_string, Loader=yaml.FullLoader)
     from ..layers import deserialize
     return deserialize(config, custom_objects=custom_objects)
 

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -35,7 +35,7 @@ except ImportError:
 
 try:
     getargspec = inspect.getfullargspec
-except:  # getargspec() is deprecated since Python 3.0
+except AttributeError:  # getargspec() is deprecated since Python 3.0
     getargspec = inspect.getargspec
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,7 @@ pep8ignore=* E402 \
            * W503
 # Enable line length testing with maximum line length of 85
 pep8maxlinelength = 85
+
+# Ignore warnings which are verbose and unrelated to Keras
+filterwarnings =
+    ignore::DeprecationWarning: np.asscalar(a)

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,4 +21,4 @@ pep8maxlinelength = 85
 
 # Ignore warnings which are verbose and unrelated to Keras
 filterwarnings =
-    ignore::DeprecationWarning: np.asscalar(a)
+    ignore:np.asscalar:DeprecationWarning


### PR DESCRIPTION
### Summary

It is important to reduce sizes of log files for using CI tools. This PR suppresses warnings in order to prevent the sizes from growing larger than necessary.

- Baseline: [the recent Python 3 + TF build on the master branch](https://travis-ci.org/keras-team/keras/jobs/506898066)
  - the message `/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/numpy/lib/type_check.py:546` wastes 793 lines,
  - the message `keras/engine/saving.py:425` wastes 43 lines,
  - the message `keras/engine/saving.py:590` wastes 6 lines.

### Related Issues

#9139
#7636