### PR TITLE
Export `is_tensor` to the public API

### DIFF
--- a/keras/ops/core.py
+++ b/keras/ops/core.py
@@ -629,3 +629,8 @@ def vectorized_map(function, elements):
     a single list of tensor arguments.
     """
     return backend.core.vectorized_map(function, elements)
+
+
+@keras_export("keras.ops.is_tensor")
+def is_tensor(x):
+    return backend.is_tensor(x)

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -411,3 +411,11 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(
             backend.convert_to_numpy(output), 2 * np.ones((2, 3))
         )
+
+    def test_is_tensor(self):
+        x = ops.array([1, 2, 3])
+        self.assertTrue(ops.is_tensor(x))
+        self.assertFalse(ops.is_tensor([1, 2, 3]))
+        if backend.backend() != "numpy":
+            x = np.array([1, 2, 3])
+            self.assertFalse(ops.is_tensor(x))


### PR DESCRIPTION
`is_tensor` was imported in the `keras/ops/__init__.py` file but not exported in the public API. This omission doesn't seem intentional. This PR fixes this by exporting the `keras.ops.is_tensor` function so it's available in the released public API.

@grasskin @fchollet 