### PR TITLE
[keras/engine/base_layer_utils.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/engine/base_layer_utils.py
+++ b/keras/engine/base_layer_utils.py
@@ -98,8 +98,8 @@ def make_variable(
         or "non_trainable_variables" (e.g. BatchNorm mean, stddev).
         Note, if the current variable scope is marked as non-trainable
         then this parameter is ignored and any added variables are also
-        marked as non-trainable. `trainable` defaults to `True` unless
-        `synchronization` is set to `ON_READ`.
+        marked as non-trainable. `trainable` becomes `True` unless
+        `synchronization` is set to `ON_READ`. Defaults to `None`.
       caching_device: Passed to `tf.Variable`.
       validate_shape: Passed to `tf.Variable`.
       constraint: Constraint instance (callable).


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748