### PR TITLE
Removing unnecessary conversion to tf.constant in documentation

### DIFF
--- a/keras/losses.py
+++ b/keras/losses.py
@@ -858,7 +858,7 @@ class CategoricalCrossentropy(LossFunctionWrapper):
     1.177
 
     >>> # Calling with 'sample_weight'.
-    >>> cce(y_true, y_pred, sample_weight=tf.constant([0.3, 0.7])).numpy()
+    >>> cce(y_true, y_pred, sample_weight=np.array([0.3, 0.7]))
     0.814
 
     >>> # Using 'sum' reduction type.
@@ -976,7 +976,7 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
     0.23315276
 
     >>> # Calling with 'sample_weight'.
-    >>> cce(y_true, y_pred, sample_weight=tf.constant([0.3, 0.7])).numpy()
+    >>> cce(y_true, y_pred, sample_weight=np.array([0.3, 0.7]))
     0.1632
 
     >>> # Using 'sum' reduction type.
@@ -1086,7 +1086,7 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
     1.177
 
     >>> # Calling with 'sample_weight'.
-    >>> scce(y_true, y_pred, sample_weight=tf.constant([0.3, 0.7])).numpy()
+    >>> scce(y_true, y_pred, sample_weight=np.array([0.3, 0.7]))
     0.814
 
     >>> # Using 'sum' reduction type.


### PR DESCRIPTION
In the documentation of some functions in losses.py there are some examples where a list is converted to a tf constant and then converted to a numpy array. Wouldn't it make more sense to convert it directly to a numpy array?

---

Note: this is my first PR here, sorry for not opening an issue but this really is a minor, cosmetic change.

I tried to see if the tf.constant follows some "smart" rule for conversion (which would justify the extra step), but I couldn't find anything, and I made a quick search and this is the only place in the whole codebase where this double conversion is made. So I really couldn't find any reason to justify the double conversion...