### PR TITLE
Make `classifier_activation` argument accessible for DenseNet and NASNet models

### DIFF
--- a/keras/applications/densenet.py
+++ b/keras/applications/densenet.py
@@ -328,10 +328,11 @@ def DenseNet121(include_top=True,
                 input_tensor=None,
                 input_shape=None,
                 pooling=None,
-                classes=1000):
+                classes=1000,
+                classifier_activation='softmax'):
   """Instantiates the Densenet121 architecture."""
   return DenseNet([6, 12, 24, 16], include_top, weights, input_tensor,
-                  input_shape, pooling, classes)
+                  input_shape, pooling, classes, classifier_activation)
 
 
 @keras_export('keras.applications.densenet.DenseNet169',
@@ -341,10 +342,11 @@ def DenseNet169(include_top=True,
                 input_tensor=None,
                 input_shape=None,
                 pooling=None,
-                classes=1000):
+                classes=1000,
+                classifier_activation='softmax'):
   """Instantiates the Densenet169 architecture."""
   return DenseNet([6, 12, 32, 32], include_top, weights, input_tensor,
-                  input_shape, pooling, classes)
+                  input_shape, pooling, classes, classifier_activation)
 
 
 @keras_export('keras.applications.densenet.DenseNet201',
@@ -354,10 +356,11 @@ def DenseNet201(include_top=True,
                 input_tensor=None,
                 input_shape=None,
                 pooling=None,
-                classes=1000):
+                classes=1000,
+                classifier_activation='softmax'):
   """Instantiates the Densenet201 architecture."""
   return DenseNet([6, 12, 48, 32], include_top, weights, input_tensor,
-                  input_shape, pooling, classes)
+                  input_shape, pooling, classes, classifier_activation)
 
 
 @keras_export('keras.applications.densenet.preprocess_input')
@@ -420,6 +423,11 @@ DOC = """
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.
+    classifier_activation: A `str` or callable. The activation function to use
+      on the "top" layer. Ignored unless `include_top=True`. Set
+      `classifier_activation=None` to return the logits of the "top" layer.
+      When loading pretrained weights, `classifier_activation` can only
+      be `None` or `"softmax"`.
 
   Returns:
     A Keras model instance.

--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -328,7 +328,8 @@ def NASNetMobile(input_shape=None,
                  weights='imagenet',
                  input_tensor=None,
                  pooling=None,
-                 classes=1000):
+                 classes=1000,
+                 classifier_activation='softmax'):
   """Instantiates a Mobile NASNet model in ImageNet mode.
 
   Reference:
@@ -373,6 +374,11 @@ def NASNetMobile(input_shape=None,
       classes: Optional number of classes to classify images
           into, only to be specified if `include_top` is True, and
           if no `weights` argument is specified.
+      classifier_activation: A `str` or callable. The activation function to use
+          on the "top" layer. Ignored unless `include_top=True`. Set
+          `classifier_activation=None` to return the logits of the "top" layer.
+          When loading pretrained weights, `classifier_activation` can only
+          be `None` or `"softmax"`.
 
   Returns:
       A Keras model instance.
@@ -395,7 +401,8 @@ def NASNetMobile(input_shape=None,
       input_tensor=input_tensor,
       pooling=pooling,
       classes=classes,
-      default_size=224)
+      default_size=224,
+      classifier_activation=classifier_activation)
 
 
 @keras_export('keras.applications.nasnet.NASNetLarge',
@@ -405,7 +412,8 @@ def NASNetLarge(input_shape=None,
                 weights='imagenet',
                 input_tensor=None,
                 pooling=None,
-                classes=1000):
+                classes=1000,
+                classifier_activation='softmax'):
   """Instantiates a NASNet model in ImageNet mode.
 
   Reference:
@@ -450,6 +458,11 @@ def NASNetLarge(input_shape=None,
       classes: Optional number of classes to classify images
           into, only to be specified if `include_top` is True, and
           if no `weights` argument is specified.
+      classifier_activation: A `str` or callable. The activation function to use
+          on the "top" layer. Ignored unless `include_top=True`. Set
+          `classifier_activation=None` to return the logits of the "top" layer.
+          When loading pretrained weights, `classifier_activation` can only
+          be `None` or `"softmax"`.
 
   Returns:
       A Keras model instance.
@@ -472,7 +485,8 @@ def NASNetLarge(input_shape=None,
       input_tensor=input_tensor,
       pooling=pooling,
       classes=classes,
-      default_size=331)
+      default_size=331,
+      classifier_activation=classifier_activation)
 
 
 def _separable_conv_block(ip,


### PR DESCRIPTION
Related to #14297.

The parent classes `DenseNet` and `NASNet` implement the argument, 
however it previously wasn't accessible in `DenseNet121`, `DenseNet169`, `DenseNet201`, `NASNetMobile` and `NASNetLarge`.