### PR TITLE
Use TENSORFLOW_VERSION when available during pip_build script

### DIFF
--- a/pip_build.py
+++ b/pip_build.py
@@ -434,6 +434,9 @@ def test_wheel(wheel_path, expected_version, requirements_path):
         "virtualenv kenv\n"
         f"source {os.path.join('kenv', 'bin', 'activate')}\n"
         f"pip3 install -r {requirements_path}\n"
+        "pip3 uninstall -y tensorflow tf-nightly\n"
+        'pip3 install "${TENSORFLOW_VERSION:-tf-nightly}"\n'
+        "pip3 uninstall -y keras keras-nightly\n"
         f"pip3 install {wheel_path} --force-reinstall\n"
         f"python3 -c 'import keras;{checks};print(keras.__version__)'\n"
         f"python3 -c 'import tensorflow as tf;tf.compat.v1.layers.Dense'\n"


### PR DESCRIPTION
`tf-nightly` has a breaking API change so when building r2.15 I needed to use the Env Variable of `TENSORFLOW_VERSION` to install the right version of TF when checking the wheel file.

CI/CD is expected to Fail since `r2.15` is not compatible with CI / CD.