### PR TITLE
Add Get All Initializers in the Form of String

### DIFF
--- a/keras/initializers/__init__.py
+++ b/keras/initializers/__init__.py
@@ -191,3 +191,16 @@ def get(identifier):
   else:
     raise ValueError('Could not interpret initializer identifier: ' +
                      str(identifier))
+
+
+@keras_export('keras.initializers.get_all_initializers')
+def get_all_initializers():
+    """Retrieve all the Keras initializers in camel cases or snake cases.
+    They are in the form of strings.
+
+    Args: None
+
+    Returns:
+        List of initializers in the form of string with camel cases or snake cases.
+    """
+    return list(LOCAL.ALL_OBJECT.keys())

--- a/keras/initializers/__init__.py
+++ b/keras/initializers/__init__.py
@@ -203,4 +203,5 @@ def get_all_initializers():
     Returns:
         List of initializers in the form of string with camel cases or snake cases.
     """
+    populate_deserializable_objects()
     return list(LOCAL.ALL_OBJECT.keys())

--- a/keras/initializers/__init__.py
+++ b/keras/initializers/__init__.py
@@ -204,4 +204,4 @@ def get_all_initializers():
         List of initializers in the form of string with camel cases or snake cases.
     """
     populate_deserializable_objects()
-    return list(LOCAL.ALL_OBJECT.keys())
+    return list(LOCAL.ALL_OBJECTS.keys())

--- a/keras/initializers/initializers_test.py
+++ b/keras/initializers/initializers_test.py
@@ -230,7 +230,8 @@ class KerasInitializersTest(tf.test.TestCase):
       
   def test_get_all_initializers(self):
     init_list = initializers.get_all_initializers()
-    self.assertEqual(set(init_list), set(initializers.LOCAL.ALL_OBJECTS))
+    for init in init_list:
+        self.assertIn(init, globals())
 
   def test_custom_initializer_saving(self):
 

--- a/keras/initializers/initializers_test.py
+++ b/keras/initializers/initializers_test.py
@@ -230,8 +230,7 @@ class KerasInitializersTest(tf.test.TestCase):
       
   def test_get_all_initializers(self):
     init_list = initializers.get_all_initializers()
-    for init in init_list:
-        self.assertIn(init, globals())
+    self.assertEqual(set(init_list), set(initializers.LOCAL.ALL_OBJECTS))
 
   def test_custom_initializer_saving(self):
 

--- a/keras/initializers/initializers_test.py
+++ b/keras/initializers/initializers_test.py
@@ -227,6 +227,10 @@ class KerasInitializersTest(tf.test.TestCase):
     tn = initializers.get('truncated_normal')
     self.assertEqual(tn.mean, 0.0)
     self.assertEqual(tn.stddev, 0.05)
+      
+  def test_get_all_initializers(self):
+    init_list = initializers.get_all_initializers()
+    self.assertEqual(set(init_list), set(initializers.LOCAL.ALL_OBJECTS))
 
   def test_custom_initializer_saving(self):
 


### PR DESCRIPTION
Add a new API 'initializers.get_all_initializers", which returns all initializers in the form of string.

As mentioned in #15393 , it can facilitate the process of fine-tuning. 