### PR TITLE
Allow single input for merging layers Add, Average, Concatenate, Maximum, Minimum, Multiply

### DIFF
--- a/keras/layers/merging/add.py
+++ b/keras/layers/merging/add.py
@@ -62,7 +62,7 @@ def add(inputs, **kwargs):
   """Functional interface to the `tf.keras.layers.Add` layer.
 
   Args:
-      inputs: A list of input tensors (at least 2) with the same shape.
+      inputs: A list of input tensors with the same shape.
       **kwargs: Standard layer keyword arguments.
 
   Returns:

--- a/keras/layers/merging/average.py
+++ b/keras/layers/merging/average.py
@@ -80,7 +80,7 @@ def average(inputs, **kwargs):
   >>> model = tf.keras.models.Model(inputs=[input1, input2], outputs=out)
 
   Args:
-      inputs: A list of input tensors (at least 2).
+      inputs: A list of input tensors.
       **kwargs: Standard layer keyword arguments.
 
   Returns:

--- a/keras/layers/merging/base_merge.py
+++ b/keras/layers/merging/base_merge.py
@@ -83,9 +83,9 @@ class _Merge(Layer):
       raise ValueError(
           'A merge layer should be called on a list of inputs. '
           f'Received: input_shape={input_shape} (not a list of shapes)')
-    if len(input_shape) < 2:
+    if len(input_shape) < 1:
       raise ValueError('A merge layer should be called '
-                       'on a list of at least 2 inputs. '
+                       'on a list of at least 1 input. '
                        f'Got {len(input_shape)} inputs. '
                        f'Full input_shape received: {input_shape}')
     batch_sizes = {s[0] for s in input_shape if s} - {None}

--- a/keras/layers/merging/concatenate.py
+++ b/keras/layers/merging/concatenate.py
@@ -207,7 +207,7 @@ def concatenate(inputs, axis=-1, **kwargs):
         [25, 26, 27, 28, 29]]])>
 
   Args:
-      inputs: A list of input tensors (at least 2).
+      inputs: A list of input tensors.
       axis: Concatenation axis.
       **kwargs: Standard layer keyword arguments.
 

--- a/keras/layers/merging/maximum.py
+++ b/keras/layers/merging/maximum.py
@@ -70,7 +70,7 @@ def maximum(inputs, **kwargs):
   ```
 
   Args:
-      inputs: A list of input tensors (at least 2) of same shape.
+      inputs: A list of input tensors of same shape.
       **kwargs: Standard layer keyword arguments.
 
   Returns:

--- a/keras/layers/merging/merging_test.py
+++ b/keras/layers/merging/merging_test.py
@@ -298,7 +298,7 @@ class MergingLayersTest(test_combinations.TestCase):
     self.assertAllClose(out, x1)
 
     # A single element must be passed as a list, not by itself.
-    with self.assertRaises(ValueError):
+    with self.assertRaisesRegex(ValueError, 'called on a list'):
       layer(i1)
 
 

--- a/keras/layers/merging/merging_test.py
+++ b/keras/layers/merging/merging_test.py
@@ -19,6 +19,7 @@ import keras
 from keras import backend
 from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
+from keras.utils import tf_inspect
 import numpy as np
 import tensorflow.compat.v2 as tf
 
@@ -271,6 +272,35 @@ class MergingLayersTest(test_combinations.TestCase):
     out = layer()([x1, x2])
     self.assertEqual(out.shape, ())
 
+  @parameterized.named_parameters(
+      *test_utils.generate_combinations_with_testcase_name(
+          layer=[keras.layers.Add, keras.layers.add,
+                 keras.layers.Average, keras.layers.average,
+                 keras.layers.Concatenate, keras.layers.concatenate,
+                 keras.layers.Maximum, keras.layers.maximum,
+                 keras.layers.Minimum, keras.layers.minimum,
+                 keras.layers.Multiply, keras.layers.multiply]))
+  def test_single_element(self, layer):
+    # Instantiate the Layer subclasses
+    if tf_inspect.isclass(layer) and issubclass(layer, keras.layers.Layer):
+      layer = layer()
+
+    # Processing a single element list should behave as identity.
+    i1 = keras.layers.Input(shape=(4, 5))
+    o = layer([i1])
+    self.assertListEqual(o.shape.as_list(), [None, 4, 5])
+    model = keras.models.Model(i1, o)
+    model.run_eagerly = test_utils.should_run_eagerly()
+
+    x1 = np.random.random((2, 4, 5))
+    out = model.predict(x1)
+    self.assertEqual(out.shape, (2, 4, 5))
+    self.assertAllClose(out, x1)
+
+    # A single element must be passed as a list, not by itself.
+    with self.assertRaises(ValueError):
+      layer(i1)
+
 
 @test_combinations.generate(test_combinations.combine(mode=['graph', 'eager']))
 class MergingLayersTestNoExecution(tf.test.TestCase):
@@ -281,11 +311,7 @@ class MergingLayersTestNoExecution(tf.test.TestCase):
     with self.assertRaises(ValueError):
       keras.layers.add([i1, i2])
     with self.assertRaises(ValueError):
-      keras.layers.add([i1])
-    with self.assertRaises(ValueError):
       keras.layers.add(i1)
-    with self.assertRaises(ValueError):
-      keras.layers.add([i1])
 
   def test_concatenate_errors(self):
     i1 = keras.layers.Input(shape=(4, 5))

--- a/keras/layers/merging/minimum.py
+++ b/keras/layers/merging/minimum.py
@@ -56,7 +56,7 @@ def minimum(inputs, **kwargs):
   """Functional interface to the `Minimum` layer.
 
   Args:
-      inputs: A list of input tensors (at least 2).
+      inputs: A list of input tensors.
       **kwargs: Standard layer keyword arguments.
 
   Returns:

--- a/keras/layers/merging/multiply.py
+++ b/keras/layers/merging/multiply.py
@@ -72,7 +72,7 @@ def multiply(inputs, **kwargs):
   >>> model = tf.keras.models.Model(inputs=[input1, input2], outputs=out)
 
   Args:
-      inputs: A list of input tensors (at least 2).
+      inputs: A list of input tensors.
       **kwargs: Standard layer keyword arguments.
 
   Returns:


### PR DESCRIPTION
The merging layers (notably `Add`, `Average`, `Concatenate`, `Maximum`, `Minimum`, `Multiply`) require at least two inputs.

This is already documented in the lowercase versions of the layers (like `add`), but is missing for `Layer` instances (like `Add`).

This PR adds this information also to the documentation of the `Layer` instances.

Also, is there any reason why the single input is not supported? For all the six mentioned layers, a single input would work fine -- both mathematically and in the current implementation,the only required change would be to remove the error in the
https://github.com/keras-team/keras/blob/980a6be629610ee58c1eae5a65a4724ce650597b/keras/layers/merging/base_merge.py#L86-L90.