### PR TITLE
[WIP] investigate-keras-backend-torch-nn.py544-ValueError

### DIFF
--- a/keras/utils/numerical_utils_test.py
+++ b/keras/utils/numerical_utils_test.py
@@ -3,40 +3,41 @@ from absl.testing import parameterized
 
 from keras import backend
 from keras import testing
+from keras.backend.common.variables import KerasVariable
 from keras.utils import numerical_utils
 
-NUM_CLASSES = 5
+num_classes = 5
 
 
 class TestNumericalUtils(testing.TestCase, parameterized.TestCase):
     @parameterized.parameters(
         [
-            ((1,), (1, NUM_CLASSES)),
-            ((3,), (3, NUM_CLASSES)),
-            ((4, 3), (4, 3, NUM_CLASSES)),
-            ((5, 4, 3), (5, 4, 3, NUM_CLASSES)),
-            ((3, 1), (3, NUM_CLASSES)),
-            ((3, 2, 1), (3, 2, NUM_CLASSES)),
+            ((1,), (1, num_classes)),
+            ((3,), (3, num_classes)),
+            ((4, 3), (4, 3, num_classes)),
+            ((5, 4, 3), (5, 4, 3, num_classes)),
+            ((3, 1), (3, num_classes)),
+            ((3, 2, 1), (3, 2, num_classes)),
         ]
     )
     def test_to_categorical(self, shape, expected_shape):
-        label = np.random.randint(0, NUM_CLASSES, shape)
-        one_hot = numerical_utils.to_categorical(label, NUM_CLASSES)
-        # Check shape
+        """Test categorical conversion of labels."""
+        label = np.random.randint(0, num_classes, shape)
+        one_hot = numerical_utils.to_categorical(label, num_classes)
         self.assertEqual(one_hot.shape, expected_shape)
-        # Make sure there is only one 1 in a row
         self.assertTrue(np.all(one_hot.sum(axis=-1) == 1))
-        # Get original labels back from one hots
         self.assertTrue(
             np.all(np.argmax(one_hot, -1).reshape(label.shape) == label)
         )
 
     def test_to_categorial_without_num_classes(self):
+        """Test conversion without specifying number of classes."""
         label = [0, 2, 5]
         one_hot = numerical_utils.to_categorical(label)
         self.assertEqual(one_hot.shape, (3, 5 + 1))
 
     def test_to_categorical_with_backend_tensor(self):
+        """Test conversion with backend tensors."""
         label = backend.convert_to_tensor(np.array([0, 2, 1, 3, 4]))
         expected = backend.convert_to_tensor(
             np.array(
@@ -49,26 +50,144 @@ class TestNumericalUtils(testing.TestCase, parameterized.TestCase):
                 ]
             )
         )
-        one_hot = numerical_utils.to_categorical(label, NUM_CLASSES)
-        assert backend.is_tensor(one_hot)
+        one_hot = numerical_utils.to_categorical(label, num_classes)
         self.assertAllClose(one_hot, expected)
 
     @parameterized.parameters([1, 2, 3])
     def test_normalize(self, order):
+        """Test the normalization function."""
         xb = backend.random.uniform((3, 3), seed=1337)
         xnp = backend.convert_to_numpy(xb)
-
-        # Expected result
         l2 = np.atleast_1d(np.linalg.norm(xnp, order, axis=-1))
         l2[l2 == 0] = 1
         expected = xnp / np.expand_dims(l2, axis=-1)
-
-        # Test NumPy
         out = numerical_utils.normalize(xnp, axis=-1, order=order)
-        self.assertIsInstance(out, np.ndarray)
         self.assertAllClose(out, expected)
-
-        # Test backend
         out = numerical_utils.normalize(xb, axis=-1, order=order)
-        self.assertTrue(backend.is_tensor(out))
         self.assertAllClose(backend.convert_to_numpy(out), expected)
