### PR TITLE
Allow predict() to potentially return RaggedTensor

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3258,14 +3258,14 @@ def concat(tensors, axis=0):
   return tf.concat(tensors, axis=axis)
 
 
-def potentially_variable_concat(tensors, axis=0):
+def potentially_variable_concat(tensors):
   """Concats `tensor`s along `axis`. When non-batch dimensions are variable, a RaggedTensor is returned instead."""
   if isinstance(tensors[0], tf.SparseTensor):
-    return tf.sparse.concat(axis=axis, sp_inputs=tensors)
+    return tf.sparse.concat(axis=0, sp_inputs=tensors)
   non_batch_shapes = tf.stack([tf.shape(tensor)[1:] for tensor in tensors])
   constant_dims = tf.math.reduce_all(non_batch_shapes == non_batch_shapes[:1], axis=0)
   if tf.math.reduce_all(constant_dims).numpy().item():  # All non-batch dimensions are constant
-    return tf.concat(tensors, axis=axis)
+    return tf.concat(tensors, axis=0)
   # First, identify constant inner dimensions by finding the rightmost dimension that is not constant
   constant_inner_dimensions = constant_dims.numpy().tolist()[::-1].index(False)
   # If there are constant inner dimensions, define a constant inner shape

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3258,8 +3258,15 @@ def concat(tensors, axis=0):
   return tf.concat(tensors, axis=axis)
 
 
-def potentially_variable_concat(tensors):
-  """Concats `tensor`s along `axis`. When non-batch dimensions are variable, a RaggedTensor is returned instead."""
+def potentially_ragged_concat(tensors):
+  """Concats `Tensor`s along their first dimension.
+
+  Args:
+    tensors: `list` of `Tensor`s
+
+  Returns:
+    `Tensor` if input shapes are compatible or `RaggedTensor` if not.
+    """
   if isinstance(tensors[0], tf.SparseTensor):
     return tf.sparse.concat(axis=0, sp_inputs=tensors)
   non_batch_shapes = tf.stack([tf.shape(tensor)[1:] for tensor in tensors])

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3269,6 +3269,8 @@ def potentially_ragged_concat(tensors):
     """
   if isinstance(tensors[0], tf.SparseTensor):
     return tf.sparse.concat(axis=0, sp_inputs=tensors)
+  elif isinstance(tensors[0], tf.RaggedTensor):
+    return tf.concat(tensors, axis=0)
   non_batch_shapes = tf.stack([tf.shape(tensor)[1:] for tensor in tensors])
   constant_dims = tf.math.reduce_all(non_batch_shapes == non_batch_shapes[:1], axis=0)
   if tf.math.reduce_all(constant_dims).numpy().item():  # All non-batch dimensions are constant

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3272,17 +3272,21 @@ def potentially_ragged_concat(tensors):
   elif isinstance(tensors[0], tf.RaggedTensor):
     return tf.concat(tensors, axis=0)
   non_batch_shapes = tf.stack([tf.shape(tensor)[1:] for tensor in tensors])
-  constant_dims = tf.math.reduce_all(non_batch_shapes == non_batch_shapes[:1], axis=0)
-  if tf.math.reduce_all(constant_dims).numpy().item():  # All non-batch dimensions are constant
+  constant_dims = tf.math.reduce_all(non_batch_shapes == non_batch_shapes[:1],
+                                     axis=0)
+  if tf.math.reduce_all(
+          constant_dims).numpy().item():  # All non-batch dims are constant
     return tf.concat(tensors, axis=0)
-  # First, identify constant inner dimensions by finding the rightmost dimension that is not constant
+  # First, identify constant inner dimensions by finding the
+  # rightmost dimension that is not constant
   constant_inner_dimensions = constant_dims.numpy().tolist()[::-1].index(False)
   # If there are constant inner dimensions, define a constant inner shape
   if constant_inner_dimensions == 0:
     constant_inner_shape = None
   else:
     constant_inner_shape = tensors[0].shape[-constant_inner_dimensions:]
-  return tf.ragged.constant([tensor.numpy() for tensor in tensors], inner_shape=constant_inner_shape).merge_dims(0, 1)
+  return tf.ragged.constant([tensor.numpy() for tensor in tensors],
+                            inner_shape=constant_inner_shape).merge_dims(0, 1)
 
 
 def _get_verbosity(verbose, distribute_strategy):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2011,7 +2011,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
                          'information of where went wrong, or file a '
                          'issue/bug to `tf.keras`.')
       callbacks.on_predict_end()
-    all_outputs = tf.__internal__.nest.map_structure_up_to(batch_outputs, potentially_variable_concat, outputs)
+    all_outputs = tf.__internal__.nest.map_structure_up_to(batch_outputs, potentially_ragged_concat, outputs)
 
     # If originally PSS strategy was used, then replace it back since predict
     # is running under `OneDeviceStrategy` after the swap and once its done

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2011,7 +2011,9 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
                          'information of where went wrong, or file a '
                          'issue/bug to `tf.keras`.')
       callbacks.on_predict_end()
-    all_outputs = tf.__internal__.nest.map_structure_up_to(batch_outputs, potentially_ragged_concat, outputs)
+    all_outputs = tf.__internal__.nest.map_structure_up_to(
+      batch_outputs, potentially_ragged_concat, outputs
+    )
 
     # If originally PSS strategy was used, then replace it back since predict
     # is running under `OneDeviceStrategy` after the swap and once its done

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3268,6 +3268,7 @@ def potentially_variable_concat(tensors, axis=0):
     return tf.concat(tensors, axis=axis)
   # First, identify constant inner dimensions by finding the rightmost dimension that is not constant
   constant_inner_dimensions = constant_dims.numpy().tolist()[::-1].index(False)
+  # If there are constant inner dimensions, define a constant inner shape
   if constant_inner_dimensions == 0:
     constant_inner_shape = None
   else:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3273,6 +3273,8 @@ def potentially_ragged_concat(tensors):
     return tf.sparse.concat(axis=0, sp_inputs=tensors)
   elif isinstance(tensors[0], tf.RaggedTensor):
     return tf.concat(tensors, axis=0)
+  elif len(tensors) == 1 or len(tensors[0].shape) < 2:
+    return tf.concat(tensors, axis=0)
   non_batch_shapes = tf.stack([tf.shape(tensor)[1:] for tensor in tensors])
   constant_dims = tf.math.reduce_all(non_batch_shapes == non_batch_shapes[:1],
                                      axis=0)

--- a/keras/tests/integration_test.py
+++ b/keras/tests/integration_test.py
@@ -317,22 +317,27 @@ class ActivationV2IntegrationTest(test_combinations.TestCase):
     loaded_model = keras.models.load_model(output_path)
     self.assertEqual(model.summary(), loaded_model.summary())
 
-@test_combinations.run_with_all_model_types
+@test_combinations.run_with_all_model_types(always_skip_v1=True)
 @test_combinations.run_all_keras_modes
 class TokenClassificationIntegrationTest(test_combinations.TestCase):
   """Tests a very simple token classification model.
 
