### PR TITLE
Update cifar10_cnn.py

### DIFF
--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -56,7 +56,7 @@ model.add(Dense(num_classes))
 model.add(Activation('softmax'))
 
 # initiate RMSprop optimizer
-opt = keras.optimizers.RMSprop(learning_rate=0.0001, decay=1e-6)
+opt = keras.optimizers.RMSprop(lr=0.0001, decay=1e-6)
 
 # Let's train the model using RMSprop
 model.compile(loss='categorical_crossentropy',


### PR DESCRIPTION
Dear, master.

While I study using Keras example (cifar10_cnn), I met errors. And I fixed it a little bit.
Please check this one. My Keras version is 2.5.5 and Tensorflow version is 1.13.1.

Best regards,
Thank you.

Denny Hwang.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary
- Example error fixing.
I changed the expression 'learning_rate' to 'lr' for fixing error.

### Related Issues
- "cifar10_cnn" example

### PR Overview

- [N] This PR requires new unit tests [y/n] (make sure tests are included)
- [Y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [N] This PR is backwards compatible [y/n]
- [N] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
