### PR TITLE
Fix assertion when inputs, targets, or weights are not necessary

### DIFF
--- a/keras/callbacks/tensorboard_v1.py
+++ b/keras/callbacks/tensorboard_v1.py
@@ -266,9 +266,9 @@ class TensorBoard(Callback):
             if epoch % self.histogram_freq == 0:
 
                 val_data = self.validation_data
-                tensors = (self.model.inputs +
-                           self.model.targets +
-                           self.model.sample_weights)
+                tensors = ([t for t in self.model.inputs if t is not None] +
+                           [t for t in self.model.targets if t is not None] +
+                           [t for t in self.model.sample_weights if t is not None])
 
                 if self.model.uses_learning_phase:
                     tensors += [K.learning_phase()]


### PR DESCRIPTION
If the model does not has any targets or sample_weights, the corresponding lists hold `None` values.
While `None` values still contribute to the length of the `tensors` variable, `assert len(val_data) == len(tensors)` asserts.
This faulty behavior is circumvented by refining the `tensors` variable so that it holds no more `None` values.

    Signed-off-by: Timo Korthals <tkorthals@cit-ec.uni-bielefeld.de>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

see above

### Related Issues

None

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
