### PR TITLE
Apply `backend.result_type` to `bincount`, `substract`, `matmul`, `multiply`, `mean` and `max`

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -64,7 +64,7 @@ def mean(x, axis=None, keepdims=False):
     # correctly, so we compute with float32 and cast back to the original type.
     compute_dtype = dtypes.result_type(x.dtype, "float32")
     if "int" in ori_dtype or ori_dtype == "bool":
-        result_dtype = "float64" if ori_dtype == "int64" else compute_dtype
+        result_dtype = compute_dtype
     else:
         result_dtype = ori_dtype
     outputs = jnp.mean(x, axis=axis, keepdims=keepdims, dtype=compute_dtype)

--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -2,6 +2,7 @@ import jax.numpy as jnp
 
 from keras.backend import config
 from keras.backend.common import dtypes
+from keras.backend.common.variables import standardize_dtype
 from keras.backend.jax.core import cast
 from keras.backend.jax.core import convert_to_tensor
 
@@ -57,17 +58,21 @@ def multiply(x1, x2):
 
 
 def mean(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    ori_dtype = standardize_dtype(x.dtype)
     # `jnp.mean` does not handle low precision (e.g., float16) overflow
     # correctly, so we compute with float32 and cast back to the original type.
-    outputs = jnp.mean(x, axis=axis, keepdims=keepdims, dtype=jnp.float32)
-    dtype = getattr(x, "dtype", None)
-    if hasattr(dtype, "name") and "float" in dtype.name:
-        return cast(outputs, dtype)
+    compute_dtype = dtypes.result_type(x.dtype, "float32")
+    if "int" in ori_dtype or ori_dtype == "bool":
+        result_dtype = "float64" if ori_dtype == "int64" else compute_dtype
     else:
-        return cast(outputs, config.floatx())
+        result_dtype = ori_dtype
+    outputs = jnp.mean(x, axis=axis, keepdims=keepdims, dtype=compute_dtype)
+    return cast(outputs, result_dtype)
 
 
 def max(x, axis=None, keepdims=False, initial=None):
+    x = convert_to_tensor(x)
     return jnp.max(x, axis=axis, keepdims=keepdims, initial=initial)
 
 

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -44,12 +44,10 @@ def mean(x, axis=None, keepdims=False):
     axis = tuple(axis) if isinstance(axis, list) else axis
     x = convert_to_tensor(x)
     ori_dtype = standardize_dtype(x.dtype)
-    compute_dtype = dtypes.result_type(x.dtype, "float32")
     if "int" in ori_dtype or ori_dtype == "bool":
-        result_dtype = compute_dtype
+        result_dtype = dtypes.result_type(x.dtype, "float32")
     else:
         result_dtype = ori_dtype
-    x = x.astype(compute_dtype)
     return np.mean(x, axis=axis, keepdims=keepdims).astype(result_dtype)
 
 

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -177,8 +177,6 @@ def bincount(x, weights=None, minlength=0):
         dtypes_to_resolve.append(weights.dtype)
         dtype = dtypes.result_type(*dtypes_to_resolve)
     else:
-        # TODO: should we upcast to int64 if the actual reaulting dtype is
-        # int64? Currently we follow the type rules of JAX.
         dtype = "int32"
     if len(x.shape) == 2:
         if weights is None:

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -153,6 +153,16 @@ def average(x, axis=None, weights=None):
 
 
 def bincount(x, weights=None, minlength=0):
+    x = convert_to_tensor(x)
+    dtypes_to_resolve = [x.dtype]
+    if weights is not None:
+        weights = convert_to_tensor(weights)
+        dtypes_to_resolve.append(weights.dtype)
+        dtype = dtypes.result_type(*dtypes_to_resolve)
+    else:
+        # TODO: should we upcast to int64 if the actual reaulting dtype is
+        # int64? Currently we follow the type rules of JAX.
+        dtype = "int32"
     if len(x.shape) == 2:
         if weights is None:
 
@@ -169,8 +179,8 @@ def bincount(x, weights=None, minlength=0):
 
             bincounts = list(map(bincount_fn, zip(x, weights)))
 
-        return np.stack(bincounts)
-    return np.bincount(x, weights, minlength)
+        return np.stack(bincounts).astype(dtype)
+    return np.bincount(x, weights, minlength).astype(dtype)
 
 
 def broadcast_to(x, shape):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -42,7 +42,15 @@ def multiply(x1, x2):
 
 def mean(x, axis=None, keepdims=False):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    return np.mean(x, axis=axis, keepdims=keepdims)
+    x = convert_to_tensor(x)
+    ori_dtype = standardize_dtype(x.dtype)
+    compute_dtype = dtypes.result_type(x.dtype, "float32")
+    if "int" in ori_dtype or ori_dtype == "bool":
+        result_dtype = "float64" if ori_dtype == "int64" else compute_dtype
+    else:
+        result_dtype = ori_dtype
+    x = x.astype(compute_dtype)
+    return np.mean(x, axis=axis, keepdims=keepdims).astype(result_dtype)
 
 
 def max(x, axis=None, keepdims=False, initial=None):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -46,7 +46,7 @@ def mean(x, axis=None, keepdims=False):
     ori_dtype = standardize_dtype(x.dtype)
     compute_dtype = dtypes.result_type(x.dtype, "float32")
     if "int" in ori_dtype or ori_dtype == "bool":
-        result_dtype = "float64" if ori_dtype == "int64" else compute_dtype
+        result_dtype = compute_dtype
     else:
         result_dtype = ori_dtype
     x = x.astype(compute_dtype)

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -20,6 +20,11 @@ def einsum(subscripts, *operands, **kwargs):
 
 
 def subtract(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = x1.astype(dtype)
+    x2 = x2.astype(dtype)
     return np.subtract(x1, x2)
 
 

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -23,9 +23,7 @@ def subtract(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
     dtype = dtypes.result_type(x1.dtype, x2.dtype)
-    x1 = x1.astype(dtype)
-    x2 = x2.astype(dtype)
-    return np.subtract(x1, x2)
+    return np.subtract(x1, x2).astype(dtype)
 
 
 def matmul(x1, x2):
@@ -36,7 +34,10 @@ def matmul(x1, x2):
 
 
 def multiply(x1, x2):
-    return np.multiply(x1, x2)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    return np.multiply(x1, x2).astype(dtype)
 
 
 def mean(x, axis=None, keepdims=False):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -29,7 +29,10 @@ def subtract(x1, x2):
 
 
 def matmul(x1, x2):
-    return np.matmul(x1, x2)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    return np.matmul(x1, x2).astype(dtype)
 
 
 def multiply(x1, x2):

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -76,6 +76,11 @@ def einsum(subscripts, *operands, **kwargs):
 
 
 def subtract(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = tf.cast(x1, dtype)
+    x2 = tf.cast(x2, dtype)
     if isinstance(x1, tf.SparseTensor) or isinstance(x2, tf.SparseTensor):
         if isinstance(x2, tf.SparseTensor):
             return tf.sparse.add(x1, tf.sparse.map_values(tf.negative, x2))

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -225,6 +225,8 @@ def mean(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
     ori_dtype = standardize_dtype(x.dtype)
     compute_dtype = dtypes.result_type(x.dtype, "float32")
+    # `tfnp.mean` does not handle low precision (e.g., float16) overflow
+    # correctly, so we compute with float32 and cast back to the original type.
     if "int" in ori_dtype or ori_dtype == "bool":
         result_dtype = compute_dtype
     else:

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -231,8 +231,7 @@ def mean(x, axis=None, keepdims=False):
         result_dtype = compute_dtype
     else:
         result_dtype = ori_dtype
-    x = tf.cast(x, compute_dtype)
-    result = tfnp.mean(x, axis=axis, keepdims=keepdims)
+    result = tfnp.mean(x, axis=axis, keepdims=keepdims, dtype=compute_dtype)
     return tf.cast(result, result_dtype)
 
 

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -228,7 +228,7 @@ def mean(x, axis=None, keepdims=False):
     ori_dtype = standardize_dtype(x.dtype)
     compute_dtype = dtypes.result_type(x.dtype, "float32")
     if "int" in ori_dtype or ori_dtype == "bool":
-        result_dtype = "float64" if ori_dtype == "int64" else compute_dtype
+        result_dtype = compute_dtype
     else:
         result_dtype = ori_dtype
     x = tf.cast(x, compute_dtype)

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -181,6 +181,11 @@ def matmul(x1, x2):
 
 
 def multiply(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = tf.cast(x1, dtype)
+    x2 = tf.cast(x2, dtype)
     if isinstance(x1, tf.SparseTensor):
         if isinstance(x2, tf.SparseTensor):
             ones_like_int8 = functools.partial(tf.ones_like, dtype=tf.int8)

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -44,8 +44,6 @@ def bincount(x, weights=None, minlength=0):
             else:
                 weights = tf.cast(weights, tf.float32)
     else:
-        # TODO: should we upcast to int64 if the actual reaulting dtype is
-        # int64? Currently we follow the type rules of JAX.
         dtype = "int32"
     if isinstance(x, tf.SparseTensor):
         result = tf.sparse.bincount(

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -66,7 +66,7 @@ def mean(x, axis=None, keepdims=False):
     ori_dtype = standardize_dtype(x.dtype)
     compute_dtype = dtypes.result_type(x.dtype, "float32")
     if "int" in ori_dtype or ori_dtype == "bool":
-        result_dtype = "float64" if ori_dtype == "int64" else compute_dtype
+        result_dtype = compute_dtype
     else:
         result_dtype = ori_dtype
     x = cast(x, compute_dtype)

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -64,6 +64,7 @@ def mean(x, axis=None, keepdims=False):
         # Torch handles the empty axis case differently from numpy.
         return x
     ori_dtype = standardize_dtype(x.dtype)
+    # torch.mean only supports floating point inputs
     compute_dtype = dtypes.result_type(x.dtype, "float32")
     if "int" in ori_dtype or ori_dtype == "bool":
         result_dtype = compute_dtype

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -31,7 +31,13 @@ def einsum(subscripts, *operands, **kwargs):
 
 
 def subtract(x1, x2):
-    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    # torch doesn't support bool substraction
+    if standardize_dtype(x1.dtype) == "bool":
+        x1 = cast(x1, standardize_dtype(x2.dtype))
+    if standardize_dtype(x2.dtype) == "bool":
+        x2 = cast(x2, standardize_dtype(x1.dtype))
     return torch.subtract(x1, x2)
 
 

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -70,8 +70,9 @@ def mean(x, axis=None, keepdims=False):
         result_dtype = compute_dtype
     else:
         result_dtype = ori_dtype
-    x = cast(x, compute_dtype)
-    result = torch.mean(x, axis=axis, keepdims=keepdims)
+    result = torch.mean(
+        x, axis=axis, keepdims=keepdims, dtype=to_torch_dtype(compute_dtype)
+    )
     return cast(result, result_dtype)
 
 

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -63,9 +63,15 @@ def mean(x, axis=None, keepdims=False):
     if axis == () or axis == []:
         # Torch handles the empty axis case differently from numpy.
         return x
-    # Conversion to float necessary for `torch.mean`
-    x = cast(x, "float32") if x.dtype in TORCH_INT_TYPES else x
-    return torch.mean(x, axis=axis, keepdims=keepdims)
+    ori_dtype = standardize_dtype(x.dtype)
+    compute_dtype = dtypes.result_type(x.dtype, "float32")
+    if "int" in ori_dtype or ori_dtype == "bool":
+        result_dtype = "float64" if ori_dtype == "int64" else compute_dtype
+    else:
+        result_dtype = ori_dtype
+    x = cast(x, compute_dtype)
+    result = torch.mean(x, axis=axis, keepdims=keepdims)
+    return cast(result, result_dtype)
 
 
 def max(x, axis=None, keepdims=False, initial=None):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -51,7 +51,8 @@ def matmul(x1, x2):
 
 
 def multiply(x1, x2):
-    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
     return torch.multiply(x1, x2)
 
 

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -281,8 +281,6 @@ def bincount(x, weights=None, minlength=0):
         dtypes_to_resolve.append(weights.dtype)
         dtype = dtypes.result_type(*dtypes_to_resolve)
     else:
-        # TODO: should we upcast to int64 if the actual reaulting dtype is
-        # int64? Currently we follow the type rules of JAX.
         dtype = "int32"
     if len(x.shape) == 2:
         if weights is None:

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -33,7 +33,7 @@ def einsum(subscripts, *operands, **kwargs):
 def subtract(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    # torch doesn't support bool substraction
+    # TODO: torch doesn't support bool substraction
     if standardize_dtype(x1.dtype) == "bool":
         x1 = cast(x1, standardize_dtype(x2.dtype))
     if standardize_dtype(x2.dtype) == "bool":
@@ -42,7 +42,11 @@ def subtract(x1, x2):
 
 
 def matmul(x1, x2):
-    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = cast(x1, dtype)
+    x2 = cast(x2, dtype)
     return torch.matmul(x1, x2)
 
 

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -5422,7 +5422,7 @@ class Mean(Operation):
         ori_dtype = backend.standardize_dtype(x.dtype)
         compute_dtype = dtypes.result_type(x.dtype, "float32")
         if "int" in ori_dtype or ori_dtype == "bool":
-            result_dtype = "float64" if ori_dtype == "int64" else compute_dtype
+            result_dtype = compute_dtype
         else:
             result_dtype = ori_dtype
         return KerasTensor(

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -1244,8 +1244,14 @@ class Bincount(Operation):
         )
 
     def compute_output_spec(self, x):
-        out_shape = backend.numpy.amax(x) + 1
-        return KerasTensor(out_shape, dtype=x.dtype)
+        dtypes_to_resolve = [x.dtype]
+        if self.weights is not None:
+            weights = backend.convert_to_tensor(self.weights)
+            dtypes_to_resolve.append(weights.dtype)
+            dtype = dtypes.result_type(*dtypes_to_resolve)
+        else:
+            dtype = "int32"
+        return KerasTensor(list(x.shape[:-1]) + [None], dtype=dtype)
 
 
 @keras_export(["keras.ops.bincount", "keras.ops.numpy.bincount"])

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -5147,7 +5147,11 @@ class Multiply(Operation):
         x1_sparse = getattr(x1, "sparse", True)
         x2_sparse = getattr(x2, "sparse", True)
         output_sparse = x1_sparse or x2_sparse
-        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
+        dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)),
+            getattr(x2, "dtype", type(x2)),
+        )
+        return KerasTensor(output_shape, dtype=dtype, sparse=output_sparse)
 
 
 @keras_export(["keras.ops.multiply", "keras.ops.numpy.multiply"])

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -5419,9 +5419,15 @@ class Mean(Operation):
         return backend.numpy.mean(x, axis=self.axis, keepdims=self.keepdims)
 
     def compute_output_spec(self, x):
+        ori_dtype = backend.standardize_dtype(x.dtype)
+        compute_dtype = dtypes.result_type(x.dtype, "float32")
+        if "int" in ori_dtype or ori_dtype == "bool":
+            result_dtype = "float64" if ori_dtype == "int64" else compute_dtype
+        else:
+            result_dtype = ori_dtype
         return KerasTensor(
             reduce_shape(x.shape, axis=self.axis, keepdims=self.keepdims),
-            dtype=x.dtype,
+            dtype=result_dtype,
         )
 
 

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -5109,7 +5109,11 @@ class Subtract(Operation):
         x1_sparse = getattr(x1, "sparse", True)
         x2_sparse = getattr(x2, "sparse", True)
         output_sparse = x1_sparse and x2_sparse
-        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
+        dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)),
+            getattr(x2, "dtype", type(x2)),
+        )
+        return KerasTensor(output_shape, dtype=dtype, sparse=output_sparse)
 
 
 @keras_export(["keras.ops.subtract", "keras.ops.numpy.subtract"])

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -3388,7 +3388,11 @@ class Matmul(Operation):
         x1_sparse = getattr(x1, "sparse", True)
         x2_sparse = getattr(x2, "sparse", True)
         output_sparse = x1_sparse and x2_sparse
-        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
+        dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)),
+            getattr(x2, "dtype", type(x2)),
+        )
+        return KerasTensor(output_shape, dtype=dtype, sparse=output_sparse)
 
 
 @keras_export(["keras.ops.matmul", "keras.ops.numpy.matmul"])

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4041,6 +4041,8 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         x = knp.ones((1,), dtype=dtype)
         x_jax = jnp.ones((1,), dtype=dtype)
         expected_dtype = standardize_dtype(jnp.mean(x_jax).dtype)
