### PR TITLE
changed 'from collections import ABC' to 'import collections' and use 'collection.ABC'

### DIFF
--- a/keras/callbacks/callbacks.py
+++ b/keras/callbacks/callbacks.py
@@ -14,10 +14,7 @@ import json
 import warnings
 import io
 
-from collections import deque
-from collections import OrderedDict
-from collections import Iterable
-from collections import defaultdict
+import collections
 from ..utils.generic_utils import Progbar
 from .. import backend as K
 from ..engine.training_utils import standardize_input_data
@@ -52,7 +49,7 @@ class CallbackList(object):
 
     def _reset_batch_timing(self):
         self._delta_t_batch = 0.
-        self._delta_ts = defaultdict(lambda: deque([], maxlen=self.queue_length))
+        self._delta_ts = collections.defaultdict(lambda: collections.deque([], maxlen=self.queue_length))
 
     def append(self, callback):
         self.callbacks.append(callback)
@@ -1122,7 +1119,7 @@ class CSVLogger(Callback):
             is_zero_dim_ndarray = isinstance(k, np.ndarray) and k.ndim == 0
             if isinstance(k, six.string_types):
                 return k
-            elif isinstance(k, Iterable) and not is_zero_dim_ndarray:
+            elif isinstance(k, collections.Iterable) and not is_zero_dim_ndarray:
                 return '"[%s]"' % (', '.join(map(str, k)))
             else:
                 return k
@@ -1146,7 +1143,7 @@ class CSVLogger(Callback):
             if self.append_header:
                 self.writer.writeheader()
 
-        row_dict = OrderedDict({'epoch': epoch})
+        row_dict = collections.OrderedDict({'epoch': epoch})
         row_dict.update((key, handle_value(logs[key])) for key in self.keys)
         self.writer.writerow(row_dict)
         self.csv_file.flush()


### PR DESCRIPTION

I get a warning like this:
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Iterable
```

Here is the picture:

[https://i.imgur.com/SAot5Zd.png](https://i.imgur.com/SAot5Zd.png)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

### Related Issues

### PR Overview

- [N] This PR requires new unit tests [y/n] (make sure tests are included)
- [N] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [Y] This PR is backwards compatible [y/n]
- [N] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
