### PR TITLE
Fix page rendering issue for Adam Optimizer docs

### DIFF
--- a/keras/optimizers/base_optimizer.py
+++ b/keras/optimizers/base_optimizer.py
@@ -656,24 +656,24 @@ class BaseOptimizer:
 base_optimizer_keyword_args = """name: String. The name to use
           for momentum accumulator weights created by
           the optimizer.
-      weight_decay: Float, defaults to None. If set, weight decay is applied.
-      clipnorm: Float. If set, the gradient of each weight is individually
+        weight_decay: Float, defaults to None. If set, weight decay is applied.
+        clipnorm: Float. If set, the gradient of each weight is individually
           clipped so that its norm is no higher than this value.
-      clipvalue: Float. If set, the gradient of each weight is clipped to be no
+        clipvalue: Float. If set, the gradient of each weight is clipped to be no
           higher than this value.
-      global_clipnorm: Float. If set, the gradient of all weights is clipped so
+        global_clipnorm: Float. If set, the gradient of all weights is clipped so
           that their global norm is no higher than this value.
-      use_ema: Boolean, defaults to False. If True, exponential moving average
+        use_ema: Boolean, defaults to False. If True, exponential moving average
           (EMA) is applied. EMA consists of computing an exponential moving
           average of the weights of the model (as the weight values change after
           each training batch), and periodically overwriting the weights with
           their moving average.
-      ema_momentum: Float, defaults to 0.99. Only used if `use_ema=True`.
+        ema_momentum: Float, defaults to 0.99. Only used if `use_ema=True`.
           This is the momentum to use when computing
           the EMA of the model's weights:
           `new_average = ema_momentum * old_average + (1 - ema_momentum) *
           current_variable_value`.
-      ema_overwrite_frequency: Int or None, defaults to None. Only used if
+        ema_overwrite_frequency: Int or None, defaults to None. Only used if
           `use_ema=True`. Every `ema_overwrite_frequency` steps of iterations,
           we overwrite the model variable by its moving average.
           If None, the optimizer
@@ -684,7 +684,7 @@ base_optimizer_keyword_args = """name: String. The name to use
           variables in-place). When using the built-in `fit()` training loop,
           this happens automatically after the last epoch,
           and you don't need to do anything.
-      loss_scale_factor: Float or `None`. If a float, the scale factor will
+        loss_scale_factor: Float or `None`. If a float, the scale factor will
           be multiplied the loss before computing gradients, and the inverse of
           the scale factor will be multiplied by the gradients before updating
           variables. Useful for preventing underflow during mixed precision

--- a/keras/optimizers/base_optimizer.py
+++ b/keras/optimizers/base_optimizer.py
@@ -659,10 +659,10 @@ base_optimizer_keyword_args = """name: String. The name to use
         weight_decay: Float, defaults to None. If set, weight decay is applied.
         clipnorm: Float. If set, the gradient of each weight is individually
           clipped so that its norm is no higher than this value.
-        clipvalue: Float. If set, the gradient of each weight is clipped to be no
-          higher than this value.
-        global_clipnorm: Float. If set, the gradient of all weights is clipped so
-          that their global norm is no higher than this value.
+        clipvalue: Float. If set, the gradient of each weight is clipped to be
+          no higher than this value.
+        global_clipnorm: Float. If set, the gradient of all weights is clipped
+          so that their global norm is no higher than this value.
         use_ema: Boolean, defaults to False. If True, exponential moving average
           (EMA) is applied. EMA consists of computing an exponential moving
           average of the weights of the model (as the weight values change after


### PR DESCRIPTION
For the Adam Optimizer classes, It observed the inline arguments descriptions all merged in one single tab where as inserted arguments rendering in nice tabular form. Please refer the snapshot below.

As suggested by @MarkDaoust , It might be due to difference in indentation levels of inline arguments that defined in the source code w.r.t inserted arguments through the variable `base_optimizer_keyword_args` from the file below.

https://github.com/keras-team/keras/blob/e237f083784579e5dcbe578c78888951b95bf016/keras/optimizers/base_optimizer.py#L698