### PR TITLE
load_weights() now properly closes file

### DIFF
--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -1215,6 +1215,10 @@ class Network(Layer):
             else:
                 saving.load_weights_from_hdf5_group(
                     f, self.layers, reshape=reshape)
+            if hasattr(f, 'close'):
+                f.close()
+            elif hasattr(f.file, 'close'):
+                f.file.close()
 
     def _updated_config(self):
         """Util hared between different serialization methods.


### PR DESCRIPTION
### Summary
In certain use cases, load_weights() would cause OSError if called repeatedly on several different files. The proposed addition will now make sure the HDF5 files are closed before exiting the method.
Fixes #4361

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
