### PR TITLE
Add support for Keras masking and causal masking

### DIFF
--- a/keras/layers/attention/multi_head_attention_test.py
+++ b/keras/layers/attention/multi_head_attention_test.py
@@ -328,6 +328,47 @@ class MultiHeadAttentionTest(test_combinations.TestCase):
         results = test_layer(query, value, key)
         self.assertAllEqual(results.shape.as_list(), query.shape.as_list())
 
+    def test_query_mask_progagation(self):
+        """Test automatic propagation of the query's mask."""
+        test_layer = keras.layers.MultiHeadAttention(num_heads=2, key_dim=2)
+        self.assertTrue(test_layer.supports_masking)
+        query = np.array([[1, 2, 3, 0, 0], [3, 3, 1, 1, 2], [1, 0, 0, 0, 0]])
+        masked_query = keras.layers.Embedding(4, 8, mask_zero=True)(query)
+        value = np.random.random((3, 3, 8))
+        output = test_layer(query=masked_query, value=value)
+        self.assertTrue(hasattr(output, "_keras_mask"))
+        self.assertAllEqual(masked_query._keras_mask, output._keras_mask)
+
+    @parameterized.named_parameters(("causal", True), ("not_causal", False))
+    def test_value_mask(self, causal):
+        """Test that the value and causal masks are taken into account."""
+        test_layer = keras.layers.MultiHeadAttention(
+            num_heads=2, key_dim=2, causal=causal
+        )
+        query = np.array([[1, 2, 3, 0, 0], [3, 3, 1, 1, 2], [1, 0, 0, 0, 0]])
+        masked_query = keras.layers.Embedding(4, 8, mask_zero=True)(query)
+        value = np.array([[5, 4, 0], [3, 0, 0], [2, 1, 1]])
+        masked_value = keras.layers.Embedding(6, 8, mask_zero=True)(value)
+        output = test_layer(query=masked_query, value=masked_value)
+        mask = np.array(
+            [[[True, True, False]] * 3 + [[False, False, False]] * 2]
+            + [[[True, False, False]] * 5]
+            + [[[True, True, True]] + [[False, False, False]] * 4]
+        )
+        if causal:
+            mask = mask & np.array(
+                [
+                    [[True, False, False], [True, True, False]]
+                    + [[True, True, True]] * 3
+                ]
+            )
+        del masked_query._keras_mask
+        del masked_value._keras_mask
+        output_with_manual_mask = test_layer(
+            query=masked_query, value=masked_value, attention_mask=mask
+        )
+        self.assertAllClose(output, output_with_manual_mask)
+
 
 class SubclassAttention(keras.layers.MultiHeadAttention):
     def _build_attention(self, qkv_rank):


### PR DESCRIPTION
This is a first go at adding Keras masking support and causal support to the `MultiHeadAttention` layer.

See the discussion in [#16248](https://github.com/keras-team/keras/issues/16248).
