### PR TITLE
Fix RNN, StackedRNNCells with nested state_size, output_size TypeError issues

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -19,6 +19,7 @@
 import tensorflow.compat.v2 as tf
 
 import collections
+import functools
 import warnings
 
 import numpy as np
@@ -153,11 +154,9 @@ class StackedRNNCells(Layer):
     if isinstance(input_shape, list):
       input_shape = input_shape[0]
 
-    def get_batch_input_shape(batch_size):
-      def _get_input_shape(dim):
-        shape = tf.TensorShape(dim).as_list()
-        return tuple([batch_size] + shape)
-      return _get_input_shape
+    def get_batch_input_shape(batch_size, dim):
+      shape = tf.TensorShape(dim).as_list()
+      return tuple([batch_size] + shape)
     
     for cell in self.cells:
       if isinstance(cell, Layer) and not cell.built:
@@ -173,7 +172,8 @@ class StackedRNNCells(Layer):
       batch_size = tf.nest.flatten(input_shape)[0]
       if tf.nest.is_nested(output_dim):
         input_shape = tf.nest.map_structure(
-                          get_batch_input_shape(batch_size), output_dim)
+                        functools.partial(get_batch_input_shape, batch_size),
+                        output_dim)
         input_shape = tuple(input_shape)
       else:
         input_shape = tuple([batch_size] +

--- a/keras/layers/recurrent_test.py
+++ b/keras/layers/recurrent_test.py
@@ -901,6 +901,76 @@ class RNNTest(keras_parameterized.TestCase):
     inputs = np.ones((8, 4, 16), dtype=np.float32)
     rnn(inputs, training=True)
 
+  def test_stacked_rnn_with_nested_cell(self):
+    batch = 10
+    t = 5
+    i1,  i2,  i3  = 3, 4, 5
+    o11, o12, o13 = 2, 3, 4
+    o21, o22, o23 = 4, 5, 6
+
+    # test 1: use_tuple=False
+    cells = [NestedCell(o11, o12, o13),
+             NestedCell(o21, o22, o23)]
+    rnn = keras.layers.RNN(cells, return_sequences=True, return_state=True)
+
+    input_1 = keras.Input((t, i1))
+    input_2 = keras.Input((t, i2, i3))
+
+    output1, output2, state1, state2 = rnn((input_1, input_2))
+    s11, s12 = state1
+    s21, s22 = state2
+
+    self.assertEqual(output1.shape.as_list(), [None, t, o21])
+    self.assertEqual(output2.shape.as_list(), [None, t, o22, o23])
+    self.assertEqual(s11.shape.as_list(), [None, o11])
+    self.assertEqual(s12.shape.as_list(), [None, o12, o13])
+    self.assertEqual(s21.shape.as_list(), [None, o21])
+    self.assertEqual(s22.shape.as_list(), [None, o22, o23])
+
+    model = keras.models.Model([input_1, input_2], [output1, output2])
+    model.compile(
+        optimizer='rmsprop',
+        loss='mse',
+        run_eagerly=testing_utils.should_run_eagerly())
+    model.train_on_batch(
+        [np.zeros((batch, t, i1)),
+         np.zeros((batch, t, i2, i3))],
+        [np.zeros((batch, t, o21)),
+         np.zeros((batch, t, o22, o23))])
+    self.assertEqual(model.output_shape, [(None, t, o21), (None, t, o22, o23)])
+
+    # test 2: use_tuple=True
+    cells = [NestedCell(o11, o12, o13, use_tuple=True),
+             NestedCell(o21, o22, o23)]
+
+    rnn = keras.layers.RNN(cells, return_sequences=True, return_state=True)
+
+    input_1 = keras.Input((t, i1))
+    input_2 = keras.Input((t, i2, i3))
+
+    output1, output2, state1, state2 = rnn(NestedInput(t1=input_1, t2=input_2))
+    s11, s12 = state1
+    s21, s22 = state2
+
+    self.assertEqual(output1.shape.as_list(), [None, t, o21])
+    self.assertEqual(output2.shape.as_list(), [None, t, o22, o23])
+    self.assertEqual(s11.shape.as_list(), [None, o11])
+    self.assertEqual(s12.shape.as_list(), [None, o12, o13])
+    self.assertEqual(s21.shape.as_list(), [None, o21])
+    self.assertEqual(s22.shape.as_list(), [None, o22, o23])
+
+    model = keras.models.Model([input_1, input_2], [output1, output2])
+    model.compile(
+        optimizer='rmsprop',
+        loss='mse',
+        run_eagerly=testing_utils.should_run_eagerly())
+    model.train_on_batch(
+        [np.zeros((batch, t, i1)),
+         np.zeros((batch, t, i2, i3))],
+        [np.zeros((batch, t, o21)),
+         np.zeros((batch, t, o22, o23))])
+    self.assertEqual(model.output_shape, [(None, t, o21), (None, t, o22, o23)])
+
   def test_trackable_dependencies(self):
     rnn = keras.layers.SimpleRNN
     x = np.random.random((2, 2, 2))


### PR DESCRIPTION
*repost from [tensorflow/tensorflow #50724](https://github.com/tensorflow/tensorflow/pull/50724)*
This PR fixed the following issues:
* `tf.keras.layers.RNN` generates an incorrect `state_spec` when using stacked LSTM cells.
* `tf.keras.layers.RNN` failed to build up when stacking multiple RNN cells that consume nested inputs/states and produce nested outputs.
* Add a unittest for stacked nested rnn cells

A full bug description/reproduction, please refer to [this gist](https://colab.research.google.com/drive/1WkI64errr70gCUCHU7YAz83jgx8o7VgP?usp=sharing).

Already run the unittest (keras/layers/recurrent_test.py) on my local machine.