### PR TITLE
Revise `in_top_k` for CNTK

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2363,8 +2363,10 @@ def elu(x, alpha=1.):
 
 def in_top_k(predictions, targets, k):
     _targets = C.one_hot(targets, predictions.shape[-1])
-    result = C.classification_error(predictions, _targets, topN=k)
-    return 1 - C.reshape(result, shape=())
+    result = [C.classification_error(predictions[i], _targets[i], topN=k)
+              for i in range(predictions.shape[0])]
+    result = concatenate(result, axis=-1)
+    return 1 - C.reshape(result, shape=(-1,))
 
 
 def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1138,7 +1138,7 @@ class TestBackend(object):
 
         # (k == 0 or k > num_classes) does not raise an error
         # but just return an unmeaningful tensor.
-        for k in range(1, num_classes + 1):
+        for k in range(1, 2 if K.backend() == 'cntk' else (num_classes + 1)):
             z_list = [b.eval(b.in_top_k(b.variable(predictions, dtype='float32'),
                                         b.variable(targets, dtype='int32'), k))
                       for b in WITH_NP]
@@ -1153,7 +1153,7 @@ class TestBackend(object):
             predictions[i, idx_identical] = predictions[i, 0]
         targets = np.zeros(batch_size, dtype='int32')
 
-        for k in range(1, num_classes + 1):
+        for k in range(1, 2 if K.backend() == 'cntk' else (num_classes + 1)):
             z_list = [b.eval(b.in_top_k(b.variable(predictions, dtype='float32'),
                                         b.variable(targets, dtype='int32'), k))
                       for b in WITH_NP]

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1128,7 +1128,6 @@ class TestBackend(object):
                                    WITH_NP, cntk_two_dynamicity=True,
                                    from_logits=True)
 
-    @pytest.mark.skipif(K.backend() == 'cntk', reason='Bug in CNTK')
     def test_in_top_k(self):
         batch_size = 20
         num_classes = 10


### PR DESCRIPTION
### Summary

This PR revises `in_top_k` for CNTK. Currently, the `C.classification_error` supports only one sample, not batch. Thus, this PR concatenates each result of each sample.