### PR TITLE
Update 00-bug-template.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug-template.md
+++ b/.github/ISSUE_TEMPLATE/00-bug-template.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Issue
 about: Use this template for reporting a bug
-labels: 'type:bug'
+labels: 'type:bug/performance'
 
 ---
 


### PR DESCRIPTION
This PR enables auto-assignment of `type:bug/performance` label when the user selects `bug` template. The other two templates (`docs` and `feature`) are correctly auto-assigning labels.