### PR TITLE
add MultiStepLR; correct CosineDecay according to the original paper and pytorch

### DIFF
--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -590,10 +590,10 @@ class MultiStepLR(tf.keras.optimizers.schedules.LearningRateSchedule):
 
     Example:
     ```python
-      Assuming optimizer uses lr = 0.05 for all groups
-      #lr = 0.05     if epoch < 30
-      #lr = 0.005    if 30 <= epoch < 80
-      #lr = 0.0005   if epoch >= 80
+      Assuming optimizer uses lr = 0.1 for all groups
+      #lr = 0.1     if epoch < 30
+      #lr = 0.01    if 30 <= epoch < 80
+      #lr = 0.001   if epoch >= 80
       scheduler = MultiStepLR(optimizer, milestones=[30,80], gamma=0.1)
     ```
 

--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -575,85 +575,95 @@ class InverseTimeDecay(LearningRateSchedule):
         }
 
 
-@keras_export(
-    "keras.optimizers.schedules.CosineDecay", "keras.experimental.CosineDecay"
-)
-class CosineDecay(LearningRateSchedule):
-    """A LearningRateSchedule that uses a cosine decay with optional warmup.
+@keras_export("keras.optimizers.schedules.MultiStepLR", "keras.optimizers.MultiStepLR")
+class MultiStepLR(tf.keras.optimizers.schedules.LearningRateSchedule):
+    """
+    A MultiStep learning rate scheduler. 
+    Decays the learning rate of each parameter group by gamma 
+    once the number of epoch reaches one of the milestones. 
+    Args:
+        lr (float): The initial learning rate.
+        batch_size (int): The batch size used for training.
+        steps_per_epoch (int): The number of batches in the training dataset.
+        milestones (list): A list of epoch indices at which the learning rate will be multiplied by the gamma value.
+        gamma (float): The multiplicative factor to apply to the learning rate at each milestone.
 
