### PR TITLE
Updating the definition of an argument in the text_dataset_from_directory function

### DIFF
--- a/keras/preprocessing/image_dataset.py
+++ b/keras/preprocessing/image_dataset.py
@@ -108,7 +108,8 @@ def image_dataset_from_directory(directory,
     seed: Optional random seed for shuffling and transformations.
     validation_split: Optional float between 0 and 1,
         fraction of data to reserve for validation.
-    subset: One of "training" or "validation".
+    subset: Subset of the data to return.
+        One of "training" or "validation".
         Only used if `validation_split` is set.
     interpolation: String, the interpolation method used when resizing images.
       Defaults to `bilinear`. Supports `bilinear`, `nearest`, `bicubic`,

--- a/keras/preprocessing/text_dataset.py
+++ b/keras/preprocessing/text_dataset.py
@@ -92,7 +92,8 @@ def text_dataset_from_directory(directory,
     seed: Optional random seed for shuffling and transformations.
     validation_split: Optional float between 0 and 1,
         fraction of data to reserve for validation.
-    subset: One of "training" or "validation".
+    subset: Subset of the data to return.
+        One of "training" or "validation".
         Only used if `validation_split` is set.
     follow_links: Whether to visits subdirectories pointed to by symlinks.
         Defaults to False.


### PR DESCRIPTION
This PR has been raised to add more clarity to the definition of the `subset` argument of the `tf.keras.utils.text_dataset_from_directory` function. At present, there is not much information on how this argument fits in. Hoping to remedy that. 