### PR TITLE
Add `to_ordinal` feature for ordinal regression/classification

### DIFF
--- a/keras/utils/__init__.py
+++ b/keras/utils/__init__.py
@@ -58,6 +58,7 @@ from keras.utils.layer_utils import get_source_inputs
 # Deprecated
 from keras.utils.np_utils import normalize
 from keras.utils.np_utils import to_categorical
+from keras.utils.np_utils import to_ordinal
 from keras.utils.data_utils import pad_sequences
 
 # Evaluation related

--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -76,23 +76,6 @@ def to_categorical(y, num_classes=None, dtype="float32"):
     return categorical
 
 
-@keras_export("keras.utils.normalize")
-def normalize(x, axis=-1, order=2):
-    """Normalizes a Numpy array.
-
-    Args:
-        x: Numpy array to normalize.
-        axis: axis along which to normalize.
-        order: Normalization order (e.g. `order=2` for L2 norm).
-
-    Returns:
-        A normalized copy of the array.
-    """
-    l2 = np.atleast_1d(np.linalg.norm(x, order, axis))
-    l2[l2 == 0] = 1
-    return x / np.expand_dims(l2, axis)
-
-
 @keras_export("keras.utils.to_ordinal")
 def to_ordinal(y, num_classes=None, dtype="float32"):
     """Converts a class vector (integers) to an ordinal class matrix for ordinal
@@ -135,3 +118,20 @@ def to_ordinal(y, num_classes=None, dtype="float32"):
     output_shape = input_shape + (num_classes - 1,)
     ordinal = np.reshape(ordinal, output_shape)
     return ordinal
+
+
+@keras_export("keras.utils.normalize")
+def normalize(x, axis=-1, order=2):
+    """Normalizes a Numpy array.
+
+    Args:
+        x: Numpy array to normalize.
+        axis: axis along which to normalize.
+        order: Normalization order (e.g. `order=2` for L2 norm).
+
+    Returns:
+        A normalized copy of the array.
+    """
+    l2 = np.atleast_1d(np.linalg.norm(x, order, axis))
+    l2[l2 == 0] = 1
+    return x / np.expand_dims(l2, axis)

--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -102,7 +102,7 @@ def to_ordinal(y, num_classes=None, dtype="float32"):
         y: Array-like with class values to be converted into a matrix
             (integers from 0 to `num_classes - 1`).
         num_classes: Total number of classes. If `None`, this would be inferred
-          as `max(y) + 1`.
+            as `max(y) + 1`.
         dtype: The data type expected by the input. Default: `'float32'`.
 
     Returns:

--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -91,3 +91,47 @@ def normalize(x, axis=-1, order=2):
     l2 = np.atleast_1d(np.linalg.norm(x, order, axis))
     l2[l2 == 0] = 1
     return x / np.expand_dims(l2, axis)
+
+
+@keras_export("keras.utils.to_ordinal")
+def to_ordinal(y, num_classes=None, dtype="float32"):
+    """Converts a class vector (integers) to an ordinal class matrix for ordinal
+        regression/classification
+
+    Args:
+        y: Array-like with class values to be converted into a matrix
+            (integers from 0 to `num_classes - 1`).
+        num_classes: Total number of classes. If `None`, this would be inferred
+          as `max(y) + 1`.
+        dtype: The data type expected by the input. Default: `'float32'`.
+
+    Returns:
+        A ordinal regression matrix representation of the input. The class axis
+        is placed last.
+
+    Example:
+
+    >>> a = tf.keras.utils.to_ordinal([0, 1, 2, 3], num_classes=4)
+    >>> a = tf.constant(a, shape=[4, 3])
+    >>> print(a)
+    tf.Tensor(
+      [[0. 0. 0.]
+       [1. 0. 0.]
+       [1. 1. 0.]
+       [1. 1. 1.]], shape=(4, 3), dtype=float32)
+    """
+    y = np.array(y, dtype="int")
+    input_shape = y.shape
+    if input_shape and input_shape[-1] == 1 and len(input_shape) > 1:
+        input_shape = tuple(input_shape[:-1])
+    y = y.ravel()
+    if not num_classes:
+        num_classes = np.max(y) + 1
+    n = y.shape[0]
+    range_values = np.arange(num_classes - 1)
+    range_values = np.tile(np.expand_dims(range_values, 0), [n, 1])
+    ordinal = np.zeros((n, num_classes - 1), dtype=dtype)
+    ordinal[range_values < np.expand_dims(y, -1)] = 1
+    output_shape = input_shape + (num_classes - 1,)
+    ordinal = np.reshape(ordinal, output_shape)
+    return ordinal

--- a/keras/utils/np_utils_test.py
+++ b/keras/utils/np_utils_test.py
@@ -72,7 +72,7 @@ class TestNPUtils(tf.test.TestCase):
             self.assertTrue(np.all(np.logical_or(ordinal == 0, ordinal == 1)))
             # Get original labels back from ordinal matrix
             self.assertTrue(
-                np.all(np.sum(np.cumprod(ordinal, -1), -1) == label)
+                ordinal.cumprod(-1).sum(-1).reshape(label.shape) == label
             )
 
 

--- a/keras/utils/np_utils_test.py
+++ b/keras/utils/np_utils_test.py
@@ -48,6 +48,29 @@ class TestNPUtils(tf.test.TestCase):
                 np.all(np.argmax(one_hot, -1).reshape(label.shape) == label)
             )
 
+    def test_to_ordinal(self):
+        num_classes = 5
+        shapes = [(1,), (3,), (4, 3), (5, 4, 3), (3, 1), (3, 2, 1)]
+        expected_shapes = [
+            (1, num_classes - 1),
+            (3, num_classes - 1),
+            (4, 3, num_classes - 1),
+            (5, 4, 3, num_classes - 1),
+            (3, num_classes - 1),
+            (3, 2, num_classes - 1),
+        ]
+        labels = [np.random.randint(0, num_classes, shape) for shape in shapes]
+        ordinal_matrix = [np_utils.to_ordinal(label, num_classes) for label in labels]
+        for label, ordinal, expected_shape in zip(
+            labels, ordinal_matrix, expected_shapes
+        ):
+            # Check shape
+            self.assertEqual(ordinal.shape, expected_shape)
+            # Make sure all the values are either 0 or 1
+            self.assertTrue(np.all(np.logical_or(ordinal == 0, ordinal == 1)))
+            # Get original labels back from ordinal matrix
+            self.assertTrue(np.all(np.sum(np.cumprod(ordinal, -1), -1) == label))
+
 
 if __name__ == "__main__":
     tf.test.main()

--- a/keras/utils/np_utils_test.py
+++ b/keras/utils/np_utils_test.py
@@ -72,7 +72,9 @@ class TestNPUtils(tf.test.TestCase):
             self.assertTrue(np.all(np.logical_or(ordinal == 0, ordinal == 1)))
             # Get original labels back from ordinal matrix
             self.assertTrue(
-                ordinal.cumprod(-1).sum(-1).reshape(label.shape) == label
+                np.all(
+                    ordinal.cumprod(-1).sum(-1).reshape(label.shape) == label
+                )
             )
 
 

--- a/keras/utils/np_utils_test.py
+++ b/keras/utils/np_utils_test.py
@@ -60,7 +60,9 @@ class TestNPUtils(tf.test.TestCase):
             (3, 2, num_classes - 1),
         ]
         labels = [np.random.randint(0, num_classes, shape) for shape in shapes]
-        ordinal_matrix = [np_utils.to_ordinal(label, num_classes) for label in labels]
+        ordinal_matrix = [
+            np_utils.to_ordinal(label, num_classes) for label in labels
+        ]
         for label, ordinal, expected_shape in zip(
             labels, ordinal_matrix, expected_shapes
         ):
@@ -69,7 +71,9 @@ class TestNPUtils(tf.test.TestCase):
             # Make sure all the values are either 0 or 1
             self.assertTrue(np.all(np.logical_or(ordinal == 0, ordinal == 1)))
             # Get original labels back from ordinal matrix
-            self.assertTrue(np.all(np.sum(np.cumprod(ordinal, -1), -1) == label))
+            self.assertTrue(
+                np.all(np.sum(np.cumprod(ordinal, -1), -1) == label)
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the feature `to_ordinal` for ordinal regression/classification mentioned in issue #17382 