### PR TITLE
Add MarkDown formatting to examples/mnist_hierarchical_rnn.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - MNIST Hierarchical RNN: examples/mnist_hierarchical_rnn.md

--- a/examples/mnist_hierarchical_rnn.py
+++ b/examples/mnist_hierarchical_rnn.py
@@ -1,4 +1,5 @@
-"""Example of using Hierarchical RNN (HRNN) to classify MNIST digits.
+"""
+# Example of using Hierarchical RNN (HRNN) to classify MNIST digits.
 
 HRNNs can learn across multiple levels
 of temporal hierarchy over a complex sequence.
@@ -10,16 +11,16 @@ such vectors (encoded by the first layer) into a document vector.
 This document vector is considered to preserve both
 the word-level and sentence-level structure of the context.
 
-# References
+### References
 
-- [A Hierarchical Neural Autoencoder for Paragraphs and Documents]
-    (https://arxiv.org/abs/1506.01057)
+- [A Hierarchical Neural Autoencoder for Paragraphs and
+  Documents](https://arxiv.org/abs/1506.01057):
     Encodes paragraphs and documents with HRNN.
     Results have shown that HRNN outperforms standard
     RNNs and may play some role in more sophisticated generation tasks like
     summarization or question answering.
-- [Hierarchical recurrent neural network for skeleton based action recognition]
-    (http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=7298714)
+- [Hierarchical recurrent neural network for skeleton based action
+  recognition](http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=7298714):
     Achieved state-of-the-art results on
     skeleton based action recognition with 3 levels
     of bidirectional HRNN combined with fully connected layers.


### PR DESCRIPTION
Signed-off-by: Marcela Morales Quispe <marcela.morales.quispe@gmail.com>

### Summary
Add MarkDown formatting to `examples/mnist_hierarchical_rnn.py`.
**Result**
<img width="1097" alt="hrnn1" src="https://user-images.githubusercontent.com/21090606/56626432-3dd9d100-6607-11e9-8fc8-e52abd28da74.png">
<img width="1096" alt="hrnn2" src="https://user-images.githubusercontent.com/21090606/56626436-43371b80-6607-11e9-8bbf-68d78832a5bf.png">

### Related Issues
#12219

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
