### PR TITLE
LayerScale fix to support pretrained ConvNeXt models with mixed precision

### DIFF
--- a/keras/applications/convnext.py
+++ b/keras/applications/convnext.py
@@ -26,6 +26,7 @@ import numpy as np
 import tensorflow.compat.v2 as tf
 
 from keras import backend
+from keras import initializers
 from keras import layers
 from keras import utils
 from keras.applications import imagenet_utils
@@ -217,9 +218,11 @@ class LayerScale(layers.Layer):
         self.projection_dim = projection_dim
 
     def build(self, input_shape):
-        self.gamma = tf.Variable(
-            self.init_values * tf.ones((self.projection_dim,)),
+        self.gamma = self.add_weight(
+            shape=(self.projection_dim,),
             dtype=self._compute_dtype_object,
+            initializer=initializers.Constant(self.init_values),
+            trainable=True,
         )
 
     def call(self, x):

--- a/keras/applications/convnext.py
+++ b/keras/applications/convnext.py
@@ -219,7 +219,7 @@ class LayerScale(layers.Layer):
     def build(self, input_shape):
         self.gamma = tf.Variable(
             self.init_values * tf.ones((self.projection_dim,)),
-            dtype=self._compute_dtype_object
+            dtype=self._compute_dtype_object,
         )
 
     def call(self, x):

--- a/keras/applications/convnext.py
+++ b/keras/applications/convnext.py
@@ -218,7 +218,8 @@ class LayerScale(layers.Layer):
 
     def build(self, input_shape):
         self.gamma = tf.Variable(
-            self.init_values * tf.ones((self.projection_dim,))
+            self.init_values * tf.ones((self.projection_dim,)),
+            dtype=self._compute_dtype_object
         )
 
     def call(self, x):

--- a/keras/applications/convnext.py
+++ b/keras/applications/convnext.py
@@ -220,7 +220,6 @@ class LayerScale(layers.Layer):
     def build(self, input_shape):
         self.gamma = self.add_weight(
             shape=(self.projection_dim,),
-            dtype=self._compute_dtype_object,
             initializer=initializers.Constant(self.init_values),
             trainable=True,
         )


### PR DESCRIPTION
Fix for the issue https://github.com/keras-team/keras/issues/16907. The proposed solution was proposed by @zibbini, and we both tested and verified that it works.

This PR fixes a bug in the [LayerScale](https://github.com/keras-team/keras/blob/master/keras/applications/convnext.py#L199) layer, which hindered ConvNeXt pretrained models to work with mixed precision. The solution was simply to set the appropriate dtype in the `gamma` variable of the LayerScale layer.

See [original gist](https://colab.research.google.com/gist/tilakrayal/30257452eebf9cc45e590f84ed8da4bd/untitled503.ipynb) to reproduce the bug.

See [new gist](https://colab.research.google.com/gist/andreped/5bc4393b64dbfcfed4c87e5c6863f3df/layerscale-mixed-precision-fix.ipynb) for verifying that the proposed fix works.