### PR TITLE
Update doc for fit() to fix epoch description

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -931,7 +931,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
             (since they generate batches).
         epochs: Integer. Number of epochs to train the model.
             An epoch is an iteration over the entire `x` and `y`
-            data provided.
+            data provided 
+            (unless the steps_per_epoch flag is set to something other than None).
             Note that in conjunction with `initial_epoch`,
             `epochs` is to be understood as "final epoch".
             The model is not trained for a number of iterations


### PR DESCRIPTION
An epoch is defined by the length of the dataset, unless the steps_per_epoch flag is set.