### PR TITLE
Validate alpha argument leaky_relu.py

### DIFF
--- a/keras/layers/activation/leaky_relu.py
+++ b/keras/layers/activation/leaky_relu.py
@@ -55,14 +55,17 @@ class LeakyReLU(Layer):
 
     Args:
         alpha: Float >= `0.`. Negative slope coefficient. Defaults to `0.3`.
+        **NOTE**: If alpha is given an int value then it will be casted to
+        float internally.
 
     """
 
     def __init__(self, alpha=0.3, **kwargs):
         super().__init__(**kwargs)
-        if alpha is None:
+        if alpha is None or alpha < 0 :
             raise ValueError(
-                "The alpha value of a Leaky ReLU layer cannot be None, "
+                "The alpha value of a Leaky ReLU layer cannot be None and"
+                "also cannot be a negative value"
                 f"Expecting a float. Received: {alpha}"
             )
         self.supports_masking = True


### PR DESCRIPTION
The value of alpha should be a float >= `0`. But if given negative value still there is no exception raised and providing output which is not correct. Hence added validation code for same.

Also if alpha is given a `int` value then it is converted into `float` internally.But documentation states alpha should be a Float >= 0 . Hence also adding a note that if given int values then it will be converted into float internally.