### PR TITLE
Add ignore_class to sparse crossentropy and IoU

### DIFF
--- a/keras/backend.py
+++ b/keras/backend.py
@@ -5545,7 +5545,7 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
 @tf.__internal__.dispatch.add_dispatch_support
 @doc_controls.do_not_generate_docs
 def sparse_categorical_crossentropy(
-    target, output, from_logits=False, axis=-1, ignore_index=None
+    target, output, from_logits=False, axis=-1, ignore_class=None
 ):
     """Categorical crossentropy with integer targets.
 
@@ -5559,14 +5559,11 @@ def sparse_categorical_crossentropy(
         axis: Int specifying the channels axis. `axis=-1` corresponds to data
             format `channels_last`, and `axis=1` corresponds to data format
             `channels_first`.
-        ignore_index: Optional integer, the id of a label that will not be
-            included in the entropy equation nor in gradient computation. This
-            is useful in segmentation problems containing the *void* label
-            (commonly -1 or 255) in its annotated segmentation maps.
-            By default, all label ids are considered. If `ignore_index` is not
-            `None` and the output is a tensor with `rank>=3`, then the valid
-            entries will be averaged over the axes `range(1, output_rank-1)`,
-            resulting in an output of shape `[batch]`.
+        ignore_class: Optional integer. The ID of a class to be ignored
+            during loss computation. This is useful, for example, in
+            segmentation problems featuring a "void" class (commonly -1
+            or 255) in segmentation maps.
+            By default (`ignore_class=None`), all classes are considered.
 
     Returns:
         Output tensor.
@@ -5620,8 +5617,8 @@ def sparse_categorical_crossentropy(
         target = flatten(target)
         output = tf.reshape(output, [-1, output_shape[-1]])
 
-    if ignore_index is not None:
-        valid_mask = tf.not_equal(target, ignore_index)
+    if ignore_class is not None:
+        valid_mask = tf.not_equal(target, ignore_class)
         target = target[valid_mask]
         output = output[valid_mask]
 
@@ -5635,7 +5632,7 @@ def sparse_categorical_crossentropy(
             labels=target, logits=output
         )
 
-    if ignore_index is not None:
+    if ignore_class is not None:
         res_shape = cast(output_shape[:-1], "int64")
         valid_mask = tf.reshape(valid_mask, res_shape)
 

--- a/keras/backend_test.py
+++ b/keras/backend_test.py
@@ -1969,6 +1969,74 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
         )
         self.assertArrayNear(self.evaluate(result)[0], [0.002, 0, 0.17], 1e-3)
 
+    @test_combinations.generate(
+        test_combinations.combine(mode=["graph", "eager"])
+    )
+    def test_sparse_categorical_crossentropy_loss_with_ignore_index(self):
+        t = backend.constant([255, 1, 2, 2])
+        p = backend.softmax(
+            backend.constant(
+                [
+                    [1.8, 1.2, 0.5],
+                    [0.2, 3.8, 0.8],
+                    [1.1, 0.4, 3.4],
+                    [1.3, 0.7, 3.8],
+                ]
+            )
+        )
+        result = backend.sparse_categorical_crossentropy(t, p, ignore_index=255)
+        self.assertArrayNear(
+            self.evaluate(result),
+            [0.0, 0.07428224, 0.13980183, 0.11967831],
+            1e-3,
+        )
+
+        t = backend.constant([-1, 1, 2, 2])
+        p = backend.constant(
+            [
+                [1.8, 1.2, 0.5],
+                [0.2, 3.8, 0.8],
+                [1.1, 0.4, 3.4],
+                [1.3, 0.7, 3.8],
+            ]
+        )
+        result = backend.sparse_categorical_crossentropy(
+            t, p, ignore_index=-1, from_logits=True
+        )
+        self.assertArrayNear(
+            self.evaluate(result),
+            [0.0, 0.07428224, 0.13980183, 0.11967831],
+            1e-3,
+        )
+
+    @test_combinations.generate(
+        test_combinations.combine(mode=["graph", "eager"])
+    )
+    def test_sparse_cce_loss_with_ignore_index_for_segmentation(self):
+        t = backend.constant(
+            [
+                [[0, 2], [-1, -1]],
+                [[0, 2], [-1, -1]],
+            ]
+        )
+        p = backend.constant(
+            [
+                [
+                    [[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+                    [[0.2, 0.5, 0.3], [0.0, 1.0, 0.0]],
+                ],
+                [
+                    [[1.0, 0.0, 0.0], [0.0, 0.5, 0.5]],
+                    [[0.2, 0.5, 0.3], [0.0, 1.0, 0.0]],
+                ],
+            ]
+        )
+
+        result = backend.sparse_categorical_crossentropy(t, p, ignore_index=-1)
+        self.assertArrayNear(
+            self.evaluate(result), [2.3841855e-07, 3.4657377e-01], 1e-3
+        )
+
     @test_combinations.generate(test_combinations.combine(mode=["graph"]))
     def test_sparse_categorical_crossentropy_loss_with_unknown_rank_tensor(
         self,

--- a/keras/backend_test.py
+++ b/keras/backend_test.py
@@ -1972,7 +1972,7 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
     @test_combinations.generate(
         test_combinations.combine(mode=["graph", "eager"])
     )
-    def test_sparse_categorical_crossentropy_loss_with_ignore_index(self):
+    def test_sparse_categorical_crossentropy_loss_with_ignore_class(self):
         t = backend.constant([255, 1, 2, 2])
         p = backend.softmax(
             backend.constant(
@@ -1984,7 +1984,7 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
                 ]
             )
         )
-        result = backend.sparse_categorical_crossentropy(t, p, ignore_index=255)
+        result = backend.sparse_categorical_crossentropy(t, p, ignore_class=255)
         self.assertArrayNear(
             self.evaluate(result),
             [0.0, 0.07428224, 0.13980183, 0.11967831],
@@ -2001,7 +2001,7 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
             ]
         )
         result = backend.sparse_categorical_crossentropy(
-            t, p, ignore_index=-1, from_logits=True
+            t, p, ignore_class=-1, from_logits=True
         )
         self.assertArrayNear(
             self.evaluate(result),
@@ -2012,7 +2012,7 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
     @test_combinations.generate(
         test_combinations.combine(mode=["graph", "eager"])
     )
-    def test_sparse_cce_loss_with_ignore_index_for_segmentation(self):
+    def test_sparse_cce_loss_with_ignore_class_for_segmentation(self):
         t = backend.constant(
             [
                 [[0, 2], [-1, -1]],
@@ -2032,7 +2032,7 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
             ]
         )
 
-        result = backend.sparse_categorical_crossentropy(t, p, ignore_index=-1)
+        result = backend.sparse_categorical_crossentropy(t, p, ignore_class=-1)
         self.assertArrayNear(
             self.evaluate(result), [2.3841855e-07, 3.4657377e-01], 1e-3
         )

--- a/keras/backend_test.py
+++ b/keras/backend_test.py
@@ -28,6 +28,7 @@ from keras.engine import input_layer
 from keras.layers import activation
 from keras.layers.normalization import batch_normalization_v1
 from keras.testing_infra import test_combinations
+from keras.utils import losses_utils
 from keras.utils import tf_inspect
 from keras.utils import tf_utils
 
@@ -1973,7 +1974,7 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
         test_combinations.combine(mode=["graph", "eager"])
     )
     def test_sparse_categorical_crossentropy_loss_with_ignore_class(self):
-        t = backend.constant([255, 1, 2, 2])
+        tests = (([255, 1, 2, 2], 255), ([-1, 1, 2, 2], -1))
         p = backend.softmax(
             backend.constant(
                 [
@@ -1984,40 +1985,24 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
                 ]
             )
         )
-        result = backend.sparse_categorical_crossentropy(t, p, ignore_class=255)
-        self.assertArrayNear(
-            self.evaluate(result),
-            [0.0, 0.07428224, 0.13980183, 0.11967831],
-            1e-3,
-        )
 
-        t = backend.constant([-1, 1, 2, 2])
-        p = backend.constant(
-            [
-                [1.8, 1.2, 0.5],
-                [0.2, 3.8, 0.8],
-                [1.1, 0.4, 3.4],
-                [1.3, 0.7, 3.8],
-            ]
-        )
-        result = backend.sparse_categorical_crossentropy(
-            t, p, ignore_class=-1, from_logits=True
-        )
-        self.assertArrayNear(
-            self.evaluate(result),
-            [0.0, 0.07428224, 0.13980183, 0.11967831],
-            1e-3,
-        )
+        for t, ignore_class in tests:
+            t = backend.constant(t)
+            result = backend.sparse_categorical_crossentropy(
+                t, p, ignore_class=ignore_class
+            )
+            self.assertArrayNear(
+                self.evaluate(result),
+                [0.0, 0.07428224, 0.13980183, 0.11967831],
+                1e-3,
+            )
 
     @test_combinations.generate(
         test_combinations.combine(mode=["graph", "eager"])
     )
     def test_sparse_cce_loss_with_ignore_class_for_segmentation(self):
         t = backend.constant(
-            [
-                [[0, 2], [-1, -1]],
-                [[0, 2], [-1, -1]],
-            ]
+            [[[0, 2], [-1, -1]], [[0, 2], [-1, -1]], [[0, 0], [0, 0]]]
         )
         p = backend.constant(
             [
@@ -2029,13 +2014,43 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
                     [[1.0, 0.0, 0.0], [0.0, 0.5, 0.5]],
                     [[0.2, 0.5, 0.3], [0.0, 1.0, 0.0]],
                 ],
+                [
+                    [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+                    [[0.1, 0.9, 0.0], [0.2, 0.8, 0.0]],
+                ],
+            ]
+        )
+
+        expected_result = [
+            [[0.0, 0.0], [0.0, 0.0]],
+            [[0.0, 0.693148], [0.0, 0.0]],
+            [[0.0, 0.0], [2.302585, 1.609438]],
+        ]
+
+        # total_entries = 12
+        # valid_entries = 8
+        expected_mask = backend.constant(
+            [
+                [[True, True], [False, False]],
+                [[True, True], [False, False]],
+                [[True, True], [True, True]],
             ]
         )
 
         result = backend.sparse_categorical_crossentropy(t, p, ignore_class=-1)
-        self.assertArrayNear(
-            self.evaluate(result), [2.3841855e-07, 3.4657377e-01], 1e-3
+        mask = losses_utils.get_mask(result)
+
+        self.assertIsNotNone(
+            mask,
+            "expected sparse_categorical_crossentropy to set the "
+            "`_keras_mask` attribute when `ignore_class is not None`, "
+            "which indicates which loss values are valid.",
         )
+
+        result = self.evaluate(result)
+        mask = self.evaluate(mask)
+        self.assertAllEqual(mask, expected_mask)
+        self.assertAllClose(result, expected_result, atol=1e-6)
 
     @test_combinations.generate(test_combinations.combine(mode=["graph"]))
     def test_sparse_categorical_crossentropy_loss_with_unknown_rank_tensor(

--- a/keras/engine/compile_utils.py
+++ b/keras/engine/compile_utils.py
@@ -261,7 +261,7 @@ class LossesContainer(Container):
                 continue
 
             y_t, y_p, sw = match_dtype_and_rank(y_t, y_p, sw)
-            sw = apply_mask(y_p, sw, get_mask(y_p))
+            sw = losses_utils.apply_mask(y_p, sw, losses_utils.get_mask(y_p))
             loss_value = loss_obj(y_t, y_p, sample_weight=sw)
 
             total_loss_mean_value = loss_value
@@ -596,8 +596,8 @@ class MetricsContainer(Container):
                 continue
 
             y_t, y_p, sw = match_dtype_and_rank(y_t, y_p, sw)
-            mask = get_mask(y_p)
-            sw = apply_mask(y_p, sw, mask)
+            mask = losses_utils.get_mask(y_p)
+            sw = losses_utils.apply_mask(y_p, sw, mask)
 
             for metric_obj in metric_objs:
                 if metric_obj is None:
@@ -845,25 +845,6 @@ def match_dtype_and_rank(y_t, y_p, sw):
     if sw is not None:
         sw = tf.cast(sw, y_p.dtype)
     return y_t, y_p, sw
-
-
-def get_mask(y_p):
-    """Returns Keras mask from tensor."""
-    return getattr(y_p, "_keras_mask", None)
-
-
-def apply_mask(y_p, sw, mask):
-    """Applies any mask on predictions to sample weights."""
-    if mask is not None:
-        mask = tf.cast(mask, y_p.dtype)
-        if sw is not None:
-            mask, _, sw = losses_utils.squeeze_or_expand_dimensions(
-                mask, sample_weight=sw
-            )
-            sw *= mask
-        else:
-            sw = mask
-    return sw
 
 
 def get_custom_object_name(obj):

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -150,8 +150,13 @@ class Loss:
                     self.call, tf.__internal__.autograph.control_status_ctx()
                 )
             losses = call_fn(y_true, y_pred)
+            mask = losses_utils.get_mask(losses)
+            reduction = self._get_reduction()
+            sample_weight = losses_utils.apply_valid_mask(
+                losses, sample_weight, mask, reduction
+            )
             return losses_utils.compute_weighted_loss(
-                losses, sample_weight, reduction=self._get_reduction()
+                losses, sample_weight, reduction=reduction
             )
 
     @classmethod
@@ -977,6 +982,7 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
     def __init__(
         self,
         from_logits=False,
+        ignore_class=None,
         reduction=losses_utils.ReductionV2.AUTO,
         name="sparse_categorical_crossentropy",
     ):
@@ -1003,6 +1009,7 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
             name=name,
             reduction=reduction,
             from_logits=from_logits,
+            ignore_class=ignore_class,
         )
 
 

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -2025,7 +2025,7 @@ def _ragged_tensor_categorical_crossentropy(
 )
 @tf.__internal__.dispatch.add_dispatch_support
 def sparse_categorical_crossentropy(
-    y_true, y_pred, from_logits=False, axis=-1, ignore_index=None
+    y_true, y_pred, from_logits=False, axis=-1, ignore_class=None
 ):
     """Computes the sparse categorical crossentropy loss.
 
