### PR TITLE
[keras/layers/convolutional/conv2d.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/layers/convolutional/conv2d.py
+++ b/keras/layers/convolutional/conv2d.py
@@ -101,8 +101,8 @@ class Conv2D(Conv):
         `channels_first`.  The ordering of the dimensions in the inputs.
         `channels_last` corresponds to inputs with shape `(batch_size, height,
         width, channels)` while `channels_first` corresponds to inputs with
-        shape `(batch_size, channels, height, width)`. When unspecified, uses
-        `image_data_format` value found in your Keras config file at
+        shape `(batch_size, channels, height, width)`. If left unspecified, it
+        uses the `image_data_format` value found in your Keras config file at
         `~/.keras/keras.json` (if exists) else 'channels_last'.
         Note that the `channels_first` format is currently not
         supported by TensorFlow on CPU. Defaults to 'channels_last'.

--- a/keras/layers/convolutional/conv2d.py
+++ b/keras/layers/convolutional/conv2d.py
@@ -101,11 +101,11 @@ class Conv2D(Conv):
         `channels_first`.  The ordering of the dimensions in the inputs.
         `channels_last` corresponds to inputs with shape `(batch_size, height,
         width, channels)` while `channels_first` corresponds to inputs with
-        shape `(batch_size, channels, height, width)`. It defaults to the
+        shape `(batch_size, channels, height, width)`. When unspecified, uses
         `image_data_format` value found in your Keras config file at
-        `~/.keras/keras.json`. If you never set it, then it will be
-        `channels_last`. Note that the `channels_first` format is currently not
-        supported by TensorFlow on CPU.
+        `~/.keras/keras.json` (if exists) else 'channels_last'.
+        Note that the `channels_first` format is currently not
+        supported by TensorFlow on CPU. Defaults to 'channels_last'.
       dilation_rate: an integer or tuple/list of 2 integers, specifying the
         dilation rate to use for dilated convolution. Can be a single integer to
         specify the same value for all spatial dimensions. Currently, specifying


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748