### PR TITLE
Add Optuna badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Build Status](https://travis-ci.org/keras-team/keras.svg?branch=master)](https://travis-ci.org/keras-team/keras)
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://github.com/keras-team/keras/blob/master/LICENSE)
+[![Optuna](https://img.shields.io/badge/Optuna-integrated-blue)](https://optuna.org)
 
 ## You have just found Keras.
 


### PR DESCRIPTION
### Summary

Hi!


[Optuna]( (optuna.org) ) is a new hyperparameter optimization library, and we’ve written an integration module for Keras to make it easy to use Optuna to search for good hyperparameter settings and prune unpromising trials. We’re looking for ways to let Keras users know this is available and thought a badge to show Optuna integration is available would be helpful.

Here’s our example of using the pruning integration with Keras: https://github.com/optuna/optuna/blob/master/examples/pruning/keras_integration.py

If there are other ways you would recommend reaching out to Keras users to let them know about Optuna, please let us know.

Thanks!

### Related Issues

None

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [n] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
