### PR TITLE
Add imports to base_rnn example

### DIFF
--- a/keras/layers/rnn/base_rnn.py
+++ b/keras/layers/rnn/base_rnn.py
@@ -186,8 +186,10 @@ class RNN(base_layer.Layer):
     Examples:
 
     ```python
-    # First, let's define a RNN Cell, as a layer subclass.
+    from keras.layers import RNN
+    from keras import backend
 
+    # First, let's define a RNN Cell, as a layer subclass.
     class MinimalRNNCell(keras.layers.Layer):
 
         def __init__(self, units, **kwargs):


### PR DESCRIPTION
This change simply adds the imports that are required for the example to be executed.