### PR TITLE
Fix performance issue with sample weights in model.fit()

### DIFF
--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -73,14 +73,15 @@ def handle_partial_sample_weights(
       describing the raw sample weights.
     """
     if not isinstance(sample_weights, (list, tuple)):
-        sample_weights = (sample_weights,)
-
-    any_sample_weight = sample_weights is not None and any(
-        w is not None for w in sample_weights
-    )
-    partial_sample_weight = any_sample_weight and any(
-        w is None for w in sample_weights
-    )
+        any_sample_weight = (sample_weights,) is not None and sample_weights is not None
+        partial_sample_weight = any_sample_weight and sample_weights is None
+    else:
+        any_sample_weight = sample_weights is not None and any(
+            w is not None for w in sample_weights
+        )
+        partial_sample_weight = any_sample_weight and any(
+            w is None for w in sample_weights
+        )
 
     if not any_sample_weight:
         return None, any_sample_weight, partial_sample_weight

--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -73,7 +73,7 @@ def handle_partial_sample_weights(
       describing the raw sample weights.
     """
     if not isinstance(sample_weights, (list, tuple)):
-        any_sample_weight = (sample_weights,) is not None and sample_weights is not None
+        any_sample_weight = sample_weights is not None
         partial_sample_weight = any_sample_weight and sample_weights is None
     else:
         any_sample_weight = sample_weights is not None and any(

--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -72,6 +72,9 @@ def handle_partial_sample_weights(
       Tuple of sample weights, one sample weight for every output, and booleans
       describing the raw sample weights.
     """
+    if not isinstance(sample_weights, (list, tuple)):
+        sample_weights = (sample_weights,)
+
     any_sample_weight = sample_weights is not None and any(
         w is not None for w in sample_weights
     )


### PR DESCRIPTION
I previously had a PR open for this but I guess it got automatically closed when I reverted my commits...

Previous PR: https://github.com/keras-team/keras/pull/16177

@gbaned 
@fchollet Since the way DataAdapter works is not clear to me I went back to `training_utils.handle_partial_sample_weights`. 

The function is being passed a tensor when it should be passed a list. I think we can simply add a typecheck and if a tensor is passed then we wrap it in a list. This will fix both the slowdown as well as make sure the functions is checking that sample_weights correspond to inputs and outputs instead of checking every single sample in the tensor.

i.e.

```
if not isinstance(sample_weights, (list, tuple)):
    sample_weights = (sample_weights,)
```

And this will work fine, when the `[sample_weights]` workaround is used in `model.fit()` this is exactly what it does, it causes a tuple of one tensor to be passed to the function instead of just a tensor. 
How is that?

