### PR TITLE
Improve compatibility with scikit-learn

### DIFF
--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -176,6 +176,8 @@ class KerasClassifier(BaseWrapper):
     """Implementation of the scikit-learn classifier API for Keras.
     """
 
+    _estimator_type = "classifier"
+
     def fit(self, x, y, sample_weight=None, **kwargs):
         """Constructs a new model with `build_fn` & fit the model to `(x, y)`.
 
@@ -303,6 +305,8 @@ class KerasClassifier(BaseWrapper):
 class KerasRegressor(BaseWrapper):
     """Implementation of the scikit-learn regressor API for Keras.
     """
+
+    _estimator_type = "regressor"
 
     def predict(self, x, **kwargs):
         """Returns predictions for the given test data.


### PR DESCRIPTION
### Summary
Some code in scikit-learn checks the `_estimator_type` attribute to distinguish between Regressors and Classifiers. For example, [this one](https://github.com/scikit-learn/scikit-learn/blob/b194674c42d54b26137a456c510c5fdba1ba23e0/sklearn/model_selection/_split.py#L2003):
```
    if isinstance(cv, numbers.Integral):
        if (classifier and (y is not None) and
                (type_of_target(y) in ('binary', 'multiclass'))):
            return StratifiedKFold(cv)
        else:
            return KFold(cv)
```
where `classifier` parameter is calculated using [`is_classifier()`](https://github.com/scikit-learn/scikit-learn/blob/b194674c42d54b26137a456c510c5fdba1ba23e0/sklearn/base.py#L639) function.

As a consequence, if we pass `KerasClassifier` to `GridSearchCV()` with numeric `cv` argument
```
clf = KerasClassifier(...)
...
grid = GridSearchCV(estimator = clf, param_grid = params, n_jobs = 1, cv = 10)
```
the `KFold` splitter would be created instead of expected `StratifiedKFold` because `KerasClassifier` contains no `_estimator_type` and, therefore, treated as regressor.

Adding such an attribute to `KerasClassifier` and `KerasRegressor` seems be a reasonable improvement solving this problem.

An alternative solution would be using [`ClassifierMixin`](https://github.com/scikit-learn/scikit-learn/blob/b194674c42d54b26137a456c510c5fdba1ba23e0/sklearn/base.py#L339) and [`RegressorMixin`](https://github.com/scikit-learn/scikit-learn/blob/b194674c42d54b26137a456c510c5fdba1ba23e0/sklearn/base.py#L372) as base classes for their corresponding wrappers but this would introduce a dependency from `scikit-learn` code.



### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

Not sure about backward compatibility. The proposed change doesn't break the existing code base but it may change the produced results.