### PR TITLE
Fix too many values to unpack error

### DIFF
--- a/examples/cnn_seq2seq.py
+++ b/examples/cnn_seq2seq.py
@@ -65,7 +65,7 @@ target_characters = set()
 with open(data_path, 'r', encoding='utf-8') as f:
     lines = f.read().split('\n')
 for line in lines[: min(num_samples, len(lines) - 1)]:
-    input_text, target_text = line.split('\t')
+    input_text, target_text, _ = line.split('\t')
     # We use "tab" as the "start sequence" character
     # for the targets, and "\n" as "end sequence" character.
     target_text = '\t' + target_text + '\n'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary
Get error as:
'''
Using TensorFlow backend.
Traceback (most recent call last):
  File "cnn_seq2seq.py", line 68, in <module>
    input_text, target_text = line.split('\t')
ValueError: too many values to unpack (expected 2)
'''
### Related Issues

### PR Overview

- [N] This PR requires new unit tests [y/n] (make sure tests are included)
- [N] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [Y] This PR is backwards compatible [y/n]
- [N] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
