### PR TITLE
More Tests for customizable reduction strategy in model

### DIFF
--- a/keras/distribute/multi_worker_test.py
+++ b/keras/distribute/multi_worker_test.py
@@ -241,42 +241,48 @@ class KerasMultiWorkerTestIndependentWorker(
     def test_distribution_reduction_method_auto_default_train_step(
         self, strategy
     ):
-        batch_size = 32
-        epochs = 2
-        steps = 2
+        BATCH = 4
+        EPOCHS = 1
+        STEPS = 2
+
+        # Dataset's targets are [0, 1, 2, 3, 4, 5, 6, 7]:
         train_ds, _ = multi_worker_testing_utils.mnist_synthetic_dataset(
-            batch_size, steps
+            BATCH, STEPS, target_values="increasing"
         )
 
-        # A model that always outputs `sum(inputs*1) + 1 = 28**2 + 1 = 785`
+        # A model that always outputs `sum(inputs*0) + 1 = 1`
         with strategy.scope():
             inputs = keras.Input(shape=(28, 28, 1))
             x = keras.layers.Flatten()(inputs)
             x = keras.layers.Dense(
-                1, kernel_initializer="ones", bias_initializer="ones"
+                1, kernel_initializer="zeros", bias_initializer="ones"
             )(x)
             model = keras.Model(inputs=inputs, outputs=x)
-            # model.distribute_reduction_method = 'auto'
             model.trainable = False
+            # model.distribute_reduction_method = 'auto'
+
             model.compile(
-                loss=keras.losses.mean_absolute_error,
+                loss=keras.losses.MeanAbsoluteError(
+                    reduction=keras.losses.losses_utils.ReductionV2.NONE
+                ),
                 optimizer=multi_worker_testing_utils.gradient_descent.SGD(
                     learning_rate=0.001
                 ),
                 metrics=["mse"],
             )
 
-        # For every output x_i = 785, every target y_i = 1,
-        #   loss_i     = |785-1| = 784; and
-        #   loss_total = sum([784, 784, ..., 784]) / (BATCH_SIZE*steps) = 784
-        orig_loss, _ = model.evaluate(train_ds, steps=steps)
-        self.assertEqual(784, orig_loss)
+        # For every output x_i = 1, and increasing target values in [0, 8):
+        #   loss_i = |i-1|
+        #   loss   = (|0-1| + |1-1| + |2-1| + ... |7-1|) / (BATCH*STEPS)
+        #          = (1+0+1+2+3+4+5+6) / 8 = 2.75
+        orig_loss, _ = model.evaluate(train_ds, steps=STEPS)
+        self.assertEqual(2.75, orig_loss)
 
-        history = model.fit(train_ds, epochs=epochs, steps_per_epoch=steps)
-        self.assertAllClose(history.history["loss"], [784] * epochs)
+        history = model.fit(train_ds, epochs=EPOCHS, steps_per_epoch=STEPS)
+        self.assertAllClose(history.history["loss"], [2.75] * EPOCHS)
 
-        trained_loss, _ = model.evaluate(train_ds, steps=steps)
-        self.assertEqual(784, trained_loss)
+        trained_loss, _ = model.evaluate(train_ds, steps=STEPS)
+        self.assertEqual(2.75, trained_loss)
 
     @tf.__internal__.distribute.combinations.generate(
         tf.__internal__.test.combinations.combine(
@@ -290,37 +296,31 @@ class KerasMultiWorkerTestIndependentWorker(
     def test_distribution_reduction_method_auto_custom_train_step(
         self, strategy
     ):
-        batch_size = 32
-        steps = 2
-        epochs = 2
+        BATCH = 4
+        EPOCHS = 1
+        STEPS = 2
+
+        # Dataset's targets are [0, 1, 2, 3]:
         train_ds, _ = multi_worker_testing_utils.mnist_synthetic_dataset(
-            batch_size, steps
+            BATCH, STEPS, target_values="increasing"
         )
 
         class MyModel(keras.Model):
-            @staticmethod
-            def reduce_loss(loss_value, global_batch_size):
-                REDUCTION_AXES = range(1, loss_value.shape.rank)
-                loss_value = tf.reduce_mean(loss_value, axis=REDUCTION_AXES)
-                return tf.nn.compute_average_loss(
-                    loss_value, global_batch_size=batch_size
-                )
-
             def train_step(self, data):
-                loss_value = 3 * tf.ones_like(data[0])
-                return {
-                    "loss": MyModel.reduce_loss(
-                        loss_value, global_batch_size=batch_size
-                    )
-                }
+                _, y = data
+                loss_value = tf.cast(y, tf.float32)
+                loss_value = tf.nn.compute_average_loss(
+                    loss_value, global_batch_size=BATCH
+                )
+                return {"loss": loss_value}
 
             def test_step(self, data):
-                loss_value = 5 * tf.ones_like(data[0])
-                return {
-                    "metric": MyModel.reduce_loss(
-                        loss_value, global_batch_size=batch_size
-                    )
-                }
+                _, y = data
+                loss_value = tf.cast(y, tf.float32)
+                loss_value = tf.nn.compute_average_loss(
+                    loss_value, global_batch_size=BATCH
+                )
+                return {"loss": loss_value}
 
         with strategy.scope():
             inputs = keras.Input(shape=(28, 28, 1))
@@ -330,26 +330,27 @@ class KerasMultiWorkerTestIndependentWorker(
             )(x)
             model = MyModel(inputs=inputs, outputs=x)
             # model.distribute_reduction_method = 'auto'
+
             model.compile(
-                loss=keras.losses.mean_absolute_error,
                 optimizer=multi_worker_testing_utils.gradient_descent.SGD(
                     learning_rate=0.001
                 ),
             )
 
-        # For 2 mirrored workers,
-        # train_loss_i_replica_r = (3+3+3+3)/batch = 6/8;
-        # test_loss_i_replica_r  = (5+5+5+5)/batch = 5/8
-        # =>
-        # train_loss_i = sum([12/8, 12/8]) = 3
-        # train_loss   = sum([3, 3, ...])/(batch*steps) = 12/4 = 3
-        history = model.fit(train_ds, epochs=epochs, steps_per_epoch=steps)
-        self.assertAllClose(history.history["loss"], [3.0] * epochs)
+        # For epochs=1 steps=2 replicas=2 batch=4, and increasing target vals,
+        #   loss_e0_s0_r0 = [0+1]/BATCH =  1/4
+        #   loss_e0_s0_r1 = [2+3]/BATCH =  5/4
+        #   loss_e0_s0    = 1/4 + 5/4   = 1.5
+        #   loss_e0_s1_r0 = [4+5]/BATCH =  9/4
+        #   loss_e0_s2_r1 = [6+7]/BATCH = 13/4
+        #   loss_e0_s1    = 9/4 + 13/4   = 5.5
+        #
+        #   loss_e0       = last([1.5, 5.5])
+        history = model.fit(train_ds, epochs=EPOCHS, steps_per_epoch=STEPS)
+        self.assertAllClose([5.5], history.history["loss"])
 
-        # test_loss_i = sum([20/8, 20/8]) = 5
-        # test_loss   = sum([5, 5, 5, 5])/(batch*steps) = 20/4 = 5
-        eval_output = model.evaluate(train_ds, steps=steps)
-        self.assertAllClose(eval_output, 5.0)
+        eval_output = model.evaluate(train_ds, steps=STEPS)
+        self.assertAllClose(5.5, eval_output)
 
 
 class KPLMultiWorkerTest(tf.test.TestCase, parameterized.TestCase):

--- a/keras/distribute/multi_worker_test.py
+++ b/keras/distribute/multi_worker_test.py
@@ -241,7 +241,7 @@ class KerasMultiWorkerTestIndependentWorker(
     def test_distribution_reduction_method_auto_default_train_step(
         self, strategy
     ):
-        batch_size = 8
+        batch_size = 32
         epochs = 2
         steps = 2
         train_ds, _ = multi_worker_testing_utils.mnist_synthetic_dataset(
@@ -290,7 +290,7 @@ class KerasMultiWorkerTestIndependentWorker(
     def test_distribution_reduction_method_auto_custom_train_step(
         self, strategy
     ):
-        batch_size = 8
+        batch_size = 32
         steps = 2
         epochs = 2
         train_ds, _ = multi_worker_testing_utils.mnist_synthetic_dataset(
@@ -300,10 +300,10 @@ class KerasMultiWorkerTestIndependentWorker(
         class MyModel(keras.Model):
             @staticmethod
             def reduce_loss(loss_value, global_batch_size):
-                REDUCTION_AXES = range(1, backend.ndim(loss_value))
+                REDUCTION_AXES = range(1, loss_value.shape.rank)
                 loss_value = tf.reduce_mean(loss_value, axis=REDUCTION_AXES)
                 return tf.nn.compute_average_loss(
-                    loss_value, global_batch_size=global_batch_size
+                    loss_value, global_batch_size=batch_size
                 )
 
             def train_step(self, data):

--- a/keras/distribute/multi_worker_test.py
+++ b/keras/distribute/multi_worker_test.py
@@ -300,11 +300,12 @@ class KerasMultiWorkerTestIndependentWorker(
         EPOCHS = 1
         STEPS = 2
 
-        # Dataset's targets are [0, 1, 2, 3]:
+        # Dataset's targets are [0, 1, 2, 3, 4, 5, 6, 7]:
         train_ds, _ = multi_worker_testing_utils.mnist_synthetic_dataset(
             BATCH, STEPS, target_values="increasing"
         )
 
+        # A model that has loss=sum(targets) / BATCH:
         class MyModel(keras.Model):
             def train_step(self, data):
                 _, y = data
@@ -344,7 +345,6 @@ class KerasMultiWorkerTestIndependentWorker(
         #   loss_e0_s1_r0 = [4+5]/BATCH =  9/4
         #   loss_e0_s2_r1 = [6+7]/BATCH = 13/4
         #   loss_e0_s1    = 9/4 + 13/4   = 5.5
-        #
         #   loss_e0       = last([1.5, 5.5])
         history = model.fit(train_ds, epochs=EPOCHS, steps_per_epoch=STEPS)
         self.assertAllClose([5.5], history.history["loss"])

--- a/keras/distribute/multi_worker_test.py
+++ b/keras/distribute/multi_worker_test.py
@@ -337,13 +337,17 @@ class KerasMultiWorkerTestIndependentWorker(
                 ),
             )
 
-        # For two mirrored workers,  output x_i = 2, every target y_i = 1,
-        #   train_loss_i = 3 test_loss_i = 5, then:
-        #   train_loss_total = sum([3, 3, ...]) / (BATCH_SIZE * steps) = 3.0
-        #   test_loss_total = sum([5, 5, ...]) / (BATCH_SIZE * steps) = 5.0
+        # For 2 mirrored workers,
+        # train_loss_i_replica_r = (3+3+3+3)/batch = 6/8;
+        # test_loss_i_replica_r  = (5+5+5+5)/batch = 5/8
+        # =>
+        # train_loss_i = sum([12/8, 12/8]) = 3
+        # train_loss   = sum([3, 3, ...])/(batch*steps) = 12/4 = 3
         history = model.fit(train_ds, epochs=epochs, steps_per_epoch=steps)
         self.assertAllClose(history.history["loss"], [3.0] * epochs)
 
+        # test_loss_i = sum([20/8, 20/8]) = 5
+        # test_loss   = sum([5, 5, 5, 5])/(batch*steps) = 20/4 = 5
         eval_output = model.evaluate(train_ds, steps=steps)
         self.assertAllClose(eval_output, 5.0)
 

--- a/keras/distribute/multi_worker_test.py
+++ b/keras/distribute/multi_worker_test.py
@@ -251,7 +251,7 @@ class KerasMultiWorkerTestIndependentWorker(
         # A model that always outputs `sum(inputs*1) + 1 = 28**2 + 1 = 785`
         with strategy.scope():
             inputs = keras.Input(shape=(28, 28, 1))
-            x = keras.layers.Flatten(inputs)
+            x = keras.layers.Flatten()(inputs)
             x = keras.layers.Dense(
                 1, kernel_initializer="ones", bias_initializer="ones"
             )(x)
@@ -324,7 +324,7 @@ class KerasMultiWorkerTestIndependentWorker(
 
         with strategy.scope():
             inputs = keras.Input(shape=(28, 28, 1))
-            x = keras.layers.Flatten(inputs)
+            x = keras.layers.Flatten()(inputs)
             x = keras.layers.Dense(
                 1, kernel_initializer="ones", bias_initializer="ones"
             )(x)

--- a/keras/distribute/multi_worker_testing_utils.py
+++ b/keras/distribute/multi_worker_testing_utils.py
@@ -45,13 +45,27 @@ ASSIGNED_PORTS = set()
 lock = threading.Lock()
 
 
-def mnist_synthetic_dataset(batch_size, steps_per_epoch):
+def mnist_synthetic_dataset(
+    batch_size, steps_per_epoch, target_values="constant"
+):
     """Generate synthetic MNIST dataset for testing."""
     # train dataset
     x_train = tf.ones(
         [batch_size * steps_per_epoch, 28, 28, 1], dtype=tf.float32
     )
-    y_train = tf.ones([batch_size * steps_per_epoch, 1], dtype=tf.int32)
+    if target_values == "constant":
+        y_train = tf.ones([batch_size * steps_per_epoch, 1], dtype=tf.int32)
+    elif target_values == "increasing":
+        y_train = tf.reshape(
+            tf.range(batch_size * steps_per_epoch, dtype=tf.int32), (-1, 1)
+        )
+    else:
+        raise ValueError(
+            'Unknown value for `target_values` "'
+            + str(target_values)
+            + '". Valid options are "constant" and "increasing".'
+        )
+
     train_ds = tf.data.Dataset.from_tensor_slices((x_train, y_train))
     train_ds = train_ds.repeat()
     # train_ds = train_ds.shuffle(100)

--- a/keras/distribute/multi_worker_testing_utils.py
+++ b/keras/distribute/multi_worker_testing_utils.py
@@ -55,13 +55,13 @@ def mnist_synthetic_dataset(batch_size, steps_per_epoch):
     train_ds = tf.data.Dataset.from_tensor_slices((x_train, y_train))
     train_ds = train_ds.repeat()
     # train_ds = train_ds.shuffle(100)
-    train_ds = train_ds.batch(64, drop_remainder=True)
+    train_ds = train_ds.batch(batch_size, drop_remainder=True)
 
     # eval dataset
     x_test = tf.random.uniform([10000, 28, 28, 1], dtype=tf.float32)
     y_test = tf.random.uniform([10000, 1], minval=0, maxval=9, dtype=tf.int32)
     eval_ds = tf.data.Dataset.from_tensor_slices((x_test, y_test))
-    eval_ds = eval_ds.batch(64, drop_remainder=True)
+    eval_ds = eval_ds.batch(batch_size, drop_remainder=True)
 
     return train_ds, eval_ds
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3879,13 +3879,10 @@ def reduce_per_replica(values, strategy, reduction):
 
     def _reduce(v):
         """Reduce a single `PerReplica` object."""
-        if reduction in (
-            "concat",
-            "sum",
-        ) and _collective_all_reduce_multi_worker(strategy):
+        if _collective_all_reduce_multi_worker(strategy):
             if reduction == "concat":
                 return _multi_worker_concat(v, strategy)
-            else:
+            elif reduction == "sum":
                 return strategy.reduce("SUM", v, axis=None)
 
         if not _is_per_replica_instance(v):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3842,8 +3842,8 @@ def reduce_per_replica(values, strategy, reduction):
     1) if the `values` is a structure of simple `tf.Tensor`s, meaning that
        reduction is not actually needed, `reduce_per_replica` returns the
        structure as-is.
-    2) else, if `reduction="auto"`, then it assumes "first" if running
-       under `TPUStrategy`, and "sum" otherwise. This should only be used
+    2) else, if `reduction="auto"`, then the best reduction strategy is
+       chosen based on the current environment. This should only be used
        for training cases (`fit()`).
     3) else, if `reduction="first"`, then `reduce_per_replica`
        returns the values of the first replica. This is used in the case of
@@ -3852,7 +3852,7 @@ def reduce_per_replica(values, strategy, reduction):
        across the replicas.
        `reduce_per_replica` does not synchronize the values.
     4) else, if `reduction="sum"`, then `reduce_per_replica` returns the sum
-       of values for all replicas. This is used in the custom training loop
+       of values for all replicas. This may be used in the custom training loop
        case, where each replica contain different values which are not
        synchronized.
     5) else, if `reduction="concat"`, then `reduce_per_replica`

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -943,11 +943,13 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
 
     @property
     def distribute_reduction_method(self):
-        """Indicates how to reduce loss & metric values from replicas.
+        """The method employed to reduce per-replica values during training.
 
-        Default: `"auto"`. This should be good for general use cases.
-        It selects `"sum"` or `"first"` conditioned on the
-        specific implementation of the `tf.distribute` strategy.
+        Unless specified, the value "auto" will be assumed, indicating that
+        the reduction strategy should be chosen based on the current
+        running environment.
+        See `reduce_per_replica` function for more details.
+
         """
         return self._distribute_reduction_method or "auto"
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3893,8 +3893,7 @@ def reduce_per_replica(values, strategy, reduction):
             else:
                 return concat(strategy.experimental_local_results(v))
         elif reduction == "sum":
-            values = strategy.experimental_local_results(v)
-            return tf.reduce_sum(values)
+            return tf.reduce_sum(strategy.experimental_local_results(v))
         else:
             raise ValueError(
                 '`reduction` must be "first", "concat", "sum", or "auto". '

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -3879,10 +3879,15 @@ def reduce_per_replica(values, strategy, reduction):
 
     def _reduce(v):
         """Reduce a single `PerReplica` object."""
-        if reduction == "concat" and _collective_all_reduce_multi_worker(
-            strategy
-        ):
-            return _multi_worker_concat(v, strategy)
+        if reduction in (
+            "concat",
+            "sum",
+        ) and _collective_all_reduce_multi_worker(strategy):
+            if reduction == "concat":
+                return _multi_worker_concat(v, strategy)
+            else:
+                return strategy.reduce("SUM", v, axis=None)
+
         if not _is_per_replica_instance(v):
             return v
         elif reduction == "first":


### PR DESCRIPTION
#16664 was automatically merged, but we were [still working](https://github.com/keras-team/keras/pull/16664#issuecomment-1216625303) on it.

This PR only fixes the docs and adds a couple more sanity tests to cover `reduction="auto"` in the `MultiWorkerMirroredStrategy` case.
Not sure if they should be added at `multi_worker_test` or `distribute_strategy_test`, but I can move it if necessary.