### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ scipy ~= 1.9.2
 # Keras-TensorFlow circular dependency issue, when one of them gets a dependency
 # incompatible with another one (protobuf in this specific case).
 protobuf==3.20.3
-tf-nightly
+tensorflow==2.14.0rc1
 portpicker
 pyyaml
 Pillow


### PR DESCRIPTION
Update the tf version used for keras 2.14 rc.

The pip package verification test was incorrectly using the tf-nightly and cause the build to fail.