### PR TITLE
Updating get_file() to respect KERAS_HOME environment variable

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -86,7 +86,6 @@ if True:  # This gets transformed to `if sys.version_info[0] == 2:` in OSS.
             for chunk in chunk_read(response, reporthook=reporthook):
                 fd.write(chunk)
 
-
 else:
     from urllib.request import urlretrieve
 

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -86,6 +86,7 @@ if True:  # This gets transformed to `if sys.version_info[0] == 2:` in OSS.
             for chunk in chunk_read(response, reporthook=reporthook):
                 fd.write(chunk)
 
+
 else:
     from urllib.request import urlretrieve
 
@@ -220,7 +221,10 @@ def get_file(
         )
 
     if cache_dir is None:
-        cache_dir = os.path.join(os.path.expanduser("~"), ".keras")
+        if "KERAS_HOME" in os.environ:
+            cache_dir = os.environ.get("KERAS_HOME")
+        else:
+            cache_dir = os.path.join(os.path.expanduser("~"), ".keras")
     if md5_hash is not None and file_hash is None:
         file_hash = md5_hash
         hash_algorithm = "md5"


### PR DESCRIPTION
This is a small feature update to enable the utils/data_utils.py get_file() function to respect the KERAS_HOME environment variable if set by a user. This would allow any datasets required by applications to be download to be cached in directories other than ~/.keras, which is especially useful for people running on systems where the HOME directory is not accessible from the place applications are being run.

