### PR TITLE
Cherrypick the fix for zlib

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,7 +42,10 @@ http_archive(
     build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
     sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
     strip_prefix = "zlib-1.2.12",
-    urls = ["https://zlib.net/zlib-1.2.12.tar.gz"],
+    urls = [
+      "https://storage.googleapis.com/mirror.tensorflow.org/zlib.net/zlib-1.2.12.tar.gz",
+      "https://zlib.net/zlib-1.2.12.tar.gz",
+      ],
 )
 
 


### PR DESCRIPTION
The one from zlib.net is returning 404 currently.

PiperOrigin-RevId: 481043423