### PR TITLE
Allow generators into Model's fit, evaluate and predict

### DIFF
--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import inspect
 import collections
 import copy
 import numpy as np
@@ -296,6 +297,22 @@ def check_loss_and_target_compatibility(targets, loss_fns, output_shapes):
                         'This loss expects '
                         'targets to have the same shape '
                         'as the output.')
+
+
+def check_generator_arguments(y=None, sample_weight=None,
+                              validation_split=None):
+    """Validates arguments passed when using a generator."""
+    if y is not None:
+        raise ValueError('`y` argument is not supported when data is'
+                         'a generator or Sequence instance. Instead pass targets'
+                         ' as the second element of the generator.')
+    if sample_weight is not None:
+        raise ValueError('`sample_weight` argument is not supported when data is'
+                         'a generator or Sequence instance. Instead pass sample'
+                         ' weights as the third element of the generator.')
+    if validation_split:
+        raise ValueError('If your data is in the form of a Python generator, '
+                         'you cannot use `validation_split`.')
 
 
 def collect_metrics(metrics, output_names):
@@ -618,6 +635,11 @@ def is_sequence(seq):
             or set(dir(Sequence())).issubset(set(dir(seq) + ['use_sequence_api'])))
 
 
+def is_generator_or_sequence(x):
+    """Check if `x` is a Keras generator type."""
+    return inspect.isgenerator(x) or is_sequence(x)
+
+
 def should_run_validation(validation_freq, epoch):
     """Checks if validation should be run this epoch.
 
@@ -646,3 +668,48 @@ def should_run_validation(validation_freq, epoch):
         raise ValueError('`validation_freq` must be an Integer or '
                          '`collections.Container` (e.g. list, tuple, etc.)')
     return one_indexed_epoch in validation_freq
+
+
+def get_static_batch_size(layer):
+    """Gets the static batch size of a Layer.
+
+    # Arguments
+        layer: a `Layer` instance.
+
+    # Returns
+        The static batch size of a Layer.
+    """
+    batch_input_shape, _ = get_input_shape_and_dtype(layer)
+    if batch_input_shape is not None:
+        return batch_input_shape[0]
+    return None
+
+
+def get_input_shape_and_dtype(layer):
+    """Retrieves input shape and input dtype of layer if applicable.
+
+    # Arguments
+        layer: Layer (or model) instance.
+
+    # Returns
+        Tuple (input_shape, input_dtype). Both could be None if the layer
+        does not have a defined input shape.
+
+    # Raises
+      ValueError: in case an empty Sequential or Functional model is passed.
+    """
+    def _is_graph_model(layer):
+        return ((hasattr(layer, '_is_graph_network') and layer._is_graph_network) or
+                layer.__class__.__name__ == 'Sequential')
+
+    # In case of nested models: recover the first layer
+    # of the deepest model to infer input shape and dtype.
+    # Subclassed Models may not have been built so can't be checked.
+    while _is_graph_model(layer):
+        if not layer.layers:
+            raise ValueError('An empty Model cannot be used as a Layer.')
+        layer = layer.layers[0]
+
+    if hasattr(layer, '_batch_input_shape'):
+        return layer._batch_input_shape, layer.dtype
+    return None, None

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -350,6 +350,9 @@ def test_model_methods():
 
     # enable verbose for evaluate_generator
     out = model.evaluate_generator(gen_data(4), steps=3, verbose=1)
+    # pass generator directly so `is_generator_or_sequence`
+    # doesn't get confused.
+    out = model.evaluate(gen_data(4).it, steps=3, verbose=1)
 
     # empty batch
     with pytest.raises(ValueError):
@@ -359,6 +362,13 @@ def test_model_methods():
                 yield (np.asarray([]), np.asarray([]))
 
         out = model.evaluate_generator(gen_data(), steps=1)
+    with pytest.raises(ValueError):
+        @threadsafe_generator
+        def gen_data():
+            while True:
+                yield (np.asarray([]), np.asarray([]))
+
+        out = model.evaluate(gen_data().it, steps=1)
 
     # x is not a list of numpy arrays.
     with pytest.raises(ValueError):
@@ -479,6 +489,20 @@ def test_fit_generator():
     assert tracker_cb.trained_batches == list(range(3)) * 5
     assert len(val_seq.logs) <= 4 * 5
 
+    tracker_cb = TrackerCallback()
+    val_seq = RandomSequence(4)
+    out = model.fit(RandomSequence(3),
+                    steps_per_epoch=3,
+                    epochs=5,
+                    initial_epoch=0,
+                    validation_data=val_seq,
+                    validation_steps=3,
+                    max_queue_size=1,
+                    callbacks=[tracker_cb])
+    assert tracker_cb.trained_epochs == [0, 1, 2, 3, 4]
+    assert tracker_cb.trained_batches == list(range(3)) * 5
+    assert len(val_seq.logs) <= 4 * 5
+
     # steps_per_epoch will be equal to len of sequence if it's unspecified
     tracker_cb = TrackerCallback()
     val_seq = RandomSequence(4)
@@ -488,6 +512,18 @@ def test_fit_generator():
                               validation_data=val_seq,
                               callbacks=[tracker_cb],
                               max_queue_size=1)
+    assert tracker_cb.trained_epochs == [0, 1, 2, 3, 4]
+    assert tracker_cb.trained_batches == list(range(12)) * 5
+    assert 12 * 5 <= len(val_seq.logs) <= (12 * 5) + 2  # the queue may be full.
+
+    tracker_cb = TrackerCallback()
+    val_seq = RandomSequence(4)
+    out = model.fit(RandomSequence(3),
+                    epochs=5,
+                    initial_epoch=0,
+                    validation_data=val_seq,
+                    callbacks=[tracker_cb],
+                    max_queue_size=1)
     assert tracker_cb.trained_epochs == [0, 1, 2, 3, 4]
     assert tracker_cb.trained_batches == list(range(12)) * 5
     assert 12 * 5 <= len(val_seq.logs) <= (12 * 5) + 2  # the queue may be full.
@@ -503,6 +539,20 @@ def test_fit_generator():
     assert tracker_cb.trained_epochs == [0, 1, 2, 3, 4]
     assert tracker_cb.trained_batches == list(range(12)) * 5
     assert len(val_seq.logs) == 12 * 5
+
+    tracker_cb = TrackerCallback()
+    val_seq = RandomSequence(4)
+    out = model.fit(RandomSequence(3),
+                    steps_per_epoch=3,
+                    epochs=5,
+                    initial_epoch=0,
+                    validation_data=val_seq,
+                    validation_steps=3,
+                    max_queue_size=1,
+                    callbacks=[tracker_cb])
+    assert tracker_cb.trained_epochs == [0, 1, 2, 3, 4]
+    assert tracker_cb.trained_batches == list(range(3)) * 5
+    assert len(val_seq.logs) <= 4 * 5
 
     # fit_generator will throw an exception
     # if steps is unspecified for regular generator
@@ -570,11 +620,19 @@ def test_fit_generator_shape():
         RandomSequence(batch_size, sequence_length=sequence_length))
     assert np.shape(out[0]) == shape_0 and np.shape(out[1]) == shape_1
 
+    out = model.predict(
+        RandomSequence(batch_size, sequence_length=sequence_length))
+    assert np.shape(out[0]) == shape_0 and np.shape(out[1]) == shape_1
+
     # Multiple outputs and multiple steps.
     batch_size = 5
     sequence_length = 2
     shape_0, shape_1 = expected_shape(batch_size, sequence_length)
     out = model.predict_generator(
+        RandomSequence(batch_size, sequence_length=sequence_length))
+    assert np.shape(out[0]) == shape_0 and np.shape(out[1]) == shape_1
+
+    out = model.predict(
         RandomSequence(batch_size, sequence_length=sequence_length))
     assert np.shape(out[0]) == shape_0 and np.shape(out[1]) == shape_1
 
@@ -591,11 +649,19 @@ def test_fit_generator_shape():
         RandomSequence(batch_size, sequence_length=sequence_length))
     assert np.shape(out) == shape_0
 
+    out = single_output_model.predict(
+        RandomSequence(batch_size, sequence_length=sequence_length))
+    assert np.shape(out) == shape_0
+
     # Single output and multiple steps.
     batch_size = 5
     sequence_length = 2
     shape_0, _ = expected_shape(batch_size, sequence_length)
     out = single_output_model.predict_generator(
+        RandomSequence(batch_size, sequence_length=sequence_length))
+    assert np.shape(out) == shape_0
+
+    out = single_output_model.predict(
         RandomSequence(batch_size, sequence_length=sequence_length))
     assert np.shape(out) == shape_0
 
@@ -1029,6 +1095,7 @@ def test_model_with_external_loss():
 
         # test evaluate_generator for framework-native data tensors
         out = model.evaluate_generator(generator, steps=3)
+        out = model.evaluate(generator, steps=3)
 
         # test fit with validation data
         with pytest.raises(ValueError):


### PR DESCRIPTION
### Summary
I've ported the interesting sections of the code implemented in [tensorflow/keras/engine/training.py#L749](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/engine/training.py#L749)
and some necessary utils. Generators and Sequences can now be passed to `Model#fit`, `Model#evaluate` and `Model#predict`.

The parameters `max_queue_size, workers, use_multiprocessing` were added to these methods (they now have the exact same signature as the ones in `tf.keras`.

### Related Issues
#11772

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
