### PR TITLE
Update training.py

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1631,9 +1631,9 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
     inference. Also, note the fact that test loss is not affected by
     regularization layers like noise and dropout.
     
-    Note: `model.predict(x)` returns a numpy array whereas `model(x)` returns a
-    `tf.Tensor`. However, numpy array can be accessed through
-    `model(x).numpy()`. 
+    Note: Check [FAQs](https://keras.io/getting_started/faq/#whats-the-difference-between-model-methods-predict-and-call) 
+    for more details about the differences between `Model` methods `predict()`
+    and `__call__()`. 
 
     Args:
         x: Input samples. It could be:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1631,9 +1631,10 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
     inference. Also, note the fact that test loss is not affected by
     regularization layers like noise and dropout.
     
-    Note: Check [FAQs](https://keras.io/getting_started/faq/#whats-the-difference-between-model-methods-predict-and-call) 
-    for more details about the differences between `Model` methods `predict()`
-    and `__call__()`. 
+    Note: See
+    [this FAQ entry](https://keras.io/getting_started/faq/#whats-the-difference-between-model-methods-predict-and-call) 
+    for more details about the difference between `Model` methods `predict()`
+    and `__call__()`.
 
     Args:
         x: Input samples. It could be:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1630,6 +1630,10 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
     `tf.keras.layers.BatchNormalization` that behaves differently during
     inference. Also, note the fact that test loss is not affected by
     regularization layers like noise and dropout.
+    
+    Note: `model.predict(x)` returns a numpy array whereas `model(x)` returns a
+    `tf.Tensor`. However, numpy array can be accessed through
+    `model(x).numpy()`. 
 
     Args:
         x: Input samples. It could be:


### PR DESCRIPTION
Added a note on difference between `model.predict(x)` and `model(x)`.

Fixes https://github.com/keras-team/keras/issues/15186