+        if dtype == "int64":
+            expected_dtype = "float32"
         self.assertEqual(standardize_dtype(knp.mean(x).dtype), expected_dtype)
         self.assertEqual(knp.Mean().symbolic_call(x).dtype, expected_dtype)
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -3944,11 +3944,9 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             ),
         )
         self.assertEqual(
-            standardize_dtype(
-                knp.Bincount(weights=weights, minlength=minlength)
-                .symbolic_call(x)
-                .dtype
-            ),
+            knp.Bincount(weights=weights, minlength=minlength)
+            .symbolic_call(x)
+            .dtype,
             standardize_dtype(
                 jnp.bincount(x, weights=weights, minlength=minlength).dtype
             ),
@@ -3961,9 +3959,7 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             standardize_dtype(jnp.bincount(x, weights=weights).dtype),
         )
         self.assertEqual(
-            standardize_dtype(
-                knp.Bincount(weights=weights).symbolic_call(x).dtype
-            ),
+            knp.Bincount(weights=weights).symbolic_call(x).dtype,
             standardize_dtype(jnp.bincount(x, weights=weights).dtype),
         )
 
@@ -3974,9 +3970,7 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             standardize_dtype(jnp.bincount(x, weights=weights).dtype),
         )
         self.assertEqual(
-            standardize_dtype(
-                knp.Bincount(weights=weights).symbolic_call(x).dtype
-            ),
+            knp.Bincount(weights=weights).symbolic_call(x).dtype,
             standardize_dtype(jnp.bincount(x, weights=weights).dtype),
         )
 
