### PR TITLE
Use layer.dtype as the default dtype when adding a new weight

### DIFF
--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -57,6 +57,7 @@ class Layer(object):
             or `K.in_test_phase()`.
         weights: The concatenation of the lists trainable_weights and
             non_trainable_weights (in this order).
+        dtype:  Default dtype of the layers's weights.
 
 
     # Methods
@@ -143,13 +144,13 @@ class Layer(object):
                     batch_size,) + tuple(kwargs['input_shape'])
             self.batch_input_shape = batch_input_shape
 
-            # Set dtype.
-            dtype = kwargs.get('dtype')
-            if dtype is None:
-                dtype = kwargs.get('input_dtype')
-            if dtype is None:
-                dtype = K.floatx()
-            self.dtype = dtype
+        # Set dtype.
+        dtype = kwargs.get('dtype')
+        if dtype is None:
+            dtype = kwargs.get('input_dtype')
+        if dtype is None:
+            dtype = K.floatx()
+        self.dtype = dtype
 
         self._initial_weights = kwargs.get('weights')
 
@@ -238,8 +239,8 @@ class Layer(object):
         """
         initializer = initializers.get(initializer)
         if dtype is None:
-            dtype = K.floatx()
-        weight = K.variable(initializer(shape),
+            dtype = self.dtype
+        weight = K.variable(initializer(shape, dtype=dtype),
                             dtype=dtype,
                             name=name,
                             constraint=constraint)

--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -48,6 +48,7 @@ class Network(Layer):
                 - ndim
                 - dtype
         trainable (boolean)
+        dtype
         input_shape
         output_shape
         weights (list of variables)
@@ -95,7 +96,7 @@ class Network(Layer):
             # Subclassed network
             self._init_subclassed_network(**kwargs)
 
-    def _base_init(self, name=None):
+    def _base_init(self, name=None, trainable=True, dtype=None):
         # The following are implemented as property functions:
         # self.trainable_weights
         # self.non_trainable_weights
@@ -112,7 +113,10 @@ class Network(Layer):
         # This acts just like the `trainable` attribute of any layer instance.
         # It does not affect users of the underlying layers, only users of the
         # Network instance.
-        self.trainable = True
+        self.trainable = trainable
+        if dtype is None:
+            dtype = K.floatx()
+        self.dtype = dtype
         self._is_compiled = False
         self._expects_training_arg = False
         self._initial_weights = None
@@ -123,6 +127,8 @@ class Network(Layer):
             self.optimizer = None
 
         # Private attributes to implement compatibility with Layer.
+        self._trainable_weights = []
+        self._non_trainable_weights = []
         self._updates = []
         self._losses = []
         self._per_input_losses = {}
@@ -136,7 +142,7 @@ class Network(Layer):
         self._outbound_nodes = []
         self._inbound_nodes = []
 
-    def _init_graph_network(self, inputs, outputs, name=None):
+    def _init_graph_network(self, inputs, outputs, name=None, **kwargs):
         self._uses_inputs_arg = True
         # Normalize and set self.inputs, self.outputs.
         self.inputs = to_list(inputs, allow_tuple=True)
@@ -186,7 +192,7 @@ class Network(Layer):
                                  'the output of a Keras `Layer` '
                                  '(thus holding past layer metadata). '
                                  'Found: ' + str(x))
-        self._base_init(name=name)
+        self._base_init(name=name, **kwargs)
         self._compute_previous_mask = (
             has_arg(self.call, 'mask') or
             hasattr(self, 'compute_mask'))
@@ -290,8 +296,8 @@ class Network(Layer):
         for layer in self._output_layers:
             self.output_names.append(layer.name)
 
-    def _init_subclassed_network(self, name=None):
-        self._base_init(name=name)
+    def _init_subclassed_network(self, name=None, **kwargs):
+        self._base_init(name=name, **kwargs)
         self._is_graph_network = False
         self._expects_training_arg = has_arg(self.call, 'training')
         self._uses_inputs_arg = has_arg(self.call, 'inputs')

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1269,7 +1269,8 @@ class GRUCell(Layer):
         input_dim = input_shape[-1]
 
         if isinstance(self.recurrent_initializer, initializers.Identity):
-            def recurrent_identity(shape, gain=1.):
+            def recurrent_identity(shape, gain=1., dtype=None):
+                del dtype
                 return gain * np.concatenate(
                     [np.identity(shape[0])] * (shape[1] // shape[0]), axis=1)
 
@@ -1872,7 +1873,8 @@ class LSTMCell(Layer):
         input_dim = input_shape[-1]
 
         if type(self.recurrent_initializer).__name__ == 'Identity':
-            def recurrent_identity(shape, gain=1.):
+            def recurrent_identity(shape, gain=1., dtype=None):
+                del dtype
                 return gain * np.concatenate(
                     [np.identity(shape[0])] * (shape[1] // shape[0]), axis=1)
 

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -840,5 +840,23 @@ def test_constant_initializer_with_numpy():
     model_from_yaml(yaml_str).summary()
 
 
+def test_initialization_dtype():
+    class TestLayer(Layer):
+        def __init__(self):
+            super(TestLayer, self).__init__(dtype='int64')
+            self.w = self.add_weight('w', [], initializer=Constant(1))
+
+    layer = TestLayer()
+    assert K.dtype(layer.w) == 'int64'
+
+    class TestModel(Model):
+        def __init__(self):
+            super(TestModel, self).__init__(dtype='int64')
+            self.w = self.add_weight('w', [], initializer=Constant(1))
+
+    model = TestModel()
+    assert K.dtype(model.w) == 'int64'
+
+
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -840,6 +840,8 @@ def test_constant_initializer_with_numpy():
     model_from_yaml(yaml_str).summary()
 
 
+@pytest.mark.skipif(K.backend() == 'ctnk',
+                    reason='Float64 not supported with CNTK.')
 def test_initialization_dtype():
     class TestLayer(Layer):
         def __init__(self):


### PR DESCRIPTION
### Summary
Use layer.dtype as the default dtype when adding a new weight and add dtype to network initialization.

### Related Issues
https://github.com/tensorflow/tensorflow/issues/27705

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n*] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

*Does not effect the public API