### PR TITLE
Update callbacks.py

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1305,7 +1305,7 @@ class ModelCheckpoint(Callback):
           epochs, the monitored metric may potentially be less reliable (it
           could reflect as little as 1 batch, since the metrics get reset every
           epoch). Defaults to `'epoch'`.
-        start_save: integer that represent the epoch on which we want to start 
+        start_save: integer that represent the epoch on which we want to start
           the backups
         options: Optional `tf.train.CheckpointOptions` object if
           `save_weights_only` is true or optional `tf.saved_model.SaveOptions`

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1305,6 +1305,8 @@ class ModelCheckpoint(Callback):
           epochs, the monitored metric may potentially be less reliable (it
           could reflect as little as 1 batch, since the metrics get reset every
           epoch). Defaults to `'epoch'`.
+        start_save: integer that represent the epoch on which we want to start 
+          the backups
         options: Optional `tf.train.CheckpointOptions` object if
           `save_weights_only` is true or optional `tf.saved_model.SaveOptions`
           object if `save_weights_only` is false.
@@ -1325,6 +1327,7 @@ class ModelCheckpoint(Callback):
         save_weights_only=False,
         mode="auto",
         save_freq="epoch",
+        start_save = 0,
         options=None,
         initial_value_threshold=None,
         **kwargs,
@@ -1337,6 +1340,7 @@ class ModelCheckpoint(Callback):
         self.save_best_only = save_best_only
         self.save_weights_only = save_weights_only
         self.save_freq = save_freq
+        self.start_save = start_save
         self.epochs_since_last_save = 0
         self._batches_seen_since_last_saving = 0
         self._last_batch_seen = 0
@@ -1459,7 +1463,7 @@ class ModelCheckpoint(Callback):
     def on_epoch_end(self, epoch, logs=None):
         self.epochs_since_last_save += 1
 
-        if self.save_freq == "epoch":
+        if self.save_freq == "epoch" and self.epochs_since_last_save >= self.start_save :
             self._save_model(epoch=epoch, batch=None, logs=logs)
 
     def _should_save_on_batch(self, batch):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1327,7 +1327,7 @@ class ModelCheckpoint(Callback):
         save_weights_only=False,
         mode="auto",
         save_freq="epoch",
-        start_save = 0,
+        start_save=0,
         options=None,
         initial_value_threshold=None,
         **kwargs,
@@ -1463,7 +1463,7 @@ class ModelCheckpoint(Callback):
     def on_epoch_end(self, epoch, logs=None):
         self.epochs_since_last_save += 1
 
-        if self.save_freq == "epoch" and self.epochs_since_last_save >= self.start_save :
+        if self.save_freq == "epoch" and epoch >= self.start_save :
             self._save_model(epoch=epoch, batch=None, logs=logs)
 
     def _should_save_on_batch(self, batch):


### PR DESCRIPTION
06/05/2022
Hi everyone a propose to add a new parameters to ModelCheckPoint callback.
This new parameter is called start_save and permited to start the backup process at a certain epoch.
In my project a train lot of model all of them are converging between 100 and 300 epochs.
With this parameters i can specified that i would like a backup on each epoch starting on 100 that permit to stored minus backup file and generaly first epochs have verry bad performance so they are not interesting to save.
To default this parameter are initiate to 0 to start backup at the first epoch.
In my case is working correctly but a don't adapt it this solution for batch_save because a don't use this possibility.

11/06/2022
I make a new commit request with the last version of the file to avoid conflict