### PR TITLE
Use torch._dynamo.disable (versus torch.compiler.disable) and version…

### DIFF
--- a/keras/backend/torch/random.py
+++ b/keras/backend/torch/random.py
@@ -1,4 +1,5 @@
 import torch
+import torch._dynamo as dynamo
 import torch.nn.functional as tnn
 
 from keras.backend.config import floatx
@@ -12,7 +13,7 @@ from keras.random.seed_generator import make_default_seed
 
 # torch.Generator not supported with dynamo
 # see: https://github.com/pytorch/pytorch/issues/88576
-@torch.compiler.disable()
+@dynamo.disable()
 def torch_seed_generator(seed):
     first_seed, second_seed = draw_seed(seed)
     device = get_device()


### PR DESCRIPTION
1. Use `@torch._dynamo.disable` which works in both `torch-2.0.1` and `torch-2.1.0`
2. Keeping `torch>=2.1.0` in `requirements.txt` since this is the recommended torch version to use (if you can)
3. Disables `jit_compile=True` for the pytorch backend if `torch<2.1.0` with a warning (since we need at least 2.1.0 for dynamo to work with the keras codebase)