### PR TITLE
Skip feature_space `test_saving` unless backend is `TensorFlow`

### DIFF
--- a/keras/kokoro/github/ubuntu/gpu/build.sh
+++ b/keras/kokoro/github/ubuntu/gpu/build.sh
@@ -47,12 +47,10 @@ then
    python3 -c 'import jax;assert jax.default_backend().lower() == "gpu"'
 
    # TODO: keras/layers/merging/merging_test.py::MergingLayersTest::test_sparse_dot_2d Fatal Python error: Aborted
-   # TODO: FAILED keras/layers/preprocessing/feature_space_test.py::FeatureSpaceTest::test_saving
    # TODO: keras/trainers/data_adapters/py_dataset_adapter_test.py::PyDatasetAdapterTest::test_basic_flow0 Fatal Python error: Aborted
    # TODO: FAILED keras/distribution/distribution_lib_test.py
    pytest keras --ignore keras/applications \
                --ignore keras/layers/merging/merging_test.py \
-               --ignore keras/layers/preprocessing/feature_space_test.py \
                --ignore keras/trainers/data_adapters/py_dataset_adapter_test.py \
                --ignore keras/distribution/distribution_lib_test.py \
                --cov=keras
@@ -67,8 +65,6 @@ then
    # Raise error if GPU is not detected.
    python3 -c 'import torch;assert torch.cuda.is_available()'
 
-   # TODO: Fix the failing Torch GPU CI tests.
    pytest keras --ignore keras/applications \
-               --ignore keras/layers/preprocessing/feature_space_test.py \
                --cov=keras
 fi

--- a/keras/layers/preprocessing/feature_space.py
+++ b/keras/layers/preprocessing/feature_space.py
@@ -735,6 +735,8 @@ class FeatureSpace(Layer):
         if rebatched:
             if self.output_mode == "concat":
                 assert merged_data.shape[0] == 1
+                if backend.backend() != "tensorflow":
+                    merged_data = backend.convert_to_numpy(merged_data)
                 merged_data = tf.squeeze(merged_data, axis=0)
             else:
                 for name, x in merged_data.items():

--- a/keras/layers/preprocessing/feature_space_test.py
+++ b/keras/layers/preprocessing/feature_space_test.py
@@ -469,8 +469,12 @@ class FeatureSpaceTest(testing.TestCase):
         out = fs(data)
         self.assertEqual(tuple(out.shape), (10, 32))
 
-    @pytest.mark.skipif(backend.backend() == "numpy", reason="TODO: debug it")
+    @pytest.mark.skipif(
+        backend.backend() != "tensorflow", reason="TODO: debug it"
+    )
     def test_saving(self):
+        # Torch GPU: `model.predict(ds.batch(4))` fails on device placement
+        # JAX GPU: out[0] and ref_out don't match. May be concat feature order?
         cls = feature_space.FeatureSpace
         fs = feature_space.FeatureSpace(
             features={


### PR DESCRIPTION
Skips Feature space `test_saving` unless backend is TensorFlow.