-  The main purpose of this test is to verify that everything works as expected when
-  input sequences have variable length, and batches are padded only to the maximum length
-  of each batch. This is very common in NLP, and results in the sequence dimension varying
-  with each batch step for both the features and the labels.
+  The main purpose of this test is to verify that everything works as expected
+  when input sequences have variable length, and batches are padded only to the
+  maximum length of each batch. This is very common in NLP, and results in the
+  sequence dimension varying with each batch step for both the features
+  and the labels.
   """
   def test_token_classification(self):
-    np.random.seed(1337)
     def densify(x, y):
         return x.to_tensor(), y.to_tensor()
-    data = tf.ragged.stack([np.random.randint(low=0, high=16, size=random.randint(4, 16)) for _ in range(100)])
-    labels = tf.ragged.stack([np.random.randint(low=0, high=3, size=len(arr)) for arr in data])
+    np.random.seed(1337)
+    keras.utils.set_random_seed(1337)
+    data = tf.ragged.stack(
+        [np.random.randint(low=0, high=16, size=random.randint(4, 16)) for _ in
+         range(100)])
+    labels = tf.ragged.stack(
+        [np.random.randint(low=0, high=3, size=len(arr)) for arr in data])
     features_dataset = tf.data.Dataset.from_tensor_slices(data)
     labels_dataset = tf.data.Dataset.from_tensor_slices(labels)
     dataset = tf.data.Dataset.zip((features_dataset, labels_dataset))
@@ -350,7 +355,7 @@ class TokenClassificationIntegrationTest(test_combinations.TestCase):
         layers, input_shape=(None,))
     model.compile(
         loss='sparse_categorical_crossentropy',
-        optimizer=keras.optimizers.optimizer_v2.adam.Adam(0.005),
+        optimizer='adam'
         metrics=['acc'],
         run_eagerly=test_utils.should_run_eagerly())
     history = model.fit(dataset, epochs=10,

--- a/keras/tests/integration_test.py
+++ b/keras/tests/integration_test.py
@@ -26,7 +26,7 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 from keras.layers.legacy_rnn import rnn_cell_impl as rnn_cell
 from keras.legacy_tf_layers import base as base_layer
-from keras.utils import np_utils
+from keras.utils import np_utils, tf_utils
 
 
 class KerasIntegrationTest(test_combinations.TestCase):
@@ -317,8 +317,8 @@ class ActivationV2IntegrationTest(test_combinations.TestCase):
     loaded_model = keras.models.load_model(output_path)
     self.assertEqual(model.summary(), loaded_model.summary())
 
-@test_combinations.run_with_all_model_types(always_skip_v1=True)
-@test_combinations.run_all_keras_modes
+@test_combinations.run_with_all_model_types
+@test_combinations.run_all_keras_modes(always_skip_v1=True)
 class TokenClassificationIntegrationTest(test_combinations.TestCase):
   """Tests a very simple token classification model.
 
