### PR TITLE
Plot model show activations

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -282,7 +282,7 @@ def model_to_dot(model,
             [format_shape(ishape) for ishape in layer.input_shapes])
       else:
         inputlabels = '?'
-      label = '%s\n|{input:|output:}|{{%s}|{%s}}' % (label,
+      label = '%s|{input:|output:}|{{%s}|{%s}}' % (label,
                                                      inputlabels,
                                                      outputlabels)
 

--- a/keras/utils/vis_utils_test.py
+++ b/keras/utils/vis_utils_test.py
@@ -104,8 +104,13 @@ class ModelToDotFormatTest(tf.test.TestCase, parameterized.TestCase):
       tf.io.gfile.remove(dot_img_file)
     except ImportError:
       pass
-  
-  def test_plot_model_cnn_with_activations(self):
+
+  @parameterized.parameters(
+      {'show_shapes': False, 'show_dtype': False},
+      {'show_shapes': False, 'show_dtype': True},
+      {'show_shapes': True, 'show_dtype': False},
+      {'show_shapes': True, 'show_dtype': True})
+  def test_plot_model_cnn_with_activations(self, show_shapes, show_dtype):
     model = keras.Sequential()
     model.add(keras.layers.Conv2D(
         filters=2,
@@ -122,8 +127,8 @@ class ModelToDotFormatTest(tf.test.TestCase, parameterized.TestCase):
     dot_img_file = 'model_5.png'
     try:
       vis_utils.plot_model(
-          model, to_file=dot_img_file, show_shapes=True,
-          show_dtype=True, show_layer_activations=True)
+          model, to_file=dot_img_file, show_shapes=show_shapes,
+          show_dtype=show_dtype, show_layer_activations=True)
       self.assertTrue(tf.io.gfile.exists(dot_img_file))
       tf.io.gfile.remove(dot_img_file)
     except ImportError:


### PR DESCRIPTION
This pull request gives library users the option to show layer activations in generated model architecture diagrams.

When the newly added `show_layer_activations` parameter is left at its default value of False, there is no behaviour change (backwards compatible). There is some minor refactoring of existing code to accommodate the changes nicely.

This pull request resolves #15211 .