### PR TITLE
Fix the use of imagenet_utils.preprocess_input within a Lambda layer with mixed precision

### DIFF
--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -286,7 +286,7 @@ def _preprocess_symbolic_input(x, data_format, mode):
   else:
     x = backend.bias_add(x, mean_tensor, data_format)
   if std is not None:
-    std_tensor = backend.constant(np.array(std))
+    std_tensor = backend.constant(np.array(std), dtype=backend.dtype(x))
     if data_format == 'channels_first':
       std_tensor = backend.reshape(std_tensor, (-1, 1, 1))
     x /= std_tensor

--- a/keras/applications/imagenet_utils_test.py
+++ b/keras/applications/imagenet_utils_test.py
@@ -22,7 +22,7 @@ import numpy as np
 import keras
 from keras import keras_parameterized
 from keras.applications import imagenet_utils as utils
-
+from keras.mixed_precision.policy import set_policy
 
 class TestImageNetUtils(keras_parameterized.TestCase):
 
@@ -143,6 +143,32 @@ class TestImageNetUtils(keras_parameterized.TestCase):
     model2 = keras.Model(inputs2, outputs2)
     out2 = model2.predict(x2[np.newaxis])[0]
     self.assertAllClose(out1, out2.transpose(1, 2, 0))
+
+  @parameterized.named_parameters([
+      {
+          'testcase_name': 'mode_torch',
+          'mode': 'torch'
+      },
+      {
+          'testcase_name': 'mode_tf',
+          'mode': 'tf'
+      },
+      {
+          'testcase_name': 'mode_caffe',
+          'mode': 'caffe'
+      },
+  ])
+  def test_preprocess_input_symbolic_mixed_precision(self, mode):
+    set_policy("mixed_float16")
+    shape = (20, 20, 3)
+    inputs = keras.layers.Input(shape=shape)
+    try:
+      keras.layers.Lambda(
+          lambda x: utils.preprocess_input(x, mode=mode),
+          output_shape=shape)(
+              inputs)
+    finally:
+      set_policy("float32")
 
   @parameterized.named_parameters([
       {'testcase_name': 'channels_last_format',


### PR DESCRIPTION
I noticed an issue when using imagenet_utils.preprocess_input within a Lambda layer and using mixed precision. I described it and gave a minimal reproducible example [here](https://github.com/tensorflow/tensorflow/issues/50668).

This PR is a very small bugfix, with the add of a unit test of the problematic behavior. If you remove the added line in `imagenet_utils.py`, the test `test_preprocess_input_symbolic_mixed_precision` in test mode `torch` will fail.