### PR TITLE
Add threshold support to `BinaryAccuracy`

### DIFF
--- a/keras/metrics/accuracy_metrics.py
+++ b/keras/metrics/accuracy_metrics.py
@@ -113,11 +113,14 @@ class BinaryAccuracy(reduction_metrics.MeanMetricWrapper):
     ```
     """
 
-    def __init__(self, name="binary_accuracy", dtype=None):
-        super().__init__(fn=binary_accuracy, name=name, dtype=dtype)
+    def __init__(self, name="binary_accuracy", dtype=None, threshold=0.5):
+        if threshold is not None and (threshold <= 0 or threshold >= 1):
+            raise ValueError(f"`threshold` must be in interval (0, 1), but found: {threshold}")
+        super().__init__(fn=binary_accuracy, name=name, dtype=dtype, threshold=threshold)
+        self.threshold = threshold
 
     def get_config(self):
-        return {"name": self.name, "dtype": self.dtype}
+        return {"name": self.name, "dtype": self.dtype, "threshold": self.threshold}
 
 
 @keras_export("keras.metrics.categorical_accuracy")

--- a/keras/metrics/accuracy_metrics.py
+++ b/keras/metrics/accuracy_metrics.py
@@ -115,12 +115,20 @@ class BinaryAccuracy(reduction_metrics.MeanMetricWrapper):
 
     def __init__(self, name="binary_accuracy", dtype=None, threshold=0.5):
         if threshold is not None and (threshold <= 0 or threshold >= 1):
-            raise ValueError(f"`threshold` must be in interval (0, 1), but found: {threshold}")
-        super().__init__(fn=binary_accuracy, name=name, dtype=dtype, threshold=threshold)
+            raise ValueError(
+                f"Invalid value for argument `threshold`. Expected a value in internal (0, 1). Received: threshold={threshold}"
+            )
+        super().__init__(
+            fn=binary_accuracy, name=name, dtype=dtype, threshold=threshold
+        )
         self.threshold = threshold
 
     def get_config(self):
-        return {"name": self.name, "dtype": self.dtype, "threshold": self.threshold}
+        return {
+            "name": self.name,
+            "dtype": self.dtype,
+            "threshold": self.threshold,
+        }
 
 
 @keras_export("keras.metrics.categorical_accuracy")

--- a/keras/metrics/accuracy_metrics_test.py
+++ b/keras/metrics/accuracy_metrics_test.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 
 from keras import testing
@@ -80,7 +82,7 @@ class BinaryAccuracyTest(testing.TestCase):
         bin_acc_obj.update_state(y_true, y_pred, sample_weight=sample_weight)
         result = bin_acc_obj.result()
         self.assertAllClose(result, 0.5, atol=1e-3)
-    
+
     def test_threshold(self):
         bin_acc_obj_1 = accuracy_metrics.BinaryAccuracy(
             name="binary_accuracy", dtype="float32", threshold=0.3
@@ -90,23 +92,29 @@ class BinaryAccuracyTest(testing.TestCase):
         )
         y_true = np.array([[1], [1], [0], [0]])
         y_pred = np.array([[0.98], [0.5], [0.1], [0.2]])
-        
+
         bin_acc_obj_1.update_state(y_true, y_pred)
         bin_acc_obj_2.update_state(y_true, y_pred)
         result_1 = bin_acc_obj_1.result()
         result_2 = bin_acc_obj_2.result()
-        
+
         # Higher threshold must result in lower measured accuracy.
         np.testing.assert_array_less(result_2, result_1)
-    
+
     def test_invalid_threshold(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             ValueError,
-            lambda: accuracy_metrics.BinaryAccuracy(threshold=-0.5)
+            re.compile(
+                r"Invalid value for argument `threshold`\. Expected a value in internal \(0, 1\). Received: threshold=-0.5"
+            ),
+            lambda: accuracy_metrics.BinaryAccuracy(threshold=-0.5),
         )
-        self.assertRaises(
+        self.assertRaisesRegex(
             ValueError,
-            lambda: accuracy_metrics.BinaryAccuracy(threshold=1.5)
+            re.compile(
+                r"Invalid value for argument `threshold`\. Expected a value in internal \(0, 1\). Received: threshold=1.5"
+            ),
+            lambda: accuracy_metrics.BinaryAccuracy(threshold=1.5),
         )
 
 

--- a/keras/metrics/accuracy_metrics_test.py
+++ b/keras/metrics/accuracy_metrics_test.py
@@ -80,6 +80,34 @@ class BinaryAccuracyTest(testing.TestCase):
         bin_acc_obj.update_state(y_true, y_pred, sample_weight=sample_weight)
         result = bin_acc_obj.result()
         self.assertAllClose(result, 0.5, atol=1e-3)
+    
+    def test_threshold(self):
+        bin_acc_obj_1 = accuracy_metrics.BinaryAccuracy(
+            name="binary_accuracy", dtype="float32", threshold=0.3
+        )
+        bin_acc_obj_2 = accuracy_metrics.BinaryAccuracy(
+            name="binary_accuracy", dtype="float32", threshold=0.9
+        )
+        y_true = np.array([[1], [1], [0], [0]])
+        y_pred = np.array([[0.98], [0.5], [0.1], [0.2]])
+        
+        bin_acc_obj_1.update_state(y_true, y_pred)
+        bin_acc_obj_2.update_state(y_true, y_pred)
+        result_1 = bin_acc_obj_1.result()
+        result_2 = bin_acc_obj_2.result()
+        
+        # Higher threshold must result in lower measured accuracy.
+        np.testing.assert_array_less(result_2, result_1)
+    
+    def test_invalid_threshold(self):
+        self.assertRaises(
+            ValueError,
+            lambda: accuracy_metrics.BinaryAccuracy(threshold=-0.5)
+        )
+        self.assertRaises(
+            ValueError,
+            lambda: accuracy_metrics.BinaryAccuracy(threshold=1.5)
+        )
 
 
 class CategoricalAccuracyTest(testing.TestCase):

--- a/keras/metrics/accuracy_metrics_test.py
+++ b/keras/metrics/accuracy_metrics_test.py
@@ -99,7 +99,8 @@ class BinaryAccuracyTest(testing.TestCase):
         result_2 = bin_acc_obj_2.result()
 
         # Higher threshold must result in lower measured accuracy.
-        np.testing.assert_array_less(result_2, result_1)
+        self.assertAllClose(result_1, 1.0)
+        self.assertAllClose(result_2, 0.75)
 
     def test_invalid_threshold(self):
         self.assertRaisesRegex(


### PR DESCRIPTION
Hi, 
I've recently found out that Keras V3 is missing support for `threshold` in `BinaryAccuracy`, 
in contrast to old `tf_keras` (https://github.com/keras-team/tf-keras/blob/master/tf_keras/metrics/accuracy_metrics.py#L113) 
The docstring was already present
```
threshold: (Optional) Float representing the threshold for deciding
        whether prediction values are 1 or 0.
```

### Changes
- [x] Add `threshold` argument
- [x] Add test case for `threshold argument`

P.S. I did not create an issue for this, since this is a tiny one 🤷 