### PR TITLE
Add support for Tensorflow SparseTensors: public API to densify.

### DIFF
--- a/keras/backend/jax/core.py
+++ b/keras/backend/jax/core.py
@@ -46,7 +46,7 @@ class Variable(KerasVariable):
         return self.value
 
 
-def convert_to_tensor(x, dtype=None, sparse=False):
+def convert_to_tensor(x, dtype=None, sparse=None):
     if sparse:
         raise ValueError("`sparse=True` is not supported with jax backend")
     if dtype is not None:

--- a/keras/backend/numpy/core.py
+++ b/keras/backend/numpy/core.py
@@ -25,7 +25,7 @@ class Variable(KerasVariable):
         return self.value
 
 
-def convert_to_tensor(x, dtype=None, sparse=False):
+def convert_to_tensor(x, dtype=None, sparse=None):
     if sparse:
         raise ValueError("`sparse=True` is not supported with numpy backend")
     if dtype is not None:

--- a/keras/backend/tensorflow/core.py
+++ b/keras/backend/tensorflow/core.py
@@ -99,14 +99,8 @@ class Variable(
         return self.value._write_object_proto(proto, options)
 
 
-def convert_to_tensor(x, dtype=None, sparse=True):
-    """Convert to a TensorFlow tensor.
-
-    `sparse=True` means that `tf.SparseTensor`s are returned as-is, which is the
-    default with the TensorFlow backend. An explicit `sparse=False` densifies
-    `tf.SparseTensor`s.
-    """
-    if isinstance(x, tf.SparseTensor) and not sparse:
+def convert_to_tensor(x, dtype=None, sparse=None):
+    if isinstance(x, tf.SparseTensor) and sparse is not None and not sparse:
         x = tf.sparse.to_dense(x)
     if dtype is not None:
         dtype = standardize_dtype(dtype)

--- a/keras/backend/torch/core.py
+++ b/keras/backend/torch/core.py
@@ -130,7 +130,7 @@ class Variable(KerasVariable):
             return False
 
 
-def convert_to_tensor(x, dtype=None, sparse=False):
+def convert_to_tensor(x, dtype=None, sparse=None):
     if sparse:
         raise ValueError("`sparse=True` is not supported with torch backend")
     if is_tensor(x):

--- a/keras/models/functional.py
+++ b/keras/models/functional.py
@@ -250,9 +250,7 @@ class Functional(Function, Model):
         converted = []
         for x, input in zip(flat_inputs, self._inputs):
             converted.append(
-                backend.convert_to_tensor(
-                    x, dtype=input.dtype, sparse=input.sparse
-                )
+                ops.convert_to_tensor(x, dtype=input.dtype, sparse=input.sparse)
             )
         return converted
 

--- a/keras/ops/core.py
+++ b/keras/ops/core.py
@@ -461,12 +461,15 @@ def cast(x, dtype):
 
 
 @keras_export("keras.ops.convert_to_tensor")
-def convert_to_tensor(x, dtype=None):
+def convert_to_tensor(x, dtype=None, sparse=None):
     """Convert a NumPy array to a tensor.
 
     Args:
         x: A NumPy array.
         dtype: The target type.
+        sparse: Whether to keep sparse tensors. `False` will cause sparse
+            tensors to be densified. The default value of `None` means that
+            sparse tensors are kept only if the backend supports them.
 
     Returns:
         A tensor of the specified `dtype`.
@@ -476,7 +479,7 @@ def convert_to_tensor(x, dtype=None):
     >>> x = np.array([1, 2, 3])
     >>> y = keras.ops.convert_to_tensor(x)
     """
-    return backend.convert_to_tensor(x, dtype=dtype)
+    return backend.convert_to_tensor(x, dtype=dtype, sparse=sparse)
 
 
 @keras_export("keras.ops.convert_to_numpy")

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -316,11 +316,10 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         x_default = ops.convert_to_tensor(x)
         self.assertIsInstance(x_default, tf.SparseTensor)
         self.assertAllClose(x, x_default)
-        # Note that ops.convert_to_tensor does not expose the 'sparse' arg
-        x_sparse = backend.convert_to_tensor(x, sparse=True)
+        x_sparse = ops.convert_to_tensor(x, sparse=True)
         self.assertIsInstance(x_sparse, tf.SparseTensor)
         self.assertAllClose(x, x_sparse)
-        x_dense = backend.convert_to_tensor(x, sparse=False)
+        x_dense = ops.convert_to_tensor(x, sparse=False)
         self.assertNotIsInstance(x_dense, tf.SparseTensor)
         self.assertAllClose(x, x_dense)
 


### PR DESCRIPTION
The `sparse` argument of `backend.convert_to_tensor` is now public. This allows densifying sparse tensors by passing `False`.