### PR TITLE
[DOC]: Remove unnecessary clip_norm in an example

### DIFF
--- a/examples/mnist_irnn.py
+++ b/examples/mnist_irnn.py
@@ -29,7 +29,6 @@ epochs = 200
 hidden_units = 100
 
 learning_rate = 1e-6
-clip_norm = 1.0
 
 # the data, split between train and test sets
 (x_train, y_train), (x_test, y_test) = mnist.load_data()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary
Removes unnecessary variable `clip_norm` in the example https://github.com/keras-team/keras/blob/master/examples/mnist_irnn.py

### Related Issues
Fixes #13734 (support issue) 

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
