### PR TITLE
Update dtype argument info for keras_core.Input API

### DIFF
--- a/keras/layers/core/input_layer.py
+++ b/keras/layers/core/input_layer.py
@@ -113,7 +113,9 @@ def Input(
             is not known and may vary (e.g. sequence length).
         batch_size: Optional static batch size (integer).
         dtype: The data type expected by the input, as a string
-            (e.g. `"float32"`, `"int32"`...)
+            (e.g. `"float32"`, `"int32"`...),
+            (or) as a `tf.dtypes.DType` (e.g. `tf.float32`,`tf.float64` etc.),
+            (or) as a `torch.dtype` (e.g. `torch.float32`,`torch.float64` etc.).
         sparse: A boolean specifying whether the expected input will be sparse
             tensors. Note that, if `sparse` is `False`, sparse tensors can still
             be passed into the input - they will be densified with a default


### PR DESCRIPTION
At present,the API keras_core.input documentation states that the argument dtype to be passed as a string such as 'tf.float32' etc. However if we pass `tf.dtypes.DType` such as `tf.float32`,`tf.float64` or  a `torch.dtype` such as `torch.float32`,`torch.float64` it will works as well as the internal code calls keras_core.backend.standardize_dtype which can convert `tf.float32` or `torch.float32` to string such as 'float32'.

IMO, its better to mention this is documentation that this API can also handle both `tf.dtypes.DType` and `torch.dtype` so that users are aware of this and they are free to choose any of the above ways to pass value to dtype.

Attached [gist](https://colab.sandbox.google.com/gist/SuryanarayanaY/f7c64a7ad6bc4c05aa132d2edcd0bea8/keras_core-layers-inputlayer-dtype.ipynb) as reference for the above exercise.