### PR TITLE
Fix non-float32 efficientnet calls

### DIFF
--- a/keras/applications/efficientnet.py
+++ b/keras/applications/efficientnet.py
@@ -331,7 +331,7 @@ def EfficientNet(
     # normalize the input, we need to divide another sqrt(var) to match the
     # original implementation.
     # See https://github.com/tensorflow/tensorflow/issues/49930 for more details
-    x = x / tf.math.sqrt(IMAGENET_STDDEV_RGB)
+    x = layers.Rescaling(1. / tf.math.sqrt(IMAGENET_STDDEV_RGB))(x)
 
   x = layers.ZeroPadding2D(
       padding=imagenet_utils.correct_pad(x, 3),


### PR DESCRIPTION
Fix #16401 

No obvious way I could see to include a breaking example of the old pattern in tests, so left as-is given it's a one-liner.