### PR TITLE
Fix DeprecationWarning for collections.abc.Iterable

### DIFF
--- a/keras/callbacks/callbacks.py
+++ b/keras/callbacks/callbacks.py
@@ -16,8 +16,8 @@ import io
 
 from collections import deque
 from collections import OrderedDict
-from collections import Iterable
 from collections import defaultdict
+from six.moves.collections_abc import Iterable
 from ..utils.generic_utils import Progbar
 from .. import backend as K
 from ..engine.training_utils import standardize_input_data


### PR DESCRIPTION
https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable

% __pytest__
```
=============================== warnings summary ===============================
/home/travis/virtualenv/python3.8.1/lib/python3.8/site-packages/keras/callbacks/callbacks.py:19
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
from collections import Iterable
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
