### PR TITLE
Correct the DepthwiseConv2d docstrings - output shape

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1759,10 +1759,10 @@ class DepthwiseConv2D(Conv2D):
 
     # Output shape
         4D tensor with shape:
-        `(batch, filters, new_rows, new_cols)`
+        `(batch, channels * depth_multiplier, new_rows, new_cols)`
         if `data_format` is `"channels_first"`
         or 4D tensor with shape:
-        `(batch, new_rows, new_cols, filters)`
+        `(batch, new_rows, new_cols,  channels * depth_multiplier)`
         if `data_format` is `"channels_last"`.
         `rows` and `cols` values might have changed due to padding.
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary
Correct the DepthwiseConv2d docstrings - output shape. Previously the doc says the output channel is `filters`, which is incorrect. 
### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)