### PR TITLE
chore: replace os.path.join with tf.io.gfile.join

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1205,7 +1205,7 @@ class ModelCheckpoint(Callback):
 
   Args:
       filepath: string or `PathLike`, path to save the model file. e.g.
-        filepath = tf.io.gfile.join(working_dir, 'ckpt', file_name). `filepath`
+        filepath = os.path.join(working_dir, 'ckpt', file_name). `filepath`
         can contain named formatting options, which will be filled the value of
         `epoch` and keys in `logs` (passed in `on_epoch_end`). For example: if
         `filepath` is `weights.{epoch:02d}-{val_loss:.2f}.hdf5`, then the model
@@ -1515,9 +1515,9 @@ class ModelCheckpoint(Callback):
     ```python
     file_pattern = 'f.batch{batch:02d}epoch{epoch:02d}.h5'
     test_dir = self.get_temp_dir()
-    path_pattern = tf.io.gfile.join(test_dir, file_pattern)
+    path_pattern = os.path.join(test_dir, file_pattern)
     file_paths = [
-        tf.io.gfile.join(test_dir, file_name) for file_name in
+        os.path.join(test_dir, file_name) for file_name in
         ['f.batch03epoch02.h5', 'f.batch02epoch02.h5', 'f.batch01epoch01.h5']
     ]
     for file_path in file_paths:
@@ -1557,7 +1557,7 @@ class ModelCheckpoint(Callback):
       for file_name in os.listdir(dir_name):
         # Only consider if `file_name` matches the pattern.
         if re.match(base_name_regex, file_name):
-          file_path = tf.io.gfile.join(dir_name, file_name)
+          file_path = os.path.join(dir_name, file_name)
           mod_time = os.path.getmtime(file_path)
           if (file_path_with_largest_file_name is None or
               file_path > file_path_with_largest_file_name):
@@ -1642,7 +1642,7 @@ class BackupAndRestore(Callback):
 
   Args:
       backup_dir: String, path to store the checkpoint.
-        e.g. backup_dir = tf.io.gfile.join(working_dir, 'backup')
+        e.g. backup_dir = os.path.join(working_dir, 'backup')
         This is the directory in which the system stores temporary files to
         recover the model from jobs terminated unexpectedly. The directory
         cannot be reused elsewhere to store other files, e.g. by
@@ -2061,7 +2061,7 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
 
   Args:
       log_dir: the path of the directory where to save the log files to be
-        parsed by TensorBoard. e.g. log_dir = tf.io.gfile.join(working_dir, 'logs')
+        parsed by TensorBoard. e.g. log_dir = os.path.join(working_dir, 'logs')
         This directory should not be reused by any other callbacks.
       histogram_freq: frequency (in epochs) at which to compute activation and
         weight histograms for the layers of the model. If set to 0, histograms
@@ -2229,10 +2229,10 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
     self.model = model
     self._log_write_dir = self._get_log_write_dir()
 
-    self._train_dir = tf.io.gfile.join(self._log_write_dir, 'train')
+    self._train_dir = os.path.join(self._log_write_dir, 'train')
     self._train_step = self.model._train_counter  # pylint: disable=protected-access
 
-    self._val_dir = tf.io.gfile.join(self._log_write_dir, 'validation')
+    self._val_dir = os.path.join(self._log_write_dir, 'validation')
     self._val_step = self.model._test_counter  # pylint: disable=protected-access
 
     self._writers = {}  # Resets writers.
@@ -2316,7 +2316,7 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
                        f'argument: {self.embeddings_metadata.keys()}')
 
     config_pbtxt = text_format.MessageToString(config)
-    path = tf.io.gfile.join(self._log_write_dir, 'projector_config.pbtxt')
+    path = os.path.join(self._log_write_dir, 'projector_config.pbtxt')
     with tf.io.gfile.GFile(path, 'w') as f:
       f.write(config_pbtxt)
 
@@ -2563,7 +2563,7 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
       tf.summary.image(weight_name, w_img, step=epoch)
 
   def _log_embeddings(self, epoch):
-    embeddings_ckpt = tf.io.gfile.join(self._log_write_dir, 'train',
+    embeddings_ckpt = os.path.join(self._log_write_dir, 'train',
                                    'keras_embedding.ckpt-{}'.format(epoch))
     self.model.save_weights(embeddings_ckpt)
 

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1205,7 +1205,7 @@ class ModelCheckpoint(Callback):
 
   Args:
       filepath: string or `PathLike`, path to save the model file. e.g.
-        filepath = os.path.join(working_dir, 'ckpt', file_name). `filepath`
+        filepath = tf.io.gfile.join(working_dir, 'ckpt', file_name). `filepath`
         can contain named formatting options, which will be filled the value of
         `epoch` and keys in `logs` (passed in `on_epoch_end`). For example: if
         `filepath` is `weights.{epoch:02d}-{val_loss:.2f}.hdf5`, then the model
@@ -1515,9 +1515,9 @@ class ModelCheckpoint(Callback):
     ```python
     file_pattern = 'f.batch{batch:02d}epoch{epoch:02d}.h5'
     test_dir = self.get_temp_dir()
