### PR TITLE
Update Argument padding for zero_padding1d.py

### DIFF
--- a/keras/layers/reshaping/zero_padding1d.py
+++ b/keras/layers/reshaping/zero_padding1d.py
@@ -56,7 +56,7 @@ class ZeroPadding1D(Layer):
         [ 0  0  0]]], shape=(2, 6, 3), dtype=int64)
 
     Args:
-        padding: Int, or tuple of int (length 2), or dictionary.
+        padding: Int, or tuple of int (length 2).
             - If int:
             How many zeros to add at the beginning and end of
             the padding dimension (axis 1).


### PR DESCRIPTION
At present the API `tf.keras.layers.ZeroPadding1D` documentation states that the argument `padding` supports `int`, `tuple of ints` or `dictionary`. But actually padding won't support `dict` as input. When passed a dict it raises `ValueError`. Even the code implementation also not supporting dict. Please refer attached [gist](https://colab.research.google.com/gist/SuryanarayanaY/d12c1dfbcdec281aaa8a7e38c0d0bf2d/60839.ipynb#scrollTo=3sWHSECl3C1p).

Hence I am proposing to remove the dictionary as supported type for the padding argument.


Fixes #60839 from TF repo