### PR TITLE
Added notebook for quick build tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,9 @@ with setup instructions.
 
 ### Option 2: Setup a local environment
 
+<a href="https://colab.research.google.com/gist/AdityaKane2001/df4086c7265a1b3519ffe65ea61d5ec1/keras-build-test-notebook.ipynb" 
+target="_blank"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
 To setup your local dev environment, you will need the following tools.
 
 1.  [Bazel](https://bazel.build/) is the tool to build and test Keras. See the


### PR DESCRIPTION
As Keras has now been shifted to a new repo, build times have reduced dramatically. It is now possible to run unit tests in Colab with reasonable speeds. In this PR I've added a notebook link which basically sets up environment for testing and runs the tests mentioned by the user. However it is not advisable to run _all_ tests in Colab as it will be quite slow.

Please share your thoughts on this.

/cc @qlzh727 @chenmoneygithub 