### PR TITLE
Change `batch_size` descriptions to proper ones

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1274,7 +1274,7 @@ class Model(Network):
                 `y` should not be specified (since targets will be obtained
                 from `x`).
             batch_size: Integer or `None`.
-                Number of samples per gradient update.
+                Number of samples per evaluation step.
                 If unspecified, `batch_size` will default to 32.
                 Do not specify the `batch_size` if your data is in the
                 form of symbolic tensors, generators, or
@@ -1383,7 +1383,7 @@ class Model(Network):
                 - None (default) if feeding from framework-native
                   tensors (e.g. TensorFlow data tensors).
             batch_size: Integer or `None`.
-                Number of samples per gradient update.
+                Number of samples to be predicted at once.
                 If unspecified, `batch_size` will default to 32.
                 Do not specify the `batch_size` if your data is in the
                 form of symbolic tensors, generators, or

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1755,7 +1755,7 @@ class Model(Network):
                 Optional for `Sequence`: if unspecified, will use
                 the `len(generator)` as a number of steps.
             callbacks: List of `keras.callbacks.Callback` instances.
-                List of callbacks to apply during training.
+                List of callbacks to apply during evaluation.
                 See [callbacks](/callbacks).
             max_queue_size: maximum size for the generator queue
             workers: Integer. Maximum number of processes to spin up
@@ -1813,7 +1813,7 @@ class Model(Network):
                 Optional for `Sequence`: if unspecified, will use
                 the `len(generator)` as a number of steps.
             callbacks: List of `keras.callbacks.Callback` instances.
-                List of callbacks to apply during training.
+                List of callbacks to apply during prediction.
                 See [callbacks](/callbacks).
             max_queue_size: Maximum size for the generator queue.
             workers: Integer. Maximum number of processes to spin up


### PR DESCRIPTION
### Summary
- Since there're no gradients to be updated during `evaulate` and `predict` processes, changed their `batch_size` docstrings from `"Number of samples per gradient update"` to `"Number of samples per evaluation step"` and `"Number of samples to be predicted at once"`. (The sentence in fit remains unchanged.)

- Corrected `callbacks` description docstrings in `evaluate_generator` and `predict_generator`: `"List of callbacks to apply during training"` -> `"- during evaluation"`, `"- during prediction"`.

I hope this fix would change related auto-generated documents as well.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
