### PR TITLE
Apply `backend.result_type` to `array` and `convert_to_tensor`

### DIFF
--- a/keras/backend/numpy/core.py
+++ b/keras/backend/numpy/core.py
@@ -3,6 +3,7 @@ import tree
 
 from keras.backend.common import KerasVariable
 from keras.backend.common import standardize_dtype
+from keras.backend.common.dtypes import result_type
 from keras.backend.common.keras_tensor import KerasTensor
 from keras.backend.common.stateless_scope import StatelessScope
 from keras.utils.nest import pack_sequence_as
@@ -34,6 +35,10 @@ def convert_to_tensor(x, dtype=None, sparse=False):
         if dtype and dtype != x.dtype:
             return x.value.astype(dtype)
         return x.value
+    if dtype is None:
+        dtype = result_type(
+            *[getattr(item, "dtype", type(item)) for item in tree.flatten(x)]
+        )
     return np.array(x, dtype=dtype)
 
 

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -200,7 +200,7 @@ def argsort(x, axis=-1):
 
 
 def array(x, dtype=None):
-    return np.array(x, dtype=dtype)
+    return convert_to_tensor(x, dtype=dtype)
 
 
 def average(x, axis=None, weights=None):

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -441,7 +441,7 @@ def argsort(x, axis=-1):
 
 
 def array(x, dtype=None):
-    return tfnp.array(x, dtype=dtype)
+    return convert_to_tensor(x, dtype=dtype)
 
 
 def average(x, axis=None, weights=None):

--- a/keras/backend/torch/core.py
+++ b/keras/backend/torch/core.py
@@ -8,8 +8,10 @@ import tree
 from keras.backend.common import KerasVariable
 from keras.backend.common import global_state
 from keras.backend.common import standardize_dtype
+from keras.backend.common.dtypes import result_type
 from keras.backend.common.keras_tensor import KerasTensor
 from keras.backend.common.stateless_scope import StatelessScope
+from keras.backend.config import floatx
 from keras.utils.nest import pack_sequence_as
 
 SUPPORTS_SPARSE_TENSORS = False
@@ -145,10 +147,14 @@ def convert_to_tensor(x, dtype=None, sparse=False):
         # Return it directly instead of pass it to the rest of the logic in the
         # function.
         return x.value
-    if isinstance(x, int):
+    if isinstance(x, bool):
+        return torch.as_tensor(x, dtype=torch.bool, device=get_device())
+    elif isinstance(x, int):
         return torch.as_tensor(x, dtype=torch.int32, device=get_device())
-    if isinstance(x, float):
-        return torch.as_tensor(x, dtype=torch.float32, device=get_device())
+    elif isinstance(x, float):
+        return torch.as_tensor(
+            x, dtype=to_torch_dtype(floatx()), device=get_device()
+        )
 
     # Convert to np in case of any array-like that is not list or tuple.
     if not isinstance(x, (list, tuple)):
@@ -160,7 +166,15 @@ def convert_to_tensor(x, dtype=None, sparse=False):
         if x.dtype == np.uint32:
             # Torch backend does not support uint32.
             x = x.astype(np.int64)
+        if standardize_dtype(x.dtype) == "bfloat16":
+            # Torch backend does not support converting bfloat16 ndarray.
+            x = x.astype(np.float32)
+            dtype = "bfloat16"
         dtype = dtype or x.dtype
+    if dtype is None:
+        dtype = result_type(
+            *[getattr(item, "dtype", type(item)) for item in tree.flatten(x)]
+        )
     dtype = to_torch_dtype(dtype)
     return torch.as_tensor(x, dtype=dtype, device=get_device())
 

--- a/keras/backend/torch/core.py
+++ b/keras/backend/torch/core.py
@@ -147,14 +147,15 @@ def convert_to_tensor(x, dtype=None, sparse=None):
         # Return it directly instead of pass it to the rest of the logic in the
         # function.
         return x.value
