### PR TITLE
Disable the stateless apply for the tf based optimizer

### DIFF
--- a/keras/backend/tensorflow/optimizer.py
+++ b/keras/backend/tensorflow/optimizer.py
@@ -58,6 +58,8 @@ class TFOptimizer(base_optimizer.BaseOptimizer):
                     variable.assign(variable - variable * wd * lr)
 
             for variable in variables:
+                if isinstance(variable, backend.Variable):
+                    variable = variable.value  # Convert to tf.Variable
                 distribution.extended.update(
                     variable, weight_decay_fn, group=False
                 )

--- a/keras/backend/tensorflow/optimizer.py
+++ b/keras/backend/tensorflow/optimizer.py
@@ -35,7 +35,7 @@ class TFOptimizer(base_optimizer.BaseOptimizer):
         # This is mainly due to the interaction with tf.distribute.Strategy,
         # which requires tf.Variable as the inputs for most of its APIs.
         raise ValueError(
-            "stateless_apply is not supported by the TF based " "optimizer. "
+            "stateless_apply is not supported by the TF based optimizer."
         )
 
     def _var_key(self, variable):

--- a/keras/backend/tensorflow/optimizer.py
+++ b/keras/backend/tensorflow/optimizer.py
@@ -31,6 +31,13 @@ class TFOptimizer(base_optimizer.BaseOptimizer):
                 reference_variable, name=name
             )
 
+    def stateless_apply(self, optimizer_variables, grads, trainable_variables):
+        # This is mainly due to the interaction with tf.distribute.Strategy,
+        # which requires tf.Variable as the inputs for most of its APIs.
+        raise ValueError(
+            "stateless_apply is not supported by the TF based " "optimizer. "
+        )
+
     def _var_key(self, variable):
         if isinstance(variable, backend.Variable):
             variable = variable.value  # Convert to tf.Variable

--- a/keras/backend/tensorflow/optimizer_distribute_test.py
+++ b/keras/backend/tensorflow/optimizer_distribute_test.py
@@ -46,7 +46,7 @@ class OptimizerDistributeTest(testing.TestCase):
                 momentum=0.06,
             )
             grads = tf.constant([1.0, 6.0, 7.0, 2.0])
