### PR TITLE
Update CSVLogger to save datetime.now()

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -13,6 +13,7 @@ import time
 import json
 import warnings
 import io
+import datetime
 
 from collections import deque
 from collections import OrderedDict
@@ -1454,7 +1455,7 @@ class CSVLogger(Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
-
+        logs['date'] = str(datetime.datetime.now())
         def handle_value(k):
             is_zero_dim_ndarray = isinstance(k, np.ndarray) and k.ndim == 0
             if isinstance(k, six.string_types):


### PR DESCRIPTION
Add a Datetime object column to the CSVLogger. Saves the time of the epoch end to the CSV, which is useful to trace the model training.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
