### PR TITLE
fix for #18365 : standardize the behavior in case of no input_shape is provided. 

### DIFF
--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -424,6 +424,10 @@ def NASNetMobile(
         RuntimeError: If attempting to run this model with a
             backend that does not support separable convolutions.
     """
+    # If no input_shape is passed we will move forward with default tuple
+    if (include_top == False) and (input_shape == None):
+        input_shape = (224,224,3)
+
     return NASNet(
         input_shape,
         penultimate_filters=1056,

--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -425,8 +425,8 @@ def NASNetMobile(
             backend that does not support separable convolutions.
     """
     # If no input_shape is passed we will move forward with default tuple
-    if (include_top == False) and (input_shape == None):
-        input_shape = (224,224,3)
+    if (include_top == False) and (input_shape is None):
+        input_shape = (224, 224, 3)
 
     return NASNet(
         input_shape,


### PR DESCRIPTION
I have provided a default input_shape if the include_top is False and no shape is provided upon the call of the function. Please have a look.