### PR TITLE
Fix contrastive_loss equation to match to the equation mentioned in the paper

### DIFF
--- a/examples/mnist_siamese.py
+++ b/examples/mnist_siamese.py
@@ -45,7 +45,7 @@ def contrastive_loss(y_true, y_pred):
     margin = 1
     square_pred = K.square(y_pred)
     margin_square = K.square(K.maximum(margin - y_pred, 0))
-    return K.mean(y_true * square_pred + (1 - y_true) * margin_square)
+    return K.mean((1 - y_true) * square_pred + y_true * margin_square)
 
 
 def create_pairs(x, digit_indices):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

This PR fixes the issue https://github.com/keras-team/keras/issues/13584
The following equation does not match the one mentioned in the paper (equation 4 in http://yann.lecun.com/exdb/publis/pdf/hadsell-chopra-lecun-06.pdf)
```
return K.mean(y_true * square_pred + (1 - y_true) * margin_square)
```
The actual loss equation is

![equation](https://user-images.githubusercontent.com/3022518/69878771-1e560580-12c6-11ea-976b-d58609c2e9f8.png)


### Related Issues

None


### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
