### PR TITLE
Less restrictive ROCm+GRU/LSTM fallback logic

### DIFF
--- a/keras/layers/rnn/gru_lstm_utils.py
+++ b/keras/layers/rnn/gru_lstm_utils.py
@@ -170,7 +170,7 @@ def has_fully_masked_sequence(mask):
 
 def is_cudnn_supported_inputs(mask, time_major, sequence_lengths):
     if tf.sysconfig.get_build_info()["is_rocm_build"]:
-        if not time_major:
+        if (not time_major) and (sequence_lengths is not None):
             return False
         if mask is not None:
             return tf.reduce_all(mask)


### PR DESCRIPTION
A previous PR #17111 added some logic to use fallback implementations of GRU and LSTM on ROCm in situations where padded i/o is needed (since ROCm does not support padded i/o).

That logic turns out to be too restrictive - it chooses the fallback path in cases where it is not really needed, which may result in significant performance degradations.

This PR resolves the problem.
