### PR TITLE
Add MarkDown formatting to examples/mnist_cnn.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
   - CIFAR-10 ResNet: examples/cifar10_resnet.md
   - Convolution filter visualization: examples/conv_filter_visualization.md
   - Convolutional LSTM: examples/conv_lstm.md
+  - Convolutional NN on MNIST: examples/mnist_cnn.md
   - Deep Dream: examples/deep_dream.md
   - Image OCR: examples/image_ocr.md
   - Bidirectional LSTM: examples/imdb_bidirectional_lstm.md

--- a/examples/mnist_cnn.py
+++ b/examples/mnist_cnn.py
@@ -1,4 +1,5 @@
-'''Trains a simple convnet on the MNIST dataset.
+'''
+# Trains a simple convnet on the MNIST dataset.
 
 Gets to 99.25% test accuracy after 12 epochs
 (there is still a lot of margin for parameter tuning).


### PR DESCRIPTION
Signed-off-by: Marcela Morales Quispe <marcela.morales.quispe@gmail.com>

### Summary
This PR adds MarkDown formatting to `examples/mnist_cnn.py`.
Result:
<img width="1097" alt="cnn_1" src="https://user-images.githubusercontent.com/21090606/56557015-2f37df00-655f-11e9-9a32-41b58981ed4a.png">
<img width="1099" alt="cnn_2" src="https://user-images.githubusercontent.com/21090606/56557019-33fc9300-655f-11e9-943c-c0e4e465e991.png">

### Related Issues
#12219

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
