### PR TITLE
Kannada MNIST Dataset

### DIFF
--- a/keras/datasets/kannada_mnist.py
+++ b/keras/datasets/kannada_mnist.py
@@ -11,24 +11,26 @@ from ..utils.data_utils import get_file
 import numpy as np
 
 
-def load_data():
+def load_data(path='kannada-mnist.tar.bz'):
     """Loads the Kannada-MNIST dataset.
 
     # Returns
         Tuple of Numpy arrays: `(x_train, y_train), (x_test, y_test)`.
     """
-    dirname = joinpath('datasets', 'kannada-mnist')
-    baseurl = 'https://unifyid-public-datasets.s3-us-west-2.amazonaws.com/kannada-mnist/'
-    fname = 'kannada-mnist.tar.bz'
-    fhash = 'c1cd9953366bb42c06f1205691d399b4'
-
     # Download and Unpack
-    basepath = splitpath(get_file(fname, baseurl + fname, cache_subdir=dirname, file_hash=fhash, extract=True))[0]
+    filepath = get_file(
+        path, 'https://unifyid-public-datasets.s3-us-west-2.amazonaws.com/kannada-mnist/kannada-mnist.tar.bz',
+        cache_subdir=joinpath('datasets', 'kannada-mnist'),
+        file_hash='c1cd9953366bb42c06f1205691d399b4',
+        extract=True,
+    )
 
-    x_train = _read_kannada_mnist(basepath + 'X_kannada_MNIST_train-idx3-ubyte', xory='x')
-    y_train = _read_kannada_mnist(basepath + 'y_kannada_MNIST_train-idx1-ubyte', xory='y')
-    x_test = _read_kannada_mnist(basepath + 'X_kannada_MNIST_test-idx3-ubyte', xory='x')
-    y_test = _read_kannada_mnist(basepath + 'y_kannada_MNIST_test-idx1-ubyte', xory='y')
+    basedir = splitpath(filepath)[0]
+
+    x_train = _read_kannada_mnist(joinpath(basedir, 'X_kannada_MNIST_train-idx3-ubyte'), xory='x')
+    y_train = _read_kannada_mnist(joinpath(basedir, 'y_kannada_MNIST_train-idx1-ubyte'), xory='y')
+    x_test = _read_kannada_mnist(joinpath(basedir, 'X_kannada_MNIST_test-idx3-ubyte'), xory='x')
+    y_test = _read_kannada_mnist(joinpath(basedir, 'y_kannada_MNIST_test-idx1-ubyte'), xory='y')
 
     return (x_train, y_train), (x_test, y_test)
 

