### PR TITLE
Docstring improvements (type annotations, `data_format` and `weights` consistency)

### DIFF
--- a/keras/applications/convnext.py
+++ b/keras/applications/convnext.py
@@ -102,9 +102,11 @@ investigate the instantiated model.
 Args:
     include_top: Whether to include the fully-connected
         layer at the top of the network. Defaults to `True`.
-    weights: One of `None` (random initialization),
-        `"imagenet"` (pre-training on ImageNet-1k), or the path to the weights
-        file to be loaded. Defaults to `"imagenet"`.
+    weights: ```Optional[Union[Literal["imagenet"], str]]```.
+        - `None`: random initialization
+        - `"imagenet"`: (pre-training on ImageNet-1k)
+        - `str`: path to the weights file to be loaded
+        Defaults to `"imagenet"`.
     input_tensor: Optional Keras tensor
         (i.e. output of `layers.Input()`)
         to use as image input for the model.
@@ -362,9 +364,11 @@ def ConvNeXt(
             to `False` and apply preprocessing to data accordingly.
         include_top: Boolean denoting whether to include classification
             head to the model.
-        weights: one of `None` (random initialization), `"imagenet"`
-            (pre-training on ImageNet-1k),
-            or the path to the weights file to be loaded.
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - `None`: random initialization
+            - `"imagenet"`: (pre-training on ImageNet-1k)
+            - `str`: path to the weights file to be loaded
+            Defaults to `None`.
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to
             use as image input for the model.
         input_shape: optional shape tuple, only to be specified if `include_top`
@@ -738,10 +742,13 @@ def preprocess_input(x, data_format=None):
 
     Args:
         x: A floating point `numpy.array` or a tensor.
-        data_format: Optional data format of the image tensor/array. Defaults to
-            None, in which case the global setting
-            `keras.backend.image_data_format()` is used
-            (unless you changed it, it defaults to `"channels_last"`).{mode}
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
 
     Returns:
         Unchanged `numpy.array` or tensor.

--- a/keras/applications/densenet.py
+++ b/keras/applications/densenet.py
@@ -142,9 +142,10 @@ def DenseNet(
         blocks: numbers of building blocks for the four dense layers.
         include_top: whether to include the fully-connected
             layer at the top of the network.
-        weights: one of `None` (random initialization),
-            `"imagenet"` (pre-training on ImageNet),
-            or the path to the weights file to be loaded.
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - `None`: random initialization
+            - `"imagenet"`: (pre-training on ImageNet-1k)
+            - `str`: path to the weights file to be loaded
         input_tensor: optional Keras tensor
             (i.e. output of `layers.Input()`)
             to use as image input for the model.
@@ -442,40 +443,39 @@ on your inputs before passing them to the model.
 
 Args:
     include_top: whether to include the fully-connected
-    layer at the top of the network.
-    weights: one of `None` (random initialization),
-    `"imagenet"` (pre-training on ImageNet),
-    or the path to the weights file to be loaded.
-    input_tensor: optional Keras tensor
-    (i.e. output of `layers.Input()`)
-    to use as image input for the model.
+      layer at the top of the network.
+    weights: ```Optional[Union[Literal["imagenet"], str]]```.
+      - `None`: random initialization
+      - `"imagenet"`: (pre-training on ImageNet-1k)
+      - `str`: path to the weights file to be loaded
+      Defaults to `"imagenet"`.
     input_shape: optional shape tuple, only to be specified
-    if `include_top` is False (otherwise the input shape
-    has to be `(224, 224, 3)` (with `'channels_last'` data format)
-    or `(3, 224, 224)` (with `'channels_first'` data format).
-    It should have exactly 3 inputs channels,
-    and width and height should be no smaller than 32.
-    E.g. `(200, 200, 3)` would be one valid value.
+      if `include_top` is False (otherwise the input shape
+      has to be `(224, 224, 3)` (with `'channels_last'` data format)
+      or `(3, 224, 224)` (with `'channels_first'` data format).
+      It should have exactly 3 inputs channels,
+      and width and height should be no smaller than 32.
+      E.g. `(200, 200, 3)` would be one valid value.
     pooling: Optional pooling mode for feature extraction
-    when `include_top` is `False`.
-    - `None` means that the output of the model will be
+      when `include_top` is `False`.
+      - `None` means that the output of the model will be
         the 4D tensor output of the
         last convolutional block.
-    - `avg` means that global average pooling
+      - `avg` means that global average pooling
         will be applied to the output of the
         last convolutional block, and thus
         the output of the model will be a 2D tensor.
-    - `max` means that global max pooling will
+      - `max` means that global max pooling will
         be applied.
     classes: optional number of classes to classify images
-    into, only to be specified if `include_top` is `True`, and
-    if no `weights` argument is specified.
-    classifier_activation: A `str` or callable.
-    The activation function to use
-    on the "top" layer. Ignored unless `include_top=True`. Set
-    `classifier_activation=None` to return the logits
-    of the "top" layer. When loading pretrained weights,
-    `classifier_activation` can only be `None` or `"softmax"`.
+      into, only to be specified if `include_top` is `True`, and
+      if no `weights` argument is specified.
+      classifier_activation: A `str` or callable.
+      The activation function to use
+      on the "top" layer. Ignored unless `include_top=True`. Set
+      `classifier_activation=None` to return the logits
+      of the "top" layer. When loading pretrained weights,
+      `classifier_activation` can only be `None` or `"softmax"`.
 
 Returns:
     A Keras model instance.

--- a/keras/applications/efficientnet.py
+++ b/keras/applications/efficientnet.py
@@ -164,9 +164,10 @@ tensors of pixels with values in the `[0-255]` range.
 Args:
     include_top: Whether to include the fully-connected
         layer at the top of the network. Defaults to `True`.
-    weights: One of `None` (random initialization),
-        `"imagenet"` (pre-training on ImageNet),
-        or the path to the weights file to be loaded.
+    weights: ```Optional[Union[Literal["imagenet"], str]]```.
+        - `None`: random initialization
+        - `"imagenet"`: (pre-training on ImageNet-1k)
+        - `str`: path to the weights file to be loaded
         Defaults to `"imagenet"`.
     input_tensor: Optional Keras tensor
         (i.e. output of `layers.Input()`)
@@ -236,9 +237,10 @@ def EfficientNet(
       model_name: string, model name.
       include_top: whether to include the fully-connected
           layer at the top of the network.
-      weights: one of `None` (random initialization),
-            'imagenet' (pre-training on ImageNet),
-            or the path to the weights file to be loaded.
+      weights: ```Optional[Union[Literal["imagenet"], str]]```.
+          - `None`: random initialization
+          - `"imagenet"`: (pre-training on ImageNet-1k)
+          - `str`: path to the weights file to be loaded
       input_tensor: optional Keras tensor
           (i.e. output of `layers.Input()`)
           to use as image input for the model.
@@ -834,9 +836,13 @@ def preprocess_input(x, data_format=None):
 
     Args:
         x: A floating point `numpy.array` or a tensor.
-        data_format: Optional data format of the image tensor/array. `None`
-            means the global setting `keras.backend.image_data_format()`
-            is used (unless you changed it, it uses `"channels_last"`).
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
             Defaults to `None`.
 
     Returns:

--- a/keras/applications/efficientnet_v2.py
+++ b/keras/applications/efficientnet_v2.py
@@ -549,9 +549,11 @@ float tensors of pixels with values in the `[-1, 1]` range.
 Args:
     include_top: Boolean, whether to include the fully-connected
         layer at the top of the network. Defaults to `True`.
-    weights: One of `None` (random initialization),
-        `"imagenet"` (pre-training on ImageNet),
-        or the path to the weights file to be loaded. Defaults to `"imagenet"`.
+    weights: ```Optional[Union[Literal["imagenet"], str]]```.
+        - `None`: random initialization
+        - `"imagenet"`: (pre-training on ImageNet-1k)
+        - `str`: path to the weights file to be loaded
+        Defaults to `"imagenet"`.
     input_tensor: Optional Keras tensor
         (i.e. output of `layers.Input()`)
         to use as image input for the model.
@@ -857,9 +859,10 @@ def EfficientNetV2(
         model_name: string, model name.
         include_top: whether to include the fully-connected layer at the top of
             the network.
-        weights: one of `None` (random initialization), `"imagenet"`
-            (pre-training on ImageNet),
-            or the path to the weights file to be loaded.
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - `None`: random initialization
+            - `"imagenet"`: (pre-training on ImageNet-1k)
+            - `str`: path to the weights file to be loaded
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) or
             numpy array to use as image input for the model.
         input_shape: optional shape tuple, only to be specified if `include_top`
@@ -1325,11 +1328,14 @@ def preprocess_input(x, data_format=None):
 
     Args:
         x: A floating point `numpy.array` or a tensor.
-        data_format: Optional data format of the image tensor/array. Defaults to
-            None, in which case the global setting
-            `keras.backend.image_data_format()` is used
-            (unless you changed it, it defaults to "channels_last").{mode}
-
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
+            Defaults to `None`.
     Returns:
         Unchanged `numpy.array` or tensor.
     """

--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -52,14 +52,14 @@ PREPROCESS_INPUT_DOC = """
   """
 
 PREPROCESS_INPUT_MODE_DOC = """
-    mode: One of "caffe", "tf" or "torch".
-      - caffe: will convert the images from RGB to BGR,
+    mode: ```Literal["caffe", "tf", "torch"]```.
+      - `"caffe"`: will convert the images from RGB to BGR,
           then will zero-center each color channel with
           respect to the ImageNet dataset,
           without scaling.
-      - tf: will scale pixels between -1 and 1,
+      - `"tf"`: will scale pixels between `-1` and `1`,
           sample-wise.
-      - torch: will scale pixels between 0 and 1 and then
+      - `"torch"`: will scale pixels between `0` and `1` and then
           will normalize each channel with respect to the
           ImageNet dataset.
       Defaults to `"caffe"`.
@@ -163,15 +163,21 @@ def _preprocess_numpy_input(x, data_format, mode):
 
     Args:
       x: Input array, 3D or 4D.
-      data_format: Data format of the image array.
-      mode: One of "caffe", "tf" or "torch".
-        - caffe: will convert the images from RGB to BGR,
+      data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+        The ordering of the dimensions in the inputs.
+        - `"channels_last"`: input shape `(batch, time, ..., channels)`
+        - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+        When unspecified, uses `image_data_format` value found in your
+        Keras config file at `~/.keras/keras.json` (if exists) else
+        `"channels_last"`.
+      mode: ```Literal["caffe", "tf", "torch"]```.
+        - `"caffe"`: will convert the images from RGB to BGR,
             then will zero-center each color channel with
             respect to the ImageNet dataset,
             without scaling.
-        - tf: will scale pixels between -1 and 1,
+        - `"tf"`: will scale pixels between -1 and 1,
             sample-wise.
-        - torch: will scale pixels between 0 and 1 and then
+        - `"torch"`: will scale pixels between 0 and 1 and then
             will normalize each channel with respect to the
             ImageNet dataset.
 
@@ -236,15 +242,21 @@ def _preprocess_tensor_input(x, data_format, mode):
 
     Args:
       x: Input tensor, 3D or 4D.
-      data_format: Data format of the image tensor.
-      mode: One of "caffe", "tf" or "torch".
-        - caffe: will convert the images from RGB to BGR,
+      data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+        The ordering of the dimensions in the inputs.
+        - `"channels_last"`: input shape `(batch, time, ..., channels)`
+        - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+        When unspecified, uses `image_data_format` value found in your
+        Keras config file at `~/.keras/keras.json` (if exists) else
+        `"channels_last"`.
+      mode: ```Literal["caffe", "tf", "torch"]```.
+        - `"caffe"`: will convert the images from RGB to BGR,
             then will zero-center each color channel with
             respect to the ImageNet dataset,
             without scaling.
-        - tf: will scale pixels between -1 and 1,
+        - `"tf"`: will scale pixels between `-1` and `1`,
             sample-wise.
-        - torch: will scale pixels between 0 and 1 and then
+        - `"torch"`: will scale pixels between `0` and `1` and then
             will normalize each channel with respect to the
             ImageNet dataset.
 
@@ -305,11 +317,18 @@ def obtain_input_shape(
         or a user-provided shape to be validated.
       default_size: Default input width/height for the model.
       min_size: Minimum input width/height accepted by the model.
-      data_format: Image data format to use.
+      data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+        The ordering of the dimensions in the inputs.
+        - `"channels_last"`: input shape `(batch, time, ..., channels)`
+        - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+        When unspecified, uses `image_data_format` value found in your
+        Keras config file at `~/.keras/keras.json` (if exists) else
+        `"channels_last"`.
       require_flatten: Whether the model is expected to
         be linked to a classifier via a Flatten layer.
-      weights: One of `None` (random initialization)
-        or 'imagenet' (pre-training on ImageNet).
+      weights: ```Optional[Literal["imagenet"]]```.
+        - `None`: random initialization
+        - `"imagenet"`: (pre-training on ImageNet).
         If weights='imagenet' input channels must be equal to 3.
 
     Returns:

--- a/keras/applications/inception_resnet_v2.py
+++ b/keras/applications/inception_resnet_v2.py
@@ -56,9 +56,10 @@ def InceptionResNetV2(
     Args:
         include_top: whether to include the fully-connected
             layer at the top of the network.
-        weights: one of `None` (random initialization),
-            `"imagenet"` (pre-training on ImageNet),
-            or the path to the weights file to be loaded.
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - `None`: random initialization
+            - `"imagenet"`: (pre-training on ImageNet-1k)
+            - `str`: path to the weights file to be loaded
         input_tensor: optional Keras tensor
             (i.e. output of `layers.Input()`)
             to use as image input for the model.

--- a/keras/applications/inception_v3.py
+++ b/keras/applications/inception_v3.py
@@ -58,9 +58,10 @@ def InceptionV3(
         include_top: Boolean, whether to include the fully-connected
             layer at the top, as the last layer of the network.
             Defaults to `True`.
-        weights: One of `None` (random initialization),
-            `imagenet` (pre-training on ImageNet),
-            or the path to the weights file to be loaded.
+        weights: ```Optional[Literal["imagenet"]]```.
+            - None: random initialization
+            - 'imagenet': (pre-training on ImageNet).
+            If weights='imagenet' input channels must be equal to 3.
             Defaults to `"imagenet"`.
         input_tensor: Optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model. `input_tensor` is useful for

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -77,9 +77,11 @@ def MobileNet(
         dropout: Dropout rate. Defaults to `0.001`.
         include_top: Boolean, whether to include the fully-connected layer
             at the top of the network. Defaults to `True`.
-        weights: One of `None` (random initialization), `"imagenet"`
-            (pre-training on ImageNet), or the path to the weights file
-            to be loaded. Defaults to `"imagenet"`.
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - None: random initialization
+            - 'imagenet': (pre-training on ImageNet)
+            - str: path to the weights file to be loaded
+            Defaults to `"imagenet"`.
         input_tensor: Optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model. `input_tensor` is useful
             for sharing inputs between multiple different networks.

--- a/keras/applications/mobilenet_v2.py
+++ b/keras/applications/mobilenet_v2.py
@@ -79,9 +79,11 @@ def MobileNetV2(
                 are used at each layer. Defaults to `1.0`.
         include_top: Boolean, whether to include the fully-connected layer
             at the top of the network. Defaults to `True`.
-        weights: One of `None` (random initialization), `"imagenet"`
-            (pre-training on ImageNet), or the path to the weights file
-            to be loaded. Defaults to `"imagenet"`.
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - None: random initialization
+            - 'imagenet': (pre-training on ImageNet)
+            - str: path to the weights file to be loaded
+            Defaults to `"imagenet"`.
         input_tensor: Optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model. `input_tensor` is useful
             for sharing inputs between multiple different networks.

--- a/keras/applications/mobilenet_v3.py
+++ b/keras/applications/mobilenet_v3.py
@@ -106,9 +106,10 @@ Args:
         are much more performant on GPU/DSP.
     include_top: Boolean, whether to include the fully-connected
         layer at the top of the network. Defaults to `True`.
-    weights: String, one of `None` (random initialization),
-        `"imagenet"` (pre-training on ImageNet),
-        or the path to the weights file to be loaded.
+    weights: ```Optional[Union[Literal["imagenet"], str]]```.
+        - `None`: random initialization
+        - `"imagenet"`: (pre-training on ImageNet-1k)
+        - `str`: path to the weights file to be loaded
     input_tensor: Optional Keras tensor (i.e. output of
         `layers.Input()`)
         to use as image input for the model.
@@ -660,10 +661,13 @@ def preprocess_input(x, data_format=None):
 
     Args:
         x: A floating point `numpy.array` or a tensor.
-        data_format: Optional data format of the image tensor/array.
-            `None` means the global setting
-            `keras.config.image_data_format()` is used
-            (unless you changed it, it uses `"channels_last"`).
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
             Defaults to `None`.
 
     Returns:

--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -78,8 +78,9 @@ def NASNet(
                 paper are used at each layer.
         include_top: Whether to include the fully-connected
             layer at the top of the network.
-        weights: `None` (random initialization) or
-            `imagenet` (ImageNet weights)
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - `None`: random initialization
+            - `"imagenet"`: (pre-training on ImageNet-1k)
         input_tensor: Optional Keras tensor (i.e. output of
             `layers.Input()`)
             to use as image input for the model.
@@ -348,9 +349,11 @@ def NASNetMobile(
             E.g. `(224, 224, 3)` would be one valid value.
         include_top: Whether to include the fully-connected
             layer at the top of the network.
-        weights: `None` (random initialization) or
-            `imagenet` (ImageNet weights). For loading `imagenet` weights,
-            `input_shape` should be (224, 224, 3)
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - `None`: random initialization
+            - `"imagenet"`: (pre-training on ImageNet-1k). For
+               loading `imagenet` weights, `input_shape` should
+               be `(224, 224, 3)`.
         input_tensor: Optional Keras tensor (i.e. output of
             `layers.Input()`)
             to use as image input for the model.
@@ -439,9 +442,11 @@ def NASNetLarge(
             E.g. `(224, 224, 3)` would be one valid value.
         include_top: Whether to include the fully-connected
             layer at the top of the network.
-        weights: `None` (random initialization) or
-            `imagenet` (ImageNet weights).  For loading `imagenet` weights,
-            `input_shape` should be (331, 331, 3)
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - `None`: random initialization
+            - `"imagenet"`: (pre-training on ImageNet). For
+               loading `imagenet` weights, `input_shape`
+               should be `(331, 331, 3)`.
         input_tensor: Optional Keras tensor (i.e. output of
             `layers.Input()`)
             to use as image input for the model.

--- a/keras/applications/resnet.py
+++ b/keras/applications/resnet.py
@@ -70,9 +70,11 @@ def ResNet(
         model_name: Name of the model.
         include_top: Whether to include the fully-connected
             layer at the top of the network.
-        weights: One of `None` (random initialization),
-            `"imagenet"` (pre-training on ImageNet),
-            or the path to the weights file to be loaded.
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - None: random initialization
+            - 'imagenet': (pre-training on ImageNet)
+            - str: path to the weights file to be loaded
+            Defaults to `"imagenet"`.
         input_tensor: Optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: Optional shape tuple, only to be specified
@@ -545,9 +547,10 @@ respect to the ImageNet dataset, without scaling.
 Args:
     include_top: whether to include the fully-connected
         layer at the top of the network.
-    weights: one of `None` (random initialization),
-        `"imagenet"` (pre-training on ImageNet), or the path to the weights
-        file to be loaded.
+    weights: ```Optional[Union[Literal["imagenet"], str]]```.
+        - `None`: random initialization
+        - `"imagenet"`: (pre-training on ImageNet-1k)
+        - `str`: path to the weights file to be loaded
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
         to use as image input for the model.
     input_shape: optional shape tuple, only to be specified if `include_top`

--- a/keras/applications/resnet_v2.py
+++ b/keras/applications/resnet_v2.py
@@ -164,9 +164,10 @@ scale input pixels between -1 and 1.
 Args:
     include_top: whether to include the fully-connected
         layer at the top of the network.
-    weights: one of `None` (random initialization),
-        `"imagenet"` (pre-training on ImageNet), or the path to the weights
-        file to be loaded.
+    weights: ```Optional[Union[Literal["imagenet"], str]]```.
+        - `None`: random initialization
+        - `"imagenet"`: (pre-training on ImageNet-1k)
+        - `str`: path to the weights file to be loaded
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
         to use as image input for the model.
     input_shape: optional shape tuple, only to be specified if `include_top`

--- a/keras/applications/vgg16.py
+++ b/keras/applications/vgg16.py
@@ -53,9 +53,10 @@ def VGG16(
     Args:
         include_top: whether to include the 3 fully-connected
             layers at the top of the network.
-        weights: one of `None` (random initialization),
-            `"imagenet"` (pre-training on ImageNet),
-            or the path to the weights file to be loaded.
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - `None`: random initialization
+            - `"imagenet"`: (pre-training on ImageNet-1k)
+            - `str`: path to the weights file to be loaded
         input_tensor: optional Keras tensor
             (i.e. output of `layers.Input()`)
             to use as image input for the model.

--- a/keras/applications/vgg19.py
+++ b/keras/applications/vgg19.py
@@ -53,9 +53,10 @@ def VGG19(
     Args:
         include_top: whether to include the 3 fully-connected
             layers at the top of the network.
-        weights: one of `None` (random initialization),
-            `"imagenet"` (pre-training on ImageNet),
-            or the path to the weights file to be loaded.
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - `None`: random initialization
+            - `"imagenet"`: (pre-training on ImageNet-1k)
+            - `str`: path to the weights file to be loaded
         input_tensor: optional Keras tensor
             (i.e. output of `layers.Input()`)
             to use as image input for the model.

--- a/keras/applications/xception.py
+++ b/keras/applications/xception.py
@@ -55,9 +55,10 @@ def Xception(
     Args:
         include_top: whether to include the 3 fully-connected
             layers at the top of the network.
-        weights: one of `None` (random initialization),
-            `"imagenet"` (pre-training on ImageNet),
-            or the path to the weights file to be loaded.
+        weights: ```Optional[Union[Literal["imagenet"], str]]```.
+            - `None`: random initialization
+            - `"imagenet"`: (pre-training on ImageNet-1k)
+            - `str`: path to the weights file to be loaded
         input_tensor: optional Keras tensor
             (i.e. output of `layers.Input()`)
             to use as image input for the model.

--- a/keras/backend/config.py
+++ b/keras/backend/config.py
@@ -138,10 +138,16 @@ def image_data_format():
     ]
 )
 def set_image_data_format(data_format):
-    """Set the value of the image data format convention.
+    """Set the global value of the image data format convention.
 
     Args:
-        data_format: string. `'channels_first'` or `'channels_last'`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
 
     Examples:
 
@@ -264,8 +270,7 @@ def backend():
     """Publicly accessible method for determining the current backend.
 
     Returns:
-        String, the name of the backend Keras is currently using. One of
-            `"tensorflow"`, `"torch"`, or `"jax"`.
+        ```Literal["tensorflow", "torch", "jax"]```. Backend in use.
 
     Example:
 

--- a/keras/backend/tensorflow/trainer.py
+++ b/keras/backend/tensorflow/trainer.py
@@ -719,8 +719,8 @@ def reduce_per_replica(values, strategy, reduction):
       values: Structure of `PerReplica` objects or `tf.Tensor`s. `tf.Tensor`s
         are returned as-is.
       strategy: `tf.distribute.Strategy` object.
-      reduction: One of `"auto"`, `"first"`, `"concat"`, or `"sum"`.
-        `"auto"` will select `"first"` when used under a TPUStrategy, or
+      reduction: ```Literal["auto", "first", "concat", "sum"]```.
+        - `"auto"`: will select `"first"` when used under a TPUStrategy, or
         `"sum"` otherwise.
 
     Returns:

--- a/keras/callbacks/early_stopping.py
+++ b/keras/callbacks/early_stopping.py
@@ -29,11 +29,14 @@ class EarlyStopping(Callback):
             be stopped. Defaults to `0`.
         verbose: Verbosity mode, 0 or 1. Mode 0 is silent, and mode 1 displays
             messages when the callback takes an action. Defaults to `0`.
-        mode: One of `{"auto", "min", "max"}`. In `min` mode, training will stop
-            when the quantity monitored has stopped decreasing; in `"max"` mode
-            it will stop when the quantity monitored has stopped increasing; in
-            `"auto"` mode, the direction is automatically inferred from the name
-            of the monitored quantity. Defaults to `"auto"`.
+        mode: ```Literal["auto", "min", "max"]```.
+            - `"min"`: training will stop when monitored quantity has
+              stopped decreasing
+            - `"max"`: mode it will stop when the quantity monitored has
+              stopped increasing
+            - `"auto"`: the direction is automatically inferred from the name
+              of the monitored quantity.
+            Defaults to `"auto"`.
         baseline: Baseline value for the monitored quantity. If not `None`,
             training will stop if the model doesn't show improvement over the
             baseline. Defaults to `None`.

--- a/keras/callbacks/model_checkpoint.py
+++ b/keras/callbacks/model_checkpoint.py
@@ -99,7 +99,7 @@ class ModelCheckpoint(Callback):
             quantity monitored will not be overwritten. If `filepath` doesn't
             contain formatting options like `{epoch}` then `filepath` will be
             overwritten by each new better model.
-        mode: one of {`"auto"`, `"min"`, `"max"`}. If `save_best_only=True`, the
+        mode: ```Literal["auto", "min", "max"]```. If `save_best_only=True`, the
             decision to overwrite the current save file is made based on either
             the maximization or the minimization of the monitored quantity.
             For `val_acc`, this should be `"max"`, for `val_loss` this should be

--- a/keras/callbacks/progbar_logger.py
+++ b/keras/callbacks/progbar_logger.py
@@ -9,7 +9,7 @@ class ProgbarLogger(Callback):
     """Callback that prints metrics to stdout.
 
     Args:
-        count_mode: One of `"steps"` or `"samples"`.
+        count_mode: ```Literal["steps", "samples"]```.
             Whether the progress bar should
             count samples seen or steps (batches) seen.
 

--- a/keras/callbacks/reduce_lr_on_plateau.py
+++ b/keras/callbacks/reduce_lr_on_plateau.py
@@ -32,12 +32,14 @@ class ReduceLROnPlateau(Callback):
         patience: Integer. Number of epochs with no improvement after which
             learning rate will be reduced.
         verbose: Integer. 0: quiet, 1: update messages.
-        mode: String. One of `{'auto', 'min', 'max'}`. In `'min'` mode,
-            the learning rate will be reduced when the
-            quantity monitored has stopped decreasing; in `'max'` mode it will
-            be reduced when the quantity monitored has stopped increasing; in
-            `'auto'` mode, the direction is automatically inferred from the name
-            of the monitored quantity.
+        mode: ```Literal["auto", "min", "max"]```.
+            - `"min"`: training will stop when monitored quantity has
+              stopped decreasing
+            - `"max"`: mode it will stop when the quantity monitored has
+              stopped increasing
+            - `"auto"`: the direction is automatically inferred from the name
+              of the monitored quantity.
+            Defaults to `"auto"`.
         min_delta: Float. Threshold for measuring the new optimum, to only focus
             on significant changes.
         cooldown: Integer. Number of epochs to wait before resuming normal

--- a/keras/initializers/random_initializers.py
+++ b/keras/initializers/random_initializers.py
@@ -220,9 +220,10 @@ class VarianceScaling(Initializer):
 
     Args:
         scale: Scaling factor (positive float).
-        mode: One of `"fan_in"`, `"fan_out"`, `"fan_avg"`.
-        distribution: Random distribution to use.
-            One of `"truncated_normal"`, `"untruncated_normal"`, or `"uniform"`.
+        mode: ```Literal["fan_in", "fan_out", "fan_avg"]```.
+        distribution: ```Literal["truncated_normal",
+              "untruncated_normal", "uniform"]```.
+              Random distribution to use.
         seed: A Python integer or instance of
             `keras.backend.SeedGenerator`.
             Used to make the behavior of the initializer

--- a/keras/layers/convolutional/base_conv.py
+++ b/keras/layers/convolutional/base_conv.py
@@ -39,13 +39,13 @@ class BaseConv(Layer):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of `rank` integers, specifying the
             dilation rate to use for dilated convolution. If only one int is
             specified, the same dilation rate will be used for all dimensions.

--- a/keras/layers/convolutional/base_conv_transpose.py
+++ b/keras/layers/convolutional/base_conv_transpose.py
@@ -39,13 +39,13 @@ class BaseConvTranspose(Layer):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of `rank` integers, specifying the
             dilation rate to use for dilated convolution. If only one int is
             specified, the same dilation rate will be used for all dimensions.

--- a/keras/layers/convolutional/base_depthwise_conv.py
+++ b/keras/layers/convolutional/base_depthwise_conv.py
@@ -51,13 +51,13 @@ class BaseDepthwiseConv(Layer):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of `rank` integers, specifying the
             dilation rate to use for dilated convolution. If only one int is
             specified, the same dilation rate will be used for all dimensions.

--- a/keras/layers/convolutional/base_separable_conv.py
+++ b/keras/layers/convolutional/base_separable_conv.py
@@ -39,13 +39,13 @@ class BaseSeparableConv(Layer):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of `rank` integers, specifying the
             dilation rate to use for dilated convolution. If only one int is
             specified, the same dilation rate will be used for all dimensions.

--- a/keras/layers/convolutional/conv1d.py
+++ b/keras/layers/convolutional/conv1d.py
@@ -30,13 +30,13 @@ class Conv1D(BaseConv):
             should not violate the temporal order.
             See [WaveNet: A Generative Model for Raw Audio, section2.1](
             https://arxiv.org/abs/1609.03499).
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of 1 integers, specifying the dilation
             rate to use for dilated convolution.
         groups: A positive int specifying the number of groups in which the

--- a/keras/layers/convolutional/conv1d_transpose.py
+++ b/keras/layers/convolutional/conv1d_transpose.py
@@ -29,13 +29,13 @@ class Conv1DTranspose(BaseConvTranspose):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of 1 integers, specifying the dilation
             rate to use for dilated transposed convolution.
         activation: Activation function. If `None`, no activation is applied.

--- a/keras/layers/convolutional/conv2d.py
+++ b/keras/layers/convolutional/conv2d.py
@@ -24,14 +24,12 @@ class Conv2D(BaseConv):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape
-            `(batch_size, channels, height, width)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch_size, channels, height, width)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
         dilation_rate: int or tuple/list of 2 integers, specifying the dilation
             rate to use for dilated convolution.

--- a/keras/layers/convolutional/conv2d_transpose.py
+++ b/keras/layers/convolutional/conv2d_transpose.py
@@ -29,14 +29,12 @@ class Conv2DTranspose(BaseConvTranspose):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape
-            `(batch_size, channels, height, width)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch_size, channels, height, width)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
         dilation_rate: int or tuple/list of 1 integers, specifying the dilation
             rate to use for dilated transposed convolution.

--- a/keras/layers/convolutional/conv3d.py
+++ b/keras/layers/convolutional/conv3d.py
@@ -24,15 +24,13 @@ class Conv3D(BaseConv):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape
-            `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`.
-            It defaults to the `image_data_format` value found in your Keras
-            config file at `~/.keras/keras.json`. If you never set it, then it
-            will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of 3 integers, specifying the dilation
             rate to use for dilated convolution.
         groups: A positive int specifying the number of groups in which the

--- a/keras/layers/convolutional/conv3d_transpose.py
+++ b/keras/layers/convolutional/conv3d_transpose.py
@@ -29,15 +29,13 @@ class Conv3DTranspose(BaseConvTranspose):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape
-            `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`.
-            It defaults to the `image_data_format` value found in your Keras
-            config file at `~/.keras/keras.json`. If you never set it, then it
-            will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of 1 integers, specifying the dilation
             rate to use for dilated transposed convolution.
         activation: Activation function. If `None`, no activation is applied.

--- a/keras/layers/convolutional/depthwise_conv1d.py
+++ b/keras/layers/convolutional/depthwise_conv1d.py
@@ -38,13 +38,13 @@ class DepthwiseConv1D(BaseDepthwiseConv):
         depth_multiplier: The number of depthwise convolution output channels
             for each input channel. The total number of depthwise convolution
             output channels will be equal to `input_channel * depth_multiplier`.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of 1 integers, specifying the dilation
             rate to use for dilated convolution.
         activation: Activation function. If `None`, no activation is applied.

--- a/keras/layers/convolutional/depthwise_conv2d.py
+++ b/keras/layers/convolutional/depthwise_conv2d.py
@@ -38,13 +38,13 @@ class DepthwiseConv2D(BaseDepthwiseConv):
         depth_multiplier: The number of depthwise convolution output channels
             for each input channel. The total number of depthwise convolution
             output channels will be equal to `input_channel * depth_multiplier`.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of 2 integers, specifying the dilation
             rate to use for dilated convolution.
         activation: Activation function. If `None`, no activation is applied.

--- a/keras/layers/convolutional/separable_conv1d.py
+++ b/keras/layers/convolutional/separable_conv1d.py
@@ -30,13 +30,13 @@ class SeparableConv1D(BaseSeparableConv):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of 1 integers, specifying the dilation
             rate to use for dilated convolution. If only one int is specified,
             the same dilation rate will be used for all dimensions.

--- a/keras/layers/convolutional/separable_conv2d.py
+++ b/keras/layers/convolutional/separable_conv2d.py
@@ -30,13 +30,13 @@ class SeparableConv2D(BaseSeparableConv):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of 2 integers, specifying the dilation
             rate to use for dilated convolution. If only one int is specified,
             the same dilation rate will be used for all dimensions.

--- a/keras/layers/pooling/average_pooling1d.py
+++ b/keras/layers/pooling/average_pooling1d.py
@@ -22,13 +22,13 @@ class AveragePooling1D(BasePooling):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
 
     Input shape:
     - If `data_format="channels_last"`:

--- a/keras/layers/pooling/average_pooling2d.py
+++ b/keras/layers/pooling/average_pooling2d.py
@@ -30,13 +30,12 @@ class AveragePooling2D(BasePooling):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, height, width, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, height, width)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
 
     Input shape:

--- a/keras/layers/pooling/average_pooling3d.py
+++ b/keras/layers/pooling/average_pooling3d.py
@@ -22,15 +22,13 @@ class AveragePooling3D(BasePooling):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape
-            `(batch, spatial_dim1, spatial_dim2, spatial_dim3, channels)` while
-            `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, spatial_dim1, spatial_dim2, spatial_dim3)`.
-            It defaults to the `image_data_format` value found in your Keras
-            config file at `~/.keras/keras.json`. If you never set it, then it
-            will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
 
     Input shape:
     - If `data_format="channels_last"`:

--- a/keras/layers/pooling/global_average_pooling1d.py
+++ b/keras/layers/pooling/global_average_pooling1d.py
@@ -14,13 +14,13 @@ class GlobalAveragePooling1D(BaseGlobalPooling):
     """Global average pooling operation for temporal data.
 
     Args:
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         keepdims: A boolean, whether to keep the temporal dimension or not.
             If `keepdims` is `False` (default), the rank of the tensor is
             reduced for spatial dimensions. If `keepdims` is `True`, the

--- a/keras/layers/pooling/global_average_pooling2d.py
+++ b/keras/layers/pooling/global_average_pooling2d.py
@@ -13,13 +13,12 @@ class GlobalAveragePooling2D(BaseGlobalPooling):
     """Global average pooling operation for 2D data.
 
     Args:
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, height, width, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, height, weight)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
         keepdims: A boolean, whether to keep the temporal dimension or not.
             If `keepdims` is `False` (default), the rank of the tensor is

--- a/keras/layers/pooling/global_average_pooling3d.py
+++ b/keras/layers/pooling/global_average_pooling3d.py
@@ -13,15 +13,13 @@ class GlobalAveragePooling3D(BaseGlobalPooling):
     """Global average pooling operation for 3D data.
 
     Args:
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape
-            `(batch, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, spatial_dim1, spatial_dim2, spatial_dim3)`.
-            It defaults to the `image_data_format` value found in your Keras
-            config file at `~/.keras/keras.json`. If you never set it, then it
-            will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         keepdims: A boolean, whether to keep the temporal dimension or not.
             If `keepdims` is `False` (default), the rank of the tensor is
             reduced for spatial dimensions. If `keepdims` is `True`, the

--- a/keras/layers/pooling/global_max_pooling1d.py
+++ b/keras/layers/pooling/global_max_pooling1d.py
@@ -13,13 +13,13 @@ class GlobalMaxPooling1D(BaseGlobalPooling):
     """Global max pooling operation for temporal data.
 
     Args:
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         keepdims: A boolean, whether to keep the temporal dimension or not.
             If `keepdims` is `False` (default), the rank of the tensor is
             reduced for spatial dimensions. If `keepdims` is `True`, the

--- a/keras/layers/pooling/global_max_pooling2d.py
+++ b/keras/layers/pooling/global_max_pooling2d.py
@@ -13,13 +13,12 @@ class GlobalMaxPooling2D(BaseGlobalPooling):
     """Global max pooling operation for 2D data.
 
     Args:
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, height, width, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, height, weight)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
         keepdims: A boolean, whether to keep the temporal dimension or not.
             If `keepdims` is `False` (default), the rank of the tensor is

--- a/keras/layers/pooling/global_max_pooling3d.py
+++ b/keras/layers/pooling/global_max_pooling3d.py
@@ -13,15 +13,13 @@ class GlobalMaxPooling3D(BaseGlobalPooling):
     """Global max pooling operation for 3D data.
 
     Args:
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape
-            `(batch, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, spatial_dim1, spatial_dim2, spatial_dim3)`.
-            It defaults to the `image_data_format` value found in your Keras
-            config file at `~/.keras/keras.json`. If you never set it, then it
-            will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         keepdims: A boolean, whether to keep the temporal dimension or not.
             If `keepdims` is `False` (default), the rank of the tensor is
             reduced for spatial dimensions. If `keepdims` is `True`, the

--- a/keras/layers/pooling/max_pooling1d.py
+++ b/keras/layers/pooling/max_pooling1d.py
@@ -23,13 +23,13 @@ class MaxPooling1D(BasePooling):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
 
     Input shape:
     - If `data_format="channels_last"`:

--- a/keras/layers/pooling/max_pooling2d.py
+++ b/keras/layers/pooling/max_pooling2d.py
@@ -30,13 +30,12 @@ class MaxPooling2D(BasePooling):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, height, width, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, height, width)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
 
     Input shape:

--- a/keras/layers/pooling/max_pooling3d.py
+++ b/keras/layers/pooling/max_pooling3d.py
@@ -22,15 +22,13 @@ class MaxPooling3D(BasePooling):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape
-            `(batch, spatial_dim1, spatial_dim2, spatial_dim3, channels)` while
-            `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, spatial_dim1, spatial_dim2, spatial_dim3)`.
-            It defaults to the `image_data_format` value found in your Keras
-            config file at `~/.keras/keras.json`. If you never set it, then it
-            will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
 
     Input shape:
     - If `data_format="channels_last"`:

--- a/keras/layers/preprocessing/center_crop.py
+++ b/keras/layers/preprocessing/center_crop.py
@@ -35,13 +35,12 @@ class CenterCrop(TFDataLayer):
     Args:
         height: Integer, the height of the output shape.
         width: Integer, the width of the output shape.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, height, width, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, height, width)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
     """
 

--- a/keras/layers/preprocessing/feature_space.py
+++ b/keras/layers/preprocessing/feature_space.py
@@ -79,10 +79,11 @@ class FeatureSpace(Layer):
             or `{"my_feature": FeatureSpace.integer_categorical()}`.
             For a complete list of all supported types, see
             "Available feature types" paragraph below.
-        output_mode: One of `"concat"` or `"dict"`. In concat mode, all
-            features get concatenated together into a single vector.
-            In dict mode, the FeatureSpace returns a dict of individually
-            encoded features (with the same keys as the input dict keys).
+        output_mode: ```Literal["concat", "dict"]```.
+            - `"concat"`: all features get concatenated together into
+              a single vector.
+            - `"dict"`: the FeatureSpace returns a dict of individually
+              encoded features (with the same keys as the input dict keys).
         crosses: List of features to be crossed together, e.g.
             `crosses=[("feature_1", "feature_2")]`. The features will be
             "crossed" by hashing their combined value into

--- a/keras/layers/preprocessing/random_translation.py
+++ b/keras/layers/preprocessing/random_translation.py
@@ -70,13 +70,12 @@ class RandomTranslation(TFDataLayer):
         seed: Integer. Used to create a random seed.
         fill_value: a float represents the value to be filled outside the
             boundaries when `fill_mode="constant"`.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, height, width, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, height, width)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
         **kwargs: Base layer keyword arguments, such as `name` and `dtype`.
     """

--- a/keras/layers/preprocessing/random_zoom.py
+++ b/keras/layers/preprocessing/random_zoom.py
@@ -70,13 +70,12 @@ class RandomZoom(TFDataLayer):
         seed: Integer. Used to create a random seed.
         fill_value: a float represents the value to be filled outside
             the boundaries when `fill_mode="constant"`.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, height, width, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, height, width)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
         **kwargs: Base layer keyword arguments, such as `name` and `dtype`.
 

--- a/keras/layers/preprocessing/resizing.py
+++ b/keras/layers/preprocessing/resizing.py
@@ -40,13 +40,12 @@ class Resizing(TFDataLayer):
             largest possible window in the image (of size `(height, width)`)
             that matches the target aspect ratio. By default
             (`crop_to_aspect_ratio=False`), aspect ratio may not be preserved.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, height, width, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, height, width)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
         **kwargs: Base layer keyword arguments, such as `name` and `dtype`.
     """

--- a/keras/layers/regularization/spatial_dropout.py
+++ b/keras/layers/regularization/spatial_dropout.py
@@ -82,12 +82,13 @@ class SpatialDropout2D(BaseSpatialDropout):
 
     Args:
         rate: Float between 0 and 1. Fraction of the input units to drop.
-        data_format: `"channels_first"` or `"channels_last"`.
-            In `"channels_first"` mode, the channels dimension (the depth)
-            is at index 1, in `"channels_last"` mode is it at index 3.
-            It defaults to the `image_data_format` value found in your
-            Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
 
     Call arguments:
         inputs: A 4D tensor.
@@ -144,12 +145,13 @@ class SpatialDropout3D(BaseSpatialDropout):
 
     Args:
         rate: Float between 0 and 1. Fraction of the input units to drop.
-        data_format: `"channels_first"` or `"channels_last"`.
-            In `"channels_first"` mode, the channels dimension (the depth)
-            is at index 1, in `"channels_last"` mode is it at index 4.
-            It defaults to the `image_data_format` value found in your
-            Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
 
     Call arguments:
         inputs: A 5D tensor.

--- a/keras/layers/reshaping/cropping2d.py
+++ b/keras/layers/reshaping/cropping2d.py
@@ -28,14 +28,12 @@ class Cropping2D(Layer):
               `(symmetric_height_crop, symmetric_width_crop)`.
             - If tuple of 2 tuples of 2 ints: interpreted as
               `((top_crop, bottom_crop), (left_crop, right_crop))`.
-        data_format: A string, one of `"channels_last"` (default) or
-            `"channels_first"`. The ordering of the dimensions in the inputs.
-            `"channels_last"` corresponds to inputs with shape
-            `(batch_size, height, width, channels)` while `"channels_first"`
-            corresponds to inputs with shape
-            `(batch_size, channels, height, width)`.
-            When unspecified, uses `image_data_format` value found in your Keras
-            config file at `~/.keras/keras.json` (if exists). Defaults to
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
 
     Input shape:

--- a/keras/layers/reshaping/cropping3d.py
+++ b/keras/layers/reshaping/cropping3d.py
@@ -27,14 +27,12 @@ class Cropping3D(Layer):
             - If tuple of 3 tuples of 2 ints: interpreted as
               `((left_dim1_crop, right_dim1_crop), (left_dim2_crop,
               right_dim2_crop), (left_dim3_crop, right_dim3_crop))`.
-        data_format: A string, one of `"channels_last"` (default) or
-            `"channels_first"`. The ordering of the dimensions in the inputs.
-            `"channels_last"` corresponds to inputs with shape
-            `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch_size, channels, spatial_dim1, spatial_dim2, spatial_dim3)`.
-            When unspecified, uses `image_data_format` value found in your Keras
-            config file at `~/.keras/keras.json` (if exists). Defaults to
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
 
     Input shape:

--- a/keras/layers/reshaping/flatten.py
+++ b/keras/layers/reshaping/flatten.py
@@ -16,13 +16,12 @@ class Flatten(Layer):
     flattening adds an extra channel dimension and output shape is `(batch, 1)`.
 
     Args:
-        data_format: A string, one of `"channels_last"` (default) or
-            `"channels_first"`. The ordering of the dimensions in the inputs.
-            `"channels_last"` corresponds to inputs with shape
-            `(batch, ..., channels)` while `"channels_first"` corresponds to
-            inputs with shape `(batch, channels, ...)`.
-            When unspecified, uses `image_data_format` value found in your Keras
-            config file at `~/.keras/keras.json` (if exists). Defaults to
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
 
     Example:

--- a/keras/layers/reshaping/up_sampling2d.py
+++ b/keras/layers/reshaping/up_sampling2d.py
@@ -37,17 +37,13 @@ class UpSampling2D(Layer):
     Args:
         size: Int, or tuple of 2 integers.
             The upsampling factors for rows and columns.
-        data_format: A string,
-            one of `"channels_last"` (default) or `"channels_first"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
             The ordering of the dimensions in the inputs.
-            `"channels_last"` corresponds to inputs with shape
-            `(batch_size, height, width, channels)` while `"channels_first"`
-            corresponds to inputs with shape
-            `(batch_size, channels, height, width)`.
-            When unspecified, uses
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json` (if exists) else `"channels_last"`.
-            Defaults to `"channels_last"`.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         interpolation: A string, one of `"bicubic"`, `"bilinear"`, `"lanczos3"`,
             `"lanczos5"`, `"nearest"`.
 
@@ -133,9 +129,16 @@ class UpSampling2D(Layer):
             x: Tensor or variable to resize.
             height_factor: Positive integer.
             width_factor: Positive integer.
-            data_format: One of `"channels_first"`, `"channels_last"`.
-            interpolation: A string, one of `"bicubic"`, `"bilinear"`,
-            `"lanczos3"`, `"lanczos5"`, or `"nearest"`.
+            data_format: ```Optional[Literal["channels_last",
+               "channels_first"]]```.
+               The ordering of the dimensions in the inputs.
+               - `"channels_last"`: input shape `(batch, time, ..., channels)`
+               - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+               When unspecified, uses `image_data_format` value found in your
+               Keras config file at `~/.keras/keras.json` (if exists) else
+               `"channels_last"`.
+            interpolation: ```Literal["bicubic", "bilinear",
+              "lanczos3", "lanczos5", "nearest"]```.
 
         Returns:
             A tensor.

--- a/keras/layers/reshaping/up_sampling3d.py
+++ b/keras/layers/reshaping/up_sampling3d.py
@@ -24,17 +24,13 @@ class UpSampling3D(Layer):
     Args:
         size: Int, or tuple of 3 integers.
             The upsampling factors for dim1, dim2 and dim3.
-        data_format: A string,
-            one of `"channels_last"` (default) or `"channels_first"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
             The ordering of the dimensions in the inputs.
-            `"channels_last"` corresponds to inputs with shape
-            `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch_size, channels, spatial_dim1, spatial_dim2, spatial_dim3)`.
-            When unspecified, uses
-            `image_data_format` value found in your Keras config file at
-             `~/.keras/keras.json` (if exists) else `"channels_last"`.
-            Defaults to `"channels_last"`.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
 
     Input shape:
         5D tensor with shape:
@@ -115,7 +111,14 @@ class UpSampling3D(Layer):
             depth_factor: Positive integer.
             height_factor: Positive integer.
             width_factor: Positive integer.
-            data_format: One of `"channels_first"`, `"channels_last"`.
+            data_format: ```Optional[Literal["channels_last",
+              "channels_first"]]```.
+              The ordering of the dimensions in the inputs.
+              - `"channels_last"`: input shape `(batch, time, ..., channels)`
+              - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+              When unspecified, uses `image_data_format` value found in your
+              Keras config file at `~/.keras/keras.json` (if exists) else
+              `"channels_last"`.
 
         Returns:
             Resized tensor.

--- a/keras/layers/reshaping/zero_padding2d.py
+++ b/keras/layers/reshaping/zero_padding2d.py
@@ -43,14 +43,12 @@ class ZeroPadding2D(Layer):
               `(symmetric_height_pad, symmetric_width_pad)`.
             - If tuple of 2 tuples of 2 ints: interpreted as
              `((top_pad, bottom_pad), (left_pad, right_pad))`.
-        data_format: A string, one of `"channels_last"` (default) or
-            `"channels_first"`. The ordering of the dimensions in the inputs.
-            `"channels_last"` corresponds to inputs with shape
-            `(batch_size, height, width, channels)` while `"channels_first"`
-            corresponds to inputs with shape
-            `(batch_size, channels, height, width)`.
-            When unspecified, uses `image_data_format` value found in your Keras
-            config file at `~/.keras/keras.json` (if exists). Defaults to
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
 
     Input shape:

--- a/keras/layers/reshaping/zero_padding3d.py
+++ b/keras/layers/reshaping/zero_padding3d.py
@@ -28,14 +28,12 @@ class ZeroPadding3D(Layer):
             - If tuple of 3 tuples of 2 ints: interpreted as
               `((left_dim1_pad, right_dim1_pad), (left_dim2_pad,
               right_dim2_pad), (left_dim3_pad, right_dim3_pad))`.
-        data_format: A string, one of `"channels_last"` (default) or
-            `"channels_first"`. The ordering of the dimensions in the inputs.
-            `"channels_last"` corresponds to inputs with shape
-            `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch_size, channels, spatial_dim1, spatial_dim2, spatial_dim3)`.
-            When unspecified, uses `image_data_format` value found in your Keras
-            config file at `~/.keras/keras.json` (if exists). Defaults to
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
 
     Input shape:

--- a/keras/layers/rnn/bidirectional.py
+++ b/keras/layers/rnn/bidirectional.py
@@ -28,8 +28,9 @@ class Bidirectional(Wrapper):
             When `return_sequences` is `True`, the output of the masked
             timestep will be zero regardless of the layer's original
             `zero_output_for_mask` value.
-        merge_mode: Mode by which outputs of the forward and backward RNNs
-            will be combined. One of `{"sum", "mul", "concat", "ave", None}`.
+        merge_mode: ```Optional[Literal["sum", "mul", "concat", "ave"]]```.
+            Mode by which outputs of the forward and backward RNNs
+            will be combined.
             If `None`, the outputs will not be combined,
             they will be returned as a list. Defaults to `"concat"`.
         backward_layer: Optional `keras.layers.RNN`,

--- a/keras/layers/rnn/conv_lstm.py
+++ b/keras/layers/rnn/conv_lstm.py
@@ -26,15 +26,18 @@ class ConvLSTMCell(Layer, DropoutRNNCell):
         strides: An integer or tuple/list of n integers, specifying the strides
             of the convolution. Specifying any stride value != 1
             is incompatible with specifying any `dilation_rate` value != 1.
-        padding: One of `"valid"` or `"same"` (case-insensitive).
-            `"valid"` means no padding. `"same"` results in padding evenly
-            to the left/right or up/down of the input such that output
-            has the same height/width dimension as the input.
-        data_format: A string, one of `channels_last` (default) or
-            `channels_first`. When unspecified, uses
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json` (if exists) else 'channels_last'.
-            Defaults to `'channels_last'`.
+        padding: ```Literal["valid", "same"]```. (case-insensitive).
+            - `"valid"`: no padding.
+            - `"same"`: pads evenly to the left/right or up/down of the input
+              such that output has the same height/width dimension as the input.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
+            Defaults to `"channels_last"`.
         dilation_rate: An integer or tuple/list of n integers, specifying the
             dilation rate to use for dilated convolution.
             Currently, specifying any `dilation_rate` value != 1 is
@@ -391,21 +394,18 @@ class ConvLSTM(RNN):
             specifying the strides of the convolution.
             Specifying any stride value != 1 is incompatible with specifying
             any `dilation_rate` value != 1.
-        padding: One of `"valid"` or `"same"` (case-insensitive).
-            `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input.
-        data_format: A string,
-            one of `channels_last` (default) or `channels_first`.
+        padding: ```Literal["valid", "same"]```. (case-insensitive).
+            - `"valid"`: no padding.
+            - `"same"`: pads evenly to the left/right or up/down of the input
+              such that output has the same height/width dimension as the input.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
             The ordering of the dimensions in the inputs.
-            `channels_last` corresponds to inputs with shape
-            `(batch, time, ..., channels)`
-            while `channels_first` corresponds to
-            inputs with shape `(batch, time, channels, ...)`.
-            When unspecified, uses
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json` (if exists) else 'channels_last'.
-            Defaults to `'channels_last'`.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
+            Defaults to `"channels_last"`.
         dilation_rate: An integer or tuple/list of n integers, specifying
             the dilation rate to use for dilated convolution.
             Currently, specifying any `dilation_rate` value != 1 is

--- a/keras/layers/rnn/conv_lstm1d.py
+++ b/keras/layers/rnn/conv_lstm1d.py
@@ -21,13 +21,13 @@ class ConvLSTM1D(ConvLSTM):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the
             same height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of 1 integers, specifying the dilation
             rate to use for dilated convolution.
         activation: Activation function to use. By default hyperbolic tangent

--- a/keras/layers/rnn/conv_lstm2d.py
+++ b/keras/layers/rnn/conv_lstm2d.py
@@ -21,13 +21,13 @@ class ConvLSTM2D(ConvLSTM):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of 2 integers, specifying the dilation
             rate to use for dilated convolution.
         activation: Activation function to use. By default hyperbolic tangent

--- a/keras/layers/rnn/conv_lstm3d.py
+++ b/keras/layers/rnn/conv_lstm3d.py
@@ -21,13 +21,13 @@ class ConvLSTM3D(ConvLSTM):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or tuple/list of 3 integers, specifying the dilation
             rate to use for dilated convolution.
         activation: Activation function to use. By default hyperbolic tangent

--- a/keras/legacy/preprocessing/image.py
+++ b/keras/legacy/preprocessing/image.py
@@ -227,9 +227,16 @@ class BatchFromFilesMixin:
                 to use for random transformations and normalization.
             target_size: tuple of integers, dimensions to resize input images
             to.
-            color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.
+            color_mode: ```Literal["rgb", "rgba", "grayscale"]```.
                 Color mode to read images.
-            data_format: String, one of `channels_first`, `channels_last`.
+            data_format: ```Optional[Literal["channels_last",
+                "channels_first"]]```.
+                The ordering of the dimensions in the inputs.
+                - `"channels_last"`: shape `(batch, time, ..., channels)`.
+                - `"channels_first"`: shape `(batch, time, channels, ...)`.
+                When unspecified, uses `image_data_format` value found in your
+                Keras config file at `~/.keras/keras.json` (if exists) else
+                `"channels_last"`.
             save_to_dir: Optional directory where to save the pictures
                 being yielded, in a viewable format. This is useful
                 for visualizing the random transformations being

--- a/keras/legacy/saving/legacy_h5_format.py
+++ b/keras/legacy/saving/legacy_h5_format.py
@@ -77,9 +77,9 @@ def load_model_from_hdf5(filepath, custom_objects=None, compile=True):
     """Loads a model saved via `save_model_to_hdf5`.
 
     Args:
-        filepath: One of the following:
-            - String, path to the saved model
-            - `h5py.File` object from which to load the model
+        filepath: ```Union[str, h5py.File]```.
+            - `str`: path to the saved model
+            - `h5py.File`: object from which to load the model
         custom_objects: Optional dictionary mapping names
             (strings) to custom classes or functions to be
             considered during deserialization.

--- a/keras/losses/__init__.py
+++ b/keras/losses/__init__.py
@@ -151,9 +151,9 @@ def get(identifier):
     <class '...CategoricalCrossentropy'>
 
     Args:
-        identifier: A loss identifier. One of None or string name of a loss
-            function/class or loss configuration dictionary or a loss function
-            or a loss class instance.
+        identifier: ```Optional[str]```. A loss identifier. One of `None` or
+            string name of a loss function/class or loss configuration dict
+            or a loss function or a loss class instance.
 
     Returns:
         A Keras loss as a `function`/ `Loss` class instance.

--- a/keras/metrics/__init__.py
+++ b/keras/metrics/__init__.py
@@ -179,9 +179,9 @@ def get(identifier):
     <class '...metrics.CategoricalCrossentropy'>
 
     Args:
-        identifier: A metric identifier. One of None or string name of a metric
-            function/class or metric configuration dictionary or a metric
-            function or a metric class instance
+        identifier: ```Optional[str]```. A metric identifier. One of `None` or
+            string name of a loss function/class or loss configuration dict
+            or a loss function or a metric class instance.
 
     Returns:
         A Keras metric as a `function`/ `Metric` class instance.

--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -70,13 +70,12 @@ def resize(
             `"bilinear"`, and `"bicubic"`. Defaults to `"bilinear"`.
         antialias: Whether to use an antialiasing filter when downsampling an
             image. Defaults to `False`.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, height, width, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, height, weight)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
 
     Returns:
@@ -198,13 +197,12 @@ def affine_transform(
                 The input is extended by the nearest pixel.
         fill_value: Value used for points outside the boundaries of the input if
             `fill_mode="constant"`. Defaults to `0`.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, height, width, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, height, weight)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
 
     Returns:
@@ -333,13 +331,12 @@ def extract_patches(
             strides must be 1. NOTE: `strides > 1` is not supported in
             conjunction with `dilation_rate > 1`
         padding: The type of padding algorithm to use: `"same"` or `"valid"`.
-        data_format: string, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, height, width, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, height, weight)`. It defaults to the
-            `image_data_format` value found in your Keras config file at
-            `~/.keras/keras.json`. If you never set it, then it will be
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
 
     Returns:

--- a/keras/ops/math.py
+++ b/keras/ops/math.py
@@ -292,9 +292,11 @@ def qr(x, mode="reduced"):
 
     Args:
         x: Input tensor.
-        mode: A string specifying the mode of the QR decomposition.
-            - 'reduced': Returns the reduced QR decomposition. (default)
-            - 'complete': Returns the complete QR decomposition.
+        mode: ```Literal["reduced", "complete"]```.
+            Mode of the QR decomposition:
+            - `"reduced"`: Returns the reduced QR decomposition.
+            - `"complete"`: Returns the complete QR decomposition.
+            Defaults to `"reduced"`.
 
     Returns:
         A tuple containing two tensors. The first tensor represents the

--- a/keras/ops/nn.py
+++ b/keras/ops/nn.py
@@ -645,12 +645,13 @@ def max_pool(
             padding is applied, and `"same"` results in padding evenly to the
             left/right or up/down of the input such that output has the
             same height/width dimension as the input when `strides=1`.
-        data_format: A string, either `"channels_last"` or `"channels_first"`.
-            `data_format` determines the ordering of the dimensions in the
-            inputs. If `data_format="channels_last"`, `inputs` is of shape
-            `(batch_size, ..., channels)` while if
-            `data_format="channels_first"`, `inputs` is of shape
-            `(batch_size, channels, ...)`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
 
     Returns:
         A tensor of rank N+2, the result of the max pooling operation.
@@ -736,12 +737,13 @@ def average_pool(
             padding is applied, and `"same"` results in padding evenly to the
             left/right or up/down of the input such that output has the
             same height/width dimension as the input when `strides=1`.
-        data_format: A string, either `"channels_last"` or `"channels_first"`.
-            `data_format` determines the ordering of the dimensions in the
-            inputs. If `data_format="channels_last"`, `inputs` is of shape
-            `(batch_size, ..., channels)` while if
-            `data_format="channels_first"`, `inputs` is of shape
-            `(batch_size, channels, ...)`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
 
     Returns:
         A tensor of rank N+2, the result of the average pooling operation.
@@ -828,12 +830,13 @@ def conv(
             padding is applied, and `"same"` results in padding evenly to the
             left/right or up/down of the input such that output has the
             same height/width dimension as the input when `strides=1`.
-        data_format: A string, either `"channels_last"` or `"channels_first"`.
-            `data_format` determines the ordering of the dimensions in the
-            inputs. If `data_format="channels_last"`, `inputs` is of shape
-            `(batch_size, ..., channels)` while if
-            `data_format="channels_first"`, `inputs` is of shape
-            `(batch_size, channels, ...)`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or int tuple/list of `len(inputs_spatial_shape)`,
             specifying the dilation rate to use for dilated convolution. If
             `dilation_rate` is int, then every spatial dimension shares
@@ -926,12 +929,13 @@ def depthwise_conv(
             padding is applied, and `"same"` results in padding evenly to the
             left/right or up/down of the input such that output has the
             same height/width dimension as the input when `strides=1`.
-        data_format: A string, either `"channels_last"` or `"channels_first"`.
-            `data_format` determines the ordering of the dimensions in the
-            inputs. If `data_format="channels_last"`, `inputs` is of shape
-            `(batch_size, ..., channels)` while if
-            `data_format="channels_first"`, `inputs` is of shape
-            `(batch_size, channels, ...)`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or int tuple/list of `len(inputs_spatial_shape)`,
             specifying the dilation rate to use for dilated convolution. If
             `dilation_rate` is int, then every spatial dimension shares
@@ -1040,12 +1044,13 @@ def separable_conv(
             padding is applied, and `"same"` results in padding evenly to the
             left/right or up/down of the input such that output has the
             same height/width dimension as the input when `strides=1`.
-        data_format: A string, either `"channels_last"` or `"channels_first"`.
-            `data_format` determines the ordering of the dimensions in the
-            inputs. If `data_format="channels_last"`, `inputs` is of shape
-            `(batch_size, ..., channels)` while if
-            `data_format="channels_first"`, `inputs` is of shape
-            `(batch_size, channels, ...)`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or int tuple/list of `len(inputs_spatial_shape)`,
             specifying the dilation rate to use for dilated convolution. If
             `dilation_rate` is int, then every spatial dimension shares
@@ -1165,12 +1170,13 @@ def conv_transpose(
             along a given dimension must be lower than the stride along that
             same dimension. If set to `None` (default), the output shape is
             inferred.
-        data_format: A string, either `"channels_last"` or `"channels_first"`.
-            `data_format` determines the ordering of the dimensions in the
-            inputs. If `data_format="channels_last"`, `inputs` is of shape
-            `(batch_size, ..., channels)` while if
-            `data_format="channels_first"`, `inputs` is of shape
-            `(batch_size, channels, ...)`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dilation_rate: int or int tuple/list of `len(inputs_spatial_shape)`,
             specifying the dilation rate to use for dilated convolution. If
             `dilation_rate` is int, then every spatial dimension shares

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -4209,10 +4209,11 @@ def pad(x, pad_width, mode="constant"):
             each axis.
             `(pad,)` or `int` is a shortcut for `before = after = pad`
             width for all axes.
-        mode: One of `"constant"`, `"edge"`, `"linear_ramp"`,
-            `"maximum"`, `"mean"`, `"median"`, `"minimum"`,
-            `"reflect"`, `"symmetric"`, `"wrap"`, `"empty"`,
-            `"circular"`. Defaults to`"constant"`.
+        mode: ```Literal["constant", "edge", "linear_ramp",
+            "maximum", "mean", "median", "minimum",
+            "reflect", "symmetric", "wrap", "empty",
+            "circular"]```.
+            Defaults to`"constant"`.
 
     Note:
         Torch backend only supports modes `"constant"`, `"reflect"`,

--- a/keras/ops/operation_utils.py
+++ b/keras/ops/operation_utils.py
@@ -22,11 +22,14 @@ def compute_pooling_output_shape(
             Defaults to `pool_size`.
         padding: Padding method. Available methods are `"valid"` or `"same"`.
             Defaults to `"valid"`.
-        data_format: String, either `"channels_last"` or `"channels_first"`.
-            The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, height, width, channels)`
-            while `"channels_first"` corresponds to inputs with shape
-            `(batch, channels, height, weight)`. Defaults to `"channels_last"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
+            Defaults to `"channels_last"`.
 
     Returns:
         Tuple of ints: The output shape of the pooling operation.
@@ -74,7 +77,7 @@ def compute_pooling_output_shape(
         output_spatial_shape = np.floor((spatial_shape - 1) / strides) + 1
     else:
         raise ValueError(
-            "`padding` must be either `'valid'` or `'same'`. Received "
+            "`padding` must be either `\"valid\"` or `\"same\"`. Received "
             f"{padding}."
         )
     output_spatial_shape = [int(i) for i in output_spatial_shape]

--- a/keras/regularizers/regularizers.py
+++ b/keras/regularizers/regularizers.py
@@ -288,10 +288,12 @@ class OrthogonalRegularizer(Regularizer):
             between the L2-normalized rows (if `mode="rows"`, or columns if
             `mode="columns"`) of the inputs, excluding the product of each
             row/column with itself.  Defaults to `0.01`.
-        mode: String, one of `{"rows", "columns"}`. Defaults to `"rows"`. In
-            rows mode, the regularization effect seeks to make the rows of the
-            input orthogonal to each other. In columns mode, it seeks to make
-            the columns of the input orthogonal to each other.
+        mode: ```Literal["rows", "columns"]```.
+            - `"rows"`: The regularization effect seeks to make the rows of
+              the input orthogonal to each other.
+            - `"columns"` Seeks to make the columns of the input orthogonal
+              to each other.
+            Defaults to `"rows"`.
 
     Example:
 

--- a/keras/utils/audio_dataset_utils.py
+++ b/keras/utils/audio_dataset_utils.py
@@ -86,8 +86,8 @@ def audio_dataset_from_directory(
         seed: Optional random seed for shuffling and transformations.
         validation_split: Optional float between 0 and 1, fraction of data to
             reserve for validation.
-        subset: Subset of the data to return. One of `"training"`,
-            `"validation"` or `"both"`. Only used if `validation_split` is set.
+        subset: ```Literal["training", "validation", "both"]```.
+            Subset of the data to return. Used if `validation_split` is set.
         follow_links: Whether to visits subdirectories pointed to by symlinks.
             Defaults to `False`.
 

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -748,8 +748,8 @@ def check_validation_split_arg(validation_split, subset, shuffle, seed):
     Args:
         validation_split: float between 0 and 1, fraction of data to reserve for
             validation.
-        subset: One of `"training"`, `"validation"`, or `"both"`. Only used if
-            `validation_split` is set.
+        subset: ```Literal["training", "validation", "both"]```.
+            Subset of the data to return. Used if `validation_split` is set.
         shuffle: Whether to shuffle the data. Either `True` or `False`.
         seed: random seed for shuffling and transformations.
     """

--- a/keras/utils/image_dataset_utils.py
+++ b/keras/utils/image_dataset_utils.py
@@ -80,7 +80,7 @@ def image_dataset_from_directory(
             This is the explicit list of class names
             (must match names of subdirectories). Used to control the order
             of the classes (otherwise alphanumerical order is used).
-        color_mode: One of `"grayscale"`, `"rgb"`, `"rgba"`.
+        color_mode: ```Literal["grayscale", "rgb", "rgba"]```.
             Defaults to `"rgb"`. Whether the images will be converted to
             have 1, 3, or 4 channels.
         batch_size: Size of the batches of data. Defaults to 32.
@@ -95,9 +95,8 @@ def image_dataset_from_directory(
         seed: Optional random seed for shuffling and transformations.
         validation_split: Optional float between 0 and 1,
             fraction of data to reserve for validation.
-        subset: Subset of the data to return.
-            One of `"training"`, `"validation"`, or `"both"`.
-            Only used if `validation_split` is set.
+        subset: ```Literal["training", "validation", "both"]```.
+            Subset of the data to return. Used if `validation_split` is set.
             When `subset="both"`, the utility returns a tuple of two datasets
             (the training and validation datasets respectively).
         interpolation: String, the interpolation method used when
@@ -113,8 +112,13 @@ def image_dataset_from_directory(
             (of size `image_size`) that matches the target aspect ratio. By
             default (`crop_to_aspect_ratio=False`), aspect ratio may not be
             preserved.
-        data_format: If None uses keras.config.image_data_format()
-            otherwise either 'channel_last' or 'channel_first'.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
 
     Returns:
 

--- a/keras/utils/image_utils.py
+++ b/keras/utils/image_utils.py
@@ -51,10 +51,13 @@ def array_to_img(x, data_format=None, scale=True, dtype=None):
 
     Args:
         x: Input data, in any form that can be converted to a NumPy array.
-        data_format: Image data format, can be either `"channels_first"` or
-            `"channels_last"`. Defaults to `None`, in which case the global
-            setting `keras.backend.image_data_format()` is used (unless you
-            changed it, it defaults to `"channels_last"`).
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         scale: Whether to rescale the image such that minimum and maximum values
             are 0 and 255 respectively. Defaults to `True`.
         dtype: Dtype to use. `None` means the global setting
@@ -127,10 +130,13 @@ def img_to_array(img, data_format=None, dtype=None):
 
     Args:
         img: Input PIL Image instance.
-        data_format: Image data format, can be either `"channels_first"` or
-            `"channels_last"`. Defaults to `None`, in which case the global
-            setting `keras.backend.image_data_format()` is used (unless you
-            changed it, it defaults to `"channels_last"`).
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         dtype: Dtype to use. `None` means the global setting
             `keras.backend.floatx()` is used (unless you changed it, it
             defaults to `"float32"`).
@@ -166,7 +172,12 @@ def save_img(path, x, data_format=None, file_format=None, scale=True, **kwargs):
     Args:
         path: Path or file object.
         x: NumPy array.
-        data_format: Image data format, either `"channels_first"` or
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
             `"channels_last"`.
         file_format: Optional file format override. If omitted, the format to
             use is determined from the filename extension. If a file object was
@@ -205,8 +216,9 @@ def load_img(
 
     Args:
         path: Path to image file.
-        color_mode: One of `"grayscale"`, `"rgb"`, `"rgba"`. Default: `"rgb"`.
-            The desired image format.
+        color_mode: ```Literal["grayscale", "rgb", "rgba"]```.
+            The desired image format. Defaults to `"rgb"`.
+
         target_size: Either `None` (default to original size) or tuple of ints
             `(img_height, img_width)`.
         interpolation: Interpolation method used to resample the image if the
@@ -353,7 +365,13 @@ def smart_resize(
             Defaults to `'bilinear'`.
             Supports `bilinear`, `nearest`, `bicubic`,
             `lanczos3`, `lanczos5`.
-        data_format: `"channels_last"` or `"channels_first"`.
+        data_format: ```Optional[Literal["channels_last", "channels_first"]]```.
+            The ordering of the dimensions in the inputs.
+            - `"channels_last"`: input shape `(batch, time, ..., channels)`
+            - `"channels_first"`: input shape `(batch, time, channels, ...)`.
+            When unspecified, uses `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json` (if exists) else
+            `"channels_last"`.
         backend_module: Backend module to use (if different from the default
             backend).
 

--- a/keras/utils/text_dataset_utils.py
+++ b/keras/utils/text_dataset_utils.py
@@ -81,9 +81,8 @@ def text_dataset_from_directory(
         seed: Optional random seed for shuffling and transformations.
         validation_split: Optional float between 0 and 1,
             fraction of data to reserve for validation.
-        subset: Subset of the data to return.
-            One of `"training"`, `"validation"` or `"both"`.
-            Only used if `validation_split` is set.
+        subset: ```Literal["training", "validation", "both"]```.
+            Subset of the data to return. Used if `validation_split` is set.
             When `subset="both"`, the utility returns a tuple of two datasets
             (the training and validation datasets respectively).
         follow_links: Whether to visits subdirectories pointed to by symlinks.


### PR DESCRIPTION
Shouldn't be anything controversial here. PR might be too large, so if you want it split to one PR per file just say the word.

The overall goal here is to expose Keras as a fully-typed SDK, CLI, GUI, series of SQL tables. This will enable a number of use-cases, most interesting (IMHO) is being able to automatically compare / mix-and-match different parts of the ontology.

E.g., mix-and-match optimisers, loss functions, applications (transfer-learning models). Automatically. For example, consider AutoML, hyperparameter and parameter optimisation use-cases.

PS: Future work, in terms of PRs to Keras, include further improvements to
- docstrings 
- type constraints (e.g., numerical ranges of `integer > 0`, or `float in range [0, 1]` [or a concise [interval](https://en.wikipedia.org/wiki/Interval_(mathematics)) syntax]).
- automatic switching from types in docstrings to types in source (optionally removing `Defaults to` from docstring); e.g., my Python compiler can already do this.