### PR TITLE
Fix Batch Normalization inference behavior when virtual_batch_size is set

### DIFF
--- a/keras/layers/normalization/batch_normalization.py
+++ b/keras/layers/normalization/batch_normalization.py
@@ -821,6 +821,9 @@ class BatchNormalizationBase(Layer):
     def call(self, inputs, training=None):
         inputs = tf.cast(inputs, self.compute_dtype)
         training = self._get_training_value(training)
+        # Determine a boolean value for `training`: could be True, False, or
+        # None.
+        training_value = control_flow_util.constant_value(training)
 
         if self.virtual_batch_size is not None:
             # Virtual batches (aka ghost batches) can be simulated by reshaping
@@ -829,9 +832,13 @@ class BatchNormalizationBase(Layer):
             original_shape = tf.concat(
                 [tf.constant([-1]), original_shape[1:]], axis=0
             )
+
+            expanded_shape = (
+                [self.virtual_batch_size, -1] if training_value else [-1, 1]
+            )
             expanded_shape = tf.concat(
                 [
-                    tf.constant([self.virtual_batch_size, -1]),
+                    tf.constant(expanded_shape),
                     original_shape[1:],
                 ],
                 axis=0,
@@ -892,9 +899,6 @@ class BatchNormalizationBase(Layer):
                 offset += then_offset
             return (scale, offset)
 
-        # Determine a boolean value for `training`: could be True, False, or
-        # None.
-        training_value = control_flow_util.constant_value(training)
         if training_value == False:  # noqa: E712
             mean, variance = self.moving_mean, self.moving_variance
         else:

--- a/keras/layers/normalization/batch_normalization_test.py
+++ b/keras/layers/normalization/batch_normalization_test.py
@@ -408,11 +408,19 @@ class BatchNormalizationV2Test(test_combinations.TestCase):
         wrapped_fn()
 
     @test_combinations.run_all_keras_modes
-    def test_basic_batchnorm_v2_none_shape_and_virtual_batch_size(self):
+    def test_basic_batchnorm_v2_input_shape_and_virtual_batch_size(self):
         # Test case for GitHub issue for 32380
         norm = batch_normalization.BatchNormalization(virtual_batch_size=8)
         inp = keras.layers.Input(shape=(None, None, 3))
         _ = norm(inp)
+
+        # Test case for https://github.com/tensorflow/tensorflow/issues/23050
+        norm = batch_normalization.BatchNormalization(virtual_batch_size=8)
+        _ = norm(np.ones((1, 28, 28)))
+
+        with self.assertRaisesRegex(Exception, "requested shape requires"):
+            norm = batch_normalization.BatchNormalization(virtual_batch_size=8)
+            _ = norm(np.ones((1, 28, 28)), training=True)
 
     @test_combinations.generate(test_combinations.combine(mode=["eager"]))
     def test_fused_batchnorm_empty_batch(self):

--- a/keras/layers/normalization/batch_normalization_test.py
+++ b/keras/layers/normalization/batch_normalization_test.py
@@ -418,7 +418,7 @@ class BatchNormalizationV2Test(test_combinations.TestCase):
         norm = batch_normalization.BatchNormalization(virtual_batch_size=8)
         _ = norm(np.ones((1, 28, 28)))
 
-        with self.assertRaisesRegex(Exception, "requested shape requires"):
+        with self.assertRaisesRegex(Exception, "Reshape"):
             norm = batch_normalization.BatchNormalization(virtual_batch_size=8)
             _ = norm(np.ones((1, 28, 28)), training=True)
 


### PR DESCRIPTION
Band-aid fix for #15790 