### PR TITLE
Add `tf.SparseTensor` and `tf.IndexedSlices` support to a number of T…

### DIFF
--- a/keras/backend/common/dtypes_test.py
+++ b/keras/backend/common/dtypes_test.py
@@ -4,7 +4,6 @@ from keras import backend
 from keras import ops
 from keras.backend.common import dtypes
 from keras.backend.common.variables import ALLOWED_DTYPES
-from keras.backend.torch.core import to_torch_dtype
 from keras.testing import test_case
 from keras.testing.test_utils import named_product
 
@@ -13,6 +12,8 @@ class DtypesTest(test_case.TestCase, parameterized.TestCase):
     """Test the dtype to verify that the behavior matches JAX."""
 
     if backend.backend() == "torch":
+        from keras.backend.torch.core import to_torch_dtype
+
         # TODO: torch doesn't support uint64.
         ALL_DTYPES = []
         for x in ALLOWED_DTYPES:

--- a/keras/backend/tensorflow/core.py
+++ b/keras/backend/tensorflow/core.py
@@ -94,6 +94,8 @@ def convert_to_tensor(x, dtype=None, sparse=True):
 def convert_to_numpy(x):
     if isinstance(x, tf.SparseTensor):
         x = tf.sparse.to_dense(x)
+    elif isinstance(x, tf.IndexedSlices):
+        x = tf.convert_to_tensor(x)
     return np.array(x)
 
 

