### PR TITLE
added clarifying statement to save_model example text

### DIFF
--- a/keras/saving/save.py
+++ b/keras/saving/save.py
@@ -58,7 +58,7 @@ def save_model(model,
   >>> loaded_model = tf.keras.models.load_model('/tmp/model')
   >>> x = tf.random.uniform((10, 3))
   >>> assert np.allclose(model.predict(x), loaded_model.predict(x))
-  
+
   Note that `model.save()` is an alias for `tf.keras.models.save_model()`.
 
   The SavedModel and HDF5 file contains:

--- a/keras/saving/save.py
+++ b/keras/saving/save.py
@@ -58,6 +58,8 @@ def save_model(model,
   >>> loaded_model = tf.keras.models.load_model('/tmp/model')
   >>> x = tf.random.uniform((10, 3))
   >>> assert np.allclose(model.predict(x), loaded_model.predict(x))
+  
+  Note that `model.save()` is an alias for `tf.keras.models.save_model()`.
 
   The SavedModel and HDF5 file contains:
 


### PR DESCRIPTION
Added a note that model.save() is an alias for keras.models.save_model() to clarify that the example above is to demonstrate save_model().