### PR TITLE
Add MarkDown formatting to examples/variational_autoencoder_deconv.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Variational Eutoencoder using CNN: examples/variational_autoencoder_deconv.md

--- a/examples/variational_autoencoder_deconv.py
+++ b/examples/variational_autoencoder_deconv.py
@@ -1,4 +1,5 @@
-'''Example of VAE on MNIST dataset using CNN
+'''
+# VAE on MNIST dataset using CNN
 
 The VAE has a modular design. The encoder, decoder and VAE
 are 3 models that share weights. After training the VAE model,
@@ -6,11 +7,11 @@ the encoder can be used to  generate latent vectors.
 The decoder can be used to generate MNIST digits by sampling the
 latent vector from a Gaussian distribution with mean=0 and std=1.
 
-# Reference
+**Reference**
 
 [1] Kingma, Diederik P., and Max Welling.
 "Auto-encoding variational bayes."
-https://arxiv.org/abs/1312.6114
+<https://arxiv.org/abs/1312.6114>
 '''
 
 from __future__ import absolute_import


### PR DESCRIPTION
### Summary
Add MarkDown formatting to `examples/variational_autoencoder_deconv.py`.
**Result**
<img width="1101" alt="cvae1" src="https://user-images.githubusercontent.com/21090606/56784656-453fdc80-67b7-11e9-8965-1f3fb7f7b726.png">
<img width="1101" alt="cvae2" src="https://user-images.githubusercontent.com/21090606/56784657-453fdc80-67b7-11e9-975e-052d5a88d30f.png">

### Related Issues
#12219 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
