### PR TITLE
Fix EarlyStopping for patience = 0

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1865,7 +1865,7 @@ class EarlyStopping(Callback):
         self.wait = 0
 
     # Only check after the first epoch.
-    if self.wait >= self.patience and epoch > 0:
+    if self.wait >= self.patience and self.wait != 0 and epoch > 0:
       self.stopped_epoch = epoch
       self.model.stop_training = True
       if self.restore_best_weights and self.best_weights is not None:


### PR DESCRIPTION
Fixed EarlyStopping problem for patience = 0 if there is improvement in accuracy or reduction in loss.

Fixes #16393