### PR TITLE
added keep_best_only for ModelCheckpoint in callbacks

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -649,12 +649,6 @@ class ModelCheckpoint(Callback):
         save_best_only: if `save_best_only=True`,
             the latest best model according to
             the quantity monitored will not be overwritten.
-        keep_best_only: If `keep_best_only=True`,
-            only the best saved model according to
-            the quantity monitored will be kept.
-            All other saved models will be deleted.
-            `keep_best_only=True` is only
-            allowed together with `save_best_only=True`.
         save_weights_only: if True, then only the model's weights will be
             saved (`model.save_weights(filepath)`), else the full model
             is saved (`model.save(filepath)`).
@@ -667,6 +661,12 @@ class ModelCheckpoint(Callback):
             be `min`, etc. In `auto` mode, the direction is
             automatically inferred from the name of the monitored quantity.
         period: Interval (number of epochs) between checkpoints.
+        keep_best_only: If `keep_best_only=True`,
+            only the best saved model according to
+            the quantity monitored will be kept.
+            All other saved models will be deleted.
+            `keep_best_only=True` is only
+            allowed together with `save_best_only=True`.
     """
 
     def __init__(self, filepath, monitor='val_loss', verbose=0,


### PR DESCRIPTION
### Summary
When using `ModelCheckpoint` with `save_best_only=True` only the best model is saved. When you specify the filename with `weights.{epoch:02d}-{val_loss:.2f}.hdf5` a history of best models is saved. This can make things confusing and is not wanted in all cases. That's why I added the `keep_best_only` option. Its default is `False` so nothing is changed in the behavior of `ModelCheckpoint`. When you set `keep_best_only=True` then the history of best model files is deleted and only the best is kept.

### Related Issues
None (see Summary).

### PR Overview
- Tests have been added
- Doctring is written
- pep8 checks done

The network for tests had to be increased in size so the model learns for more then one epoch. Otherwise the model would only be saved once and the test if old model filed are deleted can not be done.

`filepath` in case 5 of test was fixed because it did not use the `tmpdir`.

### Checklist
- [yes / done] This PR requires new unit tests [y]
- [not needed] This PR requires to update the documentation [n]
- [yes] This PR is backwards compatible [y]
- [yes and no] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
