### PR TITLE
Return back clipnorm parameter for sgd in image_ocr example

### DIFF
--- a/examples/image_ocr.py
+++ b/examples/image_ocr.py
@@ -526,7 +526,8 @@ def train(run_name, start_epoch, stop_epoch, img_w):
     sgd = SGD(learning_rate=0.02,
               decay=1e-6,
               momentum=0.9,
-              nesterov=True)
+              nesterov=True,
+              clipnorm=5)
 
     model = Model(inputs=[input_data, labels, input_length, label_length],
                   outputs=loss_out)

--- a/examples/image_ocr.py
+++ b/examples/image_ocr.py
@@ -523,7 +523,7 @@ def train(run_name, start_epoch, stop_epoch, img_w):
         name='ctc')([y_pred, labels, input_length, label_length])
 
     # clipnorm seems to speeds up convergence
-    sgd = SGD(learning_rate=0.02,
+    sgd = SGD(lr=0.02,
               decay=1e-6,
               momentum=0.9,
               nesterov=True,


### PR DESCRIPTION
### Summary
Fixes for image_ocr example

### Related Issues
#1244

### PR Overview
Hi, guys!

It seems that clipnorm parameter is necessary for sgd optimizer. Just run the source in google colab and see that model predicts only empty strings for images.

Seems it mas a mistake from code cleanup commit e6d685b1, where this parameter was removed. So, I simply return it.

Running configuration:
1x Google colab with:
  1x Tesla P100
  4x Intel(R) Xeon(R) CPU

Tested with GPU and CPU-only modes. Issue is reproduced in both configurations.

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
