### PR TITLE
Add EfficientNet variants

### DIFF
--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -19,6 +19,7 @@ Weights are downloaded automatically when instantiating a model. They are stored
 - [MobileNetV2](#mobilenetv2)
 - [DenseNet](#densenet)
 - [NASNet](#nasnet)
+- [EfficientNet](#efficientnet)
 
 All of these architectures are compatible with all the backends (TensorFlow, Theano, and CNTK), and upon instantiation the models will be built according to the image data format set in your Keras configuration file at `~/.keras/keras.json`. For instance, if you have set `image_data_format=channels_last`, then any model loaded from this repository will get built according to the TensorFlow data format convention, "Height-Width-Depth".
 
@@ -190,6 +191,14 @@ model = InceptionV3(input_tensor=input_tensor, weights='imagenet', include_top=T
 | [DenseNet201](#densenet) | 80 MB | 0.773 | 0.936 | 20,242,984 | 201 |
 | [NASNetMobile](#nasnet) | 23 MB | 0.744 | 0.919 | 5,326,716 | - |
 | [NASNetLarge](#nasnet) | 343 MB | 0.825 | 0.960 | 88,949,818 | - |
+| [EfficientNetB0](#efficientnet) | 21 MB | 0.772 | 0.935 | 5,330,564 | - |
+| [EfficientNetB1](#efficientnet) | 31 MB | 0.791 | 0.944 | 7,856,232 | - |
+| [EfficientNetB2](#efficientnet) | 36 MB | 0.802 | 0.949 | 9,177,562 | - |
+| [EfficientNetB3](#efficientnet) | 48 MB | 0.816 | 0.957 | 12,320,528 | - |
+| [EfficientNetB4](#efficientnet) | 75 MB | 0.830 | 0.963 | 19,466,816 | - |
+| [EfficientNetB5](#efficientnet) | 118 MB | 0.837 | 0.967 | 30,562,520 | - |
+| [EfficientNetB6](#efficientnet) | 166 MB | 0.841 | 0.969 | 43,265,136 | - |
+| [EfficientNetB7](#efficientnet) | 256 MB | 0.844 | 0.968 | 66,658,680 | - |
 
 The top-1 and top-5 accuracy refers to the model's performance on the ImageNet validation dataset.
 
@@ -806,3 +815,88 @@ ValueError: in case of invalid argument for `weights`,
 ### License
 
 These weights are released under [the Apache License](https://github.com/tensorflow/models/blob/master/LICENSE).
+
+-----
+
+## EfficientNet
+
+
+```python
+keras.applications.efficientnet.EfficientNetB0(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
+keras.applications.efficientnet.EfficientNetB1(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
+keras.applications.efficientnet.EfficientNetB2(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
+keras.applications.efficientnet.EfficientNetB3(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
+keras.applications.efficientnet.EfficientNetB4(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
+keras.applications.efficientnet.EfficientNetB5(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
+keras.applications.efficientnet.EfficientNetB6(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
+keras.applications.efficientnet.EfficientNetB7(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
+```
+
+EfficientNet models, with weights pre-trained on ImageNet.
+
+These models and can be built both with `'channels_first'` data format (channels, height, width) or `'channels_last'` data format (height, width, channels).
+
+The default input sizes of these models are:
+- 224x224 for EfficientNetB0,
+- 240x240 for EfficientNetB1,
+- 260x260 for EfficientNetB2,
+- 300x300 for EfficientNetB3,
+- 380x380 for EfficientNetB4,
+- 456x456 for EfficientNetB5,
+- 528x528 for EfficientNetB6,
+- 600x600 for EfficientNetB7.
+
+### Arguments
+
+- width_coefficient: float, scaling coefficient for network width.
+- depth_coefficient: float, scaling coefficient for network depth.
+- default_size: integer, default input image size.
+- dropout_rate: float, dropout rate before final classifier layer.
+- drop_connect_rate: float, dropout rate at skip connections.
+- depth_divisor: integer, a unit of network width.
+- activation_fn: activation function.
+- blocks_args: list of dicts, parameters to construct block modules.
+- model_name: string, model name.
+- include_top: whether to include the fully-connected
+    layer at the top of the network.
+- weights: one of `None` (random initialization),
+    'imagenet' (pre-training on ImageNet),
+    or the path to the weights file to be loaded.
+- input_tensor: optional Keras tensor
+    (i.e. output of `layers.Input()`)
+    to use as image input for the model.
+- input_shape: optional shape tuple, only to be specified
+    if `include_top` is False.
+    It should have exactly 3 inputs channels.
+- pooling: Optional pooling mode for feature extraction
+    when `include_top` is `False`.
+    - `None` means that the output of the model
+        will be the 4D tensor output of the
+        last convolutional block.
+    - `'avg'` means that global average pooling
+        will be applied to the output of the
+        last convolutional block, and thus
+        the output of the model will be a
+        2D tensor.
+    - `'max'` means that global max pooling will
+        be applied. 
+- classes: optional number of classes to classify images
+    into, only to be specified if `include_top` is True, and
+    if no `weights` argument is specified.
+
+### Returns
+
+A Keras model instance.
+
+### Raises
+
+ValueError: in case of invalid argument for `weights`,
+    or invalid input shape
+
+### References
+
+- [EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks](https://arxiv.org/abs/1905.11946)
+
+### License
+
+These weights are released under [the Apache License](https://github.com/tensorflow/hub/blob/master/LICENSE).

--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -191,14 +191,8 @@ model = InceptionV3(input_tensor=input_tensor, weights='imagenet', include_top=T
 | [DenseNet201](#densenet) | 80 MB | 0.773 | 0.936 | 20,242,984 | 201 |
 | [NASNetMobile](#nasnet) | 23 MB | 0.744 | 0.919 | 5,326,716 | - |
 | [NASNetLarge](#nasnet) | 343 MB | 0.825 | 0.960 | 88,949,818 | - |
-| [EfficientNetB0](#efficientnet) | 21 MB | 0.772 | 0.935 | 5,330,564 | - |
-| [EfficientNetB1](#efficientnet) | 31 MB | 0.791 | 0.944 | 7,856,232 | - |
-| [EfficientNetB2](#efficientnet) | 36 MB | 0.802 | 0.949 | 9,177,562 | - |
-| [EfficientNetB3](#efficientnet) | 48 MB | 0.816 | 0.957 | 12,320,528 | - |
-| [EfficientNetB4](#efficientnet) | 75 MB | 0.830 | 0.963 | 19,466,816 | - |
-| [EfficientNetB5](#efficientnet) | 118 MB | 0.837 | 0.967 | 30,562,520 | - |
-| [EfficientNetB6](#efficientnet) | 166 MB | 0.841 | 0.969 | 43,265,136 | - |
-| [EfficientNetB7](#efficientnet) | 256 MB | 0.844 | 0.968 | 66,658,680 | - |
+| [EfficientNetSmall](#efficientnet) | 21 MB | 0.772 | 0.935 | 5,330,564 | - |
+| [EfficientNetLarge](#efficientnet) | 118 MB | 0.837 | 0.967 | 30,562,520 | - |
 
 The top-1 and top-5 accuracy refers to the model's performance on the ImageNet validation dataset.
 
@@ -822,29 +816,16 @@ These weights are released under [the Apache License](https://github.com/tensorf
 
 
 ```python
-keras.applications.efficientnet.EfficientNetB0(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
-keras.applications.efficientnet.EfficientNetB1(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
-keras.applications.efficientnet.EfficientNetB2(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
-keras.applications.efficientnet.EfficientNetB3(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
-keras.applications.efficientnet.EfficientNetB4(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
-keras.applications.efficientnet.EfficientNetB5(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
-keras.applications.efficientnet.EfficientNetB6(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
-keras.applications.efficientnet.EfficientNetB7(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
+keras.applications.efficientnet.EfficientNetSmall(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
+keras.applications.efficientnet.EfficientNetLarge(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
 ```
 
 EfficientNet models, with weights pre-trained on ImageNet.
 
 These models and can be built both with `'channels_first'` data format (channels, height, width) or `'channels_last'` data format (height, width, channels).
 
-The default input sizes of these models are:
-- 224x224 for EfficientNetB0,
-- 240x240 for EfficientNetB1,
-- 260x260 for EfficientNetB2,
-- 300x300 for EfficientNetB3,
-- 380x380 for EfficientNetB4,
-- 456x456 for EfficientNetB5,
-- 528x528 for EfficientNetB6,
-- 600x600 for EfficientNetB7.
+The default input size for the EfficientNetLarge model is 456x456 and
+for the EfficientNetSmall model is 224x224.
 
 ### Arguments
 

--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -505,14 +505,8 @@ from keras.applications.densenet import DenseNet169
 from keras.applications.densenet import DenseNet201
 from keras.applications.nasnet import NASNetLarge
 from keras.applications.nasnet import NASNetMobile
-from keras.applications.efficientnet import EfficientNetB0
-from keras.applications.efficientnet import EfficientNetB1
-from keras.applications.efficientnet import EfficientNetB2
-from keras.applications.efficientnet import EfficientNetB3
-from keras.applications.efficientnet import EfficientNetB4
-from keras.applications.efficientnet import EfficientNetB5
-from keras.applications.efficientnet import EfficientNetB6
-from keras.applications.efficientnet import EfficientNetB7
+from keras.applications.efficientnet import EfficientNetSmall
+from keras.applications.efficientnet import EfficientNetLarge
 
 model = VGG16(weights='imagenet', include_top=True)
 ```

--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -480,6 +480,7 @@ Code and pre-trained weights are available for the following image classificatio
 - MobileNet v2
 - DenseNet
 - NASNet
+- EfficientNet
 
 They can be imported from the module `keras.applications`:
 
@@ -504,6 +505,14 @@ from keras.applications.densenet import DenseNet169
 from keras.applications.densenet import DenseNet201
 from keras.applications.nasnet import NASNetLarge
 from keras.applications.nasnet import NASNetMobile
+from keras.applications.efficientnet import EfficientNetB0
+from keras.applications.efficientnet import EfficientNetB1
+from keras.applications.efficientnet import EfficientNetB2
+from keras.applications.efficientnet import EfficientNetB3
+from keras.applications.efficientnet import EfficientNetB4
+from keras.applications.efficientnet import EfficientNetB5
+from keras.applications.efficientnet import EfficientNetB6
+from keras.applications.efficientnet import EfficientNetB7
 
 model = VGG16(weights='imagenet', include_top=True)
 ```

--- a/keras/applications/__init__.py
+++ b/keras/applications/__init__.py
@@ -34,3 +34,6 @@ from .densenet import DenseNet121, DenseNet169, DenseNet201
 from .nasnet import NASNetMobile, NASNetLarge
 from .resnet import ResNet101, ResNet152
 from .resnet_v2 import ResNet50V2, ResNet101V2, ResNet152V2
+from .efficientnet import EfficientNetB0, EfficientNetB1, EfficientNetB2
+from .efficientnet import EfficientNetB3, EfficientNetB4, EfficientNetB5
+from .efficientnet import EfficientNetB6, EfficientNetB7

--- a/keras/applications/__init__.py
+++ b/keras/applications/__init__.py
@@ -34,6 +34,4 @@ from .densenet import DenseNet121, DenseNet169, DenseNet201
 from .nasnet import NASNetMobile, NASNetLarge
 from .resnet import ResNet101, ResNet152
 from .resnet_v2 import ResNet50V2, ResNet101V2, ResNet152V2
-from .efficientnet import EfficientNetB0, EfficientNetB1, EfficientNetB2
-from .efficientnet import EfficientNetB3, EfficientNetB4, EfficientNetB5
-from .efficientnet import EfficientNetB6, EfficientNetB7
+from .efficientnet import EfficientNetSmall, EfficientNetLarge

--- a/keras/applications/efficientnet.py
+++ b/keras/applications/efficientnet.py
@@ -48,9 +48,9 @@ def EfficientNetB7(*args, **kwargs):
 
 @keras_modules_injection
 def decode_predictions(*args, **kwargs):
-    return densenet.decode_predictions(*args, **kwargs)
+    return efficientnet.decode_predictions(*args, **kwargs)
 
 
 @keras_modules_injection
 def preprocess_input(*args, **kwargs):
-    return densenet.preprocess_input(*args, **kwargs)
+    return efficientnet.preprocess_input(*args, **kwargs)

--- a/keras/applications/efficientnet.py
+++ b/keras/applications/efficientnet.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 try:
-   from keras_applications import efficientnet
+    from keras_applications import efficientnet
 except:
     efficientnet = None
 from . import keras_modules_injection

--- a/keras/applications/efficientnet.py
+++ b/keras/applications/efficientnet.py
@@ -10,43 +10,13 @@ from . import keras_modules_injection
 
 
 @keras_modules_injection
-def EfficientNetB0(*args, **kwargs):
-    return efficientnet.EfficientNetB0(*args, **kwargs)
+def EfficientNetSmall(*args, **kwargs):
+    return efficientnet.EfficientNetSmall(*args, **kwargs)
 
 
 @keras_modules_injection
-def EfficientNetB1(*args, **kwargs):
-    return efficientnet.EfficientNetB1(*args, **kwargs)
-
-
-@keras_modules_injection
-def EfficientNetB2(*args, **kwargs):
-    return efficientnet.EfficientNetB2(*args, **kwargs)
-
-
-@keras_modules_injection
-def EfficientNetB3(*args, **kwargs):
-    return efficientnet.EfficientNetB3(*args, **kwargs)
-
-
-@keras_modules_injection
-def EfficientNetB4(*args, **kwargs):
-    return efficientnet.EfficientNetB4(*args, **kwargs)
-
-
-@keras_modules_injection
-def EfficientNetB5(*args, **kwargs):
-    return efficientnet.EfficientNetB5(*args, **kwargs)
-
-
-@keras_modules_injection
-def EfficientNetB6(*args, **kwargs):
-    return efficientnet.EfficientNetB6(*args, **kwargs)
-
-
-@keras_modules_injection
-def EfficientNetB7(*args, **kwargs):
-    return efficientnet.EfficientNetB7(*args, **kwargs)
+def EfficientNetLarge(*args, **kwargs):
+    return efficientnet.EfficientNetLarge(*args, **kwargs)
 
 
 @keras_modules_injection

--- a/keras/applications/efficientnet.py
+++ b/keras/applications/efficientnet.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from keras_applications import efficientnet
+from . import keras_modules_injection
+
+
+@keras_modules_injection
+def EfficientNetB0(*args, **kwargs):
+    return efficientnet.EfficientNetB0(*args, **kwargs)
+
+
+@keras_modules_injection
+def EfficientNetB1(*args, **kwargs):
+    return efficientnet.EfficientNetB1(*args, **kwargs)
+
+
+@keras_modules_injection
+def EfficientNetB2(*args, **kwargs):
+    return efficientnet.EfficientNetB2(*args, **kwargs)
+
+
+@keras_modules_injection
+def EfficientNetB3(*args, **kwargs):
+    return efficientnet.EfficientNetB3(*args, **kwargs)
+
+
+@keras_modules_injection
+def EfficientNetB4(*args, **kwargs):
+    return efficientnet.EfficientNetB4(*args, **kwargs)
+
+
+@keras_modules_injection
+def EfficientNetB5(*args, **kwargs):
+    return efficientnet.EfficientNetB5(*args, **kwargs)
+
+
+@keras_modules_injection
+def EfficientNetB6(*args, **kwargs):
+    return efficientnet.EfficientNetB6(*args, **kwargs)
+
+
+@keras_modules_injection
+def EfficientNetB7(*args, **kwargs):
+    return efficientnet.EfficientNetB7(*args, **kwargs)
+
+
+@keras_modules_injection
+def decode_predictions(*args, **kwargs):
+    return densenet.decode_predictions(*args, **kwargs)
+
+
+@keras_modules_injection
+def preprocess_input(*args, **kwargs):
+    return densenet.preprocess_input(*args, **kwargs)

--- a/keras/applications/efficientnet.py
+++ b/keras/applications/efficientnet.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from keras_applications import efficientnet
+try:
+   from keras_applications import efficientnet
+except:
+    efficientnet = None
 from . import keras_modules_injection
 
 

--- a/tests/integration_tests/applications_test.py
+++ b/tests/integration_tests/applications_test.py
@@ -24,7 +24,13 @@ MODEL_LIST = [
     (applications.DenseNet169, 1664),
     (applications.DenseNet201, 1920),
     # Note that NASNetLarge is too heavy to test on Travis.
-    (applications.NASNetMobile, 1056)
+    (applications.NASNetMobile, 1056),
+    (applications.EfficientNetB0, 1280),
+    (applications.EfficientNetB1, 1280),
+    (applications.EfficientNetB2, 1408),
+    (applications.EfficientNetB3, 1536),
+    (applications.EfficientNetB4, 1792),
+    (applications.EfficientNetB5, 2048),
 ]
 
 

--- a/tests/integration_tests/applications_test.py
+++ b/tests/integration_tests/applications_test.py
@@ -24,13 +24,7 @@ MODEL_LIST = [
     (applications.DenseNet169, 1664),
     (applications.DenseNet201, 1920),
     # Note that NASNetLarge is too heavy to test on Travis.
-    (applications.NASNetMobile, 1056),
-    (applications.EfficientNetB0, 1280),
-    (applications.EfficientNetB1, 1280),
-    (applications.EfficientNetB2, 1408),
-    (applications.EfficientNetB3, 1536),
-    (applications.EfficientNetB4, 1792),
-    (applications.EfficientNetB5, 2048),
+    (applications.NASNetMobile, 1056)
 ]
 
 


### PR DESCRIPTION
### Summary

This PR adds EfficientNet variants. EfficientNet was published in ICML 2019 and is the current SOTA. @Callidior helped this PR.

### Related Issues

keras-team/keras-applications#113

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [y] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
