### PR TITLE
Shape inference for Conv2DTranspose

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -806,7 +806,7 @@ class Conv2DTranspose(Conv2D):
         self.built = True
 
     def call(self, inputs):
-        input_shape = K.shape(inputs)
+        input_shape = K.int_shape(inputs)
         batch_size = input_shape[0]
         if self.data_format == 'channels_first':
             h_axis, w_axis = 2, 3


### PR DESCRIPTION
Wrong backend call on output shape computation in Conv2DTranspose

### Related Issues
Shape inference (implicit or explicit) was not working (undefined shapes). Now it works.

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [X] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
