### PR TITLE
[keras/layers/convolutional/conv3d_transpose.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/layers/convolutional/conv3d_transpose.py
+++ b/keras/layers/convolutional/conv3d_transpose.py
@@ -82,9 +82,9 @@ class Conv3DTranspose(Conv3D):
         `(batch_size, depth, height, width, channels)` while `channels_first`
         corresponds to inputs with shape
         `(batch_size, channels, depth, height, width)`.
-        It defaults to the `image_data_format` value found in your
-        Keras config file at `~/.keras/keras.json`.
-        If you never set it, then it will be "channels_last".
+        When unspecified, uses `image_data_format` value found in your Keras
+        config file at `~/.keras/keras.json` (if exists) else 'channels_last'.
+        Defaults to 'channels_last'.
       dilation_rate: an integer or tuple/list of 3 integers, specifying
         the dilation rate to use for dilated convolution.
         Can be a single integer to specify the same value for


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748