### PR TITLE
Apply `backend.result_type` to `linspace`, `logspace` and `log*`

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -415,6 +415,9 @@ def log2(x):
 def logaddexp(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    x1 = cast(x1, dtype)
+    x2 = cast(x2, dtype)
     return jnp.logaddexp(x1, x2)
 
 
@@ -693,6 +696,9 @@ def square(x):
 
 
 def sqrt(x):
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "int64":
+        x = cast(x, config.floatx())
     return jnp.sqrt(x)
 
 

--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -385,18 +385,30 @@ def linspace(
 
 
 def log(x):
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "int64":
+        x = cast(x, config.floatx())
     return jnp.log(x)
 
 
 def log10(x):
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "int64":
+        x = cast(x, config.floatx())
     return jnp.log10(x)
 
 
 def log1p(x):
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "int64":
+        x = cast(x, config.floatx())
     return jnp.log1p(x)
 
 
 def log2(x):
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "int64":
+        x = cast(x, config.floatx())
     return jnp.log2(x)
 
 

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -393,6 +393,13 @@ def linspace(
     start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0
 ):
     axis = tuple(axis) if isinstance(axis, list) else axis
+    if dtype is None:
+        dtypes_to_resolve = [
+            getattr(start, "dtype", type(start)),
+            getattr(stop, "dtype", type(stop)),
+            float,
+        ]
+        dtype = dtypes.result_type(*dtypes_to_resolve)
     return np.linspace(
         start,
         stop,
@@ -405,18 +412,46 @@ def linspace(
 
 
 def log(x):
+    x = convert_to_tensor(x)
+    dtype = (
+        config.floatx()
+        if standardize_dtype(x.dtype) == "int64"
+        else dtypes.result_type(x.dtype, float)
+    )
+    x = x.astype(dtype)
     return np.log(x)
 
 
 def log10(x):
+    x = convert_to_tensor(x)
+    dtype = (
+        config.floatx()
+        if standardize_dtype(x.dtype) == "int64"
+        else dtypes.result_type(x.dtype, float)
+    )
+    x = x.astype(dtype)
     return np.log10(x)
 
 
 def log1p(x):
+    x = convert_to_tensor(x)
+    dtype = (
+        config.floatx()
+        if standardize_dtype(x.dtype) == "int64"
+        else dtypes.result_type(x.dtype, float)
+    )
+    x = x.astype(dtype)
     return np.log1p(x)
 
 
 def log2(x):
+    x = convert_to_tensor(x)
+    dtype = (
+        config.floatx()
+        if standardize_dtype(x.dtype) == "int64"
+        else dtypes.result_type(x.dtype, float)
+    )
+    x = x.astype(dtype)
     return np.log2(x)
 
 
@@ -437,6 +472,13 @@ def logical_or(x1, x2):
 
 
 def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
+    if dtype is None:
+        dtypes_to_resolve = [
+            getattr(start, "dtype", type(start)),
+            getattr(stop, "dtype", type(stop)),
+            float,
+        ]
+        dtype = dtypes.result_type(*dtypes_to_resolve)
     return np.logspace(
         start,
         stop,

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -418,8 +418,7 @@ def log(x):
         if standardize_dtype(x.dtype) == "int64"
         else dtypes.result_type(x.dtype, float)
     )
-    x = x.astype(dtype)
-    return np.log(x)
+    return np.log(x, dtype=dtype)
 
 
 def log10(x):
@@ -429,8 +428,7 @@ def log10(x):
         if standardize_dtype(x.dtype) == "int64"
         else dtypes.result_type(x.dtype, float)
     )
-    x = x.astype(dtype)
-    return np.log10(x)
+    return np.log10(x, dtype=dtype)
 
 
 def log1p(x):
@@ -440,8 +438,7 @@ def log1p(x):
         if standardize_dtype(x.dtype) == "int64"
         else dtypes.result_type(x.dtype, float)
     )
-    x = x.astype(dtype)
-    return np.log1p(x)
+    return np.log1p(x, dtype=dtype)
 
 
 def log2(x):
@@ -451,11 +448,15 @@ def log2(x):
         if standardize_dtype(x.dtype) == "int64"
         else dtypes.result_type(x.dtype, float)
     )
-    x = x.astype(dtype)
-    return np.log2(x)
+    return np.log2(x, dtype=dtype)
 
 
 def logaddexp(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    x1 = x1.astype(dtype)
+    x2 = x2.astype(dtype)
     return np.logaddexp(x1, x2)
 
 
@@ -727,7 +728,7 @@ def sqrt(x):
     x = convert_to_tensor(x)
     # upcast to float64 for int64 which matches JAX's behavior
     dtype = (
-        "float64"
+        config.floatx()
         if standardize_dtype(x.dtype) == "int64"
         else dtypes.result_type(x.dtype, float)
     )

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -702,7 +702,7 @@ def log(x):
         else dtypes.result_type(x.dtype, float)
     )
     x = tf.cast(x, dtype)
-    # TODO: tfnp.log doesn't support bfloat16
+    # TODO: tfnp.log incorrectly promote bfloat16 to float64
     return tf.cast(tfnp.log(x), dtype)
 
 
@@ -715,7 +715,7 @@ def log10(x):
         else dtypes.result_type(x.dtype, float)
     )
     x = tf.cast(x, dtype)
