### PR TITLE
(re)enable torch.compile in the pytorch trainer for train, predict, and eval

### DIFF
--- a/keras/backend/common/global_state.py
+++ b/keras/backend/common/global_state.py
@@ -77,3 +77,9 @@ def clear_session():
             from tensorflow.python.eager import context
 
             context.context().clear_kernel_cache()
+    elif backend.backend() == "torch":
+        import torch._dynamo as dynamo
+
+        # reset's torchdynamo's cache so that  cached guards, compiled fn, etc
+        # do not persist between clear_session() calls
+        dynamo.reset()

--- a/keras/backend/torch/core.py
+++ b/keras/backend/torch/core.py
@@ -149,6 +149,7 @@ def convert_to_tensor(x, dtype=None, sparse=False):
         return torch.as_tensor(x, dtype=torch.int32, device=get_device())
     if isinstance(x, float):
         return torch.as_tensor(x, dtype=torch.float32, device=get_device())
+
     # Convert to np in case of any array-like that is not list or tuple.
     if not isinstance(x, (list, tuple)):
         x = np.array(x)
@@ -180,7 +181,15 @@ def convert_to_numpy(x):
 
 
 def is_tensor(x):
-    return torch.is_tensor(x)
+    # Using the built-in `isinstance` is recommended by pytorch
+    # over using torch.is_tensor
+    # see: https://pytorch.org/docs/stable/generated/torch.is_tensor.html
+    #
+    # Also, `torch.is_tensor()` causes issues with dynamo caching when
+    # a torch.Tensor and numpy.ndarray of the same size, shape, and dtype
+    # is passed, if called on a Tensor first the second call with ndarray
+    # will return `True` and vice-versa.
+    return isinstance(x, torch.Tensor)
 
 
 def shape(x):

--- a/keras/backend/torch/random.py
+++ b/keras/backend/torch/random.py
@@ -10,6 +10,9 @@ from keras.random.seed_generator import draw_seed
 from keras.random.seed_generator import make_default_seed
 
 
+# torch.Generator not supported with dynamo
+# see: https://github.com/pytorch/pytorch/issues/88576
+@torch.compiler.disable()
 def torch_seed_generator(seed):
     first_seed, second_seed = draw_seed(seed)
     device = get_device()

--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -102,12 +102,7 @@ class TorchTrainer(base_trainer.Trainer):
             return self.train_step(data)
 
         if self.jit_compile:
-            raise ValueError(
-                "`jit_compile` is not yet enabled for the PyTorch backend."
-            )
-            # Temporarily disabled torch compile due to failed unit tests.
-            # TODO: Uncomment the following line when unit tests passes.
-            # self.train_function = torch.compile(one_step_on_data)
+            self.train_function = torch.compile(one_step_on_data)
         else:
             self.train_function = one_step_on_data
 
@@ -127,7 +122,10 @@ class TorchTrainer(base_trainer.Trainer):
             with torch.no_grad():
                 return self.test_step(data)
 
-        self.test_function = one_step_on_data
+        if self.jit_compile:
+            self.test_function = torch.compile(one_step_on_data)
+        else:
+            self.test_function = one_step_on_data
 
     def make_predict_function(self, force=False):
         if self.predict_function is not None and not force:
@@ -145,7 +143,10 @@ class TorchTrainer(base_trainer.Trainer):
             with torch.no_grad():
                 return self.predict_step(data)
 
-        self.predict_function = one_step_on_data
+        if self.jit_compile:
+            self.predict_function = torch.compile(one_step_on_data)
+        else:
+            self.predict_function = one_step_on_data
 
     def _symbolic_build(self, data_batch):
         model_unbuilt = not all(layer.built for layer in self._flatten_layers())

--- a/keras/layers/reshaping/flatten.py
+++ b/keras/layers/reshaping/flatten.py
@@ -57,7 +57,12 @@ class Flatten(Layer):
         non_batch_dims = input_shape[1:]
         if len(non_batch_dims) == 0:
             flattened_dim = 1
-        elif None in non_batch_dims:
+        elif any(d is None for d in non_batch_dims):
+            # NB: we cannot use the shorter `None in non_batch_dims` here b/c
+            # torchdynamo errors when calling `__contains__` op with
+            # a constant (in this case `None`) operand since it assumes
+            # that the elements in the collection are also `ConstantVariable`s
+            # but tensor shapes can be `SymNodeVariable`s (e.g. `SymInt`)
             flattened_dim = None
         else:
             flattened_dim = math.prod(non_batch_dims)