+    Example:
+    ```python
+      Assuming optimizer uses lr = 0.05 for all groups
+      #lr = 0.05     if epoch < 30
+      #lr = 0.005    if 30 <= epoch < 80
+      #lr = 0.0005   if epoch >= 80
+      scheduler = MultiStepLR(optimizer, milestones=[30,80], gamma=0.1)
+    ```
+
+    """
+    def __init__(self, lr, steps_per_epoch, milestones:list, gamma:int):
+        self.lr = lr
+        self.epoch = 0
+        self.steps_per_epoch = self.steps_per_epoch
+        self.milestone = milestones
+        self.gamma = gamma
+
+    def __call__(self, step):
+        with tf.name_scope(self.name or "MultiStepLR"):
+            self.epoch = int((step + 1) / self.steps_per_epoch)
+            lr = self.tf.convert_to_tensor(
+                    self.initial_learning_rate, name="initial_learning_rate"
+                )
+            for milestone in self.milestones:
+                if self.epoch >= milestone:
+                    lr *= self.gamma
+            return lr
+    
+    def get_config(self):
+        return {
+            "lr": self.lr,
+            "steps_per_epoch": self.steps_per_epoch,
+            "milestones": self.milestones,
+            "gamma": self.gamma,
+        }
+
+@keras_export(
+    "keras.optimizers.schedules.CosineDecay",
+    "keras.optimizers.CosineDecay"
+)
+class CosineDecay(tf.keras.optimizers.schedules.LearningRateSchedule):
+    """A LearningRateSchedule that uses a cosine decay schedule.
+
+    To stick to the original paper, users can pass in 
+    steps_per_epoch = num_batches_per_epoch and 
+    decay_steps = num_epochs. If not, pass in 
+    decay_steps = num_batches_per_epoch * num_epochs to decay every batch.
     See [Loshchilov & Hutter, ICLR2016](https://arxiv.org/abs/1608.03983),
     SGDR: Stochastic Gradient Descent with Warm Restarts.
 
-    For the idea of a linear warmup of our learning rate,
-    see [Goyal et al.](https://arxiv.org/pdf/1706.02677.pdf).
-
-    When we begin training a model, we often want an initial increase in our
-    learning rate followed by a decay. If `warmup_target` is an int, this
-    schedule applies a linear increase per optimizer step to our learning rate
-    from `initial_learning_rate` to `warmup_target` for a duration of
-    `warmup_steps`. Afterwards, it applies a cosine decay function taking our
-    learning rate from `warmup_target` to `alpha` for a duration of
-    `decay_steps`. If `warmup_target` is None we skip warmup and our decay
-    will take our learning rate from `initial_learning_rate` to `alpha`.
-    It requires a `step` value to  compute the learning rate. You can
+    When training a model, it is often useful to lower the learning rate as
+    the training progresses. This schedule applies a cosine decay function
+    to an optimizer step, given a provided initial learning rate.
+    It requires a `step` value to compute the decayed learning rate. You can
     just pass a TensorFlow variable that you increment at each training step.
-
-    The schedule is a 1-arg callable that produces a warmup followed by a
-    decayed learning rate when passed the current optimizer step. This can be
-    useful for changing the learning rate value across different invocations of
-    optimizer functions.
-
-    Our warmup is computed as:
-
+    The schedule is a 1-arg callable that produces a decayed learning
+    rate when passed the current optimizer step. This can be useful for changing
+    the learning rate value across different invocations of optimizer functions.
+    It is computed as:
     ```python
-    def warmup_learning_rate(step):
-        completed_fraction = step / warmup_steps
-        total_delta = target_warmup - initial_learning_rate
-        return completed_fraction * total_delta
-    ```
-
-    And our decay is computed as:
-
-    ```python
-    if warmup_target is None:
-        initial_decay_lr = initial_learning_rate
-    else:
-        initial_decay_lr = warmup_target
-
     def decayed_learning_rate(step):
-        step = min(step, decay_steps)
-        cosine_decay = 0.5 * (1 + cos(pi * step / decay_steps))
-        decayed = (1 - alpha) * cosine_decay + alpha
-        return initial_decay_lr * decayed
+      step = min(step, decay_steps)
+      cosine_decay = 0.5 * (1 + cos(pi * step / decay_steps))
+      decayed = (1 - alpha) * cosine_decay + alpha
+      return initial_learning_rate * decayed
     ```
-
-    Example usage without warmup:
-
+    Example usage:
     ```python
     decay_steps = 1000
-    initial_learning_rate = 0.1
     lr_decayed_fn = tf.keras.optimizers.schedules.CosineDecay(
         initial_learning_rate, decay_steps)
     ```
-
-    Example usage with warmup:
-
-    ```python
-    decay_steps = 1000
-    initial_learning_rate = 0
-    warmup_steps = 1000
-    target_learning_rate = 0.1
-    lr_warmup_decayed_fn = tf.keras.optimizers.schedules.CosineDecay(
-        initial_learning_rate, decay_steps, warmup_target=target_learning_rate,
-        warmup_steps=warmup_steps
-    )
-    ```
-
     You can pass this schedule directly into a `tf.keras.optimizers.Optimizer`
     as the learning rate. The learning rate schedule is also serializable and
     deserializable using `tf.keras.optimizers.schedules.serialize` and
     `tf.keras.optimizers.schedules.deserialize`.
-
     Returns:
       A 1-arg callable learning rate schedule that takes the current optimizer
       step and outputs the decayed learning rate, a scalar `Tensor` of the same
@@ -661,109 +671,59 @@ class CosineDecay(LearningRateSchedule):
     """
 
     def __init__(
-        self,
-        initial_learning_rate,
-        decay_steps,
-        alpha=0.0,
-        name=None,
-        warmup_target=None,
-        warmup_steps=0,
+        self, initial_learning_rate, decay_steps, steps_per_epoch=None, alpha=0.0, name=None
     ):
         """Applies cosine decay to the learning rate.
-
         Args:
-          initial_learning_rate: A scalar `float32` or `float64` `Tensor` or a
-            Python int. The initial learning rate.
-          decay_steps: A scalar `int32` or `int64` `Tensor` or a Python int.
-            Number of steps to decay over.
-          alpha: A scalar `float32` or `float64` `Tensor` or a Python int.
-            Minimum learning rate value for decay as a fraction of
-            `initial_learning_rate`.
+          initial_learning_rate: A scalar `float32` or `float64` Tensor or a
+            Python number. The initial learning rate.
+          decay_steps: A scalar `int32` or `int64` `Tensor` or a Python number.
+            Number of steps (epochs as per the original paper:
+              https://arxiv.org/abs/1608.03983) to decay over.
+          steps_per_epoch: specifies the number of steps (batches) per epoch.
+            Neccessary for epoch-wise decay.
+          alpha: A scalar `float32` or `float64` Tensor or a Python number.
+            Minimum learning rate value as a fraction of initial_learning_rate.
           name: String. Optional name of the operation.  Defaults to
             'CosineDecay'.
-          warmup_target: None or a scalar `float32` or `float64` `Tensor` or a
-            Python int. The target learning rate for our warmup phase. Will cast
-            to the `initial_learning_rate` datatype. Setting to None will skip
-            warmup and begins decay phase from `initial_learning_rate`.
-            Otherwise scheduler will warmup from `initial_learning_rate` to
-            `warmup_target`.
-          warmup_steps: A scalar `int32` or `int64` `Tensor` or a Python int.
-            Number of steps to warmup over.
         """
         super().__init__()
-
         self.initial_learning_rate = initial_learning_rate
         self.decay_steps = decay_steps
         self.alpha = alpha
         self.name = name
-        self.warmup_steps = warmup_steps
-        self.warmup_target = warmup_target
+        self.steps_per_epoch = steps_per_epoch
 
-    def _decay_function(self, step, decay_steps, decay_from_lr, dtype):
-        with tf.name_scope(self.name or "CosineDecay"):
-            completed_fraction = step / decay_steps
-            tf_pi = tf.constant(math.pi, dtype=dtype)
-            cosine_decayed = 0.5 * (1.0 + tf.cos(tf_pi * completed_fraction))
-            decayed = (1 - self.alpha) * cosine_decayed + self.alpha
-            return tf.multiply(decay_from_lr, decayed)
-
-    def _warmup_function(
-        self, step, warmup_steps, warmup_target, initial_learning_rate
-    ):
-        with tf.name_scope(self.name or "CosineDecay"):
-            completed_fraction = step / warmup_steps
-            total_step_delta = warmup_target - initial_learning_rate
-            return total_step_delta * completed_fraction + initial_learning_rate
 
     def __call__(self, step):
+        if self.steps_per_epoch is not None:
+            step = (step+1) / self.steps_per_epoch
         with tf.name_scope(self.name or "CosineDecay"):
             initial_learning_rate = tf.convert_to_tensor(
                 self.initial_learning_rate, name="initial_learning_rate"
             )
             dtype = initial_learning_rate.dtype
             decay_steps = tf.cast(self.decay_steps, dtype)
+
             global_step_recomp = tf.cast(step, dtype)
-
-            if self.warmup_target is None:
-                global_step_recomp = tf.minimum(global_step_recomp, decay_steps)
-                return self._decay_function(
-                    global_step_recomp,
-                    decay_steps,
-                    initial_learning_rate,
-                    dtype,
-                )
-
-            warmup_target = tf.cast(self.warmup_target, dtype)
-            warmup_steps = tf.cast(self.warmup_steps, dtype)
-
-            global_step_recomp = tf.minimum(
-                global_step_recomp, decay_steps + warmup_steps
+            global_step_recomp = tf.minimum(global_step_recomp, decay_steps)
+            completed_fraction = global_step_recomp / decay_steps
+            cosine_decayed = 0.5 * (
+                1.0
+                + tf.cos(tf.constant(math.pi, dtype=dtype) * completed_fraction)
             )
 
-            return tf.cond(
-                global_step_recomp < warmup_steps,
-                lambda: self._warmup_function(
-                    global_step_recomp,
-                    warmup_steps,
-                    warmup_target,
-                    initial_learning_rate,
-                ),
-                lambda: self._decay_function(
-                    global_step_recomp - warmup_steps,
-                    decay_steps,
-                    warmup_target,
-                    dtype,
-                ),
-            )
+            decayed = (1 - self.alpha) * cosine_decayed + self.alpha
+            return tf.multiply(initial_learning_rate, decayed)
+
 
     def get_config(self):
         return {
             "initial_learning_rate": self.initial_learning_rate,
             "decay_steps": self.decay_steps,
+            "steps_per_epoch": self.steps_per_epoch,
             "alpha": self.alpha,
             "name": self.name,
-            "warmup_target": self.warmup_target,
-            "warmup_steps": self.warmup_steps,
         }
 
 

--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -575,18 +575,22 @@ class InverseTimeDecay(LearningRateSchedule):
         }
 
 
-@keras_export("keras.optimizers.schedules.MultiStepLR", "keras.optimizers.MultiStepLR")
+@keras_export(
+    "keras.optimizers.schedules.MultiStepLR", "keras.optimizers.MultiStepLR"
+)
 class MultiStepLR(tf.keras.optimizers.schedules.LearningRateSchedule):
     """
-    A MultiStep learning rate scheduler. 
-    Decays the learning rate of each parameter group by gamma 
-    once the number of epoch reaches one of the milestones. 
+    A MultiStep learning rate scheduler.
+    Decays the learning rate of each parameter group by gamma
+    once the number of epoch reaches one of the milestones.
     Args:
         lr (float): The initial learning rate.
         batch_size (int): The batch size used for training.
         steps_per_epoch (int): The number of batches in the training dataset.
-        milestones (list): A list of epoch indices at which the learning rate will be multiplied by the gamma value.
-        gamma (float): The multiplicative factor to apply to the learning rate at each milestone.
+        milestones (list): A list of epoch indices at which the learning rate
+          will be multiplied by the gamma value.
+        gamma (float): The multiplicative factor to apply to the learning rate
+          at each milestone.
 
     Example:
     ```python
@@ -598,7 +602,8 @@ class MultiStepLR(tf.keras.optimizers.schedules.LearningRateSchedule):
     ```
 
     """
-    def __init__(self, lr, steps_per_epoch, milestones:list, gamma:int):
+
+    def __init__(self, lr, steps_per_epoch, milestones: list, gamma: int):
         self.lr = lr
         self.epoch = 0
         self.steps_per_epoch = self.steps_per_epoch
@@ -609,13 +614,13 @@ class MultiStepLR(tf.keras.optimizers.schedules.LearningRateSchedule):
         with tf.name_scope(self.name or "MultiStepLR"):
             self.epoch = int((step + 1) / self.steps_per_epoch)
             lr = self.tf.convert_to_tensor(
-                    self.initial_learning_rate, name="initial_learning_rate"
-                )
+                self.initial_learning_rate, name="initial_learning_rate"
+            )
             for milestone in self.milestones:
                 if self.epoch >= milestone:
                     lr *= self.gamma
             return lr
-    
+
     def get_config(self):
         return {
             "lr": self.lr,
@@ -624,16 +629,16 @@ class MultiStepLR(tf.keras.optimizers.schedules.LearningRateSchedule):
             "gamma": self.gamma,
         }
 
+
 @keras_export(
-    "keras.optimizers.schedules.CosineDecay",
-    "keras.optimizers.CosineDecay"
+    "keras.optimizers.schedules.CosineDecay", "keras.optimizers.CosineDecay"
 )
 class CosineDecay(tf.keras.optimizers.schedules.LearningRateSchedule):
     """A LearningRateSchedule that uses a cosine decay schedule.
 
-    To stick to the original paper, users can pass in 
-    steps_per_epoch = num_batches_per_epoch and 
-    decay_steps = num_epochs. If not, pass in 
+    To stick to the original paper, users can pass in
+    steps_per_epoch = num_batches_per_epoch and
+    decay_steps = num_epochs. If not, pass in
     decay_steps = num_batches_per_epoch * num_epochs to decay every batch.
     See [Loshchilov & Hutter, ICLR2016](https://arxiv.org/abs/1608.03983),
     SGDR: Stochastic Gradient Descent with Warm Restarts.
@@ -671,7 +676,12 @@ class CosineDecay(tf.keras.optimizers.schedules.LearningRateSchedule):
     """
 
     def __init__(
-        self, initial_learning_rate, decay_steps, steps_per_epoch=None, alpha=0.0, name=None
+        self,
+        initial_learning_rate,
+        decay_steps,
+        steps_per_epoch=None,
+        alpha=0.0,
+        name=None,
     ):
         """Applies cosine decay to the learning rate.
         Args:
@@ -694,10 +704,9 @@ class CosineDecay(tf.keras.optimizers.schedules.LearningRateSchedule):
         self.name = name
         self.steps_per_epoch = steps_per_epoch
 
-
     def __call__(self, step):
         if self.steps_per_epoch is not None:
-            step = (step+1) / self.steps_per_epoch
+            step = (step + 1) / self.steps_per_epoch
         with tf.name_scope(self.name or "CosineDecay"):
             initial_learning_rate = tf.convert_to_tensor(
                 self.initial_learning_rate, name="initial_learning_rate"
@@ -715,7 +724,6 @@ class CosineDecay(tf.keras.optimizers.schedules.LearningRateSchedule):
 
             decayed = (1 - self.alpha) * cosine_decayed + self.alpha
             return tf.multiply(initial_learning_rate, decayed)
-
 
     def get_config(self):
         return {


### PR DESCRIPTION
This is for better academic reproducibility and alignment with Pytorch to make it more user-friendly. 
1. Add MultiStepLR which decays lr by milestones, as in Pytorch.
2. Correct the implementation of CosineDecay. In the original paper(https://arxiv.org/abs/1608.03983), if you check the formulation it is clear that the decay is epoch-wise, as in Pytorch. Making it batch-wise as now can lead to non-reproducible results for developers who switch between Pytorch and TF As most research papers now are in Pytorch, this bug will deter researchers from implementing/reimplementing methods in Tensorflow.
However for compatibility with old code, this argument is optional, so if you don't change anything it will be the old batch-wise decay. 