### PR TITLE
Removed an unused variable `num_predictions` from CIFAR-10 CNN example.

### DIFF
--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -18,7 +18,6 @@ batch_size = 32
 num_classes = 10
 epochs = 100
 data_augmentation = True
-num_predictions = 20
 save_dir = os.path.join(os.getcwd(), 'saved_models')
 model_name = 'keras_cifar10_trained_model.h5'
 


### PR DESCRIPTION
The variable `num_predictions` was perhaps confusing too in addition to being unnecessary because:

- `num_classes = 10` is present 2 lines above it. (Only 10 classes in CIFAR-10)
- `model.predict` is never used in the example. Maybe the variable is vestigial?
 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary
I removed the unused variable `num_predictions` in the CIFAR-10 CNN example.

### Related Issues
None

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
