### PR TITLE
Add type check to axis

### DIFF
--- a/keras/losses.py
+++ b/keras/losses.py
@@ -29,6 +29,7 @@ from tensorflow.python.ops.ragged import ragged_util
 from tensorflow.python.util import dispatch
 from tensorflow.python.util.tf_export import keras_export
 from tensorflow.tools.docs import doc_controls
+from tensorflow.python.ops import check_ops
 
 
 @keras_export('keras.losses.Loss')
@@ -1773,6 +1774,8 @@ def categorical_crossentropy(y_true,
   Returns:
     Categorical crossentropy loss value.
   """
+  #axis assert
+  check_ops.assert_integer_v2(axis, message=('`axis` must be of type `int`.'))
   y_pred = tf.convert_to_tensor(y_pred)
   y_true = tf.cast(y_true, y_pred.dtype)
   label_smoothing = tf.convert_to_tensor(label_smoothing, dtype=y_pred.dtype)

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1775,7 +1775,7 @@ def categorical_crossentropy(y_true,
   """
   if isinstance(axis, bool):
     raise ValueError(
-      '`axis` must be of type `int`.')
+      f'`axis` must be of type `int`. Received: axis={axis} of type {type(axis)}')
   y_pred = tf.convert_to_tensor(y_pred)
   y_true = tf.cast(y_true, y_pred.dtype)
   label_smoothing = tf.convert_to_tensor(label_smoothing, dtype=y_pred.dtype)

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1775,7 +1775,7 @@ def categorical_crossentropy(y_true,
     Categorical crossentropy loss value.
   """
   #axis assert
-  check_ops.assert_integer_v2(axis, message=('`axis` must be of type `int`.'))
+  check_ops.assert_integer_v2(int(axis), message=('`axis` must be of type `int`.'))
   y_pred = tf.convert_to_tensor(y_pred)
   y_true = tf.cast(y_true, y_pred.dtype)
   label_smoothing = tf.convert_to_tensor(label_smoothing, dtype=y_pred.dtype)

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -29,7 +29,6 @@ from tensorflow.python.ops.ragged import ragged_util
 from tensorflow.python.util import dispatch
 from tensorflow.python.util.tf_export import keras_export
 from tensorflow.tools.docs import doc_controls
-from tensorflow.python.ops import check_ops
 
 
 @keras_export('keras.losses.Loss')
@@ -1774,8 +1773,7 @@ def categorical_crossentropy(y_true,
   Returns:
     Categorical crossentropy loss value.
   """
-  #axis assert
-  check_ops.assert_integer_v2(int(axis), message=('`axis` must be of type `int`.'))
+  axis = int(axis)
   y_pred = tf.convert_to_tensor(y_pred)
   y_true = tf.cast(y_true, y_pred.dtype)
   label_smoothing = tf.convert_to_tensor(label_smoothing, dtype=y_pred.dtype)

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1773,7 +1773,9 @@ def categorical_crossentropy(y_true,
   Returns:
     Categorical crossentropy loss value.
   """
-  axis = int(axis)
+  if isinstance(axis, bool):
+    raise ValueError(
+      '`axis` must be of type `int`.')
   y_pred = tf.convert_to_tensor(y_pred)
   y_true = tf.cast(y_true, y_pred.dtype)
   label_smoothing = tf.convert_to_tensor(label_smoothing, dtype=y_pred.dtype)


### PR DESCRIPTION
Added type check to axis argument to allow only integers in categorical_crossentropy.
Closes: #16192 