### PR TITLE
Normalize path separators from Windows

### DIFF
--- a/keras/utils/file_utils.py
+++ b/keras/utils/file_utils.py
@@ -437,7 +437,7 @@ def join(path, *paths):
             return gfile.join(path, *paths)
         else:
             _raise_if_no_gfile(path)
-    return os.path.join(path, *paths)
+    return os.path.join(path, *paths).replace("\\","/")
 
 
 def isdir(path):


### PR DESCRIPTION
Related issue: .keras models saved in linux don't load in windows (inconsistent path separators in .h5 weights file!) #18528

This PR simply standardizes the path separator to forward slash "/".