### PR TITLE
Metric support for cross-replica contexts

### DIFF
--- a/keras/metrics/BUILD
+++ b/keras/metrics/BUILD
@@ -67,6 +67,19 @@ tf_py_test(
 )
 
 tf_py_test(
+    name = "metrics_distributed_test",
+    size = "small",
+    srcs = ["metrics_distributed_test.py"],
+    python_version = "PY3",
+    deps = [
+        "//:expect_numpy_installed",
+        "//:expect_tensorflow_installed",
+        "//keras",
+        "//keras/testing_infra:test_combinations",
+    ],
+)
+
+tf_py_test(
     name = "metrics_test",
     size = "medium",
     srcs = ["metrics_test.py"],

--- a/keras/metrics/base_metric_test.py
+++ b/keras/metrics/base_metric_test.py
@@ -585,7 +585,9 @@ class BinaryTruePositives(metrics.Metric):
                 sample_weight, values
             )
             values = tf.multiply(values, sample_weight)
-        self.true_positives.assign_add(tf.reduce_sum(values))
+        
+        update_true_positives_value = self.true_positives.read_value() + tf.reduce_sum(values)
+        self.true_positives.assign(update_true_positives_value)
 
     def result(self):
         return self.true_positives
@@ -603,10 +605,13 @@ class BinaryTruePositivesViaControlFlow(metrics.Metric):
         for i in range(len(y_true)):
             for j in range(len(y_true[i])):
                 if y_true[i][j] and y_pred[i][j]:
+                    update_true_positives_value = self.true_positives.read_value()
                     if sample_weight is None:
-                        self.true_positives.assign_add(1)
+                        update_true_positives_value += 1
                     else:
-                        self.true_positives.assign_add(sample_weight[i][0])
+                        update_true_positives_value += sample_weight[i][0]
+                        
+                    self.true_positives.assign(update_true_positives_value)
 
     def result(self):
         if tf.constant(True):

--- a/keras/metrics/base_metric_test.py
+++ b/keras/metrics/base_metric_test.py
@@ -585,8 +585,10 @@ class BinaryTruePositives(metrics.Metric):
                 sample_weight, values
             )
             values = tf.multiply(values, sample_weight)
-        
-        update_true_positives_value = self.true_positives.read_value() + tf.reduce_sum(values)
+
+        update_true_positives_value = (
+            self.true_positives.read_value() + tf.reduce_sum(values)
+        )
         self.true_positives.assign(update_true_positives_value)
 
     def result(self):
@@ -605,12 +607,14 @@ class BinaryTruePositivesViaControlFlow(metrics.Metric):
         for i in range(len(y_true)):
             for j in range(len(y_true[i])):
                 if y_true[i][j] and y_pred[i][j]:
-                    update_true_positives_value = self.true_positives.read_value()
+                    update_true_positives_value = (
+                        self.true_positives.read_value()
+                    )
                     if sample_weight is None:
                         update_true_positives_value += 1
                     else:
                         update_true_positives_value += sample_weight[i][0]
-                        
+
                     self.true_positives.assign(update_true_positives_value)
 
     def result(self):

--- a/keras/metrics/metrics.py
+++ b/keras/metrics/metrics.py
@@ -2733,7 +2733,10 @@ class _IoUBase(base_metric.Metric):
             weights=sample_weight,
             dtype=self._dtype,
         )
-        return self.total_cm.assign_add(current_cm)
+
+        update_total_cm_value = self.total_cm.read_value() + current_cm
+        update_total_cm_op = self.total_cm.assign(update_total_cm_value)
+        return update_total_cm_op
 
     def reset_state(self):
         backend.set_value(

--- a/keras/metrics/metrics_distributed_test.py
+++ b/keras/metrics/metrics_distributed_test.py
@@ -1,0 +1,50 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for Keras metrics within tf.distribute.Strategy contexts."""
+
+import numpy as np
+import tensorflow.compat.v2 as tf
+from absl.testing import parameterized
+
+from keras import backend
+from keras import metrics
+from keras.testing_infra import test_combinations
+
+class KerasDistributedMetricsTest(tf.test.TestCase, parameterized.TestCase):
+    def test_one_device_strategy_cpu(self):
+        with self.cached_session():
+            with tf.distribute.OneDeviceStrategy("/CPU:0").scope():
+                metric = metrics.Sum()
+                output = metric.update_state(1)
+                self.assertEqual(backend.eval(output), 1)
+
+    def test_one_device_strategy_gpu(self):
+        with self.cached_session():
+            with tf.distribute.OneDeviceStrategy("/GPU:0").scope():
+                metric = metrics.Sum()
+                output = metric.update_state(1)
+                self.assertEqual(backend.eval(output), 1)
+
+
+    def test_mirrored_strategy(self):
+        with self.cached_session():
+            with tf.distribute.MirroredStrategy().scope():
+                metric = metrics.Sum()
+                output = metric.update_state(1)
+                self.assertEqual(backend.eval(output), 1)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/keras/metrics/metrics_distributed_test.py
+++ b/keras/metrics/metrics_distributed_test.py
@@ -14,13 +14,12 @@
 # ==============================================================================
 """Tests for Keras metrics within tf.distribute.Strategy contexts."""
 
-import numpy as np
 import tensorflow.compat.v2 as tf
 from absl.testing import parameterized
 
 from keras import backend
 from keras import metrics
-from keras.testing_infra import test_combinations
+
 
 class KerasDistributedMetricsTest(tf.test.TestCase, parameterized.TestCase):
     def test_one_device_strategy_cpu(self):
@@ -36,7 +35,6 @@ class KerasDistributedMetricsTest(tf.test.TestCase, parameterized.TestCase):
                 metric = metrics.Sum()
                 output = metric.update_state(1)
                 self.assertEqual(backend.eval(output), 1)
-
 
     def test_mirrored_strategy(self):
         with self.cached_session():

--- a/keras/metrics/metrics_test.py
+++ b/keras/metrics/metrics_test.py
@@ -1954,10 +1954,13 @@ class BinaryTruePositivesViaControlFlow(metrics.Metric):
         for i in range(len(y_true)):
             for j in range(len(y_true[i])):
                 if y_true[i][j] and y_pred[i][j]:
+                    update_true_positives_value = self.true_positives.read_value()
                     if sample_weight is None:
-                        self.true_positives.assign_add(1)
+                        update_true_positives_value += 1
                     else:
-                        self.true_positives.assign_add(sample_weight[i][0])
+                        update_true_positives_value += sample_weight[i][0]
+                        
+                    self.true_positives.assign(update_true_positives_value)
 
     def result(self):
         if tf.constant(True):

--- a/keras/metrics/metrics_test.py
+++ b/keras/metrics/metrics_test.py
@@ -1954,12 +1954,14 @@ class BinaryTruePositivesViaControlFlow(metrics.Metric):
         for i in range(len(y_true)):
             for j in range(len(y_true[i])):
                 if y_true[i][j] and y_pred[i][j]:
-                    update_true_positives_value = self.true_positives.read_value()
+                    update_true_positives_value = (
+                        self.true_positives.read_value()
+                    )
                     if sample_weight is None:
                         update_true_positives_value += 1
                     else:
                         update_true_positives_value += sample_weight[i][0]
-                        
+
                     self.true_positives.assign(update_true_positives_value)
 
     def result(self):


### PR DESCRIPTION
Replace all `variable.assign_add(update)` calls with `variable.assign(variable.read_value() + update)`

Resolves #16828