### PR TITLE
Introducing pre-commit to the repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "dockerFile": "Dockerfile",
-    "postCreateCommand": "pip install -r requirements.txt && pip uninstall keras-nightly -y",
+    "postCreateCommand": "pip install -r requirements.txt && pip uninstall keras-nightly -y && pre-commit",
     "extensions": ["ms-python.python"],
     "settings": {
         "files.watcherExclude": {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-added-large-files
+    -   id: check-ast
+    -   id: check-merge-conflict
+    -   id: debug-statements

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ numpy ~= 1.21.4  # Sync with the numpy version used in TF
 black==22.3.0
 isort==5.10.1
 flake8==4.0.1
+pre-commit >= 2.17.0


### PR DESCRIPTION
Re-opening the PR, now with changes to address feedback on #16351

Enabling the hooks should substantially cut down on number of minor stylistic issues,
as well as some occasional time wasting whoopsies. 

Global settings for pre-commit were kept at defaults as they are sufficient in overwhelming number of cases.

Pre-commit is installed as part of the project dependencies
in the development container and pre-commit environment is initialized
after container is successfully created.

Hooks are set to check for general style violations,
along with forgotten debug statement and merge resolution leftovers.
The checks will be run after relevant files are next edited,
to keep git-blame output clean.

I didn't run checks globally in order to minimize scope of the PR. 

