### PR TITLE
Use 4 spaces indent for Dense layer docstrings

### DIFF
--- a/keras/layers/core/dense.py
+++ b/keras/layers/core/dense.py
@@ -72,21 +72,21 @@ class Dense(Layer):
     (None, 32)
 
     Args:
-      units: Positive integer, dimensionality of the output space.
-      activation: Activation function to use.
-        If you don't specify anything, no activation is applied
-        (ie. "linear" activation: `a(x) = x`).
-      use_bias: Boolean, whether the layer uses a bias vector.
-      kernel_initializer: Initializer for the `kernel` weights matrix.
-      bias_initializer: Initializer for the bias vector.
-      kernel_regularizer: Regularizer function applied to
-        the `kernel` weights matrix.
-      bias_regularizer: Regularizer function applied to the bias vector.
-      activity_regularizer: Regularizer function applied to
-        the output of the layer (its "activation").
-      kernel_constraint: Constraint function applied to
-        the `kernel` weights matrix.
-      bias_constraint: Constraint function applied to the bias vector.
+        units: Positive integer, dimensionality of the output space.
+        activation: Activation function to use.
+            If you don't specify anything, no activation is applied
+            (ie. "linear" activation: `a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        kernel_initializer: Initializer for the `kernel` weights matrix.
+        bias_initializer: Initializer for the bias vector.
+        kernel_regularizer: Regularizer function applied to
+            the `kernel` weights matrix.
+        bias_regularizer: Regularizer function applied to the bias vector.
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+        kernel_constraint: Constraint function applied to
+            the `kernel` weights matrix.
+        bias_constraint: Constraint function applied to the bias vector.
 
     Input shape:
       N-D tensor with shape: `(batch_size, ..., input_dim)`.


### PR DESCRIPTION
This is a PR to test the updated copybara setting for attributing commits to internal developers when more changes are made internally.