### PR TITLE
[keras/optimizers/lion.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/optimizers/lion.py
+++ b/keras/optimizers/lion.py
@@ -43,7 +43,7 @@ class Lion(optimizer.Optimizer):
       learning_rate: A `tf.Tensor`, floating point value, a schedule that is a
         `tf.keras.optimizers.schedules.LearningRateSchedule`, or a callable
         that takes no arguments and returns the actual value to use. The
-        learning rate. Defaults to 0.0001.
+        learning rate. Defaults to `0.0001`.
       beta_1: A float value or a constant float tensor, or a callable
         that takes no arguments and returns the actual value to use. The rate
         to combine the current gradient and the 1st moment estimate.


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748