### PR TITLE
Throw ValueError if shapes don't match in keras.layers.Softmax

### DIFF
--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -338,7 +338,11 @@ class Softmax(Layer):
 
       # Since we are adding it to the raw scores before the softmax, this is
       # effectively the same as removing these entirely.
-      inputs += adder
+      try:
+        inputs += adder
+      except ValueError:
+        raise ValueError('Cannot apply mask to the given input. Make sure '
+                         'that shapes of input and mask match.')
     if isinstance(self.axis, (tuple, list)):
       if len(self.axis) > 1:
         return tf.exp(inputs - tf.reduce_logsumexp(


### PR DESCRIPTION
Due to https://github.com/tensorflow/tensorflow/issues/50467
(users may be not aware of how does keras.layers.Masking work)

@gbaned asked me to push this commit here (previous PR: https://github.com/tensorflow/tensorflow/pull/50586 )