### PR TITLE
Add ignore nan metric loss

### DIFF
--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1572,55 +1572,55 @@ class Huber(LossFunctionWrapper):
 
 @keras_export('keras.losses.LossIgnoreNaN')
 class LossIgnoreNaN(Loss):
-  """Computes the loss between labels and predictions while ignoring NaN.
+    """Computes the loss between labels and predictions while ignoring NaN.
 
-  Standalone usage:
+    Standalone usage:
 
-  >>> y_true = [[0., 1., numpy.nan], [0., 0., numpy.nan]]
-  >>> y_pred = [[1., 1., 0], [1., 0., 0.]]
-  >>> # Using 'auto'/'sum_over_batch_size' reduction type.
-  >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(Loss)
-  >>> loss_ignorenan(y_true, y_pred).numpy()
-  0.5
+    >>> y_true = [[0., 1., numpy.nan], [0., 0., numpy.nan]]
+    >>> y_pred = [[1., 1., 0], [1., 0., 0.]]
+    >>> # Using 'auto'/'sum_over_batch_size' reduction type.
+    >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(Loss)
+    >>> loss_ignorenan(y_true, y_pred).numpy()
+    0.5
 
-  >>> # Calling with 'sample_weight'.
-  >>> loss_ignorenan(y_true, y_pred, sample_weight=[0.7, 0.3]).numpy()
-  0.25
+    >>> # Calling with 'sample_weight'.
+    >>> loss_ignorenan(y_true, y_pred, sample_weight=[0.7, 0.3]).numpy()
+    0.25
 
-  >>> # Using 'sum' reduction type.
-  >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
-  ...     reduction=tf.keras.losses.Reduction.SUM)
-  >>> loss_ignorenan(y_true, y_pred).numpy()
-  1.0
+    >>> # Using 'sum' reduction type.
+    >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
+    ...     reduction=tf.keras.losses.Reduction.SUM)
+    >>> loss_ignorenan(y_true, y_pred).numpy()
+    1.0
 
-  >>> # Using 'none' reduction type.
-  >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
-  ...     reduction=tf.keras.losses.Reduction.NONE)
-  >>> loss_ignorenan(y_true, y_pred).numpy()
-  array([0.5, 0.5], dtype=float32)
+    >>> # Using 'none' reduction type.
+    >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
+    ...     reduction=tf.keras.losses.Reduction.NONE)
+    >>> loss_ignorenan(y_true, y_pred).numpy()
+    array([0.5, 0.5], dtype=float32)
 
-  Usage with the `compile()` API:
+    Usage with the `compile()` API:
 
-  ```python (example: using mse loss with ignore nan)
-  model.compile(optimizer='sgd', loss=tf.keras.losses.LossIgnoreNaN(keras.losses.MeanSquaredError))
-  ```
-  """
-  def __init__(self, loss, **kwargs):
-    super().__init__(name=f"{loss.name}_ignorenan", **kwargs)
-    self.loss_fn = loss
+    ```python (example: using mse loss with ignore nan)
+    model.compile(optimizer='sgd', loss=tf.keras.losses.LossIgnoreNaN(keras.losses.MeanSquaredError))
+    ```
+    """
+    def __init__(self, loss, **kwargs):
+        super().__init__(name=f"{loss.name}_ignorenan", **kwargs)
+        self.loss_fn = loss
 