@@ -2047,7 +2047,7 @@ def sparse_categorical_crossentropy(
                   [[[1.0, 0.0, 0.0], [0.0, 0.5, 0.5]],
                    [[0.2, 0.5, 0.3], [0.0, 1.0, 0.0]]]]
     >>> loss = tf.keras.losses.sparse_categorical_crossentropy(
-    ...   y_true, y_pred, ignore_index=-1)
+    ...   y_true, y_pred, ignore_class=-1)
     >>> assert loss.shape == (2,)
     >>> loss.numpy()
     array([2.3841855e-07, 3.4657377e-01], dtype=float32)
@@ -2059,14 +2059,10 @@ def sparse_categorical_crossentropy(
         default, we assume that `y_pred` encodes a probability distribution.
       axis: Defaults to -1. The dimension along which the entropy is
         computed.
-      ignore_index: Optional integer, the id of a label that will not be
-        included in the entropy equation nor in gradient computation. This
-        is useful in segmentation problems containing the *void* label
-        (commonly -1 or 255) in its annotated segmentation maps.
-        By default, all label ids are considered. If `ignore_index` is not
-        `None` and the output is a tensor with `rank>=3`, then the valid
-        entries will be averaged over the axes `range(1, output_rank-1)`,
-        resulting in an output of shape `[batch]`.
+      ignore_class: Optional integer. The ID of a class to be ignored during
+        loss computation. This is useful, for example, in segmentation
+        problems featuring a "void" class (commonly -1 or 255) in segmentation
+        maps. By default (`ignore_class=None`), all classes are considered.
 
     Returns:
       Sparse categorical crossentropy loss value.
@@ -2075,14 +2071,14 @@ def sparse_categorical_crossentropy(
         y_true,
         y_pred,
         from_logits=from_logits,
-        ignore_index=ignore_index,
+        ignore_class=ignore_class,
         axis=axis,
     )
 
 
 @dispatch.dispatch_for_types(sparse_categorical_crossentropy, tf.RaggedTensor)
 def _ragged_tensor_sparse_categorical_crossentropy(
-    y_true, y_pred, from_logits=False, axis=-1, ignore_index=None
+    y_true, y_pred, from_logits=False, axis=-1, ignore_class=None
 ):
     """Implements support for handling RaggedTensors.
 
@@ -2099,7 +2095,7 @@ def _ragged_tensor_sparse_categorical_crossentropy(
     fn = functools.partial(
         sparse_categorical_crossentropy,
         from_logits=from_logits,
-        ignore_index=ignore_index,
+        ignore_class=ignore_class,
         axis=axis,
     )
     return _ragged_tensor_apply_loss(fn, y_true, y_pred, y_pred_extra_dim=True)

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -2071,8 +2071,6 @@ def sparse_categorical_crossentropy(
     Returns:
       Sparse categorical crossentropy loss value.
     """
-    y_pred = tf.convert_to_tensor(y_pred)
-
     return backend.sparse_categorical_crossentropy(
         y_true,
         y_pred,

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -991,6 +991,11 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
         Args:
           from_logits: Whether `y_pred` is expected to be a logits tensor. By
             default, we assume that `y_pred` encodes a probability distribution.
+          ignore_class: Optional integer. The ID of a class to be ignored during
+            loss computation. This is useful, for example, in segmentation
+            problems featuring a "void" class (commonly -1 or 255) in
+            segmentation maps.
+            By default (`ignore_class=None`), all classes are considered.
           reduction: Type of `tf.keras.losses.Reduction` to apply to
             loss. Default value is `AUTO`. `AUTO` indicates that the reduction
             option will be determined by the usage context. For almost all cases

--- a/keras/losses_test.py
+++ b/keras/losses_test.py
@@ -164,8 +164,8 @@ class KerasLossesTest(tf.test.TestCase, parameterized.TestCase):
     @test_combinations.generate(
         test_combinations.combine(mode=["graph", "eager"])
     )
-    def test_sparse_categorical_crossentropy_loss_with_ignore_index(self):
-        ignore_index = 255
+    def test_sparse_categorical_crossentropy_loss_with_ignore_class(self):
+        ignore_class = 255
         target = backend.variable(np.random.randint(0, 1, (5, 1)))
         logits = backend.variable(np.random.random((5, 1)))
         softmax_output = backend.softmax(logits)
@@ -174,14 +174,14 @@ class KerasLossesTest(tf.test.TestCase, parameterized.TestCase):
             tf.constant([0, 1, 0, 1, 1], target.dtype), (5, 1)
         )
         target.assign(
-            target * valid_entries + (1 - valid_entries) * ignore_index
+            target * valid_entries + (1 - valid_entries) * ignore_class
         )
 
         output_from_logit = losses.sparse_categorical_crossentropy(
-            target, logits, ignore_index=ignore_index, from_logits=True
+            target, logits, ignore_class=ignore_class, from_logits=True
         )
         output_from_softmax = losses.sparse_categorical_crossentropy(
-            target, softmax_output, ignore_index=ignore_index
+            target, softmax_output, ignore_class=ignore_class
         )
         np.testing.assert_allclose(
             backend.eval(output_from_logit),

--- a/keras/metrics/base_metric.py
+++ b/keras/metrics/base_metric.py
@@ -698,6 +698,10 @@ class MeanMetricWrapper(Mean):
             self._fn, tf.__internal__.autograph.control_status_ctx()
         )
         matches = ag_fn(y_true, y_pred, **self._fn_kwargs)
+        mask = losses_utils.get_mask(matches)
+        sample_weight = losses_utils.apply_valid_mask(
+            matches, sample_weight, mask, self.reduction
+        )
         return super().update_state(matches, sample_weight=sample_weight)
 
     def get_config(self):
@@ -915,6 +919,10 @@ class SumOverBatchSizeMetricWrapper(SumOverBatchSize):
             self._fn, tf.__internal__.autograph.control_status_ctx()
         )
         matches = ag_fn(y_true, y_pred, **self._fn_kwargs)
