### PR TITLE
Sync up with keras-applications

### DIFF
--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -212,7 +212,7 @@ Xception V1 model, with weights pre-trained on ImageNet.
 On ImageNet, this model gets to a top-1 validation accuracy of 0.790
 and a top-5 validation accuracy of 0.945.
 
-Note that this model only supports the data format `'channels_last'` (height, width, channels).
+This model and can be built both with `'channels_first'` data format (channels, height, width) or `'channels_last'` data format (height, width, channels).
 
 The default input size for this model is 299x299.
 
@@ -555,7 +555,7 @@ keras.applications.mobilenet.MobileNet(input_shape=None, alpha=1.0, depth_multip
 
 MobileNet model, with weights pre-trained on ImageNet.
 
-Note that this model only supports the data format `'channels_last'` (height, width, channels).
+This model and can be built both with `'channels_first'` data format (channels, height, width) or `'channels_last'` data format (height, width, channels).
 
 The default input size for this model is 224x224.
 
@@ -747,7 +747,7 @@ keras.applications.mobilenet_v2.MobileNetV2(input_shape=None, alpha=1.0, include
 
 MobileNetV2 model, with weights pre-trained on ImageNet.
 
-Note that this model only supports the data format `'channels_last'` (height, width, channels).
+This model and can be built both with `'channels_first'` data format (channels, height, width) or `'channels_last'` data format (height, width, channels).
 
 The default input size for this model is 224x224.
 


### PR DESCRIPTION
### Summary

This PR revises the autogen template in order to sync up with keras-team/keras-applications#96. Users can deploy Xception, MobileNet, and MobileNetV2 for channels_first since the `1.0.8` of keras-applications.