@@ -3986,8 +3980,30 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             standardize_dtype(jnp.bincount(x).dtype),
         )
         self.assertEqual(
-            standardize_dtype(knp.Bincount().symbolic_call(x).dtype),
+            knp.Bincount().symbolic_call(x).dtype,
             standardize_dtype(jnp.bincount(x).dtype),
+        )
+
+    # TODO: test_einsum
+
+    @parameterized.product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
+    def test_subtract(self, dtype1, dtype2):
+        import jax.numpy as jnp
+
+        if dtype1 == "bool" and dtype2 == "bool":
+            self.skipTest("subtract does not support bool substraction")
+
+        x1 = knp.ones((1,), dtype=dtype1)
+        x2 = knp.ones((1,), dtype=dtype2)
+        x1_jax = jnp.ones((1,), dtype=dtype1)
+        x2_jax = jnp.ones((1,), dtype=dtype2)
+        self.assertEqual(
+            standardize_dtype(knp.subtract(x1, x2).dtype),
+            standardize_dtype(jnp.subtract(x1_jax, x2_jax).dtype),
+        )
+        self.assertEqual(
+            knp.Subtract().symbolic_call(x1, x2).dtype,
+            standardize_dtype(jnp.subtract(x1_jax, x2_jax).dtype),
         )
 
     @parameterized.parameters(ALL_DTYPES)

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -2660,6 +2660,10 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             np.mean(x, axis=1, keepdims=True),
         )
 
