### PR TITLE
Update local.py

### DIFF
--- a/keras/layers/local.py
+++ b/keras/layers/local.py
@@ -43,8 +43,8 @@ class LocallyConnected1D(Layer):
             specifying the length of the 1D convolution window.
         strides: An integer or tuple/list of a single integer,
             specifying the stride length of the convolution.
-            Specifying any stride value != 1 is incompatible with specifying
-            any `dilation_rate` value != 1.
+            Specifying any `strides!=1` is incompatible with specifying
+            any `dilation_rate!=1`.
         padding: Currently only supports `"valid"` (case-insensitive).
             `"same"` may be supported in the future.
         data_format: String, one of `channels_first`, `channels_last`.

--- a/keras/layers/local.py
+++ b/keras/layers/local.py
@@ -250,9 +250,9 @@ class LocallyConnected2D(Layer):
 
     # Input shape
         4D tensor with shape:
-        `(samples, channels, rows, cols)` if data_format='channels_first'
+        `(samples, channels, rows, cols)` if `data_format='channels_first'`
         or 4D tensor with shape:
-        `(samples, rows, cols, channels)` if data_format='channels_last'.
+        `(samples, rows, cols, channels)` if `data_format='channels_last'`.
 
     # Output shape
         4D tensor with shape:


### PR DESCRIPTION
stride value implies the input argument of 'stride', and dilation_rate implies the input argument of 'dilation rate' of Conv1D function.
It is more explicit to express as code rather than using words stride value, dilation value.
Or, at least both stride and dilation_rate should be written in code, not only dilation rate as before document

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary
change documentation words.
stride != -1, dilation_rate != -1 to code

### Related Issues

### PR Overview

- [n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
