### PR TITLE
[keras/datasets/reuters.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/datasets/reuters.py
+++ b/keras/datasets/reuters.py
@@ -65,20 +65,20 @@ def load_data(
           ranked by how often they occur (in the training set) and only
           the `num_words` most frequent words are kept. Any less frequent word
           will appear as `oov_char` value in the sequence data. If None,
-          all words are kept. Defaults to None, so all words are kept.
+          all words are kept. Defaults to `None`.
       skip_top: skip the top N most frequently occurring words
           (which may not be informative). These words will appear as
-          `oov_char` value in the dataset. Defaults to 0, so no words are
-          skipped.
+          `oov_char` value in the dataset. 0 means no words are
+          skipped. Defaults to 0
       maxlen: int or None. Maximum sequence length.
-          Any longer sequence will be truncated. Defaults to None, which
-          means no truncation.
+          Any longer sequence will be truncated. None means no truncation.
+          Defaults to `None`.
       test_split: Float between 0 and 1. Fraction of the dataset to be used
-        as test data. Defaults to 0.2, meaning 20% of the dataset is used as
-        test data.
+        as test data. 0.2 means that 20% of the dataset is used as
+        test data. Defaults to 0.2
       seed: int. Seed for reproducible data shuffling.
       start_char: int. The start of a sequence will be marked with this
-          character. Defaults to 1 because 0 is usually the padding character.
+          character. 0 is usually the padding character. Defaults to `1`.
       oov_char: int. The out-of-vocabulary character.
           Words that were cut out because of the `num_words` or
           `skip_top` limits will be replaced with this character.


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748