### PR TITLE
Change progress bars to tqdm style.

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -919,17 +919,24 @@ class Progbar:
 
       if self.target is not None:
         numdigits = int(np.log10(self.target)) + 1
-        bar = ('%' + str(numdigits) + 'd/%d [') % (current, self.target)
+        bar = ('%' + str(numdigits) + 'd/%d |') % (current, self.target)
         prog = float(current) / self.target
-        prog_width = int(self.width * prog)
+        prog_width = int(self.width * prog * 8)
         if prog_width > 0:
-          bar += ('=' * (prog_width - 1))
+          bar += ('█' * (prog_width // 8))  # prog_width - 1
           if current < self.target:
-            bar += '>'
+            if prog_width % 8 == 0: bar += ' '
+            if prog_width % 8 == 1: bar += '▏'
+            if prog_width % 8 == 2: bar += '▎'
+            if prog_width % 8 == 3: bar += '▍'
+            if prog_width % 8 == 4: bar += '▌'
+            if prog_width % 8 == 5: bar += '▋'
+            if prog_width % 8 == 6: bar += '▊'
+            if prog_width % 8 == 7: bar += '▉'
           else:
-            bar += '='
-        bar += ('.' * (self.width - prog_width))
-        bar += ']'
+            bar += '█'
+        bar += (' ' * (self.width - prog_width // 8))
+        bar += '|'
       else:
         bar = '%7d/Unknown' % current
 


### PR DESCRIPTION
Change class method `Progbar.update` to print the progress bar in the same manner as [tqdm](https://github.com/tqdm/tqdm) or pip using the partial box characters.

For example in training a model:
```
Epoch 1/100
200/200 |███████████████████████████████| - 14s 54ms/step - loss: 0.5867 - accuracy: 0.7704 - val_loss: 3.8020 - val_accuracy: 0.0415
Epoch 2/100
 39/200 |█████▊                         | - ETA: 7s - loss: 0.4454 - accuracy: 0.8308
```