### PR TITLE
Ignore error on upload to codecov

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -61,7 +61,7 @@ jobs:
           env_vars: PYTHON,KERAS_BACKEND
           flags: keras.applications,keras.applications-${{ matrix.backend }}
           files: apps-coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
       - name: Test integrations
         if: ${{ matrix.backend != 'numpy'}}
         run: |
@@ -84,7 +84,7 @@ jobs:
           env_vars: PYTHON,KERAS_BACKEND
           flags: keras,keras-${{ matrix.backend }}
           files: core-coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   format:
     name: Check the code format


### PR DESCRIPTION
Sometimes, CodeCov service is not available resulting in error - 

```
[2023-10-06T16:12:22.463Z] ['info'] Pinging Codecov: https://codecov.io/upload/v4?package=github-action-3.1.4-uploader-0.6.2&token=*******&branch=torch-wrapper-serialize&build=6433876874&build_url=https%3A%2F%2Fgithub.com%2Fkeras-team%2Fkeras%2Factions%2Fruns%2F6433876874&commit=3e62eed1cdfa59b51a4fbe48034664078500e291&job=Tests&pr=18498&service=github-actions&slug=keras-team%2Fkeras&name=&tag=&flags=keras%2Ckeras-tensorflow&parent=
[2023-10-06T16:12:52.517Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 502 - 
<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>502 Server Error</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Server Error</h1>
<h2>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.</h2>
<h2></h2>
</body></html>

Error: Codecov: Failed to properly upload: The process '/home/runner/work/_actions/codecov/codecov-action/v3/dist/codecov' failed with exit code 255
```

This error is aparently common - https://github.com/codecov/codecov-action/issues/598