### PR TITLE
Specify `stacklevel` for `warnings.warn` to make it easier to identify which lines throw warnings

### DIFF
--- a/keras/applications/efficientnet_weight_update_util.py
+++ b/keras/applications/efficientnet_weight_update_util.py
@@ -104,7 +104,8 @@ def write_ckpt_to_h5(path_h5, path_ckpt, keras_model, use_ema=True):
     except ValueError as e:
       if any([x in w.name for x in ['top', 'predictions', 'probs']]):
         warnings.warn('Fail to load top layer variable {}'
-                      'from {} because of {}.'.format(w.name, tf_name, e))
+                      'from {} because of {}.'.format(w.name, tf_name, e),
+                      stacklevel=2)
       else:
         raise ValueError('Fail to load {} from {}'.format(w.name, tf_name))
 
@@ -330,7 +331,7 @@ def check_match(keras_block, tf_block, keras_weight_names, tf_weight_names,
   names_unused = names_from_tf - names_from_keras
   if names_unused:
     warnings.warn('{} variables from checkpoint file are not used: {}'.format(
-        len(names_unused), names_unused))
+        len(names_unused), names_unused), stacklevel=2)
 
 
 if __name__ == '__main__':

--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -326,13 +326,15 @@ def obtain_input_shape(input_shape,
       if input_shape[0] not in {1, 3}:
         warnings.warn('This model usually expects 1 or 3 input channels. '
                       'However, it was passed an input_shape with ' +
-                      str(input_shape[0]) + ' input channels.')
+                      str(input_shape[0]) + ' input channels.',
+                      stacklevel=2)
       default_shape = (input_shape[0], default_size, default_size)
     else:
       if input_shape[-1] not in {1, 3}:
         warnings.warn('This model usually expects 1 or 3 input channels. '
                       'However, it was passed an input_shape with ' +
-                      str(input_shape[-1]) + ' input channels.')
+                      str(input_shape[-1]) + ' input channels.',
+                      stacklevel=2)
       default_shape = (default_size, default_size, input_shape[-1])
   else:
     if data_format == 'channels_first':

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -472,7 +472,8 @@ def learning_phase_scope(value):
   warnings.warn('`tf.keras.backend.learning_phase_scope` is deprecated and '
                 'will be removed after 2020-10-11. To update it, simply '
                 'pass a True/False value to the `training` argument of the '
-                '`__call__` method of your layer or model.')
+                '`__call__` method of your layer or model.',
+                stacklevel=2)
   with deprecated_internal_learning_phase_scope(value):
     try:
       yield
@@ -4999,7 +5000,8 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
       warnings.warn(
           '"`categorical_crossentropy` received `from_logits=True`, but '
           'the `output` argument was produced by a sigmoid or softmax '
-          'activation and thus does not represent logits. Was this intended?"')
+          'activation and thus does not represent logits. Was this intended?"',
+          stacklevel=2)
     from_logits = True
 
   if from_logits:
@@ -5059,7 +5061,8 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
       warnings.warn(
           '"`sparse_categorical_crossentropy` received `from_logits=True`, but '
           'the `output` argument was produced by a sigmoid or softmax '
-          'activation and thus does not represent logits. Was this intended?"')
+          'activation and thus does not represent logits. Was this intended?"',
+          stacklevel=2)
     from_logits = True
   elif (not from_logits and
         not isinstance(output, (tf.__internal__.EagerTensor, tf.Variable)) and
@@ -5146,7 +5149,8 @@ def binary_crossentropy(target, output, from_logits=False):
       warnings.warn(
           '"`binary_crossentropy` received `from_logits=True`, but the `output`'
           ' argument was produced by a sigmoid or softmax activation and thus '
-          'does not represent logits. Was this intended?"')
+          'does not represent logits. Was this intended?"',
+          stacklevel=2)
     from_logits = True
 
   if from_logits:
