### PR TITLE
MAINT: use f-string method

### DIFF
--- a/keras/saving/save_test.py
+++ b/keras/saving/save_test.py
@@ -57,7 +57,7 @@ class TestSaveModel(tf.test.TestCase, parameterized.TestCase):
         if h5py is not None:
             self.assertTrue(
                 h5py.is_hdf5(path),
-                "Model saved at path {} is not a valid hdf5 file.".format(path),
+                f"Model saved at path {path} is not a valid hdf5 file.",
             )
 
     def assert_saved_model(self, path):


### PR DESCRIPTION
Updated to the f-string method for cleaner and better understanding of the code.