### PR TITLE
Validate decay_steps for Learning rate schedulers

### DIFF
--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -153,6 +153,9 @@ class ExponentialDecay(LearningRateSchedule):
         self.staircase = staircase
         self.name = name
 
+        if self.decay_steps <= 0:
+            raise ValueError("Argument `decay_steps` must be > 0.")
+
     def __call__(self, step):
         with ops.name_scope(self.name):
             initial_learning_rate = ops.convert_to_tensor(
@@ -396,6 +399,9 @@ class PolynomialDecay(LearningRateSchedule):
         self.cycle = cycle
         self.name = name
 
+        if self.decay_steps <= 0:
+            raise ValueError("Argument `decay_steps` must be > 0.")
+
     def __call__(self, step):
         with ops.name_scope(self.name):
             initial_learning_rate = ops.convert_to_tensor(
@@ -523,6 +529,9 @@ class InverseTimeDecay(LearningRateSchedule):
         self.decay_rate = decay_rate
         self.staircase = staircase
         self.name = name
+
+        if self.decay_steps <= 0:
+            raise ValueError("Argument `decay_steps` must be > 0.")
 
     def __call__(self, step):
         with ops.name_scope(self.name):
@@ -666,6 +675,9 @@ class CosineDecay(LearningRateSchedule):
         self.warmup_steps = warmup_steps
         self.warmup_target = warmup_target
 
+        if self.decay_steps <= 0:
+            raise ValueError("Argument `decay_steps` must be > 0.")
+
     def _decay_function(self, step, decay_steps, decay_from_lr, dtype):
         with ops.name_scope(self.name):
             completed_fraction = step / decay_steps
@@ -807,6 +819,9 @@ class CosineDecayRestarts(LearningRateSchedule):
         self._m_mul = m_mul
         self.alpha = alpha
         self.name = name
+
+        if self.first_decay_steps <= 0:
+            raise ValueError("Argument `first_decay_steps` must be > 0.")
 
     def __call__(self, step):
         with ops.name_scope(self.name):

--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -156,7 +156,7 @@ class ExponentialDecay(LearningRateSchedule):
         if self.decay_steps <= 0:
             raise ValueError(
                 "Argument `decay_steps` must be > 0. "
-                f"Recieved : decay_steps = {self.decay_steps}. "
+                f"Received : decay_steps = {self.decay_steps}. "
             )
 
     def __call__(self, step):
@@ -405,7 +405,7 @@ class PolynomialDecay(LearningRateSchedule):
         if self.decay_steps <= 0:
             raise ValueError(
                 "Argument `decay_steps` must be > 0. "
-                f"Recieved : decay_steps = {self.decay_steps}. "
+                f"Received : decay_steps = {self.decay_steps}. "
             )
 
     def __call__(self, step):
@@ -539,7 +539,7 @@ class InverseTimeDecay(LearningRateSchedule):
         if self.decay_steps <= 0:
             raise ValueError(
                 "Argument `decay_steps` must be > 0. "
-                f"Recieved : decay_steps = {self.decay_steps}. "
+                f"Received : decay_steps = {self.decay_steps}. "
             )
 
     def __call__(self, step):
@@ -687,7 +687,7 @@ class CosineDecay(LearningRateSchedule):
         if self.decay_steps <= 0:
             raise ValueError(
                 "Argument `decay_steps` must be > 0. "
-                f"Recieved : decay_steps = {self.decay_steps}. "
+                f"Received : decay_steps = {self.decay_steps}. "
             )
 
     def _decay_function(self, step, decay_steps, decay_from_lr, dtype):
@@ -835,7 +835,7 @@ class CosineDecayRestarts(LearningRateSchedule):
         if self.first_decay_steps <= 0:
             raise ValueError(
                 "Argument `first_decay_steps` must be > 0. "
-                f"Recieved : decay_steps = {self.first_decay_steps}. "
+                f"Received : first_decay_steps = {self.first_decay_steps}. "
             )
 
     def __call__(self, step):

--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -154,7 +154,10 @@ class ExponentialDecay(LearningRateSchedule):
         self.name = name
 
         if self.decay_steps <= 0:
-            raise ValueError("Argument `decay_steps` must be > 0.")
+            raise ValueError(
+                "Argument `decay_steps` must be > 0. "
+                f"Recieved : decay_steps = {self.decay_steps}. "
+            )
 
     def __call__(self, step):
         with ops.name_scope(self.name):
@@ -400,7 +403,10 @@ class PolynomialDecay(LearningRateSchedule):
         self.name = name
 
         if self.decay_steps <= 0:
-            raise ValueError("Argument `decay_steps` must be > 0.")
+            raise ValueError(
+                "Argument `decay_steps` must be > 0. "
+                f"Recieved : decay_steps = {self.decay_steps}. "
+            )
 
     def __call__(self, step):
         with ops.name_scope(self.name):
@@ -531,7 +537,10 @@ class InverseTimeDecay(LearningRateSchedule):
         self.name = name
 
         if self.decay_steps <= 0:
-            raise ValueError("Argument `decay_steps` must be > 0.")
+            raise ValueError(
+                "Argument `decay_steps` must be > 0. "
+                f"Recieved : decay_steps = {self.decay_steps}. "
+            )
 
     def __call__(self, step):
         with ops.name_scope(self.name):
@@ -676,7 +685,10 @@ class CosineDecay(LearningRateSchedule):
         self.warmup_target = warmup_target
 
         if self.decay_steps <= 0:
-            raise ValueError("Argument `decay_steps` must be > 0.")
+            raise ValueError(
+                "Argument `decay_steps` must be > 0. "
+                f"Recieved : decay_steps = {self.decay_steps}. "
+            )
 
     def _decay_function(self, step, decay_steps, decay_from_lr, dtype):
         with ops.name_scope(self.name):
@@ -821,7 +833,10 @@ class CosineDecayRestarts(LearningRateSchedule):
         self.name = name
 
         if self.first_decay_steps <= 0:
-            raise ValueError("Argument `first_decay_steps` must be > 0.")
+            raise ValueError(
+                "Argument `first_decay_steps` must be > 0. "
+                f"Recieved : decay_steps = {self.first_decay_steps}. "
+            )
 
     def __call__(self, step):
         with ops.name_scope(self.name):

--- a/keras/optimizers/schedules/learning_rate_schedule_test.py
+++ b/keras/optimizers/schedules/learning_rate_schedule_test.py
@@ -325,7 +325,7 @@ class CosineDecayTest(testing.TestCase):
         for step in range(0, 1500, 250):
             lr = schedules.CosineDecay(
                 initial_lr,
-                0,
+                10,
                 warmup_target=target_lr,
                 warmup_steps=warmup_steps,
             )


### PR DESCRIPTION
The learning rate schedulers like `CosineDecay` ,`ExponentialDecay`, `PolynomialDecay`, `InverseTimeDecay` , `CosineDecayRestarts` has an argument `decay_steps` which should be >0. If user passes `zero` or `-ve` value this will leads to different behaviour like constant `learning_rate` or making `learning_rate` to `zero` or `NaN` etc. 

Though it is imperative to use +ve `decay_steps` but some times when users uses a generator dataset cardinality for calculating decay_steps it will lead to -ve Number generation and and example of this discussed in tensorflow ticket 
#[53284](https://github.com/tensorflow/tensorflow/issues/53284) where user uses `tf.data.Dataset.from_generator()` and uses its cardinality to calculate `decay_steps` and here model couldn't able to learn.

In this [comment](https://github.com/tensorflow/tensorflow/issues/53284#issuecomment-1017997229) it is suggested to raise an exception which can save time instead of silently training the model.



