### PR TITLE
Docker env setup related changes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,3 +25,5 @@ RUN apt update && apt install bazel -y
 
 USER $USERNAME
 ENV PATH="/home/$USERNAME/.local/bin:${PATH}"
+
+CMD ["/bin/bash"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ In the container shell, you need to install the latest dependencies with the
 following command.
 
 ```shell
-pip install -r /home/keras/requirements.txt
+pip install -r /home/keras/requirements.txt && pip uninstall keras-nightly -y
 ```
 
 Now, the environment setup is complete. You are ready to run the tests.


### PR DESCRIPTION
For those of us opting for the docker way of setting up the development environment but not using the `devcontainer.json` file, it would be useful to have this patch in place that includes the following changes: 

1) Changes to the `Dockerfile` -- As this file doesn't have a `CMD` instruction defined, the image tends to inherit the instruction of the parent python image and hence takes us to the python interpreter after the launch of the container. It would be convenient to have the `CMD` instruction defined here itself to facilitate installing the packages and proceed from thereon rather than having to append it to the run command every time.

2) Changes to `CONTRIBUTING.md` -- Added uninstalling the keras-nightly package.