### PR TITLE
[keras/layers/activation/softmax.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/layers/activation/softmax.py
+++ b/keras/layers/activation/softmax.py
@@ -72,8 +72,9 @@ class Softmax(Layer):
         normalization is applied.
     Call arguments:
       inputs: The inputs, or logits to the softmax layer.
-      mask: A boolean mask of the same shape as `inputs`. Defaults to `None`.
-        The mask specifies 1 to keep and 0 to mask.
+      mask: A boolean mask of the same shape as `inputs`. The mask
+        specifies 1 to keep and 0 to mask. Defaults to `None`.
+
 
     Returns:
       softmaxed output with the same shape as `inputs`.


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748