### PR TITLE
Update example of aggregating gradients by self

### DIFF
--- a/keras/optimizer_v2/optimizer_v2.py
+++ b/keras/optimizer_v2/optimizer_v2.py
@@ -595,9 +595,9 @@ class OptimizerV2(tf.__internal__.tracking.Trackable):
 
     ```python
     grads = tape.gradient(loss, vars)
-    grads = tf.distribute.get_replica_context().all_reduce('sum', grads)
+    grads_and_vars = optimizer.gradient_aggregator(zip(grads, vars))
     # Processing aggregated gradients.
-    optimizer.apply_gradients(zip(grads, vars),
+    optimizer.apply_gradients(grads_and_vars,
         experimental_aggregate_gradients=False)
 
     ```


### PR DESCRIPTION
Using the optimizer's own gradient aggregator seems a better choice here - the default one handles corner cases the previous documentation does not, and if the user wants to conditionally process aggregated gradients, there is greater consistency with the standard path.