### PR TITLE
Add MarkDown formatting to examples/mnist_tfrecord.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - MNIST dataset with TFRecords: examples/mnist_tfrecord.md

--- a/examples/mnist_tfrecord.py
+++ b/examples/mnist_tfrecord.py
@@ -1,4 +1,5 @@
-'''MNIST dataset with TFRecords, the standard TensorFlow data format.
+'''
+# MNIST dataset with TFRecords, the standard TensorFlow data format.
 
 TFRecord is a data format supported throughout TensorFlow.
 This example demonstrates how to load TFRecord data using
@@ -27,7 +28,7 @@ because rewiring networks is not yet supported.
 For this reason, changing the data input source means
 model weights must be saved and the model rebuilt
 from scratch to connect the new input data.
-validation cannot currently be performed as training
+Validation cannot currently be performed as training
 progresses, and must be performed after training completes.
 This example demonstrates how to train with input
 tensors, save the model weights, and then evaluate the


### PR DESCRIPTION
### Summary
Add MarkDown formatting to `examples/mnist_tfrecord.py`.
**Result**
![rec1](https://user-images.githubusercontent.com/21090606/56669491-d5c2d380-6676-11e9-848e-d4d67dddbf37.png)
![rec2](https://user-images.githubusercontent.com/21090606/56669503-d8bdc400-6676-11e9-8abb-a753d76039a4.png)

### Related Issues
#12219

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
