### PR TITLE
Remove unnecessary `print` statement

### DIFF
--- a/keras/metrics/confusion_metrics.py
+++ b/keras/metrics/confusion_metrics.py
@@ -659,7 +659,6 @@ class SensitivitySpecificityBase(Metric):
             ops.nonzero(predicate(constrained, self.value))
         )
 
-        print(feasible)
         feasible_exists = ops.greater(ops.size(feasible), 0)
         max_dependent = ops.max(ops.take(dependent, feasible), initial=0)
 


### PR DESCRIPTION
Removes print statement that unnecessarily prints intermediate computations to stdout.