### PR TITLE
Add missing bracket to error string.

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -498,7 +498,7 @@ class Flatten(Layer):
         if not all(input_shape[1:]):
             raise ValueError('The shape of the input to "Flatten" '
                              'is not fully defined '
-                             '(got ' + str(input_shape[1:]) + '. '
+                             '(got ' + str(input_shape[1:]) + '). '
                              'Make sure to pass a complete "input_shape" '
                              'or "batch_input_shape" argument to the first '
                              'layer in your model.')


### PR DESCRIPTION
### Summary
Missing bracket on raised error before full stop. For example, could read
`ValueError: The shape of the input to "Flatten" is not fully defined (got (None, 7, 128).`

but should read

`ValueError: The shape of the input to "Flatten" is not fully defined (got (None, 7, 128)**)**.`

Pull request adds the bracket. Nothing complex!

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
