### PR TITLE
History dictionary for accuracy corrected

### DIFF
--- a/docs/templates/visualization.md
+++ b/docs/templates/visualization.md
@@ -35,8 +35,8 @@ import matplotlib.pyplot as plt
 history = model.fit(x, y, validation_split=0.25, epochs=50, batch_size=16, verbose=1)
 
 # Plot training & validation accuracy values
-plt.plot(history.history['acc'])
-plt.plot(history.history['val_acc'])
+plt.plot(history.history['accuracy'])
+plt.plot(history.history['val_accuracy'])
 plt.title('Model accuracy')
 plt.ylabel('Accuracy')
 plt.xlabel('Epoch')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

The history dictionary for the model seems to be wrong for accuracy, when I tried the visualisation example, the correct key was `accuracy` and `val_accuracy` not `acc` and `val_acc`

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
