### PR TITLE
use vscode official base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,28 +1,8 @@
-FROM python:3.9
-
-# https://code.visualstudio.com/docs/remote/containers-advanced#_creating-a-nonroot-user
-ARG USERNAME=keras-vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-# Create the user
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    #
-    # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
-    && apt-get update \
-    && apt-get install -y sudo bash \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-    && chmod 0440 /etc/sudoers.d/$USERNAME
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.8
+COPY setup.sh /setup.sh
 
 # Install Bazel
-RUN apt update
-RUN apt install wget git gcc g++ -y
+RUN sudo apt install wget -y
 RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
 RUN chmod a+x bazelisk-linux-amd64
 RUN mv bazelisk-linux-amd64 /usr/bin/bazel
-
-USER $USERNAME
-ENV PATH="/home/$USERNAME/.local/bin:${PATH}"
-
-CMD ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "dockerFile": "Dockerfile",
-    "postCreateCommand": "pip install -r requirements.txt && pip uninstall keras-nightly -y",
+    "postCreateCommand": "sh /setup.sh",
     "extensions": ["ms-python.python"],
     "settings": {
         "files.watcherExclude": {
@@ -8,8 +8,6 @@
         },
         "search.exclude": {
             "**/bazel-*/**": true
-        },
-        "terminal.integrated.defaultProfile.linux": "bash"
-    },
-    "remoteUser": "keras-vscode"
+        }
+    }
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,5 @@
+sudo pip install -r requirements.txt
+sudo pip uninstall keras-nightly -y
+
+wget https://github.com/cli/cli/releases/download/v2.17.0/gh_2.17.0_linux_amd64.deb -P /tmp
+sudo apt install /tmp/gh_2.17.0_linux_amd64.deb -y


### PR DESCRIPTION
Use the official vscode Python image as the base image for devcontainer, instead
of the `tf-nightly` image.  It better handles the user and git commands.
TF-nightly is install when the container is up and running. Also added GitHub
CLI in the image for easier operations on pull requests.