### PR TITLE
Typo Lion docstring

### DIFF
--- a/keras/optimizers/lion.py
+++ b/keras/optimizers/lion.py
@@ -30,7 +30,7 @@ class Lion(optimizer.Optimizer):
 
     The Lion optimizer is a stochastic-gradient-descent method that uses the
     sign operator to control the magnitude of the update, unlike other adaptive
-    optimizers such as Adam that also rely on second-order moments. This make
+    optimizers such as Adam that rely on second-order moments. This make
     Lion more memory-efficient as it only keeps track of the momentum. According
     to the authors (see reference), its performance gain over Adam grows with
     the batch size. Because the update of Lion is produced through the sign
@@ -50,7 +50,7 @@ class Lion(optimizer.Optimizer):
       beta_2: A float value or a constant float tensor, or a callable
         that takes no arguments and returns the actual value to use. The
         exponential decay rate for the 1st moment estimate.
-    {{base_optimizer_keyword_args}}
+      {{base_optimizer_keyword_args}}
 
     References:
       - [Chen et al., 2023](http://arxiv.org/abs/2302.06675)


### PR DESCRIPTION
The docstring is not rendered well on the tensorflow api reference :
![image](https://user-images.githubusercontent.com/6018889/227682130-ba8c17a2-c674-47fb-ae75-b8ae5710734b.png)
