### PR TITLE
Fixed EfficientNetV2 b parameter not increasing with each block.

### DIFF
--- a/keras/applications/efficientnet_v2.py
+++ b/keras/applications/efficientnet_v2.py
@@ -991,6 +991,7 @@ def EfficientNetV2(
           name="block{}{}_".format(i + 1, chr(j + 97)),
           **args,
       )(x)
+      b += 1
 
   # Build top
   top_filters = round_filters(


### PR DESCRIPTION
Closes #16144 

It was found that the `survival_probability` of Efficientnet V2 networks was always 0.0, where it should be slowly increasing with each block size. The reason was I forgot to increase `b` parameter in those networks.

Thanks @SergioG-M for the find.