### PR TITLE
Fixed "reset_state" of R2Score metric

### DIFF
--- a/keras/metrics/regression_metrics.py
+++ b/keras/metrics/regression_metrics.py
@@ -598,7 +598,7 @@ class R2Score(base_metric.Metric):
 
     def reset_state(self):
         for v in self.variables:
-            v.assign(tf.zeros(v.shape))
+            v.assign(tf.zeros(v.shape, dtype=v.dtype))
 
     def get_config(self):
         config = {


### PR DESCRIPTION
"reset_state" method of R2Score metric throws an error:
`ValueError: Tensor conversion requested dtype int32 for Tensor with dtype float32: <tf.Tensor: shape=(), dtype=float32, numpy=0.0>`
Quick fix is to specify original "dtype" of variable when assigning it to zeros.