### PR TITLE
Added jax support for standardize_dtype

### DIFF
--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -374,7 +374,9 @@ def standardize_dtype(dtype):
     dtype = PYTHON_DTYPES_MAP.get(dtype, dtype)
     if hasattr(dtype, "name"):
         dtype = dtype.name
-    elif hasattr(dtype, "__str__") and "torch" in str(dtype):
+    elif hasattr(dtype, "__str__") and (
+        "torch" in str(dtype) or "jax.numpy" in str(dtype)
+    ):
         dtype = str(dtype).split(".")[-1]
 
     if dtype not in ALLOWED_DTYPES:


### PR DESCRIPTION
This PR adds jax support for `standardize_dtype`.

One thing that came up during this PR that I think is worth asking is: should `ALLOWED_DTYPES` be backend specific? See test for where things get a bit ugly with torch / jax config.