-    # TODO: tfnp.log10 doesn't support bfloat16
+    # TODO: tfnp.log10 incorrectly promote bfloat16 to float64
     return tf.cast(tfnp.log10(x), dtype)
 
 
@@ -728,7 +728,7 @@ def log1p(x):
         else dtypes.result_type(x.dtype, float)
     )
     x = tf.cast(x, dtype)
-    # TODO: tfnp.log1p doesn't support bfloat16
+    # TODO: tfnp.log1p incorrectly promote bfloat16 to float64
     return tf.cast(tfnp.log1p(x), dtype)
 
 
@@ -741,12 +741,18 @@ def log2(x):
         else dtypes.result_type(x.dtype, float)
     )
     x = tf.cast(x, dtype)
-    # TODO: tfnp.log10 doesn't support bfloat16
+    # TODO: tfnp.log10 incorrectly promote bfloat16 to float64
     return tf.cast(tfnp.log2(x), dtype)
 
 
 def logaddexp(x1, x2):
-    return tfnp.logaddexp(x1, x2)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    x1 = tf.cast(x1, dtype)
+    x2 = tf.cast(x2, dtype)
+    # TODO: tfnp.logaddexp incorrectly promote bfloat16 to float64
+    return tf.cast(tfnp.logaddexp(x1, x2), dtype)
 
 
 def logical_and(x1, x2):
@@ -1189,14 +1195,13 @@ def sqrt(x):
     x = convert_to_tensor(x)
     # upcast to float64 for int64 which matches JAX's behavior
     dtype = (
-        "float64"
+        config.floatx()
         if standardize_dtype(x.dtype) == "int64"
         else dtypes.result_type(x.dtype, float)
     )
     x = tf.cast(x, dtype)
-    # TODO: Use tfnp.sqrt. Currently, tfnp.sqrt will aggressively upcast to
-    # float64 if the input is bfloat16. This behavior mismatches with JAX.
-    return tf.sqrt(x)
+    # TODO: tfnp.sqrt incorrectly promote bfloat16 to float64
+    return tf.cast(tfnp.sqrt(x), dtype)
 
 
 def squeeze(x, axis=None):

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -675,6 +675,13 @@ def less_equal(x1, x2):
 def linspace(
     start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0
 ):
