### PR TITLE
Updating split range from [0, 1] to (0, 1) in keras.utils.split_dataset

### DIFF
--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -33,16 +33,16 @@ from tensorflow.python.util.tf_export import keras_export
 def split_dataset(
     dataset, left_size=None, right_size=None, shuffle=False, seed=None
 ):
-    """Split a dataset into a left half and a right half (e.g. train / test).
+    """Split a dataset into a left part and a right part (e.g. train / test).
 
     Args:
         dataset: A `tf.data.Dataset` object, or a list/tuple of arrays with the
           same length.
-        left_size: If float (in the range `[0, 1]`), it signifies
+        left_size: If float (in the range `(0, 1)`), it signifies
           the fraction of the data to pack in the left dataset. If integer, it
           signifies the number of samples to pack in the left dataset. If
           `None`, it uses the complement to `right_size`. Defaults to `None`.
-        right_size: If float (in the range `[0, 1]`), it signifies
+        right_size: If float (in the range `(0, 1)`), it signifies
           the fraction of the data to pack in the right dataset. If integer, it
           signifies the number of samples to pack in the right dataset. If
           `None`, it uses the complement to `left_size`. Defaults to `None`.
@@ -398,7 +398,7 @@ def _rescale_dataset_split_sizes(left_size, right_size, total_length):
         raise ValueError(
             "`left_size` should be either a positive integer "
             f"smaller than {total_length}, or a float "
-            "within the range `[0, 1]`. Received: left_size="
+            "within the range `(0, 1)`. Received: left_size="
             f"{left_size}"
         )
 
