### PR TITLE
Modify TimeDistributed.call(). Edited PR#12881

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -207,6 +207,7 @@ class TimeDistributed(Wrapper):
         return (child_output_shape[0], timesteps) + child_output_shape[1:]
 
     def call(self, inputs, training=None, mask=None):
+        global uses_learning_phase
         kwargs = {}
         if has_arg(self.layer.call, 'training'):
             kwargs['training'] = training


### PR DESCRIPTION
The variable "uses_learning_phase" inside the function "step" should be the same as defined in the outer scope.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
