### PR TITLE
Bugfix: Pass show_layer_activations to expand_nested calls

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -212,6 +212,7 @@ def model_to_dot(
                     rankdir,
                     expand_nested,
                     subgraph=True,
+                    show_layer_activations=show_layer_activations,
                     show_trainable=show_trainable,
                 )
                 # sub_w : submodel_wrapper
@@ -233,6 +234,7 @@ def model_to_dot(
                 rankdir,
                 expand_nested,
                 subgraph=True,
+                show_layer_activations=show_layer_activations,
                 show_trainable=show_trainable,
             )
             # sub_n : submodel_not_wrapper


### PR DESCRIPTION
Following the contribution guide I consider this a simple bug fix which does not require an issue before?

Ensures that the layer activations are also displayed for nested models:
Before:
![before](https://user-images.githubusercontent.com/61387986/212153706-85e97e3f-bcf7-4122-997c-9fa9c5cd67c3.png)
After:
![after](https://user-images.githubusercontent.com/61387986/212154162-03c2fa21-c0c2-44c3-af54-5c78b4583ddb.png)
Generated with:
```py
import keras
from keras.utils import vis_utils
inputs = keras.Input(shape=(None, 3))
outputs = keras.layers.Dense(1)(inputs)
model = keras.Model(inputs, outputs)
model = keras.Sequential([keras.Input(shape=(None, 3)), model, keras.layers.Dense(1)])
vis_utils.plot_model(model, show_shapes=True, expand_nested=True, show_layer_activations=True)
```
I have not written a test for it, since in the existing tests only the existence of the file is checked and is more or less tested with `test_plot_model_with_wrapped_layers_and_models`. or is it desired that there is one anyway?