### PR TITLE
Updated args of train_on_batch method

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2064,8 +2064,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
           - A dict mapping input names to the corresponding array/tensors,
               if the model has named inputs.
         y: Target data. Like the input data `x`, it could be either Numpy
-          array(s) or TensorFlow tensor(s). It should be consistent with `x`
-          (you cannot have Numpy inputs and tensor targets, or inversely).
+          array(s) or TensorFlow tensor(s). It is preferred to be consistent
+           with `x`.
         sample_weight: Optional array of the same length as x, containing
           weights to apply to the model's loss for each sample. In the case of
           temporal data, you can pass a 2D array with shape (samples,

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2064,8 +2064,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
           - A dict mapping input names to the corresponding array/tensors,
               if the model has named inputs.
         y: Target data. Like the input data `x`, it could be either Numpy
-          array(s) or TensorFlow tensor(s). It is preferred to be consistent
-           with `x`.
+          array(s) or TensorFlow tensor(s).
         sample_weight: Optional array of the same length as x, containing
           weights to apply to the model's loss for each sample. In the case of
           temporal data, you can pass a 2D array with shape (samples,


### PR DESCRIPTION
As mentioned in Keras webpage https://keras.io/api/models/model_training_apis/, keras shouldn't allow different data types for input (x) and target (y). But, currently it takes different types for input and target. For example, input can be a numpy array and target can be a tensor.

Fixes https://github.com/keras-team/keras/issues/16146