### PR TITLE
fix issue 16289

### DIFF
--- a/keras/backend.py
+++ b/keras/backend.py
@@ -4938,7 +4938,7 @@ def in_test_phase(x, alt, training=None):
 @keras_export('keras.backend.relu')
 @tf.__internal__.dispatch.add_dispatch_support
 @doc_controls.do_not_generate_docs
-def relu(x, alpha=0., max_value=None, threshold=0.):
+def relu(x, alpha=None, max_value=None, threshold=0.):
   """Rectified linear unit.
 
   With default values, it returns element-wise `max(x, 0)`.
@@ -4961,7 +4961,7 @@ def relu(x, alpha=0., max_value=None, threshold=0.):
   # numpy arrays, lists, tuples are passed as well.
   # lists, tuples do not have 'dtype' attribute.
   dtype = getattr(x, 'dtype', floatx())
-  if alpha != 0.:
+  if alpha != None:
     if max_value is None and threshold == 0:
       return tf.nn.leaky_relu(x, alpha=alpha)
 

--- a/keras/layers/activation/leaky_relu_test.py
+++ b/keras/layers/activation/leaky_relu_test.py
@@ -41,6 +41,21 @@ class LeakyReLUTest(test_combinations.TestCase):
           input_shape=(2, 3, 4),
           supports_masking=True)
 
+  def test_leaky_relu_with_zero_alpha(self):
+    # Test case for GitHub issue 16289.
+    alpha = 0.
+    import numpy as np
+    input_data = np.random.rand(2,3,4)
+    input_data *= -np.Inf
+    expected_output = input_data*np.NaN
+    test_utils.layer_test(keras.layers.LeakyReLU,
+                          kwargs={'alpha': alpha},
+                          input_shape=(2, 3, 4),
+                          input_dtype="float32",
+                          input_data=input_data,
+                          expected_output=expected_output,
+                          supports_masking=True)
+
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
This pr is to solve issue 16289.
Before this pr, keras decides whether to use `tf.nn.leaky_relu` by checking whether `alpha=0.` I change the checking condition to `alpha is not None` so `keras.layers.LeakyReLU` behaves the same as `tf.nn.leaky_relu` when `alpha=0`.
A test case has also been added (please see if it is fine.)