### PR TITLE
Consistently use "pickleable" instead of "picklable"

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1624,7 +1624,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
                 `keras.utils.Sequence` input only. If `True`, use process-based
                 threading. If unspecified, `use_multiprocessing` will default to
                 `False`. Note that because this implementation relies on
-                multiprocessing, you should not pass non-picklable arguments to
+                multiprocessing, you should not pass non-pickleable arguments to
                 the generator as they can't be passed easily to children
                 processes.
 
@@ -2154,7 +2154,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
               `keras.utils.Sequence` input only. If `True`, use process-based
               threading. If unspecified, `use_multiprocessing` will default to
               `False`. Note that because this implementation relies on
-              multiprocessing, you should not pass non-picklable arguments to
+              multiprocessing, you should not pass non-pickleable arguments to
               the generator as they can't be passed easily to children
               processes.
             return_dict: If `True`, loss and metric results are returned as a
@@ -2507,7 +2507,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
                 `keras.utils.Sequence` input only. If `True`, use process-based
                 threading. If unspecified, `use_multiprocessing` will default to
                 `False`. Note that because this implementation relies on
-                multiprocessing, you should not pass non-picklable arguments to
+                multiprocessing, you should not pass non-pickleable arguments to
                 the generator as they can't be passed easily to children
                 processes.
 

--- a/keras/engine/training_generator_v1.py
+++ b/keras/engine/training_generator_v1.py
@@ -93,7 +93,7 @@ def model_iteration(
         use_multiprocessing: Boolean. If `True`, use process-based threading. If
           unspecified, `use_multiprocessing` will default to `False`. Note that
           because this implementation relies on multiprocessing, you should not
-          pass non-picklable arguments to the generator as they can't be passed
+          pass non-pickleable arguments to the generator as they can't be passed
           easily to children processes.
         shuffle: Boolean. Whether to shuffle the order of the batches at the
           beginning of each epoch. Only used with instances of `Sequence`
@@ -423,7 +423,7 @@ def _validate_arguments(
       use_multiprocessing: Boolean. If `True`, use process-based threading. If
         unspecified, `use_multiprocessing` will default to `False`. Note that
         because this implementation relies on multiprocessing, you should not
-        pass non-picklable arguments to the generator as they can't be passed
+        pass non-pickleable arguments to the generator as they can't be passed
         easily to children processes.
       workers: Integer. Maximum number of processes to spin up when using
         process-based threading. If unspecified, `workers` will default to 1. If

--- a/keras/engine/training_v1.py
+++ b/keras/engine/training_v1.py
@@ -823,7 +823,7 @@ class Model(training_lib.Model):
                 `keras.utils.Sequence` input only. If `True`, use process-based
                 threading. If unspecified, `use_multiprocessing` will default to
                 `False`. Note that because this implementation relies on
-                multiprocessing, you should not pass non-picklable arguments to
+                multiprocessing, you should not pass non-pickleable arguments to
                 the generator as they can't be passed easily to children
                 processes.
             **kwargs: Used for backwards compatibility.
@@ -953,7 +953,7 @@ class Model(training_lib.Model):
                 `keras.utils.Sequence` input only. If `True`, use process-based
                 threading. If unspecified, `use_multiprocessing` will default to
                 `False`. Note that because this implementation relies on
-                multiprocessing, you should not pass non-picklable arguments to
+                multiprocessing, you should not pass non-pickleable arguments to
                 the generator as they can't be passed easily to children
                 processes.
 
@@ -1037,7 +1037,7 @@ class Model(training_lib.Model):
                 `keras.utils.Sequence` input only. If `True`, use process-based
                 threading. If unspecified, `use_multiprocessing` will default to
                 `False`. Note that because this implementation relies on
-                multiprocessing, you should not pass non-picklable arguments to
+                multiprocessing, you should not pass non-pickleable arguments to
                 the generator as they can't be passed easily to children
                 processes.
 

--- a/keras/layers/rnn/dropout_rnn_cell_mixin.py
+++ b/keras/layers/rnn/dropout_rnn_cell_mixin.py
@@ -57,7 +57,7 @@ class DropoutRNNCellMixin:
         ensure same mask is used every time.
 
         Also the caches are created without tracking. Since they are not
-        picklable by python when deepcopy, we don't want
+        pickleable by python when deepcopy, we don't want
         `layer._obj_reference_counts_dict` to track it by default.
         """
         self._dropout_mask_cache = backend.ContextValueCache(

--- a/keras/saving/pickle_utils_test.py
+++ b/keras/saving/pickle_utils_test.py
@@ -42,7 +42,8 @@ class TestPickleProtocol(test_combinations.TestCase):
         ),
     )
     def test_built_models(self, serializer):
-        """Built models should be copyable and picklable for all model types."""
+        """Built models should be copyable and pickleable for all model
+        types."""
         if not tf.__internal__.tf2.enabled():
             self.skipTest(
                 "pickle model only available in v2 when tf format is used."


### PR DESCRIPTION
Just a nitpick: All code in [TensorFlow](https://github.com/search?q=repo%3Atensorflow%2Ftensorflow%20pickleable&type=code) and Keras (GitHub's code search misses most) uses _pickleable_, but in some parts of Keras' documentation it's called _picklable_. This is hereby fixed.
Note that I am not a native English speaker, but the [Wiktionary](https://en.wiktionary.org/wiki/pickleable) agrees.

_This supercedes my PR against TensorFlow: https://github.com/tensorflow/tensorflow/pull/60631_.