### PR TITLE
Restore update_freq functionality

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -2733,6 +2733,13 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
                 1.0 / batch_run_time,
                 step=self._train_step,
             )
+
+        # `logs` is a `RemoteValue` when using asynchronous strategies, for now
+        # we just disable `update_freq` entirely in those cases.
+        if isinstance(logs, dict):
+            for name, value in logs.items():
+                tf.summary.scalar("batch_" + name, value, step=self._train_step)
+
         if not self._should_trace:
             return
 

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -2354,7 +2354,8 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
           same applies for `'epoch'`. If using an integer, let's say `1000`, the
           callback will write the metrics and losses to TensorBoard every 1000
           batches. Note that writing too frequently to TensorBoard can slow down
-          your training.
+          your training. May not work when doing distributed training, as
+          currently only a subset of `tf.distribute.Strategy`s are supported.
         profile_batch: Profile the batch(es) to sample compute characteristics.
           profile_batch must be a non-negative integer or a tuple of integers.
           A pair of positive integers signify a range of batches to profile.
@@ -2775,8 +2776,9 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
                 step=self._train_step,
             )
 
-        # `logs` is a `RemoteValue` when using asynchronous strategies, for now
-        # we just disable `update_freq` entirely in those cases.
+        # `logs` is a `tf.distribute.experimental.coordinator.RemoteValue` when
+        # using asynchronous strategies, for now we just disable `update_freq`
+        # entirely in those cases.
         if isinstance(logs, dict):
             for name, value in logs.items():
                 tf.summary.scalar("batch_" + name, value, step=self._train_step)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -2354,8 +2354,9 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
           same applies for `'epoch'`. If using an integer, let's say `1000`, the
           callback will write the metrics and losses to TensorBoard every 1000
           batches. Note that writing too frequently to TensorBoard can slow down
-          your training. May not work when doing distributed training, as
-          currently only a subset of `tf.distribute.Strategy`s are supported.
+          your training, especially when used with `tf.distribute.Strategy` as
+          it will incur additional synchronization overhead.
+          Use with `ParameterServerStrategy` is not supported.
         profile_batch: Profile the batch(es) to sample compute characteristics.
           profile_batch must be a non-negative integer or a tuple of integers.
           A pair of positive integers signify a range of batches to profile.

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 # Copyright 2015 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -2350,12 +2349,12 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
         write_steps_per_second: whether to log the training steps per second
           into Tensorboard. This supports both epoch and batch frequency
           logging.
