### PR TITLE
Fix tensorflow convert_to_tensor for boolean types

### DIFF
--- a/keras/backend/tensorflow/core.py
+++ b/keras/backend/tensorflow/core.py
@@ -105,6 +105,11 @@ def convert_to_tensor(x, dtype=None, sparse=None):
     if dtype is not None:
         dtype = standardize_dtype(dtype)
     if not tf.is_tensor(x):
+        if dtype == "bool":
+            # TensorFlow boolean conversion is stricter than other backends.
+            # It does not allow ints. We convert without dtype and cast instead.
+            x = tf.convert_to_tensor(x)
+            return tf.cast(x, dtype)
         return tf.convert_to_tensor(x, dtype=dtype)
     elif dtype is not None:
         return tf.cast(x, dtype=dtype)

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -11,6 +11,7 @@ from keras import models
 from keras import ops
 from keras import optimizers
 from keras import testing
+from keras.backend.common import standardize_dtype
 from keras.backend.common.keras_tensor import KerasTensor
 from keras.backend.common.variables import ALLOWED_DTYPES
 from keras.ops import core
@@ -302,6 +303,17 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         # Partially converted.
         x = ops.convert_to_tensor((1, ops.array(2), 3))
         self.assertAllEqual(x, (1, 2, 3))
+
+        # Check dtype convertion.
+        x = [[1, 0, 1], [1, 1, 0]]
+        output = ops.convert_to_tensor(x, dtype="int32")
+        self.assertEqual(standardize_dtype(output.dtype), "int32")
+        x = [[1, 0, 1], [1, 1, 0]]
+        output = ops.convert_to_tensor(x, dtype="float32")
+        self.assertEqual(standardize_dtype(output.dtype), "float32")
+        x = [[1, 0, 1], [1, 1, 0]]
+        output = ops.convert_to_tensor(x, dtype="bool")
+        self.assertEqual(standardize_dtype(output.dtype), "bool")
 
         with self.assertRaises(ValueError):
             ops.convert_to_numpy(KerasTensor((2,)))

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -2936,6 +2936,17 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertTrue(backend.is_tensor(knp.array(x)))
         self.assertTrue(backend.is_tensor(knp.Array()(x)))
 
+        # Check dtype convertion.
+        x = [[1, 0, 1], [1, 1, 0]]
+        output = knp.array(x, dtype="int32")
+        self.assertEqual(standardize_dtype(output.dtype), "int32")
+        x = [[1, 0, 1], [1, 1, 0]]
+        output = knp.array(x, dtype="float32")
+        self.assertEqual(standardize_dtype(output.dtype), "float32")
+        x = [[1, 0, 1], [1, 1, 0]]
+        output = knp.array(x, dtype="bool")
+        self.assertEqual(standardize_dtype(output.dtype), "bool")
+
     def test_average(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         weights = np.ones([2, 3])


### PR DESCRIPTION
This appears to be a recent breakage, though I am not exactly sure what chaged. `ops.convert_to_tensor([1, 0, 1], dtype="bool")` works on all backends but tf. We should allow it to work on tf.