+        # test overflow
+        x = np.array([[65500, 65500, 65500]], dtype="float16")
+        self.assertAllClose(knp.mean(x), np.mean(x))
+
     def test_all(self):
         x = np.array([[True, False, True], [True, True, True]])
         self.assertAllClose(knp.all(x), np.all(x))

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -3988,13 +3988,12 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         x2 = knp.ones((1,), dtype=dtype2)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.subtract(x1_jax, x2_jax).dtype)
         self.assertEqual(
-            standardize_dtype(knp.subtract(x1, x2).dtype),
-            standardize_dtype(jnp.subtract(x1_jax, x2_jax).dtype),
+            standardize_dtype(knp.subtract(x1, x2).dtype), expected_dtype
         )
         self.assertEqual(
-            knp.Subtract().symbolic_call(x1, x2).dtype,
-            standardize_dtype(jnp.subtract(x1_jax, x2_jax).dtype),
+            knp.Subtract().symbolic_call(x1, x2).dtype, expected_dtype
         )
 
     @parameterized.product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
@@ -4011,13 +4010,12 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         x2 = knp.ones((1,), dtype=dtype2)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.matmul(x1_jax, x2_jax).dtype)
         self.assertEqual(
-            standardize_dtype(knp.matmul(x1, x2).dtype),
-            standardize_dtype(jnp.matmul(x1_jax, x2_jax).dtype),
+            standardize_dtype(knp.matmul(x1, x2).dtype), expected_dtype
         )
         self.assertEqual(
-            knp.Matmul().symbolic_call(x1, x2).dtype,
-            standardize_dtype(jnp.matmul(x1_jax, x2_jax).dtype),
+            knp.Matmul().symbolic_call(x1, x2).dtype, expected_dtype
         )
 
     @parameterized.product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