--- a/keras/trainers/epoch_iterator.py
+++ b/keras/trainers/epoch_iterator.py
@@ -122,7 +122,7 @@ class EpochIterator:
             if buffer:
                 yield step - len(buffer) + 1, buffer
             if not self._num_batches:
-                # Infer the number of batches returned by the data_adater.
+                # Infer the number of batches returned by the data_adapter.
                 # Assumed static.
                 self._num_batches = step + 1
         self.data_adapter.on_epoch_end()

--- a/keras/utils/naming_test.py
+++ b/keras/utils/naming_test.py
@@ -61,7 +61,13 @@ class NamingUtilsTest(test_case.TestCase):
         name = "unique_name"
         unique_name = naming.uniquify(name)
         new_unique_name = naming.uniquify(unique_name)
-        self.assertEqual(new_unique_name, unique_name)
+
+        # first time `name` is uniquified so returns same name
+        self.assertEqual(name, unique_name)
+
+        # second time `name` is uniquified should be different
+        # from the first output
+        self.assertNotEqual(new_unique_name, unique_name)
 
     def test_to_snake_case_capital_after_any_character(self):
         name = "myVariableNameHere"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 tf-nightly==2.15.0.dev20231009  # Pin a working nightly until rc0.
 
 # Torch.
-torch>=2.0.1
-torchvision>=0.15.1
+torch>=2.1.0
+torchvision>=0.16.0
 
 # Jax.
 jax[cpu]


### PR DESCRIPTION
Change Summary
--------------------
0. Updates `torch` to `torch>=2.1.0` (which has many improvements to dynamo)
1. Wraps the underlying function with `torch.compile` when `jit_compile=True` for train, eval, and predict
2. Updated docs for `model.fit()` explaining that `jit_compile="auto"` defaults to eager for the torch backend (`torch.compile` only kicks in if the user explicitly sets `jit_compile=True`). 
3. Adds `setUp()` to `clear_session()` in `testing.TestCase` (required for dynamo)
4. Fixes a few functions to make the codebase dynamo friendly
5. Fix incorrect assertion in `naming_test.py:test_uniquify_already_uniquified_name()`
6. Use `jit_compile="auto"` (versus `jit_compile=True`) in `keras.testing.test_case.TestCase.run_layer_test.run_training_step()` so that the backends are tested in their "default" jitted mode (jit for tf and jax and eager for torch).

Note On Dynamo
---------------------
Currently there are two caveats to running torch backend with `jit_compile=True`

1. (performance) It is slower than eager because of too many graph breaks, which is mainly due to the usage of `tree` in the function (dynamo will not trace through `tree`, see [skipfiles](https://github.com/pytorch/pytorch/blob/0013611c8129c4481852e25a7b0813d631399d9f/torch/_dynamo/skipfiles.py#L146)) `any_symbolic_tensors()`, which in turn is called by pretty much all ops (e.g. numpy, layer, activation, etc). Therefore, no "deep-graph" can be captured and hence no opportunities for optimizations such as op-fusion. This can be fixed by not using `tree.flatten` in `any_symbolic_tensors()`

2. (overhead) `torch.core.convert_to_tensor` needs to be simplified to just calling `torch.as_tensor(x, dtype, device)` rather than using `x.to(dtype, device)`. This won't make things compile better but reduces frame eval overhead since `convert_to_tensor` is called for each op and tracing through many branches is less than ideal.

3. (compatibility) There are cases where primitive operators can be traced by dynamo, but when a sequence of them are used as a higher order operator such as a layer (e.g. up_sampling_2d), causes guard failures on the primitive ops, which in turn makes dynamo trace with dynamic shapes via symbolic variables rather than concretized values, which can often lead to tracing failures due to "missing methods". 


Testing
--------
CI for unittests

Manual testing on `examples/keras_io/vision/mnist_convnet.py` by explicitly enabling `jit_compile`.
Observations:

1. No significant speedup
4. First 1,2 epochs are slow due to (re)compilation
5. Later epochs are still slower: 19ms (eager) vs 28ms (compiled) on CPU, have not tried on GPU.
6. (3) mostly due to recompilation / graph breaks since some functions (e.g. convert_to_tensor) are highly dynamic in the input types (python types).

