### PR TITLE
Add `pad_to_bounding_box` image ops

### DIFF
--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -692,7 +692,7 @@ def pad_images(
     (2, 20, 30, 3)"""
 
     if any_symbolic_tensors((image,)):
-        return PadImage(
+        return PadImages(
             top_padding,
             bottom_padding,
             left_padding,

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -1,4 +1,5 @@
 from keras import backend
+from keras import ops
 from keras.api_export import keras_export
 from keras.backend import KerasTensor
 from keras.backend import any_symbolic_tensors
@@ -533,27 +534,28 @@ class PadImages(Operation):
         )
 
     def compute_output_spec(self, images):
+        images_shape = ops.shape(images)
         if self.target_height is None:
-            height_axis = 0 if len(images.shape) == 3 else 1
+            height_axis = 0 if len(images_shape) == 3 else 1
             self.target_height = (
                 self.top_padding
-                + images.shape[height_axis]
+                + images_shape[height_axis]
                 + self.bottom_padding
             )
         if self.target_width is None:
-            width_axis = 0 if len(images.shape) == 3 else 2
+            width_axis = 0 if len(images_shape) == 3 else 2
             self.target_width = (
                 self.left_padding
-                + images.shape[width_axis]
+                + images_shape[width_axis]
                 + self.right_padding
             )
         out_shape = (
-            images.shape[0],
+            images_shape[0],
             self.target_height,
             self.target_width,
-            images.shape[-1],
+            images_shape[-1],
         )
-        if len(images.shape) == 3:
+        if len(images_shape) == 3:
             out_shape = out_shape[1:]
         return KerasTensor(
             shape=out_shape,
@@ -572,17 +574,18 @@ def _pad_images(
 ):
     images = backend.convert_to_tensor(images)
     is_batch = True
-    images_shape = images.shape
+    images_shape = ops.shape(images)
     if len(images_shape) == 3:
         is_batch = False
         images = backend.numpy.expand_dims(images, 0)
     elif len(images_shape) != 4:
         raise ValueError(
-            f"'images' (shape {images_shape}) must have "
-            f"either 3 or 4 dimensions. Received: images.shape={images.shape}"
+            f"Invalid shape for argument `images`: "
+            "it must have rank 3 or 4. "
+            f"Received: images.shape={images_shape}"
         )
 
-    batch, height, width, depth = images.shape
+    batch, height, width, depth = ops.shape(images)
 
     if [top_padding, bottom_padding, target_height].count(None) != 1:
         raise ValueError(

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -660,8 +660,8 @@ def pad_images(
     """Pad `image` with zeros to the specified `height` and `width`.
 
     Args:
-        image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D
-            Tensor of shape `[height, width, channels]`.
+        image: 4-D Tensor of shape `(batch, height, width, channels)` or 3-D
+            Tensor of shape `(height, width, channels)`.
         top_padding: Number of rows of zeros to add on top.
         bottom_padding: Number of rows of zeros to add at the bottom.
         left_padding: Number of columns of zeros to add on the left.
@@ -671,9 +671,9 @@ def pad_images(
 
     Returns:
         If `image` was 4-D, a 4-D float Tensor of shape
-            `[batch, target_height, target_width, channels]`
+            `(batch, target_height, target_width, channels)`
         If `image` was 3-D, a 3-D float Tensor of shape
-            `[target_height, target_width, channels]`
+            `(target_height, target_width, channels)`
 
     Example:
 

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -579,7 +579,7 @@ def _pad_images(
     elif len(images_shape) != 4:
         raise ValueError(
             f"'images' (shape {images_shape}) must have "
-            "either 3 or 4 dimensions."
+            f"either 3 or 4 dimensions. Received: images.shape={images.shape}"
         )
 
     batch, height, width, depth = images.shape

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -514,7 +514,6 @@ class PadImage(Operation):
         right_padding,
         target_height,
         target_width,
-        check_dims=True,
     ):
         super().__init__()
         self.top_padding = top_padding
@@ -523,7 +522,6 @@ class PadImage(Operation):
         self.right_padding = right_padding
         self.target_height = target_height
         self.target_width = target_width
-        self.check_dims = check_dims
 
     def call(self, image):
         return _pad_image(
@@ -534,7 +532,6 @@ class PadImage(Operation):
             self.right_padding,
             self.target_height,
             self.target_width,
-            self.check_dims,
         )
 
     def compute_output_spec(self, image):

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -584,12 +584,12 @@ def _pad_images(
 
     batch, height, width, depth = images.shape
 
-    if [top_padding, bottom_padding, target_height].count(None) > 1:
+    if [top_padding, bottom_padding, target_height].count(None) != 1:
         raise ValueError(
             "Must specify exactly two of "
             "top_padding, bottom_padding, target_height"
         )
-    if [left_padding, right_padding, target_width].count(None) > 1:
+    if [left_padding, right_padding, target_width].count(None) != 1:
         raise ValueError(
             "Must specify exactly two of "
             "left_padding, right_padding, target_width"

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -506,15 +506,15 @@ def map_coordinates(
 class PadImage(Operation):
     def __init__(
         self,
-        offset_height,
-        offset_width,
+        top_padding,
+        left_padding,
         target_height,
         target_width,
         check_dims=True,
     ):
         super().__init__()
-        self.offset_height = offset_height
-        self.offset_width = offset_width
+        self.top_padding = top_padding
+        self.left_padding = left_padding
         self.target_height = target_height
         self.target_width = target_width
         self.check_dims = check_dims
@@ -522,8 +522,8 @@ class PadImage(Operation):
     def call(self, image):
         return _pad_image(
             image,
-            self.offset_height,
-            self.offset_width,
+            self.top_padding,
+            self.left_padding,
             self.target_height,
             self.target_width,
             self.check_dims,
@@ -545,7 +545,7 @@ class PadImage(Operation):
 
 
 def _pad_image(
-    image, offset_height, offset_width, target_height, target_width, check_dims
+    image, top_padding, left_padding, target_height, target_width, check_dims
 ):
     image = backend.convert_to_tensor(image)
     is_batch = True
@@ -559,14 +559,14 @@ def _pad_image(
         )
 
     batch, height, width, depth = image.shape
-    after_padding_width = target_width - offset_width - width
-    after_padding_height = target_height - offset_height - height
+    after_padding_width = target_width - left_padding - width
+    after_padding_height = target_height - top_padding - height
 
     if check_dims:
-        if not offset_height >= 0:
-            raise ValueError("offset_height must be >= 0")
-        if not offset_width >= 0:
-            raise ValueError("offset_width must be >= 0")
+        if not top_padding >= 0:
+            raise ValueError("top_padding must be >= 0")
+        if not left_padding >= 0:
+            raise ValueError("left_padding must be >= 0")
         if not after_padding_width >= 0:
             raise ValueError("width must be <= target - offset")
         if not after_padding_height >= 0:
@@ -577,9 +577,9 @@ def _pad_image(
             [
                 0,
                 0,
-                offset_height,
+                top_padding,
                 after_padding_height,
-                offset_width,
+                left_padding,
                 after_padding_width,
                 0,
                 0,
@@ -600,8 +600,8 @@ def _pad_image(
 @keras_export("keras.ops.image.pad_image")
 def pad_image(
     image,
-    offset_height,
-    offset_width,
+    top_padding,
+    left_padding,
     target_height,
     target_width,
     check_dims=True,
@@ -611,8 +611,8 @@ def pad_image(
     Args:
         image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D
             Tensor of shape `[height, width, channels]`.
-        offset_height: Number of rows of zeros to add on top.
-        offset_width: Number of columns of zeros to add on the left.
+        top_padding: Number of rows of zeros to add on top.
+        left_padding: Number of columns of zeros to add on the left.
         target_height: Height of output image.
         target_width: Width of output image.
         check_dims: If True, assert that dimensions are non-negative and in
@@ -643,13 +643,13 @@ def pad_image(
 
     if any_symbolic_tensors((image,)):
         return PadImage(
-            offset_height, offset_width, target_height, target_width, check_dims
+            top_padding, left_padding, target_height, target_width, check_dims
         ).symbolic_call(image)
 
     return _pad_image(
         image,
-        offset_height,
-        offset_width,
+        top_padding,
+        left_padding,
         target_height,
         target_width,
         check_dims,

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -555,8 +555,7 @@ def _pad_to_bounding_box(
         image = backend.numpy.expand_dims(image, 0)
     elif len(image_shape) != 4:
         raise ValueError(
-            "'image' (shape %s) must have either 3 or 4 dimensions."
-            % image_shape
+            f"'image' (shape {image_shape}) must have either 3 or 4 dimensions."
         )
 
     batch, height, width, depth = image.shape

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -660,7 +660,7 @@ def pad_images(
     """Pad `image` with zeros to the specified `height` and `width`.
 
     Args:
-        image: 4-D Tensor of shape `(batch, height, width, channels)` or 3-D
+        image: 4D Tensor of shape `(batch, height, width, channels)` or 3D
             Tensor of shape `(height, width, channels)`.
         top_padding: Number of rows of zeros to add on top.
         bottom_padding: Number of rows of zeros to add at the bottom.
@@ -670,9 +670,9 @@ def pad_images(
         target_width: Width of output image.
 
     Returns:
-        If `image` was 4-D, a 4-D float Tensor of shape
+        If `image` was 4D, a 4D float Tensor of shape
             `(batch, target_height, target_width, channels)`
-        If `image` was 3-D, a 3-D float Tensor of shape
+        If `image` was 3D, a 3D float Tensor of shape
             `(target_height, target_width, channels)`
 
     Example:

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -614,13 +614,24 @@ def _pad_images(
         right_padding = target_width - left_padding - width
 
     if top_padding < 0:
-        raise ValueError("top_padding must be >= 0")
+        raise ValueError(
+            "top_padding must be >= 0. " f"Received: top_padding={top_padding}"
+        )
     if left_padding < 0:
-        raise ValueError("left_padding must be >= 0")
+        raise ValueError(
+            "left_padding must be >= 0. "
+            f"Received: left_padding={left_padding}"
+        )
     if right_padding < 0:
-        raise ValueError("right_padding must be >= 0")
+        raise ValueError(
+            "right_padding must be >= 0. "
+            f"Received: right_padding={right_padding}"
+        )
     if bottom_padding < 0:
-        raise ValueError("bottom_padding must be >= 0")
+        raise ValueError(
+            "bottom_padding must be >= 0. "
+            f"Received: bottom_padding={bottom_padding}"
+        )
 
     paddings = backend.numpy.reshape(
         backend.numpy.stack(

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -505,7 +505,7 @@ def map_coordinates(
     )
 
 
-class PadImage(Operation):
+class PadImages(Operation):
     def __init__(
         self,
         top_padding,
@@ -524,7 +524,7 @@ class PadImage(Operation):
         self.target_width = target_width
 
     def call(self, image):
-        return _pad_image(
+        return _pad_images(
             image,
             self.top_padding,
             self.bottom_padding,
@@ -561,7 +561,7 @@ class PadImage(Operation):
         )
 
 
-def _pad_image(
+def _pad_images(
     image,
     top_padding,
     bottom_padding,
@@ -647,8 +647,8 @@ def _pad_image(
     return padded
 
 
-@keras_export("keras.ops.image.pad_image")
-def pad_image(
+@keras_export("keras.ops.image.pad_images")
+def pad_images(
     image,
     top_padding,
     left_padding,
@@ -678,14 +678,14 @@ def pad_image(
     Example:
 
     >>> image = np.random.random((15, 25, 3))
-    >>> padded_image = keras.ops.image.pad_image(
+    >>> padded_image = keras.ops.image.pad_images(
     ...     image, 2, 3, target_height=20, target_width=30
     ... )
     >>> padded_image.shape
     (20, 30, 3)
 
     >>> batch_images = np.random.random((2, 15, 25, 3))
-    >>> padded_batch = keras.ops.image.pad_image(
+    >>> padded_batch = keras.ops.image.pad_images(
     ...     batch_images, 2, 3, target_height=20, target_width=30
     ... )
     >>> padded_batch.shape
@@ -701,7 +701,7 @@ def pad_image(
             target_width,
         ).symbolic_call(image)
 
-    return _pad_image(
+    return _pad_images(
         image,
         top_padding,
         bottom_padding,

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -587,12 +587,18 @@ def _pad_images(
     if [top_padding, bottom_padding, target_height].count(None) != 1:
         raise ValueError(
             "Must specify exactly two of "
-            "top_padding, bottom_padding, target_height"
+            "top_padding, bottom_padding, target_height. "
+            f"Received: top_padding={top_padding}, "
+            f"bottom_padding={bottom_padding}, "
+            f"target_height={target_height}"
         )
     if [left_padding, right_padding, target_width].count(None) != 1:
         raise ValueError(
             "Must specify exactly two of "
-            "left_padding, right_padding, target_width"
+            "left_padding, right_padding, target_width. "
+            f"Received: left_padding={left_padding}, "
+            f"right_padding={right_padding}, "
+            f"target_width={target_width}"
         )
 
     if top_padding is None:

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -568,7 +568,6 @@ def _pad_image(
     right_padding,
     target_height,
     target_width,
-    check_dims,
 ):
     image = backend.convert_to_tensor(image)
     is_batch = True
@@ -609,15 +608,14 @@ def _pad_image(
     if bottom_padding is None:
         bottom_padding = target_height - top_padding - height
 
-    if check_dims:
-        if not top_padding >= 0:
-            raise ValueError("top_padding must be >= 0")
-        if not left_padding >= 0:
-            raise ValueError("left_padding must be >= 0")
-        if not right_padding >= 0:
-            raise ValueError("width must be <= target - offset")
-        if not bottom_padding >= 0:
-            raise ValueError("height must be <= target - offset")
+    if not top_padding >= 0:
+        raise ValueError("top_padding must be >= 0")
+    if not left_padding >= 0:
+        raise ValueError("left_padding must be >= 0")
+    if not right_padding >= 0:
+        raise ValueError("width must be <= target - offset")
+    if not bottom_padding >= 0:
+        raise ValueError("height must be <= target - offset")
 
     paddings = backend.numpy.reshape(
         backend.numpy.stack(
@@ -657,7 +655,6 @@ def pad_image(
     target_width,
     bottom_padding=None,
     right_padding=None,
-    check_dims=True,
 ):
     """Pad `image` with zeros to the specified `height` and `width`.
 
@@ -670,11 +667,6 @@ def pad_image(
         right_padding: Number of columns of zeros to add on the right.
         target_height: Height of output image.
         target_width: Width of output image.
-        check_dims: If True, assert that dimensions are non-negative and in
-            range. In multi-GPU distributed settings, assertions can cause
-            program slowdown. Setting this parameter to `False` avoids this,
-            resulting in faster speed in some situations, with the tradeoff
-            being that some error checking is not happening.
 
     Returns:
         If `image` was 4-D, a 4-D float Tensor of shape
@@ -706,7 +698,6 @@ def pad_image(
             right_padding,
             target_height,
             target_width,
-            check_dims,
         ).symbolic_call(image)
 
     return _pad_image(
@@ -717,5 +708,4 @@ def pad_image(
         right_padding,
         target_height,
         target_width,
-        check_dims,
     )

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -1,5 +1,3 @@
-import warnings
-
 from keras import backend
 from keras.api_export import keras_export
 from keras.backend import KerasTensor
@@ -580,37 +578,31 @@ def _pad_images(
         images = backend.numpy.expand_dims(images, 0)
     elif len(images_shape) != 4:
         raise ValueError(
-            f"'images' (shape {images_shape}) must have"
+            f"'images' (shape {images_shape}) must have "
             "either 3 or 4 dimensions."
         )
 
     batch, height, width, depth = images.shape
 
-    if right_padding is None and target_width is None:
-        raise ValueError("right_padding and target_width both cannot be None.")
-    if right_padding is not None and target_width is not None:
-        right_padding = None
-        warnings.warn(
-            "Both right_padding and target_width were provided. "
-            "Setting right_padding to None. target_width will be "
-            "used for calculating right_padding."
-        )
-    if right_padding is None:
-        right_padding = target_width - left_padding - width
-
-    if bottom_padding is None and target_height is None:
+    if [top_padding, bottom_padding, target_height].count(None) > 1:
         raise ValueError(
-            "bottom_padding and target_height both cannot " "be None."
+            "Must specify exactly two of "
+            "top_padding, bottom_padding, target_height"
         )
-    if bottom_padding is not None and target_height is not None:
-        bottom_padding = None
-        warnings.warn(
-            "Both bottom_padding and target_height were provided. "
-            "Setting bottom_padding to None. target_height will be "
-            "used for calculating bottom_padding."
+    if [left_padding, right_padding, target_width].count(None) > 1:
+        raise ValueError(
+            "Must specify exactly two of "
+            "left_padding, right_padding, target_width"
         )
+
+    if top_padding is None:
+        top_padding = target_height - bottom_padding - height
     if bottom_padding is None:
         bottom_padding = target_height - top_padding - height
+    if left_padding is None:
+        left_padding = target_width - right_padding - width
+    if right_padding is None:
+        right_padding = target_width - left_padding - width
 
     if not top_padding >= 0:
         raise ValueError("top_padding must be >= 0")
@@ -653,10 +645,10 @@ def _pad_images(
 @keras_export("keras.ops.image.pad_images")
 def pad_images(
     images,
-    top_padding,
-    left_padding,
-    target_height,
-    target_width,
+    top_padding=None,
+    left_padding=None,
+    target_height=None,
+    target_width=None,
     bottom_padding=None,
     right_padding=None,
 ):

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -604,14 +604,14 @@ def _pad_images(
     if right_padding is None:
         right_padding = target_width - left_padding - width
 
-    if not top_padding >= 0:
+    if top_padding < 0:
         raise ValueError("top_padding must be >= 0")
-    if not left_padding >= 0:
+    if left_padding < 0:
         raise ValueError("left_padding must be >= 0")
-    if not right_padding >= 0:
-        raise ValueError("width must be <= target - offset")
-    if not bottom_padding >= 0:
-        raise ValueError("height must be <= target - offset")
+    if right_padding < 0:
+        raise ValueError("right_padding must be >= 0")
+    if bottom_padding < 0:
+        raise ValueError("bottom_padding must be >= 0")
 
     paddings = backend.numpy.reshape(
         backend.numpy.stack(

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -539,12 +539,16 @@ class PadImage(Operation):
 
     def compute_output_spec(self, image):
         if self.target_height is None:
+            height_axis = 0 if len(image.shape) == 3 else 1
             self.target_height = (
-                self.top_padding + image.shape[1] + self.bottom_padding
+                self.top_padding
+                + image.shape[height_axis]
+                + self.bottom_padding
             )
         if self.target_width is None:
+            width_axis = 0 if len(image.shape) == 3 else 2
             self.target_width = (
-                self.left_padding + image.shape[2] + self.right_padding
+                self.left_padding + image.shape[width_axis] + self.right_padding
             )
         out_shape = (
             image.shape[0],

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -503,7 +503,7 @@ def map_coordinates(
     )
 
 
-class PadToBoundingBox(Operation):
+class PadImage(Operation):
     def __init__(
         self,
         offset_height,
@@ -520,7 +520,7 @@ class PadToBoundingBox(Operation):
         self.check_dims = check_dims
 
     def call(self, image):
-        return _pad_to_bounding_box(
+        return _pad_image(
             image,
             self.offset_height,
             self.offset_width,
@@ -544,7 +544,7 @@ class PadToBoundingBox(Operation):
         )
 
 
-def _pad_to_bounding_box(
+def _pad_image(
     image, offset_height, offset_width, target_height, target_width, check_dims
 ):
     image = backend.convert_to_tensor(image)
@@ -597,8 +597,8 @@ def _pad_to_bounding_box(
     return padded
 
 
-@keras_export("keras.ops.image.pad_to_bounding_box")
-def pad_to_bounding_box(
+@keras_export("keras.ops.image.pad_image")
+def pad_image(
     image,
     offset_height,
     offset_width,
@@ -630,23 +630,23 @@ def pad_to_bounding_box(
     Example:
 
     >>> image = np.random.random((15, 25, 3))
-    >>> padded_image = keras.ops.image.pad_to_bounding_box(image, 2, 3, 20, 30)
+    >>> padded_image = keras.ops.image.pad_image(image, 2, 3, 20, 30)
     >>> padded_image.shape
     (20, 30, 3)
 
     >>> batch_images = np.random.random((2, 15, 25, 3))
-    >>> padded_batch = keras.ops.image.pad_to_bounding_box(
+    >>> padded_batch = keras.ops.image.pad_image(
     ...     batch_images, 2, 3, 20, 30
     ... )
     >>> padded_batch.shape
     (2, 20, 30, 3)"""
 
     if any_symbolic_tensors((image,)):
-        return PadToBoundingBox(
+        return PadImage(
             offset_height, offset_width, target_height, target_width, check_dims
         ).symbolic_call(image)
 
-    return _pad_to_bounding_box(
+    return _pad_image(
         image,
         offset_height,
         offset_width,

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -640,8 +640,7 @@ def pad_to_bounding_box(
     ...     batch_images, 2, 3, 20, 30
     ... )
     >>> padded_batch.shape
-    (2, 20, 30, 3)
-"""
+    (2, 20, 30, 3)"""
 
     if any_symbolic_tensors((image,)):
         return PadToBoundingBox(

--- a/keras/ops/image_test.py
+++ b/keras/ops/image_test.py
@@ -49,7 +49,7 @@ class ImageOpsDynamicShapeTest(testing.TestCase):
 
         x = KerasTensor([None, None, 3])
         out = kimage.pad_image(x, 2, 3, target_height=20, target_width=30)
-        self.assertEqual(out.shape, (None, None, 3))
+        self.assertEqual(out.shape, (20, 30, 3))
 
 
 class ImageOpsStaticShapeTest(testing.TestCase):

--- a/keras/ops/image_test.py
+++ b/keras/ops/image_test.py
@@ -42,6 +42,11 @@ class ImageOpsDynamicShapeTest(testing.TestCase):
         out = kimage.map_coordinates(input, coordinates, 0)
         self.assertEqual(out.shape, coordinates.shape[1:])
 
+    def test_pad_image(self):
+        x = KerasTensor([None, 15, 25, 3])
+        out = kimage.pad_image(x, 2, 3, target_height=20, target_width=30)
+        self.assertEqual(out.shape, (None, 20, 30, 3))
+
 
 class ImageOpsStaticShapeTest(testing.TestCase):
     def test_resize(self):

--- a/keras/ops/image_test.py
+++ b/keras/ops/image_test.py
@@ -74,6 +74,17 @@ class ImageOpsStaticShapeTest(testing.TestCase):
         out = kimage.map_coordinates(input, coordinates, 0)
         self.assertEqual(out.shape, coordinates.shape[1:])
 
+    def test_pad_image(self):
+        x = KerasTensor([15, 25, 3])
+        out = kimage.pad_image(x, 2, 3, target_height=20, target_width=30)
+        self.assertEqual(out.shape, (20, 30, 3))
+
+        x_batch = KerasTensor([2, 15, 25, 3])
+        out_batch = kimage.pad_image(
+            x_batch, 2, 3, target_height=20, target_width=30
+        )
+        self.assertEqual(out_batch.shape, (2, 20, 30, 3))
+
 
 AFFINE_TRANSFORM_INTERPOLATIONS = {  # map to order
     "nearest": 0,

--- a/keras/ops/image_test.py
+++ b/keras/ops/image_test.py
@@ -47,6 +47,10 @@ class ImageOpsDynamicShapeTest(testing.TestCase):
         out = kimage.pad_image(x, 2, 3, target_height=20, target_width=30)
         self.assertEqual(out.shape, (None, 20, 30, 3))
 
+        x = KerasTensor([None, None, 3])
+        out = kimage.pad_image(x, 2, 3, target_height=20, target_width=30)
+        self.assertEqual(out.shape, (None, None, 3))
+
 
 class ImageOpsStaticShapeTest(testing.TestCase):
     def test_resize(self):

--- a/keras/ops/image_test.py
+++ b/keras/ops/image_test.py
@@ -434,7 +434,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
         self.assertAllClose(output, expected)
 
-    @parameterized.expand(
+    @parameterized.parameters(
         [
             (0, 0, 3, 3, None, None),
             (1, 0, 4, 3, None, None),

--- a/keras/ops/image_test.py
+++ b/keras/ops/image_test.py
@@ -476,7 +476,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             tuple(padded_image.shape), tuple(ref_padded_image.shape)
         )
         self.assertAllClose(
-            padded_image.numpy(),
-            backend.convert_to_numpy(ref_padded_image),
+            ref_padded_image.numpy(),
+            backend.convert_to_numpy(padded_image),
             atol=1e-5,
         )

--- a/keras/ops/image_test.py
+++ b/keras/ops/image_test.py
@@ -42,13 +42,13 @@ class ImageOpsDynamicShapeTest(testing.TestCase):
         out = kimage.map_coordinates(input, coordinates, 0)
         self.assertEqual(out.shape, coordinates.shape[1:])
 
-    def test_pad_image(self):
+    def test_pad_images(self):
         x = KerasTensor([None, 15, 25, 3])
-        out = kimage.pad_image(x, 2, 3, target_height=20, target_width=30)
+        out = kimage.pad_images(x, 2, 3, target_height=20, target_width=30)
         self.assertEqual(out.shape, (None, 20, 30, 3))
 
         x = KerasTensor([None, None, 3])
-        out = kimage.pad_image(x, 2, 3, target_height=20, target_width=30)
+        out = kimage.pad_images(x, 2, 3, target_height=20, target_width=30)
         self.assertEqual(out.shape, (20, 30, 3))
 
 
@@ -78,13 +78,13 @@ class ImageOpsStaticShapeTest(testing.TestCase):
         out = kimage.map_coordinates(input, coordinates, 0)
         self.assertEqual(out.shape, coordinates.shape[1:])
 
-    def test_pad_image(self):
+    def test_pad_images(self):
         x = KerasTensor([15, 25, 3])
-        out = kimage.pad_image(x, 2, 3, target_height=20, target_width=30)
+        out = kimage.pad_images(x, 2, 3, target_height=20, target_width=30)
         self.assertEqual(out.shape, (20, 30, 3))
 
         x_batch = KerasTensor([2, 15, 25, 3])
-        out_batch = kimage.pad_image(
+        out_batch = kimage.pad_images(
             x_batch, 2, 3, target_height=20, target_width=30
         )
         self.assertEqual(out_batch.shape, (2, 20, 30, 3))
@@ -446,7 +446,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             (1, 2, None, None, 3, 4),
         ]
     )
-    def test_pad_image(
+    def test_pad_images(
         self,
         top_padding,
         left_padding,
@@ -456,7 +456,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         right_padding,
     ):
         image = np.random.uniform(size=(3, 3, 1))
-        padded_image = kimage.pad_image(
+        padded_image = kimage.pad_images(
             image,
             top_padding,
             left_padding,


### PR DESCRIPTION
This PR will add `pad_to_bounding_box` functions used in `keras.io/examples` as mention in Issue: #18489. Note, test code hasn't been added yet. Will add the tests once the op gets finalized.