### PR TITLE
change plot_model to fully support plotting submodel and fix bugs

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -147,30 +147,45 @@ def model_to_dot(model,
                 for inbound_layer in node.inbound_layers:
                     inbound_layer_id = str(id(inbound_layer))
                     # if inbound_layer is not Model or wrapped Model
-                    if (not (expand_nested and isinstance(inbound_layer, Model))) and (
-                        not (expand_nested and isinstance(inbound_layer, Wrapper) and isinstance(inbound_layer.layer, Model))):
+                    if (not (expand_nested and (
+                            isinstance(inbound_layer, Model)))
+                            ) and (
+                            not (expand_nested and (
+                            isinstance(inbound_layer, Wrapper)) and (
+                            isinstance(inbound_layer.layer, Model))) ):
                         # if current layer is not Model or wrapped Model
-                        if (not (expand_nested and isinstance(layer, Model))) and (
-                            not (expand_nested and isinstance(layer, Wrapper) and isinstance(layer.layer, Model))):
+                        if (not (expand_nested and (
+                                isinstance(layer, Model)))
+                                ) and (
+                                not (expand_nested and
+                                (isinstance(layer, Wrapper)) and (
+                                isinstance(layer.layer, Model))) ):
                             assert dot.get_node(inbound_layer_id)
                             assert dot.get_node(layer_id)
                             dot.add_edge(pydot.Edge(inbound_layer_id, layer_id))
                         # if current layer is Model
                         elif expand_nested and isinstance(layer, Model):
-                            if not dot.get_edge(inbound_layer_id, sub_n_first_node.get_name()):
-                                dot.add_edge(pydot.Edge(inbound_layer_id, sub_n_first_node.get_name()))
+                            if not dot.get_edge(inbound_layer_id,
+                                                sub_n_first_node.get_name()):
+                                dot.add_edge(pydot.Edge(inbound_layer_id,
+                                                sub_n_first_node.get_name()))
                         # if current layer is wrapped Model
-                        elif expand_nested and isinstance(layer, Wrapper) and isinstance(layer.layer, Model):
+                        elif expand_nested and isinstance(layer, Wrapper) and (
+                                isinstance(layer.layer, Model)):
                             dot.add_edge(pydot.Edge(inbound_layer_id, layer_id))
-                            dot.add_edge(pydot.Edge(layer_id, sub_w_first_node.get_name()))
+                            dot.add_edge(pydot.Edge(layer_id,
+                                                sub_w_first_node.get_name()))
                     # if inbound_layer is Model
                     elif expand_nested and isinstance(inbound_layer, Model):
                         if not dot.get_edge(sub_n_last_node.get_name(), layer_id):
-                            dot.add_edge(pydot.Edge(sub_n_last_node.get_name(), layer_id))
+                            dot.add_edge(pydot.Edge(sub_n_last_node.get_name(),
+                                                        layer_id))
                     # if inbound_layer is wrapped Model
-                    elif expand_nested and isinstance(inbound_layer, Wrapper) and isinstance(inbound_layer.layer, Model):
+                    elif expand_nested and isinstance(inbound_layer, Wrapper) and (
+                                isinstance(inbound_layer.layer, Model)):
                         if not dot.get_edge(sub_w_last_node.get_name(), layer_id):
-                            dot.add_edge(pydot.Edge(sub_w_last_node.get_name(), layer_id))
+                            dot.add_edge(pydot.Edge(sub_w_last_node.get_name(),
+                                                        layer_id))
     return dot
 
 

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -63,7 +63,7 @@ def model_to_dot(model,
 
     _check_pydot()
     if subgraph:
-        dot = pydot.Cluster(style = 'dashed', graph_name = model.name)
+        dot = pydot.Cluster(style='dashed', graph_name=model.name)
         dot.set('label', model.name)
         dot.set('labeljust', 'l')
     else:
@@ -89,8 +89,9 @@ def model_to_dot(model,
         if isinstance(layer, Wrapper):
             if expand_nested and isinstance(layer.layer, Model):
                 submodel_wrapper = model_to_dot(layer.layer, show_shapes,
-                                    show_layer_names, rankdir, expand_nested,
-                                    subgraph=True)
+                                                show_layer_names, rankdir,
+                                                expand_nested,
+                                                subgraph=True)
                 # sub_w : submodel_wrapper
                 sub_w_nodes = submodel_wrapper.get_nodes()
                 sub_w_first_node = sub_w_nodes[0]
@@ -103,8 +104,9 @@ def model_to_dot(model,
 
         if expand_nested and isinstance(layer, Model):
             submodel_not_wrapper = model_to_dot(layer, show_shapes,
-                                    show_layer_names, rankdir, expand_nested,
-                                    subgraph=True)
+                                                show_layer_names, rankdir,
+                                                expand_nested,
+                                                subgraph=True)
             # sub_n : submodel_not_wrapper
             sub_n_nodes = submodel_not_wrapper.get_nodes()
             sub_n_first_node = sub_n_nodes[0]
@@ -148,18 +150,16 @@ def model_to_dot(model,
                     inbound_layer_id = str(id(inbound_layer))
                     # if inbound_layer is not Model or wrapped Model
                     if (not (expand_nested and (
-                            isinstance(inbound_layer, Model)))
-                            ) and (
+                            isinstance(inbound_layer, Model)))) and (
                             not (expand_nested and (
                             isinstance(inbound_layer, Wrapper)) and (
-                            isinstance(inbound_layer.layer, Model))) ):
+                            isinstance(inbound_layer.layer, Model)))):
                         # if current layer is not Model or wrapped Model
                         if (not (expand_nested and (
-                                isinstance(layer, Model)))
-                                ) and (
-                                not (expand_nested and
-                                (isinstance(layer, Wrapper)) and (
-                                isinstance(layer.layer, Model))) ):
+                                isinstance(layer, Model)))) and (
+                                not (expand_nested and (
+                                isinstance(layer, Wrapper)) and (
+                                isinstance(layer.layer, Model)))):
                             assert dot.get_node(inbound_layer_id)
                             assert dot.get_node(layer_id)
                             dot.add_edge(pydot.Edge(inbound_layer_id, layer_id))
