### PR TITLE
Add compute_output_shape in TFOpLambda

### DIFF
--- a/keras/layers/core/core_test.py
+++ b/keras/layers/core/core_test.py
@@ -703,6 +703,30 @@ class TFOpLambdaTest(keras_parameterized.TestCase):
     with self.assertRaisesRegex(ValueError, 'was generated from .*dummy_func'):
       layer.get_config()
 
+  def test_compute_output_shape(self):
+
+    def dummy_func(a, b):
+        return a + b
+
+    def dummy_func1(a):
+        return tf.math.reduce_sum(a)
+
+    def dummy_func2(a):
+        return tf.math.reduce_sum(a, axis=1)
+
+    input_layer = keras.Input(batch_shape=(10, None))
+    input_layer1 = keras.Input(batch_shape=(10, None))
+    layer = core.TFOpLambda(dummy_func)(input_layer, input_layer1).node.layer
+    self.assertEqual(layer.compute_output_shape(), (10, None))
+
+    input_layer = keras.Input(batch_shape=(10, None))
+    layer = core.TFOpLambda(dummy_func1)(input_layer).node.layer
+    self.assertEqual(layer.compute_output_shape(), ())
+
+    input_layer = keras.Input(batch_shape=(10, None))
+    layer = core.TFOpLambda(dummy_func2)(input_layer).node.layer
+    self.assertEqual(layer.compute_output_shape(), (10, ))
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/keras/layers/core/tf_op_layer.py
+++ b/keras/layers/core/tf_op_layer.py
@@ -243,6 +243,9 @@ class TFOpLambda(Layer):
     self._expects_training_arg = False
     self._expects_mask_arg = False
 
+  def compute_output_shape(self, input_shape=None):
+      return self.output_shape
+  
   def _call_wrapper(self, *args, **kwargs):
     created_variables = []
 


### PR DESCRIPTION
Create a new pr from the old pr: https://github.com/keras-team/keras/pull/15381
If this could be merged, I would delete the old one.