### PR TITLE
Change weight_decay arg description for AdamW

### DIFF
--- a/keras/optimizers/base_optimizer.py
+++ b/keras/optimizers/base_optimizer.py
@@ -698,7 +698,7 @@ class BaseOptimizer:
 base_optimizer_keyword_args = """name: String. The name to use
           for momentum accumulator weights created by
           the optimizer.
-        weight_decay: Float, defaults to None. If set, weight decay is applied.
+        weight_decay: Float. If set, weight decay is applied.
         clipnorm: Float. If set, the gradient of each weight is individually
           clipped so that its norm is no higher than this value.
         clipvalue: Float. If set, the gradient of each weight is clipped to be


### PR DESCRIPTION
The optimizer `AdamW` has inserted arguments and `weight_decay` is one among them. But in the description for it is mentioned like below. 

> `weight_decay: Float, defaults to None. If set, weight decay is applied.`


But this is wrong for `AdamW` where default value is `0.004`. SInce these inserted arguments are coming from the variable `base_optimizer_keyword_args` from `base_optimzer.py` file, I am proposing to change the description to remove the mention of default value from the description like below.

> `weight_decay: Float. If set, weight decay is applied.`

This change can be reflected into other Adam optimizer classes like `adadelta`,`adafactor`,`adagrad`,`adam` and `adamax` and they have `weight_decay` set to `None` and users can refer it from arguments itself. Or if it worth to have default value to be mentioned in the description may be we can remove the `weight_decay` argument from inserted argument and explicitly add it to each of this Class.

I proposed first one as it is simple fix.If second fix is worth it may be I can go for it upon confirmation.

Fixes #18712