### PR TITLE
Correct docstrings of returned data type of any(x) and all(x) in tens…

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1823,7 +1823,7 @@ def any(x, axis=None, keepdims=False):
         keepdims: whether the drop or broadcast the reduction axes.
 
     # Returns
-        A uint8 tensor (0s and 1s).
+        A bool type tensor (True and False).
     {{np_implementation}}
     """
     x = tf.cast(x, tf.bool)
@@ -1841,7 +1841,7 @@ def all(x, axis=None, keepdims=False):
         keepdims: whether the drop or broadcast the reduction axes.
 
     # Returns
-        A uint8 tensor (0s and 1s).
+        A bool type tensor (True and False).
     {{np_implementation}}
     """
     x = tf.cast(x, tf.bool)


### PR DESCRIPTION
…orflow_backend.py

Using tensorflow backend, any(x) and all(x) return a tensor of dtype with bool, not uint8.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
