### PR TITLE
Slight logic adjustments to reduce reading in backend

### DIFF
--- a/keras/backend.py
+++ b/keras/backend.py
@@ -737,7 +737,9 @@ def _get_session(op_input_list=()):
         # graph, create and cache a new session.
         if getattr(
             _SESSION, "session", None
-        ) is None or _SESSION.session.graph is not _current_graph(op_input_list):
+        ) is None or _SESSION.session.graph is not _current_graph(
+            op_input_list
+        ):
             # If we are creating the Session inside a tf.distribute.Strategy
             # scope, we ask the strategy for the right session options to use.
             if tf.distribute.has_strategy():

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -414,10 +414,11 @@ def _internal_get_learning_phase(graph):
 def _default_learning_phase():
     if context.executing_eagerly():
         return 0
-    with name_scope(""):
-        return tf.compat.v1.placeholder_with_default(
-            False, shape=(), name="keras_learning_phase"
-        )
+    else:
+        with name_scope(""):
+            return tf.compat.v1.placeholder_with_default(
+                False, shape=(), name="keras_learning_phase"
+            )
 
 
 @keras_export("keras.backend.set_learning_phase")

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -6089,10 +6089,8 @@ def conv2d_transpose(
         raise ValueError("Unknown data_format: " + str(data_format))
 
     # `atrous_conv2d_transpose` only supports NHWC format, even on GPU.
-    force_transpose = data_format == "channels_first" and dilation_rate != (
-        1,
-        1,
-    )
+    force_transpose = (data_format == "channels_first"
+                       and dilation_rate != (1, 1,))
 
     x, tf_data_format = _preprocess_conv2d_input(
         x, data_format, force_transpose

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -414,11 +414,10 @@ def _internal_get_learning_phase(graph):
 def _default_learning_phase():
     if context.executing_eagerly():
         return 0
-    else:
-        with name_scope(""):
-            return tf.compat.v1.placeholder_with_default(
-                False, shape=(), name="keras_learning_phase"
-            )
+    with name_scope(""):
+        return tf.compat.v1.placeholder_with_default(
+            False, shape=(), name="keras_learning_phase"
+        )
 
 
 @keras_export("keras.backend.set_learning_phase")

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -6092,8 +6092,10 @@ def conv2d_transpose(
         raise ValueError("Unknown data_format: " + str(data_format))
 
     # `atrous_conv2d_transpose` only supports NHWC format, even on GPU.
-    force_transpose = (data_format == "channels_first"
-                       and dilation_rate != (1, 1,))
+    force_transpose = data_format == "channels_first" and dilation_rate != (
+        1,
+        1,
+    )
 
     x, tf_data_format = _preprocess_conv2d_input(
         x, data_format, force_transpose


### PR DESCRIPTION
Noticed some inconsistencies while reading through, specifically:
```
if x:
  return y
else:
  return z
```

vs

```
if x:
  return y
return z
```
I went with the later because it is a little less typing/reading. Open to going the other way, too, but figured it should be consistent in the file.