### PR TITLE
More intuitive dilated kernel size calculation

### DIFF
--- a/keras/utils/conv_utils.py
+++ b/keras/utils/conv_utils.py
@@ -99,7 +99,7 @@ def conv_output_length(input_length, filter_size,
     if input_length is None:
         return None
     assert padding in {'same', 'valid', 'full', 'causal'}
-    dilated_filter_size = filter_size + (filter_size - 1) * (dilation - 1)
+    dilated_filter_size = (filter_size - 1) * dilation + 1
     if padding == 'same':
         output_length = input_length
     elif padding == 'valid':
@@ -157,7 +157,7 @@ def deconv_length(dim_size, stride_size, kernel_size, padding,
         return None
 
     # Get the dilated kernel size
-    kernel_size = kernel_size + (kernel_size - 1) * (dilation - 1)
+    kernel_size = (kernel_size - 1) * dilation + 1
 
     # Infer length if output padding is None, else compute the exact length
     if output_padding is None:


### PR DESCRIPTION
When we dilate a kernel of size N by D we take N - 1 steps of size D and finally sample 1 more pixel, hence (N - 1) * D + 1.

The math remains the same:
size = filter_size + (filter_size - 1) * (dilation - 1)
size = x + (x - 1) * (y - 1)
size = x + (x * y - x - y + 1)
size = x * y - y + 1
size = (x - 1) * y + 1
size = (filter_size - 1) * dilation + 1

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
