### PR TITLE
Adding weighted_metrics to model loading/saving

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -319,6 +319,7 @@ def _deserialize_model(h5dict, custom_objects=None, compile=True):
         # Recover loss functions and metrics.
         loss = convert_custom_objects(training_config['loss'])
         metrics = convert_custom_objects(training_config['metrics'])
+        weighted_metrics = convert_custom_objects(training_config['weighted_metrics'])
         sample_weight_mode = training_config['sample_weight_mode']
         loss_weights = training_config['loss_weights']
 
@@ -326,6 +327,7 @@ def _deserialize_model(h5dict, custom_objects=None, compile=True):
         model.compile(optimizer=optimizer,
                       loss=loss,
                       metrics=metrics,
+                      weighted_metrics=weighted_metrics,
                       loss_weights=loss_weights,
                       sample_weight_mode=sample_weight_mode)
 

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -319,7 +319,9 @@ def _deserialize_model(h5dict, custom_objects=None, compile=True):
         # Recover loss functions and metrics.
         loss = convert_custom_objects(training_config['loss'])
         metrics = convert_custom_objects(training_config['metrics'])
-        weighted_metrics = convert_custom_objects(training_config['weighted_metrics'])
+        # Earlier versions of keras didn't dump weighted_metrics properly. Use
+        # a get to avoid failing if the key is missing
+        weighted_metrics = convert_custom_objects(training_config.get('weighted_metrics'))
         sample_weight_mode = training_config['sample_weight_mode']
         loss_weights = training_config['loss_weights']
 

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -321,7 +321,8 @@ def _deserialize_model(h5dict, custom_objects=None, compile=True):
         metrics = convert_custom_objects(training_config['metrics'])
         # Earlier versions of keras didn't dump weighted_metrics properly. Use
         # a get to avoid failing if the key is missing
-        weighted_metrics = convert_custom_objects(training_config.get('weighted_metrics'))
+        weighted_metrics = convert_custom_objects(
+            training_config.get('weighted_metrics'))
         sample_weight_mode = training_config['sample_weight_mode']
         loss_weights = training_config['loss_weights']
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
`weighted_metrics` were not being properly serialized during saving or examined-for during loading. This patch adds `weighted_metrics` to `training_config`, and seeks `weighted_metrics` when constructing a model from a h5. A `get` is used instead of standard `__getitem__` because older versions of keras would lack this field in `training_config` and then fail on load.

### Related Issues
Fixes  #10221 .

### PR Overview

- [ N ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ N ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ Y ] This PR is backwards compatible [y/n]
- [ N ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
