### PR TITLE
Fix torch gpu tensors in `tf.data.Dataset` - `flatten_test.py`

### DIFF
--- a/keras/kokoro/github/ubuntu/gpu/build.sh
+++ b/keras/kokoro/github/ubuntu/gpu/build.sh
@@ -70,6 +70,5 @@ then
    # TODO: Fix the failing Torch GPU CI tests.
    pytest keras --ignore keras/applications \
                --ignore keras/layers/preprocessing/feature_space_test.py \
-               --ignore keras/layers/reshaping/flatten_test.py \
                --cov=keras
 fi

--- a/keras/testing/test_case.py
+++ b/keras/testing/test_case.py
@@ -309,8 +309,19 @@ class TestCase(unittest.TestCase):
             model = TestModel(layer)
 
             if input_sparse:
+                import tensorflow as tf
+
+                if backend.backend() == "torch":
+                    # Bring output Torch tensors to CPU before using `tf.data`
+                    dataset = tf.data.Dataset.from_tensors(
+                        (input_data, backend.convert_to_numpy(output_data))
+                    )
+                else:
+                    dataset = tf.data.Dataset.from_tensors(
+                        (input_data, output_data)
+                    )
                 model.compile(optimizer="sgd", loss="mse", jit_compile=False)
-                model.fit(input_data, output_data, verbose=0)
+                model.fit(dataset, verbose=0)
             else:
                 input_data = tree.map_structure(
                     lambda x: backend.convert_to_numpy(x), input_data

--- a/keras/testing/test_case.py
+++ b/keras/testing/test_case.py
@@ -309,13 +309,8 @@ class TestCase(unittest.TestCase):
             model = TestModel(layer)
 
             if input_sparse:
-                import tensorflow as tf
-
-                dataset = tf.data.Dataset.from_tensors(
-                    (input_data, output_data)
-                )
                 model.compile(optimizer="sgd", loss="mse", jit_compile=False)
-                model.fit(dataset, verbose=0)
+                model.fit(input_data, output_data, verbose=0)
             else:
                 input_data = tree.map_structure(
                     lambda x: backend.convert_to_numpy(x), input_data


### PR DESCRIPTION
Fixes #18583 
When torch gpu tensor passed to `tf.data.Dataset`, TF tries to convert it to TF tensor, but it breaks since torch GPU tensor needs to first brought to CPU before we can apply `numpy()` function on it.

This fixes by casting output torch tensors to numpy before using with `tf.data.Dataset`.