@@ -4028,14 +4026,33 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         x2 = knp.ones((1,), dtype=dtype2)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.multiply(x1_jax, x2_jax).dtype)
         self.assertEqual(
-            standardize_dtype(knp.multiply(x1, x2).dtype),
-            standardize_dtype(jnp.multiply(x1_jax, x2_jax).dtype),
+            standardize_dtype(knp.multiply(x1, x2).dtype), expected_dtype
         )
         self.assertEqual(
-            knp.Multiply().symbolic_call(x1, x2).dtype,
-            standardize_dtype(jnp.multiply(x1_jax, x2_jax).dtype),
+            knp.Multiply().symbolic_call(x1, x2).dtype, expected_dtype
         )
+
+    @parameterized.product(dtype=ALL_DTYPES)
+    def test_mean(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.mean(x_jax).dtype)
+        self.assertEqual(standardize_dtype(knp.mean(x).dtype), expected_dtype)
+        self.assertEqual(knp.Mean().symbolic_call(x).dtype, expected_dtype)
+
+    @parameterized.product(dtype=ALL_DTYPES)
+    def test_max(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.max(x_jax).dtype)
+        self.assertEqual(standardize_dtype(knp.max(x).dtype), expected_dtype)
+        self.assertEqual(knp.Max().symbolic_call(x).dtype, expected_dtype)
 
     @parameterized.parameters(ALL_DTYPES)
     def test_ones(self, dtype):

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -8,7 +8,6 @@ from keras import testing
 from keras.backend.common import standardize_dtype
 from keras.backend.common.keras_tensor import KerasTensor
 from keras.backend.common.variables import ALLOWED_DTYPES
