### PR TITLE
Fix `int` given for `float` args

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -272,7 +272,7 @@ def swish(x):
 
 @keras_export('keras.activations.relu')
 @tf.__internal__.dispatch.add_dispatch_support
-def relu(x, alpha=0., max_value=None, threshold=.0):
+def relu(x, alpha=0., max_value=None, threshold=0.):
   """Applies the rectified linear unit activation function.
 
   With default values, this returns the standard ReLU activation:

--- a/keras/activations.py
+++ b/keras/activations.py
@@ -272,7 +272,7 @@ def swish(x):
 
 @keras_export('keras.activations.relu')
 @tf.__internal__.dispatch.add_dispatch_support
-def relu(x, alpha=0., max_value=None, threshold=0):
+def relu(x, alpha=0., max_value=None, threshold=.0):
   """Applies the rectified linear unit activation function.
 
   With default values, this returns the standard ReLU activation:
@@ -289,9 +289,9 @@ def relu(x, alpha=0., max_value=None, threshold=0):
   array([ 0.,  0.,  0.,  5., 10.], dtype=float32)
   >>> tf.keras.activations.relu(foo, alpha=0.5).numpy()
   array([-5. , -2.5,  0. ,  5. , 10. ], dtype=float32)
-  >>> tf.keras.activations.relu(foo, max_value=5).numpy()
+  >>> tf.keras.activations.relu(foo, max_value=5.).numpy()
   array([0., 0., 0., 5., 5.], dtype=float32)
-  >>> tf.keras.activations.relu(foo, threshold=5).numpy()
+  >>> tf.keras.activations.relu(foo, threshold=5.).numpy()
   array([-0., -0.,  0.,  0., 10.], dtype=float32)
 
   Args:

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -1945,7 +1945,7 @@ def dot(x, y):
 
   If `x` is an N-D array and `y` is an M-D array (where M>=2), it is a sum
   product over the last axis of `x` and the second-to-last axis of `y`.
-  >>> x = tf.keras.backend.random_uniform_variable(shape=(2, 3), low=.0, high=1.)
+  >>> x = tf.keras.backend.random_uniform_variable(shape=(2, 3), low=0., high=1.)
   >>> y = tf.keras.backend.ones((4, 3, 5))
   >>> xy = tf.keras.backend.dot(x, y)
   >>> tf.keras.backend.int_shape(xy)
@@ -4667,7 +4667,7 @@ def in_test_phase(x, alt, training=None):
 @keras_export('keras.backend.relu')
 @tf.__internal__.dispatch.add_dispatch_support
 @doc_controls.do_not_generate_docs
-def relu(x, alpha=0., max_value=None, threshold=.0):
+def relu(x, alpha=0., max_value=None, threshold=0.):
   """Rectified linear unit.
 
   With default values, it returns element-wise `max(x, 0)`.

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -1945,7 +1945,7 @@ def dot(x, y):
 
   If `x` is an N-D array and `y` is an M-D array (where M>=2), it is a sum
   product over the last axis of `x` and the second-to-last axis of `y`.
-  >>> x = tf.keras.backend.random_uniform_variable(shape=(2, 3), low=0, high=1)
+  >>> x = tf.keras.backend.random_uniform_variable(shape=(2, 3), low=.0, high=1.)
   >>> y = tf.keras.backend.ones((4, 3, 5))
   >>> xy = tf.keras.backend.dot(x, y)
   >>> tf.keras.backend.int_shape(xy)

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -4667,7 +4667,7 @@ def in_test_phase(x, alt, training=None):
 @keras_export('keras.backend.relu')
 @tf.__internal__.dispatch.add_dispatch_support
 @doc_controls.do_not_generate_docs
-def relu(x, alpha=0., max_value=None, threshold=0):
+def relu(x, alpha=0., max_value=None, threshold=.0):
   """Rectified linear unit.
 
   With default values, it returns element-wise `max(x, 0)`.

--- a/keras/backend_test.py
+++ b/keras/backend_test.py
@@ -312,17 +312,17 @@ class BackendVariableTest(tf.test.TestCase):
     self.assertAllClose(val, np.ones((3, 4)))
 
   def test_random_uniform_variable(self):
-    x = backend.random_uniform_variable((30, 20), low=1, high=2, seed=0)
+    x = backend.random_uniform_variable((30, 20), low=1., high=2., seed=0)
     val = backend.eval(x)
     self.assertAllClose(val.mean(), 1.5, atol=1e-1)
     self.assertAllClose(val.max(), 2., atol=1e-1)
     self.assertAllClose(val.min(), 1., atol=1e-1)
 
   def test_random_normal_variable(self):
