### PR TITLE
Add 'scalar' label_mode in image_dataset_from_directory and load images from directory root for Regression

### DIFF
--- a/keras/preprocessing/dataset_utils.py
+++ b/keras/preprocessing/dataset_utils.py
@@ -29,7 +29,8 @@ def index_directory(directory,
                     class_names=None,
                     shuffle=True,
                     seed=None,
-                    follow_links=False):
+                    follow_links=False,
+                    label_mode="int"):
   """Make list of all files in the subdirs of `directory`, with their labels.
 
   Args:
@@ -50,14 +51,19 @@ def index_directory(directory,
         If set to False, sorts the data in alphanumeric order.
     seed: Optional random seed for shuffling.
     follow_links: Whether to visits subdirectories pointed to by symlinks.
-
+    label_mode: Indicates how the directory structure should be treated:
+        'int', 'categorical' or 'binary': files should be on labeled 
+        subdirectories with class names
+        'scalar' or None: All files should be in `directory` 
   Returns:
     tuple (file_paths, labels, class_names).
       file_paths: list of file paths (strings).
       labels: list of matching integer labels (same length as file_paths)
       class_names: names of the classes corresponding to these labels, in order.
   """
-  if labels is None:
+  #efv
+  print("BORRA ESTO")
+  if labels is None or label_mode == 'scalar':
     # in the no-label case, index from the parent directory down.
     subdirs = ['']
     class_names = subdirs
