### PR TITLE
Fix TypeError positional argument when LossScalerOptimizer is used conjointly with tfa wrappers

### DIFF
--- a/keras/mixed_precision/loss_scale_optimizer.py
+++ b/keras/mixed_precision/loss_scale_optimizer.py
@@ -800,7 +800,8 @@ class LossScaleOptimizer(tf.__internal__.tracking.DelegatingTrackableMixin,
     # self._optimizer.apply_gradients does not take
     # experimental_aggregate_gradients.
     return self._optimizer.apply_gradients(
-        list(zip(grads, wrapped_vars.value)), name,
+        list(zip(grads, wrapped_vars.value)),
+        name=name,
         experimental_aggregate_gradients=False)
 
   def get_config(self):


### PR DESCRIPTION
Some wrappers in tensorflow-addons (eg. `MultiOptimizer`) only accept the list of grads/vars as positional arguments, and reduce the remaining arguments into `**kwargs` that will be passed onto the inner optimizer. Applying `LossScalerOptimizer` to them raises the following error:

```
File ".../python3.9/site-packages/keras/mixed_precision/loss_scale_optimizer.py", line 671, in _apply_gradients
    self._optimizer.apply_gradients(

TypeError: apply_gradients() takes 2 positional arguments but 3 were given
```

Which can be easily fixed by transforming `name` into a named argument.
This way is also more consistent with how `keras.optimizer_v2.optimizer_v2.OptimizerV2#minimize` invokes `apply_gradients`.