### PR TITLE
Add ReorderChannels preprocessing layer

### DIFF
--- a/keras/layers/__init__.py
+++ b/keras/layers/__init__.py
@@ -36,6 +36,7 @@ from keras.layers.preprocessing.image_preprocessing import RandomRotation
 from keras.layers.preprocessing.image_preprocessing import RandomTranslation
 from keras.layers.preprocessing.image_preprocessing import RandomWidth
 from keras.layers.preprocessing.image_preprocessing import RandomZoom
+from keras.layers.preprocessing.image_preprocessing import ReorderChannels
 from keras.layers.preprocessing.image_preprocessing import Resizing
 from keras.layers.preprocessing.image_preprocessing import Rescaling
 

--- a/keras/layers/preprocessing/image_preprocessing.py
+++ b/keras/layers/preprocessing/image_preprocessing.py
@@ -54,6 +54,47 @@ def check_fill_mode_and_interpolation(fill_mode, interpolation):
                               '`bilinear` are supported.'.format(interpolation))
 
 
+@keras_export('keras.layers.ReorderChannels',
+              'keras.layers.experimental.preprocessing.ReorderChannels')
+class ReorderChannels(base_layer.Layer):
+  def __init__(self,
+               axis,
+               indices,
+               **kwargs):
+    """A preprocessing layer which reorder the channels of an image
+
+    This layer reorders the channels of an image for a specified axis. Intended
+    to be used for conversions between RGB and BGR.
+
+    For an overview and full list of preprocessing layers, see the preprocessing
+    [guide](https://www.tensorflow.org/guide/keras/preprocessing_layers).
+
+    Args:
+      axis: Integer, axis which will be reordered
+      indices: List[Integer], new order for axis elements
+    """
+    self.axis = axis
+    self.indices = indices
+    super(ReorderChannels, self).__init__(**kwargs)
+    base_preprocessing_layer.keras_kpl_gauge.get_cell('ReorderChannels').set(True)
+
+    def __call__(self, inputs):
+      return tf.gather(params=inputs,
+                       indices=self.indices,
+                       axis=self.axis)
+
+    def compute_output_shape(self, input_shape):
+      return input_shape
+
+    def get_config(self):
+      config = {
+          'axis': self.axis,
+          'indices': self.indices
+      }
+      base_config = super(ReorderChannels, self).get_config()
+      return dict(list(base_config.items()) + list(config.items()))
+
+
 @keras_export('keras.layers.Resizing',
               'keras.layers.experimental.preprocessing.Resizing')
 class Resizing(base_layer.Layer):

--- a/keras/layers/preprocessing/image_preprocessing.py
+++ b/keras/layers/preprocessing/image_preprocessing.py
@@ -78,21 +78,21 @@ class ReorderChannels(base_layer.Layer):
     super(ReorderChannels, self).__init__(**kwargs)
     base_preprocessing_layer.keras_kpl_gauge.get_cell('ReorderChannels').set(True)
 
-    def __call__(self, inputs):
-      return tf.gather(params=inputs,
-                       indices=self.indices,
-                       axis=self.axis)
+  def call(self, inputs):
+    return tf.gather(params=inputs,
+                      indices=self.indices,
+                      axis=self.axis+1)
 
-    def compute_output_shape(self, input_shape):
-      return input_shape
+  def compute_output_shape(self, input_shape):
+    return input_shape
 
-    def get_config(self):
-      config = {
-          'axis': self.axis,
-          'indices': self.indices
-      }
-      base_config = super(ReorderChannels, self).get_config()
-      return dict(list(base_config.items()) + list(config.items()))
+  def get_config(self):
+    config = {
+        'axis': self.axis,
+        'indices': self.indices
+    }
+    base_config = super(ReorderChannels, self).get_config()
+    return dict(list(base_config.items()) + list(config.items()))
 
 
 @keras_export('keras.layers.Resizing',

--- a/keras/layers/preprocessing/image_preprocessing_test.py
+++ b/keras/layers/preprocessing/image_preprocessing_test.py
@@ -28,6 +28,45 @@ from tensorflow.python.ops import stateless_random_ops
 
 
 @keras_parameterized.run_all_keras_modes(always_skip_v1=True)
+class ReorderChannelsTest(keras_parameterized.TestCase):
+
+  def test_reorder_channels_last(self, kwargs={}):
+    np.random.seed(1337)
+    num_samples = 2
+    height = 100
+    width = 101
+    channels = 3
+    arr = np.arange(num_samples * height * width * channels).reshape(num_samples, height, width, channels).astype(np.float32)
+
+    kwargs.update({'axis': 2, 'indices': [2, 1, 0]})
+    with testing_utils.use_gpu():
+        testing_utils.layer_test(
+            image_preprocessing.ReorderChannels,
+            kwargs=kwargs,
+            input_shape=(None, height, width, channels),
+            input_data=arr,
+            expected_output=tf.gather(arr, axis=3, indices=[2, 1, 0]).numpy().astype(np.float32),
+            expected_output_shape=(None, height, width, channels))
+
+  def test_reorder_channels_first(self, kwargs={}):
+    np.random.seed(1337)
+    num_samples = 2
+    height = 100
+    width = 101
+    channels = 3
+    arr = np.arange(num_samples * height * width * channels).reshape(num_samples, channels, height, width).astype(np.float32)
+
+    kwargs.update({'axis': 0, 'indices': [2, 1, 0]})
+    with testing_utils.use_gpu():
+        testing_utils.layer_test(
+            image_preprocessing.ReorderChannels,
+            kwargs=kwargs,
+            input_shape=(None, channels, height, width),
+            input_data=arr,
+            expected_output=tf.gather(arr, axis=1, indices=[2, 1, 0]).numpy().astype(np.float32),
+            expected_output_shape=(None, channels, height, width))
+
+@keras_parameterized.run_all_keras_modes(always_skip_v1=True)
 class ResizingTest(keras_parameterized.TestCase):
 
   def _run_test(self, kwargs, expected_height, expected_width):

--- a/keras/layers/preprocessing/image_preprocessing_test.py
+++ b/keras/layers/preprocessing/image_preprocessing_test.py
@@ -66,6 +66,7 @@ class ReorderChannelsTest(keras_parameterized.TestCase):
             expected_output=tf.gather(arr, axis=1, indices=[2, 1, 0]).numpy().astype(np.float32),
             expected_output_shape=(None, channels, height, width))
 
+
 @keras_parameterized.run_all_keras_modes(always_skip_v1=True)
 class ResizingTest(keras_parameterized.TestCase):
 


### PR DESCRIPTION
Closes #15705 .

Adds `tf.keras.layers.ReorderChannels` which let's the user permutate the channels of a tensor along a specific axis using `tf.gather` operation. Specially useful for in-model conversion from RGB to BGR. 

Also added two tests for images with channels first and channels last.  
