### PR TITLE
Fix torch reshape

### DIFF
--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -851,6 +851,8 @@ def repeat(x, repeats, axis=None):
 
 
 def reshape(x, new_shape):
+    if not isinstance(new_shape, (list, tuple)):
+        new_shape = (new_shape,)
     x = convert_to_tensor(x)
     return torch.reshape(x, new_shape)
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -3631,6 +3631,7 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertAllClose(knp.reshape(x, [3, 2]), np.reshape(x, [3, 2]))
         self.assertAllClose(knp.Reshape([3, 2])(x), np.reshape(x, [3, 2]))
+        self.assertAllClose(knp.Reshape(-1)(x), np.reshape(x, -1))
 
     @pytest.mark.skipif(
         not backend.SUPPORTS_SPARSE_TENSORS,


### PR DESCRIPTION
ops.reshape(tensor, -1) wasn't working on torch backend. It's a fairly common numpy-ism.