### PR TITLE
Fixed the typo in policy.py

### DIFF
--- a/keras/mixed_precision/policy.py
+++ b/keras/mixed_precision/policy.py
@@ -198,7 +198,7 @@ class Policy:
             raise TypeError(f"'name' must be a string, but got: {name}")
         self._name = name
         self._compute_dtype, self._variable_dtype = self._parse_name(name)
-        if name in ("mixed_float16", "mixed_bloat16"):
+        if name in ("mixed_float16", "mixed_bfloat16"):
             device_compatibility_check.log_device_compatibility_check(name)
 
     def _parse_name(self, name):


### PR DESCRIPTION
Fixed **bloat16** to **bfloat16** in `policy.py` file. 
Fixes #https://github.com/tensorflow/tensorflow/issues/60878