@@ -6241,7 +6245,8 @@ def random_binomial(shape, p=0.0, dtype=None, seed=None):
   """
   warnings.warn('`tf.keras.backend.random_binomial` is deprecated, '
                 'and will be removed in a future version.'
-                'Please use `tf.keras.backend.random_bernoulli` instead.')
+                'Please use `tf.keras.backend.random_bernoulli` instead.',
+                stacklevel=2)
   return random_bernoulli(shape, p, dtype, seed)
 
 

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1824,10 +1824,8 @@ class EarlyStopping(Callback):
       self.model.stop_training = True
       if self.restore_best_weights and self.best_weights is not None:
         if self.verbose > 0:
-          print(
-            'Restoring model weights from the end of the best epoch: '
-            f'{self.best_epoch + 1}'
-          )
+          print('Restoring model weights from the end of the best epoch (%s).' %
+                (self.best_epoch + 1))
         self.model.set_weights(self.best_weights)
 
   def on_train_end(self, logs=None):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1824,8 +1824,8 @@ class EarlyStopping(Callback):
       self.model.stop_training = True
       if self.restore_best_weights and self.best_weights is not None:
         if self.verbose > 0:
-          print('Restoring model weights from the end of the best epoch (%s).' %
-                (self.best_epoch + 1))
+          print('Restoring model weights from the end of the best epoch: '
+                f'{self.best_epoch + 1}.')
         self.model.set_weights(self.best_weights)
 
   def on_train_end(self, logs=None):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1824,8 +1824,10 @@ class EarlyStopping(Callback):
       self.model.stop_training = True
       if self.restore_best_weights and self.best_weights is not None:
         if self.verbose > 0:
-          print('Restoring model weights from the end of the best epoch: '
-                f'{self.best_epoch + 1}.')
+          print(
+            'Restoring model weights from the end of the best epoch: '
+            f'{self.best_epoch + 1}'
+          )
         self.model.set_weights(self.best_weights)
 
   def on_train_end(self, logs=None):

--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -1394,7 +1394,8 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
   def updates(self):
     warnings.warn('`layer.updates` will be removed in a future version. '
                   'This property should not be used in TensorFlow 2.0, '
-                  'as `updates` are applied automatically.')
+                  'as `updates` are applied automatically.',
+                  stacklevel=2)
     return []
 
   @property
@@ -1927,7 +1928,8 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
     """
     warnings.warn('`layer.get_updates_for` is deprecated and '
                   'will be removed in a future version. '
-                  'Please use `layer.updates` method instead.')
+                  'Please use `layer.updates` method instead.',
+                  stacklevel=2)
     return self.updates
 
   @doc_controls.do_not_generate_docs
@@ -1944,7 +1946,8 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
     """
     warnings.warn('`layer.get_losses_for` is deprecated and '
                   'will be removed in a future version. '
-                  'Please use `layer.losses` instead.')
+                  'Please use `layer.losses` instead.',
+                  stacklevel=2)
     return self.losses
 
   @doc_controls.do_not_doc_inheritable
@@ -2266,7 +2269,8 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
     """
     warnings.warn('`layer.apply` is deprecated and '
                   'will be removed in a future version. '
-                  'Please use `layer.__call__` method instead.')
+                  'Please use `layer.__call__` method instead.',
+                  stacklevel=2)
     return self.__call__(inputs, *args, **kwargs)
 
   @doc_controls.do_not_doc_inheritable
@@ -2274,7 +2278,8 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
     """Deprecated, do NOT use! Alias for `add_weight`."""
     warnings.warn('`layer.add_variable` is deprecated and '
                   'will be removed in a future version. '
-                  'Please use `layer.add_weight` method instead.')
+                  'Please use `layer.add_weight` method instead.',
+                  stacklevel=2)
     return self.add_weight(*args, **kwargs)
 
   @property

