### PR TITLE
Optimize mixed-precision finite check for sparse tensors.

### DIFF
--- a/keras/mixed_precision/loss_scale_optimizer.py
+++ b/keras/mixed_precision/loss_scale_optimizer.py
@@ -49,12 +49,14 @@ class _UnwrapPreventer:
 def _is_all_finite(grads):
     """Returns a scalar boolean tensor indicating if all gradients are
     finite."""
+
     def raw_values(g):
         return g.values if isinstance(g, tf.IndexedSlices) else g
 
     is_finite_per_grad = [
         tf.reduce_all(tf.math.is_finite(raw_values(g)))
-        for g in grads if g is not None
+        for g in grads
+        if g is not None
     ]
     return tf.reduce_all(is_finite_per_grad)
 

--- a/keras/mixed_precision/loss_scale_optimizer.py
+++ b/keras/mixed_precision/loss_scale_optimizer.py
@@ -49,8 +49,12 @@ class _UnwrapPreventer:
 def _is_all_finite(grads):
     """Returns a scalar boolean tensor indicating if all gradients are
     finite."""
+    def raw_values(g):
+        return g.values if isinstance(g, tf.IndexedSlices) else g
+
     is_finite_per_grad = [
-        tf.reduce_all(tf.math.is_finite(g)) for g in grads if g is not None
+        tf.reduce_all(tf.math.is_finite(raw_values(g)))
+        for g in grads if g is not None
     ]
     return tf.reduce_all(is_finite_per_grad)
 


### PR DESCRIPTION
Mixed precision can be very slow and memory inefficient with sparse tensors, common, for example, in recommender-type models.

The largest inefficiencies come from checking sparse tensors for NaN values when dynamic loss scaling is enabled.

This PR implements a simple optimization to use the dense values of IndexedSlices directly during NaN checks.