### PR TITLE
Set noise_shape to None in attention.py

### DIFF
--- a/keras/layers/attention/additive_attention_test.py
+++ b/keras/layers/attention/additive_attention_test.py
@@ -17,12 +17,12 @@ class AdditiveAttentionTest(testing.TestCase):
             expected_output_shape=(2, 3, 4),
             expected_num_trainable_weights=1,
             expected_num_non_trainable_weights=0,
-            expected_num_seed_generators=0,
+            expected_num_seed_generators=1,
             expected_num_losses=0,
             supports_masking=True,
             run_training_check=False,
         )
-        # Sale.
+        # Scale.
         self.run_layer_test(
             layers.AdditiveAttention,
             init_kwargs={
@@ -33,7 +33,7 @@ class AdditiveAttentionTest(testing.TestCase):
             expected_output_shape=(2, 3, 4),
             expected_num_trainable_weights=0,
             expected_num_non_trainable_weights=0,
-            expected_num_seed_generators=0,
+            expected_num_seed_generators=1,
             expected_num_losses=0,
             supports_masking=True,
             run_training_check=False,

--- a/keras/layers/attention/attention.py
+++ b/keras/layers/attention/attention.py
@@ -27,6 +27,7 @@ class Attention(Layer):
             attention scores.
         dropout: Float between 0 and 1. Fraction of the units to drop for the
             attention scores. Defaults to `0.0`.
+        seed: A Python integer to use as random seed incase of `dropout`.
         score_mode: Function to use to compute attention scores, one of
             `{"dot", "concat"}`. `"dot"` refers to the dot product between the
             query and key vectors. `"concat"` refers to the hyperbolic tangent
@@ -66,12 +67,16 @@ class Attention(Layer):
         use_scale=False,
         score_mode="dot",
         dropout=0.0,
+        seed=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.use_scale = use_scale
         self.score_mode = score_mode
         self.dropout = dropout
+        if self.dropout > 0:
+            self.seed_generator = backend.random.SeedGenerator(seed=seed)
+
         if self.score_mode not in ["dot", "concat"]:
             raise ValueError(
                 "Invalid value for argument score_mode. "

--- a/keras/layers/attention/attention.py
+++ b/keras/layers/attention/attention.py
@@ -174,7 +174,7 @@ class Attention(Layer):
             weights = backend.random.dropout(
                 weights,
                 self.dropout,
-                noise_shape=self.noise_shape,
+                noise_shape=None,
                 seed=self.seed_generator,
             )
         return ops.matmul(weights, value), weights

--- a/keras/layers/attention/attention.py
+++ b/keras/layers/attention/attention.py
@@ -175,7 +175,7 @@ class Attention(Layer):
                 weights,
                 self.dropout,
                 noise_shape=None,
-                seed=self.seed_generator,
+                seed=None,
             )
         return ops.matmul(weights, value), weights
 

--- a/keras/layers/attention/attention_test.py
+++ b/keras/layers/attention/attention_test.py
@@ -103,12 +103,8 @@ class AttentionTest(testing.TestCase):
     def test_attention_with_dropout(self):
         query = np.array([[[1.0, 0.0], [0.0, 1.0]]])
         value = np.array([[[1.0, 1.0], [1.0, 1.0]]])
-        layer_with_dropout = layers.Attention(
-            dropout=0.2, noise_shape=None, seed_generator=None
-        )
-        layer_without_dropout = layers.Attention(
-            noise_shape=None, seed_generator=None
-        )
+        layer_with_dropout = layers.Attention(dropout=0.2)
+        layer_without_dropout = layers.Attention()
 
         output1, scores1 = layer_with_dropout(
             [query, value], return_attention_scores=True, training=True

--- a/keras/layers/attention/attention_test.py
+++ b/keras/layers/attention/attention_test.py
@@ -107,6 +107,8 @@ class AttentionTest(testing.TestCase):
         output, scores = layer(
             [query, value],
             return_attention_scores=True,
+            training=True
         )
-        self.assertAllClose(output, [[[1.0, 1.0], [1.0, 1.0]]])
-        self.assertAllClose(scores, [[[0.5, 0.5], [0.5, 0.5]]])
+        self.assertIsNotNone(output)
+        self.assertIsNotNone(scores)
+        

--- a/keras/layers/attention/attention_test.py
+++ b/keras/layers/attention/attention_test.py
@@ -17,12 +17,12 @@ class AttentionTest(testing.TestCase):
             expected_output_shape=(2, 3, 4),
             expected_num_trainable_weights=0,
             expected_num_non_trainable_weights=0,
-            expected_num_seed_generators=0,
+            expected_num_seed_generators=1,
             expected_num_losses=0,
             supports_masking=True,
             run_training_check=False,
         )
-        # Sale and concat.
+        # Scale and concat.
         self.run_layer_test(
             layers.Attention,
             init_kwargs={
@@ -34,7 +34,7 @@ class AttentionTest(testing.TestCase):
             expected_output_shape=(2, 3, 4),
             expected_num_trainable_weights=2,
             expected_num_non_trainable_weights=0,
-            expected_num_seed_generators=0,
+            expected_num_seed_generators=1,
             expected_num_losses=0,
             supports_masking=True,
             run_training_check=False,

--- a/keras/layers/attention/attention_test.py
+++ b/keras/layers/attention/attention_test.py
@@ -101,14 +101,20 @@ class AttentionTest(testing.TestCase):
             layer([tensor, tensor], mask=[tensor])
 
     def test_attention_with_dropout(self):
-        layer = layers.Attention(dropout=0.2)
         query = np.array([[[1.0, 0.0], [0.0, 1.0]]])
         value = np.array([[[1.0, 1.0], [1.0, 1.0]]])
-        output, scores = layer(
-            [query, value],
-            return_attention_scores=True,
-            training=True
+        layer_with_dropout = layers.Attention(
+            dropout=0.2, noise_shape=None, seed_generator=None
         )
-        self.assertIsNotNone(output)
-        self.assertIsNotNone(scores)
-        
+        layer_without_dropout = layers.Attention(
+            noise_shape=None, seed_generator=None
+        )
+
+        output1, scores1 = layer_with_dropout(
+            [query, value], return_attention_scores=True, training=True
+        )
+        output2, scores2 = layer_without_dropout(
+            [query, value], return_attention_scores=True, training=True
+        )
+        self.assertNotAllClose(output1, output2)
+        self.assertNotAllClose(scores1, scores2)

--- a/keras/layers/attention/attention_test.py
+++ b/keras/layers/attention/attention_test.py
@@ -99,3 +99,14 @@ class AttentionTest(testing.TestCase):
 
         with self.assertRaisesRegex(ValueError, "length 2 or 3"):
             layer([tensor, tensor], mask=[tensor])
+
+    def test_attention_with_dropout(self):
+        layer = layers.Attention(dropout=0.2)
+        query = np.array([[[1.0, 0.0], [0.0, 1.0]]])
+        value = np.array([[[1.0, 1.0], [1.0, 1.0]]])
+        output, scores = layer(
+            [query, value],
+            return_attention_scores=True,
+        )
+        self.assertAllClose(output, [[[1.0, 1.0], [1.0, 1.0]]])
+        self.assertAllClose(scores, [[[0.5, 0.5], [0.5, 0.5]]])


### PR DESCRIPTION
The API `keras.layers.Attention` implementation has this below line `noise_shape=self.noise_shape` that fails since attention layer has no attribute `noise_shape`. Since this argument passed to the function `backend.random.dropout()` which has  default value set as `None`.So we can set `noise_shape=None` to make it works.

Fixes #18754