+    if dtype is None:
+        dtypes_to_resolve = [
+            getattr(start, "dtype", type(start)),
+            getattr(stop, "dtype", type(stop)),
+            float,
+        ]
+        dtype = dtypes.result_type(*dtypes_to_resolve)
     return tfnp.linspace(
         start,
         stop,
@@ -688,22 +695,54 @@ def linspace(
 
 @sparse.densifying_unary(-tfnp.inf)
 def log(x):
-    return tfnp.log(x)
+    x = convert_to_tensor(x)
+    dtype = (
+        config.floatx()
+        if standardize_dtype(x.dtype) == "int64"
+        else dtypes.result_type(x.dtype, float)
+    )
+    x = tf.cast(x, dtype)
+    # TODO: tfnp.log doesn't support bfloat16
+    return tf.cast(tfnp.log(x), dtype)
 
 
 @sparse.densifying_unary(-tfnp.inf)
 def log10(x):
-    return tfnp.log10(x)
+    x = convert_to_tensor(x)
+    dtype = (
+        config.floatx()
+        if standardize_dtype(x.dtype) == "int64"
+        else dtypes.result_type(x.dtype, float)
+    )
+    x = tf.cast(x, dtype)
+    # TODO: tfnp.log10 doesn't support bfloat16
+    return tf.cast(tfnp.log10(x), dtype)
 
 
 @sparse.elementwise_unary
 def log1p(x):
-    return tfnp.log1p(x)
+    x = convert_to_tensor(x)
+    dtype = (
+        config.floatx()
+        if standardize_dtype(x.dtype) == "int64"
+        else dtypes.result_type(x.dtype, float)
+    )
+    x = tf.cast(x, dtype)
+    # TODO: tfnp.log1p doesn't support bfloat16
+    return tf.cast(tfnp.log1p(x), dtype)
 
 
 @sparse.densifying_unary(-tfnp.inf)
 def log2(x):
-    return tfnp.log2(x)
+    x = convert_to_tensor(x)
+    dtype = (
+        config.floatx()
+        if standardize_dtype(x.dtype) == "int64"
+        else dtypes.result_type(x.dtype, float)
+    )
+    x = tf.cast(x, dtype)
+    # TODO: tfnp.log10 doesn't support bfloat16
+    return tf.cast(tfnp.log2(x), dtype)
 
 
 def logaddexp(x1, x2):
@@ -723,6 +762,15 @@ def logical_or(x1, x2):
 
 
 def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
+    if dtype is None:
+        dtypes_to_resolve = [
+            getattr(start, "dtype", type(start)),
+            getattr(stop, "dtype", type(stop)),
+            float,
+        ]
+        dtype = dtypes.result_type(*dtypes_to_resolve)
+    start = tf.cast(start, dtype)
+    stop = tf.cast(stop, dtype)
     return tfnp.logspace(
         start,
         stop,

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -694,9 +694,16 @@ def logaddexp(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
     dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
-    x1 = cast(x1, dtype)
-    x2 = cast(x2, dtype)
-    return torch.logaddexp(x1, x2)
+
+    # TODO: torch.logaddexp doesn't support float16 with cpu
+    if get_device() == "cpu" and dtype == "float16":
+        x1 = cast(x1, "float32")
+        x2 = cast(x2, "float32")
+        return cast(torch.logaddexp(x1, x2), dtype)
+    else:
+        x1 = cast(x1, dtype)
+        x2 = cast(x2, dtype)
+        return torch.logaddexp(x1, x2)
 
 
 def logical_and(x1, x2):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -691,9 +691,11 @@ def log2(x):
 
 
 def logaddexp(x1, x2):
-    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
-    x1 = cast(x1, "float32") if x1.dtype in TORCH_INT_TYPES else x1
-    x2 = cast(x2, "float32") if x2.dtype in TORCH_INT_TYPES else x2
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    x1 = cast(x1, dtype)
+    x2 = cast(x2, dtype)
     return torch.logaddexp(x1, x2)
 
 
@@ -1236,9 +1238,8 @@ def square(x):
 
 def sqrt(x):
     x = convert_to_tensor(x)
-    # upcast to float64 for int64 which matches JAX's behavior
     if x.dtype == torch.int64:
-        x = cast(x, "float64")
+        x = cast(x, config.floatx())
     return torch.sqrt(x)
 
 

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -3209,7 +3209,12 @@ class Logaddexp(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)),
+            getattr(x2, "dtype", type(x2)),
+            float,
+        )
+        return KerasTensor(output_shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.logaddexp", "keras.ops.numpy.logaddexp"])
@@ -5492,7 +5497,7 @@ class Sqrt(Operation):
 
     def compute_output_spec(self, x):
         dtype = (
-            "float64"
+            backend.floatx()
             if backend.standardize_dtype(x.dtype) == "int64"
             else dtypes.result_type(x.dtype, float)
         )

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -3028,7 +3028,12 @@ class Linspace(Operation):
                 + output_shape[self.axis + 1 :]
             )
 
-        dtype = self.dtype if self.dtype is not None else start.dtype
+        dtype = (
+            self.dtype
+            if self.dtype is not None
+            else getattr(start, "dtype", type(start))
+        )
+        dtype = backend.result_type(dtype, float)
         if self.retstep:
             return (KerasTensor(output_shape, dtype=dtype), None)
         return KerasTensor(output_shape, dtype=dtype)
@@ -3086,7 +3091,12 @@ class Log(Operation):
         return backend.numpy.log(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        dtype = (
+            backend.floatx()
+            if backend.standardize_dtype(x.dtype) == "int64"
+            else dtypes.result_type(x.dtype, float)
+        )
+        return KerasTensor(x.shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.log", "keras.ops.numpy.log"])
@@ -3109,7 +3119,12 @@ class Log10(Operation):
         return backend.numpy.log10(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        dtype = (
+            backend.floatx()
+            if backend.standardize_dtype(x.dtype) == "int64"
+            else dtypes.result_type(x.dtype, float)
+        )
+        return KerasTensor(x.shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.log10", "keras.ops.numpy.log10"])
@@ -3132,8 +3147,13 @@ class Log1p(Operation):
         return backend.numpy.log1p(x)
 
     def compute_output_spec(self, x):
+        dtype = (
+            backend.floatx()
+            if backend.standardize_dtype(x.dtype) == "int64"
+            else dtypes.result_type(x.dtype, float)
+        )
         sparse = getattr(x, "sparse", False)
-        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
+        return KerasTensor(x.shape, dtype=dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.log1p", "keras.ops.numpy.log1p"])
@@ -3158,7 +3178,12 @@ class Log2(Operation):
         return backend.numpy.log2(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        dtype = (
+            backend.floatx()
+            if backend.standardize_dtype(x.dtype) == "int64"
+            else dtypes.result_type(x.dtype, float)
+        )
+        return KerasTensor(x.shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.log2", "keras.ops.numpy.log2"])
@@ -3342,8 +3367,12 @@ class Logspace(Operation):
                 + [self.num]
                 + output_shape[self.axis + 1 :]
             )
-
-        dtype = self.dtype if self.dtype is not None else start.dtype
+        dtype = (
+            self.dtype
+            if self.dtype is not None
+            else getattr(start, "dtype", type(start))
+        )
+        dtype = backend.result_type(dtype, float)
         return KerasTensor(output_shape, dtype=dtype)
 
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4263,6 +4263,7 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         x for x in ALLOWED_DTYPES if x not in ["string", "uint64"]
     ] + [None]
     INT_DTYPES = [x for x in ALLOWED_DTYPES if "int" in x and x != "uint64"]
+    FLOAT_DTYPES = [x for x in ALLOWED_DTYPES if "float" in x]
 
     if backend.backend() == "torch":
         # TODO: torch doesn't support uint16, uint32 and uint64
@@ -4809,6 +4810,136 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knp.LessEqual().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(
+            start_and_stop=[
+                [0, 10],
+                [0.5, 10.5],
+                [np.array([0, 1], "int32"), np.array([10, 20], "int32")],
+                [np.array([0, 1], "float32"), np.array([10, 20], "float32")],
+            ],
+            num=[0, 1, 5],
+            dtype=FLOAT_DTYPES + [None],
+        )
+    )
+    def test_linspace(self, start_and_stop, num, dtype):
+        import jax.numpy as jnp
+
+        start, stop = start_and_stop
+        expected_dtype = standardize_dtype(
+            jnp.linspace(start, stop, num, dtype=dtype).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(
+                knp.linspace(start, stop, num, dtype=dtype).dtype
+            ),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(
+                knp.Linspace(num, dtype=dtype).symbolic_call(start, stop).dtype
+            ),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_log(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((3, 3), dtype=dtype)
+        x_jax = jnp.ones((3, 3), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.log(x_jax).dtype)
+        if dtype == "int64":
+            expected_dtype = backend.floatx()
+
+        self.assertEqual(standardize_dtype(knp.log(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Log().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_log10(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((3, 3), dtype=dtype)
+        x_jax = jnp.ones((3, 3), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.log10(x_jax).dtype)
+        if dtype == "int64":
+            expected_dtype = backend.floatx()
+
+        self.assertEqual(standardize_dtype(knp.log10(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Log10().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_log1p(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((3, 3), dtype=dtype)
+        x_jax = jnp.ones((3, 3), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.log1p(x_jax).dtype)
+        if dtype == "int64":
+            expected_dtype = backend.floatx()
+
+        self.assertEqual(standardize_dtype(knp.log1p(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Log1p().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_log2(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((3, 3), dtype=dtype)
+        x_jax = jnp.ones((3, 3), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.log2(x_jax).dtype)
+        if dtype == "int64":
+            expected_dtype = backend.floatx()
+
+        self.assertEqual(standardize_dtype(knp.log2(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Log2().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(
+            start_and_stop=[
+                [0, 10],
+                [0.5, 10.5],
+                [np.array([0, 1], "int32"), np.array([10, 20], "int32")],
+                [np.array([0, 1], "float32"), np.array([10, 20], "float32")],
+            ],
+            num=[0, 1, 5],
+            dtype=FLOAT_DTYPES + [None],
+        )
+    )
+    def test_logspace(self, start_and_stop, num, dtype):
+        import jax.numpy as jnp
+
+        start, stop = start_and_stop
+        expected_dtype = standardize_dtype(
+            jnp.logspace(start, stop, num, dtype=dtype).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(
+                knp.logspace(start, stop, num, dtype=dtype).dtype
+            ),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(
+                knp.Logspace(num, dtype=dtype).symbolic_call(start, stop).dtype
+            ),
             expected_dtype,
         )
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4911,6 +4911,32 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(
+        named_product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
+    )
+    def test_logaddexp(self, dtype1, dtype2):
+        import jax.numpy as jnp
+
+        x1 = knp.ones((3, 3), dtype=dtype1)
+        x2 = knp.ones((3, 3), dtype=dtype2)
+        x1_jax = jnp.ones((3, 3), dtype=dtype1)
+        x2_jax = jnp.ones((3, 3), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.logaddexp(x1_jax, x2_jax).dtype)
+        # jnp.logaddexp will promote "int64" and "uint32" to "float64"
+        # force the promotion to `backend.floatx()`
+        if dtype1 is not None and "float" not in dtype1:
+            if dtype2 is not None and "float" not in dtype2:
+                if "int64" in (dtype1, dtype2) or "uint32" in (dtype1, dtype2):
+                    expected_dtype = backend.floatx()
+
+        self.assertEqual(
+            standardize_dtype(knp.logaddexp(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Logaddexp().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
         named_product(
             start_and_stop=[
                 [0, 10],
@@ -5007,6 +5033,8 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         x1 = knp.ones((1,), dtype=dtype)
         x1_jax = jnp.ones((1,), dtype=dtype)
         expected_dtype = standardize_dtype(jnp.sqrt(x1_jax).dtype)
+        if dtype == "int64":
+            expected_dtype = backend.floatx()
 
         self.assertEqual(standardize_dtype(knp.sqrt(x1).dtype), expected_dtype)
         self.assertEqual(


### PR DESCRIPTION
The dtype promotion and compatibility rules might be as follows:
- Match the dtype inference from JAX.
- When an integer input becomes a floating-point output, use `backend.floatx()` for the best attempt.
- Make the best effort to support all dtypes for all operators in all backends (although this might introduce some overhead for checking).

Additionally, this PR fix the dtype inference of `sqrt`. We should promote to `backend.floatx()` instead of float64 when the input dtype is int64.