### PR TITLE
Adding support for variable batch_size for fit_generator()

### DIFF
--- a/keras/engine/training_generator.py
+++ b/keras/engine/training_generator.py
@@ -259,10 +259,13 @@ def fit_generator(model,
             # If generator is an instance of `keras.utils.Sequence`
             if use_sequence_api:
                 # If `on_epoch_end` method is implemented
-                if hasattr(generator,'on_epoch_end'):
+                if hasattr(generator , 'on_epoch_end'):
                     # Call `on_epoch_end` here instead of doing it inside
                     # `_run()` method in OrderedEnqueuer
-                    generator.on_epoch_end(epoch)
+                    try:
+                        generator.on_epoch_end(epoch)
+                    except TypeError: # If doesn't take epoch as parameter
+                        generator.on_epoch_end()
                 # Recomute steps_per_epochs in case if Sequence changes it's length
                 steps_per_epoch = len(generator)
                 # Update progress bar 

--- a/keras/engine/training_generator.py
+++ b/keras/engine/training_generator.py
@@ -50,6 +50,11 @@ def fit_generator(model,
                         ' and multiple workers may duplicate your data.'
                         ' Please consider using the `keras.utils.Sequence'
                         ' class.'))
+    
+    # If steps_per_epoch is provided initially, we won't recompute
+    # steps_per_epoch everytime, else recompute
+    recompute_steps_per_epoch = not steps_per_epoch
+
     if steps_per_epoch is None:
         if use_sequence_api:
             steps_per_epoch = len(generator)
@@ -257,18 +262,19 @@ def fit_generator(model,
             if callbacks.model.stop_training:
                 break
             # If generator is an instance of `keras.utils.Sequence`
-            if use_sequence_api:
+            if recompute_steps_per_epoch and use_sequence_api:
                 # If `on_epoch_end` method is implemented
-                if hasattr(generator , 'on_epoch_end'):
+                if hasattr(generator, 'on_epoch_end'):
                     # Call `on_epoch_end` here instead of doing it inside
                     # `_run()` method in OrderedEnqueuer
                     try:
                         generator.on_epoch_end(epoch)
-                    except TypeError: # If doesn't take epoch as parameter
+                    except TypeError:
+                        # If doesn't take epoch as parameter
                         generator.on_epoch_end()
                 # Recomute steps_per_epochs in case if Sequence changes it's length
                 steps_per_epoch = len(generator)
-                # Update progress bar 
+                # Update progress bar
                 # (Need api to set single parameter instead of passing all)
                 callbacks.set_params({
                     'epochs': epochs,

--- a/keras/engine/training_generator.py
+++ b/keras/engine/training_generator.py
@@ -256,6 +256,24 @@ def fit_generator(model,
             epoch += 1
             if callbacks.model.stop_training:
                 break
+            # If generator is an instance of `keras.utils.Sequence`
+            if use_sequence_api:
+                # If `on_epoch_end` method is implemented
+                if hasattr(generator,'on_epoch_end'):
+                    # Call `on_epoch_end` here instead of doing it inside
+                    # `_run()` method in OrderedEnqueuer
+                    generator.on_epoch_end(epoch)
+                # Recomute steps_per_epochs in case if Sequence changes it's length
+                steps_per_epoch = len(generator)
+                # Update progress bar 
+                # (Need api to set single parameter instead of passing all)
+                callbacks.set_params({
+                    'epochs': epochs,
+                    'steps': steps_per_epoch,
+                    'verbose': verbose,
+                    'do_validation': do_validation,
+                    'metrics': callback_metrics,
+                })
 
     finally:
         try:

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -561,9 +561,12 @@ class OrderedEnqueuer(SequenceEnqueuer):
 
     def _run(self):
         """Submits request to the executor and queue the `Future` objects."""
-        sequence = list(range(len(self.sequence)))
         self._send_sequence()  # Share the initial sequence
         while True:
+            # Calculate sequence length each time because of changing
+            # batch_size(if applied)
+            sequence = list(range(len(self.sequence)))
+
             if self.shuffle:
                 random.shuffle(sequence)
 
@@ -583,7 +586,9 @@ class OrderedEnqueuer(SequenceEnqueuer):
                     return
 
             # Call the internal on epoch end.
-            self.sequence.on_epoch_end()
+            # Don't call `sequence.on_epoch_end()` here and instead call
+            # it in `fit_generator` after each epoch.
+            # self.sequence.on_epoch_end()
             self._send_sequence()  # Update the pool
 
     def get(self):


### PR DESCRIPTION
### Summary
We have callbacks such as `LearningRateScheduler`, etc. to get a view on internal states and statistics of the model during training. Similarly, I would like to propose a feature that allows generators (of type `keras.utils.Sequence` specifically) to be able to change the `batch_size` between different epochs during training only i.e inside `fit_generator`. There’s no change in `evaluate_generator` or `predict_generator` routine.

### Related Issues
#10143
#13038

### PR Overview

- [N] This PR requires new unit tests [y/n] (make sure tests are included)
- [N] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [Y] This PR is backwards compatible [y/n]
- [N] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

A complete proposal of this PR along with coding examples is submitted to keras-user google groups
Direct link to the proposal: https://docs.google.com/document/d/1G5epNPN17MVuKvlAEM8suZmoXDI8Vv1DTXntlILljac/edit?usp=drive_web
