### PR TITLE
Enable `jit_compile=True` for Tensorflow distributed strategies

### DIFF
--- a/integration_tests/tf_distribute_training_test.py
+++ b/integration_tests/tf_distribute_training_test.py
@@ -48,10 +48,7 @@ def test_model_fit():
                 optimizers.SGD(learning_rate=0.001, momentum=0.01)
             ),
             loss=losses.MeanSquaredError(),
-            metrics=[metrics.MeanSquaredError()],
-            # TODO(scottzhu): Find out where is the variable
-            #  that is not created eagerly and break the usage of XLA.
-            jit_compile=False,
+            metrics=[metrics.MeanSquaredError()]
         )
         history = model.fit(
             x,

--- a/keras/trainers/trainer.py
+++ b/keras/trainers/trainer.py
@@ -136,6 +136,9 @@ class Trainer:
             self.optimizer = LossScaleOptimizer(
                 self.optimizer, name="loss_scale_optimizer"
             )
+        if self.optimizer is not None:
+            # Create optimizer variables.
+            self.optimizer.build(self.trainable_variables)
         if hasattr(self, "output_names"):
             output_names = self.output_names
         else:


### PR DESCRIPTION
Enable jit_compile=True for Tensorflow distributed strategies.