### PR TITLE
[keras/optimizers/adafactor.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/optimizers/adafactor.py
+++ b/keras/optimizers/adafactor.py
@@ -45,19 +45,19 @@ class Adafactor(optimizer.Optimizer):
       learning_rate: Initial value for the learning rate:
         either a floating point value,
         or a `tf.keras.optimizers.schedules.LearningRateSchedule` instance.
-        Defaults to 0.001.
-      beta_2_decay: float, defaults to -0.8. The decay rate of `beta_2`.
-      epsilon_1: float, defaults to 1e-30. A small offset to keep demoninator
-        away from 0.
-      epsilon_2: float, defaults to 1e-3. A small offset to avoid learning
-        rate becoming too small by time.
-      clip_threshold: float, defaults to 1.0. Clipping threshold. This is a part
-        of Adafactor algorithm, independent from `clipnorm`, `clipvalue` and
-        `global_clipnorm`.
-      relative_step: bool, defaults to True. If `learning_rate` is a
+        Defaults to `0.001`.
+      beta_2_decay: float. The decay rate of `beta_2`. Defaults to `-0.8`.
+      epsilon_1: float, A small offset to keep denominator
+        away from 0. Defaults to `1e-30`.
+      epsilon_2: float. A small offset to avoid learning
+        rate becoming too small by time. Defaults to `1e-3`.
+      clip_threshold: float. Clipping threshold. This is a part
+        of Adafactor algorithm, independent of `clipnorm`, `clipvalue` and
+        `global_clipnorm`. Defaults to `1.0`.
+      relative_step: bool. If `learning_rate` is a
         constant and `relative_step=True`, learning rate will be adjusted
         based on current iterations. This is a default learning rate decay
-        in Adafactor.
+        in Adafactor. Defaults to `True`.
       {{base_optimizer_keyword_args}}
 
     Reference:


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748