### PR TITLE
keras.layers.Bidirectional constructor ignores trainable argument, causing models with trainable=False layers to incorrectly be cloned 

### DIFF
--- a/keras/layers/rnn/bidirectional.py
+++ b/keras/layers/rnn/bidirectional.py
@@ -175,7 +175,7 @@ class Bidirectional(Wrapper):
         self.return_sequences = layer.return_sequences
         self.return_state = layer.return_state
         self.supports_masking = True
-        self._trainable = True
+        self._trainable = kwargs.get('trainable', True)
         self._num_constants = 0
         self.input_spec = layer.input_spec
 

--- a/keras/layers/rnn/bidirectional.py
+++ b/keras/layers/rnn/bidirectional.py
@@ -146,6 +146,7 @@ class Bidirectional(Wrapper):
             )
         else:
             self.backward_layer = backward_layer
+
             # Keep the custom backward layer config, so that we can save it
             # later. The layer's name might be updated below with prefix
             # 'backward_', and we want to preserve the original config.
@@ -175,7 +176,7 @@ class Bidirectional(Wrapper):
         self.return_sequences = layer.return_sequences
         self.return_state = layer.return_state
         self.supports_masking = True
-        self._trainable = kwargs.get('trainable', True)
+        self._trainable = kwargs.get("trainable", layer.trainable)
         self._num_constants = 0
         self.input_spec = layer.input_spec
 

--- a/keras/layers/rnn/bidirectional_test.py
+++ b/keras/layers/rnn/bidirectional_test.py
@@ -1020,6 +1020,20 @@ class BidirectionalTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllClose(output1, output3)
         self.assertNotAllClose(output1, output2)
 
+    def test_trainable_parameter_argument(self):
+        inp = keras.layers.Input([None, 3])
+        rnn = keras.layers.SimpleRNN(units=3)
+        bid = keras.layers.Bidirectional(rnn)
+        model = keras.Model(inp, bid(inp))
+
+        clone_trainable = keras.models.clone_model(model)
+        assert clone_trainable.get_config() == model.get_config()
+
+        bid.trainable = False
+
+        clone_untrainable = keras.models.clone_model(model)
+        assert clone_untrainable.get_config() == model.get_config()
+
 
 def _to_list(ls):
     if isinstance(ls, list):


### PR DESCRIPTION
This PR fixes #17466.