### PR TITLE
Add MarkDown formatting to examples/mnist_net2net.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Net2Net with MNIST: examples/mnist_net2net.md

--- a/examples/mnist_net2net.py
+++ b/examples/mnist_net2net.py
@@ -1,56 +1,59 @@
-'''This is an implementation of Net2Net experiment with MNIST in
+'''
+# Net2Net experiment with MNIST
+This is an implementation of Net2Net experiment with MNIST in
 'Net2Net: Accelerating Learning via Knowledge Transfer'
 by Tianqi Chen, Ian Goodfellow, and Jonathon Shlens
 
-arXiv:1511.05641v4 [cs.LG] 23 Apr 2016
-http://arxiv.org/abs/1511.05641
+**References**
 
-# Notes
+* arXiv:1511.05641v4 [cs.LG] 23 Apr 2016: <http://arxiv.org/abs/1511.05641>
+
+**Notes**
 
 - What:
-  + Net2Net is a group of methods to transfer knowledge from a teacher neural
-    net to a student net,so that the student net can be trained faster than
-    from scratch.
-  + The paper discussed two specific methods of Net2Net, i.e. Net2WiderNet
-    and Net2DeeperNet.
-  + Net2WiderNet replaces a model with an equivalent wider model that has
-    more units in each hidden layer.
-  + Net2DeeperNet replaces a model with an equivalent deeper model.
-  + Both are based on the idea of 'function-preserving transformations of
-    neural nets'.
+    + Net2Net is a group of methods to transfer knowledge from a teacher neural
+      net to a student net, so that the student net can be trained faster than
+      from scratch.
+    + The paper discussed two specific methods of Net2Net, i.e. Net2WiderNet
+      and Net2DeeperNet.
+    + Net2WiderNet replaces a model with an equivalent wider model that has
+      more units in each hidden layer.
+    + Net2DeeperNet replaces a model with an equivalent deeper model.
+    + Both are based on the idea of 'function-preserving transformations of
+      neural nets'.
 - Why:
-  + Enable fast exploration of multiple neural nets in experimentation and
-    design process,by creating a series of wider and deeper models with
-    transferable knowledge.
-  + Enable 'lifelong learning system' by gradually adjusting model complexity
-    to data availability,and reusing transferable knowledge.
+    + Enable fast exploration of multiple neural nets in experimentation and
+      design process, by creating a series of wider and deeper models with
+      transferable knowledge.
+    + Enable 'lifelong learning system' by gradually adjusting model complexity
+      to data availability, and reusing transferable knowledge.
 
-# Experiments
+**Experiments**
 
 - Teacher model: a basic CNN model trained on MNIST for 3 epochs.
 - Net2WiderNet experiment:
-  + Student model has a wider Conv2D layer and a wider FC layer.
-  + Comparison of 'random-padding' vs 'net2wider' weight initialization.
-  + With both methods, after 1 epoch, student model should perform as well as
-    teacher model, but 'net2wider' is slightly better.
+    + Student model has a wider Conv2D layer and a wider FC layer.
+    + Comparison of `random-padding` vs `net2wider` weight initialization.
+    + With both methods, after 1 epoch, student model should perform as well as
+      teacher model, but `net2wider` is slightly better.
 - Net2DeeperNet experiment:
-  + Student model has an extra Conv2D layer and an extra FC layer.
-  + Comparison of 'random-init' vs 'net2deeper' weight initialization.
-  + After 1 epoch, performance of 'net2deeper' is better than 'random-init'.
+    + Student model has an extra Conv2D layer and an extra FC layer.
+    + Comparison of `random-init` vs `net2deeper` weight initialization.
+    + After 1 epoch, performance of `net2deeper` is better than `random-init`.
 - Hyper-parameters:
-  + SGD with momentum=0.9 is used for training teacher and student models.
-  + Learning rate adjustment: it's suggested to reduce learning rate
-    to 1/10 for student model.
-  + Addition of noise in 'net2wider' is used to break weight symmetry
-    and thus enable full capacity of student models. It is optional
-    when a Dropout layer is used.
+    + SGD with `momentum=0.9` is used for training teacher and student models.
+    + Learning rate adjustment: it's suggested to reduce learning rate
+      to 1/10 for student model.
+    + Addition of noise in `net2wider` is used to break weight symmetry
+      and thus enable full capacity of student models. It is optional
+      when a Dropout layer is used.
 
-# Results
+**Results**
 
 - Tested with TF backend and 'channels_last' image_data_format.
 - Running on GPU GeForce GTX Titan X Maxwell
 - Performance Comparisons - validation loss values during first 3 epochs:
-
+```bash
 Teacher model ...
 (0) teacher_model:             0.0537   0.0354   0.0356
 
@@ -61,6 +64,7 @@ Experiment of Net2WiderNet ...
 Experiment of Net2DeeperNet ...
 (3) deeper_random_init:        0.0682   0.0506   0.0468
 (4) deeper_net2deeper:         0.0292   0.0294   0.0286
+```
 '''
 
 from __future__ import print_function


### PR DESCRIPTION
### Summary
Add MarkDown formatting to `examples/mnist_net2net.py`.
**Result**
<img width="1099" alt="net1" src="https://user-images.githubusercontent.com/21090606/56869257-f4510380-69c3-11e9-8f16-3936e8fd7315.png">
<img width="1101" alt="net2" src="https://user-images.githubusercontent.com/21090606/56869258-f4510380-69c3-11e9-9d2f-533bd0741201.png">
<img width="1100" alt="net3" src="https://user-images.githubusercontent.com/21090606/56869260-f4510380-69c3-11e9-8081-60b38a260698.png">

### Related Issues
#12219 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
