### PR TITLE
Respecting KERAS_HOME for get_file()

### DIFF
--- a/keras/api/api_init_files.bzl
+++ b/keras/api/api_init_files.bzl
@@ -9,6 +9,7 @@ KERAS_API_INIT_FILES = [
     "keras/__internal__/layers/__init__.py",
     "keras/__internal__/losses/__init__.py",
     "keras/__internal__/models/__init__.py",
+    "keras/__internal__/optimizers/__init__.py",
     "keras/__internal__/utils/__init__.py",
     "keras/activations/__init__.py",
     "keras/applications/__init__.py",

--- a/keras/api/create_python_api_wrapper.py
+++ b/keras/api/create_python_api_wrapper.py
@@ -26,9 +26,7 @@ from __future__ import print_function
 import keras  # noqa: F401
 
 # isort: off
-from tensorflow.python.tools.api.generator import (
-    create_python_api,
-)
+from tensorflow.python.tools.api.generator import create_python_api
 
 if __name__ == "__main__":
     create_python_api.main()

--- a/keras/api/golden/v2/tensorflow.keras.__internal__.optimizers.pbtxt
+++ b/keras/api/golden/v2/tensorflow.keras.__internal__.optimizers.pbtxt
@@ -1,0 +1,7 @@
+path: "tensorflow.keras.__internal__.optimizers"
+tf_module {
+  member_method {
+    name: "convert_to_legacy_optimizer"
+    argspec: "args=[\'optimizer\'], varargs=None, keywords=None, defaults=None"
+  }
+}

--- a/keras/api/golden/v2/tensorflow.keras.__internal__.pbtxt
+++ b/keras/api/golden/v2/tensorflow.keras.__internal__.pbtxt
@@ -17,6 +17,10 @@ tf_module {
     mtype: "<type \'module\'>"
   }
   member {
+    name: "optimizers"
+    mtype: "<type \'module\'>"
+  }
+  member {
     name: "utils"
     mtype: "<type \'module\'>"
   }

--- a/keras/api/tests/api_compatibility_test.py
+++ b/keras/api/tests/api_compatibility_test.py
@@ -41,9 +41,7 @@ from google.protobuf import text_format
 from tensorflow.python.lib.io import file_io
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.tools.api.lib import api_objects_pb2
-from tensorflow.tools.api.lib import (
-    python_object_to_proto_visitor,
-)
+from tensorflow.tools.api.lib import python_object_to_proto_visitor
 from tensorflow.tools.common import public_api
 from tensorflow.tools.common import traverse
 

--- a/keras/applications/efficientnet_v2.py
+++ b/keras/applications/efficientnet_v2.py
@@ -660,9 +660,7 @@ def MBConvBlock(
                 name=name + "expand_conv",
             )(inputs)
             x = layers.BatchNormalization(
-                axis=bn_axis,
-                momentum=bn_momentum,
-                name=name + "expand_bn",
+                axis=bn_axis, momentum=bn_momentum, name=name + "expand_bn",
             )(x)
             x = layers.Activation(activation, name=name + "expand_activation")(
                 x
@@ -965,7 +963,7 @@ def EfficientNetV2(
             x = layers.Rescaling(scale=1.0 / 255)(x)
             x = layers.Normalization(
                 mean=[0.485, 0.456, 0.406],
-                variance=[0.229**2, 0.224**2, 0.225**2],
+                variance=[0.229 ** 2, 0.224 ** 2, 0.225 ** 2],
                 axis=bn_axis,
             )(x)
         else:
@@ -988,9 +986,7 @@ def EfficientNetV2(
         name="stem_conv",
     )(x)
     x = layers.BatchNormalization(
-        axis=bn_axis,
-        momentum=bn_momentum,
-        name="stem_bn",
+        axis=bn_axis, momentum=bn_momentum, name="stem_bn",
     )(x)
     x = layers.Activation(activation, name="stem_activation")(x)
 
@@ -1055,9 +1051,7 @@ def EfficientNetV2(
         name="top_conv",
     )(x)
     x = layers.BatchNormalization(
-        axis=bn_axis,
-        momentum=bn_momentum,
-        name="top_bn",
+        axis=bn_axis, momentum=bn_momentum, name="top_bn",
     )(x)
     x = layers.Activation(activation=activation, name="top_activation")(x)
 

--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -216,7 +216,7 @@ def NASNet(
         else:
             img_input = input_tensor
 
-    if penultimate_filters % (24 * (filter_multiplier**2)) != 0:
+    if penultimate_filters % (24 * (filter_multiplier ** 2)) != 0:
         raise ValueError(
             "For NASNet-A models, the `penultimate_filters` must be a multiple "
             "of 24 * (`filter_multiplier` ** 2). Current value: %d"
@@ -242,7 +242,7 @@ def NASNet(
 
     p = None
     x, p = _reduction_a_cell(
-        x, p, filters // (filter_multiplier**2), block_id="stem_1"
+        x, p, filters // (filter_multiplier ** 2), block_id="stem_1"
     )
     x, p = _reduction_a_cell(
         x, p, filters // filter_multiplier, block_id="stem_2"
@@ -268,7 +268,7 @@ def NASNet(
     x, p0 = _reduction_a_cell(
         x,
         p,
-        filters * filter_multiplier**2,
+        filters * filter_multiplier ** 2,
         block_id="reduce_%d" % (2 * num_blocks),
     )
 
@@ -278,7 +278,7 @@ def NASNet(
         x, p = _normal_a_cell(
             x,
             p,
-            filters * filter_multiplier**2,
+            filters * filter_multiplier ** 2,
             block_id="%d" % (2 * num_blocks + i + 1),
         )
 

--- a/keras/applications/resnet_rs.py
+++ b/keras/applications/resnet_rs.py
@@ -652,7 +652,7 @@ def ResNetRS(
         if num_channels == 3:
             x = layers.Normalization(
                 mean=[0.485, 0.456, 0.406],
-                variance=[0.229**2, 0.224**2, 0.225**2],
+                variance=[0.229 ** 2, 0.224 ** 2, 0.225 ** 2],
                 axis=bn_axis,
             )(x)
 

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -1447,9 +1447,7 @@ def placeholder(
         # Add keras_history connectivity information to the placeholder
         # when the placeholder is built in a top-level eager context
         # (intended to be used with keras.backend.function)
-        from keras.engine import (
-            input_layer,
-        )
+        from keras.engine import input_layer
 
         x = input_layer.Input(tensor=x)
         x._is_backend_placeholder = True
@@ -4969,11 +4967,8 @@ def rnn(
 
         # We only specify the 'maximum_iterations' when building for XLA since
         # that causes slowdowns on GPU in TF.
-        if (
-            not tf.executing_eagerly()
-            and control_flow_util.GraphOrParentsInXlaContext(
-                tf.compat.v1.get_default_graph()
-            )
+        if not tf.executing_eagerly() and control_flow_util.GraphOrParentsInXlaContext(
+            tf.compat.v1.get_default_graph()
         ):
             if input_length is None:
                 max_iterations = time_steps_t
@@ -5263,9 +5258,7 @@ def in_train_phase(x, alt, training=None):
         Either `x` or `alt` based on the `training` flag.
         the `training` flag defaults to `K.learning_phase()`.
     """
-    from keras.engine import (
-        base_layer_utils,
-    )
+    from keras.engine import base_layer_utils
 
     if training is None:
         training = base_layer_utils.call_context().training
@@ -5731,18 +5724,14 @@ def binary_focal_crossentropy(
       A tensor.
     """
     sigmoidal = tf.__internal__.smart_cond.smart_cond(
-        from_logits,
-        lambda: sigmoid(output),
-        lambda: output,
+        from_logits, lambda: sigmoid(output), lambda: output,
     )
     p_t = target * sigmoidal + (1 - target) * (1 - sigmoidal)
     # Calculate focal factor
     focal_factor = tf.pow(1.0 - p_t, gamma)
     # Binary crossentropy
     bce = binary_crossentropy(
-        target=target,
-        output=output,
-        from_logits=from_logits,
+        target=target, output=output, from_logits=from_logits,
     )
     focal_bce = focal_factor * bce
 

--- a/keras/backend_test.py
+++ b/keras/backend_test.py
@@ -35,9 +35,7 @@ from keras.utils import tf_utils
 # isort: off
 from tensorflow.python.eager import context
 from tensorflow.python.eager.context import get_config
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 def compare_single_input_op_to_numpy(
@@ -1498,10 +1496,10 @@ class BackendNNOpsTest(tf.test.TestCase, parameterized.TestCase):
                 assert len(states) == 2
                 prev_output = states[0]
                 output = backend.dot(x, w_i) + backend.dot(prev_output, w_o)
-                return output, [
+                return (
                     output,
-                    backend.concatenate([output, output], axis=-1),
-                ]
+                    [output, backend.concatenate([output, output], axis=-1),],
+                )
 
             return step_function
 
@@ -1806,16 +1804,10 @@ class BackendNNOpsTest(tf.test.TestCase, parameterized.TestCase):
         )
         self.assertEqual(normed.shape.as_list(), [10, 3, 10, 10])
         self.assertEqual(
-            mean.shape.as_list(),
-            [
-                3,
-            ],
+            mean.shape.as_list(), [3,],
         )
         self.assertEqual(
-            var.shape.as_list(),
-            [
-                3,
-            ],
+            var.shape.as_list(), [3,],
         )
 
         # case: gamma=None
@@ -1825,16 +1817,10 @@ class BackendNNOpsTest(tf.test.TestCase, parameterized.TestCase):
         )
         self.assertEqual(normed.shape.as_list(), [10, 3, 10, 10])
         self.assertEqual(
-            mean.shape.as_list(),
-            [
-                3,
-            ],
+            mean.shape.as_list(), [3,],
         )
         self.assertEqual(
-            var.shape.as_list(),
-            [
-                3,
-            ],
+            var.shape.as_list(), [3,],
         )
 
         # case: beta=None
@@ -1844,16 +1830,10 @@ class BackendNNOpsTest(tf.test.TestCase, parameterized.TestCase):
         )
         self.assertEqual(normed.shape.as_list(), [10, 3, 10, 10])
         self.assertEqual(
-            mean.shape.as_list(),
-            [
-                3,
-            ],
+            mean.shape.as_list(), [3,],
         )
         self.assertEqual(
-            var.shape.as_list(),
-            [
-                3,
-            ],
+            var.shape.as_list(), [3,],
         )
 
     def test_dropout(self):
@@ -2228,10 +2208,7 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
         logits = backend.constant([[8.0, 1.0, 1.0]])
         result = self.evaluate(
             backend.binary_focal_crossentropy(
-                target=t,
-                output=logits,
-                gamma=2.0,
-                from_logits=True,
+                target=t, output=logits, gamma=2.0, from_logits=True,
             )
         )
         self.assertArrayNear(result[0], [7.995, 0.022, 0.701], 1e-3)
@@ -2246,11 +2223,7 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
         p = tf.identity(tf.identity(p))
         gamma = 0
         focal_result = self.evaluate(
-            backend.binary_focal_crossentropy(
-                target=t,
-                output=p,
-                gamma=gamma,
-            )
+            backend.binary_focal_crossentropy(target=t, output=p, gamma=gamma,)
         )
         non_focal_result = self.evaluate(backend.binary_crossentropy(t, p))
         self.assertArrayNear(focal_result[0], non_focal_result[0], 1e-3)
@@ -2265,9 +2238,7 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
         p = tf.identity(tf.identity(p))
         result = self.evaluate(
             backend.binary_focal_crossentropy(
-                target=t,
-                output=p,
-                apply_class_balancing=True,
+                target=t, output=p, apply_class_balancing=True,
             )
         )
         self.assertArrayNear(result[0], [5.996, 0.006, 0.526], 1e-3)
@@ -2669,12 +2640,12 @@ class FunctionTest(tf.test.TestCase):
 
         x_ph = backend.placeholder(ndim=2)
         v = backend.variable(np.ones((4, 2)))
-        output = x_ph**2 + v
+        output = x_ph ** 2 + v
         new_v = v + x_ph
         f = backend.function(x_ph, output, updates=[(v, new_v)])
         input_val = np.random.random((4, 2))
         result = f(input_val)
-        self.assertAllClose(result, input_val**2 + 1)
+        self.assertAllClose(result, input_val ** 2 + 1)
         self.assertAllClose(backend.get_value(v), np.ones((4, 2)) + input_val)
 
 

--- a/keras/benchmarks/benchmark_util.py
+++ b/keras/benchmarks/benchmark_util.py
@@ -175,9 +175,7 @@ def measure_performance(
 
             t1 = timer()
             model.compile(
-                optimizer=optimizer,
-                loss=loss,
-                metrics=metrics,
+                optimizer=optimizer, loss=loss, metrics=metrics,
             )
             compile_time = timer() - t1
         # Run one warm up epoch.

--- a/keras/benchmarks/keras_examples_benchmarks/mnist_conv_custom_training_benchmark_test.py
+++ b/keras/benchmarks/keras_examples_benchmarks/mnist_conv_custom_training_benchmark_test.py
@@ -120,13 +120,7 @@ class CustomMnistBenchmark(tf.test.Benchmark):
         """
         per_replica_losses = distribution_strategy.run(
             self.train_step,
-            args=(
-                batch_dataset,
-                model,
-                loss_fn,
-                optimizer,
-                batch_size,
-            ),
+            args=(batch_dataset, model, loss_fn, optimizer, batch_size,),
         )
         return distribution_strategy.reduce(
             tf.distribute.ReduceOp.SUM, per_replica_losses, axis=None

--- a/keras/benchmarks/layer_benchmarks/layer_benchmarks_test.py
+++ b/keras/benchmarks/layer_benchmarks/layer_benchmarks_test.py
@@ -56,7 +56,7 @@ def _get_input_data(inputs):
 def _layer_call_backward(layer, x):
     with tf.GradientTape() as tape:
         y = layer(x)
-        loss = tf.reduce_mean(y**2)
+        loss = tf.reduce_mean(y ** 2)
 
     _ = tape.gradient(loss, layer.trainable_variables)
 
@@ -100,7 +100,7 @@ CORE_LAYERS = [
     (
         "Lambda_small_shape",
         tf.keras.layers.Lambda,
-        {"function": lambda x: x**2},
+        {"function": lambda x: x ** 2},
         {"input_shape": (1, 1)},
         100,
     ),

--- a/keras/benchmarks/layer_benchmarks/layer_benchmarks_test_base.py
+++ b/keras/benchmarks/layer_benchmarks/layer_benchmarks_test_base.py
@@ -52,10 +52,7 @@ class LayerBenchmarksBase(tf.test.Benchmark):
                 "name": "examples_per_sec",
                 "value": float(f"{num_iters / total_time:.3f}"),
             },
-            {
-                "name": "us_per_example",
-                "value": float(f"{us_mean_time:.3f}"),
-            },
+            {"name": "us_per_example", "value": float(f"{us_mean_time:.3f}"),},
         ]
 
         # 2. Run with xprof with no python trace.

--- a/keras/benchmarks/optimizer_benchmarks_test.py
+++ b/keras/benchmarks/optimizer_benchmarks_test.py
@@ -20,9 +20,7 @@ from keras.benchmarks import benchmark_util
 from keras.optimizers.optimizer_v2 import adam
 
 # isort: off
-from tensorflow.python.platform.benchmark import (
-    ParameterizedBenchmark,
-)
+from tensorflow.python.platform.benchmark import ParameterizedBenchmark
 
 
 def bidirect_imdb_lstm_config():

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1437,10 +1437,8 @@ class ModelCheckpoint(Callback):
 
     def on_train_begin(self, logs=None):
         if self.load_weights_on_restart:
-            filepath_to_load = (
-                self._get_most_recently_modified_file_matching_pattern(
-                    self.filepath
-                )
+            filepath_to_load = self._get_most_recently_modified_file_matching_pattern(
+                self.filepath
             )
             if filepath_to_load is not None and self._checkpoint_exists(
                 filepath_to_load
@@ -2565,8 +2563,8 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
                         embedding.metadata_path = self.embeddings_metadata
                     else:
                         if layer.name in self.embeddings_metadata.keys():
-                            embedding.metadata_path = (
-                                self.embeddings_metadata.pop(layer.name)
+                            embedding.metadata_path = self.embeddings_metadata.pop(
+                                layer.name
                             )
 
         if self.embeddings_metadata and not isinstance(

--- a/keras/callbacks_test.py
+++ b/keras/callbacks_test.py
@@ -3331,9 +3331,7 @@ class TestTensorBoardV2NonParameterizedTest(test_combinations.TestCase):
         summary_file = list_summaries(self.logdir)
         self.assertEqual(
             summary_file.tensors,
-            {
-                _ObservedSummary(logdir=self.train_dir, tag="keras"),
-            },
+            {_ObservedSummary(logdir=self.train_dir, tag="keras"),},
         )
         if not model.run_eagerly:
             # There should be one train graph
@@ -3396,9 +3394,7 @@ class TestTensorBoardV2NonParameterizedTest(test_combinations.TestCase):
 
         self.assertEqual(
             summary_file.tensors,
-            {
-                _ObservedSummary(logdir=self.train_dir, tag="batch_1"),
-            },
+            {_ObservedSummary(logdir=self.train_dir, tag="batch_1"),},
         )
         self.assertEqual(1, self._count_trace_file(logdir=self.logdir))
 
@@ -3428,9 +3424,7 @@ class TestTensorBoardV2NonParameterizedTest(test_combinations.TestCase):
 
         self.assertEqual(
             summary_file.tensors,
-            {
-                _ObservedSummary(logdir=self.train_dir, tag="batch_1"),
-            },
+            {_ObservedSummary(logdir=self.train_dir, tag="batch_1"),},
         )
         self.assertEqual(0, self._count_trace_file(logdir=self.train_dir))
 
@@ -3453,9 +3447,7 @@ class TestTensorBoardV2NonParameterizedTest(test_combinations.TestCase):
 
         self.assertEqual(
             summary_file.tensors,
-            {
-                _ObservedSummary(logdir=self.train_dir, tag="batch_2"),
-            },
+            {_ObservedSummary(logdir=self.train_dir, tag="batch_2"),},
         )
         self.assertEqual(1, self._count_trace_file(logdir=self.logdir))
 

--- a/keras/callbacks_v1.py
+++ b/keras/callbacks_v1.py
@@ -256,9 +256,7 @@ class TensorBoard(callbacks.TensorBoard):
         # visualize embeddings.
         if self.embeddings_freq and self.embeddings_data is not None:
             # Avoid circular dependency.
-            from keras.engine import (
-                training_utils_v1,
-            )
+            from keras.engine import training_utils_v1
 
             self.embeddings_data = training_utils_v1.standardize_input_data(
                 self.embeddings_data, model.input_names

--- a/keras/constraints.py
+++ b/keras/constraints.py
@@ -307,8 +307,11 @@ class RadialConstraint(Constraint):
         while_condition = lambda index, *args: backend.less(index, start)
 
         def body_fn(i, array):
-            return i + 1, tf.pad(
-                array, padding, constant_values=kernel[start + i, start + i]
+            return (
+                i + 1,
+                tf.pad(
+                    array, padding, constant_values=kernel[start + i, start + i]
+                ),
             )
 
         _, kernel_new = tf.compat.v1.while_loop(

--- a/keras/datasets/reuters.py
+++ b/keras/datasets/reuters.py
@@ -151,8 +151,9 @@ def load_data(
         xs = [[w for w in x if skip_top <= w < num_words] for x in xs]
 
     idx = int(len(xs) * (1 - test_split))
-    x_train, y_train = np.array(xs[:idx], dtype="object"), np.array(
-        labels[:idx]
+    x_train, y_train = (
+        np.array(xs[:idx], dtype="object"),
+        np.array(labels[:idx]),
     )
     x_test, y_test = np.array(xs[idx:], dtype="object"), np.array(labels[idx:])
 

--- a/keras/distribute/custom_training_loop_metrics_test.py
+++ b/keras/distribute/custom_training_loop_metrics_test.py
@@ -22,9 +22,7 @@ from keras import metrics
 from keras.distribute import strategy_combinations
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 class KerasMetricsTest(tf.test.TestCase, parameterized.TestCase):

--- a/keras/distribute/custom_training_loop_models_test.py
+++ b/keras/distribute/custom_training_loop_models_test.py
@@ -492,8 +492,7 @@ class KerasModelsTest(tf.test.TestCase, parameterized.TestCase):
         @tf.function
         def step(features):
             per_replica_losses = distribution.run(
-                replica_step,
-                (net.trainable_variables, features),
+                replica_step, (net.trainable_variables, features),
             )
             loss = distribution.reduce(
                 tf.distribute.ReduceOp.SUM, per_replica_losses, axis=None

--- a/keras/distribute/dataset_creator_model_fit_test.py
+++ b/keras/distribute/dataset_creator_model_fit_test.py
@@ -23,9 +23,7 @@ from keras.testing_infra import test_utils
 from keras.utils import dataset_creator
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 # TODO(rchao): Investigate why there cannot be single worker and multi worker
@@ -83,11 +81,7 @@ class DatasetCreatorModelFitTest(test_base.DatasetCreatorModelFitTestBase):
         x = np.random.rand(100, 10)
         y = np.random.rand(100, 1)
         model = self._model_fit(
-            strategy,
-            x=x,
-            y=y,
-            batch_size=1,
-            validation_data=(x, y),
+            strategy, x=x, y=y, batch_size=1, validation_data=(x, y),
         )
         self.assertEqual(model.optimizer.iterations, 100)
 
@@ -95,11 +89,7 @@ class DatasetCreatorModelFitTest(test_base.DatasetCreatorModelFitTestBase):
         x = tf.random.uniform((100, 10))
         y = tf.random.uniform((100,))
         model = self._model_fit(
-            strategy,
-            x=x,
-            y=y,
-            batch_size=1,
-            validation_data=(x, y),
+            strategy, x=x, y=y, batch_size=1, validation_data=(x, y),
         )
         self.assertEqual(model.optimizer.iterations, 100)
 
@@ -132,10 +122,7 @@ class DatasetCreatorModelFitTest(test_base.DatasetCreatorModelFitTestBase):
         x = np.random.rand(100, 10)
         y = np.random.rand(100, 1)
         self._model_evaluate(
-            strategy,
-            x=x,
-            y=y,
-            batch_size=1,
+            strategy, x=x, y=y, batch_size=1,
         )
         self.assertGreaterEqual(self._accuracy_metric.result(), 0.0)
 
@@ -143,10 +130,7 @@ class DatasetCreatorModelFitTest(test_base.DatasetCreatorModelFitTestBase):
         x = tf.random.uniform((100, 10))
         y = tf.random.uniform((100,))
         self._model_evaluate(
-            strategy,
-            x=x,
-            y=y,
-            batch_size=1,
+            strategy, x=x, y=y, batch_size=1,
         )
         self.assertGreaterEqual(self._accuracy_metric.result(), 0.0)
 

--- a/keras/distribute/distribute_strategy_test.py
+++ b/keras/distribute/distribute_strategy_test.py
@@ -48,9 +48,7 @@ from keras.utils import losses_utils
 from keras.utils import np_utils
 
 # isort: off
-from tensorflow.python.distribute.cluster_resolver import (
-    SimpleClusterResolver,
-)
+from tensorflow.python.distribute.cluster_resolver import SimpleClusterResolver
 
 _RANDOM_SEED = 1337
 _TRAIN_SIZE = 200
@@ -2729,10 +2727,8 @@ class TestDistributionStrategyWithKerasModels(
             task_id=1,
             num_accelerators={"GPU": 0},
         )
-        distribution = (
-            tf.compat.v1.distribute.experimental.ParameterServerStrategy(
-                cluster_resolver
-            )
+        distribution = tf.compat.v1.distribute.experimental.ParameterServerStrategy(
+            cluster_resolver
         )
 
         self.assertIsInstance(
@@ -3024,11 +3020,7 @@ class TestModelCapturesStrategy(tf.test.TestCase, parameterized.TestCase):
         temp_dir = os.path.join(self.get_temp_dir(), "ckpt")
 
         def create_model():
-            model = keras.models.Sequential(
-                [
-                    keras.layers.Dense(1),
-                ]
-            )
+            model = keras.models.Sequential([keras.layers.Dense(1),])
             model.compile(optimizer="adam", loss="mse")
             model.build([None, 1])  # create weights.
             self.assertEmpty(model.optimizer.variables())

--- a/keras/distribute/keras_metrics_test.py
+++ b/keras/distribute/keras_metrics_test.py
@@ -94,10 +94,7 @@ def all_combinations():
 
 def tpu_combinations():
     return tf.__internal__.test.combinations.combine(
-        distribution=[
-            combinations.tpu_strategy,
-        ],
-        mode=["graph"],
+        distribution=[combinations.tpu_strategy,], mode=["graph"],
     )
 
 

--- a/keras/distribute/keras_utils_test.py
+++ b/keras/distribute/keras_utils_test.py
@@ -452,13 +452,7 @@ class TestDistributionStrategyWithNormalizationLayer(
             with distribution.scope():
                 model = keras.models.Sequential()
                 norm = keras.layers.BatchNormalization(
-                    input_shape=(
-                        10,
-                        20,
-                        30,
-                    ),
-                    momentum=0.8,
-                    fused=fused,
+                    input_shape=(10, 20, 30,), momentum=0.8, fused=fused,
                 )
                 model.add(norm)
                 model.compile(loss="mse", optimizer=optimizer())
@@ -498,11 +492,7 @@ class TestDistributionStrategyWithNormalizationLayer(
             with distribution.scope():
                 model = keras.models.Sequential()
                 norm = keras.layers.BatchNormalization(
-                    input_shape=(
-                        10,
-                        20,
-                        30,
-                    ),
+                    input_shape=(10, 20, 30,),
                     momentum=0.8,
                     fused=False,
                     renorm=True,

--- a/keras/distribute/mirrored_strategy_test.py
+++ b/keras/distribute/mirrored_strategy_test.py
@@ -26,9 +26,7 @@ from keras.utils import kpl_test_utils
 
 # isort: off
 from tensorflow.python.eager import backprop
-from tensorflow.python.training import (
-    optimizer as optimizer_lib,
-)
+from tensorflow.python.training import optimizer as optimizer_lib
 
 
 class MiniModel(keras_training.Model):
@@ -122,8 +120,8 @@ class MirroredStrategyDefunTest(tf.test.TestCase, parameterized.TestCase):
 
                 distribution.run(step_fn, args=(next(iterator),))
 
-            distributed_dataset = (
-                distribution.distribute_datasets_from_function(dataset_fn)
+            distributed_dataset = distribution.distribute_datasets_from_function(
+                dataset_fn
             )
             distributed_iterator = iter(distributed_dataset)
             num_epochs = 4

--- a/keras/distribute/multi_worker_testing_utils.py
+++ b/keras/distribute/multi_worker_testing_utils.py
@@ -23,21 +23,14 @@ import keras
 from keras.optimizers.optimizer_v2 import gradient_descent
 
 # isort: off
-from tensorflow.python.distribute.cluster_resolver import (
-    SimpleClusterResolver,
-)
+from tensorflow.python.distribute.cluster_resolver import SimpleClusterResolver
 from tensorflow.python.platform import tf_logging as logging
-from tensorflow.python.training.server_lib import (
-    ClusterSpec,
-)
+from tensorflow.python.training.server_lib import ClusterSpec
 
 _portpicker_import_error = None
 try:
     import portpicker
-except (
-    ImportError,
-    ModuleNotFoundError,
-) as _error:
+except (ImportError, ModuleNotFoundError,) as _error:
     _portpicker_import_error = _error
     portpicker = None
 

--- a/keras/distribute/optimizer_combinations.py
+++ b/keras/distribute/optimizer_combinations.py
@@ -28,11 +28,9 @@ from keras.optimizers.optimizer_v2 import (
 from keras.optimizers.optimizer_v2 import nadam as nadam_keras_v2
 from keras.optimizers.optimizer_v2 import rmsprop as rmsprop_keras_v2
 
-gradient_descent_optimizer_v1_fn = (
-    tf.__internal__.test.combinations.NamedObject(
-        "GradientDescentV1",
-        lambda: tf.compat.v1.train.GradientDescentOptimizer(0.001),
-    )
+gradient_descent_optimizer_v1_fn = tf.__internal__.test.combinations.NamedObject(
+    "GradientDescentV1",
+    lambda: tf.compat.v1.train.GradientDescentOptimizer(0.001),
 )
 adagrad_optimizer_v1_fn = tf.__internal__.test.combinations.NamedObject(
     "AdagradV1", lambda: tf.compat.v1.train.AdagradOptimizer(0.001)
@@ -76,10 +74,8 @@ nadam_optimizer_keras_v2_fn = tf.__internal__.test.combinations.NamedObject(
 ftrl_optimizer_keras_v2_fn = tf.__internal__.test.combinations.NamedObject(
     "FtrlKerasV2", lambda: ftrl_keras_v2.Ftrl(0.001)
 )
-gradient_descent_optimizer_keras_v2_fn = (
-    tf.__internal__.test.combinations.NamedObject(
-        "GradientDescentKerasV2", lambda: gradient_descent_keras_v2.SGD(0.001)
-    )
+gradient_descent_optimizer_keras_v2_fn = tf.__internal__.test.combinations.NamedObject(
+    "GradientDescentKerasV2", lambda: gradient_descent_keras_v2.SGD(0.001)
 )
 rmsprop_optimizer_keras_v2_fn = tf.__internal__.test.combinations.NamedObject(
     "RmsPropKerasV2", lambda: rmsprop_keras_v2.RMSprop(0.001)

--- a/keras/distribute/parameter_server_evaluation_test.py
+++ b/keras/distribute/parameter_server_evaluation_test.py
@@ -22,12 +22,8 @@ import keras
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.distribute import (
-    multi_worker_test_base,
-)
-from tensorflow.python.distribute.cluster_resolver import (
-    SimpleClusterResolver,
-)
+from tensorflow.python.distribute import multi_worker_test_base
+from tensorflow.python.distribute.cluster_resolver import SimpleClusterResolver
 from tensorflow.python.ops import resource_variable_ops
 
 
@@ -101,10 +97,8 @@ class EvaluationTest(tf.test.TestCase):
         cls.strategy = tf.distribute.experimental.ParameterServerStrategy(
             cluster_resolver
         )
-        cls.cluster_coord = (
-            tf.distribute.experimental.coordinator.ClusterCoordinator(
-                cls.strategy
-            )
+        cls.cluster_coord = tf.distribute.experimental.coordinator.ClusterCoordinator(
+            cls.strategy
         )
 
     @classmethod

--- a/keras/distribute/sharded_variable_test.py
+++ b/keras/distribute/sharded_variable_test.py
@@ -84,9 +84,7 @@ class ShardedVariableTest(tf.test.TestCase, parameterized.TestCase):
                 super().__init__()
                 self.w = self.add_weight(
                     shape=(2,),
-                    initializer=lambda shape, dtype: tf.constant(
-                        [0.0, 1.0],
-                    ),
+                    initializer=lambda shape, dtype: tf.constant([0.0, 1.0],),
                     trainable=True,
                 )
                 self.b = self.add_weight(
@@ -415,14 +413,12 @@ class ShardedVariableMixedPartitioningTest(tf.test.TestCase):
 
         # set min_shard_bytes such that Dense kernel is split into 2 and bias
         # into 1
-        partitioner = (
-            tf.distribute.experimental.partitioners.MinSizePartitioner(
-                min_shard_bytes=(6 * 6 * 4) // 2, max_shards=2
-            )
+        partitioner = tf.distribute.experimental.partitioners.MinSizePartitioner(
+            min_shard_bytes=(6 * 6 * 4) // 2, max_shards=2
         )
 
-        cluster_resolver = (
-            multi_worker_testing_utils.make_parameter_server_cluster(3, 2)
+        cluster_resolver = multi_worker_testing_utils.make_parameter_server_cluster(
+            3, 2
         )
         strategy = tf.distribute.experimental.ParameterServerStrategy(
             cluster_resolver, variable_partitioner=partitioner
@@ -448,10 +444,8 @@ class ShardedVariableMixedPartitioningTest(tf.test.TestCase):
 
         # set min_shard_bytes such that Dense kernel is split into 3 and bias
         # into 1
-        partitioner2 = (
-            tf.distribute.experimental.partitioners.MinSizePartitioner(
-                min_shard_bytes=(6 * 6 * 4) // 3, max_shards=3
-            )
+        partitioner2 = tf.distribute.experimental.partitioners.MinSizePartitioner(
+            min_shard_bytes=(6 * 6 * 4) // 3, max_shards=3
         )
         strategy2 = tf.distribute.experimental.ParameterServerStrategy(
             cluster_resolver, variable_partitioner=partitioner2

--- a/keras/distribute/sidecar_evaluator.py
+++ b/keras/distribute/sidecar_evaluator.py
@@ -238,8 +238,7 @@ class SidecarEvaluator:
                 # e.g.  using a custom training loop. Directly assign the
                 # iterations property to be used in callbacks.
                 if self.model.optimizer and not isinstance(
-                    self.model.optimizer,
-                    optimizer_experimental.Optimizer,
+                    self.model.optimizer, optimizer_experimental.Optimizer,
                 ):
                     # experimental optimizer automatically restores the
                     # iteration value.
@@ -259,12 +258,8 @@ class SidecarEvaluator:
                     f"Error: {e.__class__.__name__}: {e}"
                 )
                 continue
-            if (
-                self._iterations.numpy() == _ITERATIONS_UNINITIALIZED
-                and not isinstance(
-                    self.model.optimizer,
-                    optimizer_experimental.Optimizer,
-                )
+            if self._iterations.numpy() == _ITERATIONS_UNINITIALIZED and not isinstance(
+                self.model.optimizer, optimizer_experimental.Optimizer,
             ):
                 raise RuntimeError(
                     "Variable `iterations` cannot be loaded from the "

--- a/keras/distribute/tpu_strategy_test_utils.py
+++ b/keras/distribute/tpu_strategy_test_utils.py
@@ -25,9 +25,7 @@ flags.DEFINE_string("zone", None, "Name of GCP zone with TPU.")
 
 def get_tpu_cluster_resolver():
     resolver = tf.distribute.cluster_resolver.TPUClusterResolver(
-        tpu=FLAGS.tpu,
-        zone=FLAGS.zone,
-        project=FLAGS.project,
+        tpu=FLAGS.tpu, zone=FLAGS.zone, project=FLAGS.project,
     )
     return resolver
 

--- a/keras/dtensor/integration_test_utils.py
+++ b/keras/dtensor/integration_test_utils.py
@@ -59,29 +59,16 @@ def get_model_with_layout_map(layout_map):
         )
         model.add(
             layers.Conv2D(
-                64,
-                name="conv2d_2",
-                kernel_size=(3, 3),
-                activation="relu",
+                64, name="conv2d_2", kernel_size=(3, 3), activation="relu",
             )
         )
         model.add(layers.MaxPooling2D(pool_size=(2, 2)))
         model.add(layers.Dropout(0.25))
         model.add(layers.Flatten())
-        model.add(
-            layers.Dense(
-                128,
-                name="dense_1",
-                activation="relu",
-            )
-        )
+        model.add(layers.Dense(128, name="dense_1", activation="relu",))
         model.add(layers.Dropout(0.5))
         model.add(
-            layers.Dense(
-                NUM_CLASS,
-                name="dense_2",
-                activation="softmax",
-            )
+            layers.Dense(NUM_CLASS, name="dense_2", activation="softmax",)
         )
         return model
 

--- a/keras/dtensor/layout_map.py
+++ b/keras/dtensor/layout_map.py
@@ -349,8 +349,7 @@ def _map_subclass_model_variable(model, layout_map):
     # Note that the model._flatten is a method from tf.Module, and it returns
     # duplicated items (since some of the items have different paths).
     for path, variable in model._flatten(
-        predicate=_is_lazy_init_variable,
-        with_path=True,
+        predicate=_is_lazy_init_variable, with_path=True,
     ):
         # Note that path is a tuple that contains string and ints, eg:
         # ('d1', '_trainable_weights', 0) maps to model.d1._trainable_weights[0]
@@ -372,8 +371,7 @@ def _map_subclass_model_variable(model, layout_map):
     # After we replaced all the variables, we want to make sure all the cached
     # attributes are having the new variable, rather than old LazyInitVariable.
     for path, variable in model._flatten(
-        predicate=_is_lazy_init_variable,
-        with_path=True,
+        predicate=_is_lazy_init_variable, with_path=True,
     ):
         tf_variable = lazy_init_variable_to_tf_variable_map[id(variable)]
         _set_object_by_path(model, path, tf_variable)
@@ -393,8 +391,7 @@ def _map_functional_model_variable(model, layout_map):
         # name based on the class name.
         layer_name = layer.name
         for path, variable in layer._flatten(
-            predicate=_is_lazy_init_variable,
-            with_path=True,
+            predicate=_is_lazy_init_variable, with_path=True,
         ):
             # Note that path is a tuple that contains string and ints, eg:
             # ('d1', '_trainable_weights', 0) maps to
@@ -418,8 +415,7 @@ def _map_functional_model_variable(model, layout_map):
         # cached attributes are having the new variable, rather than old
         # LazyInitVariable.
         for path, variable in layer._flatten(
-            predicate=_is_lazy_init_variable,
-            with_path=True,
+            predicate=_is_lazy_init_variable, with_path=True,
         ):
             tf_variable = lazy_init_variable_to_tf_variable_map[id(variable)]
             _set_object_by_path(layer, path, tf_variable)

--- a/keras/dtensor/lazy_variable.py
+++ b/keras/dtensor/lazy_variable.py
@@ -66,15 +66,13 @@ def _infer_shape_dtype_and_create_handle(initial_value, shape, dtype, name):
 
             assert dtype
             assert shape
-            handle = (
-                resource_variable_ops._variable_handle_from_shape_and_dtype(
-                    shape=shape,
-                    dtype=dtype,
-                    shared_name=None,  # Never shared
-                    name=name,
-                    graph_mode=False,
-                    initial_value=None,
-                )
+            handle = resource_variable_ops._variable_handle_from_shape_and_dtype(
+                shape=shape,
+                dtype=dtype,
+                shared_name=None,  # Never shared
+                name=name,
+                graph_mode=False,
+                initial_value=None,
             )
             # initial_value=initial_value if not callable(initial_value) else
             # None)

--- a/keras/dtensor/mnist_model_test.py
+++ b/keras/dtensor/mnist_model_test.py
@@ -30,11 +30,7 @@ class MnistTest(test_util.DTensorBaseTest):
     def test_mnist_training_cpu(self):
         devices = tf.config.list_physical_devices("CPU")
         tf.config.set_logical_device_configuration(
-            devices[0],
-            [
-                tf.config.LogicalDeviceConfiguration(),
-            ]
-            * 8,
+            devices[0], [tf.config.LogicalDeviceConfiguration(),] * 8,
         )
 
         mesh = mesh_util.create_mesh(

--- a/keras/dtensor/test_util.py
+++ b/keras/dtensor/test_util.py
@@ -121,11 +121,7 @@ def reset_logical_devices(device_type, count):
     devices = tf.config.list_physical_devices(device_type)
     if device_type.upper() == "CPU":
         tf.config.set_logical_device_configuration(
-            devices[0],
-            [
-                tf.config.LogicalDeviceConfiguration(),
-            ]
-            * count,
+            devices[0], [tf.config.LogicalDeviceConfiguration(),] * count,
         )
     elif device_type.upper() == "GPU":
         tf.config.set_logical_device_configuration(

--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -56,9 +56,7 @@ from keras.utils.tf_utils import is_tensor_or_tensor_list  # noqa: F401
 # isort: off
 from google.protobuf import json_format
 from tensorflow.python.platform import tf_logging
-from tensorflow.python.util.tf_export import (
-    get_canonical_name_for_symbol,
-)
+from tensorflow.python.util.tf_export import get_canonical_name_for_symbol
 from tensorflow.python.util.tf_export import keras_export
 from tensorflow.tools.docs import doc_controls
 

--- a/keras/engine/data_adapter.py
+++ b/keras/engine/data_adapter.py
@@ -31,9 +31,7 @@ from keras.utils import dataset_creator
 from keras.utils import tf_utils
 
 # isort: off
-from tensorflow.python.distribute.input_lib import (
-    DistributedDataset,
-)
+from tensorflow.python.distribute.input_lib import DistributedDataset
 from tensorflow.python.eager import context
 from tensorflow.python.framework import type_spec
 from tensorflow.python.platform import tf_logging as logging

--- a/keras/engine/data_adapter_test.py
+++ b/keras/engine/data_adapter_test.py
@@ -576,9 +576,7 @@ class IncreasingBatchSizeAdapterTest(test_combinations.TestCase):
         self.assertEqual(self.sequence_input._current_epoch, 0)
         self.assertEqual(self.sequence_input._current_batch_size, 5)
         data_handler = data_adapter.get_data_handler(
-            self.sequence_input,
-            epochs=self.epochs,
-            model=self.model,
+            self.sequence_input, epochs=self.epochs, model=self.model,
         )
         self.assertEqual(
             data_handler.inferred_steps, 4
@@ -1403,10 +1401,9 @@ class TestValidationSplit(test_combinations.TestCase):
             y = tf.convert_to_tensor([0, 2, 4, 6, 8])
             sw = tf.convert_to_tensor([0, 4, 8, 12, 16])
 
-        (train_x, train_y, train_sw), (
-            val_x,
-            val_y,
-            val_sw,
+        (
+            (train_x, train_y, train_sw),
+            (val_x, val_y, val_sw,),
         ) = data_adapter.train_validation_split(
             (x, y, sw), validation_split=0.2
         )

--- a/keras/engine/feature_columns_integration_test.py
+++ b/keras/engine/feature_columns_integration_test.py
@@ -134,9 +134,7 @@ class FeatureColumnsIntegrationTest(test_combinations.TestCase):
         inp_y = np.random.randint(0, 1, size=100)
         ds = tf.data.Dataset.from_tensor_slices((inp_x, inp_y)).batch(5)
         model.compile(
-            optimizer="adam",
-            loss="binary_crossentropy",
-            metrics=["accuracy"],
+            optimizer="adam", loss="binary_crossentropy", metrics=["accuracy"],
         )
         model.fit(ds, epochs=1)
         model.fit(ds, epochs=1)

--- a/keras/engine/functional.py
+++ b/keras/engine/functional.py
@@ -238,21 +238,13 @@ class Functional(training_lib.Model):
 
         # Build self._output_layers:
         for x in self.outputs:
-            (
-                layer,
-                node_index,
-                tensor_index,
-            ) = x._keras_history
+            (layer, node_index, tensor_index,) = x._keras_history
             self._output_layers.append(layer)
             self._output_coordinates.append((layer, node_index, tensor_index))
 
         # Build self._input_layers:
         for x in self.inputs:
-            (
-                layer,
-                node_index,
-                tensor_index,
-            ) = x._keras_history
+            (layer, node_index, tensor_index,) = x._keras_history
             # It's supposed to be an input layer, so only one node
             # and one tensor output.
             assert node_index == 0
@@ -1191,11 +1183,7 @@ def _build_map_helper(
     layer_indices,
 ):
     """Recursive helper for `_build_map`."""
-    (
-        layer,
-        node_index,
-        _,
-    ) = tensor._keras_history
+    (layer, node_index, _,) = tensor._keras_history
     node = layer._inbound_nodes[node_index]
 
     # Don't repeat work for shared subgraphs

--- a/keras/engine/functional_test.py
+++ b/keras/engine/functional_test.py
@@ -35,9 +35,7 @@ from keras.utils import layer_utils
 from keras.utils import tf_utils
 
 # isort: off
-from tensorflow.python.checkpoint.checkpoint import (
-    Checkpoint,
-)
+from tensorflow.python.checkpoint.checkpoint import Checkpoint
 from tensorflow.python.framework import extension_type
 
 
@@ -225,7 +223,7 @@ class NetworkConstructionTest(test_combinations.TestCase):
     def testTopologicalAttributesMultiOutputLayer(self):
         class PowersLayer(layers.Layer):
             def call(self, inputs):
-                return [inputs**2, inputs**3]
+                return [inputs ** 2, inputs ** 3]
 
         x = input_layer_lib.Input(shape=(32,))
         test_layer = PowersLayer()

--- a/keras/engine/sequential_test.py
+++ b/keras/engine/sequential_test.py
@@ -23,9 +23,7 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 class TestSequential(test_combinations.TestCase):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1166,10 +1166,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
                 self.train_tf_function = train_function
 
             if self._cluster_coordinator:
-                self.train_function = (
-                    lambda it: self._cluster_coordinator.schedule(
-                        train_function, args=(it,)
-                    )
+                self.train_function = lambda it: self._cluster_coordinator.schedule(
+                    train_function, args=(it,)
                 )
             else:
                 self.train_function = train_function
@@ -1473,10 +1471,9 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
             # Create the validation data using the training data. Only supported
             # for `Tensor` and `NumPy` input.
             (
-                x,
-                y,
-                sample_weight,
-            ), validation_data = data_adapter.train_validation_split(
+                (x, y, sample_weight,),
+                validation_data,
+            ) = data_adapter.train_validation_split(
                 (x, y, sample_weight), validation_split=validation_split
             )
 
@@ -1488,10 +1485,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
             ) = data_adapter.unpack_x_y_sample_weight(validation_data)
 
         if self.distribute_strategy._should_use_with_coordinator:
-            self._cluster_coordinator = (
-                tf.distribute.experimental.coordinator.ClusterCoordinator(
-                    self.distribute_strategy
-                )
+            self._cluster_coordinator = tf.distribute.experimental.coordinator.ClusterCoordinator(
+                self.distribute_strategy
             )
 
         with self.distribute_strategy.scope(), training_utils.RespectCompiledTrainableState(  # noqa: E501
@@ -1732,10 +1727,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
                 )
 
             if self._cluster_coordinator:
-                self.test_function = (
-                    lambda it: self._cluster_coordinator.schedule(
-                        test_function, args=(it,)
-                    )
+                self.test_function = lambda it: self._cluster_coordinator.schedule(
+                    test_function, args=(it,)
                 )
             else:
                 self.test_function = test_function
@@ -1888,10 +1881,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
             raise TypeError(f"Invalid keyword arguments: {list(kwargs.keys())}")
 
         if self.distribute_strategy._should_use_with_coordinator:
-            self._cluster_coordinator = (
-                tf.distribute.experimental.coordinator.ClusterCoordinator(
-                    self.distribute_strategy
-                )
+            self._cluster_coordinator = tf.distribute.experimental.coordinator.ClusterCoordinator(
+                self.distribute_strategy
             )
 
         verbose = _get_verbosity(verbose, self.distribute_strategy)

--- a/keras/engine/training_arrays_test.py
+++ b/keras/engine/training_arrays_test.py
@@ -30,9 +30,7 @@ from keras.testing_infra import test_utils
 from keras.utils import io_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 def _create_dataset(num_samples, batch_size):

--- a/keras/engine/training_generator_test.py
+++ b/keras/engine/training_generator_test.py
@@ -475,8 +475,9 @@ class TestGeneratorMethodsWithSequences(test_combinations.TestCase):
 
         class CustomSequence(data_utils.Sequence):
             def __getitem__(self, idx):
-                return np.ones([10, 10], np.float32), np.ones(
-                    [10, 1], np.float32
+                return (
+                    np.ones([10, 10], np.float32),
+                    np.ones([10, 1], np.float32),
                 )
 
             def __len__(self):
@@ -528,8 +529,9 @@ class TestGeneratorMethodsWithSequences(test_combinations.TestCase):
                 self.epochs = 0
 
             def __getitem__(self, idx):
-                return np.ones([10, 10], np.float32), np.ones(
-                    [10, 1], np.float32
+                return (
+                    np.ones([10, 10], np.float32),
+                    np.ones([10, 1], np.float32),
                 )
 
             def __len__(self):

--- a/keras/engine/training_test.py
+++ b/keras/engine/training_test.py
@@ -46,13 +46,9 @@ from keras.utils import io_utils
 from keras.utils import np_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 from tensorflow.python.platform import tf_logging as logging
-from tensorflow.python.training.rmsprop import (
-    RMSPropOptimizer,
-)
+from tensorflow.python.training.rmsprop import RMSPropOptimizer
 
 try:
     import scipy.sparse as scipy_sparse
@@ -1720,9 +1716,7 @@ class TrainingTest(test_combinations.TestCase):
         model = sequential.Sequential([layers_module.Dense(1)])
         optimizer = sgd_experimental.SGD()
         model.compile(
-            optimizer,
-            "mse",
-            run_eagerly=test_utils.should_run_eagerly(),
+            optimizer, "mse", run_eagerly=test_utils.should_run_eagerly(),
         )
         model.fit(x, y, epochs=2)
         policy.set_global_policy("float32")
@@ -2219,9 +2213,7 @@ class TestExceptionsAndWarnings(test_combinations.TestCase):
 
             model.compile(
                 optimizer,
-                loss={
-                    "dense_2": "categorical_crossentropy",
-                },
+                loss={"dense_2": "categorical_crossentropy",},
                 metrics={
                     "dense_2": "categorical_accuracy",
                     "dense_1": metrics_module.CategoricalAccuracy(),
@@ -2251,10 +2243,7 @@ class TestExceptionsAndWarnings(test_combinations.TestCase):
     def test_predict_structured(self, spe, static_batch):
         inputs = layers_module.Input(shape=(2,))
         outputs = layers_module.Dense(2)(inputs)
-        model = training_module.Model(
-            inputs=inputs,
-            outputs={"out": outputs},
-        )
+        model = training_module.Model(inputs=inputs, outputs={"out": outputs},)
         model.compile(
             loss="mse",
             steps_per_execution=spe,

--- a/keras/engine/training_utils_v1.py
+++ b/keras/engine/training_utils_v1.py
@@ -357,7 +357,7 @@ class SliceAggregator(Aggregator):
     so a value of 2 ** 14 was chosen which should be reasonable on most systems.
     """
 
-    _BINARY_SIZE_THRESHOLD = 2**14
+    _BINARY_SIZE_THRESHOLD = 2 ** 14
     _MAX_COPY_SECONDS = 300
 
     def __init__(self, num_samples, batch_size):
@@ -2135,20 +2135,13 @@ def unpack_validation_data(validation_data, raise_if_ambiguous=True):
         val_sample_weight = None
     elif len(validation_data) == 2:
         try:
-            (
-                val_x,
-                val_y,
-            ) = validation_data
+            (val_x, val_y,) = validation_data
             val_sample_weight = None
         except ValueError:
             val_x, val_y, val_sample_weight = validation_data, None, None
     elif len(validation_data) == 3:
         try:
-            (
-                val_x,
-                val_y,
-                val_sample_weight,
-            ) = validation_data
+            (val_x, val_y, val_sample_weight,) = validation_data
         except ValueError:
             val_x, val_y, val_sample_weight = validation_data, None, None
     else:

--- a/keras/engine/training_v1.py
+++ b/keras/engine/training_v1.py
@@ -2006,24 +2006,20 @@ class Model(training_lib.Model):
                 output_shapes.append(None)
             else:
                 output_shapes.append(output.shape.as_list())
-        self._per_output_metrics = (
-            training_utils_v1.collect_per_output_metric_info(
-                metrics,
-                self.output_names,
-                output_shapes,
-                self.loss_functions,
-                from_serialized=self._from_serialized,
-            )
+        self._per_output_metrics = training_utils_v1.collect_per_output_metric_info(
+            metrics,
+            self.output_names,
+            output_shapes,
+            self.loss_functions,
+            from_serialized=self._from_serialized,
         )
-        self._per_output_weighted_metrics = (
-            training_utils_v1.collect_per_output_metric_info(
-                weighted_metrics,
-                self.output_names,
-                output_shapes,
-                self.loss_functions,
-                from_serialized=self._from_serialized,
-                is_weighted=True,
-            )
+        self._per_output_weighted_metrics = training_utils_v1.collect_per_output_metric_info(
+            weighted_metrics,
+            self.output_names,
+            output_shapes,
+            self.loss_functions,
+            from_serialized=self._from_serialized,
+            is_weighted=True,
         )
 
     def _add_unique_metric_name(self, metric_name, metric_fn, output_index):

--- a/keras/estimator/__init__.py
+++ b/keras/estimator/__init__.py
@@ -167,9 +167,7 @@ def model_to_estimator(
 
     try:
         # isort: off
-        from tensorflow_estimator.python.estimator import (
-            keras_lib,
-        )
+        from tensorflow_estimator.python.estimator import keras_lib
     except ImportError:
         raise NotImplementedError(
             "tf.keras.estimator.model_to_estimator function not available in "
@@ -364,9 +362,7 @@ def model_to_estimator_v2(
 
     try:
         # isort: off
-        from tensorflow_estimator.python.estimator import (
-            keras_lib,
-        )
+        from tensorflow_estimator.python.estimator import keras_lib
     except ImportError:
         raise NotImplementedError(
             "tf.keras.estimator.model_to_estimator function not available in "

--- a/keras/feature_column/dense_features.py
+++ b/keras/feature_column/dense_features.py
@@ -168,8 +168,8 @@ class DenseFeatures(kfc._BaseFeaturesLayer):
             raise ValueError(
                 "We expected a dictionary here. Instead we got: ", features
             )
-        transformation_cache = (
-            tf.__internal__.feature_column.FeatureTransformationCache(features)
+        transformation_cache = tf.__internal__.feature_column.FeatureTransformationCache(
+            features
         )
         output_tensors = []
         for column in self._feature_columns:

--- a/keras/feature_column/dense_features_test.py
+++ b/keras/feature_column/dense_features_test.py
@@ -27,9 +27,7 @@ from keras.testing_infra import test_combinations
 
 # isort: off
 from tensorflow.python.eager import backprop
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 def _initialized_session(config=None):
@@ -469,10 +467,8 @@ class DenseFeaturesTest(test_combinations.TestCase):
                 )
 
     def test_multiple_layers_with_same_embedding_column(self):
-        some_sparse_column = (
-            tf.feature_column.categorical_column_with_hash_bucket(
-                "sparse_feature", hash_bucket_size=5
-            )
+        some_sparse_column = tf.feature_column.categorical_column_with_hash_bucket(
+            "sparse_feature", hash_bucket_size=5
         )
         some_embedding_column = tf.feature_column.embedding_column(
             some_sparse_column, dimension=10
@@ -510,15 +506,11 @@ class DenseFeaturesTest(test_combinations.TestCase):
 
     @tf_test_utils.run_deprecated_v1
     def test_multiple_layers_with_same_shared_embedding_column(self):
-        categorical_column_a = (
-            tf.feature_column.categorical_column_with_identity(
-                key="aaa", num_buckets=3
-            )
+        categorical_column_a = tf.feature_column.categorical_column_with_identity(
+            key="aaa", num_buckets=3
         )
-        categorical_column_b = (
-            tf.feature_column.categorical_column_with_identity(
-                key="bbb", num_buckets=3
-            )
+        categorical_column_b = tf.feature_column.categorical_column_with_identity(
+            key="bbb", num_buckets=3
         )
         embedding_dimension = 2
         (
@@ -568,15 +560,11 @@ class DenseFeaturesTest(test_combinations.TestCase):
     def test_multiple_layers_with_same_shared_embedding_column_diff_graphs(
         self,
     ):
-        categorical_column_a = (
-            tf.feature_column.categorical_column_with_identity(
-                key="aaa", num_buckets=3
-            )
+        categorical_column_a = tf.feature_column.categorical_column_with_identity(
+            key="aaa", num_buckets=3
         )
-        categorical_column_b = (
-            tf.feature_column.categorical_column_with_identity(
-                key="bbb", num_buckets=3
-            )
+        categorical_column_b = tf.feature_column.categorical_column_with_identity(
+            key="bbb", num_buckets=3
         )
         embedding_dimension = 2
         (
@@ -677,12 +665,7 @@ class DenseFeaturesTest(test_combinations.TestCase):
 
         # Provides 1-dim tensor and dense tensor.
         features = {
-            "price": tf.constant(
-                [
-                    11.0,
-                    12.0,
-                ]
-            ),
+            "price": tf.constant([11.0, 12.0,]),
             "body-style": tf.SparseTensor(
                 indices=((0,), (1,)),
                 values=("sedan", "hardtop"),
@@ -1130,25 +1113,17 @@ class SharedEmbeddingColumnTest(tf.test.TestCase, parameterized.TestCase):
         )
 
         # Build columns.
-        categorical_column_a = (
-            tf.feature_column.categorical_column_with_identity(
-                key="aaa", num_buckets=vocabulary_size
-            )
+        categorical_column_a = tf.feature_column.categorical_column_with_identity(
+            key="aaa", num_buckets=vocabulary_size
         )
-        categorical_column_b = (
-            tf.feature_column.categorical_column_with_identity(
-                key="bbb", num_buckets=vocabulary_size
-            )
+        categorical_column_b = tf.feature_column.categorical_column_with_identity(
+            key="bbb", num_buckets=vocabulary_size
         )
-        categorical_column_c = (
-            tf.feature_column.categorical_column_with_identity(
-                key="ccc", num_buckets=vocabulary_size
-            )
+        categorical_column_c = tf.feature_column.categorical_column_with_identity(
+            key="ccc", num_buckets=vocabulary_size
         )
-        categorical_column_d = (
-            tf.feature_column.categorical_column_with_identity(
-                key="ddd", num_buckets=vocabulary_size
-            )
+        categorical_column_d = tf.feature_column.categorical_column_with_identity(
+            key="ddd", num_buckets=vocabulary_size
         )
 
         (
@@ -1324,10 +1299,8 @@ class SequenceFeatureColumnsTest(tf.test.TestCase):
             dense_shape=(2, 2),
         )
 
-        categorical_column_a = (
-            tf.feature_column.sequence_categorical_column_with_identity(
-                key="aaa", num_buckets=vocabulary_size
-            )
+        categorical_column_a = tf.feature_column.sequence_categorical_column_with_identity(
+            key="aaa", num_buckets=vocabulary_size
         )
         embedding_column_a = tf.feature_column.embedding_column(
             categorical_column_a, dimension=2
@@ -1352,10 +1325,8 @@ class SequenceFeatureColumnsTest(tf.test.TestCase):
             dense_shape=(2, 2),
         )
 
-        categorical_column_a = (
-            tf.feature_column.sequence_categorical_column_with_identity(
-                key="aaa", num_buckets=vocabulary_size
-            )
+        categorical_column_a = tf.feature_column.sequence_categorical_column_with_identity(
+            key="aaa", num_buckets=vocabulary_size
         )
         indicator_column_a = tf.feature_column.indicator_column(
             categorical_column_a

--- a/keras/feature_column/dense_features_v2_test.py
+++ b/keras/feature_column/dense_features_v2_test.py
@@ -462,10 +462,8 @@ class DenseFeaturesTest(test_combinations.TestCase):
                 )
 
     def test_multiple_layers_with_same_embedding_column(self):
-        some_sparse_column = (
-            tf.feature_column.categorical_column_with_hash_bucket(
-                "sparse_feature", hash_bucket_size=5
-            )
+        some_sparse_column = tf.feature_column.categorical_column_with_hash_bucket(
+            "sparse_feature", hash_bucket_size=5
         )
         some_embedding_column = tf.feature_column.embedding_column(
             some_sparse_column, dimension=10
@@ -502,15 +500,11 @@ class DenseFeaturesTest(test_combinations.TestCase):
             )
 
     def test_multiple_layers_with_same_shared_embedding_column(self):
-        categorical_column_a = (
-            tf.feature_column.categorical_column_with_identity(
-                key="aaa", num_buckets=3
-            )
+        categorical_column_a = tf.feature_column.categorical_column_with_identity(
+            key="aaa", num_buckets=3
         )
-        categorical_column_b = (
-            tf.feature_column.categorical_column_with_identity(
-                key="bbb", num_buckets=3
-            )
+        categorical_column_b = tf.feature_column.categorical_column_with_identity(
+            key="bbb", num_buckets=3
         )
         embedding_dimension = 2
 
@@ -560,15 +554,11 @@ class DenseFeaturesTest(test_combinations.TestCase):
     def test_multiple_layers_with_same_shared_embedding_column_diff_graphs(
         self,
     ):
-        categorical_column_a = (
-            tf.feature_column.categorical_column_with_identity(
-                key="aaa", num_buckets=3
-            )
+        categorical_column_a = tf.feature_column.categorical_column_with_identity(
+            key="aaa", num_buckets=3
         )
-        categorical_column_b = (
-            tf.feature_column.categorical_column_with_identity(
-                key="bbb", num_buckets=3
-            )
+        categorical_column_b = tf.feature_column.categorical_column_with_identity(
+            key="bbb", num_buckets=3
         )
         embedding_dimension = 2
 
@@ -670,12 +660,7 @@ class DenseFeaturesTest(test_combinations.TestCase):
         with tf.Graph().as_default():
             # Provides 1-dim tensor and dense tensor.
             features = {
-                "price": tf.constant(
-                    [
-                        11.0,
-                        12.0,
-                    ]
-                ),
+                "price": tf.constant([11.0, 12.0,]),
                 "body-style": tf.SparseTensor(
                     indices=((0,), (1,)),
                     values=("sedan", "hardtop"),

--- a/keras/feature_column/sequence_feature_column.py
+++ b/keras/feature_column/sequence_feature_column.py
@@ -144,8 +144,8 @@ class SequenceFeatures(kfc._BaseFeaturesLayer):
             )
         if training is None:
             training = backend.learning_phase()
-        transformation_cache = (
-            tf.__internal__.feature_column.FeatureTransformationCache(features)
+        transformation_cache = tf.__internal__.feature_column.FeatureTransformationCache(
+            features
         )
         output_tensors = []
         sequence_lengths = []

--- a/keras/feature_column/sequence_feature_column_integration_test.py
+++ b/keras/feature_column/sequence_feature_column_integration_test.py
@@ -31,9 +31,7 @@ from keras.layers.rnn import simple_rnn
 from google.protobuf import text_format
 from tensorflow.core.example import example_pb2
 from tensorflow.core.example import feature_pb2
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 class SequenceFeatureColumnIntegrationTest(tf.test.TestCase):
@@ -65,15 +63,11 @@ class SequenceFeatureColumnIntegrationTest(tf.test.TestCase):
             tf.feature_column.numeric_column("float_ctx"),
         ]
 
-        identity_col = (
-            tf.feature_column.sequence_categorical_column_with_identity(
-                "int_list", num_buckets=10
-            )
+        identity_col = tf.feature_column.sequence_categorical_column_with_identity(
+            "int_list", num_buckets=10
         )
-        bucket_col = (
-            tf.feature_column.sequence_categorical_column_with_hash_bucket(
-                "bytes_list", hash_bucket_size=100
-            )
+        bucket_col = tf.feature_column.sequence_categorical_column_with_hash_bucket(
+            "bytes_list", hash_bucket_size=100
         )
         seq_cols = [
             tf.feature_column.embedding_column(identity_col, dimension=10),

--- a/keras/feature_column/sequence_feature_column_test.py
+++ b/keras/feature_column/sequence_feature_column_test.py
@@ -135,10 +135,8 @@ class SequenceFeaturesTest(tf.test.TestCase, parameterized.TestCase):
 
             return _initializer
 
-        categorical_column_a = (
-            tf.feature_column.sequence_categorical_column_with_identity(
-                key="aaa", num_buckets=vocabulary_size
-            )
+        categorical_column_a = tf.feature_column.sequence_categorical_column_with_identity(
+            key="aaa", num_buckets=vocabulary_size
         )
         embedding_column_a = tf.feature_column.embedding_column(
             categorical_column_a,
@@ -147,10 +145,8 @@ class SequenceFeaturesTest(tf.test.TestCase, parameterized.TestCase):
                 embedding_dimension_a, embedding_values_a
             ),
         )
-        categorical_column_b = (
-            tf.feature_column.sequence_categorical_column_with_identity(
-                key="bbb", num_buckets=vocabulary_size
-            )
+        categorical_column_b = tf.feature_column.sequence_categorical_column_with_identity(
+            key="bbb", num_buckets=vocabulary_size
         )
         embedding_column_b = tf.feature_column.embedding_column(
             categorical_column_b,
@@ -165,10 +161,7 @@ class SequenceFeaturesTest(tf.test.TestCase, parameterized.TestCase):
             [embedding_column_b, embedding_column_a]
         )
         input_layer, sequence_length = sequence_input_layer(
-            {
-                "aaa": sparse_input_a,
-                "bbb": sparse_input_b,
-            }
+            {"aaa": sparse_input_a, "bbb": sparse_input_b,}
         )
 
         self.evaluate(tf.compat.v1.global_variables_initializer())
@@ -198,10 +191,8 @@ class SequenceFeaturesTest(tf.test.TestCase, parameterized.TestCase):
             dense_shape=(2, 2),
         )
 
-        categorical_column_a = (
-            tf.feature_column.categorical_column_with_identity(
-                key="aaa", num_buckets=vocabulary_size
-            )
+        categorical_column_a = tf.feature_column.categorical_column_with_identity(
+            key="aaa", num_buckets=vocabulary_size
         )
         embedding_column_a = tf.feature_column.embedding_column(
             categorical_column_a, dimension=2
@@ -258,15 +249,11 @@ class SequenceFeaturesTest(tf.test.TestCase, parameterized.TestCase):
             ]
             expected_sequence_length = [1, 2]
 
-            categorical_column_a = (
-                tf.feature_column.sequence_categorical_column_with_identity(
-                    key="aaa", num_buckets=vocabulary_size
-                )
+            categorical_column_a = tf.feature_column.sequence_categorical_column_with_identity(
+                key="aaa", num_buckets=vocabulary_size
             )
-            categorical_column_b = (
-                tf.feature_column.sequence_categorical_column_with_identity(
-                    key="bbb", num_buckets=vocabulary_size
-                )
+            categorical_column_b = tf.feature_column.sequence_categorical_column_with_identity(
+                key="bbb", num_buckets=vocabulary_size
             )
             # Test that columns are reordered alphabetically.
             shared_embedding_columns = tf.feature_column.shared_embeddings(
@@ -322,15 +309,11 @@ class SequenceFeaturesTest(tf.test.TestCase, parameterized.TestCase):
                 dense_shape=(2, 2),
             )
 
-            categorical_column_a = (
-                tf.feature_column.categorical_column_with_identity(
-                    key="aaa", num_buckets=vocabulary_size
-                )
+            categorical_column_a = tf.feature_column.categorical_column_with_identity(
+                key="aaa", num_buckets=vocabulary_size
             )
-            categorical_column_b = (
-                tf.feature_column.categorical_column_with_identity(
-                    key="bbb", num_buckets=vocabulary_size
-                )
+            categorical_column_b = tf.feature_column.categorical_column_with_identity(
+                key="bbb", num_buckets=vocabulary_size
             )
             shared_embedding_columns = tf.feature_column.shared_embeddings(
                 [categorical_column_a, categorical_column_b], dimension=2
@@ -426,18 +409,14 @@ class SequenceFeaturesTest(tf.test.TestCase, parameterized.TestCase):
         vocabulary_size_a = 3
         vocabulary_size_b = 2
 
-        categorical_column_a = (
-            tf.feature_column.sequence_categorical_column_with_identity(
-                key="aaa", num_buckets=vocabulary_size_a
-            )
+        categorical_column_a = tf.feature_column.sequence_categorical_column_with_identity(
+            key="aaa", num_buckets=vocabulary_size_a
         )
         indicator_column_a = tf.feature_column.indicator_column(
             categorical_column_a
         )
-        categorical_column_b = (
-            tf.feature_column.sequence_categorical_column_with_identity(
-                key="bbb", num_buckets=vocabulary_size_b
-            )
+        categorical_column_b = tf.feature_column.sequence_categorical_column_with_identity(
+            key="bbb", num_buckets=vocabulary_size_b
         )
         indicator_column_b = tf.feature_column.indicator_column(
             categorical_column_b
@@ -466,10 +445,8 @@ class SequenceFeaturesTest(tf.test.TestCase, parameterized.TestCase):
             dense_shape=(2, 2),
         )
 
-        categorical_column_a = (
-            tf.feature_column.categorical_column_with_identity(
-                key="aaa", num_buckets=vocabulary_size
-            )
+        categorical_column_a = tf.feature_column.categorical_column_with_identity(
+            key="aaa", num_buckets=vocabulary_size
         )
         indicator_column_a = tf.feature_column.indicator_column(
             categorical_column_a
@@ -802,10 +779,8 @@ class SequenceFeaturesTest(tf.test.TestCase, parameterized.TestCase):
     ):
         """Tests that we return a known static shape when we have one."""
         sparse_input = tf.compat.v1.SparseTensorValue(**sparse_input_args)
-        categorical_column = (
-            tf.feature_column.sequence_categorical_column_with_identity(
-                key="aaa", num_buckets=3
-            )
+        categorical_column = tf.feature_column.sequence_categorical_column_with_identity(
+            key="aaa", num_buckets=3
         )
         indicator_column = tf.feature_column.indicator_column(
             categorical_column

--- a/keras/initializers/initializers_test.py
+++ b/keras/initializers/initializers_test.py
@@ -74,9 +74,7 @@ def _compute_fans(shape):
 @test_combinations.generate(test_combinations.combine(mode=["graph", "eager"]))
 class KerasInitializersTest(tf.test.TestCase, parameterized.TestCase):
     def _runner(
-        self,
-        init,
-        shape,
+        self, init, shape,
     ):
         # The global seed is set so that we can get the same random streams
         # between eager and graph mode when stateful op is used.

--- a/keras/integration_test/central_storage_strategy_test.py
+++ b/keras/integration_test/central_storage_strategy_test.py
@@ -18,15 +18,9 @@ import tensorflow.compat.v2 as tf
 from absl.testing import parameterized
 
 # isort: off
-from tensorflow.python.distribute import (
-    combinations as ds_combinations,
-)
-from tensorflow.python.distribute import (
-    strategy_combinations,
-)
-from tensorflow.python.framework import (
-    test_combinations as combinations,
-)
+from tensorflow.python.distribute import combinations as ds_combinations
+from tensorflow.python.distribute import strategy_combinations
+from tensorflow.python.framework import test_combinations as combinations
 from tensorflow.python.keras.utils import kpl_test_utils
 
 
@@ -78,8 +72,8 @@ class CentralStorageStrategyTest(tf.test.TestCase, parameterized.TestCase):
 
                 distribution.run(step_fn, args=(next(iterator),))
 
-            distributed_dataset = (
-                distribution.distribute_datasets_from_function(dataset_fn)
+            distributed_dataset = distribution.distribute_datasets_from_function(
+                dataset_fn
             )
             distributed_iterator = iter(distributed_dataset)
             num_epochs = 4

--- a/keras/integration_test/forwardprop_test.py
+++ b/keras/integration_test/forwardprop_test.py
@@ -24,8 +24,11 @@ def _jvp(f, primals, tangents):
     """Compute the jacobian of `f` at `primals` multiplied by `tangents`."""
     with tf.autodiff.ForwardAccumulator(primals, tangents) as acc:
         primals_out = f(*primals)
-    return primals_out, acc.jvp(
-        primals_out, unconnected_gradients=tf.UnconnectedGradients.ZERO
+    return (
+        primals_out,
+        acc.jvp(
+            primals_out, unconnected_gradients=tf.UnconnectedGradients.ZERO
+        ),
     )
 
 

--- a/keras/integration_test/gradient_checkpoint_test.py
+++ b/keras/integration_test/gradient_checkpoint_test.py
@@ -18,9 +18,7 @@ import gc
 import tensorflow.compat.v2 as tf
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 from tensorflow.python.platform import test as test_lib
 
 layers = tf.keras.layers

--- a/keras/integration_test/multi_worker_tutorial_test.py
+++ b/keras/integration_test/multi_worker_tutorial_test.py
@@ -269,8 +269,7 @@ class MultiWorkerTutorialTest(parameterized.TestCase, tf.test.TestCase):
 
         for worker_id in range(NUM_WORKERS):
             accu_result = tf.nest.map_structure(
-                lambda x: extract_accuracy(worker_id, x),
-                mpr_result.stdout,
+                lambda x: extract_accuracy(worker_id, x), mpr_result.stdout,
             )
             self.assertTrue(
                 any(accu_result),
@@ -294,12 +293,9 @@ class MultiWorkerTutorialTest(parameterized.TestCase, tf.test.TestCase):
                 with strategy.scope():
                     multi_worker_model = self.build_cnn_model()
 
-                multi_worker_dataset = (
-                    strategy.distribute_datasets_from_function(
-                        lambda input_context: self.dataset_fn(
-                            global_batch_size,
-                            input_context,
-                        )
+                multi_worker_dataset = strategy.distribute_datasets_from_function(
+                    lambda input_context: self.dataset_fn(
+                        global_batch_size, input_context,
                     )
                 )
                 optimizer = tf.keras.optimizers.RMSprop(learning_rate=0.001)
@@ -316,11 +312,11 @@ class MultiWorkerTutorialTest(parameterized.TestCase, tf.test.TestCase):
                         x, y = inputs
                         with tf.GradientTape() as tape:
                             predictions = multi_worker_model(x, training=True)
-                            per_batch_loss = (
-                                tf.keras.losses.SparseCategoricalCrossentropy(
-                                    from_logits=True,
-                                    reduction=tf.keras.losses.Reduction.NONE,
-                                )(y, predictions)
+                            per_batch_loss = tf.keras.losses.SparseCategoricalCrossentropy(
+                                from_logits=True,
+                                reduction=tf.keras.losses.Reduction.NONE,
+                            )(
+                                y, predictions
                             )
                             loss = tf.nn.compute_average_loss(
                                 per_batch_loss,

--- a/keras/integration_test/parameter_server_custom_training_loop_test.py
+++ b/keras/integration_test/parameter_server_custom_training_loop_test.py
@@ -78,10 +78,8 @@ class ParameterServerCustomTrainingLoopTest(tf.test.TestCase):
         self.strategy = tf.distribute.experimental.ParameterServerStrategy(
             cluster_resolver
         )
-        self.coordinator = (
-            tf.distribute.experimental.coordinator.ClusterCoordinator(
-                self.strategy
-            )
+        self.coordinator = tf.distribute.experimental.coordinator.ClusterCoordinator(
+            self.strategy
         )
 
     def testCustomTrainingLoop(self):

--- a/keras/integration_test/parameter_server_keras_preprocessing_test.py
+++ b/keras/integration_test/parameter_server_keras_preprocessing_test.py
@@ -86,10 +86,8 @@ class KPLTest(tf.test.TestCase, parameterized.TestCase):
         self.strategy = tf.distribute.experimental.ParameterServerStrategy(
             cluster_resolver
         )
-        self.coordinator = (
-            tf.distribute.experimental.coordinator.ClusterCoordinator(
-                self.strategy
-            )
+        self.coordinator = tf.distribute.experimental.coordinator.ClusterCoordinator(
+            self.strategy
         )
 
     def define_kpls_for_training(self, use_adapt):
@@ -317,10 +315,8 @@ class KPLCreatedInDatasetsFromFunctionTest(
         self.strategy = tf.distribute.experimental.ParameterServerStrategy(
             cluster_resolver
         )
-        self.coordinator = (
-            tf.distribute.experimental.coordinator.ClusterCoordinator(
-                self.strategy
-            )
+        self.coordinator = tf.distribute.experimental.coordinator.ClusterCoordinator(
+            self.strategy
         )
 
     def testKPLCreatedInDatasetsFromFunction(self):
@@ -355,8 +351,8 @@ class KPLCreatedInDatasetsFromFunctionTest(
                 dataset_fn
             )
 
-        per_worker_distribute_dataset = (
-            self.coordinator.create_per_worker_dataset(per_worker_dataset_fn)
+        per_worker_distribute_dataset = self.coordinator.create_per_worker_dataset(
+            per_worker_dataset_fn
         )
         per_worker_iter = iter(per_worker_distribute_dataset)
 

--- a/keras/integration_test/tpu_strategy_test.py
+++ b/keras/integration_test/tpu_strategy_test.py
@@ -21,9 +21,7 @@ import tensorflow.compat.v2 as tf
 from absl import flags
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string("tpu", "", "Name of TPU to connect to.")
@@ -45,9 +43,7 @@ LABEL_VOCAB = ["yes", "no"]
 
 def get_tpu_cluster_resolver():
     resolver = tf.distribute.cluster_resolver.TPUClusterResolver(
-        tpu=FLAGS.tpu,
-        zone=FLAGS.zone,
-        project=FLAGS.project,
+        tpu=FLAGS.tpu, zone=FLAGS.zone, project=FLAGS.project,
     )
     return resolver
 

--- a/keras/layers/attention/attention_test.py
+++ b/keras/layers/attention/attention_test.py
@@ -344,8 +344,7 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllClose(expected, actual)
 
     @parameterized.named_parameters(
-        ("", False),
-        ("return_attention_scores", True),
+        ("", False), ("return_attention_scores", True),
     )
     def test_multi_dim_with_query_mask(self, return_attention_scores):
         # Query tensor of shape [1, 2, 1]
@@ -427,8 +426,7 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
             self.assertAllClose(1.0, attention_layer.scale.value())
 
     @parameterized.named_parameters(
-        ("", False),
-        ("return_attention_scores", True),
+        ("", False), ("return_attention_scores", True),
     )
     def test_self_attention_causal(self, return_attention_scores):
         # Query-value tensor of shape [1, 3, 1]
@@ -489,14 +487,9 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
         # Query-value tensor of shape [1, 3, 1]
         q = np.array([[[0.5], [0.8], [-0.3]]], dtype=np.float32)
         attention_layer_new = keras.layers.Attention()
-        new_scores = attention_layer_new(
-            [q, q],
-            use_causal_mask=True,
-        )
+        new_scores = attention_layer_new([q, q], use_causal_mask=True,)
         attention_layer_old = keras.layers.Attention(causal=True)
-        old_scores = attention_layer_old(
-            [q, q],
-        )
+        old_scores = attention_layer_old([q, q],)
         self.assertAllClose(new_scores, old_scores)
 
     def test_inputs_not_list(self):
@@ -565,8 +558,7 @@ class AttentionTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllClose([[[0], [1]]], actual)
 
     @parameterized.named_parameters(
-        ("", False),
-        ("use_scale", True),
+        ("", False), ("use_scale", True),
     )
     def test_serialization(self, use_scale):
         # Test serialization with use_scale

--- a/keras/layers/convolutional/conv_test.py
+++ b/keras/layers/convolutional/conv_test.py
@@ -24,9 +24,7 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 @test_combinations.run_all_keras_modes

--- a/keras/layers/core/dense.py
+++ b/keras/layers/core/dense.py
@@ -163,9 +163,7 @@ class Dense(Layer):
         if self.use_bias:
             self.bias = self.add_weight(
                 "bias",
-                shape=[
-                    self.units,
-                ],
+                shape=[self.units,],
                 initializer=self.bias_initializer,
                 regularizer=self.bias_regularizer,
                 constraint=self.bias_constraint,

--- a/keras/layers/core/tf_op_layer.py
+++ b/keras/layers/core/tf_op_layer.py
@@ -21,12 +21,8 @@ from keras.engine.base_layer import Layer
 
 # isort: off
 from tensorflow.python.platform import tf_logging
-from tensorflow.python.util.tf_export import (
-    get_canonical_name_for_symbol,
-)
-from tensorflow.python.util.tf_export import (
-    get_symbol_from_name,
-)
+from tensorflow.python.util.tf_export import get_canonical_name_for_symbol
+from tensorflow.python.util.tf_export import get_symbol_from_name
 
 
 class ClassMethod(Layer):

--- a/keras/layers/kernelized_test.py
+++ b/keras/layers/kernelized_test.py
@@ -35,9 +35,7 @@ from keras.testing_infra import test_utils
 from keras.utils import kernelized_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 def _exact_gaussian(stddev):

--- a/keras/layers/locally_connected/locally_connected1d.py
+++ b/keras/layers/locally_connected/locally_connected1d.py
@@ -227,14 +227,12 @@ class LocallyConnected1D(Layer):
                 constraint=self.kernel_constraint,
             )
 
-            self.kernel_mask = (
-                locally_connected_utils.get_locallyconnected_mask(
-                    input_shape=(input_length,),
-                    kernel_shape=self.kernel_size,
-                    strides=self.strides,
-                    padding=self.padding,
-                    data_format=self.data_format,
-                )
+            self.kernel_mask = locally_connected_utils.get_locallyconnected_mask(
+                input_shape=(input_length,),
+                kernel_shape=self.kernel_size,
+                strides=self.strides,
+                padding=self.padding,
+                data_format=self.data_format,
             )
 
         elif self.implementation == 3:

--- a/keras/layers/locally_connected/locally_connected2d.py
+++ b/keras/layers/locally_connected/locally_connected2d.py
@@ -253,14 +253,12 @@ class LocallyConnected2D(Layer):
                 constraint=self.kernel_constraint,
             )
 
-            self.kernel_mask = (
-                locally_connected_utils.get_locallyconnected_mask(
-                    input_shape=(input_row, input_col),
-                    kernel_shape=self.kernel_size,
-                    strides=self.strides,
-                    padding=self.padding,
-                    data_format=self.data_format,
-                )
+            self.kernel_mask = locally_connected_utils.get_locallyconnected_mask(
+                input_shape=(input_row, input_col),
+                kernel_shape=self.kernel_size,
+                strides=self.strides,
+                padding=self.padding,
+                data_format=self.data_format,
             )
 
         elif self.implementation == 3:

--- a/keras/layers/locally_connected/locally_connected_test.py
+++ b/keras/layers/locally_connected/locally_connected_test.py
@@ -28,12 +28,8 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_util,
-)
-from tensorflow.python.training.rmsprop import (
-    RMSPropOptimizer,
-)
+from tensorflow.python.framework import test_util as tf_test_util
+from tensorflow.python.training.rmsprop import RMSPropOptimizer
 
 _DATA_FORMAT_PADDING_IMPLEMENTATION = [
     {"data_format": "channels_first", "padding": "valid", "implementation": 1},

--- a/keras/layers/locally_connected/locally_connected_utils.py
+++ b/keras/layers/locally_connected/locally_connected_utils.py
@@ -128,10 +128,7 @@ def local_conv_matmul(inputs, kernel, kernel_mask, output_shape):
     output_flat = tf.matmul(inputs_flat, kernel, b_is_sparse=True)
     output = backend.reshape(
         output_flat,
-        [
-            backend.shape(output_flat)[0],
-        ]
-        + output_shape.as_list()[1:],
+        [backend.shape(output_flat)[0],] + output_shape.as_list()[1:],
     )
     return output
 
@@ -173,10 +170,7 @@ def local_conv_sparse_matmul(
 
     output_reshaped = backend.reshape(
         output_flat_transpose,
-        [
-            backend.shape(output_flat_transpose)[0],
-        ]
-        + output_shape.as_list()[1:],
+        [backend.shape(output_flat_transpose)[0],] + output_shape.as_list()[1:],
     )
     return output_reshaped
 

--- a/keras/layers/normalization/batch_normalization.py
+++ b/keras/layers/normalization/batch_normalization.py
@@ -27,9 +27,7 @@ from keras.utils import control_flow_util
 from keras.utils import tf_utils
 
 # isort: off
-from tensorflow.python.ops.control_flow_ops import (
-    get_enclosing_xla_context,
-)
+from tensorflow.python.ops.control_flow_ops import get_enclosing_xla_context
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util.tf_export import keras_export
 

--- a/keras/layers/normalization/batch_normalization_test.py
+++ b/keras/layers/normalization/batch_normalization_test.py
@@ -573,7 +573,7 @@ class NormalizationLayersGraphModeOnlyTest(
                         np.array([1.0]),
                         np.array([0.0]),
                         np.array([bn_mean]),
-                        np.array([bn_std**2]),
+                        np.array([bn_std ** 2]),
                     ]
                 )
                 return model1

--- a/keras/layers/normalization/layer_normalization_test.py
+++ b/keras/layers/normalization/layer_normalization_test.py
@@ -60,10 +60,7 @@ class LayerNormalizationTest(test_combinations.TestCase):
         )
         test_utils.layer_test(
             keras.layers.LayerNormalization,
-            kwargs={
-                "gamma_initializer": "ones",
-                "beta_initializer": "ones",
-            },
+            kwargs={"gamma_initializer": "ones", "beta_initializer": "ones",},
             input_shape=(3, 4, 2),
         )
         test_utils.layer_test(

--- a/keras/layers/normalization/unit_normalization_test.py
+++ b/keras/layers/normalization/unit_normalization_test.py
@@ -23,7 +23,7 @@ from keras.testing_infra import test_utils
 
 
 def squared_l2_norm(x):
-    return tf.reduce_sum(x**2)
+    return tf.reduce_sum(x ** 2)
 
 
 @test_utils.run_v2_only

--- a/keras/layers/preprocessing/benchmarks/bucketized_column_dense_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/bucketized_column_dense_benchmark.py
@@ -24,9 +24,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10  # The number of times to run each benchmark.
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/benchmarks/category_hash_dense_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_hash_dense_benchmark.py
@@ -24,9 +24,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/benchmarks/category_hash_varlen_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_hash_varlen_benchmark.py
@@ -24,9 +24,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/benchmarks/category_vocab_file_dense_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_vocab_file_dense_benchmark.py
@@ -26,9 +26,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/benchmarks/category_vocab_file_varlen_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_vocab_file_varlen_benchmark.py
@@ -26,9 +26,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/benchmarks/category_vocab_list_dense_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_vocab_list_dense_benchmark.py
@@ -24,9 +24,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/benchmarks/category_vocab_list_indicator_dense_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_vocab_list_indicator_dense_benchmark.py
@@ -25,9 +25,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/benchmarks/category_vocab_list_indicator_varlen_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_vocab_list_indicator_varlen_benchmark.py
@@ -25,9 +25,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/benchmarks/category_vocab_list_varlen_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/category_vocab_list_varlen_benchmark.py
@@ -24,9 +24,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/benchmarks/embedding_dense_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/embedding_dense_benchmark.py
@@ -22,9 +22,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/benchmarks/embedding_varlen_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/embedding_varlen_benchmark.py
@@ -23,9 +23,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/benchmarks/hashed_crossing_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/hashed_crossing_benchmark.py
@@ -25,9 +25,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/benchmarks/weighted_embedding_varlen_benchmark.py
+++ b/keras/layers/preprocessing/benchmarks/weighted_embedding_varlen_benchmark.py
@@ -23,9 +23,7 @@ from keras.layers.preprocessing.benchmarks import (
 )
 
 # isort: off
-from tensorflow.python.eager.def_function import (
-    function as tf_function,
-)
+from tensorflow.python.eager.def_function import function as tf_function
 
 NUM_REPEATS = 10
 BATCH_SIZES = [32, 256]

--- a/keras/layers/preprocessing/category_encoding_distribution_test.py
+++ b/keras/layers/preprocessing/category_encoding_distribution_test.py
@@ -27,9 +27,7 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 def batch_wrapper(dataset, batch_size, strategy, repeat=None):

--- a/keras/layers/preprocessing/category_encoding_test.py
+++ b/keras/layers/preprocessing/category_encoding_test.py
@@ -349,8 +349,7 @@ class CategoryEncodingOutputTest(
     test_combinations.TestCase, preprocessing_test_utils.PreprocessingLayerTest
 ):
     @parameterized.named_parameters(
-        ("float32", tf.float32),
-        ("float64", tf.float64),
+        ("float32", tf.float32), ("float64", tf.float64),
     )
     def test_output_dtype(self, dtype):
         inputs = keras.Input(shape=(1,), dtype=tf.int32)
@@ -510,15 +509,7 @@ class CategoryEncodingOutputTest(
         with self.assertRaisesRegex(
             ValueError, "maximum supported output rank"
         ):
-            _ = layer(
-                keras.Input(
-                    shape=(
-                        3,
-                        4,
-                    ),
-                    dtype=tf.int32,
-                )
-            )
+            _ = layer(keras.Input(shape=(3, 4,), dtype=tf.int32,))
         with self.assertRaisesRegex(
             ValueError, "maximum supported output rank"
         ):

--- a/keras/layers/preprocessing/discretization.py
+++ b/keras/layers/preprocessing/discretization.py
@@ -303,10 +303,7 @@ class Discretization(base_preprocessing_layer.PreprocessingLayer):
             name="summary",
             shape=(2, None),
             dtype=tf.float32,
-            initializer=lambda shape, dtype: [
-                [],
-                [],
-            ],
+            initializer=lambda shape, dtype: [[], [],],
             trainable=False,
         )
 

--- a/keras/layers/preprocessing/discretization_test.py
+++ b/keras/layers/preprocessing/discretization_test.py
@@ -187,8 +187,7 @@ class DiscretizationTest(
         self.assertAllEqual(outputs.shape.as_list(), [16, 4])
 
     @parameterized.named_parameters(
-        ("int32", tf.int32),
-        ("int64", tf.int64),
+        ("int32", tf.int32), ("int64", tf.int64),
     )
     def test_output_dtype(self, dtype):
         inputs = keras.Input(batch_size=16, shape=(4,), dtype="float32")
@@ -213,8 +212,7 @@ class DiscretizationTest(
         self.assertAllEqual(outputs.dtype, tf.int64)
 
     @parameterized.named_parameters(
-        ("float32", tf.float32),
-        ("float64", tf.float64),
+        ("float32", tf.float32), ("float64", tf.float64),
     )
     def test_one_hot_output_dtype(self, dtype):
         inputs = keras.Input(batch_size=16, shape=(1,), dtype="float32")
@@ -397,8 +395,7 @@ class DiscretizationAdaptTest(
         self.assertAllClose(new_output_data, expected_output)
 
     @parameterized.product(
-        save_format=["tf", "h5"],
-        adapt=[True, False],
+        save_format=["tf", "h5"], adapt=[True, False],
     )
     def test_saved_model_keras(self, save_format, adapt):
         input_data = [[1], [2], [3]]

--- a/keras/layers/preprocessing/hashed_crossing_test.py
+++ b/keras/layers/preprocessing/hashed_crossing_test.py
@@ -29,8 +29,7 @@ from keras.testing_infra import test_combinations
 @test_combinations.run_all_keras_modes(always_skip_v1=True)
 class HashedCrossingTest(test_combinations.TestCase):
     @parameterized.named_parameters(
-        ("python_value", lambda x: x),
-        ("dense", tf.constant),
+        ("python_value", lambda x: x), ("dense", tf.constant),
     )
     def test_cross_scalars(self, data_fn):
         layer = hashed_crossing.HashedCrossing(num_bins=10)
@@ -71,8 +70,7 @@ class HashedCrossingTest(test_combinations.TestCase):
         self.assertAllEqual(outputs.shape.as_list(), [5, 1])
 
     @parameterized.named_parameters(
-        ("sparse", True),
-        ("dense", False),
+        ("sparse", True), ("dense", False),
     )
     def test_cross_one_hot_output(self, sparse):
         layer = hashed_crossing.HashedCrossing(

--- a/keras/layers/preprocessing/hashing_distribution_test.py
+++ b/keras/layers/preprocessing/hashing_distribution_test.py
@@ -27,9 +27,7 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 @test_utils.run_v2_only

--- a/keras/layers/preprocessing/hashing_test.py
+++ b/keras/layers/preprocessing/hashing_test.py
@@ -347,8 +347,7 @@ class HashingTest(test_combinations.TestCase):
         self.assertAllEqual(expected_output, output_data)
 
     @parameterized.named_parameters(
-        ("int32", tf.int32),
-        ("int64", tf.int64),
+        ("int32", tf.int32), ("int64", tf.int64),
     )
     def test_output_dtype(self, dtype):
         input_data = keras.Input(batch_size=16, shape=(4,), dtype="string")
@@ -367,8 +366,7 @@ class HashingTest(test_combinations.TestCase):
         self.assertAllEqual(outputs.dtype, tf.int64)
 
     @parameterized.named_parameters(
-        ("float32", tf.float32),
-        ("float64", tf.float64),
+        ("float32", tf.float32), ("float64", tf.float64),
     )
     def test_one_hot_output_dtype(self, dtype):
         input_data = keras.Input(batch_size=16, shape=(1,), dtype="string")
@@ -415,16 +413,8 @@ class HashingTest(test_combinations.TestCase):
         self.assertAllClose(new_output_data, original_output_data)
 
     @parameterized.named_parameters(
-        (
-            "list_input",
-            [1, 2, 3],
-            [1, 1, 1],
-        ),
-        (
-            "list_input_2d",
-            [[1], [2], [3]],
-            [[1], [1], [1]],
-        ),
+        ("list_input", [1, 2, 3], [1, 1, 1],),
+        ("list_input_2d", [[1], [2], [3]], [[1], [1], [1]],),
         (
             "list_input_2d_multiple",
             [[1, 2], [2, 3], [3, 4]],

--- a/keras/layers/preprocessing/image_preprocessing_test.py
+++ b/keras/layers/preprocessing/image_preprocessing_test.py
@@ -61,10 +61,7 @@ class ResizingTest(test_combinations.TestCase):
         ("down_sample_area_3_by_2", {"interpolation": "area"}, 3, 2),
         (
             "down_sample_crop_to_aspect_ratio_3_by_2",
-            {
-                "interpolation": "bilinear",
-                "crop_to_aspect_ratio": True,
-            },
+            {"interpolation": "bilinear", "crop_to_aspect_ratio": True,},
             3,
             2,
         ),
@@ -81,10 +78,7 @@ class ResizingTest(test_combinations.TestCase):
         ("up_sample_area_12_by_12", {"interpolation": "area"}, 12, 12),
         (
             "up_sample_crop_to_aspect_ratio_12_by_14",
-            {
-                "interpolation": "bilinear",
-                "crop_to_aspect_ratio": True,
-            },
+            {"interpolation": "bilinear", "crop_to_aspect_ratio": True,},
             12,
             14,
         ),
@@ -152,12 +146,7 @@ class ResizingTest(test_combinations.TestCase):
             )
             output_image = layer(input_image)
             expected_output = np.asarray(
-                [
-                    [1, 2],
-                    [5, 6],
-                    [9, 10],
-                    [13, 14],
-                ]
+                [[1, 2], [5, 6], [9, 10], [13, 14],]
             ).astype("float32")
             expected_output = np.reshape(expected_output, (1, 4, 2, 1))
             self.assertAllEqual(expected_output, output_image)
@@ -169,12 +158,7 @@ class ResizingTest(test_combinations.TestCase):
             )
             layer = image_preprocessing.Resizing(2, 2, interpolation="nearest")
             output_image = layer(input_image)
-            expected_output = np.asarray(
-                [
-                    [5, 7],
-                    [13, 15],
-                ]
-            ).astype("float32")
+            expected_output = np.asarray([[5, 7], [13, 15],]).astype("float32")
             expected_output = np.reshape(expected_output, (2, 2, 1))
             self.assertAllEqual(expected_output, output_image)
 
@@ -346,12 +330,7 @@ class CenterCropTest(test_combinations.TestCase):
             )
             layer = image_preprocessing.CenterCrop(2, 2)
             output_image = layer(input_image)
-            expected_output = np.asarray(
-                [
-                    [5, 6],
-                    [9, 10],
-                ]
-            ).astype("float32")
+            expected_output = np.asarray([[5, 6], [9, 10],]).astype("float32")
             expected_output = np.reshape(expected_output, (2, 2, 1))
             self.assertAllEqual(expected_output, output_image)
 
@@ -619,9 +598,7 @@ class RandomFlipTest(test_combinations.TestCase):
             if mode == "vertical" or mode == "horizontal_and_vertical":
                 expected_output = np.flip(expected_output, axis=1)
         with tf.compat.v1.test.mock.patch.object(
-            np.random,
-            "choice",
-            side_effect=mock_random,
+            np.random, "choice", side_effect=mock_random,
         ):
             with test_utils.use_gpu():
                 layer = image_preprocessing.RandomFlip(mode)
@@ -665,9 +642,7 @@ class RandomFlipTest(test_combinations.TestCase):
         expected_output = np.flip(np.flip(input_images, axis=1), axis=2)
         mock_random = [True, True, True, True]
         with tf.compat.v1.test.mock.patch.object(
-            np.random,
-            "choice",
-            side_effect=mock_random,
+            np.random, "choice", side_effect=mock_random,
         ):
             with self.cached_session():
                 layer = image_preprocessing.RandomFlip()
@@ -686,9 +661,7 @@ class RandomFlipTest(test_combinations.TestCase):
         expected_output = np.flip(input_image, axis=0)
         mock_random = [True, True, True, True]
         with tf.compat.v1.test.mock.patch.object(
-            np.random,
-            "choice",
-            side_effect=mock_random,
+            np.random, "choice", side_effect=mock_random,
         ):
             with self.cached_session():
                 layer = image_preprocessing.RandomFlip("vertical")
@@ -755,9 +728,7 @@ class RandomFlipTest(test_combinations.TestCase):
         input = {"images": [image, image], "bounding_boxes": bboxes}
         mock_random = [True, True, True, True]
         with tf.compat.v1.test.mock.patch.object(
-            np.random,
-            "choice",
-            side_effect=mock_random,
+            np.random, "choice", side_effect=mock_random,
         ):
             layer = image_preprocessing.RandomFlip()
             output = layer(input, training=True)

--- a/keras/layers/preprocessing/index_lookup.py
+++ b/keras/layers/preprocessing/index_lookup.py
@@ -336,12 +336,10 @@ class IndexLookup(base_preprocessing_layer.PreprocessingLayer):
                 default_value=0,
             )
             if self.output_mode == TF_IDF:
-                self.token_document_counts = (
-                    tf.lookup.experimental.MutableHashTable(
-                        key_dtype=vocabulary_dtype,
-                        value_dtype=tf.int64,
-                        default_value=0,
-                    )
+                self.token_document_counts = tf.lookup.experimental.MutableHashTable(
+                    key_dtype=vocabulary_dtype,
+                    value_dtype=tf.int64,
+                    default_value=0,
                 )
                 self.num_documents = tf.Variable(
                     0, dtype=tf.int64, trainable=False

--- a/keras/layers/preprocessing/index_lookup_distribution_test.py
+++ b/keras/layers/preprocessing/index_lookup_distribution_test.py
@@ -29,9 +29,7 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 @test_utils.run_v2_only

--- a/keras/layers/preprocessing/index_lookup_test.py
+++ b/keras/layers/preprocessing/index_lookup_test.py
@@ -975,8 +975,7 @@ class IndexLookupOutputTest(
         self.assertAllEqual(int_data.shape.as_list(), [16, 4])
 
     @parameterized.named_parameters(
-        ("int32", tf.int32),
-        ("int64", tf.int64),
+        ("int32", tf.int32), ("int64", tf.int64),
     )
     def test_int_output_dtype(self, dtype):
         input_data = keras.Input(batch_size=16, shape=(4,), dtype=tf.string)
@@ -1257,26 +1256,13 @@ class IndexLookupOutputTest(
         )
 
         if mode == "count":
-            expected_output = np.array(
-                [
-                    [0, 0, 1, 1, 2],
-                    [2, 1, 0, 0, 1],
-                ]
-            )
+            expected_output = np.array([[0, 0, 1, 1, 2], [2, 1, 0, 0, 1],])
         elif mode == "tf_idf":
             expected_output = np.array(
-                [
-                    [0, 0, 1, 1, 2],
-                    [2, 1, 0, 0, 1],
-                ]
+                [[0, 0, 1, 1, 2], [2, 1, 0, 0, 1],]
             ) * math.log(1.5)
         else:
-            expected_output = np.array(
-                [
-                    [0, 0, 1, 1, 1],
-                    [1, 1, 0, 0, 1],
-                ]
-            )
+            expected_output = np.array([[0, 0, 1, 1, 1], [1, 1, 0, 0, 1],])
         expected_output_shape = [None, 5]
         if pad_to_max:
             expected_output = np.concatenate(

--- a/keras/layers/preprocessing/integer_lookup_test.py
+++ b/keras/layers/preprocessing/integer_lookup_test.py
@@ -56,10 +56,7 @@ def _get_end_to_end_test_cases():
                 [[1138], [1729], [725], [42], [42], [725], [1138], [4]],
                 dtype=np.int64,
             ),
-            "kwargs": {
-                "max_tokens": None,
-                "dtype": tf.int64,
-            },
+            "kwargs": {"max_tokens": None, "dtype": tf.int64,},
             "expected_output": [[1], [2], [3], [4], [4], [3], [1], [0]],
             "input_dtype": tf.int64,
         },
@@ -314,8 +311,7 @@ class IntegerLookupOutputTest(
 
         input_data = keras.Input(shape=(None,), dtype=tf.int64)
         layer = integer_lookup.IntegerLookup(
-            vocabulary=vocab_data,
-            max_tokens=None,
+            vocabulary=vocab_data, max_tokens=None,
         )
         int_data = layer(input_data)
         model = keras.Model(inputs=input_data, outputs=int_data)
@@ -329,9 +325,7 @@ class IntegerLookupOutputTest(
 
         input_data = keras.Input(shape=(None,), dtype=tf.int64)
         layer = integer_lookup.IntegerLookup(
-            vocabulary=vocab_data,
-            max_tokens=None,
-            mask_token=0,
+            vocabulary=vocab_data, max_tokens=None, mask_token=0,
         )
         int_data = layer(input_data)
         model = keras.Model(inputs=input_data, outputs=int_data)

--- a/keras/layers/preprocessing/normalization.py
+++ b/keras/layers/preprocessing/normalization.py
@@ -321,10 +321,10 @@ class Normalization(base_preprocessing_layer.PreprocessingLayer):
         # formula (see
         # https://en.wikipedia.org/wiki/Lack-of-fit_sum_of_squares).
         total_variance = (
-            self.adapt_variance + (self.adapt_mean - total_mean) ** 2
-        ) * existing_weight + (
-            batch_variance + (batch_mean - total_mean) ** 2
-        ) * batch_weight
+            (self.adapt_variance + (self.adapt_mean - total_mean) ** 2)
+            * existing_weight
+            + (batch_variance + (batch_mean - total_mean) ** 2) * batch_weight
+        )
         self.adapt_mean.assign(total_mean)
         self.adapt_variance.assign(total_variance)
         self.count.assign(total_count)

--- a/keras/layers/preprocessing/normalization_test.py
+++ b/keras/layers/preprocessing/normalization_test.py
@@ -297,20 +297,14 @@ class NormalizationAdaptTest(
 
     def test_1d_unbatched_adapt(self):
         ds = tf.data.Dataset.from_tensor_slices(
-            [
-                [2.0, 0.0, 2.0, 0.0],
-                [0.0, 2.0, 0.0, 2.0],
-            ]
+            [[2.0, 0.0, 2.0, 0.0], [0.0, 2.0, 0.0, 2.0],]
         )
         layer = normalization.Normalization(axis=-1)
         layer.adapt(ds)
         output_ds = ds.map(layer)
         self.assertAllClose(
             list(output_ds.as_numpy_iterator()),
-            [
-                [1.0, -1.0, 1.0, -1.0],
-                [-1.0, 1.0, -1.0, 1.0],
-            ],
+            [[1.0, -1.0, 1.0, -1.0], [-1.0, 1.0, -1.0, 1.0],],
         )
 
     def test_0d_unbatched_adapt(self):
@@ -390,8 +384,7 @@ class NormalizationAdaptTest(
         self.assertAllClose(actual_output, expected_second_output)
 
     @parameterized.parameters(
-        {"adapted": True},
-        {"adapted": False},
+        {"adapted": True}, {"adapted": False},
     )
     def test_saved_model_tf(self, adapted):
         input_data = [[0.0], [2.0], [0.0], [2.0]]
@@ -423,8 +416,7 @@ class NormalizationAdaptTest(
         self.assertAllClose(new_output_data, expected_output)
 
     @parameterized.product(
-        save_format=["tf", "h5"],
-        adapt=[True, False],
+        save_format=["tf", "h5"], adapt=[True, False],
     )
     def test_saved_model_keras(self, save_format, adapt):
         input_data = [[0.0], [2.0], [0.0], [2.0]]
@@ -458,8 +450,7 @@ class NormalizationAdaptTest(
         self.assertAllClose(new_output_data, expected_output)
 
     @parameterized.parameters(
-        {"adapted": True},
-        {"adapted": False},
+        {"adapted": True}, {"adapted": False},
     )
     def test_saved_weights_keras(self, adapted):
         input_data = [[0.0], [2.0], [0.0], [2.0]]

--- a/keras/layers/preprocessing/preprocessing_stage_test.py
+++ b/keras/layers/preprocessing/preprocessing_stage_test.py
@@ -44,13 +44,7 @@ class PreprocessingStageTest(
                 return inputs + 1.0
 
         # Test with NumPy array
-        stage = preprocessing_stage.PreprocessingStage(
-            [
-                PL(),
-                PL(),
-                PL(),
-            ]
-        )
+        stage = preprocessing_stage.PreprocessingStage([PL(), PL(), PL(),])
         stage.adapt(np.ones((3, 4)))
         self.assertEqual(stage.layers[0].adapt_count, 1)
         self.assertEqual(stage.layers[1].adapt_count, 1)

--- a/keras/layers/preprocessing/preprocessing_utils_test.py
+++ b/keras/layers/preprocessing/preprocessing_utils_test.py
@@ -47,8 +47,7 @@ class EncodeCategoricalInputsTest(test_combinations.TestCase):
         self.assertAllEqual([0, 1, 2], outputs)
 
     @parameterized.named_parameters(
-        ("sparse", True),
-        ("dense", False),
+        ("sparse", True), ("dense", False),
     )
     def test_one_hot_encoding(self, sparse):
         inputs = tf.constant([0, 1, 2])
@@ -60,8 +59,7 @@ class EncodeCategoricalInputsTest(test_combinations.TestCase):
         self.assertAllEqual([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]], outputs)
 
     @parameterized.named_parameters(
-        ("sparse", True),
-        ("dense", False),
+        ("sparse", True), ("dense", False),
     )
     def test_multi_hot_encoding(self, sparse):
         inputs = tf.constant([0, 1, 2])
@@ -73,8 +71,7 @@ class EncodeCategoricalInputsTest(test_combinations.TestCase):
         self.assertAllEqual([1, 1, 1, 0], outputs)
 
     @parameterized.named_parameters(
-        ("sparse", True),
-        ("dense", False),
+        ("sparse", True), ("dense", False),
     )
     def test_count_encoding(self, sparse):
         inputs = tf.constant([0, 1, 1, 2, 2, 2])
@@ -86,8 +83,7 @@ class EncodeCategoricalInputsTest(test_combinations.TestCase):
         self.assertAllEqual([1, 2, 3, 0], outputs)
 
     @parameterized.named_parameters(
-        ("sparse", True),
-        ("dense", False),
+        ("sparse", True), ("dense", False),
     )
     def test_tf_idf_encoding(self, sparse):
         inputs = tf.constant([0, 1, 1, 2, 2, 2])

--- a/keras/layers/preprocessing/string_lookup_test.py
+++ b/keras/layers/preprocessing/string_lookup_test.py
@@ -60,9 +60,7 @@ def _get_end_to_end_test_cases():
                     ["michigan"],
                 ]
             ),
-            "kwargs": {
-                "max_tokens": None,
-            },
+            "kwargs": {"max_tokens": None,},
             "expected_output": [[1], [2], [3], [4], [4], [3], [1], [0]],
             "input_dtype": tf.string,
         },

--- a/keras/layers/preprocessing/text_vectorization_distribution_test.py
+++ b/keras/layers/preprocessing/text_vectorization_distribution_test.py
@@ -27,9 +27,7 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 @test_utils.run_v2_only

--- a/keras/layers/preprocessing/text_vectorization_test.py
+++ b/keras/layers/preprocessing/text_vectorization_test.py
@@ -1443,8 +1443,7 @@ class TextVectorizationOutputTest(
         self.assertAllEqual(expected_output_2, output_dataset)
 
     @parameterized.parameters(
-        {"sparse": True},
-        {"sparse": False},
+        {"sparse": True}, {"sparse": False},
     )
     def test_multi_hot_output_hard_maximum(self, sparse):
         vocab_data = ["earth", "wind", "and", "fire"]
@@ -1484,8 +1483,7 @@ class TextVectorizationOutputTest(
             self.assertAllEqual(expected_output, output_dataset)
 
     @parameterized.parameters(
-        {"sparse": True},
-        {"sparse": False},
+        {"sparse": True}, {"sparse": False},
     )
     def test_multi_hot_output_soft_maximum(self, sparse):
         vocab_data = ["earth", "wind", "and", "fire"]
@@ -1773,8 +1771,7 @@ class TextVectorizationOutputTest(
         self.assertAllEqual(expected_output, output_dataset)
 
     @parameterized.named_parameters(
-        ("sparse", True),
-        ("dense", False),
+        ("sparse", True), ("dense", False),
     )
     def test_tfidf_output_hard_maximum(self, sparse):
         vocab_data = ["earth", "wind", "and", "fire"]
@@ -1816,8 +1813,7 @@ class TextVectorizationOutputTest(
         self.assertAllClose(expected_output, output_dataset)
 
     @parameterized.named_parameters(
-        ("sparse", True),
-        ("dense", False),
+        ("sparse", True), ("dense", False),
     )
     def test_tfidf_output_soft_maximum(self, sparse):
         vocab_data = ["earth", "wind", "and", "fire"]
@@ -1859,8 +1855,7 @@ class TextVectorizationOutputTest(
         self.assertAllClose(expected_output, output_dataset)
 
     @parameterized.named_parameters(
-        ("sparse", True),
-        ("dense", False),
+        ("sparse", True), ("dense", False),
     )
     def test_tfidf_output_set_oov_weight(self, sparse):
         vocab_data = ["[UNK]", "earth", "wind", "and", "fire"]
@@ -2011,8 +2006,7 @@ class TextVectorizationModelBuildingTest(
 @test_utils.run_v2_only
 @test_combinations.run_all_keras_modes(always_skip_v1=True)
 class TextVectorizationVocbularyTest(
-    test_combinations.TestCase,
-    preprocessing_test_utils.PreprocessingLayerTest,
+    test_combinations.TestCase, preprocessing_test_utils.PreprocessingLayerTest,
 ):
     def test_get_vocabulary(self):
         vocab = ["earth", "wind", "and", "fire"]
@@ -2208,8 +2202,7 @@ class TextVectorizationSavingTest(
         super(TextVectorizationSavingTest, self).tearDown()
 
     @parameterized.parameters(
-        {"init_vocab": True},
-        {"init_vocab": False},
+        {"init_vocab": True}, {"init_vocab": False},
     )
     def test_saving(self, init_vocab):
         vocab_data = ["earth", "wind", "and", "fire"]
@@ -2249,8 +2242,7 @@ class TextVectorizationSavingTest(
         self.assertAllEqual(loaded_model.predict(input_array), expected_output)
 
     @parameterized.parameters(
-        {"init_vocab": True},
-        {"init_vocab": False},
+        {"init_vocab": True}, {"init_vocab": False},
     )
     def test_saving_when_nested(self, init_vocab):
         vocab_data = ["earth", "wind", "and", "fire"]

--- a/keras/layers/regularization/alpha_dropout.py
+++ b/keras/layers/regularization/alpha_dropout.py
@@ -80,7 +80,7 @@ class AlphaDropout(base_layer.BaseRandomLayer):
                 kept_idx = tf.cast(kept_idx, inputs.dtype)
 
                 # Get affine transformation params
-                a = ((1 - rate) * (1 + rate * alpha_p**2)) ** -0.5
+                a = ((1 - rate) * (1 + rate * alpha_p ** 2)) ** -0.5
                 b = -a * alpha_p * rate
 
                 # Apply mask

--- a/keras/layers/reshaping/up_sampling_test.py
+++ b/keras/layers/reshaping/up_sampling_test.py
@@ -23,9 +23,7 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 @tf_test_utils.for_all_test_methods(

--- a/keras/layers/rnn/base_rnn_test.py
+++ b/keras/layers/rnn/base_rnn_test.py
@@ -35,9 +35,7 @@ from keras.testing_infra import test_utils
 from keras.utils import generic_utils
 
 # isort: off
-from tensorflow.python.checkpoint import (
-    checkpoint as trackable_util,
-)
+from tensorflow.python.checkpoint import checkpoint as trackable_util
 
 # Used for nested input/output/state RNN test.
 NestedInput = collections.namedtuple("NestedInput", ["t1", "t2"])

--- a/keras/layers/rnn/bidirectional_test.py
+++ b/keras/layers/rnn/bidirectional_test.py
@@ -30,12 +30,8 @@ from keras.testing_infra import test_utils
 from keras.utils import generic_utils
 
 # isort: off
-from tensorflow.python.checkpoint import (
-    checkpoint as trackable_util,
-)
-from tensorflow.python.framework import (
-    test_util as tf_test_util,
-)
+from tensorflow.python.checkpoint import checkpoint as trackable_util
+from tensorflow.python.framework import test_util as tf_test_util
 
 
 class _RNNCellWithConstants(keras.layers.Layer):

--- a/keras/layers/rnn/cell_wrappers.py
+++ b/keras/layers/rnn/cell_wrappers.py
@@ -423,10 +423,8 @@ class DropoutWrapper(_RNNCellWrapper):
         if _should_dropout(self._state_keep_prob):
             # Identify which subsets of the state to perform dropout on and
             # which ones to keep.
-            shallow_filtered_substructure = (
-                tf.__internal__.nest.get_traverse_shallow_structure(
-                    self._dropout_state_filter, new_state
-                )
+            shallow_filtered_substructure = tf.__internal__.nest.get_traverse_shallow_structure(
+                self._dropout_state_filter, new_state
             )
             new_state = self._dropout(
                 new_state,

--- a/keras/layers/rnn/cudnn_test.py
+++ b/keras/layers/rnn/cudnn_test.py
@@ -27,9 +27,7 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 @test_combinations.run_all_keras_modes
@@ -471,7 +469,7 @@ class CuDNNV1OnlyTest(test_combinations.TestCase):
             )
         )
         model.add(keras.layers.Bidirectional(rnn(output_dim), merge_mode=mode))
-        model.compile(loss="mse", optimizer=R"rmsprop")
+        model.compile(loss="mse", optimizer=r"rmsprop")
         model.fit(x, y, epochs=1, batch_size=1)
 
         # test with functional API
@@ -480,7 +478,7 @@ class CuDNNV1OnlyTest(test_combinations.TestCase):
             inputs
         )
         model = keras.Model(inputs, outputs)
-        model.compile(loss="mse", optimizer=R"rmsprop")
+        model.compile(loss="mse", optimizer=r"rmsprop")
         model.fit(x, y, epochs=1, batch_size=1)
 
         # Bidirectional and stateful

--- a/keras/layers/rnn/gru.py
+++ b/keras/layers/rnn/gru.py
@@ -860,9 +860,7 @@ class GRU(DropoutRNNCellMixin, RNN, base_layer.BaseRandomLayer):
             }
             normal_gru_kwargs = gpu_gru_kwargs.copy()
             normal_gru_kwargs.update(
-                {
-                    "zero_output_for_mask": self.zero_output_for_mask,
-                }
+                {"zero_output_for_mask": self.zero_output_for_mask,}
             )
 
             if tf.executing_eagerly():

--- a/keras/layers/rnn/gru_lstm_utils.py
+++ b/keras/layers/rnn/gru_lstm_utils.py
@@ -73,15 +73,11 @@ class DefunWrapper:
             + str(uuid.uuid4()),
         }
         if self.layer_name == "lstm":
-            from keras.layers.rnn import (
-                lstm,
-            )
+            from keras.layers.rnn import lstm
 
             layer_func = lstm.lstm_with_backend_selection
         else:
-            from keras.layers.rnn import (
-                gru,
-            )
+            from keras.layers.rnn import gru
 
             layer_func = gru.gru_with_backend_selection
 

--- a/keras/layers/rnn/gru_test.py
+++ b/keras/layers/rnn/gru_test.py
@@ -31,9 +31,7 @@ from keras.utils import np_utils
 
 # isort: off
 from tensorflow.core.protobuf import rewriter_config_pb2
-from tensorflow.python.framework import (
-    test_util as tf_test_util,
-)
+from tensorflow.python.framework import test_util as tf_test_util
 
 # Global config for grappler setting that is used for graph mode test.
 _rewrites = rewriter_config_pb2.RewriterConfig()

--- a/keras/layers/rnn/legacy_cell_wrappers.py
+++ b/keras/layers/rnn/legacy_cell_wrappers.py
@@ -466,10 +466,8 @@ class DropoutWrapper(_RNNCellWrapperV1):
         if _should_dropout(self._state_keep_prob):
             # Identify which subsets of the state to perform dropout on and
             # which ones to keep.
-            shallow_filtered_substructure = (
-                tf.__internal__.nest.get_traverse_shallow_structure(
-                    self._dropout_state_filter, new_state
-                )
+            shallow_filtered_substructure = tf.__internal__.nest.get_traverse_shallow_structure(
+                self._dropout_state_filter, new_state
             )
             new_state = self._dropout(
                 new_state,
@@ -656,9 +654,7 @@ class DeviceWrapper(_RNNCellWrapperV1):
 
 
 def _default_dropout_state_filter_visitor(substate):
-    from keras.layers.rnn.legacy_cells import (
-        LSTMStateTuple,
-    )
+    from keras.layers.rnn.legacy_cells import LSTMStateTuple
 
     if isinstance(substate, LSTMStateTuple):
         # Do not perform dropout on the memory state.

--- a/keras/layers/rnn/lstm.py
+++ b/keras/layers/rnn/lstm.py
@@ -703,9 +703,7 @@ class LSTM(DropoutRNNCellMixin, RNN, base_layer.BaseRandomLayer):
                 }
                 normal_lstm_kwargs = gpu_lstm_kwargs.copy()
                 normal_lstm_kwargs.update(
-                    {
-                        "zero_output_for_mask": self.zero_output_for_mask,
-                    }
+                    {"zero_output_for_mask": self.zero_output_for_mask,}
                 )
 
                 if tf.executing_eagerly():

--- a/keras/layers/rnn/lstm_test.py
+++ b/keras/layers/rnn/lstm_test.py
@@ -31,9 +31,7 @@ from keras.utils import np_utils
 
 # isort: off
 from tensorflow.core.protobuf import rewriter_config_pb2
-from tensorflow.python.framework import (
-    test_util as tf_test_util,
-)
+from tensorflow.python.framework import test_util as tf_test_util
 
 # Global config for grappler setting that is used for graph mode test.
 _rewrites = rewriter_config_pb2.RewriterConfig()

--- a/keras/layers/rnn/stacked_rnn_cells.py
+++ b/keras/layers/rnn/stacked_rnn_cells.py
@@ -159,8 +159,11 @@ class StackedRNNCells(base_layer.Layer):
                 inputs, states = cell_call_fn(inputs, states, **kwargs)
             new_nested_states.append(states)
 
-        return inputs, tf.nest.pack_sequence_as(
-            state_size, tf.nest.flatten(new_nested_states)
+        return (
+            inputs,
+            tf.nest.pack_sequence_as(
+                state_size, tf.nest.flatten(new_nested_states)
+            ),
         )
 
     @tf_utils.shape_type_conversion

--- a/keras/layers/rnn/time_distributed_test.py
+++ b/keras/layers/rnn/time_distributed_test.py
@@ -24,9 +24,7 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.checkpoint import (
-    checkpoint as trackable_util,
-)
+from tensorflow.python.checkpoint import checkpoint as trackable_util
 
 
 class TimeDistributedTest(test_combinations.TestCase):
@@ -236,10 +234,7 @@ class TimeDistributedTest(test_combinations.TestCase):
         model = keras.models.Sequential()
         model.add(
             keras.layers.TimeDistributed(
-                keras.layers.Masking(
-                    mask_value=0.0,
-                ),
-                input_shape=(None, 4),
+                keras.layers.Masking(mask_value=0.0,), input_shape=(None, 4),
             )
         )
         model.add(keras.layers.TimeDistributed(keras.layers.Dense(5)))

--- a/keras/layers/serialization.py
+++ b/keras/layers/serialization.py
@@ -140,15 +140,9 @@ def populate_deserializable_objects():
 
     # Prevent circular dependencies.
     from keras import models
-    from keras.feature_column.sequence_feature_column import (
-        SequenceFeatures,
-    )
-    from keras.premade_models.linear import (
-        LinearModel,
-    )
-    from keras.premade_models.wide_deep import (
-        WideDeepModel,
-    )
+    from keras.feature_column.sequence_feature_column import SequenceFeatures
+    from keras.premade_models.linear import LinearModel
+    from keras.premade_models.wide_deep import WideDeepModel
 
     LOCAL.ALL_OBJECTS["Input"] = input_layer.Input
     LOCAL.ALL_OBJECTS["InputSpec"] = input_spec.InputSpec
@@ -160,15 +154,11 @@ def populate_deserializable_objects():
     LOCAL.ALL_OBJECTS["WideDeepModel"] = WideDeepModel
 
     if tf.__internal__.tf2.enabled():
-        from keras.feature_column.dense_features_v2 import (
-            DenseFeatures,
-        )
+        from keras.feature_column.dense_features_v2 import DenseFeatures
 
         LOCAL.ALL_OBJECTS["DenseFeatures"] = DenseFeatures
     else:
-        from keras.feature_column.dense_features import (
-            DenseFeatures,
-        )
+        from keras.feature_column.dense_features import DenseFeatures
 
         LOCAL.ALL_OBJECTS["DenseFeatures"] = DenseFeatures
 

--- a/keras/layers/tensorflow_op_layer_test.py
+++ b/keras/layers/tensorflow_op_layer_test.py
@@ -255,11 +255,7 @@ def _inner_layer():
 
 def _reuse_ancillary_layer():
     inputs = (keras.Input(shape=(5,)), keras.Input(shape=(5,)))
-    base_model = keras.Sequential(
-        [
-            keras.layers.Dense(3, input_shape=(5,)),
-        ]
-    )
+    base_model = keras.Sequential([keras.layers.Dense(3, input_shape=(5,)),])
     outputs = base_model(inputs[0])
     model = keras.Model(inputs, outputs)
     # The second input is only involved in ancillary layers.
@@ -681,7 +677,7 @@ class AutoLambdaTest(test_combinations.TestCase):
         def f(x):
             with tf.GradientTape() as t:
                 t.watch(x)
-                z = m(x**2)
+                z = m(x ** 2)
             grads = t.gradient(z, x)
             return grads
 

--- a/keras/legacy_tf_layers/base.py
+++ b/keras/legacy_tf_layers/base.py
@@ -501,9 +501,8 @@ class Layer(base_layer.Layer):
                 )
 
                 if regularizer:
-                    if (
-                        tf.compat.v1.executing_eagerly_outside_functions()
-                        or _should_add_regularizer(variable, existing_variables)
+                    if tf.compat.v1.executing_eagerly_outside_functions() or _should_add_regularizer(
+                        variable, existing_variables
                     ):
                         self._handle_weight_regularization(
                             name, variable, regularizer

--- a/keras/legacy_tf_layers/core_test.py
+++ b/keras/legacy_tf_layers/core_test.py
@@ -29,9 +29,7 @@ from keras.legacy_tf_layers import core as core_layers
 from keras.testing_infra import test_combinations
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 from tensorflow.python.ops import variable_scope
 
 

--- a/keras/legacy_tf_layers/normalization_test.py
+++ b/keras/legacy_tf_layers/normalization_test.py
@@ -28,9 +28,7 @@ from keras.legacy_tf_layers import normalization as normalization_layers
 
 # isort: off
 from tensorflow.core.protobuf import saver_pb2
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 @tf_test_utils.run_v1_only("b/120545219")

--- a/keras/legacy_tf_layers/pooling_test.py
+++ b/keras/legacy_tf_layers/pooling_test.py
@@ -23,9 +23,7 @@ import tensorflow.compat.v2 as tf
 from keras.legacy_tf_layers import pooling as pooling_layers
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 class PoolingTest(tf.test.TestCase):

--- a/keras/legacy_tf_layers/variable_scope_shim.py
+++ b/keras/legacy_tf_layers/variable_scope_shim.py
@@ -836,10 +836,7 @@ def track_tf1_style_variables(method):
         # If this is a layer method, add the regularization losses
         # to the layer for any newly-created regularized variables
         if isinstance(self, base_layer.Layer):
-            for (
-                var_name,
-                regularizer,
-            ) in var_store._regularizers.items():
+            for (var_name, regularizer,) in var_store._regularizers.items():
                 if var_name not in existing_regularized_variables:
                     self.add_loss(regularizer)
 

--- a/keras/legacy_tf_layers/variable_scope_shim_test.py
+++ b/keras/legacy_tf_layers/variable_scope_shim_test.py
@@ -36,9 +36,7 @@ from keras.legacy_tf_layers import variable_scope_shim
 from keras.testing_infra import test_combinations
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 from tensorflow.python.ops import variable_scope
 
 
@@ -987,9 +985,7 @@ class TF1VariableScopeLayerTest(tf.test.TestCase, parameterized.TestCase):
                         name="kernel",
                     )
                     bias = tf.compat.v1.get_variable(
-                        shape=[
-                            self.units,
-                        ],
+                        shape=[self.units,],
                         initializer=tf.compat.v1.zeros_initializer(),
                         name="bias",
                     )
@@ -1004,9 +1000,7 @@ class TF1VariableScopeLayerTest(tf.test.TestCase, parameterized.TestCase):
                             name="kernel",
                         )
                         bias = tf.compat.v1.get_variable(
-                            shape=[
-                                self.units,
-                            ],
+                            shape=[self.units,],
                             initializer=tf.compat.v1.zeros_initializer(),
                             name="bias",
                         )
@@ -1166,9 +1160,7 @@ class TF1VariableScopeLayerTest(tf.test.TestCase, parameterized.TestCase):
                             name="kernel",
                         )
                         bias = tf.compat.v1.get_variable(
-                            shape=[
-                                self.units,
-                            ],
+                            shape=[self.units,],
                             initializer=tf.compat.v1.zeros_initializer(),
                             name="bias",
                         )
@@ -1183,9 +1175,7 @@ class TF1VariableScopeLayerTest(tf.test.TestCase, parameterized.TestCase):
                                 name="kernel",
                             )
                             bias = tf.compat.v1.get_variable(
-                                shape=[
-                                    self.units,
-                                ],
+                                shape=[self.units,],
                                 initializer=tf.compat.v1.zeros_initializer(),
                                 name="bias",
                             )
@@ -1245,9 +1235,7 @@ class TF1VariableScopeLayerTest(tf.test.TestCase, parameterized.TestCase):
                         name="kernel",
                     )
                     bias = tf.compat.v1.get_variable(
-                        shape=[
-                            self.units,
-                        ],
+                        shape=[self.units,],
                         initializer=tf.compat.v1.zeros_initializer(),
                         name="bias",
                     )
@@ -1262,9 +1250,7 @@ class TF1VariableScopeLayerTest(tf.test.TestCase, parameterized.TestCase):
                             name="kernel",
                         )
                         bias = tf.compat.v1.get_variable(
-                            shape=[
-                                self.units,
-                            ],
+                            shape=[self.units,],
                             initializer=tf.compat.v1.zeros_initializer(),
                             name="bias",
                         )
@@ -1380,9 +1366,7 @@ class TF1VariableScopeLayerTest(tf.test.TestCase, parameterized.TestCase):
                         name="kernel",
                     )
                     bias = tf.compat.v1.get_variable(
-                        shape=[
-                            self.units,
-                        ],
+                        shape=[self.units,],
                         initializer=tf.compat.v1.initializers.zeros,
                         name="bias",
                     )
@@ -1783,9 +1767,7 @@ class GetOrCreateLayerTest(tf.test.TestCase, parameterized.TestCase):
             def build_model(self):
                 inp = input_layer_module.Input(shape=(5, 5))
                 dense_layer = core.Dense(
-                    10,
-                    name="dense",
-                    kernel_regularizer="l2",
+                    10, name="dense", kernel_regularizer="l2",
                 )
                 model = training_module.Model(
                     inputs=inp, outputs=dense_layer(inp)

--- a/keras/losses_test.py
+++ b/keras/losses_test.py
@@ -25,9 +25,7 @@ from keras.testing_infra import test_combinations
 from keras.utils import losses_utils
 
 # isort: off
-from tensorflow.python.autograph.impl import (
-    api as autograph,
-)
+from tensorflow.python.autograph.impl import api as autograph
 
 ALL_LOSSES = [
     losses.mean_squared_error,
@@ -62,10 +60,7 @@ class KerasLossesTest(tf.test.TestCase, parameterized.TestCase):
             for obj in ALL_LOSSES:
                 objective_output = obj(y_a, y_b)
                 self.assertListEqual(
-                    objective_output.shape.as_list(),
-                    [
-                        6,
-                    ],
+                    objective_output.shape.as_list(), [6,],
                 )
 
     def test_cce_one_hot(self):
@@ -1130,12 +1125,7 @@ class BinaryFocalCrossentropyTest(tf.test.TestCase):
 
     def test_all_correct_unweighted(self):
         y_true = tf.constant(
-            [
-                [1, 0, 0],
-                [0, 1, 0],
-                [0, 0, 1],
-            ],
-            dtype=tf.float32,
+            [[1, 0, 0], [0, 1, 0], [0, 0, 1],], dtype=tf.float32,
         )
         obj = losses.BinaryFocalCrossentropy(gamma=1.5)
         loss = obj(y_true, y_true)
@@ -1289,8 +1279,7 @@ class BinaryFocalCrossentropyTest(tf.test.TestCase):
             [2, 2]
         )
         obj = losses.BinaryFocalCrossentropy(
-            gamma=2.0,
-            reduction=losses_utils.ReductionV2.NONE,
+            gamma=2.0, reduction=losses_utils.ReductionV2.NONE,
         )
         loss = obj(y_true, y_pred)
 
@@ -1325,10 +1314,7 @@ class BinaryFocalCrossentropyTest(tf.test.TestCase):
 class BinaryWeightedFocalCrossentropyTest(tf.test.TestCase):
     def test_config(self):
         obj = losses.BinaryFocalCrossentropy(
-            apply_class_balancing=True,
-            alpha=0.1,
-            gamma=1.5,
-            name="bfce_0",
+            apply_class_balancing=True, alpha=0.1, gamma=1.5, name="bfce_0",
         )
         self.assertTrue(obj.apply_class_balancing)
         self.assertEqual(obj.name, "bfce_0")
@@ -1343,12 +1329,7 @@ class BinaryWeightedFocalCrossentropyTest(tf.test.TestCase):
 
     def test_all_correct_unweighted(self):
         y_true = tf.constant(
-            [
-                [1, 0, 0],
-                [0, 1, 0],
-                [0, 0, 1],
-            ],
-            dtype=tf.float32,
+            [[1, 0, 0], [0, 1, 0], [0, 0, 1],], dtype=tf.float32,
         )
         obj = losses.BinaryFocalCrossentropy(
             apply_class_balancing=True, gamma=1.5
@@ -1365,10 +1346,7 @@ class BinaryWeightedFocalCrossentropyTest(tf.test.TestCase):
             ]
         )
         obj = losses.BinaryFocalCrossentropy(
-            apply_class_balancing=True,
-            alpha=0.3,
-            gamma=2.0,
-            from_logits=True,
+            apply_class_balancing=True, alpha=0.3, gamma=2.0, from_logits=True,
         )
         loss = obj(y_true, logits)
         self.assertAlmostEqual(self.evaluate(loss), 0.0, 3)
@@ -1379,9 +1357,7 @@ class BinaryWeightedFocalCrossentropyTest(tf.test.TestCase):
             [2, 2]
         )
         obj = losses.BinaryFocalCrossentropy(
-            apply_class_balancing=True,
-            alpha=0.4,
-            gamma=2.0,
+            apply_class_balancing=True, alpha=0.4, gamma=2.0,
         )
         loss = obj(y_true, y_pred)
 
@@ -1402,10 +1378,7 @@ class BinaryWeightedFocalCrossentropyTest(tf.test.TestCase):
         y_true = tf.constant([[1, 1, 0], [0, 1, 0]], dtype=tf.float32)
         logits = tf.constant([[1.5, -2.7, 2.9], [-3.8, 1.2, -4.5]])
         obj = losses.BinaryFocalCrossentropy(
-            apply_class_balancing=True,
-            alpha=0.3,
-            gamma=3.0,
-            from_logits=True,
+            apply_class_balancing=True, alpha=0.3, gamma=3.0, from_logits=True,
         )
         loss = obj(y_true, logits)
 
@@ -1433,9 +1406,7 @@ class BinaryWeightedFocalCrossentropyTest(tf.test.TestCase):
             [2, 2]
         )
         obj = losses.BinaryFocalCrossentropy(
-            apply_class_balancing=True,
-            alpha=0.6,
-            gamma=2.0,
+            apply_class_balancing=True, alpha=0.6, gamma=2.0,
         )
         loss = obj(y_true, y_pred, sample_weight=1.23)
 
@@ -1456,10 +1427,7 @@ class BinaryWeightedFocalCrossentropyTest(tf.test.TestCase):
         y_true = tf.constant([[1, 1, 0], [0, 1, 0]], dtype=tf.float32)
         logits = tf.constant([[1.5, -2.7, 2.9], [-3.8, 1.2, -4.5]])
         obj = losses.BinaryFocalCrossentropy(
-            apply_class_balancing=True,
-            alpha=0.2,
-            gamma=3.0,
-            from_logits=True,
+            apply_class_balancing=True, alpha=0.2, gamma=3.0, from_logits=True,
         )
         loss = obj(y_true, logits, sample_weight=3.21)
 
@@ -1490,9 +1458,7 @@ class BinaryWeightedFocalCrossentropyTest(tf.test.TestCase):
         )
         sample_weight = tf.constant([1.2, 3.4], shape=(2, 1))
         obj = losses.BinaryFocalCrossentropy(
-            apply_class_balancing=True,
-            alpha=0.1,
-            gamma=2.0,
+            apply_class_balancing=True, alpha=0.1, gamma=2.0,
         )
         loss = obj(y_true, y_pred, sample_weight=sample_weight)
 
@@ -1515,10 +1481,7 @@ class BinaryWeightedFocalCrossentropyTest(tf.test.TestCase):
         y_true = tf.constant([[1, 1, 0], [0, 1, 0]], dtype=tf.float32)
         logits = tf.constant([[1.5, -2.7, 2.9], [-3.8, 1.2, -4.5]])
         obj = losses.BinaryFocalCrossentropy(
-            apply_class_balancing=True,
-            alpha=0.2,
-            gamma=3.0,
-            from_logits=True,
+            apply_class_balancing=True, alpha=0.2, gamma=3.0, from_logits=True,
         )
         loss = obj(y_true, logits, sample_weight=sample_weight)
 
@@ -1575,9 +1538,7 @@ class BinaryWeightedFocalCrossentropyTest(tf.test.TestCase):
         y_true = tf.ragged.constant([[1, 0, 1], [0]])
         y_pred = tf.ragged.constant([[0.9, 0.8, 0.7], [0.2]])
         obj = losses.BinaryFocalCrossentropy(
-            apply_class_balancing=True,
-            alpha=0.1,
-            gamma=2.0,
+            apply_class_balancing=True, alpha=0.1, gamma=2.0,
         )
         loss = obj(y_true, y_pred)
 
@@ -2760,8 +2721,7 @@ class CustomLossTest(tf.test.TestCase):
 
         loss = loss_fn(y_true, y_pred)
         self.assertAllEqual(
-            self.evaluate(loss),
-            7.0,
+            self.evaluate(loss), 7.0,
         )
 
 

--- a/keras/metrics/base_metric.py
+++ b/keras/metrics/base_metric.py
@@ -206,9 +206,7 @@ class Metric(base_layer.Layer, metaclass=abc.ABCMeta):
                 result_t._metric_obj = self
                 return result_t
 
-        from keras.distribute import (
-            distributed_training_utils,
-        )
+        from keras.distribute import distributed_training_utils
 
         return distributed_training_utils.call_replica_local_fn(
             replica_local_fn, *args, **kwargs
@@ -453,9 +451,10 @@ class Reduce(Metric):
         Returns:
           Update op.
         """
-        [
-            values
-        ], sample_weight = metrics_utils.ragged_assert_compatible_and_get_flat_values(  # noqa: E501
+        (
+            [values],
+            sample_weight,
+        ) = metrics_utils.ragged_assert_compatible_and_get_flat_values(  # noqa: E501
             [values], sample_weight
         )
         try:
@@ -684,10 +683,10 @@ class MeanMetricWrapper(Mean):
         """
         y_true = tf.cast(y_true, self._dtype)
         y_pred = tf.cast(y_pred, self._dtype)
-        [
-            y_true,
-            y_pred,
-        ], sample_weight = metrics_utils.ragged_assert_compatible_and_get_flat_values(  # noqa: E501
+        (
+            [y_true, y_pred,],
+            sample_weight,
+        ) = metrics_utils.ragged_assert_compatible_and_get_flat_values(  # noqa: E501
             [y_true, y_pred], sample_weight
         )
         y_pred, y_true = losses_utils.squeeze_or_expand_dimensions(

--- a/keras/metrics/metrics.py
+++ b/keras/metrics/metrics.py
@@ -110,10 +110,10 @@ class MeanRelativeError(base_metric.Mean):
         """
         y_true = tf.cast(y_true, self._dtype)
         y_pred = tf.cast(y_pred, self._dtype)
-        [
-            y_pred,
-            y_true,
-        ], sample_weight = metrics_utils.ragged_assert_compatible_and_get_flat_values(  # noqa: E501
+        (
+            [y_pred, y_true,],
+            sample_weight,
+        ) = metrics_utils.ragged_assert_compatible_and_get_flat_values(  # noqa: E501
             [y_pred, y_true], sample_weight
         )
         y_pred, y_true = losses_utils.squeeze_or_expand_dimensions(
@@ -490,8 +490,8 @@ class _ConfusionMatrixConditionCount(base_metric.Metric):
         self.thresholds = metrics_utils.parse_init_thresholds(
             thresholds, default_threshold=0.5
         )
-        self._thresholds_distributed_evenly = (
-            metrics_utils.is_evenly_distributed_thresholds(self.thresholds)
+        self._thresholds_distributed_evenly = metrics_utils.is_evenly_distributed_thresholds(
+            self.thresholds
         )
         self.accumulator = self.add_weight(
             "accumulator", shape=(len(self.thresholds),), initializer="zeros"
@@ -876,8 +876,8 @@ class Precision(base_metric.Metric):
         self.thresholds = metrics_utils.parse_init_thresholds(
             thresholds, default_threshold=default_threshold
         )
-        self._thresholds_distributed_evenly = (
-            metrics_utils.is_evenly_distributed_thresholds(self.thresholds)
+        self._thresholds_distributed_evenly = metrics_utils.is_evenly_distributed_thresholds(
+            self.thresholds
         )
         self.true_positives = self.add_weight(
             "true_positives", shape=(len(self.thresholds),), initializer="zeros"
@@ -1022,8 +1022,8 @@ class Recall(base_metric.Metric):
         self.thresholds = metrics_utils.parse_init_thresholds(
             thresholds, default_threshold=default_threshold
         )
-        self._thresholds_distributed_evenly = (
-            metrics_utils.is_evenly_distributed_thresholds(self.thresholds)
+        self._thresholds_distributed_evenly = metrics_utils.is_evenly_distributed_thresholds(
+            self.thresholds
         )
         self.true_positives = self.add_weight(
             "true_positives", shape=(len(self.thresholds),), initializer="zeros"
@@ -1758,10 +1758,8 @@ class AUC(base_metric.Metric):
             # If specified, use the supplied thresholds.
             self.num_thresholds = len(thresholds) + 2
             thresholds = sorted(thresholds)
-            self._thresholds_distributed_evenly = (
-                metrics_utils.is_evenly_distributed_thresholds(
-                    np.array([0.0] + thresholds + [1.0])
-                )
+            self._thresholds_distributed_evenly = metrics_utils.is_evenly_distributed_thresholds(
+                np.array([0.0] + thresholds + [1.0])
             )
         else:
             if num_thresholds <= 1:
@@ -3562,10 +3560,10 @@ SparseCategoricalCrossentropy.update_state.__doc__ = (
 
 
 def accuracy(y_true, y_pred):
-    [
-        y_pred,
-        y_true,
-    ], _ = metrics_utils.ragged_assert_compatible_and_get_flat_values(
+    (
+        [y_pred, y_true,],
+        _,
+    ) = metrics_utils.ragged_assert_compatible_and_get_flat_values(
         [y_pred, y_true]
     )
     y_true.shape.assert_is_compatible_with(y_pred.shape)

--- a/keras/metrics/metrics_correctness_test.py
+++ b/keras/metrics/metrics_correctness_test.py
@@ -259,9 +259,7 @@ class TestMetricsCorrectnessMultiIO(test_combinations.TestCase):
             [self.x, self.x],
             [self.y1, self.y2],
             batch_size=2,
-            sample_weight={
-                "output_2": self.sample_weight_2,
-            },
+            sample_weight={"output_2": self.sample_weight_2,},
         )
         self.assertAllClose(
             eval_result, self.expected_batch_result_with_weights_output_2, 1e-3
@@ -303,9 +301,7 @@ class TestMetricsCorrectnessMultiIO(test_combinations.TestCase):
         result = model.train_on_batch(
             [self.x, self.x],
             [self.y1, self.y2],
-            sample_weight={
-                "output_2": self.sample_weight_2,
-            },
+            sample_weight={"output_2": self.sample_weight_2,},
         )
         self.assertAllClose(
             result, self.expected_batch_result_with_weights_output_2, 1e-3
@@ -334,9 +330,7 @@ class TestMetricsCorrectnessMultiIO(test_combinations.TestCase):
         result = model.test_on_batch(
             [self.x, self.x],
             [self.y1, self.y2],
-            sample_weight={
-                "output_2": self.sample_weight_2,
-            },
+            sample_weight={"output_2": self.sample_weight_2,},
         )
         self.assertAllClose(
             result, self.expected_batch_result_with_weights_output_2, 1e-3

--- a/keras/metrics/metrics_test.py
+++ b/keras/metrics/metrics_test.py
@@ -1464,13 +1464,7 @@ class OneHotMeanIoUTest(tf.test.TestCase):
 
     def test_weighted(self):
         y_true = tf.constant(
-            [
-                [0, 0, 1],
-                [1, 0, 0],
-                [0, 1, 0],
-                [1, 0, 0],
-                [1, 0, 0],
-            ]
+            [[0, 0, 1], [1, 0, 0], [0, 1, 0], [1, 0, 0], [1, 0, 0],]
         )
         # y_true will be converted to [2, 0, 1, 0, 0]
         y_pred = tf.constant(

--- a/keras/mixed_precision/layer_test.py
+++ b/keras/mixed_precision/layer_test.py
@@ -198,7 +198,7 @@ class LayerTest(test_combinations.TestCase):
                 # variable, the variable will not change. So this tests the
                 # learning rate is not applied to a float16 value, but instead
                 # the float32 variable.
-                opt = gradient_descent.SGD(2**-14)
+                opt = gradient_descent.SGD(2 ** -14)
 
                 def run_fn():
                     with tf.GradientTape() as tape:
@@ -218,7 +218,7 @@ class LayerTest(test_combinations.TestCase):
                 # variable is initialized with 1 and the learning rate is
                 # 2**-14, the new variable value should be: init_val - gradient
                 # * learning_rate, which is  1 - 1 * 2**-14
-                self.assertEqual(self.evaluate(layer.v), 1 - 2**-14)
+                self.assertEqual(self.evaluate(layer.v), 1 - 2 ** -14)
 
     def _test_checkpointing_layer_weights(
         self, strategy_fn, mixed_prec_when_saving, mixed_prec_when_loading

--- a/keras/mixed_precision/loss_scale_optimizer.py
+++ b/keras/mixed_precision/loss_scale_optimizer.py
@@ -312,7 +312,7 @@ class _DynamicLossScaleState(tf.__internal__.tracking.Trackable):
 
 
 # See LossScaleOptimizer docstring for why this is so big
-_DEFAULT_INITIAL_SCALE = 2**15
+_DEFAULT_INITIAL_SCALE = 2 ** 15
 _DEFAULT_GROWTH_STEPS = 2000
 
 
@@ -992,9 +992,7 @@ class LossScaleOptimizer(
 
     def _restore_slot_variable(self, slot_name, variable, slot_variable):
         return self._optimizer._restore_slot_variable(
-            slot_name,
-            variable,
-            slot_variable,
+            slot_name, variable, slot_variable,
         )
 
     def _create_or_restore_slot_variable(

--- a/keras/mixed_precision/loss_scale_optimizer_test.py
+++ b/keras/mixed_precision/loss_scale_optimizer_test.py
@@ -35,12 +35,8 @@ from keras.optimizers.optimizer_v2 import optimizer_v2
 from keras.testing_infra import test_combinations
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
-from tensorflow.python.keras.optimizer_v2 import (
-    gradient_descent as legacy_sgd,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
+from tensorflow.python.keras.optimizer_v2 import gradient_descent as legacy_sgd
 from tensorflow.python.platform import tf_logging
 
 # If called outside any strategy.scope() calls, this will return the default
@@ -335,10 +331,10 @@ class LossScaleOptimizerTest(tf.test.TestCase, parameterized.TestCase):
     def testDynamicLossScaleDefaultValues(self, opt_cls):
         opt = create_sgd(opt_cls)
         opt = create_lso(opt)
-        self.assertEqual(opt.initial_scale, 2**15)
+        self.assertEqual(opt.initial_scale, 2 ** 15)
         self.assertEqual(opt.dynamic_growth_steps, 2000)
         self.evaluate(tf.compat.v1.global_variables_initializer())
-        self.assertEqual(self.evaluate(opt.loss_scale), 2**15)
+        self.assertEqual(self.evaluate(opt.loss_scale), 2 ** 15)
 
     @test_combinations.generate(opt_and_strategy_and_mode_combinations())
     def testClipping(self, opt_cls, strategy_fn, use_tf_function):

--- a/keras/mixed_precision/mixed_precision_graph_rewrite_test.py
+++ b/keras/mixed_precision/mixed_precision_graph_rewrite_test.py
@@ -84,9 +84,9 @@ class MixedPrecisionTest(test_combinations.TestCase):
         )
         self.assertIsInstance(opt, loss_scale_optimizer_v2.LossScaleOptimizer)
         self.evaluate(tf.compat.v1.global_variables_initializer())
-        self.assertEqual(self.evaluate(opt.loss_scale), 2.0**15)
+        self.assertEqual(self.evaluate(opt.loss_scale), 2.0 ** 15)
         self.assertTrue(opt.dynamic)
-        self.assertTrue(opt.initial_scale, 2.0**15)
+        self.assertTrue(opt.initial_scale, 2.0 ** 15)
         self.assertTrue(opt.dynamic_growth_steps, 2000)
 
         opt = gradient_descent_v2.SGD(1.0)

--- a/keras/mixed_precision/model_test.py
+++ b/keras/mixed_precision/model_test.py
@@ -212,7 +212,7 @@ class KerasModelTest(test_combinations.TestCase):
                 # variable, the variable will not change. So this tests the
                 # learning rate not applied to a float16 value, but instead the
                 # float32 variable.
-                opt = gradient_descent.SGD(2**-14)
+                opt = gradient_descent.SGD(2 ** -14)
                 # Use a fixed loss scale, as this test will fail if gradients
                 # are skipped for a step due to dynamic loss scaling.
                 opt = loss_scale_optimizer.LossScaleOptimizer(
@@ -230,11 +230,11 @@ class KerasModelTest(test_combinations.TestCase):
         model.fit(dataset)
         # Variable starts at 1, and should have gradient of 2 ** -14 subtracted
         # from it.
-        expected = 1 - 2**-14
+        expected = 1 - 2 ** -14
         if use_regularizer:
             # Weight and activity regularizer each add another 2 ** -14 to the
             # gradient.
-            expected -= 2 * 2**-14
+            expected -= 2 * 2 ** -14
         self.assertEqual(backend.eval(layer.v), expected)
 
         if save_format:
@@ -256,16 +256,16 @@ class KerasModelTest(test_combinations.TestCase):
             for layer in model.layers
             if "MultiplyLayer" in layer.__class__.__name__
         )
-        expected = 1 - 2**-14
+        expected = 1 - 2 ** -14
         if use_regularizer:
-            expected -= 2 * 2**-14
+            expected -= 2 * 2 ** -14
         self.assertEqual(backend.eval(layer.v), expected)
 
         # Continue training, and assert variable is correct value
         model.fit(dataset)
-        new_expected = expected - 2**-14
+        new_expected = expected - 2 ** -14
         if use_regularizer:
-            new_expected -= 2 * 2**-14
+            new_expected -= 2 * 2 ** -14
         self.assertEqual(backend.eval(layer.v), new_expected)
 
         # Load saved model again, and assert variable is previous value
@@ -311,10 +311,8 @@ class KerasModelTest(test_combinations.TestCase):
             # gradient is 'loss_scale'. We divide by the batch size since the
             # loss is averaged across batch elements.
             expected_gradient = loss_scale / batch_size
-            identity_with_grad_check_fn = (
-                mp_test_util.create_identity_with_grad_check_fn(
-                    [expected_gradient]
-                )
+            identity_with_grad_check_fn = mp_test_util.create_identity_with_grad_check_fn(
+                [expected_gradient]
             )
             y = core.Lambda(identity_with_grad_check_fn)(y)
             model = models.Model(inputs=x, outputs=y)
@@ -365,7 +363,7 @@ class KerasModelTest(test_combinations.TestCase):
         strategy = strategy_fn()
         if use_loss_scaling:
             loss_scale = 8.0
-        learning_rate = 2**-14
+        learning_rate = 2 ** -14
 
         with strategy.scope():
             with policy.policy_scope(policy.Policy("mixed_float16")):
@@ -395,11 +393,9 @@ class KerasModelTest(test_combinations.TestCase):
                     # the gradient is 'loss_scale'. We divide by the batch size
                     # of 2 since the loss is averaged across batch elements.
                     expected_gradient = loss_scale / 2
-                    identity_with_grad_check_fn = (
-                        mp_test_util.create_identity_with_grad_check_fn(
-                            expected_dtype=tf.float16,
-                            expected_gradient=[expected_gradient],
-                        )
+                    identity_with_grad_check_fn = mp_test_util.create_identity_with_grad_check_fn(
+                        expected_dtype=tf.float16,
+                        expected_gradient=[expected_gradient],
                     )
                     y = core.Lambda(identity_with_grad_check_fn)(y)
                 model = models.Model(inputs=x, outputs=y)
@@ -465,17 +461,13 @@ class KerasModelTest(test_combinations.TestCase):
                 )
                 layer = mp_test_util.MultiplyLayer(assert_type=tf.float16)
                 y = layer(x)
-                identity_with_nan_grads = (
-                    mp_test_util.create_identity_with_nan_gradients_fn(
-                        have_nan_gradients
-                    )
+                identity_with_nan_grads = mp_test_util.create_identity_with_nan_gradients_fn(
+                    have_nan_gradients
                 )
                 y = core.Lambda(identity_with_nan_grads)(y)
-                identity_with_grad_check_fn = (
-                    mp_test_util.create_identity_with_grad_check_fn(
-                        expected_dtype=tf.float16,
-                        expected_gradient=expected_gradient,
-                    )
+                identity_with_grad_check_fn = mp_test_util.create_identity_with_grad_check_fn(
+                    expected_dtype=tf.float16,
+                    expected_gradient=expected_gradient,
                 )
                 y = core.Lambda(identity_with_grad_check_fn)(y)
                 model = models.Model(inputs=x, outputs=y)
@@ -617,10 +609,7 @@ class KerasModelTest(test_combinations.TestCase):
 
     @test_combinations.run_all_keras_modes
     @parameterized.named_parameters(
-        {
-            "testcase_name": "base",
-            "strategy_fn": default_strategy_fn,
-        },
+        {"testcase_name": "base", "strategy_fn": default_strategy_fn,},
         {
             "testcase_name": "distribute",
             "strategy_fn": create_mirrored_strategy,
@@ -659,10 +648,7 @@ class KerasModelTest(test_combinations.TestCase):
 
     @test_combinations.run_all_keras_modes
     @parameterized.named_parameters(
-        {
-            "testcase_name": "base",
-            "strategy_fn": default_strategy_fn,
-        },
+        {"testcase_name": "base", "strategy_fn": default_strategy_fn,},
         {
             "testcase_name": "distribute",
             "strategy_fn": create_mirrored_strategy,
@@ -768,13 +754,7 @@ class KerasModelTest(test_combinations.TestCase):
         # of LossScaleOptimizer changed, but old checkpoints can still be loaded
         opt = gradient_descent.SGD(0.1, momentum=0.1)
         opt = loss_scale_optimizer.LossScaleOptimizer(opt)
-        model = sequential.Sequential(
-            [
-                core.Dense(
-                    2,
-                )
-            ]
-        )
+        model = sequential.Sequential([core.Dense(2,)])
 
         # The checkpoint and expected values were obtained from the program in
         # testdata/BUILD.
@@ -838,10 +818,7 @@ class KerasModelTest(test_combinations.TestCase):
 
     @test_combinations.run_all_keras_modes
     @parameterized.named_parameters(
-        {
-            "testcase_name": "base",
-            "strategy_fn": default_strategy_fn,
-        },
+        {"testcase_name": "base", "strategy_fn": default_strategy_fn,},
         {
             "testcase_name": "distribute",
             "strategy_fn": create_mirrored_strategy,

--- a/keras/mixed_precision/test_util.py
+++ b/keras/mixed_precision/test_util.py
@@ -47,11 +47,9 @@ def create_identity_with_grad_check_fn(expected_gradient, expected_dtype=None):
             """Gradient function that asserts the gradient has a certain
             value."""
             if expected_dtype:
-                assert (
-                    dx.dtype == expected_dtype
-                ), "dx.dtype should be %s but is: %s" % (
-                    expected_dtype,
-                    dx.dtype,
+                assert dx.dtype == expected_dtype, (
+                    "dx.dtype should be %s but is: %s"
+                    % (expected_dtype, dx.dtype,)
                 )
             expected_tensor = tf.convert_to_tensor(
                 expected_gradient, dtype=dx.dtype, name="expected_gradient"

--- a/keras/models/cloning_test.py
+++ b/keras/models/cloning_test.py
@@ -205,12 +205,8 @@ class TestModelCloning(test_combinations.TestCase):
 
         input_a = keras.Input(shape=(4,))
         input_b = keras.Input(shape=(4,))
-        dense_1 = keras.layers.Dense(
-            4,
-        )
-        dense_2 = keras.layers.Dense(
-            4,
-        )
+        dense_1 = keras.layers.Dense(4,)
+        dense_2 = keras.layers.Dense(4,)
 
         x_a = dense_1(input_a)
         x_a = keras.layers.Dropout(0.5)(x_a)

--- a/keras/models/sharpness_aware_minimization_test.py
+++ b/keras/models/sharpness_aware_minimization_test.py
@@ -26,12 +26,7 @@ STRATEGIES = [
 @test_utils.run_v2_only
 class SharpnessAwareMinimizationTest(tf.test.TestCase, parameterized.TestCase):
     def test_sam_model_call(self):
-        model = keras.Sequential(
-            [
-                keras.Input([2, 2]),
-                keras.layers.Dense(4),
-            ]
-        )
+        model = keras.Sequential([keras.Input([2, 2]), keras.layers.Dense(4),])
         sam_model = sharpness_aware_minimization.SharpnessAwareMinimization(
             model
         )
@@ -90,11 +85,7 @@ class SharpnessAwareMinimizationTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_save_sam(self):
         model = keras.Sequential(
-            [
-                keras.Input([2, 2]),
-                keras.layers.Dense(4),
-                keras.layers.Dense(1),
-            ]
+            [keras.Input([2, 2]), keras.layers.Dense(4), keras.layers.Dense(1),]
         )
         sam_model = sharpness_aware_minimization.SharpnessAwareMinimization(
             model
@@ -118,11 +109,7 @@ class SharpnessAwareMinimizationTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_checkpoint_sam(self):
         model = keras.Sequential(
-            [
-                keras.Input([2, 2]),
-                keras.layers.Dense(4),
-                keras.layers.Dense(1),
-            ]
+            [keras.Input([2, 2]), keras.layers.Dense(4), keras.layers.Dense(1),]
         )
         sam_model_1 = sharpness_aware_minimization.SharpnessAwareMinimization(
             model

--- a/keras/optimizers/__init__.py
+++ b/keras/optimizers/__init__.py
@@ -123,7 +123,7 @@ def deserialize(config, custom_objects=None, **kwargs):
         loss_scale_optimizer,
     )
 
-    use_legacy_optimizer = kwargs.pop("use_legacy_optimizer", False)
+    use_legacy_optimizer = kwargs.pop("use_legacy_optimizer", True)
     if len(config["config"]) > 0:
         # If the optimizer config is not empty, then we use the value of
         # `is_legacy_optimizer` to override `use_legacy_optimizer`. If
@@ -204,7 +204,7 @@ def get(identifier, **kwargs):
     Raises:
         ValueError: If `identifier` cannot be interpreted.
     """
-    use_legacy_optimizer = kwargs.pop("use_legacy_optimizer", False)
+    use_legacy_optimizer = kwargs.pop("use_legacy_optimizer", True)
     if isinstance(
         identifier,
         (

--- a/keras/optimizers/__init__.py
+++ b/keras/optimizers/__init__.py
@@ -124,7 +124,7 @@ def deserialize(config, custom_objects=None, **kwargs):
         loss_scale_optimizer,
     )
 
-    use_legacy_optimizer = kwargs.pop("use_legacy_optimizer", True)
+    use_legacy_optimizer = kwargs.pop("use_legacy_optimizer", False)
     if len(config["config"]) > 0:
         # If the optimizer config is not empty, then we use the value of
         # `is_legacy_optimizer` to override `use_legacy_optimizer`. If
@@ -245,7 +245,7 @@ def get(identifier, **kwargs):
     Raises:
         ValueError: If `identifier` cannot be interpreted.
     """
-    use_legacy_optimizer = kwargs.pop("use_legacy_optimizer", True)
+    use_legacy_optimizer = kwargs.pop("use_legacy_optimizer", False)
     if isinstance(
         identifier,
         (

--- a/keras/optimizers/__init__.py
+++ b/keras/optimizers/__init__.py
@@ -120,9 +120,7 @@ def deserialize(config, custom_objects=None, **kwargs):
     """
     # loss_scale_optimizer has a direct dependency of optimizer, import here
     # rather than top to avoid the cyclic dependency.
-    from keras.mixed_precision import (
-        loss_scale_optimizer,
-    )
+    from keras.mixed_precision import loss_scale_optimizer
 
     use_legacy_optimizer = kwargs.pop("use_legacy_optimizer", False)
     if len(config["config"]) > 0:

--- a/keras/optimizers/legacy_learning_rate_decay_test.py
+++ b/keras/optimizers/legacy_learning_rate_decay_test.py
@@ -195,7 +195,7 @@ class SqrtDecayTest(test_combinations.TestCase):
         decayed_lr = tf.compat.v1.train.polynomial_decay(
             lr, step, 10, end_lr, power=power
         )
-        expected = lr * 0.5**power
+        expected = lr * 0.5 ** power
         self.assertAllClose(self.evaluate(decayed_lr), expected, 1e-6)
 
     def testEnd(self):
@@ -217,7 +217,7 @@ class SqrtDecayTest(test_combinations.TestCase):
         decayed_lr = tf.compat.v1.train.polynomial_decay(
             lr, step, 10, end_lr, power=power
         )
-        expected = (lr - end_lr) * 0.5**power + end_lr
+        expected = (lr - end_lr) * 0.5 ** power + end_lr
         self.assertAllClose(self.evaluate(decayed_lr), expected, 1e-6)
 
     def testBeyondEnd(self):
@@ -239,7 +239,7 @@ class SqrtDecayTest(test_combinations.TestCase):
         decayed_lr = tf.compat.v1.train.polynomial_decay(
             lr, step, 10, end_lr, power=power, cycle=True
         )
-        expected = (lr - end_lr) * 0.25**power + end_lr
+        expected = (lr - end_lr) * 0.25 ** power + end_lr
         self.assertAllClose(self.evaluate(decayed_lr), expected, 1e-6)
 
 

--- a/keras/optimizers/optimizer_experimental/optimizer_test.py
+++ b/keras/optimizers/optimizer_experimental/optimizer_test.py
@@ -119,7 +119,7 @@ class OptimizerFuntionalityTest(tf.test.TestCase, parameterized.TestCase):
         optimizer = adam_new.Adam(clipnorm=1)
         grad = [tf.convert_to_tensor([100.0, 100.0])]
         clipped_grad = optimizer._clip_gradients(grad)
-        self.assertAllClose(clipped_grad[0], [2**0.5 / 2, 2**0.5 / 2])
+        self.assertAllClose(clipped_grad[0], [2 ** 0.5 / 2, 2 ** 0.5 / 2])
 
     def testClipValue(self):
         optimizer = adam_new.Adam(clipvalue=1)
@@ -180,11 +180,7 @@ class OptimizerFuntionalityTest(tf.test.TestCase, parameterized.TestCase):
         all_names = [var._shared_name for var in optimizer_variables]
         self.assertLen(optimizer_variables, 2)
         self.assertCountEqual(
-            all_names,
-            [
-                "Adam/m/Variable",
-                "Adam/v/Variable",
-            ],
+            all_names, ["Adam/m/Variable", "Adam/v/Variable",],
         )
 
     def testSetLearningRate(self):

--- a/keras/optimizers/optimizer_v2/adadelta_test.py
+++ b/keras/optimizers/optimizer_v2/adadelta_test.py
@@ -100,7 +100,7 @@ class AdadeltaOptimizerTest(tf.test.TestCase, parameterized.TestCase):
                             )
 
                         # Perform initial update without previous accum values
-                        accum = accum * rho + (grad**2) * (1 - rho)
+                        accum = accum * rho + (grad ** 2) * (1 - rho)
                         update[step] = (
                             np.sqrt(accum_update + epsilon)
                             * (1.0 / np.sqrt(accum + epsilon))

--- a/keras/optimizers/optimizer_v2/ftrl_test.py
+++ b/keras/optimizers/optimizer_v2/ftrl_test.py
@@ -394,7 +394,7 @@ class FtrlOptimizerTest(tf.test.TestCase):
                 v0_val, v1_val = self.evaluate([var0, var1])
                 # var0 is experiencing L2 shrinkage so it should be smaller than
                 # var1 in magnitude.
-                self.assertTrue((v0_val**2 < v1_val**2).all())
+                self.assertTrue((v0_val ** 2 < v1_val ** 2).all())
                 accum0 = sess.run(opt0.get_slot(var0, "accumulator"))
                 accum1 = sess.run(opt1.get_slot(var1, "accumulator"))
                 # L2 shrinkage should not change how we update grad accumulator.

--- a/keras/optimizers/optimizer_v2/optimizer_v2.py
+++ b/keras/optimizers/optimizer_v2/optimizer_v2.py
@@ -474,10 +474,8 @@ class OptimizerV2(tf.__internal__.tracking.Trackable):
                 f"gradient_transformers={self.gradient_transformers}."
             )
         self._global_clipnorm = val
-        self._global_clipnorm_fn = (
-            optimizer_utils.make_global_gradient_clipnorm_fn(
-                self._global_clipnorm
-            )
+        self._global_clipnorm_fn = optimizer_utils.make_global_gradient_clipnorm_fn(
+            self._global_clipnorm
         )
 
     @property
@@ -1579,10 +1577,8 @@ class OptimizerV2(tf.__internal__.tracking.Trackable):
                 or self._distribution_strategy
             )
         ):
-            initializer = (
-                tf.__internal__.tracking.CheckpointInitialValueCallable(
-                    checkpoint_position=slot_variable_position
-                )
+            initializer = tf.__internal__.tracking.CheckpointInitialValueCallable(
+                checkpoint_position=slot_variable_position
             )
             slot_variable = self.add_slot(
                 var=variable,

--- a/keras/optimizers/optimizer_v2/optimizer_v2_test.py
+++ b/keras/optimizers/optimizer_v2/optimizer_v2_test.py
@@ -45,9 +45,7 @@ from keras.testing_infra import test_utils
 from keras.utils import np_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 _DATA_TYPES = [tf.half, tf.float32, tf.float64]
 # TODO(b/141710709): complex support in NVCC and ROCM.

--- a/keras/optimizers/optimizer_v2/rmsprop_test.py
+++ b/keras/optimizers/optimizer_v2/rmsprop_test.py
@@ -28,9 +28,7 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 _DATA_TYPES = [tf.half, tf.float32, tf.float64, tf.complex64, tf.complex128]
 

--- a/keras/optimizers/optimizers_test.py
+++ b/keras/optimizers/optimizers_test.py
@@ -22,6 +22,8 @@ import tensorflow.compat.v2 as tf
 
 import keras
 from keras.optimizers import optimizer_v1
+from keras.optimizers.optimizer_experimental import adam as adam_experimental
+from keras.optimizers.schedules import learning_rate_schedule
 from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 from keras.utils import np_utils
@@ -298,6 +300,55 @@ class KerasOptimizersTest(test_combinations.TestCase):
             ValueError, "Could not interpret optimizer"
         ):
             keras.optimizers.get(0)
+
+    @test_utils.run_v2_only
+    def test_convert_to_legacy_optimizer(self):
+        if not tf.executing_eagerly():
+            # The conversion could only happen in eager mode.
+            return
+        optimizer_list = [
+            "adadelta",
+            "adagrad",
+            "adam",
+            "adamax",
+            "nadam",
+            "rmsprop",
+            "sgd",
+            "ftrl",
+        ]
+        # Test conversion does not throw errors.
+        for name in optimizer_list:
+            experimental_optimizer = keras.optimizers.get(
+                name, use_legacy_optimizer=False
+            )
+            reference_legacy_optimizer = keras.optimizers.get(
+                name, use_legacy_optimizer=True
+            )
+            converted_legacy_optimizer = (
+                keras.optimizers.convert_to_legacy_optimizer(
+                    experimental_optimizer
+                )
+            )
+            self.assertEqual(
+                type(reference_legacy_optimizer),
+                type(converted_legacy_optimizer),
+            )
+            self.assertDictEqual(
+                reference_legacy_optimizer.get_config(),
+                converted_legacy_optimizer.get_config(),
+            )
+
+        lr_schedule = learning_rate_schedule.ExponentialDecay(
+            initial_learning_rate=1e-2, decay_steps=10000, decay_rate=0.9
+        )
+        optimizer = adam_experimental.Adam(learning_rate=lr_schedule)
+        legacy_optimizer = keras.optimizers.convert_to_legacy_optimizer(
+            optimizer
+        )
+        self.assertDictEqual(
+            optimizer.get_config()["learning_rate"],
+            legacy_optimizer.get_config()["learning_rate"],
+        )
 
 
 if __name__ == "__main__":

--- a/keras/optimizers/optimizers_test.py
+++ b/keras/optimizers/optimizers_test.py
@@ -324,10 +324,8 @@ class KerasOptimizersTest(test_combinations.TestCase):
             reference_legacy_optimizer = keras.optimizers.get(
                 name, use_legacy_optimizer=True
             )
-            converted_legacy_optimizer = (
-                keras.optimizers.convert_to_legacy_optimizer(
-                    experimental_optimizer
-                )
+            converted_legacy_optimizer = keras.optimizers.convert_to_legacy_optimizer(
+                experimental_optimizer
             )
             self.assertEqual(
                 type(reference_legacy_optimizer),

--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -769,10 +769,10 @@ class CosineDecayRestarts(LearningRateSchedule):
                         / tf.math.log(t_mul)
                     )
 
-                    sum_r = (1.0 - t_mul**i_restart) / (1.0 - t_mul)
+                    sum_r = (1.0 - t_mul ** i_restart) / (1.0 - t_mul)
                     completed_fraction = (
                         completed_fraction - sum_r
-                    ) / t_mul**i_restart
+                    ) / t_mul ** i_restart
 
                 else:
                     i_restart = tf.floor(completed_fraction)
@@ -786,7 +786,7 @@ class CosineDecayRestarts(LearningRateSchedule):
                 lambda: compute_step(completed_fraction, geometric=True),
             )
 
-            m_fac = m_mul**i_restart
+            m_fac = m_mul ** i_restart
             cosine_decayed = (
                 0.5
                 * m_fac

--- a/keras/optimizers/schedules/learning_rate_schedule_test.py
+++ b/keras/optimizers/schedules/learning_rate_schedule_test.py
@@ -229,7 +229,7 @@ class SqrtDecayTestV2(tf.test.TestCase, parameterized.TestCase):
             lr, 10, end_lr, power=power
         )
         decayed_lr = _maybe_serialized(decayed_lr, serialize)
-        expected = lr * 0.5**power
+        expected = lr * 0.5 ** power
         self.assertAllClose(self.evaluate(decayed_lr(step)), expected, 1e-6)
 
     def testEnd(self, serialize):
@@ -253,7 +253,7 @@ class SqrtDecayTestV2(tf.test.TestCase, parameterized.TestCase):
             lr, 10, end_lr, power=power
         )
         decayed_lr = _maybe_serialized(decayed_lr, serialize)
-        expected = (lr - end_lr) * 0.5**power + end_lr
+        expected = (lr - end_lr) * 0.5 ** power + end_lr
         self.assertAllClose(self.evaluate(decayed_lr(step)), expected, 1e-6)
 
     def testBeyondEnd(self, serialize):
@@ -277,7 +277,7 @@ class SqrtDecayTestV2(tf.test.TestCase, parameterized.TestCase):
             lr, 10, end_lr, power=power, cycle=True
         )
         decayed_lr = _maybe_serialized(decayed_lr, serialize)
-        expected = (lr - end_lr) * 0.25**power + end_lr
+        expected = (lr - end_lr) * 0.25 ** power + end_lr
         self.assertAllClose(self.evaluate(decayed_lr(step)), expected, 1e-6)
 
 

--- a/keras/preprocessing/image_test.py
+++ b/keras/preprocessing/image_test.py
@@ -531,11 +531,7 @@ class TestDirectoryIterator(test_combinations.TestCase):
         self.assertNotEqual(input_img[0][0][0], output_img[0][0][0])
 
     @parameterized.parameters(
-        [
-            (0.25, 30),
-            (0.50, 20),
-            (0.75, 10),
-        ]
+        [(0.25, 30), (0.50, 20), (0.75, 10),]
     )
     def test_directory_iterator_with_validation_split(
         self, validation_split, num_training
@@ -1245,11 +1241,7 @@ class TestDataFrameIterator(test_combinations.TestCase):
         self.assertAllEqual(batch_y, df[["output_0", "output_1"]].values[:3])
 
     @parameterized.parameters(
-        [
-            (0.25, 18),
-            (0.50, 12),
-            (0.75, 6),
-        ]
+        [(0.25, 18), (0.50, 12), (0.75, 6),]
     )
     def test_dataframe_iterator_with_validation_split(
         self, validation_split, num_training
@@ -2130,24 +2122,8 @@ class TestAffineTransformations(test_combinations.TestCase):
         )
 
     def test_matrix_center(self):
-        x = np.expand_dims(
-            np.array(
-                [
-                    [0, 1],
-                    [0, 0],
-                ]
-            ),
-            -1,
-        )
-        x_rotated90 = np.expand_dims(
-            np.array(
-                [
-                    [1, 0],
-                    [0, 0],
-                ]
-            ),
-            -1,
-        )
+        x = np.expand_dims(np.array([[0, 1], [0, 0],]), -1,)
+        x_rotated90 = np.expand_dims(np.array([[1, 0], [0, 0],]), -1,)
 
         self.assertAllClose(
             image.apply_affine_transform(
@@ -2157,41 +2133,11 @@ class TestAffineTransformations(test_combinations.TestCase):
         )
 
     def test_translation(self):
-        x = np.array(
-            [
-                [0, 0, 0, 0],
-                [0, 1, 0, 0],
-                [0, 0, 0, 0],
-            ]
-        )
-        x_up = np.array(
-            [
-                [0, 1, 0, 0],
-                [0, 0, 0, 0],
-                [0, 0, 0, 0],
-            ]
-        )
-        x_dn = np.array(
-            [
-                [0, 0, 0, 0],
-                [0, 0, 0, 0],
-                [0, 1, 0, 0],
-            ]
-        )
-        x_left = np.array(
-            [
-                [0, 0, 0, 0],
-                [1, 0, 0, 0],
-                [0, 0, 0, 0],
-            ]
-        )
-        x_right = np.array(
-            [
-                [0, 0, 0, 0],
-                [0, 0, 1, 0],
-                [0, 0, 0, 0],
-            ]
-        )
+        x = np.array([[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0],])
+        x_up = np.array([[0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0],])
+        x_dn = np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 1, 0, 0],])
+        x_left = np.array([[0, 0, 0, 0], [1, 0, 0, 0], [0, 0, 0, 0],])
+        x_right = np.array([[0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 0],])
 
         # Channels first
         x_test = np.expand_dims(x, 0)

--- a/keras/preprocessing/sequence_test.py
+++ b/keras/preprocessing/sequence_test.py
@@ -104,12 +104,7 @@ class TestSequence(tf.test.TestCase):
             batch[0], np.array([[[r - 10], [r - 8], [r - 6], [r - 4], [r - 2]]])
         )
         self.assertAllClose(
-            batch[1],
-            np.array(
-                [
-                    [r],
-                ]
-            ),
+            batch[1], np.array([[r],]),
         )
 
         data_gen = sequence.TimeseriesGenerator(

--- a/keras/saving/experimental/saving_lib_test.py
+++ b/keras/saving/experimental/saving_lib_test.py
@@ -126,8 +126,7 @@ class NewSavingTest(tf.test.TestCase, parameterized.TestCase):
         # and the loaded model.
         for model in [subclassed_model, loaded_model]:
             self.assertIs(
-                model.optimizer.__class__,
-                adam.Adam,
+                model.optimizer.__class__, adam.Adam,
             )
             self.assertIs(
                 model.compiled_loss.__class__,
@@ -185,8 +184,7 @@ class NewSavingTest(tf.test.TestCase, parameterized.TestCase):
         # and the loaded model.
         for model in [subclassed_model, loaded_model]:
             self.assertIs(
-                model.optimizer.__class__,
-                adam.Adam,
+                model.optimizer.__class__, adam.Adam,
             )
             self.assertIs(
                 model.compiled_loss.__class__,

--- a/keras/saving/hdf5_format.py
+++ b/keras/saving/hdf5_format.py
@@ -246,8 +246,8 @@ def load_model_from_hdf5(filepath, custom_objects=None, compile=True):
                         "a freshly initialized optimizer."
                     )
 
-                optimizer_weight_values = (
-                    load_optimizer_weights_from_hdf5_group(f)
+                optimizer_weight_values = load_optimizer_weights_from_hdf5_group(
+                    f
                 )
                 try:
                     model.optimizer.set_weights(optimizer_weight_values)

--- a/keras/saving/losses_serialization_test.py
+++ b/keras/saving/losses_serialization_test.py
@@ -83,17 +83,11 @@ def _get_multi_io_model():
         ),
         dict(
             testcase_name="dict_of_string",
-            value={
-                "output": "mae",
-                "output_1": "mae",
-            },
+            value={"output": "mae", "output_1": "mae",},
         ),
         dict(
             testcase_name="dict_of_built_in_fn",
-            value={
-                "output": losses.mae,
-                "output_1": losses.mae,
-            },
+            value={"output": losses.mae, "output_1": losses.mae,},
         ),
         dict(
             testcase_name="dict_of_built_in_class",

--- a/keras/saving/metrics_serialization_test.py
+++ b/keras/saving/metrics_serialization_test.py
@@ -87,17 +87,11 @@ def _get_multi_io_model():
     ),
     dict(
         testcase_name="dict_of_list_of_string",
-        value={
-            "output": ["mae"],
-            "output_1": ["mae"],
-        },
+        value={"output": ["mae"], "output_1": ["mae"],},
     ),
     dict(
         testcase_name="dict_of_list_of_built_in_fn",
-        value={
-            "output": [metrics.mae],
-            "output_1": [metrics.mae],
-        },
+        value={"output": [metrics.mae], "output_1": [metrics.mae],},
     ),
     dict(
         testcase_name="dict_of_list_of_built_in_class",
@@ -108,10 +102,7 @@ def _get_multi_io_model():
     ),
     dict(
         testcase_name="dict_of_list_of_custom_fn",
-        value={
-            "output": [_my_mae],
-            "output_1": [_my_mae],
-        },
+        value={"output": [_my_mae], "output_1": [_my_mae],},
     ),
     dict(
         testcase_name="dict_of_list_of_custom_class",
@@ -122,17 +113,11 @@ def _get_multi_io_model():
     ),
     dict(
         testcase_name="dict_of_string",
-        value={
-            "output": "mae",
-            "output_1": "mae",
-        },
+        value={"output": "mae", "output_1": "mae",},
     ),
     dict(
         testcase_name="dict_of_built_in_fn",
-        value={
-            "output": metrics.mae,
-            "output_1": metrics.mae,
-        },
+        value={"output": metrics.mae, "output_1": metrics.mae,},
     ),
     dict(
         testcase_name="dict_of_built_in_class",
@@ -147,10 +132,7 @@ def _get_multi_io_model():
     ),
     dict(
         testcase_name="dict_of_custom_class",
-        value={
-            "output": MyMeanAbsoluteError,
-            "output_1": MyMeanAbsoluteError,
-        },
+        value={"output": MyMeanAbsoluteError, "output_1": MyMeanAbsoluteError,},
     ),
 )
 class MetricsSerialization(test_combinations.TestCase):

--- a/keras/saving/model_config.py
+++ b/keras/saving/model_config.py
@@ -102,8 +102,6 @@ def model_from_json(json_string, custom_objects=None):
     Returns:
         A Keras model instance (uncompiled).
     """
-    from keras.layers import (
-        deserialize_from_json,
-    )
+    from keras.layers import deserialize_from_json
 
     return deserialize_from_json(json_string, custom_objects=custom_objects)

--- a/keras/saving/pickle_utils_test.py
+++ b/keras/saving/pickle_utils_test.py
@@ -69,8 +69,7 @@ class TestPickleProtocol(test_combinations.TestCase):
 
     @test_combinations.run_with_all_model_types
     @test_combinations.parameterized.named_parameters(
-        ("copy", copy.copy),
-        ("deepcopy", copy.deepcopy),
+        ("copy", copy.copy), ("deepcopy", copy.deepcopy),
     )
     def test_unbuilt_models(self, serializer):
         """Unbuilt models should be copyable & deepcopyable for all model

--- a/keras/saving/save_test.py
+++ b/keras/saving/save_test.py
@@ -755,7 +755,7 @@ class TestWholeModelSaving(test_combinations.TestCase):
             # the list of layer names into numpy array, which uses the same
             # amount of memory for every item, it increases the memory
             # requirements substantially.
-            x = keras.Input(shape=(2,), name="input_" + ("x" * (2**15)))
+            x = keras.Input(shape=(2,), name="input_" + ("x" * (2 ** 15)))
             f = x
             for i in range(4):
                 f = keras.layers.Dense(2, name="dense_%d" % (i,))(f)
@@ -805,7 +805,7 @@ class TestWholeModelSaving(test_combinations.TestCase):
             # This layer name will make the `weights_name`
             # HDF5 attribute blow out of proportion.
             f = keras.layers.Dense(
-                2, name="nested_model_output" + ("x" * (2**14))
+                2, name="nested_model_output" + ("x" * (2 ** 14))
             )(f)
             nested_model = keras.Model(
                 inputs=[x], outputs=[f], name="nested_model"

--- a/keras/saving/saved_model/saved_model_test.py
+++ b/keras/saving/saved_model/saved_model_test.py
@@ -190,16 +190,7 @@ class TestSavedModelFormatAllModes(test_combinations.TestCase):
             initializer=tf.compat.v1.constant_initializer(12),
             trainable=False,
         )
-        model = keras.Sequential(
-            [
-                keras.Input(
-                    [
-                        3,
-                    ]
-                ),
-                layer,
-            ]
-        )
+        model = keras.Sequential([keras.Input([3,]), layer,])
 
         saved_model_dir = self._save_model_dir()
         self.evaluate(tf.compat.v1.variables_initializer(layer.variables))
@@ -737,10 +728,8 @@ class TestSavedModelFormatAllModes(test_combinations.TestCase):
             bucketized = tf.feature_column.bucketized_column(
                 numeric, boundaries=[5, 10, 15]
             )
-            cat_vocab = (
-                tf.feature_column.categorical_column_with_vocabulary_list(
-                    "b", ["1", "2", "3"]
-                )
+            cat_vocab = tf.feature_column.categorical_column_with_vocabulary_list(
+                "b", ["1", "2", "3"]
             )
             one_hot = tf.feature_column.indicator_column(cat_vocab)
             embedding = tf.feature_column.embedding_column(

--- a/keras/saving/saved_model/serialized_attributes.py
+++ b/keras/saving/saved_model/serialized_attributes.py
@@ -347,9 +347,7 @@ class ModelAttributes(
 
 class MetricAttributes(
     SerializedAttributes.with_attributes(
-        "MetricAttributes",
-        checkpointable_objects=["variables"],
-        functions=[],
+        "MetricAttributes", checkpointable_objects=["variables"], functions=[],
     )
 ):
     """Attributes that are added to Metric objects when saved to SavedModel.

--- a/keras/testing_infra/test_combinations_test.py
+++ b/keras/testing_infra/test_combinations_test.py
@@ -51,11 +51,7 @@ class CombinationsTest(tf.test.TestCase):
             self.assertLen(test_params, 3)
             self.assertAllEqual(
                 test_params,
-                [
-                    ("graph", False),
-                    ("eager", True),
-                    ("eager", False),
-                ],
+                [("graph", False), ("eager", True), ("eager", False),],
             )
 
             ts = unittest.makeSuite(ExampleTest)
@@ -65,11 +61,7 @@ class CombinationsTest(tf.test.TestCase):
         else:
             self.assertLen(test_params, 2)
             self.assertAllEqual(
-                test_params,
-                [
-                    ("eager", True),
-                    ("eager", False),
-                ],
+                test_params, [("eager", True), ("eager", False),],
             )
 
             ts = unittest.makeSuite(ExampleTest)
@@ -369,12 +361,7 @@ class KerasParameterizedTest(test_combinations.TestCase):
         if not tf.__internal__.tf2.enabled():
             self.assertLen(l, 3)
             self.assertAllEqual(
-                l,
-                [
-                    ("graph", False),
-                    ("eager", True),
-                    ("eager", False),
-                ],
+                l, [("graph", False), ("eager", True), ("eager", False),],
             )
 
             ts = unittest.makeSuite(ExampleTest)
@@ -384,11 +371,7 @@ class KerasParameterizedTest(test_combinations.TestCase):
         else:
             self.assertLen(l, 2)
             self.assertAllEqual(
-                l,
-                [
-                    ("eager", True),
-                    ("eager", False),
-                ],
+                l, [("eager", True), ("eager", False),],
             )
 
             ts = unittest.makeSuite(ExampleTest)
@@ -475,11 +458,7 @@ class KerasParameterizedTest(test_combinations.TestCase):
 
         self.assertLen(l, 2)
         self.assertEqual(
-            set(l),
-            {
-                ("eager", True),
-                ("eager", False),
-            },
+            set(l), {("eager", True), ("eager", False),},
         )
 
     def test_run_all_keras_modes_with_all_model_types(self):

--- a/keras/testing_infra/test_utils.py
+++ b/keras/testing_infra/test_utils.py
@@ -42,9 +42,7 @@ from keras.utils import tf_contextlib
 from keras.utils import tf_inspect
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 from tensorflow.python.util.tf_export import keras_export
 
 
@@ -1082,9 +1080,7 @@ def run_without_tensor_float_32(description):
 
 
 # The description is just for documentation purposes.
-def run_all_without_tensor_float_32(
-    description,
-):
+def run_all_without_tensor_float_32(description,):
     """Execute all tests in a class with TensorFloat-32 disabled."""
     return for_all_test_methods(run_without_tensor_float_32, description)
 

--- a/keras/tests/add_loss_correctness_test.py
+++ b/keras/tests/add_loss_correctness_test.py
@@ -28,9 +28,7 @@ from keras.testing_infra import test_utils
 
 # isort: off
 from tensorflow.python.platform import tf_logging as logging
-from tensorflow.python.training.rmsprop import (
-    RMSPropOptimizer,
-)
+from tensorflow.python.training.rmsprop import RMSPropOptimizer
 
 MAE = losses.MeanAbsoluteError
 mae = losses.mean_absolute_error

--- a/keras/tests/automatic_outside_compilation_test.py
+++ b/keras/tests/automatic_outside_compilation_test.py
@@ -34,21 +34,11 @@ from keras.layers import reshaping as reshaping_layer_lib
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorboard.plugins.histogram import (
-    summary_v2 as histogram_summary_v2,
-)
-from tensorboard.plugins.image import (
-    summary_v2 as image_summary_v2,
-)
-from tensorboard.plugins.scalar import (
-    summary_v2 as scalar_summary_v2,
-)
-from tensorflow.python.eager.context import (
-    set_soft_device_placement,
-)
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorboard.plugins.histogram import summary_v2 as histogram_summary_v2
+from tensorboard.plugins.image import summary_v2 as image_summary_v2
+from tensorboard.plugins.scalar import summary_v2 as scalar_summary_v2
+from tensorflow.python.eager.context import set_soft_device_placement
+from tensorflow.python.framework import test_util as tf_test_utils
 
 NUM_CLASSES = 4
 
@@ -60,9 +50,7 @@ flags.DEFINE_string("zone", None, "Name of GCP zone with TPU.")
 
 def get_tpu_cluster_resolver():
     resolver = tf.distribute.cluster_resolver.TPUClusterResolver(
-        tpu=FLAGS.tpu,
-        zone=FLAGS.zone,
-        project=FLAGS.project,
+        tpu=FLAGS.tpu, zone=FLAGS.zone, project=FLAGS.project,
     )
     return resolver
 

--- a/keras/tests/graph_util_test.py
+++ b/keras/tests/graph_util_test.py
@@ -22,9 +22,7 @@ import keras
 # isort: off
 from tensorflow.core.protobuf import meta_graph_pb2
 from tensorflow.python.grappler import tf_optimizer
-from tensorflow.python.training.saver import (
-    export_meta_graph,
-)
+from tensorflow.python.training.saver import export_meta_graph
 
 
 class ConvertVariablesToConstantsTest(tf.test.TestCase):
@@ -101,10 +99,8 @@ class ConvertVariablesToConstantsTest(tf.test.TestCase):
         sess = keras.backend.get_session()
         variable_graph_def = sess.graph_def
         output_tensor = self._get_tensor_names(model.outputs)
-        constant_graph_def = (
-            tf.compat.v1.graph_util.convert_variables_to_constants(
-                sess, variable_graph_def, output_tensor
-            )
+        constant_graph_def = tf.compat.v1.graph_util.convert_variables_to_constants(
+            sess, variable_graph_def, output_tensor
         )
 
         # Validate converted graph.
@@ -131,10 +127,8 @@ class ConvertVariablesToConstantsTest(tf.test.TestCase):
             variable_graph_def, tensor_names
         )
         output_tensor = self._get_tensor_names(model.outputs)
-        constant_graph_def = (
-            tf.compat.v1.graph_util.convert_variables_to_constants(
-                sess, variable_graph_def, output_tensor
-            )
+        constant_graph_def = tf.compat.v1.graph_util.convert_variables_to_constants(
+            sess, variable_graph_def, output_tensor
         )
 
         # Validate converted graph.
@@ -158,10 +152,8 @@ class ConvertVariablesToConstantsTest(tf.test.TestCase):
             variable_graph_def, tensor_names
         )
         output_tensor = self._get_tensor_names(model.outputs)
-        constant_graph_def = (
-            tf.compat.v1.graph_util.convert_variables_to_constants(
-                sess, variable_graph_def, output_tensor
-            )
+        constant_graph_def = tf.compat.v1.graph_util.convert_variables_to_constants(
+            sess, variable_graph_def, output_tensor
         )
 
         # Validate converted graph.

--- a/keras/tests/memory_checker_test.py
+++ b/keras/tests/memory_checker_test.py
@@ -18,9 +18,7 @@ import tensorflow.compat.v2 as tf
 import keras
 
 # isort: off
-from tensorflow.python.framework.memory_checker import (
-    MemoryChecker,
-)
+from tensorflow.python.framework.memory_checker import MemoryChecker
 
 
 class MemoryCheckerTest(tf.test.TestCase):

--- a/keras/tests/memory_test.py
+++ b/keras/tests/memory_test.py
@@ -25,9 +25,7 @@ import tensorflow.compat.v2 as tf
 import keras
 
 # isort: off
-from tensorflow.python.eager.memory_tests import (
-    memory_test_util,
-)
+from tensorflow.python.eager.memory_tests import memory_test_util
 
 
 class SingleLayerNet(keras.Model):

--- a/keras/tests/model_subclassing_test.py
+++ b/keras/tests/model_subclassing_test.py
@@ -27,9 +27,7 @@ from keras.testing_infra import test_utils
 from keras.tests import model_subclassing_test_util as model_util
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 from tensorflow.python.trackable import data_structures
 
 try:

--- a/keras/tests/saved_model_test.py
+++ b/keras/tests/saved_model_test.py
@@ -22,9 +22,7 @@ from keras.layers import core
 from keras.optimizers.optimizer_v2 import adam
 
 # isort: off
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 class _ModelWithOptimizerUsingDefun(tf.train.Checkpoint):

--- a/keras/tests/saver_test.py
+++ b/keras/tests/saver_test.py
@@ -23,9 +23,7 @@ from keras.engine import training
 from keras.layers import core
 
 # isort: off
-from tensorflow.python.checkpoint import (
-    checkpoint as trackable_utils,
-)
+from tensorflow.python.checkpoint import checkpoint as trackable_utils
 
 
 class NonLayerTrackable(tf.Module):

--- a/keras/tests/temporal_sample_weights_correctness_test.py
+++ b/keras/tests/temporal_sample_weights_correctness_test.py
@@ -296,9 +296,7 @@ class TestMetricsCorrectnessMultiIOTemporal(test_combinations.TestCase):
             history = model.fit(
                 [self.x, self.x],
                 [self.y1, self.y2],
-                sample_weight={
-                    "output_2": self.sample_weight_2,
-                },
+                sample_weight={"output_2": self.sample_weight_2,},
                 batch_size=3,
                 epochs=2,
                 shuffle=False,
@@ -353,17 +351,13 @@ class TestMetricsCorrectnessMultiIOTemporal(test_combinations.TestCase):
             model.train_on_batch(
                 [self.x, self.x],
                 [self.y1, self.y2],
-                sample_weight={
-                    "output_2": self.sample_weight_2,
-                },
+                sample_weight={"output_2": self.sample_weight_2,},
             )
             eval_result = model.evaluate(
                 [self.x, self.x],
                 [self.y1, self.y2],
                 batch_size=3,
-                sample_weight={
-                    "output_2": self.sample_weight_2,
-                },
+                sample_weight={"output_2": self.sample_weight_2,},
             )
             self.assertAllClose(
                 eval_result,
@@ -408,9 +402,7 @@ class TestMetricsCorrectnessMultiIOTemporal(test_combinations.TestCase):
                 result = model.train_on_batch(
                     [self.x, self.x],
                     [self.y1, self.y2],
-                    sample_weight={
-                        "output_2": self.sample_weight_2,
-                    },
+                    sample_weight={"output_2": self.sample_weight_2,},
                 )
             self.assertAllClose(
                 result, self.expected_batch_result_with_weights_output_2, 1e-3
@@ -457,16 +449,12 @@ class TestMetricsCorrectnessMultiIOTemporal(test_combinations.TestCase):
             model.train_on_batch(
                 [self.x, self.x],
                 [self.y1, self.y2],
-                sample_weight={
-                    "output_2": self.sample_weight_2,
-                },
+                sample_weight={"output_2": self.sample_weight_2,},
             )
             result = model.test_on_batch(
                 [self.x, self.x],
                 [self.y1, self.y2],
-                sample_weight={
-                    "output_2": self.sample_weight_2,
-                },
+                sample_weight={"output_2": self.sample_weight_2,},
             )
             self.assertAllClose(
                 result, self.expected_batch_result_with_weights_output_2, 1e-3
@@ -558,9 +546,7 @@ class TestMetricsCorrectnessMultiIOTemporal(test_combinations.TestCase):
             model.train_on_batch(
                 [self.x, self.x],
                 [self.y1, self.y2],
-                sample_weight={
-                    "output_2": self.sample_weight_2,
-                },
+                sample_weight={"output_2": self.sample_weight_2,},
             )
             eval_result = model.evaluate_generator(
                 self.custom_generator_multi_io_temporal(

--- a/keras/tests/tracking_test.py
+++ b/keras/tests/tracking_test.py
@@ -480,8 +480,7 @@ class TupleTests(test_combinations.TestCase):
             )
 
     @parameterized.named_parameters(
-        ("Module", tf.Module),
-        ("Model", training.Model),
+        ("Module", tf.Module), ("Model", training.Model),
     )
     def testSubModelTracking(self, module_subclass):
         model = module_subclass()

--- a/keras/tests/tracking_util_test.py
+++ b/keras/tests/tracking_util_test.py
@@ -29,13 +29,9 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.checkpoint import (
-    checkpoint as trackable_utils,
-)
+from tensorflow.python.checkpoint import checkpoint as trackable_utils
 from tensorflow.python.eager import context
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 from tensorflow.python.platform import tf_logging as logging
 
 

--- a/keras/tests/tracking_util_with_v1_optimizers_test.py
+++ b/keras/tests/tracking_util_with_v1_optimizers_test.py
@@ -25,13 +25,9 @@ from keras.testing_infra import test_combinations
 from keras.testing_infra import test_utils
 
 # isort: off
-from tensorflow.python.checkpoint import (
-    checkpoint as trackable_utils,
-)
+from tensorflow.python.checkpoint import checkpoint as trackable_utils
 from tensorflow.python.eager import context
-from tensorflow.python.framework import (
-    test_util as tf_test_utils,
-)
+from tensorflow.python.framework import test_util as tf_test_utils
 
 
 class NonLayerTrackable(tf.Module):
@@ -311,8 +307,7 @@ class CheckpointingTests(test_combinations.TestCase):
                 # TODO(allenl): Use a Dataset and serialize/checkpoint it.
                 input_value = tf.constant([[3.0]])
                 optimizer.minimize(
-                    lambda: model(input_value),
-                    global_step=root.optimizer_step,
+                    lambda: model(input_value), global_step=root.optimizer_step,
                 )
             root.save(file_prefix=checkpoint_prefix)
             self.assertEqual(

--- a/keras/tests/tracking_util_xla_test.py
+++ b/keras/tests/tracking_util_xla_test.py
@@ -21,9 +21,7 @@ from keras.optimizers.optimizer_v2 import adam
 
 # isort: off
 from tensorflow.compiler.tests import xla_test
-from tensorflow.python.checkpoint import (
-    checkpoint as trackable_utils,
-)
+from tensorflow.python.checkpoint import checkpoint as trackable_utils
 
 
 class NonLayerTrackable(tf.Module):

--- a/keras/tools/pip_package/create_pip_helper.py
+++ b/keras/tools/pip_package/create_pip_helper.py
@@ -34,20 +34,11 @@ PIP_EXCLUDED_FILES = frozenset(
 )
 
 PIP_EXCLUDED_DIRS = frozenset(
-    [
-        "keras/benchmarks",
-        "keras/integration_tests",
-        "keras/tests",
-    ]
+    ["keras/benchmarks", "keras/integration_tests", "keras/tests",]
 )
 
 # Directories that should not have __init__.py files generated within them.
-EXCLUDED_INIT_FILE_DIRECTORIES = frozenset(
-    [
-        "keras/benchmarks",
-        "keras/tools",
-    ]
-)
+EXCLUDED_INIT_FILE_DIRECTORIES = frozenset(["keras/benchmarks", "keras/tools",])
 
 
 class PipPackagingError(Exception):

--- a/keras/utils/composite_tensor_support_test.py
+++ b/keras/utils/composite_tensor_support_test.py
@@ -700,12 +700,7 @@ class CompositeTensorModelPredictTest(test_combinations.TestCase):
             layers, model_input=model_input
         )
 
-        ragged_input = tf.ragged.constant(
-            [
-                [1, 2, 3, 4, 5],
-                [2, 4],
-            ]
-        )
+        ragged_input = tf.ragged.constant([[1, 2, 3, 4, 5], [2, 4],])
 
         shape = model(ragged_input).shape
         self.assertEqual((2, None, 5), self._normalize_shape(shape))

--- a/keras/utils/conv_utils_test.py
+++ b/keras/utils/conv_utils_test.py
@@ -326,7 +326,7 @@ class TestConvUtils(tf.test.TestCase, parameterized.TestCase):
             ):
                 p = list(p)
                 p[d] = slice(None)
-                mask[p * 2] = True
+                mask[tuple(p * 2)] = True
 
             mask = np.take(mask, range(0, min(1, input_shape[d])), ndims + d)
 

--- a/keras/utils/conv_utils_test.py
+++ b/keras/utils/conv_utils_test.py
@@ -84,11 +84,7 @@ class TestBasicConvUtilsTest(tf.test.TestCase):
             ),
         )
         self.assertEqual(
-            (
-                1,
-                2,
-                3,
-            ),
+            (1, 2, 3,),
             conv_utils.normalize_tuple((1, 2, 3), n=3, name="pool_size"),
         )
         self.assertEqual(

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -86,6 +86,7 @@ if True:  # This gets transformed to `if sys.version_info[0] == 2:` in OSS.
             for chunk in chunk_read(response, reporthook=reporthook):
                 fd.write(chunk)
 
+
 else:
     from urllib.request import urlretrieve
 
@@ -220,7 +221,10 @@ def get_file(
         )
 
     if cache_dir is None:
-        cache_dir = os.path.join(os.path.expanduser("~"), ".keras")
+        if "KERAS_HOME" in os.environ:
+            cache_dir = os.environ.get("KERAS_HOME")
+        else:
+            cache_dir = os.path.join(os.path.expanduser("~"), ".keras")
     if md5_hash is not None and file_hash is None:
         file_hash = md5_hash
         hash_algorithm = "md5"

--- a/keras/utils/dataset_creator_test.py
+++ b/keras/utils/dataset_creator_test.py
@@ -27,12 +27,8 @@ from keras.testing_infra import test_utils
 from keras.utils import dataset_creator
 
 # isort: off
-from tensorflow.python.distribute.cluster_resolver import (
-    SimpleClusterResolver,
-)
-from tensorflow.python.training.server_lib import (
-    ClusterSpec,
-)
+from tensorflow.python.distribute.cluster_resolver import SimpleClusterResolver
+from tensorflow.python.training.server_lib import ClusterSpec
 
 
 @test_utils.run_v2_only
@@ -167,10 +163,8 @@ class DatasetCreatorTest(tf.test.TestCase, parameterized.TestCase):
         strategy = self._get_parameter_server_strategy()
         with strategy.scope():
             model = sequential.Sequential([core_layers.Dense(10)])
-            model._cluster_coordinator = (
-                tf.distribute.experimental.coordinator.ClusterCoordinator(
-                    strategy
-                )
+            model._cluster_coordinator = tf.distribute.experimental.coordinator.ClusterCoordinator(
+                strategy
             )
             data_handler = data_adapter.get_data_handler(
                 x, steps_per_epoch=2, model=model

--- a/keras/utils/dataset_utils_test.py
+++ b/keras/utils/dataset_utils_test.py
@@ -108,9 +108,7 @@ class SplitDatasetTest(tf.test.TestCase):
         # test with tuple of np arrays with different shapes
         dataset = (
             np.random.rand(5, 32, 32),
-            np.random.rand(
-                5,
-            ),
+            np.random.rand(5,),
         )
         left_split, right_split = dataset_utils.split_dataset(
             dataset, left_size=2, right_size=3
@@ -195,9 +193,7 @@ class SplitDatasetTest(tf.test.TestCase):
         # test with dict of np arrays with different shapes
         dict_samples = {
             "images": np.random.rand(10, 16, 16, 3),
-            "labels": np.random.rand(
-                10,
-            ),
+            "labels": np.random.rand(10,),
         }
         dataset = tf.data.Dataset.from_tensor_slices(dict_samples)
         dataset = dataset.batch(1)
@@ -255,9 +251,7 @@ class SplitDatasetTest(tf.test.TestCase):
         # test with tuple of np arrays with different shapes
         X, Y = (
             np.random.rand(5, 3, 3),
-            np.random.rand(
-                5,
-            ),
+            np.random.rand(5,),
         )
         dataset = tf.data.Dataset.from_tensor_slices((X, Y))
         left_split, right_split = dataset_utils.split_dataset(
@@ -287,9 +281,7 @@ class SplitDatasetTest(tf.test.TestCase):
         # test with dict of np arrays with different shapes
         dict_samples = {
             "images": np.random.rand(10, 16, 16, 3),
-            "labels": np.random.rand(
-                10,
-            ),
+            "labels": np.random.rand(10,),
         }
         dataset = tf.data.Dataset.from_tensor_slices(dict_samples)
         left_split, right_split = dataset_utils.split_dataset(

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -52,8 +52,7 @@ _THREAD_LOCAL_CUSTOM_OBJECTS = threading.local()
 
 
 @keras_export(
-    "keras.utils.custom_object_scope",
-    "keras.utils.CustomObjectScope",
+    "keras.utils.custom_object_scope", "keras.utils.CustomObjectScope",
 )
 class CustomObjectScope:
     """Exposes custom classes/functions to Keras deserialization internals.

--- a/keras/utils/generic_utils_test.py
+++ b/keras/utils/generic_utils_test.py
@@ -394,11 +394,7 @@ class SerializeKerasObjectTest(tf.test.TestCase):
             old_model_config, module_objects={"Sequential": keras.Sequential}
         )
         new_model = keras.Sequential(
-            [
-                keras.layers.Dense(
-                    32, input_dim=784, kernel_initializer="Ones"
-                ),
-            ]
+            [keras.layers.Dense(32, input_dim=784, kernel_initializer="Ones"),]
         )
         input_data = np.random.normal(2, 1, (5, 784))
         output = old_model.predict(input_data)

--- a/keras/utils/layer_utils_test.py
+++ b/keras/utils/layer_utils_test.py
@@ -177,8 +177,7 @@ class LayerUtilsTest(tf.test.TestCase):
             def __init__(self):
                 super().__init__()
                 self.module = Sequential(
-                    keras.layers.Dense(10),
-                    keras.layers.Dense(10),
+                    keras.layers.Dense(10), keras.layers.Dense(10),
                 )
 
             def call(self, input_tensor):
@@ -543,7 +542,7 @@ class LayerUtilsTest(tf.test.TestCase):
                 # an instance returns the same value in different threads, but
                 # different instances return different values.
                 return int(
-                    np.random.RandomState(id(self) % (2**31)).randint(2**16)
+                    np.random.RandomState(id(self) % (2 ** 31)).randint(2 ** 16)
                 )
 
             def get_test_property(self, _):

--- a/keras/utils/losses_utils.py
+++ b/keras/utils/losses_utils.py
@@ -343,11 +343,9 @@ def compute_weighted_loss(
         sample_weight = tf.cast(sample_weight, losses.dtype)
         # Update dimensions of `sample_weight` to match with `losses` if
         # possible.
-        (
-            losses,
-            _,
-            sample_weight,
-        ) = squeeze_or_expand_dimensions(losses, None, sample_weight)
+        (losses, _, sample_weight,) = squeeze_or_expand_dimensions(
+            losses, None, sample_weight
+        )
         weighted_losses = tf.multiply(losses, sample_weight)
 
         # Apply reduction function to the individual weighted losses.

--- a/keras/utils/metrics_utils_test.py
+++ b/keras/utils/metrics_utils_test.py
@@ -43,18 +43,10 @@ class RaggedSizeOpTest(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.parameters(
         [
-            {
-                "x_list": [1],
-            },
-            {
-                "x_list": [1, 2],
-            },
-            {
-                "x_list": [1, 2, 4],
-            },
-            {
-                "x_list": [[1, 2], [3, 4]],
-            },
+            {"x_list": [1],},
+            {"x_list": [1, 2],},
+            {"x_list": [1, 2, 4],},
+            {"x_list": [[1, 2], [3, 4]],},
         ]
     )
     def test_passing_one_dense_tensor(self, x_list):
@@ -81,24 +73,12 @@ class RaggedSizeOpTest(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.parameters(
         [
-            {
-                "x_list": [1],
-            },
-            {
-                "x_list": [1, 2],
-            },
-            {
-                "x_list": [1, 2, 4],
-            },
-            {
-                "x_list": [[1, 2], [3, 4]],
-            },
-            {
-                "x_list": [[1, 2], [3, 4], [1]],
-            },
-            {
-                "x_list": [[1, 2], [], [1]],
-            },
+            {"x_list": [1],},
+            {"x_list": [1, 2],},
+            {"x_list": [1, 2, 4],},
+            {"x_list": [[1, 2], [3, 4]],},
+            {"x_list": [[1, 2], [3, 4], [1]],},
+            {"x_list": [[1, 2], [], [1]],},
         ]
     )
     def test_passing_one_ragged(self, x_list):
@@ -131,10 +111,10 @@ class RaggedSizeOpTest(tf.test.TestCase, parameterized.TestCase):
         x = tf.ragged.constant(x_list)
         y = tf.ragged.constant(y_list)
         mask = tf.ragged.constant(mask_list)
-        [
-            x,
-            y,
-        ], mask = metrics_utils.ragged_assert_compatible_and_get_flat_values(
+        (
+            [x, y,],
+            mask,
+        ) = metrics_utils.ragged_assert_compatible_and_get_flat_values(
             [x, y], mask
         )
         x.shape.assert_is_compatible_with(y.shape)
@@ -162,35 +142,31 @@ class RaggedSizeOpTest(tf.test.TestCase, parameterized.TestCase):
         x.shape.assert_is_compatible_with(mask.shape)
 
     @parameterized.parameters(
-        [
-            {"x_list": [[[1, 3]]], "y_list": [[2, 3]]},
-        ]
+        [{"x_list": [[[1, 3]]], "y_list": [[2, 3]]},]
     )
     def test_failing_different_ragged_and_dense_ranks(self, x_list, y_list):
         x = tf.ragged.constant(x_list)
         y = tf.ragged.constant(y_list)
         with self.assertRaises(ValueError):
-            [
-                x,
-                y,
-            ], _ = metrics_utils.ragged_assert_compatible_and_get_flat_values(
+            (
+                [x, y,],
+                _,
+            ) = metrics_utils.ragged_assert_compatible_and_get_flat_values(
                 [x, y]
             )
 
     @parameterized.parameters(
-        [
-            {"x_list": [[[1, 3]]], "y_list": [[[2, 3]]], "mask_list": [[0, 1]]},
-        ]
+        [{"x_list": [[[1, 3]]], "y_list": [[[2, 3]]], "mask_list": [[0, 1]]},]
     )
     def test_failing_different_mask_ranks(self, x_list, y_list, mask_list):
         x = tf.ragged.constant(x_list)
         y = tf.ragged.constant(y_list)
         mask = tf.ragged.constant(mask_list)
         with self.assertRaises(ValueError):
-            [
-                x,
-                y,
-            ], _ = metrics_utils.ragged_assert_compatible_and_get_flat_values(
+            (
+                [x, y,],
+                _,
+            ) = metrics_utils.ragged_assert_compatible_and_get_flat_values(
                 [x, y], mask
             )
 
@@ -203,10 +179,10 @@ class RaggedSizeOpTest(tf.test.TestCase, parameterized.TestCase):
         x = tf.RaggedTensor.from_row_splits(dt, row_splits=[0, 1])
         y = tf.ragged.constant([[[[1, 2]]]])
         with self.assertRaises(ValueError):
-            [
-                x,
-                y,
-            ], _ = metrics_utils.ragged_assert_compatible_and_get_flat_values(
+            (
+                [x, y,],
+                _,
+            ) = metrics_utils.ragged_assert_compatible_and_get_flat_values(
                 [x, y]
             )
 

--- a/keras/utils/tf_inspect.py
+++ b/keras/utils/tf_inspect.py
@@ -81,6 +81,7 @@ if hasattr(_inspect, "getfullargspec"):
         )
         return argspecs
 
+
 else:
     _getargspec = _inspect.getargspec
 

--- a/keras/utils/tf_utils_test.py
+++ b/keras/utils/tf_utils_test.py
@@ -457,10 +457,7 @@ class TestGetTensorSpec(parameterized.TestCase):
 
 class TestSyncToNumpyOrPythonType(parameterized.TestCase):
     @parameterized.parameters(
-        [
-            (0.5,),
-            (b"string value",),
-        ]
+        [(0.5,), (b"string value",),]
     )
     def test_types(self, value):
         if not tf.executing_eagerly():

--- a/keras/utils/vis_utils_test.py
+++ b/keras/utils/vis_utils_test.py
@@ -254,10 +254,7 @@ class ModelToDotFormatTest(tf.test.TestCase, parameterized.TestCase):
             "b": keras.Input(name="b", shape=(1), dtype=tf.float32),
         }
         outputs = DictLayer()((inputs["a"], inputs))
-        model = keras.Model(
-            inputs=inputs,
-            outputs=outputs,
-        )
+        model = keras.Model(inputs=inputs, outputs=outputs,)
         try:
             vis_utils.plot_model(
                 model, show_shapes=True, show_dtype=True, show_layer_names=True


### PR DESCRIPTION
This is a small feature update to keras/utils/data_utils.py to respect the KERAS_HOME environment variable if set by a user. In this way it's possible to allow a user to download datasets required by Keras applications and put them into a directory to be picked up by application runs on systems where /home (or at least the default ~/.keras directory) is not available when running applications.

The majority of the changes in this pull request are actually from running `sh shell/format.sh` on the code base as outlined in  the contributing guidelines.