### PR TITLE
Documentation fix for depreciated keras.preprocessing

### DIFF
--- a/keras/metrics/confusion_matrix_test.py
+++ b/keras/metrics/confusion_matrix_test.py
@@ -2092,4 +2092,4 @@ class ThresholdsTest(tf.test.TestCase, parameterized.TestCase):
 
 
 if __name__ == '__main__':
-  tf.test.main()
+    tf.test.main()

--- a/keras/metrics/confusion_matrix_test.py
+++ b/keras/metrics/confusion_matrix_test.py
@@ -49,10 +49,20 @@ class FalsePositivesTest(tf.test.TestCase, parameterized.TestCase):
         self.evaluate(tf.compat.v1.variables_initializer(fp_obj.variables))
 
         y_true = tf.constant(
-            ((0, 1, 0, 1, 0), (0, 0, 1, 1, 1), (1, 1, 1, 1, 0), (0, 0, 0, 0, 1))
+            (
+                (0, 1, 0, 1, 0),
+                (0, 0, 1, 1, 1),
+                (1, 1, 1, 1, 0),
+                (0, 0, 0, 0, 1),
+            )
         )
         y_pred = tf.constant(
-            ((0, 0, 1, 1, 0), (1, 1, 1, 1, 1), (0, 1, 0, 1, 0), (1, 1, 1, 1, 1))
+            (
+                (0, 0, 1, 1, 0),
+                (1, 1, 1, 1, 1),
+                (0, 1, 0, 1, 0),
+                (1, 1, 1, 1, 1),
+            )
         )
 
         update_op = fp_obj.update_state(y_true, y_pred)
@@ -64,10 +74,20 @@ class FalsePositivesTest(tf.test.TestCase, parameterized.TestCase):
         fp_obj = metrics.FalsePositives()
         self.evaluate(tf.compat.v1.variables_initializer(fp_obj.variables))
         y_true = tf.constant(
-            ((0, 1, 0, 1, 0), (0, 0, 1, 1, 1), (1, 1, 1, 1, 0), (0, 0, 0, 0, 1))
+            (
+                (0, 1, 0, 1, 0),
+                (0, 0, 1, 1, 1),
+                (1, 1, 1, 1, 0),
+                (0, 0, 0, 0, 1),
+            )
         )
         y_pred = tf.constant(
-            ((0, 0, 1, 1, 0), (1, 1, 1, 1, 1), (0, 1, 0, 1, 0), (1, 1, 1, 1, 1))
+            (
+                (0, 0, 1, 1, 0),
+                (1, 1, 1, 1, 1),
+                (0, 1, 0, 1, 0),
+                (1, 1, 1, 1, 1),
+            )
         )
         sample_weight = tf.constant((1.0, 1.5, 2.0, 2.5))
         result = fp_obj(y_true, y_pred, sample_weight=sample_weight)
@@ -152,10 +172,20 @@ class FalseNegativesTest(tf.test.TestCase, parameterized.TestCase):
         self.evaluate(tf.compat.v1.variables_initializer(fn_obj.variables))
 
         y_true = tf.constant(
-            ((0, 1, 0, 1, 0), (0, 0, 1, 1, 1), (1, 1, 1, 1, 0), (0, 0, 0, 0, 1))
+            (
+                (0, 1, 0, 1, 0),
+                (0, 0, 1, 1, 1),
+                (1, 1, 1, 1, 0),
+                (0, 0, 0, 0, 1),
+            )
         )
         y_pred = tf.constant(
-            ((0, 0, 1, 1, 0), (1, 1, 1, 1, 1), (0, 1, 0, 1, 0), (1, 1, 1, 1, 1))
+            (
+                (0, 0, 1, 1, 0),
+                (1, 1, 1, 1, 1),
+                (0, 1, 0, 1, 0),
+                (1, 1, 1, 1, 1),
+            )
         )
 
         update_op = fn_obj.update_state(y_true, y_pred)
