### PR TITLE
A tiny problem in an AttributeError message in base_layer.py

### DIFF
--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -2197,7 +2197,7 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
       return self._inbound_nodes[0].input_shapes
     else:
       raise AttributeError('The layer "' + str(self.name) +
-                           ' has multiple inbound nodes, '
+                           '" has multiple inbound nodes, '
                            'with different input shapes. Hence '
                            'the notion of "input shape" is '
                            'ill-defined for the layer. '


### PR DESCRIPTION
I am very sorry to disturb you.

In the definition of input_shape(self), the other half of the double quote ” is missing in the AttributeError message. Its output looks like this:

The layer "xxx has multiple inbound ...

If it is not necessary, you can close it directly. Thank you very much.