### PR TITLE
keras docs: long <code> lines need to be rearranged to short lines to be easier to read

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -50,11 +50,22 @@ def get_function_signature(function, method=True):
 
     for a in args:
         st += str(a) + ', '
+    if args and kwargs:
+        st += '\n'
+
+    not_first_line = bool(args)
     for a, v in kwargs:
         if isinstance(v, str):
             v = '\'' + v.encode('unicode_escape').decode('utf8') + '\''
-        st += str(a) + '=' + str(v) + ', '
-    if kwargs or args:
+        if not_first_line:
+            st += '    '
+        else:
+            not_first_line = True
+        st += str(a) + '=' + str(v) + ', \n'
+
+    if kwargs:
+        signature = st[:-3] + ')'
+    elif args:
         signature = st[:-2] + ')'
     else:
         signature = st + ')'

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -52,7 +52,7 @@ def get_function_signature(function, method=True):
         st += str(a) + ', '
     for a, v in kwargs:
         if isinstance(v, str):
-            v = '\'' + v + '\''
+            v = '\'' + v.encode('unicode_escape').decode('utf8') + '\''
         st += str(a) + '=' + str(v) + ', '
     if kwargs or args:
         signature = st[:-2] + ')'
@@ -109,7 +109,7 @@ def class_to_source_link(cls):
 
 def code_snippet(snippet):
     result = '```python\n'
-    result += snippet.encode('unicode_escape').decode('utf8') + '\n'
+    result += snippet + '\n'
     result += '```\n'
     return result
 


### PR DESCRIPTION
### Summary

A fix for this issue is given in two separate commits. 

The first changes a bug fix for issue #12171. That bug had caused newline and tab control characters to be interpreted as actual whitespace instead of as \n and \t. However, the previous fix had been to escape these characters in the code_snippet method, which made it impossible to add any intentional newlines before this point in the the method headers' rendering. The escaping of the control characters was moved to get_function_signature and applied only to string values of keyword arguments (since other parts of the headers won't contain control characters).

The second commit updates autogen.py to spread long class and method headers over multiple lines (#13701). The arguments are all printed on the initial line and then each keyword argument is printed on its own indented line.

### Related Issues
keras docs: long \<code\> lines need to be rearranged to short lines to be easier to read #13701
Fix documentation rendering issue #12171 

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
