### PR TITLE
Avoid import tensorflow directly

### DIFF
--- a/keras/distribution/distribution_lib.py
+++ b/keras/distribution/distribution_lib.py
@@ -18,7 +18,6 @@ from keras.api_export import keras_export
 from keras.backend import KerasTensor
 from keras.backend import distribution_lib
 from keras.backend.common import global_state
-from keras.utils.module_utils import tensorflow as tf
 
 DEFAULT_BATCH_DIM_NAME = "batch"
 GLOBAL_ATTRIBUTE_NAME = "distribution"
@@ -424,6 +423,8 @@ class DataParallel(Distribution):
         return None
 
     def distribute_dataset(self, dataset):
+        from keras.utils.module_utils import tensorflow as tf
+
         if not isinstance(dataset, tf.data.Dataset):
             raise ValueError(
                 "Only `tf.data.Dataset` is supported for "

--- a/keras/distribution/distribution_lib.py
+++ b/keras/distribution/distribution_lib.py
@@ -14,13 +14,11 @@ import warnings
 
 import numpy as np
 
-# TF is used for dataset sharding.
-import tensorflow as tf
-
 from keras.api_export import keras_export
 from keras.backend import KerasTensor
 from keras.backend import distribution_lib
 from keras.backend.common import global_state
+from keras.utils.module_utils import tensorflow as tf
 
 DEFAULT_BATCH_DIM_NAME = "batch"
 GLOBAL_ATTRIBUTE_NAME = "distribution"


### PR DESCRIPTION
People may use other backends without installing TF.