### PR TITLE
Using K.is_tensor and K.is_variable

### DIFF
--- a/keras/losses.py
+++ b/keras/losses.py
@@ -134,7 +134,7 @@ class LossFunctionWrapper(Loss):
     def get_config(self):
         config = {}
         for k, v in six.iteritems(self._fn_kwargs):
-            config[k] = K.eval(v) if is_tensor_or_variable(v) else v
+            config[k] = K.eval(v) if K.is_tensor(v) or K.is_variable(v) else v
         base_config = super(LossFunctionWrapper, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 


### PR DESCRIPTION
### Summary

`is_tensor_or_variable(x)` is undefined and replaced by `K.is_tensor(x) or K.is_variable(x)`.


### Related Issues

Fixes #13306.


### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)