### PR TITLE
Improve dtype compatibility in `ops.numpy`

### DIFF
--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -354,6 +354,9 @@ def argmin(x, axis=None):
 
 
 def argsort(x, axis=-1):
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "bool":
+        x = tf.cast(x, "uint8")
     return tf.cast(tfnp.argsort(x, axis=axis), dtype="int32")
 
 

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -37,19 +37,31 @@ def subtract(x1, x2):
     x2 = convert_to_tensor(x2)
     # TODO: torch doesn't support bool substraction
     if standardize_dtype(x1.dtype) == "bool":
-        x1 = cast(x1, standardize_dtype(x2.dtype))
+        x1 = cast(x1, x2.dtype)
     if standardize_dtype(x2.dtype) == "bool":
-        x2 = cast(x2, standardize_dtype(x1.dtype))
+        x2 = cast(x2, x1.dtype)
     return torch.subtract(x1, x2)
 
 
 def matmul(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    dtype = dtypes.result_type(x1.dtype, x2.dtype)
-    x1 = cast(x1, dtype)
-    x2 = cast(x2, dtype)
-    return torch.matmul(x1, x2)
+    result_dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    compute_dtype = result_dtype
+
+    # TODO: torch.matmul doesn't support bool
+    if compute_dtype == "bool":
+        compute_dtype = config.floatx()
+    # TODO: torch.matmul doesn't support float16 when using cpu
+    if get_device() == "cpu" and compute_dtype == "float16":
+        compute_dtype = "float32"
+    # TODO: torch.matmul doesn't support integer types when using cuda
+    if get_device() == "cuda" and "int" in compute_dtype:
+        compute_dtype = config.floatx()
+
+    x1 = cast(x1, compute_dtype)
+    x2 = cast(x2, compute_dtype)
+    return cast(torch.matmul(x1, x2), result_dtype)
 
 
 def multiply(x1, x2):
@@ -259,16 +271,31 @@ def arctanh(x):
 
 def argmax(x, axis=None):
     x = convert_to_tensor(x)
+
+    # TODO: torch.argmax doesn't support bool
+    if standardize_dtype(x.dtype) == "bool":
+        x = cast(x, "uint8")
+
     return cast(torch.argmax(x, dim=axis), dtype="int32")
 
 
 def argmin(x, axis=None):
     x = convert_to_tensor(x)
+
+    # TODO: torch.argmin doesn't support bool
+    if standardize_dtype(x.dtype) == "bool":
+        x = cast(x, "uint8")
+
     return cast(torch.argmin(x, dim=axis), dtype="int32")
 
 
 def argsort(x, axis=-1):
     x = convert_to_tensor(x)
+
+    # TODO: torch.argsort doesn't support bool
+    if standardize_dtype(x.dtype) == "bool":
+        x = cast(x, "uint8")
+
     if axis is None:
         axis = -1
         x = x.reshape(-1)
@@ -333,10 +360,19 @@ def broadcast_to(x, shape):
 
 def ceil(x):
     x = convert_to_tensor(x)
-    if standardize_dtype(x.dtype) == "int64":
+    ori_dtype = standardize_dtype(x.dtype)
+
+    # TODO: torch.ceil doesn't support bool
+    if ori_dtype == "bool":
+        x = cast(x, "uint8")
+    # TODO: torch.ceil doesn't support float16 when using cpu
+    elif get_device() == "cpu" and ori_dtype == "float16":
+        x = cast(x, config.floatx())
+
+    if ori_dtype == "int64":
         dtype = config.floatx()
     else:
-        dtype = dtypes.result_type(x.dtype, float)
+        dtype = dtypes.result_type(ori_dtype, float)
     return cast(torch.ceil(x), dtype=dtype)
 
 
@@ -344,9 +380,13 @@ def clip(x, x_min, x_max):
     x = convert_to_tensor(x)
     x_min = convert_to_tensor(x_min)
     x_max = convert_to_tensor(x_max)
-    dtype = standardize_dtype(x.dtype)
-    if dtype == "bool":
-        dtype = "int64"
+    ori_dtype = standardize_dtype(x.dtype)
+
+    # TODO: torch.clip doesn't support float16 when using cpu
+    if get_device() == "cpu" and ori_dtype == "float16":
+        x = cast(x, "float32")
+
+    dtype = "int64" if ori_dtype == "bool" else ori_dtype
     return cast(torch.clip(x, min=x_min, max=x_max), dtype=dtype)
 
 
@@ -442,11 +482,18 @@ def dot(x, y):
     x = convert_to_tensor(x)
     y = convert_to_tensor(y)
     result_dtype = dtypes.result_type(x.dtype, y.dtype)
-    x = cast(x, result_dtype)
-    y = cast(y, result_dtype)
+    # GPU only supports float types
+    compute_dtype = dtypes.result_type(result_dtype, float)
+
+    # TODO: torch.matmul doesn't support float16 when using cpu
+    if get_device() == "cpu" and compute_dtype == "float16":
+        compute_dtype = "float32"
+
+    x = cast(x, compute_dtype)
+    y = cast(y, compute_dtype)
     if x.ndim == 0 or y.ndim == 0:
-        return torch.multiply(x, y)
-    return torch.matmul(x, y)
+        return cast(torch.multiply(x, y), result_dtype)
+    return cast(torch.matmul(x, y), result_dtype)
 
 
 def empty(shape, dtype=None):
@@ -528,6 +575,13 @@ def hstack(xs):
 
 def identity(n, dtype=None):
     dtype = to_torch_dtype(dtype or config.floatx())
+
+    # TODO: torch.eye doesn't support bfloat16 when using cpu
+    if get_device() == "cpu" and dtype == torch.bfloat16:
+        return cast(
+            torch.eye(n, dtype=to_torch_dtype("float32"), device=get_device()),
+            dtype,
+        )
     return torch.eye(n, dtype=dtype, device=get_device())
 
 
@@ -1205,6 +1259,14 @@ def eye(N, M=None, k=None, dtype=None):
     M = N if M is None else M
     k = 0 if k is None else k
     if k == 0:
+        # TODO: torch.eye doesn't support bfloat16 when using cpu
+        if get_device() == "cpu" and dtype == torch.bfloat16:
+            return cast(
+                torch.eye(
+                    N, M, dtype=to_torch_dtype("float32"), device=get_device()
+                ),
+                dtype,
+            )
         return torch.eye(N, M, dtype=dtype, device=get_device())
     diag_length = builtins.max(N, M)
     diag = torch.ones(diag_length, dtype=dtype, device=get_device())

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -35,7 +35,7 @@ def einsum(subscripts, *operands, **kwargs):
 def subtract(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    # TODO: torch doesn't support bool substraction
+    # TODO: torch.subtract doesn't support bool
     if standardize_dtype(x1.dtype) == "bool":
         x1 = cast(x1, x2.dtype)
     if standardize_dtype(x2.dtype) == "bool":

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -52,10 +52,10 @@ def matmul(x1, x2):
     # TODO: torch.matmul doesn't support bool
     if compute_dtype == "bool":
         compute_dtype = config.floatx()
-    # TODO: torch.matmul doesn't support float16 when using cpu
+    # TODO: torch.matmul doesn't support float16 with cpu
     if get_device() == "cpu" and compute_dtype == "float16":
         compute_dtype = "float32"
-    # TODO: torch.matmul doesn't support integer types when using cuda
+    # TODO: torch.matmul doesn't support integer types with cuda
     if get_device() == "cuda" and "int" in compute_dtype:
         compute_dtype = config.floatx()
 
@@ -365,7 +365,7 @@ def ceil(x):
     # TODO: torch.ceil doesn't support bool
     if ori_dtype == "bool":
         x = cast(x, "uint8")
-    # TODO: torch.ceil doesn't support float16 when using cpu
+    # TODO: torch.ceil doesn't support float16 with cpu
     elif get_device() == "cpu" and ori_dtype == "float16":
         x = cast(x, config.floatx())
 
@@ -382,7 +382,7 @@ def clip(x, x_min, x_max):
     x_max = convert_to_tensor(x_max)
     ori_dtype = standardize_dtype(x.dtype)
 
-    # TODO: torch.clip doesn't support float16 when using cpu
+    # TODO: torch.clip doesn't support float16 with cpu
     if get_device() == "cpu" and ori_dtype == "float16":
         x = cast(x, "float32")
 
@@ -485,7 +485,7 @@ def dot(x, y):
     # GPU only supports float types
     compute_dtype = dtypes.result_type(result_dtype, float)
 
-    # TODO: torch.matmul doesn't support float16 when using cpu
+    # TODO: torch.matmul doesn't support float16 with cpu
     if get_device() == "cpu" and compute_dtype == "float16":
         compute_dtype = "float32"
 
@@ -576,7 +576,7 @@ def hstack(xs):
 def identity(n, dtype=None):
     dtype = to_torch_dtype(dtype or config.floatx())
 
-    # TODO: torch.eye doesn't support bfloat16 when using cpu
+    # TODO: torch.eye doesn't support bfloat16 with cpu
     if get_device() == "cpu" and dtype == torch.bfloat16:
         return cast(
             torch.eye(n, dtype=to_torch_dtype("float32"), device=get_device()),
@@ -1259,7 +1259,7 @@ def eye(N, M=None, k=None, dtype=None):
     M = N if M is None else M
     k = 0 if k is None else k
     if k == 0:
-        # TODO: torch.eye doesn't support bfloat16 when using cpu
+        # TODO: torch.eye doesn't support bfloat16 with cpu
         if get_device() == "cpu" and dtype == torch.bfloat16:
             return cast(
                 torch.eye(

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4059,13 +4059,15 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         x2 = knp.ones((1,), dtype=dtype2)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.add(x1_jax, x2_jax).dtype)
+
         self.assertEqual(
             standardize_dtype(knp.add(x1, x2).dtype),
-            standardize_dtype(jnp.add(x1_jax, x2_jax).dtype),
+            expected_dtype,
         )
         self.assertEqual(
             standardize_dtype(knp.Add().symbolic_call(x1, x2).dtype),
-            standardize_dtype(jnp.add(x1_jax, x2_jax).dtype),
+            expected_dtype,
         )
 
     @parameterized.named_parameters(named_product(dtype=INT_DTYPES))
@@ -4146,6 +4148,7 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.subtract(x1_jax, x2_jax).dtype)
+
         self.assertEqual(
             standardize_dtype(knp.subtract(x1, x2).dtype), expected_dtype
         )
@@ -4159,23 +4162,12 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_matmul(self, dtype1, dtype2):
         import jax.numpy as jnp
 
-        if backend.backend() == "torch":
-            import torch
-
-            if dtype1 == "float16" or dtype2 == "float16":
-                self.skipTest("matmul does not support float16 in torch")
-            if dtype1 == "bool" and dtype2 == "bool":
-                self.skipTest("matmul does not support bool in torch")
-            if torch.cuda.is_available():
-                dtype = backend.result_type(dtype1, dtype2)
-                if "int" in dtype:
-                    self.skipTest(f"dot does not support {dtype} in torch gpu")
-
         x1 = knp.ones((1,), dtype=dtype1)
         x2 = knp.ones((1,), dtype=dtype2)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.matmul(x1_jax, x2_jax).dtype)
+
         self.assertEqual(
             standardize_dtype(knp.matmul(x1, x2).dtype), expected_dtype
         )
@@ -4194,6 +4186,7 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.multiply(x1_jax, x2_jax).dtype)
+
         self.assertEqual(
             standardize_dtype(knp.multiply(x1, x2).dtype), expected_dtype
         )
@@ -4210,6 +4203,7 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         expected_dtype = standardize_dtype(jnp.mean(x_jax).dtype)
         if dtype == "int64":
             expected_dtype = "float32"
+
         self.assertEqual(standardize_dtype(knp.mean(x).dtype), expected_dtype)
         self.assertEqual(knp.Mean().symbolic_call(x).dtype, expected_dtype)
 
@@ -4220,6 +4214,7 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         x = knp.ones((1,), dtype=dtype)
         x_jax = jnp.ones((1,), dtype=dtype)
         expected_dtype = standardize_dtype(jnp.max(x_jax).dtype)
+
         self.assertEqual(standardize_dtype(knp.max(x).dtype), expected_dtype)
         self.assertEqual(knp.Max().symbolic_call(x).dtype, expected_dtype)
 
@@ -4227,30 +4222,34 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_ones(self, dtype):
         import jax.numpy as jnp
 
+        expected_dtype = standardize_dtype(jnp.ones([2, 3], dtype=dtype).dtype)
+
         self.assertEqual(
             standardize_dtype(knp.ones([2, 3], dtype=dtype).dtype),
-            standardize_dtype(jnp.ones([2, 3], dtype=dtype).dtype),
+            expected_dtype,
         )
         self.assertEqual(
             standardize_dtype(
                 knp.Ones().symbolic_call([2, 3], dtype=dtype).dtype
             ),
-            standardize_dtype(jnp.ones([2, 3], dtype=dtype).dtype),
+            expected_dtype,
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_zeros(self, dtype):
         import jax.numpy as jnp
 
+        expected_dtype = standardize_dtype(jnp.zeros([2, 3], dtype=dtype).dtype)
+
         self.assertEqual(
             standardize_dtype(knp.zeros([2, 3], dtype=dtype).dtype),
-            standardize_dtype(jnp.zeros([2, 3], dtype=dtype).dtype),
+            expected_dtype,
         )
         self.assertEqual(
             standardize_dtype(
                 knp.Zeros().symbolic_call([2, 3], dtype=dtype).dtype
             ),
-            standardize_dtype(jnp.zeros([2, 3], dtype=dtype).dtype),
+            expected_dtype,
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
@@ -4260,6 +4259,7 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         x = knp.ones((1,), dtype=dtype)
         x_jax = jnp.ones((1,), dtype=dtype)
         expected_dtype = standardize_dtype(jnp.absolute(x_jax).dtype)
+
         self.assertEqual(
             standardize_dtype(knp.absolute(x).dtype), expected_dtype
         )
@@ -4272,13 +4272,10 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_argmax(self, dtype):
         import jax.numpy as jnp
 
-        if backend.backend() == "torch":
-            if dtype == "bool":
-                self.skipTest(f"argmax does not support {dtype} in torch")
-
         x = knp.array([[1, 2, 3], [3, 2, 1]], dtype=dtype)
         x_jax = jnp.array([[1, 2, 3], [3, 2, 1]], dtype=dtype)
         expected_dtype = standardize_dtype(jnp.argmax(x_jax).dtype)
+
         self.assertEqual(standardize_dtype(knp.argmax(x).dtype), expected_dtype)
         self.assertEqual(
             standardize_dtype(knp.Argmax().symbolic_call(x).dtype),
@@ -4289,13 +4286,10 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_argmin(self, dtype):
         import jax.numpy as jnp
 
-        if backend.backend() == "torch":
-            if dtype == "bool":
-                self.skipTest(f"argmin does not support {dtype} in torch")
-
         x = knp.array([[1, 2, 3], [3, 2, 1]], dtype=dtype)
         x_jax = jnp.array([[1, 2, 3], [3, 2, 1]], dtype=dtype)
         expected_dtype = standardize_dtype(jnp.argmin(x_jax).dtype)
+
         self.assertEqual(standardize_dtype(knp.argmin(x).dtype), expected_dtype)
         self.assertEqual(
             standardize_dtype(knp.Argmin().symbolic_call(x).dtype),
@@ -4306,22 +4300,10 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_argsort(self, dtype):
         import jax.numpy as jnp
 
-        if backend.backend() == "tensorflow":
-            if dtype == "bool":
-                self.skipTest(f"argsort does not support {dtype} in tensorflow")
-
-        if backend.backend() == "torch":
-            import torch
-
-            if torch.cuda.is_available():
-                if dtype in ["bool", "int64"]:
-                    self.skipTest(
-                        f"argsort does not support {dtype} in torch gpu"
-                    )
-
         x = knp.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
         x_jax = jnp.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
         expected_dtype = standardize_dtype(jnp.argsort(x_jax).dtype)
+
         self.assertEqual(
             standardize_dtype(knp.argsort(x).dtype), expected_dtype
         )
@@ -4343,38 +4325,33 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_arange(self, start, stop, step, dtype):
         import jax.numpy as jnp
 
+        expected_dtype = standardize_dtype(
+            jnp.arange(start, stop, step, dtype).dtype
+        )
+
         self.assertEqual(
             standardize_dtype(knp.arange(start, stop, step, dtype).dtype),
-            standardize_dtype(jnp.arange(start, stop, step, dtype).dtype),
+            expected_dtype,
         )
         self.assertEqual(
             standardize_dtype(
                 knp.Arange().symbolic_call(start, stop, step, dtype).dtype
             ),
-            standardize_dtype(jnp.arange(start, stop, step, dtype).dtype),
+            expected_dtype,
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_ceil(self, dtype):
         import jax.numpy as jnp
 
-        if backend.backend() == "torch":
-            import torch
-
-            if dtype is None:
-                # TODO: knp.array returns float32 instead of float64 when dtype
-                # is None in torch
-                dtype = "float64"
-            if not torch.cuda.is_available() and dtype == "float16":
-                self.skipTest(f"ceil does not support {dtype} in torch cpu")
-            if dtype == "bool":
-                self.skipTest(f"ceil does not support {dtype} in torch")
-
+        if dtype is None:
+            dtype = backend.floatx()
         x = knp.array([[1.2, 2.1, 2.5], [2.4, 11.9, 5.5]], dtype=dtype)
         x_jax = jnp.array([[1.2, 2.1, 2.5], [2.4, 11.9, 5.5]], dtype=dtype)
         expected_dtype = standardize_dtype(jnp.ceil(x_jax).dtype)
         if dtype == "int64":
             expected_dtype = backend.floatx()
+
         self.assertEqual(standardize_dtype(knp.ceil(x).dtype), expected_dtype)
         self.assertEqual(
             standardize_dtype(knp.Ceil().symbolic_call(x).dtype),
@@ -4385,15 +4362,10 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_clip(self, dtype):
         import jax.numpy as jnp
 
-        if backend.backend() == "torch":
-            import torch
-
-            if not torch.cuda.is_available() and dtype == "float16":
-                self.skipTest(f"clip does not support {dtype} in torch cpu")
-
         x = knp.ones((1,), dtype=dtype)
         x_jax = jnp.ones((1,), dtype=dtype)
         expected_dtype = standardize_dtype(jnp.clip(x_jax, -2, 2).dtype)
+
         self.assertEqual(
             standardize_dtype(knp.clip(x, -2, 2).dtype), expected_dtype
         )
@@ -4408,26 +4380,12 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_dot(self, dtype1, dtype2):
         import jax.numpy as jnp
 
-        if backend.backend() == "tensorflow":
-            if dtype1 == "bool" and dtype2 == "bool":
-                self.skipTest("dot does not support bool in tensorflow")
-        if backend.backend() == "torch":
-            import torch
-
-            if "float16" in [dtype1, dtype2]:
-                self.skipTest("dot does not support float16 in torch")
-            if dtype1 == "bool" and dtype2 == "bool":
-                self.skipTest("dot does not support bool in torch")
-            if torch.cuda.is_available():
-                dtype = backend.result_type(dtype1, dtype2)
-                if "int" in dtype:
-                    self.skipTest(f"dot does not support {dtype} in torch gpu")
-
         x1 = knp.ones((2, 3, 4), dtype=dtype1)
         x2 = knp.ones((4, 3), dtype=dtype2)
         x1_jax = jnp.ones((2, 3, 4), dtype=dtype1)
         x2_jax = jnp.ones((4, 3), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.dot(x1_jax, x2_jax).dtype)
+
         self.assertEqual(
             standardize_dtype(knp.dot(x1, x2).dtype), expected_dtype
         )
@@ -4437,15 +4395,17 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_empty(self, dtype):
         import jax.numpy as jnp
 
+        expected_dtype = standardize_dtype(jnp.empty([2, 3], dtype=dtype).dtype)
+
         self.assertEqual(
             standardize_dtype(knp.empty([2, 3], dtype=dtype).dtype),
-            standardize_dtype(jnp.empty([2, 3], dtype=dtype).dtype),
+            expected_dtype,
         )
         self.assertEqual(
             standardize_dtype(
                 knp.Empty().symbolic_call([2, 3], dtype=dtype).dtype
             ),
-            standardize_dtype(jnp.empty([2, 3], dtype=dtype).dtype),
+            expected_dtype,
         )
 
     @parameterized.named_parameters(
@@ -4564,21 +4524,17 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_identity(self, dtype):
         import jax.numpy as jnp
 
-        if backend.backend() == "torch":
-            if dtype == "bfloat16":
-                self.skipTest(
-                    "identity with dtype=bfloat16 is not supported for torch"
-                )
+        expected_dtype = standardize_dtype(jnp.identity(3, dtype=dtype).dtype)
 
         self.assertEqual(
             standardize_dtype(knp.identity(3, dtype=dtype).dtype),
-            standardize_dtype(jnp.identity(3, dtype=dtype).dtype),
+            expected_dtype,
         )
         self.assertEqual(
             standardize_dtype(
                 knp.Identity().symbolic_call(3, dtype=dtype).dtype
             ),
-            standardize_dtype(jnp.identity(3, dtype=dtype).dtype),
+            expected_dtype,
         )
 
     @parameterized.named_parameters(
@@ -4667,69 +4623,55 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_tri(self, dtype):
         import jax.numpy as jnp
 
-        if backend.backend() == "torch":
-            if dtype == "bfloat16":
-                self.skipTest(
-                    "tri with dtype=bfloat16 is not supported for torch"
-                )
+        expected_dtype = standardize_dtype(jnp.tri(3, dtype=dtype).dtype)
 
         self.assertEqual(
             standardize_dtype(knp.tri(3, dtype=dtype).dtype),
-            standardize_dtype(jnp.tri(3, dtype=dtype).dtype),
+            expected_dtype,
         )
         self.assertEqual(
             standardize_dtype(knp.Tri().symbolic_call(3, dtype=dtype).dtype),
-            standardize_dtype(jnp.tri(3, dtype=dtype).dtype),
+            expected_dtype,
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_sqrt(self, dtype):
         import jax.numpy as jnp
 
-        if backend.backend() == "torch":
-            if dtype == "float16":
-                self.skipTest(
-                    "sqrt with dtype=float16 is not supported for torch"
-                )
-
         x1 = knp.ones((1,), dtype=dtype)
         x1_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.sqrt(x1_jax).dtype)
 
-        self.assertEqual(
-            standardize_dtype(knp.sqrt(x1).dtype),
-            standardize_dtype(jnp.sqrt(x1_jax).dtype),
-        )
+        self.assertEqual(standardize_dtype(knp.sqrt(x1).dtype), expected_dtype)
         self.assertEqual(
             standardize_dtype(knp.Sqrt().symbolic_call(x1).dtype),
-            standardize_dtype(jnp.sqrt(x1_jax).dtype),
+            expected_dtype,
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_eye(self, dtype):
         import jax.numpy as jnp
 
-        if backend.backend() == "torch":
-            if dtype == "bfloat16":
-                self.skipTest(
-                    "eye with dtype=bfloat16 is not supported for torch"
-                )
+        expected_dtype = standardize_dtype(jnp.eye(3, dtype=dtype).dtype)
 
         self.assertEqual(
             standardize_dtype(knp.eye(3, dtype=dtype).dtype),
-            standardize_dtype(jnp.eye(3, dtype=dtype).dtype),
+            expected_dtype,
         )
         self.assertEqual(
             standardize_dtype(knp.Eye().symbolic_call(3, dtype=dtype).dtype),
-            standardize_dtype(jnp.eye(3, dtype=dtype).dtype),
+            expected_dtype,
         )
+
+        expected_dtype = standardize_dtype(jnp.eye(3, 4, 1, dtype=dtype).dtype)
 
         self.assertEqual(
             standardize_dtype(knp.eye(3, 4, 1, dtype=dtype).dtype),
-            standardize_dtype(jnp.eye(3, 4, 1, dtype=dtype).dtype),
+            expected_dtype,
         )
         self.assertEqual(
             standardize_dtype(
                 knp.Eye().symbolic_call(3, 4, 1, dtype=dtype).dtype
             ),
-            standardize_dtype(jnp.eye(3, 4, 1, dtype=dtype).dtype),
+            expected_dtype,
         )

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4141,7 +4141,7 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         import jax.numpy as jnp
 
         if dtype1 == "bool" and dtype2 == "bool":
-            self.skipTest("subtract does not support bool substraction")
+            self.skipTest("subtract does not support bool")
 
         x1 = knp.ones((1,), dtype=dtype1)
         x2 = knp.ones((1,), dtype=dtype2)


### PR DESCRIPTION
The dtype promotion and compatibility rules might be as follows:
- Match the dtype inference from JAX.
- When an integer input becomes a floating-point output, use `backend.floatx()` for the best attempt.
- Make the best effort to support all dtypes for all operators in all backends (although this might introduce some overhead for checking).

This PR primarily enhances dtype compatibility for torch both with cpu and cuda.

The initial `skipTest` in dtype unit tests have been nearly eliminated.
