### PR TITLE
Apply `backend.result_type` to `absolute`, `argmax`, `argmin`, `argsort`, `ceil`, `clip` and `dot`

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -185,7 +185,12 @@ def broadcast_to(x, shape):
 
 
 def ceil(x):
-    return jnp.ceil(x)
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "int64":
+        dtype = config.floatx()
+    else:
+        dtype = dtypes.result_type(x.dtype, float)
+    return cast(jnp.ceil(x), dtype)
 
 
 def clip(x, x_min, x_max):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -145,17 +145,17 @@ def arctanh(x):
 
 def argmax(x, axis=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    return np.argmax(x, axis=axis)
+    return np.argmax(x, axis=axis).astype("int32")
 
 
 def argmin(x, axis=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    return np.argmin(x, axis=axis)
+    return np.argmin(x, axis=axis).astype("int32")
 
 
 def argsort(x, axis=-1):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    return np.argsort(x, axis=axis)
+    return np.argsort(x, axis=axis).astype("int32")
 
 
 def array(x, dtype=None):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -201,11 +201,19 @@ def broadcast_to(x, shape):
 
 
 def ceil(x):
-    return np.ceil(x)
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "int64":
+        dtype = config.floatx()
+    else:
+        dtype = dtypes.result_type(x.dtype, float)
+    return np.ceil(x).astype(dtype)
 
 
 def clip(x, x_min, x_max):
-    return np.clip(x, x_min, x_max)
+    dtype = standardize_dtype(x.dtype)
+    if dtype == "bool":
+        dtype = "int64"
+    return np.clip(x, x_min, x_max).astype(dtype)
 
 
 def concatenate(xs, axis=0):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -280,6 +280,11 @@ def digitize(x, bins):
 
 
 def dot(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    dtype = dtypes.result_type(x.dtype, y.dtype)
+    x = x.astype(dtype)
+    y = y.astype(dtype)
     return np.dot(x, y)
 
 

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -467,7 +467,14 @@ def digitize(x, bins):
 
 
 def dot(x, y):
-    return tfnp.dot(x, y)
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    result_dtype = dtypes.result_type(x.dtype, y.dtype)
+    # GPU only supports float types
+    compute_dtype = dtypes.result_type(result_dtype, float)
+    x = tf.cast(x, compute_dtype)
+    y = tf.cast(y, compute_dtype)
+    return tf.cast(tfnp.dot(x, y), dtype=result_dtype)
 
 
 def empty(shape, dtype=None):

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -374,11 +374,19 @@ def broadcast_to(x, shape):
 
 
 def ceil(x):
-    return tfnp.ceil(x)
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "int64":
+        dtype = config.floatx()
+    else:
+        dtype = dtypes.result_type(x.dtype, float)
+    return tf.cast(tfnp.ceil(x), dtype=dtype)
 
 
 def clip(x, x_min, x_max):
-    return tfnp.clip(x, x_min, x_max)
+    dtype = standardize_dtype(x.dtype)
+    if dtype == "bool":
+        dtype = "int64"
+    return tf.cast(tfnp.clip(x, x_min, x_max), dtype=dtype)
 
 
 def concatenate(xs, axis=0):

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -267,6 +267,10 @@ def zeros(shape, dtype=None):
 
 
 def absolute(x):
+    # uintx and bool are always non-negative
+    dtype = standardize_dtype(x.dtype)
+    if "uint" in dtype or dtype == "bool":
+        return x
     return tfnp.absolute(x)
 
 
@@ -341,15 +345,15 @@ def arctanh(x):
 
 
 def argmax(x, axis=None):
-    return tfnp.argmax(x, axis=axis)
+    return tf.cast(tfnp.argmax(x, axis=axis), dtype="int32")
 
 
 def argmin(x, axis=None):
-    return tfnp.argmin(x, axis=axis)
+    return tf.cast(tfnp.argmin(x, axis=axis), dtype="int32")
 
 
 def argsort(x, axis=-1):
-    return tfnp.argsort(x, axis=axis)
+    return tf.cast(tfnp.argsort(x, axis=axis), dtype="int32")
 
 
 def array(x, dtype=None):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -412,7 +412,11 @@ def digitize(x, bins):
 
 
 def dot(x, y):
-    x, y = convert_to_tensor(x), convert_to_tensor(y)
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+    result_dtype = dtypes.result_type(x.dtype, y.dtype)
+    x = cast(x, result_dtype)
+    y = cast(y, result_dtype)
     if x.ndim == 0 or y.ndim == 0:
         return torch.multiply(x, y)
     return torch.matmul(x, y)

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -120,6 +120,9 @@ def zeros_like(x, dtype=None):
 
 
 def absolute(x):
+    # bool are always non-negative
+    if standardize_dtype(x.dtype) == "bool":
+        return x
     return abs(x)
 
 
@@ -237,12 +240,12 @@ def arctanh(x):
 
 def argmax(x, axis=None):
     x = convert_to_tensor(x)
-    return torch.argmax(x, dim=axis)
+    return cast(torch.argmax(x, dim=axis), dtype="int32")
 
 
 def argmin(x, axis=None):
     x = convert_to_tensor(x)
-    return torch.argmin(x, dim=axis)
+    return cast(torch.argmin(x, dim=axis), dtype="int32")
 
 
 def argsort(x, axis=-1):
@@ -250,7 +253,7 @@ def argsort(x, axis=-1):
     if axis is None:
         axis = -1
         x = x.reshape(-1)
-    return torch.argsort(x, dim=axis, stable=True)
+    return cast(torch.argsort(x, dim=axis, stable=True), dtype="int32")
 
 
 def array(x, dtype=None):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -120,14 +120,14 @@ def zeros_like(x, dtype=None):
 
 
 def absolute(x):
-    # bool are always non-negative
-    if standardize_dtype(x.dtype) == "bool":
-        return x
     return abs(x)
 
 
 def abs(x):
     x = convert_to_tensor(x)
+    # bool are always non-negative
+    if standardize_dtype(x.dtype) == "bool":
+        return x
     return torch.abs(x)
 
 

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -314,13 +314,21 @@ def broadcast_to(x, shape):
 
 def ceil(x):
     x = convert_to_tensor(x)
-    return torch.ceil(x)
+    if standardize_dtype(x.dtype) == "int64":
+        dtype = config.floatx()
+    else:
+        dtype = dtypes.result_type(x.dtype, float)
+    return cast(torch.ceil(x), dtype=dtype)
 
 
 def clip(x, x_min, x_max):
     x = convert_to_tensor(x)
-    x_min, x_max = convert_to_tensor(x_min), convert_to_tensor(x_max)
-    return torch.clip(x, min=x_min, max=x_max)
+    x_min = convert_to_tensor(x_min)
+    x_max = convert_to_tensor(x_max)
+    dtype = standardize_dtype(x.dtype)
+    if dtype == "bool":
+        dtype = "int64"
+    return cast(torch.clip(x, min=x_min, max=x_max), dtype=dtype)
 
 
 def concatenate(xs, axis=0):

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -2001,10 +2001,14 @@ class Dot(Operation):
     def compute_output_spec(self, x1, x2):
         x1_shape = list(getattr(x1, "shape", []))
         x2_shape = list(getattr(x2, "shape", []))
+        dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)),
+            getattr(x2, "dtype", type(x2)),
+        )
         if x1_shape == [] or x2_shape == []:
             return multiply(x1, x2)
         if len(x1_shape) == 1 and len(x2_shape) == 1:
