### PR TITLE
Unique state names for stateful RNN layers

### DIFF
--- a/keras/layers/rnn/base_rnn.py
+++ b/keras/layers/rnn/base_rnn.py
@@ -905,8 +905,22 @@ class RNN(base_layer.Layer):
                         self.variable_dtype or backend.floatx(),
                     )
                 )
+            if len(flat_init_state_values) == 1:
+
+                def assign_unique_var(x):
+                    return backend.variable(x, name="state")
+
+            else:
+                unique_id = 0
+
+                def assign_unique_var(x):
+                    nonlocal unique_id
+                    var = backend.variable(x, name=f"state_{unique_id}")
+                    unique_id += 1
+                    return var
+
             flat_states_variables = tf.nest.map_structure(
-                backend.variable, flat_init_state_values
+                assign_unique_var, flat_init_state_values
             )
             self.states = tf.nest.pack_sequence_as(
                 self.cell.state_size, flat_states_variables

--- a/keras/layers/rnn/gru_test.py
+++ b/keras/layers/rnn/gru_test.py
@@ -993,6 +993,21 @@ class GRULayerTest(test_combinations.TestCase):
         clone_names = [x.name for x in clone.weights]
         self.assertEqual(model_names, clone_names)
 
+    def test_unique_state_names(self):
+        inp = keras.Input(batch_shape=[3, None, 3])
+        a = keras.layers.GRU(units=3, stateful=True)
+        b = keras.layers.GRU(units=3)  # no states
+        c = keras.layers.GRU(units=3, stateful=True)
+        _ = keras.Model(inp, [a(inp), b(inp), c(inp)])
+
+        names = set()
+
+        for l in [a, b, c]:
+            for s in l.states:
+                if s is not None:
+                    self.assertNotIn(s.name, names)
+                    names.add(s.name)
+
 
 @test_combinations.generate(test_combinations.combine(mode=["graph", "eager"]))
 class GRULayerGenericTest(tf.test.TestCase):

--- a/keras/layers/rnn/lstm_test.py
+++ b/keras/layers/rnn/lstm_test.py
@@ -1424,6 +1424,21 @@ class LSTMLayerTest(test_combinations.TestCase):
         clone_names = [x.name for x in clone.weights]
         self.assertEqual(model_names, clone_names)
 
+    def test_unique_state_names(self):
+        inp = keras.Input(batch_shape=[3, None, 3])
+        a = keras.layers.LSTM(units=3, stateful=True)
+        b = keras.layers.LSTM(units=3)  # no states
+        c = keras.layers.LSTM(units=3, stateful=True)
+        _ = keras.Model(inp, [a(inp), b(inp), c(inp)])
+
+        names = set()
+
+        for l in [a, b, c]:
+            for s in l.states:
+                if s is not None:
+                    self.assertNotIn(s.name, names)
+                    names.add(s.name)
+
 
 if __name__ == "__main__":
     tf.test.main()

--- a/keras/layers/rnn/simple_rnn_test.py
+++ b/keras/layers/rnn/simple_rnn_test.py
@@ -249,6 +249,21 @@ class SimpleRNNLayerTest(tf.test.TestCase, parameterized.TestCase):
         clone_names = [x.name for x in clone.weights]
         self.assertEqual(model_names, clone_names)
 
+    def test_unique_state_names(self):
+        inp = keras.Input(batch_shape=[3, None, 3])
+        a = keras.layers.SimpleRNN(units=3, stateful=True)
+        b = keras.layers.SimpleRNN(units=3)  # no states
+        c = keras.layers.SimpleRNN(units=3, stateful=True)
+        _ = keras.Model(inp, [a(inp), b(inp), c(inp)])
+
+        names = set()
+
+        for l in [a, b, c]:
+            for s in l.states:
+                if s is not None:
+                    self.assertNotIn(s.name, names)
+                    names.add(s.name)
+
 
 if __name__ == "__main__":
     tf.test.main()


### PR DESCRIPTION
Fixes #17477

It generates `{layer_name}/state` for GRU and SimpleRNN layers, and `{layer_name}/state_{idx}` for LSTM layers.