### PR TITLE
Fix module import and naming in MNIST CNN example

### DIFF
--- a/examples/mnist_cnn.py
+++ b/examples/mnist_cnn.py
@@ -6,12 +6,12 @@ Gets to 99.25% test accuracy after 12 epochs
 '''
 
 from __future__ import print_function
-import keras
-from keras.datasets import mnist
-from keras.models import Sequential
-from keras.layers import Dense, Dropout, Flatten
-from keras.layers import Conv2D, MaxPooling2D
-from keras import backend as K
+import tensorflow.keras
+from tensorflow.keras.datasets import mnist
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Dense, Dropout, Flatten
+from tensorflow.keras.layers import Conv2D, MaxPooling2D
+from tensorflow.keras import backend as K
 
 batch_size = 128
 num_classes = 10
@@ -41,8 +41,8 @@ print(x_train.shape[0], 'train samples')
 print(x_test.shape[0], 'test samples')
 
 # convert class vectors to binary class matrices
-y_train = keras.utils.to_categorical(y_train, num_classes)
-y_test = keras.utils.to_categorical(y_test, num_classes)
+y_train = tensorflow.keras.utils.to_categorical(y_train, num_classes)
+y_test = tensorflow.keras.utils.to_categorical(y_test, num_classes)
 
 model = Sequential()
 model.add(Conv2D(32, kernel_size=(3, 3),
@@ -56,8 +56,8 @@ model.add(Dense(128, activation='relu'))
 model.add(Dropout(0.5))
 model.add(Dense(num_classes, activation='softmax'))
 
-model.compile(loss=keras.losses.categorical_crossentropy,
-              optimizer=keras.optimizers.Adadelta(),
+model.compile(loss=tensorflow.keras.losses.categorical_crossentropy,
+              optimizer=tensorflow.keras.optimizers.Adadelta(),
               metrics=['accuracy'])
 
 model.fit(x_train, y_train,


### PR DESCRIPTION
### Summary

With the new version of Tensorflow (2.0.0alpha), it seems that the Keras module names have changed. Updating the MNIST CNN (and possibly others might need to be updated as well) example to reflect this.

Was found after reading through: https://github.com/keras-team/keras/issues/12379

Seems quite a straightforward thing to fix, not sure why nobody has committed patches.

Tested with Python 3.6.7, Tensorflow 2.0.0a0 and CUDA 10.1

### Related Issues

https://github.com/keras-team/keras/issues/12379

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [n] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