+        mask = losses_utils.get_mask(matches)
+        sample_weight = losses_utils.apply_valid_mask(
+            matches, sample_weight, mask, self.reduction
+        )
         return super().update_state(matches, sample_weight=sample_weight)
 
     def get_config(self):

--- a/keras/metrics/metrics.py
+++ b/keras/metrics/metrics.py
@@ -2646,10 +2646,10 @@ class _IoUBase(base_metric.Metric):
         `(num_classes, num_classes)` will be allocated.
       name: (Optional) string name of the metric instance.
       dtype: (Optional) data type of the metric result.
-      ignore_index: Optional integer, the id of a label that will not be
-        included in the metric computation. This is useful in segmentation
-        problems containing the *void* label (commonly -1 or 255) in its
-        annotated segmentation maps. By default, all label ids are considered.
+      ignore_class: Optional integer. The ID of a class to be ignored during
+        metric computation. This is useful, for example, in segmentation
+        problems featuring a "void" class (commonly -1 or 255) in segmentation
+        maps. By default (`ignore_class=None`), all classes are considered.
       sparse_labels: Wether labels are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
@@ -2665,14 +2665,14 @@ class _IoUBase(base_metric.Metric):
         num_classes: int,
         name: Optional[str] = None,
         dtype: Optional[Union[str, tf.dtypes.DType]] = None,
