### PR TITLE
Exclude default bazel paths for VsCode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,20 @@
 FROM python:3.9
 
+# https://code.visualstudio.com/docs/remote/containers-advanced#_creating-a-nonroot-user
+ARG USERNAME=keras-vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    #
+    # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
+    && apt-get update \
+    && apt-get install -y sudo bash \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
 # Install Bazel
 RUN apt update
 RUN apt install curl gnupg -y
@@ -8,5 +23,4 @@ RUN mv bazel.gpg /etc/apt/trusted.gpg.d/
 RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 RUN apt update && apt install bazel -y
 
-# Override the entrypoint
-CMD ["bash"]
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
         "search.exclude": {
             "**/bazel-*/**": true
         },
-        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.defaultProfile.linux": "bash"
     },
     "remoteUser": "keras-vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
             "**/bazel-*/**": true
         },
         "search.exclude": {
-          
             "**/bazel-*/**": true
         },
         "terminal.integrated.defaultProfile.linux": "bash",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,16 @@
 {
     "dockerFile": "Dockerfile",
     "postCreateCommand": "pip install -r requirements.txt && pip uninstall keras-nightly -y",
-    "extensions": ["ms-python.python"]
+    "extensions": ["ms-python.python"],
+    "settings": {
+        "files.watcherExclude": {
+            "**/bazel-*/**": true
+        },
+        "search.exclude": {
+          
+            "**/bazel-*/**": true
+        },
+        "terminal.integrated.defaultProfile.linux": "bash",
+    },
+    "remoteUser": "keras-vscode"
 }


### PR DESCRIPTION
This is required for performance and also to avoid to have a confusing ghost duplicated github repositories in the Vscode git tab