### PR TITLE
Persist attribute "sparse" of IndexLookup layer

### DIFF
--- a/keras/layers/preprocessing/index_lookup.py
+++ b/keras/layers/preprocessing/index_lookup.py
@@ -363,6 +363,7 @@ class IndexLookup(base_preprocessing_layer.PreprocessingLayer):
         "oov_token": self.oov_token,
         "mask_token": self.mask_token,
         "output_mode": self.output_mode,
+        "sparse": self.sparse,
         "pad_to_max_tokens": self.pad_to_max_tokens,
         "vocabulary": utils.listify_tensors(self.input_vocabulary),
         "vocabulary_dtype": self.vocabulary_dtype,

--- a/keras/layers/preprocessing/index_lookup_test.py
+++ b/keras/layers/preprocessing/index_lookup_test.py
@@ -2365,6 +2365,30 @@ class IndexLookupSavingTest(keras_parameterized.TestCase,
     new_output_dataset = model.predict(input_array)
     self.assertAllEqual(new_output_dataset, expected_output)
 
+  def test_sparse_output_across_saving(self):
+    vocab_data = ["earth", "wind", "and", "fire"]
+    input_array = np.array([["earth", "wind", "and", "fire"],
+                            ["fire", "and", "earth", "michigan"]])
+
+    expected_output = [[0., 1., 1., 1., 1.], [1., 1., 0., 1., 1.]]
+
+    layer_cls = index_lookup.IndexLookup
+    layer = layer_cls(
+        max_tokens=None,
+        num_oov_indices=1,
+        mask_token="",
+        oov_token="[OOV]",
+        vocabulary_dtype=tf.string,
+        vocabulary=vocab_data,
+        output_mode="multi_hot",
+        sparse=True)
+    config = layer.get_config()
+    layer = layer_cls.from_config(config)
+
+    output = layer(input_array)
+    self.assertIsInstance(output, tf.SparseTensor)
+    self.assertAllEqual(tf.sparse.to_dense(output), expected_output)
+
 
 class EagerExecutionDisabled(keras_parameterized.TestCase,
                              preprocessing_test_utils.PreprocessingLayerTest):


### PR DESCRIPTION
The `IndexLookup` layer doesn't persist its `sparse` attribute which makes a layer with `sparse=True` produce dense tensors after deserialization, which breaks model loading in cases where the output of `IndexLookup` are expected to be sparse. This PR fixes this by adding `sparse` to the list of persisted attributes.