### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+## Security vulnerability reports
+
+Since Keras is the high-level API of TensorFlow 2, Keras follows the same security practices as TensorFlow.
+For details on guidelines on vulnerabilities and how to report them, you can refer to [Using TensorFlow Securely](https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md). 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ used before a patch is released.
 
 You may submit the report in the following ways:
 
-- send an email to ???@???; and/or
+- send an email to fchollet@google.com; and/or
 - send a [private vulnerability report](https://github.com/keras-team/keras/security/advisories/new)
 
 Please provide the following information in your report:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,19 @@
-## Security vulnerability reports
+# Security Policy
 
-Since Keras is the high-level API of TensorFlow 2, Keras follows the same security practices as TensorFlow.
-For details on guidelines on vulnerabilities and how to report them, you can refer to [Using TensorFlow Securely](https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md). 
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to ???@???; and/or
+- send a [private vulnerability report](https://github.com/keras-team/keras/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by volunteers on a reasonable-effort basis. As such,
+please give us 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #18761.

This PR adds a security policy to keras-team/keras. It is currently the same one used in /tf-keras. If you'd rather use something else, let me know.