### PR TITLE
Fix docs about GRU and cuDNN.

### DIFF
--- a/keras/layers/__init__.py
+++ b/keras/layers/__init__.py
@@ -233,21 +233,21 @@ from keras.layers.convolutional_recurrent import ConvLSTM1D
 from keras.layers.convolutional_recurrent import ConvLSTM2D
 from keras.layers.convolutional_recurrent import ConvLSTM3D
 
-# CuDNN recurrent layers.
+# cuDNN recurrent layers.
 from keras.layers.cudnn_recurrent import CuDNNLSTM
 from keras.layers.cudnn_recurrent import CuDNNGRU
 
-# Wrapper functions
+# Wrapper functions.
 from keras.layers.wrappers import Wrapper
 from keras.layers.wrappers import Bidirectional
 from keras.layers.wrappers import TimeDistributed
 
-# # RNN Cell wrappers.
+# RNN Cell wrappers.
 from keras.layers.rnn_cell_wrapper_v2 import DeviceWrapper
 from keras.layers.rnn_cell_wrapper_v2 import DropoutWrapper
 from keras.layers.rnn_cell_wrapper_v2 import ResidualWrapper
 
-# Serialization functions
+# Serialization functions.
 from keras.layers import serialization
 from keras.layers.serialization import deserialize
 from keras.layers.serialization import serialize

--- a/keras/layers/gru_v2_test.py
+++ b/keras/layers/gru_v2_test.py
@@ -245,7 +245,7 @@ class GRUV2Test(keras_parameterized.TestCase):
       gpu_model.set_weights(weights)
       y_2 = gpu_model.predict(x_train)
 
-    # Note that CuDNN uses 'sigmoid' as activation, so the GRU V2 uses
+    # Note that cuDNN uses 'sigmoid' as activation, so the GRU V2 uses
     # 'sigmoid' as default. Construct the canonical GRU with sigmoid to achieve
     # the same output.
     with testing_utils.device(should_use_gpu=True):

--- a/keras/layers/lstm_v2_test.py
+++ b/keras/layers/lstm_v2_test.py
@@ -547,7 +547,7 @@ class LSTMV2Test(keras_parameterized.TestCase):
       gpu_model.set_weights(weights)
     y_2 = gpu_model.predict(x_train)
 
-    # Note that CuDNN uses 'sigmoid' as activation, so the LSTM V2 uses
+    # Note that cuDNN uses 'sigmoid' as activation, so the LSTM V2 uses
     # 'sigmoid' as default. Construct the canonical LSTM with sigmoid to achieve
     # the same output.
     with testing_utils.device(should_use_gpu=True):
@@ -1114,7 +1114,7 @@ class LSTMPerformanceTest(tf.test.Benchmark):
                           extras=test_config)
 
     logging.info('Expect the performance of LSTM V2 is within 80% of '
-                 'CuDNN LSTM, got {0:.2f}%'.format(cudnn_vs_v2 * 100))
+                 'cuDNN LSTM, got {0:.2f}%'.format(cudnn_vs_v2 * 100))
     logging.info('Expect the performance of LSTM V2 is more than 5 times'
                  ' of normal LSTM, got {0:.2f}'.format(v2_vs_normal))
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1740,7 +1740,7 @@ class GRUCell(DropoutRNNCellMixin, Layer):
       the linear transformation of the recurrent state.
     reset_after: GRU convention (whether to apply reset gate after or
       before matrix multiplication). False = "before" (default),
-      True = "after" (CuDNN compatible).
+      True = "after" (cuDNN compatible).
 
   Call arguments:
     inputs: A 2D tensor.
@@ -2056,7 +2056,7 @@ class GRU(RNN):
       form.
     reset_after: GRU convention (whether to apply reset gate after or
       before matrix multiplication). False = "before" (default),
-      True = "after" (CuDNN compatible).
+      True = "after" (cuDNN compatible).
 
   Call arguments:
     inputs: A 3D tensor.