-  def call(self, y_true, y_pred, sample_weight=None):
-    y_true_non_nan, y_pred_non_nan = self.mask_nan_values(y_true, y_pred)
-    loss_value_non_nan = self.loss_fn(y_true_non_nan, y_pred_non_nan, sample_weight=sample_weight)
-    return loss_value_non_nan
-  
-  @staticmethod
-  def mask_nan_values(y_true, y_pred):
-    nan_mask = tf.math.logical_or(tf.math.is_nan(y_true), tf.math.is_nan(y_pred))
-    non_nan_mask = tf.math.logical_not(nan_mask)
-    y_true_non_nan = tf.boolean_mask(y_true, non_nan_mask)
-    y_pred_non_nan = tf.boolean_mask(y_pred, non_nan_mask)
-    return y_true_non_nan, y_pred_non_nan
+    def call(self, y_true, y_pred, sample_weight=None):
+        y_true_non_nan, y_pred_non_nan = self.mask_nan_values(y_true, y_pred)
+        loss_value_non_nan = self.loss_fn(y_true_non_nan, y_pred_non_nan, sample_weight=sample_weight)
+        return loss_value_non_nan
+
+    @staticmethod
+    def mask_nan_values(y_true, y_pred):
+        nan_mask = tf.math.logical_or(tf.math.is_nan(y_true), tf.math.is_nan(y_pred))
+        non_nan_mask = tf.math.logical_not(nan_mask)
+        y_true_non_nan = tf.boolean_mask(y_true, non_nan_mask)
+        y_pred_non_nan = tf.boolean_mask(y_pred, non_nan_mask)
+        return y_true_non_nan, y_pred_non_nan
 
 
 @keras_export(

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1602,7 +1602,8 @@ class LossIgnoreNaN(Loss):
     Usage with the `compile()` API:
 
     ```python (example: using mse loss with ignore nan)
-    model.compile(optimizer='sgd', loss=tf.keras.losses.LossIgnoreNaN(keras.losses.MeanSquaredError))
+    model.compile(optimizer='sgd', 
+    loss=tf.keras.losses.LossIgnoreNaN(keras.losses.MeanSquaredError))
     ```
     """
     def __init__(self, loss, **kwargs):
@@ -1611,12 +1612,14 @@ class LossIgnoreNaN(Loss):
 
     def call(self, y_true, y_pred, sample_weight=None):
         y_true_non_nan, y_pred_non_nan = self.mask_nan_values(y_true, y_pred)
-        loss_value_non_nan = self.loss_fn(y_true_non_nan, y_pred_non_nan, sample_weight=sample_weight)
+        loss_value_non_nan = self.loss_fn(y_true_non_nan, y_pred_non_nan,
+         sample_weight=sample_weight)
         return loss_value_non_nan
 
     @staticmethod
     def mask_nan_values(y_true, y_pred):
-        nan_mask = tf.math.logical_or(tf.math.is_nan(y_true), tf.math.is_nan(y_pred))
+        nan_mask = tf.math.logical_or(tf.math.is_nan(y_true),
+         tf.math.is_nan(y_pred))
         non_nan_mask = tf.math.logical_not(nan_mask)
         y_true_non_nan = tf.boolean_mask(y_true, non_nan_mask)
         y_pred_non_nan = tf.boolean_mask(y_pred, non_nan_mask)

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1570,6 +1570,59 @@ class Huber(LossFunctionWrapper):
         super().__init__(huber, name=name, reduction=reduction, delta=delta)
 
 
+@keras_export('keras.losses.LossIgnoreNaN')
+class LossIgnoreNaN(Loss):
+  """Computes the loss between labels and predictions while ignoring NaN.
+
+  Standalone usage:
+
+  >>> y_true = [[0., 1., numpy.nan], [0., 0., numpy.nan]]
+  >>> y_pred = [[1., 1., 0], [1., 0., 0.]]
+  >>> # Using 'auto'/'sum_over_batch_size' reduction type.
+  >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(Loss)
+  >>> loss_ignorenan(y_true, y_pred).numpy()
+  0.5
+
+  >>> # Calling with 'sample_weight'.
+  >>> loss_ignorenan(y_true, y_pred, sample_weight=[0.7, 0.3]).numpy()
+  0.25
+
+  >>> # Using 'sum' reduction type.
+  >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
+  ...     reduction=tf.keras.losses.Reduction.SUM)
+  >>> loss_ignorenan(y_true, y_pred).numpy()
+  1.0
+
+  >>> # Using 'none' reduction type.
+  >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
+  ...     reduction=tf.keras.losses.Reduction.NONE)
+  >>> loss_ignorenan(y_true, y_pred).numpy()
+  array([0.5, 0.5], dtype=float32)
+
+  Usage with the `compile()` API:
+
+  ```python (example: using mse loss with ignore nan)
+  model.compile(optimizer='sgd', loss=tf.keras.losses.LossIgnoreNaN(keras.losses.MeanSquaredError))
+  ```
+  """
+  def __init__(self, loss, **kwargs):
+    super().__init__(name=f"{loss.name}_ignorenan", **kwargs)
+    self.loss_fn = loss
+
+  def call(self, y_true, y_pred, sample_weight=None):
+    y_true_non_nan, y_pred_non_nan = self.mask_nan_values(y_true, y_pred)
+    loss_value_non_nan = self.loss_fn(y_true_non_nan, y_pred_non_nan, sample_weight=sample_weight)
+    return loss_value_non_nan
+  
+  @staticmethod
+  def mask_nan_values(y_true, y_pred):
+    nan_mask = tf.math.logical_or(tf.math.is_nan(y_true), tf.math.is_nan(y_pred))
+    non_nan_mask = tf.math.logical_not(nan_mask)
+    y_true_non_nan = tf.boolean_mask(y_true, non_nan_mask)
+    y_pred_non_nan = tf.boolean_mask(y_pred, non_nan_mask)
+    return y_true_non_nan, y_pred_non_nan
+
+
 @keras_export(
     "keras.metrics.mean_squared_error",
     "keras.metrics.mse",

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1589,21 +1589,21 @@ class LossIgnoreNaN(Loss):
 
     >>> # Using 'sum' reduction type.
     >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
-    ...     reduction=tf.keras.losses.Reduction.SUM)
+        reduction=tf.keras.losses.Reduction.SUM)
     >>> loss_ignorenan(y_true, y_pred).numpy()
     1.0
 
     >>> # Using 'none' reduction type.
     >>> loss_ignorenan = tf.keras.losses.LossIgnoreNaN(
-    ...     reduction=tf.keras.losses.Reduction.NONE)
+        reduction=tf.keras.losses.Reduction.NONE)
     >>> loss_ignorenan(y_true, y_pred).numpy()
     array([0.5, 0.5], dtype=float32)
 
     Usage with the `compile()` API:
 
     ```python (example: using mse loss with ignore nan)
-    model.compile(optimizer='sgd', 
-    loss=tf.keras.losses.LossIgnoreNaN(keras.losses.MeanSquaredError))
+    model.compile(optimizer='sgd',loss=tf.keras.losses.
+    LossIgnoreNaN(keras.losses.MeanSquaredError))
     ```
     """
     def __init__(self, loss, **kwargs):
