### PR TITLE
Made clone_model return have same input/output structure

### DIFF
--- a/keras/models/cloning.py
+++ b/keras/models/cloning.py
@@ -265,6 +265,8 @@ def _clone_functional_model(model, input_tensors=None, clone_function=None):
         except TypeError as e:
             raise ValueError(
                 "`input_tensors` must have the same structure as model.input"
+                f"\nReference structure: {model.input}"
+                f"\nReceived structure: {input_tensors}"
             ) from e
     else:
         input_tensors = tree.map_structure(

--- a/keras/models/cloning.py
+++ b/keras/models/cloning.py
@@ -252,12 +252,20 @@ def _clone_functional_model(model, input_tensors=None, clone_function=None):
         )
 
     if input_tensors is not None:
-        input_tensors = tree.flatten(input_tensors)
-        if not all(isinstance(x, backend.KerasTensor) for x in input_tensors):
+        if not all(
+            isinstance(x, backend.KerasTensor)
+            for x in tree.flatten(input_tensors)
+        ):
             raise ValueError(
                 "All entries in `input_tensors` must be KerasTensors. "
                 f"Received invalid values: inputs_tensors={input_tensors}"
             )
+        try:
+            tree.assert_same_structure(input_tensors, model.input)
+        except TypeError as e:
+            raise ValueError(
+                "`input_tensors` must have the same structure as model.input"
+            ) from e
     else:
         input_tensors = tree.map_structure(
             lambda x: Input(batch_shape=x.shape, dtype=x.dtype, name=x.name),

--- a/keras/models/cloning_test.py
+++ b/keras/models/cloning_test.py
@@ -116,5 +116,8 @@ class CloneModelTest(testing.TestCase, parameterized.TestCase):
         tree.assert_same_structure(model.input, inputs)
         tree.assert_same_structure(model.output, outputs)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(
+            ValueError,
+            "`input_tensors` must have the same structure as model.input",
+        ):
             model = clone_model(model0, input_tensors=(x, y))

--- a/keras/models/cloning_test.py
+++ b/keras/models/cloning_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import tree
 from absl.testing import parameterized
 
 from keras import layers
@@ -97,3 +98,23 @@ class CloneModelTest(testing.TestCase, parameterized.TestCase):
         model = get_mlp_functional_model(shared_layers=True)
         new_model = clone_model(model)
         self.assertLen(new_model.layers, 4)
+
+    def test_structured_io_cloning(self):
+        x = layers.Input((3,))
+        y = layers.Input((3,))
+        z1 = x + y
+        z2 = layers.Dense(5)(z1)
+        inputs = dict(x=x, y=y)
+        outputs = dict(z1=z1, z2=z2)
+        model0 = models.Model(inputs, outputs)
+
+        model = clone_model(model0)
+        tree.assert_same_structure(model.input, inputs)
+        tree.assert_same_structure(model.output, outputs)
+
+        model = clone_model(model0, input_tensors=inputs)
+        tree.assert_same_structure(model.input, inputs)
+        tree.assert_same_structure(model.output, outputs)
+
+        with self.assertRaises(ValueError):
+            model = clone_model(model0, input_tensors=(x, y))


### PR DESCRIPTION
Fixes an issue where `clone_model`' would return a model with flattened inputs.

Also added an additional check to ensure `input_tensors` has the same structure as `model.input`. I could be convinced that this shouldn't be in there and could instead be e.g. replaced with ensuring the flattened lengths are the same, or just removed entirely, but I feel that would definitely lead to some late throws that are hard to debug and I can't immediately see any benefit.