### PR TITLE
Add MarkDown formatting to examples/mnist_denoising_autoencoder.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Autoencoder on MNIST dataset: examples/mnist_denoising_autoencoder.md

--- a/examples/mnist_denoising_autoencoder.py
+++ b/examples/mnist_denoising_autoencoder.py
@@ -1,4 +1,5 @@
-'''Trains a denoising autoencoder on MNIST dataset.
+'''
+# Trains a denoising autoencoder on MNIST dataset.
 
 Denoising is one of the classic applications of autoencoders.
 The denoising process removes unwanted noise that corrupted the


### PR DESCRIPTION
Signed-off-by: Marcela Morales Quispe <marcela.morales.quispe@gmail.com>

### Summary
Add MarkDown formatting to `examples/mnist_denoising_autoencoder.py`.
Result
<img width="1099" alt="autoE1" src="https://user-images.githubusercontent.com/21090606/56625339-7f1bb200-6602-11e9-9ab0-2a84114137a7.png">
<img width="1101" alt="autoE2" src="https://user-images.githubusercontent.com/21090606/56625346-83e06600-6602-11e9-9e7b-291d7fbe5ed8.png">

### Related Issues
#12219

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
