### PR TITLE
Fix sequence timeout deadlock

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -608,7 +608,6 @@ class OrderedEnqueuer(SequenceEnqueuer):
                 try:
                     future = self.queue.get(block=True)
                     inputs = future.get(timeout=30)
-                    self.queue.task_done()
                 except mp.TimeoutError:
                     idx = future.idx
                     warnings.warn(
@@ -616,6 +615,9 @@ class OrderedEnqueuer(SequenceEnqueuer):
                         ' It could be because a worker has died.'.format(idx),
                         UserWarning)
                     inputs = self.sequence[idx]
+                finally:
+                    self.queue.task_done()
+
                 if inputs is not None:
                     yield inputs
         except Exception:

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -5,6 +5,7 @@ import time
 import sys
 import tarfile
 import threading
+import signal
 import shutil
 import zipfile
 from itertools import cycle
@@ -211,6 +212,25 @@ class FaultSequence(Sequence):
         pass
 
 
+class SlowSequence(Sequence):
+    def __init__(self, shape, value=1.0):
+        self.shape = shape
+        self.inner = value
+        self.wait = True
+
+    def __getitem__(self, item):
+        if self.wait:
+            self.wait = False
+            time.sleep(40)
+        return np.ones(self.shape, dtype=np.uint32) * item * self.inner
+
+    def __len__(self):
+        return 10
+
+    def on_epoch_end(self):
+        pass
+
+
 @threadsafe_generator
 def create_generator_from_sequence_threads(ds):
     for i in cycle(range(len(ds))):
@@ -333,6 +353,29 @@ def test_ordered_enqueuer_fail_threads():
     gen_output = enqueuer.get()
     with pytest.raises(IndexError):
         next(gen_output)
+
+
+def test_ordered_enqueuer_timeout_threads():
+    enqueuer = OrderedEnqueuer(SlowSequence([3, 10, 10, 3]),
+                               use_multiprocessing=False)
+
+    def handler(signum, frame):
+        raise TimeoutError('Sequence deadlocked')
+
+    old = signal.signal(signal.SIGALRM, handler)
+    signal.setitimer(signal.ITIMER_REAL, 40)
+
+    enqueuer.start(5, 10)
+    gen_output = enqueuer.get()
+    for epoch_num in range(2):
+        acc = []
+        for i in range(10):
+            acc.append(next(gen_output)[0, 0, 0, 0])
+        assert acc == list(range(10)), ('Order was not keep in GeneratorEnqueuer '
+                                        'with processes')
+    enqueuer.stop()
+    signal.setitimer(signal.ITIMER_REAL, 0)
+    signal.signal(signal.SIGALRM, old)
 
 
 @use_spawn

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -363,7 +363,7 @@ def test_ordered_enqueuer_timeout_threads():
         raise TimeoutError('Sequence deadlocked')
 
     old = signal.signal(signal.SIGALRM, handler)
-    signal.setitimer(signal.ITIMER_REAL, 40)
+    signal.setitimer(signal.ITIMER_REAL, 60)
     with pytest.warns(UserWarning) as record:
         enqueuer.start(5, 10)
         gen_output = enqueuer.get()

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -371,7 +371,8 @@ def test_ordered_enqueuer_timeout_threads():
             acc = []
             for i in range(10):
                 acc.append(next(gen_output)[0, 0, 0, 0])
-            assert acc == list(range(10)), 'Order was not keep in OrderedEnqueuer with threads'
+            assert acc == list(range(10)), 'Order was not keep in ' \
+                                           'OrderedEnqueuer with threads'
         enqueuer.stop()
     assert len(record) == 1
     assert str(record[0].message) == 'The input 0 could not be retrieved. ' \

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -364,16 +364,18 @@ def test_ordered_enqueuer_timeout_threads():
 
     old = signal.signal(signal.SIGALRM, handler)
     signal.setitimer(signal.ITIMER_REAL, 40)
-
-    enqueuer.start(5, 10)
-    gen_output = enqueuer.get()
-    for epoch_num in range(2):
-        acc = []
-        for i in range(10):
-            acc.append(next(gen_output)[0, 0, 0, 0])
-        assert acc == list(range(10)), ('Order was not keep in GeneratorEnqueuer '
-                                        'with processes')
-    enqueuer.stop()
+    with pytest.warns(UserWarning) as record:
+        enqueuer.start(5, 10)
+        gen_output = enqueuer.get()
+        for epoch_num in range(2):
+            acc = []
+            for i in range(10):
+                acc.append(next(gen_output)[0, 0, 0, 0])
+            assert acc == list(range(10)), 'Order was not keep in OrderedEnqueuer with threads'
+        enqueuer.stop()
+    assert len(record) == 1
+    assert str(record[0].message) == 'The input 0 could not be retrieved. ' \
+                                     'It could be because a worker has died.'
     signal.setitimer(signal.ITIMER_REAL, 0)
     signal.signal(signal.SIGALRM, old)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary
In the case when fetching the batch from the worker is not finished within the timeout, `queue.task_done` method is not called. This leads to a deadlock at the end of the epoch when we do `self._wait_queue()` preventing from getting batches for the next epoch. The correct behavior would be to mark task in the queue as done regardless of if it was processed in the worker or on the main thread after the timeout.
### Related Issues

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
