### PR TITLE
Fix documentation in keras.datasets.imdb

### DIFF
--- a/keras/datasets/imdb.py
+++ b/keras/datasets/imdb.py
@@ -50,7 +50,7 @@ def load_data(
     common words, but eliminate the top 20 most common words".
 
     As a convention, "0" does not stand for a specific word, but instead is used
-    to encode any unknown word.
+    to encode the pad token.
 
     Args:
       path: where to cache the data (relative to `~/.keras/dataset`).
@@ -181,12 +181,24 @@ def get_word_index(path="imdb_word_index.json"):
     Example:
 
     ```python
+    # Use the default parameters to keras.datasets.imdb.load_data
+    start_char = 1
+    oov_char = 2
+    index_from = 3
     # Retrieve the training sequences.
-    (x_train, _), _ = keras.datasets.imdb.load_data()
+    (x_train, _), _ = keras.datasets.imdb.load_data(
+        start_char=start_char, oov_char=oov_char, index_from=index_from
+    )
     # Retrieve the word index file mapping words to indices
     word_index = keras.datasets.imdb.get_word_index()
     # Reverse the word index to obtain a dict mapping indices to words
-    inverted_word_index = dict((i, word) for (word, i) in word_index.items())
+    # And add `index_from` to indices to sync with `x_train`
+    inverted_word_index = dict(
+        (i + index_from, word) for (word, i) in word_index.items()
+    )
+    # Update `inverted_word_index` to include `start_char` and `oov_char`
+    inverted_word_index[start_char] = "[START]"
+    inverted_word_index[oov_char] = "[OOV]"
     # Decode the first sequence in the dataset
     decoded_sequence = " ".join(inverted_word_index[i] for i in x_train[0])
     ```


### PR DESCRIPTION
The current example in `get_word_index()` doesn't convert the word ids to the original words. Executing the example as it is, we'll get
```
the as you with out themselves powerful lets loves their becomes reaching had journalist of lot from anyone to have after out atmosphere never more room titillate ...
```
which is an error.

After the fix, we can get the original sentence
```
[START] this film was just brilliant casting location scenery story direction everyone's really suited the part they played and you could just imagine being ...
```

Also in function `load_data`, the current documentation "As a convention, 0 [...] is used to encode any unknown word." is misleading. Here it's not used to encode the unseen `oov_char`, but reserved for the pad token.