### PR TITLE
Apply `backend.result_type` to `append`, `average`, `broadcast_to`, `concatenate`, `copy`, `count_nonzero`, `cross`, `diag*`, `diff` and `digitize`

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -272,7 +272,7 @@ def cosh(x):
 
 
 def count_nonzero(x, axis=None):
-    return jnp.count_nonzero(x, axis=axis)
+    return cast(jnp.count_nonzero(x, axis=axis), "int32")
 
 
 def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):

--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -110,11 +110,7 @@ def amin(x, axis=None, keepdims=False):
     return jnp.amin(x, axis=axis, keepdims=keepdims)
 
 
-def append(
-    x1,
-    x2,
-    axis=None,
-):
+def append(x1, x2, axis=None):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
     return jnp.append(x1, x2, axis=axis)
@@ -212,6 +208,15 @@ def array(x, dtype=None):
 
 
 def average(x, axis=None, weights=None):
+    x = convert_to_tensor(x)
+    dtypes_to_resolve = [x.dtype, float]
+    if weights is not None:
+        weights = convert_to_tensor(weights)
+        dtypes_to_resolve.append(weights.dtype)
+    dtype = dtypes.result_type(*dtypes_to_resolve)
+    x = cast(x, dtype)
+    if weights is not None:
+        weights = cast(weights, dtype)
     return jnp.average(x, weights=weights, axis=axis)
 
 

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -320,6 +320,11 @@ def count_nonzero(x, axis=None):
 
 def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = x1.astype(dtype)
