### PR TITLE
Fix incorrect loss_weights error message, clarify docs

### DIFF
--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -837,12 +837,12 @@ def prepare_loss_weights(output_names, loss_weights=None):
 
     # Arguments
         output_names: List of model output names.
-        loss_weights: Optional list or dictionary specifying scalar coefficients
-            (Python floats) to weight the loss contributions of different model
-            outputs. The loss value that will be minimized by the model will then be
-            the *weighted sum* of all individual losses, weighted by the
-            `loss_weights` coefficients. If a list, it is expected to have a 1:1
-            mapping to the model's outputs. If a dict, it is expected to map
+        loss_weights: Optional Python list or dictionary specifying scalar
+            coefficients (Python floats) to weight the loss contributions of
+            different model outputs. The loss value that will be minimized by the
+            model will then be the *weighted sum* of all individual losses, weighted
+            by the `loss_weights` coefficients. If a list, it is expected to have a
+            1:1 mapping to the model's outputs. If a dict, it is expected to map
             output names (strings) to scalar coefficients.
 
     # Returns
@@ -868,7 +868,7 @@ def prepare_loss_weights(output_names, loss_weights=None):
         weights_list = loss_weights
     else:
         raise TypeError('Could not interpret loss_weights argument: ' +
-                        str(loss_weights) + ' - expected a list of dicts.')
+                        str(loss_weights) + ' - expected a Python list or dict.')
 
     return weights_list
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

loss_weights argument to model.fit only accepts python lists, so no numpy arrays. clarify docs for that. Also the error message was incorrect, asking for a "list **of** dicts" instead of a "list **or** dict" as the docs ask for.

### PR Overview

No special requirements, minor change to docs, error message

- `n` This PR requires new unit tests [y/n] (make sure tests are included)
- `?` This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- `n` This PR is backwards compatible [y/n]
- `n` This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

Edit:
Force-pushed to reflow text to fit in 85 cols