-    path_pattern = os.path.join(test_dir, file_pattern)
+    path_pattern = tf.io.gfile.join(test_dir, file_pattern)
     file_paths = [
-        os.path.join(test_dir, file_name) for file_name in
+        tf.io.gfile.join(test_dir, file_name) for file_name in
         ['f.batch03epoch02.h5', 'f.batch02epoch02.h5', 'f.batch01epoch01.h5']
     ]
     for file_path in file_paths:
@@ -1557,7 +1557,7 @@ class ModelCheckpoint(Callback):
       for file_name in os.listdir(dir_name):
         # Only consider if `file_name` matches the pattern.
         if re.match(base_name_regex, file_name):
-          file_path = os.path.join(dir_name, file_name)
+          file_path = tf.io.gfile.join(dir_name, file_name)
           mod_time = os.path.getmtime(file_path)
           if (file_path_with_largest_file_name is None or
               file_path > file_path_with_largest_file_name):
@@ -1642,7 +1642,7 @@ class BackupAndRestore(Callback):
 
   Args:
       backup_dir: String, path to store the checkpoint.
-        e.g. backup_dir = os.path.join(working_dir, 'backup')
+        e.g. backup_dir = tf.io.gfile.join(working_dir, 'backup')
         This is the directory in which the system stores temporary files to
         recover the model from jobs terminated unexpectedly. The directory
         cannot be reused elsewhere to store other files, e.g. by
@@ -2061,7 +2061,7 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
 
   Args:
       log_dir: the path of the directory where to save the log files to be
-        parsed by TensorBoard. e.g. log_dir = os.path.join(working_dir, 'logs')
+        parsed by TensorBoard. e.g. log_dir = tf.io.gfile.join(working_dir, 'logs')
         This directory should not be reused by any other callbacks.
       histogram_freq: frequency (in epochs) at which to compute activation and
         weight histograms for the layers of the model. If set to 0, histograms
@@ -2229,10 +2229,10 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
     self.model = model
     self._log_write_dir = self._get_log_write_dir()
 
-    self._train_dir = os.path.join(self._log_write_dir, 'train')
+    self._train_dir = tf.io.gfile.join(self._log_write_dir, 'train')
     self._train_step = self.model._train_counter  # pylint: disable=protected-access
 
-    self._val_dir = os.path.join(self._log_write_dir, 'validation')
+    self._val_dir = tf.io.gfile.join(self._log_write_dir, 'validation')
     self._val_step = self.model._test_counter  # pylint: disable=protected-access
 
     self._writers = {}  # Resets writers.
@@ -2316,7 +2316,7 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
                        f'argument: {self.embeddings_metadata.keys()}')
 
     config_pbtxt = text_format.MessageToString(config)
