### PR TITLE
fixes TypeError 

### DIFF
--- a/keras/saving/saving_api.py
+++ b/keras/saving/saving_api.py
@@ -162,7 +162,7 @@ def load_model(filepath, custom_objects=None, compile=True, safe_mode=True):
         )
 
         # Copy from remote to temporary local directory
-        file_utils.copy(filepath, local_path, overwrite=True)
+        file_utils.copy(filepath, local_path)
 
         # Switch filepath to local zipfile for loading model
         if zipfile.is_zipfile(local_path):

--- a/keras/utils/file_utils.py
+++ b/keras/utils/file_utils.py
@@ -470,7 +470,7 @@ def listdir(path):
 def copy(src, dst):
     if is_remote_path(src) or is_remote_path(dst):
         if gfile.available:
-            return gfile.copy(src, dst)
+            return gfile.copy(src, dst, overwrite=True)
         else:
             _raise_if_no_gfile(f"src={src} dst={dst}")
     return shutil.copy(src, dst)


### PR DESCRIPTION
https://github.com/keras-team/keras/issues/18736#issue-1979803521


[shutil copy overwrites by default](https://docs.python.org/3/library/shutil.html#shutil.copy)
[But gfile copy does not](https://www.tensorflow.org/api_docs/python/tf/io/gfile/copy)

Removing overwrite=True from the function call fixes the error and given that the file is copied to a tmp path, it actually probably does make sense to just always overwrite the file.