### PR TITLE
Instead of dict pop accessing dict value directly.

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -466,7 +466,7 @@ def allow_read_from_gcs(load_function):
     """
     def extract_named_arg(f, name, args, kwargs):
         if name in kwargs:
-            arg = kwargs.pop(name)
+            arg = kwargs[name]
             return arg, args, kwargs
         argnames = getargspec(f)[0]
         for i, (argname, arg) in enumerate(zip(argnames, args)):


### PR DESCRIPTION
### Summary
Since version 2.2.5 the load_weights function raises a TypeError while passing the filepath value with explicitly accessing the filepath parameter.

`model.load_weights(filepath=my_path)`

This does not work because the filepath is popped out of the kwargs dictionary inside the `extract_named_arg` function [at line 469](https://github.com/keras-team/keras/blob/master/keras/engine/saving.py#L469). 
When returning the load_function at [line 492](https://github.com/keras-team/keras/blob/master/keras/engine/saving.py#L492) the kwargs dictionary does not contain filepath anymore.

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
