### PR TITLE
Update dataset_utils.py

### DIFF
--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -596,6 +596,12 @@ def index_directory(
     if labels is None:
         io_utils.print_msg(f"Found {len(filenames)} files.")
     else:
+        #So that it works with a label list and 'categorical'
+        #Otherwise class_names contains one entry which is the parent directory...
+        #...not actual class_names from the list.
+        
+        class_names,idx,count = tf.unique_with_counts(labels)
+        
         io_utils.print_msg(
             f"Found {len(filenames)} files belonging "
             f"to {len(class_names)} classes."


### PR DESCRIPTION
Many people have an issue with tf.keras.utils.image_dataset_from_directory not working when a label list is supplied rather than using a directory structure to define classes. Adding this simple change locally means that class_names contains the classes supplied in 'labels' in the initial call, rather than just the parent/top directory name, and solved the problem going forward. Hopefully it can be incorporated??