--- a/keras/engine/base_layer_v1.py
+++ b/keras/engine/base_layer_v1.py
@@ -1675,7 +1675,8 @@ class Layer(base_layer.Layer):
     """
     warnings.warn('`layer.apply` is deprecated and '
                   'will be removed in a future version. '
-                  'Please use `layer.__call__` method instead.')
+                  'Please use `layer.__call__` method instead.',
+                  stacklevel=2)
     return self.__call__(inputs, *args, **kwargs)
 
   @doc_controls.do_not_doc_inheritable
@@ -1683,7 +1684,8 @@ class Layer(base_layer.Layer):
     """Deprecated, do NOT use! Alias for `add_weight`."""
     warnings.warn('`layer.add_variable` is deprecated and '
                   'will be removed in a future version. '
-                  'Please use `layer.add_weight` method instead.')
+                  'Please use `layer.add_weight` method instead.',
+                  stacklevel=2)
     return self.add_weight(*args, **kwargs)
 
   @property

--- a/keras/engine/functional.py
+++ b/keras/engine/functional.py
@@ -593,7 +593,8 @@ class Functional(training_lib.Model):
         warnings.warn(
             'Input dict contained keys {} which did not match any model input. '
             'They will be ignored by the model.'.format(
-                [n for n in tensors.keys() if n not in ref_input_names])
+                [n for n in tensors.keys() if n not in ref_input_names]),
+            stacklevel=2
             )
 
       try:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1720,7 +1720,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
           warnings.warn('Using Model.predict with '
                         'MultiWorkerDistributionStrategy or TPUStrategy and '
                         'AutoShardPolicy.FILE might lead to out-of-order result'
-                        '. Consider setting it to AutoShardPolicy.DATA.')
+                        '. Consider setting it to AutoShardPolicy.DATA.',
+                        stacklevel=2)
 
       data_handler = data_adapter.get_data_handler(
           x=x,
@@ -1977,7 +1978,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
     """
     warnings.warn('`Model.fit_generator` is deprecated and '
                   'will be removed in a future version. '
-                  'Please use `Model.fit`, which supports generators.')
+                  'Please use `Model.fit`, which supports generators.',
+                  stacklevel=2)
     return self.fit(
         generator,
         steps_per_epoch=steps_per_epoch,
@@ -2011,7 +2013,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
     """
     warnings.warn('`Model.evaluate_generator` is deprecated and '
                   'will be removed in a future version. '
-                  'Please use `Model.evaluate`, which supports generators.')
+                  'Please use `Model.evaluate`, which supports generators.',
+                  stacklevel=2)
     self._check_call_args('evaluate_generator')
 
     return self.evaluate(
@@ -2040,7 +2043,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
     """
     warnings.warn('`Model.predict_generator` is deprecated and '
                   'will be removed in a future version. '
-                  'Please use `Model.predict`, which supports generators.')
+                  'Please use `Model.predict`, which supports generators.',
+                  stacklevel=2)
     return self.predict(
         generator,
         steps=steps,
@@ -2480,7 +2484,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
     """
     warnings.warn('`Model.state_updates` will be removed in a future version. '
                   'This property should not be used in TensorFlow 2.0, '
-                  'as `updates` are applied automatically.')
+                  'as `updates` are applied automatically.', stacklevel=2)
     state_updates = []
     for layer in self.layers:
       if getattr(layer, 'stateful', False):

--- a/keras/engine/training_v1.py
+++ b/keras/engine/training_v1.py
@@ -1227,7 +1227,8 @@ class Model(training_lib.Model):
     """
     warnings.warn('`model.fit_generator` is deprecated and '
                   'will be removed in a future version. '
-                  'Please use `Model.fit`, which supports generators.')
+                  'Please use `Model.fit`, which supports generators.',
+                  stacklevel=2)
     return self.fit(
         generator,
         steps_per_epoch=steps_per_epoch,
@@ -1260,7 +1261,8 @@ class Model(training_lib.Model):
     """
     warnings.warn('`Model.evaluate_generator` is deprecated and '
                   'will be removed in a future version. '
-                  'Please use `Model.evaluate`, which supports generators.')
+                  'Please use `Model.evaluate`, which supports generators.',
+                  stacklevel=2)
     self._check_call_args('evaluate_generator')
 
     return self.evaluate(
@@ -1288,7 +1290,8 @@ class Model(training_lib.Model):
     """
     warnings.warn('`Model.predict_generator` is deprecated and '
                   'will be removed in a future version. '
-                  'Please use `Model.predict`, which supports generators.')
+                  'Please use `Model.predict`, which supports generators.',
+                  stacklevel=2)
     return self.predict(
         generator,
         steps=steps,

--- a/keras/layers/core/lambda_layer.py
+++ b/keras/layers/core/lambda_layer.py
@@ -335,7 +335,7 @@ class Lambda(Layer):
       # Note: we don't know the name of the function if it's a lambda.
       warnings.warn(
           '{} is not loaded, but a Lambda layer uses it. '
-          'It may cause errors.'.format(module), UserWarning)
+          'It may cause errors.'.format(module), UserWarning, stacklevel=2)
     if custom_objects:
       globs.update(custom_objects)
     function_type = config.pop(func_type_attr_name)

