### PR TITLE
Check differentiability of custom loss function before training

### DIFF
--- a/keras/engine/compile_utils.py
+++ b/keras/engine/compile_utils.py
@@ -866,9 +866,9 @@ def get_custom_object_name(obj):
         return None
 
 
-def verify_object_differentiability(custom_obj,
-                                    expected_shapes,
-                                    is_layer=False):
+def verify_object_differentiability(
+    custom_obj, expected_shapes, is_layer=False
+):
     """Verifies if a given object is differentiable.
 
     Args:
@@ -880,9 +880,9 @@ def verify_object_differentiability(custom_obj,
         ValueError: If the custom object is not differentiable.
     """
 
-    if not _verify_object_differentiability(custom_obj,
-                                            expected_shapes,
-                                            is_layer=is_layer):
+    if not _verify_object_differentiability(
+        custom_obj, expected_shapes, is_layer=is_layer
+    ):
         raise ValueError(
             f"The provided loss or layer ({custom_obj}) is not differentiable. "
             "Training requires differentiable objects. Please review your "
@@ -893,9 +893,9 @@ def verify_object_differentiability(custom_obj,
         )
 
 
-def _verify_object_differentiability(custom_obj,
-                                     expected_shapes=None,
-                                     is_layer=False):
+def _verify_object_differentiability(
+    custom_obj, expected_shapes=None, is_layer=False
+):
     """Verifies if the loss is differentiable.
 
     Args:
@@ -947,7 +947,7 @@ def _verify_object_differentiability(custom_obj,
 
 def _check_object_with_shapes(custom_obj, expected_shape, is_layer=False):
     """Evaluates the custom_obj for the given shapes using `tf.GradientTape`."""
-    # print(custom_obj)
+
     # Replace None batch dimension with 1.
     expected_shape = tuple(1 if dim is None else dim for dim in expected_shape)
 
@@ -983,7 +983,7 @@ def _check_object_with_shapes(custom_obj, expected_shape, is_layer=False):
     gradients = tape.gradient(output_value, predictions)
 
     if gradients is None:
-        # If gradients is None, then the loss is not differentiable.
+        # If `gradients` is None, then the loss is not differentiable.
         return False
 
     return True

--- a/keras/engine/compile_utils.py
+++ b/keras/engine/compile_utils.py
@@ -915,8 +915,9 @@ def _verify_object_differentiability(custom_obj, expected_shapes=None):
             shape_generator = generate_shape_tuples(1, num_dims)
             for shapes in shape_generator:
                 try:
-                    differentiable = _check_object_with_shapes(custom_obj,
-                                                               shapes)
+                    differentiable = _check_object_with_shapes(
+                        custom_obj, shapes
+                    )
                     if differentiable:
                         return True
                     else:

--- a/keras/engine/compile_utils.py
+++ b/keras/engine/compile_utils.py
@@ -879,10 +879,12 @@ def verify_loss_differentiability(loss, expected_shapes):
 
     if not _verify_loss_differentiability(loss, expected_shapes):
         raise ValueError(
-            f"Provided loss function is not differentiable. If you think "
-            "this error is raised due to a bug in Keras, please pass "
-            f"experimental_check_loss_differentiability=False in "
-            f"model.compile().\nReceived Loss: {loss}"
+            f"The provided loss function ({loss}) is not differentiable. "
+            "Training requires a differentiable loss function. Please review "
+            "your loss function or consider using a standard differentiable "
+            "loss function. You can disable the differentiability check by "
+            "setting 'experimental_check_loss_differentiability=False' in "
+            "'model.compile()'."
         )
 
 

--- a/keras/engine/compile_utils.py
+++ b/keras/engine/compile_utils.py
@@ -868,21 +868,22 @@ def get_custom_object_name(obj):
 
 def verify_loss_differentiability(loss, expected_shapes):
     """Verifies if the loss is differentiable.
-    
-        Args:
-            loss: Can be a plain function or a class instance.
-            expected_shapes: A tuple containing the shapes for the inputs to the
-                loss.
-        Raises:
-            ValueError: If the loss is not differentiable.
-        """
+
+    Args:
+        loss: Can be a plain function or a class instance.
+        expected_shapes: A tuple containing the shapes for the inputs to the
+            loss.
+    Raises:
+        ValueError: If the loss is not differentiable.
+    """
 
     if not _verify_loss_differentiability(loss, expected_shapes):
         raise ValueError(
-            f"Provided loss function is not differentiable. If you think " 
+            f"Provided loss function is not differentiable. If you think "
             "this error is raised due to a bug in Keras, please pass "
             f"experimental_check_loss_differentiability=False in "
-            f"model.compile().\nReceived Loss: {loss}")
+            f"model.compile().\nReceived Loss: {loss}"
+        )
 
 
 def _verify_loss_differentiability(loss, expected_shapes=None):
