### PR TITLE
Add multi-worker support for JAX training.

### DIFF
--- a/keras/backend/jax/core.py
+++ b/keras/backend/jax/core.py
@@ -47,6 +47,11 @@ class Variable(KerasVariable):
 
 
 def convert_to_tensor(x, dtype=None, sparse=False):
+    if isinstance(x, (jnp.ndarray, jax.Array)):
+        # Skip the conversion early if the instance is already a JAX array.abs
+        # This is important in the multi-process context since jax.array(x) for
+        # an existing distributed jax array will raise error.
+        return x
     if sparse:
         raise ValueError("`sparse=True` is not supported with jax backend")
     if dtype is not None:

--- a/keras/backend/jax/core.py
+++ b/keras/backend/jax/core.py
@@ -47,15 +47,16 @@ class Variable(KerasVariable):
 
 
 def convert_to_tensor(x, dtype=None, sparse=False):
-    if isinstance(x, (jnp.ndarray, jax.Array)):
-        # Skip the conversion early if the instance is already a JAX array.abs
-        # This is important in the multi-process context since jax.array(x) for
-        # an existing distributed jax array will raise error.
-        return x
     if sparse:
         raise ValueError("`sparse=True` is not supported with jax backend")
     if dtype is not None:
         dtype = standardize_dtype(dtype)
+    if isinstance(x, (jnp.ndarray, jax.Array)) and dtype == x.dtype:
+        # Skip the conversion early if the instance is already a JAX array.
+        # This is important in the multi-process context since jax.array(x) for
+        # an existing distributed jax array will raise error.
+        return x
+
     if isinstance(x, Variable):
         if dtype and dtype != x.dtype:
             return x.value.astype(dtype)

--- a/keras/backend/jax/distribution_lib.py
+++ b/keras/backend/jax/distribution_lib.py
@@ -115,7 +115,8 @@ def distribute_data_input(inputs, layout):
     Args:
         inputs: `jax.Array` that is already sharded to a local process size.
         layout: `TensorLayout` for the distribution information, or a
-        `jax.sharding.Sharding` instance.
+            `jax.sharding.Sharding` instance.
+
     Returns:
         Distributed inputs thats been properly put to local devices.
     """

--- a/keras/backend/jax/distribution_lib.py
+++ b/keras/backend/jax/distribution_lib.py
@@ -48,7 +48,25 @@ def distribute_variable(value, layout):
     """
     if not isinstance(layout, jax.sharding.Sharding):
         layout = _to_jax_layout(layout)
-    return jax.device_put(value, layout)
+    if isinstance(
+        value, (jax.Array, jax.numpy.ndarray)
+    ) and value.sharding.is_equivalent_to(layout, ndim=len(value.shape)):
+        # Skip the relayout if the value is already having the proper sharding
+        return value
+
+    if layout.is_fully_addressable:
+        return jax.device_put(value, layout)
+    else:
+        # Need to only distribute the value to local addressible devices, and
+        # repack them back into global format.
+        mapping = layout.addressable_devices_indices_map(value.shape)
+        local_values = jax.device_put(
+            [value[i] for i in mapping.values()], list(mapping.keys())
+        )
+        global_value = jax.make_array_from_single_device_arrays(
+            value.shape, layout, local_values
+        )
+        return global_value
 
 
 def distribute_tensor(tensor, layout):
@@ -87,6 +105,54 @@ def distribute_tensor(tensor, layout):
         return global_value
 
 
+def distribute_data_input(inputs, layout):
+    """Distribute the input data with the corresponding layout.
+
+    Note that the inputs here is a local worker batch, which has already
+    been sharded to 1/N of the global batch size (N being the number of
+    workers/processes).
+
+    Args:
+        inputs: `jax.Array` that is already sharded to a local process size.
+        layout: `TensorLayout` for the distribution information, or a
+        `jax.sharding.Sharding` instance.
+    Returns:
+        Distributed inputs thats been properly put to local devices.
+    """
+    if not isinstance(layout, jax.sharding.Sharding):
+        layout = _to_jax_layout(layout)
+    if layout.is_fully_addressable:
+        return jax.device_put(inputs, layout)
+
+    # TODO(scottzhu): Add support for data+model parallel.
+    # We assume the data are batch parallel only for now.
+    per_process_batch_size = inputs.shape[0]
+    num_local_replia = jax.local_device_count()
+    per_replica_batch_size = per_process_batch_size // num_local_replia
+
+    if per_process_batch_size % per_replica_batch_size != 0:
+        raise ValueError(
+            f"The local batch size {per_process_batch_size} is not"
+            "divisible by the number of local replica "
+            f"{num_local_replia}"
+        )
+    global_batch_size = per_process_batch_size * jax.process_count()
+    global_shape = (global_batch_size,) + inputs.shape[1:]
+    per_replica_batches = np.split(inputs, num_local_replia, axis=0)
+
+    global_batch_array = jax.make_array_from_single_device_arrays(
+        global_shape,
+        layout,
+        arrays=[
+            jax.device_put(batch, device)
+            for batch, device in zip(
+                per_replica_batches, layout.addressable_devices
+            )
+        ],
+    )
+    return global_batch_array
+
+
 def initialize(job_addresses, num_processes, process_id):
     if job_addresses and "," in job_addresses:
         # When user provide all the job addresses, we will split and get the
