### PR TITLE
[keras/layers/convolutional/base_depthwise_conv.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/layers/convolutional/base_depthwise_conv.py
+++ b/keras/layers/convolutional/base_depthwise_conv.py
@@ -65,8 +65,8 @@ class DepthwiseConv(Conv):
         `channels_first`.  The ordering of the dimensions in the inputs.
         `channels_last` corresponds to inputs with shape `(batch_size, height,
         width, channels)` while `channels_first` corresponds to inputs with
-        shape `(batch_size, channels, height, width)`. When unspecified, uses
-        `image_data_format` value found in your Keras config file at
+        shape `(batch_size, channels, height, width)`. If left unspecified,
+        uses `image_data_format` value found in your Keras config file at
         `~/.keras/keras.json` (if exists) else 'channels_last'.
         Defaults to 'channels_last'.
       dilation_rate: An integer or tuple/list of 2 integers, specifying the

--- a/keras/layers/convolutional/base_depthwise_conv.py
+++ b/keras/layers/convolutional/base_depthwise_conv.py
@@ -65,10 +65,10 @@ class DepthwiseConv(Conv):
         `channels_first`.  The ordering of the dimensions in the inputs.
         `channels_last` corresponds to inputs with shape `(batch_size, height,
         width, channels)` while `channels_first` corresponds to inputs with
-        shape `(batch_size, channels, height, width)`. It defaults to the
+        shape `(batch_size, channels, height, width)`. When unspecified, uses
         `image_data_format` value found in your Keras config file at
-        `~/.keras/keras.json`. If you never set it, then it will be
-        'channels_last'.
+        `~/.keras/keras.json` (if exists) else 'channels_last'.
+        Defaults to 'channels_last'.
       dilation_rate: An integer or tuple/list of 2 integers, specifying the
         dilation rate to use for dilated convolution. Currently, specifying any
         `dilation_rate` value != 1 is incompatible with specifying any `strides`


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748