### PR TITLE
Add MarkDown formatting to examples/mnist_transfer_cnn.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - MNIST Transfer CNN: examples/mnist_transfer_cnn.md

--- a/examples/mnist_transfer_cnn.py
+++ b/examples/mnist_transfer_cnn.py
@@ -1,7 +1,8 @@
-'''Transfer learning toy example.
+'''
+# Transfer learning toy example.
 
-1 - Train a simple convnet on the MNIST dataset the first 5 digits [0..4].
-2 - Freeze convolutional layers and fine-tune dense layers
+1. Train a simple convnet on the MNIST dataset the first 5 digits [0..4].
+2. Freeze convolutional layers and fine-tune dense layers
    for the classification of digits [5..9].
 
 Get to 99.8% test accuracy after 5 epochs


### PR DESCRIPTION
### Summary
Add MarkDown formatting to `examples/mnist_transfer_cnn.py`.
**Result**
![tra1](https://user-images.githubusercontent.com/21090606/56670770-086dcb80-6679-11e9-846b-48652d13328d.png)
![tra2](https://user-images.githubusercontent.com/21090606/56670782-0d327f80-6679-11e9-9911-d553939b2499.png)

### Related Issues
#12219

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
