### PR TITLE
Typo fix in LSTM docstring

### DIFF
--- a/keras/layers/rnn/lstm.py
+++ b/keras/layers/rnn/lstm.py
@@ -419,7 +419,7 @@ class LSTM(DropoutRNNCellMixin, RNN, base_layer.BaseRandomLayer):
       transformation of the inputs. Default: 0.
     recurrent_dropout: Float between 0 and 1. Fraction of the units to drop for
       the linear transformation of the recurrent state. Default: 0.
-    return_sequences: Boolean. Whether to return the last output. in the output
+    return_sequences: Boolean. Whether to return the last output in the output
       sequence, or the full sequence. Default: `False`.
     return_state: Boolean. Whether to return the last state in addition to the
       output. Default: `False`.


### PR DESCRIPTION
Replaced a dot with a space.