### PR TITLE
Update line 543 in metrics_utils.py

### DIFF
--- a/keras/metrics/metrics_utils.py
+++ b/keras/metrics/metrics_utils.py
@@ -540,7 +540,7 @@ def update_confusion_matrix_variables(
 
     if sample_weight is not None:
         sample_weight = ops.broadcast_to(
-            ops.cast(sample_weight, dtype=y_pred.dtype), y_pred.shape
+            ops.cast(sample_weight, dtype=y_pred.dtype), ops.shape(y_pred)
         )
         weights_tiled = ops.tile(
             ops.reshape(sample_weight, thresh_tiles), data_tiles


### PR DESCRIPTION
Changed `y_pred.shape` to `ops.shape(y_pred)` for broadcasting of sample weights in `update_confusion_matrix_variables` to avoid shape error in tensorflow. Fix for issue #18620 .

```python
    if sample_weight is not None:
        sample_weight = ops.broadcast_to(
            ops.cast(sample_weight, dtype=y_pred.dtype), ops.shape(y_pred)  # instead of y_pred.shape
        )
```