### PR TITLE
[keras/optimizers/adamax.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/optimizers/adamax.py
+++ b/keras/optimizers/adamax.py
@@ -60,7 +60,7 @@ class Adamax(optimizer.Optimizer):
       learning_rate: A `tf.Tensor`, floating point value, a schedule that is a
         `tf.keras.optimizers.schedules.LearningRateSchedule`, or a callable
         that takes no arguments and returns the actual value to use. The
-        learning rate. Defaults to 0.001.
+        learning rate. Defaults to `0.001`.
       beta_1: A float value or a constant float tensor. The exponential decay
         rate for the 1st moment estimates.
       beta_2: A float value or a constant float tensor. The exponential decay


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748