### PR TITLE
Fix dynamic display for Pycharm

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -339,7 +339,8 @@ class Progbar(object):
 
         self._dynamic_display = ((hasattr(sys.stdout, 'isatty') and
                                   sys.stdout.isatty()) or
-                                 'ipykernel' in sys.modules)
+                                 'ipykernel' in sys.modules or
+                                 'PYCHARM_HOSTED' in os.environ)
         self._total_width = 0
         self._seen_so_far = 0
         self._values = collections.OrderedDict()

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import binascii
 import numpy as np
 
+import os
 import time
 import sys
 import six


### PR DESCRIPTION
### Summary
Fixes `self._dynamic_display` not being set to true for printing out the verbose training updates. Previously in PyCharm, it would print a new line every update to the progress bar and with this change it works as expected, clearing each previous update to the line and removing the annoying bug of many, many fast printing lines to the console.