### PR TITLE
Add kwarg and documentation for dilation_rate to DepthWiseConv2D

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1727,6 +1727,12 @@ class DepthwiseConv2D(Conv2D):
             It defaults to the `image_data_format` value found in your
             Keras config file at `~/.keras/keras.json`.
             If you never set it, then it will be 'channels_last'.
+        dilation_rate: an integer or tuple/list of 2 integers, specifying
+            the dilation rate to use for dilated convolution.
+            Can be a single integer to specify the same value for
+            all spatial dimensions.
+            Currently, specifying any `dilation_rate` value != 1 is
+            incompatible with specifying any stride value != 1.
         activation: Activation function to use
             (see [activations](../activations.md)).
             If you don't specify anything, no activation is applied
@@ -1774,6 +1780,7 @@ class DepthwiseConv2D(Conv2D):
                  padding='valid',
                  depth_multiplier=1,
                  data_format=None,
+                 dilation_rate=(1, 1),
                  activation=None,
                  use_bias=True,
                  depthwise_initializer='glorot_uniform',
@@ -1790,6 +1797,7 @@ class DepthwiseConv2D(Conv2D):
             strides=strides,
             padding=padding,
             data_format=data_format,
+            dilation_rate=dilation_rate,
             activation=activation,
             use_bias=use_bias,
             bias_regularizer=bias_regularizer,

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -203,10 +203,9 @@ class _Conv(Layer):
                 dilation=self.dilation_rate[i])
             new_space.append(new_dim)
         if self.data_format == 'channels_last':
-            return (input_shape[0], new_space[0], new_space[1], self.filters)
+            return (input_shape[0],) + tuple(new_space) + (self.filters,)
         elif self.data_format == 'channels_first':
-            return (input_shape[0], self.filters, new_space[0], new_space[1])
-
+            return (input_shape[0], self.filters) + tuple(new_space)
 
     def get_config(self):
         config = {

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -433,14 +433,18 @@ def test_separable_conv_2d_invalid():
 
 
 @pytest.mark.parametrize(
-    'padding,strides,multiplier',
-    [(padding, strides, multiplier)
+    'padding,strides,multiplier,dilation_rate',
+    [(padding, strides, multiplier, dilation_rate)
      for padding in _convolution_paddings
      for strides in [(1, 1), (2, 2)]
      for multiplier in [1, 2]
-     if not (padding == 'same' and strides != (1, 1))]
+     for dilation_rate in [(1, 1), (2, 2), (2, 1), (1, 2)]
+     if (not (padding == 'same' and strides != (1, 1))
+         and not (dilation_rate != (1, 1) and strides != (1, 1))
+         and not (dilation_rate != (1, 1) and multiplier == dilation_rate[0])
+         and not (dilation_rate != (1, 1) and K.backend() == 'cntk'))]
 )
-def test_depthwise_conv_2d(padding, strides, multiplier):
+def test_depthwise_conv_2d(padding, strides, multiplier, dilation_rate):
     num_samples = 2
     stack_size = 3
     num_row = 7
@@ -450,7 +454,8 @@ def test_depthwise_conv_2d(padding, strides, multiplier):
                kwargs={'kernel_size': (3, 3),
                        'padding': padding,
                        'strides': strides,
-                       'depth_multiplier': multiplier},
+                       'depth_multiplier': multiplier,
+                       'dilation_rate': dilation_rate},
                input_shape=(num_samples,
                             num_row,
                             num_col,


### PR DESCRIPTION

### Summary

### Related Issues
fix for #12525 which is identical to #9642
### PR Overview
This PR is very close to #9844. Just adding `dilation_rate` to arguments of DepthWiseConv2D explicitly. 

- [ n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ y ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y ] This PR is backwards compatible [y/n]
- [ y ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
