### PR TITLE
Add kernel size information to layer.name in summary()

### DIFF
--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -1276,7 +1276,8 @@ class Network(Layer):
         """
         return yaml.dump(self._updated_config(), **kwargs)
 
-    def summary(self, line_length=None, positions=None, print_fn=None):
+    def summary(self, line_length=None, positions=None, print_fn=None,
+                disp_kernel_info=True):
         """Prints a string summary of the network.
 
         # Arguments
@@ -1302,7 +1303,8 @@ class Network(Layer):
         return print_layer_summary(self,
                                    line_length=line_length,
                                    positions=positions,
-                                   print_fn=print_fn)
+                                   print_fn=print_fn,
+                                   disp_kernel_info=disp_kernel_info)
 
     def __getstate__(self):
         return saving.pickle_model(self)

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -21,7 +21,8 @@ def count_params(weights):
     return int(np.sum([K.count_params(p) for p in set(weights)]))
 
 
-def print_summary(model, line_length=None, positions=None, print_fn=None):
+def print_summary(model, line_length=None, positions=None, print_fn=None,
+                  disp_kernel_info=True):
     """Prints a summary of a model.
 
     # Arguments
@@ -36,6 +37,10 @@ def print_summary(model, line_length=None, positions=None, print_fn=None):
             You can set it to a custom function
             in order to capture the string summary.
             It defaults to `print` (prints to stdout).
+        disp_kernel_info: [bool] Append kernel size information at the end 
+            of the layer name. 
+            By definition, it will only work for convolutional layers.
+            Default = True.
     """
     if print_fn is None:
         print_fn = print
@@ -74,14 +79,14 @@ def print_summary(model, line_length=None, positions=None, print_fn=None):
 
     if sequential_like:
         line_length = line_length or 65
-        positions = positions or [.45, .85, 1.]
+        positions = positions or [.48, .88, 1.]
         if positions[-1] <= 1:
             positions = [int(line_length * p) for p in positions]
         # header names for the different log elements
         to_display = ['Layer (type)', 'Output Shape', 'Param #']
     else:
         line_length = line_length or 98
-        positions = positions or [.33, .55, .67, 1.]
+        positions = positions or [.36, .58, .70, 1.]
         if positions[-1] <= 1:
             positions = [int(line_length * p) for p in positions]
         # header names for the different log elements
@@ -115,7 +120,10 @@ def print_summary(model, line_length=None, positions=None, print_fn=None):
             output_shape = 'multiple'
         name = layer.name
         cls_name = layer.__class__.__name__
-        fields = [name + ' (' + cls_name + ')',
+        kernel_size_str = ''
+        if disp_kernel_info and 'conv' in cls_name.lower():
+            kernel_size_str = '_(' + 'x'.join(map(str,layer.kernel_size)) + ')' 
+        fields = [name + kernel_size_str + ' (' + cls_name + ')',
                   output_shape, layer.count_params()]
         print_row(fields, positions)
 
@@ -144,11 +152,14 @@ def print_summary(model, line_length=None, positions=None, print_fn=None):
 
         name = layer.name
         cls_name = layer.__class__.__name__
+        kernel_size_str = ''
+        if disp_kernel_info and 'conv' in cls_name.lower():
+            kernel_size_str = '_(' + 'x'.join(map(str,layer.kernel_size)) + ')' 
         if not connections:
             first_connection = ''
         else:
             first_connection = connections[0]
-        fields = [name +
+        fields = [name + kernel_size_str +
                   ' (' + cls_name + ')',
                   output_shape,
                   layer.count_params(),

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -37,8 +37,8 @@ def print_summary(model, line_length=None, positions=None, print_fn=None,
             You can set it to a custom function
             in order to capture the string summary.
             It defaults to `print` (prints to stdout).
-        disp_kernel_info: [bool] Append kernel size information at the end 
-            of the layer name. 
+        disp_kernel_info: [bool] Append kernel size information at the end
+            of the layer name.
             By definition, it will only work for convolutional layers.
             Default = True.
     """
@@ -122,7 +122,7 @@ def print_summary(model, line_length=None, positions=None, print_fn=None,
         cls_name = layer.__class__.__name__
         kernel_size_str = ''
         if disp_kernel_info and 'conv' in cls_name.lower():
-            kernel_size_str = '_(' + 'x'.join(map(str,layer.kernel_size)) + ')' 
+            kernel_size_str = '_(' + 'x'.join(map(str, layer.kernel_size)) + ')'
         fields = [name + kernel_size_str + ' (' + cls_name + ')',
                   output_shape, layer.count_params()]
         print_row(fields, positions)
@@ -154,7 +154,7 @@ def print_summary(model, line_length=None, positions=None, print_fn=None,
         cls_name = layer.__class__.__name__
         kernel_size_str = ''
         if disp_kernel_info and 'conv' in cls_name.lower():
-            kernel_size_str = '_(' + 'x'.join(map(str,layer.kernel_size)) + ')' 
+            kernel_size_str = '_(' + 'x'.join(map(str, layer.kernel_size)) + ')'
         if not connections:
             first_connection = ''
         else:


### PR DESCRIPTION
### Commit message    
Add kernel size information to layer.name in summary(), e.g. 'conv2d_(3x3)' for a (3,3) kernel instead of 'conv2d'.

### Summary    
For the sake of clarity (and also pedagogic purposes), I added to the `summary()` method of a model the ability to display the kernel size of any convolutional layer.     
I've done this by concatenating the value of the `.kernel_size()` method to the displayed layer name in the summary.
When using the `.summary()` method of a model, it can now be displayed using a new `disp_kernel_info` flag (default=True) to the `print_summary()` function in "layer_utils.py" (and as well the `.summary()` method from the `Network` class).

I initially decided to create a new column "Kernel size" but when a network is only composed of `Dense()` layers the column remains but is empty, which was not purely optimal and I didn't find how to test all the network architecture to check whether or not there is at least one convolutional layer (but this would definitely be a better idea i.m.h.o.).

### Files changed    
`keras/keras/engine/network.py`
`keras/keras/utils/layer_utils.py` 

### Related Issues    
None.

### PR Overview    

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [?] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
