### PR TITLE
change misleading description of m_mul

### DIFF
--- a/keras/optimizer_v2/learning_rate_schedule.py
+++ b/keras/optimizer_v2/learning_rate_schedule.py
@@ -662,7 +662,7 @@ class CosineDecayRestarts(LearningRateSchedule):
   The learning rate multiplier first decays
   from 1 to `alpha` for `first_decay_steps` steps. Then, a warm
   restart is performed. Each new warm restart runs for `t_mul` times more
-  steps and with `m_mul` times larger initial learning rate.
+  steps and with `m_mul` times initial learning rate as the new learning rate.
 
   Example usage:
   ```python

--- a/keras/optimizer_v2/learning_rate_schedule.py
+++ b/keras/optimizer_v2/learning_rate_schedule.py
@@ -662,7 +662,7 @@ class CosineDecayRestarts(LearningRateSchedule):
   The learning rate multiplier first decays
   from 1 to `alpha` for `first_decay_steps` steps. Then, a warm
   restart is performed. Each new warm restart runs for `t_mul` times more
-  steps and with `m_mul` times smaller initial learning rate.
+  steps and with `m_mul` times larger initial learning rate.
 
   Example usage:
   ```python
@@ -700,9 +700,9 @@ class CosineDecayRestarts(LearningRateSchedule):
       first_decay_steps: A scalar `int32` or `int64` `Tensor` or a Python
         number. Number of steps to decay over.
       t_mul: A scalar `float32` or `float64` `Tensor` or a Python number.
-        Used to derive the number of iterations in the i-th period
+        Used to derive the number of iterations in the i-th period.
       m_mul: A scalar `float32` or `float64` `Tensor` or a Python number.
-        Used to derive the initial learning rate of the i-th period:
+        Used to derive the initial learning rate of the i-th period.
       alpha: A scalar `float32` or `float64` Tensor or a Python number.
         Minimum learning rate value as a fraction of the initial_learning_rate.
       name: String. Optional name of the operation.  Defaults to 'SGDRDecay'.


### PR DESCRIPTION
[CosineDecayRestarts](https://www.tensorflow.org/api_docs/python/tf/keras/optimizers/schedules/CosineDecayRestarts) has several parameters in addition to the inital learning rate, all of which are described in the paragraph: 

> The learning rate multiplier first decays from 1 to `alpha` for `first_decay_steps` steps. Then, a warm restart is performed. Each new warm restart runs for `t_mul` times more steps and with `m_mul` times **smaller** initial learning rate.

(my emphasis)

`m_mul` is the inverse of what is being described here. It should therefore be `... m_mul times larger initial learning rate`.

The args section does little to explain the effect of an increase or decrease in the parameter:

`m_mul`
> A scalar float32 or float64 Tensor or a Python number. Used to derive the initial learning rate of the i-th period:  