--- a/keras/layers/legacy_rnn/rnn_cell_impl.py
+++ b/keras/layers/legacy_rnn/rnn_cell_impl.py
@@ -416,7 +416,8 @@ class BasicRNNCell(LayerRNNCell):
     warnings.warn("`tf.nn.rnn_cell.BasicRNNCell` is deprecated and will be "
                   "removed in a future version. This class "
                   "is equivalent as `tf.keras.layers.SimpleRNNCell`, "
-                  "and will be replaced by that in Tensorflow 2.0.")
+                  "and will be replaced by that in Tensorflow 2.0.",
+                  stacklevel=2)
     super(BasicRNNCell, self).__init__(
         _reuse=reuse, name=name, dtype=dtype, **kwargs)
     _check_supported_dtypes(self.dtype)
@@ -526,7 +527,8 @@ class GRUCell(LayerRNNCell):
     warnings.warn("`tf.nn.rnn_cell.GRUCell` is deprecated and will be removed "
                   "in a future version. This class "
                   "is equivalent as `tf.keras.layers.GRUCell`, "
-                  "and will be replaced by that in Tensorflow 2.0.")
+                  "and will be replaced by that in Tensorflow 2.0.",
+                  stacklevel=2)
     super(GRUCell, self).__init__(
         _reuse=reuse, name=name, dtype=dtype, **kwargs)
     _check_supported_dtypes(self.dtype)
@@ -702,7 +704,8 @@ class BasicLSTMCell(LayerRNNCell):
     warnings.warn("`tf.nn.rnn_cell.BasicLSTMCell` is deprecated and will be "
                   "removed in a future version. This class "
                   "is equivalent as `tf.keras.layers.LSTMCell`, "
-                  "and will be replaced by that in Tensorflow 2.0.")
+                  "and will be replaced by that in Tensorflow 2.0.",
+                  stacklevel=2)
     super(BasicLSTMCell, self).__init__(
         _reuse=reuse, name=name, dtype=dtype, **kwargs)
     _check_supported_dtypes(self.dtype)
@@ -905,7 +908,8 @@ class LSTMCell(LayerRNNCell):
     warnings.warn("`tf.nn.rnn_cell.LSTMCell` is deprecated and will be "
                   "removed in a future version. This class "
                   "is equivalent as `tf.keras.layers.LSTMCell`, "
-                  "and will be replaced by that in Tensorflow 2.0.")
+                  "and will be replaced by that in Tensorflow 2.0.",
+                  stacklevel=2)
     super(LSTMCell, self).__init__(
         _reuse=reuse, name=name, dtype=dtype, **kwargs)
     _check_supported_dtypes(self.dtype)

--- a/keras/layers/legacy_rnn/rnn_cell_wrapper_impl.py
+++ b/keras/layers/legacy_rnn/rnn_cell_wrapper_impl.py
@@ -469,7 +469,8 @@ def _parse_config_to_function(config, custom_objects, func_attr_name,
   elif module is not None:
     # Note: we don't know the name of the function if it's a lambda.
     warnings.warn("{} is not loaded, but a layer uses it. "
-                  "It may cause errors.".format(module), UserWarning)
+                  "It may cause errors.".format(module), UserWarning,
+                  stacklevel=2)
   if custom_objects:
     globs.update(custom_objects)
   function_type = config.pop(func_type_attr_name)

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -2599,7 +2599,7 @@ class PeepholeLSTMCell(LSTMCell):
     warnings.warn('`tf.keras.experimental.PeepholeLSTMCell` is deprecated '
                   'and will be removed in a future version. '
                   'Please use tensorflow_addons.rnn.PeepholeLSTMCell '
-                  'instead.')
+                  'instead.', stacklevel=2)
     super(PeepholeLSTMCell, self).__init__(
         units=units,
         activation=activation,

--- a/keras/legacy_tf_layers/base.py
+++ b/keras/legacy_tf_layers/base.py
@@ -246,7 +246,7 @@ class Layer(base_layer.Layer):
     warnings.warn('`Layer.graph` is deprecated and '
                   'will be removed in a future version. '
                   'Please stop using this property because tf.layers layers no '
-                  'longer track their graph.')
+                  'longer track their graph.', stacklevel=2)
     if tf.executing_eagerly():
       raise RuntimeError('Layer.graph not supported when executing eagerly.')
     return None

