### PR TITLE
Fix documentation of prefix support types

### DIFF
--- a/keras/backend.py
+++ b/keras/backend.py
@@ -193,7 +193,7 @@ def get_uid(prefix=""):
     """Associates a string prefix with an integer counter in a TensorFlow graph.
 
     Args:
-      prefix: String prefix to index.
+      prefix: String/Integer/Bool/Tuple prefix to index.
 
     Returns:
       Unique integer ID.


### PR DESCRIPTION
Fixes [#16917](https://github.com/keras-team/keras/issues/16917). 

`tf.keras.backend.get_uid(prefix='')`, prefix supports bool/tuple/integer along with string. Thank you!
 