@@ -895,6 +896,7 @@ def _verify_loss_differentiability(loss, expected_shapes=None):
     Returns:
         A boolean indicating whether the loss is differentiable.
     """
+
     def generate_shape_tuples(dim, num_dims):
         for i in range(num_dims - 1):
             yield (1,) * (i + 1) + (dim,)
@@ -917,7 +919,7 @@ def _verify_loss_differentiability(loss, expected_shapes=None):
                     else:
                         continue_checking = False
                         break  # Stop the inner loop when diff is False
-                except Exception as e:
+                except Exception:
                     # if there is an issue with the loss, we
                     # continue to the next shape.
                     continue
@@ -932,14 +934,12 @@ def _check_loss_with_shapes(loss, expected_shape):
     # Replace None batch dimension with 1.
     expected_shape = tuple(1 if dim is None else dim for dim in expected_shape)
 
-    predictions = tf.random.uniform(expected_shape,
-                                    minval=0,
-                                    maxval=1,
-                                    dtype=tf.float32)
-    targets = tf.random.uniform(expected_shape,
-                                minval=0,
-                                maxval=1,
-                                dtype=tf.float32)
+    predictions = tf.random.uniform(
+        expected_shape, minval=0, maxval=1, dtype=tf.float32
+    )
+    targets = tf.random.uniform(
+        expected_shape, minval=0, maxval=1, dtype=tf.float32
+    )
 
     with tf.GradientTape() as tape:
         tape.watch(predictions)

--- a/keras/engine/compile_utils_test.py
+++ b/keras/engine/compile_utils_test.py
@@ -883,6 +883,103 @@ class MetricsContainerTest(test_combinations.TestCase):
             )
 
 
+class TestLossDifferentiabilityFunctions(test_combinations.TestCase):
+    def test_verify_loss_differentiability(self):
+        # Test case 1: Differentiable loss function
+        def differentiable_loss(y_true, y_pred):
+            return tf.reduce_mean(tf.square(y_true - y_pred))
+
+        class DifferentiableLossClass(losses_mod.Loss):
+            def call(self, y_true, y_pred):
+                return tf.reduce_mean(tf.square(y_true - y_pred))
+
+        expected_shapes = (None, 1)
+        compile_utils.verify_loss_differentiability(
+            differentiable_loss, expected_shapes)
+
+        compile_utils.verify_loss_differentiability(
+            DifferentiableLossClass(), expected_shapes)
+
+        # Test case 2: Non-differentiable loss function
+        def non_differentiable_loss(y_true, y_pred):
+            return tf.round(tf.square(y_true - y_pred))
+
+        class NonDifferentiableLossClass(losses_mod.Loss):
+            def call(self, y_true, y_pred):
+                return tf.round(tf.square(y_true - y_pred))
+
+        with self.assertRaises(ValueError):
+            compile_utils.verify_loss_differentiability(
+                non_differentiable_loss, expected_shapes)
+
+        with self.assertRaises(ValueError):
+            compile_utils.verify_loss_differentiability(
+                NonDifferentiableLossClass(), expected_shapes)
+
+    def test__verify_loss_differentiability(self):
+        # Test case 1: Differentiable loss function
+        def differentiable_loss(y_true, y_pred):
+            return tf.reduce_mean(tf.square(y_true - y_pred))
+
+        class DifferentiableLossClass(losses_mod.Loss):
+            def call(self, y_true, y_pred):
+                return tf.abs(tf.square(y_true - y_pred))
+
+        expected_shapes = (1, 1)
+        self.assertTrue(compile_utils._verify_loss_differentiability(
+            differentiable_loss, expected_shapes))
+
+        self.assertTrue(compile_utils._verify_loss_differentiability(
+            DifferentiableLossClass(), expected_shapes))
+
+        # Test case 2: Non-differentiable loss function
+        def non_differentiable_loss(y_true, y_pred):
+            return tf.round(tf.square(y_true - y_pred))
+
+        class NonDifferentiableLossClass(losses_mod.Loss):
+            def call(self, y_true, y_pred):
+                return tf.argmax(tf.square(y_true - y_pred))
+
+        self.assertFalse(compile_utils._verify_loss_differentiability(
+            non_differentiable_loss, expected_shapes))
+
+        self.assertFalse(compile_utils._verify_loss_differentiability(
+            NonDifferentiableLossClass(), expected_shapes))
+
+    def test__check_loss_with_shapes(self):
+        # Test case 1: Differentiable loss function
+        def differentiable_loss(y_true, y_pred):
+            return tf.reduce_sum(tf.square(y_true - y_pred))
+
+        class DifferentiableLossClass(losses_mod.Loss):
+            def call(self, y_true, y_pred):
+                return tf.reduce_sum(tf.square(y_true - y_pred))
+
+        expected_shape = (1, 1)
+        self.assertTrue(
+            compile_utils._check_loss_with_shapes(
+                differentiable_loss, expected_shape))
+
+        self.assertTrue(
+            compile_utils._check_loss_with_shapes(
+                DifferentiableLossClass(), expected_shape))
+
+        # Test case 2: Non-differentiable loss function
+        def non_differentiable_loss(y_true, y_pred):
+            return tf.round(tf.square(y_true - y_pred))
+
+        class NonDifferentiableLossClass(losses_mod.Loss):
+            def call(self, y_true, y_pred):
+                return tf.argmax(tf.square(y_true - y_pred))
+
+        self.assertFalse(
+            compile_utils._check_loss_with_shapes(
+                non_differentiable_loss, expected_shape))
+
+        self.assertFalse(
+            compile_utils._check_loss_with_shapes(
+                NonDifferentiableLossClass(), expected_shape))
+
 if __name__ == "__main__":
     tf.compat.v1.enable_eager_execution()
     tf.test.main()

--- a/keras/engine/compile_utils_test.py
+++ b/keras/engine/compile_utils_test.py
@@ -17,8 +17,8 @@
 import tensorflow.compat.v2 as tf
 
 from keras import backend
-from keras import losses as losses_mod
 from keras import layers as layers_mod
+from keras import losses as losses_mod
 from keras import metrics as metrics_mod
 from keras.engine import compile_utils
 from keras.testing_infra import test_combinations

--- a/keras/engine/compile_utils_test.py
+++ b/keras/engine/compile_utils_test.py
@@ -895,10 +895,12 @@ class TestLossDifferentiabilityFunctions(test_combinations.TestCase):
 
         expected_shapes = (None, 1)
         compile_utils.verify_loss_differentiability(
-            differentiable_loss, expected_shapes)
+            differentiable_loss, expected_shapes
+        )
 
         compile_utils.verify_loss_differentiability(
-            DifferentiableLossClass(), expected_shapes)
+            DifferentiableLossClass(), expected_shapes
+        )
 
         # Test case 2: Non-differentiable loss function
         def non_differentiable_loss(y_true, y_pred):
@@ -910,11 +912,13 @@ class TestLossDifferentiabilityFunctions(test_combinations.TestCase):
 
         with self.assertRaises(ValueError):
             compile_utils.verify_loss_differentiability(
-                non_differentiable_loss, expected_shapes)
+                non_differentiable_loss, expected_shapes
+            )
 
         with self.assertRaises(ValueError):
             compile_utils.verify_loss_differentiability(
-                NonDifferentiableLossClass(), expected_shapes)
+                NonDifferentiableLossClass(), expected_shapes
+            )
 
     def test__verify_loss_differentiability(self):
         # Test case 1: Differentiable loss function
@@ -926,11 +930,17 @@ class TestLossDifferentiabilityFunctions(test_combinations.TestCase):
                 return tf.abs(tf.square(y_true - y_pred))
 
         expected_shapes = (1, 1)
-        self.assertTrue(compile_utils._verify_loss_differentiability(
-            differentiable_loss, expected_shapes))
+        self.assertTrue(
+            compile_utils._verify_loss_differentiability(
+                differentiable_loss, expected_shapes
+            )
+        )
 
-        self.assertTrue(compile_utils._verify_loss_differentiability(
-            DifferentiableLossClass(), expected_shapes))
+        self.assertTrue(
+            compile_utils._verify_loss_differentiability(
+                DifferentiableLossClass(), expected_shapes
+            )
+        )
 
         # Test case 2: Non-differentiable loss function
         def non_differentiable_loss(y_true, y_pred):
@@ -940,11 +950,17 @@ class TestLossDifferentiabilityFunctions(test_combinations.TestCase):
             def call(self, y_true, y_pred):
                 return tf.argmax(tf.square(y_true - y_pred))
 
-        self.assertFalse(compile_utils._verify_loss_differentiability(
-            non_differentiable_loss, expected_shapes))
+        self.assertFalse(
+            compile_utils._verify_loss_differentiability(
+                non_differentiable_loss, expected_shapes
+            )
+        )
 
-        self.assertFalse(compile_utils._verify_loss_differentiability(
-            NonDifferentiableLossClass(), expected_shapes))
+        self.assertFalse(
+            compile_utils._verify_loss_differentiability(
+                NonDifferentiableLossClass(), expected_shapes
+            )
+        )
 
     def test__check_loss_with_shapes(self):
         # Test case 1: Differentiable loss function
@@ -958,11 +974,15 @@ class TestLossDifferentiabilityFunctions(test_combinations.TestCase):
         expected_shape = (1, 1)
         self.assertTrue(
             compile_utils._check_loss_with_shapes(
-                differentiable_loss, expected_shape))
+                differentiable_loss, expected_shape
+            )
+        )
 
         self.assertTrue(
             compile_utils._check_loss_with_shapes(
-                DifferentiableLossClass(), expected_shape))
+                DifferentiableLossClass(), expected_shape
+            )
+        )
 
         # Test case 2: Non-differentiable loss function
         def non_differentiable_loss(y_true, y_pred):
@@ -974,11 +994,16 @@ class TestLossDifferentiabilityFunctions(test_combinations.TestCase):
 
         self.assertFalse(
             compile_utils._check_loss_with_shapes(
-                non_differentiable_loss, expected_shape))
+                non_differentiable_loss, expected_shape
+            )
+        )
 
         self.assertFalse(
             compile_utils._check_loss_with_shapes(
-                NonDifferentiableLossClass(), expected_shape))
+                NonDifferentiableLossClass(), expected_shape
+            )
+        )
+
 
 if __name__ == "__main__":
     tf.compat.v1.enable_eager_execution()

--- a/keras/engine/compile_utils_test.py
+++ b/keras/engine/compile_utils_test.py
@@ -924,11 +924,11 @@ class TestObjectDifferentiabilityFunctions(test_combinations.TestCase):
         # Case 3: Non-differentiable custom layer.
         class NonDifferentiableLayer(layers_mod.Layer):
             def call(self, inputs):
-                return tf.round(inputs)
+                return inputs.numpy()
 
         with self.assertRaises(ValueError):
             compile_utils.verify_object_differentiability(
-                NonDifferentiableLayer(), None
+                NonDifferentiableLayer(), None, is_layer=True
             )
 
     def test__verify_loss_differentiability(self):
@@ -976,11 +976,11 @@ class TestObjectDifferentiabilityFunctions(test_combinations.TestCase):
         # Case 3: Non-differentiable custom layer.
         class NonDifferentiableLayer(layers_mod.Layer):
             def call(self, inputs):
-                return tf.round(inputs)
+                return inputs.numpy()
 
         self.assertFalse(
             compile_utils._verify_object_differentiability(
-                NonDifferentiableLayer(), None
+                NonDifferentiableLayer(), None, is_layer=True
             )
         )
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -788,18 +788,20 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
                         layer_copy = tf.keras.models.clone_model(layer)
                         if layer_utils.is_not_from_keras_layers(layer_copy):
                             compile_utils.verify_object_differentiability(
-                                custom_obj=layer_copy, expected_shapes=None,
-                                is_layer=True
+                                custom_obj=layer_copy,
+                                expected_shapes=None,
+                                is_layer=True,
                             )
                     # Check if it is a model instance.
                     elif isinstance(layer, Model):
                         model_copy = tf.keras.models.clone_model(layer)
                         for sublayer in model_copy.layers:
                             if layer_utils.is_not_from_keras_layers(sublayer):
-                                print(sublayer)
+
                                 compile_utils.verify_object_differentiability(
-                                    custom_obj=sublayer, expected_shapes=None,
-                                    is_layer=True
+                                    custom_obj=sublayer,
+                                    expected_shapes=None,
+                                    is_layer=True,
                                 )
 
             self.compiled_metrics = compile_utils.MetricsContainer(

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -764,17 +764,22 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
             builtin_losses = set(get_keras_losses().keys())
 
             if experimental_check_loss_differentiability:
-                if not isinstance(user_loss,
-                                  str) and user_loss not in builtin_losses:
+                if (
+                    not isinstance(user_loss, str)
+                    and user_loss not in builtin_losses
+                ):
                     # users may pass "mse" for MeanSquaredError,
                     # which is an alias for a built-in loss.
 
-                    input_shape_arg = self.input_shape if \
-                        hasattr(self, 'input_shape') else None
+                    input_shape_arg = (
+                        self.input_shape
+                        if hasattr(self, "input_shape")
+                        else None
+                    )
 
                     compile_utils.verify_loss_differentiability(
-                        loss=user_loss,
-                        expected_shapes=input_shape_arg)
+                        loss=user_loss, expected_shapes=input_shape_arg
+                    )
 
             self.compiled_metrics = compile_utils.MetricsContainer(
                 metrics,

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -766,11 +766,12 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
             if experimental_check_loss_differentiability:
                 if not isinstance(user_loss,
                                   str) and user_loss not in builtin_losses:
-                    # users may pass "mse" for MeanSquaredError, which is an alias
-                    # for a built-in loss.
+                    # users may pass "mse" for MeanSquaredError,
+                    # which is an alias for a built-in loss.
 
-                    input_shape_arg = self.input_shape if hasattr(self,
-                                                      'input_shape') else None
+                    input_shape_arg = self.input_shape if \
+                        hasattr(self, 'input_shape') else None
+
                     compile_utils.verify_loss_differentiability(
                         loss=user_loss,
                         expected_shapes=input_shape_arg)

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -1109,3 +1109,27 @@ def convert_vocab_to_list(vocab):
             " Received 0 instead."
         )
     return vocab_list
+
+
+def is_not_from_keras_layers(layer):
+    """Check if layer is not from keras.layers.
+
+    This utility will fail if users edit the keras source code and add their own
+    layers in the keras.layers namespace.
+
+    Args: layer: A keras.layer instance.
+
+    Returns: True if the layer is not from keras.layers, False otherwise.
+    """
+    _module = layer.__class__.__module__
+    # it can be keras.layers, tensorflow.keras.layers, or
+    # tensorflow.python.keras.layers
+    is_custom_layer = True
+    for prefix in ["keras.layers",
+                   "tensorflow.keras.layers",
+                   "tensorflow.python.keras.layers"]:
+        if _module.startswith(prefix):
+            is_custom_layer = False
+            break
+    return is_custom_layer
+

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -1125,11 +1125,12 @@ def is_not_from_keras_layers(layer):
     # it can be keras.layers, tensorflow.keras.layers, or
     # tensorflow.python.keras.layers
     is_custom_layer = True
-    for prefix in ["keras.layers",
-                   "tensorflow.keras.layers",
-                   "tensorflow.python.keras.layers"]:
+    for prefix in [
+        "keras.layers",
+        "tensorflow.keras.layers",
+        "tensorflow.python.keras.layers",
+    ]:
         if _module.startswith(prefix):
             is_custom_layer = False
             break
     return is_custom_layer
-

--- a/keras/utils/losses_utils.py
+++ b/keras/utils/losses_utils.py
@@ -18,8 +18,8 @@ import inspect
 import re
 
 import tensorflow.compat.v2 as tf
-import keras.losses as losses_module
 
+import keras.losses as losses_module
 from keras import backend
 from keras.engine import keras_tensor
 from keras.utils import tf_utils
@@ -447,7 +447,7 @@ def get_keras_losses():
 
             # Create alias using string operations
             # Eg. CategoricalCrossentropy -> categorical_crossentropy
-            alias = re.sub(r'(?<=[a-z])([A-Z])', r'_\1', name).lower()
+            alias = re.sub(r"(?<=[a-z])([A-Z])", r"_\1", name).lower()
 
             # Specific condition for KLDivergence
             if name == "KLDivergence":


### PR DESCRIPTION
Feature request was made in #17682.

This is a very common mistake when users define custom loss function / classes which are not differentiable which leads getting `None` gradients in fitting process. This check makes it easier for users to interpret the problem.

Example usage:

```python
import tensorflow as tf

X = tf.constant([-7.0, -4.0, -1.0])
y = tf.constant([3.0, 6.0, 9.0])

model = tf.keras.Sequential([
  tf.keras.layers.Dense(1, input_shape = (1, ))
])

class customloss(tf.keras.losses.Loss):
    def call(self, y_true, y_pred):
        return tf.round(tf.square(y_true - y_pred))

model.compile(loss=customloss(),
              optimizer="adam",
              metrics=["mae"])
```

Raises:

```python
ValueError: The provided loss function (<__main__.customloss object at 0x7f49c5dffeb0>) is not differentiable. 
Training requires a differentiable loss function. Please review your loss function or consider using a standard 
differentiable loss function. You can disable the differentiability check by setting experimental_check_loss_differentiability=False' in 'model.compile()'.
```

You can see the other usages from [this gist](https://colab.research.google.com/gist/Frightera/3bf5ead3fcf8e18b2bb63e641d333813/feature-overview.ipynb).