### PR TITLE
Fix a minor bug in the VAE example

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -100,7 +100,7 @@ def plot_results(models,
 
     plt.figure(figsize=(10, 10))
     start_range = digit_size // 2
-    end_range = n * digit_size + start_range + 1
+    end_range = (n - 1) * digit_size + start_range + 1
     pixel_range = np.arange(start_range, end_range, digit_size)
     sample_range_x = np.round(grid_x, 1)
     sample_range_y = np.round(grid_y, 1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

In the original code, len(pixel_range) is 31, which does not affect the plot though.

This commit makes `len(pixel_range) == len(sample_range_x) == len(sample_range_y) == 30`.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
