### PR TITLE
Use outputs dictionary keys as output_names if provided

### DIFF
--- a/keras/engine/functional_test.py
+++ b/keras/engine/functional_test.py
@@ -488,6 +488,24 @@ class NetworkConstructionTest(test_combinations.TestCase):
     self.assertEqual(['out', 'out_1'], model.output_names)
     self.assertAllClose([2., 3.], model(1.))
 
+    model = models.Model(inputs=inp, outputs={"first": out[0], "second": out[1]})
+    self.assertEqual(["first", "second"], model.output_names)
+    self.assertAllClose({"first": 2., "second": 3.}, model(1.))
+
+    model = models.Model(inputs=inp, outputs={"name": out})
+    self.assertEqual(["name", "name_1"], model.output_names)
+    self.assertAllClose({"name": (2., 3.)}, model(1.))
+
+    model = models.Model(inputs=inp, outputs={
+      "first": {"other": out[0], "another": out[1]},
+      "second": out
+    })
+    self.assertEqual(["first", "first_1", "second", "second_1"], model.output_names)
+    self.assertAllClose(
+      {"first": {"other": 2., "another": 3.}, "second": (2., 3.)},
+      model(1.)
+    )
+
   def test_recursion(self):
     with tf.Graph().as_default(), self.cached_session():
       a = layers.Input(shape=(32,), name='input_a')


### PR DESCRIPTION
This PR is meant to resolve issue #16405.

This implementation is the first solution mentioned in https://github.com/keras-team/keras/issues/16405#issuecomment-1102255538. You are still invited to discuss other solutions.

The implementation relies on the behavior of `tf.nest.flatten` when `model._output_layers` are created. Particularly, on the ordering, which is the sorted order of the dictionary keys. An alternative might be to search each layer from `model._output_layers` in the nested structure and then select its name. That strategy seems more complicated but would be independent of the way how `model._output_layers` is created.