### PR TITLE
Warn upon conflict between target (y) unique classes and loss function expected unique target class count

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,11 +2,38 @@ workspace(name = "org_keras")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# Needed by protobuf
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_skylib",
+    url = "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.1/bazel-skylib-1.0.1.tar.gz",
+    sha256 = "f1c8360c01fcf276778d3519394805dc2a71a64274a3a0908bc9edff7b5aebc8",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
+# Needed by protobuf
+http_archive(
+    name = "six_archive",
+    build_file = "//third_party:six.BUILD",
+    sha256 = "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73",
+    strip_prefix = "six-1.12.0",
+    urls = [
+        "http://mirror.bazel.build/pypi.python.org/packages/source/s/six/six-1.12.0.tar.gz",
+        "https://pypi.python.org/packages/source/s/six/six-1.12.0.tar.gz",  # 2018-12-10
+    ],
+)
+
+bind(
+    name = "six",
+    actual = "@six_archive//:six",
+)
+
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "b10bf4e2d1a7586f54e64a5d9e7837e5188fc75ae69e36f215eb01def4f9721b",
-    strip_prefix = "protobuf-3.15.3",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.15.3.tar.gz"],
+    sha256 = "1fbf1c2962af287607232b2eddeaec9b4f4a7a6f5934e1a9276e9af76952f7e0",
+    strip_prefix = "protobuf-3.9.2",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.9.2.tar.gz"],
 )
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 protobuf_deps()

--- a/keras/legacy_tf_layers/base.py
+++ b/keras/legacy_tf_layers/base.py
@@ -473,8 +473,7 @@ class Layer(base_layer.Layer):
             # When the shim to get variable scope working in TF2 is used,
             # We need to explicitly make the shim track the regularization
             # losses as the collections will not be accessible.
-            if isinstance(var_store,
-                          variable_scope_shim._EagerVariableStore):  # pylint: disable=protected-access
+            if hasattr(var_store, 'add_regularizer'):
               var_store.add_regularizer(variable, regularizer)
 
         if init_graph is not None:

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,0 +1,10 @@
+package(
+    licenses = ["notice"],  # Apache 2.0
+)
+
+exports_files([
+    "LICENSE",
+    "six.BUILD",
+])
+
+package(default_visibility = ["//visibility:public"])

--- a/third_party/six.BUILD
+++ b/third_party/six.BUILD
@@ -1,0 +1,23 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+py_library(
+    name = "six",
+    srcs = ["six.py"],
+)


### PR DESCRIPTION
It may be a good idea to add a warning when the user uses a multiclass target (y) with binary loss and vise versa; binary class target (y) with multiclass loss. In either case, a model will train without raising any exceptions or warnings.