### PR TITLE
Sync Keras optimizer with tf.keras optimizer

### DIFF
--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import six
 import copy
+import numpy as np
 from six.moves import zip
 
 from . import backend as K
@@ -161,23 +162,23 @@ class SGD(Optimizer):
     learning rate decay, and Nesterov momentum.
 
     # Arguments
-        lr: float >= 0. Learning rate.
+        learning_rate: float >= 0. Learning rate.
         momentum: float >= 0. Parameter that accelerates SGD
             in the relevant direction and dampens oscillations.
-        decay: float >= 0. Learning rate decay over each update.
         nesterov: boolean. Whether to apply Nesterov momentum.
     """
 
-    def __init__(self, lr=0.01, momentum=0., decay=0.,
+    def __init__(self, learning_rate=0.01, momentum=0.,
                  nesterov=False, **kwargs):
-        super(SGD, self).__init__(**kwargs)
+        self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
             self.iterations = K.variable(0, dtype='int64', name='iterations')
-            self.lr = K.variable(lr, name='lr')
+            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
             self.momentum = K.variable(momentum, name='momentum')
-            self.decay = K.variable(decay, name='decay')
-        self.initial_decay = decay
+            self.decay = K.variable(self.initial_decay, name='decay')
+        self._momentum = True if momentum > 0. else False
         self.nesterov = nesterov
+        super(SGD, self).__init__(**kwargs)
 
     @interfaces.legacy_get_updates_support
     def get_updates(self, loss, params):
@@ -188,28 +189,41 @@ class SGD(Optimizer):
         if self.initial_decay > 0:
             lr = lr * (1. / (1. + self.decay * K.cast(self.iterations,
                                                       K.dtype(self.decay))))
-        # momentum
-        shapes = [K.int_shape(p) for p in params]
-        moments = [K.zeros(shape) for shape in shapes]
-        self.weights = [self.iterations] + moments
-        for p, g, m in zip(params, grads, moments):
-            v = self.momentum * m - lr * g  # velocity
-            self.updates.append(K.update(m, v))
+        self.weights = [self.iterations]
+        if self._momentum:
+            # momentum optimizer
+            shapes = [K.int_shape(p) for p in params]
+            moments = [K.zeros(shape) for shape in shapes]
+            self.weights.extend([K.zeros(shape) for shape in shapes])
 
-            if self.nesterov:
-                new_p = p + self.momentum * v - lr * g
-            else:
-                new_p = p + v
+            for p, g, m in zip(params, grads, moments):
+                v = self.momentum * m - lr * g  # velocity
+                self.updates.append(K.update(m, v))
 
-            # Apply constraints.
-            if getattr(p, 'constraint', None) is not None:
-                new_p = p.constraint(new_p)
+                if self.nesterov:
+                    new_p = p + self.momentum * v - lr * g
+                else:
+                    new_p = p + v
 
-            self.updates.append(K.update(p, new_p))
+                # Apply constraints.
+                if getattr(p, 'constraint', None) is not None:
+                    new_p = p.constraint(new_p)
+
+                self.updates.append(K.update(p, new_p))
+        else:
+            # sgd optimizer
+            for p, g in zip(params, grads):
+                new_p = p - lr * g
+                # Apply constraints.
+                if getattr(p, 'constraint', None) is not None:
+                    new_p = p.constraint(new_p)
+
+                self.updates.append(K.update(p, new_p))
+
         return self.updates
 
     def get_config(self):
-        config = {'lr': float(K.get_value(self.lr)),
+        config = {'learning_rate': float(K.get_value(self.lr)),
                   'momentum': float(K.get_value(self.momentum)),
                   'decay': float(K.get_value(self.decay)),
                   'nesterov': self.nesterov}
@@ -225,34 +239,40 @@ class RMSprop(Optimizer):
     (except the learning rate, which can be freely tuned).
 
     # Arguments
-        lr: float >= 0. Learning rate.
+        learning_rate: float >= 0. Learning rate.
         rho: float >= 0.
-        epsilon: float >= 0. Fuzz factor. If `None`, defaults to `K.epsilon()`.
-        decay: float >= 0. Learning rate decay over each update.
+        momentum: float hyperparameter >= 0 that accelerates RMSprop in the relevant
+            direction and dampens oscillations.
+        centered: If True, gradients are normalized by the estimated variance of
+            the gradient; if False, by the uncentered second moment. Setting this to
+            True may help with training, but is slightly more expensive in terms of
+            computation and memory. Defaults to False.
 
     # References
         - [rmsprop: Divide the gradient by a running average of its recent magnitude
            ](http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf)
     """
 
