### PR TITLE
support to compat python 3.11

### DIFF
--- a/keras/utils/tf_inspect.py
+++ b/keras/utils/tf_inspect.py
@@ -19,8 +19,18 @@ import inspect as _inspect
 
 import tensorflow.compat.v2 as tf
 
-ArgSpec = _inspect.ArgSpec
-
+if hasattr(_inspect, "ArgSpec"):
+    ArgSpec = _inspect.ArgSpec
+else:
+    ArgSpec = collections.namedtuple(
+        "ArgSpec",
+        [
+            "args",
+            "varargs",
+            "keywords",
+            "defaults",
+        ],
+    )
 
 if hasattr(_inspect, "FullArgSpec"):
     FullArgSpec = _inspect.FullArgSpec


### PR DESCRIPTION
The python 3.11 has removed long-deprecated inspect methods [1], use collections.namedtuple to instead

[1] https://github.com/python/cpython/commit/d89fb9a5a610a257014d112bdceef73d7df14082

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>