+    x2 = x2.astype(dtype)
     return np.cross(
         x1,
         x2,

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -1,4 +1,5 @@
 import numpy as np
+import tree
 
 from keras.backend import config
 from keras.backend import standardize_dtype
@@ -94,12 +95,13 @@ def amin(x, axis=None, keepdims=False):
     return np.amin(x, axis=axis, keepdims=keepdims)
 
 
-def append(
-    x1,
-    x2,
-    axis=None,
-):
+def append(x1, x2, axis=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = x1.astype(dtype)
+    x2 = x2.astype(dtype)
     return np.append(x1, x2, axis=axis)
 
 
@@ -205,6 +207,15 @@ def array(x, dtype=None):
 
 def average(x, axis=None, weights=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
+    x = convert_to_tensor(x)
+    dtypes_to_resolve = [x.dtype, float]
+    if weights is not None:
+        weights = convert_to_tensor(weights)
+        dtypes_to_resolve.append(weights.dtype)
+    dtype = dtypes.result_type(*dtypes_to_resolve)
+    x = x.astype(dtype)
+    if weights is not None:
+        weights = weights.astype(dtype)
     return np.average(x, weights=weights, axis=axis)
 
 
@@ -259,6 +270,12 @@ def clip(x, x_min, x_max):
 
 def concatenate(xs, axis=0):
     axis = tuple(axis) if isinstance(axis, list) else axis
+    dtype_set = set([getattr(x, "dtype", type(x)) for x in xs])
+    if len(dtype_set) > 1:
+        dtype = dtypes.result_type(*dtype_set)
+        xs = tree.map_structure(
+            lambda x: convert_to_tensor(x).astype(dtype), xs
+        )
     return np.concatenate(xs, axis=axis)
 
 

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -313,7 +313,9 @@ def cosh(x):
 
 def count_nonzero(x, axis=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    return np.count_nonzero(x, axis=axis)
+    # np.count_nonzero will return python int when axis=None, so we need
+    # to convert_to_tensor
+    return convert_to_tensor(np.count_nonzero(x, axis=axis)).astype("int32")
 
 
 def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -547,6 +547,11 @@ def count_nonzero(x, axis=None):
 
 
 def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = tf.cast(x1, dtype)
+    x2 = tf.cast(x2, dtype)
     return tfnp.cross(
         x1,
         x2,

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -542,7 +542,7 @@ def cosh(x):
 
 
 def count_nonzero(x, axis=None):
-    return tfnp.count_nonzero(x, axis=axis)
+    return tf.cast(tfnp.count_nonzero(x, axis=axis), "int32")
 
 
 def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -605,18 +605,16 @@ def digitize(x, bins):
         x = tf.cast(x, "float32")
 
     if isinstance(x, tf.RaggedTensor):
-        out = tf.ragged.map_flat_values(
+        return tf.ragged.map_flat_values(
             lambda y: tf.raw_ops.Bucketize(input=y, boundaries=bins), x
         )
     elif isinstance(x, tf.SparseTensor):
-        out = tf.SparseTensor(
+        return tf.SparseTensor(
             indices=tf.identity(x.indices),
             values=tf.raw_ops.Bucketize(input=x.values, boundaries=bins),
             dense_shape=tf.identity(x.dense_shape),
         )
-    else:
-        out = tf.raw_ops.Bucketize(input=x, boundaries=bins)
-    return out
+    return tf.raw_ops.Bucketize(input=x, boundaries=bins)
 
 
 def dot(x, y):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -433,7 +433,7 @@ def count_nonzero(x, axis=None):
     if axis == () or axis == []:
         # Torch handles the empty axis case differently from numpy.
         return cast(torch.ne(x, 0), "int32")
-    return torch.count_nonzero(x, dim=axis).T
+    return cast(torch.count_nonzero(x, dim=axis).T, "int32")
 
 
 def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=-1):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -206,11 +206,7 @@ def amin(x, axis=None, keepdims=False):
     return torch.amin(x, dim=axis, keepdim=keepdims)
 
 
-def append(
-    x1,
-    x2,
-    axis=None,
-):
+def append(x1, x2, axis=None):
     x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
     if axis is None:
         return torch.cat((x1.flatten(), x2.flatten()))
@@ -316,13 +312,18 @@ def array(x, dtype=None):
 
 def average(x, axis=None, weights=None):
     x = convert_to_tensor(x)
-    # Conversion to float necessary for `torch.mean`
-    x = cast(x, "float32") if x.dtype in TORCH_INT_TYPES else x
+    dtypes_to_resolve = [x.dtype, float]
+    if weights is not None:
+        weights = convert_to_tensor(weights)
+        dtypes_to_resolve.append(weights.dtype)
+    dtype = dtypes.result_type(*dtypes_to_resolve)
+    x = cast(x, dtype)
+    if weights is not None:
+        weights = cast(weights, dtype)
     if axis == () or axis == []:
         # Torch handles the empty axis case differently from numpy.
         return x
     if weights is not None:
-        weights = convert_to_tensor(weights)
         return torch.sum(torch.mul(x, weights), dim=axis) / torch.sum(
             weights, dim=-1
         )

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -497,6 +497,8 @@ def diff(a, n=1, axis=-1):
 def digitize(x, bins):
     x = convert_to_tensor(x)
     bins = convert_to_tensor(bins)
+    if standardize_dtype(x.dtype) == "bool":
+        x = cast(x, "uint8")
     return cast(torch.bucketize(x, bins, right=True), "int32")
 
 

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -443,8 +443,19 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=-1):
             f"Received: axisa={axisa}, axisb={axisb}, axisc={axisc}. Please "
             "use `axis` arg in torch backend."
         )
-    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
-    return torch.cross(x1, x2, dim=axis)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    compute_dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    result_dtype = compute_dtype
+    # TODO: torch.cross doesn't support bfloat16 with gpu
+    if get_device() == "cuda" and compute_dtype == "bfloat16":
+        compute_dtype = "float32"
+    # TODO: torch.cross doesn't support float16 with cpu
+    elif get_device() == "cpu" and compute_dtype == "float16":
+        compute_dtype = "float32"
+    x1 = cast(x1, compute_dtype)
+    x2 = cast(x2, compute_dtype)
+    return cast(torch.cross(x1, x2, dim=axis), result_dtype)
 
 
 def cumprod(x, axis=None):

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -11,7 +11,6 @@ from keras import models
 from keras import ops
 from keras import optimizers
 from keras import testing
-from keras.backend.common import standardize_dtype
 from keras.backend.common.keras_tensor import KerasTensor
 from keras.backend.common.variables import ALLOWED_DTYPES
 from keras.ops import core
@@ -300,27 +299,9 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         self.assertAllEqual(x, (1, 1))
         self.assertIsInstance(x, np.ndarray)
 
-        # Empty lists should give an empty array with the default float type.
-        x = ops.convert_to_tensor([])
-        x = ops.convert_to_numpy(x)
-        self.assertAllEqual(x, [])
-        self.assertIsInstance(x, np.ndarray)
-        self.assertEqual(x.dtype.name, "float32")
-
         # Partially converted.
         x = ops.convert_to_tensor((1, ops.array(2), 3))
         self.assertAllEqual(x, (1, 2, 3))
-
-        # Check dtype convertion.
-        x = [[1, 0, 1], [1, 1, 0]]
-        output = ops.convert_to_tensor(x, dtype="int32")
-        self.assertEqual(standardize_dtype(output.dtype), "int32")
-        x = [[1, 0, 1], [1, 1, 0]]
-        output = ops.convert_to_tensor(x, dtype="float32")
-        self.assertEqual(standardize_dtype(output.dtype), "float32")
-        x = [[1, 0, 1], [1, 1, 0]]
-        output = ops.convert_to_tensor(x, dtype="bool")
-        self.assertEqual(standardize_dtype(output.dtype), "bool")
 
         with self.assertRaises(ValueError):
             ops.convert_to_numpy(KerasTensor((2,)))
@@ -435,8 +416,18 @@ class CoreOpsCorrectnessTest(testing.TestCase):
             backend.convert_to_numpy(output), 2 * np.ones((2, 3))
         )
 
+    def test_is_tensor(self):
+        np_x = np.array([[1, 2, 3], [3, 2, 1]])
+        x = backend.convert_to_tensor(np_x)
+        if backend.backend() != "numpy":
+            self.assertFalse(ops.is_tensor(np_x))
+        self.assertTrue(ops.is_tensor(x))
+        self.assertFalse(ops.is_tensor([1, 2, 3]))
+
 
 class CoreOpsDtypeTest(testing.TestCase, parameterized.TestCase):
+    import jax  # enable bfloat16 for numpy
+
     # TODO: Using uint64 will lead to weak type promotion (`float`),
     # resulting in different behavior between JAX and Keras. Currently, we
     # are skipping the test for uint64
@@ -451,23 +442,30 @@ class CoreOpsDtypeTest(testing.TestCase, parameterized.TestCase):
         ]
 
     @parameterized.parameters(
-        (bool(0), "bool"),
-        (int(0), "int32"),
-        (float(0), backend.floatx()),
-        ([False, True, False], "bool"),
-        ([1, 2, 3], "int32"),
-        ([1.0, 2.0, 3.0], backend.floatx()),
-        ([1, 2.0, 3], backend.floatx()),
-        ([[False], [True], [False]], "bool"),
-        ([[1], [2], [3]], "int32"),
-        ([[1], [2.0], [3]], backend.floatx()),
+        ((), None, backend.floatx()),
+        ([], None, backend.floatx()),
+        (bool(0), None, "bool"),
+        (int(0), None, "int32"),
+        (float(0), None, backend.floatx()),
+        ([False, True, False], None, "bool"),
+        ([1, 2, 3], None, "int32"),
+        ([1.0, 2.0, 3.0], None, backend.floatx()),
+        ([1, 2.0, 3], None, backend.floatx()),
+        ([[False], [True], [False]], None, "bool"),
+        ([[1], [2], [3]], None, "int32"),
+        ([[1], [2.0], [3]], None, backend.floatx()),
         *[
-            (np.array(0, dtype=dtype), dtype)
+            (np.array(0, dtype=dtype), None, dtype)
+            for dtype in ALL_DTYPES
+            if dtype is not None
+        ],
+        *[
+            ([[1, 0, 1], [1, 1, 0]], dtype, dtype)
             for dtype in ALL_DTYPES
             if dtype is not None
         ],
     )
-    def test_convert_to_tensor(self, x, expected_dtype):
+    def test_convert_to_tensor(self, x, dtype, expected_dtype):
         # We have to disable x64 for jax backend since jnp.array doesn't respect
         # JAX_DEFAULT_DTYPE_BITS=32 in `./conftest.py`. We also need to downcast
         # the expected dtype from 64 bit to 32 bit.
@@ -481,14 +479,8 @@ class CoreOpsDtypeTest(testing.TestCase, parameterized.TestCase):
 
         with jax_disable_x64:
             self.assertEqual(
-                backend.standardize_dtype(ops.convert_to_tensor(x).dtype),
+                backend.standardize_dtype(
+                    ops.convert_to_tensor(x, dtype=dtype).dtype
+                ),
                 expected_dtype,
             )
-
-    def test_is_tensor(self):
-        np_x = np.array([[1, 2, 3], [3, 2, 1]])
-        x = backend.convert_to_tensor(np_x)
-        if backend.backend() != "numpy":
-            self.assertFalse(ops.is_tensor(np_x))
-        self.assertTrue(ops.is_tensor(x))
-        self.assertFalse(ops.is_tensor([1, 2, 3]))

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -299,6 +299,13 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         self.assertAllEqual(x, (1, 1))
         self.assertIsInstance(x, np.ndarray)
 
+        # Empty lists should give an empty array.
+        x = ops.convert_to_tensor([])
+        np_x = ops.convert_to_numpy(x)
+        self.assertTrue(ops.is_tensor(x))
+        self.assertAllEqual(x, [])
+        self.assertIsInstance(np_x, np.ndarray)
+
         # Partially converted.
         x = ops.convert_to_tensor((1, ops.array(2), 3))
         self.assertAllEqual(x, (1, 2, 3))

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -1724,7 +1724,9 @@ class Cross(Operation):
         output_shape = (
             output_shape[: self.axisc] + value_size + output_shape[self.axisc :]
         )
-        return KerasTensor(output_shape, dtype=x1.dtype)
+
+        dtype = dtypes.result_type(x1.dtype, x2.dtype)
+        return KerasTensor(output_shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.cross", "keras.ops.numpy.cross"])

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -604,12 +604,16 @@ class Append(Operation):
     def compute_output_spec(self, x1, x2):
         x1_shape = x1.shape
         x2_shape = x2.shape
+        dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)),
+            getattr(x2, "dtype", type(x2)),
+        )
         if self.axis is None:
             if None in x1_shape or None in x2_shape:
                 output_shape = [None]
             else:
                 output_shape = [int(np.prod(x1_shape) + np.prod(x2_shape))]
