### PR TITLE
PR for solving issue #16797

### DIFF
--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -1266,6 +1266,7 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
         Returns:
           A list of trainable variables.
         """
+        self._update_trackables()
         if self.trainable:
             children_weights = self._gather_children_attribute(
                 "trainable_variables"
@@ -1286,6 +1287,7 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
         Returns:
           A list of non-trainable variables.
         """
+        self._update_trackables()
         if self.trainable:
             children_weights = self._gather_children_attribute(
                 "non_trainable_variables"
@@ -3144,6 +3146,16 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
         super(tf.__internal__.tracking.AutoTrackable, self).__setattr__(
             name, value
         )
+
+    def _update_trackables(self):
+        """Track variables added to lists/dicts after creation
+        """
+        for trackable_obj in self._self_tracked_trackables:
+            if isinstance(
+                    trackable_obj,
+                    tf.__internal__.tracking.TrackableDataStructure
+            ):
+                self._track_variables(trackable_obj)
 
     def _track_variables(self, value):
         """Tracks `Variable`s including `Variable`s in `CompositeTensor`s."""

--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -3148,12 +3148,10 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
         )
 
     def _update_trackables(self):
-        """Track variables added to lists/dicts after creation
-        """
+        """Track variables added to lists/dicts after creation"""
         for trackable_obj in self._self_tracked_trackables:
             if isinstance(
-                    trackable_obj,
-                    tf.__internal__.tracking.TrackableDataStructure
+                trackable_obj, tf.__internal__.tracking.TrackableDataStructure
             ):
                 self._track_variables(trackable_obj)
 

--- a/keras/engine/base_layer_test.py
+++ b/keras/engine/base_layer_test.py
@@ -1039,7 +1039,6 @@ class BaseLayerTest(test_combinations.TestCase):
 
     def test_tf_tracking_lists(self):
         class MyLayer(base_layer.Layer):
-
             def __init__(self, num_weights):
                 super().__init__()
                 self.num_weights = num_weights
@@ -1051,12 +1050,12 @@ class BaseLayerTest(test_combinations.TestCase):
                 for i in range(self.num_weights):
                     self.my_weights.append(
                         tf.Variable(
-                            name=f'w_{i}',
+                            name=f"w_{i}",
                             initial_value=w_init(
                                 shape=(input_shape[1], input_shape[1]),
-                                dtype="float32"
+                                dtype="float32",
                             ),
-                            trainable=True
+                            trainable=True,
                         )
                     )
 


### PR DESCRIPTION
A minimal change that solves the issue is modifying the method ```keras.layers.Layer.trainable_weights()```, in base_layer.py, by replacing it with the analogous method of keras.Model. 

But still I have some questions: Does it make sense to have two different methods for gathering weights, one for Models and other for Layers? Shouldn't they be the same?

I did not update the non_trainable_weights method, but probably with them the same thing should be done. 

I don't feel very confident with this as I don't fully understand the internal working of keras. I just checked where the discrepancy was and tried the obvious thing: copying from where it works (Model) to where it doesn't (Layer).  