### PR TITLE
Fix typo in Returns Section

### DIFF
--- a/keras/layers/preprocessing/text_vectorization.py
+++ b/keras/layers/preprocessing/text_vectorization.py
@@ -451,7 +451,7 @@ class TextVectorization(base_preprocessing_layer.PreprocessingLayer):
     """Gets the current size of the layer's vocabulary.
 
     Returns:
-      The integer size of the voculary, including optional mask and oov indices.
+      The integer size of the vocabulary, including optional mask and oov indices.
     """
     return self._lookup_layer.vocabulary_size()
 


### PR DESCRIPTION
Updated `voculary` with `vocabulary`