-    if isinstance(x, bool):
-        return torch.as_tensor(x, dtype=torch.bool, device=get_device())
-    elif isinstance(x, int):
-        return torch.as_tensor(x, dtype=torch.int32, device=get_device())
-    elif isinstance(x, float):
-        return torch.as_tensor(
-            x, dtype=to_torch_dtype(floatx()), device=get_device()
-        )
+    if dtype is None:
+        if isinstance(x, bool):
+            return torch.as_tensor(x, dtype=torch.bool, device=get_device())
+        elif isinstance(x, int):
+            return torch.as_tensor(x, dtype=torch.int32, device=get_device())
+        elif isinstance(x, float):
+            return torch.as_tensor(
+                x, dtype=to_torch_dtype(floatx()), device=get_device()
+            )
 
     # Convert to np in case of any array-like that is not list or tuple.
     if not isinstance(x, (list, tuple)):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -311,10 +311,7 @@ def argsort(x, axis=-1):
 
 
 def array(x, dtype=None):
-    dtype = to_torch_dtype(dtype)
-    if isinstance(x, torch.Tensor):
-        return x
-    return torch.tensor(x, dtype=dtype, device=get_device())
+    return convert_to_tensor(x, dtype=dtype)
 
 
 def average(x, axis=None, weights=None):

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -1,5 +1,8 @@
+import contextlib
+
 import numpy as np
 import pytest
+from absl.testing import parameterized
 
 from keras import backend
 from keras import layers
@@ -9,6 +12,7 @@ from keras import ops
 from keras import optimizers
 from keras import testing
 from keras.backend.common.keras_tensor import KerasTensor
+from keras.backend.common.variables import ALLOWED_DTYPES
 from keras.ops import core
 
 
@@ -412,3 +416,53 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(
             backend.convert_to_numpy(output), 2 * np.ones((2, 3))
         )
+
+
+class CoreOpsDtypeTest(testing.TestCase, parameterized.TestCase):
+    # TODO: Using uint64 will lead to weak type promotion (`float`),
+    # resulting in different behavior between JAX and Keras. Currently, we
+    # are skipping the test for uint64
+    ALL_DTYPES = [
+        x for x in ALLOWED_DTYPES if x not in ["string", "uint64"]
+    ] + [None]
+
+    if backend.backend() == "torch":
+        # TODO: torch doesn't support uint16, uint32 and uint64
+        ALL_DTYPES = [
+            x for x in ALL_DTYPES if x not in ["uint16", "uint32", "uint64"]
+        ]
+
+    @parameterized.parameters(
+        (bool(0), "bool"),
+        (int(0), "int32"),
+        (float(0), backend.floatx()),
+        ([False, True, False], "bool"),
+        ([1, 2, 3], "int32"),
+        ([1.0, 2.0, 3.0], backend.floatx()),
+        ([1, 2.0, 3], backend.floatx()),
+        ([[False], [True], [False]], "bool"),
+        ([[1], [2], [3]], "int32"),
+        ([[1], [2.0], [3]], backend.floatx()),
+        *[
+            (np.array(0, dtype=dtype), dtype)
+            for dtype in ALL_DTYPES
+            if dtype is not None
+        ],
+    )
+    def test_convert_to_tensor(self, x, expected_dtype):
+        # We have to disable x64 for jax backend since jnp.array doesn't respect
+        # JAX_DEFAULT_DTYPE_BITS=32 in `./conftest.py`. We also need to downcast
+        # the expected dtype from 64 bit to 32 bit.
+        if backend.backend() == "jax":
+            import jax.experimental
+
+            jax_disable_x64 = jax.experimental.disable_x64()
+            expected_dtype = expected_dtype.replace("64", "32")
+        else:
+            jax_disable_x64 = contextlib.nullcontext()
+
+        with jax_disable_x64:
+            self.assertEqual(
+                backend.standardize_dtype(ops.convert_to_tensor(x).dtype),
+                expected_dtype,
+            )

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4600,8 +4600,12 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_argmax(self, dtype):
         import jax.numpy as jnp
 
