### PR TITLE
Cherrypick: Compute LSTM and GRU via cuDNN for RaggedTensors.

### DIFF
--- a/keras/layers/recurrent_v2_test.py
+++ b/keras/layers/recurrent_v2_test.py
@@ -119,6 +119,31 @@ class RNNV2Test(keras_parameterized.TestCase):
     lstm = layer(32)
     lstm(embedded_inputs)
 
+  @parameterized.parameters([rnn_v2.LSTM, rnn_v2.GRU])
+  @testing_utils.run_v2_only
+  def test_compare_ragged_with_masks(self, layer):
+    vocab_size = 100
+    timestep = 20
+    units = 32
+    embedder = embeddings.Embedding(input_dim=vocab_size, output_dim=units)
+    layer = layer(units, return_sequences=True)
+    data = tf.constant(
+      np.random.RandomState(0).randint(0, vocab_size, [timestep, timestep]))
+    mask = tf.sequence_mask(tf.range(1, timestep + 1))
+    data_ragged = tf.ragged.boolean_mask(data, mask)
+
+    outputs = []
+    devices = [testing_utils.device(should_use_gpu=False)]
+    if tf.test.is_gpu_available():
+      devices.append(testing_utils.device(should_use_gpu=True))
+    for device in devices:
+      with device:
+        outputs.append(tf.boolean_mask(layer(embedder(data), mask=mask), mask))
+        outputs.append(layer(embedder(data_ragged)).values)
+
+    for i in range(len(outputs) - 1):
+      self.assertAllClose(outputs[i], outputs[i + 1], atol=1e-4)
+
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
Would you be open to cherrypick #15756 for r2.8?

## Pros
- This cherry-picked commit fixes a bug preventing computing LSTM and GRU for RaggedTensors via cuDNN, resulting in a large speedup on a GPU (easily 10 times, as measured on https://github.com/keras-team/keras/pull/15756#issuecomment-999958522). The ragged tensors with RNNs are quite a common usage in my opinion, so quite a lot of users will benefit, I believe.

- The patch does not create a new functionality, only correctly uses an existing cuDNN implementation which is already used for masked tensor. A test comparing RaggedTensors+RNNs versus masked Tensors+RNN is provided.

Thanks for consideration.