@@ -122,6 +188,8 @@ def process_id():
 
 
 def _to_jax_device(device_id):
+    if isinstance(device_id, jax.Device):
+        return device_id
     device_type, index = device_id.split(":")
     index = int(index)
     devices = jax.devices(backend=device_type)

--- a/keras/backend/jax/trainer.py
+++ b/keras/backend/jax/trainer.py
@@ -466,7 +466,11 @@ class JAXTrainer(base_trainer.Trainer):
             self.jax_state_sync()
 
             # Override with model metrics instead of last step logs
-            epoch_logs = self.get_metrics_result()
+            # The jax spmd_mode is need for multi-process context, since the
+            # metrics values are replicated, and we don't want to do a all
+            # gather, and only need the local copy of the value.
+            with jax.spmd_mode("allow_all"):
+                epoch_logs = self.get_metrics_result()
 
             # Run validation.
             if validation_data and self._should_eval(epoch, validation_freq):
@@ -615,7 +619,11 @@ class JAXTrainer(base_trainer.Trainer):
         # Reattach state back to model.
         self.jax_state_sync()
 
-        logs = self.get_metrics_result()
+        # The jax spmd_mode is need for multi-process context, since the
+        # metrics values are replicated, and we don't want to do a all
+        # gather, and only need the local copy of the value.
+        with jax.spmd_mode("allow_all"):
+            logs = self.get_metrics_result()
         callbacks.on_test_end(logs)
         self._jax_state = None
         if return_dict:
@@ -846,7 +854,7 @@ class JAXTrainer(base_trainer.Trainer):
 
             def distribute_single_value(d):
                 layout = distribution.get_data_layout(d.shape)
-                return jax_distribution_lib.distribute_tensor(d, layout)
+                return jax_distribution_lib.distribute_data_input(d, layout)
 
             return jax.tree_util.tree_map(distribute_single_value, data)
         else:

--- a/keras/distribution/distribution_lib.py
+++ b/keras/distribution/distribution_lib.py
@@ -424,10 +424,11 @@ class DataParallel(Distribution):
         return None
 
     def distribute_dataset(self, dataset):
-        from keras.utils.module_utils import tensorflow as tf
         from tensorflow.python.data.experimental.ops import (
             distribute as tf_data_distribute,
         )
