### PR TITLE
fix(v1):  avoid calling training_v1.Model.metrics during PREDICT

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -611,6 +611,14 @@ class CallbackList:
                 )
         # pylint: enable=protected-access
 
+    def make_logs(self, model, logs, outputs, mode, prefix=''):
+        """Computes logs for sending to `on_batch_end` methods."""
+        if not self.callbacks:
+            return logs
+
+        return make_logs(model, logs, outputs, mode, prefix=prefix)
+
+
 
 @keras_export("keras.callbacks.Callback")
 class Callback:
@@ -904,14 +912,7 @@ class Callback:
               method but that may change in the future.
         """
 
-    def make_logs(self, model, logs, outputs, mode, prefix=''):
-        """Computes logs for sending to `on_batch_end` methods."""
-        if not self.callbacks:
-            return logs
-
-        return make_logs(model, logs, outputs, mode, prefix=prefix)
-
-    def _implements_train_batch_hooks(self):
+        def _implements_train_batch_hooks(self):
         """Determines if this Callback should be called for each train batch."""
         return (
             not generic_utils.is_default(self.on_batch_begin)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -611,13 +611,12 @@ class CallbackList:
                 )
         # pylint: enable=protected-access
 
-    def make_logs(self, model, logs, outputs, mode, prefix=''):
+    def make_logs(self, model, logs, outputs, mode, prefix=""):
         """Computes logs for sending to `on_batch_end` methods."""
         if not self.callbacks:
             return logs
 
         return make_logs(model, logs, outputs, mode, prefix=prefix)
-
 
 
 @keras_export("keras.callbacks.Callback")
@@ -912,7 +911,7 @@ class Callback:
               method but that may change in the future.
         """
 
