### PR TITLE
Update Torch Req to 2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 tensorflow-cpu>=2.13.0
 
 # Torch.
-torch>=2.0.1+cpu
-torchvision>=0.15.1+cpu
+torch>=2.1.0+cpu
+torchvision>=0.16.0+cpu
 
 # Jax.
 jax[cpu]


### PR DESCRIPTION
With the recent changes to `TorchOptmizer` #18550, it no longer works with `torch 2.0.1`, so updating the min version in requirements file.  Torchvision is also updated to match the torch version as per its documentation.