### PR TITLE
Fix typo in documentation

### DIFF
--- a/keras/layers/preprocessing/index_lookup.py
+++ b/keras/layers/preprocessing/index_lookup.py
@@ -347,7 +347,7 @@ class IndexLookup(base_preprocessing_layer.PreprocessingLayer):
     """Gets the current size of the layer's vocabulary.
 
     Returns:
-      The integer size of the voculary, including optional mask and oov indices.
+      The integer size of the vocabulary, including optional mask and oov indices.
     """
     return int(self.lookup_table.size().numpy()) + self._token_start_index()
 

--- a/keras/layers/preprocessing/integer_lookup.py
+++ b/keras/layers/preprocessing/integer_lookup.py
@@ -393,7 +393,7 @@ class IntegerLookup(index_lookup.IndexLookup):
     During `adapt()`, the layer will build a vocabulary of all integer tokens
     seen in the dataset, sorted by occurance count, with ties broken by sort
     order of the tokens (high to low). At the end of `adapt()`, if `max_tokens`
-    is set, the voculary wil be truncated to `max_tokens` size. For example,
+    is set, the vocabulary wil be truncated to `max_tokens` size. For example,
     adapting a layer with `max_tokens=1000` will compute the 1000 most frequent
     tokens occurring in the input dataset. If `output_mode='tf-idf'`, `adapt()`
     will also learn the document frequencies of each token in the input dataset.

--- a/keras/layers/preprocessing/string_lookup.py
+++ b/keras/layers/preprocessing/string_lookup.py
@@ -357,7 +357,7 @@ class StringLookup(index_lookup.IndexLookup):
     During `adapt()`, the layer will build a vocabulary of all string tokens
     seen in the dataset, sorted by occurance count, with ties broken by sort
     order of the tokens (high to low). At the end of `adapt()`, if `max_tokens`
-    is set, the voculary wil be truncated to `max_tokens` size. For example,
+    is set, the vocabulary wil be truncated to `max_tokens` size. For example,
     adapting a layer with `max_tokens=1000` will compute the 1000 most frequent
     tokens occurring in the input dataset. If `output_mode='tf-idf'`, `adapt()`
     will also learn the document frequencies of each token in the input dataset.


### PR DESCRIPTION
Updated 'voculary' with 'vocabulary'.