### PR TITLE
Update documentation for fit/eval no dictionaries

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -987,7 +987,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
             if the model has named inputs.
           - A `tf.data` dataset. Should return a tuple
             of either `(inputs, targets)` or
-            `(inputs, targets, sample_weights)`.
+            `(inputs, targets, sample_weights)`.  Note: datasets returning
+            dictionaries are not supported.
           - A generator or `keras.utils.Sequence` returning `(inputs, targets)`
             or `(inputs, targets, sample_weights)`.
           - A `tf.keras.utils.experimental.DatasetCreator`, which wraps a
@@ -1493,7 +1494,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
             if the model has named inputs.
           - A `tf.data` dataset. Should return a tuple
             of either `(inputs, targets)` or
-            `(inputs, targets, sample_weights)`.
+            `(inputs, targets, sample_weights)`. Note: datasets returning
+            dictionaries are not supported.
           - A generator or `keras.utils.Sequence` returning `(inputs, targets)`
             or `(inputs, targets, sample_weights)`.
           A more detailed description of unpacking behavior for iterator types


### PR DESCRIPTION
Update the the documentation for fit and evaluate to note that datasets returning dictionaries are NOT supported.

This is important since previous versions of TF support dictionaries as input and now Keras does not.  It is a confusing issue because dictionaries do seem to work for fit, but are not supported, and they break evaluate in a weird way. Better to be explicit that dictionaries are NOT supported.