+
+        from keras.utils.module_utils import tensorflow as tf
 
         if not isinstance(dataset, tf.data.Dataset):
             raise ValueError(
@@ -440,7 +441,7 @@ class DataParallel(Distribution):
                 raise ValueError(
                     "The batch size of the input dataset is "
                     "unknown. Please config the batch size for "
-                    "the input dataset"
+                    "the input dataset, e.g via `dataset.batch(batch_size)`"
                 )
             per_worker_batch_size = tf_data_distribute.batch_sizes_for_worker(
                 global_batch_size=batch_size,

--- a/keras/distribution/distribution_lib.py
+++ b/keras/distribution/distribution_lib.py
@@ -14,9 +14,6 @@ import warnings
 
 import numpy as np
 
-# TF is used for dataset sharding.
-import tensorflow as tf
-
 from keras.api_export import keras_export
 from keras.backend import KerasTensor
 from keras.backend import distribution_lib
@@ -375,6 +372,7 @@ class DataParallel(Distribution):
             self._initialize_mesh_from_list_devices()
 
         self._batch_dim_name = self.device_mesh.axis_names[0]
+        # Those following attributes might get convert to public methods.
         self._num_process = distribution_lib.num_processes()
         self._process_id = distribution_lib.process_id()
         self._is_multi_process = self._num_process > 1
@@ -426,15 +424,38 @@ class DataParallel(Distribution):
         return None
 
     def distribute_dataset(self, dataset):
+        import tensorflow as tf
+        from tensorflow.python.data.experimental.ops import (
+            distribute as tf_data_distribute,
+        )
+
         if not isinstance(dataset, tf.data.Dataset):
             raise ValueError(
                 "Only `tf.data.Dataset` is supported for "
                 f"sharding, got {type(dataset)}"
             )
         if self._is_multi_process:
-            return dataset.shard(
-                num_shards=self._num_process, index=self._process_id
-            ).prefetch(tf.data.AUTOTUNE)
+            batch_size = tf_data_distribute.compute_batch_size(dataset)
+            if batch_size.numpy() < 0:
+                raise ValueError(
+                    "The batch size of the input dataset is "
+                    "unknown. Please config the batch size for "
+                    "the input dataset"
+                )
+            per_worker_batch_size = tf_data_distribute.batch_sizes_for_worker(
+                global_batch_size=batch_size,
+                num_workers=self._num_process,
+                num_replicas_per_worker=1,  # We hard code this for now.
+                worker_index=self._process_id,
+            )
+            distributed_dataset = dataset.rebatch(per_worker_batch_size)
+            distributed_dataset = tf_data_distribute._AutoShardDataset(
+                distributed_dataset,
+                num_workers=self._num_process,
+                index=self._process_id,
+                num_replicas=self._num_process,
+            )
+            return distributed_dataset.prefetch(tf.data.AUTOTUNE)
         return dataset
 
 

--- a/keras/trainers/data_adapters/__init__.py
+++ b/keras/trainers/data_adapters/__init__.py
@@ -1,5 +1,6 @@
 import types
 
+from keras.distribution import distribution_lib
 from keras.trainers.data_adapters import array_data_adapter
 from keras.trainers.data_adapters import py_dataset_adapter
 from keras.trainers.data_adapters.array_data_adapter import ArrayDataAdapter
@@ -22,6 +23,18 @@ def get_data_adapter(
     shuffle=False,
     class_weight=None,
 ):
+    # Check for multi-process/worker distribution. Since only tf.dataset
+    # is supported at the moment, we will raise error if the inputs fail
+    # the type check
+    distribution = distribution_lib.distribution()
+    if getattr(distribution, "_is_multi_process", False) and not is_tf_dataset(
+        x
+    ):
+        raise ValueError(
+            "Only `tf.data.Dataset` is supported for multi worker "
+            f"distribution, received input types is {type(x)}"
+        )
+
     if array_data_adapter.can_convert_arrays((x, y, sample_weight)):
         return ArrayDataAdapter(
             x,
@@ -40,7 +53,9 @@ def get_data_adapter(
             raise_unsupported_arg(
                 "sample_weights", "the sample weights", "tf.data.Dataset"
             )
-        return TFDatasetAdapter(x, class_weight=class_weight)
+        return TFDatasetAdapter(
+            x, class_weight=class_weight, distribution=distribution
+        )
         # TODO: should we warn or not?
         # warnings.warn(
         #     "`shuffle=True` was passed, but will be ignored since the "

--- a/keras/trainers/data_adapters/__init__.py
+++ b/keras/trainers/data_adapters/__init__.py
@@ -31,8 +31,8 @@ def get_data_adapter(
         x
     ):
         raise ValueError(
-            "Only `tf.data.Dataset` is supported for multi worker "
-            f"distribution, received input types is {type(x)}"
+            "When using multi-worker distribution, the data must be provided "
+            f"as a `tf.data.Dataset` instance. Received: type(x)={type(x)}."
         )
 
     if array_data_adapter.can_convert_arrays((x, y, sample_weight)):

--- a/keras/trainers/data_adapters/tf_dataset_adapter.py
+++ b/keras/trainers/data_adapters/tf_dataset_adapter.py
@@ -8,6 +8,16 @@ class TFDatasetAdapter(DataAdapter):
     """Adapter that handles `tf.data.Dataset`."""
 
     def __init__(self, dataset, class_weight=None, distribution=None):
+        """Iniitialize the TFDatasetAdapter.
+
+        Args:
+            dataset: The input `tf.data.Dataset` instance.
+            class_weight: A map where the keys are integer class ids and values
+                are the class weights, e.g. `{0: 0.2, 1: 0.6, 2: 0.3}`.
+            distribution: A `keras.distribution.Distribution` instance. Used to
+                shard the input dataset into per worker/process dataset
+                instance.
+        """
         from keras.utils.module_utils import tensorflow as tf
 
         if not isinstance(

--- a/keras/trainers/data_adapters/tf_dataset_adapter.py
+++ b/keras/trainers/data_adapters/tf_dataset_adapter.py
@@ -7,7 +7,7 @@ from keras.trainers.data_adapters.data_adapter import DataAdapter
 class TFDatasetAdapter(DataAdapter):
     """Adapter that handles `tf.data.Dataset`."""
 
-    def __init__(self, dataset, class_weight=None):
+    def __init__(self, dataset, class_weight=None, distribution=None):
         from keras.utils.module_utils import tensorflow as tf
 
         if not isinstance(
@@ -21,6 +21,8 @@ class TFDatasetAdapter(DataAdapter):
             dataset = dataset.map(
                 make_class_weight_map_fn(class_weight)
             ).prefetch(tf.data.AUTOTUNE)
+        if distribution is not None:
+            dataset = distribution.distribute_dataset(dataset)
         self._dataset = dataset
 
     def get_numpy_iterator(self):


### PR DESCRIPTION
I have tried to add some backend agnostic tests to dataset builder, and the JAX specific multi-worker test will be hosted internally.