### PR TITLE
Update supported types for validation_split data_adapter_utils.py

### DIFF
--- a/keras/trainers/data_adapters/data_adapter_utils.py
+++ b/keras/trainers/data_adapters/data_adapter_utils.py
@@ -19,7 +19,7 @@ ARRAY_TYPES = (np.ndarray,)
 if backend.backend() == "tensorflow":
     from keras.utils.module_utils import tensorflow as tf
 
-    ARRAY_TYPES = ARRAY_TYPES + (np.ndarray, tf.RaggedTensor)
+    ARRAY_TYPES = ARRAY_TYPES + (tf.Tensor, tf.RaggedTensor)
 if pandas:
     ARRAY_TYPES = ARRAY_TYPES + (pandas.Series, pandas.DataFrame)
 
@@ -164,8 +164,8 @@ def train_validation_split(arrays, validation_split):
     if unsplitable:
         raise ValueError(
             "Argument `validation_split` is only supported "
-            "for tensors or NumPy "
-            "arrays. Found incompatible type in the input: {unsplitable}"
+            "for tensors or NumPy arrays."
+            f"Found incompatible type in the input: {unsplitable}"
         )
 
     if all(t is None for t in flat_arrays):


### PR DESCRIPTION
When keras_core used with TF backend, `model.fit()` with fails to train when provided with `validation_split` .Without any `validation_split` it works fine.The error is below.

`ValueError: Argument validation_split is only supported for tensors or NumPy arrays. Found incompatible type in the input: {unsplitable}`

Firstly the error is not intuitive as {unsplitable} is internal variable which is formatted using f-string that is more informative to users.

Also Added tf.Tensor to `ARRAY_TYPES = ARRAY_TYPES + (tf.Tensor, tf.RaggedTensor)` so that model.fit() works with validation_split also.

This might fixes #18525