### PR TITLE
Refactor SGD __decayed_lr to allow tf.Variable to be used as decay parameter

### DIFF
--- a/keras/optimizer_v2/optimizer_v2_test.py
+++ b/keras/optimizer_v2/optimizer_v2_test.py
@@ -295,6 +295,8 @@ class OptimizerTest(tf.test.TestCase, parameterized.TestCase):
       for decay_schedule in [
           learning_rate_schedule.InverseTimeDecay(
               0.5, decay_steps=1.0, decay_rate=0.1),
+          learning_rate_schedule.InverseTimeDecay(
+              tf.Variable(0.5), decay_steps=1.0, decay_rate=0.1),
           learning_rate_schedule.PiecewiseConstantDecay(
               [5], [1., .5])
       ]:


### PR DESCRIPTION
This PR refactors the `__decayed_lr` implementation in SGD to use `tf.cond` and `tf.greater` rather than the native Python versions, in order to allow a `tf.Variable` to be used as the decay parameter.