### PR TITLE
[keras/optimizers/legacy/adadelta.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/optimizers/legacy/adadelta.py
+++ b/keras/optimizers/legacy/adadelta.py
@@ -48,10 +48,10 @@ class Adadelta(optimizer_v2.OptimizerV2):
       learning_rate: Initial value for the learning rate:
         either a floating point value,
         or a `tf.keras.optimizers.schedules.LearningRateSchedule` instance.
-        Defaults to 0.001.
         Note that `Adadelta` tends to benefit from higher initial learning rate
         values compared to other optimizers.
         To match the exact form in the original paper, use 1.0.
+        Defaults to `0.001`.
       rho: A `Tensor` or a floating point value. The decay rate.
       epsilon: Small floating point value used to maintain numerical stability.
       name: Optional name prefix for the operations created when applying


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748