### PR TITLE
Enable the `cumsum` backend tests for CNTK

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -556,8 +556,6 @@ class TestBackend(object):
         K.reset_uids()
         assert K.get_uid() == first
 
-    @pytest.mark.skipif(K.backend() == 'cntk', reason='cntk does not support '
-                                                      'cumsum and cumprod yet')
     def test_cumsum(self):
         check_single_tensor_operation('cumsum', (4, 2), WITH_NP)
         check_single_tensor_operation('cumsum', (4, 2), WITH_NP, axis=1)


### PR DESCRIPTION
### Summary

This PR enables the `cumsum` backend tests for CNTK.

### Related Issues

#12306