### PR TITLE
Transposed Convolution is not a deconvolution

### DIFF
--- a/keras/layers/convolutional/conv1d_transpose.py
+++ b/keras/layers/convolutional/conv1d_transpose.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Keras 1D transposed convolution layer (sometimes called deconvolution)."""
+"""Keras 1D transposed convolution layer (sometimes wrongly called deconvolution)."""
 
 
 import tensorflow.compat.v2 as tf
@@ -34,7 +34,7 @@ from tensorflow.python.util.tf_export import keras_export
     "keras.layers.Conv1DTranspose", "keras.layers.Convolution1DTranspose"
 )
 class Conv1DTranspose(Conv1D):
-    """Transposed convolution layer (sometimes called Deconvolution).
+    """Transposed convolution layer (sometimes wrongly called Deconvolution).
 
     The need for transposed convolutions generally arises
     from the desire to use a transformation going in the opposite direction

--- a/keras/layers/convolutional/conv2d_transpose.py
+++ b/keras/layers/convolutional/conv2d_transpose.py
@@ -35,7 +35,7 @@ from tensorflow.python.util.tf_export import keras_export
     "keras.layers.Conv2DTranspose", "keras.layers.Convolution2DTranspose"
 )
 class Conv2DTranspose(Conv2D):
-    """Transposed convolution layer (sometimes called Deconvolution).
+    """Transposed convolution layer (sometimes wrongly called Deconvolution).
 
     The need for transposed convolutions generally arises
     from the desire to use a transformation going in the opposite direction

--- a/keras/layers/convolutional/conv2d_transpose.py
+++ b/keras/layers/convolutional/conv2d_transpose.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Keras 2D transposed convolution layer (sometimes called deconvolution)."""
+"""Keras 2D transposed convolution layer (sometimes wrongly called deconvolution)."""
 
 
 import tensorflow.compat.v2 as tf

--- a/keras/layers/convolutional/conv3d_transpose.py
+++ b/keras/layers/convolutional/conv3d_transpose.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Keras 3D transposed convolution layer (sometimes called deconvolution)."""
+"""Keras 3D transposed convolution layer (sometimes wrongly called deconvolution)."""
 
 
 import tensorflow.compat.v2 as tf
@@ -34,7 +34,7 @@ from tensorflow.python.util.tf_export import keras_export
     "keras.layers.Conv3DTranspose", "keras.layers.Convolution3DTranspose"
 )
 class Conv3DTranspose(Conv3D):
-    """Transposed convolution layer (sometimes called Deconvolution).
+    """Transposed convolution layer (sometimes wrongly called Deconvolution).
 
     The need for transposed convolutions generally arises
     from the desire to use a transformation going in the opposite direction


### PR DESCRIPTION
It is widely used the word "Deconvolution" when we refer to Transposed Convolution. However, that's wrong and in the code documentation this is not clarified. I added a simple clarification of it. Maybe a short explanation is needed.