### PR TITLE
Fix spelling error in Initializer warning

### DIFF
--- a/keras/initializers/initializers.py
+++ b/keras/initializers/initializers.py
@@ -122,7 +122,7 @@ class Initializer:
                     "and being called multiple times, which will return "
                     "identical values each time (even if the initializer is "
                     "unseeded). Please update your code to provide a seed to "
-                    "the initializer, or avoid using the same initalizer "
+                    "the initializer, or avoid using the same initializer "
                     "instance more than once."
                 )
         else:


### PR DESCRIPTION
This PR fixes a minor spelling error `initializer` -> `initializer` in the warning message. Spelling errors could possibly block CI pipelines e.g., if it has a spell check set up to check even warning messages that come from notebooks. We've run into this in https://github.com/NVIDIA-Merlin/models when we ran `codespell` on our notebooks which usually include all outputs.