### PR TITLE
Do not copy params in `get_params`.

### DIFF
--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -99,7 +99,7 @@ class BaseWrapper(object):
         # Returns
             Dictionary of parameter names mapped to their values.
         """
-        res = copy.deepcopy(self.sk_params)
+        res = self.sk_params.copy()
         res.update({'build_fn': self.build_fn})
         return res
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

For compatibility with the scikit-learn `clone` function `get_params` has to return the same parameters as given in the __init__ function. Fix issue #13586

### Related Issues

#13586

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)