### PR TITLE
Remove @disable_tracking in Bidirectional.__init__

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -359,7 +359,7 @@ class Bidirectional(Wrapper):
         model.compile(loss='categorical_crossentropy', optimizer='rmsprop')
     ```
     """
-    
+
     def __init__(self, layer, merge_mode='concat', weights=None, **kwargs):
         if merge_mode not in ['sum', 'mul', 'ave', 'concat', None]:
             raise ValueError('Invalid merge mode. '

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -359,8 +359,7 @@ class Bidirectional(Wrapper):
         model.compile(loss='categorical_crossentropy', optimizer='rmsprop')
     ```
     """
-
-    @disable_tracking
+    
     def __init__(self, layer, merge_mode='concat', weights=None, **kwargs):
         if merge_mode not in ['sum', 'mul', 'ave', 'concat', None]:
             raise ValueError('Invalid merge mode. '


### PR DESCRIPTION
Remove @disable_tracking in ./keras/layers/wrapper.py/class Bidirectional

In 'Layer wrappers' on keras.io the following changes will be made,

### Summary

---
Before:
+ keras.engine.base_layer.wrapped_fn()

After:
+ keras.layers.Bidirectional(layer, merge_mode='concat', weights=None)
---


### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
