### PR TITLE
fix `class_names` arg checking thinko

### DIFF
--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -546,7 +546,7 @@ def index_directory(
                         subdir = subdir[:-1]
                     subdirs.append(subdir)
         if class_names is not None:
-            if set(class_names).issubset(set(subdirs)):
+            if not set(class_names).issubset(set(subdirs)):
                 raise ValueError(
                     "The `class_names` passed did not match the "
                     "names of the subdirectories of the target directory. "


### PR DESCRIPTION
Without this fix, passing valid values to `class_names` would raise a ValueError. E.g.,
```
image_dataset_from_directory(dir, class_names = ['one', 'two', 'three'])
```
would error, even when the subdirectories are `['one', 'two', 'three']`