### PR TITLE
Suggested fixes by iCR, OpenRefactory, Inc.

### DIFF
--- a/keras/engine/training_distributed_v1.py
+++ b/keras/engine/training_distributed_v1.py
@@ -460,8 +460,11 @@ def experimental_tpu_test_loop(
     callbacks._call_end_hook(mode)
 
     scope.__exit__(None, None, None)
-    if len(outs) >= 0:
-        outs[0] /= target_steps
+    # OpenRefactory Warning: Collection length comparison should be meaningful.
+    # The length of a collection is always greater than or equal to zero.
+    # So testing that a length is greater than or equal to zero is always true.
+
+    outs[0] /= target_steps
 
     if len(outs) == 1:
         return outs[0]


### PR DESCRIPTION
This issue was detected in branch `master` of `keras` project on the version with commit hash `062073`. This is an instance of an inappropriate logic.

**Fixes for inappropriate logic:**
In file: `training_distributed_v1.py`, the comparison of Collection length creates a logical short circuit. **iCR** suggested that the Collection length comparison should be done without creating a logical short circuit.

This issue was detected by **OpenRefactory's Intelligent Code Repair (iCR)**. We are running **iCR** on libraries in the `PyPI` repository to identify issues and fix them. More info at: [pypi.openrefactory.com](https://pypi.openrefactory.com/)