### PR TITLE
Modify EarlyStopping on_train_end

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -2004,7 +2004,14 @@ class EarlyStopping(Callback):
             io_utils.print_msg(
                 f"Epoch {self.stopped_epoch + 1}: early stopping"
             )
-
+		if self.restore_best_weights and self.best_weights is not None:
+			if self.verbose > 0:
+				io_utils.print_msg(
+					"Restoring model weights from the end of the best epoch: "
+					f"{self.best_epoch + 1}."
+				)
+			self.model.set_weights(self.best_weights)
+            
     def get_monitor_value(self, logs):
         logs = logs or {}
         monitor_value = logs.get(self.monitor)


### PR DESCRIPTION
If restore_best_weights=True and the last epoch of training was reached without triggering the early stop (probably because to a very high patience), the best set of model weights should be restored anyway.