### PR TITLE
RGB image data is not grayscale image data

### DIFF
--- a/keras/datasets/cifar10.py
+++ b/keras/datasets/cifar10.py
@@ -52,14 +52,14 @@ def load_data():
     Returns:
       Tuple of NumPy arrays: `(x_train, y_train), (x_test, y_test)`.
 
-    **x_train**: uint8 NumPy array of grayscale image data with shapes
+    **x_train**: uint8 NumPy array of image data with shapes
       `(50000, 32, 32, 3)`, containing the training data. Pixel values range
       from 0 to 255.
 
     **y_train**: uint8 NumPy array of labels (integers in range 0-9)
       with shape `(50000, 1)` for the training data.
 
-    **x_test**: uint8 NumPy array of grayscale image data with shapes
+    **x_test**: uint8 NumPy array of image data with shapes
       `(10000, 32, 32, 3)`, containing the test data. Pixel values range
       from 0 to 255.
 

--- a/keras/datasets/cifar100.py
+++ b/keras/datasets/cifar100.py
@@ -43,14 +43,14 @@ def load_data(label_mode="fine"):
     Returns:
       Tuple of NumPy arrays: `(x_train, y_train), (x_test, y_test)`.
 
-    **x_train**: uint8 NumPy array of grayscale image data with shapes
+    **x_train**: uint8 NumPy array of image data with shapes
       `(50000, 32, 32, 3)`, containing the training data. Pixel values range
       from 0 to 255.
 
     **y_train**: uint8 NumPy array of labels (integers in range 0-99)
       with shape `(50000, 1)` for the training data.
 
-    **x_test**: uint8 NumPy array of grayscale image data with shapes
+    **x_test**: uint8 NumPy array of image data with shapes
       `(10000, 32, 32, 3)`, containing the test data. Pixel values range
       from 0 to 255.
 


### PR DESCRIPTION
Please consider pulling in this minor detail that bugged me while reading the  documentation. 
Best regards.