### PR TITLE
Modelcheckpoint max checkpoints

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -696,9 +696,11 @@ class ModelCheckpoint(Callback):
                 self.best = np.Inf
 
         if self.max_checkpoints:
-            num_fields = len([tokens[1] for tokens in string.Formatter().parse(filepath) if tokens[1]])
+            num_fields = len([tokens[1]
+                for tokens in string.Formatter().parse(filepath) if tokens[1]])
             if num_fields == 0:
-                raise ValueError("To use max_checkpoints you must specifify a filepath with a format string.")
+                raise ValueError("To use max_checkpoints you must specifify"
+                                 " a filepath with a format string.")
 
 
     def on_epoch_end(self, epoch, logs=None):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -697,7 +697,8 @@ class ModelCheckpoint(Callback):
 
         if self.max_checkpoints:
             num_fields = len([tokens[1]
-                for tokens in string.Formatter().parse(filepath) if tokens[1]])
+                             for tokens in string.Formatter().parse(filepath)
+                             if tokens[1]])
             if num_fields == 0:
                 raise ValueError("To use max_checkpoints you must specifify"
                                  " a filepath with a format string.")

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -703,7 +703,6 @@ class ModelCheckpoint(Callback):
                 raise ValueError("To use max_checkpoints you must specifify"
                                  " a filepath with a format string.")
 
-
     def on_epoch_end(self, epoch, logs=None):
         def save_model(filepath):
             if self.save_weights_only:

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -497,9 +497,12 @@ def test_ModelCheckpoint(tmpdir):
     period = 1
     filepath = 'checkpoint.{epoch:02d}.h5'
     max_checkpoints = 2
-    cbks = [callbacks.ModelCheckpoint(filepath, monitor=monitor,
-                                      save_best_only=save_best_only, mode=mode,
-                                      period=period, max_checkpoints=max_checkpoints)]
+    cbks = [callbacks.ModelCheckpoint(filepath,
+                                      monitor=monitor,
+                                      save_best_only=save_best_only,
+                                      mode=mode,
+                                      period=period,
+                                      max_checkpoints=max_checkpoints)]
     model.fit(X_train, y_train, batch_size=batch_size,
               validation_data=(X_test, y_test), callbacks=cbks, epochs=4)
     assert os.path.isfile(filepath.format(epoch=3))

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -427,6 +427,7 @@ def test_ModelCheckpoint(tmpdir):
     (X_train, y_train), (X_test, y_test) = get_data_callbacks()
     y_test = np_utils.to_categorical(y_test)
     y_train = np_utils.to_categorical(y_train)
+
     # case 1
     monitor = 'val_loss'
     save_best_only = False
@@ -491,6 +492,25 @@ def test_ModelCheckpoint(tmpdir):
     os.remove(filepath.format(epoch=2))
     os.remove(filepath.format(epoch=4))
     assert not tmpdir.listdir()
+
+    # case 6 (max_checkpoints)
+    period = 1
+    filepath = 'checkpoint.{epoch:02d}.h5'
+    max_checkpoints = 2
+    cbks = [callbacks.ModelCheckpoint(filepath, monitor=monitor,
+                                      save_best_only=save_best_only, mode=mode,
+                                      period=period, max_checkpoints=max_checkpoints)]
+    model.fit(X_train, y_train, batch_size=batch_size,
+              validation_data=(X_test, y_test), callbacks=cbks, epochs=4)
+    assert os.path.isfile(filepath.format(epoch=3))
+    assert os.path.isfile(filepath.format(epoch=4))
+    assert not os.path.exists(filepath.format(epoch=1))
+    assert not os.path.exists(filepath.format(epoch=2))
+    os.remove(filepath.format(epoch=3))
+    os.remove(filepath.format(epoch=4))
+    assert not tmpdir.listdir()
+
+
 
 
 def test_EarlyStopping():

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -514,8 +514,6 @@ def test_ModelCheckpoint(tmpdir):
     assert not tmpdir.listdir()
 
 
-
-
 def test_EarlyStopping():
     np.random.seed(1337)
     (X_train, y_train), (X_test, y_test) = get_data_callbacks()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Added parameter max_checkpoints to keras.callbacks.ModelCheckpoint constructor.

### Related Issues

### PR Overview

To avoid keras.callbacks.ModelCheckpoint generating lots of large model weight files, the max_checkpoints parameter has been introduced to the constructor.
This keeps only the most recent max_checkpoints weights, and deletes older ones.

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [y] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
