### PR TITLE
fix save_utils.py build compiled metrics bug

### DIFF
--- a/keras/saving/saving_utils.py
+++ b/keras/saving/saving_utils.py
@@ -323,7 +323,7 @@ def try_build_compiled_arguments(model):
       if not model.compiled_loss.built:
         model.compiled_loss.build(model.outputs)
       if not model.compiled_metrics.built:
-        model.compiled_metrics.build(model.outputs, model.outputs)
+        model.compiled_metrics.build(model.outputs, model.target)
     except:  # pylint: disable=bare-except
       logging.warning(
           'Compiled the loaded model, but the compiled metrics have yet to '


### PR DESCRIPTION
##  This PR is to fix bug in the keras saving logic (which seems to be typo). issue #16023 

## Before this PR:
 `model.save` before calling fit will mess up model's internal state and cause the model untrainable. For example, the following simple mnist training code will not converge using current keras.

```python
import tensorflow as tf
mnist = tf.keras.datasets.mnist

(x_train, y_train),(x_test, y_test) = mnist.load_data()
x_train, x_test = x_train / 255.0, x_test / 255.0

model = tf.keras.models.Sequential([
  tf.keras.layers.Flatten(input_shape=(28, 28)),
  tf.keras.layers.Dense(128, activation='relu'),
  tf.keras.layers.Dropout(0.2),
  tf.keras.layers.Dense(10, activation='softmax')
])

model.compile(optimizer='adam',
              loss='sparse_categorical_crossentropy',
              metrics=['accuracy'])
model.save("/tmp/mnist_model") # Save model

model.fit(x_train, y_train, epochs=5)
```

Output:

![image](https://user-images.githubusercontent.com/10561966/154007321-9eb0079a-e74b-4866-bc1b-849a16c5e8cc.png)

## After this PR:

The above code will converge correctly.

![image](https://user-images.githubusercontent.com/10561966/154007827-d49ef70f-c9ab-47ee-a909-65551b129811.png)



