### PR TITLE
Fix: typos at mask propagation test in `MultiHeadAttention`

### DIFF
--- a/keras/layers/attention/multi_head_attention_test.py
+++ b/keras/layers/attention/multi_head_attention_test.py
@@ -170,7 +170,7 @@ class MultiHeadAttentionTest(testing.TestCase, parameterized.TestCase):
         backend.backend() == "numpy",
         reason="Numpy backend does not support masking.",
     )
-    def test_query_mask_progagation(self):
+    def test_query_mask_propagation(self):
         """Test automatic propagation of the query's mask."""
         layer = layers.MultiHeadAttention(num_heads=2, key_dim=2)
         self.assertTrue(layer.supports_masking)


### PR DESCRIPTION
This PR will fix the typos in `MultiHeadAttention` by replacing `progagation` -> `propagation`.