-            return KerasTensor([], dtype=x1.dtype)
+            return KerasTensor([], dtype=dtype)
         if len(x2_shape) == 1:
             if x1_shape[-1] != x2_shape[0]:
                 raise ValueError(
@@ -2012,7 +2016,7 @@ class Dot(Operation):
                     "`x1` is N-d array while `x2` is 1-D, but receive shape "
                     f"`x1.shape={x1.shape}` and x2.shape=`{x2.shape}`."
                 )
-            return KerasTensor(x1_shape[:-1], dtype=x1.dtype)
+            return KerasTensor(x1_shape[:-1], dtype=dtype)
 
         if (
             x1_shape[-1] is None
@@ -2021,7 +2025,7 @@ class Dot(Operation):
         ):
             del x1_shape[-1]
             del x2_shape[-2]
-            return KerasTensor(x1_shape + x2_shape, dtype=x1.dtype)
+            return KerasTensor(x1_shape + x2_shape, dtype=dtype)
 
         raise ValueError(
             "Shape must match on the last axis of `x1` and second last "

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -1343,7 +1343,11 @@ class Ceil(Operation):
         return backend.numpy.ceil(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        if backend.standardize_dtype(x.dtype) == "int64":
+            dtype = backend.floatx()
+        else:
+            dtype = dtypes.result_type(x.dtype, float)
+        return KerasTensor(x.shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.ceil", "keras.ops.numpy.ceil"])
@@ -1374,7 +1378,10 @@ class Clip(Operation):
         return backend.numpy.clip(x, self.x_min, self.x_max)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        dtype = backend.standardize_dtype(x.dtype)
+        if dtype == "bool":
+            dtype = "int64"
+        return KerasTensor(x.shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.clip", "keras.ops.numpy.clip"])

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -1361,7 +1361,7 @@ def ceil(x):
         x: Input tensor.
 
     Returns:
-        The ceiling of each element in `x`.
+        The ceiling of each element in `x`, with float dtype.
     """
     if any_symbolic_tensors((x,)):
         return Ceil().symbolic_call(x)

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -2922,22 +2922,15 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(knp.Argmin()(x), np.argmin(x))
         self.assertAllClose(knp.Argmin(axis=1)(x), np.argmin(x, axis=1))
 
-    # TODO: fix and reenable
-    def DISABLED_test_argsort(self):
+    def test_argsort(self):
         x = np.array([[1, 2, 3], [4, 5, 6]])
         self.assertAllClose(knp.argsort(x), np.argsort(x))
         self.assertAllClose(knp.argsort(x, axis=1), np.argsort(x, axis=1))
-        self.assertAllClose(
-            knp.argsort(x, axis=None),
-            np.argsort(x, axis=None),
-        )
+        self.assertAllClose(knp.argsort(x, axis=None), np.argsort(x, axis=None))
 
         self.assertAllClose(knp.Argsort()(x), np.argsort(x))
         self.assertAllClose(knp.Argsort(axis=1)(x), np.argsort(x, axis=1))
-        self.assertAllClose(
-            knp.Argsort(axis=None)(x),
-            np.argsort(x, axis=None),
-        )
+        self.assertAllClose(knp.Argsort(axis=None)(x), np.argsort(x, axis=None))
 
     def test_array(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
@@ -4092,6 +4085,82 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
                 knp.Zeros().symbolic_call([2, 3], dtype=dtype).dtype
             ),
             standardize_dtype(jnp.zeros([2, 3], dtype=dtype).dtype),
+        )
+
+    @parameterized.parameters(ALL_DTYPES)
+    def test_absolute(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.absolute(x_jax).dtype)
+        self.assertEqual(
+            standardize_dtype(knp.absolute(x).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Absolute().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    # TODO: test_arccos
+    # TODO: test_arccosh
+    # TODO: test_arcsin
+    # TODO: test_arcsinh
+    # TODO: test_arctan
+    # TODO: test_arctan2
+    # TODO: test_arctanh
+
+    @parameterized.parameters(ALL_DTYPES)
+    def test_argmax(self, dtype):
+        import jax.numpy as jnp
+
+        if backend.backend() == "torch":
+            if dtype == "bool":
+                self.skipTest(f"argmax does not support {dtype} in torch")
+
+        x = knp.array([[1, 2, 3], [3, 2, 1]], dtype=dtype)
+        x_jax = jnp.array([[1, 2, 3], [3, 2, 1]], dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.argmax(x_jax).dtype)
+        self.assertEqual(standardize_dtype(knp.argmax(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Argmax().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.parameters(ALL_DTYPES)
+    def test_argmin(self, dtype):
+        import jax.numpy as jnp
+
+        if backend.backend() == "torch":
+            if dtype == "bool":
+                self.skipTest(f"argmin does not support {dtype} in torch")
+
+        x = knp.array([[1, 2, 3], [3, 2, 1]], dtype=dtype)
+        x_jax = jnp.array([[1, 2, 3], [3, 2, 1]], dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.argmin(x_jax).dtype)
+        self.assertEqual(standardize_dtype(knp.argmin(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Argmin().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.parameters(ALL_DTYPES)
+    def test_argsort(self, dtype):
+        import jax.numpy as jnp
+
+        if backend.backend() == "tensorflow":
+            if dtype == "bool":
+                self.skipTest(f"argsort does not support {dtype} in tensorflow")
+
+        x = knp.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+        x_jax = jnp.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.argsort(x_jax).dtype)
+        self.assertEqual(
+            standardize_dtype(knp.argsort(x).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Argsort().symbolic_call(x).dtype),
+            expected_dtype,
         )
 
     @parameterized.parameters(

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4102,14 +4102,6 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             expected_dtype,
         )
 
-    # TODO: test_arccos
-    # TODO: test_arccosh
-    # TODO: test_arcsin
-    # TODO: test_arcsinh
-    # TODO: test_arctan
-    # TODO: test_arctan2
-    # TODO: test_arctanh
-
     @parameterized.parameters(ALL_DTYPES)
     def test_argmax(self, dtype):
         import jax.numpy as jnp
@@ -4186,6 +4178,29 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             ),
             standardize_dtype(jnp.arange(start, stop, step, dtype).dtype),
         )
+
+    @parameterized.product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
+    def test_dot(self, dtype1, dtype2):
+        import jax.numpy as jnp
+
+        if backend.backend() == "tensorflow":
+            if dtype1 == "bool" and dtype2 == "bool":
+                self.skipTest("dot does not support bool in tensorflow")
+        if backend.backend() == "torch":
+            if "float16" in [dtype1, dtype2]:
+                self.skipTest("dot does not support float16 in torch")
+            if dtype1 == "bool" and dtype2 == "bool":
+                self.skipTest("dot does not support bool in torch")
+
+        x1 = knp.ones((2, 3, 4), dtype=dtype1)
+        x2 = knp.ones((4, 3), dtype=dtype2)
+        x1_jax = jnp.ones((2, 3, 4), dtype=dtype1)
+        x2_jax = jnp.ones((4, 3), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.dot(x1_jax, x2_jax).dtype)
+        self.assertEqual(
+            standardize_dtype(knp.dot(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(knp.Dot().symbolic_call(x1, x2).dtype, expected_dtype)
 
     @parameterized.parameters(ALL_DTYPES)
     def test_empty(self, dtype):


### PR DESCRIPTION
Followed by #18482 and #18534 

The corresponding unit tests have also been added.

I choose these ops that are more commonly used in the codebase.
In `ceil`, int64 input will become float64 output but I have changed it to `backend.floatx()`.

The principles in my mind, which are derived from the previous discussion:
- match the type inference of JAX
- if the integer input becomes a floating point output, use `backend.floatx()`
- try to support all dtypes in all backends (even if it introduces some overhead for checking)

