### PR TITLE
Warning if categorical crossentropy is used for 2 labels

### DIFF
--- a/keras/losses.py
+++ b/keras/losses.py
@@ -18,6 +18,7 @@
 
 import abc
 import functools
+import warnings
 
 import tensorflow.compat.v2 as tf
 
@@ -1958,6 +1959,14 @@ def categorical_crossentropy(
     y_pred = tf.convert_to_tensor(y_pred)
     y_true = tf.cast(y_true, y_pred.dtype)
     label_smoothing = tf.convert_to_tensor(label_smoothing, dtype=y_pred.dtype)
+
+    if y_pred.shape[-1] == 1:
+        warnings.warn(
+            "Recieved an one-dimensional output. "
+            "Consider using binary crossentropy "
+            "instead of categorical crossentropy "
+            "if you have only 2 labels"
+        )
 
     def _smooth_labels():
         num_classes = tf.cast(tf.shape(y_true)[-1], y_pred.dtype)

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1965,7 +1965,8 @@ def categorical_crossentropy(
             "Recieved an one-dimensional output. "
             "Consider using binary crossentropy "
             "instead of categorical crossentropy "
-            "if you have only 2 labels"
+            "if you have only 2 labels",
+            SyntaxWarning,
         )
 
     def _smooth_labels():

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1962,10 +1962,10 @@ def categorical_crossentropy(
 
     if y_pred.shape[-1] == 1:
         warnings.warn(
-            "Recieved an one-dimensional output. "
-            "Consider using binary crossentropy "
-            "instead of categorical crossentropy "
-            "if you have only 2 labels",
+            "Expected the tensor's shape passed to 'categorical_crossentropy' "
+            "to be (batch_size, n_classes), "
+            f"where n_classes > 1. Received: y_pred.shape={y_pred.shape}. "
+            "Consider using 'binary_crossentropy' if you only have 2 classes.",
             SyntaxWarning,
         )
 

--- a/keras/losses_test.py
+++ b/keras/losses_test.py
@@ -1803,8 +1803,10 @@ class CategoricalCrossentropyTest(tf.test.TestCase):
             warnings.simplefilter("always")
             cce_obj = losses.CategoricalCrossentropy()
             cce_obj(tf.constant([[1.0], [0.0]]), tf.constant([[1.0], [1.0]]))
-            assert issubclass(w[-1].category, SyntaxWarning)
-            assert "Recieved an one-dimensional output..*" in str(w[-1].message)
+            self.assertIsInstance(w[-1].category, SyntaxWarning)
+            self.assertIn(
+                "Expected the tensor's shape passed..*", w[-1].message
+            )
 
 
 @test_combinations.generate(test_combinations.combine(mode=["graph", "eager"]))

--- a/keras/losses_test.py
+++ b/keras/losses_test.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Tests for Keras loss functions."""
 
+import warnings
+
 import numpy as np
 import tensorflow.compat.v2 as tf
 from absl.testing import parameterized
@@ -1793,6 +1795,16 @@ class CategoricalCrossentropyTest(tf.test.TestCase):
         # sum([0.0018*1.2, 0.0004*3.4, 0.1698*5.6]) / 3
         loss = cce_obj(y_true, logits, sample_weight=sample_weight)
         self.assertAlmostEqual(self.evaluate(loss), 0.3181, 3)
+
+    def test_binary_labels(self):
+        # raise a warning if the shape of y_true and y_pred are all (None, 1).
+        # categorical_crossentropy shouldn't be used with binary labels.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cce_obj = losses.CategoricalCrossentropy()
+            cce_obj(tf.constant([[1.0], [0.0]]), tf.constant([[1.0], [1.0]]))
+            assert issubclass(w[-1].category, SyntaxWarning)
+            assert "Recieved an one-dimensional output..*" in str(w[-1].message)
 
 
 @test_combinations.generate(test_combinations.combine(mode=["graph", "eager"]))


### PR DESCRIPTION
solves #17029 
[Solution colab notebook](https://colab.research.google.com/drive/1nUBPGfLs2CGs6LjA2_luscuWadZ0kwnQ?usp=sharing)
Raised a warning and not an error. 

Also `CategoricalHinge` loss could have the same problem but apparently the documentation itself cites an 1D tensor as an example. It should be noted that the example given in the doc returns `1.4` as answer while the correct answer is `1.3`

cc @haifeng-jin 