### PR TITLE
Fix for torch2.1.0

### DIFF
--- a/keras/backend/torch/optimizers/torch_optimizer.py
+++ b/keras/backend/torch/optimizers/torch_optimizer.py
@@ -33,6 +33,7 @@ class TorchOptimizer(BaseOptimizer):
             return OPTIMIZERS[cls](*args, **kwargs)
         return super().__new__(cls)
 
+    @torch.no_grad
     def _apply_weight_decay(self, variables):
         if self.weight_decay is None:
             return

--- a/keras/backend/torch/optimizers/torch_parallel_optimizer.py
+++ b/keras/backend/torch/optimizers/torch_parallel_optimizer.py
@@ -1,7 +1,10 @@
+import torch
+
 from keras.optimizers.base_optimizer import BaseOptimizer
 
 
 class TorchParallelOptimizer(BaseOptimizer):
+    @torch.no_grad
     def _internal_apply_gradients(self, grads_and_vars):
         grads, trainable_variables = zip(*grads_and_vars)
 

--- a/keras/layers/reshaping/up_sampling2d.py
+++ b/keras/layers/reshaping/up_sampling2d.py
@@ -151,6 +151,7 @@ class UpSampling2D(Layer):
 
         new_shape = x.shape[rows : cols + 1]
         new_shape *= np.array([height_factor, width_factor])
+        new_shape = new_shape.tolist()
 
         if data_format == "channels_first":
             x = ops.transpose(x, [0, 2, 3, 1])


### PR DESCRIPTION
Known issues:
- `torchvision.transforms.functional.resize`
TypeError: expected size to be one of int or Tuple[int] or Tuple[int, int] or Tuple[int, int, int], but got size with types [<class 'numpy.int64'>, <class 'numpy.int64'>]

- `keras.backend.torch.optimizer`
RuntimeError: a leaf Variable that requires grad is being used in an in-place operation.

This PR:
- Convert np.ndarray to list of ints
- Add `@torch.no_grad` to torch optimizer