### PR TITLE
Fix loss object name inference

### DIFF
--- a/keras/engine/compile_utils.py
+++ b/keras/engine/compile_utils.py
@@ -858,7 +858,7 @@ def get_custom_object_name(obj):
     Returns:
       Name to use, or `None` if the object was not recognized.
     """
-    if hasattr(obj, "name"):  # Accept `Loss` instance as `Metric`.
+    if hasattr(obj, "name") and obj.name is not None:  # Accept `Loss` instance as `Metric`.
         return obj.name
     elif hasattr(obj, "__name__"):  # Function.
         return obj.__name__

--- a/keras/engine/compile_utils.py
+++ b/keras/engine/compile_utils.py
@@ -353,8 +353,10 @@ class LossesContainer(Container):
         loss = losses_mod.get(loss)
         if not isinstance(loss, losses_mod.Loss):
             loss_name = get_custom_object_name(loss)
-            if loss_name is None:
+            if not callable(loss):
                 raise ValueError(f"Loss should be a callable, received: {loss}")
+            if loss_name is None:
+                raise ValueError(f"Could not infer a loss name for {loss}")
             loss = losses_mod.LossFunctionWrapper(loss, name=loss_name)
         loss._allow_sum_over_batch_size = True
         return loss


### PR DESCRIPTION
A callable loss object `obj` with `obj.name == None` would trigger a misleading exception, telling that the loss object is not callable.