### PR TITLE
Fix for bug causing failing test keras/utils/vis_utils_test.py test_layer_range_value_fail second value (empty list).

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -162,7 +162,7 @@ def model_to_dot(model,
     dot.set('dpi', dpi)
     dot.set_node_defaults(shape='record')
 
-  if layer_range:
+  if layer_range is not None:
     if len(layer_range) != 2:
       raise ValueError(
           'layer_range must be of shape (2,). Received: '


### PR DESCRIPTION
According to the tests, an empty list passed for `layer_range` should cause an exception in `model_to_dot`. As implemented an empty list is ignored. This changes to the behaviour to match the test.