### PR TITLE
Improved compatibility with sklearn

### DIFF
--- a/docs/templates/scikit-learn-api.md
+++ b/docs/templates/scikit-learn-api.md
@@ -1,6 +1,6 @@
 # Wrappers for the Scikit-Learn API
 
-You can use `Sequential` Keras models (single-input only) as part of your Scikit-Learn workflow via the wrappers found at `keras.wrappers.scikit_learn.py`.
+You can use `Sequential` (or single-input/output `Model`) Keras models as part of your Scikit-Learn workflow via the wrappers found at `keras.wrappers.scikit_learn.py`.
 
 There are two wrappers available:
 
@@ -13,9 +13,10 @@ There are two wrappers available:
 - __build_fn__: callable function or class instance
 - __sk_params__: model parameters & fitting parameters
 
-`build_fn` should construct, compile and return a Keras model, which
-will then be used to fit/predict. One of the following
-three values could be passed to `build_fn`:
+The `build_fn` should construct, compile and return a Keras model, which
+will then be used to fit/predict. It must accept `input_shape` and
+`output_shape` as arguments, both of which are tuples of integers. One of
+the following three values could be passed to `build_fn`:
 
 1. A function
 2. An instance of a class that implements the `__call__` method

--- a/docs/templates/scikit-learn-api.md
+++ b/docs/templates/scikit-learn-api.md
@@ -8,6 +8,8 @@ There are two wrappers available:
 
 `keras.wrappers.scikit_learn.KerasRegressor(build_fn=None, **sk_params)`, which implements the Scikit-Learn regressor interface.
 
+Also, the more general `Model` Keras models can be used with the generic `keras.wrappers.scikit_learn.BaseWrapper(build_fn=None, **sk_params)` wrapper, but they will not be compatible with Scikit-Learn unless restricted to single-input and single-output.
+
 ### Arguments
 
 - __build_fn__: callable function or class instance
@@ -15,14 +17,15 @@ There are two wrappers available:
 
 The `build_fn` should construct, compile and return a Keras model, which
 will then be used to fit/predict. It must accept `input_shape` and
-`output_shape` as arguments, both of which are tuples of integers. One of
-the following three values could be passed to `build_fn`:
+`output_shape` as arguments, both of which are tuples of integers or
+dictionaries (for named multi-input/output models). One of the following three
+values could be passed to `build_fn`:
 
 1. A function
 2. An instance of a class that implements the `__call__` method
 3. None. This means you implement a class that inherits from either
-`KerasClassifier` or `KerasRegressor`. The `__call__` method of the
-present class will then be treated as the default `build_fn`.
+`BaseWrapper`, `KerasClassifier` or `KerasRegressor`. The `__call__` method of
+the present class will then be treated as the default `build_fn`.
 
 `sk_params` takes both model parameters and fitting parameters. Legal model
 parameters are the arguments of `build_fn`. Note that like all other
@@ -38,7 +41,8 @@ fitting (predicting) parameters are selected in the following order:
 `fit`, `predict`, `predict_proba`, and `score` methods
 2. Values passed to `sk_params`
 3. The default values of the `keras.models.Sequential`
-`fit`, `predict`, `predict_proba` and `score` methods
+`fit`, `predict`, `predict_proba` and `score` methods, or the default values of
+the `keras.models.Model` `fit`, `predict` and `score` methods.
 
 When using scikit-learn's `grid_search` API, legal tunable parameters are
 those you could pass to `sk_params`, including fitting parameters.

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(name='Keras',
                     'pytest-cov',
                     'pandas',
                     'requests',
+                    'scikit-learn',
                     'markdown'],
       },
       classifiers=[

--- a/tests/keras/wrappers/scikit_learn_test.py
+++ b/tests/keras/wrappers/scikit_learn_test.py
@@ -24,9 +24,8 @@ np.random.seed(42)
     classification=True, num_classes=num_classes)
 
 
-def build_fn_clf(hidden_dims):
+def build_fn_clf(input_shape, output_shape, hidden_dims):
     model = Sequential()
