### PR TITLE
Bump to 2.16 nightlies for requirements

### DIFF
--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,5 +1,5 @@
 # Tensorflow cpu-only version (needed for testing).
-tf-nightly-cpu==2.15.0.dev20231009  # Pin a working nightly until rc0.
+tf-nightly-cpu==2.16.0.dev20231103  # Pin a working nightly until rc0.
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,6 +1,6 @@
 # Tensorflow with cuda support.
 --extra-index-url https://pypi.nvidia.com
-tf-nightly[and-cuda]==2.15.0.dev20231009  # Pin a working nightly until rc0.
+tf-nightly[and-cuda]==2.16.0.dev20231103  # Pin a working nightly until rc0.
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,5 +1,5 @@
 # Tensorflow cpu-only version (needed for testing).
-tf-nightly-cpu==2.15.0.dev20231009  # Pin a working nightly until rc0.
+tf-nightly-cpu==2.16.0.dev20231103  # Pin a working nightly until rc0.
 
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu118

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Tensorflow.
-tf-nightly-cpu==2.15.0.dev20231009  # Pin a working nightly until rc0.
+tf-nightly-cpu==2.16.0.dev20231103  # Pin a working nightly until rc0.
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
These nightlies are compatible with the Keras 3 nightlies, so a more friendly dev environment overall.

Tested with a quick mnist training script to verify cuda was working.