### PR TITLE
Dealing with the problem that tf.name_scope is not reflected #17538

### DIFF
--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -2494,7 +2494,7 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
                 keras_tensor.keras_tensor_to_placeholder, input_masks
             )
 
-            with backend.name_scope(self._name_scope()):
+            with backend.name_scope(self._get_unnested_name_scope()):
                 with autocast_variable.enable_auto_cast_variables(
                     self._compute_dtype_object
                 ):

--- a/keras/engine/base_layer.py
+++ b/keras/engine/base_layer.py
@@ -1113,7 +1113,6 @@ class Layer(tf.Module, version_utils.LayerVersionSelector):
             build_graph=not eager,
             training=training_mode,
         ):
-
             input_spec.assert_input_compatibility(
                 self.input_spec, inputs, self.name
             )

--- a/keras/engine/base_layer_test.py
+++ b/keras/engine/base_layer_test.py
@@ -466,7 +466,6 @@ class BaseLayerTest(test_combinations.TestCase):
     @test_combinations.generate(test_combinations.combine(mode=["eager"]))
     def test_composite_variable_assignment(self):
         class Spec(tf.TypeSpec):
-
             value_type = property(lambda self: CompositeVariable)
 
             def _component_specs(self):
@@ -1649,7 +1648,6 @@ class NameScopingTest(test_combinations.TestCase):
 )
 class AutographControlFlowTest(test_combinations.TestCase):
     def test_disabling_in_context_is_matched(self):
-
         test_obj = self
 
         class MyLayer(base_layer.Layer):

--- a/keras/engine/base_layer_test.py
+++ b/keras/engine/base_layer_test.py
@@ -1433,7 +1433,7 @@ class NameScopingTest(test_combinations.TestCase):
     def test_name_scope_layer_with_tf_name_scope(self):
         x = backend.placeholder(shape=(10, 10))
         base_layer._apply_name_scope_on_model_declaration(True)
-        with tf.name_scope("RootName") as _:
+        with tf.name_scope("RootName"):
             layer = layers.Dense(10, name="MyName")
             layer(x)
         self.assertEqual(layer.bias.name, "RootName/MyName/bias:0")
@@ -1450,7 +1450,7 @@ class NameScopingTest(test_combinations.TestCase):
     def test_name_scope_functional_api_with_tf_name_scope(self):
         base_layer._apply_name_scope_on_model_declaration(True)
         inputs = input_layer.Input((3,))
-        with tf.name_scope("RootName") as _:
+        with tf.name_scope("RootName"):
             layer = layers.Dense(10, name="MyName")
             _ = layer(inputs)
         self.assertEqual(layer.bias.name, "RootName/MyName/bias:0")
@@ -1496,7 +1496,7 @@ class NameScopingTest(test_combinations.TestCase):
         base_layer._apply_name_scope_on_model_declaration(True)
         x = backend.placeholder(shape=(10, 10))
         sublayer = NameScopeTracker(name="Sublayer")
-        with tf.name_scope("RootName") as _:
+        with tf.name_scope("RootName"):
             layer = layers.Dense(10, activation=sublayer, name="MyName2")
             layer(x)
         self.assertEqual(layer.bias.name, "RootName/MyName2/bias:0")
@@ -1517,7 +1517,7 @@ class NameScopingTest(test_combinations.TestCase):
     def test_name_scope_tf_tensor_with_tf_name_scope(self):
         base_layer._apply_name_scope_on_model_declaration(True)
         x = tf.convert_to_tensor(np.ones((10, 10)))
-        with tf.name_scope("RootName") as _:
+        with tf.name_scope("RootName"):
             layer = layers.Dense(
                 10, activation=layers.ReLU(name="MyAct"), name="MyName3"
             )


### PR DESCRIPTION
Fixed the problem that tf.name_scope is ignored even if tf.keras.__internal__.apply_name_scope_on_model_declaration is used.

related issues
- https://github.com/keras-team/keras/issues/17538
- https://github.com/tensorflow/tensorflow/issues/27298

PS. Thanks to @slanzmich for finding this solution.