### PR TITLE
Remove depreceted ndarray creation

### DIFF
--- a/keras/datasets/imdb.py
+++ b/keras/datasets/imdb.py
@@ -156,8 +156,8 @@ def load_data(path='imdb.npz',
     xs = [[w for w in x if skip_top <= w < num_words] for x in xs]
 
   idx = len(x_train)
-  x_train, y_train = np.array(xs[:idx]), np.array(labels[:idx])
-  x_test, y_test = np.array(xs[idx:]), np.array(labels[idx:])
+  x_train, y_train = np.array(xs[:idx], dtype=object), np.array(labels[:idx], dtype=object)
+  x_test, y_test = np.array(xs[idx:], dtype=object), np.array(labels[idx:], dtype=object)
 
   return (x_train, y_train), (x_test, y_test)
 

--- a/keras/datasets/reuters.py
+++ b/keras/datasets/reuters.py
@@ -145,8 +145,8 @@ def load_data(path='reuters.npz',
     xs = [[w for w in x if skip_top <= w < num_words] for x in xs]
 
   idx = int(len(xs) * (1 - test_split))
-  x_train, y_train = np.array(xs[:idx]), np.array(labels[:idx])
-  x_test, y_test = np.array(xs[idx:]), np.array(labels[idx:])
+  x_train, y_train = np.array(xs[:idx], dtype=object), np.array(labels[:idx], dtype=object)
+  x_test, y_test = np.array(xs[idx:], dtype=object)), np.array(labels[idx:], dtype=object))
 
   return (x_train, y_train), (x_test, y_test)
 


### PR DESCRIPTION
In the script imdb.py and reuters.py, it creates ndarray with
ragged nested sequence, which is deprecated and shows warning.
A simple modification can fix it.