### PR TITLE
Improve error message for input data to fit.

### DIFF
--- a/keras/engine/data_adapter.py
+++ b/keras/engine/data_adapter.py
@@ -1271,6 +1271,12 @@ class DataHandler:
         self._insufficient_data = False
         self._model = model
 
+        if steps_per_epoch == 0:
+            raise ValueError(
+                "Got argument `steps_per_epoch=0` passed to `fit()`."
+                "Try checking the argument and `Model.fit()` documentation."
+            )
+
         self._steps_per_epoch = steps_per_epoch
 
         # `steps_per_execution_value` is the cached initial value.
@@ -1307,6 +1313,11 @@ class DataHandler:
         self._configure_dataset_and_inferred_steps(
             strategy, x, steps_per_epoch, class_weight, distribute
         )
+
+        if self._inferred_steps == 0:
+            raise ValueError(
+                "Expected input data to `fit()` to be non-empty."
+            )
 
     def _configure_dataset_and_inferred_steps(
         self, strategy, x, steps_per_epoch, class_weight, distribute

--- a/keras/engine/data_adapter.py
+++ b/keras/engine/data_adapter.py
@@ -1273,8 +1273,9 @@ class DataHandler:
 
         if steps_per_epoch == 0:
             raise ValueError(
-                "Got argument `steps_per_epoch=0` passed to `fit()`."
-                "Try checking the argument and `Model.fit()` documentation."
+                "Unexpected value for `steps_per_epoch`. Received value is 0. "
+                "Please check the docstring for `model.fit()` for supported "
+                "values."
             )
 
         self._steps_per_epoch = steps_per_epoch
@@ -1315,7 +1316,7 @@ class DataHandler:
         )
 
         if self._inferred_steps == 0:
-            raise ValueError("Expected input data to `fit()` to be non-empty.")
+            raise ValueError("Expected input data to be non-empty.")
 
     def _configure_dataset_and_inferred_steps(
         self, strategy, x, steps_per_epoch, class_weight, distribute

--- a/keras/engine/data_adapter.py
+++ b/keras/engine/data_adapter.py
@@ -1315,9 +1315,7 @@ class DataHandler:
         )
 
         if self._inferred_steps == 0:
-            raise ValueError(
-                "Expected input data to `fit()` to be non-empty."
-            )
+            raise ValueError("Expected input data to `fit()` to be non-empty.")
 
     def _configure_dataset_and_inferred_steps(
         self, strategy, x, steps_per_epoch, class_weight, distribute

--- a/keras/engine/data_adapter_test.py
+++ b/keras/engine/data_adapter_test.py
@@ -1442,6 +1442,34 @@ class DataHandlerTest(test_combinations.TestCase):
                 # Check that single x input is not wrapped in a tuple.
                 self.assertIsInstance(next(iterator), tf.Tensor)
 
+    def test_error_if_zero_steps_per_epoch(self):
+        data = tf.data.Dataset.from_tensor_slices([0, 1, 2, 3]).batch(1)
+
+        with self.assertRaisesRegex(ValueError, "`steps_per_epoch=0`"):
+            data_adapter.DataHandler(
+                data, initial_epoch=0, epochs=2, steps_per_epoch=0
+            )
+
+    def test_error_if_empty_array_input_data(self):
+        x = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
+        y = np.array([0, 1, 1, 0])
+        idx = []
+
+        with self.assertRaisesWithLiteralMatch(
+            ValueError,
+            "Expected input data to `fit()` to be non-empty.",
+        ):
+            data_adapter.DataHandler(x[idx], y[idx])
+
+    def test_error_if_empty_dataset_input_data(self):
+        data = tf.data.Dataset.from_tensor_slices([]).batch(1)
+
+        with self.assertRaisesWithLiteralMatch(
+            ValueError,
+            "Expected input data to `fit()` to be non-empty.",
+        ):
+            data_adapter.DataHandler(data)
+
 
 class TestValidationSplit(test_combinations.TestCase):
     @parameterized.named_parameters(("numpy_arrays", True), ("tensors", False))

--- a/keras/engine/data_adapter_test.py
+++ b/keras/engine/data_adapter_test.py
@@ -1445,7 +1445,10 @@ class DataHandlerTest(test_combinations.TestCase):
     def test_error_if_zero_steps_per_epoch(self):
         data = tf.data.Dataset.from_tensor_slices([0, 1, 2, 3]).batch(1)
 
-        with self.assertRaisesRegex(ValueError, "`steps_per_epoch=0`"):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unexpected value for `steps_per_epoch`. Received value is 0.",
+        ):
             data_adapter.DataHandler(
                 data, initial_epoch=0, epochs=2, steps_per_epoch=0
             )
@@ -1457,7 +1460,7 @@ class DataHandlerTest(test_combinations.TestCase):
 
         with self.assertRaisesWithLiteralMatch(
             ValueError,
-            "Expected input data to `fit()` to be non-empty.",
+            "Expected input data to be non-empty.",
         ):
             data_adapter.DataHandler(x[idx], y[idx])
 
@@ -1466,7 +1469,7 @@ class DataHandlerTest(test_combinations.TestCase):
 
         with self.assertRaisesWithLiteralMatch(
             ValueError,
-            "Expected input data to `fit()` to be non-empty.",
+            "Expected input data to be non-empty.",
         ):
             data_adapter.DataHandler(data)
 

--- a/keras/engine/training_test.py
+++ b/keras/engine/training_test.py
@@ -94,7 +94,7 @@ class TrainingTest(test_combinations.TestCase):
         model = sequential.Sequential([layers_module.Dense(1)])
         model.compile("sgd", "mse", run_eagerly=test_utils.should_run_eagerly())
         with self.assertRaisesRegex(
-            ValueError, "Unexpected result of `train_function`.*"
+            ValueError, "Expected input data to be non-empty."
         ):
             model.fit(x=np.array([]), y=np.array([]))
 
@@ -2448,7 +2448,7 @@ class TestExceptionsAndWarnings(test_combinations.TestCase):
         model.compile(loss="mse")
 
         with self.assertRaisesRegex(
-            ValueError, "Unexpected result of `predict_function`.*"
+            ValueError, "Expected input data to be non-empty."
         ):
             model.predict(np.array([]))
 


### PR DESCRIPTION
The open PR for issue #16202 looks to be dead, and having conflicts. So I have added some checks in `DataHandler` to catch empty input and steps. I did not edit the error message in `fit` like the last PR did, as it looks to have been updated already.

This PR improve error message to give more useful feedback:
- if passing empty dataset or array as input data
- if passing `steps_per_epoch=0`

to `Model.fit()` by adding checks in `DataHandler`.

Resolve #16202 