### PR TITLE
Add MarkDown formatting to examples/mnist_sklearn_wrapper.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - MNIST sklearn wrapper: examples/mnist_sklearn_wrapper.md

--- a/examples/mnist_sklearn_wrapper.py
+++ b/examples/mnist_sklearn_wrapper.py
@@ -1,6 +1,8 @@
-'''Example of how to use sklearn wrapper
+'''
+# Example of how to use sklearn wrapper
 
-Builds simple CNN models on MNIST and uses sklearn's GridSearchCV to find best model
+Builds simple CNN models on MNIST and uses sklearn's GridSearchCV to find
+best model.
 '''
 
 from __future__ import print_function


### PR DESCRIPTION
Signed-off-by: Marcela Morales Quispe <marcela.morales.quispe@gmail.com>

### Summary
Add MarkDown formatting to `examples/mnist_sklearn_wrapper.py`.
**Result**
![wra1](https://user-images.githubusercontent.com/21090606/56667720-fb9aa900-6673-11e9-96a9-531a5f36b933.png)
![wra2](https://user-images.githubusercontent.com/21090606/56667726-ffc6c680-6673-11e9-8df7-8d18ac22759d.png)

### Related Issues
#12219

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
