### PR TITLE
#13239 Improved documentation for EarlyStopping/ReduceLROnPlateau, ta…

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -739,8 +739,12 @@ class EarlyStopping(Callback):
             to qualify as an improvement, i.e. an absolute
             change of less than min_delta, will count as no
             improvement.
-        patience: number of epochs with no improvement
-            after which training will be stopped.
+        patience: number of epochs that produced the monitored
+            quantity with no improvement after which training will
+            be stopped.
+            Validation quantities may not be produced for every
+            epoch, if the validation frequency
+            (`model.fit(validation_freq=5)`) is greater than one.
         verbose: verbosity mode.
         mode: one of {auto, min, max}. In `min` mode,
             training will stop when the quantity
@@ -1304,8 +1308,12 @@ class ReduceLROnPlateau(Callback):
         monitor: quantity to be monitored.
         factor: factor by which the learning rate will
             be reduced. new_lr = lr * factor
-        patience: number of epochs with no improvement
-            after which learning rate will be reduced.
+        patience: number of epochs that produced the monitored
+            quantity with no improvement after which training will
+            be stopped.
+            Validation quantities may not be produced for every
+            epoch, if the validation frequency
+            (`model.fit(validation_freq=5)`) is greater than one.
         verbose: int. 0: quiet, 1: update messages.
         mode: one of {auto, min, max}. In `min` mode,
             lr will be reduced when the quantity


### PR DESCRIPTION
Improved documentation for EarlyStopping/ReduceLROnPlateau, take validation_freq into account.
Fix for #13239.

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)