### PR TITLE
pep8 config in setup.cfg for easy pep8 linter usage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [metadata]
 description-file = README.md
+
+[pep8]
+ignore = E402,E731,W503
+max-line-length = 85


### PR DESCRIPTION
To be able to use the pep8 linter (with vscode for example) I added the pep8 config to setup.cfg as described here: https://pep8.readthedocs.io/en/release-1.7.x/intro.html?highlight=setup%20cfg#configuration

It has the same configuration as given in [pytest.ini](https://github.com/keras-team/keras/blob/master/pytest.ini#L16).
