### PR TITLE
Add MarkDown formatting to examples/mnist_irnn.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - MNIST IRNN experiment: examples/mnist_irnn.md

--- a/examples/mnist_irnn.py
+++ b/examples/mnist_irnn.py
@@ -1,16 +1,15 @@
-'''This is a reproduction of the IRNN experiment
-with pixel-by-pixel sequential MNIST in
+'''
+# A reproduction of the IRNN experiment
+Using pixel-by-pixel sequential MNIST from
 "A Simple Way to Initialize Recurrent Networks of Rectified Linear Units"
 by Quoc V. Le, Navdeep Jaitly, Geoffrey E. Hinton
-
-arxiv:1504.00941v2 [cs.NE] 7 Apr 2015
-http://arxiv.org/pdf/1504.00941v2.pdf
+([arxiv:1504.00941v2 [cs.NE] 7 Apr 2015](http://arxiv.org/pdf/1504.00941v2.pdf))
 
 Optimizer is replaced with RMSprop which yields more stable and steady
 improvement.
 
 Reaches 0.93 train/test accuracy after 900 epochs
-(which roughly corresponds to 1687500 steps in the original paper.)
+(which roughly corresponds to 1687500 steps in the original paper).
 '''
 
 from __future__ import print_function


### PR DESCRIPTION
Signed-off-by: Marcela Morales Quispe <marcela.morales.quispe@gmail.com>

### Summary
Add MarkDown formatting to `examples/mnist_irnn.py`.
**Result**
<img width="1103" alt="irnn1" src="https://user-images.githubusercontent.com/21090606/56628231-a4aeb880-660e-11e9-92cc-33958584c79b.png">
<img width="1101" alt="irnn2" src="https://user-images.githubusercontent.com/21090606/56628462-80071080-660f-11e9-84fc-650c57314a40.png">


### Related Issues
#12219

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
