### PR TITLE
Support Parameter Server strategy Batch Tensorboard callback

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -2366,7 +2366,6 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
           Note however that writing too frequently to TensorBoard can slow down
           your training, especially when used with `tf.distribute.Strategy` as
           it will incur additional synchronization overhead.
-          Use with `ParameterServerStrategy` is not supported.
           Batch-level summary writing is also available via `train_step`
           override. Please see
           [TensorBoard Scalars tutorial](https://www.tensorflow.org/tensorboard/scalars_and_keras#batch-level_logging)  # noqa: E501
@@ -2791,10 +2790,9 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
                 step=self._train_step,
             )
 
-        # `logs` isn't necessarily always a dict. For example, when using
-        # `tf.distribute.experimental.ParameterServerStrategy`, a
-        # `tf.distribute.experimental.coordinator.RemoteValue` will be passed.
-        # For now, we just disable `update_freq` in those cases.
+        if isinstance(logs, tf.distribute.experimental.coordinator.RemoteValue):
+            logs = logs.get()
+
         if isinstance(logs, dict):
             for name, value in logs.items():
                 tf.summary.scalar("batch_" + name, value, step=self._train_step)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -2790,11 +2790,9 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
                 step=self._train_step,
             )
 
-        should_record = tf.equal(self._train_step % self.update_freq, 0)
-        if (
-            isinstance(logs, tf.distribute.experimental.coordinator.RemoteValue)
-            and should_record
-        ):
+        if isinstance(
+            logs, tf.distribute.experimental.coordinator.RemoteValue
+        ) and tf.equal(self._train_step % self.update_freq, 0):
             logs = logs.get()
 
         if isinstance(logs, dict):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -2790,7 +2790,11 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
                 step=self._train_step,
             )
 
-        if isinstance(logs, tf.distribute.experimental.coordinator.RemoteValue):
+        should_record = tf.equal(self._train_step % self.update_freq, 0)
+        if (
+            isinstance(logs, tf.distribute.experimental.coordinator.RemoteValue)
+            and should_record
+        ):
             logs = logs.get()
 
         if isinstance(logs, dict):


### PR DESCRIPTION
# Summary
Recently there was a [pr](https://github.com/keras-team/keras/pull/17142) to support batch frequency metrics in Tensorboard callback. That PR supported most strategies, but did not cover Parameter Server training. This just extends it to handle parameter server. I think this should finish resolving this [issue](https://github.com/keras-team/keras/issues/16173).

# Testing
I'm running couple parameter server training on google cloud ai training and tensorboard metric curves are being produced middle epoch as expected. I've also tested locally with in process cluster that metrics get plotted as expected.

<img width="1792" alt="Screenshot 2023-01-18 at 10 17 42 PM" src="https://user-images.githubusercontent.com/16809055/213369618-db85b24e-482c-4cdf-90f1-18a1911370b9.png">

Performance wise this does add 1 sync point, but user can adjust update_freq accordingly to how often they want it to flush/sync. I've tested on baseline job and a job with this change that large cluster (~60 workers, ~10 PS) parameter server training with update_freq=500 has minimal effect on overall job completion time. update_freq=1 does have large slowdown so if using PS training you'll need to set update_freq appropriately.