### PR TITLE
Set evaluation epoch iterator object to None for each model.fit call

### DIFF
--- a/keras/backend/jax/trainer.py
+++ b/keras/backend/jax/trainer.py
@@ -352,6 +352,7 @@ class JAXTrainer(base_trainer.Trainer):
     ):
         self._assert_compile_called("fit")
         # TODO: respect compiled trainable state
+        self._eval_epoch_iterator = None
         if validation_split and validation_data is None:
             # Create the validation data using the training data. Only supported
             # for TF/numpy/jax arrays.

--- a/keras/backend/tensorflow/trainer.py
+++ b/keras/backend/tensorflow/trainer.py
@@ -265,6 +265,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
     ):
         self._assert_compile_called("fit")
         # TODO: respect compiled trainable state
+        self._eval_epoch_iterator = None
         if validation_split and validation_data is None:
             # Create the validation data using the training data. Only supported
             # for TF/numpy/jax arrays.

--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -221,6 +221,7 @@ class TorchTrainer(base_trainer.Trainer):
             )
 
         # TODO: respect compiled trainable state
+        self._eval_epoch_iterator = None
         if validation_split and validation_data is None:
             # Create the validation data using the training data. Only supported
             # for TF/numpy/jax arrays.


### PR DESCRIPTION
When using `model.fit()` with `validation_data`, during first call to `fit()` it will create an `EpochIterator` object for evaluation and cache it. This cache will be deleted after completion of all epochs.

However if we try to change the validation_data shapes for any reason and called `model.fit()` again it will raise an exception like Graph execution error which is intended. After this if we call `model.fit()` with correct `validation_data` that of first training call it won't work. 

The reason being is after first call is success evaluation `EpochIterator` will be deleted at the end and during second training call a new `EpochIterator` will be generated again with changed shape.But during `evaluate()` call it will raise an exception terminating the process without deleting evaluation `EpochIterator` object and it remains in cache. During third call though with correct validation_data it will not create new `EpochIterator` object as one already exists in cache which makes it fail again.

Hence proposing a fix for this with this commit.

Fixes #18653 

