### PR TITLE
Fix docstrings in `MultiHeadAttention layer` call argument `return_attention_scores`.

### DIFF
--- a/keras/layers/multi_head_attention.py
+++ b/keras/layers/multi_head_attention.py
@@ -195,8 +195,8 @@ class MultiHeadAttention(Layer):
       indicates no attention. Broadcasting can happen for the missing batch
       dimensions and the head dimension.
     return_attention_scores: A boolean to indicate whether the output should
-      be attention output if True, or (attention_output, attention_scores) if
-      False. Defaults to False.
+      be `(attention_output, attention_scores)` if `True`, or `attention_output`
+      if `False`. Defaults to `False`.
     training: Python boolean indicating whether the layer should behave in
       training mode (adding dropout) or in inference mode (no dropout).
       Defaults to either using the training mode of the parent layer/model,


### PR DESCRIPTION
**URL(s) with the issue:** [https://keras.io/api/layers/attention_layers/multi_head_attention/](https://keras.io/api/layers/attention_layers/multi_head_attention/)
**Summary:** In the `MultiHeadAttention layer` docstrings, the description of the call argument `return_attention_scores` implies that this argument being False makes the call return both `attention_output` and `attention_scores`. It should be the other way around. Also, an underscore was missing in `attention_output`.