@@ -167,10 +197,20 @@ class FalseNegativesTest(tf.test.TestCase, parameterized.TestCase):
         fn_obj = metrics.FalseNegatives()
         self.evaluate(tf.compat.v1.variables_initializer(fn_obj.variables))
         y_true = tf.constant(
-            ((0, 1, 0, 1, 0), (0, 0, 1, 1, 1), (1, 1, 1, 1, 0), (0, 0, 0, 0, 1))
+            (
+                (0, 1, 0, 1, 0),
+                (0, 0, 1, 1, 1),
+                (1, 1, 1, 1, 0),
+                (0, 0, 0, 0, 1),
+            )
         )
         y_pred = tf.constant(
-            ((0, 0, 1, 1, 0), (1, 1, 1, 1, 1), (0, 1, 0, 1, 0), (1, 1, 1, 1, 1))
+            (
+                (0, 0, 1, 1, 0),
+                (1, 1, 1, 1, 1),
+                (0, 1, 0, 1, 0),
+                (1, 1, 1, 1, 1),
+            )
         )
         sample_weight = tf.constant((1.0, 1.5, 2.0, 2.5))
         result = fn_obj(y_true, y_pred, sample_weight=sample_weight)
@@ -237,10 +277,20 @@ class TrueNegativesTest(tf.test.TestCase, parameterized.TestCase):
         self.evaluate(tf.compat.v1.variables_initializer(tn_obj.variables))
 
         y_true = tf.constant(
-            ((0, 1, 0, 1, 0), (0, 0, 1, 1, 1), (1, 1, 1, 1, 0), (0, 0, 0, 0, 1))
+            (
+                (0, 1, 0, 1, 0),
+                (0, 0, 1, 1, 1),
+                (1, 1, 1, 1, 0),
+                (0, 0, 0, 0, 1),
+            )
         )
         y_pred = tf.constant(
-            ((0, 0, 1, 1, 0), (1, 1, 1, 1, 1), (0, 1, 0, 1, 0), (1, 1, 1, 1, 1))
+            (
+                (0, 0, 1, 1, 0),
+                (1, 1, 1, 1, 1),
+                (0, 1, 0, 1, 0),
+                (1, 1, 1, 1, 1),
+            )
         )
 
         update_op = tn_obj.update_state(y_true, y_pred)
@@ -252,10 +302,20 @@ class TrueNegativesTest(tf.test.TestCase, parameterized.TestCase):
         tn_obj = metrics.TrueNegatives()
         self.evaluate(tf.compat.v1.variables_initializer(tn_obj.variables))
         y_true = tf.constant(
-            ((0, 1, 0, 1, 0), (0, 0, 1, 1, 1), (1, 1, 1, 1, 0), (0, 0, 0, 0, 1))
+            (
+                (0, 1, 0, 1, 0),
+                (0, 0, 1, 1, 1),
+                (1, 1, 1, 1, 0),
+                (0, 0, 0, 0, 1),
+            )
         )
         y_pred = tf.constant(
-            ((0, 0, 1, 1, 0), (1, 1, 1, 1, 1), (0, 1, 0, 1, 0), (1, 1, 1, 1, 1))
+            (
+                (0, 0, 1, 1, 0),
+                (1, 1, 1, 1, 1),
+                (0, 1, 0, 1, 0),
+                (1, 1, 1, 1, 1),
+            )
         )
         sample_weight = tf.constant((1.0, 1.5, 2.0, 2.5))
         result = tn_obj(y_true, y_pred, sample_weight=sample_weight)
@@ -322,10 +382,20 @@ class TruePositivesTest(tf.test.TestCase, parameterized.TestCase):
         self.evaluate(tf.compat.v1.variables_initializer(tp_obj.variables))
 
         y_true = tf.constant(
-            ((0, 1, 0, 1, 0), (0, 0, 1, 1, 1), (1, 1, 1, 1, 0), (0, 0, 0, 0, 1))
+            (
+                (0, 1, 0, 1, 0),
+                (0, 0, 1, 1, 1),
+                (1, 1, 1, 1, 0),
+                (0, 0, 0, 0, 1),
+            )
         )
         y_pred = tf.constant(
-            ((0, 0, 1, 1, 0), (1, 1, 1, 1, 1), (0, 1, 0, 1, 0), (1, 1, 1, 1, 1))
+            (
+                (0, 0, 1, 1, 0),
+                (1, 1, 1, 1, 1),
+                (0, 1, 0, 1, 0),
+                (1, 1, 1, 1, 1),
+            )
         )
 
         update_op = tp_obj.update_state(y_true, y_pred)
