### PR TITLE
Fix api_docs for `to_ordinal`

### DIFF
--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -79,8 +79,7 @@ def to_categorical(y, num_classes=None, dtype="float32"):
 
 @keras_export("keras.utils.to_ordinal")
 def to_ordinal(y, num_classes=None, dtype="float32"):
-    """Converts a class vector (integers) to an ordinal class matrix for ordinal
-        regression/classification.
+    """Converts a class vector (integers) to an ordinal regression matrix.
 
     Args:
         y: Array-like with class values to be converted into a matrix

--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -90,7 +90,7 @@ def to_ordinal(y, num_classes=None, dtype="float32"):
         dtype: The data type expected by the input. Default: `'float32'`.
 
     Returns:
-        A ordinal regression matrix representation of the input as a NumPy
+        An ordinal regression matrix representation of the input as a NumPy
         array. The class axis is placed last.
 
     Example:

--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -81,6 +81,10 @@ def to_categorical(y, num_classes=None, dtype="float32"):
 def to_ordinal(y, num_classes=None, dtype="float32"):
     """Converts a class vector (integers) to an ordinal regression matrix.
 
+    This utility encodes class vector to ordinal regression/classification
+    matrix where each sample is indicated by a row and rank of that sample is
+    indicated by number of ones in that row.
+
     Args:
         y: Array-like with class values to be converted into a matrix
             (integers from 0 to `num_classes - 1`).


### PR DESCRIPTION
This PR will resolve two issues and add an explanation for `to_ordinal` utility, recently merged in #17419.

It will,
1. Resolve a grammatical error in `Return`
2. Resolve abnormality in api_docs due to a new line in the docstring. [api_docs link](https://www.tensorflow.org/api_docs/python/tf/keras/utils/to_ordinal) <img src="https://user-images.githubusercontent.com/36858976/215018234-4e7b424d-c6df-4baf-89ba-cc561314578f.png" width=300>
3. Add a little explanation for `to_ordinal`

cc: @haifeng-jin 