### PR TITLE
Handle dict of metrics in distributed training

### DIFF
--- a/keras/utils/metrics_utils.py
+++ b/keras/utils/metrics_utils.py
@@ -174,7 +174,13 @@ def result_wrapper(result_fn):
                 # Wrapping result in identity so that control dependency between
                 # update_op from `update_state` and result works in case result
                 # returns a tensor.
-                return tf.identity(result)
+                if isinstance(result, dict):
+                    return {
+                        key: array_ops.identity(value)
+                        for key, value in result.items()
+                    }
+                else:
+                    return array_ops.identity(result)
 
             # Wrapping result in merge_call. merge_call is used when we want to
             # leave replica mode and compute a value in cross replica mode.


### PR DESCRIPTION
When training with a model with a subclass `tf.keras.metrics.Metric` which which returns a dict, e.g.

```
class CustomMetric(tf.keras.metrics.Metric):
    def result(self):
        return {"good", tf.convert_to_tensor([1.0]), "bad": tf.convert_to_tensor([0.0])}
```

I got an exception in `merge_fn_wrapper` when trying to call `array_ops.identity` on a `Dict[str, tf.Tensor]`. This fix allows me to do distributed training with the above metric.