### PR TITLE
Add MarkDown formatting to examples/mnist_siamese.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - MNIST Siamese MLP: examples/mnist_siamese.md

--- a/examples/mnist_siamese.py
+++ b/examples/mnist_siamese.py
@@ -1,13 +1,14 @@
-'''Trains a Siamese MLP on pairs of digits from the MNIST dataset.
+'''
+# Trains a Siamese MLP on pairs of digits from the MNIST dataset.
 
 It follows Hadsell-et-al.'06 [1] by computing the Euclidean distance on the
 output of the shared network and by optimizing the contrastive loss (see paper
 for more details).
 
-# References
+**References**
 
-- Dimensionality Reduction by Learning an Invariant Mapping
-    http://yann.lecun.com/exdb/publis/pdf/hadsell-chopra-lecun-06.pdf
+- [Dimensionality Reduction by Learning an Invariant
+Mapping](http://yann.lecun.com/exdb/publis/pdf/hadsell-chopra-lecun-06.pdf)
 
 Gets to 97.2% test accuracy after 20 epochs.
 2 seconds per epoch on a Titan X Maxwell GPU


### PR DESCRIPTION
Signed-off-by: Marcela Morales Quispe <marcela.morales.quispe@gmail.com>

### Summary
Add MarkDown formatting to `examples/mnist_siamese.py`.
**Result**
![sia1](https://user-images.githubusercontent.com/21090606/56666943-795db500-6672-11e9-8e0a-75b982fd2c26.png)
![sia2](https://user-images.githubusercontent.com/21090606/56666950-7d89d280-6672-11e9-975b-dbcea09cce8a.png)

### Related Issues
#12219

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