@@ -105,7 +111,7 @@ def index_directory(directory,
       labels[i:i + len(partial_labels)] = partial_labels
       i += len(partial_labels)
 
-  if labels is None:
+  if labels is None or label_mode == 'scalar':
     print('Found %d files.' % (len(filenames),))
   else:
     print('Found %d files belonging to %d classes.' %

--- a/keras/preprocessing/dataset_utils.py
+++ b/keras/preprocessing/dataset_utils.py
@@ -61,8 +61,6 @@ def index_directory(directory,
       labels: list of matching integer labels (same length as file_paths)
       class_names: names of the classes corresponding to these labels, in order.
   """
-  #efv
-  print("BORRA ESTO")
   if labels is None or label_mode == 'scalar':
     # in the no-label case, index from the parent directory down.
     subdirs = ['']

--- a/keras/preprocessing/dataset_utils.py
+++ b/keras/preprocessing/dataset_utils.py
@@ -55,6 +55,7 @@ def index_directory(directory,
         'int', 'categorical' or 'binary': files should be on labeled 
         subdirectories with class names
         'scalar' or None: All files should be in `directory` 
+
   Returns:
     tuple (file_paths, labels, class_names).
       file_paths: list of file paths (strings).

--- a/keras/preprocessing/image_dataset.py
+++ b/keras/preprocessing/image_dataset.py
@@ -88,6 +88,9 @@ def image_dataset_from_directory(directory,
         - 'binary' means that the labels (there can be only 2)
             are encoded as `float32` scalars with values 0 or 1
             (e.g. for `binary_crossentropy`).
+        - 'scalar' means a real (float) value is assigned for each label. Use for
+            Regression problems. As there are no classes, all files should be at
+            root of `directory`.
         - None (no labels).
     class_names: Only valid if "labels" is "inferred". This is the explicit
         list of class names (must match names of subdirectories). Used
@@ -164,7 +167,7 @@ def image_dataset_from_directory(directory,
       raise ValueError('You can only pass `class_names` if '
                        f'`labels="inferred"`. Received: labels={labels}, and '
                        f'class_names={class_names}')
-  if label_mode not in {'int', 'categorical', 'binary', None}:
+  if label_mode not in {'int', 'categorical', 'binary', 'scalar', None}:
     raise ValueError(
         '`label_mode` argument must be one of "int", "categorical", "binary", '
         f'or None. Received: label_mode={label_mode}')
@@ -194,7 +197,8 @@ def image_dataset_from_directory(directory,
       class_names=class_names,
       shuffle=shuffle,
       seed=seed,
-      follow_links=follow_links)
+      follow_links=follow_links,
+      label_mode=label_mode)
 
   if label_mode == 'binary' and len(class_names) != 2:
     raise ValueError(

--- a/keras/preprocessing/image_dataset_test.py
+++ b/keras/preprocessing/image_dataset_test.py
@@ -76,12 +76,15 @@ class ImageDatasetFromDirectoryTest(keras_parameterized.TestCase):
     # Save images to the paths
     i = 0
     for img in self._get_images(color_mode=color_mode, count=count):
-      path = paths[i % len(paths)]
+      path = ""
+      if len(paths) > 0:
+        path = paths[i % len(paths)]
       if color_mode == 'rgb':
         ext = 'jpg'
       else:
         ext = 'png'
       filename = os.path.join(path, 'image_%s.%s' % (i, ext))
+      print(os.path.join(temp_dir, filename))
       img.save(os.path.join(temp_dir, filename))
       i += 1
     return temp_dir
@@ -258,6 +261,23 @@ class ImageDatasetFromDirectoryTest(keras_parameterized.TestCase):
     batch = next(iter(dataset))
     self.assertLen(batch, 2)
     self.assertAllClose(batch[1], [0, 1])
+
+  #efv
+  def test_image_dataset_from_directory_scalar(self):
+    if PIL is None:
+      return
+
+    print("*****************AQUI")
+    directory = self._prepare_directory(num_classes=0, count=2)
+    print(f"-->{directory}")
+    print("*****************")
+    dataset = image_dataset.image_dataset_from_directory(
+        directory, batch_size=8, image_size=(18, 18),
+        labels=[0.1, 0.2], shuffle=False,
+        label_mode='scalar')
+    batch = next(iter(dataset))
+    self.assertLen(batch, 2)
+    self.assertAllClose(batch[1], [0.1, 0.2])
 
   def test_image_dataset_from_directory_follow_links(self):
     if PIL is None:

--- a/keras/preprocessing/image_dataset_test.py
+++ b/keras/preprocessing/image_dataset_test.py
@@ -84,7 +84,6 @@ class ImageDatasetFromDirectoryTest(keras_parameterized.TestCase):
       else:
         ext = 'png'
       filename = os.path.join(path, 'image_%s.%s' % (i, ext))
-      print(os.path.join(temp_dir, filename))
       img.save(os.path.join(temp_dir, filename))
       i += 1
     return temp_dir
@@ -262,15 +261,11 @@ class ImageDatasetFromDirectoryTest(keras_parameterized.TestCase):
     self.assertLen(batch, 2)
     self.assertAllClose(batch[1], [0, 1])
 
-  #efv
   def test_image_dataset_from_directory_scalar(self):
     if PIL is None:
       return
 
-    print("*****************AQUI")
     directory = self._prepare_directory(num_classes=0, count=2)
-    print(f"-->{directory}")
-    print("*****************")
     dataset = image_dataset.image_dataset_from_directory(
         directory, batch_size=8, image_size=(18, 18),
         labels=[0.1, 0.2], shuffle=False,


### PR DESCRIPTION
Feature proposal in #15440

# Describe the feature and the current behavior/state.

`image_dataset_from_directory` currently assumes that the dataset will be used in classification tasks, so the labels take some form of categorical values (integers, binary, etc). It also make strong assumptions on the directory structure in which the images are located: if a list of labels is passed, the images should be placed on subdirs named the same as the labels (even if the documentations says that the structure is ignored).

For regression purposes, I suggest a new `label_mode` called "scalar" in which labels can take a real value and are passed in labels as a list or tuple, and all images are located in the root of directory.

## Example:

You have a directory with images and a text file with their labels for regression which are floats (labels are ordered alphanumerically according to image name):

```
with open("labels.txt") as fin:
  labels = [float(item) for item in fin.readlines()]
data = image_dataset_from_directory("images_dir", labels=labels, label_mode='scalar')
```

# Will this change the current api? How?

The parameter label_mode will accept a new value scalar. This value will be passed to index_directory as a new parameter. Inside it, if label_mode is scalar then the directory indexing is not performed on the subdirs, only on root.

# Who will benefit from this feature?

Regression problems which uses images in a single directory
