### PR TITLE
For better performance

### DIFF
--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -37,9 +37,9 @@ class L1L2(Regularizer):
     def __call__(self, x):
         regularization = 0.
         if self.l1:
-            regularization += K.sum(self.l1 * K.abs(x))
+            regularization += self.l1 * K.sum(K.abs(x))
         if self.l2:
-            regularization += K.sum(self.l2 * K.square(x))
+            regularization += self.l2 * K.sum(K.square(x))
         return regularization
 
     def get_config(self):


### PR DESCRIPTION
move self.l1 and self.l2 outside K.sum may increase the performance of calculating the norm.
In deep learning, the norm should not be very large (a large norm will make loss function useless), so move self.l1 and self.l2 outside K.sum will not cause overflow problem.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
