### PR TITLE
use cpu for backends when not testing on gpu

### DIFF
--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,5 +1,5 @@
 # Tensorflow cpu-only version (needed for testing).
-tf-nightly==2.15.0.dev20231009  # Pin a working nightly until rc0.
+tf-nightly-cpu==2.15.0.dev20231009  # Pin a working nightly until rc0.
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,5 +1,5 @@
 # Tensorflow cpu-only version (needed for testing).
-tf-nightly==2.15.0.dev20231009  # Pin a working nightly until rc0.
+tf-nightly-cpu==2.15.0.dev20231009  # Pin a working nightly until rc0.
 
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu118

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # Tensorflow.
-tf-nightly==2.15.0.dev20231009  # Pin a working nightly until rc0.
+tf-nightly-cpu==2.15.0.dev20231009  # Pin a working nightly until rc0.
 
 # Torch.
+--extra-index-url https://download.pytorch.org/whl/cpu
 torch>=2.1.0
 torchvision>=0.16.0
 


### PR DESCRIPTION
This will prevent the GPU versions of different backends to mess up the GPU memory of each other.