### PR TITLE
configurable `distribute_reduction_method` in Model.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3817,6 +3817,8 @@ def reduce_per_replica(values, strategy, reduction="first"):
                 return concat(strategy.experimental_local_results(v))
         elif reduction == "sum":
             values = strategy.experimental_local_results(v)
+            # TODO remove me before finalizing PR
+            tf.print("reduce-sum", tf.stack(values))
             return tf.reduce_sum(values)
         else:
             raise ValueError(

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -939,6 +939,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
         as described in [distributed training guide](
             https://www.tensorflow.org/guide/distributed_training#use_tfdistributestrategy_with_custom_training_loops)
         you should set this property to `"sum"`.
+        This doesn't affect TPU training, where `"first"` should be used.
 
         Default: 'first', which will get the value from the first replica.
         """

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3820,7 +3820,7 @@ def reduce_per_replica(values, strategy, reduction="first"):
             return tf.reduce_sum(values)
         else:
             raise ValueError(
-                '`reduction` must be "first" or "concat" or "sum". Received: '
+                '`reduction` must be "first", "concat", or "sum". Received: '
                 f"reduction={reduction}."
             )
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -943,7 +943,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
 
         Default: 'first', which will get the value from the first replica.
         """
-        return self._distribute_reduction_method or "first"
+        return self._distribute_reduction_method or "auto"
 
     @distribute_reduction_method.setter
     def distribute_reduction_method(self, value):
@@ -3764,7 +3764,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
         return saving_lib.save(self, dirpath)
 
 
-def reduce_per_replica(values, strategy, reduction="first"):
+def reduce_per_replica(values, strategy, reduction="auto"):
     """Attempt to reduce the structure `values` to single values.
 
     Given `values` (a `tf.Tensor` or a `PerReplica` structure),
@@ -3806,6 +3806,9 @@ def reduce_per_replica(values, strategy, reduction="first"):
     Raises:
       ValueError: if the reduction method is not supported.
     """
+
+    if reduction == "auto":
+        reduction = "first" if _is_tpu_multi_host(strategy) else "sum"
 
     def _reduce(v):
         """Reduce a single `PerReplica` object."""

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3803,7 +3803,7 @@ def reduce_per_replica(values, strategy, reduction="auto"):
     """
 
     if reduction == "auto":
-        reduction = "first" if _is_tpu_multi_host(strategy) else "sum"
+        reduction = "first" if backend.is_tpu_strategy(strategy) else "sum"
 
     def _reduce(v):
         """Reduce a single `PerReplica` object."""

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -934,6 +934,12 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
         """Settable attribute indicating how the model should reduce
         loss and metric values from replicas.
 
+        By default, tf.distribute takes care of proper synchronization
+        so that "first" is sufficient. If you implement a custom `train_step`
+        as described in [distributed training guide](
+            https://www.tensorflow.org/guide/distributed_training#use_tfdistributestrategy_with_custom_training_loops)
+        you should set this property to `"sum"`.
+
         Default: 'first', which will get the value from the first replica.
         """
         return self._distribute_reduction_method or "first"

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -935,7 +935,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
         loss and metric values from replicas.
 
         Default: `"auto"`. This should be good for general use cases.
-        It boils down to using `"sum"` or `"first"` conditioned on the 
+        It boils down to using `"sum"` or `"first"` conditioned on the
         specific implementation of the `tf.distribute` strategy.
         In case of a `tf.distribute.MirroredStrategy` it boils down to `"sum"`
         to account for the case of custom training loops.

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -934,9 +934,11 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
         """Settable attribute indicating how the model should reduce
         loss and metric values from replicas.
 
-        Default: `"auto"`. This should be good for all cases.
-        It boils down to using `"sum"` or `"first"` conditioned on
-        whether TPU is used.
+        Default: `"auto"`. This should be good for general use cases.
+        It boils down to using `"sum"` or `"first"` conditioned on the 
+        specific implementation of the `tf.distribute` strategy.
+        In case of a `tf.distribute.MirroredStrategy` it boils down to `"sum"`
+        to account for the case of custom training loops.
         """
         return self._distribute_reduction_method or "auto"
 

--- a/keras/engine/training_test.py
+++ b/keras/engine/training_test.py
@@ -148,7 +148,7 @@ class TrainingTest(test_combinations.TestCase):
     @test_combinations.run_all_keras_modes(always_skip_v1=True)
     def test_distribution_reduction_method_sum(self):
 
-        strategy = tf.distribute.MirroredStrategy(["/cpu:1", "/cpu:2"])
+        strategy = tf.distribute.MirroredStrategy(["/cpu:1", "/cpu:2", "/cpu:3", "/cpu:4"])
         BATCH_SIZE = 10
 
         class MyModel(training_module.Model):

--- a/keras/engine/training_test.py
+++ b/keras/engine/training_test.py
@@ -148,7 +148,9 @@ class TrainingTest(test_combinations.TestCase):
     @test_combinations.run_all_keras_modes(always_skip_v1=True)
     def test_distribution_reduction_method_sum(self):
 
-        strategy = tf.distribute.MirroredStrategy(["/cpu:1", "/cpu:2", "/cpu:3", "/cpu:4"])
+        strategy = tf.distribute.MirroredStrategy(
+            ["/cpu:1", "/cpu:2", "/cpu:3", "/cpu:4"]
+        )
         BATCH_SIZE = 10
 
         class MyModel(training_module.Model):

--- a/keras/engine/training_test.py
+++ b/keras/engine/training_test.py
@@ -146,7 +146,38 @@ class TrainingTest(test_combinations.TestCase):
         model.predict(x)
 
     @test_combinations.run_all_keras_modes(always_skip_v1=True)
-    def test_distribution_reduction_method_sum(self):
+    def test_distribution_reduction_method_sum_default_train_step(self):
+
+        strategy = tf.distribute.MirroredStrategy(
+            ["/cpu:1", "/cpu:2", "/cpu:3", "/cpu:4"]
+        )
+        BATCH_SIZE = 10
+
+        # A model that always outputs `1`:
+        with strategy.scope():
+            inputs = layers_module.Input(shape=(1,), name="my_input")
+            outputs = layers_module.Dense(
+                units=1, kernel_initializer="zeros", bias_initializer="ones"
+            )(inputs)
+            model = training_module.Model(inputs, outputs)
+
+        model.trainable = False
+        model.compile(optimizer="sgd", loss="mean_absolute_error")
+
+        # Data points are always equal to `2`:
+        x, y = 2 * np.ones((40, 1)), 2 * np.ones((40, 1))
+
+        # For every output x_i = 1, every target y_i = 2,
+        #   loss_i     = |1-2| = 1; and
+        #   loss_total = sum([1, 1, ..., 1]) / BATCH_SIZE = 1.0
+        history = model.fit(x, y, epochs=1, batch_size=BATCH_SIZE)
+        self.assertAllClose(history.history["loss"][-1], 1.0)
+
+        eval_output = model.evaluate(x, y, batch_size=BATCH_SIZE)
+        self.assertAllClose(eval_output, 1.0)
+
+    @test_combinations.run_all_keras_modes(always_skip_v1=True)
+    def test_distribution_reduction_method_sum_custom_train_step(self):
 
         strategy = tf.distribute.MirroredStrategy(
             ["/cpu:1", "/cpu:2", "/cpu:3", "/cpu:4"]
@@ -183,7 +214,6 @@ class TrainingTest(test_combinations.TestCase):
             outputs = layers_module.Dense(1)(inputs)
             model = MyModel(inputs, outputs)
 
-        model.distribute_reduction_method = "sum"
         model.compile()
 
         x, y = np.ones((40, 1)), np.ones((40, 1))


### PR DESCRIPTION
additionally allows to reduce with `sum` to account for the metrics/losses divided by global batch size -  when training using custom training step and MirroredStrategy.

This addresses https://github.com/keras-team/keras/issues/15509