### PR TITLE
Clarify documentation of DepthwiseConv2D

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -2259,16 +2259,16 @@ class DepthwiseConv2D(Conv2D):
   """Depthwise 2D convolution.
 
   Depthwise convolution is a type of convolution in which each input channel is
-  convolved with a different filter of depth 1 (called a depthwise kernel). You
+  convolved with a different filter (called a depthwise kernel). You
   can understand depthwise convolution as the first step in a depthwise
   separable convolution.
 
   It could be implemented via the following steps:
 	
   - Split the input into individual channels.
-  - Repeat each input channel `depth_multiplier` many times.
-  - Convolve each channel with an individual depthwise kernel.
-  - Stack the convolved outputs together (along the channels axis).
+  - Convolve each channel with an individual depthwise kernel having 1 input
+    and `depth_multiplier` many output channels.
+  - Concatenate the convolved outputs (along the channels axis).
 
   Unlike a regular 2D convolution, depthwise convolution does not mix
   information across different input channels.
@@ -2292,10 +2292,9 @@ class DepthwiseConv2D(Conv2D):
       `"valid"` means no padding. `"same"` results in padding with zeros evenly
       to the left/right or up/down of the input such that output has the same
       height/width dimension as the input.
-    depth_multiplier: The number of depthwise kernels that are applied to one
-      input channel.
-      The total number of depthwise convolution output channels per input
-      channel will be equal to `filters_in * depth_multiplier`.
+    depth_multiplier: The number of output channels for the depthwise kernels.
+      It can be understood as the amount of filters that are applied to
+      each input channel.
     data_format: A string,
       one of `channels_last` (default) or `channels_first`.
       The ordering of the dimensions in the inputs.

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -2258,22 +2258,24 @@ class SeparableConv2D(SeparableConv):
 class DepthwiseConv2D(Conv2D):
   """Depthwise 2D convolution.
 
-  Depthwise convolution is a type of convolution in which a single convolutional
-  filter is apply to each input channel (i.e. in a depthwise way).
-  You can understand depthwise convolution as being
-  the first step in a depthwise separable convolution.
+  Depthwise convolution is a type of convolution in which each input channel is
+  convolved with a different filter of depth 1 (called a depthwise kernel). You
+  can understand depthwise convolution as the first step in a depthwise
+  separable convolution.
 
-  It is implemented via the following steps:
-
+  It could be implemented via the following steps:
+	
   - Split the input into individual channels.
-  - Convolve each input with the layer's kernel (called a depthwise kernel).
+  - Repeat each input channel `depth_multiplier` many times.
+  - Convolve each channel with an individual depthwise kernel.
   - Stack the convolved outputs together (along the channels axis).
 
   Unlike a regular 2D convolution, depthwise convolution does not mix
   information across different input channels.
 
-  The `depth_multiplier` argument controls how many
-  output channels are generated per input channel in the depthwise step.
+  The `depth_multiplier` argument determines how many filter are applied to one
+  input channel. Thereby, it controls the amount of output channels that are
+  generated per input channel in the depthwise step.
 
   Args:
     kernel_size: An integer or tuple/list of 2 integers, specifying the
@@ -2290,10 +2292,10 @@ class DepthwiseConv2D(Conv2D):
       `"valid"` means no padding. `"same"` results in padding with zeros evenly
       to the left/right or up/down of the input such that output has the same
       height/width dimension as the input.
-    depth_multiplier: The number of depthwise convolution output channels
-      for each input channel.
-      The total number of depthwise convolution output
-      channels will be equal to `filters_in * depth_multiplier`.
+    depth_multiplier: The number of depthwise kernels that are applied to one
+      input channel.
+      The total number of depthwise convolution output channels per input
+      channel will be equal to `filters_in * depth_multiplier`.
     data_format: A string,
       one of `channels_last` (default) or `channels_first`.
       The ordering of the dimensions in the inputs.

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -2295,6 +2295,8 @@ class DepthwiseConv2D(Conv2D):
     depth_multiplier: The number of output channels for the depthwise kernels.
       It can be understood as the amount of filters that are applied to
       each input channel.
+      The total number of depthwise convolution output
+      channels will be equal to `filters_in * depth_multiplier`.
     data_format: A string,
       one of `channels_last` (default) or `channels_first`.
       The ordering of the dimensions in the inputs.

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -2267,7 +2267,7 @@ class DepthwiseConv2D(Conv2D):
 	
   - Split the input into individual channels.
   - Convolve each channel with an individual depthwise kernel having 1 input
-    and `depth_multiplier` many output channels.
+    and `depth_multiplier` output channels.
   - Concatenate the convolved outputs (along the channels axis).
 
   Unlike a regular 2D convolution, depthwise convolution does not mix


### PR DESCRIPTION
As discussed in [tensorflow issue 49933](https://github.com/tensorflow/tensorflow/issues/49933).

The documentation for `DepthwiseConv2D` describes the operation as: split input into individual channels, convolve each with the layer's kernel and finally stack the results. This gives the impression the same kernel is applied to all channels. But in the implementation tensorflow implementation as well as the [MobileNet Paper](https://arxiv.org/pdf/1704.04861.pdf) (see page 3 formula 3), a different kernel is applied per channel.