-            vars = backend.Variable([1.0, 2.0, 3.0, 4.0]).value
+            vars = backend.Variable([1.0, 2.0, 3.0, 4.0])
 
             self.strategy.run(
                 lambda: optimizer.apply_gradients(zip([grads], [vars]))
@@ -59,9 +59,9 @@ class OptimizerDistributeTest(testing.TestCase):
         with self.strategy.scope():
             grads, var1, var2, var3 = (
                 tf.zeros(()),
-                backend.Variable(2.0).value,
-                backend.Variable(3.0, name="exclude").value,
-                backend.Variable(4.0).value,
+                backend.Variable(2.0),
+                backend.Variable(3.0, name="exclude"),
+                backend.Variable(4.0),
             )
             optimizer_1 = SGD(learning_rate=1.0, weight_decay=0.004)
             self.strategy.run(
@@ -92,7 +92,7 @@ class OptimizerDistributeTest(testing.TestCase):
         with self.strategy.scope():
             optimizer = SGD(nesterov=True)
 
-            x = backend.Variable(np.ones([10])).value
+            x = backend.Variable(np.ones([10]))
             grads = np.arange(0.1, 1.1, 0.1)
             first_grads = np.full((10,), 0.01)
 

--- a/keras/backend/tensorflow/optimizer_distribute_test.py
+++ b/keras/backend/tensorflow/optimizer_distribute_test.py
@@ -130,3 +130,11 @@ class OptimizerDistributeTest(testing.TestCase):
             grad = [np.array([100.0, 100.0])]
             clipped_grad = optimizer._clip_gradients(grad)
             self.assertAllClose(clipped_grad[0], [1.0, 1.0])
+
+    def test_stateless_not_supported(self):
+        optimizer = SGD(learning_rate=0.5)
+        grads = [np.array([1.0, 6.0, 7.0, 2.0])]
+        vars = [backend.Variable([1.0, 2.0, 3.0, 4.0])]
+        optimizer.build(vars)
+        with self.assertRaisesRegex(ValueError, "not supported"):
+            optimizer.stateless_apply(optimizer.variables, grads, vars)

--- a/keras/optimizers/loss_scale_optimizer_test.py
+++ b/keras/optimizers/loss_scale_optimizer_test.py
@@ -9,6 +9,14 @@ from keras.optimizers.sgd import SGD
 
 
 class LossScaleOptimizerTest(testing.TestCase, parameterized.TestCase):
+    def _skip_test_for_stateless(self, stateless):
+        if not stateless and backend.backend() == "jax":
+            self.skipTest("LossScaleOptimizer must use stateless_apply on jax.")
+        if stateless and backend.backend() == "tensorflow":
+            self.skipTest(
+                "stateless_apply is not supported by the tf based optimizer"
+            )
+
     def test_config(self):
         inner_optimizer = SGD(
             learning_rate=0.5,
@@ -21,8 +29,8 @@ class LossScaleOptimizerTest(testing.TestCase, parameterized.TestCase):
 
     @parameterized.named_parameters(("stateless", True), ("stateful", False))
     def test_finite_step(self, stateless):
-        if not stateless and backend.backend() == "jax":
-            self.skipTest("LossScaleOptimizer must use stateless_apply on jax.")
+        self._skip_test_for_stateless(stateless)
+
         inner_optimizer = SGD(learning_rate=0.5)
         optimizer = LossScaleOptimizer(inner_optimizer)
         grads = [ops.array([1.0, 6.0, 7.0, 2.0]) * optimizer.initial_scale]
@@ -40,8 +48,8 @@ class LossScaleOptimizerTest(testing.TestCase, parameterized.TestCase):
 
     @parameterized.named_parameters(("stateless", True), ("stateful", False))
     def test_infinite_step(self, stateless):
-        if not stateless and backend.backend() == "jax":
-            self.skipTest("LossScaleOptimizer must use stateless_apply on jax.")
+        self._skip_test_for_stateless(stateless)
+
         inner_optimizer = SGD(learning_rate=0.5)
         optimizer = LossScaleOptimizer(inner_optimizer)
         grads = [ops.array([np.inf, np.inf, np.inf, np.inf])]
@@ -57,8 +65,8 @@ class LossScaleOptimizerTest(testing.TestCase, parameterized.TestCase):
 
     @parameterized.named_parameters(("stateless", True), ("stateful", False))
     def test_downscaling(self, stateless):
-        if not stateless and backend.backend() == "jax":
-            self.skipTest("LossScaleOptimizer must use stateless_apply on jax.")
+        self._skip_test_for_stateless(stateless)
+
         inner_optimizer = SGD(learning_rate=0.5)
         optimizer = LossScaleOptimizer(inner_optimizer, initial_scale=400.0)
         vars = [backend.Variable([1.0, 2.0, 3.0, 4.0])]
@@ -76,8 +84,8 @@ class LossScaleOptimizerTest(testing.TestCase, parameterized.TestCase):
 
     @parameterized.named_parameters(("stateless", True), ("stateful", False))
     def test_upscaling(self, stateless):
-        if not stateless and backend.backend() == "jax":
-            self.skipTest("LossScaleOptimizer must use stateless_apply on jax.")
+        self._skip_test_for_stateless(stateless)
+
         inner_optimizer = SGD(learning_rate=0.5)
         optimizer = LossScaleOptimizer(
             inner_optimizer,


### PR DESCRIPTION
The main limitation is caused by the tf.distribute.Strategy API, which requires the input to be tf.Variable or mirrored variables. This cause us  to loss the chance to intercept the KerasVariable.assign(), which is the key API to do stateless update.

This should fix the unit test failure on HEAD.