### PR TITLE
Use native functions for Zeros, Ones initializers

### DIFF
--- a/keras/initializers.py
+++ b/keras/initializers.py
@@ -35,7 +35,7 @@ class Zeros(Initializer):
     """
 
     def __call__(self, shape, dtype=None):
-        return K.constant(0, shape=shape, dtype=dtype)
+        return K.zeros(shape=shape, dtype=dtype)
 
 
 class Ones(Initializer):
@@ -43,7 +43,7 @@ class Ones(Initializer):
     """
 
     def __call__(self, shape, dtype=None):
-        return K.constant(1, shape=shape, dtype=dtype)
+        return K.ones(shape=shape, dtype=dtype)
 
 
 class Constant(Initializer):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Use `K.zeros` and `K.ones` instead of `K.constant` for corresponding `initializer`s.
### Related Issues

### PR Overview

- [N] This PR requires new unit tests [y/n] (make sure tests are included)
- [N] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [Y] This PR is backwards compatible [y/n]
- [N] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
