### PR TITLE
Disable the failing tests due to numpy 1.20 change

### DIFF
--- a/keras/saving/saved_model/BUILD
+++ b/keras/saving/saved_model/BUILD
@@ -99,6 +99,7 @@ tf_py_test(
     python_version = "PY3",
     shard_count = 4,
     tags = [
+        "no_pip",  # TODO(b/202022379)
         "no_rocm",
         "no_windows",
         "notsan",  #TODO(b/181771982): it is flaky


### PR DESCRIPTION
The test has been disabled on master branch as well, we need to cherrypick this to unblock the release build.

original cl in cl/400819173.

@mihaimaruseac, @wangpengmit 