### PR TITLE
Perform all ops in apply_gradient in a given tf.name_scope.

### DIFF
--- a/keras/optimizers/optimizer.py
+++ b/keras/optimizers/optimizer.py
@@ -635,25 +635,27 @@ class _BaseOptimizer(tf.__internal__.tracking.AutoTrackable):
                 # Lift variable creation to init scope to avoid environment
                 # issues.
                 self.build(trainable_variables)
-        grads_and_vars = list(zip(grads, trainable_variables))
-        grads_and_vars = optimizer_utils.filter_empty_gradients(grads_and_vars)
-        if len(list(grads_and_vars)) == 0:
-            # Check again after filtering gradients.
-            return self._iterations
+            grads_and_vars = list(zip(grads, trainable_variables))
+            grads_and_vars = optimizer_utils.filter_empty_gradients(
+                grads_and_vars
+            )
+            if len(list(grads_and_vars)) == 0:
+                # Check again after filtering gradients.
+                return self._iterations
 
-        grads, trainable_variables = zip(*grads_and_vars)
+            grads, trainable_variables = zip(*grads_and_vars)
 
-        grads = self._clip_gradients(grads)
-        grads = self._deduplicate_sparse_grad(grads)
-        self._apply_weight_decay(trainable_variables)
-        grads_and_vars = list(zip(grads, trainable_variables))
-        iteration = self._internal_apply_gradients(grads_and_vars)
+            grads = self._clip_gradients(grads)
+            grads = self._deduplicate_sparse_grad(grads)
+            self._apply_weight_decay(trainable_variables)
+            grads_and_vars = list(zip(grads, trainable_variables))
+            iteration = self._internal_apply_gradients(grads_and_vars)
 
-        # Apply variable constraints after applying gradients.
-        for variable in trainable_variables:
-            if variable.constraint is not None:
-                variable.assign(variable.constraint(variable))
-        return iteration
+            # Apply variable constraints after applying gradients.
+            for variable in trainable_variables:
+                if variable.constraint is not None:
+                    variable.assign(variable.constraint(variable))
+            return iteration
 
     def _apply_weight_decay(self, variables):
         if self.weight_decay is None:


### PR DESCRIPTION
Hi,

today when looking in Tensorboard, I found out that the new optimizers do not create operations in a `tf.name_scope` of the `name` given to the `Optimizer` constructor.

That was the case previously -- see https://github.com/keras-team/keras/blob/bdbca4fb823b65f4dc5a9bb2acc0cf55e1276303/keras/optimizers/legacy/optimizer_v2.py#L701-L754

while the new `Optimizer` runs only `build` in the name scope, not the update operations, see https://github.com/keras-team/keras/blob/bdbca4fb823b65f4dc5a9bb2acc0cf55e1276303/keras/optimizers/optimizer.py#L633-L656.

Therefore, in this pull request, I moved the update operations in `apply_gradient` also inside the `tf.name_scope`.

The tests seem to run fine, code is correctly reformatted, and I verified in Tensorboard that after the change the update operations are indeed in a name scope.