### PR TITLE
Proposal to add a property to the Dense layer

### DIFF
--- a/keras/layers/core/dense.py
+++ b/keras/layers/core/dense.py
@@ -259,7 +259,7 @@ class Dense(Layer):
         if is_ragged:
             outputs = original_inputs.with_flat_values(outputs)
 
-        return tf.math.mul(outputs, self.factor)
+        return tf.math.multiply(outputs, self.factor)
 
     def compute_output_shape(self, input_shape):
         input_shape = tf.TensorShape(input_shape)


### PR DESCRIPTION
I added an optional property to the Dense layer to my draft, it multiplies the layer's output by a factor, this is useful for larger networks with more layers. This Lambda layers are a solution, but blocks of multiplication functions can get hard to keep track of fast. This makes it easier for the user to control the scale of the layer's output. 