### PR TITLE
Copy loss and metric to prevent side effect

### DIFF
--- a/keras/engine/compile_utils.py
+++ b/keras/engine/compile_utils.py
@@ -107,7 +107,7 @@ class LossesContainer(Container):
     self._user_losses = losses
     self._user_loss_weights = loss_weights
 
-    self._losses = losses
+    self._losses = copy.copy(losses)
     self._loss_weights = loss_weights
     self._per_output_metrics = None  # Per-output losses become metrics.
     self._loss_metric = metrics_mod.Mean(name='loss')  # Total loss.
@@ -309,7 +309,7 @@ class MetricsContainer(Container):
     self._user_metrics = metrics
     self._user_weighted_metrics = weighted_metrics
 
-    self._metrics = metrics
+    self._metrics = copy.copy(metrics)
     self._weighted_metrics = weighted_metrics
     self._built = False
 

--- a/keras/engine/compile_utils.py
+++ b/keras/engine/compile_utils.py
@@ -107,7 +107,7 @@ class LossesContainer(Container):
     self._user_losses = losses
     self._user_loss_weights = loss_weights
 
-    self._losses = copy.copy(losses)
+    self._losses = losses
     self._loss_weights = loss_weights
     self._per_output_metrics = None  # Per-output losses become metrics.
     self._loss_metric = metrics_mod.Mean(name='loss')  # Total loss.
@@ -309,7 +309,7 @@ class MetricsContainer(Container):
     self._user_metrics = metrics
     self._user_weighted_metrics = weighted_metrics
 
-    self._metrics = copy.copy(metrics)
+    self._metrics = metrics
     self._weighted_metrics = weighted_metrics
     self._built = False
 
@@ -706,6 +706,7 @@ def map_missing_dict_keys(y_pred, struct):
   """Replaces missing dict keys in `struct` with `None` placeholders."""
   if not isinstance(y_pred, dict) or not isinstance(struct, dict):
     return struct
+  struct = copy.copy(struct)
   for k in y_pred.keys():
     if k not in struct:
       struct[k] = None


### PR DESCRIPTION
This is a possible solution for #16356, a possible error that could be raised when saving weights. This happens because the inputted dict to the compile method is modified by a side effect, modifying also the keras.Model.loss attribute.