### PR TITLE
Update the shape of "y_train" and "y_test" in the document for CIFAR datasets

### DIFF
--- a/docs/templates/datasets.md
+++ b/docs/templates/datasets.md
@@ -15,7 +15,7 @@ from keras.datasets import cifar10
 - __Returns:__
     - 2 tuples:
         - __x_train, x_test__: uint8 array of RGB image data with shape (num_samples, 3, 32, 32) or (num_samples, 32, 32, 3) based on the `image_data_format` backend setting of either `channels_first` or `channels_last` respectively.
-        - __y_train, y_test__: uint8 array of category labels (integers in range 0-9) with shape (num_samples,).
+        - __y_train, y_test__: uint8 array of category labels (integers in range 0-9) with shape (num_samples, 1).
 
 
 ---
@@ -35,7 +35,7 @@ from keras.datasets import cifar100
 - __Returns:__
     - 2 tuples:
         - __x_train, x_test__: uint8 array of RGB image data with shape (num_samples, 3, 32, 32) or (num_samples, 32, 32, 3) based on the `image_data_format` backend setting of either `channels_first` or `channels_last` respectively.
-        - __y_train, y_test__: uint8 array of category labels with shape (num_samples,).
+        - __y_train, y_test__: uint8 array of category labels with shape (num_samples, 1).
 
 - __Arguments:__
 


### PR DESCRIPTION
### Summary

Update the shape of "y_train" and "y_test" in [this document](https://github.com/keras-team/keras/blob/master/docs/templates/datasets.md), which describes the output of CIFAR10 and CIFAR100 datasets. 
From (num_samples,) To (num_samples, 1)
Please see the links to the source codes, which are used to load the CIFAR10 and CIFAR100 datasets, and my test codes below as evidence.

[y_train = np.reshape(y_train, (len(y_train), 1))](https://github.com/keras-team/keras/blob/35093bc9bb14a66d09fe6ea26e302df8ffad64f4/keras/datasets/cifar10.py#L37)
[y_test = np.reshape(y_test, (len(y_test), 1))](https://github.com/keras-team/keras/blob/35093bc9bb14a66d09fe6ea26e302df8ffad64f4/keras/datasets/cifar10.py#L38)
[y_train = np.reshape(y_train, (len(y_train), 1))](https://github.com/keras-team/keras/blob/35093bc9bb14a66d09fe6ea26e302df8ffad64f4/keras/datasets/cifar100.py#L39)
[y_test = np.reshape(y_test, (len(y_test), 1))](https://github.com/keras-team/keras/blob/35093bc9bb14a66d09fe6ea26e302df8ffad64f4/keras/datasets/cifar100.py#L40)
![output](https://user-images.githubusercontent.com/43639585/56090900-a4aa0c80-5eda-11e9-82c4-90617a7cb628.png)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
