### PR TITLE
Validate alpha argument in leaky relu

### DIFF
--- a/keras/layers/activations/leaky_relu.py
+++ b/keras/layers/activations/leaky_relu.py
@@ -43,11 +43,11 @@ class LeakyReLU(Layer):
                 "Use `negative_slope` instead."
             )
         super().__init__(**kwargs)
-        if negative_slope is None:
+        if negative_slope is None or negative_slope < 0:
             raise ValueError(
                 "The negative_slope value of a Leaky ReLU layer "
-                "cannot be None. Expected a float. Received: "
-                f"negative_slope={negative_slope}"
+                "cannot be None or negative value. Expected a float."
+                f" Received: negative_slope={negative_slope}"
             )
         self.supports_masking = True
         self.negative_slope = negative_slope


### PR DESCRIPTION
The value of argument alpha should be a float >= `0` for `leaky_relu`. But if given negative value still there is no exception raised and providing incorrect output. Hence added validation code for same.

Please refer attached [gist](https://colab.sandbox.google.com/gist/SuryanarayanaY/5b19cc128a5b2f225cbe4d41a8591e56/leaky_relu_keras-nightly.ipynb) for the problem described.