### PR TITLE
Fix deprecation warnings

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -4067,13 +4067,13 @@ def pool2d(x, pool_size, strides=(1, 1),
         pool_size = (1, 1) + pool_size
 
     if pool_mode == 'max':
-        x = tf.nn.max_pool(x, pool_size, strides,
-                           padding=padding,
-                           data_format=tf_data_format)
+        x = tf.nn.max_pool2d(x, pool_size, strides,
+                             padding=padding,
+                             data_format=tf_data_format)
     elif pool_mode == 'avg':
-        x = tf.nn.avg_pool(x, pool_size, strides,
-                           padding=padding,
-                           data_format=tf_data_format)
+        x = tf.nn.avg_pool2d(x, pool_size, strides,
+                             padding=padding,
+                             data_format=tf_data_format)
     else:
         raise ValueError('Invalid pool_mode: ' + str(pool_mode))
 


### PR DESCRIPTION
- Fix tf.nn.max_pool is deprecated. Please use tf.nn.max_pool2d instead
- Fix tf.nn.avg_pool is deprecated. Please use tf.nn.avg_pool2d instead

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
