### PR TITLE
Add documentation for Model._make_predict_function

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1311,6 +1311,11 @@ class Model(Network):
 
         Computation is done in batches.
 
+        Note: the internal prediction function is not compiled until the first
+        call to `Model.predict`. If you are using `Model.predict` in a
+        multi-threaded environment, you should explicitly call
+        `Model._make_predict_function` first to avoid problems.
+
         # Arguments
             x: Input data. It could be:
                 - A Numpy array (or array-like), or a list of arrays


### PR DESCRIPTION
# Summary

This documents the `keras.Model._make_predict_function` method, which is necessary for `keras.Model.predict` to function correctly in threads.

### Related Issues

Lots of people were looking for documentation on this function and could not find it. See this issue:

https://github.com/keras-team/keras/issues/6124

and this stack overflow thread:

https://stackoverflow.com/a/43393252

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)