### PR TITLE
a new class for realizing Early Stopping

### DIFF
--- a/keras/callbacks/callbacks.py
+++ b/keras/callbacks/callbacks.py
@@ -861,9 +861,7 @@ class AdvancedEarlyStopping(Callback):
             kwargs: alpha -- Threshold for GL
                     kpq -- Stride for PQ
                     sup -- Patience for UP
-                    
         """
-
         self.mode = mode
         
         if mode == '1':
@@ -909,7 +907,6 @@ class AdvancedEarlyStopping(Callback):
         self.verbose = verbose
         super(Callback, self).__init__()
 
-
     def on_epoch_end(self, epoch, logs={}):
         
         tr_loss_cur = logs['loss']
@@ -919,19 +916,16 @@ class AdvancedEarlyStopping(Callback):
             if val_loss_cur < self.val_loss_opt:
                 self.val_loss_opt = val_loss_cur
             gl = 100. * (val_loss_cur / self.val_loss_opt - 1)
-
             if self.verbose > 0:
                 print("Epoch {0} Generalization Loss: {1}".format(epoch + 1, gl))
                 if gl > self.alpha:
                     print("Epoch %05d: GL early stopping Threshold" % (epoch + 1))
                     self.model.stop_training = True
-
 
         if self.mode == '2':
             if val_loss_cur < self.val_loss_opt:
                 self.val_loss_opt = val_loss_cur
             gl = 100. * (val_loss_cur / self.val_loss_opt - 1)
-
             self.tr_queue.append(tr_loss_cur)
             if len(self.tr_queue) == self.tr_queue.maxlen:
                 sigma = np.sum(self.tr_queue)
@@ -944,13 +938,11 @@ class AdvancedEarlyStopping(Callback):
                         print("Epoch %05d: PQ early stopping Threshold" % (epoch + 1))
                         self.model.stop_training = True
 
-            
         if self.mode == '3':
             if val_loss_cur > self.val_loss_pre:
                 self.count += 1
                 if self.verbose > 0:
                     print("Epoch {0} val_error increased: {1} times.".format(epoch + 1, self.count))
-
                 if self.count >= self.sup:
                         print("Epoch %05d: UP early stopping Threshold" % (epoch + 1))
                         self.model.stop_training = True
@@ -958,23 +950,19 @@ class AdvancedEarlyStopping(Callback):
                 self.val_loss_pre = val_loss_cur
                 self.count = 0
 
-        
         if self.mode == '4':
             if val_loss_cur < self.val_loss_opt:
                 self.val_loss_opt = val_loss_cur
             gl = 100. * (val_loss_cur / self.val_loss_opt - 1)
-
             if self.verbose > 0:
                 print("Epoch {0} Generalization Loss: {1}".format(epoch + 1, gl))
                 if gl > self.alpha:
                     print("Epoch %05d: GL early stopping Threshold" % (epoch + 1))
                     self.model.stop_training = True
-
             if val_loss_cur >= self.val_loss_pre:
                 self.count += 1
                 if self.verbose > 0:
                     print("Epoch {0} val_error increased: {1} times.".format(epoch + 1, self.count))
-
                 if self.count >= self.sup:
                         print("Epoch %05d: UP early stopping Threshold" % (epoch + 1))
                         self.model.stop_training = True
@@ -982,12 +970,10 @@ class AdvancedEarlyStopping(Callback):
                 self.val_loss_pre = val_loss_cur
                 self.count = 0
 
-
         if self.mode == '5':
             if val_loss_cur < self.val_loss_opt:
                 self.val_loss_opt = val_loss_cur
             gl = 100. * (val_loss_cur / self.val_loss_opt - 1)
-
             self.tr_queue.append(tr_loss_cur)
             if len(self.tr_queue) == self.tr_queue.maxlen:
                 sigma = np.sum(self.tr_queue)
@@ -999,7 +985,6 @@ class AdvancedEarlyStopping(Callback):
                     if pq > self.alpha:
                         print("Epoch %05d: PQ early stopping Threshold" % (epoch + 1))
                         self.model.stop_training = True
-
             if val_loss_cur >= self.val_loss_pre:
                 self.count += 1
                 if self.verbose > 0:

--- a/keras/callbacks/callbacks.py
+++ b/keras/callbacks/callbacks.py
@@ -52,7 +52,8 @@ class CallbackList(object):
 
     def _reset_batch_timing(self):
         self._delta_t_batch = 0.
-        self._delta_ts = defaultdict(lambda: deque([], maxlen=self.queue_length))
+        self._delta_ts = defaultdict(
+            lambda: deque([], maxlen=self.queue_length))
 
     def append(self, callback):
         self.callbacks.append(callback)
@@ -87,8 +88,8 @@ class CallbackList(object):
 
         delta_t_median = np.median(self._delta_ts[hook_name])
         if (self._delta_t_batch > 0. and
-           delta_t_median > 0.95 * self._delta_t_batch and
-           delta_t_median > 0.1):
+            delta_t_median > 0.95 * self._delta_t_batch and
+                delta_t_median > 0.1):
             warnings.warn(
                 'Method (%s) is slow compared '
                 'to the batch update (%f). Check your callbacks.'
@@ -723,7 +724,8 @@ class ModelCheckpoint(Callback):
                                   (epoch + 1, self.monitor, self.best))
             else:
                 if self.verbose > 0:
-                    print('\nEpoch %05d: saving model to %s' % (epoch + 1, filepath))
+                    print('\nEpoch %05d: saving model to %s' %
+                          (epoch + 1, filepath))
                 if self.save_weights_only:
                     self.model.save_weights(filepath, overwrite=True)
                 else:
@@ -849,7 +851,7 @@ class EarlyStopping(Callback):
 
 
 class AdvancedEarlyStopping(Callback):
-    
+
     def __init__(self, mode, verbose=0, **kwargs):
         """Arguments:
             mode: '1' -- Generalization Loss
