### PR TITLE
Add a PrecisionAtRecall metric.

### DIFF
--- a/tests/keras/metrics_confusion_matrix_test.py
+++ b/tests/keras/metrics_confusion_matrix_test.py
@@ -432,7 +432,7 @@ class TestPrecisionAtRecall(object):
         y_true = K.constant(label_values, dtype='float32')
         weights = K.constant(weight_values)
         result = s_obj(y_true, y_pred, sample_weight=weights)
-        assert np.isclose(2./3., K.eval(result))
+        assert np.isclose(2. / 3., K.eval(result))
 
     def test_invalid_sensitivity(self):
         with pytest.raises(Exception):


### PR DESCRIPTION
### Summary
This PR adds a new PrecisionAtRecall metric to Keras. It also fixes a couple of minor typos in the code around it.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [X] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