@@ -1612,14 +1612,14 @@ class LossIgnoreNaN(Loss):
 
     def call(self, y_true, y_pred, sample_weight=None):
         y_true_non_nan, y_pred_non_nan = self.mask_nan_values(y_true, y_pred)
-        loss_value_non_nan = self.loss_fn(y_true_non_nan, y_pred_non_nan,
-         sample_weight=sample_weight)
+        loss_value_non_nan = self.loss_fn(
+            y_true_non_nan, y_pred_non_nan, sample_weight=sample_weight)
         return loss_value_non_nan
 
     @staticmethod
     def mask_nan_values(y_true, y_pred):
-        nan_mask = tf.math.logical_or(tf.math.is_nan(y_true),
-         tf.math.is_nan(y_pred))
+        nan_mask = tf.math.logical_or(
+            tf.math.is_nan(y_true), tf.math.is_nan(y_pred))
         non_nan_mask = tf.math.logical_not(nan_mask)
         y_true_non_nan = tf.boolean_mask(y_true, non_nan_mask)
         y_pred_non_nan = tf.boolean_mask(y_pred, non_nan_mask)

--- a/keras/losses_test.py
+++ b/keras/losses_test.py
@@ -3011,7 +3011,8 @@ class LossIgnoreNaNTest(tf.test.TestCase):
         y_pred = backend.variable(np.array([1, np.nan, 4]))
         sample_weight = backend.variable(np.array([0.7, 0.3, 1]))
         loss_value = loss_fn(y_true, y_pred, sample_weight)