@@ -857,13 +859,13 @@ class AdvancedEarlyStopping(Callback):
                   '3' -- UP
                   '4' -- GL + UP
                   '5' -- GL + PQ + UP
-                    
+
             kwargs: alpha -- Threshold for GL
                     kpq -- Stride for PQ
                     sup -- Patience for UP
         """
         self.mode = mode
-        
+
         if mode == '1':
             assert 'alpha' in kwargs, "Must provide alpha for mode 1."
             self.alpha = kwargs['alpha']
@@ -908,7 +910,7 @@ class AdvancedEarlyStopping(Callback):
         super(Callback, self).__init__()
 
     def on_epoch_end(self, epoch, logs={}):
-        
+
         tr_loss_cur = logs['loss']
         val_loss_cur = logs['val_loss']
 
@@ -917,9 +919,11 @@ class AdvancedEarlyStopping(Callback):
                 self.val_loss_opt = val_loss_cur
             gl = 100. * (val_loss_cur / self.val_loss_opt - 1)
             if self.verbose > 0:
-                print("Epoch {0} Generalization Loss: {1}".format(epoch + 1, gl))
+                print("Epoch {0} Generalization Loss: {1}".format(
+                    epoch + 1, gl))
                 if gl > self.alpha:
-                    print("Epoch %05d: GL early stopping Threshold" % (epoch + 1))
+                    print("Epoch %05d: GL early stopping Threshold" %
+                          (epoch + 1))
                     self.model.stop_training = True
 
         if self.mode == '2':
@@ -933,19 +937,23 @@ class AdvancedEarlyStopping(Callback):
                 pk = 1000. * (sigma / (self.kpq * tf_loss_min) - 1)
                 pq = gl / pk
                 if self.verbose > 0:
-                    print("Epoch {0} Progress Quotient: {1}".format(epoch + 1, pq))
+                    print("Epoch {0} Progress Quotient: {1}".format(
+                        epoch + 1, pq))
                     if pq > self.alpha:
-                        print("Epoch %05d: PQ early stopping Threshold" % (epoch + 1))
+                        print("Epoch %05d: PQ early stopping Threshold" %
+                              (epoch + 1))
                         self.model.stop_training = True
 
         if self.mode == '3':
             if val_loss_cur > self.val_loss_pre:
                 self.count += 1
                 if self.verbose > 0:
-                    print("Epoch {0} val_error increased: {1} times.".format(epoch + 1, self.count))
+                    print("Epoch {0} val_error increased: {1} times.".format(
+                        epoch + 1, self.count))
                 if self.count >= self.sup:
-                        print("Epoch %05d: UP early stopping Threshold" % (epoch + 1))
-                        self.model.stop_training = True
+                    print("Epoch %05d: UP early stopping Threshold" %
+                          (epoch + 1))
+                    self.model.stop_training = True
             else:
                 self.val_loss_pre = val_loss_cur
                 self.count = 0
@@ -955,17 +963,21 @@ class AdvancedEarlyStopping(Callback):
                 self.val_loss_opt = val_loss_cur
             gl = 100. * (val_loss_cur / self.val_loss_opt - 1)
             if self.verbose > 0:
-                print("Epoch {0} Generalization Loss: {1}".format(epoch + 1, gl))
+                print("Epoch {0} Generalization Loss: {1}".format(
+                    epoch + 1, gl))
                 if gl > self.alpha:
-                    print("Epoch %05d: GL early stopping Threshold" % (epoch + 1))
+                    print("Epoch %05d: GL early stopping Threshold" %
+                          (epoch + 1))
                     self.model.stop_training = True
             if val_loss_cur >= self.val_loss_pre:
                 self.count += 1
                 if self.verbose > 0:
-                    print("Epoch {0} val_error increased: {1} times.".format(epoch + 1, self.count))
+                    print("Epoch {0} val_error increased: {1} times.".format(
+                        epoch + 1, self.count))
                 if self.count >= self.sup:
-                        print("Epoch %05d: UP early stopping Threshold" % (epoch + 1))
-                        self.model.stop_training = True
+                    print("Epoch %05d: UP early stopping Threshold" %
+                          (epoch + 1))
+                    self.model.stop_training = True
             else:
                 self.val_loss_pre = val_loss_cur
                 self.count = 0
@@ -981,18 +993,22 @@ class AdvancedEarlyStopping(Callback):
                 pk = 1000. * (sigma / (self.kpq * tf_loss_min) - 1)
                 pq = gl / pk
                 if self.verbose > 0:
-                    print("Epoch {0} Progress Quotient: {1}".format(epoch + 1, pq))
+                    print("Epoch {0} Progress Quotient: {1}".format(
+                        epoch + 1, pq))
                     if pq > self.alpha:
-                        print("Epoch %05d: PQ early stopping Threshold" % (epoch + 1))
+                        print("Epoch %05d: PQ early stopping Threshold" %
+                              (epoch + 1))
                         self.model.stop_training = True
             if val_loss_cur >= self.val_loss_pre:
                 self.count += 1
                 if self.verbose > 0:
-                    print("Epoch {0} val_error increased: {1} times.".format(epoch + 1, self.count))
+                    print("Epoch {0} val_error increased: {1} times.".format(
+                        epoch + 1, self.count))
 
                 if self.count >= self.sup:
-                        print("Epoch %05d: UP early stopping Threshold" % (epoch + 1))
-                        self.model.stop_training = True
+                    print("Epoch %05d: UP early stopping Threshold" %
+                          (epoch + 1))
+                    self.model.stop_training = True
             else:
                 self.val_loss_pre = val_loss_cur
                 self.count = 0
@@ -1047,7 +1063,8 @@ class RemoteMonitor(Callback):
                 send[k] = v
         try:
             if self.send_as_json:
-                requests.post(self.root + self.path, json=send, headers=self.headers)
+                requests.post(self.root + self.path,
+                              json=send, headers=self.headers)
             else:
                 requests.post(self.root + self.path,
                               {self.field: json.dumps(send)},
@@ -1169,7 +1186,7 @@ class ReduceLROnPlateau(Callback):
                           RuntimeWarning)
             self.mode = 'auto'
         if (self.mode == 'min' or
-           (self.mode == 'auto' and 'acc' not in self.monitor)):
+                (self.mode == 'auto' and 'acc' not in self.monitor)):
             self.monitor_op = lambda a, b: np.less(a, b - self.min_delta)
             self.best = np.Inf
         else:
@@ -1282,7 +1299,8 @@ class CSVLogger(Callback):
 
         if self.model.stop_training:
             # We set NA so that csv parsers do not fail for this last epoch.
-            logs = dict([(k, logs[k] if k in logs else 'NA') for k in self.keys])
+            logs = dict([(k, logs[k] if k in logs else 'NA')
+                         for k in self.keys])
 
         if not self.writer:
             class CustomDialect(csv.excel):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

I want to add a new class for realizing Early Stopping. I have already implemented the class in my own code.

It is based on 3 metrics from paper "Early Stopping - but when? Lutz Prechelt, University Karlsrhe". 

1. **Generalization Loss**(GL). GL can be described as a metric that can measure how much current validation loss exceeds the lowest validation loss. Training will stop as soon as GL exceeds a certain threshold. 

2. **Progress Quotient**(PQ).  It considers training strip of length `k`. Progress means how much was the average training error during the strip larger than the minimum training error during the strip. Quotient means use the quotient of GL and Progress. Thus, training will stop as soon as the PQ exceeds a certain threshold. 

3. **UP**. This is simple. Training will stop when the generalization error increased in `s` successive strips.

Combining these metrics, there are 5 modes for doing early stopping. 1, 2, 3, 1+3, 2+3.

I think basically all workers using Keras will be beneficial from this.

Now the EarlyStopping class of Keras can only stop training based on patience and delta, whereas there are advanced and useful early stopping methods.

### Related Issues

This idea comes from others paper, I just realized it. For further info, please refer to the paper.
[early stopping - but when.pdf](https://github.com/keras-team/keras/files/3774689/early.stopping.-.but.when.pdf)


### PR Overview

- [ ] This PR requires new unit tests [n] (make sure tests are included)
- [x] This PR requires to update the documentation [y] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [n] (all API changes need to be approved by fchollet)
