### PR TITLE
Bypass the require a config warning for marge layers

### DIFF
--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -220,7 +220,7 @@ class _Merge(Layer):
         backend.concatenate(masks, axis=0), axis=0, keepdims=False)
 
   def get_config(self):
-    return super(_Merge, self).get_config()
+    return super().get_config()
 
 
 @keras_export('keras.layers.Add')

--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -219,6 +219,9 @@ class _Merge(Layer):
     return backend.all(
         backend.concatenate(masks, axis=0), axis=0, keepdims=False)
 
+  def get_config(self):
+    return super(_Merge, self).get_config()
+
 
 @keras_export('keras.layers.Add')
 class Add(_Merge):


### PR DESCRIPTION
Bypass the warning `CustomMaskWarning: Custom mask layers require a config and must override get_config` when saving a model containing marge layers like `Add` / `Multiply`.
- Before:
  ```py
  tf.__version__
  # '2.7.0'

  inputs = keras.layers.Input(shape=(32, 32, 3))
  keras.models.Model(inputs, keras.layers.Add()([inputs, inputs])).save('aa.h5')
  # WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
  # /opt/anaconda3/lib/python3.8/site-packages/keras/engine/functional.py:1410: CustomMaskWarning: Custom mask layers require a config and must override get_config. When loading, the custom mask layer must be passed to the custom_objects argument.
  #   layer_config = serialize_layer_fn(layer)
  ```
- After:
  ```py
  inputs = keras.layers.Input(shape=(32, 32, 3))
  keras.models.Model(inputs, keras.layers.Add()([inputs, inputs])).save('aa.h5')
  # WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
  ```