### PR TITLE
Make python code in Sequential docs consistent

### DIFF
--- a/keras/engine/sequential.py
+++ b/keras/engine/sequential.py
@@ -46,44 +46,44 @@ class Sequential(functional.Functional):
 
   Examples:
 
-  >>> # Optionally, the first layer can receive an `input_shape` argument:
-  >>> model = tf.keras.Sequential()
-  >>> model.add(tf.keras.layers.Dense(8, input_shape=(16,)))
-  >>> # Afterwards, we do automatic shape inference:
-  >>> model.add(tf.keras.layers.Dense(4))
-
-  >>> # This is identical to the following:
-  >>> model = tf.keras.Sequential()
-  >>> model.add(tf.keras.Input(shape=(16,)))
-  >>> model.add(tf.keras.layers.Dense(8))
-
-  >>> # Note that you can also omit the `input_shape` argument.
-  >>> # In that case the model doesn't have any weights until the first call
-  >>> # to a training/evaluation method (since it isn't yet built):
-  >>> model = tf.keras.Sequential()
-  >>> model.add(tf.keras.layers.Dense(8))
-  >>> model.add(tf.keras.layers.Dense(4))
-  >>> # model.weights not created yet
-
-  >>> # Whereas if you specify the input shape, the model gets built
-  >>> # continuously as you are adding layers:
-  >>> model = tf.keras.Sequential()
-  >>> model.add(tf.keras.layers.Dense(8, input_shape=(16,)))
-  >>> model.add(tf.keras.layers.Dense(4))
-  >>> len(model.weights)
-  4
-
-  >>> # When using the delayed-build pattern (no input shape specified), you can
-  >>> # choose to manually build your model by calling
-  >>> # `build(batch_input_shape)`:
-  >>> model = tf.keras.Sequential()
-  >>> model.add(tf.keras.layers.Dense(8))
-  >>> model.add(tf.keras.layers.Dense(4))
-  >>> model.build((None, 16))
-  >>> len(model.weights)
-  4
-
   ```python
+  # Optionally, the first layer can receive an `input_shape` argument:
+  model = tf.keras.Sequential()
+  model.add(tf.keras.layers.Dense(8, input_shape=(16,)))
+  # Afterwards, we do automatic shape inference:
+  model.add(tf.keras.layers.Dense(4))
+
+  # This is identical to the following:
+  model = tf.keras.Sequential()
+  model.add(tf.keras.Input(shape=(16,)))
+  model.add(tf.keras.layers.Dense(8))
+
+  # Note that you can also omit the `input_shape` argument.
+  # In that case the model doesn't have any weights until the first call
+  # to a training/evaluation method (since it isn't yet built):
+  model = tf.keras.Sequential()
+  model.add(tf.keras.layers.Dense(8))
+  model.add(tf.keras.layers.Dense(4))
+  # model.weights not created yet
+
+  # Whereas if you specify the input shape, the model gets built
+  # continuously as you are adding layers:
+  model = tf.keras.Sequential()
+  model.add(tf.keras.layers.Dense(8, input_shape=(16,)))
+  model.add(tf.keras.layers.Dense(4))
+  len(model.weights)
+  4
+
+  # When using the delayed-build pattern (no input shape specified), you can
+  # choose to manually build your model by calling
+  # `build(batch_input_shape)`:
+  model = tf.keras.Sequential()
+  model.add(tf.keras.layers.Dense(8))
+  model.add(tf.keras.layers.Dense(4))
+  model.build((None, 16))
+  len(model.weights)
+  4
+
   # Note that when using the delayed-build pattern (no input shape specified),
   # the model gets built the first time you call `fit`, `eval`, or `predict`,
   # or the first time you call the model on some input data.

--- a/keras/engine/sequential.py
+++ b/keras/engine/sequential.py
@@ -72,7 +72,7 @@ class Sequential(functional.Functional):
   model.add(tf.keras.layers.Dense(8, input_shape=(16,)))
   model.add(tf.keras.layers.Dense(4))
   len(model.weights)
-  4
+  # Returns "4"
 
   # When using the delayed-build pattern (no input shape specified), you can
   # choose to manually build your model by calling
@@ -82,7 +82,7 @@ class Sequential(functional.Functional):
   model.add(tf.keras.layers.Dense(4))
   model.build((None, 16))
   len(model.weights)
-  4
+  # Returns "4"
 
   # Note that when using the delayed-build pattern (no input shape specified),
   # the model gets built the first time you call `fit`, `eval`, or `predict`,


### PR DESCRIPTION
As discussed in issue #14971, 

Removed `>>>` to make the python code example consistent.