### PR TITLE
add scoring methods in Luong-style attention

### DIFF
--- a/keras/layers/dense_attention.py
+++ b/keras/layers/dense_attention.py
@@ -242,8 +242,10 @@ class Attention(BaseDenseAttention):
       Defaults to `False`.
     dropout: Float between 0 and 1. Fraction of the units to drop for the
       attention scores. Defaults to 0.0.
-    score_mode: One of {'dot', 'concat'}. 'dot' refers to dot product
-      of query and key. 'concat' refers to hyperbolic tangent of query and key.
+    score_mode: Function to use to compute attention scores, one of 
+      `{"dot", "concat"}`. `"dot"` refers to the dot product between the query
+      and key vectors. `"concat"` refers to the hyperbolic tangent of the 
+      concatenation of the query and key vectors.
 
   Call Args:
 
@@ -327,7 +329,7 @@ class Attention(BaseDenseAttention):
     self.score_mode= score_mode
     if self.score_mode not in ['dot', 'concat']:
       raise ValueError(
-                "Unknown score_mode. Acceptable values "
+                f"Received: score_mode={score_mode}. Acceptable values "
                 "are: ['dot', 'concat']"
             )
 

--- a/keras/layers/dense_attention.py
+++ b/keras/layers/dense_attention.py
@@ -346,12 +346,14 @@ class Attention(BaseDenseAttention):
     else:
       self.scale = None
     if self.score_mode == 'concat':
