### PR TITLE
Fix serialization error with EfficientNet

### DIFF
--- a/keras/applications/efficientnet.py
+++ b/keras/applications/efficientnet.py
@@ -364,7 +364,9 @@ def EfficientNet(
         # original implementation.
         # See https://github.com/tensorflow/tensorflow/issues/49930 for more
         # details
-        x = layers.Rescaling(1.0 / tf.math.sqrt(IMAGENET_STDDEV_RGB))(x)
+        x = layers.Rescaling(
+            [1.0 / math.sqrt(stddev) for stddev in IMAGENET_STDDEV_RGB]
+        )(x)
 
     x = layers.ZeroPadding2D(
         padding=imagenet_utils.correct_pad(x, 3), name="stem_conv_pad"


### PR DESCRIPTION
Fixes #17199. The argument to layer.Rescaling is passed as EagerTensor which is not serializable, because tf.math.sqrt() may return EagerTensor. 
It is functionally equivalent to the solution suggested by @hctomkins in #17199 