### PR TITLE
Add MarkDown formatting to examples/tensorboard_embeddings_mnist.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Tensorboard Embeddings MNIST: examples/tensorboard_embeddings_mnist.md

--- a/examples/tensorboard_embeddings_mnist.py
+++ b/examples/tensorboard_embeddings_mnist.py
@@ -1,4 +1,6 @@
-'''Trains a simple convnet on the MNIST dataset and embeds test data.
+'''
+# Tensorboard Embeddings MNIST
+Trains a simple convnet on the MNIST dataset and embeds test data.
 
 The test data is embedded using the weights of the final dense layer, just
 before the classification head. This embedding can then be visualized using


### PR DESCRIPTION
### Summary
Add MarkDown formatting to `examples/tensorboard_embeddings_mnist.py`.
**Result**
<img width="1101" alt="board1" src="https://user-images.githubusercontent.com/21090606/56784077-78cd3780-67b4-11e9-9fef-0e9aa47cec3d.png">
<img width="1100" alt="board2" src="https://user-images.githubusercontent.com/21090606/56784078-7965ce00-67b4-11e9-9f6e-395f978d23ba.png">

### Related Issues
#12219 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
