### PR TITLE
Remove print statement in Layer.__setattr__

### DIFF
--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -1234,7 +1234,6 @@ class Layer(object):
                         if not hasattr(self, '_trainable_weights'):
                             self._trainable_weights = []
                         if not any(v is value for v in self._trainable_weights):
-                            print('tracking', value, name)
                             self._trainable_weights.append(value)
                     else:
                         if not hasattr(self, '_non_trainable_weights'):


### PR DESCRIPTION
Layer attribute tracking was introduced in 479fc3a978221bb835f7e2781dcef0db66c96e1c by @fchollet and it included what I suspect to be a debug print statement that wasn't meant to be merged.

It causes unwanted noisy outputs when loading models in [keras-retinanet](https://github.com/fizyr/keras-retinanet) for instance.