### PR TITLE
use io_utils.print_msg in datset_utils

### DIFF
--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -670,7 +670,7 @@ def get_training_or_validation_split(samples, labels, validation_split, subset):
 
     num_val_samples = int(validation_split * len(samples))
     if subset == "training":
-    	io_utils.print_msg(
+        io_utils.print_msg(
                 f"Using {len(samples) - num_val_samples} "
                 f"files for training."
         )

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -670,7 +670,10 @@ def get_training_or_validation_split(samples, labels, validation_split, subset):
 
     num_val_samples = int(validation_split * len(samples))
     if subset == "training":
-        io_utils.print_msg(f"Using {len(samples) - num_val_samples} files for training.")
+    	io_utils.print_msg(
+                f"Using {len(samples) - num_val_samples} "
+                f"files for training."
+        )
         samples = samples[:-num_val_samples]
         labels = labels[:-num_val_samples]
     elif subset == "validation":

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -671,8 +671,8 @@ def get_training_or_validation_split(samples, labels, validation_split, subset):
     num_val_samples = int(validation_split * len(samples))
     if subset == "training":
         io_utils.print_msg(
-                f"Using {len(samples) - num_val_samples} "
-                f"files for training."
+            f"Using {len(samples) - num_val_samples} "
+            f"files for training."
         )
         samples = samples[:-num_val_samples]
         labels = labels[:-num_val_samples]

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -670,11 +670,11 @@ def get_training_or_validation_split(samples, labels, validation_split, subset):
 
     num_val_samples = int(validation_split * len(samples))
     if subset == "training":
-        print(f"Using {len(samples) - num_val_samples} files for training.")
+        io_utils.print_msg(f"Using {len(samples) - num_val_samples} files for training.")
         samples = samples[:-num_val_samples]
         labels = labels[:-num_val_samples]
     elif subset == "validation":
-        print(f"Using {num_val_samples} files for validation.")
+        io_utils.print_msg(f"Using {num_val_samples} files for validation.")
         samples = samples[-num_val_samples:]
         labels = labels[-num_val_samples:]
     else:

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -671,8 +671,7 @@ def get_training_or_validation_split(samples, labels, validation_split, subset):
     num_val_samples = int(validation_split * len(samples))
     if subset == "training":
         io_utils.print_msg(
-            f"Using {len(samples) - num_val_samples} "
-            f"files for training."
+            f"Using {len(samples) - num_val_samples} " f"files for training."
         )
         samples = samples[:-num_val_samples]
         labels = labels[:-num_val_samples]


### PR DESCRIPTION
Use of  io_utils.print_msg allows to send messages to python logging by setting:
https://www.tensorflow.org/api_docs/python/tf/keras/utils/disable_interactive_logging
instead of stdout (which remains default behavior if interactive logging is not disabled).
Tested on tf 2.12.