-        x = knp.array([[1, 2, 3], [3, 2, 1]], dtype=dtype)
-        x_jax = jnp.array([[1, 2, 3], [3, 2, 1]], dtype=dtype)
+        if dtype == "bool":
+            value = [[True, False, True], [False, True, False]]
+        else:
+            value = [[1, 2, 3], [3, 2, 1]]
+        x = knp.array(value, dtype=dtype)
+        x_jax = jnp.array(value, dtype=dtype)
         expected_dtype = standardize_dtype(jnp.argmax(x_jax).dtype)
 
         self.assertEqual(standardize_dtype(knp.argmax(x).dtype), expected_dtype)
@@ -4614,8 +4618,12 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_argmin(self, dtype):
         import jax.numpy as jnp
 
-        x = knp.array([[1, 2, 3], [3, 2, 1]], dtype=dtype)
-        x_jax = jnp.array([[1, 2, 3], [3, 2, 1]], dtype=dtype)
+        if dtype == "bool":
+            value = [[True, False, True], [False, True, False]]
+        else:
+            value = [[1, 2, 3], [3, 2, 1]]
+        x = knp.array(value, dtype=dtype)
+        x_jax = jnp.array(value, dtype=dtype)
         expected_dtype = standardize_dtype(jnp.argmin(x_jax).dtype)
 
         self.assertEqual(standardize_dtype(knp.argmin(x).dtype), expected_dtype)
@@ -4628,8 +4636,12 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_argsort(self, dtype):
         import jax.numpy as jnp
 
-        x = knp.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
-        x_jax = jnp.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+        if dtype == "bool":
+            value = [[True, False, True], [False, True, False]]
+        else:
+            value = [[1, 2, 3], [4, 5, 6]]
+        x = knp.array(value, dtype=dtype)
+        x_jax = jnp.array(value, dtype=dtype)
         expected_dtype = standardize_dtype(jnp.argsort(x_jax).dtype)
 
         self.assertEqual(
@@ -4835,8 +4847,14 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
 
         if dtype is None:
             dtype = backend.floatx()
-        x = knp.array([[1.2, 2.1, 2.5], [2.4, 11.9, 5.5]], dtype=dtype)
-        x_jax = jnp.array([[1.2, 2.1, 2.5], [2.4, 11.9, 5.5]], dtype=dtype)
+        if dtype == "bool":
+            value = [[True, False, True], [True, False, True]]
+        elif "int" in dtype:
+            value = [[1, 2, 2], [2, 11, 5]]
+        else:
+            value = [[1.2, 2.1, 2.5], [2.4, 11.9, 5.5]]
+        x = knp.array(value, dtype=dtype)
+        x_jax = jnp.array(value, dtype=dtype)
         expected_dtype = standardize_dtype(jnp.ceil(x_jax).dtype)
         if dtype == "int64":
             expected_dtype = backend.floatx()

--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -825,8 +825,14 @@ class CosineDecayRestarts(LearningRateSchedule):
             def compute_step(completed_fraction, geometric=False):
                 """Helper for `cond` operation."""
                 if geometric:
+                    # ops.log is sensitive to the precision of dtype, so we need
+                    # the additional casting
                     i_restart = ops.floor(
-                        ops.log(1.0 - completed_fraction * (1.0 - t_mul))
+                        ops.log(
+                            ops.cast(
+                                1.0 - completed_fraction * (1.0 - t_mul), dtype
+                            )
+                        )
                         / ops.log(t_mul)
                     )
 


### PR DESCRIPTION
This PR assures that the inferred dtype of `ops.array` and `ops.convert_to_tensor` remains consistent across different backends.

It is worth noting that overhead is introduced in `ops.convert_to_tensor` when the incoming dtype is `None`. Please let me know if it is not suitable.

A future warning:
`JAX_DEFAULT_DTYPE_BITS=32` is not working with `jnp.array` and it should be considered as not maintained in the future. https://github.com/google/jax/issues/17842
The unit tests of dtype might require some refactoring because they relies on `JAX_DEFAULT_DTYPE_BITS`. However, I don't have a clear idea about it at the moment.
I've added the extra logic for jax in the unit tests as a temporary fix.
