### PR TITLE
Fix torch breakage for convert_to_tensor([])

### DIFF
--- a/keras/backend/common/dtypes.py
+++ b/keras/backend/common/dtypes.py
@@ -268,10 +268,9 @@ def result_type(*dtypes):
     "float32"
     """
     if len(dtypes) == 0:
-        raise ValueError(
-            "Invalid `dtypes`. At least one dtype is required. "
-            f"Received: dtypes={dtypes}"
-        )
+        # If no dtypes provided, default to floatx, this matches
+        # `ops.convert_to_tensor([])`
+        return backend.floatx()
     return _lattice_result_type(
         *(backend.floatx() if arg is None else arg for arg in dtypes),
     )

--- a/keras/backend/common/dtypes_test.py
+++ b/keras/backend/common/dtypes_test.py
@@ -66,11 +66,8 @@ class DtypesTest(test_case.TestCase, parameterized.TestCase):
 
         self.assertEqual(backend.result_type(None), jnp.result_type(None).name)
 
-    def test_result_type_invalid_dtypes(self):
-        with self.assertRaisesRegexp(
-            ValueError, "Invalid `dtypes`. At least one dtype is required."
-        ):
-            backend.result_type()
+    def test_result_type_empty_list(self):
+        self.assertEqual(backend.result_type(), "float32")
 
     def test_respect_weak_type_for_bool(self):
         self.assertEqual(dtypes._respect_weak_type("bool", True), "bool")

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -299,6 +299,13 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         self.assertAllEqual(x, (1, 1))
         self.assertIsInstance(x, np.ndarray)
 
+        # Empty lists should give an empty array with the default float type.
+        x = ops.convert_to_tensor([])
+        x = ops.convert_to_numpy(x)
+        self.assertAllEqual(x, [])
+        self.assertIsInstance(x, np.ndarray)
+        self.assertEqual(x.dtype.name, "float32")
+
         # Partially converted.
         x = ops.convert_to_tensor((1, ops.array(2), 3))
         self.assertAllEqual(x, (1, 2, 3))


### PR DESCRIPTION
Broke with https://github.com/keras-team/keras/pull/18752

Alternately we could handle this case in `torch.convert_to_tensor`, if we want to preserve the `result_type` error.