### PR TITLE
fix thresholded_relu to support list datatype

### DIFF
--- a/keras/layers/activation/thresholded_relu.py
+++ b/keras/layers/activation/thresholded_relu.py
@@ -59,8 +59,9 @@ class ThresholdedReLU(Layer):
     self.theta = backend.cast_to_floatx(theta)
 
   def call(self, inputs):
-    theta = tf.cast(self.theta, inputs.dtype)
-    return inputs * tf.cast(tf.greater(inputs, theta), inputs.dtype)
+    dtype = getattr(inputs, 'dtype', tf.keras.backend.floatx())
+    theta = tf.cast(self.theta, dtype)
+    return inputs * tf.cast(tf.greater(inputs, theta), dtype)
 
   def get_config(self):
     config = {'theta': float(self.theta)}


### PR DESCRIPTION
added support for list datatype in thresholded_relu similar to relu.

[Notebook](https://colab.research.google.com/drive/1VULJNYSZHBOdgPJqa9BdC5n2YPz4jV_r?usp=sharing) with the issue and solution.

Auto closes #16273 