+
+    def test_numpy_input_with_num_classes(self):
+        """Test numpy input with a specified number of classes."""
+        label = np.array([0, 2, 1, 3, 4])
+        one_hot = numerical_utils.to_categorical(label, 5)
+        expected = np.array(
+            [
+                [1, 0, 0, 0, 0],
+                [0, 0, 1, 0, 0],
+                [0, 1, 0, 0, 0],
+                [0, 0, 0, 1, 0],
+                [0, 0, 0, 0, 1],
+            ]
+        )
+        np.testing.assert_array_equal(one_hot, expected)
+
+    def test_without_num_classes(self):
+        """Test conversion without specifying number of classes."""
+        label = np.array([0, 2, 5])
+        one_hot = numerical_utils.to_categorical(label)
+        expected = np.array(
+            [[1, 0, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1]]
+        )
+        np.testing.assert_array_equal(one_hot, expected)
+
+    def test_non_standard_labels(self):
+        """Test with non-standard labels."""
+        label = np.array([2, 4, 8])
+        one_hot = numerical_utils.to_categorical(label)
+        expected = np.array(
+            [
+                [0, 0, 1, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 1, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 1],
+            ]
+        )
+        np.testing.assert_array_equal(one_hot, expected)
+
+    def test_with_backend_tensor(self):
+        """Test categorical conversion for backend tensors."""
+        label_tensor = backend.convert_to_tensor(np.array([0, 2, 1, 3, 4]))
+        one_hot = numerical_utils.to_categorical(label_tensor, 5)
+        expected = backend.convert_to_tensor(
+            np.array(
+                [
+                    [1, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [0, 1, 0, 0, 0],
+                    [0, 0, 0, 1, 0],
+                    [0, 0, 0, 0, 1],
+                ]
+            )
+        )
+
+        # one_hot_value = one_hot.value
+        # expected_value = expected.value
+        one_hot_value = one_hot.numpy()
+        expected_value = expected.numpy()
+        np.testing.assert_array_equal(one_hot_value, expected_value)
+
+    def test_encode_categorical_inputs_basic(self):
+        """Test basic encoding of categorical inputs."""
+        inputs = backend.convert_to_tensor(np.array([0, 1, 2, 1, 0, 2]))
+        output = numerical_utils.encode_categorical_inputs(
+            inputs, output_mode="int", depth=3
+        )
+        expected_output = backend.convert_to_tensor(
+            np.array([0, 1, 2, 1, 0, 2])
+        )
+        self.assertAllClose(output, expected_output)
+
+    def test_encode_categorical_inputs_output_modes(self):
+        """Test various output modes for encoding."""
+        inputs = backend.convert_to_tensor(np.array([0, 1, 2, 1, 0, 2]))
+
+        output_one_hot = numerical_utils.encode_categorical_inputs(
+            inputs, output_mode="one_hot", depth=3
+        )
+        expected_one_hot = backend.convert_to_tensor(
+            np.array(
+                [
+                    [1, 0, 0],
+                    [0, 1, 0],
+                    [0, 0, 1],
+                    [0, 1, 0],
+                    [1, 0, 0],
+                    [0, 0, 1],
+                ]
+            )
+        )
+        self.assertAllClose(output_one_hot, expected_one_hot)
+
+    def test_normalize_invalid_order(self):
+        """Test normalization with an invalid order."""
+        x = np.array([1, 2, 3])
+        with self.assertRaisesRegex(
+            ValueError,
+            "Argument `order` must be an int >= 1. Received: order=0",
+        ):
+            numerical_utils.normalize(x, order=0)
+
+    def test_encode_categorical_inputs_multi_hot(self):
+        """Test multi-hot encoding of categorical inputs."""
+        inputs = backend.convert_to_tensor(np.array([[0, 1], [2, 1], [0, 2]]))
+        output_multi_hot = numerical_utils.encode_categorical_inputs(
+            inputs, output_mode="multi_hot", depth=3
+        )
+        expected_multi_hot = backend.convert_to_tensor(
+            np.array([[1, 1, 0], [0, 1, 1], [1, 0, 1]])
+        )
+        self.assertAllClose(output_multi_hot, expected_multi_hot)
+
+    def test_encode_categorical_inputs_invalid_output_mode(self):
+        """Test encoding with an invalid output mode."""
+        inputs = backend.convert_to_tensor(
+            np.array([[[0, 1, 2], [1, 0, 2]], [[1, 2, 0], [2, 0, 1]]])
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "When output_mode is not `'int'`, maximum supported output rank "
+            "is 2. Received output_mode invalid_mode and input shape "
+            "\(2, 2, 3\), which would result in output rank 3.",
+        ):
+            numerical_utils.encode_categorical_inputs(
+                inputs, "invalid_mode", depth=3
+            )


### PR DESCRIPTION

```


=================================== FAILURES ===================================
______________ ModelCheckpointTest.test_model_checkpoint_loading _______________

self = <keras.callbacks.model_checkpoint_test.ModelCheckpointTest testMethod=test_model_checkpoint_loading>

    @pytest.mark.skipif(
        h5py is None,
        reason="`h5py` is a required dependency for `ModelCheckpoint` tests.",
    )
    @pytest.mark.requires_trainable_backend
    def test_model_checkpoint_loading(self):
        def get_model():
            inputs = layers.Input(shape=(INPUT_DIM,), batch_size=2)
            x = layers.Dense(NUM_HIDDEN, activation="relu")(inputs)
            outputs = layers.Dense(NUM_CLASSES, activation="softmax")(x)
            functional_model = models.Model(inputs, outputs)
            functional_model.compile(
                loss="categorical_crossentropy",
                optimizer="sgd",
                metrics=[metrics.Accuracy("acc")],
            )
            return functional_model
    
        (x_train, y_train), (x_test, y_test) = test_utils.get_test_data(
            train_samples=TRAIN_SAMPLES,
            test_samples=TEST_SAMPLES,
            input_shape=(INPUT_DIM,),
            num_classes=NUM_CLASSES,
        )
        y_test = numerical_utils.to_categorical(y_test)
        y_train = numerical_utils.to_categorical(y_train)
    
        # Model Checkpoint load model (default)
        model = get_model()
        temp_dir = self.get_temp_dir()
        filepath = os.path.join(temp_dir, "checkpoint.model.keras")
        mode = "auto"
        monitor = "val_loss"
        save_best_only = True
    
        cbks = [
            callbacks.ModelCheckpoint(
                filepath,
                monitor=monitor,
                save_best_only=save_best_only,
                mode=mode,
            )
        ]
>       model.fit(
            x_train,
            y_train,
            batch_size=BATCH_SIZE,
            validation_data=(x_test, y_test),
            callbacks=cbks,
            epochs=1,
            verbose=0,
        )

keras/callbacks/model_checkpoint_test.py:488: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
keras/utils/traceback_utils.py:114: in error_handler
    return fn(*args, **kwargs)
keras/backend/torch/trainer.py:295: in fit
    logs = self.train_function(data)
keras/backend/torch/trainer.py:100: in one_step_on_data
    return self.train_step(data)
keras/backend/torch/trainer.py:39: in train_step
    loss = self.compute_loss(
keras/trainers/trainer.py:300: in compute_loss
    loss = self._compile_loss(y, y_pred, sample_weight)
keras/trainers/compile_utils.py:592: in __call__
    return self.call(y_true, y_pred, sample_weight)
keras/trainers/compile_utils.py:628: in call
    loss(y_t, y_p, sample_weight), dtype=backend.floatx()
keras/losses/loss.py:43: in __call__
    losses = self.call(y_true, y_pred)
keras/losses/losses.py:22: in call
    return self.fn(y_true, y_pred, **self._fn_kwargs)
keras/losses/losses.py:1559: in categorical_crossentropy
    return ops.categorical_crossentropy(
keras/ops/nn.py:1405: in categorical_crossentropy
    return backend.nn.categorical_crossentropy(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

target = tensor([[1.],
        [1.],
        [1.],
        [1.],
        [1.]])
output = tensor([[0.6275, 0.3725],
        [0.9202, 0.0798],
        [0.8848, 0.1152],
        [0.8186, 0.1814],
        [0.9200, 0.0800]], grad_fn=<SoftmaxBackward0>)
from_logits = False, axis = -1

    def categorical_crossentropy(target, output, from_logits=False, axis=-1):
        target = convert_to_tensor(target)
        output = convert_to_tensor(output)
    
        if target.shape != output.shape:
>           raise ValueError(
                "Arguments `target` and `output` must have the same shape. "
                "Received: "
                f"target.shape={target.shape}, output.shape={output.shape}"
            )
E           ValueError: Arguments `target` and `output` must have the same shape. Received: target.shape=torch.Size([5, 1]), output.shape=torch.Size([5, 2])

keras/backend/torch/nn.py:544: ValueError
```
