### PR TITLE
Add variable.trainable setter so torch can set requires_grad

### DIFF
--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -30,7 +30,7 @@ class KerasVariable:
         self._dtype = dtype
         self._shape = None
         self._initializer = None
-        self.trainable = trainable
+        self._trainable = trainable
         if callable(initializer):
             if shape is None:
                 raise ValueError(
@@ -150,6 +150,14 @@ class KerasVariable:
     @property
     def ndim(self):
         return self._ndim
+
+    @property
+    def trainable(self):
+        return self._trainable
+
+    @trainable.setter
+    def trainable(self, value):
+        self._trainable = value
 
     def __repr__(self):
         return (

--- a/keras/backend/common/variables_test.py
+++ b/keras/backend/common/variables_test.py
@@ -35,6 +35,21 @@ class VariablesTest(test_case.TestCase):
         out = scope.get_current_value(v)
         self.assertAllClose(out, np.ones((2, 2)))
 
+    def test_trainable_setter(self):
+        v = backend.Variable(
+            initializer=initializers.RandomNormal(),
+            shape=(2, 2),
+        )
+        self.assertTrue(v.trainable)
+        v.trainable = False
+        self.assertFalse(v.trainable)
+
+        if backend.backend() == "torch":
+            v.trainable = True
+            self.assertTrue(v._value.requires_grad)
+            v.trainable = False
+            self.assertFalse(v._value.requires_grad)
+
     def test_autocasting(self):
         v = backend.Variable(
             initializer=initializers.RandomNormal(),

--- a/keras/backend/torch/core.py
+++ b/keras/backend/torch/core.py
@@ -113,6 +113,16 @@ class Variable(KerasVariable):
             )
         return value
 
+    @property
+    def trainable(self):
+        return self._trainable
+
+    @trainable.setter
+    def trainable(self, value):
+        self._trainable = value
+        if self._value is not None:
+            self._value.requires_grad = value
+
     def __eq__(self, other):
         try:
             return super().__eq__(other)


### PR DESCRIPTION
This looks like it has major impacts on torch efficiency when a layer or model is set to non trainable.

I ran a quick test on KerasNLP:

```python
classifier = BertClassifier()
classifier.backbone.trainable = False
classifier.fit(..)
```

Train step time went from 500ms before this change, to 150ms after.