@@ -331,8 +331,7 @@ class TokenClassificationIntegrationTest(test_combinations.TestCase):
   def test_token_classification(self):
     def densify(x, y):
         return x.to_tensor(), y.to_tensor()
-    np.random.seed(1337)
-    keras.utils.set_random_seed(1337)
+    tf_utils.set_random_seed(1337)
     data = tf.ragged.stack(
         [np.random.randint(low=0, high=16, size=random.randint(4, 16)) for _ in
          range(100)])
@@ -355,7 +354,7 @@ class TokenClassificationIntegrationTest(test_combinations.TestCase):
         layers, input_shape=(None,))
     model.compile(
         loss='sparse_categorical_crossentropy',
-        optimizer='adam'
+        optimizer='adam',
         metrics=['acc'],
         run_eagerly=test_utils.should_run_eagerly())
     history = model.fit(dataset, epochs=10,

--- a/keras/tests/integration_test.py
+++ b/keras/tests/integration_test.py
@@ -344,7 +344,7 @@ class TokenClassificationIntegrationTest(test_combinations.TestCase):
         keras.layers.Conv1D(4, 5, padding='same', activation='relu'),
         keras.layers.Conv1D(8, 5, padding='same'),
         keras.layers.BatchNormalization(),
-        keras.layers.Conv2D(3, 5, padding='same', activation='softmax'),
+        keras.layers.Conv1D(3, 5, padding='same', activation='softmax'),
     ]
     model = test_utils.get_model_from_layers(
         layers, input_shape=(None,))

--- a/keras/tests/integration_test.py
+++ b/keras/tests/integration_test.py
@@ -349,14 +349,14 @@ class TokenClassificationIntegrationTest(test_combinations.TestCase):
     model = test_utils.get_model_from_layers(
         layers, input_shape=(None,))
     model.compile(
-        loss='categorical_crossentropy',
+        loss='sparse_categorical_crossentropy',
         optimizer=keras.optimizers.optimizer_v2.adam.Adam(0.005),
         metrics=['acc'],
         run_eagerly=test_utils.should_run_eagerly())
     history = model.fit(dataset, epochs=10,
                         validation_data=dataset,
                         verbose=2)
-    self.assertGreater(history.history['val_acc'][-1], 0.7)
+    self.assertGreater(history.history['val_acc'][-1], 0.5)
     _, val_acc = model.evaluate(dataset)
     self.assertAlmostEqual(history.history['val_acc'][-1], val_acc)
     predictions = model.predict(dataset)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # The rest of the packages are mostly used for testing purpose.
 pandas
 pydot
-scipy ~= 1.5.2
+scipy == 1.5.2
 tf-nightly
 portpicker
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # The rest of the packages are mostly used for testing purpose.
 pandas
 pydot
-scipy == 1.5.2
+scipy ~= 1.5.2
 tf-nightly
 portpicker
 pyyaml


### PR DESCRIPTION
Currently, predict() throws an error if the batches it's concatenating have variable sizes. This is a headache in NLP in particular, because batches with variable sequence length dimensions are very common. This change maintains the current behaviour when batches can be concatenated into a dense Tensor, but when they can't it attempts to return a RaggedTensor instead, while inferring as many constant inner dimensions as it can.

I discussed this with @fchollet already and he approved in principle, but please let me know if there are any issues with my implementation - I know `tf.ragged.constant` in particular can have a very long runtime if you're not careful with the inputs, but I believe it's efficient when the inputs are Numpy arrays.