### PR TITLE
[keras/layers/pooling/max_pooling2d.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/layers/pooling/max_pooling2d.py
+++ b/keras/layers/pooling/max_pooling2d.py
@@ -127,9 +127,10 @@ class MaxPooling2D(Pooling2D):
         `(batch, height, width, channels)` while `channels_first`
         corresponds to inputs with shape
         `(batch, channels, height, width)`.
-        It defaults to the `image_data_format` value found in your
-        Keras config file at `~/.keras/keras.json`.
-        If you never set it, then it will be "channels_last".
+        When unspecified, uses
+        `image_data_format` value found in your Keras config file at
+         `~/.keras/keras.json` (if exists) else 'channels_last'.
+        Defaults to 'channels_last'.
 
     Input shape:
       - If `data_format='channels_last'`:


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748