### PR TITLE
Overriding __add__ on KerasTensor

### DIFF
--- a/keras/engine/keras_tensor.py
+++ b/keras/engine/keras_tensor.py
@@ -290,6 +290,10 @@ class KerasTensor:
         self.type_spec, inferred_value_string,
         name_string, symbolic_description)
 
+  def __add__(self,other):
+    from keras.layers.merge import Add
+    return Add()([self,other])
+
   def __repr__(self):
     symbolic_description = ''
     inferred_value_string = ''
@@ -363,6 +367,10 @@ class KerasTensor:
   @classmethod
   def _overload_all_operators(cls, tensor_class):  # pylint: disable=invalid-name
     """Register overloads for all operators."""
+    # KerasTensor has custom implementation for __add__
+    if cls is KerasTensor:
+      tf.Tensor.OVERLOADABLE_OPERATORS.remove('__add__')
+
     for operator in tf.Tensor.OVERLOADABLE_OPERATORS:
       cls._overload_operator(tensor_class, operator)
 


### PR DESCRIPTION
Overriding the `__add__` method of `KerasTensor` to return a keras `Add` layer.
As suggested in issue #14910, it can be done for other methods as well once this is approved.

/auto Close #14910

<img width="707" alt="Screenshot 2021-08-08 at 4 51 47 PM" src="https://user-images.githubusercontent.com/43729346/128630313-6c9d60e1-1b32-4b2d-9d1a-37679dfe0ca6.png">