-        ignore_index: Optional[int] = None,
+        ignore_class: Optional[int] = None,
         sparse_labels: bool = True,
         sparse_preds: bool = True,
         axis: int = -1,
     ):
         super().__init__(name=name, dtype=dtype)
         self.num_classes = num_classes
-        self.ignore_index = ignore_index
+        self.ignore_class = ignore_class
         self.sparse_labels = sparse_labels
         self.sparse_preds = sparse_preds
         self.axis = axis
@@ -2713,8 +2713,8 @@ class _IoUBase(base_metric.Metric):
         if y_true.shape.ndims > 1:
             y_true = tf.reshape(y_true, [-1])
 
-        if self.ignore_index is not None:
-            valid_mask = tf.not_equal(y_true, self.ignore_index)
+        if self.ignore_class is not None:
+            valid_mask = tf.not_equal(y_true, self.ignore_class)
             y_true = y_true[valid_mask]
             y_pred = y_pred[valid_mask]
 
@@ -2774,10 +2774,10 @@ class IoU(_IoUBase):
         single id value should be provided.
       name: (Optional) string name of the metric instance.
       dtype: (Optional) data type of the metric result.
-      ignore_index: Optional integer, the id of a label that will not be
-        included in the metric computation. This is useful in segmentation
-        problems containing the *void* label (commonly -1 or 255) in its
-        annotated segmentation maps. By default, all label ids are considered.
+      ignore_class: Optional integer. The ID of a class to be ignored during
+        metric computation. This is useful, for example, in segmentation
+        problems featuring a "void" class (commonly -1 or 255) in segmentation
+        maps. By default (`ignore_class=None`), all classes are considered.
       sparse_labels: Wether labels are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
@@ -2826,7 +2826,7 @@ class IoU(_IoUBase):
         target_class_ids: Union[List[int], Tuple[int, ...]],
         name: Optional[str] = None,
         dtype: Optional[Union[str, tf.dtypes.DType]] = None,
-        ignore_index: Optional[int] = None,
+        ignore_class: Optional[int] = None,
         sparse_labels: bool = True,
         sparse_preds: bool = True,
         axis: int = -1,
@@ -2834,7 +2834,7 @@ class IoU(_IoUBase):
         super().__init__(
             name=name,
             num_classes=num_classes,
-            ignore_index=ignore_index,
+            ignore_class=ignore_class,
             sparse_labels=sparse_labels,
             sparse_preds=sparse_preds,
             axis=axis,
@@ -2883,7 +2883,7 @@ class IoU(_IoUBase):
         config = {
             "num_classes": self.num_classes,
             "target_class_ids": self.target_class_ids,
-            "ignore_index": self.ignore_index,
+            "ignore_class": self.ignore_class,
             "sparse_labels": self.sparse_labels,
             "sparse_preds": self.sparse_preds,
             "axis": self.axis,
@@ -3042,10 +3042,10 @@ class MeanIoU(IoU):
         [num_classes, num_classes] will be allocated.
       name: (Optional) string name of the metric instance.
       dtype: (Optional) data type of the metric result.
-      ignore_index: Optional integer, the id of a label that will not be
-        included in the metric computation. This is useful in segmentation
-        problems containing the *void* label (commonly -1 or 255) in its
-        annotated segmentation maps. By default, all label ids are considered.
+      ignore_class: Optional integer. The ID of a class to be ignored during
+        metric computation. This is useful, for example, in segmentation
+        problems featuring a "void" class (commonly -1 or 255) in segmentation
+        maps. By default (`ignore_class=None`), all classes are considered.
       sparse_labels: Wether labels are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
@@ -3088,7 +3088,7 @@ class MeanIoU(IoU):
         num_classes: int,
         name: Optional[str] = None,
         dtype: Optional[Union[str, tf.dtypes.DType]] = None,
-        ignore_index: Optional[int] = None,
+        ignore_class: Optional[int] = None,
         sparse_labels: bool = True,
         sparse_preds: bool = True,
         axis: int = -1,
@@ -3100,7 +3100,7 @@ class MeanIoU(IoU):
             target_class_ids=target_class_ids,
             axis=axis,
             dtype=dtype,
-            ignore_index=ignore_index,
+            ignore_class=ignore_class,
             sparse_labels=sparse_labels,
             sparse_preds=sparse_preds,
         )
@@ -3110,7 +3110,7 @@ class MeanIoU(IoU):
             "num_classes": self.num_classes,
             "name": self.name,
             "dtype": self._dtype,
-            "ignore_index": self.ignore_index,
+            "ignore_class": self.ignore_class,
             "sparse_labels": self.sparse_labels,
             "sparse_preds": self.sparse_preds,
             "axis": self.axis,
@@ -3161,10 +3161,10 @@ class OneHotIoU(IoU):
         single id value should be provided.
       name: (Optional) string name of the metric instance.
       dtype: (Optional) data type of the metric result.
-      ignore_index: Optional integer, the id of a label that will not be
-        included in the metric computation. This is useful in segmentation
-        problems containing the *void* label (commonly -1 or 255) in its
-        annotated segmentation maps. By default, all label ids are considered.
+      ignore_class: Optional integer. The ID of a class to be ignored during
+        metric computation. This is useful, for example, in segmentation
+        problems featuring a "void" class (commonly -1 or 255) in segmentation
+        maps. By default (`ignore_class=None`), all classes are considered.
       sparse_preds: Wether predictions are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
@@ -3206,7 +3206,7 @@ class OneHotIoU(IoU):
         target_class_ids: Union[List[int], Tuple[int, ...]],
         name=None,
         dtype=None,
-        ignore_index: Optional[int] = None,
+        ignore_class: Optional[int] = None,
         sparse_preds: bool = False,
         axis: int = -1,
     ):
