### PR TITLE
Identity is not the same thing as equality in Python

### DIFF
--- a/keras/backend/numpy_backend.py
+++ b/keras/backend/numpy_backend.py
@@ -249,16 +249,10 @@ def in_train_phase(x, alt, training=None):
     if training is None:
         training = learning_phase()
 
-    if training is 1 or training is True:
-        if callable(x):
-            return x()
-        else:
-            return x
+    if training in (1, True):
+        return x() if callable(x) else x
     else:
-        if callable(alt):
-            return alt()
-        else:
-            return alt
+        return alt() if callable(alt) else alt
 
 
 def in_test_phase(x, alt, training=None):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3366,17 +3366,10 @@ def in_train_phase(x, alt, training=None):
     else:
         uses_learning_phase = False
 
-    if training is 1 or training is True:
-        if callable(x):
-            return x()
-        else:
-            return x
-
-    elif training is 0 or training is False:
-        if callable(alt):
-            return alt()
-        else:
-            return alt
+    if training in (1, True):
+        return x() if callable(x) else x
+    elif training in (0, False):
+        return alt() if callable(alt) else alt
 
     # else: assume learning phase is a placeholder tensor.
     x = switch(training, x, alt)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1690,17 +1690,10 @@ def in_train_phase(x, alt, training=None):
     else:
         uses_learning_phase = False
 
-    if training is 1 or training is True:
-        if callable(x):
-            return x()
-        else:
-            return x
-
-    elif training is 0 or training is False:
-        if callable(alt):
-            return alt()
-        else:
-            return alt
+    if training in (1, True):
+        return x() if callable(x) else x
+    elif training in (0, False):
+        return alt() if callable(alt) else alt
 
     if callable(x):
         x = x()

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -179,7 +179,7 @@ def test_node_construction():
     a_layer, a_node_index, a_tensor_index = a._keras_history
     b_layer, b_node_index, b_tensor_index = b._keras_history
     assert len(a_layer._inbound_nodes) == 1
-    assert a_tensor_index is 0
+    assert a_tensor_index == 0
     node = a_layer._inbound_nodes[a_node_index]
     assert node.outbound_layer == a_layer
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Use ==/!= to compare str, bytes, and int literals
### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

[flake8](http://flake8.pycqa.org) testing of https://github.com/keras-team/keras on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72 --show-source --statistics__
```
./keras/backend/numpy_backend.py:252:8: F632 use ==/!= to compare str, bytes, and int literals
    if training is 1 or training is True:
       ^
./keras/backend/tensorflow_backend.py:3369:8: F632 use ==/!= to compare str, bytes, and int literals
    if training is 1 or training is True:
       ^
./keras/backend/tensorflow_backend.py:3375:10: F632 use ==/!= to compare str, bytes, and int literals
    elif training is 0 or training is False:
         ^
./keras/backend/theano_backend.py:1693:8: F632 use ==/!= to compare str, bytes, and int literals
    if training is 1 or training is True:
       ^
./keras/backend/theano_backend.py:1699:10: F632 use ==/!= to compare str, bytes, and int literals
    elif training is 0 or training is False:
         ^
./tests/keras/engine/test_topology.py:182:12: F632 use ==/!= to compare str, bytes, and int literals
    assert a_tensor_index is 0
           ^
6     F632 use ==/!= to compare str, bytes, and int literals
6
```