### PR TITLE
check the trainable type for Layer init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Python temp files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Vim temp files
+*.swp
+*.swo
+
+# VS Code configs
+.devcontainer
+.vscode
+
+# Bazel files
+bazel-bin
+bazel-keras
+bazel-out
+bazel-testlogs

--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -325,8 +325,10 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
     # Mutable properties
     # Indicates whether the layer's weights are updated during training
     # and whether the layer's updates are run during training.
-    if not isinstance(trainable, bool):
-      raise TypeError('Expect trainable to be a boolean, got ' + str(trainable))
+    if not (isinstance(trainable, bool) or
+            (isinstance(trainable, (tf.Tensor, tf.Variable)) and
+             trainable.dtype is tf.bool)):
+      raise TypeError(f'Expect trainable to be a boolean, got {trainable}.')
     self._trainable = trainable
     # A stateful layer is a layer whose updates are run during inference too,
     # for instance stateful RNNs.

--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -325,6 +325,8 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
     # Mutable properties
     # Indicates whether the layer's weights are updated during training
     # and whether the layer's updates are run during training.
+    if not isinstance(trainable, bool):
+      raise TypeError('Expect trainable to be a boolean, got ' + str(trainable))
     self._trainable = trainable
     # A stateful layer is a layer whose updates are run during inference too,
     # for instance stateful RNNs.

--- a/keras/engine/base_layer_test.py
+++ b/keras/engine/base_layer_test.py
@@ -466,9 +466,8 @@ class BaseLayerTest(keras_parameterized.TestCase):
     base_layer.Layer(trainable=True)
     base_layer.Layer(trainable=tf.constant(True))
     base_layer.Layer(trainable=tf.Variable(tf.constant(True)))
-    with self.assertRaises(TypeError) as e:
+    with self.assertRaisesRegex(TypeError, 'Expect trainable to be a boolean'):
       base_layer.Layer(trainable=0)
-      self.assertIn('Expect trainable to be a boolean', str(e))
 
   @combinations.generate(combinations.combine(mode=['graph', 'eager']))
   def test_layer_names(self):

--- a/keras/engine/base_layer_test.py
+++ b/keras/engine/base_layer_test.py
@@ -462,6 +462,11 @@ class BaseLayerTest(keras_parameterized.TestCase):
     self.assertEqual(self.evaluate(layer.weights[0]), 1.)
     self.assertEqual(self.evaluate(layer.weights[1]), 2.)
 
+  def test_exception_if_trainable_not_boolean(self):
+    with self.assertRaises(TypeError) as e:
+      base_layer.Layer(trainable=0)
+      self.assertIn('Expect trainable to be a boolean', str(e))
+
   @combinations.generate(combinations.combine(mode=['graph', 'eager']))
   def test_layer_names(self):
     inputs = input_layer.Input(shape=[2])
@@ -912,7 +917,7 @@ class BaseLayerTest(keras_parameterized.TestCase):
     class MyLayer(base_layer.Layer):
 
       def __init__(self, **kwargs):
-        super(MyLayer, self).__init__(self, **kwargs)
+        super(MyLayer, self).__init__(**kwargs)
         self.my_modules = {}
         self.my_modules['a'] = MyModule()
 

--- a/keras/engine/base_layer_test.py
+++ b/keras/engine/base_layer_test.py
@@ -463,6 +463,9 @@ class BaseLayerTest(keras_parameterized.TestCase):
     self.assertEqual(self.evaluate(layer.weights[1]), 2.)
 
   def test_exception_if_trainable_not_boolean(self):
+    base_layer.Layer(trainable=True)
+    base_layer.Layer(trainable=tf.constant(True))
+    base_layer.Layer(trainable=tf.Variable(tf.constant(True)))
     with self.assertRaises(TypeError) as e:
       base_layer.Layer(trainable=0)
       self.assertIn('Expect trainable to be a boolean', str(e))

--- a/keras/feature_column/dense_features_test.py
+++ b/keras/feature_column/dense_features_test.py
@@ -1005,7 +1005,6 @@ class SharedEmbeddingColumnTest(tf.test.TestCase, parameterized.TestCase):
 class DenseFeaturesSerializationTest(tf.test.TestCase, parameterized.TestCase):
 
   @parameterized.named_parameters(
-      ('default', None, None),
       ('trainable', True, 'trainable'),
       ('not_trainable', False, 'frozen'))
   def test_get_config(self, trainable, name):
@@ -1026,7 +1025,6 @@ class DenseFeaturesSerializationTest(tf.test.TestCase, parameterized.TestCase):
         config['feature_columns'][1]['class_name'], 'EmbeddingColumn')
 
   @parameterized.named_parameters(
-      ('default', None, None),
       ('trainable', True, 'trainable'),
       ('not_trainable', False, 'frozen'))
   def test_from_config(self, trainable, name):

--- a/keras/feature_column/sequence_feature_column_test.py
+++ b/keras/feature_column/sequence_feature_column_test.py
@@ -563,8 +563,7 @@ class SequenceFeaturesTest(tf.test.TestCase, parameterized.TestCase):
 @combinations.generate(combinations.combine(mode=['graph', 'eager']))
 class SequenceFeaturesSerializationTest(tf.test.TestCase, parameterized.TestCase):
 
-  @parameterized.named_parameters(('default', None, None),
-                                  ('trainable', True, 'trainable'),
+  @parameterized.named_parameters(('trainable', True, 'trainable'),
                                   ('not_trainable', False, 'frozen'))
   def test_get_config(self, trainable, name):
     cols = [tf.feature_column.sequence_numeric_column('a')]
@@ -578,8 +577,7 @@ class SequenceFeaturesSerializationTest(tf.test.TestCase, parameterized.TestCase
                      'SequenceNumericColumn')
     self.assertEqual(config['feature_columns'][0]['config']['shape'], (1,))
 
-  @parameterized.named_parameters(('default', None, None),
-                                  ('trainable', True, 'trainable'),
+  @parameterized.named_parameters(('trainable', True, 'trainable'),
                                   ('not_trainable', False, 'frozen'))
   def test_from_config(self, trainable, name):
     cols = [tf.feature_column.sequence_numeric_column('a')]


### PR DESCRIPTION
Enforce the `trainable` arg in `Layer.__init__` to be boolean.
It seems in the tests there are some use cases setting `trainable=None`.