### PR TITLE
Revise `logsumexp` in np backend and reduce those redundant tests

### DIFF
--- a/keras/backend/numpy_backend.py
+++ b/keras/backend/numpy_backend.py
@@ -372,7 +372,7 @@ def std(x, axis=None, keepdims=False):
 def logsumexp(x, axis=None, keepdims=False):
     if isinstance(axis, list):
         axis = tuple(axis)
-    return sp.misc.logsumexp(x, axis=axis, keepdims=keepdims)
+    return sp.special.logsumexp(x, axis=axis, keepdims=keepdims)
 
 
 def sum(x, axis=None, keepdims=False):

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -506,9 +506,16 @@ class TestBackend(object):
         check_single_tensor_operation('std', (4, 2), WITH_NP, axis=1, keepdims=True)
         check_single_tensor_operation('std', (4, 2, 3), WITH_NP, axis=[1, -1])
 
-        check_single_tensor_operation('logsumexp', (4, 2), WITH_NP)
-        check_single_tensor_operation('logsumexp', (4, 2),
-                                      WITH_NP, axis=1, keepdims=True)
+        check_single_tensor_operation('logsumexp', (3,), WITH_NP, axis=0)
+        for shape in [(1, 3), (2, 1), (4, 2)]:
+            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=None)
+            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=0)
+            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=1)
+            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=1,
+                                          keepdims=True)
+            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=-1)
+            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=-1,
+                                          keepdims=True)
         check_single_tensor_operation('logsumexp', (4, 2, 3), WITH_NP, axis=[1, -1])
 
         check_single_tensor_operation('prod', (4, 2), WITH_NP)
@@ -1022,32 +1029,8 @@ class TestBackend(object):
             # not updated last timestep:
             assert_allclose(K.eval(last_states[0]), expected_last_state)
 
-    @pytest.mark.parametrize('x_np,axis,keepdims', [
-        (np.array([1.1, 0.8, 0.9]), 0, False),
-        (np.array([[1.1, 0.8, 0.9]]), 0, False),
-        (np.array([[1.1, 0.8, 0.9]]), 1, False),
-        (np.array([[1.1, 0.8, 0.9]]), -1, False),
-        (np.array([[1.1, 0.8, 0.9]]), 1, True),
-        (np.array([[1.1], [1.2]]), 0, False),
-        (np.array([[1.1], [1.2]]), 1, False),
-        (np.array([[1.1], [1.2]]), -1, False),
-        (np.array([[1.1], [1.2]]), -1, True),
-        (np.array([[1.1, 1.2, 1.3], [0.9, 0.7, 1.4]]), None, False),
-        (np.array([[1.1, 1.2, 1.3], [0.9, 0.7, 1.4]]), 0, False),
-        (np.array([[1.1, 1.2, 1.3], [0.9, 0.7, 1.4]]), 1, False),
-        (np.array([[1.1, 1.2, 1.3], [0.9, 0.7, 1.4]]), -1, False),
-    ])
-    def test_logsumexp(self, x_np, axis, keepdims):
-        '''
-        Check if K.logsumexp works properly for values close to one.
-        '''
-        x = K.variable(x_np)
-        assert_allclose(K.eval(K.logsumexp(x, axis=axis, keepdims=keepdims)),
-                        np.log(np.sum(np.exp(x_np), axis=axis, keepdims=keepdims)),
-                        rtol=1e-5)
-
-    @pytest.mark.skipif(K.backend() != 'tensorflow',
-                        reason='The optimization is applied only with TensorFlow.')
+    @pytest.mark.skipif(K.backend() == 'cntk',
+                        reason='The logsumexp is not optimized in CNTK.')
     def test_logsumexp_optim(self):
         '''
         Check if optimization works.

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1029,8 +1029,8 @@ class TestBackend(object):
             # not updated last timestep:
             assert_allclose(K.eval(last_states[0]), expected_last_state)
 
-    @pytest.mark.skipif(K.backend() == 'cntk',
-                        reason='The logsumexp is not optimized in CNTK.')
+    @pytest.mark.skipif(K.backend() != 'tensorflow',
+                        reason='The optimization is applied only with TensorFlow.')
     def test_logsumexp_optim(self):
         '''
         Check if optimization works.

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -506,18 +506,6 @@ class TestBackend(object):
         check_single_tensor_operation('std', (4, 2), WITH_NP, axis=1, keepdims=True)
         check_single_tensor_operation('std', (4, 2, 3), WITH_NP, axis=[1, -1])
 
-        check_single_tensor_operation('logsumexp', (3,), WITH_NP, axis=0)
-        for shape in [(1, 3), (2, 1), (4, 2)]:
-            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=None)
-            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=0)
-            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=1)
-            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=1,
-                                          keepdims=True)
-            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=-1)
-            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=-1,
-                                          keepdims=True)
-        check_single_tensor_operation('logsumexp', (4, 2, 3), WITH_NP, axis=[1, -1])
-
         check_single_tensor_operation('prod', (4, 2), WITH_NP)
         check_single_tensor_operation('prod', (4, 2), WITH_NP, axis=1, keepdims=True)
         check_single_tensor_operation('prod', (4, 2, 3), WITH_NP, axis=[1, -1])
@@ -1028,6 +1016,22 @@ class TestBackend(object):
 
             # not updated last timestep:
             assert_allclose(K.eval(last_states[0]), expected_last_state)
+
+    @pytest.mark.parametrize('shape', [(3, ), (1, 3), (2, 1), (4, 2), (4, 2, 3)])
+    def test_logsumexp(self, shape):
+        check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=None)
+        check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=0)
+        check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=-1)
+        check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=-1,
+                                      keepdims=True)
+        if len(shape) > 1:
+            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=1)
+            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=1,
+                                          keepdims=True)
+        if len(shape) > 2:
+            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=[1, -1])
+            check_single_tensor_operation('logsumexp', shape, WITH_NP, axis=[1, -1],
+                                          keepdims=True)
 
     @pytest.mark.skipif(K.backend() != 'tensorflow',
                         reason='The optimization is applied only with TensorFlow.')


### PR DESCRIPTION
### Summary

This PR includes the following:
1. The `sp.misc.logsumexp` in the numpy backend has been replaced with the `sp.special.logsumexp` because the former will be deprecated.
2. The `test_logsumexp` has been removed because it is redundant to `test_elementwise_operations`.
3. The `test_logsumexp_optim` for Theano has been enabled.