@@ -337,10 +407,20 @@ class TruePositivesTest(tf.test.TestCase, parameterized.TestCase):
         tp_obj = metrics.TruePositives()
         self.evaluate(tf.compat.v1.variables_initializer(tp_obj.variables))
         y_true = tf.constant(
-            ((0, 1, 0, 1, 0), (0, 0, 1, 1, 1), (1, 1, 1, 1, 0), (0, 0, 0, 0, 1))
+            (
+                (0, 1, 0, 1, 0),
+                (0, 0, 1, 1, 1),
+                (1, 1, 1, 1, 0),
+                (0, 0, 0, 0, 1),
+            )
         )
         y_pred = tf.constant(
-            ((0, 0, 1, 1, 0), (1, 1, 1, 1, 1), (0, 1, 0, 1, 0), (1, 1, 1, 1, 1))
+            (
+                (0, 0, 1, 1, 0),
+                (1, 1, 1, 1, 1),
+                (0, 1, 0, 1, 0),
+                (1, 1, 1, 1, 1),
+            )
         )
         sample_weight = tf.constant((1.0, 1.5, 2.0, 2.5))
         result = tp_obj(y_true, y_pred, sample_weight=sample_weight)
@@ -480,7 +560,9 @@ class PrecisionTest(tf.test.TestCase, parameterized.TestCase):
     def test_weighted_with_threshold(self):
         p_obj = metrics.Precision(thresholds=[0.5, 1.0])
         y_true = tf.constant([[0, 1], [1, 0]], shape=(2, 2))
