### PR TITLE
Add Keras trackable logic for TF backend (fixes list and dictionary deps)

### DIFF
--- a/keras/backend/tensorflow/layer.py
+++ b/keras/backend/tensorflow/layer.py
@@ -2,6 +2,7 @@ import tensorflow as tf
 
 from keras.backend.tensorflow.trackable import KerasAutoTrackable
 from keras.utils import tf_utils
+from keras.utils import tracking
 
 
 class TFLayer(KerasAutoTrackable):
@@ -9,6 +10,7 @@ class TFLayer(KerasAutoTrackable):
         # Export-related attributes
         self._saved_model_inputs_spec = None
         self._saved_model_arg_spec = None
+        self._tracked = []
 
     @tf.__internal__.tracking.no_automatic_dependency_tracking
     def _set_save_spec(self, inputs, args=None, kwargs=None):
@@ -58,6 +60,15 @@ class TFLayer(KerasAutoTrackable):
             self.train_function = train_function
             self.test_function = test_function
             self.predict_function = predict_function
+
+            for tracked_attr in self._tracked:
+                tracked_item = getattr(self, tracked_attr)
+                if isinstance(tracked_item, tracking.TrackedList):
+                    children[tracked_attr] = list(tracked_item)
+                if isinstance(tracked_item, tracking.TrackedDict):
+                    children[tracked_attr] = dict(tracked_item)
+                if isinstance(tracked_item, tracking.TrackedSet):
+                    children[tracked_attr] = list(tracked_item)
 
         return children
 

--- a/keras/backend/tensorflow/layer.py
+++ b/keras/backend/tensorflow/layer.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 
-from keras.utils import tf_utils
 from keras.backend.tensorflow.trackable import KerasAutoTrackable
+from keras.utils import tf_utils
 
 
 class TFLayer(KerasAutoTrackable):

--- a/keras/backend/tensorflow/layer.py
+++ b/keras/backend/tensorflow/layer.py
@@ -1,9 +1,10 @@
 import tensorflow as tf
 
 from keras.utils import tf_utils
+from keras.backend.tensorflow.trackable import KerasAutoTrackable
 
 
-class TFLayer(tf.__internal__.tracking.AutoTrackable):
+class TFLayer(KerasAutoTrackable):
     def __init__(self, *args, **kwargs):
         # Export-related attributes
         self._saved_model_inputs_spec = None

--- a/keras/backend/tensorflow/saved_model_test.py
+++ b/keras/backend/tensorflow/saved_model_test.py
@@ -178,3 +178,37 @@ class SavedModelTest(testing.TestCase):
         restored_model = tf.saved_model.load(path)
         output = restored_model.call(*inp)
         self.assertAllClose(expected, output, rtol=1e-4, atol=1e-4)
+
+    def test_list_trackable_children_tracking(self):
+        @object_registration.register_keras_serializable(package="my_package")
+        class CustomLayerList(layers.Layer):
+            def __init__(self):
+                super().__init__()
+                self.sublayers = [
+                    layers.Dense(2),
+                    layers.Dense(2),
+                ]
+
+            def call(self, inputs):
+                x = inputs
+                for sublayer in self.sublayers:
+                    x = sublayer(x)
+                return x
+
+        inputs = layers.Input(shape=(1,))
+        outputs = CustomLayerList()(inputs)
+        model = models.Model(inputs, outputs)
+
+        inp = np.array([[1.0]])
+        expected = model(inp)
+        path = os.path.join(self.get_temp_dir(), "my_keras_model")
+        tf.saved_model.save(model, path)
+        restored_model = tf.saved_model.load(path)
+        self.assertAllClose(
+            expected,
+            restored_model.signatures["serving_default"](
+                tf.convert_to_tensor(inp, dtype=tf.float32)
+            )["output_0"],
+            rtol=1e-4,
+            atol=1e-4,
+        )

--- a/keras/backend/tensorflow/trackable.py
+++ b/keras/backend/tensorflow/trackable.py
@@ -11,6 +11,7 @@ class KerasAutoTrackable(tf.__internal__.tracking.AutoTrackable):
 
     This serves as an interface between Keras tracking and TF tracking.
     """
+
     def __setattr__(self, name, value):
         """Support self.foo = trackable syntax."""
         try:
@@ -22,9 +23,9 @@ class KerasAutoTrackable(tf.__internal__.tracking.AutoTrackable):
 
         if getattr(self, "_self_setattr_tracking", True):
             value = sticky_attribute_assignment(
-                trackable=self, value=value, name=name)
+                trackable=self, value=value, name=name
+            )
         super().__setattr__(name, value)
-
 
 
 def sticky_attribute_assignment(trackable, name, value):
@@ -50,9 +51,11 @@ def sticky_attribute_assignment(trackable, name, value):
         return value
     if isinstance(value, tf.__internal__.tracking.Trackable):
         trackable._track_trackable(  # pylint: disable=protected-access
-            value, name=name,
+            value,
+            name=name,
             # Allow the user to switch the Trackable which is tracked by this
             # name, since assigning a new variable to an attribute has
             # historically been fine (e.g. Adam did this).
-            overwrite=True)
+            overwrite=True,
+        )
     return value

--- a/keras/backend/tensorflow/trackable.py
+++ b/keras/backend/tensorflow/trackable.py
@@ -40,13 +40,10 @@ def sticky_attribute_assignment(trackable, name, value):
     Returns:
         The value which should be stored in the attribute.
     """
