### PR TITLE
Updates Permute doc with 3D example

### DIFF
--- a/keras/layers/reshaping/permute.py
+++ b/keras/layers/reshaping/permute.py
@@ -63,8 +63,10 @@ class Permute(Layer):
         if sorted(dims) != list(range(1, len(dims) + 1)):
             raise ValueError(
                 "Invalid permutation `dims` for Permute Layer: %s. "
-                "`dims` must be a permutation (reordering) of the input's axis ids, excluding the batch-dimension. "
-                f"To transpose a batch of tensors with shape `[batch, n, m]` pass `Permute([2,1])`"
+                "`dims` must be a permutation (reordering) of the input's axis ids, "
+                "excluding the batch-dimension."
+                "To transpose a batch of tensors with shape `[batch, n, m]` "
+                "pass `Permute([2,1])` "
             )
         self.input_spec = InputSpec(ndim=len(self.dims) + 1)
 

--- a/keras/layers/reshaping/permute.py
+++ b/keras/layers/reshaping/permute.py
@@ -63,7 +63,7 @@ class Permute(Layer):
         if sorted(dims) != list(range(1, len(dims) + 1)):
             raise ValueError(
                 "Invalid permutation `dims` for Permute Layer: %s. "
-                "`dims` must be a permutation (reordering) of the input's axis ids, "
+                "`dims` must be a permutation of the input's axis ids, "
                 "excluding the batch-dimension."
                 "To transpose a batch of tensors with shape `[batch, n, m]` "
                 "pass `Permute([2,1])` "

--- a/keras/layers/reshaping/permute.py
+++ b/keras/layers/reshaping/permute.py
@@ -62,9 +62,9 @@ class Permute(Layer):
         self.dims = tuple(dims)
         if sorted(dims) != list(range(1, len(dims) + 1)):
             raise ValueError(
-                "Invalid permutation argument `dims` for Permute Layer. "
-                "The set of indices in `dims` must be consecutive and start "
-                f"from 1. Received dims={dims}"
+                "Invalid permutation `dims` for Permute Layer: %s. "
+                "`dims` must be a permutation (reordering) of the input's axis ids, excluding the batch-dimension. "
+                f"To transpose a batch of tensors with shape `[batch, n, m]` pass `Permute([2,1])`"
             )
         self.input_spec = InputSpec(ndim=len(self.dims) + 1)
 

--- a/keras/layers/reshaping/permute.py
+++ b/keras/layers/reshaping/permute.py
@@ -17,7 +17,7 @@
 
 import copy
 
-import tensorflow.compat.v2 as tf
+import tensorflow as tf
 
 from keras.engine.base_layer import Layer
 from keras.engine.input_spec import InputSpec
@@ -36,8 +36,8 @@ class Permute(Layer):
 
     ```python
     model = Sequential()
-    model.add(Permute((2, 1), input_shape=(10, 64)))
-    # now: model.output_shape == (None, 64, 10)
+    model.add(Permute((1, 3, 2), input_shape=(30, 6, 8)))
+    # now: model.output_shape == (None, 8, 6)
     # note: `None` is the batch dimension
     ```
 


### PR DESCRIPTION
Fixes  [#41123](https://github.com/tensorflow/tensorflow/issues/41123). 

1.  Removed compat.v2 
2. Added a new 3D example and updated Invalid argument error.

 As per MarkDaoust's[comment](https://github.com/tensorflow/tensorflow/issues/41123#issuecomment-991229661)
