### PR TITLE
Added EfficientNet lite option.

### DIFF
--- a/keras/applications/BUILD
+++ b/keras/applications/BUILD
@@ -18,6 +18,7 @@ py_library(
         "convnext.py",
         "densenet.py",
         "efficientnet.py",
+        "efficientnet_lite.py",
         "efficientnet_v2.py",
         "imagenet_utils.py",
         "inception_resnet_v2.py",

--- a/keras/applications/applications_load_weight_test.py
+++ b/keras/applications/applications_load_weight_test.py
@@ -86,6 +86,7 @@ ARG_TO_MODEL = {
             efficientnet.EfficientNetB7,
         ],
     ),
+    # TODO: efficientnet_lite - after weight upload.
     "efficientnet_v2": (
         efficientnet_v2,
         [

--- a/keras/applications/applications_test.py
+++ b/keras/applications/applications_test.py
@@ -69,6 +69,7 @@ MODEL_LIST_NO_NASNET = [
     (efficientnet.EfficientNetB5, 2048),
     (efficientnet.EfficientNetB6, 2304),
     (efficientnet.EfficientNetB7, 2560),
+    # TODO: efficientnet_lite after weight upload.
     (efficientnet_v2.EfficientNetV2B0, 1280),
     (efficientnet_v2.EfficientNetV2B1, 1280),
     (efficientnet_v2.EfficientNetV2B2, 1408),

--- a/keras/applications/efficientnet.py
+++ b/keras/applications/efficientnet.py
@@ -71,6 +71,27 @@ WEIGHTS_HASHES = {
         "8c03f828fec3ef71311cd463b6759d99",
         "cbcfe4450ddf6f3ad90b1b398090fe4a",
     ),
+    # Lite variants are ending with lite<number>, e.g lite0, lite1 etc.
+    "e0": (
+        "a1fac1765ff9bff7776d7363ff4ab6aa",
+        "219361f78697276dbd254abb00cc6c94",
+    ),
+    "e1": (
+        "60953b9cbe6dae1962c7ab1e2526372e",
+        "8795803d7dc8ba7cc0d325d0a9190fb1",
+    ),
+    "e2": (
+        "a8ea4d2559a62b13237190c797051233",
+        "a1b0962e9648ec4b090a480bd78b1e61",
+    ),
+    "e3": (
+        "4240c64bcdef593895e0f77832ee753e",
+        "34f0d1eaaeaf601ec463f3281d012586",
+    ),
+    "e4": (
+        "c8d5b68b8c02463a6d980032b0f35add",
+        "ec01dca94123384d6e86c86445ed3bf6",
+    ),
 }
 
 DEFAULT_BLOCKS_ARGS = [
@@ -202,6 +223,10 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
     input_shape: Optional shape tuple, only to be specified
         if `include_top` is False.
         It should have exactly 3 inputs channels.
+    lite: Optional boolean, whether to create a 'lite' variant of the network.
+        Note, that only B0-B4 variants have lite option. For more details on
+        lite variants, you can read:
+        https://github.com/tensorflow/tpu/blob/master/models/official/efficientnet/lite/README.md
     pooling: Optional pooling mode for feature extraction
         when `include_top` is `False`. Defaults to None.
         - `None` means that the output of the model will be
@@ -237,6 +262,7 @@ def EfficientNet(
     depth_coefficient,
     default_size,
     dropout_rate=0.2,
+    lite=False,
     drop_connect_rate=0.2,
     depth_divisor=8,
     activation="swish",
@@ -257,6 +283,8 @@ def EfficientNet(
       depth_coefficient: float, scaling coefficient for network depth.
       default_size: integer, default input image size.
       dropout_rate: float, dropout rate before final classifier layer.
+      lite: optional bool, whether to create 'lite' variant of the network.
+          Note: only B0-B4 variants have lite version.
       drop_connect_rate: float, dropout rate at skip connections.
       depth_divisor: integer, a unit of network width.
       activation: activation function.
@@ -317,6 +345,13 @@ def EfficientNet(
             " as true, `classes` should be 1000"
         )
 
+    if lite and not model_name.endswith(("0", "1", "2", "3", "4")):
+        raise ValueError(
+            "`lite` option is only available for B0, B1, B2, B3 and B4 "
+            f"variants. Attempted to create EfficientNet lite {model_name[-2:]}"
+            f" variant."
+        )
+
     # Determine proper input shape
     input_shape = imagenet_utils.obtain_input_shape(
         input_shape,
@@ -354,23 +389,31 @@ def EfficientNet(
 
     # Build stem
     x = img_input
-    x = layers.Rescaling(1.0 / 255.0)(x)
-    x = layers.Normalization(axis=bn_axis)(x)
-    if weights == "imagenet":
-        # Note that the normaliztion layer uses square value of STDDEV as the
+
+    if lite:
+        x = layers.Normalization(mean=127.0, variance=128.0**2)(x)
+    else:
+        x = layers.Rescaling(1.0 / 255.0)(x)
+        x = layers.Normalization(axis=bn_axis)(x)
+
+    if weights == "imagenet" and not lite:
+        # Note that the normalization layer uses square value of STDDEV as the
         # variance for the layer: result = (input - mean) / sqrt(var)
-        # However, the original implemenetation uses (input - mean) / var to
+        # However, the original implementation uses (input - mean) / var to
         # normalize the input, we need to divide another sqrt(var) to match the
         # original implementation.
         # See https://github.com/tensorflow/tensorflow/issues/49930 for more
-        # details
+        # details.
+        # This doesn't apply to `lite` variants, which follow different
+        # preprocessing.
         x = layers.Rescaling(1.0 / tf.math.sqrt(IMAGENET_STDDEV_RGB))(x)
 
     x = layers.ZeroPadding2D(
         padding=imagenet_utils.correct_pad(x, 3), name="stem_conv_pad"
     )(x)
+
     x = layers.Conv2D(
-        round_filters(32),
+        32 if lite else round_filters(32),
         3,
         strides=2,
         padding="valid",
@@ -385,14 +428,25 @@ def EfficientNet(
     blocks_args = copy.deepcopy(blocks_args)
 
     b = 0
-    blocks = float(sum(round_repeats(args["repeats"]) for args in blocks_args))
+    if lite:
+        blocks = float(sum(args["repeats"] for args in blocks_args))
+    else:
+        blocks = float(
+            sum(round_repeats(args["repeats"]) for args in blocks_args)
+        )
+
     for i, args in enumerate(blocks_args):
         assert args["repeats"] > 0
         # Update block input and output filters based on depth multiplier.
         args["filters_in"] = round_filters(args["filters_in"])
         args["filters_out"] = round_filters(args["filters_out"])
 
-        for j in range(round_repeats(args.pop("repeats"))):
+        if lite and i in (0, len(blocks_args) - 1):
+            repeats = args.pop("repeats")
+        else:
+            repeats = round_repeats(args.pop("repeats"))
+
+        for j in range(repeats):
             # The first block needs to take care of stride and filter size
             # increase.
             if j > 0:
@@ -402,6 +456,7 @@ def EfficientNet(
                 x,
                 activation,
                 drop_connect_rate * b / blocks,
+                lite=lite,
                 name=f"block{i + 1}{chr(j + 97)}_",
                 **args,
             )
@@ -409,7 +464,7 @@ def EfficientNet(
 
     # Build top
     x = layers.Conv2D(
-        round_filters(1280),
+        1280 if lite else round_filters(1280),
         1,
         padding="same",
         use_bias=False,
@@ -470,6 +525,7 @@ def block(
     inputs,
     activation="swish",
     drop_rate=0.0,
+    lite=False,
     name="",
     filters_in=32,
     filters_out=16,
@@ -485,6 +541,7 @@ def block(
         inputs: input tensor.
         activation: activation function.
         drop_rate: float between 0 and 1, fraction of the input units to drop.
+        lite: boolean, whether to use `lite` block variant.
         name: string, block label.
         filters_in: integer, the number of input filters.
         filters_out: integer, the number of output filters.
@@ -536,7 +593,7 @@ def block(
     x = layers.Activation(activation, name=name + "activation")(x)
 
     # Squeeze and Excitation phase
-    if 0 < se_ratio <= 1:
+    if 0 < se_ratio <= 1 and not lite:
         filters_se = max(1, int(filters_in * se_ratio))
         se = layers.GlobalAveragePooling2D(name=name + "se_squeeze")(x)
         if bn_axis == 1:
@@ -588,6 +645,7 @@ def block(
 def EfficientNetB0(
     include_top=True,
     weights="imagenet",
+    lite=False,
     input_tensor=None,
     input_shape=None,
     pooling=None,
@@ -600,9 +658,11 @@ def EfficientNetB0(
         1.0,
         224,
         0.2,
-        model_name="efficientnetb0",
+        lite=lite,
+        model_name="efficientnetlite0" if lite else "efficientnetb0",
         include_top=include_top,
         weights=weights,
+        activation="relu6" if lite else "swish",
         input_tensor=input_tensor,
         input_shape=input_shape,
         pooling=pooling,
@@ -619,6 +679,7 @@ def EfficientNetB0(
 def EfficientNetB1(
     include_top=True,
     weights="imagenet",
+    lite=False,
     input_tensor=None,
     input_shape=None,
     pooling=None,
@@ -631,9 +692,11 @@ def EfficientNetB1(
         1.1,
         240,
         0.2,
-        model_name="efficientnetb1",
+        lite=lite,
+        model_name="efficientnetlite1" if lite else "efficientnetb1",
         include_top=include_top,
         weights=weights,
+        activation="relu6" if lite else "swish",
         input_tensor=input_tensor,
         input_shape=input_shape,
         pooling=pooling,
@@ -650,6 +713,7 @@ def EfficientNetB1(
 def EfficientNetB2(
     include_top=True,
     weights="imagenet",
+    lite=False,
     input_tensor=None,
     input_shape=None,
     pooling=None,
@@ -662,9 +726,11 @@ def EfficientNetB2(
         1.2,
         260,
         0.3,
-        model_name="efficientnetb2",
+        lite=lite,
+        model_name="efficientnetlite2" if lite else "efficientnetb2",
         include_top=include_top,
         weights=weights,
+        activation="relu6" if lite else "swish",
         input_tensor=input_tensor,
         input_shape=input_shape,
         pooling=pooling,
@@ -681,6 +747,7 @@ def EfficientNetB2(
 def EfficientNetB3(
     include_top=True,
     weights="imagenet",
+    lite=False,
     input_tensor=None,
     input_shape=None,
     pooling=None,
@@ -691,11 +758,13 @@ def EfficientNetB3(
     return EfficientNet(
         1.2,
         1.4,
-        300,
+        280 if lite else 300,
         0.3,
-        model_name="efficientnetb3",
+        lite=lite,
+        model_name="efficientnetlite3" if lite else "efficientnetb3",
         include_top=include_top,
         weights=weights,
+        activation="relu6" if lite else "swish",
         input_tensor=input_tensor,
         input_shape=input_shape,
         pooling=pooling,
@@ -712,6 +781,7 @@ def EfficientNetB3(
 def EfficientNetB4(
     include_top=True,
     weights="imagenet",
+    lite=False,
     input_tensor=None,
     input_shape=None,
     pooling=None,
@@ -722,9 +792,11 @@ def EfficientNetB4(
     return EfficientNet(
         1.4,
         1.8,
-        380,
-        0.4,
-        model_name="efficientnetb4",
+        300 if lite else 380,
+        0.3 if lite else 0.4,
+        lite=lite,
+        model_name="efficientnetlite4" if lite else "efficientnetb4",
+        activation="relu6" if lite else "swish",
         include_top=include_top,
         weights=weights,
         input_tensor=input_tensor,

--- a/keras/applications/efficientnet_lite.py
+++ b/keras/applications/efficientnet_lite.py
@@ -103,6 +103,9 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
         Defaults to 'softmax'.
         When loading pretrained weights, `classifier_activation` can only
         be `None` or `"softmax"`.
+    include_preprocessing: Boolean, whether to include the preprocessing
+        layer (`Normalization`) at the bottom of the network. Defaults to
+        `True`.
 
   Returns:
     A `keras.Model` instance.
@@ -118,7 +121,7 @@ def EfficientNetLite(
     depth_divisor=8,
     activation="relu6",
     blocks_args="default",
-    model_name="efficientnet",
+    model_name="efficientnetlite",
     include_top=True,
     weights="imagenet",
     input_tensor=None,
@@ -168,7 +171,7 @@ def EfficientNetLite(
             `include_top=True`. Set`classifier_activation=None`
             to return the logits of the "top" layer.
         include_preprocessing: Boolean, whether to include the preprocessing
-            layer (`Rescaling`) at the bottom of the network. Defaults to
+            layer (`Normalization`) at the bottom of the network. Defaults to
             `True`.  Note: Input image is normalized by ImageNet mean and
             standard deviation.
 
@@ -182,7 +185,6 @@ def EfficientNetLite(
             using a pretrained top layer.
     """
     if blocks_args == "default":
-        # By default, we use EfficientNet V1 blocks args
         blocks_args = efficientnet.DEFAULT_BLOCKS_ARGS
 
     if not (weights in {"imagenet", None} or tf.io.gfile.exists(weights)):
@@ -247,7 +249,7 @@ def EfficientNetLite(
     blocks = float(sum(args["repeats"] for args in blocks_args))
 
     for (i, args) in enumerate(blocks_args):
-        # Lite variant do not use Squeeze and Excitation block:
+        # Lite variants do not use Squeeze and Excitation block:
         args.pop("se_ratio")
 
         assert args["repeats"] > 0
@@ -458,6 +460,7 @@ def BlockLite(
     return apply
 
 
+@keras_export("keras.applications.efficientnet_lite.EfficientNetLiteB0")
 def EfficientNetLiteB0(
     include_top=True,
     weights="imagenet",
@@ -484,6 +487,7 @@ def EfficientNetLiteB0(
     )
 
 
+@keras_export("keras.applications.efficientnet_lite.EfficientNetLiteB1")
 def EfficientNetLiteB1(
     include_top=True,
     weights="imagenet",
@@ -510,6 +514,7 @@ def EfficientNetLiteB1(
     )
 
 
+@keras_export("keras.applications.efficientnet_lite.EfficientNetLiteB2")
 def EfficientNetLiteB2(
     include_top=True,
     weights="imagenet",
@@ -536,6 +541,7 @@ def EfficientNetLiteB2(
     )
 
 
+@keras_export("keras.applications.efficientnet_lite.EfficientNetLiteB3")
 def EfficientNetLiteB3(
     include_top=True,
     weights="imagenet",
@@ -562,6 +568,7 @@ def EfficientNetLiteB3(
     )
 
 
+@keras_export("keras.applications.efficientnet_lite.EfficientNetLiteB4")
 def EfficientNetLiteB4(
     include_top=True,
     weights="imagenet",

--- a/keras/applications/efficientnet_lite.py
+++ b/keras/applications/efficientnet_lite.py
@@ -39,6 +39,73 @@ WEIGHTS_HASHES = {
     ),
 }
 
+
+DEFAULT_BLOCKS_ARGS = [
+    {
+        "kernel_size": 3,
+        "repeats": 1,
+        "filters_in": 32,
+        "filters_out": 16,
+        "expand_ratio": 1,
+        "id_skip": True,
+        "strides": 1,
+    },
+    {
+        "kernel_size": 3,
+        "repeats": 2,
+        "filters_in": 16,
+        "filters_out": 24,
+        "expand_ratio": 6,
+        "id_skip": True,
+        "strides": 2,
+    },
+    {
+        "kernel_size": 5,
+        "repeats": 2,
+        "filters_in": 24,
+        "filters_out": 40,
+        "expand_ratio": 6,
+        "id_skip": True,
+        "strides": 2,
+    },
+    {
+        "kernel_size": 3,
+        "repeats": 3,
+        "filters_in": 40,
+        "filters_out": 80,
+        "expand_ratio": 6,
+        "id_skip": True,
+        "strides": 2,
+    },
+    {
+        "kernel_size": 5,
+        "repeats": 3,
+        "filters_in": 80,
+        "filters_out": 112,
+        "expand_ratio": 6,
+        "id_skip": True,
+        "strides": 1,
+    },
+    {
+        "kernel_size": 5,
+        "repeats": 4,
+        "filters_in": 112,
+        "filters_out": 192,
+        "expand_ratio": 6,
+        "id_skip": True,
+        "strides": 2,
+    },
+    {
+        "kernel_size": 3,
+        "repeats": 1,
+        "filters_in": 192,
+        "filters_out": 320,
+        "expand_ratio": 6,
+        "id_skip": True,
+        "strides": 1,
+    },
+]
+
 BASE_DOCSTRING = """Instantiates the {name} architecture.
 
   Reference:
@@ -185,7 +252,7 @@ def EfficientNetLite(
             using a pretrained top layer.
     """
     if blocks_args == "default":
-        blocks_args = efficientnet.DEFAULT_BLOCKS_ARGS
+        blocks_args = DEFAULT_BLOCKS_ARGS
 
     if not (weights in {"imagenet", None} or tf.io.gfile.exists(weights)):
         raise ValueError(
@@ -249,8 +316,6 @@ def EfficientNetLite(
     blocks = float(sum(args["repeats"] for args in blocks_args))
 
     for (i, args) in enumerate(blocks_args):
-        # Lite variants do not use Squeeze and Excitation block:
-        args.pop("se_ratio")
 
         assert args["repeats"] > 0
         # Update block input and output filters based on depth multiplier.
@@ -469,6 +534,7 @@ def EfficientNetLiteB0(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
+    include_preprocessing=True,
 ):
     """Create EfficientNetLite B0 variant."""
     return EfficientNetLite(
@@ -484,6 +550,7 @@ def EfficientNetLiteB0(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
+        include_preprocessing=include_preprocessing,
     )
 
 
@@ -496,6 +563,7 @@ def EfficientNetLiteB1(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
+    include_preprocessing=True,
 ):
     """Create EfficientNetLite B1 variant."""
     return EfficientNetLite(
@@ -511,6 +579,7 @@ def EfficientNetLiteB1(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
+        include_preprocessing=include_preprocessing,
     )
 
 
@@ -523,6 +592,7 @@ def EfficientNetLiteB2(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
+    include_preprocessing=True,
 ):
     """Create EfficientNetLite B2 variant."""
     return EfficientNetLite(
@@ -538,6 +608,7 @@ def EfficientNetLiteB2(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
+        include_preprocessing=include_preprocessing,
     )
 
 
@@ -550,6 +621,7 @@ def EfficientNetLiteB3(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
+    include_preprocessing=True,
 ):
     """Create EfficientNetLite B3 variant."""
     return EfficientNetLite(
@@ -565,6 +637,7 @@ def EfficientNetLiteB3(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
+        include_preprocessing=include_preprocessing,
     )
 
 
@@ -577,6 +650,7 @@ def EfficientNetLiteB4(
     pooling=None,
     classes=1000,
     classifier_activation="softmax",
+    include_preprocessing=True,
 ):
     """Create EfficientNetLite B4 variant."""
     return EfficientNetLite(
@@ -592,6 +666,7 @@ def EfficientNetLiteB4(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
+        include_preprocessing=include_preprocessing,
     )
 
 

--- a/keras/applications/efficientnet_weight_update_util.py
+++ b/keras/applications/efficientnet_weight_update_util.py
@@ -41,6 +41,7 @@ import warnings
 
 import tensorflow.compat.v2 as tf
 from tensorflow.keras.applications import efficientnet
+from tensorflow.keras.applications import efficientnet_lite
 
 from keras.utils import io_utils
 
@@ -372,6 +373,11 @@ if __name__ == "__main__":
         "b5": efficientnet.EfficientNetB5,
         "b6": efficientnet.EfficientNetB6,
         "b7": efficientnet.EfficientNetB7,
+        "b0-lite": efficientnet_lite.EfficientNetLiteB0,
+        "b1-lite": efficientnet_lite.EfficientNetLiteB1,
+        "b2-lite": efficientnet_lite.EfficientNetLiteB2,
+        "b3-lite": efficientnet_lite.EfficientNetLiteB3,
+        "b4-lite": efficientnet_lite.EfficientNetLiteB4,
     }
 
     p = argparse.ArgumentParser(

--- a/keras/applications/efficientnet_weight_update_util.py
+++ b/keras/applications/efficientnet_weight_update_util.py
@@ -385,12 +385,6 @@ if __name__ == "__main__":
         choices=arg_to_model.keys(),
     )
     p.add_argument(
-        "--lite",
-        action="store_true",
-        help="Whether to use lite variant of the model.",
-        default=False,
-    )
-    p.add_argument(
         "--notop",
         action="store_true",
         help="do not include top layers",
@@ -404,7 +398,5 @@ if __name__ == "__main__":
 
     include_top = not args.notop
 
-    model = arg_to_model[args.model](
-        include_top=include_top, lite=args.lite, weights=None
-    )
+    model = arg_to_model[args.model](include_top=include_top, weights=None)
     write_ckpt_to_h5(args.output, args.ckpt, keras_model=model)

--- a/keras/applications/efficientnet_weight_update_util.py
+++ b/keras/applications/efficientnet_weight_update_util.py
@@ -385,6 +385,12 @@ if __name__ == "__main__":
         choices=arg_to_model.keys(),
     )
     p.add_argument(
+        "--lite",
+        action="store_true",
+        help="Whether to use lite variant of the model.",
+        default=False,
+    )
+    p.add_argument(
         "--notop",
         action="store_true",
         help="do not include top layers",
@@ -398,5 +404,7 @@ if __name__ == "__main__":
 
     include_top = not args.notop
 
-    model = arg_to_model[args.model](include_top=include_top)
+    model = arg_to_model[args.model](
+        include_top=include_top, lite=args.lite, weights=None
+    )
     write_ckpt_to_h5(args.output, args.ckpt, keras_model=model)


### PR DESCRIPTION
# What does this PR do

This PR adds `lite` option to existing EfficientNet V1's.

EfficientNet lite's are slightly modified efficientnets that better support edge devices. 

The models and weights are ported from original repository:
https://github.com/tensorflow/tpu/blob/master/models/official/efficientnet/lite/README.md 

### Linked issues:
In Keras repo: #16835  
Previously in Tensorflow repo: 
https://github.com/tensorflow/tensorflow/pull/48400
https://github.com/tensorflow/tensorflow/issues/45091

# How does this affect the API
This works similar to `minimalistic` flag in MobileNetV3. Users can create EfficientNet lite's by passing `lite=True` argument upon model creation:
```python
model = tf.keras.applications.efficientnet.EfficientNetB0(lite=True)
```
(Keep in mind that the above, will raise an error as the weights are not in the GCS bucket. The above works with `weights=None`)

NOTE: lite options have been only released for B0-B4 variants.

# Pretrained weights
The weights have been converted from the original repository, using already present [efficientnet_weight_update_util.py](https://github.com/keras-team/keras/blob/master/keras/applications/efficientnet_weight_update_util.py).

I cannot attach them to this PR as they exceed the allowed file size. They can be downloaded from my Google Drive:
https://drive.google.com/file/d/1XSpE1NGhbaP8dN1Rem3QrmeuC--2E9QR/view?usp=sharing 

# Imagenet Accuracy
I evaluated the models using my [external repository](https://github.com/sebastian-sz/efficientnet-lite-keras/tree/main/imagenet_evaluation), so I'm copy pasting the accuracy results below:
#### Results table
| Variant | Image size | Reported Top 1 | This repo Top 1 | This repo Top 5 | Top 1 difference |
| ------- | ---------- | -------------- | --------------- | --------------- | ---------------- |
|   B0    |     224    |     75.1       |       75.1      |       92.3      |       0.0        |
|   B1    |     240    |     76.7       |       76.8      |       93.3      |       +0.1       |
|   B2    |     260    |     77.6       |       77.6      |       93.8      |       0.0        |
|   B3    |     280    |     79.8       |       79.4*     |       94.7      |       -0.4      |
|   B4    |     300    |     81.5       |       80.8*     |       95.2      |       -0.7      |

We can observe that the accuracy for B3/B4 variants slightly differs from reported. The errors are below 1% and the model outputs the same probabilities as the ones in the original repository.

If this is an issue we can discuss the origin of the differences - let me know.

# Known Issues
Similar to `minimalistic` MobileNet's V3 the models are not covered under `applications_test.py`, because they are created based on a parameter. It would be nice to have those tests, I can try to further modify `applications_test.py` to try and include these models. Let me know. 