### PR TITLE
Update layout_map to use re.search instead of re.match.

### DIFF
--- a/keras/distribution/distribution_lib.py
+++ b/keras/distribution/distribution_lib.py
@@ -444,34 +444,31 @@ class LayoutMap(collections.abc.MutableMapping):
 
         When there isn't an exact match, all the existing keys in the layout map
         will be treated as a regex and map against the input key again. When
-        there are multiple matches for the regex, an ValueError will be raised.
-        Returns `None` if there isn't any match found.
+        there are multiple matches for the regex, an `ValueError` will be
+        raised. Returns `None` if there isn't any match found.
 
         Args:
             key: String key to query a layout.
 
         Returns:
             Corresponding layout based on the query.
-
-        Raises:
-            ValueError when multiple keys are matched if the keys are treated
-            as regex.
         """
         if key in self._layout_map:
             return self._layout_map[key]
 
-        matching_key = []
+        matching_keys = []
         for k in self._layout_map:
             if re.search(k, key):
-                matching_key.append(k)
-        if len(matching_key) > 1:
+                matching_keys.append(k)
+        if len(matching_keys) > 1:
             raise ValueError(
-                f"The input {key} has matched to multiple layout "
-                f"rule: {matching_key}. Please make sure the "
-                "key only match to one rule."
+                f"Path '{key}' matches multiple layout "
+                f"specification keys: {matching_keys}. Please make "
+                "sure each tensor/variable path only matches at most "
+                "one layout specification key in the LayoutMap."
             )
-        elif len(matching_key) == 1:
-            return self._layout_map[matching_key[0]]
+        elif len(matching_keys) == 1:
+            return self._layout_map[matching_keys[0]]
         return None
 
     def __setitem__(self, key, layout):

--- a/keras/distribution/distribution_lib_test.py
+++ b/keras/distribution/distribution_lib_test.py
@@ -302,7 +302,7 @@ class LayoutMapTest(testing.TestCase):
         # Map against the wildcard bias rule for dense. This will cause a
         # ValueError
         with self.assertRaisesRegex(
-            ValueError, "The input dense_2/bias has matched to multiple"
+            ValueError, "Path 'dense_2/bias' matches multiple layout"
         ):
             layout_map["dense_2/bias"]
 

--- a/keras/distribution/distribution_lib_test.py
+++ b/keras/distribution/distribution_lib_test.py
@@ -293,15 +293,18 @@ class LayoutMapTest(testing.TestCase):
         layout_map["dense.*kernel"] = self.replicated_2d
         layout_map["dense.*bias"] = self.replicated_1d
 
-        layout_map[".*bias"] = self.sharded_1d
+        layout_map["bias"] = self.sharded_1d
 
         self.assertEqual(layout_map["dense/kernel"], self.sharded_2d)
         self.assertEqual(layout_map["dense/bias"], self.sharded_1d)
 
-        # Map against the wildcard bias rule for dense, and based on the order
-        # of insertion, it will not use .*bias.
         self.assertEqual(layout_map["dense_2/kernel"], self.replicated_2d)
-        self.assertEqual(layout_map["dense_2/bias"], self.replicated_1d)
+        # Map against the wildcard bias rule for dense. This will cause a
+        # ValueError
+        with self.assertRaisesRegex(
+            ValueError, "The input dense_2/bias has matched to multiple"
+        ):
+            layout_map["dense_2/bias"]
 
         self.assertIsNone(layout_map["conv2d/kernel"])
         self.assertEqual(layout_map["conv2d/bias"], self.sharded_1d)


### PR DESCRIPTION
This allow user to skip the leading ".*' and make the rule more readable.