### PR TITLE
Support for Tensorflow>2.0

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -501,7 +501,7 @@ def _get_available_gpus():
         if _is_tf_1():
             devices = get_session().list_devices()
             _LOCAL_DEVICES = [x.name for x in devices]
-        elif int(tf.__version__.split('.')[1])>1:
+        elif int(tf.__version__.split('.')[1]) > 1:
             devices = tf.config.list_logical_devices()
             _LOCAL_DEVICES = [x.name for x in devices]
         else:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -493,7 +493,6 @@ def _is_current_explicit_device(device_type):
 
 def _get_available_gpus():
     """Get a list of available gpu devices (formatted as strings).
-
     # Returns
         A list of available GPU devices.
     """
@@ -502,9 +501,11 @@ def _get_available_gpus():
         if _is_tf_1():
             devices = get_session().list_devices()
             _LOCAL_DEVICES = [x.name for x in devices]
-        else:
+        elif int(tf.__version__.split('.')[1])>1:
             devices = tf.config.list_logical_devices()
             _LOCAL_DEVICES = [x.name for x in devices]
+        else:
+            _LOCAL_DEVICES = tf.config.experimental_list_devices()
     return [x for x in _LOCAL_DEVICES if 'device:gpu' in x.lower()]
 
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -501,7 +501,7 @@ def _get_available_gpus():
         if _is_tf_1():
             devices = get_session().list_devices()
             _LOCAL_DEVICES = [x.name for x in devices]
-        elif int(tf.__version__.split('.')[1]) > 1:
+        elif int(tf.__version__.split('.')[1]) >= 1:
             devices = tf.config.list_logical_devices()
             _LOCAL_DEVICES = [x.name for x in devices]
         else:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -503,7 +503,8 @@ def _get_available_gpus():
             devices = get_session().list_devices()
             _LOCAL_DEVICES = [x.name for x in devices]
         else:
-            _LOCAL_DEVICES = tf.config.experimental_list_devices()
+            devices = tf.config.list_logical_devices()
+            _LOCAL_DEVICES = [x.name for x in devices]
     return [x for x in _LOCAL_DEVICES if 'device:gpu' in x.lower()]
 
 


### PR DESCRIPTION
[experimental_list_devices is removed on Tensorflow 2.1](https://github.com/tensorflow/tensorflow/releases). tf.config.list_logical_devices can be used to retrieve the same information. 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary
experimental_list_devices is removed on Tensorflow 2. tf.config.list_logical_devices can be used to retrieve the same information.
### Related Issues
https://github.com/keras-team/keras/issues/13684
### PR Overview

- [ n] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
