### PR TITLE
Add f-string format and check with flynt for the whole codebase

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -89,8 +89,7 @@ def softmax(x, axis=-1):
             output = e / s
     else:
         raise ValueError(
-            "Cannot apply softmax to a tensor that is 1D. "
-            f"Received input: {x}"
+            f"Cannot apply softmax to a tensor that is 1D. Received input: {x}"
         )
 
     # Cache the logits to use for crossentropy loss.

--- a/keras/applications/applications_load_weight_test.py
+++ b/keras/applications/applications_load_weight_test.py
@@ -172,10 +172,10 @@ class ApplicationsLoadWeightTest(tf.test.TestCase, parameterized.TestCase):
     def assertShapeEqual(self, shape1, shape2):
         if len(shape1) != len(shape2):
             raise AssertionError(
-                "Shapes are different rank: %s vs %s" % (shape1, shape2)
+                f"Shapes are different rank: {shape1} vs {shape2}"
             )
         if shape1 != shape2:
-            raise AssertionError("Shapes differ: %s vs %s" % (shape1, shape2))
+            raise AssertionError(f"Shapes differ: {shape1} vs {shape2}")
 
     def test_application_pretrained_weights_loading(self):
         app_module = ARG_TO_MODEL[FLAGS.module][0]

--- a/keras/applications/applications_test.py
+++ b/keras/applications/applications_test.py
@@ -138,13 +138,11 @@ class ApplicationsTest(tf.test.TestCase, parameterized.TestCase):
     def assertShapeEqual(self, shape1, shape2):
         if len(shape1) != len(shape2):
             raise AssertionError(
-                "Shapes are different rank: %s vs %s" % (shape1, shape2)
+                f"Shapes are different rank: {shape1} vs {shape2}"
             )
         for v1, v2 in zip(shape1, shape2):
             if v1 != v2:
-                raise AssertionError(
-                    "Shapes differ: %s vs %s" % (shape1, shape2)
-                )
+                raise AssertionError(f"Shapes differ: {shape1} vs {shape2}")
 
     @parameterized.parameters(*MODEL_LIST)
     def test_application_base(self, app, _):

