### PR TITLE
plot_model: allowed to return the image as a Jupyter Image only for not pdf file

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -245,8 +245,9 @@ def plot_model(model,
         extension = extension[1:]
     dot.write(to_file, format=extension)
     # Return the image as a Jupyter Image object, to be displayed in-line.
-    try:
-        from IPython import display
-        return display.Image(filename=to_file)
-    except ImportError:
-        pass
+    if extension != 'pdf':
+        try:
+            from IPython import display
+            return display.Image(filename=to_file)
+        except ImportError:
+            pass


### PR DESCRIPTION
### Summary
This is a possible fix for #13383.
In [plot_model](https://github.com/keras-team/keras/blob/985521ee7050df39f9c06f53b54e17927bd1e6ea/keras/utils/vis_utils.py#L214) allow the return the image as a Jupyter Image only if the extension is not pdf.

### Related Issues
#13383
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
