### PR TITLE
[keras/saving/legacy/saved_model/save.py] Standardise docstring usage of "Default to"

### DIFF
--- a/keras/saving/legacy/saved_model/save.py
+++ b/keras/saving/legacy/saved_model/save.py
@@ -64,9 +64,9 @@ def save(
       save_traces: (only applies to SavedModel format) When enabled, the
         SavedModel will store the function traces for each layer. This
         can be disabled, so that only the configs of each layer are stored.
-        Defaults to `True`. Disabling this will decrease serialization time
-        and reduce file size, but it requires that all custom layers/models
-        implement a `get_config()` method.
+        Disabling this will decrease serialization time and filesize, but
+        it requires that all custom layers/models implement a
+        `get_config()` method. Defaults to `True`.
 
     Raises:
       ValueError: if the model's inputs have not been defined.


### PR DESCRIPTION
This is one of many PRs. Discussion + request to split into multiple PRs @ #17748