--- a/keras/backend/tensorflow/sparse.py
+++ b/keras/backend/tensorflow/sparse.py
@@ -1,0 +1,778 @@
+import functools
+
+import tensorflow as tf
+
+ones_bool = functools.partial(tf.ones, dtype=tf.bool)
+ones_int8 = functools.partial(tf.ones, dtype=tf.int8)
+zeros_int8 = functools.partial(tf.zeros, dtype=tf.int8)
+ones_like_int8 = functools.partial(tf.ones_like, dtype=tf.int8)
+zeros_like_int8 = functools.partial(tf.zeros_like, dtype=tf.int8)
+
+
+def empty_tensor(shape, dtype):
+    return tf.reshape(tf.convert_to_tensor((), dtype=dtype), shape=shape)
+
+
+def sparse_subtract(x1, x2):
+    """Subtraction for `tf.SparseTensor`s.
+
+    Either `x1` or `x2` or both can be `tf.SparseTensor`s.
+
+    Args:
+        x1: fist tensor to add.
+        x2: second tensor to add.
+    Returns:
+        The sum of `x1` and `x2`, which is a `tf.SparseTensor` if and only if
+        both `x1` or `x2` are `tf.SparseTensor`s.
+    """
+    if isinstance(x2, tf.SparseTensor):
+        return tf.sparse.add(x1, tf.sparse.map_values(tf.negative, x2))
+    else:
+        return tf.sparse.add(x1, tf.negative(x2))
+
+
+def sparse_union_indices_and_values(x1, x2_indices, x2_values=None):
+    """Compute the indices for the union of the indices of the provided
+    `tf.SparseTensor`s and another set of indices and return the modified values
+    for these indices.
+
+    Args:
+        x: a `tf.SparseTensor`.
+        indices: another set of indices in the `tf.SparseTensor` format.
+    Returns: A tuple containing:
+        - the indices for the union
+        - `x1` values for the union indices (some zeros were added)
+        - `x2` values for the union indices (some zeros were added) or `None` if
+          `x2_values` was `None`.
+    """
+    # Add zeros at the x2 indices to x1 to create the union.
+    zeros2 = tf.SparseTensor(
+        x2_indices,
+        tf.zeros((tf.shape(x2_indices)[0],), x1.values.dtype),
+        x1.dense_shape,
+    )
+    x1_for_union = tf.sparse.add(x1, zeros2)
+    if x2_values is not None:
+        # Add zeros at the x1 indices to x2 to create the union.
+        x2 = tf.SparseTensor(x2_indices, x2_values, x1.dense_shape)
+        zeros1 = tf.sparse.map_values(tf.zeros_like, x1)
+        x2_for_union = tf.sparse.add(x2, zeros1)
+        return x1_for_union.indices, x1_for_union.values, x2_for_union.values
+    else:
+        return x1_for_union.indices, x1_for_union.values, None
+
+
+def indexed_slices_union_indices_and_values(x1, x2_indices, x2_values=None):
+    """Compute the indices for the union of two `tf.IndexedSlices` and modify
+    the values for these indices.
+
+    Args:
+        x1: the first `tf.IndexedSlices`.
+        x2_indices: the indices for the second `tf.IndexedSlices`.
+        x2_value: (optional) the values for the second `tf.IndexedSlices`.
+    Returns: A tuple containing:
+        - the indices for the union
+        - `x1` values for the union indices (some zeros were added)
+        - `x2` values for the union indices (some zeros were added) or `None` if
+          `x2_values` was `None`.
+    """
+    # Compute the union of the indices by doing a logical or between the one-hot
+    # encoded indices for x1 and x2.
+    dim_0 = x1.dense_shape[0]
+    x1_indices_expanded = tf.expand_dims(x1.indices, axis=1)
+    x2_indices_expanded = tf.expand_dims(x2_indices, axis=1)
+    x1_indices_count = tf.shape(x1_indices_expanded)[0]
+    x2_indices_count = tf.shape(x2_indices_expanded)[0]
+    x1_indices_one_hot = tf.scatter_nd(
+        x1_indices_expanded,
+        ones_bool((x1_indices_count,)),
+        (dim_0,),
+    )
+    x2_indices_one_hot = tf.scatter_nd(
+        x2_indices_expanded,
+        ones_bool((x2_indices_count,)),
+        (dim_0,),
+    )
+    union_indices = tf.squeeze(
+        tf.where(tf.math.logical_or(x1_indices_one_hot, x2_indices_one_hot)),
+        axis=-1,
+    )
+    union_indices_count = tf.shape(union_indices)[0]
+
+    # Re-gather the values with extra zeros added at indices that are part of
+    # the union but were not in x1 or x2.
+    def values_for_union(indices_expanded, indices_count, values):
+        indices_indices = tf.scatter_nd(
+            indices_expanded,
+            tf.range(1, indices_count + 1),
+            (dim_0,),
+        )
+        to_union_indices = tf.gather(indices_indices, union_indices)
+        values_with_leading_zeros = tf.concat(
+            [tf.zeros((1,) + x1.dense_shape[1:], values.dtype), values], axis=0
+        )
+        return tf.gather(values_with_leading_zeros, to_union_indices)
+
+    # Only recompute values if some indices were added.
+    x1_values_for_union_indices = tf.cond(
+        tf.equal(x1_indices_count, union_indices_count),
+        lambda: x1.values,
+        lambda: values_for_union(
+            x1_indices_expanded, x1_indices_count, x1.values
+        ),
+    )
+    if x2_values is not None:
+        x2_values_for_union_indices = tf.cond(
+            tf.equal(x2_indices_count, union_indices_count),
+            lambda: x2_values,
+            lambda: values_for_union(
+                x2_indices_expanded, x2_indices_count, x2_values
+            ),
+        )
+    else:
+        x2_values_for_union_indices = None
+
+    return (
+        union_indices,
+        x1_values_for_union_indices,
+        x2_values_for_union_indices,
+    )
+
+
+def sparse_intersection_indices_and_values(x1, x2):
+    """Compute the indices for the intersection of two `tf.SparseTensor`s and
+    modify the values for these indices.
+
+    Args:
+        x1: the first `tf.SparseTensor`.
+        x2: the second `tf.SparseTensor`.
+    Returns: A tuple containing:
+        - the indices for the intersection
+        - `x1` values for the intersection indices (some values were removed)
+        - `x2` values for the intersection indices (some values were removed)
+    """
+    # Compute the intersection of indices in the form of a sparse
+    # tensor containing ones as values.
+    ones1 = tf.sparse.map_values(ones_like_int8, x1)
+    ones2 = tf.sparse.map_values(ones_like_int8, x2)
+    # tf.sets.intersection ignores the last dimension when, so we
+    # need to add a dummy extra dimension and then remove it.
+    intersection_extra_dim = tf.sets.intersection(
+        tf.sparse.expand_dims(ones1, axis=-1),
+        tf.sparse.expand_dims(ones2, axis=-1),
+    )
+
+    def empty_intersection():
+        return (
+            empty_tensor((0, x1.indices.shape[1]), dtype=tf.int64),
+            empty_tensor((0,), dtype=x1.values.dtype),
+            empty_tensor((0,), dtype=x2.values.dtype),
+        )
+
+    def non_empty_intersection():
+        intersection = tf.sparse.reshape(intersection_extra_dim, x1.dense_shape)
+
+        # Compute the masks to remove indices in x1 and x2 that are not
+        # in the intersection, then trim x1 and x2.
+        zeros1 = tf.sparse.map_values(zeros_like_int8, x1)
+        zeros2 = tf.sparse.map_values(zeros_like_int8, x2)
+        mask1 = tf.sparse.add(zeros1, intersection)
+        mask2 = tf.sparse.add(zeros2, intersection)
+        return (
+            intersection.indices,
+            tf.sparse.retain(x1, tf.cast(mask1.values, tf.bool)).values,
+            tf.sparse.retain(x2, tf.cast(mask2.values, tf.bool)).values,
+        )
+
+    return tf.cond(
+        tf.equal(tf.size(intersection_extra_dim), 0),
+        empty_intersection,
+        non_empty_intersection,
+    )
+
+
+def indexed_slices_intersection_indices_and_values(x1, x2):
+    """Compute the indices for the intersection of two `tf.IndexedSlices` and
+    modify the values for these indices.
+
+    Args:
+        x1: the first `tf.IndexedSlices`.
+        x2: the second `tf.IndexedSlices`.
+    Returns: A tuple containing:
+        - the indices for the intersection
+        - `x1` values for the intersection indices (some values were removed)
+        - `x2` values for the intersection indices (some values were removed)
+    """
+    # Compute the intersection of the indices by doing a logical
+    # and between the one hot encoded indices for x1 and x2.
+    dim_0 = x1.dense_shape[0]
+    x1_indices_expanded = tf.expand_dims(x1.indices, axis=1)
+    x2_indices_expanded = tf.expand_dims(x2.indices, axis=1)
+    x1_indices_count = x1_indices_expanded.shape[0]
+    x2_indices_count = x2_indices_expanded.shape[0]
+    x1_indices_one_hot = tf.scatter_nd(
+        x1_indices_expanded,
+        ones_bool((x1_indices_count,)),
+        (dim_0,),
+    )
+    x2_indices_one_hot = tf.scatter_nd(
+        x2_indices_expanded,
+        ones_bool((x2_indices_count,)),
+        (dim_0,),
+    )
+    intersection_indices = tf.squeeze(
+        tf.where(tf.math.logical_and(x1_indices_one_hot, x2_indices_one_hot)),
+        axis=-1,
+    )
+    intersection_indices_count = tf.shape(intersection_indices)[0]
+
+    def empty_intersection():
+        return (
+            intersection_indices,
+            empty_tensor((0,) + x1.values.shape[1:], x1.dtype),
+            empty_tensor((0,) + x2.values.shape[1:], x2.dtype),
+        )
+
+    def non_empty_intersection():
+        # Re-gather sub parts of the values that are part of the intersection.
+        def values_for_intersection(indices_expanded, indices_count, values):
+            indices_indices = tf.scatter_nd(
+                indices_expanded,
+                tf.range(indices_count),
+                (dim_0,),
+            )
+            to_intersection_indices = tf.gather(
+                indices_indices, intersection_indices
+            )
+            return tf.gather(values, to_intersection_indices)
+
+        # Only recompute values if some indices were removed.
+        x1_values_for_intersection = tf.cond(
+            tf.equal(x1_indices_count, intersection_indices_count),
+            lambda: x1.values,
+            lambda: values_for_intersection(
+                x1_indices_expanded, x1_indices_count, x1.values
+            ),
+        )
+        x2_values_for_intersection = tf.cond(
+            tf.equal(x2_indices_count, intersection_indices_count),
+            lambda: x2.values,
+            lambda: values_for_intersection(
+                x2_indices_expanded, x2_indices_count, x2.values
+            ),
+        )
+
+        return (
+            intersection_indices,
+            x1_values_for_intersection,
+            x2_values_for_intersection,
+        )
+
+    return tf.cond(
+        tf.equal(intersection_indices_count, 0),
+        empty_intersection,
+        non_empty_intersection,
+    )
+
+
+def densifying_unary(default_value):
+    """Decorator to add support for `tf.SparseTensor` and `tf.IndexedSlices` to
+    a non-zero-preserving element-wise unary operator.
+
+    There are requirements on the operator for this decorator to work correctly:
+
+    - The operator must be element-wise
+    - The operator must be unary (one input tensor and one output tensor)
+    - The operator must return a tensor of the same shape.
+
+    Additional arguments to the function (besides the input tensor) are
+    supported. The returned result is a dense tensor and contains
+    `default_value` outside of the indices of the input tensor.
+
+    Args:
+        default_value: The value to use outside of indices. It must be the value
+        that the operator returns for zero values.
+    Returns:
+        Wrapped function that supports `tf.SparseTensor` and `tf.IndexedSlices`.
+    """
+
+    def wrap_densifying_unary(func):
+        @functools.wraps(func)
+        def sparse_wrapper(x, *args, **kwargs):
+            if isinstance(x, tf.SparseTensor):
+                sparse_output = tf.SparseTensor(
+                    x.indices, func(x.values, *args, **kwargs), x.dense_shape
+                )
+                return tf.sparse.to_dense(
+                    sparse_output,
+                    tf.cast(default_value, sparse_output.values.dtype),
+                )
+            elif isinstance(x, tf.IndexedSlices):
+                sparse_output_values = func(x.values, *args, **kwargs)
+                output = tf.fill(
+                    x.dense_shape,
+                    tf.cast(default_value, sparse_output_values.dtype),
+                )
+                return tf.tensor_scatter_nd_update(
+                    output, tf.expand_dims(x.indices, 1), sparse_output_values
+                )
+            return func(x, *args, **kwargs)
+
+        return sparse_wrapper
+
+    return wrap_densifying_unary
+
+
+def elementwise_unary(func):
+    """Decorator to add support for `tf.SparseTensor` and `tf.IndexedSlices` to
+    a zero-preserving element-wise unary operator.
+
+    There are requirements on the operator for this decorator to work correctly:
+
+    - The operator must be element-wise
+    - The operator must be unary (one input tensor and one output tensor)
+    - The operator must return a tensor of the same shape, and if it is a
+      `tf.SparseTensor` or `tf.IndexedSlices`, the indices of the result must be
+      the same. Therefore:
+        - Reduction operations are not supported (e.g. `mean`).
+        - Operation for which the result may be dense (e.g. `reciprocal`), or
+          the sparse indices depend on the inputs are not supported (e.g.
+          `clip`). This implies that `func(0)` must be 0.
+
+    Additional arguments to the function (besides the input tensor) are
+    supported as long as they cannot change the indices of the result. For
+    instance,`round` is supported, but `clip` is not supported as
+    `clip(x, 1.0, 2.0)` would always return a dense tensor.
+
+    Note that if an input sparse tensor contains zero values, the indices and
+    the zero values are preserved.
+
+    Args:
+        func: The function to wrap.
+    Returns:
+        Wrapped function that supports `tf.SparseTensor` and `tf.IndexedSlices`.
+    """
+
+    @functools.wraps(func)
+    def sparse_wrapper(x, *args, **kwargs):
+        if isinstance(x, tf.SparseTensor):
+            return tf.SparseTensor(
+                x.indices, func(x.values, *args, **kwargs), x.dense_shape
+            )
+        elif isinstance(x, tf.IndexedSlices):
+            return tf.IndexedSlices(
+                func(x.values, *args, **kwargs), x.indices, x.dense_shape
+            )
+        else:
+            return func(x, *args, **kwargs)
+
+    return sparse_wrapper
+
+
+def elementwise_binary_union(sparse_op, densify_mixed=False):
+    """Decorator to add support for `tf.SparseTensor` and `tf.IndexedSlices` to
+    an element-wise binary operator such that the indices present in the result
+    are the union of the indices in the two operand.
+
+    The primary use case for this is the `add` and `subtract` operators.
+
+    There are requirements on the operator for this decorator to work correctly:
+
+    - The operator must be element-wise.
+    - The operator must be binary (two input tensors and one output tensor).
+    - Both inputs must be of the same shape or one input must be a scalar.
+    - The output must be of the same shape as the (non scalar) inputs.
+    - The indices of the output must be the union of the indices of the inputs.
+      This implies that func(0, 0) must be 0. As a result, if one operand is
+      dense or a scalar, then the result will be dense.
+
+    Additional arguments to the function (besides the input tensors) are not
+    supported.
+
+    Note that if the result of the operation is zero at some indices, including
+    because the operands were zero at these indices, the zeros and indices are
+    preserved.
+
+    Args:
+        sparse_op: implementation of the operation for `tf.SparseTensor`. Must
+            work if both of the operands are `tf.SparseTensor`s and can
+            optionally work if one of the operand is a `tf.SparseTensor` and
+            the other one is dense tensor, see `densify_mixed`.
+        densify_mixed: if `True`, `sparse_op` does not support a mix of
+            `tf.SparseTensor` and dense tensor or dense tensor with
+            `tf.SparseTensor` and the `tf.SparseTensor` tensor is densified.
+    Returns:
+        Wrapped function that supports `tf.SparseTensor` and `tf.IndexedSlices`.
+    """
+
+    def wrap_elementwise_binary_union(func):
+        @functools.wraps(func)
+        def sparse_wrapper(x1, x2):
+            if isinstance(x1, tf.SparseTensor):
+                if isinstance(x2, tf.SparseTensor):
+                    # x1 is a SparseTensor and x2 is a SparseTensor.
+                    if x1.indices is x2.indices:
+                        return tf.SparseTensor(
+                            x1.indices,
+                            func(x1.values, x2.values),
+                            x1.dense_shape,
+                        )
+                    else:
+                        return sparse_op(x1, x2)
+                else:
+                    # x1 is a SparseTensor.
+                    if densify_mixed:
+                        x1 = tf.sparse.to_dense(x1)
+                    else:
+                        if not hasattr(x2, "shape") or len(x2.shape) == 0:
+                            # x2 is a scalar, broadcast.
+                            x2 = tf.broadcast_to(x2, x1.dense_shape)
+                        return sparse_op(x1, x2)
+            elif isinstance(x2, tf.SparseTensor):
+                # x2 is a SparseTensor.
+                if densify_mixed:
+                    x2 = tf.sparse.to_dense(x2)
+                else:
+                    if not hasattr(x1, "shape") or len(x1.shape) == 0:
+                        # x1 is a scalar, broadcast.
+                        x1 = tf.broadcast_to(x1, x2.dense_shape)
+                    return sparse_op(x1, x2)
+            elif isinstance(x1, tf.IndexedSlices):
+                if isinstance(x2, tf.IndexedSlices):
+                    # x1 is an IndexedSlices and x2 is an IndexedSlices.
+                    if x1.indices is x2.indices:
+                        return tf.IndexedSlices(
+                            func(x1.values, x2.values),
+                            x1.indices,
+                            x1.dense_shape,
+                        )
+                    else:
+                        # Compute the union of indices.
+                        (
+                            union_indices,
+                            x1_values_for_union,
+                            x2_values_for_union,
+                        ) = indexed_slices_union_indices_and_values(
+                            x1, x2.indices, x2.values
+                        )
+                        # Now, it is an element-wise operation on the union.
+                        return tf.IndexedSlices(
+                            func(
+                                x1_values_for_union,
+                                x2_values_for_union,
+                            ),
+                            union_indices,
+                            x1.dense_shape,
+                        )
+                else:
+                    # x1 is an IndexedSlices, densify.
+                    x1 = tf.convert_to_tensor(x1)
+            elif isinstance(x2, tf.IndexedSlices):
+                # x2 is an IndexedSlices, densify.
+                x2 = tf.convert_to_tensor(x2)
+            return func(x1, x2)
+
+        return sparse_wrapper
+
+    return wrap_elementwise_binary_union
+
+
+def elementwise_binary_intersection(func):
+    """Decorator to add support for `tf.SparseTensor` and `tf.IndexedSlices` to
+    an element-wise binary operator such that the indices present in the result
+    are the intersection of the indices in the two operand.
+
+    The primary use case for this is the `multiply` operator.
+
+    There are requirements on the operator for this decorator to work correctly:
+
+    - The operator must be element-wise.
+    - The operator must be binary (two input tensors and one output tensor).
+    - Both inputs must be of the same shape or one input must be a scalar.
+    - The output must be of the same shape as the (non scalar) inputs.
+    - The indices of the output must be the intersection of the indices of the
+      inputs. This implies that func(0, x) and func(x, 0) must be 0 for any x.
+      As a result, if one operand is dense or a scalar, then the indices are the
+      ones from the other operand.
+
+    Additional arguments to the function (besides the input tensors) are not
+    supported.
+
+    Note that if the operands contains zero values at some common indices, the
+    indices and the zero values are preserved.
+
+    Args:
+        func: The function to wrap.
+    Returns:
+        Wrapped function that supports `tf.SparseTensor` and `tf.IndexedSlices`.
+    """
+
+    @functools.wraps(func)
+    def sparse_wrapper(x1, x2):
+        if isinstance(x1, tf.SparseTensor):
+            if isinstance(x2, tf.SparseTensor):
+                # x1 is a SparseTensor and x2 is a SparseTensor.
+                if x1.indices is x2.indices:
+                    return tf.SparseTensor(
+                        x1.indices, func(x1.values, x2.values), x1.dense_shape
+                    )
+                else:
+                    # Compute the intersection of indices.
+                    (
+                        intersection_indices,
+                        x1_values_for_intersection,
+                        x2_values_for_intersection,
+                    ) = sparse_intersection_indices_and_values(x1, x2)
+                    # Now, it is an element-wise operation on the intersection.
+                    return tf.SparseTensor(
+                        intersection_indices,
+                        func(
+                            x1_values_for_intersection,
+                            x2_values_for_intersection,
+                        ),
+                        x1.dense_shape,
+                    )
+            else:
+                # x1 is a SparseTensor.
+                if not hasattr(x2, "shape") or len(x2.shape) == 0:
+                    # x2 is a scalar, apply func element-wise.
+                    return tf.SparseTensor(
+                        x1.indices,
+                        func(x1.values, x2),
+                        x1.dense_shape,
+                    )
+                else:
+                    # x2 is dense, gather values from x1 indices.
+                    return tf.SparseTensor(
+                        x1.indices,
+                        func(x1.values, tf.gather_nd(x2, x1.indices)),
+                        x1.dense_shape,
+                    )
+        elif isinstance(x2, tf.SparseTensor):
+            # x2 is a SparseTensor.
+            if not hasattr(x1, "shape") or len(x1.shape) == 0:
+                # x1 is a scalar, apply func element-wise.
+                return tf.SparseTensor(
+                    x2.indices,
+                    func(x1, x2.values),
+                    x2.dense_shape,
+                )
+            else:
+                # x1 is dense, gather values from x2 indices.
+                return tf.SparseTensor(
+                    x2.indices,
+                    func(tf.gather_nd(x1, x2.indices), x2.values),
+                    x2.dense_shape,
+                )
+        elif isinstance(x1, tf.IndexedSlices):
+            if isinstance(x2, tf.IndexedSlices):
+                # x1 is an IndexedSlices and x2 is an IndexedSlices.
+                if x1.indices is x2.indices:
+                    return tf.IndexedSlices(
+                        func(x1.values, x2.values), x1.indices, x1.dense_shape
+                    )
+                else:
+                    # Compute the intersection of indices.
+                    (
+                        intersection_indices,
+                        x1_values_for_intersection,
+                        x2_values_for_intersection,
+                    ) = indexed_slices_intersection_indices_and_values(x1, x2)
+                    # Now, it is an element-wise operation on the intersection.
+                    return tf.IndexedSlices(
+                        func(
+                            x1_values_for_intersection,
+                            x2_values_for_intersection,
+                        ),
+                        intersection_indices,
+                        x1.dense_shape,
+                    )
+            else:
+                # x1 is an IndexedSlices.
+                if not hasattr(x2, "shape") or len(x2.shape) == 0:
+                    # x2 is a scalar, apply func element-wise.
+                    return tf.IndexedSlices(
+                        func(x1.values, x2), x1.indices, x1.dense_shape
+                    )
+                else:
+                    # x2 is dense, gather values from x1 indices.
+                    return tf.IndexedSlices(
+                        func(x1.values, tf.gather(x2, x1.indices)),
+                        x1.indices,
+                        x1.dense_shape,
+                    )
+        elif isinstance(x2, tf.IndexedSlices):
+            # x2 is an IndexedSlices.
+            if not hasattr(x1, "shape") or len(x1.shape) == 0:
+                # x1 is a scalar, apply func element-wise.
+                return tf.IndexedSlices(
+                    func(x1, x2.values), x2.indices, x2.dense_shape
+                )
+            else:
+                # x1 is dense, gather values from x2 indices.
+                return tf.IndexedSlices(
+                    func(tf.gather(x1, x2.indices), x2.values),
+                    x2.indices,
+                    x2.dense_shape,
+                )
+        # Default case, no SparseTensor and no IndexedSlices.
+        return func(x1, x2)
+
+    return sparse_wrapper
+
+
+def elementwise_division(func):
+    """Decorator to add support for `tf.SparseTensor` and `tf.IndexedSlices` to
+    element-wise binary division and related operators.
+
+    This decorator is designed for operations related to the division of the
+    two operands (e.g. `divide`, `mod`). It accepts `tf.SparseTensor` and
+    `tf.IndexedSlices` for both the dividend and the divisor, but handles them
+    differently based on whether they are the dividend or the divisor.
+
+    - If the divisor is a `tf.SparseTensor` or `tf.IndexedSlices`, it is
+      densified and the result is dense because the result contains Inf or Nan
+      outside of the indices of the dividend.
+    - If the dividend is a `tf.SparseTensor` or `tf.IndexedSlices` and the
+      divisor is dense, it finds occurrences of zeros and NaNs in the divisor.
+      The result may therefore have more indices than there were in the dividend
+      to return correct values where the divisor was zero or NaN.
+    - If the dividend is a `tf.SparseTensor` or `tf.IndexedSlices` and the
+      divisor is a scalar, it does the division element-wise. Note that the
+      result is incorrectly sparse if the scalar divisor is zero.
+
+    Args:
+        func: The function to wrap.
+    Returns:
+        Wrapped function that supports `tf.SparseTensor` and `tf.IndexedSlices`.
+    """
+
+    @functools.wraps(func)
+    def sparse_wrapper(x1, x2):
+        if isinstance(x1, tf.SparseTensor):
+            if isinstance(x2, tf.SparseTensor):
+                # x1 is a SparseTensor and x2 is a SparseTensor.
+                # Divisor is sparse, meaning we're doing divisions by zero
+                # outside of x2.indices, so the result is dense. Densify both.
+                x1 = tf.sparse.to_dense(x1)
+                x2 = tf.sparse.to_dense(x2)
+            else:
+                # x1 is a SparseTensor.
+                if not hasattr(x2, "shape") or len(x2.shape) == 0:
+                    # x2 is a scalar, apply func element-wise.
+                    return tf.SparseTensor(
+                        x1.indices,
+                        func(x1.values, x2),
+                        x1.dense_shape,
+                    )
+                else:
+                    # x2 is dense.
+                    x2_zeros_and_nans = tf.equal(x2, 0)
+                    if not tf.as_dtype(x2.dtype).is_integer:
+                        x2_zeros_and_nans = tf.math.logical_or(
+                            x2_zeros_and_nans, tf.math.is_nan(x2)
+                        )
+
+                    def func_for_x1_indices():
+                        # Gather values from x1 indices.
+                        return tf.SparseTensor(
+                            x1.indices,
+                            func(x1.values, tf.gather_nd(x2, x1.indices)),
+                            x1.dense_shape,
+                        )
+
+                    def func_for_union_indices():
+                        # Compute the union of indices to keep zeros and NaNs.
+                        x2_zeros_and_nan_indices = tf.where(x2_zeros_and_nans)
+                        (
+                            union_indices,
+                            x1_values_for_union,
+                            _,
+                        ) = sparse_union_indices_and_values(
+                            x1, x2_zeros_and_nan_indices
+                        )
+                        return tf.SparseTensor(
+                            union_indices,
+                            func(
+                                x1_values_for_union,
+                                tf.gather_nd(x2, union_indices),
+                            ),
+                            x1.dense_shape,
+                        )
+
+                    return tf.cond(
+                        tf.reduce_any(x2_zeros_and_nans),
+                        func_for_union_indices,
+                        func_for_x1_indices,
+                    )
+        elif isinstance(x2, tf.SparseTensor):
+            # x2 is a SparseTensor.
+            # Divisor is sparse, densify to do the divisions by zero correctly.
+            x2 = tf.sparse.to_dense(x2)
+        elif isinstance(x1, tf.IndexedSlices):
+            if isinstance(x2, tf.IndexedSlices):
+                # x1 is an IndexedSlices and x2 is an IndexedSlices.
+                # Divisor is slices, meaning we're doing divisions by zero
+                # outside of x2.indices, so the result is dense. Densify both.
+                x1 = tf.convert_to_tensor(x1)
+                x2 = tf.convert_to_tensor(x2)
+            else:
+                # x1 is a IndexedSlices.
+                if not hasattr(x2, "shape") or len(x2.shape) == 0:
+                    # x2 is a scalar, apply func element-wise.
+                    return tf.IndexedSlices(
+                        func(x1.values, x2), x1.indices, x1.dense_shape
+                    )
+                else:
+                    # x2 is dense.
+                    x2_zeros_and_nans = tf.equal(x2, 0)
+                    if not tf.as_dtype(x2.dtype).is_integer:
+                        x2_zeros_and_nans = tf.math.logical_or(
+                            x2_zeros_and_nans, tf.math.is_nan(x2)
+                        )
+                    x2_zeros_and_nans = tf.reduce_any(
+                        x2_zeros_and_nans, axis=tuple(range(1, x2.shape.rank))
+                    )
+
+                    def func_for_x1_indices():
+                        # Gather values from x1 indices.
+                        return tf.IndexedSlices(
+                            func(x1.values, tf.gather(x2, x1.indices)),
+                            x1.indices,
+                            x1.dense_shape,
+                        )
+
+                    def func_for_union_indices():
+                        x2_zeros_and_nan_indices = tf.squeeze(
+                            tf.where(x2_zeros_and_nans), axis=-1
+                        )
+                        # Compute the union of indices to keep zeros and NaNs.
+                        (
+                            union_indices,
+                            x1_values_for_union,
+                            _,
+                        ) = indexed_slices_union_indices_and_values(
+                            x1, x2_zeros_and_nan_indices
+                        )
+                        return tf.IndexedSlices(
+                            func(
+                                x1_values_for_union,
+                                tf.gather(x2, union_indices),
+                            ),
+                            union_indices,
+                            x1.dense_shape,
+                        )
+
+                    return tf.cond(
+                        tf.reduce_any(x2_zeros_and_nans),
+                        func_for_union_indices,
+                        func_for_x1_indices,
+                    )
+        elif isinstance(x2, tf.IndexedSlices):
+            # x2 is a IndexedSlices.
+            # Divisor is slices, densify to do the divisions by zero correctly.
+            x2 = tf.convert_to_tensor(x2)
+        # Default case, no SparseTensor and no IndexedSlices.
+        return func(x1, x2)
+
+    return sparse_wrapper

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -261,7 +261,8 @@ class Absolute(Operation):
         return backend.numpy.absolute(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.absolute", "keras.ops.numpy.absolute"])
@@ -309,8 +310,8 @@ class Add(Operation):
             getattr(x1, "dtype", type(x1)),
             getattr(x2, "dtype", type(x2)),
         )
