### PR TITLE
Optimize L2 Regularizer

### DIFF
--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -241,7 +241,7 @@ class L1L2(Regularizer):
     if self.l1:
       regularization += self.l1 * tf.reduce_sum(tf.abs(x))
     if self.l2:
-      regularization += self.l2 * tf.reduce_sum(tf.square(x))
+      regularization += 2.0 * self.l2 * tf.nn.l2_loss(x)
     return regularization
 
   def get_config(self):
@@ -310,7 +310,7 @@ class L2(Regularizer):
     self.l2 = backend.cast_to_floatx(l2)
 
   def __call__(self, x):
-    return self.l2 * tf.reduce_sum(tf.square(x))
+    return 2.0 * self.l2 * tf.nn.l2_loss(x)
 
   def get_config(self):
     return {'l2': float(self.l2)}


### PR DESCRIPTION
By using L2Loss op we make graph much smaller.

![image](https://user-images.githubusercontent.com/37601244/167823516-01cf5dbb-0526-4878-acf7-c99631fce078.png)

I didn't change docs in order to avoid confusion (math remains unchanged).