### PR TITLE
Update Python ver to 3.9 in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.8
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.9
 COPY setup.sh /setup.sh
 
 # Install Bazel


### PR DESCRIPTION
Since support for Python 3.8 will be deprecated after the current TF 2.13 Release, updating to 3.9 on DevContainer Dockerfile.