### PR TITLE
Add MarkDown formatting to examples/mnist_mlp.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - MNIST MLP: examples/mnist_mlp.md

--- a/examples/mnist_mlp.py
+++ b/examples/mnist_mlp.py
@@ -1,4 +1,5 @@
-'''Trains a simple deep NN on the MNIST dataset.
+'''
+# Trains a simple deep NN on the MNIST dataset.
 
 Gets to 98.40% test accuracy after 20 epochs
 (there is *a lot* of margin for parameter tuning).


### PR DESCRIPTION
Signed-off-by: Marcela Morales Quispe <marcela.morales.quispe@gmail.com>

### Summary
Add MarkDown formatting to `examples/mnist_mlp.py`.
**Result**
<img width="1101" alt="mlp1" src="https://user-images.githubusercontent.com/21090606/56628899-37505700-6611-11e9-9874-26d402b9696e.png">
<img width="1103" alt="mlp2" src="https://user-images.githubusercontent.com/21090606/56629053-be053400-6611-11e9-8157-31c729a06e16.png">


### Related Issues
#12219

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