--- a/keras/applications/densenet.py
+++ b/keras/applications/densenet.py
@@ -33,7 +33,7 @@ from keras.utils import layer_utils
 from tensorflow.python.util.tf_export import keras_export
 
 BASE_WEIGHTS_PATH = (
-    "https://storage.googleapis.com/tensorflow/" "keras-applications/densenet/"
+    "https://storage.googleapis.com/tensorflow/keras-applications/densenet/"
 )
 DENSENET121_WEIGHT_PATH = (
     BASE_WEIGHTS_PATH + "densenet121_weights_tf_dim_ordering_tf_kernels.h5"

--- a/keras/applications/efficientnet.py
+++ b/keras/applications/efficientnet.py
@@ -386,7 +386,7 @@ def EfficientNet(
 
     b = 0
     blocks = float(sum(round_repeats(args["repeats"]) for args in blocks_args))
-    for (i, args) in enumerate(blocks_args):
+    for i, args in enumerate(blocks_args):
         assert args["repeats"] > 0
         # Update block input and output filters based on depth multiplier.
         args["filters_in"] = round_filters(args["filters_in"])
@@ -402,8 +402,8 @@ def EfficientNet(
                 x,
                 activation,
                 drop_connect_rate * b / blocks,
-                name="block{}{}_".format(i + 1, chr(j + 97)),
-                **args
+                name=f"block{i + 1}{chr(j + 97)}_",
+                **args,
             )
             b += 1
 
@@ -593,7 +593,7 @@ def EfficientNetB0(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
-    **kwargs
+    **kwargs,
 ):
     return EfficientNet(
         1.0,
@@ -608,7 +608,7 @@ def EfficientNetB0(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -624,7 +624,7 @@ def EfficientNetB1(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
-    **kwargs
+    **kwargs,
 ):
     return EfficientNet(
         1.0,
@@ -639,7 +639,7 @@ def EfficientNetB1(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -655,7 +655,7 @@ def EfficientNetB2(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
-    **kwargs
+    **kwargs,
 ):
     return EfficientNet(
         1.1,
@@ -670,7 +670,7 @@ def EfficientNetB2(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -686,7 +686,7 @@ def EfficientNetB3(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
-    **kwargs
+    **kwargs,
 ):
     return EfficientNet(
         1.2,
@@ -701,7 +701,7 @@ def EfficientNetB3(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -717,7 +717,7 @@ def EfficientNetB4(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
-    **kwargs
+    **kwargs,
 ):
     return EfficientNet(
         1.4,
@@ -732,7 +732,7 @@ def EfficientNetB4(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -748,7 +748,7 @@ def EfficientNetB5(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
-    **kwargs
+    **kwargs,
 ):
     return EfficientNet(
         1.6,
@@ -763,7 +763,7 @@ def EfficientNetB5(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -779,7 +779,7 @@ def EfficientNetB6(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
-    **kwargs
+    **kwargs,
 ):
     return EfficientNet(
         1.8,
@@ -794,7 +794,7 @@ def EfficientNetB6(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -810,7 +810,7 @@ def EfficientNetB7(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
-    **kwargs
+    **kwargs,
 ):
     return EfficientNet(
         2.0,
@@ -825,7 +825,7 @@ def EfficientNetB7(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/keras/applications/efficientnet_v2.py
+++ b/keras/applications/efficientnet_v2.py
@@ -999,7 +999,7 @@ def EfficientNetV2(
     b = 0
     blocks = float(sum(args["num_repeat"] for args in blocks_args))
 
-    for (i, args) in enumerate(blocks_args):
+    for i, args in enumerate(blocks_args):
         assert args["num_repeat"] > 0
 
         # Update block input and output filters based on depth multiplier.
@@ -1032,7 +1032,7 @@ def EfficientNetV2(
                 activation=activation,
                 bn_momentum=bn_momentum,
                 survival_probability=drop_connect_rate * b / blocks,
-                name="block{}{}_".format(i + 1, chr(j + 97)),
+                name=f"block{i + 1}{chr(j + 97)}_",
                 **args,
             )(x)
             b += 1

--- a/keras/applications/efficientnet_weight_update_util.py
+++ b/keras/applications/efficientnet_weight_update_util.py
@@ -76,7 +76,7 @@ def write_ckpt_to_h5(path_h5, path_ckpt, keras_model, use_ema=True):
             tf_weight_names,
             model_name_tf,
         )
-        io_utils.print_msg("{} and {} match.".format(tf_block, keras_block))
+        io_utils.print_msg(f"{tf_block} and {keras_block} match.")
 
     block_mapping = {x[0]: x[1] for x in zip(keras_blocks, tf_blocks)}
 
@@ -106,7 +106,7 @@ def write_ckpt_to_h5(path_h5, path_ckpt, keras_model, use_ema=True):
             )
             continue
         else:
-            raise ValueError("{} failed to parse.".format(w.name))
+            raise ValueError(f"{w.name} failed to parse.")
 
         try:
             w_tf = tf.train.load_variable(path_ckpt, tf_name)
@@ -121,9 +121,7 @@ def write_ckpt_to_h5(path_h5, path_ckpt, keras_model, use_ema=True):
                     stacklevel=2,
                 )
             else:
-                raise ValueError(
-                    "Fail to load {} from {}".format(w.name, tf_name)
-                )
+                raise ValueError(f"Fail to load {w.name} from {tf_name}")
 
     total_weights = len(keras_model.weights)
     io_utils.print_msg(f"{changed_weights}/{total_weights} weights updated")
@@ -212,18 +210,18 @@ def keras_name_to_tf_name_stem_top(
         tf_name = "{}/stem/tpu_batch_normalization/{}{}".format(
             model_name_tf, bn_weights, ema
         )
-        stem_top_dict["stem_bn/{}:0".format(bn_weights)] = tf_name
+        stem_top_dict[f"stem_bn/{bn_weights}:0"] = tf_name
 
     # top / head batch normalization
     for bn_weights in ["beta", "gamma", "moving_mean", "moving_variance"]:
         tf_name = "{}/head/tpu_batch_normalization/{}{}".format(
             model_name_tf, bn_weights, ema
         )
-        stem_top_dict["top_bn/{}:0".format(bn_weights)] = tf_name
+        stem_top_dict[f"top_bn/{bn_weights}:0"] = tf_name
 
     if keras_name in stem_top_dict:
         return stem_top_dict[keras_name]
-    raise KeyError("{} from h5 file cannot be parsed".format(keras_name))
+    raise KeyError(f"{keras_name} from h5 file cannot be parsed")
 
 
 def keras_name_to_tf_name_block(
@@ -253,9 +251,7 @@ def keras_name_to_tf_name_block(
     """
 
     if keras_block not in keras_name:
-        raise ValueError(
-            "block name {} not found in {}".format(keras_block, keras_name)
-        )
+        raise ValueError(f"block name {keras_block} not found in {keras_name}")
 
     # all blocks in the first group will not have expand conv and bn
     is_first_blocks = keras_block[5] == "1"

--- a/keras/applications/inception_resnet_v2.py
+++ b/keras/applications/inception_resnet_v2.py
@@ -52,7 +52,7 @@ def InceptionResNetV2(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
-    **kwargs
+    **kwargs,
 ):
     """Instantiates the Inception-ResNet v2 architecture.
 
@@ -122,7 +122,7 @@ def InceptionResNetV2(
     else:
         layers = VersionAwareLayers()
     if kwargs:
-        raise ValueError("Unknown argument(s): %s" % (kwargs,))
+        raise ValueError(f"Unknown argument(s): {kwargs}")
     if not (weights in {"imagenet", None} or tf.io.gfile.exists(weights)):
         raise ValueError(
             "The `weights` argument should be either "

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -74,7 +74,7 @@ from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util.tf_export import keras_export
 
 BASE_WEIGHT_PATH = (
-    "https://storage.googleapis.com/tensorflow/" "keras-applications/mobilenet/"
+    "https://storage.googleapis.com/tensorflow/keras-applications/mobilenet/"
 )
 layers = None
 
@@ -302,7 +302,7 @@ def MobileNet(
         inputs = img_input
 
     # Create model.
-    model = training.Model(inputs, x, name="mobilenet_%0.2f_%s" % (alpha, rows))
+    model = training.Model(inputs, x, name=f"mobilenet_{alpha:0.2f}_{rows}")
 
     # Load weights.
     if weights == "imagenet":

--- a/keras/applications/mobilenet_v2.py
+++ b/keras/applications/mobilenet_v2.py
@@ -88,8 +88,7 @@ from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util.tf_export import keras_export
 
 BASE_WEIGHT_PATH = (
-    "https://storage.googleapis.com/tensorflow/"
-    "keras-applications/mobilenet_v2/"
+    "https://storage.googleapis.com/tensorflow/keras-applications/mobilenet_v2/"
 )
 layers = None
 
@@ -450,9 +449,7 @@ def MobileNetV2(
         inputs = img_input
 
     # Create model.
-    model = training.Model(
-        inputs, x, name="mobilenetv2_%0.2f_%s" % (alpha, rows)
-    )
+    model = training.Model(inputs, x, name=f"mobilenetv2_{alpha:0.2f}_{rows}")
 
     # Load weights.
     if weights == "imagenet":
@@ -498,7 +495,7 @@ def _inverted_res_block(inputs, expansion, stride, alpha, filters, block_id):
     # 8.
     pointwise_filters = _make_divisible(pointwise_conv_filters, 8)
     x = inputs
-    prefix = "block_{}_".format(block_id)
+    prefix = f"block_{block_id}_"
 
     if block_id:
         # Expand with a pointwise 1x1 convolution.

--- a/keras/applications/mobilenet_v3.py
+++ b/keras/applications/mobilenet_v3.py
@@ -31,8 +31,7 @@ from tensorflow.python.util.tf_export import keras_export
 
 # TODO(scottzhu): Change this to the GCS path.
 BASE_WEIGHT_PATH = (
-    "https://storage.googleapis.com/tensorflow/"
-    "keras-applications/mobilenet_v3/"
+    "https://storage.googleapis.com/tensorflow/keras-applications/mobilenet_v3/"
 )
 WEIGHTS_HASHES = {
     "large_224_0.75_float": (
@@ -611,7 +610,7 @@ def _inverted_res_block(
     infilters = backend.int_shape(x)[channel_axis]
     if block_id:
         # Expand
-        prefix = "expanded_conv_{}/".format(block_id)
+        prefix = f"expanded_conv_{block_id}/"
         x = layers.Conv2D(
             _depth(infilters * expansion),
             kernel_size=1,

--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -51,7 +51,7 @@ from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util.tf_export import keras_export
 
 BASE_WEIGHTS_PATH = (
-    "https://storage.googleapis.com/tensorflow/" "keras-applications/nasnet/"
+    "https://storage.googleapis.com/tensorflow/keras-applications/nasnet/"
 )
 NASNET_MOBILE_WEIGHT_PATH = BASE_WEIGHTS_PATH + "NASNet-mobile.h5"
 NASNET_MOBILE_WEIGHT_PATH_NO_TOP = BASE_WEIGHTS_PATH + "NASNet-mobile-no-top.h5"
@@ -546,12 +546,12 @@ def _separable_conv_block(
     """
     channel_dim = 1 if backend.image_data_format() == "channels_first" else -1
 
-    with backend.name_scope("separable_conv_block_%s" % block_id):
+    with backend.name_scope(f"separable_conv_block_{block_id}"):
         x = layers.Activation("relu")(ip)
         if strides == (2, 2):
             x = layers.ZeroPadding2D(
                 padding=imagenet_utils.correct_pad(x, kernel_size),
-                name="separable_conv_1_pad_%s" % block_id,
+                name=f"separable_conv_1_pad_{block_id}",
             )(x)
             conv_pad = "valid"
         else:
@@ -560,7 +560,7 @@ def _separable_conv_block(
             filters,
             kernel_size,
             strides=strides,
-            name="separable_conv_1_%s" % block_id,
+            name=f"separable_conv_1_{block_id}",
             padding=conv_pad,
             use_bias=False,
             kernel_initializer="he_normal",
@@ -569,13 +569,13 @@ def _separable_conv_block(
             axis=channel_dim,
             momentum=0.9997,
             epsilon=1e-3,
-            name="separable_conv_1_bn_%s" % (block_id),
+            name=f"separable_conv_1_bn_{block_id}",
         )(x)
         x = layers.Activation("relu")(x)
         x = layers.SeparableConv2D(
             filters,
             kernel_size,
-            name="separable_conv_2_%s" % block_id,
+            name=f"separable_conv_2_{block_id}",
             padding="same",
             use_bias=False,
             kernel_initializer="he_normal",
@@ -584,7 +584,7 @@ def _separable_conv_block(
             axis=channel_dim,
             momentum=0.9997,
             epsilon=1e-3,
-            name="separable_conv_2_bn_%s" % (block_id),
+            name=f"separable_conv_2_bn_{block_id}",
         )(x)
     return x
 
@@ -616,22 +616,22 @@ def _adjust_block(p, ip, filters, block_id=None):
             p = ip
 
         elif p_shape[img_dim] != ip_shape[img_dim]:
-            with backend.name_scope("adjust_reduction_block_%s" % block_id):
-                p = layers.Activation(
-                    "relu", name="adjust_relu_1_%s" % block_id
-                )(p)
+            with backend.name_scope(f"adjust_reduction_block_{block_id}"):
+                p = layers.Activation("relu", name=f"adjust_relu_1_{block_id}")(
+                    p
+                )
                 p1 = layers.AveragePooling2D(
                     (1, 1),
                     strides=(2, 2),
                     padding="valid",
-                    name="adjust_avg_pool_1_%s" % block_id,
+                    name=f"adjust_avg_pool_1_{block_id}",
                 )(p)
                 p1 = layers.Conv2D(
                     filters // 2,
                     (1, 1),
                     padding="same",
                     use_bias=False,
-                    name="adjust_conv_1_%s" % block_id,
+                    name=f"adjust_conv_1_{block_id}",
                     kernel_initializer="he_normal",
                 )(p1)
 
@@ -641,14 +641,14 @@ def _adjust_block(p, ip, filters, block_id=None):
                     (1, 1),
                     strides=(2, 2),
                     padding="valid",
-                    name="adjust_avg_pool_2_%s" % block_id,
+                    name=f"adjust_avg_pool_2_{block_id}",
                 )(p2)
                 p2 = layers.Conv2D(
                     filters // 2,
                     (1, 1),
                     padding="same",
                     use_bias=False,
-                    name="adjust_conv_2_%s" % block_id,
+                    name=f"adjust_conv_2_{block_id}",
                     kernel_initializer="he_normal",
                 )(p2)
 
@@ -657,18 +657,18 @@ def _adjust_block(p, ip, filters, block_id=None):
                     axis=channel_dim,
                     momentum=0.9997,
                     epsilon=1e-3,
-                    name="adjust_bn_%s" % block_id,
+                    name=f"adjust_bn_{block_id}",
                 )(p)
 
         elif p_shape[channel_dim] != filters:
-            with backend.name_scope("adjust_projection_block_%s" % block_id):
+            with backend.name_scope(f"adjust_projection_block_{block_id}"):
                 p = layers.Activation("relu")(p)
                 p = layers.Conv2D(
                     filters,
                     (1, 1),
                     strides=(1, 1),
                     padding="same",
-                    name="adjust_conv_projection_%s" % block_id,
+                    name=f"adjust_conv_projection_{block_id}",
                     use_bias=False,
                     kernel_initializer="he_normal",
                 )(p)
@@ -676,7 +676,7 @@ def _adjust_block(p, ip, filters, block_id=None):
                     axis=channel_dim,
                     momentum=0.9997,
                     epsilon=1e-3,
-                    name="adjust_bn_%s" % block_id,
+                    name=f"adjust_bn_{block_id}",
                 )(p)
     return p
 
@@ -695,7 +695,7 @@ def _normal_a_cell(ip, p, filters, block_id=None):
     """
     channel_dim = 1 if backend.image_data_format() == "channels_first" else -1
 
-    with backend.name_scope("normal_A_block_%s" % block_id):
+    with backend.name_scope(f"normal_A_block_{block_id}"):
         p = _adjust_block(p, ip, filters, block_id)
 
         h = layers.Activation("relu")(ip)
@@ -704,7 +704,7 @@ def _normal_a_cell(ip, p, filters, block_id=None):
             (1, 1),
             strides=(1, 1),
             padding="same",
-            name="normal_conv_1_%s" % block_id,
+            name=f"normal_conv_1_{block_id}",
             use_bias=False,
             kernel_initializer="he_normal",
         )(h)
@@ -712,7 +712,7 @@ def _normal_a_cell(ip, p, filters, block_id=None):
             axis=channel_dim,
             momentum=0.9997,
             epsilon=1e-3,
-            name="normal_bn_1_%s" % block_id,
+            name=f"normal_bn_1_{block_id}",
         )(h)
 
         with backend.name_scope("block_1"):
@@ -720,56 +720,56 @@ def _normal_a_cell(ip, p, filters, block_id=None):
                 h,
                 filters,
                 kernel_size=(5, 5),
-                block_id="normal_left1_%s" % block_id,
+                block_id=f"normal_left1_{block_id}",
             )
             x1_2 = _separable_conv_block(
-                p, filters, block_id="normal_right1_%s" % block_id
+                p, filters, block_id=f"normal_right1_{block_id}"
             )
-            x1 = layers.add([x1_1, x1_2], name="normal_add_1_%s" % block_id)
+            x1 = layers.add([x1_1, x1_2], name=f"normal_add_1_{block_id}")
 
         with backend.name_scope("block_2"):
             x2_1 = _separable_conv_block(
-                p, filters, (5, 5), block_id="normal_left2_%s" % block_id
+                p, filters, (5, 5), block_id=f"normal_left2_{block_id}"
             )
             x2_2 = _separable_conv_block(
-                p, filters, (3, 3), block_id="normal_right2_%s" % block_id
+                p, filters, (3, 3), block_id=f"normal_right2_{block_id}"
             )
-            x2 = layers.add([x2_1, x2_2], name="normal_add_2_%s" % block_id)
+            x2 = layers.add([x2_1, x2_2], name=f"normal_add_2_{block_id}")
 
         with backend.name_scope("block_3"):
             x3 = layers.AveragePooling2D(
                 (3, 3),
                 strides=(1, 1),
                 padding="same",
-                name="normal_left3_%s" % (block_id),
+                name=f"normal_left3_{block_id}",
             )(h)
-            x3 = layers.add([x3, p], name="normal_add_3_%s" % block_id)
+            x3 = layers.add([x3, p], name=f"normal_add_3_{block_id}")
 
         with backend.name_scope("block_4"):
             x4_1 = layers.AveragePooling2D(
                 (3, 3),
                 strides=(1, 1),
                 padding="same",
-                name="normal_left4_%s" % (block_id),
+                name=f"normal_left4_{block_id}",
             )(p)
             x4_2 = layers.AveragePooling2D(
                 (3, 3),
                 strides=(1, 1),
                 padding="same",
-                name="normal_right4_%s" % (block_id),
+                name=f"normal_right4_{block_id}",
             )(p)
-            x4 = layers.add([x4_1, x4_2], name="normal_add_4_%s" % block_id)
+            x4 = layers.add([x4_1, x4_2], name=f"normal_add_4_{block_id}")
 
         with backend.name_scope("block_5"):
             x5 = _separable_conv_block(
-                h, filters, block_id="normal_left5_%s" % block_id
+                h, filters, block_id=f"normal_left5_{block_id}"
             )
-            x5 = layers.add([x5, h], name="normal_add_5_%s" % block_id)
+            x5 = layers.add([x5, h], name=f"normal_add_5_{block_id}")
 
         x = layers.concatenate(
             [p, x1, x2, x3, x4, x5],
             axis=channel_dim,
-            name="normal_concat_%s" % block_id,
+            name=f"normal_concat_{block_id}",
         )
     return x, ip
 
@@ -788,7 +788,7 @@ def _reduction_a_cell(ip, p, filters, block_id=None):
     """
     channel_dim = 1 if backend.image_data_format() == "channels_first" else -1
 
-    with backend.name_scope("reduction_A_block_%s" % block_id):
+    with backend.name_scope(f"reduction_A_block_{block_id}"):
         p = _adjust_block(p, ip, filters, block_id)
 
         h = layers.Activation("relu")(ip)
@@ -797,7 +797,7 @@ def _reduction_a_cell(ip, p, filters, block_id=None):
             (1, 1),
             strides=(1, 1),
             padding="same",
-            name="reduction_conv_1_%s" % block_id,
+            name=f"reduction_conv_1_{block_id}",
             use_bias=False,
             kernel_initializer="he_normal",
         )(h)
@@ -805,11 +805,11 @@ def _reduction_a_cell(ip, p, filters, block_id=None):
             axis=channel_dim,
             momentum=0.9997,
             epsilon=1e-3,
-            name="reduction_bn_1_%s" % block_id,
+            name=f"reduction_bn_1_{block_id}",
         )(h)
         h3 = layers.ZeroPadding2D(
             padding=imagenet_utils.correct_pad(h, 3),
-            name="reduction_pad_1_%s" % block_id,
+            name=f"reduction_pad_1_{block_id}",
         )(h)
 
         with backend.name_scope("block_1"):
@@ -818,74 +818,74 @@ def _reduction_a_cell(ip, p, filters, block_id=None):
                 filters,
                 (5, 5),
                 strides=(2, 2),
-                block_id="reduction_left1_%s" % block_id,
+                block_id=f"reduction_left1_{block_id}",
             )
             x1_2 = _separable_conv_block(
                 p,
                 filters,
                 (7, 7),
                 strides=(2, 2),
-                block_id="reduction_right1_%s" % block_id,
+                block_id=f"reduction_right1_{block_id}",
             )
-            x1 = layers.add([x1_1, x1_2], name="reduction_add_1_%s" % block_id)
+            x1 = layers.add([x1_1, x1_2], name=f"reduction_add_1_{block_id}")
 
         with backend.name_scope("block_2"):
             x2_1 = layers.MaxPooling2D(
                 (3, 3),
                 strides=(2, 2),
                 padding="valid",
-                name="reduction_left2_%s" % block_id,
+                name=f"reduction_left2_{block_id}",
             )(h3)
             x2_2 = _separable_conv_block(
                 p,
                 filters,
                 (7, 7),
                 strides=(2, 2),
-                block_id="reduction_right2_%s" % block_id,
+                block_id=f"reduction_right2_{block_id}",
             )
-            x2 = layers.add([x2_1, x2_2], name="reduction_add_2_%s" % block_id)
+            x2 = layers.add([x2_1, x2_2], name=f"reduction_add_2_{block_id}")
 
         with backend.name_scope("block_3"):
             x3_1 = layers.AveragePooling2D(
                 (3, 3),
                 strides=(2, 2),
                 padding="valid",
-                name="reduction_left3_%s" % block_id,
+                name=f"reduction_left3_{block_id}",
             )(h3)
             x3_2 = _separable_conv_block(
                 p,
                 filters,
                 (5, 5),
                 strides=(2, 2),
-                block_id="reduction_right3_%s" % block_id,
+                block_id=f"reduction_right3_{block_id}",
             )
-            x3 = layers.add([x3_1, x3_2], name="reduction_add3_%s" % block_id)
+            x3 = layers.add([x3_1, x3_2], name=f"reduction_add3_{block_id}")
 
         with backend.name_scope("block_4"):
             x4 = layers.AveragePooling2D(
                 (3, 3),
                 strides=(1, 1),
                 padding="same",
-                name="reduction_left4_%s" % block_id,
+                name=f"reduction_left4_{block_id}",
             )(x1)
             x4 = layers.add([x2, x4])
 
         with backend.name_scope("block_5"):
             x5_1 = _separable_conv_block(
-                x1, filters, (3, 3), block_id="reduction_left4_%s" % block_id
+                x1, filters, (3, 3), block_id=f"reduction_left4_{block_id}"
             )
             x5_2 = layers.MaxPooling2D(
                 (3, 3),
                 strides=(2, 2),
                 padding="valid",
-                name="reduction_right5_%s" % block_id,
+                name=f"reduction_right5_{block_id}",
             )(h3)
-            x5 = layers.add([x5_1, x5_2], name="reduction_add4_%s" % block_id)
+            x5 = layers.add([x5_1, x5_2], name=f"reduction_add4_{block_id}")
 
         x = layers.concatenate(
             [x2, x3, x4, x5],
             axis=channel_dim,
-            name="reduction_concat_%s" % block_id,
+            name=f"reduction_concat_{block_id}",
         )
         return x, ip
 

--- a/keras/applications/regnet.py
+++ b/keras/applications/regnet.py
@@ -826,7 +826,7 @@ def Stage(block_type, depth, group_width, filters_in, filters_out, name=None):
         else:
             raise NotImplementedError(
                 f"Block type `{block_type}` not recognized."
-                f"block_type must be one of (`X`, `Y`, `Z`). "
+                "block_type must be one of (`X`, `Y`, `Z`). "
             )
         return x
 

--- a/keras/applications/resnet.py
+++ b/keras/applications/resnet.py
@@ -85,7 +85,7 @@ def ResNet(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
-    **kwargs
+    **kwargs,
 ):
     """Instantiates the ResNet, ResNetV2, and ResNeXt architecture.
 
@@ -140,7 +140,7 @@ def ResNet(
     else:
         layers = VersionAwareLayers()
     if kwargs:
-        raise ValueError("Unknown argument(s): %s" % (kwargs,))
+        raise ValueError(f"Unknown argument(s): {kwargs}")
     if not (weights in {"imagenet", None} or tf.io.gfile.exists(weights)):
         raise ValueError(
             "The `weights` argument should be either "
@@ -508,7 +508,7 @@ def ResNet50(
     input_shape=None,
     pooling=None,
     classes=1000,
-    **kwargs
+    **kwargs,
 ):
     """Instantiates the ResNet50 architecture."""
 
@@ -529,7 +529,7 @@ def ResNet50(
         input_shape,
         pooling,
         classes,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -543,7 +543,7 @@ def ResNet101(
     input_shape=None,
     pooling=None,
     classes=1000,
-    **kwargs
+    **kwargs,
 ):
     """Instantiates the ResNet101 architecture."""
 
@@ -564,7 +564,7 @@ def ResNet101(
         input_shape,
         pooling,
         classes,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -578,7 +578,7 @@ def ResNet152(
     input_shape=None,
     pooling=None,
     classes=1000,
-    **kwargs
+    **kwargs,
 ):
     """Instantiates the ResNet152 architecture."""
 
@@ -599,7 +599,7 @@ def ResNet152(
         input_shape,
         pooling,
         classes,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/keras/applications/resnet_rs.py
+++ b/keras/applications/resnet_rs.py
@@ -39,7 +39,7 @@ from keras.utils import layer_utils
 from tensorflow.python.util.tf_export import keras_export
 
 BASE_WEIGHTS_URL = (
-    "https://storage.googleapis.com/tensorflow/" "keras-applications/resnet_rs/"
+    "https://storage.googleapis.com/tensorflow/keras-applications/resnet_rs/"
 )
 
 WEIGHT_HASHES = {
@@ -619,9 +619,9 @@ def ResNetRS(
 
     if weights in weights_allow_list and include_top and classes != 1000:
         raise ValueError(
-            f"If using `weights` as `'imagenet'` or any "
+            "If using `weights` as `'imagenet'` or any "
             f"of {weights_allow_list} "
-            f"with `include_top` as true, `classes` should be 1000. "
+            "with `include_top` as true, `classes` should be 1000. "
             f"Received classes={classes}"
         )
 

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -689,7 +689,7 @@ def _current_graph(op_input_list, graph=None):
 
     op_input_list = tuple(op_input_list)  # Handle generators correctly
     if graph and not isinstance(graph, tf.Graph):
-        raise TypeError("Input graph needs to be a Graph: %s" % (graph,))
+        raise TypeError(f"Input graph needs to be a Graph: {graph}")
 
     # 1. We validate that all of the inputs are from the same graph. This is
     #    either the supplied graph parameter, or the first one selected from one
@@ -718,7 +718,7 @@ def _current_graph(op_input_list, graph=None):
                 _assert_same_graph(original_graph_element, graph_element)
             elif graph_element.graph is not graph:
                 raise ValueError(
-                    "%s is not from the passed-in graph." % graph_element
+                    f"{graph_element} is not from the passed-in graph."
                 )
 
     # 2. If all else fails, we use the default graph, which is always there.
@@ -2576,8 +2576,8 @@ def batch_dot(x, y, axes=None):
             + str(y_shape)
             + " with axes="
             + str(axes)
-            + ". x.shape[%d] != "
-            "y.shape[%d] (%d != %d)." % (axes[0], axes[1], d1, d2)
+            + ". x.shape[%d] != y.shape[%d] (%d != %d)."
+            % (axes[0], axes[1], d1, d2)
         )
 
     # backup ndims. Need them later.
@@ -3661,7 +3661,7 @@ def resize_images(
     elif data_format == "channels_last":
         rows, cols = 1, 2
     else:
-        raise ValueError("Invalid `data_format` argument: %s" % (data_format,))
+        raise ValueError(f"Invalid `data_format` argument: {data_format}")
 
     new_shape = x.shape[rows : cols + 1]
     if new_shape.is_fully_defined():
@@ -4446,8 +4446,8 @@ class GraphExecutionFunction:
 
         if session_kwargs:
             raise ValueError(
-                "Some keys in session_kwargs are not supported at this "
-                "time: %s" % (session_kwargs.keys(),)
+                "Some keys in session_kwargs are not supported at this time: %s"
+                % (session_kwargs.keys(),)
             )
 
         self._callable_fn = None
@@ -4640,8 +4640,8 @@ def function(inputs, outputs, updates=None, name=None, **kwargs):
             ] and key not in ["inputs", "outputs", "updates", "name"]:
                 msg = (
                     'Invalid argument "%s" passed to K.function with '
-                    "TensorFlow backend"
-                ) % key
+                    "TensorFlow backend" % key
+                )
                 raise ValueError(msg)
     return GraphExecutionFunction(
         inputs, outputs, updates=updates, name=name, **kwargs
@@ -4809,11 +4809,11 @@ def rnn(
     def _expand_mask(mask_t, input_t, fixed_dim=1):
         if tf.nest.is_nested(mask_t):
             raise ValueError(
-                "mask_t is expected to be tensor, but got %s" % mask_t
+                f"mask_t is expected to be tensor, but got {mask_t}"
             )
         if tf.nest.is_nested(input_t):
             raise ValueError(
-                "input_t is expected to be tensor, but got %s" % input_t
+                f"input_t is expected to be tensor, but got {input_t}"
             )
         rank_diff = len(input_t.shape) - len(mask_t.shape)
         for _ in range(rank_diff):
@@ -4931,7 +4931,7 @@ def rnn(
             tf.TensorArray(
                 dtype=inp.dtype,
                 size=time_steps_t,
-                tensor_array_name="input_ta_%s" % i,
+                tensor_array_name=f"input_ta_{i}",
             )
             for i, inp in enumerate(flatted_inputs)
         )
@@ -4960,7 +4960,7 @@ def rnn(
                 dtype=out.dtype,
                 size=output_ta_size,
                 element_shape=out.shape,
-                tensor_array_name="output_ta_%s" % i,
+                tensor_array_name=f"output_ta_{i}",
             )
             for i, out in enumerate(tf.nest.flatten(output_time_zero))
         )
@@ -5224,8 +5224,8 @@ def switch(condition, then_expression, else_expression):
                 " equal to rank of `then_expression` and "
                 "`else_expression`. ndim(condition)="
                 + str(cond_ndim)
-                + ", ndim(then_expression)"
-                "=" + str(expr_ndim)
+                + ", ndim(then_expression)="
+                + str(expr_ndim)
             )
         if cond_ndim > 1:
             ndim_diff = expr_ndim - cond_ndim

--- a/keras/backend_test.py
+++ b/keras/backend_test.py
@@ -67,8 +67,12 @@ def compare_single_input_op_to_numpy(
         np.testing.assert_allclose(keras_output, np_output, atol=1e-4)
     except AssertionError:
         raise AssertionError(
-            "Test for op `" + str(keras_op.__name__) + "` failed; "
-            "Expected " + str(np_output) + " but got " + str(keras_output)
+            "Test for op `"
+            + str(keras_op.__name__)
+            + "` failed; Expected "
+            + str(np_output)
+            + " but got "
+            + str(keras_output)
         )
 
 
@@ -93,7 +97,7 @@ def compare_two_inputs_op_to_numpy(
         backend.variable(input_a, dtype=dtype),
         backend.variable(input_b, dtype=dtype),
         *keras_args,
-        **keras_kwargs
+        **keras_kwargs,
     )
     keras_output = backend.eval(keras_output)
     np_output = np_op(
@@ -103,8 +107,12 @@ def compare_two_inputs_op_to_numpy(
         np.testing.assert_allclose(keras_output, np_output, atol=1e-4)
     except AssertionError:
         raise AssertionError(
-            "Test for op `" + str(keras_op.__name__) + "` failed; "
-            "Expected " + str(np_output) + " but got " + str(keras_output)
+            "Test for op `"
+            + str(keras_op.__name__)
+            + "` failed; Expected "
+            + str(np_output)
+            + " but got "
+            + str(keras_output)
         )
 
 
@@ -295,7 +303,7 @@ class BackendUtilsTest(tf.test.TestCase):
         # we cannot test correctness.
         # The message gets correctly printed in practice.
         x = backend.placeholder(shape=())
-        y = backend.print_tensor(x, "eager=%s" % tf.executing_eagerly())
+        y = backend.print_tensor(x, f"eager={tf.executing_eagerly()}")
         f = backend.function(x, y)
         f(0)
 
@@ -1445,7 +1453,7 @@ class BackendNNOpsTest(tf.test.TestCase, parameterized.TestCase):
             state_list[i].append(backend.eval(new_states[0]))
 
             def assert_list_pairwise(z_list, atol=1e-05):
-                for (z1, z2) in zip(z_list[1:], z_list[:-1]):
+                for z1, z2 in zip(z_list[1:], z_list[:-1]):
                     self.assertAllClose(z1, z2, atol=atol)
 
             assert_list_pairwise(last_output_list[0], atol=1e-04)
@@ -1557,7 +1565,7 @@ class BackendNNOpsTest(tf.test.TestCase, parameterized.TestCase):
             additional_state_list[i].append(backend.eval(new_states[1]))
 
             def assert_list_pairwise(z_list, atol=1e-05):
-                for (z1, z2) in zip(z_list[1:], z_list[:-1]):
+                for z1, z2 in zip(z_list[1:], z_list[:-1]):
                     self.assertAllClose(z1, z2, atol=atol)
 
             assert_list_pairwise(last_output_list[0], atol=1e-04)

--- a/keras/benchmarks/distribution_util.py
+++ b/keras/benchmarks/distribution_util.py
@@ -128,8 +128,7 @@ def get_distribution_strategy(
             return tf.distribute.OneDeviceStrategy("device:CPU:0")
         if num_gpus > 1:
             raise ValueError(
-                "`OneDeviceStrategy` can not be used for more than "
-                "one device."
+                "`OneDeviceStrategy` can not be used for more than one device."
             )
         return tf.distribute.OneDeviceStrategy("device:GPU:0")
 

--- a/keras/benchmarks/keras_examples_benchmarks/mnist_conv_custom_training_benchmark_test.py
+++ b/keras/benchmarks/keras_examples_benchmarks/mnist_conv_custom_training_benchmark_test.py
@@ -248,12 +248,12 @@ class CustomMnistBenchmark(tf.test.Benchmark):
 
         if not isinstance(loss_fn, tf.keras.losses.Loss):
             raise ValueError(
-                "`tf.keras.losses.Loss` instance " "for loss_fn is required."
+                "`tf.keras.losses.Loss` instance for loss_fn is required."
             )
 
         if not isinstance(optimizer, tf.keras.optimizers.Optimizer):
             raise ValueError(
-                "`tf.keras.optimizers` instance " "for optimizer is required."
+                "`tf.keras.optimizers` instance for optimizer is required."
             )
 
         avg_epoch_time_list, train_step_time_list = [], []

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -327,7 +327,7 @@ class CallbackList:
 
     def _call_batch_begin_hook(self, mode, batch, logs):
         """Helper function for `on_*_batch_begin` methods."""
-        hook_name = "on_{mode}_batch_begin".format(mode=mode)
+        hook_name = f"on_{mode}_batch_begin"
         self._call_batch_hook_helper(hook_name, batch, logs)
 
         if self._check_timing:
@@ -335,7 +335,7 @@ class CallbackList:
 
     def _call_batch_end_hook(self, mode, batch, logs):
         """Helper function for `on_*_batch_end` methods."""
-        hook_name = "on_{mode}_batch_end".format(mode=mode)
+        hook_name = f"on_{mode}_batch_end"
 
         if self._check_timing and batch >= 1:
             batch_time = time.time() - self._batch_start_time
@@ -345,7 +345,7 @@ class CallbackList:
 
         if len(self._batch_times) >= self._num_batches_for_timing_check:
             end_hook_name = hook_name
-            begin_hook_name = "on_{mode}_batch_begin".format(mode=mode)
+            begin_hook_name = f"on_{mode}_batch_begin"
             avg_batch_time = sum(self._batch_times) / len(self._batch_times)
             avg_end_hook_time = sum(self._hook_times[end_hook_name]) / len(
                 self._hook_times[end_hook_name]
@@ -1361,7 +1361,7 @@ class ModelCheckpoint(Callback):
             else:
                 raise TypeError(
                     "If save_weights_only is True, then `options` must be "
-                    f"either None or a tf.train.CheckpointOptions. "
+                    "either None or a tf.train.CheckpointOptions. "
                     f"Got {options}."
                 )
         else:
@@ -1372,7 +1372,7 @@ class ModelCheckpoint(Callback):
             else:
                 raise TypeError(
                     "If save_weights_only is False, then `options` must be "
-                    f"either None or a tf.saved_model.SaveOptions. "
+                    "either None or a tf.saved_model.SaveOptions. "
                     f"Got {options}."
                 )
 
@@ -1402,7 +1402,7 @@ class ModelCheckpoint(Callback):
 
         if mode not in ["auto", "min", "max"]:
             logging.warning(
-                "ModelCheckpoint mode %s is unknown, " "fallback to auto mode.",
+                "ModelCheckpoint mode %s is unknown, fallback to auto mode.",
                 mode,
             )
             mode = "auto"
@@ -1984,7 +1984,7 @@ class EarlyStopping(Callback):
 
         if mode not in ["auto", "min", "max"]:
             logging.warning(
-                "EarlyStopping mode %s is unknown, " "fallback to auto mode.",
+                "EarlyStopping mode %s is unknown, fallback to auto mode.",
                 mode,
             )
             mode = "auto"
@@ -2138,8 +2138,8 @@ class RemoteMonitor(Callback):
                 )
         except requests.exceptions.RequestException:
             logging.warning(
-                "Warning: could not reach RemoteMonitor "
-                "root server at " + str(self.root)
+                "Warning: could not reach RemoteMonitor root server at "
+                + str(self.root)
             )
 
 
@@ -2857,7 +2857,7 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
         embeddings_ckpt = os.path.join(
             self._log_write_dir,
             "train",
-            "keras_embedding.ckpt-{}".format(epoch),
+            f"keras_embedding.ckpt-{epoch}",
         )
         self.model.save_weights(embeddings_ckpt)
 
@@ -2947,7 +2947,7 @@ class ReduceLROnPlateau(Callback):
         self.monitor = monitor
         if factor >= 1.0:
             raise ValueError(
-                f"ReduceLROnPlateau does not support "
+                "ReduceLROnPlateau does not support "
                 f"a factor >= 1.0. Got {factor}"
             )
         if "epsilon" in kwargs:
@@ -3023,7 +3023,7 @@ class ReduceLROnPlateau(Callback):
                         if self.verbose > 0:
                             io_utils.print_msg(
                                 f"\nEpoch {epoch +1}: "
-                                f"ReduceLROnPlateau reducing "
+                                "ReduceLROnPlateau reducing "
                                 f"learning rate to {new_lr}."
                             )
                         self.cooldown_counter = self.cooldown
@@ -3084,7 +3084,7 @@ class CSVLogger(Callback):
                 isinstance(k, collections.abc.Iterable)
                 and not is_zero_dim_ndarray
             ):
-                return '"[%s]"' % (", ".join(map(str, k)))
+                return f"\"[{', '.join(map(str, k))}]\""
             else:
                 return k
 

--- a/keras/callbacks_test.py
+++ b/keras/callbacks_test.py
@@ -1585,7 +1585,7 @@ class KerasCallbacksTest(test_combinations.TestCase):
 
         with self.assertRaisesRegex(
             IOError,
-            "Please specify a non-directory " "filepath for ModelCheckpoint.",
+            "Please specify a non-directory filepath for ModelCheckpoint.",
         ):
             model.fit(train_ds, epochs=1, callbacks=[callback])
 
@@ -1602,7 +1602,7 @@ class KerasCallbacksTest(test_combinations.TestCase):
         callback = keras.callbacks.ModelCheckpoint(filepath=filepath)
 
         with self.assertRaisesRegex(
-            KeyError, "Failed to format this callback " "filepath.*"
+            KeyError, "Failed to format this callback filepath.*"
         ):
             model.fit(train_ds, epochs=1, callbacks=[callback])
 
@@ -2763,7 +2763,7 @@ def list_summaries(logdir):
       ValueError: If an event file contains an summary of unexpected kind.
     """
     result = _SummaryFile()
-    for (dirpath, _, filenames) in os.walk(logdir):
+    for dirpath, _, filenames in os.walk(logdir):
         for filename in filenames:
             if not filename.startswith("events.out."):
                 continue
@@ -2930,7 +2930,7 @@ class TestTensorBoardV2(test_combinations.TestCase):
         model.fit(x, y, batch_size=2, epochs=2, callbacks=[tb_cbk])
 
         events_file_run_basenames = set()
-        for (dirpath, _, filenames) in os.walk(self.train_dir):
+        for dirpath, _, filenames in os.walk(self.train_dir):
             if any(fn.startswith("events.out.") for fn in filenames):
                 events_file_run_basenames.add(os.path.basename(dirpath))
         self.assertEqual(events_file_run_basenames, {"train"})
@@ -3153,11 +3153,9 @@ class TestTensorBoardV2(test_combinations.TestCase):
                 f.readlines(),
                 [
                     "embeddings {\n",
-                    (
-                        "  tensor_name: "
-                        '"layer_with_weights-0/embeddings/.ATTRIBUTES/'
-                        'VARIABLE_VALUE"\n'
-                    ),
+                    "  tensor_name: "
+                    '"layer_with_weights-0/embeddings/.ATTRIBUTES/'
+                    'VARIABLE_VALUE"\n',
                     '  metadata_path: "metadata.tsv"\n',
                     "}\n",
                 ],
@@ -3236,7 +3234,7 @@ class TestTensorBoardV2(test_combinations.TestCase):
         result = set()
         for summary in summaries:
             if "/" not in summary.tag:
-                raise ValueError("tag has no layer name: %r" % summary.tag)
+                raise ValueError(f"tag has no layer name: {summary.tag!r}")
             start_from = 2 if "subclass" in model_type else 1
             new_tag = "/".join(summary.tag.split("/")[start_from:])
             result.add(summary._replace(tag=new_tag))
@@ -3307,7 +3305,7 @@ class TestTensorBoardV2NonParameterizedTest(test_combinations.TestCase):
     def _count_trace_file(self, logdir):
         profile_dir = os.path.join(logdir, "plugins", "profile")
         count = 0
-        for (dirpath, dirnames, filenames) in os.walk(profile_dir):
+        for dirpath, dirnames, filenames in os.walk(profile_dir):
             del dirpath  # unused
             del dirnames  # unused
             for filename in filenames:
@@ -3875,7 +3873,7 @@ def events_from_logdir(logdir):
     """
     assert tf.compat.v1.gfile.Exists(logdir)
     files = tf.compat.v1.gfile.ListDirectory(logdir)
-    assert len(files) == 1, "Found not exactly one file in logdir: %s" % files
+    assert len(files) == 1, f"Found not exactly one file in logdir: {files}"
     return events_from_file(os.path.join(logdir, files[0]))
 
 

--- a/keras/callbacks_v1.py
+++ b/keras/callbacks_v1.py
@@ -228,18 +228,18 @@ class TensorBoard(callbacks.TensorBoard):
                             for grad in grads
                         ]
                         tf.compat.v1.summary.histogram(
-                            "{}_grad".format(mapped_weight_name), grads
+                            f"{mapped_weight_name}_grad", grads
                         )
 
                 if hasattr(layer, "output"):
                     if isinstance(layer.output, list):
                         for i, output in enumerate(layer.output):
                             tf.compat.v1.summary.histogram(
-                                "{}_out_{}".format(layer.name, i), output
+                                f"{layer.name}_out_{i}", output
                             )
                     else:
                         tf.compat.v1.summary.histogram(
-                            "{}_out".format(layer.name), layer.output
+                            f"{layer.name}_out", layer.output
                         )
 
     def set_model(self, model):
@@ -456,7 +456,7 @@ class TensorBoard(callbacks.TensorBoard):
 
         if self.embeddings_data is None and self.embeddings_freq:
             raise ValueError(
-                "To visualize embeddings, embeddings_data must " "be provided."
+                "To visualize embeddings, embeddings_data must be provided."
             )
 
         if self.embeddings_freq and self.embeddings_data is not None:

--- a/keras/datasets/boston_housing.py
+++ b/keras/datasets/boston_housing.py
@@ -67,7 +67,9 @@ def load_data(path="boston_housing.npz", test_split=0.2, seed=113):
     path = get_file(
         path,
         origin=origin_folder + "boston_housing.npz",
-        file_hash="f553886a1f8d56431e820c5b82552d9d95cfcb96d1e678153f8839538947dff5",  # noqa: E501
+        file_hash=(  # noqa: E501
+            "f553886a1f8d56431e820c5b82552d9d95cfcb96d1e678153f8839538947dff5"
+        ),
     )
     with np.load(path, allow_pickle=True) as f:
         x = f["x"]

--- a/keras/datasets/cifar10.py
+++ b/keras/datasets/cifar10.py
@@ -82,7 +82,9 @@ def load_data():
         dirname,
         origin=origin,
         untar=True,
-        file_hash="6d958be074577803d12ecdefd02955f39262c83c16fe9348329d7fe0b5c001ce",  # noqa: E501
+        file_hash=(  # noqa: E501
+            "6d958be074577803d12ecdefd02955f39262c83c16fe9348329d7fe0b5c001ce"
+        ),
     )
 
     num_train_samples = 50000

--- a/keras/datasets/cifar100.py
+++ b/keras/datasets/cifar100.py
@@ -79,7 +79,9 @@ def load_data(label_mode="fine"):
         dirname,
         origin=origin,
         untar=True,
-        file_hash="85cd44d02ba6437773c5bbd22e183051d648de2e7d6b014e1ef29b855ba677a7",  # noqa: E501
+        file_hash=(  # noqa: E501
+            "85cd44d02ba6437773c5bbd22e183051d648de2e7d6b014e1ef29b855ba677a7"
+        ),
     )
 
     fpath = os.path.join(path, "train")

--- a/keras/datasets/imdb.py
+++ b/keras/datasets/imdb.py
@@ -111,7 +111,9 @@ def load_data(
     path = get_file(
         path,
         origin=origin_folder + "imdb.npz",
-        file_hash="69664113be75683a8fe16e3ed0ab59fda8886cb3cd7ada244f7d9544e4676b9f",  # noqa: E501
+        file_hash=(  # noqa: E501
+            "69664113be75683a8fe16e3ed0ab59fda8886cb3cd7ada244f7d9544e4676b9f"
+        ),
     )
     with np.load(path, allow_pickle=True) as f:
         x_train, labels_train = f["x_train"], f["y_train"]

--- a/keras/datasets/mnist.py
+++ b/keras/datasets/mnist.py
@@ -75,7 +75,9 @@ def load_data(path="mnist.npz"):
     path = get_file(
         path,
         origin=origin_folder + "mnist.npz",
-        file_hash="731c5ac602752760c8e48fbffcf8c3b850d9dc2a2aedcf2cc48468fc17b673d1",  # noqa: E501
+        file_hash=(  # noqa: E501
+            "731c5ac602752760c8e48fbffcf8c3b850d9dc2a2aedcf2cc48468fc17b673d1"
+        ),
     )
     with np.load(path, allow_pickle=True) as f:
         x_train, y_train = f["x_train"], f["y_train"]

--- a/keras/datasets/reuters.py
+++ b/keras/datasets/reuters.py
@@ -117,7 +117,9 @@ def load_data(
     path = get_file(
         path,
         origin=origin_folder + "reuters.npz",
-        file_hash="d6586e694ee56d7a4e65172e12b3e987c03096cb01eab99753921ef915959916",  # noqa: E501
+        file_hash=(  # noqa: E501
+            "d6586e694ee56d7a4e65172e12b3e987c03096cb01eab99753921ef915959916"
+        ),
     )
     with np.load(path, allow_pickle=True) as f:
         xs, labels = f["x"], f["y"]

--- a/keras/distribute/distribute_coordinator_utils.py
+++ b/keras/distribute/distribute_coordinator_utils.py
@@ -755,7 +755,7 @@ def run_distribute_coordinator(
             )
         else:
             if task_type != _TaskType.PS:
-                raise ValueError("Unexpected task_type: %r" % task_type)
+                raise ValueError(f"Unexpected task_type: {task_type!r}")
             server.join()
 
 

--- a/keras/distribute/distribute_strategy_test.py
+++ b/keras/distribute/distribute_strategy_test.py
@@ -456,7 +456,7 @@ class TestDistributionStrategyWithNumpyArrays(
                 # Computed global batch size can not be sharded across replicas
                 with self.assertRaisesRegex(
                     ValueError,
-                    "could not be sharded evenly " "across the sync replicas",
+                    "could not be sharded evenly across the sync replicas",
                 ):
                     distributed_training_utils_v1.get_input_params(
                         distribution, 63, steps=1, batch_size=None

--- a/keras/distribute/distributed_file_utils.py
+++ b/keras/distribute/distributed_file_utils.py
@@ -162,8 +162,7 @@ def _on_gcp():
         # issue. There is not default timeout, which means it might block
         # forever.
         response = requests.get(
-            "%s/computeMetadata/v1/%s"
-            % (gce_metadata_endpoint, "instance/hostname"),
+            f"{gce_metadata_endpoint}/computeMetadata/v1/{'instance/hostname'}",
             headers=GCP_METADATA_HEADER,
             timeout=5,
         )

--- a/keras/distribute/distributed_training_utils_v1.py
+++ b/keras/distribute/distributed_training_utils_v1.py
@@ -1057,8 +1057,8 @@ def _make_graph_execution_function(model, mode):
             all_inputs,
             all_outputs,
             updates=all_updates,
-            name="distributed_{}_function".format(mode),
-            **all_session_args
+            name=f"distributed_{mode}_function",
+            **all_session_args,
         )
 
 
@@ -1105,7 +1105,7 @@ def _make_eager_execution_function(model, mode):
         return backend.function(
             all_inputs,
             all_outputs,
-            name="eager_distributed_{}_function".format(mode),
+            name=f"eager_distributed_{mode}_function",
         )
 
 

--- a/keras/distribute/keras_correctness_test_base.py
+++ b/keras/distribute/keras_correctness_test_base.py
@@ -310,7 +310,7 @@ def fit_eval_and_predict(
         if is_stateful_model:
             predict_length = 3
         for i in range(predict_length):
-            result_key = "predict_result_{}".format(i)
+            result_key = f"predict_result_{i}"
             result[result_key] = model.predict(**predict_inputs)
 
     # Train and eval again to mimic user's flow.
@@ -397,7 +397,7 @@ def compare_results(
             results_without_ds[key],
             atol=tolerance,
             rtol=tolerance,
-            msg="Fail to assert {}.".format(key),
+            msg=f"Fail to assert {key}.",
         )
 
 

--- a/keras/distribute/keras_rnn_model_correctness_test.py
+++ b/keras/distribute/keras_rnn_model_correctness_test.py
@@ -139,7 +139,7 @@ class DistributionStrategyLstmModelCorrectnessTest(
             ),
         ):
             self.skipTest(
-                "CentralStorageStrategy is not supported by " "mixed precision."
+                "CentralStorageStrategy is not supported by mixed precision."
             )
         if isinstance(
             distribution,

--- a/keras/distribute/minimize_loss_test.py
+++ b/keras/distribute/minimize_loss_test.py
@@ -268,7 +268,7 @@ class MinimizeLossStepTest(tf.test.TestCase, parameterized.TestCase):
                     variables = VAR_MAP_V1[name]
 
                 extended_variables = [
-                    v + "/replica_{}".format(replica)
+                    v + f"/replica_{replica}"
                     for v in variables
                     for replica in range(1, num_parameter_devices)
                 ]

--- a/keras/distribute/multi_worker_callback_tf2_test.py
+++ b/keras/distribute/multi_worker_callback_tf2_test.py
@@ -373,7 +373,7 @@ class KerasCallbackMultiProcessTest(parameterized.TestCase, tf.test.TestCase):
 
             saving_filepath = os.path.join(
                 test_obj.get_temp_dir(),
-                "logfile_%s" % (get_tf_config_task()["type"]),
+                f"logfile_{get_tf_config_task()['type']}",
             )
 
             saving_filepath_for_temp = os.path.join(

--- a/keras/distribute/multi_worker_testing_utils.py
+++ b/keras/distribute/multi_worker_testing_utils.py
@@ -145,14 +145,14 @@ def _create_cluster(
     cluster_dict = {}
     if num_workers > 0:
         cluster_dict[worker_name] = [
-            "localhost:%s" % port for port in worker_ports
+            f"localhost:{port}" for port in worker_ports
         ]
     if num_ps > 0:
-        cluster_dict[ps_name] = ["localhost:%s" % port for port in ps_ports]
+        cluster_dict[ps_name] = [f"localhost:{port}" for port in ps_ports]
     if has_eval:
-        cluster_dict["evaluator"] = ["localhost:%s" % pick_unused_port()]
+        cluster_dict["evaluator"] = [f"localhost:{pick_unused_port()}"]
     if has_chief:
-        cluster_dict[chief_name] = ["localhost:%s" % pick_unused_port()]
+        cluster_dict[chief_name] = [f"localhost:{pick_unused_port()}"]
 
     cs = tf.train.ClusterSpec(cluster_dict)
 

--- a/keras/distribute/sidecar_evaluator.py
+++ b/keras/distribute/sidecar_evaluator.py
@@ -293,7 +293,7 @@ class SidecarEvaluator:
                 "End of evaluation. Metrics: %s",
                 " ".join(
                     [
-                        "{}={}".format(name, value.numpy())
+                        f"{name}={value.numpy()}"
                         for name, value in return_metrics.items()
                     ]
                 ),

--- a/keras/distribute/sidecar_evaluator_test.py
+++ b/keras/distribute/sidecar_evaluator_test.py
@@ -79,8 +79,7 @@ class SidecarEvaluatorTest(tf.test.TestCase, parameterized.TestCase):
         summary_files = tf.io.gfile.listdir(log_dir)
         self.assertNotEmpty(
             summary_files,
-            "Summary should have been written and "
-            "log_dir should not be empty.",
+            "Summary should have been written and log_dir should not be empty.",
         )
 
         # Asserts the content of the summary file.
@@ -138,7 +137,7 @@ class SidecarEvaluatorTest(tf.test.TestCase, parameterized.TestCase):
         )
         with self.assertRaisesRegex(
             RuntimeError,
-            "`iterations` cannot be loaded " "from the checkpoint file.",
+            "`iterations` cannot be loaded from the checkpoint file.",
         ):
             sidecar_evaluator.start()
 
@@ -342,7 +341,7 @@ class SidecarEvaluatorTest(tf.test.TestCase, parameterized.TestCase):
             sidecar_evaluator_lib.SidecarEvaluatorExperimental(None, None, None)
 
         warning_msg = (
-            "`tf.keras.experimental.SidecarEvaluator` " "endpoint is deprecated"
+            "`tf.keras.experimental.SidecarEvaluator` endpoint is deprecated"
         )
         self.assertIn(warning_msg, "\n".join(warning_messages))
 

--- a/keras/dtensor/layout_map.py
+++ b/keras/dtensor/layout_map.py
@@ -121,8 +121,7 @@ class LayoutMap(collections.abc.MutableMapping):
             )
         if not isinstance(layout, dtensor.Layout):
             raise ValueError(
-                f"{layout} should be a dtensor.Layout type, "
-                f"got {type(layout)}"
+                f"{layout} should be a dtensor.Layout type, got {type(layout)}"
             )
 
         self._layout_map[key] = layout
@@ -488,7 +487,7 @@ def _config_dvariable_regularization(
         ID and newly created DVariable.
     """
 
-    for (name, variable, regualarizer) in layer._captured_weight_regularizer:
+    for name, variable, regualarizer in layer._captured_weight_regularizer:
         if not _is_lazy_init_variable(variable):
             raise ValueError(
                 "Expect the regularization loss are created from "

--- a/keras/dtensor/lazy_variable.py
+++ b/keras/dtensor/lazy_variable.py
@@ -141,7 +141,7 @@ class LazyInitVariable(resource_variable_ops.BaseResourceVariable):
 
         if constraint is not None and not callable(constraint):
             raise ValueError(
-                f"Argument `constraint` must be None or a callable. "
+                "Argument `constraint` must be None or a callable. "
                 f"a callable. Got a {type(constraint)}:  {constraint}"
             )
 
@@ -186,9 +186,9 @@ class LazyInitVariable(resource_variable_ops.BaseResourceVariable):
 
                 if not initial_value.shape.is_compatible_with(self._shape):
                     raise ValueError(
-                        f"In this `tf.Variable` creation, the initial value's "
+                        "In this `tf.Variable` creation, the initial value's "
                         f"shape ({initial_value.shape}) is not compatible with "
-                        f"the explicitly supplied `shape` "
+                        "the explicitly supplied `shape` "
                         f"argument ({self._shape})."
                     )
                 assert self._dtype is initial_value.dtype.base_dtype

--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -1075,8 +1075,10 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
 
             call_fn = traceback_utils.inject_argument_info_in_traceback(
                 call_fn,
-                object_name=f'layer "{self.name}" " \
-                f"(type {self.__class__.__name__})',
+                object_name=(
+                    f'layer "{self.name}" "                 f"(type'
+                    f" {self.__class__.__name__})"
+                ),
             )
             with contextlib.ExitStack() as namescope_stack:
                 if _is_name_scope_on_model_declaration_enabled:
@@ -1439,7 +1441,7 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
         """
         kwargs.pop("inputs", None)
         if kwargs:
-            raise TypeError("Unknown keyword arguments: %s" % (kwargs.keys(),))
+            raise TypeError(f"Unknown keyword arguments: {kwargs.keys()}")
 
         def _tag_callable(loss):
             """Tags callable loss tensor as `_unconditional_loss`."""
@@ -1612,8 +1614,8 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
 
         if not in_call_context and not is_symbolic:
             raise ValueError(
-                "Expected a symbolic Tensor for the metric value, "
-                "received: " + str(value)
+                "Expected a symbolic Tensor for the metric value, received: "
+                + str(value)
             )
 
         # If a metric was added in a Layer's `call` or `build`.
@@ -2268,7 +2270,7 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
             self.__class__, api_name="keras", add_prefix_to_v1_names=True
         )
         if canonical_name is not None:
-            return "tf.{}".format(canonical_name)
+            return f"tf.{canonical_name}"
         return self.__class__.__module__ + "." + self.__class__.__name__
 
     def _instrument_layer_creation(self):
@@ -3609,7 +3611,7 @@ def _apply_name_scope_on_model_declaration(enable):
     """
     if not isinstance(enable, bool):
         raise TypeError(
-            "`enable` argument must be `True` or `False`, got {}".format(enable)
+            f"`enable` argument must be `True` or `False`, got {enable}"
         )
 
     global _is_name_scope_on_model_declaration_enabled

--- a/keras/engine/base_layer_test.py
+++ b/keras/engine/base_layer_test.py
@@ -1530,12 +1530,12 @@ class NameScopingTest(test_combinations.TestCase):
                 "MatMul/ReadVariableOp/resource",
                 "call_scope/model/outer/ThreeDenses/NestedDense3/"
                 "MatMul/ReadVariableOp",
-                "call_scope/model/outer/ThreeDenses/NestedDense3/" "MatMul",
+                "call_scope/model/outer/ThreeDenses/NestedDense3/MatMul",
                 "call_scope/model/outer/ThreeDenses/NestedDense3/"
                 "BiasAdd/ReadVariableOp/resource",
                 "call_scope/model/outer/ThreeDenses/NestedDense3/"
                 "BiasAdd/ReadVariableOp",
-                "call_scope/model/outer/ThreeDenses/NestedDense3/" "BiasAdd",
+                "call_scope/model/outer/ThreeDenses/NestedDense3/BiasAdd",
                 "call_scope/model/OuterDense/MatMul/ReadVariableOp/resource",
                 "call_scope/model/OuterDense/MatMul/ReadVariableOp",
                 "call_scope/model/OuterDense/MatMul",

--- a/keras/engine/base_layer_v1.py
+++ b/keras/engine/base_layer_v1.py
@@ -2135,8 +2135,9 @@ class Layer(base_layer.Layer):
         """
         if not self._inbound_nodes:
             raise RuntimeError(
-                "The layer has never been called "
-                "and thus has no defined " + attr_name + "."
+                "The layer has never been called and thus has no defined "
+                + attr_name
+                + "."
             )
         if not len(self._inbound_nodes) > node_index:
             raise ValueError(

--- a/keras/engine/data_adapter.py
+++ b/keras/engine/data_adapter.py
@@ -118,9 +118,7 @@ class DataAdapter(object, metaclass=abc.ABCMeta):
             provided.
         """
         if not self.can_handle(x, y):
-            raise ValueError(
-                "{} Cannot handle input {}, {}".format(self.__class__, x, y)
-            )
+            raise ValueError(f"{self.__class__} Cannot handle input {x}, {y}")
 
     @abc.abstractmethod
     def get_dataset(self):
@@ -241,7 +239,7 @@ class TensorLikeDataAdapter(DataAdapter):
         epochs=1,
         steps=None,
         shuffle=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(x, y, **kwargs)
         x, y, sample_weights = _process_tensorlike((x, y, sample_weights))
@@ -617,7 +615,7 @@ class CompositeTensorDataAdapter(DataAdapter):
         batch_size=None,
         steps=None,
         shuffle=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(x, y, **kwargs)
         x, y, sample_weights = _process_tensorlike((x, y, sample_weights))
@@ -701,7 +699,7 @@ class ListsOfScalarsDataAdapter(DataAdapter):
         sample_weight_modes=None,
         batch_size=None,
         shuffle=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(x, y, **kwargs)
         x = np.asarray(x)
@@ -720,7 +718,7 @@ class ListsOfScalarsDataAdapter(DataAdapter):
             sample_weight_modes=sample_weight_modes,
             batch_size=batch_size,
             shuffle=shuffle,
-            **kwargs
+            **kwargs,
         )
 
     def get_dataset(self):
@@ -797,7 +795,7 @@ class DatasetAdapter(DataAdapter):
         # Arguments that shouldn't be passed.
         if not is_none_or_empty(y):
             raise ValueError(
-                "`y` argument is not supported when using " "dataset as input."
+                "`y` argument is not supported when using dataset as input."
             )
         if not is_none_or_empty(sample_weights):
             raise ValueError(
@@ -845,7 +843,7 @@ class GeneratorDataAdapter(DataAdapter):
         use_multiprocessing=False,
         max_queue_size=10,
         model=None,
-        **kwargs
+        **kwargs,
     ):
         # Generators should never shuffle as exhausting the generator in order
         # to shuffle the batches is inefficient.
@@ -991,7 +989,7 @@ class KerasSequenceAdapter(GeneratorDataAdapter):
         use_multiprocessing=False,
         max_queue_size=10,
         model=None,
-        **kwargs
+        **kwargs,
     ):
         if not is_none_or_empty(y):
             raise ValueError(
@@ -1014,7 +1012,7 @@ class KerasSequenceAdapter(GeneratorDataAdapter):
             use_multiprocessing=use_multiprocessing,
             max_queue_size=max_queue_size,
             model=model,
-            **kwargs
+            **kwargs,
         )
 
     @staticmethod
@@ -1081,8 +1079,9 @@ def select_data_adapter(x, y):
     if not adapter_cls:
         # TODO(scottzhu): This should be a less implementation-specific error.
         raise ValueError(
-            "Failed to find data adapter that can handle "
-            "input: {}, {}".format(_type_name(x), _type_name(y))
+            "Failed to find data adapter that can handle input: {}, {}".format(
+                _type_name(x), _type_name(y)
+            )
         )
     elif len(adapter_cls) > 1:
         raise RuntimeError(
@@ -1100,12 +1099,10 @@ def _type_name(x):
     if isinstance(x, dict):
         key_types = set(_type_name(key) for key in x.keys())
         val_types = set(_type_name(key) for key in x.values())
-        return "({} containing {} keys and {} values)".format(
-            type(x), key_types, val_types
-        )
+        return f"({type(x)} containing {key_types} keys and {val_types} values)"
     if isinstance(x, (list, tuple)):
         types = set(_type_name(val) for val in x)
-        return "({} containing values of types {})".format(type(x), types)
+        return f"({type(x)} containing values of types {types})"
     return str(type(x))
 
 
@@ -1621,7 +1618,7 @@ def _make_class_weight_map_fn(class_weight):
 
         if y.shape.rank > 2:
             raise ValueError(
-                "`class_weight` not supported for " "3+ dimensional targets."
+                "`class_weight` not supported for 3+ dimensional targets."
             )
 
         y_classes = tf.__internal__.smart_cond.smart_cond(

--- a/keras/engine/functional.py
+++ b/keras/engine/functional.py
@@ -422,7 +422,7 @@ class Functional(training_lib.Model):
             proposal = layer.name
             while proposal in output_names:
                 existing_count = prefix_count.get(layer.name, 1)
-                proposal = "{}_{}".format(layer.name, existing_count)
+                proposal = f"{layer.name}_{existing_count}"
                 prefix_count[layer.name] = existing_count + 1
             output_names.add(proposal)
             uniquified.append(proposal)
@@ -589,14 +589,14 @@ class Functional(training_lib.Model):
                     for j, shape in enumerate(
                         tf.nest.flatten(layer_output_shapes)
                     ):
-                        shape_key = layer.name + "_%s_%s" % (node_index, j)
+                        shape_key = layer.name + f"_{node_index}_{j}"
                         layers_to_output_shapes[shape_key] = shape
 
             # Read final output shapes from layers_to_output_shapes.
             output_shapes = []
             for i in range(len(self._output_layers)):
                 layer, node_index, tensor_index = self._output_coordinates[i]
-                shape_key = layer.name + "_%s_%s" % (node_index, tensor_index)
+                shape_key = layer.name + f"_{node_index}_{tensor_index}"
                 output_shapes.append(layers_to_output_shapes[shape_key])
             output_shapes = tf.nest.pack_sequence_as(
                 self._nested_outputs, output_shapes
@@ -916,7 +916,7 @@ class Functional(training_lib.Model):
             # Model are being relied on.
             if i > 10000:
                 raise ValueError(
-                    "Layers could not be added due to missing " "dependencies."
+                    "Layers could not be added due to missing dependencies."
                 )
 
             node = unprocessed_nodes.pop(0)
@@ -1126,7 +1126,7 @@ def _map_graph_network(inputs, outputs):
                 for x in tf.nest.flatten(node.keras_inputs):
                     if id(x) not in computable_tensors:
                         raise ValueError(
-                            f"Graph disconnected: cannot obtain value for "
+                            "Graph disconnected: cannot obtain value for "
                             f'tensor {x} at layer "{layer.name}". '
                             "The following previous layers were accessed "
                             f"without issue: {layers_with_complete_input}"
@@ -1205,7 +1205,7 @@ def _build_map_helper(
     # Prevent cycles.
     if node in nodes_in_progress:
         raise ValueError(
-            f'Tensor {tensor} from layer "{layer.name}" ' "is part of a cycle."
+            f'Tensor {tensor} from layer "{layer.name}" is part of a cycle.'
         )
 
     # Store the traversal order for layer sorting.
@@ -1639,9 +1639,7 @@ class ModuleWrapper(base_layer.Layer):
             elif hasattr(module, "call"):
                 method_name = "call"
         if method_name is None or not hasattr(module, method_name):
-            raise ValueError(
-                "{} is not defined on object {}".format(method_name, module)
-            )
+            raise ValueError(f"{method_name} is not defined on object {module}")
 
         self._module = module
         self._method_name = method_name

--- a/keras/engine/functional_test.py
+++ b/keras/engine/functional_test.py
@@ -1702,7 +1702,7 @@ class DefaultShapeInferenceBehaviorTest(test_combinations.TestCase):
         self.assertTrue(model.built, "Model should be built")
         self.assertTrue(
             model.weights,
-            "Model should have its weights created as it " "has been built",
+            "Model should have its weights created as it has been built",
         )
         sample_input = tf.ones((1, 10, 10, 1))
         output = model(sample_input)
@@ -1739,7 +1739,7 @@ class DefaultShapeInferenceBehaviorTest(test_combinations.TestCase):
         self.assertTrue(model.built, "Model should be built")
         self.assertTrue(
             model.weights,
-            "Model should have its weights created as it " "has been built",
+            "Model should have its weights created as it has been built",
         )
         sample_input = tf.ones((1, 10, 10, 1))
         output = model(sample_input)
@@ -1772,7 +1772,7 @@ class DefaultShapeInferenceBehaviorTest(test_combinations.TestCase):
         self.assertTrue(model.built, "Model should be built")
         self.assertTrue(
             model.weights,
-            "Model should have its weights created as it " "has been built",
+            "Model should have its weights created as it has been built",
         )
         sample_input = tf.ones((1, 10, 10, 1))
         output = model(sample_input)

--- a/keras/engine/input_spec.py
+++ b/keras/engine/input_spec.py
@@ -126,7 +126,7 @@ class InputSpec:
             ("min_ndim=" + str(self.min_ndim)) if self.min_ndim else "",
             ("axes=" + str(self.axes)) if self.axes else "",
         ]
-        return "InputSpec(%s)" % ", ".join(x for x in spec if x)
+        return f"InputSpec({', '.join(x for x in spec if x)})"
 
     def get_config(self):
         return {

--- a/keras/engine/keras_tensor.py
+++ b/keras/engine/keras_tensor.py
@@ -323,9 +323,9 @@ class KerasTensor:
                 layer.name,
             )
         if self._inferred_value is not None:
-            inferred_value_string = ", inferred_value=%s" % self._inferred_value
+            inferred_value_string = f", inferred_value={self._inferred_value}"
         if self.name is not None:
-            name_string = ", name='%s'" % self._name
+            name_string = f", name='{self._name}'"
         return "KerasTensor(type_spec=%s%s%s%s)" % (
             self.type_spec,
             inferred_value_string,
@@ -337,18 +337,15 @@ class KerasTensor:
         symbolic_description = ""
         inferred_value_string = ""
         if isinstance(self.type_spec, tf.TensorSpec):
-            type_spec_string = "shape=%s dtype=%s" % (
-                self.shape,
-                self.dtype.name,
-            )
+            type_spec_string = f"shape={self.shape} dtype={self.dtype.name}"
         else:
-            type_spec_string = "type_spec=%s" % self.type_spec
+            type_spec_string = f"type_spec={self.type_spec}"
 
         if hasattr(self, "_keras_history"):
             layer = self._keras_history.layer
-            symbolic_description = " (created by layer '%s')" % (layer.name,)
+            symbolic_description = f" (created by layer '{layer.name}')"
         if self._inferred_value is not None:
-            inferred_value_string = " inferred_value=%s" % self._inferred_value
+            inferred_value_string = f" inferred_value={self._inferred_value}"
         return "<KerasTensor: %s%s%s>" % (
             type_spec_string,
             inferred_value_string,
@@ -595,8 +592,8 @@ class UserRegisteredTypeKerasTensor(KerasTensor):
     @classmethod
     def from_type_spec(cls, type_spec, name=None):
         raise NotImplementedError(
-            "You cannot instantiate a KerasTensor "
-            "directly from TypeSpec: %s" % type_spec
+            "You cannot instantiate a KerasTensor directly from TypeSpec: %s"
+            % type_spec
         )
 
     def _to_placeholder(self):

--- a/keras/engine/node.py
+++ b/keras/engine/node.py
@@ -227,8 +227,7 @@ class Node:
                 + " was passed non-JSON-serializable arguments. "
                 + "Arguments had types: "
                 + str(kwarg_types)
-                + ". They cannot be serialized out "
-                "when saving the model."
+                + ". They cannot be serialized out when saving the model."
             )
 
         # `kwargs` is added to each Tensor in the first arg. This should be

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3277,7 +3277,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
                 f"{list(layer.name for layer in self.layers)}."
             )
         raise ValueError(
-            "Provide either a layer name or layer index at " "`get_layer`."
+            "Provide either a layer name or layer index at `get_layer`."
         )
 
     def get_weight_paths(self):

--- a/keras/engine/training_arrays_v1.py
+++ b/keras/engine/training_arrays_v1.py
@@ -59,7 +59,7 @@ def model_iteration(
     validation_in_fit=False,
     prepared_feed_values_from_dataset=False,
     steps_name="steps",
-    **kwargs
+    **kwargs,
 ):
     """Loop function for arrays of data with modes TRAIN/TEST/PREDICT.
 
@@ -124,7 +124,7 @@ def model_iteration(
     if "steps" in kwargs:
         steps_per_epoch = kwargs.pop("steps")
     if kwargs:
-        raise TypeError("Unknown arguments: %s" % (kwargs,))
+        raise TypeError(f"Unknown arguments: {kwargs}")
 
     # In case we were passed a dataset, we extract symbolic tensors from it.
     reset_dataset_after_each_epoch = False
@@ -520,13 +520,9 @@ def _get_model_feed(model, mode):
 
 def _print_train_info(num_samples_or_steps, val_samples_or_steps, is_dataset):
     increment = "steps" if is_dataset else "samples"
-    msg = "Train on {0} {increment}".format(
-        num_samples_or_steps, increment=increment
-    )
+    msg = f"Train on {num_samples_or_steps} {increment}"
     if val_samples_or_steps:
-        msg += ", validate on {0} {increment}".format(
-            val_samples_or_steps, increment=increment
-        )
+        msg += f", validate on {val_samples_or_steps} {increment}"
     io_utils.print_msg(msg)
 
 
@@ -693,7 +689,7 @@ class ArrayLikeTrainingLoop(training_utils_v1.TrainingLoop):
         steps_per_epoch=None,
         validation_steps=None,
         validation_freq=1,
-        **kwargs
+        **kwargs,
     ):
         batch_size = model._validate_or_infer_batch_size(
             batch_size, steps_per_epoch, x
@@ -765,7 +761,7 @@ class ArrayLikeTrainingLoop(training_utils_v1.TrainingLoop):
         sample_weight=None,
         steps=None,
         callbacks=None,
-        **kwargs
+        **kwargs,
     ):
         batch_size = model._validate_or_infer_batch_size(batch_size, steps, x)
         x, y, sample_weights = model._standardize_user_data(
@@ -796,7 +792,7 @@ class ArrayLikeTrainingLoop(training_utils_v1.TrainingLoop):
         verbose=0,
         steps=None,
         callbacks=None,
-        **kwargs
+        **kwargs,
     ):
         batch_size = model._validate_or_infer_batch_size(batch_size, steps, x)
         x, _, _ = model._standardize_user_data(

--- a/keras/engine/training_generator_v1.py
+++ b/keras/engine/training_generator_v1.py
@@ -52,7 +52,7 @@ def model_iteration(
     mode=ModeKeys.TRAIN,
     batch_size=None,
     steps_name="steps",
-    **kwargs
+    **kwargs,
 ):
     """Loop function for arrays of data with modes TRAIN/TEST/PREDICT.
 
@@ -457,8 +457,7 @@ def _validate_arguments(
     if steps_per_epoch is None and not is_dataset:
         arg_name = "steps_per_epoch" if mode == ModeKeys.TRAIN else "steps"
         raise ValueError(
-            "Please specify the number of steps via the "
-            "`{}` argument.".format(arg_name)
+            f"Please specify the number of steps via the `{arg_name}` argument."
         )
 
     val_gen = data_utils.is_generator_or_sequence(
@@ -473,9 +472,7 @@ def _validate_arguments(
 
     if any(k != "steps" for k in kwargs):
         raise ValueError(
-            "Invalid arguments passed: {}".format(
-                [k for k in kwargs if k != "steps"]
-            )
+            f"Invalid arguments passed: {[k for k in kwargs if k != 'steps']}"
         )
 
 
@@ -540,7 +537,7 @@ def convert_to_generator_like(
             if shuffle:
                 np.random.shuffle(index_array)
             batches = generic_utils.make_batches(num_samples, batch_size)
-            for (batch_start, batch_end) in batches:
+            for batch_start, batch_end in batches:
                 batch_ids = index_array[batch_start:batch_end]
                 flat_batch_data = training_utils.slice_arrays(
                     tf.nest.flatten(data), batch_ids, contiguous=(not shuffle)
@@ -739,7 +736,7 @@ class EagerDatasetOrIteratorTrainingLoop(training_utils_v1.TrainingLoop):
         steps_per_epoch=None,
         validation_steps=None,
         validation_freq=1,
-        **kwargs
+        **kwargs,
     ):
         model._validate_or_infer_batch_size(batch_size, steps_per_epoch, x)
         # Make sure that y, sample_weights, validation_split are not passed.
@@ -779,7 +776,7 @@ class EagerDatasetOrIteratorTrainingLoop(training_utils_v1.TrainingLoop):
         sample_weight=None,
         steps=None,
         callbacks=None,
-        **kwargs
+        **kwargs,
     ):
         model._validate_or_infer_batch_size(batch_size, steps, x)
         # Make sure that y, sample_weights, validation_split are not passed.
@@ -801,7 +798,7 @@ class EagerDatasetOrIteratorTrainingLoop(training_utils_v1.TrainingLoop):
         verbose=0,
         steps=None,
         callbacks=None,
-        **kwargs
+        **kwargs,
     ):
         model._validate_or_infer_batch_size(batch_size, steps, x)
         return predict_generator(
@@ -841,7 +838,7 @@ class GeneratorLikeTrainingLoop(training_utils_v1.TrainingLoop):
         steps_per_epoch=None,
         validation_steps=None,
         validation_freq=1,
-        **kwargs
+        **kwargs,
     ):
         batch_size = model._validate_or_infer_batch_size(
             batch_size, steps_per_epoch, x
@@ -909,7 +906,7 @@ class GeneratorLikeTrainingLoop(training_utils_v1.TrainingLoop):
         sample_weight=None,
         steps=None,
         callbacks=None,
-        **kwargs
+        **kwargs,
     ):
         batch_size = model._validate_or_infer_batch_size(batch_size, steps, x)
         x, y, sample_weights = model._standardize_user_data(
@@ -939,7 +936,7 @@ class GeneratorLikeTrainingLoop(training_utils_v1.TrainingLoop):
         verbose=0,
         steps=None,
         callbacks=None,
-        **kwargs
+        **kwargs,
     ):
         batch_size = model._validate_or_infer_batch_size(batch_size, steps, x)
         x, _, _ = model._standardize_user_data(

--- a/keras/engine/training_integration_test.py
+++ b/keras/engine/training_integration_test.py
@@ -181,9 +181,7 @@ class CoreLayerIntegrationTest(test_combinations.TestCase):
         for x in [layer_result, model_result]:
             if not isinstance(x, tf.Tensor):
                 raise ValueError(
-                    "Tensor or EagerTensor expected, got type {}".format(
-                        type(x)
-                    )
+                    f"Tensor or EagerTensor expected, got type {type(x)}"
                 )
 
             if (
@@ -196,9 +194,7 @@ class CoreLayerIntegrationTest(test_combinations.TestCase):
                     else tf.Tensor
                 )
                 raise ValueError(
-                    "Expected type {}, got type {}".format(
-                        expected_type, type(x)
-                    )
+                    f"Expected type {expected_type}, got type {type(x)}"
                 )
 
     def _run_fit_eval_predict(

--- a/keras/engine/training_utils_v1.py
+++ b/keras/engine/training_utils_v1.py
@@ -194,14 +194,10 @@ def _append_ragged_tensor_value(target, to_append):
     """Append ragged tensor value objects."""
     # Make sure the ragged tensors are of the same size (save for the 0th dim).
     if len(target.shape) != len(to_append.shape):
-        raise RuntimeError(
-            "Unable to concatenate %s and %s" % (target, to_append)
-        )
+        raise RuntimeError(f"Unable to concatenate {target} and {to_append}")
 
     if target.shape[1:] != to_append.shape[1:]:
-        raise RuntimeError(
-            "Unable to concatenate %s and %s" % (target, to_append)
-        )
+        raise RuntimeError(f"Unable to concatenate {target} and {to_append}")
 
     adjusted_row_splits = to_append.row_splits[1:] + target.row_splits[-1]
     new_row_splits = np.append(target.row_splits, adjusted_row_splits)
@@ -238,7 +234,7 @@ def _append_composite_tensor(target, to_append):
     """
     if type(target) is not type(to_append):
         raise RuntimeError(
-            "Unable to concatenate %s and %s" % (type(target), type(to_append))
+            f"Unable to concatenate {type(target)} and {type(to_append)}"
         )
 
     # Perform type-specific concatenation.
@@ -263,7 +259,7 @@ def _append_composite_tensor(target, to_append):
         return _append_ragged_tensor_value(target, to_append)
     else:
         raise RuntimeError(
-            "Attempted to concatenate unsupported object %s." % type(target)
+            f"Attempted to concatenate unsupported object {type(target)}."
         )
 
 
@@ -555,7 +551,7 @@ def standardize_single_array(x, expected_shape=None):
 
     if isinstance(x, int):
         raise ValueError(
-            "Expected an array data type but received an integer: {}".format(x)
+            f"Expected an array data type but received an integer: {x}"
         )
 
     if (
@@ -612,8 +608,9 @@ def standardize_input_data(
     if not names:
         if data_len and not isinstance(data, dict):
             raise ValueError(
-                "Error when checking model " + exception_prefix + ": "
-                "expected no data, but got:",
+                "Error when checking model "
+                + exception_prefix
+                + ": expected no data, but got:",
                 data,
             )
         return []
@@ -630,8 +627,10 @@ def standardize_input_data(
             ]
         except KeyError as e:
             raise ValueError(
-                'No data provided for "' + e.args[0] + '". Need data '
-                "for each key in: " + str(names)
+                'No data provided for "'
+                + e.args[0]
+                + '". Need data for each key in: '
+                + str(names)
             )
     elif isinstance(data, (list, tuple)):
         if isinstance(data[0], (list, tuple)):
@@ -667,8 +666,7 @@ def standardize_input_data(
                 + " array(s), "
                 + "for inputs "
                 + str(names)
-                + " but instead got the "
-                "following list of "
+                + " but instead got the following list of "
                 + str(len(data))
                 + " arrays: "
                 + str(data)[:200]
@@ -718,8 +716,8 @@ def standardize_input_data(
                         + names[i]
                         + " to have "
                         + str(len(shape))
-                        + " dimensions, but got array "
-                        "with shape " + str(data_shape)
+                        + " dimensions, but got array with shape "
+                        + str(data_shape)
                     )
                 if not check_batch_axis:
                     data_shape = data_shape[1:]
@@ -778,9 +776,9 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
                 + str(len(x_weight))
                 + " elements, but the model has "
                 + str(len(output_names))
-                + " outputs. "
-                "You should provide one `" + weight_type + "`"
-                "array per model output."
+                + " outputs. You should provide one `"
+                + weight_type
+                + "`array per model output."
             )
         return x_weight
     if isinstance(x_weight, collections.abc.Mapping):
@@ -793,9 +791,9 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
         return x_weights
     else:
         raise TypeError(
-            "The model has multiple outputs, so `" + weight_type + "` "
-            "should be either a list or a dict. "
-            "Provided `"
+            "The model has multiple outputs, so `"
+            + weight_type
+            + "` should be either a list or a dict. Provided `"
             + weight_type
             + "` type not understood: "
             + str(x_weight)
@@ -862,8 +860,11 @@ def check_array_lengths(inputs, targets, weights=None):
         raise ValueError(
             "Input arrays should have "
             "the same number of samples as target arrays. "
-            "Found " + str(list(set_x)[0]) + " input samples "
-            "and " + str(list(set_y)[0]) + " target samples."
+            "Found "
+            + str(list(set_x)[0])
+            + " input samples and "
+            + str(list(set_y)[0])
+            + " target samples."
         )
     if len(set_w) > 1:
         raise ValueError(
@@ -1110,14 +1111,14 @@ def standardize_weights(
     if sample_weight_mode is not None and sample_weight_mode != "samplewise":
         if sample_weight_mode != "temporal":
             raise ValueError(
-                '"sample_weight_mode '
-                'should be None or "temporal". '
-                "Found: " + str(sample_weight_mode)
+                '"sample_weight_mode should be None or "temporal". Found: '
+                + str(sample_weight_mode)
             )
         if len(y.shape) < 3:
             raise ValueError(
-                "Found a sample_weight array for "
-                "an input with shape " + str(y.shape) + ". "
+                "Found a sample_weight array for an input with shape "
+                + str(y.shape)
+                + ". "
                 "Timestep-wise sample weighting (use of "
                 'sample_weight_mode="temporal") is restricted to '
                 "outputs that are at least 3D, i.e. that have "
@@ -1148,9 +1149,8 @@ def standardize_weights(
             raise ValueError(
                 "Found a sample_weight with shape"
                 + str(sample_weight.shape)
-                + "."
-                "Expected sample_weight with rank "
-                "less than or equal to " + str(len(y.shape))
+                + ".Expected sample_weight with rank less than or equal to "
+                + str(len(y.shape))
             )
 
         if (
@@ -1162,8 +1162,7 @@ def standardize_weights(
                 + str(sample_weight.shape)
                 + " for an input with shape "
                 + str(y.shape)
-                + ". "
-                "sample_weight cannot be broadcast."
+                + ". sample_weight cannot be broadcast."
             )
 
     # Class weights applied per-sample.
@@ -1171,7 +1170,7 @@ def standardize_weights(
     if isinstance(class_weight, dict):
         if len(y.shape) > 2:
             raise ValueError(
-                "`class_weight` not supported for " "3+ dimensional targets."
+                "`class_weight` not supported for 3+ dimensional targets."
             )
 
         if tf.is_tensor(y):
@@ -1447,7 +1446,7 @@ def validate_input_types(inp, orig_inp, allow_dict=True, field_name="inputs"):
     elif isinstance(inp, dict):
         if not allow_dict:
             raise ValueError(
-                "You cannot pass a dictionary as model {}.".format(field_name)
+                f"You cannot pass a dictionary as model {field_name}."
             )
     elif not isinstance(inp, np.ndarray) and not tf.is_tensor(inp):
         raise ValueError(

--- a/keras/engine/training_v1.py
+++ b/keras/engine/training_v1.py
@@ -232,7 +232,7 @@ class Model(training_lib.Model):
         weighted_metrics=None,
         target_tensors=None,
         distribute=None,
-        **kwargs
+        **kwargs,
     ):
         """Configures the model for training.
 
@@ -304,8 +304,7 @@ class Model(training_lib.Model):
         unknown_kwargs = set(kwargs.keys()) - allowed_kwargs
         if unknown_kwargs:
             raise TypeError(
-                "Invalid keyword argument(s) in `compile`: %s"
-                % (unknown_kwargs,)
+                f"Invalid keyword argument(s) in `compile`: {unknown_kwargs}"
             )
         self._function_kwargs = kwargs
         if self._function_kwargs:
@@ -687,7 +686,7 @@ class Model(training_lib.Model):
         max_queue_size=10,
         workers=1,
         use_multiprocessing=False,
-        **kwargs
+        **kwargs,
     ):
         """Trains the model for a fixed number of epochs (iterations on a dataset).
 
@@ -2052,10 +2051,7 @@ class Model(training_lib.Model):
             # want to prepend the output name even if we are loading a
             # serialized model.
             if not getattr(metric_fn, "_from_serialized", False):
-                metric_name = "%s_%s" % (
-                    self.output_names[output_index],
-                    metric_name,
-                )
+                metric_name = f"{self.output_names[output_index]}_{metric_name}"
 
         j = 1
         base_metric_name = metric_name
@@ -2257,7 +2253,7 @@ class Model(training_lib.Model):
         self._check_trainable_weights_consistency()
         if isinstance(self.optimizer, list):
             raise ValueError(
-                "The `optimizer` in `compile` should be a single " "optimizer."
+                "The `optimizer` in `compile` should be a single optimizer."
             )
         # If we have re-compiled the loss/weighted metric sub-graphs then create
         # train function even if one exists already. This is because
@@ -2301,7 +2297,7 @@ class Model(training_lib.Model):
                     [self.total_loss] + metrics_tensors,
                     updates=updates,
                     name="train_function",
-                    **self._function_kwargs
+                    **self._function_kwargs,
                 )
                 setattr(self, "train_function", fn)
 
@@ -2337,7 +2333,7 @@ class Model(training_lib.Model):
                     [self.total_loss] + metrics_tensors,
                     updates=updates,
                     name="test_function",
-                    **self._function_kwargs
+                    **self._function_kwargs,
                 )
                 setattr(self, "test_function", fn)
 
@@ -2355,7 +2351,7 @@ class Model(training_lib.Model):
                     self.outputs,
                     updates=self.state_updates,
                     name="predict_function",
-                    **kwargs
+                    **kwargs,
                 )
 
     def _make_execution_function(self, mode):
@@ -2711,7 +2707,7 @@ class Model(training_lib.Model):
             flat_inputs = tf.nest.flatten(x)
             flat_expected_inputs = tf.nest.flatten(self.inputs)
             converted_x = []
-            for (a, b) in zip(flat_inputs, flat_expected_inputs):
+            for a, b in zip(flat_inputs, flat_expected_inputs):
                 converted_x.append(_convert_scipy_sparse_tensor(a, b))
             x = tf.nest.pack_sequence_as(x, converted_x)
 
@@ -2728,7 +2724,7 @@ class Model(training_lib.Model):
         flat_expected_inputs = tf.nest.flatten(
             tf_utils.convert_variables_to_tensors(self.inputs)
         )
-        for (a, b) in zip(flat_inputs, flat_expected_inputs):
+        for a, b in zip(flat_inputs, flat_expected_inputs):
             tf.nest.assert_same_structure(a, b, expand_composites=True)
 
         if y is not None:

--- a/keras/initializers/initializers_v2.py
+++ b/keras/initializers/initializers_v2.py
@@ -82,7 +82,7 @@ class Initializer:
           **kwargs: Additional keyword arguments.
         """
         raise NotImplementedError(
-            "Initializer subclasses must implement the " "`__call__()` method."
+            "Initializer subclasses must implement the `__call__()` method."
         )
 
     def get_config(self):
@@ -573,7 +573,7 @@ class VarianceScaling(Initializer):
     ):
         if scale <= 0.0:
             raise ValueError(
-                "`scale` must be positive float. " f"Received: scale={scale}."
+                f"`scale` must be positive float. Received: scale={scale}."
             )
         allowed_modes = {"fan_in", "fan_out", "fan_avg"}
         if mode not in allowed_modes:

--- a/keras/integration_test/forwardprop_test.py
+++ b/keras/integration_test/forwardprop_test.py
@@ -134,7 +134,7 @@ def _test_gradients(
     gradients."""
     if order < 1:
         raise ValueError(
-            "`order` should be a positive integer, got '{}'.".format(order)
+            f"`order` should be a positive integer, got '{order}'."
         )
     if order > 1:
         _test_gradients(

--- a/keras/integration_test/multi_worker_tutorial_test.py
+++ b/keras/integration_test/multi_worker_tutorial_test.py
@@ -85,7 +85,7 @@ class MultiWorkerTutorialTest(parameterized.TestCase, tf.test.TestCase):
                 raise
 
     def mnist_dataset(self):
-        path_to_use = "mnist_{}.npz".format(str(uuid.uuid4()))
+        path_to_use = f"mnist_{str(uuid.uuid4())}.npz"
         with self.skip_fetch_failure_exception():
             (x_train, y_train), _ = tf.keras.datasets.mnist.load_data(
                 path=path_to_use

--- a/keras/integration_test/parameter_server_custom_training_loop_test.py
+++ b/keras/integration_test/parameter_server_custom_training_loop_test.py
@@ -39,11 +39,9 @@ class ParameterServerCustomTrainingLoopTest(tf.test.TestCase):
         ps_ports = [portpicker.pick_unused_port() for _ in range(num_ps)]
 
         cluster_dict = {}
-        cluster_dict["worker"] = [
-            "localhost:%s" % port for port in worker_ports
-        ]
+        cluster_dict["worker"] = [f"localhost:{port}" for port in worker_ports]
         if num_ps > 0:
-            cluster_dict["ps"] = ["localhost:%s" % port for port in ps_ports]
+            cluster_dict["ps"] = [f"localhost:{port}" for port in ps_ports]
 
         cluster_spec = tf.train.ClusterSpec(cluster_dict)
 

--- a/keras/integration_test/parameter_server_keras_preprocessing_test.py
+++ b/keras/integration_test/parameter_server_keras_preprocessing_test.py
@@ -46,9 +46,9 @@ def create_in_process_cluster(num_workers, num_ps):
     ps_ports = [portpicker.pick_unused_port() for _ in range(num_ps)]
 
     cluster_dict = {}
-    cluster_dict["worker"] = ["localhost:%s" % port for port in worker_ports]
+    cluster_dict["worker"] = [f"localhost:{port}" for port in worker_ports]
     if num_ps > 0:
-        cluster_dict["ps"] = ["localhost:%s" % port for port in ps_ports]
+        cluster_dict["ps"] = [f"localhost:{port}" for port in ps_ports]
 
     cluster_spec = tf.train.ClusterSpec(cluster_dict)
 

--- a/keras/integration_test/tpu_strategy_test.py
+++ b/keras/integration_test/tpu_strategy_test.py
@@ -125,7 +125,7 @@ class TpuStrategyTest(tf.test.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "Trying to run metric.update_state " "in replica context",
+            "Trying to run metric.update_state in replica context",
         ):
             with strategy.scope():
                 for i in dataset:

--- a/keras/layers/attention/multi_head_attention.py
+++ b/keras/layers/attention/multi_head_attention.py
@@ -118,7 +118,7 @@ def _build_proj_equation(free_dims, bound_dims, output_dims):
         kernel_str += char
         output_str += char
         bias_axes += char
-    equation = "%s,%s->%s" % (input_str, kernel_str, output_str)
+    equation = f"{input_str},{kernel_str}->{output_str}"
 
     return equation, bias_axes, len(output_str)
 
@@ -246,7 +246,7 @@ class MultiHeadAttention(Layer):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.supports_masking = True
@@ -362,7 +362,7 @@ class MultiHeadAttention(Layer):
                 ),
                 bias_axes=bias_axes if self._use_bias else None,
                 name="query",
-                **self._get_common_kwargs_for_sublayer()
+                **self._get_common_kwargs_for_sublayer(),
             )
             einsum_equation, bias_axes, output_rank = _build_proj_equation(
                 self._key_shape.rank - 1, bound_dims=1, output_dims=2
@@ -374,7 +374,7 @@ class MultiHeadAttention(Layer):
                 ),
                 bias_axes=bias_axes if self._use_bias else None,
                 name="key",
-                **self._get_common_kwargs_for_sublayer()
+                **self._get_common_kwargs_for_sublayer(),
             )
             einsum_equation, bias_axes, output_rank = _build_proj_equation(
                 self._value_shape.rank - 1, bound_dims=1, output_dims=2
@@ -386,7 +386,7 @@ class MultiHeadAttention(Layer):
                 ),
                 bias_axes=bias_axes if self._use_bias else None,
                 name="value",
-                **self._get_common_kwargs_for_sublayer()
+                **self._get_common_kwargs_for_sublayer(),
             )
 
             # Builds the attention computations for multi-head dot product
@@ -446,7 +446,7 @@ class MultiHeadAttention(Layer):
             output_shape=_get_output_shape(output_rank - 1, output_shape),
             bias_axes=bias_axes if self._use_bias else None,
             name=name,
-            **common_kwargs
+            **common_kwargs,
         )
 
     def _build_attention(self, rank):

--- a/keras/layers/convolutional/base_conv.py
+++ b/keras/layers/convolutional/base_conv.py
@@ -174,14 +174,14 @@ class Conv(Layer):
 
         if not all(self.kernel_size):
             raise ValueError(
-                "The argument `kernel_size` cannot contain 0(s). "
-                "Received: %s" % (self.kernel_size,)
+                "The argument `kernel_size` cannot contain 0(s). Received: %s"
+                % (self.kernel_size,)
             )
 
         if not all(self.strides):
             raise ValueError(
-                "The argument `strides` cannot contains 0(s). "
-                "Received: %s" % (self.strides,)
+                "The argument `strides` cannot contains 0(s). Received: %s"
+                % (self.strides,)
             )
 
         if self.padding == "causal":
@@ -345,12 +345,12 @@ class Conv(Layer):
 
         except ValueError:
             raise ValueError(
-                f"One of the dimensions in the output is <= 0 "
+                "One of the dimensions in the output is <= 0 "
                 f"due to downsampling in {self.name}. Consider "
-                f"increasing the input size. "
+                "increasing the input size. "
                 f"Received input shape {input_shape} which would produce "
-                f"output shape with a zero or negative value in a "
-                f"dimension."
+                "output shape with a zero or negative value in a "
+                "dimension."
             )
 
     def _recreate_conv_op(self, inputs):

--- a/keras/layers/core/dense.py
+++ b/keras/layers/core/dense.py
@@ -119,7 +119,7 @@ class Dense(Layer):
         self.units = int(units) if not isinstance(units, int) else units
         if self.units < 0:
             raise ValueError(
-                f"Received an invalid value for `units`, expected "
+                "Received an invalid value for `units`, expected "
                 f"a positive integer. Received: units={units}"
             )
         self.activation = activations.get(activation)

--- a/keras/layers/core/lambda_layer.py
+++ b/keras/layers/core/lambda_layer.py
@@ -228,9 +228,7 @@ class Lambda(Layer):
             v for v in created_variables if v.ref() not in tracked_weights
         ]
         if untracked_new_vars:
-            variable_str = "\n".join(
-                "  {}".format(i) for i in untracked_new_vars
-            )
+            variable_str = "\n".join(f"  {i}" for i in untracked_new_vars)
             error_str = textwrap.dedent(
                 """
           The following Variables were created within a Lambda layer ({name})
@@ -248,9 +246,7 @@ class Lambda(Layer):
             v for v in accessed_variables if v.ref() not in tracked_weights
         ]
         if untracked_used_vars and not self._already_warned:
-            variable_str = "\n".join(
-                "  {}".format(i) for i in untracked_used_vars
-            )
+            variable_str = "\n".join(f"  {i}" for i in untracked_used_vars)
             self._warn(
                 textwrap.dedent(
                     """
@@ -316,7 +312,7 @@ class Lambda(Layer):
             module = None
         else:
             raise ValueError(
-                "Invalid input for serialization, type: %s " % type(inputs)
+                f"Invalid input for serialization, type: {type(inputs)} "
             )
 
         return output, output_type, module
@@ -399,7 +395,7 @@ class Lambda(Layer):
         else:
             supported_types = ["function", "lambda", "raw"]
             raise TypeError(
-                f"Unsupported value for `function_type` argument. Received: "
+                "Unsupported value for `function_type` argument. Received: "
                 f"function_type={function_type}. "
                 f"Expected one of {supported_types}"
             )

--- a/keras/layers/core/tf_op_layer.py
+++ b/keras/layers/core/tf_op_layer.py
@@ -292,9 +292,7 @@ class TFOpLambda(Layer):
             v for v in created_variables if v.ref() not in tracked_weights
         ]
         if untracked_new_vars:
-            variable_str = "\n".join(
-                "  {}".format(i) for i in untracked_new_vars
-            )
+            variable_str = "\n".join(f"  {i}" for i in untracked_new_vars)
             raise ValueError(
                 "The following Variables were created within a Lambda layer "
                 f"({self.name}) but are not tracked by said layer: "
@@ -311,9 +309,7 @@ class TFOpLambda(Layer):
             v for v in accessed_variables if v.ref() not in tracked_weights
         ]
         if untracked_used_vars and not self._already_warned:
-            variable_str = "\n".join(
-                "  {}".format(i) for i in untracked_used_vars
-            )
+            variable_str = "\n".join(f"  {i}" for i in untracked_used_vars)
             self._warn(
                 "The following Variables were used in a Lambda layer's call "
                 f"({self.name}), but are not present in its tracked objects: "

--- a/keras/layers/locally_connected/locally_connected1d.py
+++ b/keras/layers/locally_connected/locally_connected1d.py
@@ -171,7 +171,7 @@ class LocallyConnected1D(Layer):
 
         if input_dim is None:
             raise ValueError(
-                "Axis 2 of input should be fully-defined. " "Found shape:",
+                "Axis 2 of input should be fully-defined. Found shape:",
                 input_shape,
             )
         self.output_length = conv_utils.conv_output_length(
@@ -180,12 +180,12 @@ class LocallyConnected1D(Layer):
 
         if self.output_length <= 0:
             raise ValueError(
-                f"One of the dimensions in the output is <= 0 "
+                "One of the dimensions in the output is <= 0 "
                 f"due to downsampling in {self.name}. Consider "
-                f"increasing the input size. "
+                "increasing the input size. "
                 f"Received input shape {input_shape} which would produce "
-                f"output shape with a zero or negative value in a "
-                f"dimension."
+                "output shape with a zero or negative value in a "
+                "dimension."
             )
 
         if self.implementation == 1:

--- a/keras/layers/locally_connected/locally_connected2d.py
+++ b/keras/layers/locally_connected/locally_connected2d.py
@@ -202,12 +202,12 @@ class LocallyConnected2D(Layer):
 
         if self.output_row <= 0 or self.output_col <= 0:
             raise ValueError(
-                f"One of the dimensions in the output is <= 0 "
+                "One of the dimensions in the output is <= 0 "
                 f"due to downsampling in {self.name}. Consider "
-                f"increasing the input size. "
+                "increasing the input size. "
                 f"Received input shape {input_shape} which would produce "
-                f"output shape with a zero or negative value in a "
-                f"dimension."
+                "output shape with a zero or negative value in a "
+                "dimension."
             )
 
         if self.implementation == 1:

--- a/keras/layers/normalization/batch_normalization.py
+++ b/keras/layers/normalization/batch_normalization.py
@@ -228,7 +228,7 @@ class BatchNormalizationBase(Layer):
             keys = ["rmax", "rmin", "dmax"]
             if set(renorm_clipping) - set(keys):
                 raise ValueError(
-                    f"Received invalid keys for `renorm_clipping` argument: "
+                    "Received invalid keys for `renorm_clipping` argument: "
                     f"{renorm_clipping}. Supported values: {keys}."
                 )
             self.renorm_clipping = renorm_clipping
@@ -250,8 +250,7 @@ class BatchNormalizationBase(Layer):
         # when no virtual batch size or adjustment is used.
         if self.renorm:
             raise ValueError(
-                "Passing both `fused=True` and `renorm=True` is "
-                "not supported"
+                "Passing both `fused=True` and `renorm=True` is not supported"
             )
         axis = [self.axis] if isinstance(self.axis, int) else self.axis
         # Axis -3 is equivalent to 1, and axis -1 is equivalent to 3, when the
@@ -328,8 +327,8 @@ class BatchNormalizationBase(Layer):
         if self.virtual_batch_size is not None:
             if self.virtual_batch_size <= 0:
                 raise ValueError(
-                    f"`virtual_batch_size` must be a positive integer that "
-                    f"divides the true batch size of the input tensor. "
+                    "`virtual_batch_size` must be a positive integer that "
+                    "divides the true batch size of the input tensor. "
                     f"Received: virtual_batch_size={self.virtual_batch_size}"
                 )
             # If using virtual batches, the first dimension must be the batch

--- a/keras/layers/preprocessing/benchmarks/bucketized_column_dense_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/bucketized_column_dense_benchmark.py
@@ -75,7 +75,7 @@ class BenchmarkLayer(fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "bucketized|dense|batch_%s" % batch
+            name = f"bucketized|dense|batch_{batch}"
             k_time, f_time = embedding_varlen(batch_size=batch, max_length=256)
             self.report(name, k_time, f_time, NUM_REPEATS)
 

--- a/keras/layers/preprocessing/benchmarks/category_hash_dense_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_hash_dense_benchmark.py
@@ -79,7 +79,7 @@ class BenchmarkLayer(fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "hash|dense|batch_%s" % batch
+            name = f"hash|dense|batch_{batch}"
             k_time, f_time = embedding_varlen(batch_size=batch, max_length=256)
             self.report(name, k_time, f_time, NUM_REPEATS)
 

--- a/keras/layers/preprocessing/benchmarks/category_hash_varlen_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_hash_varlen_benchmark.py
@@ -79,7 +79,7 @@ class BenchmarkLayer(fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "hash|varlen|batch_%s" % batch
+            name = f"hash|varlen|batch_{batch}"
             k_time, f_time = embedding_varlen(batch_size=batch, max_length=256)
             self.report(name, k_time, f_time, NUM_REPEATS)
 

--- a/keras/layers/preprocessing/benchmarks/category_vocab_file_dense_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_vocab_file_dense_benchmark.py
@@ -98,7 +98,7 @@ class BenchmarkLayer(tf.test.TestCase, fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "vocab_list|dense|batch_%s" % batch
+            name = f"vocab_list|dense|batch_{batch}"
             k_time, f_time = self.embedding_varlen(
                 batch_size=batch, max_length=256
             )

--- a/keras/layers/preprocessing/benchmarks/category_vocab_file_varlen_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_vocab_file_varlen_benchmark.py
@@ -91,7 +91,7 @@ class BenchmarkLayer(tf.test.TestCase, fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "vocab_list|varlen|batch_%s" % batch
+            name = f"vocab_list|varlen|batch_{batch}"
             k_time, f_time = self.embedding_varlen(
                 batch_size=batch, max_length=256
             )

--- a/keras/layers/preprocessing/benchmarks/category_vocab_list_dense_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_vocab_list_dense_benchmark.py
@@ -77,7 +77,7 @@ class BenchmarkLayer(fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "vocab_list|dense|batch_%s" % batch
+            name = f"vocab_list|dense|batch_{batch}"
             k_time, f_time = embedding_varlen(batch_size=batch, max_length=256)
             self.report(name, k_time, f_time, NUM_REPEATS)
 

--- a/keras/layers/preprocessing/benchmarks/category_vocab_list_indicator_dense_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_vocab_list_indicator_dense_benchmark.py
@@ -86,7 +86,7 @@ class BenchmarkLayer(fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "vocab_list_indicator|dense|batch_%s" % batch
+            name = f"vocab_list_indicator|dense|batch_{batch}"
             k_time, f_time = embedding_varlen(batch_size=batch, max_length=256)
             self.report(name, k_time, f_time, NUM_REPEATS)
 

--- a/keras/layers/preprocessing/benchmarks/category_vocab_list_indicator_varlen_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_vocab_list_indicator_varlen_benchmark.py
@@ -86,7 +86,7 @@ class BenchmarkLayer(fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "vocab_list_indicator|varlen|batch_%s" % batch
+            name = f"vocab_list_indicator|varlen|batch_{batch}"
             k_time, f_time = embedding_varlen(batch_size=batch, max_length=256)
             self.report(name, k_time, f_time, NUM_REPEATS)
 

--- a/keras/layers/preprocessing/benchmarks/category_vocab_list_varlen_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_vocab_list_varlen_benchmark.py
@@ -77,7 +77,7 @@ class BenchmarkLayer(fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "vocab_list|varlen|batch_%s" % batch
+            name = f"vocab_list|varlen|batch_{batch}"
             k_time, f_time = embedding_varlen(batch_size=batch, max_length=256)
             self.report(name, k_time, f_time, NUM_REPEATS)
 

--- a/keras/layers/preprocessing/benchmarks/embedding_dense_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/embedding_dense_benchmark.py
@@ -76,7 +76,7 @@ class BenchmarkLayer(fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "embedding|dense|batch_%s" % batch
+            name = f"embedding|dense|batch_{batch}"
             k_time, f_time = embedding_varlen(batch_size=batch, max_length=256)
             self.report(name, k_time, f_time, NUM_REPEATS)
 

--- a/keras/layers/preprocessing/benchmarks/embedding_varlen_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/embedding_varlen_benchmark.py
@@ -79,7 +79,7 @@ class BenchmarkLayer(fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "embedding|varlen|batch_%s" % batch
+            name = f"embedding|varlen|batch_{batch}"
             k_time, f_time = embedding_varlen(batch_size=batch, max_length=256)
             self.report(name, k_time, f_time, NUM_REPEATS)
 

--- a/keras/layers/preprocessing/benchmarks/hashed_crossing_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/hashed_crossing_benchmark.py
@@ -80,7 +80,7 @@ class BenchmarkLayer(fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "hashed_cross|dense|batch_%s" % batch
+            name = f"hashed_cross|dense|batch_{batch}"
             k_time, f_time = embedding_varlen(batch_size=batch)
             self.report(name, k_time, f_time, NUM_REPEATS)
 

--- a/keras/layers/preprocessing/benchmarks/hashing_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/hashing_benchmark.py
@@ -84,7 +84,7 @@ class BenchmarkLayer(tf.test.Benchmark):
             ends.append(time.time())
 
         avg_time = np.mean(np.array(ends) - np.array(starts)) / num_batches
-        name = "hashing|batch_%s" % batch_size
+        name = f"hashing|batch_{batch_size}"
         baseline = self.run_dataset_implementation(batch_size)
         extras = {
             "dataset implementation baseline": baseline,

--- a/keras/layers/preprocessing/benchmarks/image_preproc_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/image_preproc_benchmark.py
@@ -138,7 +138,7 @@ class BenchmarkLayer(tf.test.Benchmark):
                 ends.append(time.time())
 
         avg_time = np.mean(np.array(ends) - np.array(starts)) / count
-        name = "image_preprocessing|batch_%s" % batch_size
+        name = f"image_preprocessing|batch_{batch_size}"
         baseline = self.run_dataset_implementation(batch_size)
         extras = {
             "dataset implementation baseline": baseline,

--- a/keras/layers/preprocessing/benchmarks/normalization_adapt_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/normalization_adapt_benchmark.py
@@ -101,10 +101,7 @@ class BenchmarkAdapt(tf.test.Benchmark):
             ends.append(time.time())
 
         avg_time = np.mean(np.array(ends) - np.array(starts))
-        name = "normalization_adapt|%s_elements|batch_%s" % (
-            num_elements,
-            batch_size,
-        )
+        name = f"normalization_adapt|{num_elements}_elements|batch_{batch_size}"
         baseline = self.run_dataset_implementation(num_elements, batch_size)
         extras = {
             "tf.data implementation baseline": baseline,

--- a/keras/layers/preprocessing/benchmarks/weighted_embedding_varlen_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/weighted_embedding_varlen_benchmark.py
@@ -89,7 +89,7 @@ class BenchmarkLayer(fc_bm.LayerBenchmark):
 
     def benchmark_layer(self):
         for batch in BATCH_SIZES:
-            name = "weighted_embedding|varlen|batch_%s" % batch
+            name = f"weighted_embedding|varlen|batch_{batch}"
             k_time, f_time = embedding_varlen(batch_size=batch, max_length=256)
             self.report(name, k_time, f_time, NUM_REPEATS)
 

--- a/keras/layers/preprocessing/discretization.py
+++ b/keras/layers/preprocessing/discretization.py
@@ -264,8 +264,8 @@ class Discretization(base_preprocessing_layer.PreprocessingLayer):
 
         if sparse and output_mode == INT:
             raise ValueError(
-                f"`sparse` may only be true if `output_mode` is "
-                f"`'one_hot'`, `'multi_hot'`, or `'count'`. "
+                "`sparse` may only be true if `output_mode` is "
+                "`'one_hot'`, `'multi_hot'`, or `'count'`. "
                 f"Received: sparse={sparse} and "
                 f"output_mode={output_mode}"
             )

--- a/keras/layers/preprocessing/hashing.py
+++ b/keras/layers/preprocessing/hashing.py
@@ -165,7 +165,7 @@ class Hashing(base_layer.Layer):
     ):
         if num_bins is None or num_bins <= 0:
             raise ValueError(
-                f"The `num_bins` for `Hashing` cannot be `None` or "
+                "The `num_bins` for `Hashing` cannot be `None` or "
                 f"non-positive values. Received: num_bins={num_bins}."
             )
 
@@ -205,8 +205,8 @@ class Hashing(base_layer.Layer):
 
         if sparse and output_mode == INT:
             raise ValueError(
-                f"`sparse` may only be true if `output_mode` is "
-                f'`"one_hot"`, `"multi_hot"`, or `"count"`. '
+                "`sparse` may only be true if `output_mode` is "
+                '`"one_hot"`, `"multi_hot"`, or `"count"`. '
                 f"Received: sparse={sparse} and "
                 f"output_mode={output_mode}"
             )

--- a/keras/layers/preprocessing/image_preprocessing.py
+++ b/keras/layers/preprocessing/image_preprocessing.py
@@ -1265,7 +1265,7 @@ class RandomRotation(BaseImageAugmentationLayer):
             self.upper = factor
         if self.upper < self.lower:
             raise ValueError(
-                "Factor cannot have negative values, " "got {}".format(factor)
+                f"Factor cannot have negative values, got {factor}"
             )
         check_fill_mode_and_interpolation(fill_mode, interpolation)
         self.fill_mode = fill_mode
@@ -1909,8 +1909,7 @@ class RandomHeight(BaseImageAugmentationLayer):
             )
         if self.height_lower < -1.0 or self.height_upper < -1.0:
             raise ValueError(
-                "`factor` must have values larger than -1, "
-                "got {}".format(factor)
+                f"`factor` must have values larger than -1, got {factor}"
             )
         self.interpolation = interpolation
         self._interpolation_method = image_utils.get_interpolation(
@@ -2033,8 +2032,7 @@ class RandomWidth(BaseImageAugmentationLayer):
             )
         if self.width_lower < -1.0 or self.width_upper < -1.0:
             raise ValueError(
-                "`factor` must have values larger than -1, "
-                "got {}".format(factor)
+                f"`factor` must have values larger than -1, got {factor}"
             )
         self.interpolation = interpolation
         self._interpolation_method = image_utils.get_interpolation(

--- a/keras/layers/preprocessing/index_lookup.py
+++ b/keras/layers/preprocessing/index_lookup.py
@@ -179,19 +179,19 @@ class IndexLookup(base_preprocessing_layer.PreprocessingLayer):
         # are creating a 0-element vocab, which doesn't make sense.
         if max_tokens is not None and max_tokens <= 1:
             raise ValueError(
-                f"If set, `max_tokens` must be greater than 1. "
+                "If set, `max_tokens` must be greater than 1. "
                 f"Received: max_tokens={max_tokens}"
             )
 
         if pad_to_max_tokens and max_tokens is None:
             raise ValueError(
-                f"If pad_to_max_tokens is True, must set `max_tokens`. "
+                "If pad_to_max_tokens is True, must set `max_tokens`. "
                 f"Received: max_tokens={max_tokens}"
             )
 
         if num_oov_indices < 0:
             raise ValueError(
-                f"`num_oov_indices` must be greater than or equal to 0. "
+                "`num_oov_indices` must be greater than or equal to 0. "
                 f"Received: num_oov_indices={num_oov_indices}"
             )
 
@@ -210,21 +210,21 @@ class IndexLookup(base_preprocessing_layer.PreprocessingLayer):
 
         if invert and output_mode != INT:
             raise ValueError(
-                f"`output_mode` must be `'int'` when `invert` is true. "
+                "`output_mode` must be `'int'` when `invert` is true. "
                 f"Received: output_mode={output_mode}"
             )
 
         if sparse and output_mode == INT:
             raise ValueError(
-                f"`sparse` may only be true if `output_mode` is "
-                f"`'one_hot'`, `'multi_hot'`, `'count'` or `'tf_idf'`. "
+                "`sparse` may only be true if `output_mode` is "
+                "`'one_hot'`, `'multi_hot'`, `'count'` or `'tf_idf'`. "
                 f"Received: sparse={sparse} and "
                 f"output_mode={output_mode}"
             )
 
         if idf_weights is not None and output_mode != TF_IDF:
             raise ValueError(
-                f"`idf_weights` should only be set if `output_mode` is "
+                "`idf_weights` should only be set if `output_mode` is "
                 f"`'tf_idf'`. Received: idf_weights={idf_weights} and "
                 f"output_mode={output_mode}"
             )
@@ -462,7 +462,7 @@ class IndexLookup(base_preprocessing_layer.PreprocessingLayer):
         """
         if self.output_mode != TF_IDF and idf_weights is not None:
             raise ValueError(
-                f"`idf_weights` should only be set if output_mode is "
+                "`idf_weights` should only be set if output_mode is "
                 f"`'tf_idf'`. Received: output_mode={self.output_mode} "
                 f"and idf_weights={idf_weights}"
             )
@@ -470,7 +470,7 @@ class IndexLookup(base_preprocessing_layer.PreprocessingLayer):
         if isinstance(vocabulary, str):
             if not tf.io.gfile.exists(vocabulary):
                 raise ValueError(
-                    "Vocabulary file {} does not exist.".format(vocabulary)
+                    f"Vocabulary file {vocabulary} does not exist."
                 )
             if self.output_mode == TF_IDF:
                 raise ValueError(
@@ -504,9 +504,7 @@ class IndexLookup(base_preprocessing_layer.PreprocessingLayer):
 
         if vocabulary.size == 0:
             raise ValueError(
-                "Cannot set an empty vocabulary, you passed {}.".format(
-                    vocabulary
-                )
+                f"Cannot set an empty vocabulary, you passed {vocabulary}."
             )
 
         oov_start = self._oov_start_index()

--- a/keras/layers/preprocessing/integer_lookup.py
+++ b/keras/layers/preprocessing/integer_lookup.py
@@ -375,14 +375,14 @@ class IntegerLookup(index_lookup.IndexLookup):
         # are creating a 0-element vocab, which doesn't make sense.
         if max_tokens is not None and max_tokens <= 1:
             raise ValueError(
-                f"If `max_tokens` is set for `IntegerLookup`, it must be "
+                "If `max_tokens` is set for `IntegerLookup`, it must be "
                 f"greater than 1. Received: max_tokens={max_tokens}."
             )
 
         if num_oov_indices < 0:
             raise ValueError(
-                f"The value of `num_oov_indices` argument for `IntegerLookup` "
-                f"must >= 0. Received num_oov_indices="
+                "The value of `num_oov_indices` argument for `IntegerLookup` "
+                "must >= 0. Received num_oov_indices="
                 f"{num_oov_indices}."
             )
 

--- a/keras/layers/preprocessing/normalization_test.py
+++ b/keras/layers/preprocessing/normalization_test.py
@@ -199,11 +199,9 @@ class NormalizationTest(
     def test_list_input(self):
         with self.assertRaisesRegex(
             ValueError,
-            (
-                "Normalization only accepts a single input. If you are "
-                "passing a python list or tuple as a single input, "
-                "please convert to a numpy array or `tf.Tensor`."
-            ),
+            "Normalization only accepts a single input. If you are "
+            "passing a python list or tuple as a single input, "
+            "please convert to a numpy array or `tf.Tensor`.",
         ):
             normalization.Normalization()([1, 2, 3])
 

--- a/keras/layers/preprocessing/preprocessing_stage.py
+++ b/keras/layers/preprocessing/preprocessing_stage.py
@@ -53,7 +53,7 @@ class PreprocessingStage(
             data, (tf.data.Dataset, np.ndarray, tf.__internal__.EagerTensor)
         ):
             raise ValueError(
-                f"`adapt()` requires a batched Dataset, an EagerTensor, or a "
+                "`adapt()` requires a batched Dataset, an EagerTensor, or a "
                 f"Numpy array as input. Received data={data}"
             )
         if isinstance(data, tf.data.Dataset):

--- a/keras/layers/preprocessing/preprocessing_test_utils.py
+++ b/keras/layers/preprocessing/preprocessing_test_utils.py
@@ -46,7 +46,7 @@ class PreprocessingLayerTest(tf.test.TestCase):
             self.assertEqual(len(a), len(b))
             for key, a_value in a.items():
                 b_value = b[key]
-                error_message = "{} ({})".format(msg, key) if msg else None
+                error_message = f"{msg} ({key})" if msg else None
                 self.assertAllCloseOrEqual(a_value, b_value, error_message)
         elif (
             isinstance(a, float)
@@ -71,7 +71,7 @@ class PreprocessingLayerTest(tf.test.TestCase):
         identical."""
         if len(data) < 4:
             raise AssertionError(
-                f"Data must have at least 4 elements. Received "
+                "Data must have at least 4 elements. Received "
                 f"len(data)={len(data)}."
             )
         data_0 = np.array([data[0]])
@@ -104,8 +104,10 @@ class PreprocessingLayerTest(tf.test.TestCase):
         self.compare_accumulators(
             all_merge,
             unordered_all_merge,
-            msg="The order of merge arguments should not change the data "
-            "output.",
+            msg=(
+                "The order of merge arguments should not change the data "
+                "output."
+            ),
         )
 
         hierarchical_merge = combiner.merge(
@@ -140,8 +142,10 @@ class PreprocessingLayerTest(tf.test.TestCase):
         self.compare_accumulators(
             all_merge,
             mixed_compute,
-            msg="Mixing merge and compute calls should not change the data "
-            "output.",
+            msg=(
+                "Mixing merge and compute calls should not change the data "
+                "output."
+            ),
         )
 
         single_merge = combiner.merge(
@@ -153,15 +157,16 @@ class PreprocessingLayerTest(tf.test.TestCase):
         self.compare_accumulators(
             all_merge,
             single_merge,
-            msg="Calling merge with a data length of 1 should not change "
-            "the data output.",
+            msg=(
+                "Calling merge with a data length of 1 should not change "
+                "the data output."
+            ),
         )
 
         self.compare_accumulators(
             expected,
             all_merge,
-            msg="Calculated accumulators "
-            "did not match expected accumulator.",
+            msg="Calculated accumulators did not match expected accumulator.",
         )
 
     def validate_accumulator_extract(self, combiner, data, expected):

--- a/keras/layers/preprocessing/preprocessing_utils.py
+++ b/keras/layers/preprocessing/preprocessing_utils.py
@@ -118,7 +118,7 @@ def encode_categorical_inputs(
     # TODO(b/190445202): remove output rank restriction.
     if inputs.shape.rank > 2:
         raise ValueError(
-            f"When output_mode is not `'int'`, maximum supported output rank "
+            "When output_mode is not `'int'`, maximum supported output rank "
             f"is 2. Received output_mode {output_mode} and input shape "
             f"{original_shape}, "
             f"which would result in output rank {inputs.shape.rank}."
@@ -139,7 +139,7 @@ def encode_categorical_inputs(
 
     if idf_weights is None:
         raise ValueError(
-            f"When output mode is `'tf_idf'`, idf_weights must be provided. "
+            "When output mode is `'tf_idf'`, idf_weights must be provided. "
             f"Received: output_mode={output_mode} and idf_weights={idf_weights}"
         )
 

--- a/keras/layers/preprocessing/text_vectorization.py
+++ b/keras/layers/preprocessing/text_vectorization.py
@@ -265,7 +265,7 @@ class TextVectorization(base_preprocessing_layer.PreprocessingLayer):
         # a dtype of 'string'.
         if "dtype" in kwargs and kwargs["dtype"] != tf.string:
             raise ValueError(
-                f"`TextVectorization` may only have a dtype of string. "
+                "`TextVectorization` may only have a dtype of string. "
                 f"Received dtype: {kwargs['dtype']}."
             )
         elif "dtype" not in kwargs:
@@ -319,7 +319,7 @@ class TextVectorization(base_preprocessing_layer.PreprocessingLayer):
             and all(isinstance(item, int) for item in ngrams)
         ):
             raise ValueError(
-                f"`ngrams` must be None, an integer, or a tuple of "
+                "`ngrams` must be None, an integer, or a tuple of "
                 f"integers. Received: ngrams={ngrams}"
             )
 
@@ -330,28 +330,28 @@ class TextVectorization(base_preprocessing_layer.PreprocessingLayer):
             or (output_sequence_length is None)
         ):
             raise ValueError(
-                f"`output_sequence_length` must be either None or an "
-                f"integer when `output_mode` is 'int'. Received: "
+                "`output_sequence_length` must be either None or an "
+                "integer when `output_mode` is 'int'. Received: "
                 f"output_sequence_length={output_sequence_length}"
             )
 
         if output_mode != INT and output_sequence_length is not None:
             raise ValueError(
-                f"`output_sequence_length` must not be set if `output_mode` is "
-                f"not 'int'. "
+                "`output_sequence_length` must not be set if `output_mode` is "
+                "not 'int'. "
                 f"Received output_sequence_length={output_sequence_length}."
             )
 
         if ragged and output_mode != INT:
             raise ValueError(
-                f"`ragged` must not be true if `output_mode` is "
+                "`ragged` must not be true if `output_mode` is "
                 f"`'int'`. Received: ragged={ragged} and "
                 f"output_mode={output_mode}"
             )
 
         if ragged and output_sequence_length is not None:
             raise ValueError(
-                f"`output_sequence_length` must not be set if ragged "
+                "`output_sequence_length` must not be set if ragged "
                 f"is True. Received: ragged={ragged} and "
                 f"output_sequence_length={output_sequence_length}"
             )
@@ -585,11 +585,9 @@ class TextVectorization(base_preprocessing_layer.PreprocessingLayer):
                 inputs = self._split(inputs)
             else:
                 raise ValueError(
-                    (
-                        "%s is not a supported splitting."
-                        "TextVectorization supports the following options "
-                        "for `split`: None, 'whitespace', or a Callable."
-                    )
+                    "%s is not a supported splitting."
+                    "TextVectorization supports the following options "
+                    "for `split`: None, 'whitespace', or a Callable."
                     % self._split
                 )
 

--- a/keras/layers/regularization/dropout.py
+++ b/keras/layers/regularization/dropout.py
@@ -82,7 +82,7 @@ class Dropout(base_layer.BaseRandomLayer):
         if isinstance(rate, (int, float)) and not 0 <= rate <= 1:
             raise ValueError(
                 f"Invalid value {rate} received for "
-                f"`rate`, expected a value between 0 and 1."
+                "`rate`, expected a value between 0 and 1."
             )
         self.rate = rate
         self.noise_shape = noise_shape

--- a/keras/layers/regularization/spatial_dropout2d.py
+++ b/keras/layers/regularization/spatial_dropout2d.py
@@ -65,7 +65,7 @@ class SpatialDropout2D(Dropout):
             data_format = backend.image_data_format()
         if data_format not in {"channels_last", "channels_first"}:
             raise ValueError(
-                f'`data_format` must be "channels_last" or "channels_first". '
+                '`data_format` must be "channels_last" or "channels_first". '
                 f"Received: data_format={data_format}."
             )
         self.data_format = data_format

--- a/keras/layers/regularization/spatial_dropout3d.py
+++ b/keras/layers/regularization/spatial_dropout3d.py
@@ -65,7 +65,7 @@ class SpatialDropout3D(Dropout):
             data_format = backend.image_data_format()
         if data_format not in {"channels_last", "channels_first"}:
             raise ValueError(
-                f'`data_format` must be "channels_last" or "channels_first". '
+                '`data_format` must be "channels_last" or "channels_first". '
                 f"Received: data_format={data_format}."
             )
         self.data_format = data_format

--- a/keras/layers/reshaping/cropping3d.py
+++ b/keras/layers/reshaping/cropping3d.py
@@ -91,8 +91,7 @@ class Cropping3D(Layer):
         elif hasattr(cropping, "__len__"):
             if len(cropping) != 3:
                 raise ValueError(
-                    "`cropping` should have 3 elements. "
-                    f"Received: {cropping}."
+                    f"`cropping` should have 3 elements. Received: {cropping}."
                 )
             dim1_cropping = conv_utils.normalize_tuple(
                 cropping[0], 2, "1st entry of cropping", allow_zero=True

--- a/keras/layers/reshaping/reshape.py
+++ b/keras/layers/reshaping/reshape.py
@@ -103,7 +103,7 @@ class Reshape(Layer):
                     unknown = index
                 else:
                     raise ValueError(
-                        f"There must be at most one unknown dimension in "
+                        "There must be at most one unknown dimension in "
                         f"output_shape. Received: output_shape={output_shape}."
                     )
             else:

--- a/keras/layers/reshaping/zero_padding2d.py
+++ b/keras/layers/reshaping/zero_padding2d.py
@@ -101,8 +101,7 @@ class ZeroPadding2D(Layer):
         elif hasattr(padding, "__len__"):
             if len(padding) != 2:
                 raise ValueError(
-                    "`padding` should have two elements. "
-                    f"Received: {padding}."
+                    f"`padding` should have two elements. Received: {padding}."
                 )
             height_padding = conv_utils.normalize_tuple(
                 padding[0], 2, "1st entry of padding", allow_zero=True

--- a/keras/layers/reshaping/zero_padding3d.py
+++ b/keras/layers/reshaping/zero_padding3d.py
@@ -92,7 +92,7 @@ class ZeroPadding3D(Layer):
         elif hasattr(padding, "__len__"):
             if len(padding) != 3:
                 raise ValueError(
-                    "`padding` should have 3 elements. " f"Received: {padding}."
+                    f"`padding` should have 3 elements. Received: {padding}."
                 )
             dim1_padding = conv_utils.normalize_tuple(
                 padding[0], 2, "1st entry of padding", allow_zero=True

--- a/keras/layers/rnn/bidirectional.py
+++ b/keras/layers/rnn/bidirectional.py
@@ -188,9 +188,9 @@ class Bidirectional(Wrapper):
             raise ValueError(
                 "Forward layer and backward layer should have different "
                 "`go_backwards` value."
-                f"forward_layer.go_backwards = "
+                "forward_layer.go_backwards = "
                 f"{self.forward_layer.go_backwards},"
-                f"backward_layer.go_backwards = "
+                "backward_layer.go_backwards = "
                 f"{self.backward_layer.go_backwards}"
             )
 

--- a/keras/layers/rnn/bidirectional_test.py
+++ b/keras/layers/rnn/bidirectional_test.py
@@ -663,8 +663,9 @@ class BidirectionalTest(tf.test.TestCase, parameterized.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     def test_Bidirectional_last_output_with_masking(self):
         rnn = keras.layers.LSTM
@@ -696,8 +697,9 @@ class BidirectionalTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.parameters([keras.layers.LSTM, keras.layers.GRU])
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     def test_Bidirectional_sequence_output_with_masking(self, rnn):
         samples = 2
@@ -925,8 +927,9 @@ class BidirectionalTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.parameters(["ave", "concat", "mul"])
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm RNN does not support ragged "
-        "tensors yet.",
+        skip_message=(
+            "Skipping as ROCm RNN does not support ragged tensors yet."
+        ),
     )
     def test_Bidirectional_ragged_input(self, merge_mode):
         np.random.seed(100)

--- a/keras/layers/rnn/cell_wrappers.py
+++ b/keras/layers/rnn/cell_wrappers.py
@@ -263,9 +263,9 @@ class DropoutWrapper(_RNNCellWrapper):
                             f"Parameter {attr} must be between 0 and 1. "
                             f"Received {const_prob}"
                         )
-                    setattr(self, "_%s" % attr, float(const_prob))
+                    setattr(self, f"_{attr}", float(const_prob))
                 else:
-                    setattr(self, "_%s" % attr, tensor_prob)
+                    setattr(self, f"_{attr}", tensor_prob)
 
         # Set variational_recurrent, seed before running the code below
         self._variational_recurrent = variational_recurrent

--- a/keras/layers/rnn/gru.py
+++ b/keras/layers/rnn/gru.py
@@ -137,7 +137,7 @@ class GRUCell(DropoutRNNCellMixin, base_layer.BaseRandomLayer):
     ):
         if units < 0:
             raise ValueError(
-                f"Received an invalid value for argument `units`, "
+                "Received an invalid value for argument `units`, "
                 f"expected a positive integer, got {units}."
             )
         # By default use cached variable under v2 mode, see b/143699808.

--- a/keras/layers/rnn/gru_test.py
+++ b/keras/layers/rnn/gru_test.py
@@ -213,8 +213,9 @@ class GRUGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     def test_with_masking_layer_GRU(self):
         layer_class = keras.layers.GRU
@@ -232,8 +233,9 @@ class GRUGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     def test_masking_with_stacking_GRU(self):
         inputs = np.random.random((2, 3, 4))
@@ -283,8 +285,9 @@ class GRUGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     def test_return_states_GRU(self):
         layer_class = keras.layers.GRU
@@ -370,8 +373,9 @@ class GRUGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     def test_statefulness_GRU(self):
         num_samples = 2
@@ -481,8 +485,9 @@ class GRUGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     @test_utils.run_v2_only
     def test_explicit_device_with_go_backward_and_mask(self):
@@ -630,8 +635,9 @@ class GRUGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     @test_utils.run_v2_only
     def test_GRU_runtime_with_mask(self):

--- a/keras/layers/rnn/gru_v1_test.py
+++ b/keras/layers/rnn/gru_v1_test.py
@@ -40,8 +40,9 @@ _config = tf.compat.v1.ConfigProto(graph_options=_graph_options)
 class GRUGraphRewriteTest(test_combinations.TestCase):
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     @test_utils.run_v2_only
     def test_gru_feature_parity_v1_v2(self):
@@ -143,8 +144,9 @@ class GRUGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     @test_utils.run_v2_only
     def test_explicit_device_with_go_backward_and_mask_v1(self):

--- a/keras/layers/rnn/legacy_cell_wrappers.py
+++ b/keras/layers/rnn/legacy_cell_wrappers.py
@@ -298,9 +298,9 @@ class DropoutWrapper(_RNNCellWrapperV1):
                             f"Parameter {attr} must be between 0 and 1. "
                             f"Received {const_prob}"
                         )
-                    setattr(self, "_%s" % attr, float(const_prob))
+                    setattr(self, f"_{attr}", float(const_prob))
                 else:
-                    setattr(self, "_%s" % attr, tensor_prob)
+                    setattr(self, f"_{attr}", tensor_prob)
 
         # Set variational_recurrent, seed before running the code below
         self._variational_recurrent = variational_recurrent

--- a/keras/layers/rnn/legacy_cells.py
+++ b/keras/layers/rnn/legacy_cells.py
@@ -265,7 +265,7 @@ class RNNCell(base_layer.Layer):
                 if inputs.shape.dims[0].value != static_batch_size:
                     raise ValueError(
                         "batch size from input tensor is different from the "
-                        f"input param. Input tensor batch: "
+                        "input param. Input tensor batch: "
                         f"{inputs.shape.dims[0].value}, "
                         f"batch_size: {batch_size}"
                     )
@@ -575,12 +575,12 @@ class GRUCell(LayerRNNCell):
         _check_supported_dtypes(self.dtype)
         input_depth = inputs_shape[-1]
         self._gate_kernel = self.add_weight(
-            "gates/%s" % _WEIGHTS_VARIABLE_NAME,
+            f"gates/{_WEIGHTS_VARIABLE_NAME}",
             shape=[input_depth + self._num_units, 2 * self._num_units],
             initializer=self._kernel_initializer,
         )
         self._gate_bias = self.add_weight(
-            "gates/%s" % _BIAS_VARIABLE_NAME,
+            f"gates/{_BIAS_VARIABLE_NAME}",
             shape=[2 * self._num_units],
             initializer=(
                 self._bias_initializer
@@ -589,12 +589,12 @@ class GRUCell(LayerRNNCell):
             ),
         )
         self._candidate_kernel = self.add_weight(
-            "candidate/%s" % _WEIGHTS_VARIABLE_NAME,
+            f"candidate/{_WEIGHTS_VARIABLE_NAME}",
             shape=[input_depth + self._num_units, self._num_units],
             initializer=self._kernel_initializer,
         )
         self._candidate_bias = self.add_weight(
-            "candidate/%s" % _BIAS_VARIABLE_NAME,
+            f"candidate/{_BIAS_VARIABLE_NAME}",
             shape=[self._num_units],
             initializer=(
                 self._bias_initializer
@@ -1075,7 +1075,7 @@ class LSTMCell(LayerRNNCell):
                 else None
             )
             self._proj_kernel = self.add_weight(
-                "projection/%s" % _WEIGHTS_VARIABLE_NAME,
+                f"projection/{_WEIGHTS_VARIABLE_NAME}",
                 shape=[self._num_units, self._num_proj],
                 initializer=self._initializer,
                 partitioner=maybe_proj_partitioner,
@@ -1311,7 +1311,7 @@ class MultiRNNCell(RNNCell):
                 if self._state_is_tuple:
                     if not tf.nest.is_nested(state):
                         raise ValueError(
-                            f"Expected state to be a tuple of length "
+                            "Expected state to be a tuple of length "
                             f"{len(self.state_size)}"
                             f", but received: {state}"
                         )

--- a/keras/layers/rnn/lstm.py
+++ b/keras/layers/rnn/lstm.py
@@ -141,7 +141,7 @@ class LSTMCell(DropoutRNNCellMixin, base_layer.BaseRandomLayer):
     ):
         if units < 0:
             raise ValueError(
-                f"Received an invalid value for argument `units`, "
+                "Received an invalid value for argument `units`, "
                 f"expected a positive integer, got {units}."
             )
         # By default use cached variable under v2 mode, see b/143699808.

--- a/keras/layers/rnn/lstm_test.py
+++ b/keras/layers/rnn/lstm_test.py
@@ -265,8 +265,9 @@ class LSTMGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     def test_return_state(self):
         num_states = 2
@@ -349,8 +350,9 @@ class LSTMGraphRewriteTest(test_combinations.TestCase):
     @parameterized.named_parameters(("v0", 0), ("v1", 1), ("v2", 2))
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     def test_implementation_mode_LSTM(self, implementation_mode):
         num_samples = 2
@@ -396,8 +398,9 @@ class LSTMGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     def test_masking_with_stacking_LSTM(self):
         inputs = np.random.random((2, 3, 4))
@@ -532,8 +535,9 @@ class LSTMGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     def test_statefulness_LSTM(self):
         num_samples = 2
@@ -680,8 +684,9 @@ class LSTMGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     @test_utils.run_v2_only
     def test_explicit_device_with_go_backward_and_mask(self):
@@ -834,8 +839,9 @@ class LSTMGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     @test_utils.run_v2_only
     def test_LSTM_runtime_with_mask(self):

--- a/keras/layers/rnn/lstm_v1_test.py
+++ b/keras/layers/rnn/lstm_v1_test.py
@@ -44,8 +44,9 @@ _config = tf.compat.v1.ConfigProto(graph_options=_graph_options)
 class LSTMGraphRewriteTest(test_combinations.TestCase):
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     @test_utils.run_v2_only
     def test_lstm_feature_parity_v1_v2(self):
@@ -172,8 +173,9 @@ class LSTMGraphRewriteTest(test_combinations.TestCase):
 
     @tf.test.disable_with_predicate(
         pred=tf.test.is_built_with_rocm,
-        skip_message="Skipping as ROCm MIOpen does not support padded "
-        "input yet.",
+        skip_message=(
+            "Skipping as ROCm MIOpen does not support padded input yet."
+        ),
     )
     @test_utils.run_v2_only
     def test_explicit_device_with_go_backward_and_mask_v1(self):

--- a/keras/layers/rnn/simple_rnn.py
+++ b/keras/layers/rnn/simple_rnn.py
@@ -123,7 +123,7 @@ class SimpleRNNCell(DropoutRNNCellMixin, base_layer.BaseRandomLayer):
     ):
         if units < 0:
             raise ValueError(
-                f"Received an invalid value for argument `units`, "
+                "Received an invalid value for argument `units`, "
                 f"expected a positive integer, got {units}."
             )
         # By default use cached variable under v2 mode, see b/143699808.

--- a/keras/layers/tensorflow_op_layer_test.py
+++ b/keras/layers/tensorflow_op_layer_test.py
@@ -219,7 +219,7 @@ def _float64_op():
     inputs = keras.Input(shape=(10,))
     x = keras.layers.Dense(10, dtype="float64")(inputs)
     x = tf.nn.relu(x)
-    assert x.dtype == "float64", "x has dtype: %s" % x.dtype
+    assert x.dtype == "float64", f"x has dtype: {x.dtype}"
     outputs = keras.layers.Dense(10)(x)
     return keras.Model(inputs, outputs)
 

--- a/keras/legacy_tf_layers/core_test.py
+++ b/keras/legacy_tf_layers/core_test.py
@@ -382,19 +382,19 @@ class DenseTest(tf.test.TestCase, parameterized.TestCase):
                 core_layers.dense(inputs, 2, name="my_dense")
                 var_dict = _get_variable_dict_from_varstore()
                 var_key = "test/my_dense/kernel"
-                self.assertEqual(var_dict[var_key].name, "%s:0" % var_key)
+                self.assertEqual(var_dict[var_key].name, f"{var_key}:0")
             with tf.compat.v1.variable_scope("test1") as scope:
                 inputs = tf.random.uniform((5, 3), seed=1)
                 core_layers.dense(inputs, 2, name=scope)
                 var_dict = _get_variable_dict_from_varstore()
                 var_key = "test1/kernel"
-                self.assertEqual(var_dict[var_key].name, "%s:0" % var_key)
+                self.assertEqual(var_dict[var_key].name, f"{var_key}:0")
             with tf.compat.v1.variable_scope("test2"):
                 inputs = tf.random.uniform((5, 3), seed=1)
                 core_layers.dense(inputs, 2)
                 var_dict = _get_variable_dict_from_varstore()
                 var_key = "test2/dense/kernel"
-                self.assertEqual(var_dict[var_key].name, "%s:0" % var_key)
+                self.assertEqual(var_dict[var_key].name, f"{var_key}:0")
 
     @test_combinations.generate(
         test_combinations.combine(mode=["graph", "eager"])

--- a/keras/legacy_tf_layers/migration_utils.py
+++ b/keras/legacy_tf_layers/migration_utils.py
@@ -51,7 +51,7 @@ class DeterministicRandomTestTool(object):
         if mode not in {"constant", "num_random_ops"}:
             raise ValueError(
                 "Mode arg must be 'constant' or 'num_random_ops'. "
-                + "Got: {}".format(mode)
+                + f"Got: {mode}"
             )
         self.seed_implementation = sys.modules[tf.compat.v1.get_seed.__module__]
         self._mode = mode
@@ -91,7 +91,7 @@ class DeterministicRandomTestTool(object):
                     raise ValueError(
                         "This `DeterministicRandomTestTool` "
                         "object is trying to re-use the "
-                        + "already-used operation seed {}. ".format(op_seed)
+                        + f"already-used operation seed {op_seed}. "
                         + "It cannot guarantee random numbers will match "
                         + "between eager and sessions when an operation seed "
                         + "is reused. You most likely set "

--- a/keras/legacy_tf_layers/normalization_test.py
+++ b/keras/legacy_tf_layers/normalization_test.py
@@ -209,7 +209,7 @@ class BNTest(tf.test.TestCase):
         )
 
         checkpoint_path_a = os.path.join(
-            self.get_temp_dir(), "checkpoint_a_%s" % base_path
+            self.get_temp_dir(), f"checkpoint_a_{base_path}"
         )
         self._train(
             checkpoint_path_a,
@@ -220,7 +220,7 @@ class BNTest(tf.test.TestCase):
             freeze_mode=freeze_mode,
         )
         checkpoint_path_b = os.path.join(
-            self.get_temp_dir(), "checkpoint_b_%s" % base_path
+            self.get_temp_dir(), f"checkpoint_b_{base_path}"
         )
         self._train(
             checkpoint_path_b,

--- a/keras/legacy_tf_layers/variable_scope_shim.py
+++ b/keras/legacy_tf_layers/variable_scope_shim.py
@@ -64,9 +64,7 @@ def _has_kwargs(fn):
         fn = fn.__call__
     elif not callable(fn):
         raise TypeError(
-            "fn should be a function-like object, but is of type {}.".format(
-                type(fn)
-            )
+            f"fn should be a function-like object, but is of type {type(fn)}."
         )
     return tf_inspect.getfullargspec(fn).varkw is not None
 
@@ -291,8 +289,7 @@ class _EagerVariableStore(tf.Module):
         """
         if custom_getter is not None and not callable(custom_getter):
             raise ValueError(
-                "Passed a custom_getter which is not callable: %s"
-                % custom_getter
+                f"Passed a custom_getter which is not callable: {custom_getter}"
             )
 
         with tf.init_scope():
@@ -352,7 +349,7 @@ class _EagerVariableStore(tf.Module):
                 )
 
             # Single variable case
-            if "%s/part_0" % name in self._vars:
+            if f"{name}/part_0" in self._vars:
                 raise ValueError(
                     "No partitioner was provided, but a partitioned version of "
                     "the variable was found: %s/part_0. Perhaps a variable of "

--- a/keras/legacy_tf_layers/variable_scope_shim_test.py
+++ b/keras/legacy_tf_layers/variable_scope_shim_test.py
@@ -97,7 +97,7 @@ class VariableScopeTest(tf.test.TestCase):
         vs = variable_scope._get_default_variable_store()
         vs.get_variable("v1", [2])
         vs.get_variable("v2", [2])
-        expected_names = ["%s:0" % name for name in ["v1", "v2"]]
+        expected_names = [f"{name}:0" for name in ["v1", "v2"]]
         self.assertEqual(
             set(expected_names), set(v.name for v in vs._vars.values())
         )
@@ -174,7 +174,7 @@ class VariableScopeTest(tf.test.TestCase):
         ]
 
         # Use different variable_name to distinguish various dtypes
-        for (i, dtype) in enumerate(types):
+        for i, dtype in enumerate(types):
             x = tf.compat.v1.get_variable(
                 name="xx%d" % i, shape=(3, 4), dtype=dtype
             )

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1970,7 +1970,7 @@ def categorical_crossentropy(
     """
     if isinstance(axis, bool):
         raise ValueError(
-            f"`axis` must be of type `int`. "
+            "`axis` must be of type `int`. "
             f"Received: axis={axis} of type {type(axis)}"
         )
     y_pred = tf.convert_to_tensor(y_pred)

--- a/keras/metrics/base_metric.py
+++ b/keras/metrics/base_metric.py
@@ -816,7 +816,7 @@ class MeanTensor(Metric):
         elif values.shape != self._shape:
             raise ValueError(
                 "MeanTensor input values must always have the same "
-                f"shape. Expected shape (set during the first call): "
+                "shape. Expected shape (set during the first call): "
                 f"{self._shape}. "
                 f"Got: {values.shape}."
             )

--- a/keras/metrics/confusion_matrix_test.py
+++ b/keras/metrics/confusion_matrix_test.py
@@ -1650,7 +1650,7 @@ class AUCTest(tf.test.TestCase, parameterized.TestCase):
             result = auc_obj(labels, logits)
             self.assertEqual(self.evaluate(result), 0.5)
         except ImportError as e:
-            tf_logging.warning("Cannot test special functions: %s" % str(e))
+            tf_logging.warning(f"Cannot test special functions: {str(e)}")
 
 
 @test_combinations.generate(test_combinations.combine(mode=["graph", "eager"]))

--- a/keras/metrics/metrics.py
+++ b/keras/metrics/metrics.py
@@ -1747,7 +1747,7 @@ class AUC(base_metric.Metric):
             summation_method, metrics_utils.AUCSummationMethod
         ) and summation_method not in list(metrics_utils.AUCSummationMethod):
             raise ValueError(
-                f"Invalid `summation_method` "
+                "Invalid `summation_method` "
                 f'argument value "{summation_method}". '
                 f"Expected one of: {list(metrics_utils.AUCSummationMethod)}"
             )
@@ -2845,7 +2845,7 @@ class IoU(_IoUBase):
         if max(target_class_ids) >= num_classes:
             raise ValueError(
                 f"Target class id {max(target_class_ids)} "
-                f"is out of range, which is "
+                "is out of range, which is "
                 f"[{0}, {num_classes})."
             )
         self.target_class_ids = list(target_class_ids)

--- a/keras/mixed_precision/autocast_variable.py
+++ b/keras/mixed_precision/autocast_variable.py
@@ -72,13 +72,13 @@ class AutoCastVariable(tf.Variable, tf.__internal__.types.Tensor):
         """
         if not isinstance(variable, tf.Variable):
             raise ValueError(
-                "variable must be of type tf.ResourceVariable, but got: "
-                "%s" % variable
+                "variable must be of type tf.ResourceVariable, but got: %s"
+                % variable
             )
         if not variable.dtype.is_floating:
             raise ValueError(
-                "variable must be a floating point variable but has "
-                "type: %s" % variable.dtype.name
+                "variable must be a floating point variable but has type: %s"
+                % variable.dtype.name
             )
         self._variable = variable
         # 'delegate' means AutoCastVariable.op return self._variable.op, which

--- a/keras/mixed_precision/device_compatibility_check.py
+++ b/keras/mixed_precision/device_compatibility_check.py
@@ -77,7 +77,7 @@ def _log_device_compatibility_check(policy_name, gpu_details_list):
         name = details.get("device_name", "Unknown GPU")
         cc = details.get("compute_capability")
         if cc:
-            device_str = "%s, compute capability %s.%s" % (name, cc[0], cc[1])
+            device_str = f"{name}, compute capability {cc[0]}.{cc[1]}"
             if cc >= (7, 0):
                 supported_device_strs.append(device_str)
             else:

--- a/keras/mixed_precision/loss_scale_optimizer.py
+++ b/keras/mixed_precision/loss_scale_optimizer.py
@@ -340,9 +340,9 @@ class LossScaleOptimizerMetaclass(type):
 
         # Raise TypeError because inner_optimizer is not an optimizer
         msg = (
-            f'"inner_optimizer" must be an instance of '
-            f"`tf.keras.optimizers.Optimizer` or "
-            f"`tf.keras.optimizers.experimental.Optimizer`, but got: "
+            '"inner_optimizer" must be an instance of '
+            "`tf.keras.optimizers.Optimizer` or "
+            "`tf.keras.optimizers.experimental.Optimizer`, but got: "
             f"{inner_optimizer}."
         )
         if isinstance(inner_optimizer, legacy_optimizer.OptimizerV2):
@@ -607,16 +607,16 @@ class LossScaleOptimizer(
                 # Give better error message if the new experimental optimizer is
                 # passed.
                 raise TypeError(
-                    f"You passed an instance of the new experimental "
-                    f"optimizer, `optimizer_experimental.Optimizer`, "
-                    f"to LossScaleOptimizer, but "
-                    f"only the classic optimizers subclassing from "
-                    f"`tf.keras.optimizers.Optimizer` can be passed. Please "
-                    f"use `loss_scale_optimizer.LossScaleOptimizerV3` "
-                    f"instead of "
-                    f"`tf.keras.mixed_precision.LossScaleOptimizer`, "
-                    f"as the former supports wrapping "
-                    f"instances of the new experimental optimizer. "
+                    "You passed an instance of the new experimental "
+                    "optimizer, `optimizer_experimental.Optimizer`, "
+                    "to LossScaleOptimizer, but "
+                    "only the classic optimizers subclassing from "
+                    "`tf.keras.optimizers.Optimizer` can be passed. Please "
+                    "use `loss_scale_optimizer.LossScaleOptimizerV3` "
+                    "instead of "
+                    "`tf.keras.mixed_precision.LossScaleOptimizer`, "
+                    "as the former supports wrapping "
+                    "instances of the new experimental optimizer. "
                     f"Got optimizer: {inner_optimizer}"
                 )
             msg = (
@@ -679,7 +679,7 @@ class LossScaleOptimizer(
         else:
             if initial_scale is None:
                 raise ValueError(
-                    '"initial_scale" must be specified if "dynamic" is ' "False"
+                    '"initial_scale" must be specified if "dynamic" is False'
                 )
             self._loss_scale = float(initial_scale)
             if dynamic_growth_steps is not None:
@@ -1125,18 +1125,18 @@ class LossScaleOptimizerV3(
                 # Give better error message if the OptimizerV2 class is passed
                 # instead of the new experimental optimizer.
                 raise TypeError(
-                    f"You passed a `tf.keras.optimizer.Optimizer` instance to "
-                    f"LossScaleOptimizerV3, but only the new experimental "
-                    f"optimizer defined in "
-                    f"keras/optimizer_expeirmental/optimizer.py can be "
-                    f"passed. Please use "
-                    f"`tf.keras.mixed_precision.LossScaleOptimizer` "
-                    f"instead of LossScaleOptimizerV3, as the former supports "
-                    f"`tf.keras.optimizer.Optimizer`s. Got optimizer: "
+                    "You passed a `tf.keras.optimizer.Optimizer` instance to "
+                    "LossScaleOptimizerV3, but only the new experimental "
+                    "optimizer defined in "
+                    "keras/optimizer_expeirmental/optimizer.py can be "
+                    "passed. Please use "
+                    "`tf.keras.mixed_precision.LossScaleOptimizer` "
+                    "instead of LossScaleOptimizerV3, as the former supports "
+                    "`tf.keras.optimizer.Optimizer`s. Got optimizer: "
                     f"{inner_optimizer}"
                 )
             raise TypeError(
-                f'"inner_optimizer" must be an instance of '
+                '"inner_optimizer" must be an instance of '
                 f"Optimizer, but got: {inner_optimizer}."
             )
         if not isinstance(dynamic, bool):
@@ -1144,12 +1144,12 @@ class LossScaleOptimizerV3(
             # second argument argument, as this was commonly done for the
             # now-removed LossScaleOptimizerV1.
             raise TypeError(
-                f'"dynamic" argument to LossScaleOptimizer.__init__ must '
+                '"dynamic" argument to LossScaleOptimizer.__init__ must '
                 f"be a bool, but got: {repr(dynamic)}"
             )
         if isinstance(inner_optimizer, LossScaleOptimizerV3):
             raise TypeError(
-                f"LossScaleOptimizer cannot wrap another "
+                "LossScaleOptimizer cannot wrap another "
                 f"LossScaleOptimizer, but got: {inner_optimizer}"
             )
         _raise_if_strategy_unsupported()
@@ -1186,12 +1186,12 @@ class LossScaleOptimizerV3(
         else:
             if initial_scale is None:
                 raise ValueError(
-                    '"initial_scale" must be specified if "dynamic" is ' "False"
+                    '"initial_scale" must be specified if "dynamic" is False'
                 )
             self._loss_scale = float(initial_scale)
             if dynamic_growth_steps is not None:
                 raise ValueError(
-                    f'"dynamic_growth_steps" must be None if "dynamic" '
+                    '"dynamic_growth_steps" must be None if "dynamic" '
                     f"is False, but got: {dynamic_growth_steps}"
                 )
 
@@ -1482,8 +1482,8 @@ def _create_loss_scale_optimizer_from_v1_loss_scale(optimizer, loss_scale):
     elif isinstance(loss_scale, tf.compat.v1.mixed_precision.DynamicLossScale):
         if loss_scale.multiplier != 2:
             raise ValueError(
-                f'When passing a DynamicLossScale to "loss_scale", '
-                f"DynamicLossScale.multiplier must be 2. Got: "
+                'When passing a DynamicLossScale to "loss_scale", '
+                "DynamicLossScale.multiplier must be 2. Got: "
                 f"{loss_scale}"
             )
         return LossScaleOptimizer(
@@ -1493,14 +1493,14 @@ def _create_loss_scale_optimizer_from_v1_loss_scale(optimizer, loss_scale):
         )
     elif isinstance(loss_scale, tf.compat.v1.mixed_precision.LossScale):
         raise TypeError(
-            f"Passing a LossScale that is not a FixedLossScale or a "
+            "Passing a LossScale that is not a FixedLossScale or a "
             f"DynamicLossScale is not supported. Got: {loss_scale}"
         )
     else:
         raise ValueError(
-            f"Invalid value passed to loss_scale. loss_scale "
-            f'must be the string "dynamic" (recommended), an int, '
-            f"a float, a FixedLossScale, or a DynamicLossScale. Got "
+            "Invalid value passed to loss_scale. loss_scale "
+            'must be the string "dynamic" (recommended), an int, '
+            "a float, a FixedLossScale, or a DynamicLossScale. Got "
             f"value: {loss_scale}"
         )
 
@@ -1573,8 +1573,8 @@ def _raise_if_strategy_unsupported():
             )
         else:
             raise ValueError(
-                f"Loss scaling is not supported with the "
-                f"tf.distribute.Strategy: "
+                "Loss scaling is not supported with the "
+                "tf.distribute.Strategy: "
                 f"{strategy.__class__.__name__}. Try using a different "
-                f"Strategy, e.g. a MirroredStrategy"
+                "Strategy, e.g. a MirroredStrategy"
             )

--- a/keras/mixed_precision/mixed_precision_graph_rewrite_test.py
+++ b/keras/mixed_precision/mixed_precision_graph_rewrite_test.py
@@ -147,7 +147,7 @@ class MixedPrecisionTest(test_combinations.TestCase):
         opt = loss_scale_optimizer_v2.LossScaleOptimizer(opt)
         with self.assertRaisesRegex(
             ValueError,
-            '"opt" must not already be an instance of a ' "LossScaleOptimizer.",
+            '"opt" must not already be an instance of a LossScaleOptimizer.',
         ):
             tf.compat.v1.mixed_precision.enable_mixed_precision_graph_rewrite(
                 opt

--- a/keras/mixed_precision/model_test.py
+++ b/keras/mixed_precision/model_test.py
@@ -75,16 +75,14 @@ class KerasModelTest(test_combinations.TestCase):
             and test_utils.get_model_type() == "subclass"
         ):
             self.skipTest(
-                "Non-default strategies are unsupported with subclassed "
-                "models"
+                "Non-default strategies are unsupported with subclassed models"
             )
 
     def _skip_if_save_format_unsupported(self, save_format):
         model_type = test_utils.get_model_type()
         if save_format == "h5" and model_type == "subclass":
             self.skipTest(
-                "Saving subclassed models with the HDF5 format is "
-                "unsupported"
+                "Saving subclassed models with the HDF5 format is unsupported"
             )
         if (
             save_format == "tf"
@@ -92,8 +90,7 @@ class KerasModelTest(test_combinations.TestCase):
             and not tf.executing_eagerly()
         ):
             self.skipTest(
-                "b/148820505: This combination of features is currently "
-                "broken."
+                "b/148820505: This combination of features is currently broken."
             )
 
     @test_combinations.run_with_all_model_types

--- a/keras/mixed_precision/policy.py
+++ b/keras/mixed_precision/policy.py
@@ -194,7 +194,7 @@ class Policy:
                 "Instead, pass DType.name. Got: %s" % (name.name,)
             )
         elif not isinstance(name, str):
-            raise TypeError("'name' must be a string, but got: %s" % (name,))
+            raise TypeError(f"'name' must be a string, but got: {name}")
         self._name = name
         self._compute_dtype, self._variable_dtype = self._parse_name(name)
         if name in ("mixed_float16", "mixed_bloat16"):
@@ -223,7 +223,7 @@ class Policy:
                 error_msg += " Please use the 'mixed_float16' policy instead."
             elif name == "bfloat16_with_float32_vars":
                 error_msg += " Please use the 'mixed_bfloat16' policy instead."
-            error_msg += " Got policy name: '%s'" % name
+            error_msg += f" Got policy name: '{name}'"
             raise ValueError(error_msg)
 
         if name == "mixed_float16":
@@ -306,7 +306,7 @@ class Policy:
         return self._name
 
     def __repr__(self):
-        return '<Policy "%s">' % self._name
+        return f'<Policy "{self._name}">'
 
     def get_config(self):
         return {"name": self.name}

--- a/keras/mixed_precision/policy_test.py
+++ b/keras/mixed_precision/policy_test.py
@@ -61,7 +61,7 @@ class PolicyTest(tf.test.TestCase, parameterized.TestCase):
             "_infer",
         ):
             self.assertEqual(
-                repr(mp_policy.Policy(policy)), '<Policy "%s">' % policy
+                repr(mp_policy.Policy(policy)), f'<Policy "{policy}">'
             )
 
     @test_utils.enable_v2_dtype_behavior

--- a/keras/mixed_precision/test_util.py
+++ b/keras/mixed_precision/test_util.py
@@ -49,10 +49,7 @@ def create_identity_with_grad_check_fn(expected_gradient, expected_dtype=None):
             if expected_dtype:
                 assert (
                     dx.dtype == expected_dtype
-                ), "dx.dtype should be %s but is: %s" % (
-                    expected_dtype,
-                    dx.dtype,
-                )
+                ), f"dx.dtype should be {expected_dtype} but is: {dx.dtype}"
             expected_tensor = tf.convert_to_tensor(
                 expected_gradient, dtype=dx.dtype, name="expected_gradient"
             )
@@ -143,7 +140,7 @@ class MultiplyLayer(AssertTypeLayer):
         activity_regularizer=None,
         use_operator=False,
         var_name="v",
-        **kwargs
+        **kwargs,
     ):
         """Initializes the MultiplyLayer.
 

--- a/keras/models/sharpness_aware_minimization.py
+++ b/keras/models/sharpness_aware_minimization.py
@@ -77,7 +77,7 @@ class SharpnessAwareMinimization(Model):
 
         gradients_all_batches = []
         pred_all_batches = []
-        for (x_batch, y_batch) in zip(x_split, y_split):
+        for x_batch, y_batch in zip(x_split, y_split):
             epsilon_w_cache = []
             with tf.GradientTape() as tape:
                 pred = self.model(x_batch)
@@ -89,7 +89,7 @@ class SharpnessAwareMinimization(Model):
             gradients_order2_norm = self._gradients_order2_norm(gradients)
             scale = self.rho / (gradients_order2_norm + 1e-12)
 
-            for (gradient, variable) in zip(gradients, trainable_variables):
+            for gradient, variable in zip(gradients, trainable_variables):
                 epsilon_w = gradient * scale
                 self._distributed_apply_epsilon_w(
                     variable, epsilon_w, tf.distribute.get_strategy()
@@ -104,11 +104,11 @@ class SharpnessAwareMinimization(Model):
                 for gradient in gradients:
                     gradients_all_batches.append([gradient])
             else:
-                for (gradient, gradient_all_batches) in zip(
+                for gradient, gradient_all_batches in zip(
                     gradients, gradients_all_batches
                 ):
                     gradient_all_batches.append(gradient)
-            for (variable, epsilon_w) in zip(
+            for variable, epsilon_w in zip(
                 trainable_variables, epsilon_w_cache
             ):
                 # Restore the variable to its original value before

--- a/keras/optimizers/legacy_learning_rate_decay.py
+++ b/keras/optimizers/legacy_learning_rate_decay.py
@@ -180,7 +180,7 @@ def piecewise_constant(x, boundaries, values, name=None):
     for v in values[1:]:
         if v.dtype.base_dtype != values[0].dtype.base_dtype:
             raise ValueError(
-                f"`values` must have elements all with the same dtype "
+                "`values` must have elements all with the same dtype "
                 f"({values[0].dtype.base_dtype} vs {v.dtype.base_dtype})."
             )
     decayed_lr = learning_rate_schedule.PiecewiseConstantDecay(

--- a/keras/optimizers/optimizer_experimental/ftrl.py
+++ b/keras/optimizers/optimizer_experimental/ftrl.py
@@ -128,7 +128,7 @@ class Ftrl(optimizer.Optimizer):
         if initial_accumulator_value < 0.0:
             raise ValueError(
                 "`initial_accumulator_value` needs to be positive or zero. "
-                f"Received: initial_accumulator_value="
+                "Received: initial_accumulator_value="
                 f"{initial_accumulator_value}."
             )
         if learning_rate_power > 0.0:
@@ -139,13 +139,13 @@ class Ftrl(optimizer.Optimizer):
         if l1_regularization_strength < 0.0:
             raise ValueError(
                 "`l1_regularization_strength` needs to be positive or zero. "
-                f"Received: l1_regularization_strength="
+                "Received: l1_regularization_strength="
                 f"{l1_regularization_strength}."
             )
         if l2_regularization_strength < 0.0:
             raise ValueError(
                 "`l2_regularization_strength` needs to be positive or zero. "
-                f"Received: l2_regularization_strength="
+                "Received: l2_regularization_strength="
                 f"{l2_regularization_strength}."
             )
         if l2_shrinkage_regularization_strength < 0.0:

--- a/keras/optimizers/optimizer_experimental/optimizer.py
+++ b/keras/optimizers/optimizer_experimental/optimizer.py
@@ -70,7 +70,7 @@ class _BaseOptimizer(tf.__internal__.tracking.AutoTrackable):
             ):
                 raise ValueError(
                     "`ema_overwrite_frequency` must be an integer > 1 or None. "
-                    f"Received: ema_overwrite_frequency="
+                    "Received: ema_overwrite_frequency="
                     f"{ema_overwrite_frequency}"
                 )
         self.ema_momentum = ema_momentum
@@ -78,7 +78,7 @@ class _BaseOptimizer(tf.__internal__.tracking.AutoTrackable):
 
         if self.clipnorm is not None and self.global_clipnorm is not None:
             raise ValueError(
-                f"At most one of `clipnorm` and `global_clipnorm` can "
+                "At most one of `clipnorm` and `global_clipnorm` can "
                 f"be set. Received: clipnorm={self.clipnorm}, "
                 f"global_clipnorm={self.global_clipnorm}."
             )
@@ -195,8 +195,8 @@ class _BaseOptimizer(tf.__internal__.tracking.AutoTrackable):
         if self._var_key(variable) not in self._index_dict:
             raise KeyError(
                 f"The optimizer cannot recognize variable {variable.name}. "
-                f"This usually means that you're reusing an optimizer "
-                f"previously created for a different model. Try creating a "
+                "This usually means that you're reusing an optimizer "
+                "previously created for a different model. Try creating a "
                 "new optimizer instance."
             )
         self.update_step(gradient, variable)
@@ -549,7 +549,7 @@ class _BaseOptimizer(tf.__internal__.tracking.AutoTrackable):
     def _update_model_variables_moving_average(self, var_list):
         """Update the stored moving average using the latest value."""
         if self.use_ema:
-            for (var, average) in zip(
+            for var, average in zip(
                 var_list, self._model_variables_moving_average
             ):
                 average.assign(
@@ -561,10 +561,10 @@ class _BaseOptimizer(tf.__internal__.tracking.AutoTrackable):
         if len(var_list) != len(self._model_variables_moving_average):
             raise ValueError(
                 f"The length of model variables ({len(var_list)}) to "
-                f"override does not match the length of model variables "
-                f"stored in the optimizer "
+                "override does not match the length of model variables "
+                "stored in the optimizer "
                 f"({len(self._model_variables_moving_average)}). Please "
-                f"check if the optimizer was called on your model."
+                "check if the optimizer was called on your model."
             )
         self._overwrite_model_variables_with_average_value_helper(var_list)
 
@@ -975,7 +975,7 @@ class Optimizer(_BaseOptimizer):
                     self.ema_momentum * average + (1 - self.ema_momentum) * var
                 )
 
-            for (var, average) in zip(
+            for var, average in zip(
                 var_list, self._model_variables_moving_average
             ):
                 self._distribution_strategy.extended.update(

--- a/keras/optimizers/optimizer_v1.py
+++ b/keras/optimizers/optimizer_v1.py
@@ -43,8 +43,7 @@ class Optimizer:
         for k in kwargs:
             if k not in allowed_kwargs:
                 raise TypeError(
-                    "Unexpected keyword argument "
-                    "passed to optimizer: " + str(k)
+                    "Unexpected keyword argument passed to optimizer: " + str(k)
                 )
             # checks that clipnorm >= 0 and clipvalue >= 0
             if kwargs[k] < 0:
@@ -123,8 +122,9 @@ class Optimizer:
             raise ValueError(
                 "Length of the specified weight list ("
                 + str(len(weights))
-                + ") does not match the number of weights "
-                "of the optimizer (" + str(len(params)) + ")"
+                + ") does not match the number of weights of the optimizer ("
+                + str(len(params))
+                + ")"
             )
         weight_value_tuples = []
         param_values = backend.batch_get_value(params)
@@ -133,8 +133,8 @@ class Optimizer:
                 raise ValueError(
                     "Optimizer weight shape "
                     + str(pv.shape)
-                    + " not compatible with "
-                    "provided weight shape " + str(w.shape)
+                    + " not compatible with provided weight shape "
+                    + str(w.shape)
                 )
             weight_value_tuples.append((p, w))
         backend.batch_set_value(weight_value_tuples)

--- a/keras/optimizers/optimizer_v2/ftrl.py
+++ b/keras/optimizers/optimizer_v2/ftrl.py
@@ -132,13 +132,13 @@ class Ftrl(optimizer_v2.OptimizerV2):
         if l1_regularization_strength < 0.0:
             raise ValueError(
                 "`l1_regularization_strength` needs to be positive or zero. "
-                f"Received: l1_regularization_strength="
+                "Received: l1_regularization_strength="
                 f"{l1_regularization_strength}."
             )
         if l2_regularization_strength < 0.0:
             raise ValueError(
                 "`l2_regularization_strength` needs to be positive or zero. "
-                f"Received: l2_regularization_strength="
+                "Received: l2_regularization_strength="
                 f"{l2_regularization_strength}."
             )
         if l2_shrinkage_regularization_strength < 0.0:

--- a/keras/optimizers/optimizer_v2/gradient_descent.py
+++ b/keras/optimizers/optimizer_v2/gradient_descent.py
@@ -123,7 +123,7 @@ class SGD(optimizer_v2.OptimizerV2):
             momentum < 0 or momentum > 1
         ):
             raise ValueError(
-                f"`momentum` must be between [0, 1]. Received: "
+                "`momentum` must be between [0, 1]. Received: "
                 f"momentum={momentum} (of type {type(momentum)})."
             )
         self._set_hyper("momentum", momentum)

--- a/keras/optimizers/optimizer_v2/optimizer_v2.py
+++ b/keras/optimizers/optimizer_v2/optimizer_v2.py
@@ -753,7 +753,7 @@ class OptimizerV2(tf.__internal__.tracking.Trackable):
             """Apply gradient to variable."""
             if isinstance(var, tf.Tensor):
                 raise NotImplementedError(
-                    f"Updating a `Tensor` is not implemented. "
+                    "Updating a `Tensor` is not implemented. "
                     f"Received: var={var}."
                 )
 
@@ -1420,7 +1420,7 @@ class OptimizerV2(tf.__internal__.tracking.Trackable):
           An `Operation` which updates the value of the variable.
         """
         raise NotImplementedError(
-            "`_resource_apply_dense` must be implemented in " "subclasses."
+            "`_resource_apply_dense` must be implemented in subclasses."
         )
 
     def _resource_apply_sparse_duplicate_indices(
@@ -1474,7 +1474,7 @@ class OptimizerV2(tf.__internal__.tracking.Trackable):
           An `Operation` which updates the value of the variable.
         """
         raise NotImplementedError(
-            "`_resource_apply_sparse` Must be implemented in " "subclasses."
+            "`_resource_apply_sparse` Must be implemented in subclasses."
         )
 
     def _resource_scatter_add(self, x, i, v):

--- a/keras/optimizers/optimizer_v2/rmsprop.py
+++ b/keras/optimizers/optimizer_v2/rmsprop.py
@@ -153,7 +153,7 @@ class RMSprop(optimizer_v2.OptimizerV2):
             momentum < 0 or momentum > 1
         ):
             raise ValueError(
-                f"`momentum` must be between [0, 1]. Received: "
+                "`momentum` must be between [0, 1]. Received: "
                 f"momentum={momentum} (of type {type(momentum)})."
             )
         self._set_hyper("momentum", momentum)

--- a/keras/optimizers/optimizer_v2/utils.py
+++ b/keras/optimizers/optimizer_v2/utils.py
@@ -80,11 +80,9 @@ def filter_empty_gradients(grads_and_vars):
         )
     if vars_with_empty_grads:
         logging.warning(
-            (
-                "Gradients do not exist for variables %s when minimizing the "
-                "loss. If you're using `model.compile()`, did you forget to "
-                "provide a `loss` argument?"
-            ),
+            "Gradients do not exist for variables %s when minimizing the "
+            "loss. If you're using `model.compile()`, did you forget to "
+            "provide a `loss` argument?",
             ([v.name for v in vars_with_empty_grads]),
         )
     return filtered

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -764,13 +764,13 @@ class NumpyArrayIterator(Iterator):
         channels_axis = 3 if data_format == "channels_last" else 1
         if self.x.shape[channels_axis] not in {1, 3, 4}:
             warnings.warn(
-                "NumpyArrayIterator is set to use the "
-                'data format convention "' + data_format + '" '
-                "(channels on axis "
+                'NumpyArrayIterator is set to use the data format convention "'
+                + data_format
+                + '" (channels on axis '
                 + str(channels_axis)
-                + "), i.e. expected either 1, 3, or 4 "
-                "channels on axis " + str(channels_axis) + ". "
-                "However, it was passed an array with shape "
+                + "), i.e. expected either 1, 3, or 4 channels on axis "
+                + str(channels_axis)
+                + ". However, it was passed an array with shape "
                 + str(self.x.shape)
                 + " ("
                 + str(self.x.shape[channels_axis])
@@ -1028,7 +1028,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         # check that filenames/filepaths column values are all strings
         if not all(df[x_col].apply(lambda x: isinstance(x, str))):
             raise TypeError(
-                "All values in column x_col={} must be strings.".format(x_col)
+                f"All values in column x_col={x_col} must be strings."
             )
         # check labels are string if class_mode is binary or sparse
         if self.class_mode in {"binary", "sparse"}:
@@ -1075,9 +1075,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             )
         # check that if weight column that the values are numerical
         if weight_col and not issubclass(df[weight_col].dtype.type, np.number):
-            raise TypeError(
-                "Column weight_col={} must be numeric.".format(weight_col)
-            )
+            raise TypeError(f"Column weight_col={weight_col} must be numeric.")
 
     def get_classes(self, df, y_col):
         labels = []
@@ -2087,8 +2085,8 @@ class ImageDataGenerator:
         x = np.asarray(x, dtype=self.dtype)
         if x.ndim != 4:
             raise ValueError(
-                "Input to `.fit()` should have rank 4. "
-                "Got array with shape: " + str(x.shape)
+                "Input to `.fit()` should have rank 4. Got array with shape: "
+                + str(x.shape)
             )
         if x.shape[self.channel_axis] not in {1, 3, 4}:
             warnings.warn(
@@ -2097,11 +2095,9 @@ class ImageDataGenerator:
                 + self.data_format
                 + '" (channels on axis '
                 + str(self.channel_axis)
-                + "), i.e. expected "
-                "either 1, 3 or 4 channels on axis "
+                + "), i.e. expected either 1, 3 or 4 channels on axis "
                 + str(self.channel_axis)
-                + ". "
-                "However, it was passed an array with shape "
+                + ". However, it was passed an array with shape "
                 + str(x.shape)
                 + " ("
                 + str(x.shape[self.channel_axis])
@@ -2347,8 +2343,8 @@ def random_zoom(
     """
     if len(zoom_range) != 2:
         raise ValueError(
-            "`zoom_range` should be a tuple or list of two"
-            " floats. Received: %s" % (zoom_range,)
+            "`zoom_range` should be a tuple or list of two floats. Received: %s"
+            % (zoom_range,)
         )
 
     if zoom_range[0] == 1 and zoom_range[1] == 1:
@@ -2425,7 +2421,7 @@ def apply_brightness_shift(x, brightness, scale=True):
     """
     if ImageEnhance is None:
         raise ImportError(
-            "Using brightness shifts requires PIL. " "Install PIL or Pillow."
+            "Using brightness shifts requires PIL. Install PIL or Pillow."
         )
     x_min, x_max = np.min(x), np.max(x)
     local_scale = (x_min < 0) or (x_max > 255)
@@ -2527,16 +2523,14 @@ def apply_affine_transform(
         ImportError: if SciPy is not available.
     """
     if scipy is None:
-        raise ImportError(
-            "Image transformations require SciPy. " "Install SciPy."
-        )
+        raise ImportError("Image transformations require SciPy. Install SciPy.")
 
     # Input sanity checks:
     # 1. x must 2D image with one or more channels (i.e., a 3D tensor)
     # 2. channels must be either first or last dimension
     if np.unique([row_axis, col_axis, channel_axis]).size != 3:
         raise ValueError(
-            "'row_axis', 'col_axis', and 'channel_axis'" " must be distinct"
+            "'row_axis', 'col_axis', and 'channel_axis' must be distinct"
         )
 
     # shall we support negative indices?

--- a/keras/preprocessing/image_test.py
+++ b/keras/preprocessing/image_test.py
@@ -203,7 +203,7 @@ class TestImage(test_combinations.TestCase):
         # create folders and subfolders
         paths = []
         for cl in range(num_classes):
-            class_directory = "class-{}".format(cl)
+            class_directory = f"class-{cl}"
             classpaths = [
                 class_directory,
                 os.path.join(class_directory, "subfolder-1"),
@@ -225,7 +225,7 @@ class TestImage(test_combinations.TestCase):
                 classpaths = paths[im_class]
                 filename = os.path.join(
                     classpaths[count % len(classpaths)],
-                    "image-{}.jpg".format(count),
+                    f"image-{count}.jpg",
                 )
                 filenames.append(filename)
                 im.save(os.path.join(temp_dir, filename))
@@ -294,7 +294,7 @@ class TestImage(test_combinations.TestCase):
         # create folders and subfolders
         paths = []
         for cl in range(num_classes):
-            class_directory = "class-{}".format(cl)
+            class_directory = f"class-{cl}"
             classpaths = [
                 class_directory,
                 os.path.join(class_directory, "subfolder-1"),
@@ -316,7 +316,7 @@ class TestImage(test_combinations.TestCase):
                 classpaths = paths[im_class]
                 filename = os.path.join(
                     classpaths[count % len(classpaths)],
-                    "image-{}.jpg".format(count),
+                    f"image-{count}.jpg",
                 )
                 filenames.append(filename)
                 im.save(os.path.join(tmp_folder, filename))
@@ -426,7 +426,7 @@ class TestDirectoryIterator(test_combinations.TestCase):
         # create folders and subfolders
         paths = []
         for cl in range(num_classes):
-            class_directory = "class-{}".format(cl)
+            class_directory = f"class-{cl}"
             classpaths = [
                 class_directory,
                 os.path.join(class_directory, "subfolder-1"),
@@ -448,7 +448,7 @@ class TestDirectoryIterator(test_combinations.TestCase):
                 classpaths = paths[im_class]
                 filename = os.path.join(
                     classpaths[count % len(classpaths)],
-                    "image-{}.png".format(count),
+                    f"image-{count}.png",
                 )
                 filenames.append(filename)
                 im.save(os.path.join(tmpdir.full_path, filename))
@@ -509,9 +509,7 @@ class TestDirectoryIterator(test_combinations.TestCase):
         count = 0
         for test_images in all_test_images:
             for im in test_images:
-                filename = os.path.join(
-                    tmpdir, "class-1", "image-{}.png".format(count)
-                )
+                filename = os.path.join(tmpdir, "class-1", f"image-{count}.png")
                 im.save(filename)
                 count += 1
 
@@ -549,7 +547,7 @@ class TestDirectoryIterator(test_combinations.TestCase):
         # create folders and subfolders
         paths = []
         for cl in range(num_classes):
-            class_directory = "class-{}".format(cl)
+            class_directory = f"class-{cl}"
             classpaths = [
                 class_directory,
                 os.path.join(class_directory, "subfolder-1"),
@@ -571,7 +569,7 @@ class TestDirectoryIterator(test_combinations.TestCase):
                 classpaths = paths[im_class]
                 filename = os.path.join(
                     classpaths[count % len(classpaths)],
-                    "image-{}.png".format(count),
+                    f"image-{count}.png",
                 )
                 filenames.append(filename)
                 im.save(os.path.join(tmpdir.full_path, filename))
@@ -856,8 +854,8 @@ class TestDataFrameIterator(test_combinations.TestCase):
         filenames_without = []
         for test_images in all_test_images:
             for im in test_images:
-                filename = "image-{}.png".format(count)
-                filename_without = "image-{}".format(count)
+                filename = f"image-{count}.png"
+                filename_without = f"image-{count}"
                 filenames.append(filename)
                 filepaths.append(os.path.join(tmpdir.full_path, filename))
                 filenames_without.append(filename_without)
@@ -954,7 +952,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
         filenames = []
         for test_images in all_test_images:
             for im in test_images:
-                filename = "image-{}.png".format(count)
+                filename = f"image-{count}.png"
                 im.save(os.path.join(tmpdir.full_path, filename))
                 filenames.append(filename)
                 count += 1
@@ -977,7 +975,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
         filenames = []
         for test_images in all_test_images:
             for im in test_images:
-                filename = "image-{}.png".format(count)
+                filename = f"image-{count}.png"
                 im.save(os.path.join(tmpdir.full_path, filename))
                 filenames.append(filename)
                 count += 1
@@ -1021,7 +1019,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
         filenames = []
         for test_images in all_test_images:
             for im in test_images:
-                filename = "image-{}.png".format(count)
+                filename = f"image-{count}.png"
                 im.save(os.path.join(tmpdir.full_path, filename))
                 filenames.append(filename)
                 count += 1
@@ -1071,7 +1069,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
         count = 0
         for test_images in all_test_images:
             for im in test_images:
-                filename = "image-{}.png".format(count)
+                filename = f"image-{count}.png"
                 im.save(os.path.join(tmpdir.full_path, filename))
                 filenames.append(filename)
                 count += 1
@@ -1126,7 +1124,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
         count = 0
         for test_images in all_test_images:
             for im in test_images:
-                filename = "image-{}.png".format(count)
+                filename = f"image-{count}.png"
                 im.save(os.path.join(tmpdir.full_path, filename))
                 filenames.append(filename)
                 count += 1
@@ -1205,7 +1203,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
         count = 0
         for test_images in all_test_images:
             for im in test_images:
-                filename = "image-{}.png".format(count)
+                filename = f"image-{count}.png"
                 im.save(os.path.join(tmpdir.full_path, filename))
                 filenames.append(filename)
                 count += 1
@@ -1264,8 +1262,8 @@ class TestDataFrameIterator(test_combinations.TestCase):
         filenames_without = []
         for test_images in all_test_images:
             for im in test_images:
-                filename = "image-{}.png".format(count)
-                filename_without = "image-{}".format(count)
+                filename = f"image-{count}.png"
+                filename_without = f"image-{count}"
                 filenames.append(filename)
                 filenames_without.append(filename_without)
                 im.save(os.path.join(tmpdir.full_path, filename))
@@ -1315,7 +1313,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
         filenames = []
         for test_images in all_test_images:
             for im in test_images:
-                filename = "image-{}.png".format(count)
+                filename = f"image-{count}.png"
                 filenames.append(filename)
                 im.save(os.path.join(tmpdir.full_path, filename))
                 count += 1
@@ -1364,7 +1362,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
         filenames = []
         for test_images in all_test_images:
             for im in test_images:
-                filename = "image-{}.png".format(count)
+                filename = f"image-{count}.png"
                 filenames.append(filename)
                 im.save(os.path.join(tmpdir.full_path, filename))
                 count += 1
@@ -1401,7 +1399,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
         file_paths = []
         for test_images in all_test_images:
             for im in test_images:
-                filename = "image-{:0>5}.png".format(count)
+                filename = f"image-{count:0>5}.png"
                 file_path = os.path.join(tmpdir.full_path, filename)
                 file_paths.append(file_path)
                 im.save(file_path)
@@ -1490,7 +1488,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
         # create folders and subfolders
         paths = []
         for cl in range(num_classes):
-            class_directory = "class-{}".format(cl)
+            class_directory = f"class-{cl}"
             classpaths = [
                 class_directory,
                 os.path.join(class_directory, "subfolder-1"),
@@ -1512,7 +1510,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
                 classpaths = paths[im_class]
                 filename = os.path.join(
                     classpaths[count % len(classpaths)],
-                    "image-{}.png".format(count),
+                    f"image-{count}.png",
                 )
                 filenames.append(filename)
                 im.save(os.path.join(tmpdir.full_path, filename))
@@ -1541,7 +1539,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
         filenames = []
         for test_images in all_test_images:
             for im in test_images:
-                filename = "image-{}.png".format(count)
+                filename = f"image-{count}.png"
                 im.save(os.path.join(tmpdir.full_path, filename))
                 filenames.append(filename)
                 count += 1

--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -136,9 +136,9 @@ class TimeseriesGenerator(data_utils.Sequence):
 
         if len(data) != len(targets):
             raise ValueError(
-                "Data and targets have to be" + " of same length. "
-                "Data length is {}".format(len(data))
-                + " while target length is {}".format(len(targets))
+                "Data and targets have to be"
+                + f" of same length. Data length is {len(data)}"
+                + f" while target length is {len(targets)}"
             )
 
         self.data = data

--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -491,7 +491,7 @@ class Tokenizer(object):
 
         if mode == "tfidf" and not self.document_count:
             raise ValueError(
-                "Fit the Tokenizer on some data " "before using tfidf mode."
+                "Fit the Tokenizer on some data before using tfidf mode."
             )
 
         x = np.zeros((len(sequences), num_words))

--- a/keras/saving/hdf5_format.py
+++ b/keras/saving/hdf5_format.py
@@ -815,7 +815,7 @@ def load_weights_from_hdf5_group(f, model):
     layer_names = filtered_layer_names
     if len(layer_names) != len(filtered_layers):
         raise ValueError(
-            f"Layer count mismatch when loading weights from file. "
+            "Layer count mismatch when loading weights from file. "
             f"Model expected {len(filtered_layers)} layers, found "
             f"{len(layer_names)} saved layers."
         )
@@ -849,8 +849,8 @@ def load_weights_from_hdf5_group(f, model):
         )
         if len(weight_values) != len(symbolic_weights):
             raise ValueError(
-                f"Weight count mismatch for top-level weights when loading "
-                f"weights from file. "
+                "Weight count mismatch for top-level weights when loading "
+                "weights from file. "
                 f"Model expects {len(symbolic_weights)} top-level weight(s). "
                 f"Received {len(weight_values)} saved top-level weight(s)"
             )
@@ -937,7 +937,7 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
                             f"{layer.name}) due to mismatch in shape for "
                             f"weight {symbolic_weights[i].name}. "
                             f"Weight expects shape {expected_shape}. "
-                            f"Received saved weight "
+                            "Received saved weight "
                             f"with shape {received_shape}"
                         )
                         continue
@@ -945,7 +945,7 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
                         f"Shape mismatch in layer #{k} (named {layer.name}) "
                         f"for weight {symbolic_weights[i].name}. "
                         f"Weight expects shape {expected_shape}. "
-                        f"Received saved weight "
+                        "Received saved weight "
                         f"with shape {received_shape}"
                     )
                 else:
@@ -964,17 +964,17 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
         if len(weight_values) != len(symbolic_weights):
             if skip_mismatch:
                 logging.warning(
-                    f"Skipping loading top-level weights for model due to "
-                    f"mismatch in number of weights. "
+                    "Skipping loading top-level weights for model due to "
+                    "mismatch in number of weights. "
                     f"Model expects {len(symbolic_weights)} "
-                    f"top-level weight(s). "
+                    "top-level weight(s). "
                     f"Received {len(weight_values)} saved top-level weight(s)"
                 )
             else:
                 raise ValueError(
-                    f"Weight count mismatch for top-level weights of model. "
+                    "Weight count mismatch for top-level weights of model. "
                     f"Model expects {len(symbolic_weights)} "
-                    f"top-level weight(s). "
+                    "top-level weight(s). "
                     f"Received {len(weight_values)} saved top-level weight(s)"
                 )
         else:
@@ -984,19 +984,19 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
                 if expected_shape != received_shape:
                     if skip_mismatch:
                         logging.warning(
-                            f"Skipping loading top-level weight for model due "
-                            f"to mismatch in shape for "
+                            "Skipping loading top-level weight for model due "
+                            "to mismatch in shape for "
                             f"weight {symbolic_weights[i].name}. "
                             f"Weight expects shape {expected_shape}. "
-                            f"Received saved weight "
+                            "Received saved weight "
                             f"with shape {received_shape}"
                         )
                     else:
                         raise ValueError(
-                            f"Shape mismatch in model for top-level weight "
+                            "Shape mismatch in model for top-level weight "
                             f"{symbolic_weights[i].name}. "
                             f"Weight expects shape {expected_shape}. "
-                            f"Received saved weight "
+                            "Received saved weight "
                             f"with shape {received_shape}"
                         )
                 else:
@@ -1109,8 +1109,8 @@ def _legacy_weights(layer):
     weights = layer.trainable_weights + layer.non_trainable_weights
     if any(not isinstance(w, tf.Variable) for w in weights):
         raise NotImplementedError(
-            f"Save or restore weights that is not an instance of `tf.Variable` "
-            f"is not supported in h5, use `save_format='tf'` instead. Received "
+            "Save or restore weights that is not an instance of `tf.Variable` "
+            "is not supported in h5, use `save_format='tf'` instead. Received "
             f"a model or layer {layer.__class__.__name__} "
             f"with weights {weights}"
         )

--- a/keras/saving/save_test.py
+++ b/keras/saving/save_test.py
@@ -57,7 +57,7 @@ class TestSaveModel(tf.test.TestCase, parameterized.TestCase):
         if h5py is not None:
             self.assertTrue(
                 h5py.is_hdf5(path),
-                "Model saved at path {} is not a valid hdf5 file.".format(path),
+                f"Model saved at path {path} is not a valid hdf5 file.",
             )
 
     def assert_saved_model(self, path):

--- a/keras/saving/save_weights_test.py
+++ b/keras/saving/save_weights_test.py
@@ -333,8 +333,10 @@ class TestWeightSavingAndLoading(tf.test.TestCase, parameterized.TestCase):
             )
             with self.assertRaises(
                 ValueError,
-                msg="Weight count mismatch for layer #0 (named d1). "
-                "Layer expects 1 weight(s). Received 2 saved weight(s)",
+                msg=(
+                    "Weight count mismatch for layer #0 (named d1). "
+                    "Layer expects 1 weight(s). Received 2 saved weight(s)"
+                ),
             ):
                 hdf5_format.load_weights_from_hdf5_group_by_name(f_model, model)
 
@@ -388,9 +390,11 @@ class TestWeightSavingAndLoading(tf.test.TestCase, parameterized.TestCase):
             )
             with self.assertRaises(
                 ValueError,
-                msg="Shape mismatch in layer #0 (named d1) for weight "
-                "d1_1/kernel:0. Weight expects shape (3, 10). "
-                "Received saved weight with shape (3, 5)",
+                msg=(
+                    "Shape mismatch in layer #0 (named d1) for weight "
+                    "d1_1/kernel:0. Weight expects shape (3, 10). "
+                    "Received saved weight with shape (3, 5)"
+                ),
             ):
                 hdf5_format.load_weights_from_hdf5_group_by_name(f_model, model)
 

--- a/keras/saving/saved_model/load.py
+++ b/keras/saving/saved_model/load.py
@@ -249,9 +249,7 @@ def _generate_object_paths(object_graph_def):
         for reference in object_graph_def.nodes[current_node].children:
             if reference.node_id in paths:
                 continue
-            paths[reference.node_id] = "{}.{}".format(
-                current_path, reference.local_name
-            )
+            paths[reference.node_id] = f"{current_path}.{reference.local_name}"
             nodes_to_visit.append(reference.node_id)
 
     return paths
@@ -384,7 +382,7 @@ class KerasObjectLoader:
                     )
                     children.append((metric, reference.node_id, metric_path))
 
-        for (obj_child, child_id, child_name) in children:
+        for obj_child, child_id, child_name in children:
             child_proto = self._proto.nodes[child_id]
 
             if not isinstance(obj_child, tf.__internal__.tracking.Trackable):
@@ -428,7 +426,7 @@ class KerasObjectLoader:
             ):
                 setter = lambda *args: None
 
-            child_path = "{}.{}".format(parent_path, child_name)
+            child_path = f"{parent_path}.{child_name}"
             self._node_paths[child_id] = child_path
             self._add_children_recreated_from_config(
                 obj_child, child_proto, child_id
@@ -598,7 +596,7 @@ class KerasObjectLoader:
             if builtin_layer:
                 raise RuntimeError(
                     f"Unable to restore object of class '{class_name}' likely "
-                    f"due to name conflict with built-in Keras class "
+                    "due to name conflict with built-in Keras class "
                     f"'{builtin_layer}'. To override the built-in Keras "
                     "definition of the object, decorate your class with "
                     "`@keras.utils.register_keras_serializable` and include "
@@ -760,8 +758,8 @@ class KerasObjectLoader:
                 for model_id in uninitialized_model_ids
             ]
             raise ValueError(
-                f"Error loading model(s) in the SavedModel format. "
-                f"The following model(s) could not be initialized: "
+                "Error loading model(s) in the SavedModel format. "
+                "The following model(s) could not be initialized: "
                 f"{uninitialized_model_names}"
             )
 
@@ -1136,9 +1134,9 @@ def revive_custom_object(identifier, metadata):
     else:
         raise ValueError(
             f"Unable to restore custom object of type {identifier}. "
-            f"Please make sure that any custom layers are included in the "
-            f"`custom_objects` arg when calling `load_model()` and make sure "
-            f"that all layers implement `get_config` and `from_config`."
+            "Please make sure that any custom layers are included in the "
+            "`custom_objects` arg when calling `load_model()` and make sure "
+            "that all layers implement `get_config` and `from_config`."
         )
 
 
@@ -1285,7 +1283,7 @@ def recursively_deserialize_keras_object(config, module_objects=None):
         ]
     else:
         raise ValueError(
-            f"Unable to decode Keras layer config. Config should be a "
+            "Unable to decode Keras layer config. Config should be a "
             f"dictionary, tuple or list. Received: config={config}"
         )
 

--- a/keras/saving/saved_model/save.py
+++ b/keras/saving/saved_model/save.py
@@ -120,9 +120,7 @@ def generate_keras_metadata(saved_nodes, node_paths):
             if not path:
                 node_path = "root"
             else:
-                node_path = "root.{}".format(
-                    ".".join([ref.name for ref in path])
-                )
+                node_path = f"root.{'.'.join([ref.name for ref in path])}"
 
             metadata.nodes.add(
                 node_id=node_id,

--- a/keras/saving/saved_model/save_impl.py
+++ b/keras/saving/saved_model/save_impl.py
@@ -175,7 +175,7 @@ def wrap_layer_functions(layer, serialization_cache):
     call_collection = LayerCallCollection(layer)
     call_fn_with_losses = call_collection.add_function(
         _wrap_call_and_conditional_losses(layer),
-        "{}_layer_call_and_return_conditional_losses".format(layer.name),
+        f"{layer.name}_layer_call_and_return_conditional_losses",
         # If any of this layer's child layers use the training arg, the traced
         # call functions of this layer will have a training keyword argument. If
         # the original layer does not expect the training arg, then it will have
@@ -184,7 +184,7 @@ def wrap_layer_functions(layer, serialization_cache):
     )
     call_fn = call_collection.add_function(
         _extract_outputs_from_fn(layer, call_fn_with_losses),
-        "{}_layer_call_fn".format(layer.name),
+        f"{layer.name}_layer_call_fn",
         # Since `call_fn` wraps call_fn_with_losses and not the original call
         # function, `match_layer_training_arg` should be set to False.
         match_layer_training_arg=False,
@@ -203,9 +203,7 @@ def wrap_layer_functions(layer, serialization_cache):
             _append_activity_regularizer_loss(
                 layer, call_fn_with_losses, fns["activity_regularizer_fn"]
             ),
-            "{}_layer_call_and_return_all_conditional_losses".format(
-                layer.name
-            ),
+            f"{layer.name}_layer_call_and_return_all_conditional_losses",
             match_layer_training_arg=False,
         )
     else:
@@ -757,7 +755,7 @@ def _wrap_unconditional_loss(loss_fn, index):
         return fn
     else:
         return tf.__internal__.function.Function(
-            fn, "loss_fn_{}".format(index), input_signature=[]
+            fn, f"loss_fn_{index}", input_signature=[]
         )
 
 
@@ -770,7 +768,7 @@ def _wrap_activity_regularizer(layer):
         return layer._activity_regularizer
     return tf.__internal__.function.Function(
         layer._activity_regularizer,
-        "{}_activity_regularizer".format(layer.name),
+        f"{layer.name}_activity_regularizer",
         input_signature=[
             tf.TensorSpec(None, layer._compute_dtype or backend.floatx())
         ],

--- a/keras/saving/saved_model/serialized_attributes.py
+++ b/keras/saving/saved_model/serialized_attributes.py
@@ -249,7 +249,7 @@ class SerializedAttributes:
                         "The object dictionary contained a non-trackable "
                         f"object: {object_dict[key]} (for key {key}). "
                         "Only trackable objects are "
-                        f"allowed, such as Keras layers/models or "
+                        "allowed, such as Keras layers/models or "
                         "tf.Module instances."
                     )
                 self._object_dict[key] = object_dict[key]

--- a/keras/saving/saving_utils_test.py
+++ b/keras/saving/saving_utils_test.py
@@ -273,9 +273,7 @@ def _import_and_infer(save_dir, inputs):
         ]
         assert set(inputs.keys()) == set(
             signature.inputs.keys()
-        ), "expected {}, found {}".format(
-            signature.inputs.keys(), inputs.keys()
-        )
+        ), f"expected {signature.inputs.keys()}, found {inputs.keys()}"
         feed_dict = {}
         for arg_name in inputs.keys():
             feed_dict[

--- a/keras/saving/utils_v1/export_output.py
+++ b/keras/saving/utils_v1/export_output.py
@@ -54,9 +54,7 @@ class ExportOutput:
 
         if not isinstance(key, str):
             raise ValueError(
-                "{} output key must be a string; got {}.".format(
-                    error_label, key
-                )
+                f"{error_label} output key must be a string; got {key}."
             )
         return key
 
@@ -91,9 +89,7 @@ class ExportOutput:
             key = self._check_output_key(key, error_name)
             if not isinstance(value, tf.Tensor):
                 raise ValueError(
-                    "{} output value must be a Tensor; got {}.".format(
-                        error_name, value
-                    )
+                    f"{error_name} output value must be a Tensor; got {value}."
                 )
 
             output_dict[key] = value
@@ -138,16 +134,14 @@ class ClassificationOutput(ExportOutput):
             isinstance(scores, tf.Tensor) and scores.dtype.is_floating
         ):
             raise ValueError(
-                "Classification scores must be a float32 Tensor; "
-                "got {}".format(scores)
+                f"Classification scores must be a float32 Tensor; got {scores}"
             )
         if classes is not None and not (
             isinstance(classes, tf.Tensor)
             and tf.as_dtype(classes.dtype) == tf.string
         ):
             raise ValueError(
-                "Classification classes must be a string Tensor; "
-                "got {}".format(classes)
+                f"Classification classes must be a string Tensor; got {classes}"
             )
         if scores is None and classes is None:
             raise ValueError(
@@ -207,8 +201,7 @@ class RegressionOutput(ExportOutput):
         """
         if not (isinstance(value, tf.Tensor) and value.dtype.is_floating):
             raise ValueError(
-                "Regression output value must be a float32 Tensor; "
-                "got {}".format(value)
+                f"Regression output value must be a float32 Tensor; got {value}"
             )
         self._value = value
 
@@ -391,9 +384,7 @@ class _SupervisedOutput(ExportOutput):
             op_name = key + self._SEPARATOR_CHAR + self.METRIC_UPDATE_SUFFIX
             if not isinstance(metric_val, tf.Tensor):
                 raise ValueError(
-                    "{} output value must be a Tensor; got {}.".format(
-                        key, metric_val
-                    )
+                    f"{key} output value must be a Tensor; got {metric_val}."
                 )
             if not (
                 tf.is_tensor(metric_op) or isinstance(metric_op, tf.Operation)

--- a/keras/saving/utils_v1/export_utils.py
+++ b/keras/saving/utils_v1/export_utils.py
@@ -104,7 +104,7 @@ def build_all_signature_defs(
     signature_def_map = {}
     excluded_signatures = {}
     for output_key, export_output in export_outputs.items():
-        signature_name = "{}".format(output_key or "None")
+        signature_name = f"{output_key or 'None'}"
         try:
             signature = export_output.as_signature_def(receiver_tensors)
             signature_def_map[signature_name] = signature
@@ -188,7 +188,7 @@ def _log_signature_report(signature_def_map, excluded_signatures):
             "be served via TensorFlow Serving APIs:"
         )
         for signature_name, message in excluded_signatures.items():
-            logging.info("'{}' : {}".format(signature_name, message))
+            logging.info(f"'{signature_name}' : {message}")
 
     if not signature_def_map:
         logging.warning("Export includes no signatures!")
@@ -273,7 +273,7 @@ def get_temp_export_dir(timestamped_export_dir):
         str_name = str(basename)
     temp_export_dir = tf.io.gfile.join(
         tf.compat.as_bytes(dirname),
-        tf.compat.as_bytes("temp-{}".format(str_name)),
+        tf.compat.as_bytes(f"temp-{str_name}"),
     )
     return temp_export_dir
 

--- a/keras/saving/utils_v1/mode_keys.py
+++ b/keras/saving/utils_v1/mode_keys.py
@@ -95,7 +95,7 @@ class ModeKeyMap(collections.abc.Mapping):
             return KerasModeKeys.TEST
         if is_predict(key):
             return KerasModeKeys.PREDICT
-        raise ValueError("Invalid mode key: {}.".format(key))
+        raise ValueError(f"Invalid mode key: {key}.")
 
     def __getitem__(self, key):
         return self._internal_dict[self._get_internal_key(key)]

--- a/keras/testing_infra/keras_doctest_lib_test.py
+++ b/keras/testing_infra/keras_doctest_lib_test.py
@@ -128,9 +128,7 @@ class KerasDoctestOutputCheckerTest(parameterized.TestCase):
                 )
             )
         except AssertionError as e:
-            msg = "\n\n  expected: {}\n  found:     {}".format(
-                text_with_wildcards, text
-            )
+            msg = f"\n\n  expected: {text_with_wildcards}\n  found:     {text}"
             e.args = (e.args[0] + msg,)
             raise e
 

--- a/keras/testing_infra/test_combinations.py
+++ b/keras/testing_infra/test_combinations.py
@@ -127,7 +127,7 @@ def run_with_all_saved_model_formats(test_or_class=None, exclude_formats=None):
         exclude_formats.append(["h5"])
     saved_model_formats = ["h5", "tf", "tf_no_traces"]
     params = [
-        ("_%s" % saved_format, saved_format)
+        (f"_{saved_format}", saved_format)
         for saved_format in saved_model_formats
         if saved_format not in tf.nest.flatten(exclude_formats)
     ]
@@ -147,7 +147,7 @@ def run_with_all_saved_model_formats(test_or_class=None, exclude_formats=None):
             elif saved_format == "tf_no_traces":
                 _test_tf_saved_model_format_no_traces(f, self, *args, **kwargs)
             else:
-                raise ValueError("Unknown model type: %s" % (saved_format,))
+                raise ValueError(f"Unknown model type: {saved_format}")
 
         return decorated
 
@@ -270,7 +270,7 @@ def run_with_all_model_types(test_or_class=None, exclude_models=None):
     """
     model_types = ["functional", "subclass", "sequential"]
     params = [
-        ("_%s" % model, model)
+        (f"_{model}", model)
         for model in model_types
         if model not in tf.nest.flatten(exclude_models)
     ]
@@ -290,7 +290,7 @@ def run_with_all_model_types(test_or_class=None, exclude_models=None):
             elif model_type == "sequential":
                 _test_sequential_model_type(f, self, *args, **kwargs)
             else:
-                raise ValueError("Unknown model type: %s" % (model_type,))
+                raise ValueError(f"Unknown model type: {model_type}")
 
         return decorated
 
@@ -317,7 +317,7 @@ def run_all_keras_modes(
     config=None,
     always_skip_v1=False,
     always_skip_eager=False,
-    **kwargs
+    **kwargs,
 ):
     """Execute the decorated test with all keras execution modes.
 
@@ -389,7 +389,7 @@ def run_all_keras_modes(
         a target dependency.
     """
     if kwargs:
-        raise ValueError("Unrecognized keyword args: {}".format(kwargs))
+        raise ValueError(f"Unrecognized keyword args: {kwargs}")
 
     params = [("_v2_function", "v2_function")]
     if not always_skip_eager:
@@ -413,7 +413,7 @@ def run_all_keras_modes(
             elif run_mode == "v2_function":
                 _v2_function_test(f, self, *args, **kwargs)
             else:
-                return ValueError("Unknown run mode %s" % run_mode)
+                return ValueError(f"Unknown run mode {run_mode}")
 
         return decorated
 

--- a/keras/testing_infra/test_utils.py
+++ b/keras/testing_infra/test_utils.py
@@ -553,7 +553,7 @@ def get_small_mlp(num_hidden, num_classes, input_dim):
         return get_small_sequential_mlp(num_hidden, num_classes, input_dim)
     if model_type == "functional":
         return get_small_functional_mlp(num_hidden, num_classes, input_dim)
-    raise ValueError("Unknown model type {}".format(model_type))
+    raise ValueError(f"Unknown model type {model_type}")
 
 
 class _SubclassModel(models.Model):
@@ -582,7 +582,7 @@ class _SubclassModel(models.Model):
             self._set_inputs(inputs)
 
     def _layer_name_for_i(self, i):
-        return "layer{}".format(i)
+        return f"layer{i}"
 
     def call(self, inputs, **kwargs):
         x = inputs
@@ -691,7 +691,7 @@ def get_model_from_layers(
             outputs = layer(outputs)
         return models.Model(inputs, outputs, name=name)
 
-    raise ValueError("Unknown model type {}".format(model_type))
+    raise ValueError(f"Unknown model type {model_type}")
 
 
 class Bias(layers.Layer):
@@ -902,7 +902,7 @@ def get_multi_io_model(
 
     if model_type == "sequential":
         raise ValueError(
-            "Cannot use `get_multi_io_model` to construct " "sequential models"
+            "Cannot use `get_multi_io_model` to construct sequential models"
         )
 
     if model_type == "functional":
@@ -927,7 +927,7 @@ def get_multi_io_model(
 
         return models.Model(inputs, outputs)
 
-    raise ValueError("Unknown model type {}".format(model_type))
+    raise ValueError(f"Unknown model type {model_type}")
 
 
 _V2_OPTIMIZER_MAP = {
@@ -1168,8 +1168,7 @@ def generate_combinations_with_testcase_name(**kwargs):
         )
         named_combinations.append(
             collections.OrderedDict(
-                list(combination.items())
-                + [("testcase_name", "_test{}".format(name))]
+                list(combination.items()) + [("testcase_name", f"_test{name}")]
             )
         )
 

--- a/keras/tests/integration_test.py
+++ b/keras/tests/integration_test.py
@@ -32,7 +32,7 @@ class KerasIntegrationTest(test_combinations.TestCase):
     def _save_and_reload_model(self, model):
         self.temp_dir = self.get_temp_dir()
         fpath = os.path.join(
-            self.temp_dir, "test_model_%s" % (random.randint(0, 1e7),)
+            self.temp_dir, f"test_model_{random.randint(0, 10000000.0)}"
         )
         if tf.executing_eagerly():
             save_format = "tf"

--- a/keras/tests/model_subclassing_test.py
+++ b/keras/tests/model_subclassing_test.py
@@ -58,7 +58,7 @@ class ModelSubclassingTest(test_combinations.TestCase):
         test_model(dummy_data)
         self.assertTrue(
             test_model.uses_custom_build,
-            "Model should use user " "defined build when called.",
+            "Model should use user defined build when called.",
         )
 
     def test_attribute_conflict_error(self):
@@ -119,7 +119,7 @@ class ModelSubclassingTest(test_combinations.TestCase):
         self.assertFalse(model.built, "Model should not have been built")
         self.assertFalse(
             model.weights,
-            ("Model should have no weights since it " "has not been built."),
+            "Model should have no weights since it has not been built.",
         )
         with self.assertRaisesRegex(
             ValueError, "input shape is not one of the valid types"
@@ -161,7 +161,7 @@ class ModelSubclassingTest(test_combinations.TestCase):
         self.assertFalse(model.built, "Model should not have been built")
         self.assertFalse(
             model.weights,
-            ("Model should have no weights since it " "has not been built."),
+            "Model should have no weights since it has not been built.",
         )
         with self.assertRaisesRegex(
             ValueError, "if your layers do not support float type inputs"
@@ -186,15 +186,12 @@ class ModelSubclassingTest(test_combinations.TestCase):
         self.assertFalse(model.built, "Model should not have been built")
         self.assertFalse(
             model.weights,
-            ("Model should have no weights since it " "has not been built."),
+            "Model should have no weights since it has not been built.",
         )
         model.build(batch_input_shape)
         self.assertTrue(
             model.weights,
-            (
-                "Model should have weights now that it "
-                "has been properly built."
-            ),
+            "Model should have weights now that it has been properly built.",
         )
         self.assertTrue(
             model.built, "Model should be built after calling `build`."
@@ -213,15 +210,12 @@ class ModelSubclassingTest(test_combinations.TestCase):
         self.assertFalse(model.built, "Model should not have been built")
         self.assertFalse(
             model.weights,
-            ("Model should have no weights since it " "has not been built."),
+            "Model should have no weights since it has not been built.",
         )
         model.build(input_shape=(batch_size, input_dim))
         self.assertTrue(
             model.weights,
-            (
-                "Model should have weights now that it "
-                "has been properly built."
-            ),
+            "Model should have weights now that it has been properly built.",
         )
         self.assertTrue(
             model.built, "Model should be built after calling `build`."
@@ -240,15 +234,12 @@ class ModelSubclassingTest(test_combinations.TestCase):
         self.assertFalse(model.built, "Model should not have been built")
         self.assertFalse(
             model.weights,
-            ("Model should have no weights since it " "has not been built."),
+            "Model should have no weights since it has not been built.",
         )
         model.build(input_shape=(batch_size, input_dim))
         self.assertTrue(
             model.weights,
-            (
-                "Model should have weights now that it "
-                "has been properly built."
-            ),
+            "Model should have weights now that it has been properly built.",
         )
         self.assertTrue(
             model.built, "Model should be built after calling `build`."
@@ -265,16 +256,13 @@ class ModelSubclassingTest(test_combinations.TestCase):
         self.assertFalse(model.built, "Model should not have been built")
         self.assertFalse(
             model.weights,
-            ("Model should have no weights since it " "has not been built."),
+            "Model should have no weights since it has not been built.",
         )
         batch_input_shape = (batch_size,) + input_shape
         model.build(input_shape=batch_input_shape)
         self.assertTrue(
             model.weights,
-            (
-                "Model should have weights now that it "
-                "has been properly built."
-            ),
+            "Model should have weights now that it has been properly built.",
         )
         self.assertTrue(
             model.built, "Model should be built after calling `build`."
@@ -292,15 +280,12 @@ class ModelSubclassingTest(test_combinations.TestCase):
         self.assertFalse(model.built, "Model should not have been built")
         self.assertFalse(
             model.weights,
-            ("Model should have no weights since it " "has not been built."),
+            "Model should have no weights since it has not been built.",
         )
         model.build(input_shape=tf.TensorShape((batch_size,) + input_shape))
         self.assertTrue(
             model.weights,
-            (
-                "Model should have weights now that it "
-                "has been properly built."
-            ),
+            "Model should have weights now that it has been properly built.",
         )
         self.assertTrue(
             model.built, "Model should be built after calling `build`."
@@ -318,15 +303,12 @@ class ModelSubclassingTest(test_combinations.TestCase):
         self.assertFalse(model.built, "Model should not have been built")
         self.assertFalse(
             model.weights,
-            ("Model should have no weights since it " "has not been built."),
+            "Model should have no weights since it has not been built.",
         )
         model.build(input_shape=tf.TensorShape((batch_size,) + input_shape))
         self.assertTrue(
             model.weights,
-            (
-                "Model should have weights now that it "
-                "has been properly built."
-            ),
+            "Model should have weights now that it has been properly built.",
         )
         self.assertTrue(
             model.built, "Model should be built after calling `build`."
@@ -355,16 +337,13 @@ class ModelSubclassingTest(test_combinations.TestCase):
         self.assertFalse(model.built, "Model should not have been built")
         self.assertFalse(
             model.weights,
-            ("Model should have no weights since it " "has not been built."),
+            "Model should have no weights since it has not been built.",
         )
         batch_input_shape = tf.TensorShape((batch_size, input_dim))
         model.build(input_shape=[batch_input_shape, batch_input_shape])
         self.assertTrue(
             model.weights,
-            (
-                "Model should have weights now that it "
-                "has been properly built."
-            ),
+            "Model should have weights now that it has been properly built.",
         )
         self.assertTrue(
             model.built, "Model should be built after calling `build`."
@@ -697,15 +676,12 @@ class CustomCallSignatureTests(tf.test.TestCase, parameterized.TestCase):
         self.assertFalse(model.built, "Model should not have been built")
         self.assertFalse(
             model.weights,
-            ("Model should have no weights since it " "has not been built."),
+            "Model should have no weights since it has not been built.",
         )
         model.build((None, input_dim))
         self.assertTrue(
             model.weights,
-            (
-                "Model should have weights now that it "
-                "has been properly built."
-            ),
+            "Model should have weights now that it has been properly built.",
         )
         self.assertTrue(
             model.built, "Model should be built after calling `build`."
@@ -718,15 +694,12 @@ class CustomCallSignatureTests(tf.test.TestCase, parameterized.TestCase):
         self.assertFalse(model.built, "Model should not have been built")
         self.assertFalse(
             model.weights,
-            ("Model should have no weights since it " "has not been built."),
+            "Model should have no weights since it has not been built.",
         )
         model.build((None, input_dim))
         self.assertTrue(
             model.weights,
-            (
-                "Model should have weights now that it "
-                "has been properly built."
-            ),
+            "Model should have weights now that it has been properly built.",
         )
         self.assertTrue(
             model.built, "Model should be built after calling `build`."
@@ -740,7 +713,7 @@ class CustomCallSignatureTests(tf.test.TestCase, parameterized.TestCase):
         self.assertFalse(model.built, "Model should not have been built")
         self.assertFalse(
             model.weights,
-            ("Model should have no weights since it " "has not been built."),
+            "Model should have no weights since it has not been built.",
         )
         with self.assertRaisesRegex(
             ValueError, "cannot build your model if it has positional"

--- a/keras/tools/pip_package/create_pip_helper.py
+++ b/keras/tools/pip_package/create_pip_helper.py
@@ -108,20 +108,15 @@ def verify_python_files_in_pip(pip_root, bazel_root):
             file_excluded = file_name.lstrip("./") in PIP_EXCLUDED_FILES
             if not path_exists and not file_excluded:
                 raise PipPackagingError(
-                    (
-                        "Pip package missing the file %s. If this is expected, "
-                        "add it to PIP_EXCLUDED_FILES in "
-                        "create_pip_helper.py. Otherwise, "
-                        "make sure it is a build dependency of the pip package"
-                    )
+                    "Pip package missing the file %s. If this is expected, "
+                    "add it to PIP_EXCLUDED_FILES in "
+                    "create_pip_helper.py. Otherwise, "
+                    "make sure it is a build dependency of the pip package"
                     % file_name
                 )
             if path_exists and file_excluded:
                 raise PipPackagingError(
-                    (
-                        "File in PIP_EXCLUDED_FILES included in pip. %s"
-                        % file_name
-                    )
+                    f"File in PIP_EXCLUDED_FILES included in pip. {file_name}"
                 )
 
 

--- a/keras/utils/audio_dataset.py
+++ b/keras/utils/audio_dataset.py
@@ -164,7 +164,7 @@ def audio_dataset_from_directory(
 
         if sampling_rate <= 0:
             raise ValueError(
-                f"`sampling_rate` should be higher than 0. "
+                "`sampling_rate` should be higher than 0. "
                 f"Received: sampling_rate={sampling_rate}"
             )
 
@@ -198,7 +198,7 @@ def audio_dataset_from_directory(
 
     if label_mode == "binary" and len(class_names) != 2:
         raise ValueError(
-            f'When passing `label_mode="binary"`, there must be exactly 2 '
+            'When passing `label_mode="binary"`, there must be exactly 2 '
             f"class_names. Received: class_names={class_names}"
         )
 

--- a/keras/utils/audio_dataset_test.py
+++ b/keras/utils/audio_dataset_test.py
@@ -59,7 +59,7 @@ class AudioDatasetFromDirectoryTest(test_combinations.TestCase):
         # Generate paths to class subdirectories
         paths = []
         for class_index in range(num_classes):
-            class_directory = "class_%s" % (class_index,)
+            class_directory = f"class_{class_index}"
             if nested_dirs:
                 class_paths = [
                     class_directory,
@@ -82,7 +82,7 @@ class AudioDatasetFromDirectoryTest(test_combinations.TestCase):
         ):
             path = paths[i % len(paths)]
             ext = "wav"
-            filename = os.path.join(path, "audio_%s.%s" % (i, ext))
+            filename = os.path.join(path, f"audio_{i}.{ext}")
             with open(os.path.join(temp_dir, filename), "wb") as f:
                 f.write(audio.numpy())
             i += 1
@@ -94,7 +94,7 @@ class AudioDatasetFromDirectoryTest(test_combinations.TestCase):
         # Save a few extra audio in the parent directory.
         directory = self._prepare_directory(count=7, num_classes=2)
         for i, audio in enumerate(self._get_audio_samples(3)):
-            filename = "audio_%s.wav" % (i,)
+            filename = f"audio_{i}.wav"
             with open(os.path.join(directory, filename), "wb") as f:
                 f.write(audio.numpy())
 

--- a/keras/utils/composite_tensor_support_test.py
+++ b/keras/utils/composite_tensor_support_test.py
@@ -52,7 +52,7 @@ class ToDense(Layer):
         elif isinstance(inputs, tf.Tensor):
             output = inputs
         else:
-            raise TypeError("Unexpected tensor type %s" % type(inputs).__name__)
+            raise TypeError(f"Unexpected tensor type {type(inputs).__name__}")
 
         # Return a float so that we can compile models with this as the final
         # layer.
@@ -97,7 +97,7 @@ class _SubclassModel(keras.Model):
             self._set_inputs(i_layer)
 
     def _layer_name_for_i(self, i):
-        return "layer{}".format(i)
+        return f"layer{i}"
 
     def call(self, inputs, **kwargs):
         x = inputs
@@ -143,7 +143,7 @@ def get_model_from_layers_with_input(
             outputs = layer(outputs)
         return keras.Model(inputs, outputs)
 
-    raise ValueError("Unknown model type {}".format(model_type))
+    raise ValueError(f"Unknown model type {model_type}")
 
 
 def get_test_mode_kwargs():
@@ -355,7 +355,7 @@ class SparseTensorInputTest(test_combinations.TestCase):
             optimizer="sgd",
             loss="mse",
             metrics=["accuracy"],
-            **get_test_mode_kwargs()
+            **get_test_mode_kwargs(),
         )
         kwargs = get_kwargs(use_dataset, action)
 
@@ -543,7 +543,7 @@ class RaggedTensorInputTest(test_combinations.TestCase, tf.test.TestCase):
             optimizer="sgd",
             loss="mse",
             metrics=["accuracy"],
-            **get_test_mode_kwargs()
+            **get_test_mode_kwargs(),
         )
 
         # Prepare the input data
@@ -599,7 +599,7 @@ class RaggedTensorInputValidationTest(
             optimizer="sgd",
             loss="mse",
             metrics=["accuracy"],
-            **get_test_mode_kwargs()
+            **get_test_mode_kwargs(),
         )
 
         for data_element in data:
@@ -638,7 +638,7 @@ class RaggedTensorInputValidationTest(
             optimizer="sgd",
             loss="mse",
             metrics=["accuracy"],
-            **get_test_mode_kwargs()
+            **get_test_mode_kwargs(),
         )
         kwargs = get_kwargs(use_dataset)
 

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -260,7 +260,7 @@ def get_file(
                 io_utils.print_msg(
                     "A local file was found, but it seems to be "
                     f"incomplete or outdated because the {hash_algorithm} "
-                    f"file hash does not match the original value of "
+                    "file hash does not match the original value of "
                     f"{file_hash} "
                     "so we will re-download the data."
                 )
@@ -309,9 +309,9 @@ def get_file(
         if os.path.exists(fpath) and file_hash is not None:
             if not validate_file(fpath, file_hash, algorithm=hash_algorithm):
                 raise ValueError(
-                    f"Incomplete or corrupted file detected. "
+                    "Incomplete or corrupted file detected. "
                     f"The {hash_algorithm} "
-                    f"file hash does not match the provided value "
+                    "file hash does not match the provided value "
                     f"of {file_hash}."
                 )
 
@@ -836,7 +836,7 @@ def init_pool_generator(gens, random_seed=None, id_queue=None):
 
     # name isn't used for anything, but setting a more descriptive name is
     # helpful when diagnosing orphaned processes.
-    worker_proc.name = "Keras_worker_{}".format(worker_proc.name)
+    worker_proc.name = f"Keras_worker_{worker_proc.name}"
 
     if random_seed is not None:
         np.random.seed(random_seed + worker_proc.ident)

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -180,8 +180,8 @@ def _get_data_iterator_from_dataset(dataset, dataset_type_spec):
                         f"lengths. Mismatch found at index {i}, "
                         f"Expected shape={expected_shape} "
                         f"Received shape={np.array(element).shape}."
-                        f"Please provide a list of NumPy arrays with "
-                        f"the same length."
+                        "Please provide a list of NumPy arrays with "
+                        "the same length."
                     )
         else:
             raise ValueError(
@@ -206,7 +206,7 @@ def _get_data_iterator_from_dataset(dataset, dataset_type_spec):
                         f"lengths. Mismatch found at index {i}, "
                         f"Expected shape={expected_shape} "
                         f"Received shape={np.array(element).shape}."
-                        f"Please provide a tuple of NumPy arrays with "
+                        "Please provide a tuple of NumPy arrays with "
                         "the same length."
                     )
         else:
@@ -358,7 +358,7 @@ def _rescale_dataset_split_sizes(left_size, right_size, total_length):
     # check right_size is a integer or float
     if right_size is not None and right_size_type not in [int, float]:
         raise TypeError(
-            f"Invalid `right_size` Type. "
+            "Invalid `right_size` Type. "
             "Expected: int or float or None,"
             f"Received: type(right_size)={right_size_type}."
         )

--- a/keras/utils/dataset_utils_test.py
+++ b/keras/utils/dataset_utils_test.py
@@ -61,14 +61,14 @@ class SplitDatasetTest(tf.test.TestCase):
     def test_dataset_with_invalid_shape(self):
         with self.assertRaisesRegex(
             ValueError,
-            "Received a list of NumPy arrays " "with different lengths",
+            "Received a list of NumPy arrays with different lengths",
         ):
             dataset = [np.ones(shape=(200, 32)), np.zeros(shape=(100, 32))]
             dataset_utils.split_dataset(dataset, left_size=4)
 
         with self.assertRaisesRegex(
             ValueError,
-            "Received a tuple of NumPy arrays " "with different lengths",
+            "Received a tuple of NumPy arrays with different lengths",
         ):
             dataset = (np.ones(shape=(200, 32)), np.zeros(shape=(201, 32)))
             dataset_utils.split_dataset(dataset, left_size=4)

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -784,7 +784,7 @@ def deserialize_keras_object(
         return identifier
     else:
         raise ValueError(
-            f"Could not interpret serialized "
+            "Could not interpret serialized "
             f"{printable_module_name}: {identifier}"
         )
 
@@ -975,7 +975,7 @@ class Progbar:
 
         message = ""
         now = time.time()
-        info = " - %.0fs" % (now - self._start)
+        info = f" - {now - self._start:.0f}s"
         if current == self.target:
             self._time_at_epoch_end = now
         if self.verbose == 1:
@@ -1025,20 +1025,20 @@ class Progbar:
                 else:
                     eta_format = "%ds" % eta
 
-                info = " - ETA: %s" % eta_format
+                info = f" - ETA: {eta_format}"
 
             for k in self._values_order:
-                info += " - %s:" % k
+                info += f" - {k}:"
                 if isinstance(self._values[k], list):
                     avg = np.mean(
                         self._values[k][0] / max(1, self._values[k][1])
                     )
                     if abs(avg) > 1e-3:
-                        info += " %.4f" % avg
+                        info += f" {avg:.4f}"
                     else:
-                        info += " %.4e" % avg
+                        info += f" {avg:.4e}"
                 else:
-                    info += " %s" % self._values[k]
+                    info += f" {self._values[k]}"
 
             self._total_width += len(info)
             if prev_total_width > self._total_width:
@@ -1057,14 +1057,14 @@ class Progbar:
                 count = ("%" + str(numdigits) + "d/%d") % (current, self.target)
                 info = count + info
                 for k in self._values_order:
-                    info += " - %s:" % k
+                    info += f" - {k}:"
                     avg = np.mean(
                         self._values[k][0] / max(1, self._values[k][1])
                     )
                     if avg > 1e-3:
-                        info += " %.4f" % avg
+                        info += f" {avg:.4f}"
                     else:
-                        info += " %.4e" % avg
+                        info += f" {avg:.4e}"
                 if self._time_at_epoch_end:
                     time_per_epoch = (
                         self._time_at_epoch_end - self._time_at_epoch_start
@@ -1099,11 +1099,11 @@ class Progbar:
         """
         formatted = ""
         if time_per_unit >= 1 or time_per_unit == 0:
-            formatted += " %.0fs/%s" % (time_per_unit, unit_name)
+            formatted += f" {time_per_unit:.0f}s/{unit_name}"
         elif time_per_unit >= 1e-3:
-            formatted += " %.0fms/%s" % (time_per_unit * 1e3, unit_name)
+            formatted += f" {time_per_unit * 1000.0:.0f}ms/{unit_name}"
         else:
-            formatted += " %.0fus/%s" % (time_per_unit * 1e6, unit_name)
+            formatted += f" {time_per_unit * 1000000.0:.0f}us/{unit_name}"
         return formatted
 
     def _estimate_step_duration(self, current, now):

--- a/keras/utils/generic_utils_test.py
+++ b/keras/utils/generic_utils_test.py
@@ -206,7 +206,7 @@ class SerializeKerasObjectTest(tf.test.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "Cannot register a class that does " "not have a get_config.*",
+            "Cannot register a class that does not have a get_config.*",
         ):
 
             @keras.utils.generic_utils.register_keras_serializable(

--- a/keras/utils/image_dataset.py
+++ b/keras/utils/image_dataset.py
@@ -216,7 +216,7 @@ def image_dataset_from_directory(
 
     if label_mode == "binary" and len(class_names) != 2:
         raise ValueError(
-            f'When passing `label_mode="binary"`, there must be exactly 2 '
+            'When passing `label_mode="binary"`, there must be exactly 2 '
             f"class_names. Received: class_names={class_names}"
         )
 

--- a/keras/utils/image_dataset_test.py
+++ b/keras/utils/image_dataset_test.py
@@ -65,7 +65,7 @@ class ImageDatasetFromDirectoryTest(test_combinations.TestCase):
         # Generate paths to class subdirectories
         paths = []
         for class_index in range(num_classes):
-            class_directory = "class_%s" % (class_index,)
+            class_directory = f"class_{class_index}"
             if nested_dirs:
                 class_paths = [
                     class_directory,
@@ -89,7 +89,7 @@ class ImageDatasetFromDirectoryTest(test_combinations.TestCase):
                 ext = "jpg"
             else:
                 ext = "png"
-            filename = os.path.join(path, "image_%s.%s" % (i, ext))
+            filename = os.path.join(path, f"image_{i}.{ext}")
             img.save(os.path.join(temp_dir, filename))
             i += 1
         return temp_dir
@@ -103,7 +103,7 @@ class ImageDatasetFromDirectoryTest(test_combinations.TestCase):
         # Save a few extra images in the parent directory.
         directory = self._prepare_directory(count=7, num_classes=2)
         for i, img in enumerate(self._get_images(3)):
-            filename = "image_%s.jpg" % (i,)
+            filename = f"image_{i}.jpg"
             img.save(os.path.join(directory, filename))
 
         dataset = image_dataset.image_dataset_from_directory(
@@ -417,7 +417,7 @@ class ImageDatasetFromDirectoryTest(test_combinations.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            '`subset` must be either "training", ' '"validation" or "both"',
+            '`subset` must be either "training", "validation" or "both"',
         ):
             _ = image_dataset.image_dataset_from_directory(
                 directory, validation_split=0.2, subset="other"

--- a/keras/utils/image_utils.py
+++ b/keras/utils/image_utils.py
@@ -131,7 +131,7 @@ def smart_resize(x, size, interpolation="bilinear"):
     """
     if len(size) != 2:
         raise ValueError(
-            "Expected `size` to be a tuple of 2 integers, " f"but got: {size}."
+            f"Expected `size` to be a tuple of 2 integers, but got: {size}."
         )
     img = tf.convert_to_tensor(x)
     if img.shape.rank is not None:
@@ -355,7 +355,7 @@ def save_img(path, x, data_format=None, file_format=None, scale=True, **kwargs):
     img = array_to_img(x, data_format=data_format, scale=scale)
     if img.mode == "RGBA" and (file_format == "jpg" or file_format == "jpeg"):
         warnings.warn(
-            "The JPG format does not support " "RGBA images, converting to RGB."
+            "The JPG format does not support RGBA images, converting to RGB."
         )
         img = img.convert("RGB")
     img.save(path, format=file_format, **kwargs)
@@ -407,12 +407,12 @@ def load_img(
     """
     if grayscale:
         warnings.warn(
-            "grayscale is deprecated. Please use " 'color_mode = "grayscale"'
+            'grayscale is deprecated. Please use color_mode = "grayscale"'
         )
         color_mode = "grayscale"
     if pil_image is None:
         raise ImportError(
-            "Could not import PIL.Image. " "The use of `load_img` requires PIL."
+            "Could not import PIL.Image. The use of `load_img` requires PIL."
         )
     if isinstance(path, io.BytesIO):
         img = pil_image.open(path)
@@ -423,8 +423,7 @@ def load_img(
             img = pil_image.open(io.BytesIO(f.read()))
     else:
         raise TypeError(
-            "path should be path-like or io.BytesIO"
-            ", not {}".format(type(path))
+            f"path should be path-like or io.BytesIO, not {type(path)}"
         )
 
     if color_mode == "grayscale":

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -113,13 +113,13 @@ def ask_to_proceed_with_overwrite(filepath):
         True if we can proceed with overwrite, False otherwise.
     """
     overwrite = (
-        input("[WARNING] %s already exists - overwrite? " "[y/n]" % (filepath))
+        input(f"[WARNING] {filepath} already exists - overwrite? [y/n]")
         .strip()
         .lower()
     )
     while overwrite not in ("y", "n"):
         overwrite = (
-            input('Enter "y" (overwrite) or "n" ' "(cancel).").strip().lower()
+            input('Enter "y" (overwrite) or "n" (cancel).').strip().lower()
         )
     if overwrite == "n":
         return False

--- a/keras/utils/kernelized_utils.py
+++ b/keras/utils/kernelized_utils.py
@@ -22,8 +22,7 @@ def _to_matrix(u):
     u_rank = len(u.shape)
     if u_rank not in [1, 2]:
         raise ValueError(
-            "The input tensor should have rank 1 or 2. "
-            f"Received rank: {u_rank}"
+            f"The input tensor should have rank 1 or 2. Received rank: {u_rank}"
         )
     if u_rank == 1:
         return tf.expand_dims(u, 0)

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -86,9 +86,7 @@ def validate_string_arg(
     else:
         allowed_args = "`None`, " if allow_none else ""
         allowed_args += "a `Callable`, " if allow_callables else ""
-        allowed_args += "or one of the following values: %s" % (
-            allowable_strings,
-        )
+        allowed_args += f"or one of the following values: {allowable_strings}"
         if allow_callables:
             callable_note = (
                 f"If restoring a model and `{arg_name}` is a custom callable, "
@@ -317,7 +315,7 @@ def print_summary(
             line += "|" * nested_level
             print_fn(line)
 
-    print_fn('Model: "{}"'.format(model.name))
+    print_fn(f'Model: "{model.name}"')
     print_fn("_" * line_length)
     print_row(to_display, positions)
     print_fn("=" * line_length)
@@ -377,9 +375,7 @@ def print_summary(
                 _,
             ) in node.iterate_inbound():
                 connections.append(
-                    "{}[{}][{}]".format(
-                        inbound_layer.name, node_index, tensor_index
-                    )
+                    f"{inbound_layer.name}[{node_index}][{tensor_index}]"
                 )
 
         name = layer.name
@@ -440,9 +436,9 @@ def print_summary(
 
     non_trainable_count = count_params(model.non_trainable_weights)
 
-    print_fn("Total params: {:,}".format(trainable_count + non_trainable_count))
-    print_fn("Trainable params: {:,}".format(trainable_count))
-    print_fn("Non-trainable params: {:,}".format(non_trainable_count))
+    print_fn(f"Total params: {trainable_count + non_trainable_count:,}")
+    print_fn(f"Trainable params: {trainable_count:,}")
+    print_fn(f"Non-trainable params: {non_trainable_count:,}")
     print_fn("_" * line_length)
 
 

--- a/keras/utils/metrics_utils.py
+++ b/keras/utils/metrics_utils.py
@@ -213,7 +213,7 @@ def assert_thresholds_range(thresholds):
         ]
         if invalid_thresholds:
             raise ValueError(
-                f"Threshold values must be in [0, 1]. "
+                "Threshold values must be in [0, 1]. "
                 f"Received: {invalid_thresholds}"
             )
 

--- a/keras/utils/object_identity.py
+++ b/keras/utils/object_identity.py
@@ -40,7 +40,7 @@ class _ObjectIdentityWrapper:
         if not isinstance(other, _ObjectIdentityWrapper):
             raise TypeError(
                 "Cannot compare wrapped object with unwrapped object. "
-                f"Expect the object to be `_ObjectIdentityWrapper`. "
+                "Expect the object to be `_ObjectIdentityWrapper`. "
                 f"Got: {other}"
             )
 
@@ -68,7 +68,7 @@ class _ObjectIdentityWrapper:
         return id(self._wrapped)
 
     def __repr__(self):
-        return "<{} wrapping {!r}>".format(type(self).__name__, self._wrapped)
+        return f"<{type(self).__name__} wrapping {self._wrapped!r}>"
 
 
 class _WeakObjectIdentityWrapper(_ObjectIdentityWrapper):
@@ -152,7 +152,7 @@ class ObjectIdentityDictionary(collections.abc.MutableMapping):
             yield key.unwrapped
 
     def __repr__(self):
-        return "ObjectIdentityDictionary(%s)" % repr(self._storage)
+        return f"ObjectIdentityDictionary({repr(self._storage)})"
 
 
 class ObjectIdentityWeakKeyDictionary(ObjectIdentityDictionary):

--- a/keras/utils/text_dataset.py
+++ b/keras/utils/text_dataset.py
@@ -167,7 +167,7 @@ def text_dataset_from_directory(
 
     if label_mode == "binary" and len(class_names) != 2:
         raise ValueError(
-            f'When passing `label_mode="binary"`, there must be exactly 2 '
+            'When passing `label_mode="binary"`, there must be exactly 2 '
             f"class_names. Received: class_names={class_names}"
         )
 
@@ -187,12 +187,12 @@ def text_dataset_from_directory(
         if not file_paths_train:
             raise ValueError(
                 f"No training text files found in directory {directory}. "
-                f"Allowed format: .txt"
+                "Allowed format: .txt"
             )
         if not file_paths_val:
             raise ValueError(
                 f"No validation text files found in directory {directory}. "
-                f"Allowed format: .txt"
+                "Allowed format: .txt"
             )
         train_dataset = paths_and_labels_to_dataset(
             file_paths=file_paths_train,
@@ -235,7 +235,7 @@ def text_dataset_from_directory(
         if not file_paths:
             raise ValueError(
                 f"No text files found in directory {directory}. "
-                f"Allowed format: .txt"
+                "Allowed format: .txt"
             )
         dataset = paths_and_labels_to_dataset(
             file_paths=file_paths,

--- a/keras/utils/text_dataset_test.py
+++ b/keras/utils/text_dataset_test.py
@@ -41,7 +41,7 @@ class TextDatasetFromDirectoryTest(test_combinations.TestCase):
         # Generate paths to class subdirectories
         paths = []
         for class_index in range(num_classes):
-            class_directory = "class_%s" % (class_index,)
+            class_directory = f"class_{class_index}"
             if nested_dirs:
                 class_paths = [
                     class_directory,
@@ -59,7 +59,7 @@ class TextDatasetFromDirectoryTest(test_combinations.TestCase):
 
         for i in range(count):
             path = paths[i % len(paths)]
-            filename = os.path.join(path, "text_%s.txt" % (i,))
+            filename = os.path.join(path, f"text_{i}.txt")
             f = open(os.path.join(temp_dir, filename), "w")
             text = "".join(
                 [random.choice(string.printable) for _ in range(length)]
@@ -73,7 +73,7 @@ class TextDatasetFromDirectoryTest(test_combinations.TestCase):
         # subdirs. Save a few extra files in the parent directory.
         directory = self._prepare_directory(count=7, num_classes=2)
         for i in range(3):
-            filename = "text_%s.txt" % (i,)
+            filename = f"text_{i}.txt"
             f = open(os.path.join(directory, filename), "w")
             text = "".join([random.choice(string.printable) for _ in range(20)])
             f.write(text)
@@ -292,7 +292,7 @@ class TextDatasetFromDirectoryTest(test_combinations.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            '`subset` must be either "training", ' '"validation" or "both"',
+            '`subset` must be either "training", "validation" or "both"',
         ):
             _ = text_dataset.text_dataset_from_directory(
                 directory, validation_split=0.2, subset="other"

--- a/keras/utils/tf_utils.py
+++ b/keras/utils/tf_utils.py
@@ -116,7 +116,7 @@ def get_reachable_from_inputs(inputs, targets=None):
             outputs = x.consumers()
         else:
             raise TypeError(
-                f"Expected tf.Operation, tf.Variable, or tf.Tensor. "
+                "Expected tf.Operation, tf.Variable, or tf.Tensor. "
                 f"Received: {x}"
             )
 

--- a/keras/utils/timeseries_dataset.py
+++ b/keras/utils/timeseries_dataset.py
@@ -150,25 +150,25 @@ def timeseries_dataset_from_array(
     if start_index:
         if start_index < 0:
             raise ValueError(
-                f"`start_index` must be 0 or greater. Received: "
+                "`start_index` must be 0 or greater. Received: "
                 f"start_index={start_index}"
             )
         if start_index >= len(data):
             raise ValueError(
-                f"`start_index` must be lower than the length of the "
+                "`start_index` must be lower than the length of the "
                 f"data. Received: start_index={start_index}, for data "
                 f"of length {len(data)}"
             )
     if end_index:
         if start_index and end_index <= start_index:
             raise ValueError(
-                f"`end_index` must be higher than `start_index`. "
+                "`end_index` must be higher than `start_index`. "
                 f"Received: start_index={start_index}, and "
                 f"end_index={end_index} "
             )
         if end_index >= len(data):
             raise ValueError(
-                f"`end_index` must be lower than the length of the "
+                "`end_index` must be lower than the length of the "
                 f"data. Received: end_index={end_index}, for data of "
                 f"length {len(data)}"
             )
@@ -181,23 +181,23 @@ def timeseries_dataset_from_array(
     # Validate strides
     if sampling_rate <= 0:
         raise ValueError(
-            f"`sampling_rate` must be higher than 0. Received: "
+            "`sampling_rate` must be higher than 0. Received: "
             f"sampling_rate={sampling_rate}"
         )
     if sampling_rate >= len(data):
         raise ValueError(
-            f"`sampling_rate` must be lower than the length of the "
+            "`sampling_rate` must be lower than the length of the "
             f"data. Received: sampling_rate={sampling_rate}, for data "
             f"of length {len(data)}"
         )
     if sequence_stride <= 0:
         raise ValueError(
-            f"`sequence_stride` must be higher than 0. Received: "
+            "`sequence_stride` must be higher than 0. Received: "
             f"sequence_stride={sequence_stride}"
         )
     if sequence_stride >= len(data):
         raise ValueError(
-            f"`sequence_stride` must be lower than the length of the "
+            "`sequence_stride` must be lower than the length of the "
             f"data. Received: sequence_stride={sequence_stride}, for "
             f"data of length {len(data)}"
         )

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -216,9 +216,9 @@ def model_to_dot(
                 sub_w_last_node[layer.layer.name] = sub_w_nodes[-1]
                 dot.add_subgraph(submodel_wrapper)
             else:
-                layer_name = "{}({})".format(layer_name, layer.layer.name)
+                layer_name = f"{layer_name}({layer.layer.name})"
                 child_class_name = layer.layer.__class__.__name__
-                class_name = "{}({})".format(class_name, child_class_name)
+                class_name = f"{class_name}({child_class_name})"
 
         if expand_nested and isinstance(layer, functional.Functional):
             submodel_not_wrapper = model_to_dot(
@@ -255,7 +255,7 @@ def model_to_dot(
 
         # Rebuild the label as a table including the layer's name.
         if show_layer_names:
-            label = "%s|%s" % (layer_name, label)
+            label = f"{layer_name}|{label}"
 
         # Rebuild the label as a table including the layer's dtype.
         if show_dtype:
@@ -266,7 +266,7 @@ def model_to_dot(
                 else:
                     return str(dtype)
 
-            label = "%s|%s" % (label, format_dtype(layer.dtype))
+            label = f"{label}|{format_dtype(layer.dtype)}"
 
         # Rebuild the label as a table including input/output shapes.
         if show_shapes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ numpy ~= 1.21.4  # Sync with the numpy version used in TF
 black==22.3.0
 isort==5.10.1
 flake8==4.0.1
+flynt==0.76

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ numpy ~= 1.21.4  # Sync with the numpy version used in TF
 black==22.3.0
 isort==5.10.1
 flake8==4.0.1
-flynt==0.76

--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 isort --sl keras
-flynt --line-length 80 keras
 black --line-length 80 keras
 flake8 keras

--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 isort --sl keras
+flynt --line-length 80 keras
 black --line-length 80 keras
 flake8 keras

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -6,13 +6,6 @@ then
   exit 1
 fi
 echo "no issues with isort"
-flynt --line-length 80 --fail-on-change keras
-if ! [ $? -eq 0 ]
-then
-  echo "Please fix the f-string formatting."
-  exit 1
-fi
-echo "no issues with flynt"
 flake8 keras
 if ! [ $? -eq 0 ]
 then

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -6,6 +6,13 @@ then
   exit 1
 fi
 echo "no issues with isort"
+flynt --line-length 80 --fail-on-change keras
+if ! [ $? -eq 0 ]
+then
+  echo "Please fix the f-string formatting."
+  exit 1
+fi
+echo "no issues with flynt"
 flake8 keras
 if ! [ $? -eq 0 ]
 then


### PR DESCRIPTION
Hi,

In order to standardize the f-string usage of the whole codebase I have added [flynt](https://github.com/ikamensh/flynt) to the `format` and `lint` scripts. This avoids multiple ["f-string"](https://github.com/keras-team/keras/pulls?page=1&q=f-string) one line pull requests and makes it go into the github check process to avoid introduction of old style string formatting once merged.

The reformatting was all made by flynt. I am not using flynt's `--aggressive` to avoid _"conversions with potentially changed behavior"_.