### PR TITLE
Fixing embedding matrix incorrect index bug

### DIFF
--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -109,7 +109,7 @@ for word, i in word_index.items():
     embedding_vector = embeddings_index.get(word)
     if embedding_vector is not None:
         # words not found in embedding index will be all-zeros.
-        embedding_matrix[i] = embedding_vector
+        embedding_matrix[i - 1] = embedding_vector
 
 # load pre-trained word embeddings into an Embedding layer
 # note that we set trainable = False so as to keep the embeddings fixed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

Change the loop index so that the embedding matrix is correctly built.

### Related Issues

This embedding_matrix[i] = embedding_vector creates an incorrect embedding vector, and it should be embedding_matrix[i - 1] = embedding_vector.

Here's why the embedding matrix is wrong and what it can causes. The loop starts from index 1 in word_index.items(), so this "i" starts as 1. Therefore, it always ignores the first row of the embedding matrix (leaving it all zeros) and shifts every word embedding vector backward, so that each word has the vector of its previous word. Having an "i - 1" resolves this issue because once we loop from the 0 index of the embedding matrix, every word will have its correct corresponding vector.

The Keras blog post can be found at [here](https://blog.keras.io/using-pre-trained-word-embeddings-in-a-keras-model.html).

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)