@@ -413,7 +413,7 @@ def _rescale_dataset_split_sizes(left_size, right_size, total_length):
         raise ValueError(
             "`right_size` should be either a positive integer "
             f"and smaller than {total_length} or a float "
-            "within the range `[0, 1]`. Received: right_size="
+            "within the range `(0, 1)`. Received: right_size="
             f"{right_size}"
         )
 

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -38,10 +38,10 @@ def split_dataset(
     Args:
         dataset: A `tf.data.Dataset` object, or a list/tuple of arrays with the
           same length.
-        left_size: If float (in the range `[0, 1]` (excluding the 
-          boundary values 0 and 1), it signifies the fraction of the data to 
-          pack in the left dataset.If integer, it signifies the number of 
-          samples to pack in the left dataset.If `None`, it uses the complement 
+        left_size: If float (in the range `[0, 1]` (excluding the
+          boundary values 0 and 1)), it signifies the fraction of the data to
+          pack in the left dataset.If integer, it signifies the number of
+          samples to pack in the left dataset.If `None`, it uses the complement
           to `right_size`. Defaults to `None`.
         right_size: If float (in the range `(0, 1)`), it signifies
           the fraction of the data to pack in the right dataset. If integer, it

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -40,11 +40,12 @@ def split_dataset(
           same length.
         left_size: If float (in the range `[0, 1]` (excluding the
           boundary values 0 and 1)), it signifies the fraction of the data to
-          pack in the left dataset.If integer, it signifies the number of
-          samples to pack in the left dataset.If `None`, it uses the complement
-          to `right_size`. Defaults to `None`.
-        right_size: If float (in the range `(0, 1)`), it signifies
-          the fraction of the data to pack in the right dataset. If integer, it
+          pack in the left dataset. If integer, it signifies the number of
+          samples to pack in the left dataset. If `None`, it uses the 
+          complement to `right_size`. Defaults to `None`.
+        right_size: If float (in the range `[0, 1]` (excluding the
+          boundary values 0 and 1)), it signifiesthe fraction of 
+          the data to pack in the right dataset. If integer, it
           signifies the number of samples to pack in the right dataset. If
           `None`, it uses the complement to `left_size`. Defaults to `None`.
         shuffle: Boolean, whether to shuffle the data before splitting it.
@@ -399,7 +400,7 @@ def _rescale_dataset_split_sizes(left_size, right_size, total_length):
         raise ValueError(
             "`left_size` should be either a positive integer "
             f"smaller than {total_length}, or a float "
-            "within the range '[0, 1] (excluding the boundary values 0 and 1)'."
+            "within the range `[0, 1]` (excluding the boundary values 0 and 1)."
             f"Received: left_size = {left_size}"
         )
 
@@ -414,7 +415,7 @@ def _rescale_dataset_split_sizes(left_size, right_size, total_length):
         raise ValueError(
             "`right_size` should be either a positive integer "
             f"and smaller than {total_length} or a float "
-            "within the range '[0, 1] (excluding the boundary values 0 and 1)'."
+            "within the range `[0, 1]` (excluding the boundary values 0 and 1)."
             f"Received: right_size = {right_size}"
         )
 

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -38,10 +38,11 @@ def split_dataset(
     Args:
         dataset: A `tf.data.Dataset` object, or a list/tuple of arrays with the
           same length.
-        left_size: If float (in the range "[0, 1] (excluding the boundary values 0 and 1)"), it signifies
-          the fraction of the data to pack in the left dataset. If integer, it
-          signifies the number of samples to pack in the left dataset. If
-          `None`, it uses the complement to `right_size`. Defaults to `None`.
+        left_size: If float (in the range `[0, 1]` (excluding the 
+          boundary values 0 and 1), it signifies the fraction of the data to 
+          pack in the left dataset.If integer, it signifies the number of 
+          samples to pack in the left dataset.If `None`, it uses the complement 
+          to `right_size`. Defaults to `None`.
         right_size: If float (in the range `(0, 1)`), it signifies
           the fraction of the data to pack in the right dataset. If integer, it
           signifies the number of samples to pack in the right dataset. If

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -399,8 +399,8 @@ def _rescale_dataset_split_sizes(left_size, right_size, total_length):
         raise ValueError(
             "`left_size` should be either a positive integer "
             f"smaller than {total_length}, or a float "
-            "within the range '[0, 1] (excluding the boundary values 0 and 1)'. Received: left_size="
-            f"{left_size}"
+            "within the range '[0, 1] (excluding the boundary values 0 and 1)'."
+            f"Received: left_size = {left_size}"
         )
 
     # check right_size is non-negative and less than 1 and less than
@@ -414,8 +414,8 @@ def _rescale_dataset_split_sizes(left_size, right_size, total_length):
         raise ValueError(
             "`right_size` should be either a positive integer "
             f"and smaller than {total_length} or a float "
-            "within the range '[0, 1] (excluding the boundary values 0 and 1)'. Received: right_size="
-            f"{right_size}"
+            "within the range '[0, 1] (excluding the boundary values 0 and 1)'."
+            f"Received: right_size = {right_size}"
         )
 
     # check sum of left_size and right_size is less than or equal to

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -38,7 +38,7 @@ def split_dataset(
     Args:
         dataset: A `tf.data.Dataset` object, or a list/tuple of arrays with the
           same length.
-        left_size: If float (in the range `(0, 1)`), it signifies
+        left_size: If float (in the range "[0, 1] (excluding the boundary values 0 and 1)"), it signifies
           the fraction of the data to pack in the left dataset. If integer, it
           signifies the number of samples to pack in the left dataset. If
           `None`, it uses the complement to `right_size`. Defaults to `None`.
@@ -398,7 +398,7 @@ def _rescale_dataset_split_sizes(left_size, right_size, total_length):
         raise ValueError(
             "`left_size` should be either a positive integer "
             f"smaller than {total_length}, or a float "
-            "within the range `(0, 1)`. Received: left_size="
+            "within the range '[0, 1] (excluding the boundary values 0 and 1)'. Received: left_size="
             f"{left_size}"
         )
 
@@ -413,7 +413,7 @@ def _rescale_dataset_split_sizes(left_size, right_size, total_length):
         raise ValueError(
             "`right_size` should be either a positive integer "
             f"and smaller than {total_length} or a float "
-            "within the range `(0, 1)`. Received: right_size="
+            "within the range '[0, 1] (excluding the boundary values 0 and 1)'. Received: right_size="
             f"{right_size}"
         )
 

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -41,10 +41,10 @@ def split_dataset(
         left_size: If float (in the range `[0, 1]` (excluding the
           boundary values 0 and 1)), it signifies the fraction of the data to
           pack in the left dataset. If integer, it signifies the number of
-          samples to pack in the left dataset. If `None`, it uses the 
+          samples to pack in the left dataset. If `None`, it uses the
           complement to `right_size`. Defaults to `None`.
         right_size: If float (in the range `[0, 1]` (excluding the
-          boundary values 0 and 1)), it signifiesthe fraction of 
+          boundary values 0 and 1)), it signifiesthe fraction of
           the data to pack in the right dataset. If integer, it
           signifies the number of samples to pack in the right dataset. If
           `None`, it uses the complement to `left_size`. Defaults to `None`.


### PR DESCRIPTION
In the `tf.keras.utils.split_dataset` API , that can be used to split a dataset into left and right parts, the documentation states it splits dataset into `left half` and `right half` where the parts need not be equal parts.The split can be anything in range (0, 1). Hence I thought to replace the word `half` with `part`. 

Also in the `Args` section of documentation and `exception handling` in `source code` the range for split used as `[0, 1]` which is not a correct notation as 0 and 1 are actually not inclusive in the range and raises exception if we use either `0 or 1 `for either of `left_size` or `right_size` for splitting the dataset. Hence I have replaced `[0, 1] `with `(0, 1)` to make it more intuitive. Thanks.