### PR TITLE
Add MarkDown formatting to examples/mnist_dataset_api.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - MNIST classification with TensorFlow: examples/mnist_dataset_api.md

--- a/examples/mnist_dataset_api.py
+++ b/examples/mnist_dataset_api.py
@@ -1,20 +1,21 @@
-'''MNIST classification with TensorFlow's Dataset API.
+'''
+# MNIST classification with TensorFlow's Dataset API.
 
 Introduced in TensorFlow 1.3, the Dataset API is now the
 standard method for loading data into TensorFlow models.
 A Dataset is a sequence of elements, which are themselves
-composed of tf.Tensor components. For more details, see:
-https://www.tensorflow.org/programmers_guide/datasets
+composed of `tf.Tensor` components. For more details, see:
+[tensorflow/datasets](https://www.tensorflow.org/programmers_guide/datasets)
 
 To use this with Keras, we make a dataset out of elements
 of the form (input batch, output batch). From there, we
 create a one-shot iterator and a graph node corresponding
-to its get_next() method. Its components are then provided
-to the network's Input layer and the Model.compile() method,
+to its `get_next()` method. Its components are then provided
+to the network's Input layer and the `Model.compile()` method,
 respectively.
 
 This example is intended to closely follow the
-mnist_tfrecord.py example.
+`mnist_tfrecord.py` example.
 '''
 import numpy as np
 import os


### PR DESCRIPTION
Signed-off-by: Marcela Morales Quispe <marcela.morales.quispe@gmail.com>

### Summary
This PR adds MarkDown formatting to `examples/mnist_dataset_api.py`.
Result
<img width="1104" alt="mnistTF1" src="https://user-images.githubusercontent.com/21090606/56558695-2ba75680-6565-11e9-868f-328fc3066ce1.png">
<img width="1049" alt="mnistTF2" src="https://user-images.githubusercontent.com/21090606/56558703-3104a100-6565-11e9-9f73-10d327f6b83a.png">

### Related Issues
#12219

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
