### PR TITLE
fix: `recurrent_activation` parameter's docstring

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1206,7 +1206,7 @@ class GRUCell(Layer):
         recurrent_activation: Activation function to use
             for the recurrent step
             (see [activations](../activations.md)).
-            Default: hard sigmoid (`hard_sigmoid`).
+            Default: sigmoid (`sigmoid`).
             If you pass `None`, no activation is applied
             (ie. "linear" activation: `a(x) = x`).
         use_bias: Boolean, whether the layer uses a bias vector.
@@ -1543,7 +1543,7 @@ class GRU(RNN):
         recurrent_activation: Activation function to use
             for the recurrent step
             (see [activations](../activations.md)).
-            Default: hard sigmoid (`hard_sigmoid`).
+            Default: sigmoid (`sigmoid`).
             If you pass `None`, no activation is applied
             (ie. "linear" activation: `a(x) = x`).
         use_bias: Boolean, whether the layer uses a bias vector.
@@ -1808,7 +1808,7 @@ class LSTMCell(Layer):
         recurrent_activation: Activation function to use
             for the recurrent step
             (see [activations](../activations.md)).
-            Default: hard sigmoid (`hard_sigmoid`).
+            Default: sigmoid (`sigmoid`).
             If you pass `None`, no activation is applied
             (ie. "linear" activation: `a(x) = x`).x
         use_bias: Boolean, whether the layer uses a bias vector.
@@ -2096,7 +2096,7 @@ class LSTM(RNN):
         recurrent_activation: Activation function to use
             for the recurrent step
             (see [activations](../activations.md)).
-            Default: hard sigmoid (`hard_sigmoid`).
+            Default: sigmoid (`sigmoid`).
             If you pass `None`, no activation is applied
             (ie. "linear" activation: `a(x) = x`).
         use_bias: Boolean, whether the layer uses a bias vector.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

Fixing `recurrent_activation` parameter docstring, it was saying that the default is "hard_sigmoid" [even though the code defaults to "sigmoid"](https://github.com/keras-team/keras/blob/master/keras/layers/recurrent.py#L1206) (I only selected the `GRUCell` because multi-line cross referencing isn't a feature. BTW, if you're wondering whether `tf.keras` has the same issue, [it's not](https://github.com/tensorflow/tensorflow/blob/r2.0/tensorflow/python/keras/layers/recurrent_v2.py#L766). 
### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
