### PR TITLE
Restore hacky workaround for tf dict wrapper errors

### DIFF
--- a/keras/models/model_test.py
+++ b/keras/models/model_test.py
@@ -286,6 +286,11 @@ class ModelTest(testing.TestCase, parameterized.TestCase):
                 "output_b": ["mean_squared_error", "accuracy"],
             },
         )
+        # Check dict outputs.
+        outputs = model.predict(x)
+        self.assertIsInstance(outputs, dict)
+        self.assertEqual(outputs["output_a"].shape, (8, 1))
+        self.assertEqual(outputs["output_b"].shape, (8, 1))
         # Fit the model to make sure compile_metrics are built
         hist = model.fit(
             x,
@@ -332,6 +337,11 @@ class ModelTest(testing.TestCase, parameterized.TestCase):
                 "output_b": ["mean_squared_error", "accuracy"],
             },
         )
+        # Check list outputs.
+        outputs = model.predict(x)
+        self.assertIsInstance(outputs, list)
+        self.assertEqual(outputs[0].shape, (8, 1))
+        self.assertEqual(outputs[1].shape, (8, 1))
         # Fit the model to make sure compile_metrics are built
         hist = model.fit(x, (y1, y2), batch_size=2, epochs=1, verbose=0)
         hist_keys = sorted(hist.history.keys())


### PR DESCRIPTION
In https://github.com/keras-team/keras/pull/18507 we removed a hacky workaround for functional models so dictionary output is not made a trackable.

We actually still need this when calling `predict` on a functional with dictionary output.

Added testing to plug the coverage gap. Still no idea what the status of the underlying bug is :/, filed with tensorflow

https://github.com/tensorflow/tensorflow/issues/62217