-            return KerasTensor(output_shape, dtype=x1.dtype)
+            return KerasTensor(output_shape, dtype=dtype)
 
         if not shape_equal(x1_shape, x2_shape, [self.axis]):
             raise ValueError(
@@ -620,7 +624,7 @@ class Append(Operation):
 
         output_shape = list(x1_shape)
         output_shape[self.axis] = x1_shape[self.axis] + x2_shape[self.axis]
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        return KerasTensor(output_shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.append", "keras.ops.numpy.append"])
@@ -1183,18 +1187,18 @@ class Average(Operation):
         return backend.numpy.average(x, weights=weights, axis=self.axis)
 
     def compute_output_spec(self, x, weights=None):
+        dtypes_to_resolve = [getattr(x, "dtype", type(x)), float]
         if weights is not None:
             shape_match = shape_equal(x.shape, weights.shape, allow_none=True)
             if self.axis is not None:
                 shape_match_on_axis = shape_equal(
                     [x.shape[self.axis]], weights.shape, allow_none=True
                 )
+            dtypes_to_resolve.append(getattr(weights, "dtype", type(weights)))
+        dtype = dtypes.result_type(*dtypes_to_resolve)
         if self.axis is None:
             if weights is None or shape_match:
-                return KerasTensor(
-                    [],
-                    dtype=x.dtype,
-                )
+                return KerasTensor([], dtype=dtype)
             else:
                 raise ValueError(
                     "`weights` must have the same shape as `x` when "
@@ -1204,8 +1208,7 @@ class Average(Operation):
 
         if weights is None or shape_match_on_axis or shape_match:
             return KerasTensor(
-                reduce_shape(x.shape, axis=[self.axis]),
-                dtype=x.dtype,
+                reduce_shape(x.shape, axis=[self.axis]), dtype=dtype
             )
         else:
             # `weights` can either be a 1D array of length `x.shape[axis]` or
@@ -1463,6 +1466,7 @@ class Concatenate(Operation):
         first_shape = xs[0].shape
         total_size_on_axis = 0
         all_sparse = True
+        dtypes_to_resolve = []
         for x in xs:
             if not shape_equal(
                 x.shape, first_shape, axis=[self.axis], allow_none=True
@@ -1478,9 +1482,11 @@ class Concatenate(Operation):
             else:
                 total_size_on_axis += x.shape[self.axis]
             all_sparse = all_sparse and getattr(x, "sparse", False)
+            dtypes_to_resolve.append(getattr(x, "dtype", type(x)))
         output_shape = list(first_shape)
         output_shape[self.axis] = total_size_on_axis
-        return KerasTensor(output_shape, dtype=x.dtype, sparse=all_sparse)
+        dtype = dtypes.result_type(*dtypes_to_resolve)
+        return KerasTensor(output_shape, dtype=dtype, sparse=all_sparse)
 
 
 @keras_export(

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -5090,6 +5090,38 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             expected_dtype,
         )
 
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_diff(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.diff(x_jax).dtype)
+
+        self.assertEqual(standardize_dtype(knp.diff(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Diff().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_digitize(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        bins = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        x_bins = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.digitize(x_jax, x_bins).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.digitize(x, bins).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Digitize().symbolic_call(x, bins).dtype),
+            expected_dtype,
+        )
+
     @parameterized.named_parameters(
         named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
     )

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -5043,6 +5043,56 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(
         named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
     )
+    def test_cross(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1, 1, 3), dtype=dtype1)
+        x2 = knp.ones((1, 1, 3), dtype=dtype2)
+        x1_jax = jnp.ones((1, 1, 3), dtype=dtype1)
+        x2_jax = jnp.ones((1, 1, 3), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.cross(x1_jax, x2_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.cross(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            knp.Cross().symbolic_call(x1, x2).dtype, expected_dtype
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_diag(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.diag(x_jax).dtype)
+
+        self.assertEqual(standardize_dtype(knp.diag(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Diag().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_diagonal(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1, 1, 1), dtype=dtype)
+        x_jax = jnp.ones((1, 1, 1), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.diagonal(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.diagonal(x).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Diagonal().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
     def test_divide(self, dtypes):
         import jax.numpy as jnp
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4596,6 +4596,26 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
 
     # TODO: test_einsum
 
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_append(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1,), dtype=dtype1)
+        x2 = knp.ones((1,), dtype=dtype2)
+        x1_jax = jnp.ones((1,), dtype=dtype1)
+        x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.append(x1_jax, x2_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.append(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            knp.Append().symbolic_call(x1, x2).dtype, expected_dtype
+        )
+
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_argmax(self, dtype):
         import jax.numpy as jnp
@@ -4841,6 +4861,50 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             )
         # TODO: support the assertion of knp.Array
 
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_average(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1,), dtype=dtype1)
+        x2 = knp.ones((1,), dtype=dtype2)
+        x1_jax = jnp.ones((1,), dtype=dtype1)
+        x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(
+            jnp.average(x1_jax, weights=x2_jax).dtype
+        )
+        if dtype1 is not None and "float" not in dtype1:
+            if dtype2 is not None and "float" not in dtype2:
+                if "int64" in (dtype1, dtype2) or "uint32" in (dtype1, dtype2):
+                    expected_dtype = backend.floatx()
+
+        self.assertEqual(
+            standardize_dtype(knp.average(x1, weights=x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            knp.Average().symbolic_call(x1, weights=x2).dtype, expected_dtype
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_broadcast_to(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((3,), dtype=dtype)
+        x_jax = jnp.ones((3,), dtype=dtype)
+        expected_dtype = standardize_dtype(
+            jnp.broadcast_to(x_jax, (3, 3)).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(knp.broadcast_to(x, (3, 3)).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.BroadcastTo((3, 3)).symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_ceil(self, dtype):
         import jax.numpy as jnp
@@ -4881,6 +4945,28 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             expected_dtype,
         )
 
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_concatenate(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1,), dtype=dtype1)
+        x2 = knp.ones((1,), dtype=dtype2)
+        x1_jax = jnp.ones((1,), dtype=dtype1)
+        x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(
+            jnp.concatenate([x1_jax, x2_jax]).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(knp.concatenate([x1, x2]).dtype), expected_dtype
+        )
+        self.assertEqual(
+            knp.Concatenate().symbolic_call([x1, x2]).dtype, expected_dtype
+        )
+
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_cos(self, dtype):
         import jax.numpy as jnp
@@ -4910,6 +4996,20 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(standardize_dtype(knp.cosh(x).dtype), expected_dtype)
         self.assertEqual(
             standardize_dtype(knp.Cosh().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_copy(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.copy(x_jax).dtype)
+
+        self.assertEqual(standardize_dtype(knp.copy(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Copy().symbolic_call(x).dtype),
             expected_dtype,
         )
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -5013,6 +5013,19 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             expected_dtype,
         )
 
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_count_nonzero(self, dtype):
+        x = knp.ones((1,), dtype=dtype)
+        expected_dtype = "int32"
+
+        self.assertEqual(
+            standardize_dtype(knp.count_nonzero(x).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.CountNonzero().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
     @parameterized.named_parameters(
         named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
     )


### PR DESCRIPTION
In addition to the applying `backend.result_type`, I have cleaned up the dtype tests of `convert_to_tensor`.
- Add test for `ops.convert_to_tensor(())`
- Add tests for `ops.convert_to_tensor(..., dtype=...)`
- Move `test_is_tensor` to `CoreOpsCorrectnessTest`

Currently, the status of ops applied backend.result_type is as follows:

<details>

- [x] abs
- [x] absolute
- [x] add
- [x] all
- [x] amax
- [x] amin
- [x] append
- [x] arange
- [x] arccos
- [x] arccosh
- [x] arcsin
- [x] arcsinh
- [x] arctan
- [x] arctan2
- [x] arctanh
- [x] argmax
- [x] argmin
- [x] argsort
- [x] array
- [x] average
- [x] bincount
- [x] broadcast_to
- [x] ceil
- [x] clip
- [x] concatenate
- [ ] conj  (Keras does not directly support complex data)
- [ ] conjugate  (Keras does not directly support complex data)
- [x] copy
- [x] cos
- [x] cosh
- [x] count_nonzero
- [x] cross
- [ ] cumprod  (left for #18734)
- [ ] cumsum (left for #18734)
- [x] diag
- [x] diagonal
- [x] diff
- [x] digitize
- [x] divide
- [x] dot
- [ ] einsum
- [x] empty
- [x] equal
- [x] exp
- [ ] expand_dims
- [x] expm1
- [x] eye
- [ ] flip
- [ ] floor
- [x] full
- [ ] full_like
- [x] greater
- [x] greater_equal
- [ ] hstack
- [x] identity
- [ ] imag
- [ ] interp
- [ ] isclose
- [ ] isfinite
- [ ] isinf
- [ ] isnan
- [x] less
- [x] less_equal
- [x] linspace
- [x] log
- [x] log10
- [x] log1p
- [x] log2
- [x] logaddexp
- [x] logical_and
- [x] logical_not
- [x] logical_or
- [x] logspace
- [x] matmul
- [x] max
- [x] maximum
- [x] mean
- [x] median
- [ ] meshgrid
- [ ] mgrid
- [x] min
- [x] minimum
- [x] mod
- [ ] moveaxis
- [x] multiply
- [x] nan_to_num
- [ ] ndim
- [ ] nonzero
- [x] not_equal
- [x] ones
- [ ] ones_like
- [ ] outer
- [ ] pad
- [ ] percentile
- [ ] power
- [ ] prod
- [x] quantile
- [ ] ravel
- [ ] real
- [ ] reciprocal
- [ ] repeat
- [ ] reshape
- [ ] roll
- [ ] round
- [ ] sign
- [x] sin
- [x] sinh
- [ ] size
- [ ] sort
- [ ] split
- [x] sqrt
- [ ] square
- [ ] squeeze
- [ ] stack
- [ ] std
- [x] subtract
- [x] sum
- [ ] swapaxes
- [ ] take
- [ ] take_along_axis
- [x] tan
- [x] tanh
- [ ] tensordot
- [ ] tile
- [ ] trace
- [ ] transpose
- [x] tri
- [ ] tril
- [ ] triu
- [ ] true_divide
- [ ] vdot
- [ ] vstack
- [ ] where
- [x] zeros
- [ ] zeros_like

</details>
