### PR TITLE
Fix CategoricalFocalCE documentation

### DIFF
--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1004,7 +1004,7 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
     model.compile(optimizer='adam',
                   loss=tf.keras.losses.CategoricalFocalCrossentropy())
     ```
-    
+
     Args:
         alpha: A weight balancing factor for all classes, default is `0.25` as
             mentioned in the reference. It can be a list of floats or a scalar.
@@ -1033,7 +1033,7 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
             for more details.
         name: Optional name for the instance.
             Defaults to 'categorical_focal_crossentropy'.
-    
+
     """
 
     def __init__(

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1004,6 +1004,7 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
     model.compile(optimizer='adam',
                   loss=tf.keras.losses.CategoricalFocalCrossentropy())
     ```
+    
     Args:
         alpha: A weight balancing factor for all classes, default is `0.25` as
             mentioned in the reference. It can be a list of floats or a scalar.
@@ -1032,6 +1033,7 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
             for more details.
         name: Optional name for the instance.
             Defaults to 'categorical_focal_crossentropy'.
+    
     """
 
     def __init__(


### PR DESCRIPTION
Looks like we need some spaces/newlines in the docstring, documentation looks like this:

![image](https://github.com/keras-team/keras/assets/46622558/91c8ad15-5f8f-4eeb-8608-a83877314fc0)
