### PR TITLE
RNN initial state: bug fix + suppress false warning

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -595,6 +595,18 @@ class RNN(Layer):
                 initial_state = inputs[1:]
             else:
                 initial_state = inputs[1:-self._num_constants]
+                if constants is None:
+                    constants = inputs[-self._num_constants:]
+                elif len(inputs) > 1 + len(initial_state):
+                    raise ValueError('Layer expected ' + str(self._num_constants) +
+                                     'constants but was passed ' +
+                                     str(len(inputs[-self._num_constants]) +
+                                     len(constants)) +
+                                     'constants.')
+                elif len(constants) != self._num_constants:
+                    raise ValueError('Layer expected ' + str(self._num_constants) +
+                                     'constants but was passed ' +
+                                     str(len(constants)) + 'constants.')             
             if len(initial_state) == 0:
                 initial_state = None
             inputs = inputs[0]

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -538,14 +538,21 @@ class RNN(Layer):
 
         additional_inputs = []
         additional_specs = []
+
+        # tensors and variables are non-serializable and has to be popped
+        # from node arguments to suppress false warning
+
+        args_to_pop = []
         if initial_state is not None:
             kwargs['initial_state'] = initial_state
+            args_to_pop.append('initial_state')
             additional_inputs += initial_state
             self.state_spec = [InputSpec(shape=K.int_shape(state))
                                for state in initial_state]
             additional_specs += self.state_spec
         if constants is not None:
             kwargs['constants'] = constants
+            args_to_pop.append('constants')
             additional_inputs += constants
             self.constants_spec = [InputSpec(shape=K.int_shape(constant))
                                    for constant in constants]
@@ -570,6 +577,8 @@ class RNN(Layer):
             self.input_spec = full_input_spec
             output = super(RNN, self).__call__(full_input, **kwargs)
             self.input_spec = original_input_spec
+            for arg in args_to_pop:
+                self._inbound_nodes[-1].arguments.pop(arg)
             return output
         else:
             return super(RNN, self).__call__(inputs, **kwargs)

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -539,20 +539,14 @@ class RNN(Layer):
         additional_inputs = []
         additional_specs = []
 
-        # tensors and variables are non-serializable and has to be popped
-        # from node arguments to suppress false warning
-
-        args_to_pop = []
         if initial_state is not None:
             kwargs['initial_state'] = initial_state
-            args_to_pop.append('initial_state')
             additional_inputs += initial_state
             self.state_spec = [InputSpec(shape=K.int_shape(state))
                                for state in initial_state]
             additional_specs += self.state_spec
         if constants is not None:
             kwargs['constants'] = constants
-            args_to_pop.append('constants')
             additional_inputs += constants
             self.constants_spec = [InputSpec(shape=K.int_shape(constant))
                                    for constant in constants]
@@ -575,10 +569,12 @@ class RNN(Layer):
             # Perform the call with temporarily replaced input_spec
             original_input_spec = self.input_spec
             self.input_spec = full_input_spec
+            if 'initial_state' in kwargs:
+                kwargs.pop('initial_state')
+            if 'constants' in kwargs:
+                kwargs.pop('constants')
             output = super(RNN, self).__call__(full_input, **kwargs)
             self.input_spec = original_input_spec
-            for arg in args_to_pop:
-                self._inbound_nodes[-1].arguments.pop(arg)
             return output
         else:
             return super(RNN, self).__call__(inputs, **kwargs)

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -477,6 +477,10 @@ class Bidirectional(Wrapper):
             # Perform the call with temporarily replaced input_spec
             original_input_spec = self.input_spec
             self.input_spec = full_input_spec
+            if 'initial_state' in kwargs:
+                kwargs.pop('initial_state')
+            if 'constants' in kwargs:
+                kwargs.pop('constants')
             output = super(Bidirectional, self).__call__(full_input, **kwargs)
             self.input_spec = original_input_spec
             return output
