### PR TITLE
Add ignore nan loss and metric

### DIFF
--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1572,55 +1572,55 @@ class Huber(LossFunctionWrapper):
 
 @keras_export('keras.losses.LossIgnoreNaN')
 class LossIgnoreNaN(Loss):
-  """Computes the loss between labels and predictions while ignoring NaN.
+    """Computes the loss between labels and predictions while ignoring NaN.
 
-  Standalone usage:
+    Standalone usage:
 
-  >>> y_true = [[0., 1., numpy.nan], [0., 0., numpy.nan]]
-  >>> y_pred = [[1., 1., 0], [1., 0., 0.]]
-  >>> # Using 'auto'/'sum_over_batch_size' reduction type.
-  >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(Loss)
-  >>> loss_ignorenan(y_true, y_pred).numpy()
-  0.5
+    >>> y_true = [[0., 1., numpy.nan], [0., 0., numpy.nan]]
+    >>> y_pred = [[1., 1., 0], [1., 0., 0.]]
+    >>> # Using 'auto'/'sum_over_batch_size' reduction type.
+    >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(Loss)
+    >>> loss_ignorenan(y_true, y_pred).numpy()
+    0.5
 
-  >>> # Calling with 'sample_weight'.
-  >>> loss_ignorenan(y_true, y_pred, sample_weight=[0.7, 0.3]).numpy()
-  0.25
+    >>> # Calling with 'sample_weight'.
+    >>> loss_ignorenan(y_true, y_pred, sample_weight=[0.7, 0.3]).numpy()
+    0.25
 
-  >>> # Using 'sum' reduction type.
-  >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
-  ...     reduction=tf.keras.losses.Reduction.SUM)
-  >>> loss_ignorenan(y_true, y_pred).numpy()
-  1.0
+    >>> # Using 'sum' reduction type.
+    >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
+    ...     reduction=tf.keras.losses.Reduction.SUM)
+    >>> loss_ignorenan(y_true, y_pred).numpy()
+    1.0
 
-  >>> # Using 'none' reduction type.
-  >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
-  ...     reduction=tf.keras.losses.Reduction.NONE)
-  >>> loss_ignorenan(y_true, y_pred).numpy()
-  array([0.5, 0.5], dtype=float32)
+    >>> # Using 'none' reduction type.
+    >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
+    ...     reduction=tf.keras.losses.Reduction.NONE)
+    >>> loss_ignorenan(y_true, y_pred).numpy()
+    array([0.5, 0.5], dtype=float32)
 
-  Usage with the `compile()` API:
+    Usage with the `compile()` API:
 
-  ```python (example: using mse loss with ignore nan)
-  model.compile(optimizer='sgd', loss=tf.keras.losses.LossIgnoreNaN(keras.losses.MeanSquaredError))
-  ```
-  """
-  def __init__(self, loss, **kwargs):
-    super().__init__(name=f"{loss.name}_ignorenan", **kwargs)
-    self.loss_fn = loss
+    ```python (example: using mse loss with ignore nan)
+    model.compile(optimizer='sgd', loss=tf.keras.losses.LossIgnoreNaN(keras.losses.MeanSquaredError))
+    ```
+    """
+    def __init__(self, loss, **kwargs):
+        super().__init__(name=f"{loss.name}_ignorenan", **kwargs)
+        self.loss_fn = loss
 
