### PR TITLE
Updated image_dataset.py with `label_mode` is None and interpolation is `bilinear` it yields `uint8`.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2276,7 +2276,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
     """Loads all layer weights, either from a TensorFlow or an HDF5 weight file.
 
     If `by_name` is False weights are loaded based on the network's
-    topology. This means the architecture should be the same as when the weights
+    topology. This means the architecture should be the same as when, the weights
     were saved.  Note that layers that don't have weights are not taken into
     account in the topological ordering, so adding or removing layers is fine as
     long as they don't have weights.

--- a/keras/preprocessing/image_dataset.py
+++ b/keras/preprocessing/image_dataset.py
@@ -126,6 +126,7 @@ def image_dataset_from_directory(directory,
       - If `label_mode` is None, it yields `float32` tensors of shape
         `(batch_size, image_size[0], image_size[1], num_channels)`,
         encoding images (see below for rules regarding `num_channels`).
+      - If `label_mode` is None and interpolation is `bilinear` it yields `uint8`.
       - Otherwise, it yields a tuple `(images, labels)`, where `images`
         has shape `(batch_size, image_size[0], image_size[1], num_channels)`,
         and `labels` follows the format described below.


### PR DESCRIPTION
Updated image_dataset.py with `label_mode` is None and interpolation is `bilinear` it yields `uint8`.
#49861