### PR TITLE
Fix compute_output_shape in MobileNetV3

### DIFF
--- a/keras/applications/applications_test.py
+++ b/keras/applications/applications_test.py
@@ -137,6 +137,17 @@ class ApplicationsTest(tf.test.TestCase, parameterized.TestCase):
       self.assertShapeEqual(output_shape, (None, None, None, last_dim))
     backend.clear_session()
 
+  @parameterized.parameters(MODEL_LIST)
+  def test_application_models_compute_output_shape(self, app, last_dim):
+    input_shape = (None, None, None, 4)
+    model = app(weights=None, include_top=False)
+    output_shape = model.compute_output_shape(input_shape)
+    if 'MobileNetV3' in app.__name__:
+        self.assertShapeEqual(output_shape, (None, 1, 1, last_dim))
+    else:
+        self.assertShapeEqual(output_shape, (None, None, None, last_dim))
+    backend.clear_session()
+
 
 def _get_output_shape(model_fn):
   model = model_fn()

--- a/keras/layers/core/core_test.py
+++ b/keras/layers/core/core_test.py
@@ -612,6 +612,30 @@ class TFOpLambdaTest(keras_parameterized.TestCase):
     with self.assertRaisesRegex(ValueError, 'was generated from .*dummy_func'):
       layer.get_config()
 
+  def test_compute_output_shape(self):
+
+    def dummy_func(a, b):
+        return a + b
+
+    def dummy_func1(a):
+        return tf.math.reduce_sum(a)
+
+    def dummy_func2(a):
+        return tf.math.reduce_sum(a, axis=1)
+
+    input_layer = keras.Input(batch_shape=(10, None))
+    input_layer1 = keras.Input(batch_shape=(10, None))
+    layer = core.TFOpLambda(dummy_func)(input_layer, input_layer1).node.layer
+    self.assertEqual(layer.compute_output_shape(), (10, None))
+
+    input_layer = keras.Input(batch_shape=(10, None))
+    layer = core.TFOpLambda(dummy_func1)(input_layer).node.layer
+    self.assertEqual(layer.compute_output_shape(), ())
+
+    input_layer = keras.Input(batch_shape=(10, None))
+    layer = core.TFOpLambda(dummy_func2)(input_layer).node.layer
+    self.assertEqual(layer.compute_output_shape(), (10, ))
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/keras/layers/core/tf_op_layer.py
+++ b/keras/layers/core/tf_op_layer.py
@@ -243,6 +243,9 @@ class TFOpLambda(Layer):
     self._expects_training_arg = False
     self._expects_mask_arg = False
 
+  def compute_output_shape(self, input_shape=None):
+      return self.output_shape
+
   def _call_wrapper(self, *args, **kwargs):
     created_variables = []
 


### PR DESCRIPTION
Fix this [issue](https://github.com/keras-team/keras/issues/15282) Implement the `compute_output_shape` in `TFOpLambda` 
 layer, so mobileNetV3* models could  be able to compute their output shapes. 