### PR TITLE
top_k_categorical_accuracy produces wrong result when weighted by sample

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -44,13 +44,13 @@ def sparse_categorical_accuracy(y_true, y_pred):
 
 
 def top_k_categorical_accuracy(y_true, y_pred, k=5):
-    return K.mean(K.in_top_k(y_pred, K.argmax(y_true, axis=-1), k), axis=-1)
+    return K.cast(K.in_top_k(y_pred, K.argmax(y_true, axis=-1), k), K.floatx())
 
 
 def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):
     # If the shape of y_true is (num_samples, 1), flatten to (num_samples,)
-    return K.mean(K.in_top_k(y_pred, K.cast(K.flatten(y_true), 'int32'), k),
-                  axis=-1)
+    return K.cast(K.in_top_k(y_pred, K.cast(K.flatten(y_true), 'int32'), k),
+                  K.floatx())
 
 
 # Aliases

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -87,13 +87,13 @@ def test_top_k_categorical_accuracy():
     y_true = K.variable(np.array([[0, 1, 0], [1, 0, 0]]))
     success_result = K.eval(metrics.top_k_categorical_accuracy(y_true, y_pred,
                                                                k=3))
-    assert success_result == 1
+    assert np.mean(success_result) == 1
     partial_result = K.eval(metrics.top_k_categorical_accuracy(y_true, y_pred,
                                                                k=2))
-    assert partial_result == 0.5
+    assert np.mean(partial_result) == 0.5
     failure_result = K.eval(metrics.top_k_categorical_accuracy(y_true, y_pred,
                                                                k=1))
-    assert failure_result == 0
+    assert np.mean(failure_result) == 0
 
 
 @pytest.mark.skipif((K.backend() == 'cntk'),
@@ -110,15 +110,15 @@ def test_sparse_top_k_categorical_accuracy(y_pred, y_true):
     success_result = K.eval(
         metrics.sparse_top_k_categorical_accuracy(y_true, y_pred, k=3))
 
-    assert success_result == 1
+    assert np.mean(success_result) == 1
     partial_result = K.eval(
         metrics.sparse_top_k_categorical_accuracy(y_true, y_pred, k=2))
 
-    assert partial_result == 0.5
+    assert np.mean(partial_result) == 0.5
     failure_result = K.eval(
         metrics.sparse_top_k_categorical_accuracy(y_true, y_pred, k=1))
 
-    assert failure_result == 0
+    assert np.mean(failure_result) == 0
 
 
 # TODO: resolve flakyness issue. Tracked with #11064


### PR DESCRIPTION
### Summary

Metrics top_k_categorical_accuracy and sparse_top_k_categorical_accuracy should output a vector of accuracies instead of single scalar to be compatible with weighted_masked_objective function:
https://github.com/keras-team/keras/blob/7c7e51ea5ab47b67cd68374400051dd022bdc662/keras/engine/training_utils.py#L398

weighted_masked_objective function expects to receive a vector with separate accuracy for every sample in batch, it's needed to properly reduce accuracies when sample weight is 0:
https://github.com/keras-team/keras/blob/7c7e51ea5ab47b67cd68374400051dd022bdc662/keras/engine/training_utils.py#L446

If weighted_masked_objective receives a scalar instead of vector, it won't be able to mask samples with weight 0.

Consider this example:
```
y_true = [[0, 1, 0], [1, 0, 0], [0, 0, 1]]
y_pred = [[0, 0.9, 0.1], [0, 0.9, 0.1], [0, 0.9, 0.1]]
sample_weights=[1.0, 0.0, 1.0]

fn = partial(top_k_categorical_accuracy, k=2)

# before fix:
fn(y_true, y_pred) # returns 0.66
weighted_masked_objective(fn)(y_true, y_pred, sample_weights) # returns 0.66

# after fix:
fn(y_true, y_pred) # returns [1.0, 0.0, 1.0]
weighted_masked_objective(fn)(y_true, y_pred, sample_weights) # returns 1.0
```


I'm not sure whether or not this requires a unit test.

### Related Issues

### PR Overview

- [?] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)