### PR TITLE
Revise `reverse` for Theano and Enable the tests for CNTK

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1310,6 +1310,11 @@ def reverse(x, axes):
     """
     if isinstance(axes, int):
         axes = [axes]
+    elif isinstance(axes, tuple):
+        axes = list(axes)
+    for i in range(len(axes)):
+        if axes[i] == -1:
+            axes[i] = x.ndim - 1
     slices = []
     for i in range(x.ndim):
         if i in axes:

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -296,8 +296,8 @@ class TestBackend(object):
 
         check_single_tensor_operation('transpose', (4, 2), WITH_NP)
         check_single_tensor_operation('reverse', (4, 3, 2), WITH_NP, axes=1)
-        if K.backend() != 'cntk':
-            check_single_tensor_operation('reverse', (4, 3, 2), WITH_NP, axes=(1, 2))
+        check_single_tensor_operation('reverse', (4, 3, 2), WITH_NP, axes=(1, 2))
+        check_single_tensor_operation('reverse', (4, 3, 2), WITH_NP, axes=(0, -1))
 
     def test_random_variables(self):
         check_single_tensor_operation('random_uniform_variable', (2, 3), WITH_NP,


### PR DESCRIPTION
### Summary

This PR revises `reverse` for Theano and enables the tests for CNTK.