### PR TITLE
[keras/optimizers/rmsprop.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/optimizers/rmsprop.py
+++ b/keras/optimizers/rmsprop.py
@@ -47,14 +47,15 @@ class RMSprop(optimizer.Optimizer):
       learning_rate: Initial value for the learning rate:
         either a floating point value,
         or a `tf.keras.optimizers.schedules.LearningRateSchedule` instance.
-        Defaults to 0.001.
-      rho: float, defaults to 0.9. Discounting factor for the old gradients.
-      momentum: float, defaults to 0.0. If not 0.0., the optimizer tracks the
+        Defaults to `0.001`.
+      rho: float. Discounting factor for the old gradients. Defaults to `0.9`.
+      momentum: float. If not `0.0`, the optimizer tracks the
         momentum value, with a decay rate equals to `1 - momentum`.
+        Defaults to `0.0`.
       epsilon: A small constant for numerical stability. This epsilon is
         "epsilon hat" in the Kingma and Ba paper (in the formula just before
         Section 2.1), not the epsilon in Algorithm 1 of the paper. Defaults to
-        1e-7.
+        `1e-7`.
       centered: Boolean. If `True`, gradients are normalized by the estimated
         variance of the gradient; if False, by the uncentered second moment.
         Setting this to `True` may help with training, but is slightly more


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748