### PR TITLE
Allow unrolled RNNs with input_length=1

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1489,7 +1489,7 @@ def rnn(step_function, inputs, initial_states,
                              'an `input_length` '
                              'must be provided to `rnn`.')
         if input_length == 1:
-            raise ValueError('`input_length=1` is not
+            raise ValueError('`input_length=1` is not'
                              ' supported when `unroll=True`.')
 
     axes = [1, 0] + list(range(2, ndim))

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1484,10 +1484,13 @@ def rnn(step_function, inputs, initial_states,
     assert ndim >= 3, 'Input should be at least 3D.'
 
     if unroll:
-        if input_length is None:
+        if input_length is None]:
             raise ValueError('When specifying `unroll=True`, '
                              'an `input_length` '
                              'must be provided to `rnn`.')
+        if input_length == 1:
+            raise ValueError('`input_length=1` is not
+                             ' supported when `unroll=True`.')
 
     axes = [1, 0] + list(range(2, ndim))
     inputs = inputs.dimshuffle(axes)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1484,7 +1484,7 @@ def rnn(step_function, inputs, initial_states,
     assert ndim >= 3, 'Input should be at least 3D.'
 
     if unroll:
-        if input_length is None]:
+        if input_length is None:
             raise ValueError('When specifying `unroll=True`, '
                              'an `input_length` '
                              'must be provided to `rnn`.')

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -610,9 +610,9 @@ class RNN(Layer):
                              ' initial states.')
         input_shape = K.int_shape(inputs)
         timesteps = input_shape[1]
-        if self.unroll and timesteps in [None, 1]:
+        if self.unroll and timesteps is None:
             raise ValueError('Cannot unroll a RNN if the '
-                             'time dimension is undefined or equal to 1. \n'
+                             'time dimension is undefined. \n'
                              '- If using a Sequential model, '
                              'specify the time dimension by passing '
                              'an `input_shape` or `batch_input_shape` '

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -209,8 +209,11 @@ def check_rnn_operation(step_function_k,
         constants=constants_np,
         **kwargs)
     # note that numpy reference implementation is independent of `unroll` argument
-
-    for unroll in [True, False]:
+    if 'unroll' in kwargs:
+        unroll_options = [kwargs.pop('unroll')]
+    else:
+        unroll_options = [True, False]
+    for unroll in unroll_options:
         last_output_k, output_k, last_states_k = K.rnn(
             step_function_k,
             inputs_k,
@@ -769,6 +772,43 @@ class TestBackend(object):
                                 inputs_np=x,
                                 initial_states_np=[h0],
                                 mask_np=kwargs.pop('mask', None),
+                                **kwargs)
+
+    def test_rnn_unroll_with_len_1(self):
+        # implement a simple RNN
+        num_samples = 4
+        input_dim = 5
+        output_dim = 3
+        timesteps = 6
+
+        _, x = parse_shape_or_val((num_samples, 1, input_dim))
+        _, h0 = parse_shape_or_val((num_samples, output_dim))
+        _, wi = parse_shape_or_val((input_dim, output_dim))
+        _, wh = parse_shape_or_val((output_dim, output_dim))
+
+        wi_k = K.variable(wi)
+        wh_k = K.variable(wh)
+
+        def get_step_function(backend, w_i, w_h):
+
+            def simple_rnn(inputs, states):
+                assert len(states) == 1
+                h = states[0]
+                y = backend.dot(inputs, w_i) + backend.dot(h, w_h)
+                return y, [y]
+
+            return simple_rnn
+
+        kwargs_list = [
+            {'go_backwards': False},
+            {'go_backwards': True},
+        ]
+        for kwargs in kwargs_list:
+            check_rnn_operation(step_function_k=get_step_function(K, wi_k, wh_k),
+                                step_function_np=get_step_function(KNP, wi, wh),
+                                inputs_np=x,
+                                initial_states_np=[h0],
+                                unroll=True,
                                 **kwargs)
 
     def test_rnn_additional_states(self):

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -775,11 +775,9 @@ class TestBackend(object):
                                 **kwargs)
 
     def test_rnn_unroll_with_len_1(self):
-        # implement a simple RNN
         num_samples = 4
         input_dim = 5
         output_dim = 3
-        timesteps = 6
 
         _, x = parse_shape_or_val((num_samples, 1, input_dim))
         _, h0 = parse_shape_or_val((num_samples, output_dim))

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -773,7 +773,7 @@ class TestBackend(object):
                                 initial_states_np=[h0],
                                 mask_np=kwargs.pop('mask', None),
                                 **kwargs)
-
+    @pytest.mark.skipif(K.backend() == 'theano', reason='Not supported')
     def test_rnn_unroll_with_len_1(self):
         num_samples = 4
         input_dim = 5

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -2113,5 +2113,6 @@ class TestBackend(object):
             assert cfg.intra_op_parallelism_threads == threads
             assert cfg.inter_op_parallelism_threads == threads
 
+
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -773,6 +773,7 @@ class TestBackend(object):
                                 initial_states_np=[h0],
                                 mask_np=kwargs.pop('mask', None),
                                 **kwargs)
+
     @pytest.mark.skipif(K.backend() == 'theano', reason='Not supported')
     def test_rnn_unroll_with_len_1(self):
         num_samples = 4


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

Allow unrolling RNNs with input_length=1. For e.g, this is required to deploy seqseq models on mobile (tflite doesnt support symbolic loop)

### Related Issues

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
