### PR TITLE
Fix use of numpy.load() in example datasets

### DIFF
--- a/keras/datasets/boston_housing.py
+++ b/keras/datasets/boston_housing.py
@@ -26,7 +26,7 @@ def load_data(path='boston_housing.npz', test_split=0.2, seed=113):
         path,
         origin='https://s3.amazonaws.com/keras-datasets/boston_housing.npz',
         file_hash='f553886a1f8d56431e820c5b82552d9d95cfcb96d1e678153f8839538947dff5')
-    with np.load(path) as f:
+    with np.load(path, allow_pickle=True) as f:
         x = f['x']
         y = f['y']
 

--- a/keras/datasets/imdb.py
+++ b/keras/datasets/imdb.py
@@ -55,7 +55,7 @@ def load_data(path='imdb.npz', num_words=None, skip_top=0,
     path = get_file(path,
                     origin='https://s3.amazonaws.com/text-datasets/imdb.npz',
                     file_hash='599dadb1135973df5b59232a0e9a887c')
-    with np.load(path) as f:
+    with np.load(path, allow_pickle=True) as f:
         x_train, labels_train = f['x_train'], f['y_train']
         x_test, labels_test = f['x_test'], f['y_test']
 

--- a/keras/datasets/mnist.py
+++ b/keras/datasets/mnist.py
@@ -21,7 +21,7 @@ def load_data(path='mnist.npz'):
     path = get_file(path,
                     origin='https://s3.amazonaws.com/img-datasets/mnist.npz',
                     file_hash='8a61469f7ea1b51cbae51d4f78837e45')
-    with np.load(path) as f:
+    with np.load(path, allow_pickle=True) as f:
         x_train, y_train = f['x_train'], f['y_train']
         x_test, y_test = f['x_test'], f['y_test']
     return (x_train, y_train), (x_test, y_test)

--- a/keras/datasets/reuters.py
+++ b/keras/datasets/reuters.py
@@ -53,7 +53,7 @@ def load_data(path='reuters.npz', num_words=None, skip_top=0,
     path = get_file(path,
                     origin='https://s3.amazonaws.com/text-datasets/reuters.npz',
                     file_hash='87aedbeb0cb229e378797a632c1997b6')
-    with np.load(path) as f:
+    with np.load(path, allow_pickle=True) as f:
         xs, labels = f['x'], f['y']
 
     rng = np.random.RandomState(seed)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

In the imdb, reuters, boston_housing, and mnist datasets, `load_data()` calls `numpy.load()`, but omits the `allow_pickle` parameter. In recent versions of numpy, the `allow_pickle` parameter defaults to `False`, which causes the load to throw an exception (these datasets are stored in pickled files).

This PR simply passes `allow_pickle=True` to `numpy.load`.

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
