### PR TITLE
Update typo in `compute_output_shape`

### DIFF
--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -841,7 +841,7 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
                 instead of an integer.
 
         Returns:
-            An input shape tuple.
+            An output shape tuple.
         """
         if tf.executing_eagerly():
             # In this case we build the model first in order to do shape


### PR DESCRIPTION
Since the method name is `compute_output_shape` returns should be `an output shape tuple` not `an input shape tuple`.