### PR TITLE
Fix LSTM and GRU cuDNN kernel failure for RaggedTensors.

### DIFF
--- a/keras/layers/recurrent_v2_test.py
+++ b/keras/layers/recurrent_v2_test.py
@@ -120,6 +120,7 @@ class RNNV2Test(keras_parameterized.TestCase):
     lstm(embedded_inputs)
 
   @parameterized.parameters([rnn_v2.LSTM, rnn_v2.GRU])
+  @testing_utils.run_v2_only
   def test_compare_ragged_with_masks(self, layer):
     vocab_size = 100
     timestep = 20


### PR DESCRIPTION
The `keras.layers.LSTM` and `keras.layers.GRU` layers currently do not use cuDNN kernel for `tf.RaggedTensor`s, as reported by https://github.com/tensorflow/tensorflow/issues/48838 and also as documented in the code at
- https://github.com/keras-team/keras/blob/5d2993b78603bda911f0a4912d08b1e5f36eb633/keras/layers/recurrent_v2.py#L424-L426
- https://github.com/keras-team/keras/blob/5d2993b78603bda911f0a4912d08b1e5f36eb633/keras/layers/recurrent_v2.py#L1153-L1155

I have traced the problem to https://github.com/keras-team/keras/blob/5d2993b78603bda911f0a4912d08b1e5f36eb633/keras/layers/recurrent_v2.py#L616-L623 -- the problem is that even if `mask` can be `None`, `sequence_lengths` might not be `None` -- and in that case the CudnnRNNV3 is used https://github.com/keras-team/keras/blob/5d2993b78603bda911f0a4912d08b1e5f36eb633/keras/layers/recurrent_v2.py#L655-L664 and the inputs **should not** be transposed.

This condition (`mask=None`, `sequence_lengths != None`) is actually forgotten in several places in `gpu_gru` and `gpu_lstm` -- also on https://github.com/keras-team/keras/blob/5d2993b78603bda911f0a4912d08b1e5f36eb633/keras/layers/recurrent_v2.py#L686-L687 and then on https://github.com/keras-team/keras/blob/5d2993b78603bda911f0a4912d08b1e5f36eb633/keras/layers/recurrent_v2.py#L690-L697. I therefore provide a patch, which:
- moves the copy of `mask` to `sequence_lengths` https://github.com/keras-team/keras/blob/5d2993b78603bda911f0a4912d08b1e5f36eb633/keras/layers/recurrent_v2.py#L652-L653 to the beginning of the function
- then checks only for `sequence_lengths` being `None` or not -- this way both cases (either `mask` or `sequence_lengths` being non-None) are handled consistently.

I also removed the test disallowing using the cuDNN kernel for `tf.keras.layers.{LSTM/GRU}` and removed the reference to the internal bug: https://github.com/keras-team/keras/blob/5d2993b78603bda911f0a4912d08b1e5f36eb633/keras/layers/recurrent_v2.py#L1153-L1154 https://github.com/keras-team/keras/blob/5d2993b78603bda911f0a4912d08b1e5f36eb633/keras/layers/recurrent_v2.py#L424-L425 . But maybe this needs to be handled also internally in Google somehow?