### PR TITLE
Validate keras.optimizers.schedules.CosineDecay Arg

### DIFF
--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -641,6 +641,12 @@ class CosineDecay(LearningRateSchedule):
         self.decay_steps = decay_steps
         self.alpha = alpha
         self.name = name
+        
+        #validating decay_steps argument to raise error if passed
+        #negative values or zero or float values
+        if not isinstance(self.decay_steps,int) or self.decay_steps<=0:
+            raise ValueError("'decay_steps' should be a nonzero "+
+                             "positive integer")
 
     def __call__(self, step):
         with tf.name_scope(self.name or "CosineDecay"):


### PR DESCRIPTION
At present the code for `keras.optimizers.schedules.CosineDecay` not validating value for the argument `decay_steps`.As per document `decay_steps` should be : A scalar int32 or int64 Tensor or a Python number.Even if users passes Zero or Negative number it is not throwing any error and in the github issue #53284 user passing negative value to this argument but it was not raised any error and training happened without updating model weights.Hence proposed changes in code to validate arguments and raise suitable error if not valid argument. Fixes github issue #53284 .