### PR TITLE
[keras/feature_column/sequence_feature_column.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/feature_column/sequence_feature_column.py
+++ b/keras/feature_column/sequence_feature_column.py
@@ -122,8 +122,8 @@ class SequenceFeatures(kfc._BaseFeaturesLayer):
             method of any `FeatureColumn` that takes a `training` argument. For
             example, if a `FeatureColumn` performed dropout, the column could
             expose a `training` argument to control whether the dropout should
-            be applied. If `None`, defaults to
-            `tf.keras.backend.learning_phase()`.
+            be applied. If `None`, becomes `tf.keras.backend.learning_phase()`.
+            Defaults to `None`.
 
 
         Returns:


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748