### PR TITLE
Check if layer has _metrics_lock attribute

### DIFF
--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -1561,6 +1561,8 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
     """
     collected_metrics = []
     for layer in self._flatten_layers():
+      if not hasattr(layer, '_metrics_lock'): 
+        continue
       with layer._metrics_lock:
         collected_metrics.extend(layer._metrics)
     return collected_metrics


### PR DESCRIPTION
Solving error `AttributeError: 'InputLayer' object has no attribute '_metrics_lock'` when trying to export a keras model.

This occurred when exporting a model with weights loaded from `.index` and `.data-xxx` files (exported in tf=2.4), but not with a model loaded directly from `saved_model.pb` + `variables/` (exported in tf=2.3)

Full stack trace:

```
  File "/Scribosermo/extras/exporting/export.py", line 90, in <module>
    main()
  File "/Scribosermo/extras/exporting/export.py", line 71, in main
    tf.keras.models.save_model(
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/saving/save.py", line 133, in save_model
    saved_model_save.save(model, filepath, overwrite, include_optimizer,
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/saving/saved_model/save.py", line 80, in save
    save_lib.save(model, filepath, signatures, options)
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/saved_model/save.py", line 975, in save
    _, exported_graph, object_saver, asset_info = _build_meta_graph(
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/saved_model/save.py", line 1046, in _build_meta_graph
    signatures = signature_serialization.find_function_to_export(
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/saved_model/signature_serialization.py", line 75, in find_function_to_export
    functions = saveable_view.list_functions(saveable_view.root)
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/saved_model/save.py", line 144, in list_functions
    obj_functions = obj._list_functions_for_serialization(  # pylint: disable=protected-access
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/engine/training.py", line 2589, in _list_functions_for_serialization
    functions = super(
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/engine/base_layer_v1.py", line 2380, in _list_functions_for_serialization
    return (self._trackable_saved_model_saver
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/saving/saved_model/base_serialization.py", line 87, in list_functions_for_serialization
    fns = self.functions_to_serialize(serialization_cache)
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/saving/saved_model/layer_serialization.py", line 78, in functions_to_serialize
    return (self._get_serialized_attributes(
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/saving/saved_model/layer_serialization.py", line 94, in _get_serialized_attributes
    object_dict, function_dict = self._get_serialized_attributes_internal(
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/saving/saved_model/model_serialization.py", line 56, in _get_serialized_attributes_internal
    super(ModelSavedModelSaver, self)._get_serialized_attributes_internal(
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/saving/saved_model/layer_serialization.py", line 103, in _get_serialized_attributes_internal
    objects = save_impl.wrap_layer_objects(self.obj, serialization_cache)
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/saving/saved_model/save_impl.py", line 125, in wrap_layer_objects
    metrics=data_structures.ListWrapper(layer.metrics),
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/engine/training_v1.py", line 502, in metrics
    metrics.extend(_get_metrics_from_layers(self._layers))
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/engine/training_v1.py", line 3198, in _get_metrics_from_layers
    metrics.extend(_get_metrics_from_layers(layer.layers))
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/engine/training_v1.py", line 3198, in _get_metrics_from_layers
    metrics.extend(_get_metrics_from_layers(layer.layers))
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/engine/training_v1.py", line 3200, in _get_metrics_from_layers
    metrics.extend(layer.metrics)
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/keras/engine/base_layer.py", line 1588, in metrics
    with layer._metrics_lock:
AttributeError: 'InputLayer' object has no attribute '_metrics_lock'
```

Model code can be found at: https://gitlab.com/Jaco-Assistant/Scribosermo/-/tree/master/extras/exporting

Tested with tf=2.3.3 and tf=2.4.0
Moved from: https://github.com/tensorflow/tensorflow/pull/50701