### PR TITLE
validate end_learning_rate and warmup targets in lr_decay_schedulers

### DIFF
--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -674,7 +674,7 @@ class CosineDecay(LearningRateSchedule):
         self.warmup_steps = warmup_steps
         self.warmup_target = warmup_target
 
-        if self.warmup_target and warmup_target >= self.initial_learning_rate:
+        if self.warmup_target and warmup_target <= self.initial_learning_rate:
             raise ValueError(
                 "When `warmup_target` is provided, it should be "
                 "less than `initial_learning_rate`. "

--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -396,6 +396,14 @@ class PolynomialDecay(LearningRateSchedule):
         self.cycle = cycle
         self.name = name
 
+        if self.end_learning_rate >= self.initial_learning_rate:
+            raise ValueError(
+                "`end_learning_rate` should be less than "
+                "`initial_learning_rate`. "
+                f"Received end_learning_rate = {end_learning_rate}, "
+                f"initial_learning_rate = {initial_learning_rate}. "
+            )
+
     def __call__(self, step):
         with ops.name_scope(self.name):
             initial_learning_rate = ops.convert_to_tensor(
@@ -665,6 +673,14 @@ class CosineDecay(LearningRateSchedule):
         self.name = name
         self.warmup_steps = warmup_steps
         self.warmup_target = warmup_target
+
+        if self.warmup_target and warmup_target >= self.initial_learning_rate:
+            raise ValueError(
+                "When `warmup_target` is provided, it should be "
+                "less than `initial_learning_rate`. "
+                f"Received warmup_target = {self.warmup_target}, "
+                f"initial_learning_rate = {self.initial_learning_rate}. "
+            )
 
     def _decay_function(self, step, decay_steps, decay_from_lr, dtype):
         with ops.name_scope(self.name):


### PR DESCRIPTION
As per documentation of `PolynomialDecay`, the purpose of this scheduler is to monotonically decrease the learning rate, whose degree of change is carefully chosen, can result in a better performing model. As per my understanding this scheduler is meant to given a provided `initial_learning_rate`, to reach an `end_learning_rate` in the given `decay_steps`. But in current implementation if we provide `end_learning_rate` greater than `initial_learning_rate` the scheduler will increase the `learning_rate` to `end_learning_rate` which is not the intended use of this decay scheduler and it also affects model performance. Hence it is appropriate to throw an exception for this case.

Similarly for `Cosinedecay` scheduler, we have an option of `warmup`, purpose of which is increasing from `initial_learning_rate` to `warmup_target` for a duration of `warmup_steps`. But here also if we provide `warmup_target` which is lower than `initial_learning_rate` instead of increasing learning rate, which is the purpose of warmup, it actually decreasing the learning rate as there is no validation for this.

Attached [gist](https://colab.sandbox.google.com/gist/SuryanarayanaY/71a8d1a55e1e9a8053f3aeadfc03e3a5/keras3_polynomialdecay-cosinedecay.ipynb) for the demo described above.

Hence proposing validation for both of the above schedulers to make sure they are used for intended purpose only.

Fixes #18747 