### PR TITLE
Update searchbox.html, search bug fix

### DIFF
--- a/docs/theme/searchbox.html
+++ b/docs/theme/searchbox.html
@@ -1,5 +1,5 @@
 <div role="search">
-  <form id ="rtd-search-form" class="wy-form" action="{{ base_url }}/search.html" method="get">
+  <form id ="rtd-search-form" class="wy-form" action="./search.html" method="get">
     <input type="text" name="q" placeholder="Search docs" title="Type search term here" />
   </form>
 </div>


### PR DESCRIPTION
When visiting a site that returns a 404 error, for example "keras.io/atreatthth", using the searchbar functionality results in the browser navigating to "https://search.html/?q=SEARCH_TEXT". This was documented in DOCS BUG #13736.

This is due to the searchbar form "action" attribute being set to "//search.html" on the 404-returning sites. 

By changing the searchbox to always be "action="./search.html"", instead of {{base_url}} /search.html, I believe this issue can be avoided.

<!--
![searchbox_action_example](https://user-images.githubusercontent.com/55195974/74684749-4735ba80-5192-11ea-9228-0bf28436a343.png)

Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
