### PR TITLE
Fixed clone_model with no inputs

### DIFF
--- a/keras/models/cloning.py
+++ b/keras/models/cloning.py
@@ -260,7 +260,8 @@ def _clone_functional_model(model, input_tensors=None, clone_function=None):
             )
     else:
         input_tensors = tree.map_structure(
-            lambda x: Input(x.shape, dtype=x.dtype, name=x.name), model.input
+            lambda x: Input(batch_shape=x.shape, dtype=x.dtype, name=x.name),
+            model.input,
         )
 
     def operation_fn(layer):

--- a/keras/models/cloning_test.py
+++ b/keras/models/cloning_test.py
@@ -8,7 +8,7 @@ from keras import testing
 from keras.models.cloning import clone_model
 
 
-def get_functional_model(shared_layers=False):
+def get_mlp_functional_model(shared_layers=False):
     inputs = layers.Input(shape=(3,))
     x = layers.Dense(2)(inputs)
     if shared_layers:
@@ -16,6 +16,18 @@ def get_functional_model(shared_layers=False):
         x = layer(x)
         x = layer(x)
     outputs = layers.Dense(2)(x)
+    model = models.Model(inputs, outputs)
+    return model
+
+
+def get_cnn_functional_model(shared_layers=False):
+    inputs = layers.Input(shape=(7, 3))
+    x = layers.Conv1D(2, 2, padding="same")(inputs)
+    if shared_layers:
+        layer = layers.Conv1D(2, 2, padding="same", name="shared")
+        x = layer(x)
+        x = layer(x)
+    outputs = layers.Conv1D(2, 2, padding="same")(x)
     model = models.Model(inputs, outputs)
     return model
 
@@ -45,7 +57,8 @@ def get_subclassed_model():
 @pytest.mark.requires_trainable_backend
 class CloneModelTest(testing.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(
-        ("functional", get_functional_model),
+        ("mlp_functional", get_mlp_functional_model),
+        ("cnn_functional", get_cnn_functional_model, True),
         ("sequential", get_sequential_model),
         (
             "deferred_sequential",
@@ -53,8 +66,8 @@ class CloneModelTest(testing.TestCase, parameterized.TestCase):
         ),
         ("subclassed", get_subclassed_model),
     )
-    def test_cloning_correctness(self, model_fn):
-        ref_input = np.random.random((2, 3))
+    def test_cloning_correctness(self, model_fn, is_conv=False):
+        ref_input = np.random.random((2, 7, 3) if is_conv else (2, 3))
         model = model_fn()
         new_model = clone_model(model)
         ref_output = model(ref_input)
@@ -64,7 +77,8 @@ class CloneModelTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(ref_output, output)
 
     @parameterized.named_parameters(
-        ("functional", get_functional_model),
+        ("mlp_functional", get_mlp_functional_model),
+        ("cnn_functional", get_cnn_functional_model),
         ("sequential", get_sequential_model),
     )
     def test_custom_clone_function(self, model_fn):
@@ -80,6 +94,6 @@ class CloneModelTest(testing.TestCase, parameterized.TestCase):
                 self.assertEqual(l2.name, l1.name + "_custom")
 
     def test_shared_layers_cloning(self):
-        model = get_functional_model(shared_layers=True)
+        model = get_mlp_functional_model(shared_layers=True)
         new_model = clone_model(model)
         self.assertLen(new_model.layers, 4)


### PR DESCRIPTION
Fixes an issue where `clone_model` without inputs created inputs with an additional leading dimension. This does not affect MLP models (`Dense` layers can have any number of dimensions) but causes issues with layers that depend on inputs with a specific number of dimensions (e.g. Conv1D).