### PR TITLE
fix trainable attribute to enable embedding layer 'trainable' option

### DIFF
--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -253,7 +253,7 @@ class Layer(object):
                    dtype=None,
                    initializer=None,
                    regularizer=None,
-                   trainable=True,
+                   trainable=None,
                    constraint=None):
         """Adds a weight variable to the layer.
 
@@ -271,6 +271,8 @@ class Layer(object):
         # Returns
             The created weight variable.
         """
+        if trainable is None:
+            trainable = getattr(self, 'trainable', True)
         if shape is None:
             shape = ()
         initializer = initializers.get(initializer)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary
This pull fix the embedding layer trainable option. 

### Related Issues
Embedding trainable option does not work since the `trainable` arg  is not specified in `keras/layers/embeddings.py`.

To enable the `trainable` option in `Embedding`, I did minor fix in the method of `add_weights()` in `base_layer.py`. 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
NO
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
No
- [ ] This PR is backwards compatible [y/n]
Yes
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
No
