### PR TITLE
Apply `backend.result_type` to `all`, `amax`, `amin`, `any`, `logical*`, `maximum`, `min`, `minimum`, `mod`, `nan_to_num` and `not_equal`

### DIFF
--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -492,7 +492,15 @@ def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
 
 
 def maximum(x1, x2):
-    return np.maximum(x1, x2)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    # TODO: np.maximum doesn't support dtype=bfloat16, so we need to cast it
+    # first
+    if dtype == "bfloat16":
+        x1 = x1.astype(dtype)
+        x2 = x2.astype(dtype)
+    return np.maximum(x1, x2, dtype=dtype)
 
 
 def median(x, axis=None, keepdims=False):
@@ -510,10 +518,25 @@ def min(x, axis=None, keepdims=False, initial=None):
 
 
 def minimum(x1, x2):
-    return np.minimum(x1, x2)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    # TODO: np.minimum doesn't support dtype=bfloat16, so we need to cast it
+    # first
+    if dtype == "bfloat16":
+        x1 = x1.astype(dtype)
+        x2 = x2.astype(dtype)
+    return np.minimum(x1, x2, dtype=dtype)
 
 
 def mod(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    if dtype == "bool":
+        dtype = "int32"
+    x1 = x1.astype(dtype)
+    x2 = x2.astype(dtype)
     return np.mod(x1, x2)
 
 

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -790,6 +790,11 @@ def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
 
 @sparse.elementwise_binary_union(tf.sparse.maximum, densify_mixed=True)
 def maximum(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = tf.cast(x1, dtype)
+    x2 = tf.cast(x2, dtype)
     return tfnp.maximum(x1, x2)
 
 
@@ -824,11 +829,23 @@ def min(x, axis=None, keepdims=False, initial=None):
 
 @sparse.elementwise_binary_union(tf.sparse.minimum, densify_mixed=True)
 def minimum(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = tf.cast(x1, dtype)
+    x2 = tf.cast(x2, dtype)
     return tfnp.minimum(x1, x2)
 
 
 @sparse.elementwise_division
 def mod(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    if dtype == "bool":
+        dtype = "int32"
+    x1 = tf.cast(x1, dtype)
+    x2 = tf.cast(x2, dtype)
     return tfnp.mod(x1, x2)
 
 

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -165,25 +165,25 @@ def abs(x):
 def all(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
     if axis is None:
-        return torch.all(x)
+        return cast(torch.all(x), "bool")
     if not isinstance(axis, (list, tuple)):
         axis = (axis,)
     for a in axis:
         # `torch.all` does not handle multiple axes.
         x = torch.all(x, dim=a, keepdim=keepdims)
-    return x
+    return cast(x, "bool")
 
 
 def any(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
     if axis is None:
-        return torch.any(x)
+        return cast(torch.any(x), "bool")
     if not isinstance(axis, (list, tuple)):
         axis = (axis,)
     for a in axis:
         # `torch.any` does not handle multiple axes.
         x = torch.any(x, dim=a, keepdim=keepdims)
-    return x
+    return cast(x, "bool")
 
 
 def amax(x, axis=None, keepdims=False):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -853,7 +853,12 @@ def minimum(x1, x2):
 
 
 def mod(x1, x2):
-    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    if dtype == "bool":
+        x1 = cast(x1, "int32")
+        x2 = cast(x2, "int32")
     return torch.remainder(x1, x2)
 
 

--- a/keras/layers/normalization/unit_normalization.py
+++ b/keras/layers/normalization/unit_normalization.py
@@ -45,7 +45,9 @@ class UnitNormalization(Layer):
         x = ops.cast(inputs, self.compute_dtype)
 
         square_sum = ops.sum(ops.square(x), axis=self.axis, keepdims=True)
-        x_inv_norm = ops.rsqrt(ops.maximum(square_sum, 1e-12))
+        x_inv_norm = ops.rsqrt(
+            ops.maximum(square_sum, ops.cast(1e-12, self.compute_dtype))
+        )
         return ops.multiply(x, x_inv_norm)
 
     def compute_output_shape(self, input_shape):

--- a/keras/layers/preprocessing/normalization.py
+++ b/keras/layers/preprocessing/normalization.py
@@ -298,13 +298,19 @@ class Normalization(Layer):
                 self.mean,
                 ops.multiply(
                     inputs,
-                    ops.maximum(ops.sqrt(self.variance), backend.epsilon()),
+                    ops.maximum(
+                        ops.sqrt(self.variance),
+                        ops.cast(backend.epsilon(), self.compute_dtype),
+                    ),
                 ),
             )
         else:
             return ops.divide(
                 ops.subtract(inputs, self.mean),
-                ops.maximum(ops.sqrt(self.variance), backend.epsilon()),
+                ops.maximum(
+                    ops.sqrt(self.variance),
+                    ops.cast(backend.epsilon(), self.compute_dtype),
+                ),
             )
 
     def compute_output_shape(self, input_shape):

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -3932,7 +3932,7 @@ class NotEqual(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        return KerasTensor(output_shape, dtype="bool")
 
 
 @keras_export(["keras.ops.not_equal", "keras.ops.numpy.not_equal"])

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -3244,7 +3244,7 @@ class LogicalAnd(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        return KerasTensor(output_shape, dtype="bool")
 
 
 @keras_export(
@@ -3275,7 +3275,7 @@ class LogicalNot(Operation):
         return backend.numpy.logical_not(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        return KerasTensor(x.shape, dtype="bool")
 
 
 @keras_export(
@@ -3308,7 +3308,7 @@ class LogicalOr(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        return KerasTensor(output_shape, dtype="bool")
 
 
 @keras_export(
@@ -3537,10 +3537,16 @@ class Maximum(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
+        output_dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)),
+            getattr(x2, "dtype", type(x2)),
+        )
         x1_sparse = getattr(x1, "sparse", False)
         x2_sparse = getattr(x2, "sparse", False)
         output_sparse = x1_sparse and x2_sparse
-        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
+        return KerasTensor(
+            output_shape, dtype=output_dtype, sparse=output_sparse
+        )
 
 
 @keras_export(["keras.ops.maximum", "keras.ops.numpy.maximum"])
@@ -3722,10 +3728,16 @@ class Minimum(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
+        output_dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)),
+            getattr(x2, "dtype", type(x2)),
+        )
         x1_sparse = getattr(x1, "sparse", False)
         x2_sparse = getattr(x2, "sparse", False)
         output_sparse = x1_sparse and x2_sparse
-        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
+        return KerasTensor(
+            output_shape, dtype=output_dtype, sparse=output_sparse
+        )
 
 
 @keras_export(["keras.ops.minimum", "keras.ops.numpy.minimum"])
@@ -3752,10 +3764,18 @@ class Mod(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
+        output_dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)),
+            getattr(x2, "dtype", type(x2)),
+        )
+        if output_dtype == "bool":
+            output_dtype = "int32"
         x1_sparse = getattr(x1, "sparse", False)
         x2_sparse = getattr(x2, "sparse", False)
         output_sparse = x1_sparse and not x2_sparse
-        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
+        return KerasTensor(
+            output_shape, dtype=output_dtype, sparse=output_sparse
+        )
 
 
 @keras_export(["keras.ops.mod", "keras.ops.numpy.mod"])
@@ -5834,7 +5854,7 @@ class LogicalXor(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        return KerasTensor(output_shape, dtype="bool")
 
 
 @keras_export(["keras.ops.logical_xor", "keras.ops.numpy.logical_xor"])

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -5146,6 +5146,44 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_nan_to_num(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((), dtype=dtype)
+        x_jax = jnp.ones((), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.nan_to_num(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.nan_to_num(x).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.NanToNum().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    # TODO: test_non_zero
+
+    @parameterized.named_parameters(
+        named_product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
+    )
+    def test_not_equal(self, dtype1, dtype2):
+        import jax.numpy as jnp
+
+        x1 = knp.ones((), dtype=dtype1)
+        x2 = knp.ones((), dtype=dtype2)
+        x1_jax = jnp.ones((), dtype=dtype1)
+        x2_jax = jnp.ones((), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.not_equal(x1_jax, x2_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.not_equal(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.NotEqual().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_quantile(self, dtype):
         import jax.numpy as jnp
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4969,6 +4969,106 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             expected_dtype,
         )
 
+    @parameterized.named_parameters(
+        named_product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
+    )
+    def test_logical_and(self, dtype1, dtype2):
+        import jax.numpy as jnp
+
+        x1 = knp.ones((), dtype=dtype1)
+        x2 = knp.ones((), dtype=dtype2)
+        x1_jax = jnp.ones((), dtype=dtype1)
+        x2_jax = jnp.ones((), dtype=dtype2)
+        expected_dtype = standardize_dtype(
+            jnp.logical_and(x1_jax, x2_jax).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(knp.logical_and(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.LogicalAnd().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_logical_not(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((), dtype=dtype)
+        x_jax = jnp.ones((), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.logical_not(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.logical_not(x).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.LogicalNot().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
+    )
+    def test_logical_or(self, dtype1, dtype2):
+        import jax.numpy as jnp
+
+        x1 = knp.ones((), dtype=dtype1)
+        x2 = knp.ones((), dtype=dtype2)
+        x1_jax = jnp.ones((), dtype=dtype1)
+        x2_jax = jnp.ones((), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.logical_or(x1_jax, x2_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.logical_or(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.LogicalOr().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
+    )
+    def test_logical_xor(self, dtype1, dtype2):
+        import jax.numpy as jnp
+
+        x1 = knp.ones((), dtype=dtype1)
+        x2 = knp.ones((), dtype=dtype2)
+        x1_jax = jnp.ones((), dtype=dtype1)
+        x2_jax = jnp.ones((), dtype=dtype2)
+        expected_dtype = standardize_dtype(
+            jnp.logical_xor(x1_jax, x2_jax).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(knp.logical_xor(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.LogicalXor().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
+    )
+    def test_maximum(self, dtype1, dtype2):
+        import jax.numpy as jnp
+
+        x1 = knp.ones((), dtype=dtype1)
+        x2 = knp.ones((), dtype=dtype2)
+        x1_jax = jnp.ones((), dtype=dtype1)
+        x2_jax = jnp.ones((), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.maximum(x1_jax, x2_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.maximum(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Maximum().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_median(self, dtype):
         import jax.numpy as jnp
@@ -4989,6 +5089,59 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knp.Median(axis=1).symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    # TODO: test_meshgrid
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_min(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.min(x_jax).dtype)
+
+        self.assertEqual(standardize_dtype(knp.min(x).dtype), expected_dtype)
+        self.assertEqual(knp.Min().symbolic_call(x).dtype, expected_dtype)
+
+    @parameterized.named_parameters(
+        named_product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
+    )
+    def test_minimum(self, dtype1, dtype2):
+        import jax.numpy as jnp
+
+        x1 = knp.ones((), dtype=dtype1)
+        x2 = knp.ones((), dtype=dtype2)
+        x1_jax = jnp.ones((), dtype=dtype1)
+        x2_jax = jnp.ones((), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.minimum(x1_jax, x2_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.minimum(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Minimum().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtype1=ALL_DTYPES, dtype2=ALL_DTYPES)
+    )
+    def test_mod(self, dtype1, dtype2):
+        import jax.numpy as jnp
+
+        x1 = knp.ones((), dtype=dtype1)
+        x2 = knp.ones((), dtype=dtype2)
+        x1_jax = jnp.ones((), dtype=dtype1)
+        x2_jax = jnp.ones((), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.mod(x1_jax, x2_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.mod(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Mod().symbolic_call(x1, x2).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
The dtype promotion and compatibility rules:
- Match the dtype inference from JAX.
- When an integer input becomes a floating-point output, use `backend.floatx()` for the best attempt.
- Make the best effort to support all dtypes for all operators in all backends (although this might introduce some overhead for checking).

Additionally, this PR has refactored the dtype tests involving two inputs. We can simply use the combinations of `ALL_DTYPES` instead of their product to verify the dtype inference of the operator. This has saved a significant amount of testing time.

Currently, the status of ops applied `backend.result_type` is as follows:

<details>

- [x] abs
- [x] absolute
- [x] add
- [x] all
- [x] amax
- [x] amin
- [ ] append
- [x] arange
- [ ] arccos
- [ ] arccosh
- [ ] arcsin
- [ ] arcsinh
- [ ] arctan
- [ ] arctan2
- [ ] arctanh
- [x] argmax
- [x] argmin
- [x] argsort
- [ ] array
- [ ] average
- [x] bincount
- [ ] broadcast_to
- [x] ceil
- [x] clip
- [ ] concatenate
- [ ] conj
- [ ] conjugate
- [ ] copy
- [ ] cos
- [ ] cosh
- [ ] count_nonzero
- [ ] cross
- [ ] cumprod
- [ ] cumsum
- [ ] diag
- [ ] diagonal
- [ ] diff
- [ ] digitize
- [ ] divide
- [x] dot
- [ ] einsum
- [x] empty
- [x] equal
- [x] exp
- [ ] expand_dims
- [x] expm1
- [x] eye
- [ ] flip
- [ ] floor
- [x] full
- [ ] full_like
- [x] greater
- [x] greater_equal
- [ ] hstack
- [x] identity
- [ ] imag
- [ ] interp
- [ ] isclose
- [ ] isfinite
- [ ] isinf
- [ ] isnan
- [x] less
- [x] less_equal
- [x] linspace
- [x] log
- [x] log10
- [x] log1p
- [x] log2
- [x] logaddexp
- [x] logical_and
- [x] logical_not
- [x] logical_or
- [x] logspace
- [x] matmul
- [x] max
- [x] maximum
- [x] mean
- [x] median
- [ ] meshgrid
- [ ] mgrid
- [x] min
- [x] minimum
- [x] mod
- [ ] moveaxis
- [x] multiply
- [x] nan_to_num
- [ ] ndim
- [ ] nonzero
- [x] not_equal
- [x] ones
- [ ] ones_like
- [ ] outer
- [ ] pad
- [ ] percentile
- [ ] power
- [ ] prod
- [x] quantile
- [ ] ravel
- [ ] real
- [ ] reciprocal
- [ ] repeat
- [ ] reshape
- [ ] roll
- [ ] round
- [ ] sign
- [ ] sin
- [ ] sinh
- [ ] size
- [ ] sort
- [ ] split
- [x] sqrt
- [ ] square
- [ ] squeeze
- [ ] stack
- [ ] std
- [x] subtract
- [ ] sum
- [ ] swapaxes
- [ ] take
- [ ] take_along_axis
- [ ] tan
- [ ] tanh
- [ ] tensordot
- [ ] tile
- [ ] trace
- [ ] transpose
- [x] tri
- [ ] tril
- [ ] triu
- [ ] true_divide
- [ ] vdot
- [ ] vstack
- [ ] where
- [x] zeros
- [ ] zeros_like

</details>
