### PR TITLE
Cherrypick Sequential serialization bug fix for r2.13

### DIFF
--- a/keras/engine/sequential.py
+++ b/keras/engine/sequential.py
@@ -26,6 +26,7 @@ from keras.engine import input_layer
 from keras.engine import training
 from keras.engine import training_utils
 from keras.saving import serialization_lib
+from keras.saving.legacy import serialization as legacy_serialization
 from keras.saving.legacy.saved_model import model_serialization
 from keras.utils import generic_utils
 from keras.utils import layer_utils
@@ -441,14 +442,15 @@ class Sequential(functional.Functional):
 
     def get_config(self):
         layer_configs = []
+        serialize_obj_fn = serialization_lib.serialize_keras_object
+        if getattr(self, "use_legacy_config", None):
+            serialize_obj_fn = legacy_serialization.serialize_keras_object
         for layer in super().layers:
             # `super().layers` include the InputLayer if available (it is
             # filtered out of `self.layers`). Note that
             # `self._self_tracked_trackables` is managed by the tracking
             # infrastructure and should not be used.
-            layer_configs.append(
-                serialization_lib.serialize_keras_object(layer)
-            )
+            layer_configs.append(serialize_obj_fn(layer))
         config = training.Model.get_config(self)
         config["name"] = self.name
         config["layers"] = copy.deepcopy(layer_configs)

--- a/keras/saving/legacy/hdf5_format.py
+++ b/keras/saving/legacy/hdf5_format.py
@@ -81,6 +81,9 @@ def save_model_to_hdf5(model, filepath, overwrite=True, include_optimizer=True):
             "import h5py."
         )
 
+    # Ensures that all models saved in HDF5 format follow the old serialization
+    model.use_legacy_config = True
+
     # TODO(psv) Add warning when we save models that contain non-serializable
     # entities like metrics added using `add_metric` and losses added using
     # `add_loss.`


### PR DESCRIPTION
This PR is a fix based on the serialization bug reported by @seanpmorgan.

It fixes the serialization format of Sequential models saved with HDF5 and is important for ensuring backwards compatibility with the serialization format switch in TF 2.13.