### PR TITLE
Fix for disabling tensorflow v2 behavior.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -374,10 +374,6 @@ def get_session():
         RuntimeError: if no session is available
             (e.g. when using TensorFlow 2.0).
     """
-    if not _is_tf_1():
-        raise RuntimeError(
-            '`get_session` is not available '
-            'when using TensorFlow 2.0.')
     if tf.executing_eagerly():
         raise RuntimeError(
             '`get_session` is not available when '
@@ -2921,10 +2917,10 @@ def get_value(x):
     # Returns
         A Numpy array.
     """
-    if _is_tf_1():
-        return x.eval(session=get_session())
-    else:
+    if tf.executing_eagerly():
         return x.numpy()
+    else:
+        return x.eval(session=get_session())
 
 
 def batch_get_value(ops):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -389,12 +389,8 @@ def set_session(session):
 
     # Raises
         RuntimeError: if no session is available
-            (e.g. when using TensorFlow 2.0).
+            (e.g. when using TensorFlow eagerly).
     """
-    if not _is_tf_1():
-        raise RuntimeError(
-            '`set_session` is not available '
-            'when using TensorFlow 2.0.')
     if tf.executing_eagerly():
         raise RuntimeError(
             '`set_session` is not available when '


### PR DESCRIPTION
### Summary
Due to a difficult migration to tf2, I plan to disable tf2 behavior for now in our project (using `tf.compat.v1.disable_v2_behavior`). However, with tf2 behavior disabled, I run into the following runtime error:

```shell
Traceback (most recent call last):
  File "keras_retinanet/bin/train.py", line 528, in <module>
    main()
  File "keras_retinanet/bin/train.py", line 523, in main
    validation_data=validation_generator
  File "/usr/lib/python3.7/site-packages/keras/legacy/interfaces.py", line 91, in wrapper
    return func(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/keras/engine/training.py", line 1732, in fit_generator
    initial_epoch=initial_epoch)
  File "/usr/lib/python3.7/site-packages/keras/engine/training_generator.py", line 260, in fit_generator
    callbacks.on_epoch_end(epoch, epoch_logs)
  File "/usr/lib/python3.7/site-packages/keras/callbacks/callbacks.py", line 152, in on_epoch_end
    callback.on_epoch_end(epoch, logs)
  File "/usr/lib/python3.7/site-packages/keras/callbacks/callbacks.py", line 1036, in on_epoch_end
    logs['lr'] = K.get_value(self.model.optimizer.lr)
  File "/usr/lib/python3.7/site-packages/keras/backend/tensorflow_backend.py", line 2927, in get_value
    return x.numpy()
  File "/usr/lib/python3.7/site-packages/tensorflow_core/python/ops/resource_variable_ops.py", line 579, in numpy
    "numpy() is only available when eager execution is enabled.")
NotImplementedError: numpy() is only available when eager execution is enabled.
```

The reason for this is that `tensorflow_backend` uses the version of tensorflow to decide if it will execute eagerly or if it will use a `tf.Session` to evaluate a variable. A better check would be to check if tensorflow is executing eagerly or not, regardless of its version. This PR makes the necessary changes for that.

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
