### PR TITLE
Clarify axis in normalization.py

### DIFF
--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -21,8 +21,10 @@ class BatchNormalization(Layer):
     close to 0 and the activation standard deviation close to 1.
 
     # Arguments
-        axis: Integer, the axis that should be normalized
-            (typically the features axis).
+        axis: Integer, the axis that should be comparable on the same 
+            scale (typically the features axis), i.e. preserve the 
+            dimensions, and normalize with respect to the mean and 
+            standard deviation over every other axis.
             For instance, after a `Conv2D` layer with
             `data_format="channels_first"`,
             set `axis=1` in `BatchNormalization`.


### PR DESCRIPTION
The phrase "axis that should be normalized" is ambiguous and unclear.  

See: https://stackoverflow.com/a/47549590/6296435

Many people understand it to be taking mean and std **along** that axis, i.e. collapse that dimension and preserve all other dimensions. This is also the behavior of np.mean, and other operations.  

But this is obviously the opposite of what is going on here, and so the documentation should be corrected to reflect this.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
