### PR TITLE
Add MarkDown formatting to examples/reuters_mlp_relu_vs_selu.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Reuters MLP ReLU vs SeLU: examples/reuters_mlp_relu_vs_selu.md

--- a/examples/reuters_mlp_relu_vs_selu.py
+++ b/examples/reuters_mlp_relu_vs_selu.py
@@ -1,14 +1,15 @@
-'''Compares self-normalizing MLPs with regular MLPs.
+'''
+# Self-normalizing MLPs with regular MLPs comparison.
 
 Compares the performance of a simple MLP using two
 different activation functions: RELU and SELU
 on the Reuters newswire topic classification task.
 
-# Reference
+**Reference**
 
 - Klambauer, G., Unterthiner, T., Mayr, A., & Hochreiter, S. (2017).
   Self-Normalizing Neural Networks. arXiv preprint arXiv:1706.02515.
-  https://arxiv.org/abs/1706.02515
+  <https://arxiv.org/abs/1706.02515>
 '''
 from __future__ import print_function
 


### PR DESCRIPTION
### Summary
Add MarkDown formatting to `examples/reuters_mlp_relu_vs_selu.py`.
**Result**
<img width="1101" alt="selu1" src="https://user-images.githubusercontent.com/21090606/56783419-4a9a2880-67b1-11e9-90e0-979b2e25b132.png">
<img width="1101" alt="selu2" src="https://user-images.githubusercontent.com/21090606/56783420-4b32bf00-67b1-11e9-9640-3c036039d5ec.png">

### Related Issues
#12219 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
