### PR TITLE
Fix the docstring for DenseFeatures

### DIFF
--- a/keras/feature_column/dense_features.py
+++ b/keras/feature_column/dense_features.py
@@ -53,7 +53,7 @@ class DenseFeatures(kfc._BaseFeaturesLayer):
     ```python
     price = tf.feature_column.numeric_column('price')
     keywords_embedded = tf.feature_column.embedding_column(
-        tf.feature_column.categorical_column_with_hash_bucket("keywords", 10K),
+        tf.feature_column.categorical_column_with_hash_bucket("keywords", 10000),
         dimension=16)
     columns = [price, keywords_embedded, ...]
     partitioner = tf.compat.v1.fixed_size_partitioner(num_shards=4)


### PR DESCRIPTION
Replace with the appropriate syntax in a given example `tf.keras.layers.DenseFeatures`. Kindly find the gist of it [here](https://colab.research.google.com/gist/tilakrayal/8b00af071ae0b4e41e5f880f0a4dedb4/untitled777.ipynb) for the reference.