### PR TITLE
Updating TensorBoard Class

### DIFF
--- a/keras/callbacks/tensorboard_v1.py
+++ b/keras/callbacks/tensorboard_v1.py
@@ -93,7 +93,7 @@ class TensorBoard(Callback):
         global tf, projector
         try:
             import tensorflow as tf
-            from tensorflow.contrib.tensorboard.plugins import projector
+            from tensorflow.compat.v1.tensorboard.plugins import projector
         except ImportError:
             raise ImportError('You need the TensorFlow (v1) module installed to '
                               'use TensorBoard.')


### PR DESCRIPTION
Updating TensorBoard Class to make it compatible to tensorflow 2.0. This is done to solve the issue #13870. Earlier, we were unable to call TensorBoard Class, because it was importing from tensorflow.contrib while new version of tensorflow import with tensorflow.compat.v1 . This problem was preventing many users to call several functions inside TensorBoard Class such as _write_logs.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
