### PR TITLE
Update indentation level - utils/image_dataset

### DIFF
--- a/keras/utils/image_dataset.py
+++ b/keras/utils/image_dataset.py
@@ -72,17 +72,17 @@ def image_dataset_from_directory(
     Animated gifs are truncated to the first frame.
 
     Args:
-      directory: Directory where the data is located.
-          If `labels` is "inferred", it should contain
-          subdirectories, each containing images for a class.
-          Otherwise, the directory structure is ignored.
+        directory: Directory where the data is located.
+            If `labels` is "inferred", it should contain
+            subdirectories, each containing images for a class.
+            Otherwise, the directory structure is ignored.
       labels: Either "inferred"
-          (labels are generated from the directory structure),
-          None (no labels),
-          or a list/tuple of integer labels of the same size as the number of
-          image files found in the directory. Labels should be sorted according
-          to the alphanumeric order of the image file paths
-          (obtained via `os.walk(directory)` in Python).
+            (labels are generated from the directory structure),
+            None (no labels),
+            or a list/tuple of integer labels of the same size as the number of
+            image files found in the directory. Labels should be sorted according
+            to the alphanumeric order of the image file paths
+            (obtained via `os.walk(directory)` in Python).
       label_mode: String describing the encoding of `labels`. Options are:
           - 'int': means that the labels are encoded as integers
               (e.g. for `sparse_categorical_crossentropy` loss).
@@ -95,14 +95,13 @@ def image_dataset_from_directory(
           - None (no labels).
       class_names: Only valid if "labels" is "inferred". This is the explicit
           list of class names (must match names of subdirectories). Used
-          to control the order of the classes
-          (otherwise alphanumerical order is used).
+          to control the order of the classes (otherwise alphanumerical order
+          is used).
       color_mode: One of "grayscale", "rgb", "rgba". Default: "rgb".
-          Whether the images will be converted to
-          have 1, 3, or 4 channels.
+          Whether the images will be converted to have 1, 3, or 4 channels.
       batch_size: Size of the batches of data. Default: 32.
-        If `None`, the data will not be batched
-        (the dataset will yield individual samples).
+            If `None`, the data will not be batched
+            (the dataset will yield individual samples).
       image_size: Size to resize images to after they are read from disk,
           specified as `(height, width)`. Defaults to `(256, 256)`.
           Since the pipeline processes batches of images that must all have
@@ -118,46 +117,47 @@ def image_dataset_from_directory(
           When `subset="both"`, the utility returns a tuple of two datasets
           (the training and validation datasets respectively).
       interpolation: String, the interpolation method used when resizing images.
-        Defaults to `bilinear`. Supports `bilinear`, `nearest`, `bicubic`,
-        `area`, `lanczos3`, `lanczos5`, `gaussian`, `mitchellcubic`.
+            Defaults to `bilinear`. Supports `bilinear`, `nearest`, `bicubic`,
+            `area`, `lanczos3`, `lanczos5`, `gaussian`, `mitchellcubic`.
       follow_links: Whether to visit subdirectories pointed to by symlinks.
           Defaults to False.
       crop_to_aspect_ratio: If True, resize the images without aspect
-        ratio distortion. When the original aspect ratio differs from the target
-        aspect ratio, the output image will be cropped so as to return the
-        largest possible window in the image (of size `image_size`) that matches
-        the target aspect ratio. By default (`crop_to_aspect_ratio=False`),
-        aspect ratio may not be preserved.
+            ratio distortion. When the original aspect ratio differs from the
+            target aspect ratio, the output image will be cropped so as to
+            return the largest possible window in the image
+            (of size `image_size`) that matches the target aspect ratio. By
+            default (`crop_to_aspect_ratio=False`), aspect ratio may not be
+            preserved.
       **kwargs: Legacy keyword arguments.
 
     Returns:
       A `tf.data.Dataset` object.
 
         - If `label_mode` is None, it yields `float32` tensors of shape
-          `(batch_size, image_size[0], image_size[1], num_channels)`,
-          encoding images (see below for rules regarding `num_channels`).
+            `(batch_size, image_size[0], image_size[1], num_channels)`,
+            encoding images (see below for rules regarding `num_channels`).
         - Otherwise, it yields a tuple `(images, labels)`, where `images`
-          has shape `(batch_size, image_size[0], image_size[1], num_channels)`,
-          and `labels` follows the format described below.
+            has shape `(batch_size, image_size[0], image_size[1], num_channels)`,
+            and `labels` follows the format described below.
 
     Rules regarding labels format:
 
       - if `label_mode` is `int`, the labels are an `int32` tensor of shape
-        `(batch_size,)`.
+          `(batch_size,)`.
       - if `label_mode` is `binary`, the labels are a `float32` tensor of
-        1s and 0s of shape `(batch_size, 1)`.
+          1s and 0s of shape `(batch_size, 1)`.
       - if `label_mode` is `categorical`, the labels are a `float32` tensor
-        of shape `(batch_size, num_classes)`, representing a one-hot
-        encoding of the class index.
+          of shape `(batch_size, num_classes)`, representing a one-hot
+          encoding of the class index.
 
     Rules regarding number of channels in the yielded images:
 
       - if `color_mode` is `grayscale`,
-        there's 1 channel in the image tensors.
+          there's 1 channel in the image tensors.
       - if `color_mode` is `rgb`,
-        there are 3 channels in the image tensors.
+          there are 3 channels in the image tensors.
       - if `color_mode` is `rgba`,
-        there are 4 channels in the image tensors.
+          there are 4 channels in the image tensors.
     """
     if "smart_resize" in kwargs:
         crop_to_aspect_ratio = kwargs.pop("smart_resize")
@@ -268,6 +268,7 @@ def image_dataset_from_directory(
         )
         train_dataset = train_dataset.prefetch(tf.data.AUTOTUNE)
         val_dataset = val_dataset.prefetch(tf.data.AUTOTUNE)
+
         if batch_size is not None:
             if shuffle:
                 # Shuffle locally at each iteration
@@ -285,6 +286,7 @@ def image_dataset_from_directory(
         # Users may need to reference `class_names`.
         train_dataset.class_names = class_names
         val_dataset.class_names = class_names
+
         # Include file paths for images as attribute.
         train_dataset.file_paths = image_paths_train
         val_dataset.file_paths = image_paths_val
@@ -321,6 +323,7 @@ def image_dataset_from_directory(
 
         # Users may need to reference `class_names`.
         dataset.class_names = class_names
+
         # Include file paths for images as attribute.
         dataset.file_paths = image_paths
     return dataset

--- a/keras/utils/image_dataset.py
+++ b/keras/utils/image_dataset.py
@@ -80,8 +80,8 @@ def image_dataset_from_directory(
             (labels are generated from the directory structure),
             None (no labels),
             or a list/tuple of integer labels of the same size as the number of
-            image files found in the directory. Labels should be sorted according
-            to the alphanumeric order of the image file paths
+            image files found in the directory. Labels should be sorted
+            according to the alphanumeric order of the image file paths
             (obtained via `os.walk(directory)` in Python).
       label_mode: String describing the encoding of `labels`. Options are:
           - 'int': means that the labels are encoded as integers
@@ -136,8 +136,8 @@ def image_dataset_from_directory(
         - If `label_mode` is None, it yields `float32` tensors of shape
             `(batch_size, image_size[0], image_size[1], num_channels)`,
             encoding images (see below for rules regarding `num_channels`).
-        - Otherwise, it yields a tuple `(images, labels)`, where `images`
-            has shape `(batch_size, image_size[0], image_size[1], num_channels)`,
+        - Otherwise, it yields a tuple `(images, labels)`, where `images` has
+            shape `(batch_size, image_size[0], image_size[1], num_channels)`,
             and `labels` follows the format described below.
 
     Rules regarding labels format:


### PR DESCRIPTION
This PR changes the indentation level of the docstrings to 4 spaces. 

Another thing is that the order of dataset methods:
1) prefetch
2) shuffle
3) batch

I think it would be better if the order was:
1) shuffle
2) batch
3) prefetch

https://github.com/keras-team/keras/blob/059dde81959129470e10abfa0c218a96fab96557/keras/utils/image_dataset.py#L312-L320

And also can add `caching` option to the parameters.