### PR TITLE
Update babi_rnn.py

### DIFF
--- a/examples/babi_rnn.py
+++ b/examples/babi_rnn.py
@@ -79,7 +79,7 @@ def tokenize(sent):
     >>> tokenize('Bob dropped the apple. Where is the apple?')
     ['Bob', 'dropped', 'the', 'apple', '.', 'Where', 'is', 'the', 'apple', '?']
     '''
-    return [x.strip() for x in re.split(r'(\W+)?', sent) if x.strip()]
+    return [x.strip() for x in re.split(r'(\W+)', sent) if x.strip()]
 
 
 def parse_stories(lines, only_supporting=False):


### PR DESCRIPTION
Change line 82.
Remove the "?" so the reg exp works as it says on token above in the comment
because else it gives - AttributeError: 'NoneType' object has no attribute 'strip'

This is happening because the tokenize gives as return letters not what the comment above it says