### PR TITLE
Explicitely set `AutoShardPolicy.DATA` for `TensorLike` datasets

### DIFF
--- a/keras/engine/data_adapter.py
+++ b/keras/engine/data_adapter.py
@@ -353,6 +353,12 @@ class TensorLikeDataAdapter(DataAdapter):
 
             dataset = dataset.map(shuffle_batch)
 
+        options = tf.data.Options()
+        options.experimental_distribute.auto_shard_policy = (
+            tf.data.experimental.AutoShardPolicy.DATA
+        )
+        dataset = dataset.with_options(options)
+
         self._dataset = dataset
 
     def slice_inputs(self, indices_dataset, inputs):


### PR DESCRIPTION
`TensorLike` datasets – as used when passing numpy arrays to `mode.fit()` – are never file based datasets 

When training or predicting inside a `MirroredStrategy` `AutoShardPolicy.AUTO` will therefore always fall back to `AutoShardPolicy.DATA` for `TensorLike` datasets resulting in very verbose warning messages:
```
tensorflow/core/grappler/optimizers/data/auto_shard.cc:776] AUTO sharding policy will apply DATA sharding policy as it failed to apply FILE sharding policy because of the following reason: Did not find a shardable source, walked to a node which is not a dataset: name: "FlatMapDataset/_9"
op: "FlatMapDataset"
input: "PrefetchDataset/_8"
attr {
  key: "Targuments"
  value {
    list {
    }
  }
}
attr {
  key: "_cardinality"
  value {
    i: -2
  }
}
attr {
  key: "f"
  value {
    func {
      name: "__inference_Dataset_flat_map_slice_batch_indices_528475"
    }
  }
}
attr {
  key: "metadata"
  value {
    s: "\n\024FlatMapDataset:15504"
  }
}
attr {
  key: "output_shapes"
  value {
    list {
      shape {
        dim {
          size: -1
        }
      }
    }
  }
}
attr {
  key: "output_types"
  value {
    list {
      type: DT_INT64
    }
  }
}
experimental_type {
  type_id: TFT_PRODUCT
  args {
    type_id: TFT_DATASET
    args {
      type_id: TFT_PRODUCT
      args {
        type_id: TFT_TENSOR
        args {
          type_id: TFT_INT64
        }
      }
    }
  }
}
. Consider either turning off auto-sharding or switching the auto_shard_policy to DATA to shard this dataset. You can do this by creating a new `tf.data.Options()` object then setting `options.experimental_distribute.auto_shard_policy = AutoShardPolicy.DATA` before applying the options object to the dataset via `dataset.with_options(options)`.
```

This error message can lead to big confusing since it is in-actionable for users.

This PR shouldn't change any behaviour since `TensorLike` datasets already fall back to data sharding, but removes the very verbose warning.