-        update_freq: **disabled**
-
-          Warning: Batch-level summary writing using `update_freq` is
-          currently unsupported. A suggested workaround is shown in the
-          [TensorBoard Scalars tutorial](https://www.tensorflow.org/tensorboard/scalars_and_keras#batch-level_logging). # pylint: disable=protected-access
-
+        update_freq: `'batch'` or `'epoch'` or integer. When using `'batch'`,
+          writes the losses and metrics to TensorBoard after each batch. The
+          same applies for `'epoch'`. If using an integer, let's say `1000`, the
+          callback will write the metrics and losses to TensorBoard every 1000
+          batches. Note that writing too frequently to TensorBoard can slow down
+          your training.
         profile_batch: Profile the batch(es) to sample compute characteristics.
           profile_batch must be a non-negative integer or a tuple of integers.
           A pair of positive integers signify a range of batches to profile.
@@ -2377,6 +2376,48 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
     # Then run the tensorboard command to view the visualizations.
     ```
 
+    Custom batch-level summaries in a subclassed Model:
+
+    ```python
+    class MyModel(tf.keras.Model):
+
+      def build(self, _):
+        self.dense = tf.keras.layers.Dense(10)
+
+      def call(self, x):
+        outputs = self.dense(x)
+        tf.summary.histogram('outputs', outputs)
+        return outputs
+
+    model = MyModel()
+    model.compile('sgd', 'mse')
+
+    # Make sure to set `update_freq=N` to log a batch-level summary every N
+    # batches.  In addition to any `tf.summary` contained in `Model.call`,
+    # metrics added in `Model.compile` will be logged every N batches.
+    tb_callback = tf.keras.callbacks.TensorBoard('./logs', update_freq=1)
+    model.fit(x_train, y_train, callbacks=[tb_callback])
+    ```
+
+    Custom batch-level summaries in a Functional API Model:
+
+    ```python
+    def my_summary(x):
+      tf.summary.histogram('x', x)
+      return x
+
+    inputs = tf.keras.Input(10)
+    x = tf.keras.layers.Dense(10)(inputs)
+    outputs = tf.keras.layers.Lambda(my_summary)(x)
+    model = tf.keras.Model(inputs, outputs)
+    model.compile('sgd', 'mse')
+
+    # Make sure to set `update_freq=N` to log a batch-level summary every N
+    # batches. In addition to any `tf.summary` contained in `Model.call`,
+    # metrics added in `Model.compile` will be logged every N batches.
+    tb_callback = tf.keras.callbacks.TensorBoard('./logs', update_freq=1)
+    model.fit(x_train, y_train, callbacks=[tb_callback])
+    ```
 
     Profiling:
 

--- a/keras/callbacks_test.py
+++ b/keras/callbacks_test.py
@@ -3038,6 +3038,7 @@ class TestTensorBoardV2(test_combinations.TestCase):
         self.assertEqual(
             summary_file.scalars,
             {
+                _ObservedSummary(logdir=self.train_dir, tag="batch_loss"),
                 _ObservedSummary(logdir=self.train_dir, tag="epoch_loss"),
                 _ObservedSummary(logdir=self.validation_dir, tag="epoch_loss"),
                 _ObservedSummary(
@@ -3100,6 +3101,7 @@ class TestTensorBoardV2(test_combinations.TestCase):
         self.assertEqual(
             summary_file.scalars,
             {
+                _ObservedSummary(logdir=self.train_dir, tag="batch_loss"),
                 _ObservedSummary(logdir=self.train_dir, tag="epoch_loss"),
                 _ObservedSummary(
                     logdir=self.train_dir, tag="epoch_learning_rate"
@@ -3285,6 +3287,7 @@ class TestTensorBoardV2(test_combinations.TestCase):
         self.assertEqual(
             summary_file.scalars,
             {
+                _ObservedSummary(logdir=self.train_dir, tag="batch_loss"),
                 _ObservedSummary(logdir=self.train_dir, tag="epoch_loss"),
                 _ObservedSummary(logdir=self.validation_dir, tag="epoch_loss"),
                 _ObservedSummary(

--- a/keras/integration_test/distributed_training_test.py
+++ b/keras/integration_test/distributed_training_test.py
@@ -77,7 +77,17 @@ class DistributedTrainingTest(tf.test.TestCase):
 
         x = tf.keras.utils.experimental.DatasetCreator(dataset_fn)
 
-        model.fit(x, epochs=2, steps_per_epoch=10)
+        model.fit(
+            x,
+            epochs=2,
+            steps_per_epoch=10,
+            callbacks=[
+                tf.keras.callbacks.TensorBoard(
+                    update_freq=5,
+                    write_steps_per_second=True,
+                )
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/keras/integration_test/distributed_training_test.py
+++ b/keras/integration_test/distributed_training_test.py
@@ -117,8 +117,9 @@ class DistributedTrainingTest(tf.test.TestCase):
             strategy.cluster_resolver
             and strategy.cluster_resolver.task_type == "worker"
         ):
-            # Workaround for an issue with
-            # `tf.distribute.MultiWorkerMirroredStrategy`
+            # The below assertion is run by both chief and workers when using
+            # `tf.distribute.MultiWorkerMirroredStrategy`, but only the chief
+            # will log events.
             events_expected = []
 
         self.assertEqual(events_got, events_expected)


### PR DESCRIPTION
Revision of #17052 , adapted from code by @foxik 

@rchao It turns out that all the logging checks in the previous version were unnecessary, since `_push_writer()` already sets a writer that logs at the rate set by update_freq. Can you take a look to see if this version also has performance problems with asynchronous strategies?