-    model.add(Dense(input_dim, input_shape=(input_dim,)))
     model.add(Activation('relu'))
     model.add(Dense(hidden_dims))
     model.add(Activation('relu'))
@@ -49,8 +48,8 @@ def test_classify_build_fn():
 def test_classify_class_build_fn():
     class ClassBuildFnClf(object):
 
-        def __call__(self, hidden_dims):
-            return build_fn_clf(hidden_dims)
+        def __call__(self, input_shape, output_shape, hidden_dims):
+            return build_fn_clf(input_shape, output_shape, hidden_dims)
 
     clf = KerasClassifier(
         build_fn=ClassBuildFnClf(), hidden_dims=hidden_dims,
@@ -63,8 +62,8 @@ def test_classify_class_build_fn():
 def test_classify_inherit_class_build_fn():
     class InheritClassBuildFnClf(KerasClassifier):
 
-        def __call__(self, hidden_dims):
-            return build_fn_clf(hidden_dims)
+        def __call__(self, input_shape, output_shape, hidden_dims):
+            return build_fn_clf(input_shape, output_shape, hidden_dims)
 
     clf = InheritClassBuildFnClf(
         build_fn=None, hidden_dims=hidden_dims,
@@ -110,9 +109,8 @@ def assert_string_classification_works(clf):
     assert np.allclose(np.sum(proba, axis=1), np.ones(num_test))
 
 
-def build_fn_reg(hidden_dims=50):
+def build_fn_reg(input_shape, output_shape, hidden_dims=50):
     model = Sequential()
-    model.add(Dense(input_dim, input_shape=(input_dim,)))
     model.add(Activation('relu'))
     model.add(Dense(hidden_dims))
     model.add(Activation('relu'))
@@ -134,8 +132,8 @@ def test_regression_build_fn():
 def test_regression_class_build_fn():
     class ClassBuildFnReg(object):
 
-        def __call__(self, hidden_dims):
-            return build_fn_reg(hidden_dims)
+        def __call__(self, input_shape, output_shape, hidden_dims):
+            return build_fn_reg(input_shape, output_shape, hidden_dims)
 
     reg = KerasRegressor(
         build_fn=ClassBuildFnReg(), hidden_dims=hidden_dims,
@@ -147,8 +145,8 @@ def test_regression_class_build_fn():
 def test_regression_inherit_class_build_fn():
     class InheritClassBuildFnReg(KerasRegressor):
 
-        def __call__(self, hidden_dims):
-            return build_fn_reg(hidden_dims)
+        def __call__(self, input_shape, output_shape, hidden_dims):
+            return build_fn_reg(input_shape, output_shape, hidden_dims)
 
     reg = InheritClassBuildFnReg(
         build_fn=None, hidden_dims=hidden_dims,
@@ -188,17 +186,145 @@ def assert_regression_predict_shape_correct(num_test):
 if __name__ == '__main__':
     pytest.main([__file__])
 
-# Usage of sklearn's grid_search
-# from sklearn import grid_search
-# parameters = dict(hidden_dims = [20, 30], batch_size=[64, 128],
-#                   epochs=[2], verbose=[0])
-# classifier = Inherit_class_build_fn_clf()
-# clf = grid_search.GridSearchCV(classifier, parameters)
-# clf.fit(X_train, y_train)
-# parameters = dict(hidden_dims = [20, 30], batch_size=[64, 128],
-#                   epochs=[2], verbose=[0])
-# regressor = Inherit_class_build_fn_reg()
-# reg = grid_search.GridSearchCV(regressor, parameters,
-#                                scoring='mean_squared_error',
-#                                n_jobs=1, cv=2, verbose=2)
-# reg.fit(X_train_reg, y_train_reg)
+
+# Usage of sklearn's Pipelines, SearchCVs, Ensembles and CalibratedClassifierCVs
+
+
+# from keras import backend as K
+# from keras.layers import Conv2D, Dense, Flatten, Input
+# from keras.models import Model
+# from keras.wrappers.scikit_learn import KerasClassifier, KerasRegressor
+# import numpy as np
+# import pickle
+# from scipy.stats import randint
+# from sklearn.calibration import CalibratedClassifierCV
+# from sklearn.datasets import load_boston, load_digits, load_iris
+# from sklearn.ensemble import (AdaBoostClassifier, AdaBoostRegressor,
+#                               BaggingClassifier, BaggingRegressor)
+# from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
+# from sklearn.pipeline import Pipeline
+# from sklearn.preprocessing import StandardScaler
+
+
+# def load_digits8x8():
+#     data = load_digits()
+#     data.data = data.data.reshape([data.data.shape[0], 1, 8, 8]) / 16.0
+#     K.set_image_data_format('channels_first')
+#     return data
+
+
+# def check(estimator, loader):
+#     data = loader()
+#     estimator.fit(data.data, data.target)
+#     preds = estimator.predict(data.data)
+#     score = estimator.score(data.data, data.target)
+#     serialized_estimator = pickle.dumps(estimator)
+#     K.clear_session()
+#     deserialized_estimator = pickle.loads(serialized_estimator)
+#     preds = deserialized_estimator.predict(data.data)
+#     score = deserialized_estimator.score(data.data, data.target)
+#     assert True
+
+
+# def build_fn_regs(input_shape, output_shape, hidden_layer_sizes=[]):
+#     model = Sequential()
+#     for size in hidden_layer_sizes:
+#         model.add(Dense(size, activation='relu'))
+#     model.add(Dense(np.prod(output_shape, dtype=np.uint8)))
+#     model.compile('adam', loss='mean_squared_error')
+#     return model
+
+
+# def build_fn_clss(input_shape, output_shape, hidden_layer_sizes=[]):
+#     model = Sequential()
+#     for size in hidden_layer_sizes:
+#         model.add(Dense(size, activation='relu'))
+#     model.add(Dense(np.prod(output_shape, dtype=np.uint8),
+#                     activation='softmax'))
+#     model.compile('adam', loss='categorical_crossentropy', metrics=['accuracy'])
+#     return model
+
+
+# def build_fn_clscs(input_shape, output_shape, hidden_layer_sizes=[]):
+#     model = Sequential()
+#     model.add(Conv2D(3, (3, 3)))
+#     model.add(Flatten())
+#     for size in hidden_layer_sizes:
+#         model.add(Dense(size, activation='relu'))
+#     model.add(Dense(np.prod(output_shape, dtype=np.uint8),
+#                     activation='softmax'))
+#     model.compile('adam', loss='categorical_crossentropy', metrics=['accuracy'])
+#     return model
+
+
+# def build_fn_clscf(input_shape, output_shape, hidden_layer_sizes=[]):
+#     # https://github.com/keras-team/keras/issues/5176
+#     x = Input(shape=input_shape)
+#     z = Conv2D(3, (3, 3))(x)
+#     z = Flatten()(z)
+#     for size in hidden_layer_sizes:
+#         z = Dense(size, activation='relu')(z)
+#     y = Dense(np.prod(output_shape, dtype=np.uint8),
+#                     activation='softmax')(z)
+#     model = Model(inputs=x, outputs=y)
+#     model.compile('adam', loss='categorical_crossentropy', metrics=['accuracy'])
+#     return model
+
+
+# CONFIG = {'MLPRegressor': (load_boston, KerasRegressor, build_fn_regs,
+#                            (BaggingRegressor, AdaBoostRegressor)),
+#           'MLPClassifier': (load_iris, KerasClassifier, build_fn_clss,
+#                             (BaggingClassifier, AdaBoostClassifier)),
+#           'CNNClassifier': (load_digits8x8, KerasClassifier, build_fn_clscs,
+#                             (BaggingClassifier, AdaBoostClassifier)),
+#           'CNNClassifierF': (load_digits8x8, KerasClassifier, build_fn_clscf,
+#                              (BaggingClassifier, AdaBoostClassifier))}
+
+
+# def test_standalone():
+#     """Tests standalone estimator."""
+#     for config in ['MLPRegressor', 'MLPClassifier', 'CNNClassifier',
+#                    'CNNClassifierF']:
+#         loader, model, build_fn, _ = CONFIG[config]
+#         estimator = model(build_fn, epochs=1)
+#         check(estimator, loader)
+
+
+# def test_pipeline():
+#     """Tests compatibility with Scikit-learn's pipeline."""
+#     for config in ['MLPRegressor', 'MLPClassifier']:
+#         loader, model, build_fn, _ = CONFIG[config]
+#         estimator = model(build_fn, epochs=1)
+#         estimator = Pipeline([('s', StandardScaler()), ('e', estimator)])
+#         check(estimator, loader)
+
+
+# def test_searchcv():
+#     """Tests compatibility with Scikit-learn's hyperparameter search CV."""
+#     for config in ['MLPRegressor', 'MLPClassifier', 'CNNClassifier',
+#                    'CNNClassifierF']:
+#         loader, model, build_fn, _ = CONFIG[config]
+#         estimator = model(build_fn, epochs=1, validation_split=0.1)
+#         check(GridSearchCV(estimator, {'hidden_layer_sizes': [[], [5]]}),
+#               loader)
+#         check(RandomizedSearchCV(estimator, {'epochs': randint(1, 5)},
+#                                  n_iter=2), loader)
+
+
+# def test_ensemble():
+#     """Tests compatibility with Scikit-learn's ensembles."""
+#     for config in ['MLPRegressor', 'MLPClassifier']:
+#         loader, model, build_fn, ensembles = CONFIG[config]
+#         base_estimator = model(build_fn, epochs=1)
+#         for ensemble in ensembles:
+#             estimator = ensemble(base_estimator=base_estimator, n_estimators=2)
+#             check(estimator, loader)
+
+
+# def test_calibratedclassifiercv():
+#     """Tests compatibility with Scikit-learn's calibrated classifier CV."""
+#     for config in ['MLPClassifier']:
+#         loader, _, build_fn, _ = CONFIG[config]
+#         base_estimator = KerasClassifier(build_fn, epochs=1)
+#         estimator = CalibratedClassifierCV(base_estimator=base_estimator)
+#         check(estimator, loader)

--- a/tests/keras/wrappers/scikit_learn_test.py
+++ b/tests/keras/wrappers/scikit_learn_test.py
@@ -1,11 +1,23 @@
 import pytest
 import numpy as np
+import pickle
+from scipy.stats import randint
+from sklearn.calibration import CalibratedClassifierCV
+from sklearn.datasets import load_boston, load_digits, load_iris
+from sklearn.ensemble import (AdaBoostClassifier, AdaBoostRegressor,
+                              BaggingClassifier, BaggingRegressor)
+from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 
+from keras import backend as K
+from keras.layers import Activation, Concatenate, Conv2D, Dense, Flatten, Input
+from keras.models import Model, Sequential
 from keras.utils.test_utils import get_test_data
+from keras.utils.np_utils import to_categorical
 
-from keras.models import Sequential
-from keras.layers.core import Dense, Activation
-from keras.wrappers.scikit_learn import KerasClassifier, KerasRegressor
+from keras.wrappers.scikit_learn import (BaseWrapper, KerasClassifier,
+                                         KerasRegressor)
 
 input_dim = 5
 hidden_dims = 5
@@ -183,186 +195,165 @@ def assert_regression_predict_shape_correct(num_test):
     assert preds.shape == (num_test, )
 
 
-if __name__ == '__main__':
-    pytest.main([__file__])
-
-
 # Usage of sklearn's Pipelines, SearchCVs, Ensembles and CalibratedClassifierCVs
 
 
-# from keras import backend as K
-# from keras.layers import Concatenate, Conv2D, Dense, Flatten, Input
-# from keras.models import Model
-# from keras.utils.np_utils import to_categorical
-# import numpy as np
-# import pickle
-# from scipy.stats import randint
-# from sklearn.calibration import CalibratedClassifierCV
-# from sklearn.datasets import load_boston, load_digits, load_iris
-# from sklearn.ensemble import (AdaBoostClassifier, AdaBoostRegressor,
-#                               BaggingClassifier, BaggingRegressor)
-# from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
-# from sklearn.pipeline import Pipeline
-# from sklearn.preprocessing import StandardScaler
-
-# from keras.wrappers.scikit_learn import (BaseWrapper, KerasClassifier,
-#                                          KerasRegressor)
+def load_digits8x8():
+    data = load_digits()
+    data.data = data.data.reshape([data.data.shape[0], 1, 8, 8]) / 16.0
+    K.set_image_data_format('channels_first')
+    return data
 
 
-# def load_digits8x8():
-#     data = load_digits()
-#     data.data = data.data.reshape([data.data.shape[0], 1, 8, 8]) / 16.0
-#     K.set_image_data_format('channels_first')
-#     return data
+def check(estimator, loader):
+    data = loader()
+    estimator.fit(data.data, data.target)
+    preds = estimator.predict(data.data)
+    score = estimator.score(data.data, data.target)
+    serialized_estimator = pickle.dumps(estimator)
+    deserialized_estimator = pickle.loads(serialized_estimator)
+    preds = deserialized_estimator.predict(data.data)
+    score = deserialized_estimator.score(data.data, data.target)
+    assert True
 
 
-# def check(estimator, loader):
-#     data = loader()
-#     estimator.fit(data.data, data.target)
-#     preds = estimator.predict(data.data)
-#     score = estimator.score(data.data, data.target)
-#     serialized_estimator = pickle.dumps(estimator)
-#     K.clear_session()
-#     deserialized_estimator = pickle.loads(serialized_estimator)
-#     preds = deserialized_estimator.predict(data.data)
-#     score = deserialized_estimator.score(data.data, data.target)
-#     assert True
+def build_fn_regs(input_shape, output_shape, hidden_layer_sizes=[]):
+    model = Sequential()
+    for size in hidden_layer_sizes:
+        model.add(Dense(size, activation='relu'))
+    model.add(Dense(np.prod(output_shape, dtype=np.uint8)))
+    model.compile('adam', loss='mean_squared_error')
+    return model
 
 
-# def build_fn_regs(input_shape, output_shape, hidden_layer_sizes=[]):
-#     model = Sequential()
-#     for size in hidden_layer_sizes:
-#         model.add(Dense(size, activation='relu'))
-#     model.add(Dense(np.prod(output_shape, dtype=np.uint8)))
-#     model.compile('adam', loss='mean_squared_error')
-#     return model
+def build_fn_clss(input_shape, output_shape, hidden_layer_sizes=[]):
+    model = Sequential()
+    for size in hidden_layer_sizes:
+        model.add(Dense(size, activation='relu'))
+    model.add(Dense(np.prod(output_shape), activation='softmax'))
+    model.compile('adam', loss='categorical_crossentropy', metrics=['accuracy'])
+    return model
 
 
-# def build_fn_clss(input_shape, output_shape, hidden_layer_sizes=[]):
-#     model = Sequential()
-#     for size in hidden_layer_sizes:
-#         model.add(Dense(size, activation='relu'))
-#     model.add(Dense(np.prod(output_shape), activation='softmax'))
-#     model.compile('adam', loss='categorical_crossentropy', metrics=['accuracy'])
-#     return model
+def build_fn_clscs(input_shape, output_shape, hidden_layer_sizes=[]):
+    model = Sequential()
+    model.add(Conv2D(3, (3, 3)))
+    model.add(Flatten())
+    for size in hidden_layer_sizes:
+        model.add(Dense(size, activation='relu'))
+    model.add(Dense(np.prod(output_shape), activation='softmax'))
+    model.compile('adam', loss='categorical_crossentropy', metrics=['accuracy'])
+    return model
 
 
-# def build_fn_clscs(input_shape, output_shape, hidden_layer_sizes=[]):
-#     model = Sequential()
-#     model.add(Conv2D(3, (3, 3)))
-#     model.add(Flatten())
-#     for size in hidden_layer_sizes:
-#         model.add(Dense(size, activation='relu'))
-#     model.add(Dense(np.prod(output_shape), activation='softmax'))
-#     model.compile('adam', loss='categorical_crossentropy', metrics=['accuracy'])
-#     return model
+def build_fn_clscf(input_shape, output_shape, hidden_layer_sizes=[]):
+    x = Input(shape=input_shape)
+    z = Conv2D(3, (3, 3))(x)
+    z = Flatten()(z)
+    for size in hidden_layer_sizes:
+        z = Dense(size, activation='relu')(z)
+    y = Dense(np.prod(output_shape), activation='softmax')(z)
+    model = Model(inputs=x, outputs=y)
+    model.compile('adam', loss='categorical_crossentropy', metrics=['accuracy'])
+    return model
 
 
-# def build_fn_clscf(input_shape, output_shape, hidden_layer_sizes=[]):
-#     x = Input(shape=input_shape)
-#     z = Conv2D(3, (3, 3))(x)
-#     z = Flatten()(z)
-#     for size in hidden_layer_sizes:
-#         z = Dense(size, activation='relu')(z)
-#     y = Dense(np.prod(output_shape), activation='softmax')(z)
-#     model = Model(inputs=x, outputs=y)
-#     model.compile('adam', loss='categorical_crossentropy', metrics=['accuracy'])
-#     return model
+def build_fn_multi(input_shape, output_shape, hidden_layer_sizes=[]):
+    features = Input(shape=input_shape['features'], name='features')
+    class_in = Input(shape=input_shape['class_in'], name='class_in')
+    z = Concatenate()([features, class_in])
+    for size in hidden_layer_sizes:
+        z = Dense(size, activation='relu')(z)
+    onehot = Dense(np.prod(output_shape['onehot']), activation='softmax',
+                   name='onehot')(z)
+    class_out = Dense(np.prod(output_shape['class_out']), name='class_out')(z)
+    model = Model(inputs=[features, class_in], outputs=[onehot, class_out])
+    model.compile('adam',
+                  loss={'onehot': 'categorical_crossentropy',
+                        'class_out': 'mse'},
+                  metrics={'onehot': 'accuracy'})
+    return model
 
 
-# def build_fn_multi(input_shape, output_shape, hidden_layer_sizes=[]):
-#     features = Input(shape=input_shape['features'], name='features')
-#     class_in = Input(shape=input_shape['class_in'], name='class_in')
-#     z = Concatenate()([features, class_in])
-#     for size in hidden_layer_sizes:
-#         z = Dense(size, activation='relu')(z)
-#     onehot = Dense(np.prod(output_shape['onehot']), activation='softmax',
-#                    name='onehot')(z)
-#     class_out = Dense(np.prod(output_shape['class_out']), name='class_out')(z)
-#     model = Model(inputs=[features, class_in], outputs=[onehot, class_out])
-#     model.compile('adam',
-#                   loss={'onehot': 'categorical_crossentropy',
-#                         'class_out': 'mse'},
-#                   metrics={'onehot': 'accuracy'})
-#     return model
+CONFIG = {'MLPRegressor': (load_boston, KerasRegressor, build_fn_regs,
+                           (BaggingRegressor, AdaBoostRegressor)),
+          'MLPClassifier': (load_iris, KerasClassifier, build_fn_clss,
+                            (BaggingClassifier, AdaBoostClassifier)),
+          'CNNClassifier': (load_digits8x8, KerasClassifier, build_fn_clscs,
+                            (BaggingClassifier, AdaBoostClassifier)),
+          'CNNClassifierF': (load_digits8x8, KerasClassifier, build_fn_clscf,
+                             (BaggingClassifier, AdaBoostClassifier))}
 
 
-# CONFIG = {'MLPRegressor': (load_boston, KerasRegressor, build_fn_regs,
-#                            (BaggingRegressor, AdaBoostRegressor)),
-#           'MLPClassifier': (load_iris, KerasClassifier, build_fn_clss,
-#                             (BaggingClassifier, AdaBoostClassifier)),
-#           'CNNClassifier': (load_digits8x8, KerasClassifier, build_fn_clscs,
-#                             (BaggingClassifier, AdaBoostClassifier)),
-#           'CNNClassifierF': (load_digits8x8, KerasClassifier, build_fn_clscf,
-#                              (BaggingClassifier, AdaBoostClassifier))}
+def test_standalone():
+    """Tests standalone estimator."""
+    for config in ['MLPRegressor', 'MLPClassifier', 'CNNClassifier',
+                   'CNNClassifierF']:
+        loader, model, build_fn, _ = CONFIG[config]
+        estimator = model(build_fn, epochs=1)
+        check(estimator, loader)
 
 
-# def test_standalone():
-#     """Tests standalone estimator."""
-#     for config in ['MLPRegressor', 'MLPClassifier', 'CNNClassifier',
-#                    'CNNClassifierF']:
-#         loader, model, build_fn, _ = CONFIG[config]
-#         estimator = model(build_fn, epochs=1)
-#         check(estimator, loader)
+def test_pipeline():
+    """Tests compatibility with Scikit-learn's pipeline."""
+    for config in ['MLPRegressor', 'MLPClassifier']:
+        loader, model, build_fn, _ = CONFIG[config]
+        estimator = model(build_fn, epochs=1)
+        estimator = Pipeline([('s', StandardScaler()), ('e', estimator)])
+        check(estimator, loader)
 
 
-# def test_pipeline():
-#     """Tests compatibility with Scikit-learn's pipeline."""
-#     for config in ['MLPRegressor', 'MLPClassifier']:
-#         loader, model, build_fn, _ = CONFIG[config]
-#         estimator = model(build_fn, epochs=1)
-#         estimator = Pipeline([('s', StandardScaler()), ('e', estimator)])
-#         check(estimator, loader)
+def test_searchcv():
+    """Tests compatibility with Scikit-learn's hyperparameter search CV."""
+    for config in ['MLPRegressor', 'MLPClassifier', 'CNNClassifier',
+                   'CNNClassifierF']:
+        loader, model, build_fn, _ = CONFIG[config]
+        estimator = model(build_fn, epochs=1, validation_split=0.1)
+        check(GridSearchCV(estimator, {'hidden_layer_sizes': [[], [5]]}),
+              loader)
+        check(RandomizedSearchCV(estimator, {'epochs': randint(1, 5)},
+                                 n_iter=2), loader)
 
 
-# def test_searchcv():
-#     """Tests compatibility with Scikit-learn's hyperparameter search CV."""
-#     for config in ['MLPRegressor', 'MLPClassifier', 'CNNClassifier',
-#                    'CNNClassifierF']:
-#         loader, model, build_fn, _ = CONFIG[config]
-#         estimator = model(build_fn, epochs=1, validation_split=0.1)
-#         check(GridSearchCV(estimator, {'hidden_layer_sizes': [[], [5]]}),
-#               loader)
-#         check(RandomizedSearchCV(estimator, {'epochs': randint(1, 5)},
-#                                  n_iter=2), loader)
+def test_ensemble():
+    """Tests compatibility with Scikit-learn's ensembles."""
+    for config in ['MLPRegressor', 'MLPClassifier']:
+        loader, model, build_fn, ensembles = CONFIG[config]
+        base_estimator = model(build_fn, epochs=1)
+        for ensemble in ensembles:
+            estimator = ensemble(base_estimator=base_estimator, n_estimators=2)
+            check(estimator, loader)
 
 
-# def test_ensemble():
-#     """Tests compatibility with Scikit-learn's ensembles."""
-#     for config in ['MLPRegressor', 'MLPClassifier']:
-#         loader, model, build_fn, ensembles = CONFIG[config]
-#         base_estimator = model(build_fn, epochs=1)
-#         for ensemble in ensembles:
-#             estimator = ensemble(base_estimator=base_estimator, n_estimators=2)
-#             check(estimator, loader)
+def test_calibratedclassifiercv():
+    """Tests compatibility with Scikit-learn's calibrated classifier CV."""
+    for config in ['MLPClassifier']:
+        loader, _, build_fn, _ = CONFIG[config]
+        base_estimator = KerasClassifier(build_fn, epochs=1)
+        estimator = CalibratedClassifierCV(base_estimator=base_estimator)
+        check(estimator, loader)
 
 
-# def test_calibratedclassifiercv():
-#     """Tests compatibility with Scikit-learn's calibrated classifier CV."""
-#     for config in ['MLPClassifier']:
-#         loader, _, build_fn, _ = CONFIG[config]
-#         base_estimator = KerasClassifier(build_fn, epochs=1)
-#         estimator = CalibratedClassifierCV(base_estimator=base_estimator)
-#         check(estimator, loader)
+def test_standalone_multi():
+    """Tests standalone estimator with multiple inputs and outputs."""
+    estimator = BaseWrapper(build_fn_multi, epochs=1)
+    data = load_iris()
+    features = data.data
+    klass = data.target.reshape((-1, 1)).astype(np.float32)
+    onehot = to_categorical(data.target)
+    estimator.fit({'features': features, 'class_in': klass},
+                  {'onehot': onehot, 'class_out': klass})
+    preds = estimator.predict({'features': features, 'class_in': klass})
+    score = estimator.score({'features': features, 'class_in': klass},
+                            {'onehot': onehot, 'class_out': klass})
+    serialized_estimator = pickle.dumps(estimator)
+    deserialized_estimator = pickle.loads(serialized_estimator)
+    preds = deserialized_estimator.predict({'features': features,
+                                            'class_in': klass})
+    score = deserialized_estimator.score({'features': features,
+                                          'class_in': klass},
+                                         {'onehot': onehot, 'class_out': klass})
 
 
-# def test_standalone_multi():
-#     """Tests standalone estimator with multiple inputs and outputs."""
-#     estimator = BaseWrapper(build_fn_multi, epochs=1)
-#     data = load_iris()
-#     features = data.data
-#     klass = data.target.reshape((-1, 1)).astype(np.float32)
-#     onehot = to_categorical(data.target)
-#     estimator.fit({'features': features, 'class_in': klass},
-#                   {'onehot': onehot, 'class_out': klass})
-#     preds = estimator.predict({'features': features, 'class_in': klass})
-#     score = estimator.score({'features': features, 'class_in': klass},
-#                             {'onehot': onehot, 'class_out': klass})
-#     serialized_estimator = pickle.dumps(estimator)
-#     K.clear_session()
-#     deserialized_estimator = pickle.loads(serialized_estimator)
-#     preds = deserialized_estimator.predict({'features': features,
-#                                             'class_in': klass})
-#     score = deserialized_estimator.score({'features': features,
-#                                           'class_in': klass},
-#                                          {'onehot': onehot, 'class_out': klass})
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Scikit-learn estimators are instanced only with hyper-parameter information. No knowledge on the data (X or y) is needed until the estimator is fitted. On the other hand, KerasRegressor and KerasClassifier receive as argument a build_fn that instantiates and compiles the estimator. At this point, the input and output shapes are needed to define the network's architecture. This is a subtle but important difference between Scikit-learn estimators and KerasClassifier/KerasRegressor.
Also, Scikit-learn's GridSearchCV and RandomizedSearchCV (and probably Scikit-optimize's BayesSearchCV) automatically infer the most appropriate CV folding (stratified or not) from the base_estimator. KerasClassifier and KerasRegressor, however, do not have the attribute needed for this to work.

### Related Issues
#5176
#12832

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [n] This PR is backwards compatible [y/n]
- [y] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
