### PR TITLE
Remove redundant  call in ops.numpy.matmul

### DIFF
--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -61,6 +61,9 @@ def subtract(x1, x2):
 
 
 def matmul(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+
     def with_combined_batch_dimensions(a, b, fn_3d):
         batch_shape = (
             b.shape[:-2] if isinstance(b, tf.SparseTensor) else a.shape[:-2]

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -3407,9 +3407,6 @@ def matmul(x1, x2):
     """
     if any_symbolic_tensors((x1, x2)):
         return Matmul().symbolic_call(x1, x2)
-    # The below conversion works around an outstanding JAX bug.
-    x1 = backend.convert_to_tensor(x1)
-    x2 = backend.convert_to_tensor(x2)
     return backend.numpy.matmul(x1, x2)
 
 


### PR DESCRIPTION
`keras.backend.jax.numpy.matmul` already calls `convert_to_tensor()` on both operands so we can safely remove this redundant call in `keras.ops.numpy.matmul`.

see: https://github.com/keras-team/keras/blob/master/keras/backend/jax/numpy.py#L48-L50