--- a/keras/legacy_tf_layers/convolutional.py
+++ b/keras/legacy_tf_layers/convolutional.py
@@ -262,7 +262,8 @@ def conv1d(inputs,
   """
   warnings.warn('`tf.layers.conv1d` is deprecated and '
                 'will be removed in a future version. '
-                'Please Use `tf.keras.layers.Conv1D` instead.')
+                'Please Use `tf.keras.layers.Conv1D` instead.',
+                stacklevel=2)
   layer = Conv1D(
       filters=filters,
       kernel_size=kernel_size,
@@ -535,7 +536,8 @@ def conv2d(inputs,
   """
   warnings.warn('`tf.layers.conv2d` is deprecated and '
                 'will be removed in a future version. '
-                'Please Use `tf.keras.layers.Conv2D` instead.')
+                'Please Use `tf.keras.layers.Conv2D` instead.',
+                stacklevel=2)
   layer = Conv2D(
       filters=filters,
       kernel_size=kernel_size,
@@ -810,7 +812,8 @@ def conv3d(inputs,
   """
   warnings.warn('`tf.layers.conv3d` is deprecated and '
                 'will be removed in a future version. '
-                'Please Use `tf.keras.layers.Conv3D` instead.')
+                'Please Use `tf.keras.layers.Conv3D` instead.',
+                stacklevel=2)
   layer = Conv3D(
       filters=filters,
       kernel_size=kernel_size,
@@ -1243,7 +1246,8 @@ def separable_conv1d(inputs,
   """
   warnings.warn('`tf.layers.separable_conv1d` is deprecated and '
                 'will be removed in a future version. '
-                'Please Use `tf.keras.layers.SeparableConv1D` instead.')
+                'Please Use `tf.keras.layers.SeparableConv1D` instead.',
+                stacklevel=2)
   layer = SeparableConv1D(
       filters=filters,
       kernel_size=kernel_size,
@@ -1404,7 +1408,8 @@ def separable_conv2d(inputs,
   """
   warnings.warn('`tf.layers.separable_conv2d` is deprecated and '
                 'will be removed in a future version. '
-                'Please Use `tf.keras.layers.SeparableConv2D` instead.')
+                'Please Use `tf.keras.layers.SeparableConv2D` instead.',
+                stacklevel=2)
   layer = SeparableConv2D(
       filters=filters,
       kernel_size=kernel_size,
@@ -1659,7 +1664,8 @@ def conv2d_transpose(inputs,
   """
   warnings.warn('`tf.layers.conv2d_transpose` is deprecated and '
                 'will be removed in a future version. '
-                'Please Use `tf.keras.layers.Conv2DTranspose` instead.')
+                'Please Use `tf.keras.layers.Conv2DTranspose` instead.',
+                stacklevel=2)
   layer = Conv2DTranspose(
       filters=filters,
       kernel_size=kernel_size,
@@ -1900,7 +1906,8 @@ def conv3d_transpose(inputs,
   """
   warnings.warn('`tf.layers.conv3d_transpose` is deprecated and '
                 'will be removed in a future version. '
-                'Please Use `tf.keras.layers.Conv3DTranspose` instead.')
+                'Please Use `tf.keras.layers.Conv3DTranspose` instead.',
+                stacklevel=2)
   layer = Conv3DTranspose(
       filters=filters,
       kernel_size=kernel_size,

--- a/keras/legacy_tf_layers/core.py
+++ b/keras/legacy_tf_layers/core.py
@@ -235,7 +235,8 @@ def dense(
   """
   warnings.warn('`tf.layers.dense` is deprecated and '
                 'will be removed in a future version. '
-                'Please use `tf.keras.layers.Dense` instead.')
+                'Please use `tf.keras.layers.Dense` instead.',
+                stacklevel=2)
   layer = Dense(units,
                 activation=activation,
                 use_bias=use_bias,
@@ -392,7 +393,8 @@ def dropout(inputs,
   """
   warnings.warn('`tf.layers.dropout` is deprecated and '
                 'will be removed in a future version. '
-                'Please use `tf.keras.layers.Dropout` instead.')
+                'Please use `tf.keras.layers.Dropout` instead.',
+                stacklevel=2)
   layer = Dropout(rate, noise_shape=noise_shape, seed=seed, name=name)
   return layer.apply(inputs, training=training)
 
@@ -512,7 +514,8 @@ def flatten(inputs, name=None, data_format='channels_last'):
   """
   warnings.warn('`tf.layers.flatten` is deprecated and '
                 'will be removed in a future version. '
-                'Please use `tf.keras.layers.Flatten` instead.')
+                'Please use `tf.keras.layers.Flatten` instead.',
+                stacklevel=2)
   layer = Flatten(name=name, data_format=data_format)
   return layer.apply(inputs)
 

--- a/keras/legacy_tf_layers/normalization.py
+++ b/keras/legacy_tf_layers/normalization.py
@@ -426,7 +426,7 @@ def batch_normalization(inputs,
       'Please use `tf.keras.layers.BatchNormalization` instead. '
       'In particular, `tf.control_dependencies(tf.GraphKeys.UPDATE_OPS)` '
       'should not be used (consult the `tf.keras.layers.BatchNormalization` '
-      'documentation).')
+      'documentation).', stacklevel=2)
   layer = BatchNormalization(
       axis=axis,
       momentum=momentum,

--- a/keras/legacy_tf_layers/pooling.py
+++ b/keras/legacy_tf_layers/pooling.py
@@ -149,7 +149,8 @@ def average_pooling1d(inputs, pool_size, strides,
   """
   warnings.warn('`tf.layers.average_pooling1d` is deprecated and '
                 'will be removed in a future version. '
-                'Please use `tf.keras.layers.AveragePooling1D` instead.')
+                'Please use `tf.keras.layers.AveragePooling1D` instead.',
+                stacklevel=2)
   layer = AveragePooling1D(pool_size=pool_size,
                            strides=strides,
                            padding=padding,
@@ -281,7 +282,8 @@ def max_pooling1d(inputs, pool_size, strides,
   """
   warnings.warn('`tf.layers.max_pooling1d` is deprecated and '
                 'will be removed in a future version. '
-                'Please use `tf.keras.layers.MaxPooling1D` instead.')
+                'Please use `tf.keras.layers.MaxPooling1D` instead.',
+                stacklevel=2)
   layer = MaxPooling1D(pool_size=pool_size,
                        strides=strides,
                        padding=padding,
@@ -418,7 +420,8 @@ def average_pooling2d(inputs,
   """
   warnings.warn('`tf.layers.average_pooling2d` is deprecated and '
                 'will be removed in a future version. '
-                'Please use `tf.keras.layers.AveragePooling2D` instead.')
+                'Please use `tf.keras.layers.AveragePooling2D` instead.',
+                stacklevel=2)
   layer = AveragePooling2D(pool_size=pool_size, strides=strides,
                            padding=padding, data_format=data_format,
                            name=name)
@@ -553,7 +556,8 @@ def max_pooling2d(inputs,
   """
   warnings.warn('`tf.layers.max_pooling2d` is deprecated and '
                 'will be removed in a future version. '
-                'Please use `tf.keras.layers.MaxPooling2D` instead.')
+                'Please use `tf.keras.layers.MaxPooling2D` instead.',
+                stacklevel=2)
   layer = MaxPooling2D(pool_size=pool_size, strides=strides,
                        padding=padding, data_format=data_format,
                        name=name)
@@ -692,7 +696,8 @@ def average_pooling3d(inputs,
   """
   warnings.warn('`tf.layers.average_pooling3d` is deprecated and '
                 'will be removed in a future version. '
-                'Please use `tf.keras.layers.AveragePooling3D` instead.')
+                'Please use `tf.keras.layers.AveragePooling3D` instead.',
+                stacklevel=2)
   layer = AveragePooling3D(pool_size=pool_size, strides=strides,
                            padding=padding, data_format=data_format,
                            name=name)
@@ -829,7 +834,8 @@ def max_pooling3d(inputs,
   """
   warnings.warn('`tf.layers.max_pooling3d` is deprecated and '
                 'will be removed in a future version. '
-                'Please use `tf.keras.layers.MaxPooling3D` instead.')
+                'Please use `tf.keras.layers.MaxPooling3D` instead.',
+                stacklevel=2)
   layer = MaxPooling3D(pool_size=pool_size, strides=strides,
                        padding=padding, data_format=data_format,
                        name=name)

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -258,7 +258,7 @@ class Metric(base_layer.Layer, metaclass=abc.ABCMeta):
       warnings.warn('Metric %s implements a `reset_states()` method; rename it '
                     'to `reset_state()` (without the final "s"). The name '
                     '`reset_states()` has been deprecated to improve API '
-                    'consistency.' % (self.__class__.__name__,))
+                    'consistency.' % (self.__class__.__name__,), stacklevel=2)
       return self.reset_states()
     else:
       backend.batch_set_value([(v, 0) for v in self.variables])

--- a/keras/optimizer_v2/optimizer_v2.py
+++ b/keras/optimizer_v2/optimizer_v2.py
@@ -354,7 +354,8 @@ class OptimizerV2(tf.__internal__.tracking.Trackable):
         raise ValueError("Expected {} >= 0, received: {}".format(k, kwargs[k]))
       if k == "lr":
         warnings.warn(
-            "The `lr` argument is deprecated, use `learning_rate` instead.")
+            "The `lr` argument is deprecated, use `learning_rate` instead.",
+            stacklevel=2)
 
     self._use_locking = True
     self._init_set_name(name)

--- a/keras/saving/saved_model_experimental.py
+++ b/keras/saving/saved_model_experimental.py
@@ -117,7 +117,8 @@ def export_saved_model(model,
   warnings.warn('`tf.keras.experimental.export_saved_model` is deprecated'
                 'and will be removed in a future version. '
                 'Please use `model.save(..., save_format="tf")` or '
-                '`tf.keras.models.save_model(..., save_format="tf")`.')
+                '`tf.keras.models.save_model(..., save_format="tf")`.',
+                stacklevel=2)
   if serving_only:
     tf.saved_model.save(
         model,
@@ -400,7 +401,8 @@ def load_from_saved_model(saved_model_path, custom_objects=None):
   """
   warnings.warn('`tf.keras.experimental.load_from_saved_model` is deprecated'
                 'and will be removed in a future version. '
-                'Please switch to `tf.keras.models.load_model`.')
+                'Please switch to `tf.keras.models.load_model`.',
+                stacklevel=2)
   # restore model topology from json string
   model_json_filepath = os.path.join(
       tf.compat.as_bytes(saved_model_path),

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -502,7 +502,7 @@ def serialize_keras_object(instance):
     warnings.warn('Custom mask layers require a config and must override '
                   'get_config. When loading, the custom mask layer must be '
                   'passed to the custom_objects argument.',
-                  category=CustomMaskWarning)
+                  category=CustomMaskWarning, stacklevel=2)
   # pylint: enable=protected-access
 
   if hasattr(instance, 'get_config'):

--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -197,7 +197,7 @@ class KerasClassifier(BaseWrapper):
     warnings.warn(
         'KerasClassifier is deprecated, '
         'use Sci-Keras (https://github.com/adriangb/scikeras) instead.',
-        DeprecationWarning
+        DeprecationWarning, stacklevel=2
     )
     super().__init__(build_fn, **sk_params)
 
@@ -334,7 +334,7 @@ class KerasRegressor(BaseWrapper):
     warnings.warn(
         'KerasRegressor is deprecated, '
         'use Sci-Keras (https://github.com/adriangb/scikeras) instead.',
-        DeprecationWarning
+        DeprecationWarning, stacklevel=2
     )
     super().__init__(build_fn, **sk_params)
 


### PR DESCRIPTION
Specify `stacklevel` for `warnings.warn` to make it easier to identify which lines throw warnings.

## Example

```python
from tensorflow import keras
import numpy as np


model = keras.Sequential()
model.add(keras.layers.Dense(16, activation="relu", input_shape=(4,)))
model.add(keras.layers.Dense(3, activation="softmax"))
model.compile(
    optimizer=keras.optimizers.Adam(lr=0.001, epsilon=1e-07),
    loss="categorical_crossentropy",
    metrics=["acc"],
)


def generator():
    while True:
        n = 30
        n_class = 3
        features = np.random.random((n, 4))
        classes = np.random.randint(0, n_class, n)
        labels = np.zeros((n, n_class))
        labels[np.arange(n), classes] = 1
        yield features, labels


model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
```

### Without `stacklevel`

The code above outputs:

```
/path/to/lib/python3.7/site-packages/keras/engine/training.py:1972: UserWarning: `Model.fit_generator` is deprecated and will be removed in a future version. Please use `Model.fit`, which supports generators.
```

### With `stacklevel = 2`

The code above outputs:

```
a.py:26: UserWarning: `Model.fit_generator` is deprecated and will be removed in a future version. Please use `Model.fit`, which supports generators.
  model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
```