### PR TITLE
Use `assign_sub` when computing `moving_average_update`

### DIFF
--- a/keras/backend.py
+++ b/keras/backend.py
@@ -2147,7 +2147,7 @@ def moving_average_update(x, value, momentum):
   if tf.__internal__.tf2.enabled():
     momentum = tf.cast(momentum, x.dtype)
     value = tf.cast(value, x.dtype)
-    return x.assign(x * momentum + value * (1 - momentum))
+    return x.assign_sub((x - value) * (1 - momentum))
   else:
     return tf.__internal__.train.assign_moving_average(
         x, value, momentum, zero_debias=True)


### PR DESCRIPTION
This PR brings the computation inline with [`tf.__internal__.train.assign_moving_average`](https://github.com/tensorflow/tensorflow/blob/38f67391fa2960b16154bf14352268e574d08afb/tensorflow/python/training/moving_averages.py#L36-L41) which also uses `assign_sub` to reduce the number of operations that need to be executed for this function.

It is easy to verify that this PR doesn't change the computation:
```python
x_ = x - ((x - value) * (1 - momentum))                 # <-- this PR
x_ = x - (x - x * momentum - value + value * momentum)
x_ = x - x + x * momentum + value - momentum * value
x_ = x * momentum + value * (1 - momentum)              # <-- master
```