### PR TITLE
Add user bin path for pip installed packages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,3 +24,4 @@ RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.
 RUN apt update && apt install bazel -y
 
 USER $USERNAME
+ENV PATH="/home/$USERNAME/.local/bin:${PATH}"


### PR DESCRIPTION
As we are not installing `postCreateCommand` anymore as root or sudo we could add the user binary path for the installed wheels to the system `PATH`

/cc @haifeng-jin 