### PR TITLE
Fix h5py group naming while model saving

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -746,11 +746,7 @@ def save_weights_to_hdf5_group(group, layers):
 
     # Sort model layers by layer name to ensure that group names are strictly
     # growing to avoid prefix issues.
-    sorted_layers = [(layers[i].name, i) for i in range(len(layers))]
-    sorted_layers.sort()
-
-    for layer_name, original_layer_index in sorted_layers:
-        layer = layers[original_layer_index]
+    for layer in sorted(layers, key=lambda x: x.name):
         g = group.create_group(layer.name)
         symbolic_weights = layer.weights
         weight_values = K.batch_get_value(symbolic_weights)

--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -744,7 +744,13 @@ def save_weights_to_hdf5_group(group, layers):
     group.attrs['backend'] = K.backend().encode('utf8')
     group.attrs['keras_version'] = str(keras_version).encode('utf8')
 
-    for layer in layers:
+    # Sort model layers by layer name to ensure that group names are strictly
+    # growing to avoid prefix issues.
+    sorted_layers = [(layers[i].name, i) for i in range(len(layers))]
+    sorted_layers.sort()
+
+    for layer_name, original_layer_index in sorted_layers:
+        layer = layers[original_layer_index]
         g = group.create_group(layer.name)
         symbolic_weights = layer.weights
         weight_values = K.batch_get_value(symbolic_weights)

--- a/tests/keras/metrics_training_test.py
+++ b/tests/keras/metrics_training_test.py
@@ -1,7 +1,6 @@
 """Tests for metric objects training and evaluation."""
 import pytest
 import numpy as np
-from flaky import flaky
 
 from keras import metrics
 from keras import backend as K
@@ -81,8 +80,7 @@ def test_sensitivity_metrics():
     model.evaluate(x, y)
 
 
-@pytest.mark.skipif(K.backend() != 'tensorflow', reason='requires tensorflow')
-@flaky(rerun_filter=lambda err, *args: issubclass(err[0], InvalidArgumentError))
+@pytest.mark.skipif(True, reason='It is a flaky test, see #13477 for more context.')
 def test_mean_iou():
     import tensorflow as tf
     if not tf.__version__.startswith('2.'):

--- a/tests/keras/metrics_training_test.py
+++ b/tests/keras/metrics_training_test.py
@@ -1,6 +1,7 @@
 """Tests for metric objects training and evaluation."""
 import pytest
 import numpy as np
+from flaky import flaky
 
 from keras import metrics
 from keras import backend as K
@@ -81,6 +82,7 @@ def test_sensitivity_metrics():
 
 
 @pytest.mark.skipif(K.backend() != 'tensorflow', reason='requires tensorflow')
+@flaky(rerun_filter=lambda err, *args: issubclass(err[0], InvalidArgumentError))
 def test_mean_iou():
     import tensorflow as tf
     if not tf.__version__.startswith('2.'):

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -14,7 +14,7 @@ from keras.engine.saving import preprocess_weights_for_loading
 from keras.models import Model, Sequential
 from keras.layers import Dense, Lambda, RepeatVector, TimeDistributed
 from keras.layers import Bidirectional, GRU, LSTM, CuDNNGRU, CuDNNLSTM
-from keras.layers import Conv2D, Flatten
+from keras.layers import Conv2D, Flatten, Activation
 from keras.layers import Input, InputLayer
 from keras.initializers import Constant
 from keras import optimizers
@@ -705,6 +705,22 @@ def test_saving_constant_initializer_with_numpy():
     _, fname = tempfile.mkstemp('.h5')
     save_model(model, fname)
     model = load_model(fname)
+    os.remove(fname)
+
+
+def test_saving_group_naming_h5py():
+    """Test saving model with layer which name is prefix to a previous layer
+    name
+    """
+
+    input_layer = Input((None, None, 3), name='test_input')
+    x = Conv2D(1, 1, name='conv1/conv')(input_layer)
+    x = Activation('relu', name='conv1')(x)
+
+    model = Model(inputs=input_layer, outputs=x)
+    _, fname = tempfile.mkstemp('.h5')
+    model.save_weights(fname)
+    model.load_weights(fname)
     os.remove(fname)
 
 

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -708,7 +708,7 @@ def test_saving_constant_initializer_with_numpy():
     os.remove(fname)
 
 
-def test_saving_group_naming_h5py():
+def test_saving_group_naming_h5py(tmpdir):
     """Test saving model with layer which name is prefix to a previous layer
     name
     """
@@ -718,10 +718,9 @@ def test_saving_group_naming_h5py():
     x = Activation('relu', name='conv1')(x)
 
     model = Model(inputs=input_layer, outputs=x)
-    _, fname = tempfile.mkstemp('.h5')
-    model.save_weights(fname)
-    model.load_weights(fname)
-    os.remove(fname)
+    p = tmpdir.mkdir("test").join("test.h5")
+    model.save_weights(p)
+    model.load_weights(p)
 
 
 def test_save_load_weights_gcs():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

This pull request is related to issue [#12195 ](url). There is a bug while saving .h5 models. In a model, if a layer name is prefix of a previously defined layer name, then h5py will fail with error: "ValueError: Unable to create group (name already exists)".

```
Traceback (most recent call last):
  File "$PATH/test.py", line 12, in <module>
    model.save_weights('test.h5')
  File "$PATH/keras/keras/engine/saving.py", line 449, in save_wrapper
    save_function(obj, filepath, overwrite, *args, **kwargs)
  File "$PATH/keras/keras/engine/network.py", line 1184, in save_weights
    saving.save_weights_to_hdf5_group(f, self.layers)
  File "$PATH/keras/keras/engine/saving.py", line 748, in save_weights_to_hdf5_group
    g = group.create_group(layer.name)
  File "$PATH/keras_pr_py3/lib/python3.5/site-packages/h5py/_hl/group.py", line 68, in create_group
    gid = h5g.create(self.id, name, lcpl=lcpl, gcpl=gcpl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5g.pyx", line 161, in h5py.h5g.create
ValueError: Unable to create group (name already exists)

```

This problem is even more present in Tensorflow 2.0 because saving a model with tf.ones_like, tf.zeros_like, tf.boolean_mask, ...  Tensors will lead to this error.

The first commit of this pull request sorts the model layers by name to ensure that h5py group names are strictly growing to avoid prefix issues. File: keras/engine/saving.py
The second commit of this pull request add a test described problem.
Function: test_saving_group_naming_h5py() in File: tests/test_model_saving.py


### Related Issues
Fixes #12195 .

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
     Included in second commit
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
