### PR TITLE
update description on validation_split

### DIFF
--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -338,7 +338,7 @@ Find out more in the [callbacks documentation](/callbacks).
 
 ### How is the validation split computed?
 
-If you set the `validation_split` argument in `model.fit` to e.g. 0.1, then the validation data used will be the *last 10%* of the data. If you set it to 0.25, it will be the last 25% of the data, etc. Note that the data isn't shuffled before extracting the validation split, so the validation is literally just the *last* x% of samples in the input you passed.
+If you set the `validation_split` argument in `model.fit` to e.g. 0.1, then the validation data used will be the *first 10%* of the data. If you set it to 0.25, it will be the first 25% of the data, etc. Note that the data isn't shuffled before extracting the validation split, so the validation is literally just the *first* x% of samples in the input you passed.
 
 The same validation set is used for all epochs (within a same call to `fit`).
 


### PR DESCRIPTION
https://github.com/keras-team/keras-preprocessing/blob/6ff9af6971f97f69c39d090be15c2f7d93aa4d6d/keras_preprocessing/image/numpy_array_iterator.py#L90
https://github.com/keras-team/keras-preprocessing/blob/6ff9af6971f97f69c39d090be15c2f7d93aa4d6d/keras_preprocessing/image/numpy_array_iterator.py#L101-L102

According to these 3 lines, the validation set is actually from the first percentage not the last. I personally think this is a very urgent issue to be dealt with since people without coding experience can only rely on the documents for doing project.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
