### PR TITLE
Pad the input sequence in lstm_seq2seq_restore.py

### DIFF
--- a/examples/lstm_seq2seq_restore.py
+++ b/examples/lstm_seq2seq_restore.py
@@ -71,6 +71,7 @@ encoder_input_data = np.zeros(
 for i, input_text in enumerate(input_texts):
     for t, char in enumerate(input_text):
         encoder_input_data[i, t, input_token_index[char]] = 1.
+    encoder_input_data[i, t + 1:, input_token_index[' ']] = 1.
 
 # Restore the model and construct the encoder and decoder.
 model = load_model('s2s.h5')


### PR DESCRIPTION
Currently, if we run lstm_seq2seq.py, and then run lstm_seq2seq_restore.py, we'll get different results, because we only pad the input sequence in lstm_seq2seq.py.
This PR pad the input sequence in lstm_seq2seq_restore.py. After this PR, if we run lstm_seq2seq.py, and then run lstm_seq2seq_restore.py, we'll get the same result.