-    x = backend.random_normal_variable((30, 20), 1., 0.5, seed=0)
+    x = backend.random_normal_variable((30, 20), 1., .5, seed=0)
     val = backend.eval(x)
     self.assertAllClose(val.mean(), 1., atol=1e-1)
-    self.assertAllClose(val.std(), 0.5, atol=1e-1)
+    self.assertAllClose(val.std(), .5, atol=1e-1)
 
   def test_count_params(self):
     x = backend.zeros((4, 5))
@@ -505,17 +505,17 @@ class BackendLinearAlgebraTest(tf.test.TestCase, parameterized.TestCase):
     self.assertAllClose(backend.eval(relu_op), [[-2, 0], [2, 7]])
 
     # max_value < some elements
-    relu_op = backend.relu(x, max_value=5)
+    relu_op = backend.relu(x, max_value=5.)
     self.assertAllClose(backend.eval(relu_op), [[0, 0], [2, 5]])
 
     # nn.relu6 used
-    relu_op = backend.relu(x, max_value=6)
+    relu_op = backend.relu(x, max_value=6.)
     if not tf.executing_eagerly():
       self.assertTrue('Relu6' in relu_op.name)  # uses tf.nn.relu6
     self.assertAllClose(backend.eval(relu_op), [[0, 0], [2, 6]])
 
     # max value > 6
-    relu_op = backend.relu(x, max_value=10)
+    relu_op = backend.relu(x, max_value=10.)
     self.assertAllClose(backend.eval(relu_op), [[0, 0], [2, 7]])
 
     # max value is float
@@ -523,11 +523,11 @@ class BackendLinearAlgebraTest(tf.test.TestCase, parameterized.TestCase):
     self.assertAllClose(backend.eval(relu_op), [[0, 0], [2, 4.3]])
 
     # max value == 0
-    relu_op = backend.relu(x, max_value=0)
+    relu_op = backend.relu(x, max_value=.0)
     self.assertAllClose(backend.eval(relu_op), [[0, 0], [0, 0]])
 
     # alpha and max_value
-    relu_op = backend.relu(x, alpha=0.25, max_value=3)
+    relu_op = backend.relu(x, alpha=0.25, max_value=3.)
     self.assertAllClose(backend.eval(relu_op), [[-1, 0], [2, 3]])
 
     # threshold
@@ -543,20 +543,20 @@ class BackendLinearAlgebraTest(tf.test.TestCase, parameterized.TestCase):
     self.assertAllClose(backend.eval(relu_op), [[-4, 0], [2, 7]])
 
     # threshold and max_value
-    relu_op = backend.relu(x, threshold=3, max_value=5)
+    relu_op = backend.relu(x, threshold=3, max_value=5.)
     self.assertAllClose(backend.eval(relu_op), [[0, 0], [0, 5]])
 
     # threshold and alpha
-    relu_op = backend.relu(x, alpha=0.25, threshold=4)
+    relu_op = backend.relu(x, alpha=0.25, threshold=4.)
     self.assertAllClose(backend.eval(relu_op), [[-2, -1], [-0.5, 7]])
 
     # threshold, alpha, and max_value
-    relu_op = backend.relu(x, alpha=0.25, threshold=4, max_value=5)
+    relu_op = backend.relu(x, alpha=0.25, threshold=4., max_value=5.)
     self.assertAllClose(backend.eval(relu_op), [[-2, -1], [-0.5, 5]])
 
     # Test case for GitHub issue 35430, with integer dtype
     x = input_layer.Input(shape=(), name='x', dtype='int64')
-    _ = advanced_activations.ReLU(max_value=100, dtype='int64')(x)
+    _ = advanced_activations.ReLU(max_value=100., dtype='int64')(x)
 
 
 @combinations.generate(combinations.combine(mode=['graph', 'eager']))

--- a/keras/backend_test.py
+++ b/keras/backend_test.py
@@ -319,10 +319,10 @@ class BackendVariableTest(tf.test.TestCase):
     self.assertAllClose(val.min(), 1., atol=1e-1)
 
   def test_random_normal_variable(self):
-    x = backend.random_normal_variable((30, 20), 1., .5, seed=0)
+    x = backend.random_normal_variable((30, 20), 1., 0.5, seed=0)
     val = backend.eval(x)
     self.assertAllClose(val.mean(), 1., atol=1e-1)
