### PR TITLE
Fix docs of `metrics` parameter in `compile`

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -653,8 +653,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
               strings 'accuracy' or 'acc', we convert this to one of
               `tf.keras.metrics.BinaryAccuracy`,
               `tf.keras.metrics.CategoricalAccuracy`,
-              `tf.keras.metrics.SparseCategoricalAccuracy` based on the loss
-              function used and the model output shape. We do a similar
+              `tf.keras.metrics.SparseCategoricalAccuracy` based on the shapes
+              of the targets and of the model output. We do a similar
               conversion for the strings 'crossentropy' and 'ce' as well.
               The metrics passed here are evaluated without sample weighting; if
               you would like sample weighting to apply, you can specify your


### PR DESCRIPTION
Fix https://github.com/tensorflow/tensorflow/issues/41361. The existing documentation refers to an old behavior which was replaced when MetricsContainer was added (see commit https://github.com/tensorflow/tensorflow/commit/fb30b12e101e55bf008588a9cd72d4150ba67ad8). The [current code](https://github.com/keras-team/keras/blob/master/keras/engine/compile_utils.py#L647) does not use the loss function for deciding which accuracy metric to use, it uses only the shapes of the targets and of the model output.