### PR TITLE
Add unittest for supporting VariablePolicy in saved_model.load

### DIFF
--- a/keras/tests/saved_model_test.py
+++ b/keras/tests/saved_model_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,40 @@
 import tensorflow.compat.v2 as tf
 
 import os
+import subprocess
 from tensorflow.python.framework import test_util as tf_test_utils
-from keras.layers import core
+from keras import Model, models
+from keras.layers import core, Layer
 from keras.optimizers.optimizer_v2 import adam
+
+
+class _Embedding(Layer):
+  def __init__(self, input_dim, output_dim, trainable=True):
+    super(_Embedding, self).__init__(dtype=tf.float32)
+    self.input_dim = input_dim
+    self.output_dim = output_dim
+    self.embedding_table = None
+    self.trainable = trainable
+
+  def build(self, input_shape):
+    self.embedding_table = self.add_weight(
+        "embedding_table", shape=[self.input_dim, self.output_dim],
+        dtype=tf.float32, trainable=self.trainable)
+
+  def call(self, indices):
+    return tf.gather(params=self.embedding_table, indices=indices)
+
+class _TestModel(Model):
+  def __init__(self, rows, cols):
+    super().__init__()
+    self.embedding = _Embedding(input_dim=rows, output_dim=cols)
+
+  def call(self, x):
+    with tf.device('/cpu:0'):
+      x = self.embedding(x)
+    with tf.device('/gpu:0'):
+      x = tf.math.reduce_sum(x, axis=1)
+    return x
 
 
 class _ModelWithOptimizerUsingDefun(tf.train.Checkpoint):
@@ -54,6 +85,36 @@ class MemoryTests(tf.test.TestCase):
     self._model.call(x, y)
     save_dir = os.path.join(self.get_temp_dir(), "saved_model")
     tf.saved_model.save(self._model, save_dir, self._model.call)
+
+class SavedModelLoadMemoryTests(tf.test.TestCase):
+
+  def get_gpu_memory(self):
+    command = "nvidia-smi --query-gpu=memory.total --format=csv"
+    memory_free_info = subprocess.check_output(command.split()).decode('ascii').split('\n')[:-1][1:]
+    memory_free_values = [int(x.split()[0]) for i, x in enumerate(memory_free_info)]
+    if isinstance(memory_free_values, list):
+        return int(memory_free_values[0] / 1024)
+    return int(memory_free_values)
+
+  @tf_test_utils.run_gpu_only
+  def test_no_oom_loading_large_tenor(self):
+    if not tf.config.get_soft_device_placement():
+      self.skipTest("This test only works for soft device placement is on")
+    max_gpu_memory_in_Gb = self.get_gpu_memory()
+    save_dir = os.path.join(self.get_temp_dir(), "saved_model")
+    ncols = 128
+    nrows = (max_gpu_memory_in_Gb + 1) * 2**30 // ncols // 4
+    model = _TestModel(rows=nrows, cols=ncols)
+    x = tf.zeros(shape=(65536, 1), dtype=tf.int32)
+    y = model(x)
+    models.save_model(
+        model=model, filepath=save_dir, overwrite=True,
+        options=tf.saved_model.SaveOptions(
+            experimental_variable_policy=tf.saved_model.experimental.VariablePolicy.SAVE_VARIABLE_DEVICES))
+    loaded = models.load_model(
+        save_dir,
+        options=tf.saved_model.SaveOptions(
+            experimental_variable_policy=tf.saved_model.experimental.VariablePolicy.SAVE_VARIABLE_DEVICES))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds unittest for adding VariablePolicy to saved_model.load when soft placement is disabled. A related PR is https://github.com/tensorflow/tensorflow/pull/54319