### PR TITLE
Removed seemingly useless self-assignment

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1879,8 +1879,6 @@ def pool2d(x, pool_size, strides=(1, 1),
     data_format = normalize_data_format(data_format)
 
     padding = _preprocess_border_mode(padding)
-    strides = strides
-    pool_size = pool_size
     x = _preprocess_conv2d_input(x, data_format)
     if pool_mode == 'max':
         x = C.pooling(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
I observed a seemingly useless self-assignment inside the function pool2d from the cntk_backend.py file. This assignment is not present in pool3d function which is a similar one, thus I considered removing it.  
### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [n] This PR is backwards compatible [y/n]
- [y] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
