### PR TITLE
Fix for issue #12868

### DIFF
--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -239,7 +239,7 @@ class Layer(object):
         initializer = initializers.get(initializer)
         if dtype is None:
             dtype = K.floatx()
-        weight = K.variable(initializer(shape),
+        weight = K.variable(initializer(shape, dtype=dtype),
                             dtype=dtype,
                             name=name,
                             constraint=constraint)


### PR DESCRIPTION
Setting initailizer dtype same as added weight dtype in Layer.add_weight method

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
