### PR TITLE
Increase test coverage

### DIFF
--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -586,6 +586,7 @@ def test_saving_model_with_long_weights_names():
     f = x
     for i in range(4):
         f = Dense(2, name='nested_model_dense_%d' % (i,))(f)
+    f = Dense(2, name='nested_model_dense_4', trainable=False)(f)
     # This layer name will make the `weights_name`
     # HDF5 attribute blow out of proportion.
     f = Dense(2, name='nested_model_output' + ('x' * (2**15)))(f)


### PR DESCRIPTION
### Summary

This PR increases test coverages by adding a non-trainable nested case in `preprocess_weights_for_loading` for [the current](https://travis-ci.org/keras-team/keras/jobs/506898066) following missing lines:
```
keras/engine/saving.py                      492     88    82%  789-794
```

### Related Issues

#10259
#10236