@@ -3215,7 +3215,7 @@ class OneHotIoU(IoU):
             target_class_ids=target_class_ids,
             name=name,
             dtype=dtype,
-            ignore_index=ignore_index,
+            ignore_class=ignore_class,
             sparse_labels=False,
             sparse_preds=sparse_preds,
             axis=axis,
@@ -3227,7 +3227,7 @@ class OneHotIoU(IoU):
             "target_class_ids": self.target_class_ids,
             "name": self.name,
             "dtype": self._dtype,
-            "ignore_index": self.ignore_index,
+            "ignore_class": self.ignore_class,
             "sparse_preds": self.sparse_preds,
             "axis": self.axis,
         }
@@ -3275,10 +3275,10 @@ class OneHotMeanIoU(MeanIoU):
         allocated to accumulate predictions from which the metric is calculated.
       name: (Optional) string name of the metric instance.
       dtype: (Optional) data type of the metric result.
-      ignore_index: Optional integer, the id of a label that will not be
-        included in the metric computation. This is useful in segmentation
-        problems containing the *void* label (commonly -1 or 255) in its
-        annotated segmentation maps. By default, all label ids are considered.
+      ignore_class: Optional integer. The ID of a class to be ignored during
+        metric computation. This is useful, for example, in segmentation
+        problems featuring a "void" class (commonly -1 or 255) in segmentation
+        maps. By default (`ignore_class=None`), all classes are considered.
       sparse_preds: Wether predictions are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
@@ -3319,7 +3319,7 @@ class OneHotMeanIoU(MeanIoU):
         num_classes: int,
         name: str = None,
         dtype: Optional[Union[str, tf.dtypes.DType]] = None,
-        ignore_index: Optional[int] = None,
+        ignore_class: Optional[int] = None,
         sparse_preds: bool = False,
         axis: int = -1,
     ):
@@ -3328,7 +3328,7 @@ class OneHotMeanIoU(MeanIoU):
             axis=axis,
             name=name,
             dtype=dtype,
-            ignore_index=ignore_index,
+            ignore_class=ignore_class,
             sparse_labels=False,
             sparse_preds=sparse_preds,
         )
@@ -3338,7 +3338,7 @@ class OneHotMeanIoU(MeanIoU):
             "num_classes": self.num_classes,
             "name": self.name,
             "dtype": self._dtype,
-            "ignore_index": self.ignore_index,
+            "ignore_class": self.ignore_class,
             "sparse_preds": self.sparse_preds,
             "axis": self.axis,
         }
@@ -3493,10 +3493,10 @@ class SparseCategoricalCrossentropy(base_metric.MeanMetricWrapper):
       dtype: (Optional) data type of the metric result.
       from_logits: (Optional) Whether output is expected to be a logits tensor.
         By default, we consider that output encodes a probability distribution.
-      ignore_index: Optional integer, the id of a label that will not be
-        included in the metric computation. This is useful in segmentation
-        problems containing the *void* label (commonly -1 or 255) in its
-        annotated segmentation maps. By default, all label ids are considered.
+      ignore_class: Optional integer. The ID of a class to be ignored during
+        metric computation. This is useful, for example, in segmentation
+        problems featuring a "void" class (commonly -1 or 255) in segmentation
+        maps. By default (`ignore_class=None`), all classes are considered.
       axis: (Optional) Defaults to -1. The dimension along which entropy is
         computed.
 
@@ -3541,7 +3541,7 @@ class SparseCategoricalCrossentropy(base_metric.MeanMetricWrapper):
         name: str = "sparse_categorical_crossentropy",
         dtype: Optional[Union[str, tf.dtypes.DType]] = None,
         from_logits: bool = False,
-        ignore_index: Optional[int] = None,
+        ignore_class: Optional[int] = None,
         axis: int = -1,
     ):
         super().__init__(
@@ -3549,7 +3549,7 @@ class SparseCategoricalCrossentropy(base_metric.MeanMetricWrapper):
             name,
             dtype=dtype,
             from_logits=from_logits,
-            ignore_index=ignore_index,
+            ignore_class=ignore_class,
             axis=axis,
         )
 

--- a/keras/metrics/metrics.py
+++ b/keras/metrics/metrics.py
@@ -2713,15 +2713,18 @@ class _IoUBase(base_metric.Metric):
         if y_true.shape.ndims > 1:
             y_true = tf.reshape(y_true, [-1])
 
-        if self.ignore_class is not None:
-            valid_mask = tf.not_equal(y_true, self.ignore_class)
-            y_true = y_true[valid_mask]
-            y_pred = y_pred[valid_mask]
-
         if sample_weight is not None:
             sample_weight = tf.cast(sample_weight, self._dtype)
             if sample_weight.shape.ndims > 1:
                 sample_weight = tf.reshape(sample_weight, [-1])
+
+        if self.ignore_class is not None:
+            ignore_class = tf.cast(self.ignore_class, y_true.dtype)
+            valid_mask = tf.not_equal(y_true, ignore_class)
+            y_true = y_true[valid_mask]
+            y_pred = y_pred[valid_mask]
+            if sample_weight is not None:
+                sample_weight = sample_weight[valid_mask]
 
         # Accumulate the prediction to current confusion matrix.
         current_cm = tf.math.confusion_matrix(

--- a/keras/metrics/metrics.py
+++ b/keras/metrics/metrics.py
@@ -2650,10 +2650,10 @@ class _IoUBase(base_metric.Metric):
         metric computation. This is useful, for example, in segmentation
         problems featuring a "void" class (commonly -1 or 255) in segmentation
         maps. By default (`ignore_class=None`), all classes are considered.
-      sparse_labels: Wether labels are encoded using natural numbers or
+      sparse_y_true: Whether labels are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
-      sparse_preds: Wether predictions are encoded using natural numbers or
+      sparse_y_pred: Whether predictions are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
       axis: (Optional) Defaults to -1. The dimension containing the logits.
@@ -2666,15 +2666,15 @@ class _IoUBase(base_metric.Metric):
         name: Optional[str] = None,
         dtype: Optional[Union[str, tf.dtypes.DType]] = None,
         ignore_class: Optional[int] = None,
-        sparse_labels: bool = True,
-        sparse_preds: bool = True,
+        sparse_y_true: bool = True,
+        sparse_y_pred: bool = True,
         axis: int = -1,
     ):
         super().__init__(name=name, dtype=dtype)
         self.num_classes = num_classes
         self.ignore_class = ignore_class