-  def call(self, y_true, y_pred, sample_weight=None):
-    y_true_non_nan, y_pred_non_nan = self.mask_nan_values(y_true, y_pred)
-    loss_value_non_nan = self.loss_fn(y_true_non_nan, y_pred_non_nan, sample_weight=sample_weight)
-    return loss_value_non_nan
-  
-  @staticmethod
-  def mask_nan_values(y_true, y_pred):
-    nan_mask = tf.math.logical_or(tf.math.is_nan(y_true), tf.math.is_nan(y_pred))
-    non_nan_mask = tf.math.logical_not(nan_mask)
-    y_true_non_nan = tf.boolean_mask(y_true, non_nan_mask)
-    y_pred_non_nan = tf.boolean_mask(y_pred, non_nan_mask)
-    return y_true_non_nan, y_pred_non_nan
+    def call(self, y_true, y_pred, sample_weight=None):
+        y_true_non_nan, y_pred_non_nan = self.mask_nan_values(y_true, y_pred)
+        loss_value_non_nan = self.loss_fn(y_true_non_nan, y_pred_non_nan, sample_weight=sample_weight)
+        return loss_value_non_nan
+
+    @staticmethod
+    def mask_nan_values(y_true, y_pred):
+        nan_mask = tf.math.logical_or(tf.math.is_nan(y_true), tf.math.is_nan(y_pred))
+        non_nan_mask = tf.math.logical_not(nan_mask)
+        y_true_non_nan = tf.boolean_mask(y_true, non_nan_mask)
+        y_pred_non_nan = tf.boolean_mask(y_pred, non_nan_mask)
+        return y_true_non_nan, y_pred_non_nan
 
 
 @keras_export(

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1570,6 +1570,59 @@ class Huber(LossFunctionWrapper):
         super().__init__(huber, name=name, reduction=reduction, delta=delta)
 
 
+@keras_export('keras.losses.LossIgnoreNaN')
+class LossIgnoreNaN(Loss):
+  """Computes the loss between labels and predictions while ignoring NaN.
+
+  Standalone usage:
+
+  >>> y_true = [[0., 1., numpy.nan], [0., 0., numpy.nan]]
+  >>> y_pred = [[1., 1., 0], [1., 0., 0.]]
+  >>> # Using 'auto'/'sum_over_batch_size' reduction type.
+  >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(Loss)
+  >>> loss_ignorenan(y_true, y_pred).numpy()
+  0.5
+
+  >>> # Calling with 'sample_weight'.
+  >>> loss_ignorenan(y_true, y_pred, sample_weight=[0.7, 0.3]).numpy()
+  0.25
+
+  >>> # Using 'sum' reduction type.
+  >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
+  ...     reduction=tf.keras.losses.Reduction.SUM)
+  >>> loss_ignorenan(y_true, y_pred).numpy()
+  1.0
+
+  >>> # Using 'none' reduction type.
+  >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
+  ...     reduction=tf.keras.losses.Reduction.NONE)
+  >>> loss_ignorenan(y_true, y_pred).numpy()
+  array([0.5, 0.5], dtype=float32)
+
+  Usage with the `compile()` API:
+
+  ```python (example: using mse loss with ignore nan)
+  model.compile(optimizer='sgd', loss=tf.keras.losses.LossIgnoreNaN(keras.losses.MeanSquaredError))
+  ```
+  """
+  def __init__(self, loss, **kwargs):
+    super().__init__(name=f"{loss.name}_ignorenan", **kwargs)
+    self.loss_fn = loss
+
+  def call(self, y_true, y_pred, sample_weight=None):
+    y_true_non_nan, y_pred_non_nan = self.mask_nan_values(y_true, y_pred)
+    loss_value_non_nan = self.loss_fn(y_true_non_nan, y_pred_non_nan, sample_weight=sample_weight)
+    return loss_value_non_nan
+  
+  @staticmethod
+  def mask_nan_values(y_true, y_pred):
+    nan_mask = tf.math.logical_or(tf.math.is_nan(y_true), tf.math.is_nan(y_pred))
+    non_nan_mask = tf.math.logical_not(nan_mask)
+    y_true_non_nan = tf.boolean_mask(y_true, non_nan_mask)
+    y_pred_non_nan = tf.boolean_mask(y_pred, non_nan_mask)
+    return y_true_non_nan, y_pred_non_nan
+
+
 @keras_export(
     "keras.metrics.mean_squared_error",
     "keras.metrics.mse",

--- a/keras/losses_test.py
+++ b/keras/losses_test.py
@@ -2980,6 +2980,7 @@ class CustomLossTest(tf.test.TestCase):
             7.0,
         )
 
+
 @test_combinations.generate(test_combinations.combine(mode=["graph", "eager"]))
 class LossIgnoreNaNTest(tf.test.TestCase):
     def test_loss_ignorenan(self):

--- a/keras/metrics/metrics_functional_test.py
+++ b/keras/metrics/metrics_functional_test.py
@@ -185,6 +185,40 @@ class KerasFunctionalMetricsTest(tf.test.TestCase, parameterized.TestCase):
             )
             self.assertEqual(np.mean(result), 0.0)
 
+    def test_metric_ignorenan(self):
+        with self.cached_session():
+            metric = metrics.MetricIgnoreNaN(metrics.MeanSquaredError())
+
+            y_true = backend.variable(np.array([1, 2, 3]))
+            y_pred = backend.variable(np.array([1, 2, 4]))
+            metric.update_state(y_true, y_pred)
+            self.assertAlmostEqual(backend.eval(metric.result()), 1 / 3)
+
+            y_true = backend.variable(np.array([1, np.nan, 3]))
+            y_pred = backend.variable(np.array([1, 2, 4]))
+            metric.update_state(y_true, y_pred)
+            self.assertAlmostEqual(backend.eval(metric.result()), 2 / 3)
+
+            y_true = backend.variable(np.array([1, 2, 3]))
+            y_pred = backend.variable(np.array([1, np.nan, 4]))
+            metric.update_state(y_true, y_pred)
+            self.assertAlmostEqual(backend.eval(metric.result()), 1 / 3)
+
+            y_true = backend.variable(np.array([1, np.nan, 3]))
+            y_pred = backend.variable(np.array([1, np.nan, 4]))
+            metric.update_state(y_true, y_pred)
+            self.assertAlmostEqual(backend.eval(metric.result()), 0.5)
+
+            metric.reset_state()
+            self.assertEqual(backend.eval(metric.result()), 0.0)
+
+
+
+
+
+
+
+
 
 if __name__ == "__main__":
     tf.test.main()

--- a/keras/metrics/metrics_functional_test.py
+++ b/keras/metrics/metrics_functional_test.py
@@ -213,12 +213,5 @@ class KerasFunctionalMetricsTest(tf.test.TestCase, parameterized.TestCase):
             self.assertEqual(backend.eval(metric.result()), 0.0)
 
 
-
-
-
-
-
-
-
 if __name__ == "__main__":
     tf.test.main()


### PR DESCRIPTION
Create classes for metrics and losses in the Keras TensorFlow project that can ignore NaN values in the labels by wrapping another metric or loss and computing it.