### PR TITLE
docs: Fix a few typos

### DIFF
--- a/keras/layers/preprocessing/discretization.py
+++ b/keras/layers/preprocessing/discretization.py
@@ -167,7 +167,7 @@ class Discretization(base_preprocessing_layer.PreprocessingLayer):
       output_mode: Specification for the output of the layer. Defaults to
         `"int"`.  Values can be `"int"`, `"one_hot"`, `"multi_hot"`, or
         `"count"` configuring the layer as follows:
-          - `"int"`: Return the discritized bin indices directly.
+          - `"int"`: Return the discretized bin indices directly.
           - `"one_hot"`: Encodes each individual element in the input into an
             array the same size as `num_bins`, containing a 1 at the input's bin
             index. If the last dimension is size 1, will encode on that

--- a/keras/layers/preprocessing/image_preprocessing.py
+++ b/keras/layers/preprocessing/image_preprocessing.py
@@ -238,7 +238,7 @@ class CenterCrop(base_layer.Layer):
 
 @keras_export("keras.__internal__.layers.BaseImageAugmentationLayer")
 class BaseImageAugmentationLayer(base_layer.BaseRandomLayer):
-    """Abstract base layer for image augmentaion.
+    """Abstract base layer for image augmentation.
 
     This layer contains base functionalities for preprocessing layers which
     augment image related data, eg. image and in future, label and bounding

--- a/keras/saving/pickle_utils_test.py
+++ b/keras/saving/pickle_utils_test.py
@@ -24,7 +24,7 @@ from keras.testing_infra import test_utils
 
 
 class TestPickleProtocol(test_combinations.TestCase):
-    """Tests pickle protoocol support."""
+    """Tests pickle protocol support."""
 
     @test_combinations.run_with_all_model_types
     @test_combinations.parameterized.named_parameters(


### PR DESCRIPTION
There are small typos in:
- keras/layers/preprocessing/discretization.py
- keras/layers/preprocessing/image_preprocessing.py
- keras/saving/pickle_utils_test.py

Fixes:
- Should read `protocol` rather than `protoocol`.
- Should read `discretized` rather than `discritized`.
- Should read `augmentation` rather than `augmentaion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md