### PR TITLE
Updating docs of validation_steps in Model.fit

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1068,9 +1068,10 @@ class Model(Network):
                 TensorFlow data tensors, the default `None` is equal to
                 the number of samples in your dataset divided by
                 the batch size, or 1 if that cannot be determined.
-            validation_steps: Only relevant if `steps_per_epoch`
-                is specified. Total number of steps (batches of samples)
-                to validate before stopping.
+            validation_steps: Required if `validation_data` is provided and is a tuple 
+                and model is being trained by step wise training(`steps_per_epoch` 
+                is specified). Total number of steps (batches of samples) to 
+                validate before stopping.
             validation_steps: Only relevant if `validation_data` is provided
                 and is a generator. Total number of steps (batches of samples)
                 to draw before stopping when performing validation at the end

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1068,7 +1068,7 @@ class Model(Network):
                 TensorFlow data tensors, the default `None` is equal to
                 the number of samples in your dataset divided by
                 the batch size, or 1 if that cannot be determined.
-            validation_steps: Required if `validation_data` is provided and is a tuple 
+            validation_steps: Required if `validation_data` is provided
                 and model is being trained by step wise training(`steps_per_epoch` 
                 is specified). Total number of steps (batches of samples) to 
                 validate before stopping.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary
In the method 'fit' of class 'Model'  in keras/engine/training.py,
When performing step wise training('steps_per_epoch'), if validation_data is provided, validation_steps need to be specified.
### Related Issues
issue  #13652 
### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
