### PR TITLE
BugFix of "AttributeError: 'ProgbarLogger' object has no attribute 'target'" (or 'log_values') error (#12898) (#12893) (#8944)

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -549,16 +549,18 @@ class ProgbarLogger(Callback):
     # Raises
         ValueError: In case of invalid `count_mode`.
     """
-    verbose = None
-    epochs = None
-    log_values = None
-    target = 0
-    seen = 0
-    progbar = None
 
     def __init__(self, count_mode='samples',
                  stateful_metrics=None):
         super(ProgbarLogger, self).__init__()
+
+        self.verbose = None
+        self.epochs = None
+        self.log_values = None
+        self.target = 0
+        self.seen = 0
+        self.progbar = None
+
         if count_mode == 'samples':
             self.use_steps = False
         elif count_mode == 'steps':
@@ -574,9 +576,6 @@ class ProgbarLogger(Callback):
         self.verbose = self.params['verbose']
         self.epochs = self.params['epochs']
         self.log_values = []
-        if self.target is 0:
-            warnings.warn('%s count is 0 and this run will do noop' %
-                          ('steps' if self.use_steps else 'samples'))
 
     def on_epoch_begin(self, epoch, logs=None):
         if self.use_steps:

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -549,6 +549,12 @@ class ProgbarLogger(Callback):
     # Raises
         ValueError: In case of invalid `count_mode`.
     """
+    verbose = None
+    epochs = None
+    log_values = None
+    target = 0
+    seen = 0
+    progbar = None
 
     def __init__(self, count_mode='samples',
                  stateful_metrics=None):
@@ -567,19 +573,22 @@ class ProgbarLogger(Callback):
     def on_train_begin(self, logs=None):
         self.verbose = self.params['verbose']
         self.epochs = self.params['epochs']
+        self.log_values = []
+        if self.target is 0:
+            warnings.warn('%s count is 0 and this run will do noop' %
+                          ('steps' if self.use_steps else 'samples'))
 
     def on_epoch_begin(self, epoch, logs=None):
+        if self.use_steps:
+            self.target = self.params['steps']
+        else:
+            self.target = self.params['samples']
+        self.seen = 0
         if self.verbose:
             print('Epoch %d/%d' % (epoch + 1, self.epochs))
-            if self.use_steps:
-                target = self.params['steps']
-            else:
-                target = self.params['samples']
-            self.target = target
             self.progbar = Progbar(target=self.target,
                                    verbose=self.verbose,
                                    stateful_metrics=self.stateful_metrics)
-        self.seen = 0
 
     def on_batch_begin(self, batch, logs=None):
         if self.seen < self.target:

--- a/keras/engine/training_arrays.py
+++ b/keras/engine/training_arrays.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import numpy as np
 from scipy.sparse import issparse
+import warnings
 
 from .training_utils import batch_shuffle
 from .training_utils import check_num_samples
@@ -183,6 +184,9 @@ def fit_loop(model, fit_function, fit_inputs,
                 np.random.shuffle(index_array)
 
             batches = make_batches(num_train_samples, batch_size)
+            if len(batches) == 0:
+                warnings.warn('batches count is 0 and this run will do noop')
+            batch_index = 0
             for batch_index, (batch_start, batch_end) in enumerate(batches):
                 batch_ids = index_array[batch_start:batch_end]
                 try:

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -388,10 +388,11 @@ class Progbar(object):
                 sys.stdout.write('\n')
 
             if self.target is not None:
-                numdigits = int(np.floor(np.log10(self.target))) + 1
+                numdigits = int(np.floor(np.log10(self.target or 1))) + 1
                 barstr = '%%%dd/%d [' % (numdigits, self.target)
                 bar = barstr % current
-                prog = float(current) / self.target
+                # if target is 0 we considering progress as auto-completed (1.0)
+                prog = (float(current) / self.target) if self.target else 1.0
                 prog_width = int(self.width * prog)
                 if prog_width > 0:
                     bar += ('=' * (prog_width - 1))


### PR DESCRIPTION
This Change set is fixing two missing attribute bugs in `callback.ProgbarLogger` class
* AttributeError: 'ProgbarLogger' object has no attribute 'target' #12898
  Abstract reproduction scenario is provided in ticket
* AttributeError: 'ProgbarLogger' object has no attribute 'log_values' #3657
* AttributeError: 'ProgbarLogger' object has no attribute 'log_values' #8944 (dup)

Related changes:
* Cases of regression are covered by tests.
* Some potential bugs with same nature are prevented and covered by manifestation checks.
* run with empty data array (but having valid shape) is now handled properly
  and yielding related warnings on callback and training routine level without execution fail

Note:
Changes that affect `ProgbarLogger` should be aware of following things:
* proper target initialisation is requiring two attributes: `params` and `use_steps` to be defined
* `use_steps` is guaranteed attribute the is set in the constructor (but could be altered after object instantiation. It's currently safe condition.
* class `params` attribute could be altered between initialisation and training start. And current logic is made to be aware of this
* we don't have `params` initialisation in constructor, this attribute will be assigned on call of `set_params` of base class somewhere on caller level (no strict guarantees :( )
* `seen` attribute is working in pair with `target` during `log_values` initialisation and their initialisation should be under the equal condition, currently thats not true
* `if self.seen < self.target` condition is being checked whenever verbose mode value so both of them should be initialised without any conditions
* `if self.seen < self.target` is checking for training iteration being not finished but in case of degenerate case with zero length it will not be called and `log_values` will stay not initialised but i don't see any explicit logic preventing using it on exit from 0-length training cycle and potentially it is the bug of some kind that is prevented on caller logic level
* `progbar` attribute initialisation is definitely related to output verbosity (log values accumulation are not) and should be left under verbosity condition

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