-        y_pred = tf.constant([[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32)
+        y_pred = tf.constant(
+            [[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32
+        )
         weights = tf.constant([[4, 0], [3, 1]], shape=(2, 2), dtype=tf.float32)
         self.evaluate(tf.compat.v1.variables_initializer(p_obj.variables))
         result = p_obj(y_true, y_pred, sample_weight=weights)
@@ -494,7 +576,9 @@ class PrecisionTest(tf.test.TestCase, parameterized.TestCase):
     def test_multiple_updates(self):
         p_obj = metrics.Precision(thresholds=[0.5, 1.0])
         y_true = tf.constant([[0, 1], [1, 0]], shape=(2, 2))
-        y_pred = tf.constant([[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32)
+        y_pred = tf.constant(
+            [[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32
+        )
         weights = tf.constant([[4, 0], [3, 1]], shape=(2, 2), dtype=tf.float32)
         self.evaluate(tf.compat.v1.variables_initializer(p_obj.variables))
         update_op = p_obj.update_state(y_true, y_pred, sample_weight=weights)
@@ -686,7 +770,9 @@ class RecallTest(tf.test.TestCase, parameterized.TestCase):
     def test_weighted_with_threshold(self):
         r_obj = metrics.Recall(thresholds=[0.5, 1.0])
         y_true = tf.constant([[0, 1], [1, 0]], shape=(2, 2))
-        y_pred = tf.constant([[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32)
+        y_pred = tf.constant(
+            [[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32
+        )
         weights = tf.constant([[1, 4], [3, 2]], shape=(2, 2), dtype=tf.float32)
         self.evaluate(tf.compat.v1.variables_initializer(r_obj.variables))
         result = r_obj(y_true, y_pred, sample_weight=weights)
@@ -698,7 +784,9 @@ class RecallTest(tf.test.TestCase, parameterized.TestCase):
     def test_multiple_updates(self):
         r_obj = metrics.Recall(thresholds=[0.5, 1.0])
         y_true = tf.constant([[0, 1], [1, 0]], shape=(2, 2))
-        y_pred = tf.constant([[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32)
+        y_pred = tf.constant(
+            [[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32
+        )
         weights = tf.constant([[1, 4], [3, 2]], shape=(2, 2), dtype=tf.float32)
         self.evaluate(tf.compat.v1.variables_initializer(r_obj.variables))
         update_op = r_obj.update_state(y_true, y_pred, sample_weight=weights)
@@ -1373,7 +1461,8 @@ class AUCTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(auc_obj2.num_thresholds, 100)
         self.assertEqual(auc_obj2.curve, metrics_utils.AUCCurve.PR)
         self.assertEqual(
-            auc_obj2.summation_method, metrics_utils.AUCSummationMethod.MAJORING
+            auc_obj2.summation_method,
+            metrics_utils.AUCSummationMethod.MAJORING,
         )
         self.assertTrue(auc_obj2.multi_label)
         self.assertEqual(auc_obj2.num_labels, 2)
@@ -1412,7 +1501,8 @@ class AUCTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(auc_obj2.num_thresholds, 4)
         self.assertEqual(auc_obj2.curve, metrics_utils.AUCCurve.PR)
         self.assertEqual(
-            auc_obj2.summation_method, metrics_utils.AUCSummationMethod.MAJORING
+            auc_obj2.summation_method,
+            metrics_utils.AUCSummationMethod.MAJORING,
         )
         new_config = auc_obj2.get_config()
         self.assertDictEqual(old_config, new_config)
@@ -1598,7 +1688,7 @@ class AUCTest(tf.test.TestCase, parameterized.TestCase):
         # dP = [10-4, 4-0] = [6, 4]
         # slope = dTP/dP = [0.5, 1]
         # intercept = (TPa+(slope*Pa) = [(4 - 0.5*4), (0 - 1*0)] = [2, 0]
-        # (Pb/Pa) = (Pb/Pa) if Pb > 0 AND Pa > 0 else 1 = [10/4, 4/0] = [2.5, 1]
+        # (Pb/Pa)= (Pb/Pa) if Pb > 0 AND Pa > 0 else 1 = [10/4, 4/0] = [2.5, 1]
         # auc * TotalPos = [(0.5 * (3 + 2 * log(2.5))), (1 * (4 + 0))]
         #                = [2.416, 4]
         # auc = [2.416, 4]/(tp[1:]+fn[1:])
@@ -1643,10 +1733,13 @@ class AUCTest(tf.test.TestCase, parameterized.TestCase):
                 )
             )
             labels = np.array(
-                [[[1, 0, 0], [1, 0, 0]], [[0, 1, 1], [0, 1, 1]]], dtype=np.int64
+                [[[1, 0, 0], [1, 0, 0]], [[0, 1, 1], [0, 1, 1]]],
+                dtype=np.int64,
             )
             auc_obj = metrics.AUC()
-            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
+            self.evaluate(
+                tf.compat.v1.variables_initializer(auc_obj.variables)
+            )
             result = auc_obj(labels, logits)
             self.assertEqual(self.evaluate(result), 0.5)
         except ImportError as e:
@@ -1665,7 +1758,9 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
         epsilon = 1e-12
         self.y_pred_logits = -tf.math.log(1.0 / (self.y_pred + epsilon) - 1.0)
 
-        self.y_true_good = tf.constant(np.array([[0, 0, 1, 1], [0, 0, 1, 1]]).T)
+        self.y_true_good = tf.constant(
+            np.array([[0, 0, 1, 1], [0, 0, 1, 1]]).T
+        )
         self.y_true_bad = tf.constant(np.array([[0, 0, 1, 1], [1, 1, 0, 0]]).T)
         self.sample_weight = [1, 2, 3, 4]
 
@@ -1708,7 +1803,9 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
         with self.test_session():
             self.setup()
             auc_obj = metrics.AUC(num_thresholds=5, multi_label=True)
-            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
+            self.evaluate(
+                tf.compat.v1.variables_initializer(auc_obj.variables)
+            )
 
             # Run several updates.
             update_op = auc_obj.update_state(self.y_true_good, self.y_pred)
@@ -1726,7 +1823,9 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
         with self.test_session():
             self.setup()
             auc_obj = metrics.AUC(multi_label=True)
-            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
+            self.evaluate(
+                tf.compat.v1.variables_initializer(auc_obj.variables)
+            )
             result = auc_obj(self.y_true_good, self.y_true_good)
             self.assertEqual(self.evaluate(result), 1)
 
@@ -1743,7 +1842,9 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
             auc_obj = metrics.AUC(
                 num_thresholds=self.num_thresholds, multi_label=True
             )
-            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
+            self.evaluate(
+                tf.compat.v1.variables_initializer(auc_obj.variables)
+            )
             result = auc_obj(self.y_true_good, self.y_pred)
 
             # tpr = [[1, 1, 0.5, 0.5, 0], [1, 1, 0, 0, 0]]
@@ -1759,7 +1860,9 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
                 multi_label=True,
                 from_logits=True,
             )
-            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
+            self.evaluate(
+                tf.compat.v1.variables_initializer(auc_obj.variables)
+            )
             result = auc_obj(self.y_true_good, self.y_pred_logits)
 
             # tpr = [[1, 1, 0.5, 0.5, 0], [1, 1, 0, 0, 0]]
@@ -1805,7 +1908,9 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
                 multi_label=True,
                 label_weights=[0.75, 0.25],
             )
-            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
+            self.evaluate(
+                tf.compat.v1.variables_initializer(auc_obj.variables)
+            )
             result = auc_obj(self.y_true_good, self.y_pred)
 
             # tpr = [[1, 1, 0.5, 0.5, 0], [1, 1, 0, 0, 0]]
@@ -1876,7 +1981,9 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
             )
             self.assertEqual(auc_obj.num_thresholds, 3)
             self.assertAllClose(auc_obj.thresholds, [0.0, 0.5, 1.0])
-            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
+            self.evaluate(
+                tf.compat.v1.variables_initializer(auc_obj.variables)
+            )
             result = auc_obj(self.y_true_good, self.y_pred)
 
             # tp = [[2, 1, 0], [2, 0, 0]]
@@ -1898,7 +2005,9 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
             auc_obj = metrics.AUC(
                 num_thresholds=self.num_thresholds, multi_label=True
             )
-            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
+            self.evaluate(
+                tf.compat.v1.variables_initializer(auc_obj.variables)
+            )
             result = auc_obj(
                 self.y_true_good, self.y_pred, sample_weight=self.sample_weight
             )
@@ -1912,9 +2021,13 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
         with self.test_session():
             self.setup()
             auc_obj = metrics.AUC(
-                num_thresholds=self.num_thresholds, curve="PR", multi_label=True
+                num_thresholds=self.num_thresholds,
+                curve="PR",
+                multi_label=True,
             )
-            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
+            self.evaluate(
+                tf.compat.v1.variables_initializer(auc_obj.variables)
+            )
             good_result = auc_obj(self.y_true_good, self.y_pred)
             with self.subTest(name="good"):
                 # PR AUCs are 0.917 and 1.0 respectively
@@ -1932,9 +2045,13 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
         with self.test_session():
             self.setup()
             auc_obj = metrics.AUC(
-                num_thresholds=self.num_thresholds, curve="PR", multi_label=True
+                num_thresholds=self.num_thresholds,
+                curve="PR",
+                multi_label=True,
             )
-            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
+            self.evaluate(
+                tf.compat.v1.variables_initializer(auc_obj.variables)
+            )
             good_result = auc_obj(
                 self.y_true_good, self.y_pred, sample_weight=self.sample_weight
             )
@@ -1957,7 +2074,9 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
             auc_obj = metrics.AUC(
                 num_thresholds=self.num_thresholds, multi_label=True
             )
-            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
+            self.evaluate(
+                tf.compat.v1.variables_initializer(auc_obj.variables)
+            )
             auc_obj(self.y_true_good, self.y_pred)
             auc_obj.reset_state()
             self.assertAllEqual(auc_obj.true_positives, np.zeros((5, 2)))
@@ -2091,5 +2210,5 @@ class ThresholdsTest(tf.test.TestCase, parameterized.TestCase):
                 self.assertAllClose(v1, v2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     tf.test.main()

--- a/keras/metrics/confusion_matrix_test.py
+++ b/keras/metrics/confusion_matrix_test.py
@@ -560,9 +560,7 @@ class PrecisionTest(tf.test.TestCase, parameterized.TestCase):
     def test_weighted_with_threshold(self):
         p_obj = metrics.Precision(thresholds=[0.5, 1.0])
         y_true = tf.constant([[0, 1], [1, 0]], shape=(2, 2))
-        y_pred = tf.constant(
-            [[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32
-        )
+        y_pred = tf.constant([[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32)
         weights = tf.constant([[4, 0], [3, 1]], shape=(2, 2), dtype=tf.float32)
         self.evaluate(tf.compat.v1.variables_initializer(p_obj.variables))
         result = p_obj(y_true, y_pred, sample_weight=weights)
@@ -576,9 +574,7 @@ class PrecisionTest(tf.test.TestCase, parameterized.TestCase):
     def test_multiple_updates(self):
         p_obj = metrics.Precision(thresholds=[0.5, 1.0])
         y_true = tf.constant([[0, 1], [1, 0]], shape=(2, 2))
-        y_pred = tf.constant(
-            [[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32
-        )
+        y_pred = tf.constant([[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32)
         weights = tf.constant([[4, 0], [3, 1]], shape=(2, 2), dtype=tf.float32)
         self.evaluate(tf.compat.v1.variables_initializer(p_obj.variables))
         update_op = p_obj.update_state(y_true, y_pred, sample_weight=weights)
@@ -770,9 +766,7 @@ class RecallTest(tf.test.TestCase, parameterized.TestCase):
     def test_weighted_with_threshold(self):
         r_obj = metrics.Recall(thresholds=[0.5, 1.0])
         y_true = tf.constant([[0, 1], [1, 0]], shape=(2, 2))
-        y_pred = tf.constant(
-            [[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32
-        )
+        y_pred = tf.constant([[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32)
         weights = tf.constant([[1, 4], [3, 2]], shape=(2, 2), dtype=tf.float32)
         self.evaluate(tf.compat.v1.variables_initializer(r_obj.variables))
         result = r_obj(y_true, y_pred, sample_weight=weights)
@@ -784,9 +778,7 @@ class RecallTest(tf.test.TestCase, parameterized.TestCase):
     def test_multiple_updates(self):
         r_obj = metrics.Recall(thresholds=[0.5, 1.0])
         y_true = tf.constant([[0, 1], [1, 0]], shape=(2, 2))
-        y_pred = tf.constant(
-            [[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32
-        )
+        y_pred = tf.constant([[1, 0], [0.6, 0]], shape=(2, 2), dtype=tf.float32)
         weights = tf.constant([[1, 4], [3, 2]], shape=(2, 2), dtype=tf.float32)
         self.evaluate(tf.compat.v1.variables_initializer(r_obj.variables))
         update_op = r_obj.update_state(y_true, y_pred, sample_weight=weights)
@@ -1737,9 +1729,7 @@ class AUCTest(tf.test.TestCase, parameterized.TestCase):
                 dtype=np.int64,
             )
             auc_obj = metrics.AUC()
-            self.evaluate(
-                tf.compat.v1.variables_initializer(auc_obj.variables)
-            )
+            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
             result = auc_obj(labels, logits)
             self.assertEqual(self.evaluate(result), 0.5)
         except ImportError as e:
@@ -1758,9 +1748,7 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
         epsilon = 1e-12
         self.y_pred_logits = -tf.math.log(1.0 / (self.y_pred + epsilon) - 1.0)
 
-        self.y_true_good = tf.constant(
-            np.array([[0, 0, 1, 1], [0, 0, 1, 1]]).T
-        )
+        self.y_true_good = tf.constant(np.array([[0, 0, 1, 1], [0, 0, 1, 1]]).T)
         self.y_true_bad = tf.constant(np.array([[0, 0, 1, 1], [1, 1, 0, 0]]).T)
         self.sample_weight = [1, 2, 3, 4]
 
@@ -1803,9 +1791,7 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
         with self.test_session():
             self.setup()
             auc_obj = metrics.AUC(num_thresholds=5, multi_label=True)
-            self.evaluate(
-                tf.compat.v1.variables_initializer(auc_obj.variables)
-            )
+            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
 
             # Run several updates.
             update_op = auc_obj.update_state(self.y_true_good, self.y_pred)
@@ -1823,9 +1809,7 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
         with self.test_session():
             self.setup()
             auc_obj = metrics.AUC(multi_label=True)
-            self.evaluate(
-                tf.compat.v1.variables_initializer(auc_obj.variables)
-            )
+            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
             result = auc_obj(self.y_true_good, self.y_true_good)
             self.assertEqual(self.evaluate(result), 1)
 
@@ -1842,9 +1826,7 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
             auc_obj = metrics.AUC(
                 num_thresholds=self.num_thresholds, multi_label=True
             )
-            self.evaluate(
-                tf.compat.v1.variables_initializer(auc_obj.variables)
-            )
+            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
             result = auc_obj(self.y_true_good, self.y_pred)
 
             # tpr = [[1, 1, 0.5, 0.5, 0], [1, 1, 0, 0, 0]]
@@ -1860,9 +1842,7 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
                 multi_label=True,
                 from_logits=True,
             )
-            self.evaluate(
-                tf.compat.v1.variables_initializer(auc_obj.variables)
-            )
+            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
             result = auc_obj(self.y_true_good, self.y_pred_logits)
 
             # tpr = [[1, 1, 0.5, 0.5, 0], [1, 1, 0, 0, 0]]
@@ -1908,9 +1888,7 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
                 multi_label=True,
                 label_weights=[0.75, 0.25],
             )
-            self.evaluate(
-                tf.compat.v1.variables_initializer(auc_obj.variables)
-            )
+            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
             result = auc_obj(self.y_true_good, self.y_pred)
 
             # tpr = [[1, 1, 0.5, 0.5, 0], [1, 1, 0, 0, 0]]
@@ -1981,9 +1959,7 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
             )
             self.assertEqual(auc_obj.num_thresholds, 3)
             self.assertAllClose(auc_obj.thresholds, [0.0, 0.5, 1.0])
-            self.evaluate(
-                tf.compat.v1.variables_initializer(auc_obj.variables)
-            )
+            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
             result = auc_obj(self.y_true_good, self.y_pred)
 
             # tp = [[2, 1, 0], [2, 0, 0]]
@@ -2005,9 +1981,7 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
             auc_obj = metrics.AUC(
                 num_thresholds=self.num_thresholds, multi_label=True
             )
-            self.evaluate(
-                tf.compat.v1.variables_initializer(auc_obj.variables)
-            )
+            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
             result = auc_obj(
                 self.y_true_good, self.y_pred, sample_weight=self.sample_weight
             )
@@ -2025,9 +1999,7 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
                 curve="PR",
                 multi_label=True,
             )
-            self.evaluate(
-                tf.compat.v1.variables_initializer(auc_obj.variables)
-            )
+            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
             good_result = auc_obj(self.y_true_good, self.y_pred)
             with self.subTest(name="good"):
                 # PR AUCs are 0.917 and 1.0 respectively
@@ -2049,9 +2021,7 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
                 curve="PR",
                 multi_label=True,
             )
-            self.evaluate(
-                tf.compat.v1.variables_initializer(auc_obj.variables)
-            )
+            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
             good_result = auc_obj(
                 self.y_true_good, self.y_pred, sample_weight=self.sample_weight
             )
@@ -2074,9 +2044,7 @@ class MultiAUCTest(tf.test.TestCase, parameterized.TestCase):
             auc_obj = metrics.AUC(
                 num_thresholds=self.num_thresholds, multi_label=True
             )
-            self.evaluate(
-                tf.compat.v1.variables_initializer(auc_obj.variables)
-            )
+            self.evaluate(tf.compat.v1.variables_initializer(auc_obj.variables))
             auc_obj(self.y_true_good, self.y_pred)
             auc_obj.reset_state()
             self.assertAllEqual(auc_obj.true_positives, np.zeros((5, 2)))

--- a/keras/utils/image_utils.py
+++ b/keras/utils/image_utils.py
@@ -203,7 +203,7 @@ def array_to_img(x, data_format=None, scale=True, dtype=None):
     ```python
     from PIL import Image
     img = np.random.random(size=(100, 100, 3))
-    pil_img = tf.keras.preprocessing.image.array_to_img(img)
+    pil_img = tf.keras.utils.array_to_img(img)
     ```
 
 
@@ -284,8 +284,8 @@ def img_to_array(img, data_format=None, dtype=None):
     ```python
     from PIL import Image
     img_data = np.random.random(size=(100, 100, 3))
-    img = tf.keras.preprocessing.image.array_to_img(img_data)
-    array = tf.keras.preprocessing.image.img_to_array(img)
+    img = tf.keras.utils.array_to_img(img_data)
+    array = tf.keras.utils.img_to_array(img)
     ```
 
 
@@ -369,8 +369,8 @@ def load_img(
     Usage:
 
     ```
-    image = tf.keras.preprocessing.image.load_img(image_path)
-    input_arr = tf.keras.preprocessing.image.img_to_array(image)
+    image = tf.keras.utils.load_img(image_path)
+    input_arr = tf.keras.utils.img_to_array(image)
     input_arr = np.array([input_arr])  # Convert single image to a batch.
     predictions = model.predict(input_arr)
     ```


### PR DESCRIPTION
Code still used the depreciated `tf.keras.preprocessing.image` method in usage documentation which caused other docs to show wrong documentation as well such as the [Tensorflow's img_to_array](https://www.tensorflow.org/api_docs/python/tf/keras/utils/img_to_array#usage)