### PR TITLE
Added subheadings for examples grouped as in examples/readme.md

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -68,23 +68,27 @@ nav:
 - Utils: utils.md
 - Contributing: contributing.md
 - Examples:
-  - Addition RNN: examples/addition_rnn.md
-  - Custom layer - antirectifier: examples/antirectifier.md
-  - Baby RNN: examples/babi_rnn.md
-  - Baby MemNN: examples/babi_memnn.md
-  - CIFAR-10 CNN: examples/cifar10_cnn.md
-  - CIFAR-10 ResNet: examples/cifar10_resnet.md
-  - Convolution filter visualization: examples/conv_filter_visualization.md
-  - Convolutional LSTM: examples/conv_lstm.md
-  - Deep Dream: examples/deep_dream.md
-  - Image OCR: examples/image_ocr.md
-  - Bidirectional LSTM: examples/imdb_bidirectional_lstm.md
-  - 1D CNN for text classification: examples/imdb_cnn.md
-  - Sentiment classification CNN-LSTM: examples/imdb_cnn_lstm.md
-  - Fasttext for text classification: examples/imdb_fasttext.md
-  - Sentiment classification LSTM: examples/imdb_lstm.md
-  - Sequence to sequence - training: examples/lstm_seq2seq.md
-  - Sequence to sequence - prediction: examples/lstm_seq2seq_restore.md
-  - Stateful LSTM: examples/lstm_stateful.md
-  - LSTM for text generation: examples/lstm_text_generation.md
-  - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Vision models examples:
+    - CIFAR-10 CNN: examples/cifar10_cnn.md
+    - CIFAR-10 ResNet: examples/cifar10_resnet.md
+    - Convolutional LSTM: examples/conv_lstm.md
+    - Image OCR: examples/image_ocr.md
+    - Auxiliary Classifier GAN: examples/mnist_acgan.md
+  - Text & sequences examples:
+    - Addition RNN: examples/addition_rnn.md
+    - Baby RNN: examples/babi_rnn.md
+    - Baby MemNN: examples/babi_memnn.md
+    - Bidirectional LSTM: examples/imdb_bidirectional_lstm.md
+    - 1D CNN for text classification: examples/imdb_cnn.md
+    - Sentiment classification CNN-LSTM: examples/imdb_cnn_lstm.md
+    - Fasttext for text classification: examples/imdb_fasttext.md
+    - Sentiment classification LSTM: examples/imdb_lstm.md
+    - Stateful LSTM: examples/lstm_stateful.md
+    - Sequence to sequence - training: examples/lstm_seq2seq.md
+    - Sequence to sequence - prediction: examples/lstm_seq2seq_restore.md
+  - Generative models examples:
+    - LSTM for text generation: examples/lstm_text_generation.md
+    - Convolution filter visualization: examples/conv_filter_visualization.md
+    - Deep Dream: examples/deep_dream.md
+  - Examples demonstrating specific Keras functionality:
+    - Custom layer - antirectifier: examples/antirectifier.md


### PR DESCRIPTION
As suggested by #13727  To make it easier to identify useful examples and navigate through examples, added subheadings for examples section. Headings and ordering now match those of [examples/readme.md](https://github.com/keras-team/keras/blob/master/examples/README.md).

I realize this is one extra depth compared to everything else on the sidebar, but I believe it may be worth it for the added clarity.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
