### PR TITLE
Fixed plot_model for expand_nested=True

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -197,7 +197,11 @@ def model_to_dot(model,
                         # if inbound_layer is Model
                         elif is_model(inbound_layer):
                             name = sub_n_last_node[inbound_layer.name].get_name()
-                            add_edge(dot, name, layer_id)
+                            if is_model(layer):
+                                output_name = sub_n_first_node[layer.name].get_name()
+                                add_edge(dot, name, output_name)
+                            else:
+                                add_edge(dot, name, layer_id)
                         # if inbound_layer is wrapped Model
                         elif is_wrapped_model(inbound_layer):
                             inbound_layer_name = inbound_layer.layer.name

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -88,6 +88,11 @@ def model_to_dot(model,
         dot.set('dpi', dpi)
         dot.set_node_defaults(shape='record')
 
+    sub_n_first_node = {}
+    sub_n_last_node = {}
+    sub_w_first_node = {}
+    sub_w_last_node = {}
+
     if isinstance(model, Sequential):
         if not model.built:
             model.build()
@@ -109,8 +114,8 @@ def model_to_dot(model,
                                                 subgraph=True)
                 # sub_w : submodel_wrapper
                 sub_w_nodes = submodel_wrapper.get_nodes()
-                sub_w_first_node = sub_w_nodes[0]
-                sub_w_last_node = sub_w_nodes[len(sub_w_nodes) - 1]
+                sub_w_first_node[layer.layer.name] = sub_w_nodes[0]
+                sub_w_last_node[layer.layer.name] = sub_w_nodes[len(sub_w_nodes) - 1]
                 dot.add_subgraph(submodel_wrapper)
             else:
                 layer_name = '{}({})'.format(layer_name, layer.layer.name)
@@ -124,8 +129,8 @@ def model_to_dot(model,
                                                 subgraph=True)
             # sub_n : submodel_not_wrapper
             sub_n_nodes = submodel_not_wrapper.get_nodes()
-            sub_n_first_node = sub_n_nodes[0]
-            sub_n_last_node = sub_n_nodes[len(sub_n_nodes) - 1]
+            sub_n_first_node[layer.name] = sub_n_nodes[0]
+            sub_n_last_node[layer.name] = sub_n_nodes[len(sub_n_nodes) - 1]
             dot.add_subgraph(submodel_not_wrapper)
 
         # Create node's label.
@@ -181,19 +186,24 @@ def model_to_dot(model,
                             # if current layer is Model
                             elif is_model(layer):
                                 add_edge(dot, inbound_layer_id,
-                                         sub_n_first_node.get_name())
+                                         sub_n_first_node[layer.name].get_name())
                             # if current layer is wrapped Model
                             elif is_wrapped_model(layer):
                                 dot.add_edge(pydot.Edge(inbound_layer_id,
                                                         layer_id))
+                                name = sub_w_first_node[layer.layer.name].get_name()
                                 dot.add_edge(pydot.Edge(layer_id,
-                                                        sub_w_first_node.get_name()))
+                                                        name))
                         # if inbound_layer is Model
                         elif is_model(inbound_layer):
-                            add_edge(dot, sub_n_last_node.get_name(), layer_id)
+                            name = sub_n_last_node[inbound_layer.name].get_name()
+                            add_edge(dot, name, layer_id)
                         # if inbound_layer is wrapped Model
                         elif is_wrapped_model(inbound_layer):
-                            add_edge(dot, sub_w_last_node.get_name(), layer_id)
+                            inbound_layer_name = inbound_layer.layer.name
+                            add_edge(dot,
+                                     sub_w_last_node[inbound_layer_name].get_name(),
+                                     layer_id)
     return dot
 
 

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -115,7 +115,7 @@ def model_to_dot(model,
                 # sub_w : submodel_wrapper
                 sub_w_nodes = submodel_wrapper.get_nodes()
                 sub_w_first_node[layer.layer.name] = sub_w_nodes[0]
-                sub_w_last_node[layer.layer.name] = sub_w_nodes[len(sub_w_nodes) - 1]
+                sub_w_last_node[layer.layer.name] = sub_w_nodes[-1]
                 dot.add_subgraph(submodel_wrapper)
             else:
                 layer_name = '{}({})'.format(layer_name, layer.layer.name)
@@ -130,7 +130,7 @@ def model_to_dot(model,
             # sub_n : submodel_not_wrapper
             sub_n_nodes = submodel_not_wrapper.get_nodes()
             sub_n_first_node[layer.name] = sub_n_nodes[0]
-            sub_n_last_node[layer.name] = sub_n_nodes[len(sub_n_nodes) - 1]
+            sub_n_last_node[layer.name] = sub_n_nodes[-1]
             dot.add_subgraph(submodel_not_wrapper)
 
         # Create node's label.


### PR DESCRIPTION
### Summary
Keras plot_model with ```expand_nested=True``` does not work if there are multiple submodels with the same nesting level.

Let's take a slightly modified version from unit tests (https://github.com/keras-team/keras/blob/master/tests/keras/utils/vis_utils_test.py#L31-L40) as an example:
```python
    inner_input = Input(shape=(2, 3), dtype='float32', name='inner_input')
    inner_lstm = Bidirectional(LSTM(16, name='inner_lstm'), name='bd')(inner_input)
    encoder = Model(inner_input, inner_lstm, name='Encoder_Model')
    inner_input2 = Input(shape=(2, 3), dtype='float32', name='inner_input2')
    inner_lstm2 = Bidirectional(LSTM(16, name='inner_lstm2'), name='bd')(inner_input2)
    encoder2 = Model(inner_input2, inner_lstm2, name='Encoder_Model2')
    outer_input = Input(shape=(5, 2, 3), dtype='float32', name='input')
    outer_input2 = Input(shape=(5, 2, 3), dtype='float32', name='input2')
    inner_encoder = TimeDistributed(encoder, name='td_encoder')(outer_input)
    inner_encoder2 = TimeDistributed(encoder2, name='td_encoder2')(outer_input2)
    lstm = LSTM(16, name='outer_lstm')(concatenate([inner_encoder, inner_encoder2]))
    preds = Dense(5, activation='softmax', name='predictions')(lstm)
    model = Model([outer_input, outer_input2], preds)
    vis_utils.plot_model(model, to_file='model3.png', show_shapes=True,
                         expand_nested=True, dpi=300)
```
This produces currently the following output
![model3](https://user-images.githubusercontent.com/42428595/56793933-d180ec80-6815-11e9-9d09-e4f864b466bc.png)

With the fix of PR model is plotted properly as:
![model_new](https://user-images.githubusercontent.com/42428595/56793973-e198cc00-6815-11e9-9959-957f1bed6fac.png)

### Related Issues
https://github.com/keras-team/keras/issues/12750

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
