### PR TITLE
Implement all tf interpolation upscaling methods

### DIFF
--- a/keras/backend.py
+++ b/keras/backend.py
@@ -3389,7 +3389,7 @@ def resize_images(x, height_factor, width_factor, data_format,
       height_factor: Positive integer.
       width_factor: Positive integer.
       data_format: One of `"channels_first"`, `"channels_last"`.
-      interpolation: A string, one of `nearest` or `bilinear`.
+      interpolation: A string any of `tf.image.ResizeMethod`.
 
   Returns:
       A tensor.
@@ -3415,15 +3415,21 @@ def resize_images(x, height_factor, width_factor, data_format,
 
   if data_format == 'channels_first':
     x = permute_dimensions(x, [0, 2, 3, 1])
-  if interpolation == 'nearest':
-    x = tf.image.resize(
-        x, new_shape, method=tf.image.ResizeMethod.NEAREST_NEIGHBOR)
-  elif interpolation == 'bilinear':
-    x = tf.image.resize(x, new_shape,
-                                   method=tf.image.ResizeMethod.BILINEAR)
+  interpolations = {
+    'area': tf.image.ResizeMethod.AREA,
+    'bicubic': tf.image.ResizeMethod.BICUBIC,
+    'bilinear': tf.image.ResizeMethod.BILINEAR,
+    'gaussian': tf.image.ResizeMethod.GAUSSIAN,
+    'lanczos3': tf.image.ResizeMethod.LANCZOS3,
+    'lanczos5': tf.image.ResizeMethod.LANCZOS5,
+    'mitchellcubic': tf.image.ResizeMethod.MITCHELLCUBIC,
+    'nearest': tf.image.ResizeMethod.NEAREST_NEIGHBOR,
+  }
+  if interpolation in interpolations:
+    x = tf.image.resize(x, new_shape, method=interpolations[interpolation])
   else:
-    raise ValueError('interpolation should be one '
-                     'of "nearest" or "bilinear".')
+    raise ValueError('interpolation should be '
+                     'from `tf.image.ResizeMethod`.')
   if data_format == 'channels_first':
     x = permute_dimensions(x, [0, 3, 1, 2])
 

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -3389,8 +3389,9 @@ def resize_images(x, height_factor, width_factor, data_format,
       height_factor: Positive integer.
       width_factor: Positive integer.
       data_format: One of `"channels_first"`, `"channels_last"`.
-      interpolation: A string, one of `area`, `bicubic`, `bilinear`,
-        `gaussian`, `lanczos3`, `lanczos5`, `mitchellcubic`, `nearest`.
+      interpolation: A string, one of `"area"`, `"bicubic"`, `"bilinear"`,
+        `"gaussian"`, `"lanczos3"`, `"lanczos5"`, `"mitchellcubic"`,
+        `"nearest"`.
 
   Returns:
       A tensor.
@@ -3426,7 +3427,7 @@ def resize_images(x, height_factor, width_factor, data_format,
     'mitchellcubic': tf.image.ResizeMethod.MITCHELLCUBIC,
     'nearest': tf.image.ResizeMethod.NEAREST_NEIGHBOR,
   }
-  interploations_list = '`' + '`, `'.join(interpolations.keys()) + '`'
+  interploations_list = '"' + '", "'.join(interpolations.keys()) + '"'
   if interpolation in interpolations:
     x = tf.image.resize(x, new_shape, method=interpolations[interpolation])
   else:

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -3389,7 +3389,8 @@ def resize_images(x, height_factor, width_factor, data_format,
       height_factor: Positive integer.
       width_factor: Positive integer.
       data_format: One of `"channels_first"`, `"channels_last"`.
-      interpolation: A string any of `tf.image.ResizeMethod`.
+      interpolation: A string, one of `area`, `bicubic`, `bilinear`,
+        `gaussian`, `lanczos3`, `lanczos5`, `mitchellcubic`, `nearest`.
 
   Returns:
       A tensor.
@@ -3425,11 +3426,12 @@ def resize_images(x, height_factor, width_factor, data_format,
     'mitchellcubic': tf.image.ResizeMethod.MITCHELLCUBIC,
     'nearest': tf.image.ResizeMethod.NEAREST_NEIGHBOR,
   }
+  interploations_list = '`' + '`, `'.join(interpolations.keys()) + '`'
   if interpolation in interpolations:
     x = tf.image.resize(x, new_shape, method=interpolations[interpolation])
   else:
-    raise ValueError('interpolation should be '
-                     'from `tf.image.ResizeMethod`.')
+    raise ValueError('`interpolation` argument should be one of: '
+                     f'{interploations_list}. Received: "{interpolation}".')
   if data_format == 'channels_first':
     x = permute_dimensions(x, [0, 3, 1, 2])
 

--- a/keras/layers/reshaping/up_sampling2d.py
+++ b/keras/layers/reshaping/up_sampling2d.py
@@ -65,7 +65,7 @@ class UpSampling2D(Layer):
       It defaults to the `image_data_format` value found in your
       Keras config file at `~/.keras/keras.json`.
       If you never set it, then it will be "channels_last".
-    interpolation: A string, one of `nearest` or `bilinear`.
+    interpolation: A string any of `tf.image.ResizeMethod`.
 
   Input shape:
     4D tensor with shape:
@@ -90,9 +90,19 @@ class UpSampling2D(Layer):
     super(UpSampling2D, self).__init__(**kwargs)
     self.data_format = conv_utils.normalize_data_format(data_format)
     self.size = conv_utils.normalize_tuple(size, 2, 'size')
-    if interpolation not in {'nearest', 'bilinear'}:
-      raise ValueError('`interpolation` argument should be one of `"nearest"` '
-                       f'or `"bilinear"`. Received: "{interpolation}".')
+    interpolations = {
+      'area': tf.image.ResizeMethod.AREA,
+      'bicubic': tf.image.ResizeMethod.BICUBIC,
+      'bilinear': tf.image.ResizeMethod.BILINEAR,
+      'gaussian': tf.image.ResizeMethod.GAUSSIAN,
+      'lanczos3': tf.image.ResizeMethod.LANCZOS3,
+      'lanczos5': tf.image.ResizeMethod.LANCZOS5,
+      'mitchellcubic': tf.image.ResizeMethod.MITCHELLCUBIC,
+      'nearest': tf.image.ResizeMethod.NEAREST_NEIGHBOR,
+    }
+    if interpolation not in interpolations:
+      raise ValueError('`interpolation` argument should be from `tf.image.ResizeMethod`. '
+                       f'Received: "{interpolation}".')
     self.interpolation = interpolation
     self.input_spec = InputSpec(ndim=4)
 

--- a/keras/layers/reshaping/up_sampling2d.py
+++ b/keras/layers/reshaping/up_sampling2d.py
@@ -65,7 +65,8 @@ class UpSampling2D(Layer):
       It defaults to the `image_data_format` value found in your
       Keras config file at `~/.keras/keras.json`.
       If you never set it, then it will be "channels_last".
-    interpolation: A string any of `tf.image.ResizeMethod`.
+    interpolation: A string, one of `area`, `bicubic`, `bilinear`, `gaussian`,
+      `lanczos3`, `lanczos5`, `mitchellcubic`, `nearest`.
 
   Input shape:
     4D tensor with shape:
@@ -100,9 +101,10 @@ class UpSampling2D(Layer):
       'mitchellcubic': tf.image.ResizeMethod.MITCHELLCUBIC,
       'nearest': tf.image.ResizeMethod.NEAREST_NEIGHBOR,
     }
+    interploations_list = '`' + '`, `'.join(interpolations.keys()) + '`'
     if interpolation not in interpolations:
-      raise ValueError('`interpolation` argument should be from `tf.image.ResizeMethod`. '
-                       f'Received: "{interpolation}".')
+      raise ValueError('`interpolation` argument should be one of: '
+                       f'{interploations_list}. Received: "{interpolation}".')
     self.interpolation = interpolation
     self.input_spec = InputSpec(ndim=4)
 

--- a/keras/layers/reshaping/up_sampling2d.py
+++ b/keras/layers/reshaping/up_sampling2d.py
@@ -65,8 +65,8 @@ class UpSampling2D(Layer):
       It defaults to the `image_data_format` value found in your
       Keras config file at `~/.keras/keras.json`.
       If you never set it, then it will be "channels_last".
-    interpolation: A string, one of `area`, `bicubic`, `bilinear`, `gaussian`,
-      `lanczos3`, `lanczos5`, `mitchellcubic`, `nearest`.
+    interpolation: A string, one of `"area"`, `"bicubic"`, `"bilinear"`,
+      `"gaussian"`, `"lanczos3"`, `"lanczos5"`, `"mitchellcubic"`, `"nearest"`.
 
   Input shape:
     4D tensor with shape:
@@ -101,7 +101,7 @@ class UpSampling2D(Layer):
       'mitchellcubic': tf.image.ResizeMethod.MITCHELLCUBIC,
       'nearest': tf.image.ResizeMethod.NEAREST_NEIGHBOR,
     }
-    interploations_list = '`' + '`, `'.join(interpolations.keys()) + '`'
+    interploations_list = '"' + '", "'.join(interpolations.keys()) + '"'
     if interpolation not in interpolations:
       raise ValueError('`interpolation` argument should be one of: '
                        f'{interploations_list}. Received: "{interpolation}".')


### PR DESCRIPTION
As mentioned in #16243 

This pull request implements all the available `tf.image.resize` methods to be used for the `UpSampling2D` layer.