### PR TITLE
Update depthwise_conv2d.py

### DIFF
--- a/keras/layers/convolutional/depthwise_conv2d.py
+++ b/keras/layers/convolutional/depthwise_conv2d.py
@@ -53,9 +53,10 @@ class DepthwiseConv2D(DepthwiseConv):
         specify the same value for all spatial dimensions.
       strides: An integer or tuple/list of 2 integers, specifying the strides of
         the convolution along the height and width. Can be a single integer to
-        specify the same value for all spatial dimensions. Specifying any stride
-        value != 1 is incompatible with specifying any `dilation_rate` value !=
-        1.
+        specify the same value for all spatial dimensions. Current implementation
+        only supports equal length strides in row and column dimensions.
+        Specifying any stride value != 1 is incompatible with specifying any 
+        `dilation_rate` value !=1.
       padding: one of `'valid'` or `'same'` (case-insensitive). `"valid"` means
         no padding. `"same"` results in padding with zeros evenly to the
         left/right or up/down of the input such that output has the same

--- a/keras/layers/convolutional/depthwise_conv2d.py
+++ b/keras/layers/convolutional/depthwise_conv2d.py
@@ -53,10 +53,10 @@ class DepthwiseConv2D(DepthwiseConv):
         specify the same value for all spatial dimensions.
       strides: An integer or tuple/list of 2 integers, specifying the strides of
         the convolution along the height and width. Can be a single integer to
-        specify the same value for all spatial dimensions. Current implementation
-        only supports equal length strides in row and column dimensions.
-        Specifying any stride value != 1 is incompatible with specifying any 
-        `dilation_rate` value !=1.
+        specify the same value for all spatial dimensions. Current
+        implementation only supports equal length strides in row and 
+        column dimensions. Specifying any stride value != 1 is incompatible
+        with specifying any `dilation_rate` value !=1.
       padding: one of `'valid'` or `'same'` (case-insensitive). `"valid"` means
         no padding. `"same"` results in padding with zeros evenly to the
         left/right or up/down of the input such that output has the same

--- a/keras/layers/convolutional/depthwise_conv2d.py
+++ b/keras/layers/convolutional/depthwise_conv2d.py
@@ -54,7 +54,7 @@ class DepthwiseConv2D(DepthwiseConv):
       strides: An integer or tuple/list of 2 integers, specifying the strides of
         the convolution along the height and width. Can be a single integer to
         specify the same value for all spatial dimensions. Current
-        implementation only supports equal length strides in row and 
+        implementation only supports equal length strides in row and
         column dimensions. Specifying any stride value != 1 is incompatible
         with specifying any `dilation_rate` value !=1.
       padding: one of `'valid'` or `'same'` (case-insensitive). `"valid"` means


### PR DESCRIPTION
Updating `stride` argument in `DepthwiseConv2D` class as it currently supports equal length strides in the row and column dimensions.

Related to this [issue](https://github.com/tensorflow/tensorflow/issues/33005) 