### PR TITLE
Added an optional argument

### DIFF
--- a/keras/layers/core/dense.py
+++ b/keras/layers/core/dense.py
@@ -259,7 +259,7 @@ class Dense(Layer):
         if is_ragged:
             outputs = original_inputs.with_flat_values(outputs)
 
-        return tf.math.mul(outputs, self.factor)
+        return tf.math.multiply(outputs, self.factor)
 
     def compute_output_shape(self, input_shape):
         input_shape = tf.TensorShape(input_shape)


### PR DESCRIPTION
I added an optional argument for the Dense layer that sets a factor, the Dense layer's output is multiplied by this Factor. It is to avoid needing to do this with multiple Lambda layers in larger models.