@@ -168,24 +168,24 @@ def model_to_dot(model,
                             if not dot.get_edge(inbound_layer_id,
                                                 sub_n_first_node.get_name()):
                                 dot.add_edge(pydot.Edge(inbound_layer_id,
-                                                sub_n_first_node.get_name()))
+                                             sub_n_first_node.get_name()))
                         # if current layer is wrapped Model
                         elif expand_nested and isinstance(layer, Wrapper) and (
                                 isinstance(layer.layer, Model)):
                             dot.add_edge(pydot.Edge(inbound_layer_id, layer_id))
                             dot.add_edge(pydot.Edge(layer_id,
-                                                sub_w_first_node.get_name()))
+                                                    sub_w_first_node.get_name()))
                     # if inbound_layer is Model
                     elif expand_nested and isinstance(inbound_layer, Model):
                         if not dot.get_edge(sub_n_last_node.get_name(), layer_id):
                             dot.add_edge(pydot.Edge(sub_n_last_node.get_name(),
-                                                        layer_id))
+                                                    layer_id))
                     # if inbound_layer is wrapped Model
                     elif expand_nested and isinstance(inbound_layer, Wrapper) and (
-                                isinstance(inbound_layer.layer, Model)):
+                            isinstance(inbound_layer.layer, Model)):
                         if not dot.get_edge(sub_w_last_node.get_name(), layer_id):
                             dot.add_edge(pydot.Edge(sub_w_last_node.get_name(),
-                                                        layer_id))
+                                                    layer_id))
     return dot
 
 

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -4,6 +4,8 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+from ..models import Model
+from ..layers.wrappers import Wrapper
 
 # `pydot` is an optional dependency,
 # see `extras_require` in `setup.py`.
@@ -32,13 +34,10 @@ def _check_pydot():
 
 
 def is_model(layer):
-    from ..models import Model
     return isinstance(layer, Model)
 
 
 def is_wrapped_model(layer):
