### PR TITLE
Fix serialising index lookup when the input vocabulary is a numpy array

### DIFF
--- a/keras/layers/preprocessing/index_lookup.py
+++ b/keras/layers/preprocessing/index_lookup.py
@@ -798,7 +798,7 @@ class IndexLookup(Layer):
             self.idf_weights_const = self.idf_weights.value()
 
     def save_assets(self, dir_path):
-        if self.input_vocabulary:
+        if self.input_vocabulary is not None:
             # Vocab saved in config.
             # TODO: consider unifying both paths.
             return
@@ -808,7 +808,7 @@ class IndexLookup(Layer):
             f.write("\n".join([str(w) for w in vocabulary]))
 
     def load_assets(self, dir_path):
-        if self.input_vocabulary:
+        if self.input_vocabulary is not None:
             # Vocab saved in config.
             # TODO: consider unifying both paths.
             return


### PR DESCRIPTION
When using a layer such as IntegerLookup and the vocabulary is set to a numpy array the following exception is raised. Instead `self.input_vocabulary` should be tested to see if it is `None`.

I am using tf.Keras, but this also looks to be an issue in Keras 3.

```
Traceback (most recent call last):
  File ".venv\Lib\site-packages\keras\src\engine\training.py", line 395, in __reduce__
    (pickle_utils.serialize_model_as_bytecode(self),),
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv\Lib\site-packages\keras\src\saving\pickle_utils.py", line 73, in serialize_model_as_bytecode
    raise e
  File ".venv\Lib\site-packages\keras\src\saving\pickle_utils.py", line 69, in serialize_model_as_bytecode
    saving_lib.save_model(model, filepath)
  File ".venv\Lib\site-packages\keras\src\saving\saving_lib.py", line 213, in save_model
    raise e
  File ".venv\Lib\site-packages\keras\src\saving\saving_lib.py", line 197, in save_model
    _save_state(
  File ".venv\Lib\site-packages\keras\src\saving\saving_lib.py", line 403, in _save_state
    _save_container_state(
  File ".venv\Lib\site-packages\keras\src\saving\saving_lib.py", line 498, in _save_container_state
    _save_state(
  File ".venv\Lib\site-packages\keras\src\saving\saving_lib.py", line 388, in _save_state
    trackable.save_assets(assets_store.make(inner_path))
  File ".venv\Lib\site-packages\keras\src\layers\preprocessing\index_lookup.py", line 839, in save_assets
    if self.input_vocabulary:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Version information:
```
Python 3.11.6 (tags/v3.11.6:8b6ee5b, Oct  2 2023, 14:57:12) [MSC v.1935 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import keras
>>> keras.__version__
'2.14.0'
```