### PR TITLE
Added function get_reversed_word_index in imdb dataset

### DIFF
--- a/keras/datasets/imdb.py
+++ b/keras/datasets/imdb.py
@@ -191,14 +191,11 @@ def get_word_index(path="imdb_word_index.json"):
     )
     # Retrieve the word index file mapping words to indices
     word_index = keras.datasets.imdb.get_word_index()
-    # Reverse the word index to obtain a dict mapping indices to words
-    # And add `index_from` to indices to sync with `x_train`
-    inverted_word_index = dict(
-        (i + index_from, word) for (word, i) in word_index.items()
+    # Retrieve the reversed the word index to obtain a dict mapping indices to
+    # Words and add `index_from` to indices to sync with `x_train`
+    inverted_word_index = keras.datasets.imdb.get_reversed_word_index(\
+        word_index
     )
-    # Update `inverted_word_index` to include `start_char` and `oov_char`
-    inverted_word_index[start_char] = "[START]"
-    inverted_word_index[oov_char] = "[OOV]"
     # Decode the first sequence in the dataset
     decoded_sequence = " ".join(inverted_word_index[i] for i in x_train[0])
     ```
@@ -213,3 +210,51 @@ def get_word_index(path="imdb_word_index.json"):
     )
     with open(path) as f:
         return json.load(f)
+
+
+@keras_export("keras.datasets.imdb.get_reversed_word_index")
+def get_reversed_word_index(word_index=None, path="imdb_word_index.json"):
+    """Retrieves a dict mapping indexes to words in the IMDB dataset.
+
+    Args:
+        word_index: word index dictionary. Keys are word strings, values are
+        their index. If None, the one returned by get_word_index is used.
+
+        path: where to cache the data (relative to `~/.keras/dataset`).
+
+    Returns:
+        The index word dictionary. Keys are indexes, values are word strings.
+
+    Example:
+
+    ```python
+    # Use the default parameters to keras.datasets.imdb.load_data
+    start_char = 1
+    oov_char = 2
+    index_from = 3
+    # Retrieve the training sequences.
+    (x_train, _), _ = keras.datasets.imdb.load_data(
+        start_char=start_char, oov_char=oov_char, index_from=index_from
+    )
+    # Retrieve the word index file mapping words to indices
+    word_index = keras.datasets.imdb.get_word_index()
+    # Retrieve the reversed the word index to obtain a dict mapping indices to
+    # Words and add `index_from` to indices to sync with `x_train`
+    inverted_word_index = keras.datasets.imdb.get_reversed_word_index(
+        word_index
+    )
+    # Decode the first sequence in the dataset
+    decoded_sequence = " ".join(inverted_word_index[i] for i in x_train[0])
+    ```
+    """
+    start_char = 1
+    oov_char = 2
+    index_from = 3
+    if word_index is None:
+        word_index = get_word_index(path)
+    inverted_word_index = dict(
+        (i + index_from, word) for (word, i) in word_index.items()
+    )
+    inverted_word_index[start_char] = "[START]"
+    inverted_word_index[oov_char] = "[OOV]"
+    return inverted_word_index


### PR DESCRIPTION
The rationale for this PR is to provide an easy way to obtain the reversed word index. 

Without it the user should first get the word index with the function `get_word_index` and then iterate inverting the keys and the values. However the conversion is not straightforward due to an existing offset of the index given by special words such as `oov` (out of vocabulary) and `start` (which marks the beginning of a sentence).

With this modification the user does not have to know about the offset of 3, which is very tricky considering alsoe that even the [official tensorflow documentation](https://www.tensorflow.org/api_docs/python/tf/keras/datasets/imdb/get_word_index) does not take into consideration this aspect.