### PR TITLE
[keras/optimizers/legacy/gradient_descent.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/optimizers/legacy/gradient_descent.py
+++ b/keras/optimizers/legacy/gradient_descent.py
@@ -54,10 +54,10 @@ class SGD(optimizer_v2.OptimizerV2):
       learning_rate: A `Tensor`, floating point value, or a schedule that is a
         `tf.keras.optimizers.schedules.LearningRateSchedule`, or a callable
         that takes no arguments and returns the actual value to use. The
-        learning rate. Defaults to 0.01.
+        learning rate. Defaults to `0.01`.
       momentum: float hyperparameter >= 0 that accelerates gradient descent in
-        the relevant direction and dampens oscillations. Defaults to 0, i.e.,
-        vanilla gradient descent.
+        the relevant direction and dampens oscillations. Vanilla gradient
+        descent means no momentum. Defaults to `0.`.
       nesterov: boolean. Whether to apply Nesterov momentum.
         Defaults to `False`.
       name: Optional name prefix for the operations created when applying


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748