### PR TITLE
Modify TimeDistributed.call()

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -216,7 +216,7 @@ class TimeDistributed(Wrapper):
         if input_shape[0]:
             # batch size matters, use rnn-based implementation
             def step(x, _):
-                global uses_learning_phase
+                nonlocal uses_learning_phase
                 output = self.layer.call(x, **kwargs)
                 if hasattr(output, '_uses_learning_phase'):
                     uses_learning_phase = (output._uses_learning_phase or


### PR DESCRIPTION
The variable "uses_learning_phase" inside the function "step" should be the same as defined in the outer scope, not a new global variable.

Hence, nonlocal keyword instead of global keyword.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
