### PR TITLE
Remove "docs" from distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,4 @@ setup(name='Keras',
           'Topic :: Software Development :: Libraries',
           'Topic :: Software Development :: Libraries :: Python Modules'
       ],
-      packages=find_packages())
+      packages=find_packages(exclude=['docs']))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

The `docs` directory has a `__init__.py` and is as such recognized by `setuptools.find_packages` as a package.
Thus, a separate `docs` package is included in the distributed packages.
That is avoided with this PR by invoking `find_packages(exclude=['docs'])`.
```sh
$ curl -sLO https://pypi.io/packages/py2.py3/K/Keras/Keras-2.4.3-py2.py3-none-any.whl
$ bsdtar -tvf Keras-2.4.3-py2.py3-none-any.whl docs
-rw-r--r--  0 0      0           0 Jun 24 22:38 docs/__init__.py
-rw-r--r--  0 0      0       17185 Jun 24 22:38 docs/autogen.py
-rw-r--r--  0 0      0        9391 Jun 24 22:38 docs/structure.py
```
### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
