### PR TITLE
Add devcontainer for easier external contribution

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,26 @@
+# Dev container configurations
+
+This directory contains the configuration for dev containers, which is used to
+initialize the development environment in **Codespaces**, **Visual Studio
+Code**, and **JetBrains IDEs**. The environment is installed with all the
+necessary dependencies for development and is ready for linting, formatting, and
+running tests.
+
+* **GitHub Codespaces**. Create a codespace for the repo by clicking
+    the "Code" button on the main page of the repo, selecting the "Codespaces"
+    tab, and clicking the "+". The configurations will automatically be used.
+    Follow
+    [this guide](https://docs.github.com/en/codespaces/developing-in-a-codespace/creating-a-codespace-for-a-repository)
+    for more details.
+
+* **Visual Studio Code**. Open the root folder of the repo in VS Code. A
+    notification will pop up to open it in a dev container with the
+    configuration. Follow
+    [this guide](https://code.visualstudio.com/docs/devcontainers/tutorial)
+    for more details.
+
+* **JetBrains IDEs**. Open the `.devcontainer/devcontainer.json` in your
+   JetBrains IDE. Click the docker icon to create a dev container.
+   Follow
+   [this guide](https://www.jetbrains.com/help/idea/connect-to-devcontainer.html)
+   for more details.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+    "image": "mcr.microsoft.com/vscode/devcontainers/python:3.10",
+    "postCreateCommand": "sh ./.devcontainer/setup.sh",
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "python.testing.pytestEnabled": true,
+                "editor.formatOnSave": true,
+                "editor.codeActionsOnSave": {
+                    "source.organizeImports": true
+                },
+                "[python]": {
+                    "editor.defaultFormatter": "ms-python.black-formatter"
+                },
+                "editor.rulers": [
+                    80
+                ]
+            },
+            "extensions": [
+                "ms-python.python",
+                "ms-python.isort",
+                "ms-python.flake8",
+                "ms-python.black-formatter"
+            ]
+        }
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/github-cli:1": {}
+    }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,4 @@
+sudo pip install --upgrade pip
+sudo pip install -r requirements.txt
+echo "bash shell/lint.sh" > .git/hooks/pre-commit
+chmod a+x .git/hooks/pre-commit


### PR DESCRIPTION
With this PR, the codespaces (or vscode) would start with all the linting and formatting set up, and all the dependencies installed.

Makes it easier for contributors to contribute code.