### PR TITLE
Use keras backend for identity initializer

### DIFF
--- a/keras/initializers.py
+++ b/keras/initializers.py
@@ -284,7 +284,7 @@ class Identity(Initializer):
             raise ValueError(
                 'Identity matrix initializer can only be used for 2D matrices.')
 
-        return self.gain * np.eye(shape[0], shape[1])
+        return self.gain * K.eye((shape[0], shape[1]), dtype=dtype)
 
     def get_config(self):
         return {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
- Use Keras backend for `identity` initializer
- Fix unused dtype argument

See original PR #12438 
### Related Issues

### PR Overview

- [N] This PR requires new unit tests [y/n] (make sure tests are included)
- [N] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [Y] This PR is backwards compatible [y/n]
- [N] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
