### PR TITLE
Fix ModelCheckpoint trained-on batch counting when using steps_per_execution>1

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1351,7 +1351,7 @@ class ModelCheckpoint(Callback):
         self.save_freq = save_freq
         self.epochs_since_last_save = 0
         self._batches_seen_since_last_saving = 0
-        self._last_batch_seen = 0
+        self._last_batch_seen = -1
         self.best = initial_value_threshold
 
         if save_weights_only:

--- a/keras/callbacks_test.py
+++ b/keras/callbacks_test.py
@@ -1744,6 +1744,7 @@ class KerasCallbacksTest(test_combinations.TestCase):
         shutil.rmtree(savepath)
 
     @test_combinations.run_with_all_model_types
+    @test_utils.run_v2_only
     def test_fit_with_ModelCheckpoint_with_steps_per_execution(self):
         layers = [
             keras.layers.Dense(

--- a/keras/callbacks_test.py
+++ b/keras/callbacks_test.py
@@ -1688,6 +1688,121 @@ class KerasCallbacksTest(test_combinations.TestCase):
         cb_list.on_predict_batch_end(logs)
         cb_list.on_predict_end(logs)
 
+    def _run_fit_with_ModelCheckpoint_with_steps_per_execution(
+        self,
+        model,
+        savepath,
+        save_freq,
+        train_samples,
+        steps_per_execution,
+        epochs,
+        check_ckpt_epochs,
+        check_ckpt_batchs,
+    ):
+        assert len(check_ckpt_epochs) == len(check_ckpt_batchs)
+
+        (x_train, y_train), _ = test_utils.get_test_data(
+            train_samples=train_samples,
+            test_samples=0,
+            input_shape=(INPUT_DIM,),
+            num_classes=NUM_CLASSES,
+        )
+        y_train = np_utils.to_categorical(y_train)
+
+        model.compile(
+            loss="categorical_crossentropy",
+            optimizer="rmsprop",
+            steps_per_execution=steps_per_execution,
+        )
+
+        self.assertFalse(os.path.exists(savepath))
+
+        callback = keras.callbacks.ModelCheckpoint(
+            filepath=os.path.join(savepath, "ckpt_{epoch}_{batch}"),
+            save_freq=save_freq,
+        )
+
+        model.fit(
+            x_train,
+            y_train,
+            batch_size=1,
+            epochs=epochs,
+            verbose=0,
+            callbacks=[callback],
+        )
+
+        self.assertTrue(os.path.exists(savepath))
+
+        for i in range(len(check_ckpt_epochs)):
+            epoch = check_ckpt_epochs[i]
+            batch = check_ckpt_batchs[i]
+            ckpt_name = "ckpt_" + str(epoch) + "_" + str(batch)
+            ckpt_path = os.path.join(savepath, ckpt_name)
+            self.assertTrue(os.path.exists(ckpt_path))
+            self.assertIn("saved_model.pb", os.listdir(ckpt_path))
+
+        shutil.rmtree(savepath)
+
+    @test_combinations.run_with_all_model_types
+    def test_fit_with_ModelCheckpoint_with_steps_per_execution(self):
+        layers = [
+            keras.layers.Dense(
+                NUM_HIDDEN, input_dim=INPUT_DIM, activation="relu"
+            ),
+            keras.layers.Dense(NUM_CLASSES, activation="softmax"),
+        ]
+        model = test_utils.get_model_from_layers(
+            layers, input_shape=(INPUT_DIM,)
+        )
+
+        temp_dir = self.get_temp_dir()
+        savepath = os.path.join(temp_dir, "checkpoint")
+
+        for steps_per_execution in [None, 7]:
+            self._run_fit_with_ModelCheckpoint_with_steps_per_execution(
+                model,
+                savepath,
+                save_freq=7,
+                train_samples=7,
+                steps_per_execution=steps_per_execution,
+                epochs=1,
+                check_ckpt_epochs=[1],
+                check_ckpt_batchs=[7],
+            )
+
+            self._run_fit_with_ModelCheckpoint_with_steps_per_execution(
+                model,
+                savepath,
+                save_freq=7,
+                train_samples=7,
+                steps_per_execution=steps_per_execution,
+                epochs=2,
+                check_ckpt_epochs=[1, 2],
+                check_ckpt_batchs=[7, 7],
+            )
+
+            self._run_fit_with_ModelCheckpoint_with_steps_per_execution(
+                model,
+                savepath,
+                save_freq=14,
+                train_samples=7,
+                steps_per_execution=steps_per_execution,
+                epochs=2,
+                check_ckpt_epochs=[2],
+                check_ckpt_batchs=[7],
+            )
+
+            self._run_fit_with_ModelCheckpoint_with_steps_per_execution(
+                model,
+                savepath,
+                save_freq=7,
+                train_samples=14,
+                steps_per_execution=steps_per_execution,
+                epochs=2,
+                check_ckpt_epochs=[1, 1, 2, 2],
+                check_ckpt_batchs=[7, 14, 7, 14],
+            )
+
     def test_verbose_2_logging(self):
         data = np.random.random((100, 1))
         labels = np.where(data > 0.5, 1, 0)


### PR DESCRIPTION
When setting the steps_per_execution argument to a value N>1 when calling model.compile(), the on_train_batch_end() method of model.fit()'s callbacks only gets called every N batches with an argument batch equal to the 0-indexed index of the last batch which has been trained on. That is, after the first N trained-on batches, on_train_batch_end() gets called with its batch argument equal to N-1, then N trained-on batches later, to 2N-1, etc. until the end of the epoch.

In order to handle this situation, ModelCheckpoint uses a _last_batch_seen member integer variable to record the value of the batch argument of its on_train_batch_end() method the last time this method was called. When on_train_batch_end() is called again, ModelCheckpoint then computes (in its _should_save_on_batch() method) add_batches = batch - self._last_batch_seen in order to know the number of batches which have been trained on between two consecutive calls to its on_train_batch_end() method.

However, the _last_batch_seen member variable is initialized to 0 which means that, when using steps_per_execution=N, the first time on_train_batch_end() is called after N batches have been trained on (with a batch argument equal to N-1), only N-1 batches are counted since add_batches = batch - self._last_batch_seen = (N-1) - 0 = N-1 instead of N. This makes ModelCheckpoint miss one batch when counting them and effectively offset its save_freq contructor argument by 1. Therefore an initialization value of -1 is needed.

In the special cases of steps_per_execution=1 or
steps_per_execution=None (which are equivalent), the bug was hidden by the fact that the condition to check for a new epoch (batch <= self._last_batch_seen) was true since on the first call to on_train_batch_end() both the batch argument and _last_batch_seen variable were equal to 0. In this case, the number of batches trained on is counted by computing add_batches = batch + 1 = 1, which is indeed the correct result.