### PR TITLE
Added new update_state for class Mean() and Sum()

### DIFF
--- a/keras/metrics/base_metric.py
+++ b/keras/metrics/base_metric.py
@@ -582,6 +582,9 @@ class Mean(Reduce):
   
   def update_state(self, y_true, y_pred, sample_weight=None):
         super().update_state(y_pred, sample_weight=sample_weight)
+  
+  def test(self):
+    print("No")
 
 @keras_export('keras.metrics.MeanMetricWrapper')
 class MeanMetricWrapper(Mean):

--- a/keras/metrics/base_metric.py
+++ b/keras/metrics/base_metric.py
@@ -534,7 +534,9 @@ class Sum(Reduce):
   def __init__(self, name='sum', dtype=None):
     super(Sum, self).__init__(reduction=metrics_utils.Reduction.SUM,
                               name=name, dtype=dtype)
-
+  
+  def update_state(self, y_true, y_pred, sample_weight=None):
+        super().update_state(y_pred, sample_weight=sample_weight)
 
 @keras_export('keras.metrics.Mean')
 class Mean(Reduce):
@@ -577,7 +579,9 @@ class Mean(Reduce):
   def __init__(self, name='mean', dtype=None):
     super(Mean, self).__init__(
         reduction=metrics_utils.Reduction.WEIGHTED_MEAN, name=name, dtype=dtype)
-
+  
+  def update_state(self, y_true, y_pred, sample_weight=None):
+        super().update_state(y_pred, sample_weight=sample_weight)
 
 @keras_export('keras.metrics.MeanMetricWrapper')
 class MeanMetricWrapper(Mean):

--- a/keras/metrics/base_metric.py
+++ b/keras/metrics/base_metric.py
@@ -582,9 +582,7 @@ class Mean(Reduce):
   
   def update_state(self, y_true, y_pred, sample_weight=None):
         super().update_state(y_pred, sample_weight=sample_weight)
-  
-  def test(self):
-    print("No")
+
 
 @keras_export('keras.metrics.MeanMetricWrapper')
 class MeanMetricWrapper(Mean):

--- a/keras/metrics/base_metric_test.py
+++ b/keras/metrics/base_metric_test.py
@@ -738,6 +738,43 @@ class CustomMetricsTest(tf.test.TestCase):
                     metrics=[dict_metric])
       model.fit(np.ones((10, 2)), np.ones((10, 3)))
 
+  def test_training_with_mean_and_sum(self):
+    mean_metric = metrics.Mean()
+    sum_metric = metrics.Sum()
+    metrics.Mean().test()
+    try:
+      print("TESTING FOR MEAN CLASS...")
+      model = tf.keras.models.Sequential()
+
+      model.add(tf.keras.layers.Dense(4, input_shape=(1,)))
+      model.add(tf.keras.layers.Dense(1, ))
+
+      model.compile(optimizer='Adam', loss='binary_crossentropy', metrics=[tf.keras.metrics.Sum()]) or model.compile(optimizer='Adam', loss='binary_crossentropy', metrics=[metrics.Mean()])
+
+      model.fit([1], [0])
+      print("TEST FINISHED SUCCESSFULLY")
+    except:
+      print("TEST FAILED")
+      raise
+
+    print()
+    print("---------------------------------")
+    print()    
+    try:
+      print("TESTINT FOR SUM CLASS...")
+      model = tf.keras.models.Sequential()
+
+      model.add(tf.keras.layers.Dense(4, input_shape=(1,)))
+      model.add(tf.keras.layers.Dense(1, ))
+
+      model.compile(optimizer='Adam', loss='binary_crossentropy', metrics=[tf.keras.metrics.Sum()]) or model.compile(optimizer='Adam', loss='binary_crossentropy', metrics=[metrics.Sum()])
+
+      model.fit([1], [0])
+      print("TEST FINISHED SUCCESSFULLY")
+    except:
+      print("TEST FAILED")
+      raise
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/keras/metrics/base_metric_test.py
+++ b/keras/metrics/base_metric_test.py
@@ -739,9 +739,16 @@ class CustomMetricsTest(tf.test.TestCase):
       model.fit(np.ones((10, 2)), np.ones((10, 3)))
 
   def test_training_with_mean_and_sum(self):
-    mean_metric = metrics.Mean()
-    sum_metric = metrics.Sum()
-    metrics.Mean().test()
+
+    '''
+    This fix is made with regards to the github issue https://github.com/keras-team/keras/issues/16291 on the update_state function
+    receiving multiple values argument for "sample_weight" when using Mean() or Sum() metric for fitting a model.
+
+    This fix was inspired by the stack overflow post https://stackoverflow.com/questions/68354367/getting-an-error-when-using-tf-keras-metrics-mean-in-functional-keras-api.
+
+    While fixing this error however, new assert errors are shown due to the current fix now taking an extra argument. May need to update some of the test cases with this fix.
+    '''
+
     try:
       print("TESTING FOR MEAN CLASS...")
       model = tf.keras.models.Sequential()
@@ -761,7 +768,7 @@ class CustomMetricsTest(tf.test.TestCase):
     print("---------------------------------")
     print()    
     try:
-      print("TESTINT FOR SUM CLASS...")
+      print("TESTING FOR SUM CLASS...")
       model = tf.keras.models.Sequential()
 
       model.add(tf.keras.layers.Dense(4, input_shape=(1,)))


### PR DESCRIPTION
There was a small bug found [on using metrics such as Mean() and Sum() #16291](https://github.com/keras-team/keras/issues/16291)  when fitting a model. This new fix was inspired by [this Stack Overflow post](https://stackoverflow.com/questions/68354367/getting-an-error-when-using-tf-keras-metrics-mean-in-functional-keras-api) where they re-introduced the function with correct parameters so that the multiple values error will no longer show up.