### PR TITLE
Add Flag to control Dropout() behavior at test time

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -136,9 +136,10 @@ class Dropout(Layer):
     def get_config(self):
         config = {'rate': self.rate,
                   'noise_shape': self.noise_shape,
-                  'seed': self.seed,
-                  'drop_at_test_time': self.drop_at_test_time
+                  'seed': self.seed
                  }
+        if self.drop_at_test_time:
+            config['drop_at_test_time']=True
         base_config = super(Dropout, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -94,18 +94,20 @@ class Dropout(Layer):
             you want the dropout mask to be the same for all timesteps,
             you can use `noise_shape=(batch_size, 1, features)`.
         seed: A Python integer to use as random seed.
+        drop_at_test_time: wether to use
 
     # References
         - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](
            http://www.jmlr.org/papers/volume15/srivastava14a/srivastava14a.pdf)
     """
     @interfaces.legacy_dropout_support
-    def __init__(self, rate, noise_shape=None, seed=None, **kwargs):
+    def __init__(self, rate, noise_shape=None, seed=None, drop_at_test_time=False, **kwargs):
         super(Dropout, self).__init__(**kwargs)
         self.rate = min(1., max(0., rate))
         self.noise_shape = noise_shape
         self.seed = seed
         self.supports_masking = True
+        self.drop_at_test_time = drop_at_test_time
 
     def _get_noise_shape(self, inputs):
         if self.noise_shape is None:
@@ -124,13 +126,15 @@ class Dropout(Layer):
                 return K.dropout(inputs, self.rate, noise_shape,
                                  seed=self.seed)
             return K.in_train_phase(dropped_inputs, inputs,
-                                    training=training)
+                                    training=(training or drop_at_test_time))
         return inputs
 
     def get_config(self):
         config = {'rate': self.rate,
                   'noise_shape': self.noise_shape,
-                  'seed': self.seed}
+                  'seed': self.seed,
+                  'drop_at_test_time': self.drop_at_test_time
+                 }
         base_config = super(Dropout, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -101,11 +101,13 @@ class Dropout(Layer):
     # References
         - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](
            http://www.jmlr.org/papers/volume15/srivastava14a/srivastava14a.pdf)
-        - [Dropout as a Bayesian Approximation: Representing Model Uncertainty in Deep Learning](
+        - [Dropout as a Bayesian Approximation: Representing Model Uncertainty 
+           in Deep Learning](
            https://arxiv.org/abs/1506.02142)
     """
     @interfaces.legacy_dropout_support
-    def __init__(self, rate, noise_shape=None, seed=None, drop_at_test_time=False, **kwargs):
+    def __init__(self, rate, noise_shape=None, seed=None, 
+                 drop_at_test_time=False, **kwargs):
         super(Dropout, self).__init__(**kwargs)
         self.rate = min(1., max(0., rate))
         self.noise_shape = noise_shape

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -137,9 +137,9 @@ class Dropout(Layer):
         config = {'rate': self.rate,
                   'noise_shape': self.noise_shape,
                   'seed': self.seed
-                 }
+                  }
         if self.drop_at_test_time:
-            config['drop_at_test_time']=True
+            config['drop_at_test_time'] = True
         base_config = super(Dropout, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
@@ -682,7 +682,8 @@ class Lambda(Layer):
                           for shape, dtype in zip(input_shape, self._input_dtypes)]
                     x = self.call(xs)
                 else:
-                    x = K.placeholder(shape=input_shape, dtype=self._input_dtypes)
+                    x = K.placeholder(shape=input_shape,
+                                      dtype=self._input_dtypes)
                     x = self.call(x)
                 if isinstance(x, list):
                     return [K.int_shape(x_elem) for x_elem in x]

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -132,7 +132,7 @@ class Dropout(Layer):
                 return K.dropout(inputs, self.rate, noise_shape,
                                  seed=self.seed)
             return K.in_train_phase(dropped_inputs, inputs,
-                                    training=(training or self.drop_at_test_time))
+                                    training=(self.drop_at_test_time or training))
         return inputs
 
     def get_config(self):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -126,7 +126,7 @@ class Dropout(Layer):
                 return K.dropout(inputs, self.rate, noise_shape,
                                  seed=self.seed)
             return K.in_train_phase(dropped_inputs, inputs,
-                                    training=(training or drop_at_test_time))
+                                    training=(training or self.drop_at_test_time))
         return inputs
 
     def get_config(self):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -94,11 +94,15 @@ class Dropout(Layer):
             you want the dropout mask to be the same for all timesteps,
             you can use `noise_shape=(batch_size, 1, features)`.
         seed: A Python integer to use as random seed.
-        drop_at_test_time: wether to use
+        drop_at_test_time: if True, apply dropout at test time.
+            Note: This will introduce non-deterministic predictions at 
+            test time, use with caution.
 
     # References
         - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](
            http://www.jmlr.org/papers/volume15/srivastava14a/srivastava14a.pdf)
+        - [Dropout as a Bayesian Approximation: Representing Model Uncertainty in Deep Learning](
+           https://arxiv.org/abs/1506.02142)
     """
     @interfaces.legacy_dropout_support
     def __init__(self, rate, noise_shape=None, seed=None, drop_at_test_time=False, **kwargs):


### PR DESCRIPTION
### Summary
Adds a Flag, called `drop_at_test_time` to the Dropout layer.
This flag allows users to explicitly to apply the training phase dropout behavior at test time.
The motivation behind this mainly comes from [this paper](https://arxiv.org/abs/1506.02142), which uses Dropout at test time to obtain uncertainty estimates for neuralnetwork predictions.
The default behavior of the Dropout layer remains unchanged, since the argument is set to `False` by default.
### Related Issues
In #5357, the desire for more control over dropout behavior at test time has been voiced. Currently, the recommended solution is hacky and requires the use of undocumented features of the Keras API, either by creating custom layers or by 
### PR Overview

- [**Y**] This PR requires new unit tests [y/n] -> I am not sure how to create appropriate tests, suggestions are welcome.
- [Y] This PR requires to update the documentation [y/n] -> Documentation has been updated accordingly.
- [**N**] This PR is backwards compatible [y/n] -> Default behavior is backwards compatible, newly introduced behavior adds the flag to `get_config()` and thus prevents loading the layer in previous versions of Keras.
- [**Y**] This PR changes the current API [y/n] (all API changes need to be approved by fchollet) -> non-breaking changes to the API are introduced via a new optional argument.
