### PR TITLE
Change import statement of keras_core in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ In Colab, you can do:
 import os
 os.environ["KERAS_BACKEND"] = "jax"
 
-import keras
+import keras_core as keras
 ```
 
 **Note:** The backend must be configured before importing `keras`, and the backend cannot be changed after 


### PR DESCRIPTION
Changed the import statement from `import keras` to `import keras_core as keras` to avoid confusion and this is valid until **Keras3** release. `import keras` will pick-up the `keras` package present in that environment instead of `keras_core` package.

Shall fix #18592 also.