### PR TITLE
incorrect label value for the blank input in the batch generation

### DIFF
--- a/examples/image_ocr.py
+++ b/examples/image_ocr.py
@@ -278,7 +278,7 @@ class TextImageGenerator(keras.callbacks.Callback):
         else:
             X_data = np.ones([size, self.img_w, self.img_h, 1])
 
-        labels = np.ones([size, self.absolute_max_string_len])
+        labels = np.ones([size, self.absolute_max_string_len]) * -1
         input_length = np.zeros([size, 1])
         label_length = np.zeros([size, 1])
         source_str = []


### PR DESCRIPTION
At line 281 the initialization of the labels should be multiplied by -1 as in the build_word_list method at line 227, otherwise, when filling with the blank label at line 293 the rest of the label in the blank inputs have the value 1 which is a valid character (i.e b).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
