### PR TITLE
vis_utils.py adding ability to show kernel_size for layers that have …

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -86,6 +86,7 @@ def model_to_dot(
     subgraph=False,
     layer_range=None,
     show_layer_activations=False,
+    show_kernel_size=False,
 ):
     """Convert a Keras model to dot format.
 
@@ -112,6 +113,8 @@ def model_to_dot(
           must be complete.
       show_layer_activations: Display layer activations (only for layers that
           have an `activation` property).
+      show_kernel_size: Display layer kernel_size attribute (only for layers that
+        have it)
 
     Returns:
       A `pydot.Dot` instance representing the Keras model or
@@ -253,6 +256,14 @@ def model_to_dot(
                 activation_name = str(layer.activation)
             label = "{%s|%s}" % (label, activation_name)
 
+        # Rebuild the label as a table including the layer's kernel size.
+        if (
+            show_kernel_size
+            and hasattr(layer, "kernel_size")
+            and layer.kernel_size is not None
+        ):
+            label = "{%s|%s}" % (label, str(layer.kernel_size))
+
         # Rebuild the label as a table including the layer's name.
         if show_layer_names:
             label = "%s|%s" % (layer_name, label)
@@ -370,6 +381,7 @@ def plot_model(
     dpi=96,
     layer_range=None,
     show_layer_activations=False,
+    show_kernel_size=False,
 ):
     """Converts a Keras model to dot format and save to a file.
 
@@ -411,6 +423,8 @@ def plot_model(
         complete.
       show_layer_activations: Display layer activations (only for layers that
         have an `activation` property).
+      show_kernel_size: Display layer kernel_size attribute (only for layers that
+        have it)
 
     Raises:
       ImportError: if graphviz or pydot are not available.
@@ -453,6 +467,7 @@ def plot_model(
         dpi=dpi,
         layer_range=layer_range,
         show_layer_activations=show_layer_activations,
+        show_kernel_size=show_kernel_size,
     )
     to_file = io_utils.path_to_string(to_file)
     if dot is None:


### PR DESCRIPTION
System information.

TensorFlow version 2.9.1:
Are you willing to contribute it (Yes/No) : Yes

Describe the feature and the current behavior/state.

Add an argument to plot_model that allows kernel_size to be displayed on the model plot. Right now there doesn't seem to be a way to have this information displayed.

Will this change the current api? How?
I don't think so

Who will benefit from this feature?
Anybody that has a created a lot of different model architectures that they would like to visually compare kernel_sizes for.

[Contributing](https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md)

Do you want to contribute a PR? (yes/no): yes
If yes, please read [this page](https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md) for instructions
Briefly describe your candidate solution(if contributing):
The proposed solution is basically just a copy of the 'show_layer_activations' code, but with the kernel_size property of a layer

resolves #16715 