@@ -495,31 +499,28 @@ class Bidirectional(Wrapper):
         if has_arg(self.layer.call, 'mask'):
             kwargs['mask'] = mask
         if has_arg(self.layer.call, 'constants'):
+            if self._num_constants is not None and constants is None:
+                    constants = inputs[-self._num_constants:]
+                    inputs = inputs[:-self._num_constants]
             kwargs['constants'] = constants
-
-        if initial_state is not None and has_arg(self.layer.call, 'initial_state'):
-            forward_inputs = [inputs[0]]
-            backward_inputs = [inputs[0]]
-            pivot = len(initial_state) // 2 + 1
-            # add forward initial state
-            forward_state = inputs[1:pivot]
-            forward_inputs += forward_state
-            if self._num_constants is None:
-                # add backward initial state
-                backward_state = inputs[pivot:]
-                backward_inputs += backward_state
+        if has_arg(self.layer.call, 'initial_state'):
+            if initial_state is None and len(inputs) > 1:
+                    initial_state = inputs[1:]
+                    inputs = [inputs[0]]
+            if initial_state is None:
+                forward_state = None
+                backward_state = None
             else:
-                # add backward initial state
-                backward_state = inputs[pivot:-self._num_constants]
-                backward_inputs += backward_state
-                # add constants for forward and backward layers
-                forward_inputs += inputs[-self._num_constants:]
-                backward_inputs += inputs[-self._num_constants:]
-            y = self.forward_layer.call(forward_inputs,
+                pivot = len(initial_state) // 2
+                forward_state = initial_state[:pivot]
+                backward_state = initial_state[pivot:]
+            y = self.forward_layer.call(inputs,
                                         initial_state=forward_state, **kwargs)
-            y_rev = self.backward_layer.call(backward_inputs,
+            y_rev = self.backward_layer.call(inputs,
                                              initial_state=backward_state, **kwargs)
         else:
+            if len(inputs) > 1 or initial_state is not None:
+                raise ValueError('Layer does not accept initial_state argument.')
             y = self.forward_layer.call(inputs, **kwargs)
             y_rev = self.backward_layer.call(inputs, **kwargs)
 

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -504,9 +504,12 @@ class Bidirectional(Wrapper):
                     inputs = inputs[:-self._num_constants]
             kwargs['constants'] = constants
         if has_arg(self.layer.call, 'initial_state'):
-            if initial_state is None and len(inputs) > 1:
-                    initial_state = inputs[1:]
-                    inputs = [inputs[0]]
+            if isinstance(inputs, list) and len(inputs) > 1:
+                if initial_state is not None:
+                    raise ValueError('Layer was passed initial state ' +
+                                     'via both kwarg and inputs list)')
+                initial_state = inputs[1:]
+                inputs = [inputs[0]]
             if initial_state is None:
                 forward_state = None
                 backward_state = None
@@ -519,7 +522,7 @@ class Bidirectional(Wrapper):
             y_rev = self.backward_layer.call(inputs,
                                              initial_state=backward_state, **kwargs)
         else:
-            if len(inputs) > 1 or initial_state is not None:
+            if isinstance(inputs, list) and len(inputs) > 1 or initial_state:
                 raise ValueError('Layer does not accept initial_state argument.')
             y = self.forward_layer.call(inputs, **kwargs)
             y_rev = self.backward_layer.call(inputs, **kwargs)

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -3,6 +3,7 @@ import pytest
 import os
 import h5py
 import tempfile
+import warnings
 from contextlib import contextmanager
 import numpy as np
 from numpy.testing import assert_allclose
@@ -951,6 +952,37 @@ def test_preprocess_weights_for_loading_gru_incompatible():
     assert_not_compatible(gru(reset_after=True), gru(),
                           'GRU(reset_after=True) is not compatible with '
                           'GRU(reset_after=False)')
+
+
+def test_model_saving_with_rnn_initial_state_and_args():
+    class CustomRNN(LSTM):
+        def call(self, inputs, arg=1, mask=None, training=None, initial_state=None):
+            if isinstance(inputs, list):
+                inputs = inputs.copy()
+                inputs[0] *= arg
+            else:
+                inputs *= arg
+            return super(CustomRNN, self).call(inputs, mask, training, initial_state)
+
+    inp = Input((3, 2))
+    rnn_out, h, c = CustomRNN(2, return_state=True, return_sequences=True)(inp)
+    assert hasattr(rnn_out, '_keras_history')
+    assert hasattr(h, '_keras_history')
+    assert hasattr(c, '_keras_history')
+    rnn2_out = CustomRNN(2)(rnn_out, arg=2, initial_state=[h, c])
+    assert hasattr(rnn2_out, '_keras_history')
+    model = Model(inputs=inp, outputs=rnn2_out)
+    x = np.random.random((2, 3, 2))
+    y1 = model.predict(x)
+    _, fname = tempfile.mkstemp('.h5')
+    with warnings.catch_warnings():
+        warnings.filterwarnings('False serialization warning raised!')
+        model.save(fname)
+    model2 = load_model(fname, custom_objects={'CustomRNN': CustomRNN})
+    y2 = model2.predict(x)
+    assert_allclose(y1, y2, atol=1e-5)
+    os.remove(fname)
+
 
 
 if __name__ == '__main__':

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -963,7 +963,7 @@ def test_model_saving_with_rnn_initial_state_and_args():
                 inputs[0] *= arg
                 inputs[0]._keras_shape = shape  # for theano backend
             else:
-                shape = K.int_shape(inputs[0])
+                shape = K.int_shape(inputs)
                 inputs *= arg
                 inputs._keras_shape = shape  # for theano backend
             return super(CustomRNN, self).call(inputs, mask, training, initial_state)

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -959,9 +959,13 @@ def test_model_saving_with_rnn_initial_state_and_args():
         def call(self, inputs, arg=1, mask=None, training=None, initial_state=None):
             if isinstance(inputs, list):
                 inputs = inputs[:]
+                shape = K.int_shape(inputs[0])
                 inputs[0] *= arg
+                inputs[0]._keras_shape = shape  # for theano backend
             else:
+                shape = K.int_shape(inputs[0])
                 inputs *= arg
+                inputs._keras_shape = shape  # for theano backend
             return super(CustomRNN, self).call(inputs, mask, training, initial_state)
 
     inp = Input((3, 2))

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -984,6 +984,5 @@ def test_model_saving_with_rnn_initial_state_and_args():
     os.remove(fname)
 
 
-
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -958,7 +958,7 @@ def test_model_saving_with_rnn_initial_state_and_args():
     class CustomRNN(LSTM):
         def call(self, inputs, arg=1, mask=None, training=None, initial_state=None):
             if isinstance(inputs, list):
-                inputs = inputs.copy()
+                inputs = inputs[:]
                 inputs[0] *= arg
             else:
                 inputs *= arg
@@ -976,7 +976,7 @@ def test_model_saving_with_rnn_initial_state_and_args():
     y1 = model.predict(x)
     _, fname = tempfile.mkstemp('.h5')
     with warnings.catch_warnings():
-        warnings.filterwarnings('False serialization warning raised!')
+        warnings.filterwarnings('error')
         model.save(fname)
     model2 = load_model(fname, custom_objects={'CustomRNN': CustomRNN})
     y2 = model2.predict(x)


### PR DESCRIPTION

### Summary
1 - Suppresses a false warning when serializing models containing RNNs with initial state (makes people think seq2seq models are not serializable)

2 - Makes custom RNNs with extra args in `call()` serializable when an initial state is also provided (super niche, I know)

### Related Issues

#9914 
[StackOverflow Saving Keras model - UserWarning: Layer XX was passed non-serializable keyword arguments](https://stackoverflow.com/questions/53761145)

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
