### PR TITLE
Add MarkDown formatting to examples/reuters_mlp.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Reuters MLP: examples/reuters_mlp.md

--- a/examples/reuters_mlp.py
+++ b/examples/reuters_mlp.py
@@ -1,4 +1,6 @@
-'''Trains and evaluate a simple MLP
+'''
+# Reuters MLP
+Trains and evaluate a simple MLP
 on the Reuters newswire topic classification task.
 '''
 from __future__ import print_function


### PR DESCRIPTION
### Summary
Add MarkDown formatting to `examples/reuters_mlp.py`.
**Result**
<img width="1101" alt="reut1" src="https://user-images.githubusercontent.com/21090606/56783022-45d47500-67af-11e9-9335-3d8e35d54c5b.png">
<img width="1102" alt="reut2" src="https://user-images.githubusercontent.com/21090606/56783023-466d0b80-67af-11e9-8182-15fc98bad16f.png">

### Related Issues
#12219 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