-        def _implements_train_batch_hooks(self):
+    def _implements_train_batch_hooks(self):
         """Determines if this Callback should be called for each train batch."""
         return (
             not generic_utils.is_default(self.on_batch_begin)

--- a/keras/engine/training_arrays_v1.py
+++ b/keras/engine/training_arrays_v1.py
@@ -363,7 +363,9 @@ def model_iteration(
                 aggregator.aggregate(batch_outs)
 
                 # Callbacks batch end.
-                batch_logs = callbacks.make_logs(model, batch_logs, batch_outs, mode)
+                batch_logs = callbacks.make_logs(
+                    model, batch_logs, batch_outs, mode
+                )
                 callbacks._call_batch_hook(mode, "end", step, batch_logs)
                 step += 1
 
@@ -426,7 +428,9 @@ def model_iteration(
                 aggregator.aggregate(batch_outs, batch_start, batch_end)
 
                 # Callbacks batch end.
-                batch_logs = callbacks.make_logs(model, batch_logs, batch_outs, mode)
+                batch_logs = callbacks.make_logs(
+                    model, batch_logs, batch_outs, mode
+                )
                 callbacks._call_batch_hook(mode, "end", batch_index, batch_logs)
 
                 if callbacks.model.stop_training:

--- a/keras/engine/training_arrays_v1.py
+++ b/keras/engine/training_arrays_v1.py
@@ -363,7 +363,7 @@ def model_iteration(
                 aggregator.aggregate(batch_outs)
 
                 # Callbacks batch end.
-                batch_logs = cbks.make_logs(model, batch_logs, batch_outs, mode)
+                batch_logs = callbacks.make_logs(model, batch_logs, batch_outs, mode)
                 callbacks._call_batch_hook(mode, "end", step, batch_logs)
                 step += 1
 
@@ -426,7 +426,7 @@ def model_iteration(
                 aggregator.aggregate(batch_outs, batch_start, batch_end)
 
                 # Callbacks batch end.
-                batch_logs = cbks.make_logs(model, batch_logs, batch_outs, mode)
+                batch_logs = callbacks.make_logs(model, batch_logs, batch_outs, mode)
                 callbacks._call_batch_hook(mode, "end", batch_index, batch_logs)
 
                 if callbacks.model.stop_training:
@@ -434,7 +434,7 @@ def model_iteration(
 
         aggregator.finalize()
         results = aggregator.results
-        epoch_logs = cbks.make_logs(model, epoch_logs, results, mode)
+        epoch_logs = callbacks.make_logs(model, epoch_logs, results, mode)
         if len(results) == 1:
             results = results[0]
 
@@ -469,7 +469,7 @@ def model_iteration(
             )
             if not isinstance(val_results, list):
                 val_results = [val_results]
-            epoch_logs = cbks.make_logs(
+            epoch_logs = callbacks.make_logs(
                 model, epoch_logs, val_results, mode, prefix="val_"
             )
             if val_iterator and epoch < epochs - 1:

--- a/keras/engine/training_distributed_v1.py
+++ b/keras/engine/training_distributed_v1.py
@@ -448,7 +448,7 @@ def experimental_tpu_test_loop(
                 # mirrored vars.
                 outs[i] = batch_outs[label]
 
-        batch_logs = cbks.make_logs(model, batch_logs, outs, mode)
+        batch_logs = callbacks.make_logs(model, batch_logs, outs, mode)
         callbacks._call_batch_hook(mode, "end", current_step, batch_logs)
         if verbose == 1:
             progbar.update(current_step + 1)
@@ -617,7 +617,7 @@ def experimental_tpu_predict_loop(
             ]
             unconcatenated_outs[i].extend(single_model_output)
 
-        batch_logs = cbks.make_logs(model, batch_logs, batch_outs, mode)
+        batch_logs = callbacks.make_logs(model, batch_logs, batch_outs, mode)
         callbacks._call_batch_hook(mode, "end", current_step, batch_logs)
         if verbose == 1:
             progbar.update(current_step + 1)

--- a/keras/engine/training_generator_v1.py
+++ b/keras/engine/training_generator_v1.py
@@ -306,7 +306,7 @@ def model_iteration(
             aggregator.aggregate(batch_outs)
 
             # Callbacks batch end.
-            batch_logs = cbks.make_logs(model, batch_logs, batch_outs, mode)
+            batch_logs = callbacks.make_logs(model, batch_logs, batch_outs, mode)
             callbacks._call_batch_hook(mode, "end", step, batch_logs)
             step += 1
 
@@ -315,7 +315,7 @@ def model_iteration(
 
         aggregator.finalize()
         results = aggregator.results
-        epoch_logs = cbks.make_logs(model, epoch_logs, results, mode)
+        epoch_logs = callbacks.make_logs(model, epoch_logs, results, mode)
         if len(results) == 1:
             results = results[0]
 
@@ -342,7 +342,7 @@ def model_iteration(
 
             if not isinstance(val_results, list):
                 val_results = [val_results]
-            epoch_logs = cbks.make_logs(
+            epoch_logs = callbacks.make_logs(
                 model, epoch_logs, val_results, mode, prefix="val_"
             )
 

--- a/keras/engine/training_generator_v1.py
+++ b/keras/engine/training_generator_v1.py
@@ -306,7 +306,9 @@ def model_iteration(
             aggregator.aggregate(batch_outs)
 
             # Callbacks batch end.
-            batch_logs = callbacks.make_logs(model, batch_logs, batch_outs, mode)
+            batch_logs = callbacks.make_logs(
+                model, batch_logs, batch_outs, mode
+            )
             callbacks._call_batch_hook(mode, "end", step, batch_logs)
             step += 1
 


### PR DESCRIPTION
training_v1.Model.metrics adds about 10% overhead to my v1 model predictions.

During inference (with no callbacks), `make_logs` and `set_callback_parameters` is repeatedly called, which eventually calls a very expensive `_flatten_layers`.

This change only generates the metrics names when required.

An alternative is to make the metrics a cached property but that can be tricky with memory leak management. Let me know what you prefer.

<img width="476" alt="pstats" src="https://user-images.githubusercontent.com/32464643/170502814-9fe38b9e-2305-4517-8c81-3eae148f06ac.png">

