### PR TITLE
Bugfix/normalization invert

### DIFF
--- a/keras/layers/preprocessing/normalization.py
+++ b/keras/layers/preprocessing/normalization.py
@@ -373,6 +373,7 @@ class Normalization(base_preprocessing_layer.PreprocessingLayer):
         config.update(
             {
                 "axis": self.axis,
+                "invert": self.invert,
                 "mean": utils.listify_tensors(self.input_mean),
                 "variance": utils.listify_tensors(self.input_variance),
             }

--- a/keras/layers/preprocessing/normalization_test.py
+++ b/keras/layers/preprocessing/normalization_test.py
@@ -480,8 +480,7 @@ class NormalizationAdaptTest(
 
         # Save the model to disk.
         output_path = os.path.join(
-            self.get_temp_dir(),
-            "tf_keras_saved_model_invert"
+            self.get_temp_dir(), "tf_keras_saved_model_invert"
         )
         model.save(output_path, save_format=save_format)
         loaded_model = keras.models.load_model(

--- a/keras/layers/preprocessing/normalization_test.py
+++ b/keras/layers/preprocessing/normalization_test.py
@@ -455,7 +455,7 @@ class NormalizationAdaptTest(
         # Validate correctness of the new model.
         new_output_data = loaded_model.predict(input_data)
         self.assertAllClose(new_output_data, expected_output)
-        
+
     @parameterized.product(
         save_format=["tf", "h5"],
         adapt=[True, False],
@@ -479,7 +479,10 @@ class NormalizationAdaptTest(
         self.assertAllClose(output_data, expected_output)
 
         # Save the model to disk.
-        output_path = os.path.join(self.get_temp_dir(), "tf_keras_saved_model_invert")
+        output_path = os.path.join(
+            self.get_temp_dir(),
+            "tf_keras_saved_model_invert"
+        )
         model.save(output_path, save_format=save_format)
         loaded_model = keras.models.load_model(
             output_path, custom_objects={"Normalization": cls}

--- a/keras/layers/preprocessing/normalization_test.py
+++ b/keras/layers/preprocessing/normalization_test.py
@@ -465,13 +465,12 @@ class NormalizationAdaptTest(
         input_data = [[-1.0], [1.0], [-1.0], [1.0]]
 
         cls = normalization.Normalization
-        cls.invert = True
         inputs = keras.Input(shape=(1,), dtype=tf.float32)
         if adapt:
-            layer = cls(axis=-1)
+            layer = cls(axis=-1, invert=True)
             layer.adapt(expected_output)
         else:
-            layer = cls(mean=1.0, variance=1.0)
+            layer = cls(mean=1.0, variance=1.0, invert=True)
         outputs = layer(inputs)
         model = keras.Model(inputs=inputs, outputs=outputs)
 


### PR DESCRIPTION
Fix bug #17486 , by:

- making sure the ```invert``` attribute is tracked when saving / loading
- adding extra test for this case.

Notes:

- I am not too familiar with the keras tests setup, so the test I added may need editing
- there are several tests around my new additional test, it is possible that one may want to add extra "invert" tests corresponding to each of these.