### PR TITLE
Change description of `batch_size` to proper one

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1274,7 +1274,7 @@ class Model(Network):
                 `y` should not be specified (since targets will be obtained
                 from `x`).
             batch_size: Integer or `None`.
-                Number of samples per gradient update.
+                Number of samples to be computed at once.
                 If unspecified, `batch_size` will default to 32.
                 Do not specify the `batch_size` if your data is in the
                 form of symbolic tensors, generators, or
@@ -1383,7 +1383,7 @@ class Model(Network):
                 - None (default) if feeding from framework-native
                   tensors (e.g. TensorFlow data tensors).
             batch_size: Integer or `None`.
-                Number of samples per gradient update.
+                Number of samples to be computed at once.
                 If unspecified, `batch_size` will default to 32.
                 Do not specify the `batch_size` if your data is in the
                 form of symbolic tensors, generators, or


### PR DESCRIPTION
Since there're no gradients updated within `evaulate` and `predict` processes, changed their `batch_size` docstrings from `"Number of samples per gradient update"` to `"Number of samples to be computed at once"`. (The sentence in `fit` remains unchanged.) 

I hope this fix would change related auto-generated documents as well.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
