### PR TITLE
Handled StopIteration exception

### DIFF
--- a/keras/engine/training_generator.py
+++ b/keras/engine/training_generator.py
@@ -176,8 +176,7 @@ def fit_generator(model,
                 m.reset_states()
             callbacks.on_epoch_begin(epoch)
             steps_done = 0
-            batch_index = 0
-            
+            batch_index = 0            
             try:
                 while steps_done < steps_per_epoch:
                     generator_output = next(output_generator)
@@ -221,7 +220,6 @@ def fit_generator(model,
                         batch_logs[l] = o
 
                     callbacks._call_batch_hook('train', 'end', batch_index, batch_logs)
-
                     batch_index += 1
                     steps_done += 1
 

--- a/keras/engine/training_generator.py
+++ b/keras/engine/training_generator.py
@@ -176,7 +176,7 @@ def fit_generator(model,
                 m.reset_states()
             callbacks.on_epoch_begin(epoch)
             steps_done = 0
-            batch_index = 0            
+            batch_index = 0
             try:
                 while steps_done < steps_per_epoch:
                     generator_output = next(output_generator)
@@ -219,7 +219,8 @@ def fit_generator(model,
                     for l, o in zip(out_labels, outs):
                         batch_logs[l] = o
 
-                    callbacks._call_batch_hook('train', 'end', batch_index, batch_logs)
+                    callbacks._call_batch_hook('train', 'end', batch_index,
+                                               batch_logs)
                     batch_index += 1
                     steps_done += 1
 


### PR DESCRIPTION
### Summary
Added `try-except` block to handle the  `StopIteration` exception in the `fit_generator` method itself.  We have to estimate to estimate the `max_queue_size` parameter of `fit_generator` beforehand, otherwise the training is stopped abruptly throwing a `StopIteration` when the `max_queue_size` parameter is passed incorrectly.
### PR Overview
- This PR is backwards compatible
