### PR TITLE
Use the fallback method for GRU and LSTM on ROCm if padded I/O is needed

### DIFF
--- a/keras/layers/rnn/BUILD
+++ b/keras/layers/rnn/BUILD
@@ -414,7 +414,6 @@ cuda_py_test(
     srcs = ["gru_test.py"],
     python_version = "PY3",
     shard_count = 12,
-    tags = ["no_rocm"],
     deps = [
         ":gru_lstm_utils",
         "//:expect_absl_installed",
@@ -501,7 +500,6 @@ tf_py_test(
     python_version = "PY3",
     shard_count = 12,
     tags = [
-        "no_rocm",
         "notsan",  # TODO(b/170870794)
     ],
     deps = [
@@ -544,7 +542,6 @@ tf_py_test(
     srcs = ["conv_lstm_test.py"],
     python_version = "PY3",
     shard_count = 8,
-    tags = ["no_rocm"],
     deps = [
         "//:expect_absl_installed",
         "//:expect_numpy_installed",

--- a/keras/layers/rnn/gru.py
+++ b/keras/layers/rnn/gru.py
@@ -878,9 +878,8 @@ class GRU(DropoutRNNCellMixin, RNN, base_layer.BaseRandomLayer):
                         )
                     )
                     and (
-                        mask is None
-                        or gru_lstm_utils.is_cudnn_supported_inputs(
-                            mask, self.time_major
+                        gru_lstm_utils.is_cudnn_supported_inputs(
+                            mask, self.time_major, sequence_lengths
                         )
                     )
                 )
@@ -1215,20 +1214,6 @@ def gru_with_backend_selection(
         return_sequences,
     ):
         """Use cuDNN kernel when mask is none or strictly right padded."""
-        if mask is None:
-            return gpu_gru(
-                inputs=inputs,
-                init_h=init_h,
-                kernel=kernel,
-                recurrent_kernel=recurrent_kernel,
-                bias=bias,
-                mask=mask,
-                time_major=time_major,
-                go_backwards=go_backwards,
-                sequence_lengths=sequence_lengths,
-                return_sequences=return_sequences,
-            )
-
         def cudnn_gru_fn():
             return gpu_gru(
                 inputs=inputs,
@@ -1259,7 +1244,7 @@ def gru_with_backend_selection(
             )
 
         return tf.cond(
-            gru_lstm_utils.is_cudnn_supported_inputs(mask, time_major),
+            gru_lstm_utils.is_cudnn_supported_inputs(mask, time_major, sequence_lengths),
             true_fn=cudnn_gru_fn,
             false_fn=standard_gru_fn,
         )

--- a/keras/layers/rnn/gru.py
+++ b/keras/layers/rnn/gru.py
@@ -1214,6 +1214,7 @@ def gru_with_backend_selection(
         return_sequences,
     ):
         """Use cuDNN kernel when mask is none or strictly right padded."""
+
         def cudnn_gru_fn():
             return gpu_gru(
                 inputs=inputs,
@@ -1243,8 +1244,10 @@ def gru_with_backend_selection(
                 return_sequences=return_sequences,
             )
 
-        return tf.cond(
-            gru_lstm_utils.is_cudnn_supported_inputs(mask, time_major, sequence_lengths),
+        return tf.__internal__.smart_cond.smart_cond(
+            gru_lstm_utils.is_cudnn_supported_inputs(
+                mask, time_major, sequence_lengths
+            ),
             true_fn=cudnn_gru_fn,
             false_fn=standard_gru_fn,
         )

--- a/keras/layers/rnn/gru_lstm_utils.py
+++ b/keras/layers/rnn/gru_lstm_utils.py
@@ -169,18 +169,19 @@ def has_fully_masked_sequence(mask):
 
 
 def is_cudnn_supported_inputs(mask, time_major, sequence_lengths):
-    if tf.sysconfig.get_build_info()['is_rocm_build']:
-       if not time_major:
-          return tf.constant(False)
-       if mask!=None:
-          return tf.reduce_all(mask)
-       elif sequence_lengths!=None:
-          return tf.math.equal(tf.reduce_min(sequence_lengths), tf.reduce_max(sequence_lengths))
-       else:
-          return tf.constant(True)
-
-    if mask==None:
-        return tf.constant(True)
+    if tf.sysconfig.get_build_info()["is_rocm_build"]:
+        if not time_major:
+            return False
+        if mask is not None:
+            return tf.reduce_all(mask)
+        elif sequence_lengths is not None:
+            return tf.math.equal(
+                tf.reduce_min(sequence_lengths), tf.reduce_max(sequence_lengths)
+            )
+        else:
+            return True
+    if mask is None:
+        return True
     if time_major:
         mask = tf.transpose(mask)
 

--- a/keras/layers/rnn/gru_lstm_utils.py
+++ b/keras/layers/rnn/gru_lstm_utils.py
@@ -168,7 +168,19 @@ def has_fully_masked_sequence(mask):
     return tf.reduce_any(tf.reduce_all(tf.logical_not(mask), axis=1))
 
 
-def is_cudnn_supported_inputs(mask, time_major):
+def is_cudnn_supported_inputs(mask, time_major, sequence_lengths):
+    if tf.sysconfig.get_build_info()['is_rocm_build']:
+       if not time_major:
+          return tf.constant(False)
+       if mask!=None:
+          return tf.reduce_all(mask)
+       elif sequence_lengths!=None:
+          return tf.math.equal(tf.reduce_min(sequence_lengths), tf.reduce_max(sequence_lengths))
+       else:
+          return tf.constant(True)
+
+    if mask==None:
+        return tf.constant(True)
     if time_major:
         mask = tf.transpose(mask)
 

--- a/keras/layers/rnn/gru_test.py
+++ b/keras/layers/rnn/gru_test.py
@@ -610,10 +610,11 @@ class GRUGraphRewriteTest(test_combinations.TestCase):
             existing_loss = loss_value
 
         _, runtime_value = model.predict(x_train)
-        if tf.test.is_gpu_available():
-            self.assertEqual(runtime_value[0], gru_lstm_utils.RUNTIME_GPU)
-        else:
-            self.assertEqual(runtime_value[0], gru_lstm_utils.RUNTIME_CPU)
+        if not tf.sysconfig.get_build_info()["is_rocm_build"]:
+            if tf.test.is_gpu_available():
+                self.assertEqual(runtime_value[0], gru_lstm_utils.RUNTIME_GPU)
+            else:
+                self.assertEqual(runtime_value[0], gru_lstm_utils.RUNTIME_CPU)
 
     @test_utils.run_v2_only
     def test_GRU_runtime(self):

--- a/keras/layers/rnn/lstm.py
+++ b/keras/layers/rnn/lstm.py
@@ -721,8 +721,8 @@ class LSTM(DropoutRNNCellMixin, RNN, base_layer.BaseRandomLayer):
                             )
                         )
                         and gru_lstm_utils.is_cudnn_supported_inputs(
-                                mask, self.time_major, row_lengths
-                            )
+                            mask, self.time_major, row_lengths
+                        )
                     )
                     # Under eager context, check the device placement and prefer
                     # the GPU implementation when GPU is available.
@@ -1253,6 +1253,7 @@ def lstm_with_backend_selection(
         return_sequences,
     ):
         """Use cuDNN kernel when mask is none or strictly right padded."""
+
         def cudnn_lstm_fn():
             return gpu_lstm(
                 inputs=inputs,
@@ -1284,8 +1285,10 @@ def lstm_with_backend_selection(
                 return_sequences=return_sequences,
             )
 
-        return tf.cond(
-            gru_lstm_utils.is_cudnn_supported_inputs(mask, time_major, sequence_lengths),
+        return tf.__internal__.smart_cond.smart_cond(
+            gru_lstm_utils.is_cudnn_supported_inputs(
+                mask, time_major, sequence_lengths
+            ),
             true_fn=cudnn_lstm_fn,
             false_fn=stardard_lstm_fn,
         )

--- a/keras/layers/rnn/lstm.py
+++ b/keras/layers/rnn/lstm.py
@@ -720,12 +720,9 @@ class LSTM(DropoutRNNCellMixin, RNN, base_layer.BaseRandomLayer):
                                 and tf.config.list_logical_devices("GPU")
                             )
                         )
-                        and (
-                            mask is None
-                            or gru_lstm_utils.is_cudnn_supported_inputs(
-                                mask, self.time_major
+                        and gru_lstm_utils.is_cudnn_supported_inputs(
+                                mask, self.time_major, row_lengths
                             )
-                        )
                     )
                     # Under eager context, check the device placement and prefer
                     # the GPU implementation when GPU is available.
@@ -1256,21 +1253,6 @@ def lstm_with_backend_selection(
         return_sequences,
     ):
         """Use cuDNN kernel when mask is none or strictly right padded."""
-        if mask is None:
-            return gpu_lstm(
-                inputs=inputs,
-                init_h=init_h,
-                init_c=init_c,
-                kernel=kernel,
-                recurrent_kernel=recurrent_kernel,
-                bias=bias,
-                mask=mask,
-                time_major=time_major,
-                go_backwards=go_backwards,
-                sequence_lengths=sequence_lengths,
-                return_sequences=return_sequences,
-            )
-
         def cudnn_lstm_fn():
             return gpu_lstm(
                 inputs=inputs,
@@ -1303,7 +1285,7 @@ def lstm_with_backend_selection(
             )
 
         return tf.cond(
-            gru_lstm_utils.is_cudnn_supported_inputs(mask, time_major),
+            gru_lstm_utils.is_cudnn_supported_inputs(mask, time_major, sequence_lengths),
             true_fn=cudnn_lstm_fn,
             false_fn=stardard_lstm_fn,
         )

--- a/keras/layers/rnn/lstm_test.py
+++ b/keras/layers/rnn/lstm_test.py
@@ -814,10 +814,11 @@ class LSTMGraphRewriteTest(test_combinations.TestCase):
             existing_loss = loss_value
 
         _, runtime_value = model.predict(x_train)
-        if tf.test.is_gpu_available():
-            self.assertEqual(runtime_value[0], gru_lstm_utils.RUNTIME_GPU)
-        else:
-            self.assertEqual(runtime_value[0], gru_lstm_utils.RUNTIME_CPU)
+        if not tf.sysconfig.get_build_info()["is_rocm_build"]:
+            if tf.test.is_gpu_available():
+                self.assertEqual(runtime_value[0], gru_lstm_utils.RUNTIME_GPU)
+            else:
+                self.assertEqual(runtime_value[0], gru_lstm_utils.RUNTIME_CPU)
 
     @test_utils.run_v2_only
     def test_LSTM_runtime(self):


### PR DESCRIPTION
On ROCm, the low-end library that implements RNNs (MIOpen) does not support inputs with variable sequence lengths. At present, an attempt to pass such inputs to a RNN results in an exception. Because of this limitation, several Keras unit tests are disabled for ROCm and several others currently fail.

This change correctly switches from GPU-optimized RNNs (CudnnRNNV3) to the fallback implementation as needed.