### PR TITLE
Fixing the incorrect link in backend.py

### DIFF
--- a/keras/backend.py
+++ b/keras/backend.py
@@ -1370,7 +1370,7 @@ def placeholder(
         ragged: Boolean, whether the placeholder should have a ragged type.
             In this case, values of 'None' in the 'shape' argument represent
             ragged dimensions. For more information about RaggedTensors, see
-            this [guide](https://www.tensorflow.org/guide/ragged_tensors).
+            this [guide](https://www.tensorflow.org/guide/ragged_tensor).
 
     Raises:
         ValueError: If called with sparse = True and ragged = True.


### PR DESCRIPTION
Added the correct link for `RaggedTensor`