### PR TITLE
Pass dtype to cumsum and cumprod

### DIFF
--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -260,12 +260,14 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
 
 def cumprod(x, axis=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    return np.cumprod(x, axis=axis)
+    dtype = dtypes.result_type(x.dtype)
+    return np.cumprod(x, axis=axis, dtype=dtype)
 
 
 def cumsum(x, axis=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    return np.cumsum(x, axis=axis)
+    dtype = dtypes.result_type(x.dtype)
+    return np.cumsum(x, axis=axis, dtype=dtype)
 
 
 def diag(x, k=0):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -260,13 +260,13 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
 
 def cumprod(x, axis=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    dtype = dtypes.result_type(x.dtype)
+    dtype = standardize_dtype(x.dtype)
     return np.cumprod(x, axis=axis, dtype=dtype)
 
 
 def cumsum(x, axis=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    dtype = dtypes.result_type(x.dtype)
+    dtype = standardize_dtype(x.dtype)
     return np.cumsum(x, axis=axis, dtype=dtype)
 
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4733,3 +4733,26 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             ),
             standardize_dtype(jnp.eye(3, 4, 1, dtype=dtype).dtype),
         )
+
+
+class NumpyOutputDtypesTest(testing.TestCase, parameterized.TestCase):
+    """Test the dtypes of numpy outputs to match with inputs dtype"""
+
+    INT_DTYPES = [x for x in ALLOWED_DTYPES if "int" in x]
+
+    @parameterized.named_parameters(named_product(dtype=INT_DTYPES))
+    def test_cumsum_with_int(self, dtype):
+        x = np.array([1, 1, 2, 3, 2, 4, 4, 5], dtype=dtype)
+        output = knp.cumsum(x)
+        self.assertEqual(
+            standardize_dtype(output.dtype), standardize_dtype(x.dtype)
+        )
+
+    @parameterized.named_parameters(named_product(dtype=INT_DTYPES))
+    def test_cumprod_with_int(self, dtype):
+        x = np.array([1, 1, 2, 3, 2, 4, 4, 5], dtype=dtype)
+
+        output = knp.cumprod(x)
+        self.assertEqual(
+            standardize_dtype(output.dtype), standardize_dtype(x.dtype)
+        )


### PR DESCRIPTION
Currently the APIs [keras.ops.cumsum](https://github.com/keras-team/keras/blob/master/keras/ops/numpy.py#L1825) and [keras.ops.cumprod](https://github.com/keras-team/keras/blob/master/keras/ops/numpy.py#L1790) are calling numpy backend where in all `int` dtypes are being converted into `int64` if specific `dtype` is not provided explicitly for `numpy.cumsum` and `numpy.cumprod` as by default numpy will be converting this unspecified `int` dtype to `int64`.

Hence proposing to infer `dtype` and the pass it explicitly to numpy backend.

#Fixes #18730