-    def __init__(self, lr=0.001, rho=0.9, epsilon=None, decay=0.,
+    def __init__(self, learning_rate=0.001, rho=0.9, momentum=0., centered=False,
                  **kwargs):
-        super(RMSprop, self).__init__(**kwargs)
+        self.initial_decay = kwargs.pop('decay', 0.0)
+        self._momentum = True if momentum > 0. else False
         with K.name_scope(self.__class__.__name__):
-            self.lr = K.variable(lr, name='lr')
+            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
             self.rho = K.variable(rho, name='rho')
-            self.decay = K.variable(decay, name='decay')
+            self.decay = K.variable(self.initial_decay, name='decay')
             self.iterations = K.variable(0, dtype='int64', name='iterations')
-        if epsilon is None:
-            epsilon = K.epsilon()
-        self.epsilon = epsilon
-        self.initial_decay = decay
+            if self._momentum:
+                self.momentum = K.variable(momentum, name='momentum')
+        self.epsilon = kwargs.pop('epsilon', K.epsilon())
+        self.centered = centered
+        super(RMSprop, self).__init__(**kwargs)
 
     @interfaces.legacy_get_updates_support
     def get_updates(self, loss, params):
         grads = self.get_gradients(loss, params)
         accumulators = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
-        self.weights = accumulators
+        self.weights = [self.iterations] + accumulators
         self.updates = [K.update_add(self.iterations, 1)]
 
         lr = self.lr
@@ -260,18 +280,48 @@ class RMSprop(Optimizer):
             lr = lr * (1. / (1. + self.decay * K.cast(self.iterations,
                                                       K.dtype(self.decay))))
 
-        for p, g, a in zip(params, grads, accumulators):
-            # update accumulator
+        if self._momentum:
+            ms = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+            self.weights.extend(ms)
+            if self.centered:
+                mgs = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+                self.weights.extend(mgs)
+            else:
+                mgs = [None] * len(params)
+        else:
+            ms = [None] * len(params)
+            mgs = [None] * len(params)
+
+        for p, g, a, m, mg in zip(params, grads, accumulators, ms, mgs):
             new_a = self.rho * a + (1. - self.rho) * K.square(g)
             self.updates.append(K.update(a, new_a))
-            new_p = p - lr * g / (K.sqrt(new_a) + self.epsilon)
-
+            if m:
+                if mg:
+                    new_mg = self.rho * mg + (1. - self.rho) * g
+                    new_m = self.momentum * m + lr * g / K.sqrt(new_a - K.square(new_mg) + self.epsilon)
+                    self.updates.append(K.update(mg, new_mg))
+                else:
+                    new_m = self.momentum * m + lr * g / K.sqrt(new_a + self.epsilon)
+                self.updates.append(K.update(m, new_m))
+                new_p = p - new_m
+            else:
+                new_p = p - lr * g / (K.sqrt(new_a) + self.epsilon)
             # Apply constraints.
             if getattr(p, 'constraint', None) is not None:
                 new_p = p.constraint(new_p)
 
-            self.updates.append(K.update(p, new_p))
+            self.updates.append(K.update(p, new_p)) 
+
         return self.updates
+
+    def set_weights(self, weights):
+        params = self.weights
+        # Override set_weights for backward compatibility of Keras 2.2.4 optimizer
+        # since it does not include iteration at head of the weight list. Set
+        # iteration to 0.
+        if len(params) == len(weights) + 1:
+            weights = [np.array(0)] + weights
+        super(RMSprop, self).set_weights(weights)
 
     def get_config(self):
         config = {'lr': float(K.get_value(self.lr)),
@@ -294,32 +344,31 @@ class Adagrad(Optimizer):
     at their default values.
 
     # Arguments
-        lr: float >= 0. Initial learning rate.
-        epsilon: float >= 0. If `None`, defaults to `K.epsilon()`.
-        decay: float >= 0. Learning rate decay over each update.
+        learning_rate: float >= 0. Initial learning rate.
+        initial_accumulator_value: A floating point value.
+            Starting value for the accumulators, must be positive.
 
     # References
         - [Adaptive Subgradient Methods for Online Learning and Stochastic
            Optimization](http://www.jmlr.org/papers/volume12/duchi11a/duchi11a.pdf)
     """
 
-    def __init__(self, lr=0.01, epsilon=None, decay=0., **kwargs):
-        super(Adagrad, self).__init__(**kwargs)
+    def __init__(self, learning_rate=0.001, initial_accumulator_value=0.1, **kwargs):
+        self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
-            self.lr = K.variable(lr, name='lr')
-            self.decay = K.variable(decay, name='decay')
+            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
+            self.decay = K.variable(self.initial_decay, name='decay')
             self.iterations = K.variable(0, dtype='int64', name='iterations')
-        if epsilon is None:
-            epsilon = K.epsilon()
-        self.epsilon = epsilon
-        self.initial_decay = decay
+        self.epsilon = kwargs.pop('epsilon', K.epsilon())
+        self._initial_accumulator_value = initial_accumulator_value
+        super(Adagrad, self).__init__(**kwargs)
 
     @interfaces.legacy_get_updates_support
     def get_updates(self, loss, params):
         grads = self.get_gradients(loss, params)
         shapes = [K.int_shape(p) for p in params]
-        accumulators = [K.zeros(shape) for shape in shapes]
-        self.weights = accumulators
+        accumulators = [K.variable(np.full(shape, self._initial_accumulator_value)) for shape in shapes]
+        self.weights = [self.iterations] + accumulators
         self.updates = [K.update_add(self.iterations, 1)]
 
         lr = self.lr
@@ -339,10 +388,19 @@ class Adagrad(Optimizer):
             self.updates.append(K.update(p, new_p))
         return self.updates
 
+    def set_weights(self, weights):
+        params = self.weights
+        # Override set_weights for backward compatibility of Keras 2.2.4 optimizer
+        # since it does not include iteration at head of the weight list. Set
+        # iteration to 0.
+        if len(params) == len(weights) + 1:
+            weights = [np.array(0)] + weights
+        super(Adagrad, self).set_weights(weights)
+
     def get_config(self):
-        config = {'lr': float(K.get_value(self.lr)),
+        config = {'learning_rate': float(K.get_value(self.lr)),
                   'decay': float(K.get_value(self.decay)),
-                  'epsilon': self.epsilon}
+                  'initial_accumulator_value': self._initial_accumulator_value}
         base_config = super(Adagrad, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
@@ -362,30 +420,25 @@ class Adadelta(Optimizer):
     at their default values.
 
     # Arguments
-        lr: float >= 0. Initial learning rate, defaults to 1.
+        learning_rate: float >= 0. Initial learning rate, defaults to 1.
             It is recommended to leave it at the default value.
         rho: float >= 0. Adadelta decay factor, corresponding to fraction of
             gradient to keep at each time step.
-        epsilon: float >= 0. Fuzz factor. If `None`, defaults to `K.epsilon()`.
-        decay: float >= 0. Initial learning rate decay.
 
     # References
         - [Adadelta - an adaptive learning rate method](
            https://arxiv.org/abs/1212.5701)
     """
 
-    def __init__(self, lr=1.0, rho=0.95, epsilon=None, decay=0.,
-                 **kwargs):
-        super(Adadelta, self).__init__(**kwargs)
+    def __init__(self, learning_rate=0.001, rho=0.95, **kwargs):
+        self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
-            self.lr = K.variable(lr, name='lr')
-            self.decay = K.variable(decay, name='decay')
+            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
+            self.decay = K.variable(self.initial_decay, name='decay')
             self.iterations = K.variable(0, dtype='int64', name='iterations')
-        if epsilon is None:
-            epsilon = K.epsilon()
         self.rho = rho
-        self.epsilon = epsilon
-        self.initial_decay = decay
+        self.epsilon = kwargs.pop('epsilon', K.epsilon())
+        super(Adadelta, self).__init__(**kwargs)
 
     @interfaces.legacy_get_updates_support
     def get_updates(self, loss, params):
@@ -393,7 +446,7 @@ class Adadelta(Optimizer):
         shapes = [K.int_shape(p) for p in params]
         accumulators = [K.zeros(shape) for shape in shapes]
         delta_accumulators = [K.zeros(shape) for shape in shapes]
-        self.weights = accumulators + delta_accumulators
+        self.weights = [self.iterations] + accumulators + delta_accumulators
         self.updates = [K.update_add(self.iterations, 1)]
 
         lr = self.lr
@@ -421,11 +474,19 @@ class Adadelta(Optimizer):
             self.updates.append(K.update(d_a, new_d_a))
         return self.updates
 
+    def set_weights(self, weights):
+        params = self.weights
+        # Override set_weights for backward compatibility of Keras 2.2.4 optimizer
+        # since it does not include iteration at head of the weight list. Set
+        # iteration to 0.
+        if len(params) == len(weights) + 1:
+            weights = [np.array(0)] + weights
+        super(Adadelta, self).set_weights(weights)
+
     def get_config(self):
-        config = {'lr': float(K.get_value(self.lr)),
+        config = {'learning_rate': float(K.get_value(self.lr)),
                   'rho': self.rho,
-                  'decay': float(K.get_value(self.decay)),
-                  'epsilon': self.epsilon}
+                  'decay': float(K.get_value(self.decay))}
         base_config = super(Adadelta, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
@@ -436,11 +497,9 @@ class Adam(Optimizer):
     Default parameters follow those provided in the original paper.
 
     # Arguments
-        lr: float >= 0. Learning rate.
+        learning_rate: float >= 0. Learning rate.
         beta_1: float, 0 < beta < 1. Generally close to 1.
         beta_2: float, 0 < beta < 1. Generally close to 1.
-        epsilon: float >= 0. Fuzz factor. If `None`, defaults to `K.epsilon()`.
-        decay: float >= 0. Learning rate decay over each update.
         amsgrad: boolean. Whether to apply the AMSGrad variant of this
             algorithm from the paper "On the Convergence of Adam and
             Beyond".
@@ -452,20 +511,18 @@ class Adam(Optimizer):
            https://openreview.net/forum?id=ryQu7f-RZ)
     """
 
-    def __init__(self, lr=0.001, beta_1=0.9, beta_2=0.999,
-                 epsilon=None, decay=0., amsgrad=False, **kwargs):
-        super(Adam, self).__init__(**kwargs)
+    def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
+                 amsgrad=False, **kwargs):
+        self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
             self.iterations = K.variable(0, dtype='int64', name='iterations')
-            self.lr = K.variable(lr, name='lr')
+            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
             self.beta_1 = K.variable(beta_1, name='beta_1')
             self.beta_2 = K.variable(beta_2, name='beta_2')
-            self.decay = K.variable(decay, name='decay')
-        if epsilon is None:
-            epsilon = K.epsilon()
-        self.epsilon = epsilon
-        self.initial_decay = decay
+            self.decay = K.variable(self.initial_decay, name='decay')
+        self.epsilon = kwargs.pop('epsilon', K.epsilon())
         self.amsgrad = amsgrad
+        super(Adam, self).__init__(**kwargs)
 
     @interfaces.legacy_get_updates_support
     def get_updates(self, loss, params):
@@ -483,39 +540,46 @@ class Adam(Optimizer):
 
         ms = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
         vs = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+        self.weights = [self.iterations] + ms + vs
         if self.amsgrad:
             vhats = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+            self.weights.extend(vhats)
         else:
-            vhats = [K.zeros(1) for _ in params]
-        self.weights = [self.iterations] + ms + vs + vhats
-
+            vhats = [None] * len(params)
         for p, g, m, v, vhat in zip(params, grads, ms, vs, vhats):
             m_t = (self.beta_1 * m) + (1. - self.beta_1) * g
             v_t = (self.beta_2 * v) + (1. - self.beta_2) * K.square(g)
+            self.updates.append(K.update(m, m_t))
+            self.updates.append(K.update(v, v_t))
             if self.amsgrad:
                 vhat_t = K.maximum(vhat, v_t)
                 p_t = p - lr_t * m_t / (K.sqrt(vhat_t) + self.epsilon)
-                self.updates.append(K.update(vhat, vhat_t))
+                self.updates.append(K.update(vhat, vhat_t))  
             else:
                 p_t = p - lr_t * m_t / (K.sqrt(v_t) + self.epsilon)
-
-            self.updates.append(K.update(m, m_t))
-            self.updates.append(K.update(v, v_t))
             new_p = p_t
-
             # Apply constraints.
             if getattr(p, 'constraint', None) is not None:
                 new_p = p.constraint(new_p)
-
             self.updates.append(K.update(p, new_p))
+
         return self.updates
 
+    def set_weights(self, weights):
+        params = self.weights
+        # If the weights are generated by Keras V1 optimizer, it includes vhats
+        # even without amsgrad, i.e, V1 optimizer has 3x + 1 variables, while V2
+        # optimizer has 2x + 1 variables. Filter vhats out for compatibility.
+        num_vars = int((len(params) - 1) / 2)
+        if len(weights) == 3 * num_vars + 1:
+            weights = weights[:len(params)]
+        super(Adam, self).set_weights(weights)
+
     def get_config(self):
-        config = {'lr': float(K.get_value(self.lr)),
+        config = {'learning_rate': float(K.get_value(self.lr)),
                   'beta_1': float(K.get_value(self.beta_1)),
                   'beta_2': float(K.get_value(self.beta_2)),
                   'decay': float(K.get_value(self.decay)),
-                  'epsilon': self.epsilon,
                   'amsgrad': self.amsgrad}
         base_config = super(Adam, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -528,30 +592,25 @@ class Adamax(Optimizer):
     Default parameters follow those provided in the paper.
 
     # Arguments
-        lr: float >= 0. Learning rate.
+        learning_rate: float >= 0. Learning rate.
         beta_1: float, 0 < beta < 1. Generally close to 1.
         beta_2: float, 0 < beta < 1. Generally close to 1.
-        epsilon: float >= 0. Fuzz factor. If `None`, defaults to `K.epsilon()`.
-        decay: float >= 0. Learning rate decay over each update.
 
     # References
         - [Adam - A Method for Stochastic Optimization](
            https://arxiv.org/abs/1412.6980v8)
     """
 
-    def __init__(self, lr=0.002, beta_1=0.9, beta_2=0.999,
-                 epsilon=None, decay=0., **kwargs):
-        super(Adamax, self).__init__(**kwargs)
+    def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999, **kwargs):
+        self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
             self.iterations = K.variable(0, dtype='int64', name='iterations')
-            self.lr = K.variable(lr, name='lr')
+            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
             self.beta_1 = K.variable(beta_1, name='beta_1')
             self.beta_2 = K.variable(beta_2, name='beta_2')
-            self.decay = K.variable(decay, name='decay')
-        if epsilon is None:
-            epsilon = K.epsilon()
-        self.epsilon = epsilon
-        self.initial_decay = decay
+            self.decay = K.variable(self.initial_decay, name='decay')
+        self.epsilon = kwargs.pop('epsilon', K.epsilon())
+        super(Adamax, self).__init__(**kwargs)
 
     @interfaces.legacy_get_updates_support
     def get_updates(self, loss, params):
@@ -591,11 +650,10 @@ class Adamax(Optimizer):
         return self.updates
 
     def get_config(self):
-        config = {'lr': float(K.get_value(self.lr)),
+        config = {'learning_rate': float(K.get_value(self.lr)),
                   'beta_1': float(K.get_value(self.beta_1)),
                   'beta_2': float(K.get_value(self.beta_2)),
-                  'decay': float(K.get_value(self.decay)),
-                  'epsilon': self.epsilon}
+                  'decay': float(K.get_value(self.decay))}
         base_config = super(Adamax, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
@@ -611,11 +669,9 @@ class Nadam(Optimizer):
     at their default values.
 
     # Arguments
-        lr: float >= 0. Learning rate.
+        learning_rate: float >= 0. Learning rate.
         beta_1: float, 0 < beta < 1. Generally close to 1.
         beta_2: float, 0 < beta < 1. Generally close to 1.
-        epsilon: float >= 0. Fuzz factor. If `None`, defaults to `K.epsilon()`.
-        schedule_decay: float, 0 < schedule_decay < 1.
 
     # References
         - [Nadam report](http://cs229.stanford.edu/proj2015/054_report.pdf)
@@ -623,19 +679,16 @@ class Nadam(Optimizer):
            http://www.cs.toronto.edu/~fritz/absps/momentum.pdf)
     """
 
-    def __init__(self, lr=0.002, beta_1=0.9, beta_2=0.999,
-                 epsilon=None, schedule_decay=0.004, **kwargs):
-        super(Nadam, self).__init__(**kwargs)
+    def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999, **kwargs):
+        self.schedule_decay = kwargs.pop('schedule_decay', 0.004)
         with K.name_scope(self.__class__.__name__):
             self.iterations = K.variable(0, dtype='int64', name='iterations')
             self.m_schedule = K.variable(1., name='m_schedule')
-            self.lr = K.variable(lr, name='lr')
+            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
             self.beta_1 = K.variable(beta_1, name='beta_1')
             self.beta_2 = K.variable(beta_2, name='beta_2')
-        if epsilon is None:
-            epsilon = K.epsilon()
-        self.epsilon = epsilon
-        self.schedule_decay = schedule_decay
+        self.epsilon = kwargs.pop('epsilon', K.epsilon())
+        super(Nadam, self).__init__(**kwargs)
 
     @interfaces.legacy_get_updates_support
     def get_updates(self, loss, params):
@@ -657,7 +710,7 @@ class Nadam(Optimizer):
         ms = [K.zeros(shape) for shape in shapes]
         vs = [K.zeros(shape) for shape in shapes]
 
-        self.weights = [self.iterations] + ms + vs
+        self.weights = [self.iterations, self.m_schedule] + ms + vs
 
         for p, g, m, v in zip(params, grads, ms, vs):
             # the following equations given in [1]
@@ -682,11 +735,19 @@ class Nadam(Optimizer):
             self.updates.append(K.update(p, new_p))
         return self.updates
 
+    def set_weights(self, weights):
+        params = self.weights
+        # Override set_weights for backward compatibility of Keras 2.2.4 optimizer
+        # since it does not include iteration at head of the weight list. Set
+        # iteration to 0.
+        if len(params) == len(weights) + 1:
+            weights = [weights[0]] + [np.array(1.)] + weights[1:]
+        super(Nadam, self).set_weights(weights)
+
     def get_config(self):
-        config = {'lr': float(K.get_value(self.lr)),
+        config = {'learning_rate': float(K.get_value(self.lr)),
                   'beta_1': float(K.get_value(self.beta_1)),
                   'beta_2': float(K.get_value(self.beta_2)),
-                  'epsilon': self.epsilon,
                   'schedule_decay': self.schedule_decay}
         base_config = super(Nadam, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -173,7 +173,8 @@ class SGD(Optimizer):
         self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
             self.iterations = K.variable(0, dtype='int64', name='iterations')
-            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
+            kwargs.pop('lr', learning_rate)
+            self.lr = K.variable(learning_rate, name='learning_rate')
             self.momentum = K.variable(momentum, name='momentum')
             self.decay = K.variable(self.initial_decay, name='decay')
         self._momentum = True if momentum > 0. else False
@@ -252,7 +253,8 @@ class RMSprop(Optimizer):
         self.initial_decay = kwargs.pop('decay', 0.0)
         self._momentum = True if momentum > 0. else False
         with K.name_scope(self.__class__.__name__):
-            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
+            kwargs.pop('lr', learning_rate)
+            self.lr = K.variable(learning_rate, name='learning_rate')
             self.rho = K.variable(rho, name='rho')
             self.decay = K.variable(self.initial_decay, name='decay')
             self.iterations = K.variable(0, dtype='int64', name='iterations')
@@ -292,7 +294,8 @@ class RMSprop(Optimizer):
             if m:
                 if mg:
                     new_mg = self.rho * mg + (1. - self.rho) * g
-                    new_m = self.momentum * m + lr * g / K.sqrt(new_a - K.square(new_mg) + self.epsilon)
+                    new_m = self.momentum * m + lr * g / K.sqrt(
+                        new_a - K.square(new_mg) + self.epsilon)
                     self.updates.append(K.update(mg, new_mg))
                 else:
                     new_m = self.momentum * m + lr * g / K.sqrt(new_a + self.epsilon)
@@ -304,7 +307,7 @@ class RMSprop(Optimizer):
             if getattr(p, 'constraint', None) is not None:
                 new_p = p.constraint(new_p)
 
-            self.updates.append(K.update(p, new_p)) 
+            self.updates.append(K.update(p, new_p))
 
         return self.updates
 
@@ -350,7 +353,8 @@ class Adagrad(Optimizer):
     def __init__(self, learning_rate=0.001, initial_accumulator_value=0.1, **kwargs):
         self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
-            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
+            kwargs.pop('lr', learning_rate)
+            self.lr = K.variable(learning_rate, name='learning_rate')
             self.decay = K.variable(self.initial_decay, name='decay')
             self.iterations = K.variable(0, dtype='int64', name='iterations')
         self.epsilon = kwargs.pop('epsilon', K.epsilon())
@@ -361,7 +365,8 @@ class Adagrad(Optimizer):
     def get_updates(self, loss, params):
         grads = self.get_gradients(loss, params)
         shapes = [K.int_shape(p) for p in params]
-        accumulators = [K.variable(np.full(shape, self._initial_accumulator_value)) for shape in shapes]
+        accumulators = [K.variable(np.full(shape, self._initial_accumulator_value))
+                        for shape in shapes]
         self.weights = [self.iterations] + accumulators
         self.updates = [K.update_add(self.iterations, 1)]
 
@@ -427,7 +432,8 @@ class Adadelta(Optimizer):
     def __init__(self, learning_rate=0.001, rho=0.95, **kwargs):
         self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
-            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
+            kwargs.pop('lr', learning_rate)
+            self.lr = K.variable(learning_rate, name='learning_rate')
             self.decay = K.variable(self.initial_decay, name='decay')
             self.iterations = K.variable(0, dtype='int64', name='iterations')
         self.rho = rho
@@ -510,7 +516,8 @@ class Adam(Optimizer):
         self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
             self.iterations = K.variable(0, dtype='int64', name='iterations')
-            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
+            kwargs.pop('lr', learning_rate)
+            self.lr = K.variable(learning_rate, name='learning_rate')
             self.beta_1 = K.variable(beta_1, name='beta_1')
             self.beta_2 = K.variable(beta_2, name='beta_2')
             self.decay = K.variable(self.initial_decay, name='decay')
@@ -599,7 +606,8 @@ class Adamax(Optimizer):
         self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
             self.iterations = K.variable(0, dtype='int64', name='iterations')
-            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
+            kwargs.pop('lr', learning_rate)
+            self.lr = K.variable(learning_rate, name='learning_rate')
             self.beta_1 = K.variable(beta_1, name='beta_1')
             self.beta_2 = K.variable(beta_2, name='beta_2')
             self.decay = K.variable(self.initial_decay, name='decay')
@@ -678,7 +686,8 @@ class Nadam(Optimizer):
         with K.name_scope(self.__class__.__name__):
             self.iterations = K.variable(0, dtype='int64', name='iterations')
             self.m_schedule = K.variable(1., name='m_schedule')
-            self.lr = K.variable(kwargs.pop('lr', learning_rate), name='learning_rate')
+            kwargs.pop('lr', learning_rate)
+            self.lr = K.variable(learning_rate, name='learning_rate')
             self.beta_1 = K.variable(beta_1, name='beta_1')
             self.beta_2 = K.variable(beta_2, name='beta_2')
         self.epsilon = kwargs.pop('epsilon', K.epsilon())

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -173,7 +173,7 @@ class SGD(Optimizer):
         self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
             self.iterations = K.variable(0, dtype='int64', name='iterations')
-            kwargs.pop('lr', learning_rate)
+            learning_rate = kwargs.pop('lr', learning_rate)
             self.lr = K.variable(learning_rate, name='learning_rate')
             self.momentum = K.variable(momentum, name='momentum')
             self.decay = K.variable(self.initial_decay, name='decay')
@@ -253,7 +253,7 @@ class RMSprop(Optimizer):
         self.initial_decay = kwargs.pop('decay', 0.0)
         self._momentum = True if momentum > 0. else False
         with K.name_scope(self.__class__.__name__):
-            kwargs.pop('lr', learning_rate)
+            learning_rate = kwargs.pop('lr', learning_rate)
             self.lr = K.variable(learning_rate, name='learning_rate')
             self.rho = K.variable(rho, name='rho')
             self.decay = K.variable(self.initial_decay, name='decay')
@@ -321,7 +321,7 @@ class RMSprop(Optimizer):
         super(RMSprop, self).set_weights(weights)
 
     def get_config(self):
-        config = {'lr': float(K.get_value(self.lr)),
+        config = {'learning_rate': float(K.get_value(self.lr)),
                   'rho': float(K.get_value(self.rho)),
                   'decay': float(K.get_value(self.decay)),
                   'epsilon': self.epsilon}
@@ -353,7 +353,7 @@ class Adagrad(Optimizer):
     def __init__(self, learning_rate=0.001, initial_accumulator_value=0.1, **kwargs):
         self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
-            kwargs.pop('lr', learning_rate)
+            learning_rate = kwargs.pop('lr', learning_rate)
             self.lr = K.variable(learning_rate, name='learning_rate')
             self.decay = K.variable(self.initial_decay, name='decay')
             self.iterations = K.variable(0, dtype='int64', name='iterations')
@@ -432,7 +432,7 @@ class Adadelta(Optimizer):
     def __init__(self, learning_rate=0.001, rho=0.95, **kwargs):
         self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
-            kwargs.pop('lr', learning_rate)
+            learning_rate = kwargs.pop('lr', learning_rate)
             self.lr = K.variable(learning_rate, name='learning_rate')
             self.decay = K.variable(self.initial_decay, name='decay')
             self.iterations = K.variable(0, dtype='int64', name='iterations')
@@ -516,7 +516,7 @@ class Adam(Optimizer):
         self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
             self.iterations = K.variable(0, dtype='int64', name='iterations')
-            kwargs.pop('lr', learning_rate)
+            learning_rate = kwargs.pop('lr', learning_rate)
             self.lr = K.variable(learning_rate, name='learning_rate')
             self.beta_1 = K.variable(beta_1, name='beta_1')
             self.beta_2 = K.variable(beta_2, name='beta_2')
@@ -606,7 +606,7 @@ class Adamax(Optimizer):
         self.initial_decay = kwargs.pop('decay', 0.0)
         with K.name_scope(self.__class__.__name__):
             self.iterations = K.variable(0, dtype='int64', name='iterations')
-            kwargs.pop('lr', learning_rate)
+            learning_rate = kwargs.pop('lr', learning_rate)
             self.lr = K.variable(learning_rate, name='learning_rate')
             self.beta_1 = K.variable(beta_1, name='beta_1')
             self.beta_2 = K.variable(beta_2, name='beta_2')
@@ -686,7 +686,7 @@ class Nadam(Optimizer):
         with K.name_scope(self.__class__.__name__):
             self.iterations = K.variable(0, dtype='int64', name='iterations')
             self.m_schedule = K.variable(1., name='m_schedule')
-            kwargs.pop('lr', learning_rate)
+            learning_rate = kwargs.pop('lr', learning_rate)
             self.lr = K.variable(learning_rate, name='learning_rate')
             self.beta_1 = K.variable(beta_1, name='beta_1')
             self.beta_2 = K.variable(beta_2, name='beta_2')

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -548,7 +548,7 @@ class Adam(Optimizer):
             if self.amsgrad:
                 vhat_t = K.maximum(vhat, v_t)
                 p_t = p - lr_t * m_t / (K.sqrt(vhat_t) + self.epsilon)
-                self.updates.append(K.update(vhat, vhat_t))  
+                self.updates.append(K.update(vhat, vhat_t))
             else:
                 p_t = p - lr_t * m_t / (K.sqrt(v_t) + self.epsilon)
             new_p = p_t

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -191,34 +191,28 @@ class SGD(Optimizer):
                                                       K.dtype(self.decay))))
         self.weights = [self.iterations]
         if self._momentum:
-            # momentum optimizer
             shapes = [K.int_shape(p) for p in params]
             moments = [K.zeros(shape) for shape in shapes]
             self.weights.extend([K.zeros(shape) for shape in shapes])
-
-            for p, g, m in zip(params, grads, moments):
+        else:
+            moments = [None] * len(params)
+        for p, g, m in zip(params, grads, moments):
+            if self._momentum:
+                # momentum optimizer
                 v = self.momentum * m - lr * g  # velocity
                 self.updates.append(K.update(m, v))
-
                 if self.nesterov:
                     new_p = p + self.momentum * v - lr * g
                 else:
                     new_p = p + v
-
-                # Apply constraints.
-                if getattr(p, 'constraint', None) is not None:
-                    new_p = p.constraint(new_p)
-
-                self.updates.append(K.update(p, new_p))
-        else:
-            # sgd optimizer
-            for p, g in zip(params, grads):
+            else:
+                # sgd optimizer.
                 new_p = p - lr * g
-                # Apply constraints.
-                if getattr(p, 'constraint', None) is not None:
-                    new_p = p.constraint(new_p)
+            # Apply constraints.
+            if getattr(p, 'constraint', None) is not None:
+                new_p = p.constraint(new_p)
 
-                self.updates.append(K.update(p, new_p))
+            self.updates.append(K.update(p, new_p))
 
         return self.updates
 

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -137,7 +137,8 @@ def test_adam():
 def test_adamax():
     _test_optimizer(optimizers.Adamax(lr=0.002))
     _test_optimizer(optimizers.Adamax(lr=0.002, decay=1e-3))
-    _test_optimizer(optimizers.Adamax(learning_rate=0.002, epsilon=0.001, decay=0.001))
+    _test_optimizer(optimizers.Adamax(learning_rate=0.002, epsilon=0.001,
+                                      decay=0.001))
 
 
 def test_nadam():

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -81,36 +81,74 @@ def test_no_grad():
 def test_sgd():
     sgd = optimizers.SGD(lr=0.01, momentum=0.9, nesterov=True)
     _test_optimizer(sgd)
+    sgd = optimizers.SGD(learning_rate=0.01, momentum=0.9, decay=0.1, nesterov=True)
+    _test_optimizer(sgd)
 
 
 def test_rmsprop():
     _test_optimizer(optimizers.RMSprop())
     _test_optimizer(optimizers.RMSprop(decay=1e-3))
+    _test_optimizer(optimizers.RMSprop(learning_rate=0.1, epsilon=0.01, decay=0.1))
+    _test_optimizer(optimizers.RMSprop(learning_rate=0.1, momentum=0.1))
+    _test_optimizer(optimizers.RMSprop(learning_rate=0.1, momentum=0.1, centered=True))
 
 
 def test_adagrad():
-    _test_optimizer(optimizers.Adagrad())
+    adagrad = optimizers.Adagrad()
+    _test_optimizer(adagrad)
     _test_optimizer(optimizers.Adagrad(decay=1e-3))
+    new_adagrad = optimizers.Adagrad(learning_rate=0.1,
+                                     initial_accumulator_value=1.,
+                                     epsilon=0.01, decay=0.1)
+    _test_optimizer(new_adagrad)
+    # test backward compatibility for adding opt.iterations.
+    assert len(adagrad.get_weights()) == len(new_adagrad.get_weights())
+    new_adagrad.set_weights(adagrad.get_weights()[1:])
+    _test_optimizer(new_adagrad)
 
 
 def test_adadelta():
-    _test_optimizer(optimizers.Adadelta(), target=0.6)
+    adadelta = optimizers.Adadelta()
+    _test_optimizer(adadelta, target=0.6)
     _test_optimizer(optimizers.Adadelta(decay=1e-3), target=0.6)
+    new_adadelta = optimizers.Adadelta(learning_rate=0.1,
+                                       epsilon=0.01, decay=0.1)
+    _test_optimizer(new_adadelta)
+    # test backward compatibility for adding opt.iterations.
+    assert len(adadelta.get_weights()) == len(new_adadelta.get_weights())
+    new_adadelta.set_weights(adadelta.get_weights()[1:])
+    _test_optimizer(new_adadelta, target=0.6)
 
 
 def test_adam():
-    _test_optimizer(optimizers.Adam())
+    adam = optimizers.Adam()
+    _test_optimizer(adam)
     _test_optimizer(optimizers.Adam(decay=1e-3))
+    new_adam = optimizers.Adam(learning_rate=0.1, epsilon=0.01, decay=0.1)
+    _test_optimizer(new_adam)
+    num_vars = int((len(adam.weights) - 1) / 2)
+    ms = adam.weights[1:num_vars+1]
+    adam.weights.extend([K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in ms])
+    new_adam.set_weights(adam.get_weights())
+    _test_optimizer(new_adam)
 
 
 def test_adamax():
     _test_optimizer(optimizers.Adamax())
     _test_optimizer(optimizers.Adamax(decay=1e-3))
+    _test_optimizer(optimizers.Adamax(learning_rate=0.1, epsilon=0.01, decay=0.1))
 
 
 def test_nadam():
-    _test_optimizer(optimizers.Nadam())
-
+    nadam = optimizers.Nadam()
+    _test_optimizer(nadam)
+    new_nadam = optimizers.Nadam(learning_rate=0.1, epsilon=0.01, schedule_decay=0.1)
+    _test_optimizer(new_nadam)
+    # test backward compatibility for adding opt.m_schedule.
+    assert len(nadam.get_weights()) == len(new_nadam.get_weights())
+    weights = nadam.get_weights()
+    new_nadam.set_weights([weights[0]] + weights[1:])
+    _test_optimizer(new_nadam)
 
 def test_adam_amsgrad():
     _test_optimizer(optimizers.Adam(amsgrad=True))

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -90,7 +90,8 @@ def test_rmsprop():
     _test_optimizer(optimizers.RMSprop(decay=1e-3))
     _test_optimizer(optimizers.RMSprop(learning_rate=0.1, epsilon=0.01, decay=0.1))
     _test_optimizer(optimizers.RMSprop(learning_rate=0.1, momentum=0.1))
-    _test_optimizer(optimizers.RMSprop(learning_rate=0.1, momentum=0.1, centered=True))
+    _test_optimizer(optimizers.RMSprop(learning_rate=0.1, momentum=0.1,
+                                       centered=True))
 
 
 def test_adagrad():
@@ -127,7 +128,7 @@ def test_adam():
     new_adam = optimizers.Adam(learning_rate=0.1, epsilon=0.01, decay=0.1)
     _test_optimizer(new_adam)
     num_vars = int((len(adam.weights) - 1) / 2)
-    ms = adam.weights[1:num_vars+1]
+    ms = adam.weights[1:(num_vars + 1)]
     adam.weights.extend([K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in ms])
     new_adam.set_weights(adam.get_weights())
     _test_optimizer(new_adam)
@@ -149,6 +150,7 @@ def test_nadam():
     weights = nadam.get_weights()
     new_nadam.set_weights([weights[0]] + weights[1:])
     _test_optimizer(new_nadam)
+
 
 def test_adam_amsgrad():
     _test_optimizer(optimizers.Adam(amsgrad=True))

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -95,12 +95,12 @@ def test_rmsprop():
 
 
 def test_adagrad():
-    adagrad = optimizers.Adagrad()
+    adagrad = optimizers.Adagrad(lr=0.01)
     _test_optimizer(adagrad)
-    _test_optimizer(optimizers.Adagrad(decay=1e-3))
-    new_adagrad = optimizers.Adagrad(learning_rate=0.1,
-                                     initial_accumulator_value=1.,
-                                     epsilon=0.01, decay=0.1)
+    _test_optimizer(optimizers.Adagrad(lr=0.01, decay=1e-3))
+    new_adagrad = optimizers.Adagrad(learning_rate=0.01,
+                                     initial_accumulator_value=0.001,
+                                     epsilon=0.01, decay=0.01)
     _test_optimizer(new_adagrad)
     # test backward compatibility for adding opt.iterations.
     assert len(adagrad.get_weights()) == len(new_adagrad.get_weights())
@@ -109,12 +109,12 @@ def test_adagrad():
 
 
 def test_adadelta():
-    adadelta = optimizers.Adadelta()
+    adadelta = optimizers.Adadelta(lr=1.0)
     _test_optimizer(adadelta, target=0.6)
-    _test_optimizer(optimizers.Adadelta(decay=1e-3), target=0.6)
-    new_adadelta = optimizers.Adadelta(learning_rate=0.1,
-                                       epsilon=0.01, decay=0.1)
-    _test_optimizer(new_adadelta)
+    _test_optimizer(optimizers.Adadelta(lr=1.0, decay=1e-3), target=0.6)
+    new_adadelta = optimizers.Adadelta(learning_rate=1.0,
+                                       epsilon=0.01, decay=0.01)
+    _test_optimizer(new_adadelta, target=0.6)
     # test backward compatibility for adding opt.iterations.
     assert len(adadelta.get_weights()) == len(new_adadelta.get_weights())
     new_adadelta.set_weights(adadelta.get_weights()[1:])
@@ -135,9 +135,9 @@ def test_adam():
 
 
 def test_adamax():
-    _test_optimizer(optimizers.Adamax())
-    _test_optimizer(optimizers.Adamax(decay=1e-3))
-    _test_optimizer(optimizers.Adamax(learning_rate=0.1, epsilon=0.01, decay=0.1))
+    _test_optimizer(optimizers.Adamax(lr=0.002))
+    _test_optimizer(optimizers.Adamax(lr=0.002, decay=1e-3))
+    _test_optimizer(optimizers.Adamax(learning_rate=0.002, epsilon=0.01, decay=0.1))
 
 
 def test_nadam():

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -100,7 +100,7 @@ def test_adagrad():
     _test_optimizer(optimizers.Adagrad(lr=0.01, decay=1e-3))
     new_adagrad = optimizers.Adagrad(learning_rate=0.01,
                                      initial_accumulator_value=0.001,
-                                     epsilon=0.01, decay=0.01)
+                                     epsilon=0.001, decay=0.001)
     _test_optimizer(new_adagrad)
     # test backward compatibility for adding opt.iterations.
     assert len(adagrad.get_weights()) == len(new_adagrad.get_weights())
@@ -113,7 +113,7 @@ def test_adadelta():
     _test_optimizer(adadelta, target=0.6)
     _test_optimizer(optimizers.Adadelta(lr=1.0, decay=1e-3), target=0.6)
     new_adadelta = optimizers.Adadelta(learning_rate=1.0,
-                                       epsilon=0.01, decay=0.01)
+                                       epsilon=0.001, decay=0.001)
     _test_optimizer(new_adadelta, target=0.6)
     # test backward compatibility for adding opt.iterations.
     assert len(adadelta.get_weights()) == len(new_adadelta.get_weights())
@@ -137,7 +137,7 @@ def test_adam():
 def test_adamax():
     _test_optimizer(optimizers.Adamax(lr=0.002))
     _test_optimizer(optimizers.Adamax(lr=0.002, decay=1e-3))
-    _test_optimizer(optimizers.Adamax(learning_rate=0.002, epsilon=0.01, decay=0.1))
+    _test_optimizer(optimizers.Adamax(learning_rate=0.002, epsilon=0.001, decay=0.001))
 
 
 def test_nadam():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Changes:
1) epsilon has been removed from argument list, using default instead
   for future support of mixed precision. passing epsilon is still
   supported.
2) decay has been removed from argument list, for future support of
   learning rate decay objects. passing decay is still supported.
3) all lr has been changed to learning_rate. passing lr is still
   supported.
4) add initial_accumulator_value to Adagrad.
5) add momentum and centered to RMSprop.
6) Adam optimize won't have vhat if amsgrad is not present. set_weights
   is override to maintain backward compatibility.
7) Adadelta adds iterations to its weight list. set_weights is override
   to maintain backward compatibility.
8) Adagrad adds iterations to its weight list. set_weights is override
   to maintain backward compatibility.
9) RMSprop adds iterations to its weight list. set_weights is override
   to maintain backward compatibility.
10) Nadam changes default learning rate from 0.002 to 0.001
11) Adamax changes default learning rate from 0.002 to 0.001
12) Adadelta changes default learning rate from 1.0 to 0.001
13) Adagrad changes default learning rate from 0.01 to 0.001
### Related Issues

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [y] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
