### PR TITLE
Add support for Tensorflow SparseTensors: data adapters.

### DIFF
--- a/keras/trainers/data_adapters/generator_data_adapter_test.py
+++ b/keras/trainers/data_adapters/generator_data_adapter_test.py
@@ -1,6 +1,7 @@
 import math
 
 import numpy as np
+import scipy
 import tensorflow as tf
 from absl.testing import parameterized
 
@@ -88,3 +89,49 @@ class GeneratorDataAdapterTest(testing.TestCase, parameterized.TestCase):
             for i in range(by.shape[0]):
                 sample_order.append(by[i, 0])
         self.assertAllClose(sample_order, list(range(64)))
+
+    def test_tf_sparse_tensors(self):
+        def generate_tf():
+            for i in range(4):
+                x = tf.SparseTensor(
+                    indices=[[0, 0], [1, 2]],
+                    values=[1.0, 2.0],
+                    dense_shape=(2, 4),
+                )
+                y = tf.SparseTensor(
+                    indices=[[0, 0], [1, 1]],
+                    values=[3.0, 4.0],
+                    dense_shape=(2, 2),
+                )
+                yield x, y
+
+        adapter = generator_data_adapter.GeneratorDataAdapter(generate_tf())
+        ds = adapter.get_tf_dataset()
+        for batch in ds:
+            self.assertEqual(len(batch), 2)
+            bx, by = batch
+            self.assertIsInstance(bx, tf.SparseTensor)
+            self.assertIsInstance(by, tf.SparseTensor)
+            self.assertEqual(bx.shape, (2, 4))
+            self.assertEqual(by.shape, (2, 2))
+
+    def test_scipy_sparse_tensors(self):
+        def generate_scipy():
+            for i in range(4):
+                x = scipy.sparse.coo_matrix(
+                    ([1.0, 2.0], ([0, 1], [0, 2])), shape=[2, 4]
+                )
+                y = scipy.sparse.coo_matrix(
+                    ([3.0, 4.0], ([0, 1], [0, 1])), shape=[2, 2]
+                )
+                yield x, y
+
+        adapter = generator_data_adapter.GeneratorDataAdapter(generate_scipy())
+        ds = adapter.get_tf_dataset()
+        for batch in ds:
+            self.assertEqual(len(batch), 2)
+            bx, by = batch
+            self.assertIsInstance(bx, tf.SparseTensor)
+            self.assertIsInstance(by, tf.SparseTensor)
+            self.assertEqual(bx.shape, (2, 4))
+            self.assertEqual(by.shape, (2, 2))

--- a/keras/trainers/data_adapters/tf_dataset_adapter.py
+++ b/keras/trainers/data_adapters/tf_dataset_adapter.py
@@ -36,8 +36,15 @@ class TFDatasetAdapter(DataAdapter):
         self._dataset = dataset
 
     def get_numpy_iterator(self):
+        from keras.utils.module_utils import tensorflow as tf
+
+        def convert_to_numpy(x):
+            if isinstance(x, tf.SparseTensor):
+                x = tf.sparse.to_dense(x)
+            return x.numpy()
+
         for batch in self._dataset:
-            yield tree.map_structure(lambda x: x.numpy(), batch)
+            yield tree.map_structure(convert_to_numpy, batch)
 
     def get_tf_dataset(self):
         return self._dataset

--- a/keras/trainers/data_adapters/tf_dataset_adapter_test.py
+++ b/keras/trainers/data_adapters/tf_dataset_adapter_test.py
@@ -252,3 +252,30 @@ class TestTFDatasetAdapter(testing.TestCase):
             else:
                 self.assertEqual(tuple(bx.shape), (2, 4))
                 self.assertEqual(tuple(by.shape), (2, 2))
+
+    def test_tf_sparse_tensors(self):
+        x = tf.SparseTensor(
+            indices=[[0, 0], [1, 2]], values=[1.0, 2.0], dense_shape=(2, 4)
+        )
+        y = tf.SparseTensor(
+            indices=[[0, 0], [1, 1]], values=[3.0, 4.0], dense_shape=(2, 2)
+        )
+        base_ds = tf.data.Dataset.from_tensors((x, y))
+        adapter = tf_dataset_adapter.TFDatasetAdapter(base_ds)
+
+        gen = adapter.get_numpy_iterator()
+        for batch in gen:
+            self.assertEqual(len(batch), 2)
+            bx, by = batch
+            self.assertIsInstance(bx, np.ndarray)
+            self.assertIsInstance(by, np.ndarray)
+            self.assertEqual(bx.shape, (2, 4))
+            self.assertEqual(by.shape, (2, 2))
+        ds = adapter.get_tf_dataset()
+        for batch in ds:
+            self.assertEqual(len(batch), 2)
+            bx, by = batch
+            self.assertIsInstance(bx, tf.SparseTensor)
+            self.assertIsInstance(by, tf.SparseTensor)
+            self.assertEqual(bx.shape, (2, 4))
+            self.assertEqual(by.shape, (2, 2))


### PR DESCRIPTION
`GeneratorDataAdapter` now accepts `tf.SparseTensor`s and `scipy.sparse` matrices.

`TFDatasetAdapter` now accepts `tf.SparseTensor`s.