-    if isinstance(value, tracking.TrackedList):
-        value = list(value)
-    if isinstance(value, tracking.TrackedDict):
-        value = dict(value)
-    if isinstance(value, tracking.TrackedSet):
-        value = set(value)
-    value = tf.__internal__.tracking.wrap(value)
+    if isinstance(
+        value, (tracking.TrackedList, tracking.TrackedDict, tracking.TrackedSet)
+    ) and hasattr(trackable, "_tracked"):
+        trackable._tracked.append(name)
     if not tracking.is_tracking_enabled():
         return value
     if isinstance(value, tf.__internal__.tracking.Trackable):

--- a/keras/backend/tensorflow/trackable.py
+++ b/keras/backend/tensorflow/trackable.py
@@ -1,0 +1,44 @@
+import tensorflow as tf
+
+from keras.utils import tracking
+
+
+class KerasAutoTrackable(tf.__internal__.tracking.AutoTrackable):
+    def __setattr__(self, name, value):
+        """Support self.foo = trackable syntax."""
+        try:
+            if getattr(self, name) is value:
+                # Short circuit for `self.$x = self.$x`.
+                return
+        except AttributeError:
+            pass
+
+        if getattr(self, "_self_setattr_tracking", True):
+            value = sticky_attribute_assignment(
+                trackable=self, value=value, name=name)
+        super().__setattr__(name, value)
+
+    # def _no_dependency(self, value):
+    #     """Override to allow TrackableBase to disable dependency tracking."""
+    #     with tracking.DotNotTrackScope():
+    #         return value
+
+
+def sticky_attribute_assignment(trackable, name, value):
+    if isinstance(value, tracking.TrackedList):
+        value = list(value)
+    if isinstance(value, tracking.TrackedDict):
+        value = dict(value)
+    if isinstance(value, tracking.TrackedSet):
+        value = set(value)
+    value = tf.__internal__.tracking.wrap(value)
+    if not tracking.is_tracking_enabled():
+        return value
+    if isinstance(value, tf.__internal__.tracking.Trackable):
+        trackable._track_trackable(  # pylint: disable=protected-access
+            value, name=name,
+            # Allow the user to switch the Trackable which is tracked by this
+            # name, since assigning a new variable to an attribute has
+            # historically been fine (e.g. Adam did this).
+            overwrite=True)
+    return value

--- a/keras/ops/function.py
+++ b/keras/ops/function.py
@@ -4,7 +4,6 @@ import tree
 
 from keras.api_export import keras_export
 from keras.backend import KerasTensor
-from keras.backend.config import backend
 from keras.ops.operation import Operation
 from keras.utils.nest import pack_sequence_as
 
@@ -47,21 +46,10 @@ class Function(Operation):
     def __init__(self, inputs, outputs, name=None):
         super().__init__(name=name)
 
-        if backend() == "tensorflow":
-            # Temporary work around for
-            # https://github.com/keras-team/keras/issues/931
-            # This stop tensorflow from wrapping tf.function output in a
-            # _DictWrapper object.
-            _self_setattr_tracking = getattr(
-                self, "_self_setattr_tracking", True
-            )
-            self._self_setattr_tracking = False
         self._inputs_struct = tree.map_structure(lambda x: x, inputs)
         self._outputs_struct = tree.map_structure(lambda x: x, outputs)
         self._inputs = tree.flatten(inputs)
         self._outputs = tree.flatten(outputs)
-        if backend() == "tensorflow":
-            self._self_setattr_tracking = _self_setattr_tracking
 
         (nodes, nodes_by_depth, operations, operations_by_depth) = map_graph(
             self._inputs, self._outputs


### PR DESCRIPTION
This PR adds interfacing logic between Keras tracking and TF trackable logic.

Associated issue: https://github.com/keras-team/keras/issues/18398

- I have created a special subclass KerasAutoTrackable with __setattr__ logic that takes into account Keras's own tracking suite.
- All TF layers now inherit from KerasAutoTrackable, which inherits from the original TF AutoTrackable.
- I have also added associated tests for lists and dictionaries of Trackables in `saved_model_test.py`.
