### PR TITLE
Remove unused `amsgrad` argument in SGD

### DIFF
--- a/keras/optimizers/optimizer_experimental/sgd.py
+++ b/keras/optimizers/optimizer_experimental/sgd.py
@@ -97,7 +97,6 @@ class SGD(optimizer.Optimizer):
         learning_rate=0.01,
         momentum=0.0,
         nesterov=False,
-        amsgrad=False,
         weight_decay=None,
         clipnorm=None,
         clipvalue=None,


### PR DESCRIPTION
This PR removes the unused `amsgrad` argument from `keras.optimizers.SGD`. This argument should've only been part of the Adam optimizer and probably was added to SGD by accident.

Noticed while trying to debug #17187.