-    self.assertAllClose(val.std(), .5, atol=1e-1)
+    self.assertAllClose(val.std(), 0.5, atol=1e-1)
 
   def test_count_params(self):
     x = backend.zeros((4, 5))
@@ -523,7 +523,7 @@ class BackendLinearAlgebraTest(tf.test.TestCase, parameterized.TestCase):
     self.assertAllClose(backend.eval(relu_op), [[0, 0], [2, 4.3]])
 
     # max value == 0
-    relu_op = backend.relu(x, max_value=.0)
+    relu_op = backend.relu(x, max_value=0.)
     self.assertAllClose(backend.eval(relu_op), [[0, 0], [0, 0]])
 
     # alpha and max_value

--- a/keras/distribute/keras_premade_models_test.py
+++ b/keras/distribute/keras_premade_models_test.py
@@ -46,7 +46,7 @@ def strategy_combinations_eager_data_fn():
 
 
 def get_numpy():
-  inputs = np.random.uniform(low=-5, high=5, size=(64, 2)).astype(np.float32)
+  inputs = np.random.uniform(low=-5., high=5., size=(64, 2)).astype(np.float32)
   output = .3 * inputs[:, 0] + .2 * inputs[:, 1]
   return inputs, output
 

--- a/keras/engine/training_v1.py
+++ b/keras/engine/training_v1.py
@@ -2091,7 +2091,7 @@ class Model(training_lib.Model):
                                           sample_weight=None,
                                           class_weight=None,
                                           batch_size=None,
-                                          validation_split=0,
+                                          validation_split=.0,
                                           shuffle=False,
                                           epochs=1,
                                           allow_partial_batch=False):
@@ -2205,7 +2205,7 @@ class Model(training_lib.Model):
                              check_steps=False,
                              steps_name='steps',
                              steps=None,
-                             validation_split=0,
+                             validation_split=.0,
                              shuffle=False,
                              extract_tensors_from_dataset=False):
     """Runs validation checks on input and target data passed by the user.

--- a/keras/engine/training_v1.py
+++ b/keras/engine/training_v1.py
@@ -2091,7 +2091,7 @@ class Model(training_lib.Model):
                                           sample_weight=None,
                                           class_weight=None,
                                           batch_size=None,
-                                          validation_split=.0,
+                                          validation_split=0.,
                                           shuffle=False,
                                           epochs=1,
                                           allow_partial_batch=False):
@@ -2205,7 +2205,7 @@ class Model(training_lib.Model):
                              check_steps=False,
                              steps_name='steps',
                              steps=None,
-                             validation_split=.0,
+                             validation_split=0.,
                              shuffle=False,
                              extract_tensors_from_dataset=False):
     """Runs validation checks on input and target data passed by the user.

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -406,7 +406,7 @@ class ReLU(Layer):
       to 0.
   """
 
-  def __init__(self, max_value=None, negative_slope=.0, threshold=.0, **kwargs):
+  def __init__(self, max_value=None, negative_slope=0., threshold=0., **kwargs):
     super(ReLU, self).__init__(**kwargs)
     if max_value is not None and max_value < 0.:
       raise ValueError('max_value of a ReLU layer cannot be a negative '

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -406,7 +406,7 @@ class ReLU(Layer):
       to 0.
   """
 