-        self.assertAlmostEqual(backend.eval(loss_value), (0.7 * 0 + 0.3 * 0.5 + 1 * 0.5) / 2)
+        self.assertAlmostEqual(backend.eval(loss_value),
+         (0.7 * 0 + 0.3 * 0.5 + 1 * 0.5) / 2)
 
         loss_fn = losses.LossIgnoreNaN(mse_loss, reduction=losses.Reduction.SUM)
         y_true = backend.variable(np.array([1, np.nan, 3]))
@@ -3019,7 +3020,8 @@ class LossIgnoreNaNTest(tf.test.TestCase):
         loss_value = loss_fn(y_true, y_pred)
         self.assertAlmostEqual(backend.eval(loss_value), 1.0)
 
-        loss_fn = losses.LossIgnoreNaN(mse_loss, reduction=losses.Reduction.NONE)
+        loss_fn = losses.LossIgnoreNaN(mse_loss, 
+        reduction=losses.Reduction.NONE)
         y_true = backend.variable(np.array([1, np.nan, 3]))
         y_pred = backend.variable(np.array([1, np.nan, 4]))
         loss_value = loss_fn(y_true, y_pred)

--- a/keras/losses_test.py
+++ b/keras/losses_test.py
@@ -2980,6 +2980,7 @@ class CustomLossTest(tf.test.TestCase):
             7.0,
         )
 
+
 @test_combinations.generate(test_combinations.combine(mode=["graph", "eager"]))
 class LossIgnoreNaNTest(tf.test.TestCase):
     def test_loss_ignorenan(self):

--- a/keras/losses_test.py
+++ b/keras/losses_test.py
@@ -3012,7 +3012,7 @@ class LossIgnoreNaNTest(tf.test.TestCase):
         sample_weight = backend.variable(np.array([0.7, 0.3, 1]))
         loss_value = loss_fn(y_true, y_pred, sample_weight)
         self.assertAlmostEqual(backend.eval(loss_value),
-         (0.7 * 0 + 0.3 * 0.5 + 1 * 0.5) / 2)
+                               (0.7 * 0 + 0.3 * 0.5 + 1 * 0.5) / 2)
 
         loss_fn = losses.LossIgnoreNaN(mse_loss, reduction=losses.Reduction.SUM)
         y_true = backend.variable(np.array([1, np.nan, 3]))
@@ -3020,8 +3020,8 @@ class LossIgnoreNaNTest(tf.test.TestCase):
         loss_value = loss_fn(y_true, y_pred)
         self.assertAlmostEqual(backend.eval(loss_value), 1.0)
 
-        loss_fn = losses.LossIgnoreNaN(mse_loss, 
-        reduction=losses.Reduction.NONE)
+        loss_fn = losses.LossIgnoreNaN(mse_loss,
+                                       reduction=losses.Reduction.NONE)
         y_true = backend.variable(np.array([1, np.nan, 3]))
         y_pred = backend.variable(np.array([1, np.nan, 4]))
         loss_value = loss_fn(y_true, y_pred)

--- a/keras/metrics/base_metric.py
+++ b/keras/metrics/base_metric.py
@@ -894,7 +894,8 @@ class MeanTensor(Metric):
 
 @keras_export('keras.metrics.MetricIgnoreNaN')
 class MetricIgnoreNaN(Metric):
-    """Computes the given metric between the labels and predictions while ignoring NaN.
+    """Computes the given metric between the labels and predictions while
+    ignoring NaN.
 
     This class wraps another metric and computes it, ignoring any NaN values
     in the labels and predictions.
@@ -927,7 +928,8 @@ class MetricIgnoreNaN(Metric):
 
     def update_state(self, y_true, y_pred, sample_weight=None):
         y_true_non_nan, y_pred_non_nan = self.mask_nan_values(y_true, y_pred)
-        self.metric_fn.update_state(y_true_non_nan, y_pred_non_nan, sample_weight=sample_weight)
+        self.metric_fn.update_state(y_true_non_nan, y_pred_non_nan, 
+        sample_weight=sample_weight)
 
     def result(self):
         return self.metric_fn.result()
@@ -937,7 +939,8 @@ class MetricIgnoreNaN(Metric):
 
     @staticmethod
     def mask_nan_values(y_true, y_pred):