-        x1_sparse = getattr(x1, "sparse", True)
-        x2_sparse = getattr(x2, "sparse", True)
+        x1_sparse = getattr(x1, "sparse", False)
+        x2_sparse = getattr(x2, "sparse", False)
         output_sparse = x1_sparse and x2_sparse
         return KerasTensor(
             output_shape, dtype=output_dtype, sparse=output_sparse
@@ -795,7 +796,8 @@ class Arcsin(Operation):
         return backend.numpy.arcsin(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.arcsin", "keras.ops.numpy.arcsin"])
@@ -824,7 +826,8 @@ class Arcsinh(Operation):
         return backend.numpy.arcsinh(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.arcsinh", "keras.ops.numpy.arcsinh"])
@@ -852,7 +855,8 @@ class Arctan(Operation):
         return backend.numpy.arctan(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.arctan", "keras.ops.numpy.arctan"])
@@ -936,7 +940,8 @@ class Arctanh(Operation):
         return backend.numpy.arctanh(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.arctanh", "keras.ops.numpy.arctanh"])
@@ -1348,7 +1353,8 @@ class Ceil(Operation):
             dtype = backend.floatx()
         else:
             dtype = dtypes.result_type(x.dtype, float)
-        return KerasTensor(x.shape, dtype=dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.ceil", "keras.ops.numpy.ceil"])
@@ -1433,8 +1439,7 @@ class Concatenate(Operation):
                 total_size_on_axis = None
             else:
                 total_size_on_axis += x.shape[self.axis]
-            if not x.sparse:
-                all_sparse = False
+            all_sparse = all_sparse and getattr(x, "sparse", False)
         output_shape = list(first_shape)
         output_shape[self.axis] = total_size_on_axis
         return KerasTensor(output_shape, dtype=x.dtype, sparse=all_sparse)
@@ -1466,7 +1471,8 @@ class Conjugate(Operation):
         return backend.numpy.conjugate(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.conjugate", "keras.ops.numpy.conjugate"])
@@ -1504,7 +1510,8 @@ class Copy(Operation):
         return backend.numpy.copy(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.copy", "keras.ops.numpy.copy"])
@@ -2430,7 +2437,8 @@ class ExpandDims(Operation):
         else:
             axis = self.axis
         output_shape = x_shape[:axis] + [1] + x_shape[axis:]
-        return KerasTensor(output_shape, dtype=x.dtype, sparse=x.sparse)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(output_shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(
@@ -2465,7 +2473,8 @@ class Expm1(Operation):
         dtype = backend.standardize_dtype(x.dtype)
         if "int" in dtype or dtype == "bool":
             dtype = backend.floatx()
-        return KerasTensor(x.shape, dtype=dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.expm1", "keras.ops.numpy.expm1"])
@@ -2519,7 +2528,8 @@ class Floor(Operation):
         return backend.numpy.floor(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.floor", "keras.ops.numpy.floor"])
@@ -2799,7 +2809,8 @@ class Imag(Operation):
         return backend.numpy.imag(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.imag", "keras.ops.numpy.imag"])
@@ -3121,7 +3132,8 @@ class Log1p(Operation):
         return backend.numpy.log1p(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.log1p", "keras.ops.numpy.log1p"])
@@ -3491,8 +3503,8 @@ class Maximum(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        x1_sparse = getattr(x1, "sparse", True)
-        x2_sparse = getattr(x2, "sparse", True)
+        x1_sparse = getattr(x1, "sparse", False)
+        x2_sparse = getattr(x2, "sparse", False)
         output_sparse = x1_sparse and x2_sparse
         return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
 
@@ -3676,8 +3688,8 @@ class Minimum(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        x1_sparse = getattr(x1, "sparse", True)
-        x2_sparse = getattr(x2, "sparse", True)
+        x1_sparse = getattr(x1, "sparse", False)
+        x2_sparse = getattr(x2, "sparse", False)
         output_sparse = x1_sparse and x2_sparse
         return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
 
@@ -3706,7 +3718,10 @@ class Mod(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        x1_sparse = getattr(x1, "sparse", False)
+        x2_sparse = getattr(x2, "sparse", False)
+        output_sparse = x1_sparse and not x2_sparse
+        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
 
 
 @keras_export(["keras.ops.mod", "keras.ops.numpy.mod"])
@@ -4211,7 +4226,8 @@ class Real(Operation):
         return backend.numpy.real(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.real", "keras.ops.numpy.real"])
@@ -4323,7 +4339,8 @@ class Reshape(Operation):
         output_shape = operation_utils.compute_reshape_output_shape(
             x.shape, self.new_shape, "new_shape"
         )
-        return KerasTensor(output_shape, dtype=x.dtype, sparse=x.sparse)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(output_shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.reshape", "keras.ops.numpy.reshape"])
@@ -4387,7 +4404,8 @@ class Round(Operation):
         return backend.numpy.round(x, self.decimals)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.round", "keras.ops.numpy.round"])
@@ -4411,7 +4429,8 @@ class Sign(Operation):
         return backend.numpy.sign(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype="int32")
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype="int32", sparse=sparse)
 
 
 @keras_export(["keras.ops.sign", "keras.ops.numpy.sign"])
@@ -4434,7 +4453,8 @@ class Sin(Operation):
         return backend.numpy.sin(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.sin", "keras.ops.numpy.sin"])
@@ -4457,7 +4477,8 @@ class Sinh(Operation):
         return backend.numpy.sinh(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.sinh", "keras.ops.numpy.sinh"])
@@ -4823,7 +4844,8 @@ class Tan(Operation):
         return backend.numpy.tan(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.tan", "keras.ops.numpy.tan"])
@@ -4846,7 +4868,8 @@ class Tanh(Operation):
         return backend.numpy.tanh(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.tanh", "keras.ops.numpy.tanh"])
@@ -5239,8 +5262,8 @@ class Subtract(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        x1_sparse = getattr(x1, "sparse", True)
-        x2_sparse = getattr(x2, "sparse", True)
+        x1_sparse = getattr(x1, "sparse", False)
+        x2_sparse = getattr(x2, "sparse", False)
         output_sparse = x1_sparse and x2_sparse
         dtype = dtypes.result_type(
             getattr(x1, "dtype", type(x1)),
@@ -5307,7 +5330,10 @@ class Divide(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        x1_sparse = getattr(x1, "sparse", False)
+        x2_sparse = getattr(x2, "sparse", False)
+        output_sparse = x1_sparse and not x2_sparse
+        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
 
 
 @keras_export(["keras.ops.divide", "keras.ops.numpy.divide"])
@@ -5336,7 +5362,10 @@ class TrueDivide(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        x1_sparse = getattr(x1, "sparse", False)
+        x2_sparse = getattr(x2, "sparse", False)
+        output_sparse = x1_sparse and not x2_sparse
+        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
 
 
 @keras_export(
@@ -5384,7 +5413,8 @@ class Negative(Operation):
         return backend.numpy.negative(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.negative", "keras.ops.numpy.negative"])
@@ -5407,7 +5437,8 @@ class Square(Operation):
         return backend.numpy.square(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.square", "keras.ops.numpy.square"])
@@ -5436,7 +5467,8 @@ class Sqrt(Operation):
             if backend.standardize_dtype(x.dtype) == "int64"
             else dtypes.result_type(x.dtype, float)
         )
-        return KerasTensor(x.shape, dtype=dtype)
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype=dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.sqrt", "keras.ops.numpy.sqrt"])
@@ -5465,9 +5497,10 @@ class Squeeze(Operation):
 
     def compute_output_spec(self, x):
         input_shape = list(x.shape)
+        sparse = getattr(x, "sparse", False)
         if self.axis is None:
             output_shape = list(filter((1).__ne__, input_shape))
-            return KerasTensor(output_shape, dtype=x.dtype, sparse=x.sparse)
+            return KerasTensor(output_shape, dtype=x.dtype, sparse=sparse)
         else:
             if input_shape[self.axis] != 1:
                 raise ValueError(
@@ -5475,7 +5508,7 @@ class Squeeze(Operation):
                     "is not 1."
                 )
             del input_shape[self.axis]
-            return KerasTensor(input_shape, dtype=x.dtype, sparse=x.sparse)
+            return KerasTensor(input_shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.squeeze", "keras.ops.numpy.squeeze"])
@@ -5505,8 +5538,9 @@ class Transpose(Operation):
 
     def compute_output_spec(self, x):
         x_shape = x.shape
+        sparse = getattr(x, "sparse", False)
         if self.axes is None:
-            return KerasTensor(x_shape[::-1], dtype=x.dtype, sparse=x.sparse)
+            return KerasTensor(x_shape[::-1], dtype=x.dtype, sparse=sparse)
 
         if len(self.axes) != len(x_shape):
             raise ValueError(
@@ -5516,7 +5550,7 @@ class Transpose(Operation):
         output_shape = []
         for ax in self.axes:
             output_shape.append(x_shape[ax])
-        return KerasTensor(output_shape, dtype=x.dtype, sparse=x.sparse)
+        return KerasTensor(output_shape, dtype=x.dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.transpose", "keras.ops.numpy.transpose"])
@@ -5736,7 +5770,10 @@ class FloorDivide(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        x1_sparse = getattr(x1, "sparse", False)
+        x2_sparse = getattr(x2, "sparse", False)
+        output_sparse = x1_sparse and not x2_sparse
+        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
 
 
 @keras_export(["keras.ops.floor_divide", "keras.ops.numpy.floor_divide"])

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -389,25 +389,6 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             y = KerasTensor((2, 3, 4))
             knp.add(x, y)
 
-    def test_add_sparse(self):
-        x = KerasTensor((2, 3), sparse=True)
-        y = KerasTensor((2, 3))
-        result = knp.add(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertFalse(result.sparse)
-
-        x = KerasTensor((2, 3))
-        y = KerasTensor((2, 3), sparse=True)
-        result = knp.add(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertFalse(result.sparse)
-
-        x = KerasTensor((2, 3), sparse=True)
-        y = KerasTensor((2, 3), sparse=True)
-        result = knp.add(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertTrue(result.sparse)
-
     def test_subtract(self):
         x = KerasTensor((2, 3))
         y = KerasTensor((2, 3))
@@ -421,25 +402,6 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             y = KerasTensor((2, 3, 4))
             knp.subtract(x, y)
 
-    def test_subtract_sparse(self):
-        x = KerasTensor((2, 3), sparse=True)
-        y = KerasTensor((2, 3))
-        result = knp.subtract(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertFalse(result.sparse)
-
-        x = KerasTensor((2, 3))
-        y = KerasTensor((2, 3), sparse=True)
-        result = knp.subtract(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertFalse(result.sparse)
-
-        x = KerasTensor((2, 3), sparse=True)
-        y = KerasTensor((2, 3), sparse=True)
-        result = knp.subtract(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertTrue(result.sparse)
-
     def test_multiply(self):
         x = KerasTensor((2, 3))
         y = KerasTensor((2, 3))
@@ -452,25 +414,6 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             x = KerasTensor((2, 3))
             y = KerasTensor((2, 3, 4))
             knp.multiply(x, y)
-
-    def test_multiply_sparse(self):
-        x = KerasTensor((2, 3), sparse=True)
-        y = KerasTensor((2, 3))
-        result = knp.multiply(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertTrue(result.sparse)
-
-        x = KerasTensor((2, 3))
-        y = KerasTensor((2, 3), sparse=True)
-        result = knp.multiply(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertTrue(result.sparse)
-
-        x = KerasTensor((2, 3), sparse=True)
-        y = KerasTensor((2, 3), sparse=True)
-        result = knp.multiply(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertTrue(result.sparse)
 
     def test_matmul(self):
         x = KerasTensor((2, 3))
@@ -742,25 +685,6 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             y = KerasTensor((2, 3, 4))
             knp.maximum(x, y)
 
-    def test_maximum_sparse(self):
-        x = KerasTensor((2, 3), sparse=True)
-        y = KerasTensor((2, 3))
-        result = knp.maximum(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertFalse(result.sparse)
-
-        x = KerasTensor((2, 3))
-        y = KerasTensor((2, 3), sparse=True)
-        result = knp.maximum(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertFalse(result.sparse)
-
-        x = KerasTensor((2, 3), sparse=True)
-        y = KerasTensor((2, 3), sparse=True)
-        result = knp.maximum(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertTrue(result.sparse)
-
     def test_minimum(self):
         x = KerasTensor((2, 3))
         y = KerasTensor((2, 3))
@@ -773,25 +697,6 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             x = KerasTensor((2, 3))
             y = KerasTensor((2, 3, 4))
             knp.minimum(x, y)
-
-    def test_minimum_sparse(self):
-        x = KerasTensor((2, 3), sparse=True)
-        y = KerasTensor((2, 3))
-        result = knp.minimum(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertFalse(result.sparse)
-
-        x = KerasTensor((2, 3))
-        y = KerasTensor((2, 3), sparse=True)
-        result = knp.minimum(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertFalse(result.sparse)
-
-        x = KerasTensor((2, 3), sparse=True)
-        y = KerasTensor((2, 3), sparse=True)
-        result = knp.minimum(x, y)
-        self.assertEqual(result.shape, (2, 3))
-        self.assertTrue(result.sparse)
 
     def test_mod(self):
         x = KerasTensor((2, 3))
@@ -2099,20 +2004,20 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase, parameterized.TestCase):
 
         rng = np.random.default_rng(0)
         if x_sparse:
-            x = 4 * rng.standard_normal(x_shape)
-            x = tf.sparse.from_dense(tf.cast(tf.nn.dropout(x, 0.7), dtype))
-            x_np = tf.sparse.to_dense(x).numpy()
+            x_np = (4 * rng.standard_normal(x_shape)).astype(dtype)
+            x_np = np.multiply(x_np, rng.random(x_shape) < 0.7)
+            x = tf.sparse.from_dense(x_np)
         else:
             x = x_np = (4 * rng.standard_normal(x_shape)).astype(dtype)
         y = y_np = (4 * rng.standard_normal(y_shape)).astype(dtype)
         if y_sparse:
-            y = 4 * rng.standard_normal(y_shape)
-            y = tf.sparse.from_dense(tf.cast(tf.nn.dropout(y, 0.7), dtype))
-            y_np = tf.sparse.to_dense(y).numpy()
+            y_np = (4 * rng.standard_normal(y_shape)).astype(dtype)
+            y_np = np.multiply(y_np, rng.random(y_shape) < 0.7)
+            y = tf.sparse.from_dense(y_np)
         else:
             y = y_np = (4 * rng.standard_normal(y_shape)).astype(dtype)
 
-        atol = 0.1 if dtype == "float16" else 1e-5
+        atol = 0.1 if dtype == "float16" else 1e-4
         self.assertAllClose(knp.matmul(x, y), np.matmul(x_np, y_np), atol=atol)
         if x_sparse and y_sparse:
             self.assertIsInstance(knp.matmul(x, y), tf.SparseTensor)
@@ -2677,85 +2582,6 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase, parameterized.TestCase):
             standardize_dtype(knp.Digitize()(x, bins).dtype) == "int32"
         )
 
-    @parameterized.named_parameters(
-        [
-            {
-                "testcase_name": "add",
-                "op_function": knp.add,
-                "op_class": knp.Add,
-                "np_op": np.add,
-            },
-            {
-                "testcase_name": "subtract",
-                "op_function": knp.subtract,
-                "op_class": knp.Subtract,
-                "np_op": np.subtract,
-            },
-            {
-                "testcase_name": "multiply",
-                "op_function": knp.multiply,
-                "op_class": knp.Multiply,
-                "np_op": np.multiply,
-                "mixed_inputs_produce_sparse_output": True,
-            },
-            {
-                "testcase_name": "minimum",
-                "op_function": knp.minimum,
-                "op_class": knp.Minimum,
-                "np_op": np.minimum,
-            },
-            {
-                "testcase_name": "maximum",
-                "op_function": knp.maximum,
-                "op_class": knp.Maximum,
-                "np_op": np.maximum,
-            },
-        ]
-    )
-    @pytest.mark.skipif(
-        not backend.SUPPORTS_SPARSE_TENSORS,
-        reason="Backend does not support sparse tensors.",
-    )
-    def test_sparse(
-        self,
-        op_function,
-        op_class,
-        np_op,
-        mixed_inputs_produce_sparse_output=False,
-    ):
-        import tensorflow as tf
-
-        x = tf.SparseTensor(
-            indices=[[0, 0], [1, 2]], values=[1.0, 2.0], dense_shape=(2, 3)
-        )
-        x_np = tf.sparse.to_dense(x).numpy()
-
-        y = tf.SparseTensor(
-            indices=[[0, 0], [1, 1]], values=[4.0, 5.0], dense_shape=(2, 3)
-        )
-        y_np = tf.sparse.to_dense(y).numpy()
-        z = np.random.rand(2, 3).astype("float32")
-
-        # sparse tensor and dense tensor as inputs
-        if mixed_inputs_produce_sparse_output:
-            self.assertIsInstance(op_function(x, z), tf.SparseTensor)
-            self.assertIsInstance(op_class()(x, z), tf.SparseTensor)
-        self.assertAllClose(op_function(x, z), np_op(x_np, z))
-        self.assertAllClose(op_class()(x, z), np_op(x_np, z))
-
-        # dense tensor and sparse tensor as inputs
-        if mixed_inputs_produce_sparse_output:
-            self.assertIsInstance(op_function(z, x), tf.SparseTensor)
-            self.assertIsInstance(op_class()(z, x), tf.SparseTensor)
-        self.assertAllClose(op_function(z, x), np_op(z, x_np))
-        self.assertAllClose(op_class()(z, x), np_op(z, x_np))
-
-        # sparse tensor and sparse tensor as inputs
-        self.assertIsInstance(op_function(x, y), tf.SparseTensor)
-        self.assertIsInstance(op_class()(x, y), tf.SparseTensor)
-        self.assertAllClose(op_function(x, y), np_op(x_np, y_np))
-        self.assertAllClose(op_class()(x, y), np_op(x_np, y_np))
-
 
 class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
     def test_mean(self):
@@ -2779,6 +2605,36 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         # test overflow
         x = np.array([65504, 65504, 65504], dtype="float16")
         self.assertAllClose(knp.mean(x), np.mean(x))
+
+    @parameterized.product(
+        axis=[None, (), 0, 1, 2, -1, -2, -3, (0, 1), (1, 2), (0, 2), (0, 1, 2)],
+        keepdims=[True, False],
+    )
+    @pytest.mark.skipif(
+        backend.backend() != "tensorflow",
+        reason="IndexedSlices are only supported with TensorFlow backend.",
+    )
+    def test_mean_indexed_slices(self, axis, keepdims):
+        import tensorflow as tf
+
+        x = tf.IndexedSlices(
+            [
+                [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+                [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+            ],
+            (0, 2),
+            (4, 2, 3),
+        )
+        x_np = tf.convert_to_tensor(x).numpy()
+        self.assertAllClose(
+            knp.mean(x, axis=axis, keepdims=keepdims),
+            np.mean(x_np, axis=axis, keepdims=keepdims),
+        )
+
+        self.assertAllClose(
+            knp.Mean(axis=axis, keepdims=keepdims)(x),
+            np.mean(x_np, axis=axis, keepdims=keepdims),
+        )
 
     def test_all(self):
         x = np.array([[True, False, True], [True, True, True]])
@@ -4016,6 +3872,385 @@ class NumpyArrayCreateOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.Tri()(3), np.tri(3))
         self.assertAllClose(knp.Tri()(3, 4), np.tri(3, 4))
         self.assertAllClose(knp.Tri()(3, 4, 1), np.tri(3, 4, 1))
+
+
+def create_sparse_tensor(x, indices_from=None, start=0, delta=2):
+    if indices_from is not None:
+        indices = indices_from.indices
+    else:
+        flat_indices = np.arange(start, x.size, delta)
+        indices = np.stack(np.where(np.ones_like(x)), axis=1)[flat_indices]
+
+    if backend.backend() == "tensorflow":
+        import tensorflow as tf
+
+        return tf.SparseTensor(indices, tf.gather_nd(x, indices), x.shape)
+
+
+def create_indexed_slices(x, indices_from=None, start=0, delta=2):
+    indices = np.arange(start, x.shape[0], delta)
+
+    if backend.backend() == "tensorflow":
+        import tensorflow as tf
+
+        if indices_from is not None:
+            indices = indices_from.indices
+        return tf.IndexedSlices(tf.gather(x, indices), indices, x.shape)
+
+
+def get_sparseness_combinations(sparsify_fn):
+    x = np.array([[1, 2, 3], [3, 2, 1]])
+    y = np.array([[4, 5, 6], [3, 2, 1]])
+    scalar = backend.convert_to_tensor(2)
+    x_sp = sparsify_fn(x)
+    y_sp = sparsify_fn(y, indices_from=x_sp)
+    x_sp_sup = sparsify_fn(x, start=0, delta=1)
+    y_sp_dis = sparsify_fn(y, start=1)
+    y_sp_sup = sparsify_fn(y, start=0, delta=1)
+    x = backend.convert_to_tensor(x)
+    y = backend.convert_to_tensor(y)
+    return [
+        {"testcase_name": "sparse_dense", "x": x_sp, "y": y},
+        {"testcase_name": "dense_sparse", "x": x, "y": y_sp},
+        {"testcase_name": "sparse_scalar", "x": x_sp, "y": scalar},
+        {"testcase_name": "scalar_sparse", "x": scalar, "y": y_sp},
+        {"testcase_name": "sparse_sparse_same", "x": x_sp, "y": y_sp},
+        {"testcase_name": "sparse_sparse_disjoint", "x": x_sp, "y": y_sp_dis},
+        {"testcase_name": "sparse_sparse_superset", "x": x_sp, "y": y_sp_sup},
+        {"testcase_name": "sparse_sparse_subset", "x": x_sp_sup, "y": y_sp},
+    ]
+
+
+def sparseness(x):
+    if isinstance(x, KerasTensor):
+        return "sparse" if x.sparse else "dense"
+    elif x.__class__.__name__ == "SparseTensor":
+        return "sparse"
+    elif x.__class__.__name__ == "IndexedSlices":
+        return "slices"
+    elif not hasattr(x, "shape") or not x.shape:
+        return "scalar"
+    else:
+        return "dense"
+
+
+def union_sparseness(x1, x2):
+    x1_sparseness = sparseness(x1)
+    x2_sparseness = sparseness(x2)
+    if any(s in ("scalar", "dense") for s in (x1_sparseness, x2_sparseness)):
+        return "dense"
+    if x1_sparseness != x2_sparseness:
+        raise ValueError(f"Illegal combination of operands: {x1} {x2}")
+    return x1_sparseness
+
+
+def intersection_sparseness(x1, x2):
+    x1_sparseness = sparseness(x1)
+    x2_sparseness = sparseness(x2)
+    if x1_sparseness == "scalar":
+        return x2_sparseness
+    if x2_sparseness in ("scalar", "dense"):
+        return x1_sparseness
+    if x1_sparseness == "dense":
+        return x2_sparseness
+    if x1_sparseness != x2_sparseness:
+        raise ValueError(f"Illegal combination of operands: {x1} {x2}")
+    return x1_sparseness
+
+
+def division_sparseness(x1, x2):
+    x1_sparseness = sparseness(x1)
+    x2_sparseness = sparseness(x2)
+    if x2_sparseness in ("sparse", "slices"):
+        return "dense"
+    return "dense" if x1_sparseness == "scalar" else x1_sparseness
+
+
+@pytest.mark.skipif(
+    not backend.SUPPORTS_SPARSE_TENSORS,
+    reason="Backend does not support sparse tensors.",
+)
+class SparseTest(testing.TestCase, parameterized.TestCase):
+    DTYPES = ["int32", "float32"]
+    DENSIFYING_UNARY_OPS = [
+        "arccos",
+        "arccosh",
+        "cos",
+        "cosh",
+        "exp",
+        "log",
+        "log10",
+        "log2",
+        "reciprocal",
+    ]
+    DENSIFYING_UNARY_OPS_TESTS = [
+        {
+            "testcase_name": op,
+            "op_function": getattr(knp, op),
+            "op_class": getattr(knp, op.capitalize()),
+            "np_op": getattr(np, op),
+        }
+        for op in DENSIFYING_UNARY_OPS
+    ]
+    UNARY_OPS = [
+        "abs",
+        "absolute",
+        "arcsin",
+        "arcsinh",
+        "arctan",
+        "arctanh",
+        "ceil",
+        "conj",
+        "conjugate",
+        "copy",
+        "expm1",
+        "floor",
+        "imag",
+        "log1p",
+        "negative",
+        "real",
+        "round",
+        "sign",
+        "sin",
+        "sinh",
+        "sqrt",
+        "square",
+        "tan",
+        "tanh",
+    ]
+    UNARY_OPS_TESTS = [
+        {
+            "testcase_name": op,
+            "op_function": getattr(knp, op),
+            "op_class": getattr(knp, op.capitalize()),
+            "np_op": getattr(np, op),
+        }
+        for op in UNARY_OPS
+    ]
+
+    BINARY_OPS = [
+        ("add", union_sparseness),
+        ("subtract", union_sparseness),
+        ("maximum", union_sparseness),
+        ("minimum", union_sparseness),
+        ("multiply", intersection_sparseness),
+        ("mod", division_sparseness),
+        ("divide", division_sparseness),
+        ("true_divide", division_sparseness),
+        ("floor_divide", division_sparseness),
+    ]
+    BINARY_OPS_TESTS = [
+        {
+            "testcase_name": op,
+            "op_function": getattr(knp, op),
+            "op_class": getattr(
+                knp, "".join(w.capitalize() for w in op.split("_"))
+            ),
+            "np_op": getattr(np, op),
+            "op_sparseness": op_sparseness,
+        }
+        for op, op_sparseness in BINARY_OPS
+    ]
+
+    def assertSameSparseness(self, x, y):
+        self.assertEquals(sparseness(x), sparseness(y))
+
+    def assertSparseness(self, x, expected_sparseness):
+        self.assertEquals(sparseness(x), expected_sparseness)
+
+    @parameterized.named_parameters(UNARY_OPS_TESTS)
+    def test_unary_symbolic_static_shape(self, op_function, op_class, np_op):
+        x = KerasTensor([2, 3], sparse=True)
+        self.assertEqual(op_function(x).shape, (2, 3))
+        self.assertTrue(op_function(x).sparse)
+        self.assertEqual(op_class()(x).shape, (2, 3))
+        self.assertTrue(op_class()(x).sparse)
+
+    @parameterized.named_parameters(UNARY_OPS_TESTS)
+    def test_unary_symbolic_dynamic_shape(self, op_function, op_class, np_op):
+        x = KerasTensor([None, 3], sparse=True)
+        self.assertEqual(op_function(x).shape, (None, 3))
+        self.assertTrue(op_function(x).sparse)
+        self.assertEqual(op_class()(x).shape, (None, 3))
+        self.assertTrue(op_class()(x).sparse)
+
+    @parameterized.named_parameters(DENSIFYING_UNARY_OPS_TESTS)
+    def test_densifying_unary_sparse_correctness(
+        self, op_function, op_class, np_op
+    ):
+        x = np.array([[1, 0.5, -0.7], [0.9, 0.2, -1]])
+        x = create_sparse_tensor(x)
+        x_np = backend.convert_to_numpy(x)
+
+        self.assertAllClose(op_function(x), np_op(x_np))
+        self.assertAllClose(op_class()(x), np_op(x_np))
+
+    @parameterized.named_parameters(DENSIFYING_UNARY_OPS_TESTS)
+    def test_densifying_unary_indexed_slices_correctness(
+        self, op_function, op_class, np_op
+    ):
+        x = np.array([[1, 0.5, -0.7], [0.9, 0.2, -1]])
+        x = create_indexed_slices(x)
+        x_np = backend.convert_to_numpy(x)
+
+        self.assertAllClose(op_function(x), np_op(x_np))
+        self.assertAllClose(op_class()(x), np_op(x_np))
+
+    @parameterized.named_parameters(UNARY_OPS_TESTS)
+    def test_unary_sparse_correctness(self, op_function, op_class, np_op):
+        if op_function.__name__ in ("conj", "conjugate", "imag", "real"):
+            x = np.array([[1 + 1j, 2 + 2j, 3 + 3j], [3 + 3j, 2 + 2j, 1 + 1j]])
+        else:
+            x = np.array([[1, 0.5, -0.7], [0.9, 0.2, -1]])
+        x = create_sparse_tensor(x)
+        x_np = backend.convert_to_numpy(x)
+
+        self.assertAllClose(op_function(x), np_op(x_np))
+        self.assertSameSparseness(op_function(x), x)
+        self.assertAllClose(op_class()(x), np_op(x_np))
+        self.assertSameSparseness(op_class()(x), x)
+
+    @parameterized.named_parameters(UNARY_OPS_TESTS)
+    def test_unary_indexed_slices_correctness(
+        self, op_function, op_class, np_op
+    ):
+        if op_function.__name__ in ("conj", "conjugate", "imag", "real"):
+            x = np.array([[1 + 1j, 2 + 2j, 3 + 3j], [3 + 3j, 2 + 2j, 1 + 1j]])
+        else:
+            x = np.array([[1, 0.5, -0.7], [0.9, 0.2, -1]])
+        x = create_indexed_slices(x)
+        x_np = backend.convert_to_numpy(x)
+
+        self.assertAllClose(op_function(x), np_op(x_np))
+        self.assertSameSparseness(op_function(x), x)
+        self.assertAllClose(op_class()(x), np_op(x_np))
+        self.assertSameSparseness(op_class()(x), x)
+
+    @parameterized.named_parameters(
+        named_product(
+            BINARY_OPS_TESTS, x_sparse=[True, False], y_sparse=[True, False]
+        )
+    )
+    def test_binary_symbolic_static_shape(
+        self, x_sparse, y_sparse, op_function, op_class, np_op, op_sparseness
+    ):
+        x = KerasTensor([2, 3], sparse=x_sparse)
+        y = KerasTensor([2, 3], sparse=y_sparse)
+        self.assertEqual(op_function(x, y).shape, (2, 3))
+        self.assertSparseness(op_function(x, y), op_sparseness(x, y))
+        self.assertEqual(op_class()(x, y).shape, (2, 3))
+        self.assertSparseness(op_class()(x, y), op_sparseness(x, y))
+
+    @parameterized.named_parameters(
+        named_product(
+            BINARY_OPS_TESTS, x_sparse=[True, False], y_sparse=[True, False]
+        )
+    )
+    def test_binary_symbolic_dynamic_shape(
+        self, x_sparse, y_sparse, op_function, op_class, np_op, op_sparseness
+    ):
+        x = KerasTensor([None, 3], sparse=x_sparse)
+        y = KerasTensor([2, None], sparse=y_sparse)
+        self.assertEqual(op_function(x, y).shape, (2, 3))
+        self.assertSparseness(op_function(x, y), op_sparseness(x, y))
+        self.assertEqual(op_class()(x, y).shape, (2, 3))
+        self.assertSparseness(op_class()(x, y), op_sparseness(x, y))
+
+    @parameterized.named_parameters(
+        named_product(
+            BINARY_OPS_TESTS,
+            get_sparseness_combinations(create_sparse_tensor),
+            dtype=DTYPES,
+        )
+    )
+    def test_binary_correctness_sparse_tensor(
+        self, x, y, op_function, op_class, np_op, op_sparseness, dtype
+    ):
+        if dtype == "int32" and op_function.__name__ in ("floor_divide", "mod"):
+            self.skipTest(f"{op_function.__name__} does not support integers")
+
+        x = backend.cast(x, dtype)
+        y = backend.cast(y, dtype)
+        expected_result = np_op(
+            backend.convert_to_numpy(x), backend.convert_to_numpy(y)
+        )
+
+        self.assertAllClose(op_function(x, y), expected_result)
+        self.assertSparseness(op_function(x, y), op_sparseness(x, y))
+        self.assertAllClose(op_class()(x, y), expected_result)
+        self.assertSparseness(op_class()(x, y), op_sparseness(x, y))
+
+    @parameterized.named_parameters(
+        named_product(
+            BINARY_OPS_TESTS,
+            get_sparseness_combinations(create_indexed_slices),
+            dtype=DTYPES,
+        )
+    )
+    def test_binary_correctness_indexed_slices(
+        self, x, y, op_function, op_class, np_op, op_sparseness, dtype
+    ):
+        if dtype == "int32" and op_function.__name__ in ("floor_divide", "mod"):
+            self.skipTest(f"{op_function.__name__} does not support integers")
+
+        x = backend.cast(x, dtype)
+        y = backend.cast(y, dtype)
+        expected_result = np_op(
+            backend.convert_to_numpy(x), backend.convert_to_numpy(y)
+        )
+
+        self.assertAllClose(op_function(x, y), expected_result)
+        self.assertSparseness(op_function(x, y), op_sparseness(x, y))
+        self.assertAllClose(op_class()(x, y), expected_result)
+        self.assertSparseness(op_class()(x, y), op_sparseness(x, y))
+
+    def test_divide_with_zeros_in_int_sparse_tensor(self):
+        x = backend.convert_to_tensor([[0, 2, 3], [3, 2, 1]], dtype="int32")
+        x = create_sparse_tensor(x, start=0, delta=2)
+        y = backend.convert_to_tensor([[0, 0, 0], [0, 0, 0]], dtype="int32")
+        expected_result = np.divide(
+            backend.convert_to_numpy(x), backend.convert_to_numpy(y)
+        )
+
+        self.assertAllClose(knp.divide(x, y), expected_result)
+        self.assertAllClose(knp.Divide()(x, y), expected_result)
+
+    def test_divide_with_zeros_nans_in_float_sparse_tensor(self):
+        x = backend.convert_to_tensor([[0, 2, 3], [3, 2, 1]], dtype="float32")
+        x = create_sparse_tensor(x, start=0, delta=2)
+        y = backend.convert_to_tensor(
+            [[np.nan, np.nan, 3], [0, 0, 1]], dtype="float32"
+        )
+        expected_result = np.divide(
+            backend.convert_to_numpy(x), backend.convert_to_numpy(y)
+        )
+
+        self.assertAllClose(knp.divide(x, y), expected_result)
+        self.assertAllClose(knp.Divide()(x, y), expected_result)
+
+    def test_divide_with_zeros_in_int_indexed_slices(self):
+        x = backend.convert_to_tensor([[0, 2, 3], [3, 2, 1]], dtype="int32")
+        x = create_indexed_slices(x, start=0, delta=2)
+        y = backend.convert_to_tensor([[0, 0, 3], [0, 0, 1]], dtype="int32")
+        expected_result = np.divide(
+            backend.convert_to_numpy(x), backend.convert_to_numpy(y)
+        )
+
+        self.assertAllClose(knp.divide(x, y), expected_result)
+        self.assertAllClose(knp.Divide()(x, y), expected_result)
+
+    def test_divide_with_zeros_nans_in_float_indexed_slices(self):
+        x = backend.convert_to_tensor([[0, 2, 3], [3, 2, 1]], dtype="float32")
+        x = create_indexed_slices(x, start=0, delta=2)
+        y = backend.convert_to_tensor(
+            [[np.nan, 0, 3], [np.nan, 0, 1]], dtype="float32"
+        )
+        expected_result = np.divide(
+            backend.convert_to_numpy(x), backend.convert_to_numpy(y)
+        )
+
+        self.assertAllClose(knp.divide(x, y), expected_result)
+        self.assertAllClose(knp.Divide()(x, y), expected_result)
 
 
 class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):


### PR DESCRIPTION
…ensorFlow ops.

The following element-wise unary ops now support `tf.SparseTensor` and `tf.IndexedSlices`. The output is of the same type as the input.
- abs
- absolute
- arcsin
- arcsinh
- arctan
- arctanh
- ceil
- conj
- conjugate
- copy
- expm1
- floor
- imag
- log1p
- negative
- real
- round
- sign
- sin
- sinh
- sqrt
- square
- tan
- tanh

The following element-wise unary ops now support `tf.SparseTensor` and `tf.IndexedSlices`. The output is dense.
- arccos
- arccosh
- cos
- cosh
- exp
- log
- log10
- log2
- reciprocal
   
The following element-wise binary ops now support `tf.SparseTensor` and `tf.IndexedSlices`. The output type depends on the two inputs and the op.
- add (already supported `tf.SparseTensor`)
- subtract (already supported `tf.SparseTensor`)
- maximum (already supported `tf.SparseTensor`)
- minimum (already supported `tf.SparseTensor`)
- multiply (already supported `tf.SparseTensor`)
- mod
- divide
- true_divide
- floor_divide

The following reduction op now supports `tf.IndexedSlices`. The output is an `tf.IndexedSlices` unless dimension 0 is reduced or the rank of the output is 1 or less.
- mean

This is in preparation for supporting sparse gradients in optimizers.