--- a/keras/datasets/kannada_mnist.py
+++ b/keras/datasets/kannada_mnist.py
@@ -1,0 +1,44 @@
+"""Kannada-MNIST dataset.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from os.path import join as joinpath
+from os.path import split as splitpath
+
+from ..utils.data_utils import get_file
+import numpy as np
+
+
+def load_data():
+    """Loads the Kannada-MNIST dataset.
+
+    # Returns
+        Tuple of Numpy arrays: `(x_train, y_train), (x_test, y_test)`.
+    """
+    dirname = joinpath('datasets', 'kannada-mnist')
+    baseurl = 'https://unifyid-public-datasets.s3-us-west-2.amazonaws.com/kannada-mnist/'
+    fname = 'kannada-mnist.tar.bz'
+    fhash = 'c1cd9953366bb42c06f1205691d399b4'
+
+    # Download and Unpack
+    basepath = splitpath(get_file(fname, baseurl + fname, cache_subdir=dirname, file_hash=fhash, extract=True))[0]
+
+    x_train = _read_kmnist(basepath + 'X_kannada_MNIST_train-idx3-ubyte', xory='x')
+    y_train = _read_kmnist(basepath + 'y_kannada_MNIST_train-idx1-ubyte', xory='y')
+    x_test = _read_kmnist(basepath + 'X_kannada_MNIST_test-idx3-ubyte', xory='x')
+    y_test = _read_kmnist(basepath + 'y_kannada_MNIST_test-idx1-ubyte', xory='y')
+
+    return (x_train, y_train), (x_test, y_test)
+
+def _read_kmnist(filepath, xory='x'):
+    """Read and deserialize kmnist files containing raw binary tensors
+
+    # Returns
+        Numpy tensors
+    """
+    offset, shape = (16, (-1, 28, 28)) if xory == 'x' else (8, -1)
+
+    with open(filepath, 'rb') as fp:
+        return np.frombuffer(fp.read(), np.uint8, offset=offset).reshape(shape)

--- a/keras/datasets/kannada_mnist.py
+++ b/keras/datasets/kannada_mnist.py
@@ -25,15 +25,15 @@ def load_data():
     # Download and Unpack
     basepath = splitpath(get_file(fname, baseurl + fname, cache_subdir=dirname, file_hash=fhash, extract=True))[0]
 
-    x_train = _read_kmnist(basepath + 'X_kannada_MNIST_train-idx3-ubyte', xory='x')
-    y_train = _read_kmnist(basepath + 'y_kannada_MNIST_train-idx1-ubyte', xory='y')
-    x_test = _read_kmnist(basepath + 'X_kannada_MNIST_test-idx3-ubyte', xory='x')
-    y_test = _read_kmnist(basepath + 'y_kannada_MNIST_test-idx1-ubyte', xory='y')
+    x_train = _read_kannada_mnist(basepath + 'X_kannada_MNIST_train-idx3-ubyte', xory='x')
+    y_train = _read_kannada_mnist(basepath + 'y_kannada_MNIST_train-idx1-ubyte', xory='y')
+    x_test = _read_kannada_mnist(basepath + 'X_kannada_MNIST_test-idx3-ubyte', xory='x')
+    y_test = _read_kannada_mnist(basepath + 'y_kannada_MNIST_test-idx1-ubyte', xory='y')
 
     return (x_train, y_train), (x_test, y_test)
 
-def _read_kmnist(filepath, xory='x'):
-    """Read and deserialize kmnist files containing raw binary tensors
+def _read_kannada_mnist(filepath, xory='x'):
+    """Read and deserialize kannada mnist files containing raw binary tensors
 
     # Returns
         Numpy tensors

--- a/tests/keras/datasets/datasets_test.py
+++ b/tests/keras/datasets/datasets_test.py
@@ -6,6 +6,7 @@ import pytest
 from keras.datasets import boston_housing
 from keras.datasets import imdb
 from keras.datasets import reuters
+from keras.datasets import kannada_mnist
 
 
 @pytest.fixture
@@ -88,3 +89,10 @@ def test_reuters_load_does_not_affect_global_rng(fake_downloaded_reuters_path):
     after = np.random.randint(0, 100, size=10)
 
     assert np.array_equal(before, after)
+
+
+def test_kannada_mnist_load():
+    (x_train, y_train), (x_test, y_test) = kannada_mnist.load_data(path='fake-kannada-mnist.tar.bz')
+
+    assert x_train.shape[0] == y_train.shape[0] == 60000
+    assert y_test.shape[0] == y_test.shape[0] == 10000


### PR DESCRIPTION
# Summary

This is a new handwritten digits-dataset, termed Kannada-MNIST, for the Kannada script, that can potentially serve as a direct drop-in replacement for the original MNIST dataset. The images are  28 x 28 grayscale (much akin to MNIST) and belong to one of the 10-digit classes.

The raw scanned images that the volunteers who helped create this dataset along with the scanner settings have been open sourced [here](https://github.com/vinayprabhu/Kannada_MNIST)

If you use Kannada-MNIST in a peer reviewed paper, we would appreciate referencing it as:

```
Prabhu, Vinay Uday. "Kannada-MNIST: A new handwritten digits dataset for the Kannada language." arXiv preprint arXiv:1908.01242 (2019).
```

Bibtex
```
@article{prabhu2019kannada,
 title={Kannada-MNIST: A new handwritten digits dataset for the Kannada language},
 author={Prabhu, Vinay Uday},
 journal={arXiv preprint arXiv:1908.01242},
 year={2019}
}
```

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
