### PR TITLE
Ingore `xla_gpu` which is specially reserved by TF

### DIFF
--- a/keras/utils/multi_gpu_utils.py
+++ b/keras/utils/multi_gpu_utils.py
@@ -153,7 +153,7 @@ def multi_gpu_model(model, gpus=None, cpu_merge=True, cpu_relocation=False):
     if not gpus:
         # Using all visible GPUs when not specifying `gpus`
         # e.g. CUDA_VISIBLE_DEVICES=0,2 python keras_mgpu.py
-        gpus = len([x for x in available_devices if 'gpu' in x])
+        gpus = len([x for x in available_devices if '/gpu:' in x])
 
     if isinstance(gpus, (list, tuple)):
         if len(gpus) <= 1:


### PR DESCRIPTION
### Summary

If building TF with XLA option enabled, an additional
`xla_gpu:0` device will be exposed to users which is a domain
for running graph in XLA mode. Should skip this device to
avoid the number of multi_gpu improperly inferred.

### Related Issues

https://github.com/keras-team/keras/issues/11644

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