-        nan_mask = tf.math.logical_or(tf.math.is_nan(y_true), tf.math.is_nan(y_pred))
+        nan_mask = tf.math.logical_or(tf.math.is_nan(y_true), 
+        tf.math.is_nan(y_pred))
         non_nan_mask = tf.math.logical_not(nan_mask)
         y_true_non_nan = tf.boolean_mask(y_true, non_nan_mask)
         y_pred_non_nan = tf.boolean_mask(y_pred, non_nan_mask)

--- a/keras/metrics/base_metric.py
+++ b/keras/metrics/base_metric.py
@@ -928,8 +928,8 @@ class MetricIgnoreNaN(Metric):
 
     def update_state(self, y_true, y_pred, sample_weight=None):
         y_true_non_nan, y_pred_non_nan = self.mask_nan_values(y_true, y_pred)
-        self.metric_fn.update_state(y_true_non_nan, y_pred_non_nan, 
-        sample_weight=sample_weight)
+        self.metric_fn.update_state(y_true_non_nan, y_pred_non_nan,
+                                    sample_weight=sample_weight)
 
     def result(self):
         return self.metric_fn.result()
@@ -939,8 +939,8 @@ class MetricIgnoreNaN(Metric):
 
     @staticmethod
     def mask_nan_values(y_true, y_pred):
-        nan_mask = tf.math.logical_or(tf.math.is_nan(y_true), 
-        tf.math.is_nan(y_pred))
+        nan_mask = tf.math.logical_or(tf.math.is_nan(y_true),
+                                      tf.math.is_nan(y_pred))
         non_nan_mask = tf.math.logical_not(nan_mask)
         y_true_non_nan = tf.boolean_mask(y_true, non_nan_mask)
         y_pred_non_nan = tf.boolean_mask(y_pred, non_nan_mask)

--- a/keras/metrics/metrics_functional_test.py
+++ b/keras/metrics/metrics_functional_test.py
@@ -185,6 +185,40 @@ class KerasFunctionalMetricsTest(tf.test.TestCase, parameterized.TestCase):
             )
             self.assertEqual(np.mean(result), 0.0)
 
+    def test_metric_ignorenan(self):
+        with self.cached_session():
+            metric = metrics.MetricIgnoreNaN(metrics.MeanSquaredError())
+
+            y_true = backend.variable(np.array([1, 2, 3]))
+            y_pred = backend.variable(np.array([1, 2, 4]))
+            metric.update_state(y_true, y_pred)
+            self.assertAlmostEqual(backend.eval(metric.result()), 1 / 3)
+
+            y_true = backend.variable(np.array([1, np.nan, 3]))
+            y_pred = backend.variable(np.array([1, 2, 4]))
+            metric.update_state(y_true, y_pred)
+            self.assertAlmostEqual(backend.eval(metric.result()), 2 / 3)
+
+            y_true = backend.variable(np.array([1, 2, 3]))
+            y_pred = backend.variable(np.array([1, np.nan, 4]))
+            metric.update_state(y_true, y_pred)
+            self.assertAlmostEqual(backend.eval(metric.result()), 1 / 3)
+
+            y_true = backend.variable(np.array([1, np.nan, 3]))
+            y_pred = backend.variable(np.array([1, np.nan, 4]))
+            metric.update_state(y_true, y_pred)
+            self.assertAlmostEqual(backend.eval(metric.result()), 0.5)
+
+            metric.reset_state()
+            self.assertEqual(backend.eval(metric.result()), 0.0)
+
+
+
+
+
+
+
+
 
 if __name__ == "__main__":
     tf.test.main()

--- a/keras/metrics/metrics_functional_test.py
+++ b/keras/metrics/metrics_functional_test.py
@@ -213,12 +213,5 @@ class KerasFunctionalMetricsTest(tf.test.TestCase, parameterized.TestCase):
             self.assertEqual(backend.eval(metric.result()), 0.0)
 
 
-
-
-
-
-
-
-
 if __name__ == "__main__":
     tf.test.main()


### PR DESCRIPTION
Create classes for metrics and losses in the Keras TensorFlow project that can ignore NaN values in the labels by wrapping another metric or loss and computing it.