### PR TITLE
Add dataset related function for multi worker/process distribution.

### DIFF
--- a/keras/backend/jax/distribution_lib.py
+++ b/keras/backend/jax/distribution_lib.py
@@ -111,6 +111,16 @@ def initialize(job_addresses, num_processes, process_id):
     )
 
 
+def num_processes():
+    """Return the number of processes for the current distribution setting."""
+    return jax.process_count()
+
+
+def process_id():
+    """Return the current process ID for the distribution setting."""
+    return jax.process_index()
+
+
 def _to_jax_device(device_id):
     device_type, index = device_id.split(":")
     index = int(index)

--- a/keras/backend/jax/distribution_lib_test.py
+++ b/keras/backend/jax/distribution_lib_test.py
@@ -81,6 +81,10 @@ class JaxDistributionLibTest(testing.TestCase):
         result = distribution_lib.distribute_tensor(inputs, target_layout)
         self.assertTrue(result.sharding.is_equivalent_to(target_layout, ndim=2))
 
+    def test_processes(self):
+        self.assertEqual(backend_dlib.process_id(), 0)
+        self.assertEqual(backend_dlib.num_processes(), 1)
+
     def test_to_jax_mesh(self):
         devices = [f"cpu:{i}" for i in range(8)]
         shape = (4, 2)

--- a/keras/distribution/distribution_lib_test.py
+++ b/keras/distribution/distribution_lib_test.py
@@ -163,6 +163,10 @@ class DistributionTest(testing.TestCase):
         self.assertIsNone(distribution_lib.distribution())
 
 
+@pytest.mark.skipif(
+    backend.backend() != "jax",
+    reason="Only JAX has the proper backend distribution lib",
+)
 class DataParallelDistributionTest(testing.TestCase):
     def setUp(self):
         super().setUp()

--- a/keras/distribution/distribution_lib_test.py
+++ b/keras/distribution/distribution_lib_test.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import numpy as np
 import pytest
+import tensorflow as tf
 
 from keras import backend
 from keras import testing
@@ -183,6 +184,10 @@ class DataParallelDistributionTest(testing.TestCase):
         self.assertEqual(device_mesh.axis_names, ["data"])
         self.assertEqual(distribution._batch_dim_name, "data")
 
+        self.assertFalse(distribution._is_multi_process)
+        self.assertEqual(distribution._process_id, 0)
+        self.assertEqual(distribution._num_process, 1)
+
     def test_create_with_devices(self):
         distribution = distribution_lib.DataParallel(devices=self.devices)
         device_mesh = distribution.device_mesh
@@ -232,6 +237,15 @@ class DataParallelDistributionTest(testing.TestCase):
         path = "path/to/tensor"
         tensor_layout = distribution.get_tensor_layout(path)
         self.assertIsNone(tensor_layout)
+
+    def test_distribute_dataset(self):
+        # We can only verify the single worker/process case in OSS for now.
+        dataset = tf.data.Dataset.range(8)
+        distribution = distribution_lib.DataParallel(
+            device_mesh=self.device_mesh
+        )
+        distributed_dataset = distribution.distribute_dataset(dataset)
+        self.assertIs(dataset, distributed_dataset)
 
 
 class ModelParallelDistributionTest(testing.TestCase):


### PR DESCRIPTION
1. Update the distribution class to aware of single/multi worker setting.
2. Add a new method in Distribution to shard the dataset. 
3. Added unit test for newly added methods.

TODO: 
1. Will have to add test coverage in the multi-worker setting internally.
2. Make sure the sharding are correct both data parallel (simple case), and model+data parallel (harder case).

This will address part of the #18561