### PR TITLE
Added missing get_config on select LossFunctionWrappers

### DIFF
--- a/keras/losses/losses.py
+++ b/keras/losses/losses.py
@@ -182,6 +182,9 @@ class CosineSimilarity(LossFunctionWrapper):
             cosine_similarity, reduction=reduction, name=name, axis=axis
         )
 
+    def get_config(self):
+        return Loss.get_config(self)
+
 
 @keras_export("keras.losses.Huber")
 class Huber(LossFunctionWrapper):
@@ -217,6 +220,9 @@ class Huber(LossFunctionWrapper):
     ):
         super().__init__(huber, name=name, reduction=reduction, delta=delta)
 
+    def get_config(self):
+        return Loss.get_config(self)
+
 
 @keras_export("keras.losses.LogCosh")
 class LogCosh(LossFunctionWrapper):
@@ -239,6 +245,9 @@ class LogCosh(LossFunctionWrapper):
 
     def __init__(self, reduction="sum_over_batch_size", name="log_cosh"):
         super().__init__(log_cosh, name=name, reduction=reduction)
+
+    def get_config(self):
+        return Loss.get_config(self)
 
 
 @keras_export("keras.losses.Hinge")

--- a/keras/losses/losses_test.py
+++ b/keras/losses/losses_test.py
@@ -433,6 +433,8 @@ class CosineSimilarityTest(testing.TestCase):
         )
         self.assertEqual(cosine_obj.name, "cosine_loss")
         self.assertEqual(cosine_obj.reduction, "sum")
+        config = cosine_obj.get_config()
+        self.assertEqual(config, {"name": "cosine_loss", "reduction": "sum"})
 
     def test_unweighted(self):
         self.setup()
@@ -517,6 +519,8 @@ class HuberLossTest(testing.TestCase):
         h_obj = losses.Huber(reduction="sum", name="huber")
         self.assertEqual(h_obj.name, "huber")
         self.assertEqual(h_obj.reduction, "sum")
+        config = h_obj.get_config()
+        self.assertEqual(config, {"name": "huber", "reduction": "sum"})
 
     def test_all_correct(self):
         self.setup()
@@ -615,6 +619,8 @@ class LogCoshTest(testing.TestCase):
         logcosh_obj = losses.LogCosh(reduction="sum", name="logcosh_loss")
         self.assertEqual(logcosh_obj.name, "logcosh_loss")
         self.assertEqual(logcosh_obj.reduction, "sum")
+        config = logcosh_obj.get_config()
+        self.assertEqual(config, {"name": "logcosh_loss", "reduction": "sum"})
 
     def test_unweighted(self):
         self.setup()


### PR DESCRIPTION
Some `LossFunctionWrapper` implementations were still calling `LossFunctionWrapper.get_config` rather than `Loss.get_config`, making deserialization fail. This PR addresses these.

Note the existing `test_config` tests seem misleadingly named, as they don't test the config returned by `get_config`.