### PR TITLE
Added messages about the future of multi-backend Keras.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,13 +23,13 @@ The more information you provide, the easier it is for us to validate that there
 
 ## Requesting a Feature
 
-You can also use Github issues to request features you would like to see in Keras, or changes in the Keras API.
+You can also use [Tensorflow Github issues](https://github.com/tensorflow/tensorflow/issues) to request features you would like to see in Keras, or changes in the Keras API.
 
 1. Provide a clear and detailed explanation of the feature you want and why it's important to add. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on library for Keras. It is crucial for Keras to avoid bloating the API and codebase.
 
 2. Provide code snippets demonstrating the API you have in mind and illustrating the use cases of your feature. Of course, you don't need to write any real code at this point!
 
-3. After discussing the feature you may choose to attempt a Pull Request. If you're at all able, start writing some code. We always have more work to do than time to do it. If you can write some code then that will speed the process along.
+3. After discussing the feature you may choose to attempt a Pull Request on tf.keras. If you're at all able, start writing some code. We always have more work to do than time to do it. If you can write some code then that will speed the process along.
 
 
 ---
@@ -44,6 +44,10 @@ You can also use Github issues to request features you would like to see in Kera
 ## Pull Requests
 
 **Where should I submit my pull request?**
+
+#### Note:
+
+We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
 
 1. **Keras improvements and bugfixes** go to the [Keras `master` branch](https://github.com/keras-team/keras/tree/master).
 2. **Experimental new features** such as layers and datasets go to [keras-contrib](https://github.com/farizrahman4u/keras-contrib). Unless it is a new feature listed in [Requests for Contributions](https://github.com/keras-team/keras/projects/1), in which case it belongs in core Keras. If you think your feature belongs in core Keras, you can submit a design doc to explain your feature and argue for it (see explanations below).

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,9 @@
 <!--
 Please make sure you've read and understood our contributing guidelines;
 https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
+
+Note:
+We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
 -->
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The next release will be 2.3.0, which makes significant API changes and add supp
 
 At this time, we recommend that Keras users who use multi-backend Keras with the TensorFlow backend switch to tf.keras in TensorFlow 2.0. tf.keras is better maintained and has better integration with TensorFlow features (eager execution, distribution support and other).
 
-Bugs present in multi-backend Keras will only be fixed for the next 6 months.
+Bugs present in multi-backend Keras will only be fixed until April 2020.
 
 For more information about the future of Keras, see [the Keras meeting notes](http://bit.ly/keras-meeting-notes).
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ Keras is compatible with: __Python 2.7-3.6__.
 
 ------------------
 
+## Multi-backend Keras and tf.keras:
+
+Keras 2.2.5 is the last release of Keras that implements the 2.2.* API. It is the last release to only support TensorFlow 1 (as well as Theano and CNTK).
+
+The next release will be 2.3.0, which makes significant API changes and add support for TensorFlow 2.0. The 2.3.0 release will be the last major release of multi-backend Keras. Multi-backend Keras is superseded by tf.keras.
+
+At this time, we recommend that Keras users who use multi-backend Keras with the TensorFlow backend switch to tf.keras in TensorFlow 2.0. tf.keras is better maintained and has better integration with TensorFlow features (eager execution, distribution support and other).
+
+Bugs present in multi-backend Keras will only be fixed for the next 6 months.
+
+For more information about the future of Keras, see [the Keras meeting notes](http://bit.ly/keras-meeting-notes).
+
+------------------
 
 ## Guiding principles
 


### PR DESCRIPTION
This PR add messages about the future of Keras. Many of the users don't read the meeting notes or the release notes. They're copied for a much better visibility.