### PR TITLE
Compact formatting of layer I/O shapes in plot_model

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -136,15 +136,17 @@ def model_to_dot(model,
 
         # Rebuild the label as a table including input/output shapes.
         if show_shapes:
+            def format_shape(shape):
+                return str(shape).replace(str(None), '?')
             try:
-                outputlabels = str(layer.output_shape)
+                outputlabels = format_shape(layer.output_shape)
             except AttributeError:
                 outputlabels = 'multiple'
             if hasattr(layer, 'input_shape'):
-                inputlabels = str(layer.input_shape)
+                inputlabels = format_shape(layer.input_shape)
             elif hasattr(layer, 'input_shapes'):
                 inputlabels = ', '.join(
-                    [str(ishape) for ishape in layer.input_shapes])
+                    [format_shape(ishape) for ishape in layer.input_shapes])
             else:
                 inputlabels = 'multiple'
             label = '%s\n|{input:|output:}|{{%s}|{%s}}' % (label,


### PR DESCRIPTION
### Summary
Render the input/output shapes of a layer more compactly by replacing `None` with `?`, e.g. render `(None,100,100)` to `(?,100,100)`.

### Related Issues
N/A

### PR Overview

- [ n] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y ] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
