### PR TITLE
Make Dense and EinsumDense agree more closely

### DIFF
--- a/keras/layers/core/dense.py
+++ b/keras/layers/core/dense.py
@@ -99,14 +99,16 @@ class Dense(Layer):
                 initializer=self.bias_initializer,
                 regularizer=self.bias_regularizer,
             )
+        else:
+            self.bias = None
         self.input_spec = InputSpec(min_ndim=2, axes={-1: input_dim})
         self.built = True
 
     def call(self, inputs):
         x = ops.matmul(inputs, self.kernel)
-        if self.use_bias:
+        if self.bias is not None:
             x = x + self.bias
-        if self.activation:
+        if self.activation is not None:
             x = self.activation(x)
         return x
 

--- a/keras/layers/core/dense_test.py
+++ b/keras/layers/core/dense_test.py
@@ -47,6 +47,7 @@ class DenseTest(testing.TestCase):
         )
 
     def test_dense_correctness(self):
+        # With bias and activation.
         layer = layers.Dense(units=2, activation="relu")
         layer.build((1, 2))
         layer.set_weights(
@@ -59,6 +60,20 @@ class DenseTest(testing.TestCase):
             [[-1.0, 2.0]],
         )
         self.assertAllClose(layer(inputs), [[10.0, 0.0]])
+
+        # Just a kernel matmul.
+        layer = layers.Dense(units=2, use_bias=False)
+        layer.build((1, 2))
+        layer.set_weights(
+            [
+                np.array([[1.0, -2.0], [3.0, -4.0]]),
+            ]
+        )
+        inputs = np.array(
+            [[-1.0, 2.0]],
+        )
+        self.assertEqual(layer.bias, None)
+        self.assertAllClose(layer(inputs), [[5.0, -6.0]])
 
     def test_dense_errors(self):
         with self.assertRaisesRegex(ValueError, "incompatible with the layer"):


### PR DESCRIPTION
Minor annoyance when doing LoRA stuff. EinsumDense always has a bias attr, it is just sometimes `None`. Dense only has a bias attr if `use_bias` is True. I see no reason for the divergence.