### PR TITLE
Add MarkDown formatting to examples/class_activation_maps.py

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,3 +90,4 @@ nav:
   - Stateful LSTM: examples/lstm_stateful.md
   - LSTM for text generation: examples/lstm_text_generation.md
   - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Class Activation Maps: examples/class_activation_maps.md

--- a/examples/class_activation_maps.py
+++ b/examples/class_activation_maps.py
@@ -1,5 +1,6 @@
-# -*- coding: utf-8 -*-
-
+'''
+# Class Activation Maps
+'''
 import numpy as np
 import cv2
 import matplotlib.pyplot as plt


### PR DESCRIPTION
### Summary
Add MarkDown formatting to `examples/class_activation_maps.py`.
**Result**
<img width="1101" alt="cla1" src="https://user-images.githubusercontent.com/21090606/56870470-6716aa80-69d5-11e9-8e6d-798be9669201.png">
<img width="1097" alt="cla2" src="https://user-images.githubusercontent.com/21090606/56870471-6716aa80-69d5-11e9-9003-989633b8eebf.png">

### Related Issues
#12219 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
