### PR TITLE
Issue #16090: Split input_shapes horizontally in utils.vis_utils.plot_model

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -290,8 +290,7 @@ def model_to_dot(model,
             [format_shape(ishape) for ishape in layer.input_shapes])
       else:
         inputlabels = '?'
-      label = '{%s}|{input:|output:}|{{%s}|{%s}}' % (label, inputlabels,
-                                                       outputlabels)
+      label = '{%s}|{input:|output:}|{{%s}|{%s}}' % (label, inputlabels, outputlabels)
     if not expand_nested or not isinstance(
         layer, functional.Functional):
       node = pydot.Node(layer_id, label=label)

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -290,7 +290,8 @@ def model_to_dot(model,
             [format_shape(ishape) for ishape in layer.input_shapes])
       else:
         inputlabels = '?'
-      label = '{%s}|{input:|output:}|{{%s}|{%s}}' % (label, inputlabels, outputlabels)
+      label = '{%s}|{input:|output:}|{{%s}|{%s}}' % (
+          label, inputlabels, outputlabels)
     if not expand_nested or not isinstance(
         layer, functional.Functional):
       node = pydot.Node(layer_id, label=label)

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -290,7 +290,7 @@ def model_to_dot(model,
             [format_shape(ishape) for ishape in layer.input_shapes])
       else:
         inputlabels = '?'
-      label = '{%s}|{input:|output:}|{{%s}}|{{%s}}' % (label, inputlabels,
+      label = '{%s}|{input:|output:}|{{%s}|{%s}}' % (label, inputlabels,
                                                        outputlabels)
     if not expand_nested or not isinstance(
         layer, functional.Functional):


### PR DESCRIPTION
From Issue #16090 

Split input_shapes horizontally and not vertically in keras.utils.vis_utils.plot_model when show_shapes=True

Currently, the plot_model function with show_shapes=True returns a table like this:
![image](https://user-images.githubusercontent.com/11573780/154796435-66f2ff99-fcbd-4585-b499-c5c060f23021.png)

With my contribution, the table will show the last cell, the one with input shapes, splitted horizontally so that the input shape is on  top of the output shape, making it fit with the previus cell (input:/output:)

Here's an example of the execution with the fix:

![image](https://user-images.githubusercontent.com/11573780/154796417-136a3ecf-8350-4009-a2cd-8f6765154ccd.png)
