### PR TITLE
Add 'ConvRNN2D' to layers/recurrent.md

### DIFF
--- a/docs/structure.py
+++ b/docs/structure.py
@@ -205,6 +205,7 @@ PAGES = [
             layers.SimpleRNN,
             layers.GRU,
             layers.LSTM,
+            layers.ConvRNN2D,
             layers.ConvLSTM2D,
             layers.ConvLSTM2DCell,
             layers.SimpleRNNCell,

--- a/keras/layers/__init__.py
+++ b/keras/layers/__init__.py
@@ -122,6 +122,7 @@ from .advanced_activations import ReLU
 from .wrappers import Bidirectional
 from .wrappers import TimeDistributed
 
+from .convolutional_recurrent import ConvRNN2D
 from .convolutional_recurrent import ConvLSTM2D
 from .convolutional_recurrent import ConvLSTM2DCell
 

--- a/keras/layers/convolutional_recurrent.py
+++ b/keras/layers/convolutional_recurrent.py
@@ -133,11 +133,8 @@ class ConvRNN2D(RNN):
                  return_state=False,
                  go_backwards=False,
                  stateful=False,
-                 unroll=False,
                  **kwargs):
-        if unroll:
-            raise TypeError('Unrolling isn\'t possible with '
-                            'convolutional RNNs.')
+        # Unrolling is not possible with Convolutional RNNs
         if isinstance(cell, (list, tuple)):
             # The StackedConvRNN2DCells isn't implemented yet.
             raise TypeError('It is not possible at the moment to'
@@ -147,7 +144,6 @@ class ConvRNN2D(RNN):
                                         return_state,
                                         go_backwards,
                                         stateful,
-                                        unroll,
                                         **kwargs)
         self.input_spec = [InputSpec(ndim=5)]
 


### PR DESCRIPTION
### Summary
Although the `ConvLSTM2D` docstring is properly coded into layers/recurrent.md of Keras Documentation, `ConvRNN2D`, which is the base class of Convolutional RNN layers and also a well-working layer by itself at the same time, is missing in the document. Therefore, most of users don't even know `ConvRNN2D` exists. So I added it for the convinience of users. The two filed listed below were edited to make autogen.py properly load the `ConvRNN2D` docstring.

- Add `import ConvRNN2D` to layers/__init__.py
- Add `layers.ConvRNN2D` to 'page': 'layers/recurrent.md' - 'classes'
- Remove argument `unroll` from `ConvRNN2D` 

Argument `unroll` is not supported in `ConvRNN2D` as it is written in the docs that it's not possible with Convolutional RNNS. But the argument itself still exists and causes an error in Travis CI test_doc: **ValueError: ("ConvRNN2D ['unroll'] arguments are not present in documentation ", 'keras.layers.convolutional_recurrent')**.

There are two ways to fix this error: **1. add `unroll` method explanations in `ConvRNN2D`document, 2. remove `unroll` argument from `ConvRNN2D` code. I chose the latter**, because an argument which has no other selectives doesn't need to be noted for user convinience and simplicity(as it was in docs before this fix), and `RNN`, the parent of `ConvRNN2D`, owns `unroll=False` as its default, so `unroll` of ConvRNN2D stays fixed as `False`. Currenty `unroll` arguement does nothing but putting out a TypeError when `unroll=True`, which can't happen if there's no `unroll`.



### Related Issues
#13089 also contains an edited version of structure.py which load all methods of all classes listed in the file. In my opinon, adding `ConvRNN2D` and other missing important layers seems better to be done in advance, especially in case not all methods are necessarily noted on the documentation pages.

### PR Overview
- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)