### PR TITLE
Add support for Tensorflow SparseTensors: optimizers.

### DIFF
--- a/keras/backend/tensorflow/optimizer_sparse_test.py
+++ b/keras/backend/tensorflow/optimizer_sparse_test.py
@@ -1,0 +1,223 @@
+from unittest import mock
+
+import pytest
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras import backend
+from keras import optimizers
+from keras import testing
+
+TEST_CASES = [
+    {
+        "testcase_name": "adadelta",
+        "optimizer_class": optimizers.Adadelta,
+        "expect_model_sparse_variable_updates": True,
+    },
+    {
+        "testcase_name": "adafactor",
+        "optimizer_class": optimizers.Adafactor,
+        "init_kwargs": {"clip_threshold": 0.5},
+        "expect_model_sparse_variable_updates": True,
+    },
+    {
+        "testcase_name": "adagrad",
+        "optimizer_class": optimizers.Adagrad,
+        "expect_model_sparse_variable_updates": True,
+        "expect_optimizer_sparse_variable_updates": True,
+    },
+    {
+        "testcase_name": "adam",
+        "optimizer_class": optimizers.Adam,
+    },
+    {
+        "testcase_name": "adam_amsgrad",
+        "optimizer_class": optimizers.Adam,
+        "init_kwargs": {"amsgrad": True},
+    },
+    {
+        "testcase_name": "adamax",
+        "optimizer_class": optimizers.Adamax,
+    },
+    {
+        "testcase_name": "adamw",
+        "optimizer_class": optimizers.AdamW,
+    },
+    {
+        "testcase_name": "adamw_amsgrad",
+        "optimizer_class": optimizers.AdamW,
+        "init_kwargs": {"amsgrad": True},
+    },
+    {
+        "testcase_name": "ftrl",
+        "optimizer_class": optimizers.Ftrl,
+    },
+    {
+        "testcase_name": "lion",
+        "optimizer_class": optimizers.Lion,
+    },
+    {
+        "testcase_name": "loss_scale_optimizer_sgd",
+        "optimizer_class": lambda: optimizers.LossScaleOptimizer(
+            optimizers.SGD(learning_rate=0.5)
+        ),
+        "expect_model_sparse_variable_updates": True,
+    },
+    {
+        "testcase_name": "nadam",
+        "optimizer_class": optimizers.Nadam,
+    },
+    {
+        "testcase_name": "rmsprop",
+        "optimizer_class": optimizers.RMSprop,
+        "expect_model_sparse_variable_updates": True,
+    },
+    {
+        "testcase_name": "rmsprop_momentum",
+        "optimizer_class": optimizers.RMSprop,
+        "init_kwargs": {"momentum": 0.05},
+    },
+    {
+        "testcase_name": "rmsprop_momentum_centered",
+        "optimizer_class": optimizers.RMSprop,
+        "init_kwargs": {"momentum": 0.05, "centered": True},
+    },
+    {
+        "testcase_name": "sgd",
+        "optimizer_class": optimizers.SGD,
+        "expect_model_sparse_variable_updates": True,
+    },
+    {
+        "testcase_name": "sgd_momentum",
+        "optimizer_class": optimizers.SGD,
+        "init_kwargs": {"momentum": 0.05},
+    },
+    {
+        "testcase_name": "sgd_momentum_nesterov",
+        "optimizer_class": optimizers.SGD,
+        "init_kwargs": {"momentum": 0.05, "nesterov": True},
+    },
+]
+
+
+@pytest.mark.skipif(
+    backend.backend() != "tensorflow",
+    reason="The TensorFlow sparse test can only run with TensorFlow backend.",
+)
+class OptimizerSparseTest(testing.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(TEST_CASES)
+    def test_sparse_gradients(
+        self,
+        optimizer_class,
+        init_kwargs={},
+        expect_model_sparse_variable_updates=False,
+        expect_optimizer_sparse_variable_updates=False,
+    ):
+        # This test verifies that:
+        # - Optimizers use Keras ops everywhere instead of native operators
+        #   (e.g. `ops.add()` instead of `+`) where sparse gradients are handled
+        # - The used ops handle sparse gradients (`tf.IndexedSlices`)
+        # - Optimizers use `self.assign/assign_add/assign_sub` instead of
+        #   calling the method on the variable directly. Otherwise, the sparse
+        #   updates are densified before being applied.
+        # - For some optimizers, a sparse gradient actually results in a sparse
+        #   variable update as per `expect_model_sparse_variable_updates` and
+        #   `expect_optimizer_sparse_variable_updates`
+
+        model_variable = backend.Variable(initializer=tf.ones, shape=(5, 10))
+        optimizer = optimizer_class(**init_kwargs)
+
+        # Mocking "tensorflow.Variable" won't work as it gets substituted with
+        # the resource variable class.
+        tf_variable_class = model_variable._value.__class__
+
+        optimizer_to_patch = (
+            optimizer.inner_optimizer
+            if isinstance(optimizer, optimizers.LossScaleOptimizer)
+            else optimizer
+        )
+
+        model_sparse_variable_updates = False
+        optimizer_sparse_variable_updates = False
+
+        def mock_optimizer_assign(variable, value):
+            nonlocal model_sparse_variable_updates
+            nonlocal optimizer_sparse_variable_updates
+            if isinstance(variable, backend.Variable):
+                variable = variable._value
+            if isinstance(value, tf.IndexedSlices):
+                if variable is model_variable._value:
+                    model_sparse_variable_updates = True
+                elif any(variable is v._value for v in optimizer.variables):
+                    optimizer_sparse_variable_updates = True
+
+        def mock_variable_assign(variable, value):
+            # Make an exception for scalar variables
+            if len(variable.shape):
+                pytest.fail(
+                    "Optimizer is calling `assign`, `assign_add` or "
+                    "`assign_sub` directly on a variable. Use "
+                    "`self.assign/assign_add/assign_sub(variable, value)` "
+                    "instead to support sparse updates."
+                )
+
+        # patch "_apply_weight_decay" to exclude this special case.
+        # patch the optimizer "assign" methods to detect sparse udpates.
+        # patch the tf.Variable "assign" methods to detect direct assign calls.
+        with mock.patch.object(
+            optimizer_to_patch, "_apply_weight_decay", autospec=True
+        ), mock.patch.object(
+            optimizer_to_patch, "assign", autospec=True
+        ) as optimizer_assign, mock.patch.object(
+            optimizer_to_patch, "assign_add", autospec=True
+        ) as optimizer_assign_add, mock.patch.object(
+            optimizer_to_patch, "assign_sub", autospec=True
+        ) as optimizer_assign_sub, mock.patch.object(
+            tf_variable_class, "assign", autospec=True
+        ) as variable_assign, mock.patch.object(
+            tf_variable_class, "assign_add", autospec=True
+        ) as variable_assign_add, mock.patch.object(
+            tf_variable_class, "assign_sub", autospec=True
+        ) as variable_assign_sub:
+            optimizer_assign.side_effect = mock_optimizer_assign
+            optimizer_assign_add.side_effect = mock_optimizer_assign
+            optimizer_assign_sub.side_effect = mock_optimizer_assign
+            variable_assign.side_effect = mock_variable_assign
+            variable_assign_add.side_effect = mock_variable_assign
+            variable_assign_sub.side_effect = mock_variable_assign
+
+            grad = tf.IndexedSlices(
+                values=tf.ones((3, 10)), indices=(0, 2, 4), dense_shape=(5, 10)
+            )
+            optimizer.apply_gradients(zip([grad], [model_variable]))
+
+        self.assertEqual(
+            model_sparse_variable_updates, expect_model_sparse_variable_updates
+        )
+        self.assertEqual(
+            optimizer_sparse_variable_updates,
+            expect_optimizer_sparse_variable_updates,
+        )
+
+    @parameterized.named_parameters(TEST_CASES)
+    def test_sparse_correctness(
+        self, optimizer_class, init_kwargs={}, **kwargs
+    ):
+        # This test verifies that applying a sparse gradient gives the same
+        # numerical results as the same dense gradient.
+
+        optimizer_sparse = optimizer_class(**init_kwargs)
+        optimizer_dense = optimizer_class(**init_kwargs)
+        var_sparse = backend.Variable(initializer=tf.ones, shape=(5, 3, 2))
+        var_dense = backend.Variable(initializer=tf.ones, shape=(5, 3, 2))
+
+        for i in range(5):
+            grads_sparse = tf.IndexedSlices(
+                values=tf.ones((3, 3, 2)) * (10.0 - i),
+                indices=(0, 2, 4),
+                dense_shape=(5, 3, 2),
+            )
+            grads_dense = tf.convert_to_tensor(grads_sparse)
+            optimizer_sparse.apply_gradients(zip([grads_sparse], [var_sparse]))
+            optimizer_dense.apply_gradients(zip([grads_dense], [var_dense]))
+            self.assertAllClose(var_sparse, var_dense)

--- a/keras/optimizers/adafactor.py
+++ b/keras/optimizers/adafactor.py
@@ -147,35 +147,43 @@ class Adafactor(optimizer.Optimizer):
 
         rho_t = ops.minimum(lr, 1 / ops.sqrt(local_step))
         alpha_t = ops.maximum(epsilon_2, self._rms(variable)) * rho_t
-        regulated_grad_square = ops.square(gradient) + self.epsilon_1
+        regulated_grad_square = ops.add(ops.square(gradient), self.epsilon_1)
         beta_2_t = 1 - ops.power(local_step, self.beta_2_decay)
 
         if len(variable.shape) >= 2:
             # `r` deletes the last dimension of gradient, so it is of shape
             # `gradient.shape[:-1]`.
-            r.assign(
+            self.assign(
+                r,
                 beta_2_t * r
-                + (1 - beta_2_t) * ops.mean(regulated_grad_square, axis=-1)
+                + (1 - beta_2_t) * ops.mean(regulated_grad_square, axis=-1),
             )
             # `c` deletes the second last dimension of gradient, so it is of
             # shape `gradient.shape[:-2] + gradient.shape[-1]`.
-            c.assign(
+            self.assign(
+                c,
                 beta_2_t * c
-                + (1 - beta_2_t) * ops.mean(regulated_grad_square, axis=-2)
+                + (1 - beta_2_t) * ops.mean(regulated_grad_square, axis=-2),
             )
-            v.assign(
+            self.assign(
+                v,
                 ops.expand_dims(
                     r / ops.mean(r, axis=-1, keepdims=True), axis=-1
                 )
-                * ops.expand_dims(c, -2)
+                * ops.expand_dims(c, -2),
             )
         else:
-            v.assign(beta_2_t * v + (1 - beta_2_t) * regulated_grad_square)
+            self.assign(
+                v, beta_2_t * v + (1 - beta_2_t) * regulated_grad_square
+            )
 
         # `convert_to_tensor` unifies the handling of sparse and dense grads.
-        u_t = gradient / ops.sqrt(v)
-        u_t_hat = u_t / ops.maximum(one, (self._rms(u_t) / self.clip_threshold))
-        variable.assign(variable - alpha_t * u_t_hat)
+        u_t = ops.divide(gradient, ops.sqrt(v))
+        u_t_hat = ops.divide(
+            u_t,
+            ops.maximum(one, ops.divide(self._rms(u_t), self.clip_threshold)),
+        )
+        self.assign_sub(variable, ops.multiply(alpha_t, u_t_hat))
 
     def get_config(self):
         config = super().get_config()

--- a/keras/optimizers/adagrad.py
+++ b/keras/optimizers/adagrad.py
@@ -85,9 +85,13 @@ class Adagrad(optimizer.Optimizer):
 
         accumulator = self._accumulators[self._get_variable_index(variable)]
 
-        accumulator.assign(accumulator + gradient * gradient)
-        variable.assign(
-            variable - (lr * gradient / ops.sqrt(accumulator + self.epsilon))
+        self.assign_add(accumulator, ops.square(gradient))
+        self.assign_sub(
+            variable,
+            ops.divide(
+                ops.multiply(lr, gradient),
+                ops.sqrt(ops.add(accumulator, self.epsilon)),
+            ),
         )
 
     def get_config(self):

--- a/keras/optimizers/adam.py
+++ b/keras/optimizers/adam.py
@@ -125,13 +125,25 @@ class Adam(optimizer.Optimizer):
 
         alpha = lr * ops.sqrt(1 - beta_2_power) / (1 - beta_1_power)
 
-        m.assign(m + (gradient - m) * (1 - self.beta_1))
-        v.assign(v + (ops.square(gradient) - v) * (1 - self.beta_2))
+        self.assign_add(
+            m, ops.multiply(ops.subtract(gradient, m), 1 - self.beta_1)
+        )
+        self.assign_add(
+            v,
+            ops.multiply(
+                ops.subtract(ops.square(gradient), v), 1 - self.beta_2
+            ),
+        )
         if self.amsgrad:
             v_hat = self._velocity_hats[self._get_variable_index(variable)]
-            v_hat.assign(ops.maximum(v_hat, v))
+            self.assign(v_hat, ops.maximum(v_hat, v))
             v = v_hat
-        variable.assign(variable - (m * alpha) / (ops.sqrt(v) + self.epsilon))
+        self.assign_sub(
+            variable,
+            ops.divide(
+                ops.multiply(m, alpha), ops.add(ops.sqrt(v), self.epsilon)
+            ),
+        )
 
     def get_config(self):
         config = super().get_config()

--- a/keras/optimizers/adamax.py
+++ b/keras/optimizers/adamax.py
@@ -120,10 +120,18 @@ class Adamax(optimizer.Optimizer):
         m = self._m[self._get_variable_index(variable)]
         u = self._u[self._get_variable_index(variable)]
 
-        m.assign(m + (gradient - m) * (1 - self.beta_1))
-        u.assign(ops.maximum(self.beta_2 * u, ops.abs(gradient)))
-        variable.assign(
-            variable - (lr * m) / ((1 - beta_1_power) * (u + self.epsilon))
+        self.assign_add(
+            m, ops.multiply(ops.subtract(gradient, m), (1 - self.beta_1))
+        )
+        self.assign(
+            u, ops.maximum(ops.multiply(self.beta_2, u), ops.abs(gradient))
+        )
+        self.assign_sub(
+            variable,
+            ops.divide(
+                ops.multiply(lr, m),
+                ops.multiply((1 - beta_1_power), ops.add(u, self.epsilon)),
+            ),
         )
 
     def get_config(self):

--- a/keras/optimizers/base_optimizer.py
+++ b/keras/optimizers/base_optimizer.py
@@ -154,7 +154,7 @@ class BaseOptimizer:
     def add_variable(
         self,
         shape,
-        initializer,
+        initializer="zeros",
         dtype=None,
         name=None,
     ):
@@ -197,6 +197,48 @@ class BaseOptimizer:
                     "When working with a new set of variables, you should "
                     "recreate a new optimizer instance."
                 )
+
+    def assign(self, variable, value):
+        """Assign a value to a variable.
+
+        This should be used in optimizers instead of `variable.assign(value)` to
+        support backend specific optimizations.
+        Note that the variable can be a model variable or an optimizer variable;
+        it can be a backend native variable or a Keras variable.
+
+        Args:
+            variable: The variable to update.
+            value: The value to add to the variable.
+        """
+        variable.assign(value)
+
+    def assign_add(self, variable, value):
+        """Add a value to a variable.
+
+        This should be used in optimizers instead of
+        `variable.assign_add(value)` to support backend specific optimizations.
+        Note that the variable can be a model variable or an optimizer variable;
+        it can be a backend native variable or a Keras variable.
+
+        Args:
+            variable: The variable to update.
+            value: The value to add to the variable.
+        """
+        variable.assign_add(value)
+
+    def assign_sub(self, variable, value):
+        """Subtract a value from a variable.
+
+        This should be used in optimizers instead of
+        `variable.assign_sub(value)` to support backend specific optimizations.
+        Note that the variable can be a model variable or an optimizer variable;
+        it can be a backend native variable or a Keras variable.
+
+        Args:
+            variable: The variable to update.
+            value: The value to add to the variable.
+        """
+        variable.assign_sub(value)
 
     def update_step(self, gradient, variable, learning_rate):
         raise NotImplementedError

--- a/keras/optimizers/lion.py
+++ b/keras/optimizers/lion.py
@@ -103,11 +103,24 @@ class Lion(optimizer.Optimizer):
         beta_2 = ops.cast(self.beta_2, variable.dtype)
         m = self._momentums[self._get_variable_index(variable)]
 
-        # TODO: currently only support dense gradients
-        variable.assign_sub(
-            lr * ops.sign(m * beta_1 + gradient * (1.0 - beta_1))
+        self.assign_sub(
+            variable,
+            ops.multiply(
+                lr,
+                ops.sign(
+                    ops.add(
+                        ops.multiply(m, beta_1),
+                        ops.multiply(gradient, (1.0 - beta_1)),
+                    )
+                ),
+            ),
         )
-        m.assign(m * beta_2 + gradient * (1.0 - beta_2))
+        self.assign(
+            m,
+            ops.add(
+                ops.multiply(m, beta_2), ops.multiply(gradient, (1.0 - beta_2))
+            ),
+        )
 
     def get_config(self):
         config = super().get_config()

--- a/keras/optimizers/sgd.py
+++ b/keras/optimizers/sgd.py
@@ -103,15 +103,25 @@ class SGD(optimizer.Optimizer):
 
         if m is not None:
             momentum = ops.cast(self.momentum, variable.dtype)
-            m.assign(-gradient * learning_rate + m * momentum)
+            self.assign(
+                m,
+                ops.subtract(
+                    ops.multiply(m, momentum),
+                    ops.multiply(gradient, learning_rate),
+                ),
+            )
             if self.nesterov:
-                variable.assign(
-                    variable - gradient * learning_rate + m * momentum
+                self.assign_add(
+                    variable,
+                    ops.subtract(
+                        ops.multiply(m, momentum),
+                        ops.multiply(gradient, learning_rate),
+                    ),
                 )
             else:
-                variable.assign(variable + m)
+                self.assign_add(variable, m)
         else:
-            variable.assign(variable - gradient * learning_rate)
+            self.assign_sub(variable, ops.multiply(gradient, learning_rate))
 
     def get_config(self):
         config = super().get_config()


### PR DESCRIPTION
All optimizers now handle sparse gradients in the form of `tf.IndexedSlices`. Where applicable, this results in partial updates of variables using `scatter_add`/`scatter_sub`.

This was done by performing the following changes in optimizers code:
- replacing all negative operations (e.g. `+`) with the equivalent Keras op (e.g. `ops.add`). Note that an exception was made for scalars.
- replacing `variable.assign/assign_add/assign_sub` with `self.assign/assign_add/assign_sub`.