### PR TITLE
validate l1,l2 values in regularizers

### DIFF
--- a/keras/regularizers/regularizers.py
+++ b/keras/regularizers/regularizers.py
@@ -340,11 +340,13 @@ class OrthogonalRegularizer(Regularizer):
 
 def validate_float_arg(value, name):
     """check penalty number availability, raise ValueError if failed."""
-    if not isinstance(value, (float, int)) or (
-        math.isinf(value) or math.isnan(value)
+    if (
+        not isinstance(value, (float, int))
+        or (math.isinf(value) or math.isnan(value))
+        or value < 0
     ):
         raise ValueError(
-            f"Invalid value for argument {name}: expected a float. "
+            f"Invalid value for argument {name}: expected a non-negative float. "
             f"Received: {name}={value}"
         )
     return float(value)


### PR DESCRIPTION
The API `keras.layers.ActivityRegularization` has arguments regularisation factors `l1`, `l2` which should take positive float values.But currently even if we pass negative values there is no exception raised due lack of validation. 

Hence proposing this fix to validate the `l1`,`l2` values and should raise exception if any of them is a negative value.

