### PR TITLE
Implement compute_output_shape() method for MultiHeadAttention #16951

### DIFF
--- a/keras/layers/attention/multi_head_attention.py
+++ b/keras/layers/attention/multi_head_attention.py
@@ -696,3 +696,31 @@ class MultiHeadAttention(Layer):
         return tf.linalg.band_part(  # creates a lower triangular matrix
             tf.ones((1, q_seq_length, v_seq_length), tf.bool), -1, 0
         )
+
+    def compute_output_shape(self, query_shape, value_shape, key_shape=None):
+
+        if key_shape is None:
+            key_shape = value_shape
+
+        query_shape = tf.TensorShape(query_shape)
+        value_shape = tf.TensorShape(value_shape)
+        key_shape = tf.TensorShape(key_shape)
+
+        if query_shape[-1] != value_shape[-1]:
+            raise ValueError(
+                "The last dimension of `query_shape` and `value_shape` "
+                f"must be equal, but are {query_shape[-1]}, {value_shape[-1]}. "
+                "Received: query_shape={query_shape}, value_shape={value_shape}"
+            )
+
+        if value_shape[1:-1] != key_shape[1:-1]:
+            raise ValueError(
+                "All dimensions of `value` and `key`, except the last one, "
+                f"must be equal. Received {value_shape} and "
+                f"{key_shape}"
+            )
+
+        if self._output_shape:
+            return query_shape[:-1].concatenate(self._output_shape)
+
+        return query_shape


### PR DESCRIPTION
- computes the output shape of a MultiHeadAttention layer without calling it .
- tests compute_output_shape 