### PR TITLE
Fix value error for Units of tf.keras.layers.Dense

### DIFF
--- a/keras/layers/core/dense.py
+++ b/keras/layers/core/dense.py
@@ -117,7 +117,7 @@ class Dense(Layer):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
 
         self.units = int(units) if not isinstance(units, int) else units
-        if self.units < 0:
+        if self.units <= 0:
             raise ValueError(
                 "Received an invalid value for `units`, expected "
                 f"a positive integer. Received: units={units}"


### PR DESCRIPTION
The parameter `units=0` of `tf.keras.layers.Dense` should raise ValueError. Since `Units` expects Positive integer. 
Fixes [#16902](https://github.com/keras-team/keras/issues/16902). Thank you!