### PR TITLE
Fixed typo in optimizer error

### DIFF
--- a/keras/optimizers/optimizer.py
+++ b/keras/optimizers/optimizer.py
@@ -133,7 +133,7 @@ class _BaseOptimizer(tf.__internal__.tracking.AutoTrackable):
         for k in kwargs:
             if k in legacy_kwargs:
                 raise ValueError(
-                    f"{k} is deprecated in the new Keras optimizer, please"
+                    f"{k} is deprecated in the new Keras optimizer, please "
                     "check the docstring for valid arguments, or use the "
                     "legacy optimizer, e.g., "
                     f"tf.keras.optimizers.legacy.{self.__class__.__name__}."


### PR DESCRIPTION
Hi,

I tried using the decay in Adam, and got the error:

"ValueError: decay is deprecated in the new Keras optimizer, pleasecheck the docstring for valid arguments, or use the legacy optimizer, e.g., tf.keras.optimizers.legacy.Adam."

There was a missing space between "please" and "check", this commit fixes this.