### PR TITLE
[keras/optimizers/schedules/learning_rate_schedule.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -405,8 +405,9 @@ class PolynomialDecay(LearningRateSchedule):
           end_learning_rate: A scalar `float32` or `float64` `Tensor` or a
             Python number.  The minimal end learning rate.
           power: A scalar `float32` or `float64` `Tensor` or a
-            Python number. The power of the polynomial. Defaults to linear, 1.0.
-          cycle: A boolean, whether or not it should cycle beyond decay_steps.
+            Python number. The power of the polynomial. Linear default.
+            Defaults to `1.0`.
+          cycle: A boolean, whether it should cycle beyond decay_steps.
           name: String.  Optional name of the operation. Defaults to
             'PolynomialDecay'.
         """


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748