### PR TITLE
Add MarkDown formatting to examples/pretrained_word_embeddings.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Pretrained Word Embeddings: examples/pretrained_word_embeddings.md

--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -1,14 +1,16 @@
-'''This script loads pre-trained word embeddings (GloVe embeddings)
+'''
+# Pretrained Word Embeddings
+This script loads pre-trained word embeddings (GloVe embeddings)
 into a frozen Keras Embedding layer, and uses it to
 train a text classification model on the 20 Newsgroup dataset
 (classification of newsgroup messages into 20 different categories).
 
 GloVe embedding data can be found at:
-http://nlp.stanford.edu/data/glove.6B.zip
-(source page: http://nlp.stanford.edu/projects/glove/)
+<http://nlp.stanford.edu/data/glove.6B.zip>
+(source page: <http://nlp.stanford.edu/projects/glove/>)
 
 20 Newsgroup data can be found at:
-http://www.cs.cmu.edu/afs/cs.cmu.edu/project/theo-20/www/data/news20.html
+<http://www.cs.cmu.edu/afs/cs.cmu.edu/project/theo-20/www/data/news20.html>
 '''
 
 from __future__ import print_function


### PR DESCRIPTION
### Summary
Add MarkDown formatting to `examples/pretrained_word_embeddings.py`.
**Result**
<img width="1101" alt="pre1" src="https://user-images.githubusercontent.com/21090606/56782699-e2961300-67ad-11e9-890a-09a6abed5e34.png">
<img width="1103" alt="pre2" src="https://user-images.githubusercontent.com/21090606/56782701-e32ea980-67ad-11e9-975b-074d491b468f.png">

### Related Issues
#12219

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
