### PR TITLE
allow other masking for Embedding

### DIFF
--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -114,7 +114,7 @@ class Embedding(Layer):
 
     def compute_mask(self, inputs, mask=None):
         if not self.mask_zero:
-            return None
+            return mask
         output_mask = K.not_equal(inputs, 0)
         return output_mask
 


### PR DESCRIPTION
Even we do not mask zero, we may has other mask from previous layer. Return None directly is not very rigorous.