### PR TITLE
Allow keras.utils.Sequence sub-classes to use sparse/ragged tensors

### DIFF
--- a/keras/engine/data_adapter.py
+++ b/keras/engine/data_adapter.py
@@ -817,7 +817,7 @@ class GeneratorDataAdapter(DataAdapter):
     self._first_batch_size = int(tf.nest.flatten(peek)[0].shape[0])
 
     def _get_tensor_spec(t):
-      return type_spec.type_spec_from_value(t)
+      return type_spec.type_spec_from_value(t)._with_tensor_ranks_only()
 
     output_signature = tf.nest.map_structure(_get_tensor_spec, peek)
 

--- a/keras/engine/data_adapter.py
+++ b/keras/engine/data_adapter.py
@@ -817,9 +817,9 @@ class GeneratorDataAdapter(DataAdapter):
     self._first_batch_size = int(tf.nest.flatten(peek)[0].shape[0])
 
     def _get_tensor_spec(t):
-      return type_spec._type_spec_from_value(t)._with_tensor_ranks_only()
+      return type_spec.type_spec_from_value(t)
 
-    output_signature = nest.map_structure(_get_tensor_spec, peek)
+    output_signature = tf.nest.map_structure(_get_tensor_spec, peek)
 
     # Note that dataset API takes a callable that creates a generator object,
     # rather than generator itself, which is why we define a function here.

--- a/keras/engine/data_adapter_test.py
+++ b/keras/engine/data_adapter_test.py
@@ -103,7 +103,7 @@ class TestSparseSequence(TestSequence):
   def __getitem__(self, item):
     indices = [[row, self.feature_shape-1] for row in range(self.batch_size)]
     values = [1 for row in range(self.batch_size)]
-    st = tf.ops.sparse_tensor.SparseTensor(
+    st = tf.SparseTensor(
       indices, values, (self.batch_size,self.feature_shape)
     )
     return (st, np.ones((self.batch_size,)))
@@ -118,7 +118,7 @@ class TestRaggedSequence(TestSequence):
       (self.batch_size, 2)
     ).reshape(-1)
     row_lengths = np.full(self.batch_size, 2)
-    rt = tf.ops.ragged_tensor.RaggedTensor.from_row_lengths(values, row_lengths)
+    rt = tf.RaggedTensor.from_row_lengths(values, row_lengths)
     return (rt, np.ones((self.batch_size,)))
 
 
@@ -840,7 +840,7 @@ class KerasSequenceAdapterRaggedTest(KerasSequenceAdapterTest):
     self.model = keras.models.Sequential([
         keras.layers.Input(shape=(None, ), ragged=True),
         keras.layers.Embedding(10, 10),
-        keras.layers.Lambda(tf.ops.math_ops.reduce_mean, arguments=dict(axis=1)),
+        keras.layers.Lambda(tf.reduce_mean, arguments=dict(axis=1)),
         keras.layers.Dense(8, input_shape=(10,), activation='relu'),
       ])
 

--- a/keras/engine/data_adapter_test.py
+++ b/keras/engine/data_adapter_test.py
@@ -98,6 +98,30 @@ class TestSequence(data_utils.Sequence):
     return 10
 
 
+class TestSparseSequence(TestSequence):
+
+  def __getitem__(self, item):
+    indices = [[row, self.feature_shape-1] for row in range(self.batch_size)]
+    values = [1 for row in range(self.batch_size)]
+    st = tf.ops.sparse_tensor.SparseTensor(
+      indices, values, (self.batch_size,self.feature_shape)
+    )
+    return (st, np.ones((self.batch_size,)))
+
+
+class TestRaggedSequence(TestSequence):
+
+  def __getitem__(self, item):
+    values = np.random.randint(
+      0,
+      self.feature_shape,
+      (self.batch_size, 2)
+    ).reshape(-1)
+    row_lengths = np.full(self.batch_size, 2)
+    rt = tf.ops.ragged_tensor.RaggedTensor.from_row_lengths(values, row_lengths)
+    return (rt, np.ones((self.batch_size,)))
+
+
 class TensorLikeDataAdapterTest(DataAdapterTestBase):
 
   def setUp(self):
@@ -798,6 +822,27 @@ class KerasSequenceAdapterTest(DataAdapterTestBase):
     with self.assertRaisesRegex(ValueError,
                                 r'`sample_weight` argument is not supported'):
       self.adapter_cls(self.sequence_input, sample_weights=self.sequence_input)
+
+
+class KerasSequenceAdapterSparseTest(KerasSequenceAdapterTest):
+
+  def setUp(self):
+    super(KerasSequenceAdapterSparseTest, self).setUp()
+    self.sequence_input = TestSparseSequence(self.batch_size, 10)
+
+
+class KerasSequenceAdapterRaggedTest(KerasSequenceAdapterTest):
+
+  def setUp(self):
+    super(KerasSequenceAdapterRaggedTest, self).setUp()
+    self.sequence_input = TestRaggedSequence(self.batch_size, 10)
+
+    self.model = keras.models.Sequential([
+        keras.layers.Input(shape=(None, ), ragged=True),
+        keras.layers.Embedding(10, 10),
+        keras.layers.Lambda(tf.ops.math_ops.reduce_mean, arguments=dict(axis=1)),
+        keras.layers.Dense(8, input_shape=(10,), activation='relu'),
+      ])
 
 
 class DataHandlerTest(keras_parameterized.TestCase):


### PR DESCRIPTION
This adjusts the way GeneratorDataAdapter supplies the shapes and types of tensors from the first (peeked) batch when converting from a generator to a Dataset, in order to allow sub-classes of keras.utils.Sequence to return SparseTensors or RaggedTensors in batches.

Previously submitted as tensorflow/tensorflow#49872, resolves tensorflow/tensorflow#41419.