-  def __init__(self, max_value=None, negative_slope=0, threshold=0, **kwargs):
+  def __init__(self, max_value=None, negative_slope=.0, threshold=.0, **kwargs):
     super(ReLU, self).__init__(**kwargs)
     if max_value is not None and max_value < 0.:
       raise ValueError('max_value of a ReLU layer cannot be a negative '

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -556,7 +556,7 @@ class BinaryCrossentropy(LossFunctionWrapper):
 
   def __init__(self,
                from_logits=False,
-               label_smoothing=0,
+               label_smoothing=.0,
                axis=-1,
                reduction=losses_utils.ReductionV2.AUTO,
                name='binary_crossentropy'):
@@ -640,7 +640,7 @@ class CategoricalCrossentropy(LossFunctionWrapper):
 
   def __init__(self,
                from_logits=False,
-               label_smoothing=0,
+               label_smoothing=.0,
                axis=-1,
                reduction=losses_utils.ReductionV2.AUTO,
                name='categorical_crossentropy'):
@@ -1623,7 +1623,7 @@ def log_cosh(y_true, y_pred):
 def categorical_crossentropy(y_true,
                              y_pred,
                              from_logits=False,
-                             label_smoothing=0,
+                             label_smoothing=.0,
                              axis=-1):
   """Computes the categorical crossentropy loss.
 
@@ -1671,7 +1671,7 @@ def categorical_crossentropy(y_true,
 def _ragged_tensor_categorical_crossentropy(y_true,
                                             y_pred,
                                             from_logits=False,
-                                            label_smoothing=0,
+                                            label_smoothing=.0,
                                             axis=-1):
   """Implements support for handling RaggedTensors.
 
@@ -1768,7 +1768,7 @@ def _ragged_tensor_sparse_categorical_crossentropy(y_true,
 def binary_crossentropy(y_true,
                         y_pred,
                         from_logits=False,
-                        label_smoothing=0,
+                        label_smoothing=.0,
                         axis=-1):
   """Computes the binary crossentropy loss.
 
@@ -1814,7 +1814,7 @@ def binary_crossentropy(y_true,
 def _ragged_tensor_binary_crossentropy(y_true,
                                        y_pred,
                                        from_logits=False,
-                                       label_smoothing=0,
+                                       label_smoothing=.0,
                                        axis=-1):
   """Implements support for handling RaggedTensors.
 

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -556,7 +556,7 @@ class BinaryCrossentropy(LossFunctionWrapper):
 
   def __init__(self,
                from_logits=False,
-               label_smoothing=.0,
+               label_smoothing=0.,
                axis=-1,
                reduction=losses_utils.ReductionV2.AUTO,
                name='binary_crossentropy'):
@@ -640,7 +640,7 @@ class CategoricalCrossentropy(LossFunctionWrapper):
 
   def __init__(self,
                from_logits=False,
-               label_smoothing=.0,
+               label_smoothing=0.,
                axis=-1,
                reduction=losses_utils.ReductionV2.AUTO,
                name='categorical_crossentropy'):
@@ -1623,7 +1623,7 @@ def log_cosh(y_true, y_pred):
 def categorical_crossentropy(y_true,
                              y_pred,
                              from_logits=False,
-                             label_smoothing=.0,
+                             label_smoothing=0.,
                              axis=-1):
   """Computes the categorical crossentropy loss.
 
@@ -1671,7 +1671,7 @@ def categorical_crossentropy(y_true,
 def _ragged_tensor_categorical_crossentropy(y_true,
                                             y_pred,
                                             from_logits=False,
-                                            label_smoothing=.0,
+                                            label_smoothing=0.,
                                             axis=-1):
   """Implements support for handling RaggedTensors.
 
@@ -1768,7 +1768,7 @@ def _ragged_tensor_sparse_categorical_crossentropy(y_true,
 def binary_crossentropy(y_true,
                         y_pred,
                         from_logits=False,
-                        label_smoothing=.0,
+                        label_smoothing=0.,
                         axis=-1):
   """Computes the binary crossentropy loss.
 
@@ -1814,7 +1814,7 @@ def binary_crossentropy(y_true,
 def _ragged_tensor_binary_crossentropy(y_true,
                                        y_pred,
                                        from_logits=False,
-                                       label_smoothing=.0,
+                                       label_smoothing=0.,
                                        axis=-1):
   """Implements support for handling RaggedTensors.
 

--- a/keras/mixed_precision/policy_test.py
+++ b/keras/mixed_precision/policy_test.py
@@ -60,7 +60,7 @@ class PolicyTest(tf.test.TestCase, parameterized.TestCase):
     for policy in ('float32', 'int8', 'mixed_bfloat16', '_infer'):
       self.assertEqual(repr(mp_policy.PolicyV1(policy)),
                        '<PolicyV1 "%s", loss_scale=None>' % policy)
-    self.assertEqual(repr(mp_policy.PolicyV1('float16', loss_scale=2)),
+    self.assertEqual(repr(mp_policy.PolicyV1('float16', loss_scale=2.)),
                      '<PolicyV1 "float16", loss_scale=FixedLossScale(2.0)>')
     self.assertStartsWith(
         repr(mp_policy.PolicyV1('mixed_float16')),

--- a/keras/premade/linear_test.py
+++ b/keras/premade/linear_test.py
@@ -34,7 +34,7 @@ class LinearModelTest(keras_parameterized.TestCase):
 
   def test_linear_model_with_single_input(self):
     model = linear.LinearModel()
-    inp = np.random.uniform(low=-5, high=5, size=(64, 2))
+    inp = np.random.uniform(low=-5., high=5., size=(64, 2))
     output = .3 * inp[:, 0] + .2 * inp[:, 1]
     model.compile('sgd', 'mse', [])
     model.fit(inp, output, epochs=5)
@@ -42,16 +42,16 @@ class LinearModelTest(keras_parameterized.TestCase):
 
   def test_linear_model_with_list_input(self):
     model = linear.LinearModel()
-    input_a = np.random.uniform(low=-5, high=5, size=(64, 1))
-    input_b = np.random.uniform(low=-5, high=5, size=(64, 1))
+    input_a = np.random.uniform(low=-5., high=5., size=(64, 1))
+    input_b = np.random.uniform(low=-5., high=5., size=(64, 1))
     output = .3 * input_a + .2 * input_b
     model.compile('sgd', 'mse', [])
     model.fit([input_a, input_b], output, epochs=5)
 
   def test_linear_model_with_mismatched_dict_inputs(self):
     model = linear.LinearModel()
-    input_a = np.random.uniform(low=-5, high=5, size=(64, 1))
-    input_b = np.random.uniform(low=-5, high=5, size=(64, 1))
+    input_a = np.random.uniform(low=-5., high=5., size=(64, 1))
+    input_b = np.random.uniform(low=-5., high=5., size=(64, 1))
     output = .3 * input_a + .2 * input_b
     model.compile('sgd', 'mse', [])
     model.build({'a': tf.TensorShape([None, 1]),
@@ -61,8 +61,8 @@ class LinearModelTest(keras_parameterized.TestCase):
 
   def test_linear_model_with_dict_input(self):
     model = linear.LinearModel()
-    input_a = np.random.uniform(low=-5, high=5, size=(64, 1))
-    input_b = np.random.uniform(low=-5, high=5, size=(64, 1))
+    input_a = np.random.uniform(low=-5., high=5., size=(64, 1))
+    input_b = np.random.uniform(low=-5., high=5., size=(64, 1))
     output = .3 * input_a + .2 * input_b
     model.compile('sgd', 'mse', [])
     model.fit({'a': input_a, 'b': input_b}, output, epochs=5)
@@ -74,8 +74,8 @@ class LinearModelTest(keras_parameterized.TestCase):
     output_b = core.Dense(units=1)(input_b)
     output = output_a + output_b
     model = training.Model(inputs=[input_a, input_b], outputs=[output])
-    input_a_np = np.random.uniform(low=-5, high=5, size=(64, 1))
-    input_b_np = np.random.uniform(low=-5, high=5, size=(64, 1))
+    input_a_np = np.random.uniform(low=-5., high=5., size=(64, 1))
+    input_b_np = np.random.uniform(low=-5., high=5., size=(64, 1))
     output_np = .3 * input_a_np + .2 * input_b_np
     model.compile('sgd', 'mse', [])
     model.fit([input_a_np, input_b_np], output_np, epochs=5)
@@ -105,19 +105,19 @@ class LinearModelTest(keras_parameterized.TestCase):
       rand_int = np.random.randint(3)
       if rand_int == 0:
         indices.append((i, 0))
-        val = np.random.uniform(low=-5, high=5)
+        val = np.random.uniform(low=-5., high=5.)
         values.append(val)
         target[i] = 0.3 * val
       elif rand_int == 1:
         indices.append((i, 1))
-        val = np.random.uniform(low=-5, high=5)
+        val = np.random.uniform(low=-5., high=5.)
         values.append(val)
         target[i] = 0.2 * val
       else:
         indices.append((i, 0))
         indices.append((i, 1))
-        val_1 = np.random.uniform(low=-5, high=5)
-        val_2 = np.random.uniform(low=-5, high=5)
+        val_1 = np.random.uniform(low=-5., high=5.)
+        val_2 = np.random.uniform(low=-5., high=5.)
         values.append(val_1)
         values.append(val_2)
         target[i] = 0.3 * val_1 + 0.2 * val_2

--- a/keras/premade/wide_deep_test.py
+++ b/keras/premade/wide_deep_test.py
@@ -36,8 +36,8 @@ class WideDeepModelTest(keras_parameterized.TestCase):
     linear_model = linear.LinearModel(units=1)
     dnn_model = sequential.Sequential([core.Dense(units=1, input_dim=3)])
     wide_deep_model = wide_deep.WideDeepModel(linear_model, dnn_model)
-    linear_inp = np.random.uniform(low=-5, high=5, size=(64, 2))
-    dnn_inp = np.random.uniform(low=-5, high=5, size=(64, 3))
+    linear_inp = np.random.uniform(low=-5., high=5., size=(64, 2))
+    dnn_inp = np.random.uniform(low=-5., high=5., size=(64, 3))
     inputs = [linear_inp, dnn_inp]
     output = .3 * linear_inp[:, 0] + .2 * dnn_inp[:, 1]
     wide_deep_model.compile(
@@ -78,7 +78,7 @@ class WideDeepModelTest(keras_parameterized.TestCase):
     linear_model = linear.LinearModel(units=1)
     dnn_model = sequential.Sequential([core.Dense(units=1, input_dim=3)])
     wide_deep_model = wide_deep.WideDeepModel(linear_model, dnn_model)
-    inputs = np.random.uniform(low=-5, high=5, size=(64, 3))
+    inputs = np.random.uniform(low=-5., high=5., size=(64, 3))
     output = .3 * inputs[:, 0]
     wide_deep_model.compile(
         optimizer=['sgd', 'adam'],
@@ -115,8 +115,8 @@ class WideDeepModelTest(keras_parameterized.TestCase):
     linear_model = linear.LinearModel(units=1)
     dnn_model = sequential.Sequential([core.Dense(units=1, input_dim=3)])
     wide_deep_model = wide_deep.WideDeepModel(linear_model, dnn_model)
-    linear_inp = np.random.uniform(low=-5, high=5, size=(64, 2))
-    dnn_inp = np.random.uniform(low=-5, high=5, size=(64, 3))
+    linear_inp = np.random.uniform(low=-5., high=5., size=(64, 2))
+    dnn_inp = np.random.uniform(low=-5., high=5., size=(64, 3))
     inputs = [linear_inp, dnn_inp]
     output = .3 * linear_inp[:, 0] + .2 * dnn_inp[:, 1]
     wide_deep_model.compile(
@@ -139,9 +139,9 @@ class WideDeepModelTest(keras_parameterized.TestCase):
     model = training.Model(
         inputs=[linear_input, dnn_input, input_b],
         outputs=[wide_deep_output + output_b])
-    linear_input_np = np.random.uniform(low=-5, high=5, size=(64, 3))
-    dnn_input_np = np.random.uniform(low=-5, high=5, size=(64, 5))
-    input_b_np = np.random.uniform(low=-5, high=5, size=(64,))
+    linear_input_np = np.random.uniform(low=-5., high=5., size=(64, 3))
+    dnn_input_np = np.random.uniform(low=-5., high=5., size=(64, 5))
+    input_b_np = np.random.uniform(low=-5., high=5., size=(64,))
     output_np = linear_input_np[:, 0] + .2 * dnn_input_np[:, 1] + input_b_np
     model.compile(
         optimizer='sgd',
@@ -156,8 +156,8 @@ class WideDeepModelTest(keras_parameterized.TestCase):
     wide_deep_model = wide_deep.WideDeepModel(
         linear.LinearModel(units=1),
         sequential.Sequential([core.Dense(units=1, input_dim=3)]))
-    linear_inp = np.random.uniform(low=-5, high=5, size=(64, 2))
-    dnn_inp = np.random.uniform(low=-5, high=5, size=(64, 3))
+    linear_inp = np.random.uniform(low=-5., high=5., size=(64, 2))
+    dnn_inp = np.random.uniform(low=-5., high=5., size=(64, 3))
     inputs = [linear_inp, dnn_inp]
     output = .3 * linear_inp[:, 0] + .2 * dnn_inp[:, 1]
     linear_model.compile(


### PR DESCRIPTION
This is the sister commit to https://github.com/tensorflow/tensorflow/pull/49974

> I'm writing a parser/emitter that goes from Python to Python (and also OpenAPI). I found some type inconsistencies, when I would run `type(func_argument)` it would not match the argument type referenced in the docstring. This PR solves one such problem.

PS: Previously when I've tried to commit here I've come across issues, so though it'd be good to start small with a proof-of-concept before going full-throttle. So before I go through the effort of manually making these changes… or extending my [`ast`](https://docs.python.org/3/library/ast.html) parser/emitter to automatically make numeric types consistent (between docstring and default/provided argument), I wanted to gain your feedback. Thanks.

EDIT: Ended up going through the codebase and [probably] fixing all the obvious cases