-    from ..layers.wrappers import Wrapper
-    from ..models import Model
     return isinstance(layer, Wrapper) and isinstance(layer.layer, Model)
 
 

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -63,7 +63,7 @@ def model_to_dot(model,
 
     _check_pydot()
     if subgraph:
-        dot = pydot.Cluster(style='dashed')
+        dot = pydot.Cluster(style = 'dashed', graph_name = model.name)
         dot.set('label', model.name)
         dot.set('labeljust', 'l')
     else:
@@ -85,23 +85,31 @@ def model_to_dot(model,
         # Append a wrapped layer's label to node's label, if it exists.
         layer_name = layer.name
         class_name = layer.__class__.__name__
+
         if isinstance(layer, Wrapper):
             if expand_nested and isinstance(layer.layer, Model):
-                submodel = model_to_dot(layer.layer, show_shapes,
-                                        show_layer_names, rankdir, expand_nested,
-                                        subgraph=True)
-                model_nodes = submodel.get_nodes()
-                dot.add_edge(pydot.Edge(layer_id, model_nodes[0].get_name()))
-                if len(layers) > i + 1:
-                    next_layer_id = str(id(layers[i + 1]))
-                    dot.add_edge(pydot.Edge(
-                        model_nodes[len(model_nodes) - 1].get_name(),
-                        next_layer_id))
-                dot.add_subgraph(submodel)
+                submodel_wrapper = model_to_dot(layer.layer, show_shapes,
+                                    show_layer_names, rankdir, expand_nested,
+                                    subgraph=True)
+                # sub_w : submodel_wrapper
+                sub_w_nodes = submodel_wrapper.get_nodes()
+                sub_w_first_node = sub_w_nodes[0]
+                sub_w_last_node = sub_w_nodes[len(sub_w_nodes) - 1]
+                dot.add_subgraph(submodel_wrapper)
             else:
                 layer_name = '{}({})'.format(layer_name, layer.layer.name)
                 child_class_name = layer.layer.__class__.__name__
                 class_name = '{}({})'.format(class_name, child_class_name)
+
+        if expand_nested and isinstance(layer, Model):
+            submodel_not_wrapper = model_to_dot(layer, show_shapes,
+                                    show_layer_names, rankdir, expand_nested,
+                                    subgraph=True)
+            # sub_n : submodel_not_wrapper
+            sub_n_nodes = submodel_not_wrapper.get_nodes()
+            sub_n_first_node = sub_n_nodes[0]
+            sub_n_last_node = sub_n_nodes[len(sub_n_nodes) - 1]
+            dot.add_subgraph(submodel_not_wrapper)
 
         # Create node's label.
         if show_layer_names:
@@ -125,8 +133,10 @@ def model_to_dot(model,
             label = '%s\n|{input:|output:}|{{%s}|{%s}}' % (label,
                                                            inputlabels,
                                                            outputlabels)
-        node = pydot.Node(layer_id, label=label)
-        dot.add_node(node)
+
+        if not expand_nested or not isinstance(layer, Model):
+            node = pydot.Node(layer_id, label=label)
+            dot.add_node(node)
 
     # Connect nodes with edges.
     for layer in layers:
@@ -135,16 +145,32 @@ def model_to_dot(model,
             node_key = layer.name + '_ib-' + str(i)
             if node_key in model._network_nodes:
                 for inbound_layer in node.inbound_layers:
-                    if not expand_nested or not (
-                            isinstance(inbound_layer, Wrapper) and
-                            isinstance(inbound_layer.layer, Model)):
-                        inbound_layer_id = str(id(inbound_layer))
-                        # Make sure that both nodes exist before connecting them with
-                        # an edge, as add_edge would otherwise
-                        # create any missing node.
-                        assert dot.get_node(inbound_layer_id)
-                        assert dot.get_node(layer_id)
-                        dot.add_edge(pydot.Edge(inbound_layer_id, layer_id))
+                    inbound_layer_id = str(id(inbound_layer))
+                    # if inbound_layer is not Model or wrapped Model
+                    if (not (expand_nested and isinstance(inbound_layer, Model))) and (
+                        not (expand_nested and isinstance(inbound_layer, Wrapper) and isinstance(inbound_layer.layer, Model))):
+                        # if current layer is not Model or wrapped Model
+                        if (not (expand_nested and isinstance(layer, Model))) and (
+                            not (expand_nested and isinstance(layer, Wrapper) and isinstance(layer.layer, Model))):
+                            assert dot.get_node(inbound_layer_id)
+                            assert dot.get_node(layer_id)
+                            dot.add_edge(pydot.Edge(inbound_layer_id, layer_id))
+                        # if current layer is Model
+                        elif expand_nested and isinstance(layer, Model):
+                            if not dot.get_edge(inbound_layer_id, sub_n_first_node.get_name()):
+                                dot.add_edge(pydot.Edge(inbound_layer_id, sub_n_first_node.get_name()))
+                        # if current layer is wrapped Model
+                        elif expand_nested and isinstance(layer, Wrapper) and isinstance(layer.layer, Model):
+                            dot.add_edge(pydot.Edge(inbound_layer_id, layer_id))
+                            dot.add_edge(pydot.Edge(layer_id, sub_w_first_node.get_name()))
+                    # if inbound_layer is Model
+                    elif expand_nested and isinstance(inbound_layer, Model):
+                        if not dot.get_edge(sub_n_last_node.get_name(), layer_id):
+                            dot.add_edge(pydot.Edge(sub_n_last_node.get_name(), layer_id))
+                    # if inbound_layer is wrapped Model
+                    elif expand_nested and isinstance(inbound_layer, Wrapper) and isinstance(inbound_layer.layer, Model):
+                        if not dot.get_edge(sub_w_last_node.get_name(), layer_id):
+                            dot.add_edge(pydot.Edge(sub_w_last_node.get_name(), layer_id))
     return dot
 
 


### PR DESCRIPTION
### Summary

Changed plot_model function in vis_utils.py to fully support plotting submodels and also fixed some bugs. Previous PR [#11431](https://github.com/keras-team/keras/pull/11431) had add ability to visualize only wrapped submodels with plot_model function, but it works wrong sometimes, as shown below later. This PR can not only support plotting wrapped submodels, but also add ability to plot unwrapped submodels. And it doesn't get wrong results according to my tests.

For example, this model is from [Video question answering model](https://keras.io/getting-started/functional-api-guide/#video-question-answering-model) in Keras Documentation.

```python
from keras.layers import Conv2D, MaxPooling2D, Flatten
from keras.layers import Input, LSTM, Embedding, Dense
from keras.layers import TimeDistributed
from keras.models import Model, Sequential
from keras.utils.vis_utils import plot_model
import keras

# Define a vision model using a Sequential model.
# This model will encode an image into a vector.
vision_model = Sequential()
vision_model.add(Conv2D(64, (3, 3), activation='relu', padding='same', input_shape=(224, 224, 3)))
vision_model.add(Conv2D(64, (3, 3), activation='relu'))
vision_model.add(MaxPooling2D((2, 2)))
vision_model.add(Conv2D(128, (3, 3), activation='relu', padding='same'))
vision_model.add(Conv2D(128, (3, 3), activation='relu'))
vision_model.add(MaxPooling2D((2, 2)))
vision_model.add(Conv2D(256, (3, 3), activation='relu', padding='same'))
vision_model.add(Conv2D(256, (3, 3), activation='relu'))
vision_model.add(Conv2D(256, (3, 3), activation='relu'))
vision_model.add(MaxPooling2D((2, 2)))
vision_model.add(Flatten())

# This is our video encoded via the previously trained vision_model (weights are reused)
video_input = Input(shape=(100, 224, 224, 3))
encoded_frame_sequence = TimeDistributed(vision_model)(video_input)  # the output will be a sequence of vectors
encoded_video = LSTM(256)(encoded_frame_sequence)  # the output will be a vector

# Define a language model to encode the question into a vector.
# Each question will be at most 100 word long,
# and we will index words as integers from 1 to 9999.
question_input = Input(shape=(100,), dtype='int32')
embedded_question = Embedding(input_dim=10000, output_dim=256, input_length=100)(question_input)
encoded_question = LSTM(256)(embedded_question)

# This is a model-level representation of the question encoder
question_encoder = Model(inputs=question_input, outputs=encoded_question)

# Let's use it to encode the question:
video_question_input = Input(shape=(100,), dtype='int32')
encoded_video_question = question_encoder(video_question_input)

# And this is our video question answering model:
merged = keras.layers.concatenate([encoded_video, encoded_video_question])
output = Dense(1000, activation='softmax')(merged)
video_qa_model = Model(inputs=[video_input, video_question_input], outputs=output)
```

Calling plot_model without parameter ```expand_nested``` will produce:
```python
plot_model(video_qa_model, to_file="model.png", show_shapes=True)
```
![model_new_not_expand](https://user-images.githubusercontent.com/42084654/56105055-1763c800-5f6d-11e9-98b7-19b2a3042b50.png)

Calling plot_model with parameter ```expand_nested=True``` will produce the picture below. As we can see, it plotted both wrapped submodels and unwrapped submodels, i.e., time_distributed_1(sequential_1) and model_1.

```python
plot_model(video_qa_model, to_file="model.png", show_shapes=True, expand_nested=True)
```
![model_new_expand](https://user-images.githubusercontent.com/42084654/56105079-2c405b80-5f6d-11e9-8d4a-6524fc67fa6e.png)

However, calling the same with previous PR will produce something wrong as below. First, it can't plot unwrapped models; Second, it  even got wrong model structure, which is the bug we talked before.

![model_old_expand](https://user-images.githubusercontent.com/42084654/56105095-3a8e7780-5f6d-11e9-955a-7d27661f15ec.png)


### Related Issues

[#5937](https://github.com/keras-team/keras/issues/5937)

### Related PRs

[#11431](https://github.com/keras-team/keras/pull/11431)

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