-        self.sparse_labels = sparse_labels
-        self.sparse_preds = sparse_preds
+        self.sparse_y_true = sparse_y_true
+        self.sparse_y_pred = sparse_y_pred
         self.axis = axis
 
         # Variable to accumulate the predictions in the confusion matrix.
@@ -2698,9 +2698,9 @@ class _IoUBase(base_metric.Metric):
           Update op.
         """
 
-        if not self.sparse_labels:
+        if not self.sparse_y_true:
             y_true = tf.argmax(y_true, axis=self.axis)
-        if not self.sparse_preds:
+        if not self.sparse_y_pred:
             y_pred = tf.argmax(y_pred, axis=self.axis)
 
         y_true = tf.cast(y_true, self._dtype)
@@ -2781,10 +2781,10 @@ class IoU(_IoUBase):
         metric computation. This is useful, for example, in segmentation
         problems featuring a "void" class (commonly -1 or 255) in segmentation
         maps. By default (`ignore_class=None`), all classes are considered.
-      sparse_labels: Wether labels are encoded using natural numbers or
+      sparse_y_true: Whether labels are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
-      sparse_preds: Wether predictions are encoded using natural numbers or
+      sparse_y_pred: Whether predictions are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
       axis: (Optional) Defaults to -1. The dimension containing the logits.
@@ -2830,16 +2830,16 @@ class IoU(_IoUBase):
         name: Optional[str] = None,
         dtype: Optional[Union[str, tf.dtypes.DType]] = None,
         ignore_class: Optional[int] = None,
-        sparse_labels: bool = True,
-        sparse_preds: bool = True,
+        sparse_y_true: bool = True,
+        sparse_y_pred: bool = True,
         axis: int = -1,
     ):
         super().__init__(
             name=name,
             num_classes=num_classes,
             ignore_class=ignore_class,
-            sparse_labels=sparse_labels,
-            sparse_preds=sparse_preds,
+            sparse_y_true=sparse_y_true,
+            sparse_y_pred=sparse_y_pred,
             axis=axis,
             dtype=dtype,
         )
@@ -2887,8 +2887,8 @@ class IoU(_IoUBase):
             "num_classes": self.num_classes,
             "target_class_ids": self.target_class_ids,
             "ignore_class": self.ignore_class,
-            "sparse_labels": self.sparse_labels,
-            "sparse_preds": self.sparse_preds,
+            "sparse_y_true": self.sparse_y_true,
+            "sparse_y_pred": self.sparse_y_pred,
             "axis": self.axis,
         }
         base_config = super().get_config()
@@ -3049,10 +3049,10 @@ class MeanIoU(IoU):
         metric computation. This is useful, for example, in segmentation
         problems featuring a "void" class (commonly -1 or 255) in segmentation
         maps. By default (`ignore_class=None`), all classes are considered.
-      sparse_labels: Wether labels are encoded using natural numbers or
+      sparse_y_true: Whether labels are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
-      sparse_preds: Wether predictions are encoded using natural numbers or
+      sparse_y_pred: Whether predictions are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
       axis: (Optional) Defaults to -1. The dimension containing the logits.
@@ -3092,8 +3092,8 @@ class MeanIoU(IoU):
         name: Optional[str] = None,
         dtype: Optional[Union[str, tf.dtypes.DType]] = None,
         ignore_class: Optional[int] = None,
-        sparse_labels: bool = True,
-        sparse_preds: bool = True,
+        sparse_y_true: bool = True,
+        sparse_y_pred: bool = True,
         axis: int = -1,
     ):
         target_class_ids = list(range(num_classes))
@@ -3104,8 +3104,8 @@ class MeanIoU(IoU):
             axis=axis,
             dtype=dtype,
             ignore_class=ignore_class,
-            sparse_labels=sparse_labels,
-            sparse_preds=sparse_preds,
+            sparse_y_true=sparse_y_true,
+            sparse_y_pred=sparse_y_pred,
         )
 
     def get_config(self):
@@ -3114,8 +3114,8 @@ class MeanIoU(IoU):
             "name": self.name,
             "dtype": self._dtype,
             "ignore_class": self.ignore_class,
-            "sparse_labels": self.sparse_labels,
-            "sparse_preds": self.sparse_preds,
+            "sparse_y_true": self.sparse_y_true,
+            "sparse_y_pred": self.sparse_y_pred,
             "axis": self.axis,
         }
 
@@ -3168,7 +3168,7 @@ class OneHotIoU(IoU):
         metric computation. This is useful, for example, in segmentation
         problems featuring a "void" class (commonly -1 or 255) in segmentation
         maps. By default (`ignore_class=None`), all classes are considered.
-      sparse_preds: Wether predictions are encoded using natural numbers or
+      sparse_y_pred: Whether predictions are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
       axis: (Optional) Defaults to -1. The dimension containing the logits.
@@ -3210,7 +3210,7 @@ class OneHotIoU(IoU):
         name=None,
         dtype=None,
         ignore_class: Optional[int] = None,
-        sparse_preds: bool = False,
+        sparse_y_pred: bool = False,
         axis: int = -1,
     ):
         super().__init__(
@@ -3219,8 +3219,8 @@ class OneHotIoU(IoU):
             name=name,
             dtype=dtype,
             ignore_class=ignore_class,
-            sparse_labels=False,
-            sparse_preds=sparse_preds,
+            sparse_y_true=False,
+            sparse_y_pred=sparse_y_pred,
             axis=axis,
         )
 
@@ -3231,7 +3231,7 @@ class OneHotIoU(IoU):
             "name": self.name,
             "dtype": self._dtype,
             "ignore_class": self.ignore_class,
-            "sparse_preds": self.sparse_preds,
+            "sparse_y_pred": self.sparse_y_pred,
             "axis": self.axis,
         }
 
@@ -3282,7 +3282,7 @@ class OneHotMeanIoU(MeanIoU):
         metric computation. This is useful, for example, in segmentation
         problems featuring a "void" class (commonly -1 or 255) in segmentation
         maps. By default (`ignore_class=None`), all classes are considered.
-      sparse_preds: Wether predictions are encoded using natural numbers or
+      sparse_y_pred: Whether predictions are encoded using natural numbers or
         probability distribution vectors. If `False`, the `tf.argmax` function
         will be used to determine each sample's most likely associated label.
       axis: (Optional) Defaults to -1. The dimension containing the logits.
@@ -3323,7 +3323,7 @@ class OneHotMeanIoU(MeanIoU):
         name: str = None,
         dtype: Optional[Union[str, tf.dtypes.DType]] = None,
         ignore_class: Optional[int] = None,
-        sparse_preds: bool = False,
+        sparse_y_pred: bool = False,
         axis: int = -1,
     ):
         super().__init__(
@@ -3332,8 +3332,8 @@ class OneHotMeanIoU(MeanIoU):
             name=name,
             dtype=dtype,
             ignore_class=ignore_class,
-            sparse_labels=False,
-            sparse_preds=sparse_preds,
+            sparse_y_true=False,
+            sparse_y_pred=sparse_y_pred,
         )
 
     def get_config(self):
@@ -3342,7 +3342,7 @@ class OneHotMeanIoU(MeanIoU):
             "name": self.name,
             "dtype": self._dtype,
             "ignore_class": self.ignore_class,
-            "sparse_preds": self.sparse_preds,
+            "sparse_y_pred": self.sparse_y_pred,
             "axis": self.axis,
         }
 

--- a/keras/metrics/metrics_test.py
+++ b/keras/metrics/metrics_test.py
@@ -1282,11 +1282,11 @@ class MeanIoUTest(tf.test.TestCase):
         expected_result = (1 / (2 + 2 - 1) + 1 / (2 + 2 - 1)) / 2
         self.assertAllClose(self.evaluate(result), expected_result, atol=1e-3)
 
-    def test_unweighted_ignore_index_255(self):
+    def test_unweighted_ignore_class_255(self):
         y_pred = [0, 1, 1, 1]
         y_true = [0, 1, 2, 255]
 
-        m_obj = metrics.MeanIoU(num_classes=3, ignore_index=255)
+        m_obj = metrics.MeanIoU(num_classes=3, ignore_class=255)
         self.evaluate(tf.compat.v1.variables_initializer(m_obj.variables))
 
         result = m_obj(y_true, y_pred)
@@ -1301,11 +1301,11 @@ class MeanIoUTest(tf.test.TestCase):
         ) / 3
         self.assertAllClose(self.evaluate(result), expected_result, atol=1e-3)
 
-    def test_unweighted_ignore_index_1(self):
+    def test_unweighted_ignore_class_1(self):
         y_pred = [0, 1, 1, 1]
         y_true = [0, 1, 2, -1]
 
-        m_obj = metrics.MeanIoU(num_classes=3, ignore_index=-1)
+        m_obj = metrics.MeanIoU(num_classes=3, ignore_class=-1)
         self.evaluate(tf.compat.v1.variables_initializer(m_obj.variables))
 
         result = m_obj(y_true, y_pred)
@@ -1340,12 +1340,12 @@ class MeanIoUTest(tf.test.TestCase):
         ) / 2
         self.assertAllClose(self.evaluate(result), expected_result, atol=1e-3)
 
-    def test_weighted_ignore_index_1(self):
+    def test_weighted_ignore_class_1(self):
         y_pred = tf.constant([0, 1, 0, 1], dtype=tf.float32)
         y_true = tf.constant([0, 0, 1, -1])
         sample_weight = tf.constant([0.2, 0.3, 0.4, 0.1])
 
-        m_obj = metrics.MeanIoU(num_classes=2, ignore_index=-1)
+        m_obj = metrics.MeanIoU(num_classes=2, ignore_class=-1)
         self.evaluate(tf.compat.v1.variables_initializer(m_obj.variables))
 
         result = m_obj(y_true, y_pred, sample_weight=sample_weight)

--- a/keras/metrics/metrics_test.py
+++ b/keras/metrics/metrics_test.py
@@ -1794,6 +1794,16 @@ class SparseCategoricalCrossentropyTest(tf.test.TestCase):
 
         self.assertAllClose(self.evaluate(result), 1.176, atol=1e-3)
 
+    def test_unweighted_ignore_class(self):
+        scce_obj = metrics.SparseCategoricalCrossentropy(ignore_class=-1)
+        self.evaluate(tf.compat.v1.variables_initializer(scce_obj.variables))
+
+        y_true = np.asarray([-1, 2])
+        y_pred = np.asarray([[0.05, 0.95, 0], [0.1, 0.8, 0.1]])
+        result = scce_obj(y_true, y_pred)
+
+        self.assertAllClose(self.evaluate(result), 2.3026, atol=1e-3)
+
     def test_unweighted_from_logits(self):
         scce_obj = metrics.SparseCategoricalCrossentropy(from_logits=True)
         self.evaluate(tf.compat.v1.variables_initializer(scce_obj.variables))
@@ -1845,6 +1855,17 @@ class SparseCategoricalCrossentropyTest(tf.test.TestCase):
         # xent = [0.0513, 2.3026]
         # Weighted xent = [0.051 * 1.5, 2.302 * 2.]
         # Reduced xent = (0.051 * 1.5 + 2.302 * 2.) / 3.5
+
+        self.assertAllClose(self.evaluate(result), 1.338, atol=1e-3)
+
+    def test_weighted_ignore_class(self):
+        scce_obj = metrics.SparseCategoricalCrossentropy(ignore_class=-1)
+        self.evaluate(tf.compat.v1.variables_initializer(scce_obj.variables))
+
+        y_true = np.asarray([1, 2, -1])
+        y_pred = np.asarray([[0.05, 0.95, 0], [0.1, 0.8, 0.1], [0.1, 0.8, 0.1]])
+        sample_weight = tf.constant([1.5, 2.0, 1.5])
+        result = scce_obj(y_true, y_pred, sample_weight=sample_weight)
 
         self.assertAllClose(self.evaluate(result), 1.338, atol=1e-3)
 

--- a/keras/utils/losses_utils.py
+++ b/keras/utils/losses_utils.py
@@ -393,3 +393,50 @@ def cast_losses_to_common_dtype(losses):
     if highest_float:
         losses = [tf.cast(loss, highest_float) for loss in losses]
     return losses
+
+
+def get_mask(y_p):
+    """Returns Keras mask from tensor."""
+    return getattr(y_p, "_keras_mask", None)
+
+
+def apply_mask(y_p, sw, mask):
+    """Applies any mask on predictions to sample weights."""
+    if mask is not None:
+        mask = tf.cast(mask, y_p.dtype)
+        if sw is not None:
+            mask, _, sw = squeeze_or_expand_dimensions(mask, sample_weight=sw)
+            sw *= mask
+        else:
+            sw = mask
+    return sw
+
+
+def apply_valid_mask(losses, sw, mask, reduction):
+    """Redistribute pair-wise weights considering only valid entries."""
+    if mask is not None:
+        mask = tf.cast(mask, losses.dtype)
+
+        if reduction in (ReductionV2.AUTO, ReductionV2.SUM_OVER_BATCH_SIZE):
+            # Valid entries have weight `# total / # valid`,
+            # while invalid ones assume weight 0. When summed
+            # over batch size, they will be reduced to:
+            #
+            # mean(loss * sample_weight * total / valid)
+            #   = sum(loss * sample_weight * total / valid) / total
+            #   = sum(loss * sample_weight) / total * total / valid
+            #   = sum(loss * sample_weight) / valid
+
+            total = tf.cast(tf.size(mask), losses.dtype)
+            valid = tf.reduce_sum(mask)
+            mask *= total / valid
+        elif reduction in (ReductionV2.NONE, ReductionV2.SUM):
+            # Nothing to do. Nothing is being averaged.
+            ...
+        elif reduction == "weighted_mean":
+            # Nothing to do. A binary mask is enough because
+            # it will also be used in the mean operation's
+            # denominator as `tf.reduce_sum(sample_weight)`.
+            ...
+
+    return apply_mask(losses, sw, mask)

--- a/keras/utils/losses_utils.py
+++ b/keras/utils/losses_utils.py
@@ -413,14 +413,13 @@ def apply_mask(y_p, sw, mask):
 
 
 def apply_valid_mask(losses, sw, mask, reduction):
-    """Redistribute pair-wise weights considering only valid entries."""
+    """Redistribute sample weights considering only valid entries."""
     if mask is not None:
         mask = tf.cast(mask, losses.dtype)
 
         if reduction in (ReductionV2.AUTO, ReductionV2.SUM_OVER_BATCH_SIZE):
-            # Valid entries have weight `# total / # valid`,
-            # while invalid ones assume weight 0. When summed
-            # over batch size, they will be reduced to:
+            # Valid entries have weight `total/valid`, while invalid ones
+            # have 0. When summed over batch, they will be reduced to:
             #
             # mean(loss * sample_weight * total / valid)
             #   = sum(loss * sample_weight * total / valid) / total
@@ -430,13 +429,5 @@ def apply_valid_mask(losses, sw, mask, reduction):
             total = tf.cast(tf.size(mask), losses.dtype)
             valid = tf.reduce_sum(mask)
             mask *= total / valid
-        elif reduction in (ReductionV2.NONE, ReductionV2.SUM):
-            # Nothing to do. Nothing is being averaged.
-            ...
-        elif reduction == "weighted_mean":
-            # Nothing to do. A binary mask is enough because
-            # it will also be used in the mean operation's
-            # denominator as `tf.reduce_sum(sample_weight)`.
-            ...
 
     return apply_mask(losses, sw, mask)


### PR DESCRIPTION
Fix #6118
Fix #5911
Relates to #16513

#### Summary
* Add the `ignore_class: Optional[int]` parameter to the following functions/constructors:
  - `backend.sparse_categorical_crossentropy`
  - `lossses.sparse_categorical_crossentropy`
  - `metrics.SparseCategoricalCrossentropy`
  - `metrics._IoUBase`
  - `metrics.IoU`
  - `metrics.MeanIoU`
  - `metrics.OneHotIoU`
  - `metrics.OneHotMeanIoU`
* Add `sparse_y_true: bool` and `sparse_y_pred: bool` parameters in `_IoUBase`, `IoU`, `MeanIoU` metric classes.
* Add `sparse_y_pred:bool` to the `OneHotIoU` and `OneHotMeanIoU` metric classes and refactor these classes to reuse more of the base class.
* Refactor: A replicated code section shared among `backend.categorical_crossentropy`, `backend.sparse_categorical_crossentropy`, and `backend.binary_crossentropy` into a single function named `_get_logits`.

#### Goals
1. **ignore_class**: In segmentation problems, some pixels in segmentation maps might not represent valid categorical labels. Examples:
   - object boundaries are marked with void category, as the annotators disagree on which label to attribute
   - small maps are padded with the *void* class to conform with the sizes of larger ones after `Dataset#padded_batch`
   - specific objects out of the context of the problem, such as the hood of a car being captured by a static camera
   - pseudo-labels (originated from weakly supervised strategies) might contain pixels/regions where label is uncertain

   It's common to attribute the label `-1` or `255` and ignore these pixels during training. This PR implements this feature by masking the target and the output signals, only computing the metrics over the valid pixels. Moreover, it mirrors PyTorch's [CrossEntropyLoss(ignore_index=-100)](https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html).

2. **sparse_y_pred**: `IoU` and `MeanIoU` assumes both `target` and `output` are sparse signals, where categories are represented as natural integers. Conversely, `OneHotIoU` and `OneHotMeanIoU` assume both are probability distribution vectors. This is far from what I believe to be the most obvious case: sparse segmentation labels and dense output vectors:
   ```py
   >>> classes = 20
   >>> model = Sequential([
   >>>    ResNet50V2(input_shape=[512, 512, 3], include_top=False, pooling=None, weights=None),
   >>>    Conv2D(classes, kernel_size=1, activation='softmax', name='predictions')
   >>> ])
   >>> print(model.output.shape)
   (None, 16, 16, 20)
   ```

   So now IoU can be easily used as this:
   ```py
   model.compile(opt='sgd', loss='sparse_categorical_crossentropy', metrics=[
     MeanIoU(classes, sparse_y_pred=False, ignore_index=-1)
   ])
   ```

#### Limitations
~Currently, `backend.sparse_categorical_crossentropy` only reduces the dimension containing the logits, and the result is reshaped into the original output shape (except for the last axis) if the information is available.
However, when a pixel is not valid, its associated cross-entropy value is not available and reshape cannot occur without creating a ragged tensor. Therefore, when `ignore_index is not None` (and only then), I opted to sum all cross-entropy values over the axes `range(1, output_rank-1)` and divide by the number of valid pixels (similar to what pytorch does). In this case, the output tensor will have `shape=[output_shape[0]]=[batch_size]`. An alternative would be to return a flatten array containing only valid entries, though the batch information would be lost and the user would have difficulties if they had per-sample operations being applied to these loss values.~

No visible limitations now. `backend.sparse_categorical_crossentropy` will set the `_keras_mask` property in the loss Tensor, which will be used during the reduction procedure to mask out invalid pixels.