-    path = os.path.join(self._log_write_dir, 'projector_config.pbtxt')
+    path = tf.io.gfile.join(self._log_write_dir, 'projector_config.pbtxt')
     with tf.io.gfile.GFile(path, 'w') as f:
       f.write(config_pbtxt)
 
@@ -2563,7 +2563,7 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
       tf.summary.image(weight_name, w_img, step=epoch)
 
   def _log_embeddings(self, epoch):
-    embeddings_ckpt = os.path.join(self._log_write_dir, 'train',
+    embeddings_ckpt = tf.io.gfile.join(self._log_write_dir, 'train',
                                    'keras_embedding.ckpt-{}'.format(epoch))
     self.model.save_weights(embeddings_ckpt)
 

--- a/keras/saving/pickle_utils.py
+++ b/keras/saving/pickle_utils.py
@@ -39,7 +39,7 @@ def deserialize_model_from_bytecode(serialized_model):
   b = io.BytesIO(serialized_model)
   with tarfile.open(fileobj=b, mode="r") as archive:
     for name in archive.getnames():
-      dest_path = os.path.join(temp_dir, name)
+      dest_path = tf.io.gfile.join(temp_dir, name)
       member = archive.getmember(name)
       tf.io.gfile.makedirs(os.path.dirname(dest_path))
       if member.isfile():
@@ -66,12 +66,12 @@ def serialize_model_as_bytecode(model):
   with tarfile.open(fileobj=b, mode="w") as archive:
     for root, dirs, filenames in tf.io.gfile.walk(temp_dir):
       for dirname in dirs:
-        dest_path = os.path.join(root, dirname)
+        dest_path = tf.io.gfile.join(root, dirname)
         t = tarfile.TarInfo(dest_path)
         t.type = tarfile.DIRTYPE
         archive.addfile(t)
       for filename in filenames:
-        dest_path = os.path.join(root, filename)
+        dest_path = tf.io.gfile.join(root, filename)
         with tf.io.gfile.GFile(dest_path, "rb") as f:
           info = tarfile.TarInfo(name=os.path.relpath(dest_path, temp_dir))
           info.size = f.size()

--- a/keras/saving/saved_model/load.py
+++ b/keras/saving/saved_model/load.py
@@ -108,7 +108,7 @@ def load(path, compile=True, options=None):  # pylint: disable=redefined-builtin
   meta_graph_def = tf.__internal__.saved_model.parse_saved_model(
       path).meta_graphs[0]
   object_graph_def = meta_graph_def.object_graph_def
-  path_to_metadata_pb = os.path.join(path, constants.SAVED_METADATA_PATH)
+  path_to_metadata_pb = tf.io.gfile.join(path, constants.SAVED_METADATA_PATH)
   if tf.compat.v1.gfile.Exists(path_to_metadata_pb):
     try:
       with tf.io.gfile.GFile(path_to_metadata_pb, 'rb') as f:

--- a/keras/saving/saved_model/save.py
+++ b/keras/saving/saved_model/save.py
@@ -97,7 +97,7 @@ def save(model, filepath, overwrite, include_optimizer, signatures=None,
     metadata = generate_keras_metadata(saved_nodes, node_paths)
 
   with tf.io.gfile.GFile(
-      os.path.join(filepath, constants.SAVED_METADATA_PATH), "wb") as w:
+      tf.io.gfile.join(filepath, constants.SAVED_METADATA_PATH), "wb") as w:
     w.write(metadata.SerializeToString(deterministic=True))
 
   if not include_optimizer:

--- a/keras/saving/saved_model_experimental.py
+++ b/keras/saving/saved_model_experimental.py
@@ -139,7 +139,7 @@ def export_saved_model(model,
 def _export_model_json(model, saved_model_path):
   """Saves model configuration as a json string under assets folder."""
   model_json = model.to_json()
-  model_json_filepath = os.path.join(
+  model_json_filepath = tf.io.gfile.join(
       _get_or_create_assets_dir(saved_model_path),
       tf.compat.as_text(SAVED_MODEL_FILENAME_JSON))
   with tf.io.gfile.GFile(model_json_filepath, 'w') as f:
@@ -406,7 +406,7 @@ def load_from_saved_model(saved_model_path, custom_objects=None):
       'Please switch to `tf.keras.models.load_model`.',
       stacklevel=2)
   # restore model topology from json string
-  model_json_filepath = os.path.join(
+  model_json_filepath = tf.io.gfile.join(
       tf.compat.as_bytes(saved_model_path),
       tf.compat.as_bytes(tf.saved_model.ASSETS_DIRECTORY),
       tf.compat.as_bytes(SAVED_MODEL_FILENAME_JSON))
@@ -416,7 +416,7 @@ def load_from_saved_model(saved_model_path, custom_objects=None):
       model_json, custom_objects=custom_objects)
 
   # restore model weights
-  checkpoint_prefix = os.path.join(
+  checkpoint_prefix = tf.io.gfile.join(
       tf.compat.as_text(saved_model_path),
       tf.compat.as_text(tf.saved_model.VARIABLES_DIRECTORY),
       tf.compat.as_text(tf.saved_model.VARIABLES_FILENAME))
@@ -436,14 +436,14 @@ def _get_or_create_variables_dir(export_dir):
 
 def _get_variables_dir(export_dir):
   """Return variables sub-directory in the SavedModel."""
-  return os.path.join(
+  return tf.io.gfile.join(
       tf.compat.as_text(export_dir),
       tf.compat.as_text(tf.saved_model.VARIABLES_DIRECTORY))
 
 
 def _get_variables_path(export_dir):
   """Return the variables path, used as the prefix for checkpoint files."""
-  return os.path.join(
+  return tf.io.gfile.join(
       tf.compat.as_text(_get_variables_dir(export_dir)),
       tf.compat.as_text(tf.saved_model.VARIABLES_FILENAME))
 
@@ -459,6 +459,6 @@ def _get_or_create_assets_dir(export_dir):
 
 def _get_assets_dir(export_dir):
   """Return path to asset directory in the SavedModel."""
-  return os.path.join(
+  return tf.io.gfile.join(
       tf.compat.as_text(export_dir),
       tf.compat.as_text(tf.saved_model.ASSETS_DIRECTORY))

--- a/keras/saving/utils_v1/export_utils.py
+++ b/keras/saving/utils_v1/export_utils.py
@@ -206,7 +206,7 @@ def get_timestamped_export_dir(export_dir_base):
   while attempts < MAX_DIRECTORY_CREATION_ATTEMPTS:
     timestamp = int(time.time())
 
-    result_dir = os.path.join(
+    result_dir = tf.io.gfile.join(
         tf.compat.as_bytes(export_dir_base), tf.compat.as_bytes(str(timestamp)))
     if not tf.compat.v1.gfile.Exists(result_dir):
       # Collisions are still possible (though extremely unlikely): this
@@ -241,7 +241,7 @@ def get_temp_export_dir(timestamped_export_dir):
     str_name = basename.decode('utf-8')
   else:
     str_name = str(basename)
-  temp_export_dir = os.path.join(
+  temp_export_dir = tf.io.gfile.join(
       tf.compat.as_bytes(dirname),
       tf.compat.as_bytes('temp-{}'.format(str_name)))
   return temp_export_dir


### PR DESCRIPTION
Partially addresses #15300

I only replaced some uses of `os.path.join`.
I didn't want to replace it where not needed (it is only needed in things that interact `ram://` or `gcs://` filesystems). But I probably replied it in some places where it's not needed and neglected to replace it in places where it is needed. The codebase is very large and I'm unfamiliar with a lot of it; I'd appreciate some guidance from someone with more global knowledge of the codebase.