### PR TITLE
validate l1,l2 values in regularizers

### DIFF
--- a/keras/layers/regularization/activity_regularization.py
+++ b/keras/layers/regularization/activity_regularization.py
@@ -29,6 +29,9 @@ class ActivityRegularization(Layer):
     Args:
       l1: L1 regularization factor (positive float).
       l2: L2 regularization factor (positive float).
+      
+      Note: Both l1 and l2 also accepts integers and 
+      they internally converted into floats.
 
     Input shape:
       Arbitrary. Use the keyword argument `input_shape`

--- a/keras/layers/regularization/activity_regularization.py
+++ b/keras/layers/regularization/activity_regularization.py
@@ -29,8 +29,6 @@ class ActivityRegularization(Layer):
     Args:
       l1: L1 regularization factor (positive float).
       l2: L2 regularization factor (positive float).
-      Note: Both l1 and l2 also accepts integers and
-            they internally converted into floats.
 
     Input shape:
       Arbitrary. Use the keyword argument `input_shape`

--- a/keras/layers/regularization/activity_regularization.py
+++ b/keras/layers/regularization/activity_regularization.py
@@ -29,9 +29,8 @@ class ActivityRegularization(Layer):
     Args:
       l1: L1 regularization factor (positive float).
       l2: L2 regularization factor (positive float).
-      
-      Note: Both l1 and l2 also accepts integers and 
-      they internally converted into floats.
+      Note: Both l1 and l2 also accepts integers and
+            they internally converted into floats.
 
     Input shape:
       Arbitrary. Use the keyword argument `input_shape`

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -34,7 +34,7 @@ def _check_penalty_number(x):
     if not isinstance(x, (float, int)) or x < 0:
         raise ValueError(
             f"Value {x} is not a valid regularization penalty number, "
-            "expected positive int or float value."
+            "expected non-negative int or float value."
         )
 
     if math.isinf(x) or math.isnan(x):

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -31,10 +31,10 @@ from tensorflow.python.util.tf_export import keras_export
 
 def _check_penalty_number(x):
     """check penalty number availability, raise ValueError if failed."""
-    if not isinstance(x, (float, int)):
+    if not isinstance(x, (float, int)) or x < 0:
         raise ValueError(
             f"Value {x} is not a valid regularization penalty number, "
-            "expected an int or float value."
+            "expected positive int or float value."
         )
 
     if math.isinf(x) or math.isnan(x):


### PR DESCRIPTION
The API `tf.keras.layers.ActivityRegularization` has arguments regularisation factors which should take positive float values.But currently even if we pass negative values there is no exception raised due lack of validation. I believe the code should validate the l1,l2 values and should raise exception if any of them `<0`.

I believe validating these parameters`(l1, l2)` in this file will also validate these parameters in `L1` , `L2` and `L1L2` classes also.

Also attached [gist](https://colab.research.google.com/gist/SuryanarayanaY/7c1c8ab210314d7ec933f7b978084aa7/61254.ipynb) for referring the problem and also result with proposed validation.

Fixes #61254