-from keras.backend.torch.core import to_torch_dtype
 from keras.ops import numpy as knp
 
 # TODO: remove reliance on this (or alternatively, turn it on by default).
@@ -3892,8 +3891,13 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     INT_DTYPES = [x for x in ALLOWED_DTYPES if "int" in x and x != "uint64"]
 
     if backend.backend() == "torch":
-        ALL_DTYPES = [str(to_torch_dtype(x)).split(".")[-1] for x in ALL_DTYPES]
-        INT_DTYPES = [str(to_torch_dtype(x)).split(".")[-1] for x in INT_DTYPES]
+        # TODO: torch doesn't support uint16, uint32 and uint64
+        ALL_DTYPES = [
+            x for x in ALL_DTYPES if x not in ["uint16", "uint32", "uint64"]
+        ]
+        INT_DTYPES = [
+            x for x in INT_DTYPES if x not in ["uint16", "uint32", "uint64"]
+        ]
 
     def setUp(self):
         from jax.experimental import enable_x64

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -2660,7 +2660,7 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         )
 
         # test overflow
-        x = np.array([[65500, 65500, 65500]], dtype="float16")
+        x = np.array([65504, 65504, 65504], dtype="float16")
         self.assertAllClose(knp.mean(x), np.mean(x))
 
     def test_all(self):

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4020,6 +4020,23 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             standardize_dtype(jnp.matmul(x1_jax, x2_jax).dtype),
         )
 
+    @parameterized.product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
+    def test_multiply(self, dtype1, dtype2):
+        import jax.numpy as jnp
+
+        x1 = knp.ones((1,), dtype=dtype1)
+        x2 = knp.ones((1,), dtype=dtype2)
+        x1_jax = jnp.ones((1,), dtype=dtype1)
+        x2_jax = jnp.ones((1,), dtype=dtype2)
+        self.assertEqual(
+            standardize_dtype(knp.multiply(x1, x2).dtype),
+            standardize_dtype(jnp.multiply(x1_jax, x2_jax).dtype),
+        )
+        self.assertEqual(
+            knp.Multiply().symbolic_call(x1, x2).dtype,
+            standardize_dtype(jnp.multiply(x1_jax, x2_jax).dtype),
+        )
+
     @parameterized.parameters(ALL_DTYPES)
     def test_ones(self, dtype):
         import jax.numpy as jnp


### PR DESCRIPTION
Followed by #18482 

This PR has applied `result_type` to the following ops:
- `bincount`
- `substract`
- `matmul`
- `multiply`
- `mean`
- `max`

The corresponding unit tests have also been added.