### PR TITLE
Fix ReduceLROnPlateau documentation

### DIFF
--- a/keras/callbacks/callbacks.py
+++ b/keras/callbacks/callbacks.py
@@ -963,9 +963,8 @@ class ReduceLROnPlateau(Callback):
         monitor: quantity to be monitored.
         factor: factor by which the learning rate will
             be reduced. new_lr = lr * factor
-        patience: number of epochs that produced the monitored
-            quantity with no improvement after which training will
-            be stopped.
+        patience: number of epochs with no improvement
+            after which learning rate will be reduced.
             Validation quantities may not be produced for every
             epoch, if the validation frequency
             (`model.fit(validation_freq=5)`) is greater than one.


### PR DESCRIPTION
### Summary
Looks like the documentation for ReduceLROnPlateau was mistakenly overwritten with the documentation from EarlyStopping. This patch fixes that.

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
