### PR TITLE
Reset dropout masks in RNN layer

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -593,6 +593,13 @@ class RNN(Layer):
              training=None,
              initial_state=None,
              constants=None):
+        cells = [self.cell]
+        if isinstance(self.cell, StackedRNNCells):
+            cells = self.cell.cells
+        for cell in cells:
+            cell._dropout_mask = None
+            cell._recurrent_dropout_mask = None
+
         if not isinstance(initial_state, (list, tuple, type(None))):
             initial_state = [initial_state]
         if not isinstance(constants, (list, tuple, type(None))):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary
`keras.layer.RNN` cannot be shared between two models if recurrent_dropout is set. 

Here is a small reproduction scenario using seq2seq architecture: 

```
import numpy as np
import keras
import tensorflow as tf
from keras import backend as K


rnn_dim = 64
time_steps = 10
n_out = 5
input_dim = 1
output_dim = 1

# ----------------------------
encoder_inputs = keras.layers.Input(
    shape=(time_steps, input_dim), name='encoder_inputs'
)
decoder_inputs = keras.layers.Input(shape=(None, output_dim), name='decoder_inputs')

cell = keras.layers.LSTMCell(rnn_dim)
encoder = keras.layers.RNN(cell, name='encoder-lstm', return_sequences=False, return_state=True)
encoder_outputs, encoder_state_h, encoder_state_c = encoder(encoder_inputs)
encoder_states = [encoder_state_h, encoder_state_c]

cell = keras.layers.LSTMCell(rnn_dim, recurrent_dropout=0.8),
decoder = keras.layers.RNN(cell, name='decoder-lstm', return_sequences=True, return_state=True)
decoder_outputs = decoder(decoder_inputs, initial_state=encoder_states)
decoder_outputs = decoder_outputs[0]

dense = keras.layers.Dense(1, activation='linear', name='output-layer')
outputs = dense(decoder_outputs)

training_inputs = [encoder_inputs, decoder_inputs]
model = keras.models.Model(training_inputs, outputs)

encoder_model = keras.models.Model([encoder_inputs], [encoder_outputs] + encoder_states)

decoder_state_input_h = keras.layers.Input(shape=(rnn_dim,))
decoder_state_input_c = keras.layers.Input(shape=(rnn_dim,))
decoder_state_inputs = [decoder_state_input_h, decoder_state_input_c]

decoder_outputs = decoder(decoder_inputs, initial_state=decoder_state_inputs)
decoder_states = decoder_outputs[1:]
decoder_outputs = decoder_outputs[0]

outputs = dense(decoder_outputs)

inp = [decoder_inputs] + decoder_state_inputs
out = [outputs] + decoder_states
decoder_model = keras.models.Model(inp, out)
# ----------------------------

X1 = np.random.random((100, time_steps, input_dim))
X2 = np.random.random((100, n_out, output_dim))
y = np.random.random((100, n_out, output_dim))

model.compile(loss='mae', optimizer='adam')
model.fit([X1, X2], y, verbose=True, epochs=5, batch_size=4)

_, h, c = encoder_model.predict(X1)
decoder_model.predict([X2, h, c]
```

Decoder RNN layer is shared between training `model` and `decoder_model`. This snippet fails on the last line of code with exception: 
```
    decoder_model.predict([X2, h, c])
  File "/Users/viktor.kovryzhkin/.virtualenvs/kerasseq2seqtest/lib/python2.7/site-packages/keras/engine/training.py", line 1401, in predict
    callbacks=callbacks)
  File "/Users/viktor.kovryzhkin/.virtualenvs/kerasseq2seqtest/lib/python2.7/site-packages/keras/engine/training_arrays.py", line 332, in predict_loop
    batch_outs = f(ins_batch)
  File "/Users/viktor.kovryzhkin/.virtualenvs/kerasseq2seqtest/lib/python2.7/site-packages/keras/backend/tensorflow_backend.py", line 2979, in __call__
    return self._call(inputs)
  File "/Users/viktor.kovryzhkin/.virtualenvs/kerasseq2seqtest/lib/python2.7/site-packages/keras/backend/tensorflow_backend.py", line 2937, in _call
    fetched = self._callable_fn(*array_vals)
  File "/Users/viktor.kovryzhkin/.virtualenvs/kerasseq2seqtest/lib/python2.7/site-packages/tensorflow_core/python/client/session.py", line 1472, in __call__
    run_metadata_ptr)
tensorflow.python.framework.errors_impl.InvalidArgumentError: You must feed a value for placeholder tensor 'encoder_inputs' with dtype float and shape [?,10,1]
	 [[{{node encoder_inputs}}]]
```

If you recurrent_dropout or using `keras.layers.LSTM` instead of `keras.layers.RNN` - code will be executed successfully. 

Looks like RNN layer doesn't set internal `_dropout_mask` and `_recurrent_dropout_mask` to None, whereas LSTM or GRU layers do. 

### PR Overview
Resetting `_dropout_mask` and `_recurrent_dropout_mask` for cells of RNN layer.
Added a test case which also reproduces the issue. 

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
