### PR TITLE
Update autogen.py

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -84,6 +84,8 @@ def post_process_signature(signature):
             signature = 'keras.utils.' + '.'.join(parts[3:])
         if parts[1] == 'backend':
             signature = 'keras.backend.' + '.'.join(parts[3:])
+        if parts[1] == 'callbacks':
+            signature = 'keras.callbacks.' + '.'.join(parts[3:])
     return signature
 
 


### PR DESCRIPTION
fix duplicate module name for callbacks module

Callback() should be 
`keras.callbacks.Callback()`
but autogen.py generated
`keras.callbacks.callbacks.Callback()`

Classes in callbacks module had the same issue.
Added callback in `post_process_signature` method in autogen.py

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
