### PR TITLE
Implement missing pieces from Trackable interface for TF-based variable.

### DIFF
--- a/keras/backend/tensorflow/core.py
+++ b/keras/backend/tensorflow/core.py
@@ -70,10 +70,21 @@ class Variable(
         return self.value._shared_name
 
     def _serialize_to_tensors(self):
-        return self.value._serialize_to_tensors()
+        try:
+            return self.value._serialize_to_tensors()
+        except NotImplementedError:
+            return {"VARIABLE_VALUE": self.value}
 
     def _restore_from_tensors(self, restored_tensors):
-        return self.value._restore_from_tensors(restored_tensors)
+        try:
+            return self.value._restore_from_tensors(restored_tensors)
+        except NotImplementedError:
+            self.assign(restored_tensors["VARIABLE_VALUE"])
+            return self.value
+
+    def _copy_trackable_to_cpu(self, object_map):
+        self.value._copy_trackable_to_cpu(object_map)
+        object_map[self] = tf.Variable(object_map[self.value])
 
     def _export_to_saved_model_graph(
         self, object_map, tensor_map, options, **kwargs


### PR DESCRIPTION
Some tf.Variable implementations (such as `TPUDistributedVariable`) don't override _restore_from_tensors/_serialize_to_tensors since they rely on the `_gather_saveables_for_checkpoint` interface, which causes Keras to fail (with `NotImplementedError`) when creating a tf.Checkpoint in a distributed environment for example. Here, we add a simple workaround in case this interface is not implemented.

Additonally, we also add the _copy_trackable_to_cpu interface to support async checkpointing on TF.