### PR TITLE
Delegate `finalize_variable_values` in `LossScaleOptimizerV3`

### DIFF
--- a/keras/engine/training_test.py
+++ b/keras/engine/training_test.py
@@ -2293,9 +2293,13 @@ class TrainingTest(test_combinations.TestCase):
         )
 
     @test_combinations.run_all_keras_modes(always_skip_v1=True)
-    def test_ema_overwrite(self):
+    @parameterized.named_parameters(
+        ("mixed_float16", "mixed_float16"), ("float32", "float32")
+    )
+    def test_ema_overwrite(self, test_policy):
         if not tf.__internal__.tf2.enabled():
             self.skipTest("EMA optimizer is only available in TF2.")
+        policy.set_global_policy(test_policy)
         model = sequential.Sequential()
         model.add(input_layer.Input(shape=(4,)))
         model.add(layers_module.Dense(1, activation="relu"))
@@ -2309,6 +2313,7 @@ class TrainingTest(test_combinations.TestCase):
         history = model.fit(dataset, epochs=2, steps_per_epoch=10)
         self.assertLen(history.history["loss"], 2)
         self.assertAllClose(initial_value, model.trainable_variables[0])
+        policy.set_global_policy("float32")
 
     @test_combinations.run_all_keras_modes(always_skip_v1=True)
     def test_get_verbosity(self):

--- a/keras/mixed_precision/loss_scale_optimizer.py
+++ b/keras/mixed_precision/loss_scale_optimizer.py
@@ -1398,6 +1398,9 @@ class LossScaleOptimizerV3(
     def ema_momentum(self, ema_momentum):
         self._optimizer.ema_momentum = ema_momentum
 
+    def finalize_variable_values(self, var_list):
+        self._optimizer.finalize_variable_values(var_list)
+
 
 class FakeOptimizerForRestoration(tf.__internal__.tracking.Trackable):
     """A fake optimizer used to support restoring TensorFlow 2.2 checkpoints.


### PR DESCRIPTION
This PR delegates `finalize_variable_values()` in `LossScaleOptimizerV3` to the wrapped optimizer.

This fixes exponential moving averages when used together with mixed precision.

Prior to this change
```python
import tensorflow as tf

tf.keras.mixed_precision.set_global_policy("mixed_float16")

dataset = tf.data.Dataset.from_tensors(([1.0], [1.0])).repeat(100).batch(10)
model = tf.keras.Sequential([tf.keras.layers.Dense(1, input_shape=(1,))])
model.compile(loss="mse", optimizer=tf.keras.optimizers.SGD(use_ema=True))
model.fit(dataset, epochs=2)
```
would throw
```python-traceback
/usr/local/lib/python3.7/dist-packages/keras/optimizers/optimizer_experimental/optimizer.py in _overwrite_model_variables_with_average_value(self, var_list)
    677     def _overwrite_model_variables_with_average_value(self, var_list):
    678         """Overwrite model variables with its moving average."""
--> 679         if len(var_list) != len(self._model_variables_moving_average):
    680             raise ValueError(
    681                 f"The length of model variables ({len(var_list)}) to "

AttributeError: 'LossScaleOptimizerV3' object has no attribute '_model_variables_moving_average'
```

See [this colab notebook](https://colab.research.google.com/drive/1s7wkWHw-RFFmxxeG4jwgbuAg7lqvfn9a?usp=sharing).

/cc @reedwm @fchollet would it be possible to also cherry-pick this fix onto `r2.11` so it can be included in the 2.11.0 stable release?