### PR TITLE
Update description of image.py

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -303,7 +303,9 @@ class ImageDataGenerator(image.ImageDataGenerator):
             Keras config file at `~/.keras/keras.json`.
             If you never set it, then it will be "channels_last".
         validation_split: Float. Fraction of images reserved for validation
-            (strictly between 0 and 1).
+            (strictly between 0 and 1). e.g. validation_split = 0.1 and subset
+            is "validation" in .flow(), the returned validation set will be the
+            first 10% of the data.
         dtype: Dtype to use for the generated arrays.
 
     # Examples


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Sorry about last PR didn't quite make myself clear. I didn't see the validation_split in FAQ.md is explaining only the .fit() and .fit_generator().
I'm looking into the ImageDataGenerator's validation_split. Acutally there's no description for the validation_split and by searching for validation_split there're only explanations for .fit() and .fit_generator(). Using the same input parameter but having a different output might be misleading. So I added some description in the new PR for image.py.
Below is my poc.

``` python3
from keras.datasets import cifar10
#import pdb
from keras.preprocessing.image import ImageDataGenerator
import numpy as np

(x_train, y_train), (x_test, y_test) = cifar10.load_data()

def poc():
    gen = ImageDataGenerator(validation_split=0.1)
    out = gen.flow(x_train, y_train, batch_size=1, shuffle=False, subset="validation")
    v1 = out.next()[0]
    v2 = x_train[0]
    res = np.all(v1 == v2)
    print(res) 
    
if __name__ == '__main__':
    poc()
```
### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
