### PR TITLE
fix __array__ for numpy support

### DIFF
--- a/keras/engine/keras_tensor.py
+++ b/keras/engine/keras_tensor.py
@@ -240,7 +240,7 @@ class KerasTensor:
   # with ndarrays.
   __array_priority__ = 100
 
-  def __array__(self):
+  def __array__(self, dtype=None):
     raise TypeError(
         'Cannot convert a symbolic Keras input/output to a numpy array. '
         'This error may indicate that you\'re trying to pass a symbolic value '


### PR DESCRIPTION
The `__array__` method of numpy is changed, as specified in https://numpy.org/doc/stable/reference/generated/numpy.ndarray.__array__.html
Sometimes an extra parameter will be passed to `__array__` by numpy methods, in that case, instead of throwing the defined as expected, a `TypeError: __array__() takes 1 positional argument but 2 were given` will be thrown so it will be confusing.
It is similar to the change in tensorflow https://github.com/tensorflow/tensorflow/commit/fc0f0e61ca9fe3ca3b9b58f51bcf00e0643ed9e3 