### PR TITLE
Bugfix: removed side effect of extract_named_arg

### DIFF
--- a/keras/engine/saving.py
+++ b/keras/engine/saving.py
@@ -466,8 +466,9 @@ def allow_read_from_gcs(load_function):
     """
     def extract_named_arg(f, name, args, kwargs):
         if name in kwargs:
-            arg = kwargs.pop(name)
-            return arg, args, kwargs
+            _kwargs = kwargs.copy()
+            arg = _kwargs.pop(name)
+            return arg, args, _kwargs
         argnames = getargspec(f)[0]
         for i, (argname, arg) in enumerate(zip(argnames, args)):
             if argname == name:


### PR DESCRIPTION
### Summary

`extract_named_arg` changed it's given parameter `kwargs`, if it contains the extracted `arg`.
This lead to an error when calling `load_wrapper` with `filename=foo` (when not using gcs), as it expects to continue working with the original variable `kwargs`.
Therefore now a copy of `kwargs` is edited and returned.

### Issue

```python
model.load_weights(filepath=foo)
```

gave:

```
TypeError: load_weights() missing 1 required positional argument: 'filepath'
```

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
