### PR TITLE
Fix index_directory directory structure ignoring when passing labels explicitly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,7 +294,7 @@ mind.
 -   You should add any new applications to the unit tests defined in
     `applications_test.py` and `applications_load_weight_test.py`.
 -   For backwards compatibility, all applications should provide a
-    `preprocess_input()` function. For new applciations, you should leave the
+    `preprocess_input()` function. For new applications, you should leave the
     function empty (pass through inputs unaltered), and write the model so it
     can handle raw inputs directly. Adding
     [preprocessing layers](https://keras.io/guides/preprocessing_layers/) to the

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -496,10 +496,13 @@ def index_directory(
     seed=None,
     follow_links=False,
 ):
-    """Make list of all files in the subdirs of `directory`, with their labels.
+    """Make list of all files in `directory`, with their labels.
 
     Args:
-      directory: The target directory (string).
+      directory: Directory where the data is located.
+          If `labels` is "inferred", it should contain
+          subdirectories, each containing files for a class.
+          Otherwise, the directory structure is ignored.
       labels: Either "inferred"
           (labels are generated from the directory structure),
           None (no labels),
@@ -524,8 +527,8 @@ def index_directory(
         class_names: names of the classes corresponding to these labels, in
           order.
     """
-    if labels is None:
-        # in the no-label case, index from the parent directory down.
+    if labels != "inferred":
+        # in the explicit/no-label cases, index from the parent directory down.
         subdirs = [""]
         class_names = subdirs
     else:
@@ -572,6 +575,7 @@ def index_directory(
                 f"{len(labels)} while we found {len(filenames)} files "
                 f"in directory {directory}."
             )
+        class_names = sorted(set(labels))
     else:
         i = 0
         labels = np.zeros((len(filenames),), dtype="int32")
@@ -641,7 +645,9 @@ def index_subdirectory(directory, class_indices, follow_links, formats):
     return filenames, labels
 
 
-def get_training_or_validation_split(samples, labels, validation_split, subset):
+def get_training_or_validation_split(
+    samples, labels, validation_split, subset
+):
     """Potentially restict samples & labels to a training or validation split.
 
     Args:


### PR DESCRIPTION
If you pass explicit `labels` (list/tuple) to `index_directory`, the directory structure should be ignored and indexing of the files start from the parent `directory`. After all, if the files were already placed in class-specific subdirectories, you could pass `labels="inferred"`.

The change I made simply allows placing the files directly in the parent `directory`, when passing `labels` explicitly, while using subdirectories will continue to work (passing `labels=None` already allows this). Currently files in the parent `directory` are not found. I also updated the docstring to match both the change in behaviour and the docstrings of all its callers such as `image_dataset_from_directory` (from which I copied the wording).