### PR TITLE
Masking improvements for MultiHeadAttention layer

### DIFF
--- a/keras/layers/multi_head_attention.py
+++ b/keras/layers/multi_head_attention.py
@@ -142,7 +142,11 @@ class MultiHeadAttention(Layer):
 
   Finally, the result tensor with the last dimension as value_dim can take an
   linear projection and return.
-
+  
+  Because of the softmax, some information from masked inputs may leak
+  despite the attention mask. In most scenarios with masked keys,
+  it is appropriate to further multiply the attention outputs by the mask.
+  
   Examples:
 
   Performs 1D cross-attention over two sequence inputs with an attention mask.


### PR DESCRIPTION
The MultiHeadAttention (MHA) layer currently provides users with only one parameter `attention_mask` to use for masking (which is a N by M matrix mask where N and M are the lengths of the Key and Query tensors respectively).

I ran into an issue where this parameter is not sufficient, and it is necessary to additionally multiply the outputs of the MHA layer by a mask again, in order to prevent information leaking through. See the quoted text for my original summary.

After discussion with @fchollet, the correct course of action is to add 3 additional masking parameters to the MHA layer: `key_mask`, `query_mask` and `value_mask`. 

The most important change to fix my original issue is the addition of `value_mask`. When provided, `value_mask` should be multiplied against the `value` tensor before applying the attention operation. This will prevent very small floating point values from leaking through the MHA layer. A network can learn a setup to use these very small values, which manifests as inexplicably good performance. 

When provided, `key_mask` and `query_mask` should be used to compute `attention_mask` (e.g. with a broadcasted `tf.logical_and`). Providing either or both `key_mask` and `query_mask` should be mutually exclusive with providing `attention_mask`. Additionally, (not sure about this, or whether it is important) the implementation of the attention operation may be able to avoid materializing an N by M `attention_mask` when only `key_mask` or `query_mask` is provided.

Adding all three parameters means the MHA layer can be compaatible with Keras mask propagation. The values of `key_mask`, `query_mask` and `value_mask` can default to `x._keras_mask` for the respective tensor.

The original PR was only to change the documentation. Original text:

> Hi,
> 
> I discovered while working on an MNIST attention demo, that a network is able to learn adequate reconstruction performance on MNIST test set, even when the entire input is masked out.
> 
> When masking, before the softmax operation in the MultiHeadAttention layer the masked inputs are set to -1E9. This correctly results in masked value vectors having a negligible contribution to the final sum.
> 
> However, the network is able to learn to distinguish between the resulting *very small* floating point numbers of the masked out values, which appears as inexplicable good performance.
> 
> The fix (for self attention) is to multiply the attention outputs by the mask. This PR just puts a warning in the docs, but I encourage someone to think of a better solution.