### PR TITLE
URGENT: FIX TensorFlow api compatibility problem

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -208,7 +208,11 @@ def get_session():
                         uninitialized_vars.append(v)
                     v._keras_initialized = True
                 if uninitialized_vars:
-                    session.run(tf.variables_initializer(uninitialized_vars))
+                    if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+                        session.run(tf.initialize_variables(uninitialized_vars))
+                    else: # For tf version >= 0.12.0
+                        session.run(tf.variables_initializer(uninitialized_vars))
+ 
     # hack for list_devices() function.
     # list_devices() function is not available under tensorflow r1.3.
     if not hasattr(session, 'list_devices'):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -208,9 +208,13 @@ def get_session():
                         uninitialized_vars.append(v)
                     v._keras_initialized = True
                 if uninitialized_vars:
-                    if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+                    tf_major_ver = int(tf.__version__.split(".")[0])
+                    tf_minor_ver = int(tf.__version__.split(".")[1])
+                    if(tf_major_ver == 0 and tf_minor_ver < 12): 
+                        # For tf version < 0.12.0
                         session.run(tf.initialize_variables(uninitialized_vars))
-                    else: # For tf version >= 0.12.0
+                    else: 
+                        # For tf version >= 0.12.0
                         session.run(tf.variables_initializer(uninitialized_vars))
  
     # hack for list_devices() function.

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -210,13 +210,12 @@ def get_session():
                 if uninitialized_vars:
                     tf_major_ver = int(tf.__version__.split(".")[0])
                     tf_minor_ver = int(tf.__version__.split(".")[1])
-                    if(tf_major_ver == 0 and tf_minor_ver < 12): 
+                    if(tf_major_ver == 0 and tf_minor_ver < 12):
                         # For tf version < 0.12.0
                         session.run(tf.initialize_variables(uninitialized_vars))
-                    else: 
+                    else:
                         # For tf version >= 0.12.0
                         session.run(tf.variables_initializer(uninitialized_vars))
- 
     # hack for list_devices() function.
     # list_devices() function is not available under tensorflow r1.3.
     if not hasattr(session, 'list_devices'):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Dear developers,

I found some compatibility problems in your use of TensorFlow APIs, which might lead to crashes in a low version of TensorFlow. And I fix it for you as below:

`tf. variables_initializer` is the updated version of `tf.initialize_variables`, however, it appears until tf 0.12.0-rc0. So for version before that, it's better to use `tf.initialize_variables` to be safe.

@bmabey @smgt @moustaki @edsonmedina @jfsantos 
This fix can make your code compatible on more versions of TensorFlow.
Hope you could take my advice and look forward to your reply! 😄
### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
