### PR TITLE
Add CategoricalFocalCrossentropy to Losses API

### DIFF
--- a/keras/backend.py
+++ b/keras/backend.py
@@ -5585,7 +5585,7 @@ def categorical_focal_crossentropy(
         from_logits=False,
         axis=-1,
 ):
-    
+
     output, from_logits = _get_logits(
         output, from_logits, "Softmax", "categorical_focal_crossentropy"
     )
@@ -5595,6 +5595,8 @@ def categorical_focal_crossentropy(
         lambda: softmax(output),
         lambda: output,
     )
+
+    output = output / tf.reduce_sum(output, axis=axis, keepdims=True)
 
     epsilon_ = _constant_to_tensor(epsilon(), output.dtype.base_dtype)
     output = tf.clip_by_value(output, epsilon_, 1.0 - epsilon_)

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -5585,6 +5585,36 @@ def categorical_focal_crossentropy(
         from_logits=False,
         axis=-1,
 ):
+    """Categorical focal crossentropy (alpha balanced) between an output tensor and a target tensor.
+            According to [Lin et al., 2018](https://arxiv.org/pdf/1708.02002.pdf), it
+            helps to apply a focal factor to down-weight easy examples and focus more on
+            hard examples. By default, the focal tensor is computed as follows:
+            It has pt defined as:
+            pt = p, if y = 1 else 1 - p
+            The authors use alpha-balanced variant of focal loss in the paper:
+            FL(pt) = −α_t * (1 − pt)^gamma * log(pt)
+            Extending this to multi-class case is straightforward:
+            FL(pt) = α_t * (1 − pt)^gamma * CE, where minus comes from negative log-likelihood and included in CE.
+            `modulating_factor` is (1 − pt)^gamma,
+            where `gamma` is a focusing parameter. When `gamma` = 0, there is no focal
+            effect on the categorical crossentropy.
+            Args:
+              target: A tensor with the same shape as `output`.
+              output: A tensor.
+              alpha: A weight balancing factor for all classes, default is `0.25` as
+                     mentioned in the reference. It can be a list of floats or a scalar.
+                     In the multi-class case, alpha may be set by inverse class frequency by
+                     using `compute_class_weight` from `sklearn.utils`.
+              gamma: A focusing parameter, default is `2.0` as mentioned in the
+                     reference. It helps to gradually reduce the importance given to
+                     simple examples in a smooth manner.
+              from_logits: Whether `output` is expected to be a logits tensor. By
+                default, we consider that `output` encodes a probability distribution.
+            Returns:
+              A tensor.
+            """
+    target = tf.convert_to_tensor(target)
+    output = tf.convert_to_tensor(output)
     target.shape.assert_is_compatible_with(output.shape)
     output, from_logits = _get_logits(
         output, from_logits, "Softmax", "categorical_focal_crossentropy"

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -5578,41 +5578,41 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
 @tf.__internal__.dispatch.add_dispatch_support
 @doc_controls.do_not_generate_docs
 def categorical_focal_crossentropy(
-        target,
-        output,
-        alpha=0.25,
-        gamma=2.0,
-        from_logits=False,
-        axis=-1,
+    target,
+    output,
+    alpha=0.25,
+    gamma=2.0,
+    from_logits=False,
+    axis=-1,
 ):
     """Categorical focal crossentropy (alpha balanced) between an output tensor and a target tensor.
-            According to [Lin et al., 2018](https://arxiv.org/pdf/1708.02002.pdf), it
-            helps to apply a focal factor to down-weight easy examples and focus more on
-            hard examples. By default, the focal tensor is computed as follows:
-            It has pt defined as:
-            pt = p, if y = 1 else 1 - p
-            The authors use alpha-balanced variant of focal loss in the paper:
-            FL(pt) = −α_t * (1 − pt)^gamma * log(pt)
-            Extending this to multi-class case is straightforward:
-            FL(pt) = α_t * (1 − pt)^gamma * CE, where minus comes from negative log-likelihood and included in CE.
-            `modulating_factor` is (1 − pt)^gamma,
-            where `gamma` is a focusing parameter. When `gamma` = 0, there is no focal
-            effect on the categorical crossentropy.
-            Args:
-              target: A tensor with the same shape as `output`.
-              output: A tensor.
-              alpha: A weight balancing factor for all classes, default is `0.25` as
-                     mentioned in the reference. It can be a list of floats or a scalar.
-                     In the multi-class case, alpha may be set by inverse class frequency by
-                     using `compute_class_weight` from `sklearn.utils`.
-              gamma: A focusing parameter, default is `2.0` as mentioned in the
-                     reference. It helps to gradually reduce the importance given to
-                     simple examples in a smooth manner.
-              from_logits: Whether `output` is expected to be a logits tensor. By
-                default, we consider that `output` encodes a probability distribution.
-            Returns:
-              A tensor.
-            """
+    According to [Lin et al., 2018](https://arxiv.org/pdf/1708.02002.pdf), it
+    helps to apply a focal factor to down-weight easy examples and focus more on
+    hard examples. By default, the focal tensor is computed as follows:
+    It has pt defined as:
+    pt = p, if y = 1 else 1 - p
+    The authors use alpha-balanced variant of focal loss in the paper:
+    FL(pt) = −α_t * (1 − pt)^gamma * log(pt)
+    Extending this to multi-class case is straightforward:
+    FL(pt) = α_t * (1 − pt)^gamma * CE, where minus comes from negative log-likelihood and included in CE.
+    `modulating_factor` is (1 − pt)^gamma,
+    where `gamma` is a focusing parameter. When `gamma` = 0, there is no focal
+    effect on the categorical crossentropy.
+    Args:
+      target: A tensor with the same shape as `output`.
+      output: A tensor.
+      alpha: A weight balancing factor for all classes, default is `0.25` as
+             mentioned in the reference. It can be a list of floats or a scalar.
+             In the multi-class case, alpha may be set by inverse class frequency by
+             using `compute_class_weight` from `sklearn.utils`.
+      gamma: A focusing parameter, default is `2.0` as mentioned in the
+             reference. It helps to gradually reduce the importance given to
+             simple examples in a smooth manner.
+      from_logits: Whether `output` is expected to be a logits tensor. By
+        default, we consider that `output` encodes a probability distribution.
+    Returns:
+      A tensor.
+    """
     target = tf.convert_to_tensor(target)
     output = tf.convert_to_tensor(output)
     target.shape.assert_is_compatible_with(output.shape)
@@ -5641,6 +5641,7 @@ def categorical_focal_crossentropy(
     focal_cce = tf.multiply(weighting_factor, cce)
     focal_cce = tf.reduce_sum(focal_cce, axis=axis)
     return focal_cce
+
 
 @keras_export("keras.backend.sparse_categorical_crossentropy")
 @tf.__internal__.dispatch.add_dispatch_support

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -5605,24 +5605,28 @@ def categorical_focal_crossentropy(
     parameter. When `gamma` = 0, there is no focal effect on the categorical
     crossentropy. And if alpha = 1, at the same time the loss is equivalent
     to the categorical crossentropy.
+
     Args:
-      target: A tensor with the same shape as `output`.
-      output: A tensor.
-      alpha: A weight balancing factor for all classes, default is `0.25` as
-             mentioned in the reference. It can be a list of floats or a scalar.
-             In the multi-class case, alpha may be set by inverse class
-             frequency by using `compute_class_weight` from `sklearn.utils`.
-      gamma: A focusing parameter, default is `2.0` as mentioned in the
-             reference. It helps to gradually reduce the importance given to
-             simple examples in a smooth manner.
-      from_logits: Whether `output` is expected to be a logits tensor. By
-        default, we consider that `output` encodes a probability distribution.
+        target: A tensor with the same shape as `output`.
+        output: A tensor.
+        alpha: A weight balancing factor for all classes, default is `0.25` as
+            mentioned in the reference. It can be a list of floats or a scalar.
+            In the multi-class case, alpha may be set by inverse class
+            frequency by using `compute_class_weight` from `sklearn.utils`.
+        gamma: A focusing parameter, default is `2.0` as mentioned in the
+            reference. It helps to gradually reduce the importance given to
+            simple examples in a smooth manner.
+        from_logits: Whether `output` is expected to be a logits tensor. By
+            default, we consider that `output` encodes a probability
+            distribution.
+
     Returns:
-      A tensor.
+        A tensor.
     """
     target = tf.convert_to_tensor(target)
     output = tf.convert_to_tensor(output)
     target.shape.assert_is_compatible_with(output.shape)
+
     output, from_logits = _get_logits(
         output, from_logits, "Softmax", "categorical_focal_crossentropy"
     )
@@ -5633,11 +5637,13 @@ def categorical_focal_crossentropy(
         lambda: output,
     )
 
+    # scale preds so that the class probas of each sample sum to 1
     output = output / tf.reduce_sum(output, axis=axis, keepdims=True)
 
     epsilon_ = _constant_to_tensor(epsilon(), output.dtype.base_dtype)
     output = tf.clip_by_value(output, epsilon_, 1.0 - epsilon_)
 
+    # Calculate cross entropy
     cce = -target * tf.math.log(output)
 
     # Calculate factors

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -5589,26 +5589,38 @@ def categorical_focal_crossentropy(
 
     According to [Lin et al., 2018](https://arxiv.org/pdf/1708.02002.pdf), it
     helps to apply a focal factor to down-weight easy examples and focus more on
-    hard examples. By default, the focal tensor is computed as follows:
+    hard examples. The general formula for the focal loss (FL)
+    is as follows:
 
-    It has pt defined as:
-    pt = p, if y = 1 else 1 - p
+    `FL(p_t) = (1 − p_t)^gamma * log(p_t)`
 
-    The authors use alpha-balanced variant of focal loss in the paper:
-    FL(pt) = −α_t * (1 − pt)^gamma * log(pt)
+    where `p_t` is defined as follows:
+    `p_t = output if y_true == 1, else 1 - output`
+
+    `(1 − p_t)^gamma` is the `modulating_factor`, where `gamma` is a focusing
+    parameter. When `gamma` = 0, there is no focal effect on the cross entropy.
+    `gamma` reduces the importance given to simple examples in a smooth manner.
+
+    The authors use alpha-balanced variant of focal loss (FL) in the paper:
+    `FL(p_t) = −alpha * (1 − p_t)^gamma * log(p_t)`
+
+    where `alpha` is the weight factor for the classes. If `alpha` = 1, the
+    loss won't be able to handle class imbalance properly as all
+    classes will have the same weight. This can be a constant or a list of
+    constants. If alpha is a list, it must have the same length as the number
+    of classes.
+
+    The formula above can be generalized to:
+    `FL(p_t) = alpha * (1 − p_t)^gamma * CrossEntropy(target, output)`
+
+    where minus comes from `CrossEntropy(target, output)` (CE).
 
     Extending this to multi-class case is straightforward:
-    FL(pt) = α_t * (1 − pt)^gamma * CE, where minus comes from
-    negative log-likelihood and included in CE.
-
-    `modulating_factor` is (1 − pt)^gamma, where `gamma` is a focusing
-    parameter. When `gamma` = 0, there is no focal effect on the categorical
-    crossentropy. And if alpha = 1, at the same time the loss is equivalent
-    to the categorical crossentropy.
+    `FL(p_t) = alpha * (1 − p_t)^gamma * CategoricalCE(target, output)`
 
     Args:
-        target: A tensor with the same shape as `output`.
-        output: A tensor.
+        target: Ground truth values from the dataset.
+        output: Predictions of the model.
         alpha: A weight balancing factor for all classes, default is `0.25` as
             mentioned in the reference. It can be a list of floats or a scalar.
             In the multi-class case, alpha may be set by inverse class
@@ -5619,6 +5631,9 @@ def categorical_focal_crossentropy(
         from_logits: Whether `output` is expected to be a logits tensor. By
             default, we consider that `output` encodes a probability
             distribution.
+        axis: Int specifying the channels axis. `axis=-1` corresponds to data
+             format `channels_last`, and `axis=1` corresponds to data format
+             `channels_first`.
 
     Returns:
         A tensor.
@@ -5631,13 +5646,13 @@ def categorical_focal_crossentropy(
         output, from_logits, "Softmax", "categorical_focal_crossentropy"
     )
 
-    output = tf.__internal__.smart_cond.smart_cond(
-        from_logits,
-        lambda: softmax(output),
-        lambda: output,
-    )
+    if from_logits:
+        output = tf.nn.softmax(output, axis=axis)
 
-    # scale preds so that the class probas of each sample sum to 1
+    # Adjust the predictions so that the probability of
+    # each class for every sample adds up to 1
+    # This is needed to ensure that the cross entropy is
+    # computed correctly.
     output = output / tf.reduce_sum(output, axis=axis, keepdims=True)
 
     epsilon_ = _constant_to_tensor(epsilon(), output.dtype.base_dtype)

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -5585,7 +5585,7 @@ def categorical_focal_crossentropy(
         from_logits=False,
         axis=-1,
 ):
-
+    target.shape.assert_is_compatible_with(output.shape)
     output, from_logits = _get_logits(
         output, from_logits, "Softmax", "categorical_focal_crossentropy"
     )

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -5585,26 +5585,33 @@ def categorical_focal_crossentropy(
     from_logits=False,
     axis=-1,
 ):
-    """Categorical focal crossentropy (alpha balanced) between an output tensor and a target tensor.
+    """Computes the alpha balanced focal crossentropy loss between
+    the labels and predictions.
     According to [Lin et al., 2018](https://arxiv.org/pdf/1708.02002.pdf), it
     helps to apply a focal factor to down-weight easy examples and focus more on
     hard examples. By default, the focal tensor is computed as follows:
+
     It has pt defined as:
     pt = p, if y = 1 else 1 - p
+
     The authors use alpha-balanced variant of focal loss in the paper:
     FL(pt) = −α_t * (1 − pt)^gamma * log(pt)
+
     Extending this to multi-class case is straightforward:
-    FL(pt) = α_t * (1 − pt)^gamma * CE, where minus comes from negative log-likelihood and included in CE.
-    `modulating_factor` is (1 − pt)^gamma,
-    where `gamma` is a focusing parameter. When `gamma` = 0, there is no focal
-    effect on the categorical crossentropy.
+    FL(pt) = α_t * (1 − pt)^gamma * CE, where minus comes from
+    negative log-likelihood and included in CE.
+
+    `modulating_factor` is (1 − pt)^gamma, where `gamma` is a focusing
+    parameter. When `gamma` = 0, there is no focal effect on the categorical
+    crossentropy. And if alpha = 1, at the same time the loss is equivalent
+    to the categorical crossentropy.
     Args:
       target: A tensor with the same shape as `output`.
       output: A tensor.
       alpha: A weight balancing factor for all classes, default is `0.25` as
              mentioned in the reference. It can be a list of floats or a scalar.
-             In the multi-class case, alpha may be set by inverse class frequency by
-             using `compute_class_weight` from `sklearn.utils`.
+             In the multi-class case, alpha may be set by inverse class
+             frequency by using `compute_class_weight` from `sklearn.utils`.
       gamma: A focusing parameter, default is `2.0` as mentioned in the
              reference. It helps to gradually reduce the importance given to
              simple examples in a smooth manner.

--- a/keras/backend.py
+++ b/keras/backend.py
@@ -5585,8 +5585,8 @@ def categorical_focal_crossentropy(
     from_logits=False,
     axis=-1,
 ):
-    """Computes the alpha balanced focal crossentropy loss between
-    the labels and predictions.
+    """Computes the alpha balanced focal crossentropy loss.
+
     According to [Lin et al., 2018](https://arxiv.org/pdf/1708.02002.pdf), it
     helps to apply a focal factor to down-weight easy examples and focus more on
     hard examples. By default, the focal tensor is computed as follows:

--- a/keras/backend_test.py
+++ b/keras/backend_test.py
@@ -2247,6 +2247,19 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
     @test_combinations.generate(
         test_combinations.combine(mode=["graph", "eager"])
     )
+    def test_categorical_focal_crossentropy_with_softmax(self):
+        t = backend.constant([[0, 1, 0]])
+        logits = backend.constant([[8.0, 1.0, 1.0]])
+        p = backend.softmax(logits)
+        p = tf.identity(tf.identity(p))
+        result = self.evaluate(
+            backend.categorical_focal_crossentropy(t, p, gamma=2.0)
+        )
+        self.assertArrayNear(result, [1.747], 1e-3)
+
+    @test_combinations.generate(
+        test_combinations.combine(mode=["graph", "eager"])
+    )
     def test_binary_focal_crossentropy_from_logits(self):
         t = backend.constant([[0, 1, 0]])
         logits = backend.constant([[8.0, 1.0, 1.0]])
@@ -2259,6 +2272,21 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
             )
         )
         self.assertArrayNear(result[0], [7.995, 0.022, 0.701], 1e-3)
+
+    @test_combinations.generate(
+        test_combinations.combine(mode=["graph", "eager"])
+    )
+    def test_categorical_focal_crossentropy_from_logits(self):
+        t = backend.constant([[0, 1, 0]])
+        logits = backend.constant([[8.0, 1.0, 1.0]])
+        result = self.evaluate(
+            backend.categorical_focal_crossentropy(
+                target=t,
+                output=logits,
+                from_logits=True,
+            )
+        )
+        self.assertArrayNear(result, [1.7472], 1e-3)
 
     @test_combinations.generate(
         test_combinations.combine(mode=["graph", "eager"])
@@ -2278,6 +2306,25 @@ class BackendCrossEntropyLossesTest(tf.test.TestCase, parameterized.TestCase):
         )
         non_focal_result = self.evaluate(backend.binary_crossentropy(t, p))
         self.assertArrayNear(focal_result[0], non_focal_result[0], 1e-3)
+
+    @test_combinations.generate(
+        test_combinations.combine(mode=["graph", "eager"])
+    )
+    def test_categorical_focal_crossentropy_no_focal_effect(self):
+        t = backend.constant([[0, 1, 0]])
+        logits = backend.constant([[8.0, 1.0, 1.0]])
+        p = backend.softmax(logits)
+        p = tf.identity(tf.identity(p))
+        focal_result = self.evaluate(
+            backend.categorical_focal_crossentropy(
+                target=t,
+                output=p,
+                gamma=0.0,
+                alpha=1.0,
+            )
+        )
+        non_focal_result = self.evaluate(backend.categorical_crossentropy(t, p))
+        self.assertArrayNear(focal_result, non_focal_result, 1e-3)
 
     @test_combinations.generate(
         test_combinations.combine(mode=["graph", "eager"])

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -923,6 +923,76 @@ class CategoricalCrossentropy(LossFunctionWrapper):
 
 @keras_export("keras.losses.CategoricalFocalCrossentropy")
 class CategoricalFocalCrossentropy(LossFunctionWrapper):
+    """Computes the alpha balanced focal crossentropy loss between the labels and predictions.
+        According to [Lin et al., 2018](https://arxiv.org/pdf/1708.02002.pdf), it
+        helps to apply a focal factor to down-weight easy examples and focus more on
+        hard examples. By default, the focal tensor is computed as follows:
+        It has pt defined as:
+        pt = p, if y = 1 else 1 - p
+        The authors use alpha-balanced variant of focal loss in the paper:
+        FL(pt) = −α_t * (1 − pt)^gamma * log(pt)
+        Extending this to multi-class case is straightforward:
+        FL(pt) = α_t * (1 − pt)^gamma * CE, where minus comes from negative log-likelihood and included in CE.
+        `modulating_factor` is (1 − pt)^gamma,
+        where `gamma` is a focusing parameter. When `gamma` = 0, there is no focal
+        effect on the categorical crossentropy. And if alpha = 1, at the same time the loss is
+        equivalent to the categorical crossentropy.
+        In the snippet below, there is `# classes` floating pointing values per
+        example. The shape of both `y_pred` and `y_true` are
+        `[batch_size, num_classes]`.
+        Standalone usage:
+        >>> y_true = [[0., 1., 0.], [0., 0., 1.]]
+        >>> y_pred = [[0.05, 0.95, 0], [0.1, 0.8, 0.1]]
+        >>> # Using 'auto'/'sum_over_batch_size' reduction type.
+        >>> cce = tf.keras.losses.CategoricalFocalCrossentropy()
+        >>> cce(y_true, y_pred).numpy()
+        0.23315276
+        >>> # Calling with 'sample_weight'.
+        >>> cce(y_true, y_pred, sample_weight=tf.constant([0.3, 0.7])).numpy()
+        0.1632
+        >>> # Using 'sum' reduction type.
+        >>> cce = tf.keras.losses.CategoricalFocalCrossentropy(
+        ...     reduction=tf.keras.losses.Reduction.SUM)
+        >>> cce(y_true, y_pred).numpy()
+        0.46631
+        >>> # Using 'none' reduction type.
+        >>> cce = tf.keras.losses.CategoricalFocalCrossentropy(
+        ...     reduction=tf.keras.losses.Reduction.NONE)
+        >>> cce(y_true, y_pred).numpy()
+        array([3.2058331e-05, 4.6627346e-01], dtype=float32)
+        Usage with the `compile()` API:
+        ```python
+        model.compile(optimizer='sgd',
+                      loss=tf.keras.losses.CategoricalFocalCrossentropy())
+        ```
+        Args:
+          alpha: A weight balancing factor for all classes, default is `0.25` as
+                 mentioned in the reference. It can be a list of floats or a scalar.
+                 In the multi-class case, alpha may be set by inverse class frequency by
+                 using `compute_class_weight` from `sklearn.utils`.
+          gamma: A focusing parameter, default is `2.0` as mentioned in the
+                 reference. It helps to gradually reduce the importance given to
+                 simple (easy) examples in a smooth manner.
+          from_logits: Whether `output` is expected to be a logits tensor. By
+            default, we consider that `output` encodes a probability distribution.
+          label_smoothing: Float in [0, 1]. When > 0, label values are smoothed,
+            meaning the confidence on label values are relaxed. For example, if
+            `0.1`, use `0.1 / num_classes` for non-target labels and
+            `0.9 + 0.1 / num_classes` for target labels.
+          axis: The axis along which to compute crossentropy (the features
+            axis). Defaults to -1.
+          reduction: Type of `tf.keras.losses.Reduction` to apply to
+            loss. Default value is `AUTO`. `AUTO` indicates that the reduction
+            option will be determined by the usage context. For almost all cases
+            this defaults to `SUM_OVER_BATCH_SIZE`. When used under a
+            `tf.distribute.Strategy`, except via `Model.compile()` and
+            `Model.fit()`, using `AUTO` or `SUM_OVER_BATCH_SIZE`
+            will raise an error. Please see this custom training [tutorial](
+            https://www.tensorflow.org/tutorials/distribute/custom_training)
+            for more details.
+          name: Optional name for the instance.
+            Defaults to 'categorical_focal_crossentropy'.
+        """
     def __init__(
             self,
             alpha=0.25,
@@ -2073,7 +2143,35 @@ def categorical_focal_crossentropy(
         label_smoothing=0.0,
         axis=-1,
 ):
-
+    """Computes the categorical focal crossentropy loss.
+        Standalone usage:
+        >>> y_true = [[0, 1, 0], [0, 0, 1]]
+        >>> y_pred = [[0.05, 0.9, 0.05], [0.1, 0.85, 0.05]]
+        >>> loss = tf.keras.losses.categorical_focal_crossentropy(y_true, y_pred)
+        >>> assert loss.shape == (2,)
+        >>> loss.numpy()
+        array([2.63401289e-04, 6.75912094e-01], dtype=float32)
+        Args:
+          y_true: Tensor of one-hot true targets.
+          y_pred: Tensor of predicted targets.
+          alpha: A weight balancing factor for all classes, default is `0.25` as
+             mentioned in the reference. It can be a list of floats or a scalar.
+             In the multi-class case, alpha may be set by inverse class frequency by
+             using `compute_class_weight` from `sklearn.utils`.
+          gamma: A focusing parameter, default is `2.0` as mentioned in the
+             reference. It helps to gradually reduce the importance given to
+             simple examples in a smooth manner. When `gamma` = 0, there is no focal
+             effect on the categorical crossentropy.
+          from_logits: Whether `y_pred` is expected to be a logits tensor. By
+            default, we assume that `y_pred` encodes a probability distribution.
+          label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
+            example, if `0.1`, use `0.1 / num_classes` for non-target labels
+            and `0.9 + 0.1 / num_classes` for target labels.
+          axis: Defaults to -1. The dimension along which the entropy is
+            computed.
+        Returns:
+          Categorical focal crossentropy loss value.
+        """
     if isinstance(axis, bool):
         raise ValueError(
             "`axis` must be of type `int`. "
@@ -2121,6 +2219,33 @@ def _ragged_tensor_categorical_focal_crossentropy(
     label_smoothing=0.0,
     axis=-1,
 ):
+    """Implements support for handling RaggedTensors.
+        Expected shape: (batch, sequence_len, n_classes) with sequence_len
+        being variable per batch.
+        Return shape: (batch, sequence_len).
+        When used by CategoricalFocalCrossentropy() with the default reduction
+        (SUM_OVER_BATCH_SIZE), the reduction averages the loss over the
+        number of elements independent of the batch. E.g. if the RaggedTensor
+        has 2 batches with [2, 1] values respectively the resulting loss is
+        the sum of the individual loss values divided by 3.
+        alpha: A weight balancing factor for all classes, default is `0.25` as
+             mentioned in the reference. It can be a list of floats or a scalar.
+             In the multi-class case, alpha may be set by inverse class frequency by
+             using `compute_class_weight` from `sklearn.utils`.
+        gamma: A focusing parameter, default is `2.0` as mentioned in the
+             reference. It helps to gradually reduce the importance given to
+             simple examples in a smooth manner. When `gamma` = 0, there is no focal
+             effect on the categorical crossentropy.
+        from_logits: Whether `y_pred` is expected to be a logits tensor. By
+            default, we assume that `y_pred` encodes a probability distribution.
+        label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
+            example, if `0.1`, use `0.1 / num_classes` for non-target labels
+            and `0.9 + 0.1 / num_classes` for target labels.
+        axis: Defaults to -1. The dimension along which the entropy is
+            computed.
+        Returns:
+          Categorical focal crossentropy loss value.
+        """
     fn = functools.partial(
         categorical_focal_crossentropy,
         alpha=alpha,

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -924,20 +924,27 @@ class CategoricalCrossentropy(LossFunctionWrapper):
 
 @keras_export("keras.losses.CategoricalFocalCrossentropy")
 class CategoricalFocalCrossentropy(LossFunctionWrapper):
-    """Computes the alpha balanced focal crossentropy loss between the labels and predictions.
+    """Computes the alpha balanced focal crossentropy loss between
+    the labels and predictions.
     According to [Lin et al., 2018](https://arxiv.org/pdf/1708.02002.pdf), it
     helps to apply a focal factor to down-weight easy examples and focus more on
     hard examples. By default, the focal tensor is computed as follows:
+
     It has pt defined as:
     pt = p, if y = 1 else 1 - p
+
     The authors use alpha-balanced variant of focal loss in the paper:
     FL(pt) = −α_t * (1 − pt)^gamma * log(pt)
+
     Extending this to multi-class case is straightforward:
-    FL(pt) = α_t * (1 − pt)^gamma * CE, where minus comes from negative log-likelihood and included in CE.
-    `modulating_factor` is (1 − pt)^gamma,
-    where `gamma` is a focusing parameter. When `gamma` = 0, there is no focal
-    effect on the categorical crossentropy. And if alpha = 1, at the same time the loss is
-    equivalent to the categorical crossentropy.
+    FL(pt) = α_t * (1 − pt)^gamma * CE, where minus comes from
+    negative log-likelihood and included in CE.
+
+    `modulating_factor` is (1 − pt)^gamma, where `gamma` is a focusing
+    parameter. When `gamma` = 0, there is no focal effect on the categorical
+    crossentropy. And if alpha = 1, at the same time the loss is equivalent to
+    the categorical crossentropy.
+
     In the snippet below, there is `# classes` floating pointing values per
     example. The shape of both `y_pred` and `y_true` are
     `[batch_size, num_classes]`.
@@ -969,8 +976,8 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
     Args:
       alpha: A weight balancing factor for all classes, default is `0.25` as
              mentioned in the reference. It can be a list of floats or a scalar.
-             In the multi-class case, alpha may be set by inverse class frequency by
-             using `compute_class_weight` from `sklearn.utils`.
+             In the multi-class case, alpha may be set by inverse class
+             frequency by using `compute_class_weight` from `sklearn.utils`.
       gamma: A focusing parameter, default is `2.0` as mentioned in the
              reference. It helps to gradually reduce the importance given to
              simple (easy) examples in a smooth manner.

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -945,29 +945,40 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
     crossentropy. And if alpha = 1, at the same time the loss is equivalent to
     the categorical crossentropy.
 
+    Use this crossentropy loss function when there are two or more label
+    classes and if you want to handle class imbalance without using
+    `class_weights`.
+    We expect labels to be provided in a `one_hot` representation.
+
     In the snippet below, there is `# classes` floating pointing values per
     example. The shape of both `y_pred` and `y_true` are
     `[batch_size, num_classes]`.
+
     Standalone usage:
+
     >>> y_true = [[0., 1., 0.], [0., 0., 1.]]
     >>> y_pred = [[0.05, 0.95, 0], [0.1, 0.8, 0.1]]
     >>> # Using 'auto'/'sum_over_batch_size' reduction type.
     >>> cce = tf.keras.losses.CategoricalFocalCrossentropy()
     >>> cce(y_true, y_pred).numpy()
     0.23315276
+
     >>> # Calling with 'sample_weight'.
     >>> cce(y_true, y_pred, sample_weight=tf.constant([0.3, 0.7])).numpy()
     0.1632
+
     >>> # Using 'sum' reduction type.
     >>> cce = tf.keras.losses.CategoricalFocalCrossentropy(
     ...     reduction=tf.keras.losses.Reduction.SUM)
     >>> cce(y_true, y_pred).numpy()
     0.46631
+
     >>> # Using 'none' reduction type.
     >>> cce = tf.keras.losses.CategoricalFocalCrossentropy(
     ...     reduction=tf.keras.losses.Reduction.NONE)
     >>> cce(y_true, y_pred).numpy()
     array([3.2058331e-05, 4.6627346e-01], dtype=float32)
+
     Usage with the `compile()` API:
     ```python
     model.compile(optimizer='sgd',
@@ -975,12 +986,12 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
     ```
     Args:
       alpha: A weight balancing factor for all classes, default is `0.25` as
-             mentioned in the reference. It can be a list of floats or a scalar.
-             In the multi-class case, alpha may be set by inverse class
-             frequency by using `compute_class_weight` from `sklearn.utils`.
+        mentioned in the reference. It can be a list of floats or a scalar.
+        In the multi-class case, alpha may be set by inverse class
+        frequency by using `compute_class_weight` from `sklearn.utils`.
       gamma: A focusing parameter, default is `2.0` as mentioned in the
-             reference. It helps to gradually reduce the importance given to
-             simple (easy) examples in a smooth manner.
+        reference. It helps to gradually reduce the importance given to
+        simple (easy) examples in a smooth manner.
       from_logits: Whether `output` is expected to be a logits tensor. By
         default, we consider that `output` encodes a probability distribution.
       label_smoothing: Float in [0, 1]. When > 0, label values are smoothed,
@@ -2154,6 +2165,7 @@ def categorical_focal_crossentropy(
     axis=-1,
 ):
     """Computes the categorical focal crossentropy loss.
+
     Standalone usage:
     >>> y_true = [[0, 1, 0], [0, 0, 1]]
     >>> y_pred = [[0.05, 0.9, 0.05], [0.1, 0.85, 0.05]]
@@ -2161,17 +2173,18 @@ def categorical_focal_crossentropy(
     >>> assert loss.shape == (2,)
     >>> loss.numpy()
     array([2.63401289e-04, 6.75912094e-01], dtype=float32)
+
     Args:
       y_true: Tensor of one-hot true targets.
       y_pred: Tensor of predicted targets.
       alpha: A weight balancing factor for all classes, default is `0.25` as
-         mentioned in the reference. It can be a list of floats or a scalar.
-         In the multi-class case, alpha may be set by inverse class frequency by
-         using `compute_class_weight` from `sklearn.utils`.
+        mentioned in the reference. It can be a list of floats or a scalar.
+        In the multi-class case, alpha may be set by inverse class frequency by
+        using `compute_class_weight` from `sklearn.utils`.
       gamma: A focusing parameter, default is `2.0` as mentioned in the
-         reference. It helps to gradually reduce the importance given to
-         simple examples in a smooth manner. When `gamma` = 0, there is no focal
-         effect on the categorical crossentropy.
+        reference. It helps to gradually reduce the importance given to
+        simple examples in a smooth manner. When `gamma` = 0, there is no focal
+        effect on the categorical crossentropy.
       from_logits: Whether `y_pred` is expected to be a logits tensor. By
         default, we assume that `y_pred` encodes a probability distribution.
       label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
@@ -2179,6 +2192,7 @@ def categorical_focal_crossentropy(
         and `0.9 + 0.1 / num_classes` for target labels.
       axis: Defaults to -1. The dimension along which the entropy is
         computed.
+
     Returns:
       Categorical focal crossentropy loss value.
     """
@@ -2240,21 +2254,24 @@ def _ragged_tensor_categorical_focal_crossentropy(
     number of elements independent of the batch. E.g. if the RaggedTensor
     has 2 batches with [2, 1] values respectively the resulting loss is
     the sum of the individual loss values divided by 3.
-    alpha: A weight balancing factor for all classes, default is `0.25` as
-         mentioned in the reference. It can be a list of floats or a scalar.
-         In the multi-class case, alpha may be set by inverse class frequency by
-         using `compute_class_weight` from `sklearn.utils`.
-    gamma: A focusing parameter, default is `2.0` as mentioned in the
-         reference. It helps to gradually reduce the importance given to
-         simple examples in a smooth manner. When `gamma` = 0, there is no focal
-         effect on the categorical crossentropy.
-    from_logits: Whether `y_pred` is expected to be a logits tensor. By
+
+    Args:
+      alpha: A weight balancing factor for all classes, default is `0.25` as
+        mentioned in the reference. It can be a list of floats or a scalar.
+        In the multi-class case, alpha may be set by inverse class frequency by
+        using `compute_class_weight` from `sklearn.utils`.
+      gamma: A focusing parameter, default is `2.0` as mentioned in the
+        reference. It helps to gradually reduce the importance given to
+        simple examples in a smooth manner. When `gamma` = 0, there is no focal
+        effect on the categorical crossentropy.
+      from_logits: Whether `y_pred` is expected to be a logits tensor. By
         default, we assume that `y_pred` encodes a probability distribution.
-    label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
+      label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
         example, if `0.1`, use `0.1 / num_classes` for non-target labels
         and `0.9 + 0.1 / num_classes` for target labels.
-    axis: Defaults to -1. The dimension along which the entropy is
+      axis: Defaults to -1. The dimension along which the entropy is
         computed.
+
     Returns:
       Categorical focal crossentropy loss value.
     """

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -924,8 +924,8 @@ class CategoricalCrossentropy(LossFunctionWrapper):
 
 @keras_export("keras.losses.CategoricalFocalCrossentropy")
 class CategoricalFocalCrossentropy(LossFunctionWrapper):
-    """Computes the alpha balanced focal crossentropy loss between
-    the labels and predictions.
+    """Computes the alpha balanced focal crossentropy loss.
+
     According to [Lin et al., 2018](https://arxiv.org/pdf/1708.02002.pdf), it
     helps to apply a focal factor to down-weight easy examples and focus more on
     hard examples. By default, the focal tensor is computed as follows:
@@ -985,32 +985,32 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
                   loss=tf.keras.losses.CategoricalFocalCrossentropy())
     ```
     Args:
-      alpha: A weight balancing factor for all classes, default is `0.25` as
-        mentioned in the reference. It can be a list of floats or a scalar.
-        In the multi-class case, alpha may be set by inverse class
-        frequency by using `compute_class_weight` from `sklearn.utils`.
-      gamma: A focusing parameter, default is `2.0` as mentioned in the
-        reference. It helps to gradually reduce the importance given to
-        simple (easy) examples in a smooth manner.
-      from_logits: Whether `output` is expected to be a logits tensor. By
-        default, we consider that `output` encodes a probability distribution.
-      label_smoothing: Float in [0, 1]. When > 0, label values are smoothed,
-        meaning the confidence on label values are relaxed. For example, if
-        `0.1`, use `0.1 / num_classes` for non-target labels and
-        `0.9 + 0.1 / num_classes` for target labels.
-      axis: The axis along which to compute crossentropy (the features
-        axis). Defaults to -1.
-      reduction: Type of `tf.keras.losses.Reduction` to apply to
-        loss. Default value is `AUTO`. `AUTO` indicates that the reduction
-        option will be determined by the usage context. For almost all cases
-        this defaults to `SUM_OVER_BATCH_SIZE`. When used under a
-        `tf.distribute.Strategy`, except via `Model.compile()` and
-        `Model.fit()`, using `AUTO` or `SUM_OVER_BATCH_SIZE`
-        will raise an error. Please see this custom training [tutorial](
-        https://www.tensorflow.org/tutorials/distribute/custom_training)
-        for more details.
-      name: Optional name for the instance.
-        Defaults to 'categorical_focal_crossentropy'.
+        alpha: A weight balancing factor for all classes, default is `0.25` as
+            mentioned in the reference. It can be a list of floats or a scalar.
+            In the multi-class case, alpha may be set by inverse class
+            frequency by using `compute_class_weight` from `sklearn.utils`.
+        gamma: A focusing parameter, default is `2.0` as mentioned in the
+            reference. It helps to gradually reduce the importance given to
+            simple (easy) examples in a smooth manner.
+        from_logits: Whether `output` is expected to be a logits tensor. By
+            default, we consider that `output` encodes a probability distribution.
+        label_smoothing: Float in [0, 1]. When > 0, label values are smoothed,
+            meaning the confidence on label values are relaxed. For example, if
+            `0.1`, use `0.1 / num_classes` for non-target labels and
+            `0.9 + 0.1 / num_classes` for target labels.
+        axis: The axis along which to compute crossentropy (the features
+            axis). Defaults to -1.
+        reduction: Type of `tf.keras.losses.Reduction` to apply to
+            loss. Default value is `AUTO`. `AUTO` indicates that the reduction
+            option will be determined by the usage context. For almost all cases
+            this defaults to `SUM_OVER_BATCH_SIZE`. When used under a
+            `tf.distribute.Strategy`, except via `Model.compile()` and
+            `Model.fit()`, using `AUTO` or `SUM_OVER_BATCH_SIZE`
+            will raise an error. Please see this custom training [tutorial](
+            https://www.tensorflow.org/tutorials/distribute/custom_training)
+            for more details.
+        name: Optional name for the instance.
+            Defaults to 'categorical_focal_crossentropy'.
     """
 
     def __init__(
@@ -2175,26 +2175,26 @@ def categorical_focal_crossentropy(
     array([2.63401289e-04, 6.75912094e-01], dtype=float32)
 
     Args:
-      y_true: Tensor of one-hot true targets.
-      y_pred: Tensor of predicted targets.
-      alpha: A weight balancing factor for all classes, default is `0.25` as
-        mentioned in the reference. It can be a list of floats or a scalar.
-        In the multi-class case, alpha may be set by inverse class frequency by
-        using `compute_class_weight` from `sklearn.utils`.
-      gamma: A focusing parameter, default is `2.0` as mentioned in the
-        reference. It helps to gradually reduce the importance given to
-        simple examples in a smooth manner. When `gamma` = 0, there is no focal
-        effect on the categorical crossentropy.
-      from_logits: Whether `y_pred` is expected to be a logits tensor. By
-        default, we assume that `y_pred` encodes a probability distribution.
-      label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
-        example, if `0.1`, use `0.1 / num_classes` for non-target labels
-        and `0.9 + 0.1 / num_classes` for target labels.
-      axis: Defaults to -1. The dimension along which the entropy is
-        computed.
+        y_true: Tensor of one-hot true targets.
+        y_pred: Tensor of predicted targets.
+        alpha: A weight balancing factor for all classes, default is `0.25` as
+            mentioned in the reference. It can be a list of floats or a scalar.
+            In the multi-class case, alpha may be set by inverse class frequency by
+            using `compute_class_weight` from `sklearn.utils`.
+        gamma: A focusing parameter, default is `2.0` as mentioned in the
+            reference. It helps to gradually reduce the importance given to
+            simple examples in a smooth manner. When `gamma` = 0, there is no focal
+            effect on the categorical crossentropy.
+        from_logits: Whether `y_pred` is expected to be a logits tensor. By
+            default, we assume that `y_pred` encodes a probability distribution.
+        label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
+            example, if `0.1`, use `0.1 / num_classes` for non-target labels
+            and `0.9 + 0.1 / num_classes` for target labels.
+        axis: Defaults to -1. The dimension along which the entropy is
+            computed.
 
     Returns:
-      Categorical focal crossentropy loss value.
+        Categorical focal crossentropy loss value.
     """
     if isinstance(axis, bool):
         raise ValueError(
@@ -2246,6 +2246,7 @@ def _ragged_tensor_categorical_focal_crossentropy(
     axis=-1,
 ):
     """Implements support for handling RaggedTensors.
+
     Expected shape: (batch, sequence_len, n_classes) with sequence_len
     being variable per batch.
     Return shape: (batch, sequence_len).
@@ -2256,21 +2257,21 @@ def _ragged_tensor_categorical_focal_crossentropy(
     the sum of the individual loss values divided by 3.
 
     Args:
-      alpha: A weight balancing factor for all classes, default is `0.25` as
-        mentioned in the reference. It can be a list of floats or a scalar.
-        In the multi-class case, alpha may be set by inverse class frequency by
-        using `compute_class_weight` from `sklearn.utils`.
-      gamma: A focusing parameter, default is `2.0` as mentioned in the
-        reference. It helps to gradually reduce the importance given to
-        simple examples in a smooth manner. When `gamma` = 0, there is no focal
-        effect on the categorical crossentropy.
-      from_logits: Whether `y_pred` is expected to be a logits tensor. By
-        default, we assume that `y_pred` encodes a probability distribution.
-      label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
-        example, if `0.1`, use `0.1 / num_classes` for non-target labels
-        and `0.9 + 0.1 / num_classes` for target labels.
-      axis: Defaults to -1. The dimension along which the entropy is
-        computed.
+        alpha: A weight balancing factor for all classes, default is `0.25` as
+            mentioned in the reference. It can be a list of floats or a scalar.
+            In the multi-class case, alpha may be set by inverse class frequency by
+            using `compute_class_weight` from `sklearn.utils`.
+        gamma: A focusing parameter, default is `2.0` as mentioned in the
+            reference. It helps to gradually reduce the importance given to
+            simple examples in a smooth manner. When `gamma` = 0, there is no focal
+            effect on the categorical crossentropy.
+        from_logits: Whether `y_pred` is expected to be a logits tensor. By
+            default, we assume that `y_pred` encodes a probability distribution.
+        label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
+            example, if `0.1`, use `0.1 / num_classes` for non-target labels
+            and `0.9 + 0.1 / num_classes` for target labels.
+        axis: Defaults to -1. The dimension along which the entropy is
+            computed.
 
     Returns:
       Categorical focal crossentropy loss value.

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -993,7 +993,8 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
             reference. It helps to gradually reduce the importance given to
             simple (easy) examples in a smooth manner.
         from_logits: Whether `output` is expected to be a logits tensor. By
-            default, we consider that `output` encodes a probability distribution.
+            default, we consider that `output` encodes a probability
+            distribution.
         label_smoothing: Float in [0, 1]. When > 0, label values are smoothed,
             meaning the confidence on label values are relaxed. For example, if
             `0.1`, use `0.1 / num_classes` for non-target labels and
@@ -2179,14 +2180,15 @@ def categorical_focal_crossentropy(
         y_pred: Tensor of predicted targets.
         alpha: A weight balancing factor for all classes, default is `0.25` as
             mentioned in the reference. It can be a list of floats or a scalar.
-            In the multi-class case, alpha may be set by inverse class frequency by
-            using `compute_class_weight` from `sklearn.utils`.
+            In the multi-class case, alpha may be set by inverse class
+            frequency by using `compute_class_weight` from `sklearn.utils`.
         gamma: A focusing parameter, default is `2.0` as mentioned in the
             reference. It helps to gradually reduce the importance given to
-            simple examples in a smooth manner. When `gamma` = 0, there is no focal
-            effect on the categorical crossentropy.
+            simple examples in a smooth manner. When `gamma` = 0, there is
+            no focal effect on the categorical crossentropy.
         from_logits: Whether `y_pred` is expected to be a logits tensor. By
-            default, we assume that `y_pred` encodes a probability distribution.
+            default, we assume that `y_pred` encodes a probability
+            distribution.
         label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
             example, if `0.1`, use `0.1 / num_classes` for non-target labels
             and `0.9 + 0.1 / num_classes` for target labels.
@@ -2259,12 +2261,12 @@ def _ragged_tensor_categorical_focal_crossentropy(
     Args:
         alpha: A weight balancing factor for all classes, default is `0.25` as
             mentioned in the reference. It can be a list of floats or a scalar.
-            In the multi-class case, alpha may be set by inverse class frequency by
-            using `compute_class_weight` from `sklearn.utils`.
+            In the multi-class case, alpha may be set by inverse class
+            frequency by using `compute_class_weight` from `sklearn.utils`.
         gamma: A focusing parameter, default is `2.0` as mentioned in the
             reference. It helps to gradually reduce the importance given to
-            simple examples in a smooth manner. When `gamma` = 0, there is no focal
-            effect on the categorical crossentropy.
+            simple examples in a smooth manner. When `gamma` = 0, there is
+            no focal effect on the categorical crossentropy.
         from_logits: Whether `y_pred` is expected to be a logits tensor. By
             default, we assume that `y_pred` encodes a probability distribution.
         label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -921,87 +921,89 @@ class CategoricalCrossentropy(LossFunctionWrapper):
             axis=axis,
         )
 
+
 @keras_export("keras.losses.CategoricalFocalCrossentropy")
 class CategoricalFocalCrossentropy(LossFunctionWrapper):
     """Computes the alpha balanced focal crossentropy loss between the labels and predictions.
-        According to [Lin et al., 2018](https://arxiv.org/pdf/1708.02002.pdf), it
-        helps to apply a focal factor to down-weight easy examples and focus more on
-        hard examples. By default, the focal tensor is computed as follows:
-        It has pt defined as:
-        pt = p, if y = 1 else 1 - p
-        The authors use alpha-balanced variant of focal loss in the paper:
-        FL(pt) = −α_t * (1 − pt)^gamma * log(pt)
-        Extending this to multi-class case is straightforward:
-        FL(pt) = α_t * (1 − pt)^gamma * CE, where minus comes from negative log-likelihood and included in CE.
-        `modulating_factor` is (1 − pt)^gamma,
-        where `gamma` is a focusing parameter. When `gamma` = 0, there is no focal
-        effect on the categorical crossentropy. And if alpha = 1, at the same time the loss is
-        equivalent to the categorical crossentropy.
-        In the snippet below, there is `# classes` floating pointing values per
-        example. The shape of both `y_pred` and `y_true` are
-        `[batch_size, num_classes]`.
-        Standalone usage:
-        >>> y_true = [[0., 1., 0.], [0., 0., 1.]]
-        >>> y_pred = [[0.05, 0.95, 0], [0.1, 0.8, 0.1]]
-        >>> # Using 'auto'/'sum_over_batch_size' reduction type.
-        >>> cce = tf.keras.losses.CategoricalFocalCrossentropy()
-        >>> cce(y_true, y_pred).numpy()
-        0.23315276
-        >>> # Calling with 'sample_weight'.
-        >>> cce(y_true, y_pred, sample_weight=tf.constant([0.3, 0.7])).numpy()
-        0.1632
-        >>> # Using 'sum' reduction type.
-        >>> cce = tf.keras.losses.CategoricalFocalCrossentropy(
-        ...     reduction=tf.keras.losses.Reduction.SUM)
-        >>> cce(y_true, y_pred).numpy()
-        0.46631
-        >>> # Using 'none' reduction type.
-        >>> cce = tf.keras.losses.CategoricalFocalCrossentropy(
-        ...     reduction=tf.keras.losses.Reduction.NONE)
-        >>> cce(y_true, y_pred).numpy()
-        array([3.2058331e-05, 4.6627346e-01], dtype=float32)
-        Usage with the `compile()` API:
-        ```python
-        model.compile(optimizer='sgd',
-                      loss=tf.keras.losses.CategoricalFocalCrossentropy())
-        ```
-        Args:
-          alpha: A weight balancing factor for all classes, default is `0.25` as
-                 mentioned in the reference. It can be a list of floats or a scalar.
-                 In the multi-class case, alpha may be set by inverse class frequency by
-                 using `compute_class_weight` from `sklearn.utils`.
-          gamma: A focusing parameter, default is `2.0` as mentioned in the
-                 reference. It helps to gradually reduce the importance given to
-                 simple (easy) examples in a smooth manner.
-          from_logits: Whether `output` is expected to be a logits tensor. By
-            default, we consider that `output` encodes a probability distribution.
-          label_smoothing: Float in [0, 1]. When > 0, label values are smoothed,
-            meaning the confidence on label values are relaxed. For example, if
-            `0.1`, use `0.1 / num_classes` for non-target labels and
-            `0.9 + 0.1 / num_classes` for target labels.
-          axis: The axis along which to compute crossentropy (the features
-            axis). Defaults to -1.
-          reduction: Type of `tf.keras.losses.Reduction` to apply to
-            loss. Default value is `AUTO`. `AUTO` indicates that the reduction
-            option will be determined by the usage context. For almost all cases
-            this defaults to `SUM_OVER_BATCH_SIZE`. When used under a
-            `tf.distribute.Strategy`, except via `Model.compile()` and
-            `Model.fit()`, using `AUTO` or `SUM_OVER_BATCH_SIZE`
-            will raise an error. Please see this custom training [tutorial](
-            https://www.tensorflow.org/tutorials/distribute/custom_training)
-            for more details.
-          name: Optional name for the instance.
-            Defaults to 'categorical_focal_crossentropy'.
-        """
+    According to [Lin et al., 2018](https://arxiv.org/pdf/1708.02002.pdf), it
+    helps to apply a focal factor to down-weight easy examples and focus more on
+    hard examples. By default, the focal tensor is computed as follows:
+    It has pt defined as:
+    pt = p, if y = 1 else 1 - p
+    The authors use alpha-balanced variant of focal loss in the paper:
+    FL(pt) = −α_t * (1 − pt)^gamma * log(pt)
+    Extending this to multi-class case is straightforward:
+    FL(pt) = α_t * (1 − pt)^gamma * CE, where minus comes from negative log-likelihood and included in CE.
+    `modulating_factor` is (1 − pt)^gamma,
+    where `gamma` is a focusing parameter. When `gamma` = 0, there is no focal
+    effect on the categorical crossentropy. And if alpha = 1, at the same time the loss is
+    equivalent to the categorical crossentropy.
+    In the snippet below, there is `# classes` floating pointing values per
+    example. The shape of both `y_pred` and `y_true` are
+    `[batch_size, num_classes]`.
+    Standalone usage:
+    >>> y_true = [[0., 1., 0.], [0., 0., 1.]]
+    >>> y_pred = [[0.05, 0.95, 0], [0.1, 0.8, 0.1]]
+    >>> # Using 'auto'/'sum_over_batch_size' reduction type.
+    >>> cce = tf.keras.losses.CategoricalFocalCrossentropy()
+    >>> cce(y_true, y_pred).numpy()
+    0.23315276
+    >>> # Calling with 'sample_weight'.
+    >>> cce(y_true, y_pred, sample_weight=tf.constant([0.3, 0.7])).numpy()
+    0.1632
+    >>> # Using 'sum' reduction type.
+    >>> cce = tf.keras.losses.CategoricalFocalCrossentropy(
+    ...     reduction=tf.keras.losses.Reduction.SUM)
+    >>> cce(y_true, y_pred).numpy()
+    0.46631
+    >>> # Using 'none' reduction type.
+    >>> cce = tf.keras.losses.CategoricalFocalCrossentropy(
+    ...     reduction=tf.keras.losses.Reduction.NONE)
+    >>> cce(y_true, y_pred).numpy()
+    array([3.2058331e-05, 4.6627346e-01], dtype=float32)
+    Usage with the `compile()` API:
+    ```python
+    model.compile(optimizer='sgd',
+                  loss=tf.keras.losses.CategoricalFocalCrossentropy())
+    ```
+    Args:
+      alpha: A weight balancing factor for all classes, default is `0.25` as
+             mentioned in the reference. It can be a list of floats or a scalar.
+             In the multi-class case, alpha may be set by inverse class frequency by
+             using `compute_class_weight` from `sklearn.utils`.
+      gamma: A focusing parameter, default is `2.0` as mentioned in the
+             reference. It helps to gradually reduce the importance given to
+             simple (easy) examples in a smooth manner.
+      from_logits: Whether `output` is expected to be a logits tensor. By
+        default, we consider that `output` encodes a probability distribution.
+      label_smoothing: Float in [0, 1]. When > 0, label values are smoothed,
+        meaning the confidence on label values are relaxed. For example, if
+        `0.1`, use `0.1 / num_classes` for non-target labels and
+        `0.9 + 0.1 / num_classes` for target labels.
+      axis: The axis along which to compute crossentropy (the features
+        axis). Defaults to -1.
+      reduction: Type of `tf.keras.losses.Reduction` to apply to
+        loss. Default value is `AUTO`. `AUTO` indicates that the reduction
+        option will be determined by the usage context. For almost all cases
+        this defaults to `SUM_OVER_BATCH_SIZE`. When used under a
+        `tf.distribute.Strategy`, except via `Model.compile()` and
+        `Model.fit()`, using `AUTO` or `SUM_OVER_BATCH_SIZE`
+        will raise an error. Please see this custom training [tutorial](
+        https://www.tensorflow.org/tutorials/distribute/custom_training)
+        for more details.
+      name: Optional name for the instance.
+        Defaults to 'categorical_focal_crossentropy'.
+    """
+
     def __init__(
-            self,
-            alpha=0.25,
-            gamma=2.0,
-            from_logits=False,
-            label_smoothing=0.0,
-            axis=-1,
-            reduction=losses_utils.ReductionV2.AUTO,
-            name="categorical_focal_crossentropy",
+        self,
+        alpha=0.25,
+        gamma=2.0,
+        from_logits=False,
+        label_smoothing=0.0,
+        axis=-1,
+        reduction=losses_utils.ReductionV2.AUTO,
+        name="categorical_focal_crossentropy",
     ):
         """Initializes `CategoricalFocalCrossentropy` instance."""
         super().__init__(
@@ -1025,6 +1027,7 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
 
 @keras_export("keras.losses.SparseCategoricalCrossentropy")
 class SparseCategoricalCrossentropy(LossFunctionWrapper):
@@ -2135,43 +2138,43 @@ def _ragged_tensor_categorical_crossentropy(
 )
 @tf.__internal__.dispatch.add_dispatch_support
 def categorical_focal_crossentropy(
-        y_true,
-        y_pred,
-        alpha=0.25,
-        gamma=2.0,
-        from_logits=False,
-        label_smoothing=0.0,
-        axis=-1,
+    y_true,
+    y_pred,
+    alpha=0.25,
+    gamma=2.0,
+    from_logits=False,
+    label_smoothing=0.0,
+    axis=-1,
 ):
     """Computes the categorical focal crossentropy loss.
-        Standalone usage:
-        >>> y_true = [[0, 1, 0], [0, 0, 1]]
-        >>> y_pred = [[0.05, 0.9, 0.05], [0.1, 0.85, 0.05]]
-        >>> loss = tf.keras.losses.categorical_focal_crossentropy(y_true, y_pred)
-        >>> assert loss.shape == (2,)
-        >>> loss.numpy()
-        array([2.63401289e-04, 6.75912094e-01], dtype=float32)
-        Args:
-          y_true: Tensor of one-hot true targets.
-          y_pred: Tensor of predicted targets.
-          alpha: A weight balancing factor for all classes, default is `0.25` as
-             mentioned in the reference. It can be a list of floats or a scalar.
-             In the multi-class case, alpha may be set by inverse class frequency by
-             using `compute_class_weight` from `sklearn.utils`.
-          gamma: A focusing parameter, default is `2.0` as mentioned in the
-             reference. It helps to gradually reduce the importance given to
-             simple examples in a smooth manner. When `gamma` = 0, there is no focal
-             effect on the categorical crossentropy.
-          from_logits: Whether `y_pred` is expected to be a logits tensor. By
-            default, we assume that `y_pred` encodes a probability distribution.
-          label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
-            example, if `0.1`, use `0.1 / num_classes` for non-target labels
-            and `0.9 + 0.1 / num_classes` for target labels.
-          axis: Defaults to -1. The dimension along which the entropy is
-            computed.
-        Returns:
-          Categorical focal crossentropy loss value.
-        """
+    Standalone usage:
+    >>> y_true = [[0, 1, 0], [0, 0, 1]]
+    >>> y_pred = [[0.05, 0.9, 0.05], [0.1, 0.85, 0.05]]
+    >>> loss = tf.keras.losses.categorical_focal_crossentropy(y_true, y_pred)
+    >>> assert loss.shape == (2,)
+    >>> loss.numpy()
+    array([2.63401289e-04, 6.75912094e-01], dtype=float32)
+    Args:
+      y_true: Tensor of one-hot true targets.
+      y_pred: Tensor of predicted targets.
+      alpha: A weight balancing factor for all classes, default is `0.25` as
+         mentioned in the reference. It can be a list of floats or a scalar.
+         In the multi-class case, alpha may be set by inverse class frequency by
+         using `compute_class_weight` from `sklearn.utils`.
+      gamma: A focusing parameter, default is `2.0` as mentioned in the
+         reference. It helps to gradually reduce the importance given to
+         simple examples in a smooth manner. When `gamma` = 0, there is no focal
+         effect on the categorical crossentropy.
+      from_logits: Whether `y_pred` is expected to be a logits tensor. By
+        default, we assume that `y_pred` encodes a probability distribution.
+      label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
+        example, if `0.1`, use `0.1 / num_classes` for non-target labels
+        and `0.9 + 0.1 / num_classes` for target labels.
+      axis: Defaults to -1. The dimension along which the entropy is
+        computed.
+    Returns:
+      Categorical focal crossentropy loss value.
+    """
     if isinstance(axis, bool):
         raise ValueError(
             "`axis` must be of type `int`. "
@@ -2194,7 +2197,7 @@ def categorical_focal_crossentropy(
     def _smooth_labels():
         num_classes = tf.cast(tf.shape(y_true)[-1], y_pred.dtype)
         return y_true * (1.0 - label_smoothing) + (
-                label_smoothing / num_classes
+            label_smoothing / num_classes
         )
 
     y_true = tf.__internal__.smart_cond.smart_cond(
@@ -2202,12 +2205,14 @@ def categorical_focal_crossentropy(
     )
 
     return backend.categorical_focal_crossentropy(
-            target=y_true,
-            output=y_pred,
-            alpha=alpha,
-            gamma=gamma,
-            from_logits=from_logits,
-            axis=axis, )
+        target=y_true,
+        output=y_pred,
+        alpha=alpha,
+        gamma=gamma,
+        from_logits=from_logits,
+        axis=axis,
+    )
+
 
 @dispatch.dispatch_for_types(categorical_focal_crossentropy, tf.RaggedTensor)
 def _ragged_tensor_categorical_focal_crossentropy(
@@ -2220,32 +2225,32 @@ def _ragged_tensor_categorical_focal_crossentropy(
     axis=-1,
 ):
     """Implements support for handling RaggedTensors.
-        Expected shape: (batch, sequence_len, n_classes) with sequence_len
-        being variable per batch.
-        Return shape: (batch, sequence_len).
-        When used by CategoricalFocalCrossentropy() with the default reduction
-        (SUM_OVER_BATCH_SIZE), the reduction averages the loss over the
-        number of elements independent of the batch. E.g. if the RaggedTensor
-        has 2 batches with [2, 1] values respectively the resulting loss is
-        the sum of the individual loss values divided by 3.
-        alpha: A weight balancing factor for all classes, default is `0.25` as
-             mentioned in the reference. It can be a list of floats or a scalar.
-             In the multi-class case, alpha may be set by inverse class frequency by
-             using `compute_class_weight` from `sklearn.utils`.
-        gamma: A focusing parameter, default is `2.0` as mentioned in the
-             reference. It helps to gradually reduce the importance given to
-             simple examples in a smooth manner. When `gamma` = 0, there is no focal
-             effect on the categorical crossentropy.
-        from_logits: Whether `y_pred` is expected to be a logits tensor. By
-            default, we assume that `y_pred` encodes a probability distribution.
-        label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
-            example, if `0.1`, use `0.1 / num_classes` for non-target labels
-            and `0.9 + 0.1 / num_classes` for target labels.
-        axis: Defaults to -1. The dimension along which the entropy is
-            computed.
-        Returns:
-          Categorical focal crossentropy loss value.
-        """
+    Expected shape: (batch, sequence_len, n_classes) with sequence_len
+    being variable per batch.
+    Return shape: (batch, sequence_len).
+    When used by CategoricalFocalCrossentropy() with the default reduction
+    (SUM_OVER_BATCH_SIZE), the reduction averages the loss over the
+    number of elements independent of the batch. E.g. if the RaggedTensor
+    has 2 batches with [2, 1] values respectively the resulting loss is
+    the sum of the individual loss values divided by 3.
+    alpha: A weight balancing factor for all classes, default is `0.25` as
+         mentioned in the reference. It can be a list of floats or a scalar.
+         In the multi-class case, alpha may be set by inverse class frequency by
+         using `compute_class_weight` from `sklearn.utils`.
+    gamma: A focusing parameter, default is `2.0` as mentioned in the
+         reference. It helps to gradually reduce the importance given to
+         simple examples in a smooth manner. When `gamma` = 0, there is no focal
+         effect on the categorical crossentropy.
+    from_logits: Whether `y_pred` is expected to be a logits tensor. By
+        default, we assume that `y_pred` encodes a probability distribution.
+    label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
+        example, if `0.1`, use `0.1 / num_classes` for non-target labels
+        and `0.9 + 0.1 / num_classes` for target labels.
+    axis: Defaults to -1. The dimension along which the entropy is
+        computed.
+    Returns:
+      Categorical focal crossentropy loss value.
+    """
     fn = functools.partial(
         categorical_focal_crossentropy,
         alpha=alpha,
@@ -2255,6 +2260,7 @@ def _ragged_tensor_categorical_focal_crossentropy(
         axis=axis,
     )
     return _ragged_tensor_apply_loss(fn, y_true, y_pred)
+
 
 @keras_export(
     "keras.metrics.sparse_categorical_crossentropy",

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -2111,6 +2111,26 @@ def categorical_focal_crossentropy(
             from_logits=from_logits,
             axis=axis, )
 
+@dispatch.dispatch_for_types(categorical_focal_crossentropy, tf.RaggedTensor)
+def _ragged_tensor_categorical_focal_crossentropy(
+    y_true,
+    y_pred,
+    alpha=0.25,
+    gamma=2.0,
+    from_logits=False,
+    label_smoothing=0.0,
+    axis=-1,
+):
+    fn = functools.partial(
+        categorical_focal_crossentropy,
+        alpha=alpha,
+        gamma=gamma,
+        from_logits=from_logits,
+        label_smoothing=label_smoothing,
+        axis=axis,
+    )
+    return _ragged_tensor_apply_loss(fn, y_true, y_pred)
+
 @keras_export(
     "keras.metrics.sparse_categorical_crossentropy",
     "keras.losses.sparse_categorical_crossentropy",

--- a/keras/losses_test.py
+++ b/keras/losses_test.py
@@ -1809,6 +1809,199 @@ class CategoricalCrossentropyTest(tf.test.TestCase):
                 str(w[-1].message),
             )
 
+@test_combinations.generate(test_combinations.combine(mode=["graph", "eager"]))
+class CategoricalFocalCrossentropyTest(tf.test.TestCase):
+    def test_config(self):
+
+        cce_obj = losses.CategoricalFocalCrossentropy(name="focal_cce",
+                                                      reduction=losses_utils.ReductionV2.SUM,
+                                                      alpha=0.25,
+                                                      gamma=2.0)
+        self.assertEqual(cce_obj.name, "focal_cce")
+        self.assertEqual(cce_obj.reduction, losses_utils.ReductionV2.SUM)
+        self.assertEqual(cce_obj.alpha, 0.25)
+        self.assertEqual(cce_obj.gamma, 2.0)
+
+        # Test alpha as a list
+        cce_obj = losses.CategoricalFocalCrossentropy(alpha=[0.25, 0.5, 0.75])
+        self.assertEqual(cce_obj.alpha, [0.25, 0.5, 0.75])
+
+    def test_all_correct_unweighted(self):
+        y_true = tf.constant([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=tf.int64)
+        y_pred = tf.constant(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            dtype=tf.float32,
+        )
+        cce_obj = losses.CategoricalFocalCrossentropy(alpha=0.25, gamma=2.0)
+        loss = cce_obj(y_true, y_pred)
+        self.assertAlmostEqual(self.evaluate(loss), 0.0, 3)
+
+        # Test with logits.
+        logits = tf.constant(
+            [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]
+        )
+        cce_obj = losses.CategoricalFocalCrossentropy(from_logits=True)
+        loss = cce_obj(y_true, logits)
+        self.assertAlmostEqual(self.evaluate(loss), 0.0, 3)
+
+    def test_unweighted(self):
+        cce_obj = losses.CategoricalFocalCrossentropy()
+        y_true = tf.constant([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        y_pred = tf.constant(
+            [[0.9, 0.05, 0.05], [0.5, 0.89, 0.6], [0.05, 0.01, 0.94]],
+            dtype=tf.float32,
+        )
+        loss = cce_obj(y_true, y_pred)
+        self.assertAlmostEqual(self.evaluate(loss), 0.02059, 3)
+
+        # Test with logits.
+        logits = tf.constant(
+            [[8.0, 1.0, 1.0], [0.0, 9.0, 1.0], [2.0, 3.0, 5.0]]
+        )
+        cce_obj = losses.CategoricalFocalCrossentropy(from_logits=True)
+        loss = cce_obj(y_true, logits)
+        self.assertAlmostEqual(self.evaluate(loss), 0.000345, 3)
+
+    def test_scalar_weighted(self):
+        cce_obj = losses.CategoricalFocalCrossentropy()
+        y_true = tf.constant([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        y_pred = tf.constant(
+            [[0.9, 0.05, 0.05], [0.5, 0.89, 0.6], [0.05, 0.01, 0.94]],
+            dtype=tf.float32,
+        )
+        loss = cce_obj(y_true, y_pred, sample_weight=2.3)
+        self.assertAlmostEqual(self.evaluate(loss), 0.047368, 3)
+
+        # Test with logits.
+        logits = tf.constant(
+            [[8.0, 1.0, 1.0], [0.0, 9.0, 1.0], [2.0, 3.0, 5.0]]
+        )
+        cce_obj = losses.CategoricalFocalCrossentropy(from_logits=True)
+        loss = cce_obj(y_true, logits, sample_weight=2.3)
+        self.assertAlmostEqual(self.evaluate(loss), 0.000794, 4)
+
+    def test_sample_weighted(self):
+        cce_obj = losses.CategoricalFocalCrossentropy()
+        y_true = tf.constant([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        y_pred = tf.constant(
+            [[0.9, 0.05, 0.05], [0.5, 0.89, 0.6], [0.05, 0.01, 0.94]],
+            dtype=tf.float32,
+        )
+        sample_weight = tf.constant([[1.2], [3.4], [5.6]], shape=(3, 1))
+        loss = cce_obj(y_true, y_pred, sample_weight=sample_weight)
+        self.assertAlmostEqual(self.evaluate(loss), 0.06987, 3)
+
+        # Test with logits.
+        logits = tf.constant(
+            [[8.0, 1.0, 1.0], [0.0, 9.0, 1.0], [2.0, 3.0, 5.0]]
+        )
+        cce_obj = losses.CategoricalFocalCrossentropy(from_logits=True)
+        loss = cce_obj(y_true, logits, sample_weight=sample_weight)
+        self.assertAlmostEqual(self.evaluate(loss), 0.001933, 3)
+
+    def test_no_reduction(self):
+        y_true = tf.constant([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        logits = tf.constant(
+            [[8.0, 1.0, 1.0], [0.0, 9.0, 1.0], [2.0, 3.0, 5.0]]
+        )
+        cce_obj = losses.CategoricalFocalCrossentropy(
+            from_logits=True, reduction=losses_utils.ReductionV2.NONE
+        )
+        loss = cce_obj(y_true, logits)
+        self.assertAllClose(
+            (1.5096224e-09, 2.4136547e-11, 1.0360638e-03), self.evaluate(loss), 3
+        )
+
+    def test_label_smoothing(self):
+        logits = tf.constant([[4.9, -0.5, 2.05]])
+        y_true = tf.constant([[1, 0, 0]])
+        label_smoothing = 0.1
+
+        cce_obj = losses.CategoricalFocalCrossentropy(
+            from_logits=True, label_smoothing=label_smoothing)
+        loss = cce_obj(y_true, logits)
+
+        expected_value = 0.06685
+        self.assertAlmostEqual(self.evaluate(loss), expected_value, 3)
+
+    def test_label_smoothing_ndarray(self):
+        logits = np.asarray([[4.9, -0.5, 2.05]])
+        y_true = np.asarray([[1, 0, 0]])
+        label_smoothing = 0.1
+
+        cce_obj = losses.CategoricalFocalCrossentropy(
+            from_logits=True, label_smoothing=label_smoothing)
+        loss = cce_obj(y_true, logits)
+
+        expected_value = 0.06685
+        self.assertAlmostEqual(self.evaluate(loss), expected_value, 3)
+
+    def test_shape_mismatch(self):
+        y_true = tf.constant([[0], [1], [2]])
+        y_pred = tf.constant(
+            [[0.9, 0.05, 0.05], [0.5, 0.89, 0.6], [0.05, 0.01, 0.94]]
+        )
+
+        cce_obj = losses.CategoricalFocalCrossentropy()
+        with self.assertRaisesRegex(ValueError, "Shapes .+ are incompatible"):
+            cce_obj(y_true, y_pred)
+
+    def test_ragged_tensors(self):
+        cce_obj = losses.CategoricalFocalCrossentropy()
+        y_true = tf.ragged.constant([[[1, 0, 0], [0, 1, 0]], [[0, 0, 1]]])
+        y_pred = tf.ragged.constant(
+            [[[0.9, 0.05, 0.05], [0.5, 0.89, 0.6]], [[0.05, 0.01, 0.94]]],
+            dtype=tf.float32,
+        )
+        # batch losses [[0.1054, 0.8047], [0.0619]]
+        sample_weight = tf.constant([[1.2], [3.4]], shape=(2, 1))
+        loss = cce_obj(y_true, y_pred, sample_weight=sample_weight)
+
+        self.assertAlmostEqual(self.evaluate(loss), 0.024754, 3)
+
+        # Test with logits.
+        logits = tf.ragged.constant(
+            [[[8.0, 1.0, 1.0], [0.0, 9.0, 1.0]], [[2.0, 3.0, 5.0]]]
+        )
+        cce_obj = losses.CategoricalFocalCrossentropy(from_logits=True)
+
+        loss = cce_obj(y_true, logits, sample_weight=sample_weight)
+        self.assertAlmostEqual(self.evaluate(loss), 0.00117, 3)
+
+    def test_ragged_tensors_ragged_sample_weights(self):
+        cce_obj = losses.CategoricalFocalCrossentropy()
+        y_true = tf.ragged.constant([[[1, 0, 0], [0, 1, 0]], [[0, 0, 1]]])
+        y_pred = tf.ragged.constant(
+            [[[0.9, 0.05, 0.05], [0.05, 0.89, 0.06]], [[0.05, 0.01, 0.94]]],
+            dtype=tf.float32,
+        )
+        sample_weight = tf.ragged.constant(
+            [[1.2, 3.4], [5.6]], dtype=tf.float32
+        )
+        loss = cce_obj(y_true, y_pred, sample_weight=sample_weight)
+        self.assertAlmostEqual(self.evaluate(loss), 0.0006088, 4)
+
+        # Test with logits.
+        logits = tf.ragged.constant(
+            [[[8.0, 1.0, 1.0], [0.0, 9.0, 1.0]], [[2.0, 3.0, 5.0]]]
+        )
+        cce_obj = losses.CategoricalFocalCrossentropy(from_logits=True)
+
+        loss = cce_obj(y_true, logits, sample_weight=sample_weight)
+        self.assertAlmostEqual(self.evaluate(loss), 0.001933, 3)
+
+    def test_binary_labels(self):
+        # raise a warning if the shape of y_true and y_pred are all (None, 1).
+        # categorical_crossentropy shouldn't be used with binary labels.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cce_obj = losses.CategoricalFocalCrossentropy()
+            cce_obj(tf.constant([[1.0], [0.0]]), tf.constant([[1.0], [1.0]]))
+            self.assertIs(w[-1].category, SyntaxWarning)
+            self.assertIn(
+                "In loss categorical_focal_crossentropy, expected ",
+                str(w[-1].message),
+            )
 
 @test_combinations.generate(test_combinations.combine(mode=["graph", "eager"]))
 class SparseCategoricalCrossentropyTest(tf.test.TestCase):

--- a/keras/losses_test.py
+++ b/keras/losses_test.py
@@ -1809,14 +1809,17 @@ class CategoricalCrossentropyTest(tf.test.TestCase):
                 str(w[-1].message),
             )
 
+
 @test_combinations.generate(test_combinations.combine(mode=["graph", "eager"]))
 class CategoricalFocalCrossentropyTest(tf.test.TestCase):
     def test_config(self):
 
-        cce_obj = losses.CategoricalFocalCrossentropy(name="focal_cce",
-                                                      reduction=losses_utils.ReductionV2.SUM,
-                                                      alpha=0.25,
-                                                      gamma=2.0)
+        cce_obj = losses.CategoricalFocalCrossentropy(
+            name="focal_cce",
+            reduction=losses_utils.ReductionV2.SUM,
+            alpha=0.25,
+            gamma=2.0,
+        )
         self.assertEqual(cce_obj.name, "focal_cce")
         self.assertEqual(cce_obj.reduction, losses_utils.ReductionV2.SUM)
         self.assertEqual(cce_obj.alpha, 0.25)
@@ -1909,7 +1912,9 @@ class CategoricalFocalCrossentropyTest(tf.test.TestCase):
         )
         loss = cce_obj(y_true, logits)
         self.assertAllClose(
-            (1.5096224e-09, 2.4136547e-11, 1.0360638e-03), self.evaluate(loss), 3
+            (1.5096224e-09, 2.4136547e-11, 1.0360638e-03),
+            self.evaluate(loss),
+            3,
         )
 
     def test_label_smoothing(self):
@@ -1918,7 +1923,8 @@ class CategoricalFocalCrossentropyTest(tf.test.TestCase):
         label_smoothing = 0.1
 
         cce_obj = losses.CategoricalFocalCrossentropy(
-            from_logits=True, label_smoothing=label_smoothing)
+            from_logits=True, label_smoothing=label_smoothing
+        )
         loss = cce_obj(y_true, logits)
 
         expected_value = 0.06685
@@ -1930,7 +1936,8 @@ class CategoricalFocalCrossentropyTest(tf.test.TestCase):
         label_smoothing = 0.1
 
         cce_obj = losses.CategoricalFocalCrossentropy(
-            from_logits=True, label_smoothing=label_smoothing)
+            from_logits=True, label_smoothing=label_smoothing
+        )
         loss = cce_obj(y_true, logits)
 
         expected_value = 0.06685
@@ -2002,6 +2009,7 @@ class CategoricalFocalCrossentropyTest(tf.test.TestCase):
                 "In loss categorical_focal_crossentropy, expected ",
                 str(w[-1].message),
             )
+
 
 @test_combinations.generate(test_combinations.combine(mode=["graph", "eager"]))
 class SparseCategoricalCrossentropyTest(tf.test.TestCase):


### PR DESCRIPTION
Implements the `CategoricalFocalCrossentropy()` loss based on the paper [Focal Loss for Dense Object Detection](https://arxiv.org/pdf/1708.02002.pdf) (Lin et al., 2018).

Feature request was made in #17583.