### PR TITLE
Distribution tests causing core dump on JAX GPU

### DIFF
--- a/kokoro/github/ubuntu/gpu/build.sh
+++ b/kokoro/github/ubuntu/gpu/build.sh
@@ -53,7 +53,6 @@ then
                --ignore keras/layers/merging/merging_test.py \
                --ignore keras/trainers/data_adapters/py_dataset_adapter_test.py \
                --ignore keras/backend/jax/distribution_lib_test.py \
-               --ignore keras/initializers/constant_initializers_test.py \
                --ignore keras/distribution/distribution_lib_test.py \
                --cov=keras
 fi

--- a/kokoro/github/ubuntu/gpu/build.sh
+++ b/kokoro/github/ubuntu/gpu/build.sh
@@ -49,12 +49,12 @@ then
    # TODO: keras/layers/merging/merging_test.py::MergingLayersTest::test_sparse_dot_2d Fatal Python error: Aborted
    # TODO: keras/trainers/data_adapters/py_dataset_adapter_test.py::PyDatasetAdapterTest::test_basic_flow0 Fatal Python error: Aborted
    # keras/backend/jax/distribution_lib_test.py is configured for CPU test for now.
-   # keras/initializers/constant_initializers_test.py::ConstantInitializersTest::test_constant_initializer Fatal Python error: Aborted
    pytest keras --ignore keras/applications \
                --ignore keras/layers/merging/merging_test.py \
                --ignore keras/trainers/data_adapters/py_dataset_adapter_test.py \
                --ignore keras/backend/jax/distribution_lib_test.py \
                --ignore keras/initializers/constant_initializers_test.py \
+               --ignore keras/distribution/distribution_lib_test.py \
                --cov=keras
 fi
 


### PR DESCRIPTION
Distribution tests are causing core dumps on other layers in JAX when run on GPU.  Added distribution test to ignore list for JAX GPU. Currently JAX GPU CI is failing on Master.  Ignore distributed tests for now.

Tested and verified that JAX GPU CI is now successful with this PR.

cc: @qlzh727 