--- a/keras/layers/recurrent_v2.py
+++ b/keras/layers/recurrent_v2.py
@@ -231,7 +231,7 @@ class GRU(recurrent.DropoutRNNCellMixin, recurrent.GRU):
 
   The second variant is compatible with CuDNNGRU (GPU-only) and allows
   inference on CPU. Thus it has separate biases for `kernel` and
-  `recurrent_kernel`. To use this variant, set `'reset_after'=True` and
+  `recurrent_kernel`. To use this variant, set `reset_after=True` and
   `recurrent_activation='sigmoid'`.
 
   For example:

--- a/keras/saving/hdf5_format.py
+++ b/keras/saving/hdf5_format.py
@@ -229,7 +229,7 @@ def preprocess_weights_for_loading(layer,
   """Preprocess layer weights between different Keras formats.
 
   Converts layers weights from Keras 1 format to Keras 2 and also weights of
-  CuDNN layers in Keras 2.
+  cuDNN layers in Keras 2.
 
   Args:
       layer: Layer instance.
@@ -317,7 +317,7 @@ def preprocess_weights_for_loading(layer,
 
   # Convert layers nested in Bidirectional/Model/Sequential.
   # Both transformation should be ran for both Keras 1->2 conversion
-  # and for conversion of CuDNN layers.
+  # and for conversion of cuDNN layers.
   if layer.__class__.__name__ == 'Bidirectional':
     weights = convert_nested_bidirectional(weights)
   if layer.__class__.__name__ == 'TimeDistributed':
@@ -405,12 +405,12 @@ def preprocess_weights_for_loading(layer,
       if layer.__class__.__name__ == 'ConvLSTM2D':
         weights[1] = np.transpose(weights[1], (3, 2, 0, 1))
 
-  # convert CuDNN layers
+  # convert cuDNN layers
   return _convert_rnn_weights(layer, weights)
 
 
 def _convert_rnn_weights(layer, weights):
-  """Converts weights for RNN layers between native and CuDNN format.
+  """Converts weights for RNN layers between native and cuDNN format.
 
   Input kernels for each gate are transposed and converted between Fortran
   and C layout, recurrent kernels are transposed. For LSTM biases are summed/
@@ -448,12 +448,12 @@ def _convert_rnn_weights(layer, weights):
     return np.hstack([func(k) for k in np.hsplit(kernels, n_gates)])
 
   def transpose_input(from_cudnn):
-    """Makes a function that transforms input kernels from/to CuDNN format.
+    """Makes a function that transforms input kernels from/to cuDNN format.
 
     It keeps the shape, but changes between the layout (Fortran/C). Eg.:
 
     ```
-    Keras                 CuDNN
+    Keras                 cuDNN
     [[0, 1, 2],  <--->  [[0, 2, 4],
      [3, 4, 5]]          [1, 3, 5]]
     ```
@@ -461,7 +461,7 @@ def _convert_rnn_weights(layer, weights):
     It can be passed to `transform_kernels()`.
 
     Args:
-        from_cudnn: `True` if source weights are in CuDNN format, `False`
+        from_cudnn: `True` if source weights are in cuDNN format, `False`
             if they're in plain Keras format.
 
     Returns:
@@ -498,7 +498,7 @@ def _convert_rnn_weights(layer, weights):
 
       Args:
         weights: Original weights.
-        from_cudnn: Indicates whether original weights are from CuDNN layer.
+        from_cudnn: Indicates whether original weights are from cuDNN layer.
 
       Returns:
         Updated weights compatible with LSTM.
@@ -535,7 +535,7 @@ def _convert_rnn_weights(layer, weights):
 
       Args:
         weights: Original weights.
-        from_cudnn: Indicates whether original weights are from CuDNN layer.
+        from_cudnn: Indicates whether original weights are from cuDNN layer.
 
       Returns:
         Updated weights compatible with GRU.


### PR DESCRIPTION
- GRU: Fix a typo in doc comment about `reset_after` - it's a named argument, not a string.
- Fix docs: CuDNN -> cuDNN: "cuDNN" with lower-case "c" is the official name of the library, even though in tensorflow the layer name start with a capital (as classes).