-      self.attention_v = self.add_weight(
-          name='attention_v',
+      self.concat_score_weight = self.add_weight(
+          name='concat_score_weight',
           shape=(),
           initializer='ones',
           dtype=self.dtype,
           trainable=True)
+    else:
+      self.concat_score_weight = None
     super(Attention, self).build(input_shape)
 
   def _calculate_scores(self, query, key):
@@ -374,10 +376,10 @@ class Attention(BaseDenseAttention):
       # Reshape into [batch_size, 1, Tv, dim].
       k_reshaped = tf.expand_dims(key, axis=-3)
       if self.scale is not None:
-        scores = self.attention_v * tf.reduce_sum(
+        scores = self.concat_score_weight * tf.reduce_sum(
          tf.tanh(self.scale * (q_reshaped + k_reshaped)), axis=-1)
       else:
-        scores = self.attention_v * tf.reduce_sum(
+        scores = self.concat_score_weight * tf.reduce_sum(
          tf.tanh(q_reshaped + k_reshaped), axis=-1)
 
     return scores

--- a/keras/layers/dense_attention.py
+++ b/keras/layers/dense_attention.py
@@ -242,7 +242,7 @@ class Attention(BaseDenseAttention):
       Defaults to `False`.
     dropout: Float between 0 and 1. Fraction of the units to drop for the
       attention scores. Defaults to 0.0.
-    score: One of {'dot', 'concat'}. 'dot' refers to dot multiplication
+    score_type: One of {'dot', 'concat'}. 'dot' refers to dot product
       of query and key. 'concat' refers to hyperbolic tangent of query and key.
 
   Call Args:
@@ -321,17 +321,19 @@ class Attention(BaseDenseAttention):
   ```
   """
 
-  def __init__(self, use_scale=False, score='dot', **kwargs):
+  def __init__(self, use_scale=False, score_type='dot', **kwargs):
     super(Attention, self).__init__(**kwargs)
     self.use_scale = use_scale
-    self.score_type= score
+    self.score_type= score_type
     if self.score_type not in ['dot', 'concat']:
-      logging.warning(f'Score type {self.score_type} is unknown, '
-                      'fallback to score_type dot.')
-      self.score_type= 'dot'
+      raise ValueError(
+                "Unknown score_type. Acceptable values "
+                "are: ['dot', 'concat']"
+            )
 
   def build(self, input_shape):
-    """Creates scale variable if use_scale==True."""
+    """Creates scale variable if use_scale==True and
+      v parameter if score_type==concat"""
     if self.use_scale:
       self.scale = self.add_weight(
           name='scale',
@@ -341,72 +343,48 @@ class Attention(BaseDenseAttention):
           trainable=True)
     else:
       self.scale = None
+    if self.score_type == 'concat':
+      self.attention_v = self.add_weight(
+          name='attention_v',
+          shape=(),
+          initializer='ones',
+          dtype=self.dtype,
+          trainable=True)
     super(Attention, self).build(input_shape)
 
-  def _calculate_scores(self, query, key, score_type):
+  def _calculate_scores(self, query, key):
     """Calculates attention scores as a query-key dot product.
 
     Args:
       query: Query tensor of shape `[batch_size, Tq, dim]`.
       key: Key tensor of shape `[batch_size, Tv, dim]`.
-      score: One of {'dot', 'concat'}.
     Returns:
       Tensor of shape `[batch_size, Tq, Tv]`.
     """
-    if score_type == 'dot':
+    if self.score_type == 'dot':
       scores = tf.matmul(query, key, transpose_b=True)
-    elif score_type == 'concat':
+      if self.scale is not None:
+        scores *= self.scale
+    elif self.score_type == 'concat':
       # Reshape tensors to enable broadcasting.
       # Reshape into [batch_size, Tq, 1, dim].
       q_reshaped = tf.expand_dims(query, axis=-2)
       # Reshape into [batch_size, 1, Tv, dim].
       k_reshaped = tf.expand_dims(key, axis=-3)
-      scores = tf.reduce_sum(
+      if self.scale is not None:
+        scores = self.attention_v * tf.reduce_sum(
+         tf.tanh(self.scale * (q_reshaped + k_reshaped)), axis=-1)
+      else:
+        scores = self.attention_v * tf.reduce_sum(
          tf.tanh(q_reshaped + k_reshaped), axis=-1)
 
-    if self.scale is not None:
-      scores *= self.scale
     return scores
 
   def get_config(self):
-    config = {'use_scale': self.use_scale}
+    config = {'use_scale': self.use_scale,
+              'score_type': self.score_type}
     base_config = super(Attention, self).get_config()
     return dict(list(base_config.items()) + list(config.items()))
-  
-  def call(self,
-           inputs,
-           mask=None,
-           training=None,
-           return_attention_scores=False):
-    self._validate_call_args(inputs=inputs, mask=mask)
-    q = inputs[0]
-    v = inputs[1]
-    k = inputs[2] if len(inputs) > 2 else v
-    q_mask = mask[0] if mask else None
-    v_mask = mask[1] if mask else None
-    scores = self._calculate_scores(
-        query=q, key=k, score_type= self.score_type)
-    if v_mask is not None:
-      # Mask of shape [batch_size, 1, Tv].
-      v_mask = tf.expand_dims(v_mask, axis=-2)
-    if self.causal:
-      scores_shape = tf.shape(scores)
-      causal_mask_shape = tf.concat(
-          [tf.ones_like(scores_shape[:-2]), scores_shape[-2:]],
-          axis=0)
-      causal_mask = _lower_triangular_mask(causal_mask_shape)
-    else:
-      causal_mask = None
-    scores_mask = _merge_masks(v_mask, causal_mask)
-    result, attention_scores = self._apply_scores(
-        scores=scores, value=v, scores_mask=scores_mask, training=training)
-    if q_mask is not None:
-      # Mask of shape [batch_size, Tq, 1].
-      q_mask = tf.expand_dims(q_mask, axis=-1)
-      result *= tf.cast(q_mask, dtype=result.dtype)
-    if return_attention_scores:
-      return result, attention_scores
-    return result
 
 
 @keras_export('keras.layers.AdditiveAttention')

--- a/keras/layers/dense_attention_test.py
+++ b/keras/layers/dense_attention_test.py
@@ -214,7 +214,8 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
     attention_layer = dense_attention.Attention(score_mode='concat')
     attention_layer.concat_score_weight = 1
     attention_layer.build(input_shape=([1, 2, 4], [1, 3, 4]))
-    actual = attention_layer._calculate_scores(query=q, key=k)
+    actual = keras.backend.get_value(
+            attention_layer._calculate_scores(query=q, key=k))
 
     # pylint:disable=line-too-long
     # expected000 = tanh(1.+1.5) + tanh(1.1+1.6) + tanh(1.2+1.7) + tanh(1.3+1.8) = 3.96753427840
@@ -269,7 +270,8 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
     attention_layer.concat_score_weight = 1
     attention_layer.build(input_shape=([1, 1, 1], [1, 1, 1]))
     attention_layer.scale = 2.
-    actual = attention_layer._calculate_scores(query=q, key=k)
+    actual = keras.backend.get_value(
+            attention_layer._calculate_scores(query=q, key=k))
 
     # Expected tensor of shape [1, 1, 1].
     # expected000 = tanh(2*(1.1+1.6)) = 0.9999592018254402

--- a/keras/layers/dense_attention_test.py
+++ b/keras/layers/dense_attention_test.py
@@ -212,9 +212,9 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
         [[[1.5, 1.6, 1.7, 1.8], [2.5, 2.6, 2.7, 2.8], [3.5, 3.6, 3.7, 3.8]]],
         dtype=np.float32)
     attention_layer = dense_attention.Attention(score_mode='concat')
+    attention_layer.concat_score_weight = 1
     attention_layer.build(input_shape=([1, 2, 4], [1, 3, 4]))
     actual = attention_layer._calculate_scores(query=q, key=k)
-    attention_layer.attention_v = 1
 
     # pylint:disable=line-too-long
     # expected000 = tanh(1.+1.5) + tanh(1.1+1.6) + tanh(1.2+1.7) + tanh(1.3+1.8) = 3.96753427840
@@ -266,10 +266,10 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
     # Key tensor of shape [1, 1, 1]
     k = np.array([[[1.6]]], dtype=np.float32)
     attention_layer = dense_attention.Attention(use_scale=True, score_mode='concat')
+    attention_layer.concat_score_weight = 1
     attention_layer.build(input_shape=([1, 1, 1], [1, 1, 1]))
     attention_layer.scale = 2.
     actual = attention_layer._calculate_scores(query=q, key=k)
-    attention_layer.attention_v = 1
 
     # Expected tensor of shape [1, 1, 1].
     # expected000 = tanh(2*(1.1+1.6)) = 0.9999592018254402
@@ -301,7 +301,7 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
     # Value mask tensor of shape [1, 3]
     v_mask = np.array([[True, True, False]], dtype=np.bool_)
     attention_layer = dense_attention.Attention(score_mode='concat')
-    attention_layer.attention_v = 1
+    attention_layer.concat_score_weight = 1
     actual = attention_layer([q, v], mask=[None, v_mask])
 
     expected_shape = [1, 2, 4]
@@ -340,7 +340,7 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
     # Value mask tensor of shape [1, 3]
     v_mask = np.array([[True, True, False]], dtype=np.bool_)
     attention_layer = dense_attention.Attention(score='concat')
-    attention_layer.attention_v = 1
+    attention_layer.concat_score_weight = 1
     actual = attention_layer([q, v, k], mask=[None, v_mask])
 
     expected_shape = [1, 2, 4]

--- a/keras/layers/dense_attention_test.py
+++ b/keras/layers/dense_attention_test.py
@@ -175,7 +175,7 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
     k = np.array([[[1.6]]], dtype=np.float32)
     attention_layer = dense_attention.Attention()
     attention_layer.build(input_shape=([1, 1, 1], [1, 1, 1]))
-    actual = attention_layer._calculate_scores(query=q, key=k, score_type='dot')
+    actual = attention_layer._calculate_scores(query=q, key=k)
 
     # Expected tensor of shape [1, 1, 1].
     # expected000 = 1.1*1.6 = 1.76
@@ -191,7 +191,7 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
         dtype=np.float32)
     attention_layer = dense_attention.Attention()
     attention_layer.build(input_shape=([1, 2, 4], [1, 3, 4]))
-    actual = attention_layer._calculate_scores(query=q, key=k, score_type='dot')
+    actual = attention_layer._calculate_scores(query=q, key=k)
 
     # Expected tensor of shape [1, 2, 3].
     # expected000 = 1.*1.5+1.1*1.6+1.2*1.7+1.3*1.8 = 7.64
@@ -211,7 +211,7 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
     k = np.array(
         [[[1.5, 1.6, 1.7, 1.8], [2.5, 2.6, 2.7, 2.8], [3.5, 3.6, 3.7, 3.8]]],
         dtype=np.float32)
-    attention_layer = dense_attention.Attention(score_type='dot')
+    attention_layer = dense_attention.Attention(score_mode='concat')
     attention_layer.build(input_shape=([1, 2, 4], [1, 3, 4]))
     actual = attention_layer._calculate_scores(query=q, key=k)
     attention_layer.attention_v = 1
@@ -265,7 +265,7 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
     q = np.array([[[1.1]]], dtype=np.float32)
     # Key tensor of shape [1, 1, 1]
     k = np.array([[[1.6]]], dtype=np.float32)
-    attention_layer = dense_attention.Attention(use_scale=True, score_type='concat')
+    attention_layer = dense_attention.Attention(use_scale=True, score_mode='concat')
     attention_layer.build(input_shape=([1, 1, 1], [1, 1, 1]))
     attention_layer.scale = 2.
     actual = attention_layer._calculate_scores(query=q, key=k)
@@ -300,7 +300,7 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
         dtype=np.float32)
     # Value mask tensor of shape [1, 3]
     v_mask = np.array([[True, True, False]], dtype=np.bool_)
-    attention_layer = dense_attention.Attention(score_type='concat')
+    attention_layer = dense_attention.Attention(score_mode='concat')
     attention_layer.attention_v = 1
     actual = attention_layer([q, v], mask=[None, v_mask])
 

--- a/keras/layers/dense_attention_test.py
+++ b/keras/layers/dense_attention_test.py
@@ -341,7 +341,7 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
         dtype=np.float32)
     # Value mask tensor of shape [1, 3]
     v_mask = np.array([[True, True, False]], dtype=np.bool_)
-    attention_layer = dense_attention.Attention(score='concat')
+    attention_layer = dense_attention.Attention(score_mode='concat')
     attention_layer.concat_score_weight = 1
     actual = attention_layer([q, v, k], mask=[None, v_mask])
 

--- a/keras/layers/dense_attention_test.py
+++ b/keras/layers/dense_attention_test.py
@@ -203,6 +203,29 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
     expected = np.array([[[7.64, 12.24, 16.84], [14.24, 22.84, 31.44]]],
                         dtype=np.float32)
     self.assertAllClose(expected, actual)
+ 
+  def test_calculate_scores_multi_dim_concat(self):
+    # Query tensor of shape [1, 2, 4]
+    q = np.array([[[1., 1.1, 1.2, 1.3], [2., 2.1, 2.2, 2.3]]], dtype=np.float32)
+    # Key tensor of shape [1, 3, 4]
+    k = np.array(
+        [[[1.5, 1.6, 1.7, 1.8], [2.5, 2.6, 2.7, 2.8], [3.5, 3.6, 3.7, 3.8]]],
+        dtype=np.float32)
+    attention_layer = dense_attention.Attention()
+    attention_layer.build(input_shape=([1, 2, 4], [1, 3, 4]))
+    actual = attention_layer._calculate_scores(query=q, key=k, score_type='concat')
+
+    # pylint:disable=line-too-long
+    # expected000 = tanh(1.+1.5) + tanh(1.1+1.6) + tanh(1.2+1.7) + tanh(1.3+1.8) = 3.96753427840
+    # expected001 = tanh(1.+2.5) + tanh(1.1+2.6) + tanh(1.2+2.7) + tanh(1.3+2.8) = 3.99558784825
+    # expected002 = tanh(1.+3.5) + tanh(1.1+3.6) + tanh(1.2+3.7) + tanh(1.3+3.8) = 3.99940254147
+    # expected010 = tanh(2.+1.5) + tanh(2.1+1.6) + tanh(2.2+1.7) + tanh(2.3+1.8) = 3.99558784825
+    # expected011 = tanh(2.+2.5) + tanh(2.1+2.6) + tanh(2.2+2.7) + tanh(2.3+2.8) = 3.99940254147
+    # expected012 = tanh(2.+3.5) + tanh(2.1+3.6) + tanh(2.2+3.7) + tanh(2.3+3.8) = 3.99991913657
+    expected = np.array([[[3.96753427840, 3.99558784825, 3.99940254147],
+                          [3.99558784825, 3.99940254147, 3.99991913657]]],
+                        dtype=np.float32)
+    self.assertAllClose(expected, actual)
 
   def test_calculate_scores_one_dim_batch_size_two(self):
     # Query tensor of shape [2, 1, 1]
@@ -234,6 +257,22 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
     # expected000 = -2*1.1*1.6 = -3.52
     expected = np.array([[[-3.52]]], dtype=np.float32)
     self.assertAllClose(expected, actual)
+   
+  def test_calculate_scores_one_dim_with_scale_concat(self):
+    """Tests that scores are multiplied by scale."""
+    # Query tensor of shape [1, 1, 1]
+    q = np.array([[[1.1]]], dtype=np.float32)
+    # Key tensor of shape [1, 1, 1]
+    k = np.array([[[1.6]]], dtype=np.float32)
+    attention_layer = dense_attention.Attention(use_scale=True)
+    attention_layer.build(input_shape=([1, 1, 1], [1, 1, 1]))
+    attention_layer.scale = 2.
+    actual = attention_layer._calculate_scores(query=q, key=k)
+
+    # Expected tensor of shape [1, 1, 1].
+    # expected000 = 2 * tanh(1.1+1.6) = 1.982014907
+    expected = np.array([[[1.98201491]]], dtype=np.float32)
+    self.assertAllClose(expected, actual)
 
   def test_shape(self):
     # Query tensor of shape [1, 2, 4]
@@ -245,6 +284,21 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
     # Value mask tensor of shape [1, 3]
     v_mask = np.array([[True, True, False]], dtype=np.bool_)
     attention_layer = dense_attention.Attention()
+    actual = attention_layer([q, v], mask=[None, v_mask])
+
+    expected_shape = [1, 2, 4]
+    self.assertAllEqual(expected_shape, tf.shape(actual))
+  
+  def test_shape_concat(self):
+    # Query tensor of shape [1, 2, 4]
+    q = np.array([[[1., 1.1, 1.2, 1.3], [2., 2.1, 2.2, 2.3]]], dtype=np.float32)
+    # Value tensor of shape [1, 3, 4]
+    v = np.array(
+        [[[1.5, 1.6, 1.7, 1.8], [2.5, 2.6, 2.7, 2.8], [3.5, 3.6, 3.7, 3.8]]],
+        dtype=np.float32)
+    # Value mask tensor of shape [1, 3]
+    v_mask = np.array([[True, True, False]], dtype=np.bool_)
+    attention_layer = dense_attention.Attention(score='concat')
     actual = attention_layer([q, v], mask=[None, v_mask])
 
     expected_shape = [1, 2, 4]
@@ -264,6 +318,25 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
     # Value mask tensor of shape [1, 3]
     v_mask = np.array([[True, True, False]], dtype=np.bool_)
     attention_layer = dense_attention.Attention()
+    actual = attention_layer([q, v, k], mask=[None, v_mask])
+
+    expected_shape = [1, 2, 4]
+    self.assertAllEqual(expected_shape, tf.shape(actual))
+   
+  def test_shape_with_key_concat(self):
+    # Query tensor of shape [1, 2, 4]
+    q = np.array([[[1., 1.1, 1.2, 1.3], [2., 2.1, 2.2, 2.3]]], dtype=np.float32)
+    # Value tensor of shape [1, 3, 4]
+    v = np.array(
+        [[[1.5, 1.6, 1.7, 1.8], [2.5, 2.6, 2.7, 2.8], [3.5, 3.6, 3.7, 3.8]]],
+        dtype=np.float32)
+    # Key tensor of shape [1, 3, 4]
+    k = np.array(
+        [[[1.5, 1.6, 1.7, 1.8], [2.5, 2.6, 2.7, 2.8], [3.5, 3.6, 3.7, 3.8]]],
+        dtype=np.float32)
+    # Value mask tensor of shape [1, 3]
+    v_mask = np.array([[True, True, False]], dtype=np.bool_)
+    attention_layer = dense_attention.Attention(score='concat')
     actual = attention_layer([q, v, k], mask=[None, v_mask])
 
     expected_shape = [1, 2, 4]


### PR DESCRIPTION
Luong-style attention attention use three types of scoring methods, namely dot, general and concat. This can be found in the 3rd page of the [original paper](https://arxiv.org/pdf/1508.04025.pdf) and explained [here](https://stackoverflow.com/a/44454253). 
Implementation of the Layer can be found in this [notebook](https://colab.research.google.com/drive/1lShkQNWZJJdaGmm205CppFjbLnOx0OD_?usp=sharing)

Auto closes #15866 