### PR TITLE
PR #18152: Changed regular divide to tf.math.divide_no_nan - global_average_pooling1d.py

### DIFF
--- a/keras/layers/pooling/global_average_pooling1d.py
+++ b/keras/layers/pooling/global_average_pooling1d.py
@@ -88,9 +88,11 @@ class GlobalAveragePooling1D(GlobalPooling1D):
                 mask, 2 if self.data_format == "channels_last" else 1
             )
             inputs *= mask
-            return backend.sum(
-                inputs, axis=steps_axis, keepdims=self.keepdims
-            ) / tf.reduce_sum(mask, axis=steps_axis, keepdims=self.keepdims)
+            return tf.math.divide_no_nan(
+                backend.sum(inputs, axis=steps_axis, keepdims=self.keepdims),
+                tf.reduce_sum(mask, axis=steps_axis, keepdims=self.keepdims),
+                name=None,
+            )
         else:
             return backend.mean(inputs, axis=steps_axis, keepdims=self.keepdims)
 


### PR DESCRIPTION
Replaced the divide with the safer: tf.math.divide_no_nan, as denominator has the potential to be 0.