### PR TITLE
Correct the docstring of Head func in convnext.py

### DIFF
--- a/keras/applications/convnext.py
+++ b/keras/applications/convnext.py
@@ -328,7 +328,7 @@ def PreStem(name=None):
 
 
 def Head(num_classes=1000, classifier_activation=None, name=None):
-    """Implementation of classification head of RegNet.
+    """Implementation of classification head of ConvNeXt.
 
     Args:
       num_classes: number of classes for Dense layer
@@ -336,7 +336,7 @@ def Head(num_classes=1000, classifier_activation=None, name=None):
       name: name prefix
 
     Returns:
-      Classification head function.
+      Tensor of logits or softmax values as the output.
     """
     if name is None:
         name = str(backend.get_uid("head"))

--- a/keras/applications/convnext.py
+++ b/keras/applications/convnext.py
@@ -336,7 +336,7 @@ def Head(num_classes=1000, classifier_activation=None, name=None):
       name: name prefix
 
     Returns:
-      Tensor of logits or softmax values as the output.
+      Classification head function.
     """
     if name is None:
         name = str(backend.get_uid("head"))

--- a/keras/applications/regnet.py
+++ b/keras/applications/regnet.py
@@ -841,7 +841,7 @@ def Head(num_classes=1000, name=None):
       name: name prefix
 
     Returns:
-      Output logits tensor.
+      Classification head function.
     """
     if name is None:
         name = str(backend.get_uid("head"))


### PR DESCRIPTION
Small fixes on `def Head()` function's docstring as it was a copy from `RegNet`.