### PR TITLE
Fix speedup test

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -81,7 +81,7 @@ jobs:
       #     coverage xml --omit='keras/applications/*' -o core-coverage.xml
       - name: Test with pytest
         run: |
-          pytest keras --ignore keras/applications --cov=keras -k test_speedup -s
+          pytest keras --ignore keras/applications -k test_speedup -s
           coverage xml --omit='keras/applications/*' -o core-coverage.xml
       # - name: Codecov keras
       #   uses: codecov/codecov-action@v3

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -63,33 +63,29 @@ jobs:
           flags: keras.applications,keras.applications-${{ matrix.backend }}
           files: apps-coverage.xml
           fail_ci_if_error: false
-      # - name: Test integrations
-      #   if: ${{ matrix.backend != 'numpy'}}
-      #   run: |
-      #     python integration_tests/import_test.py
-      # - name: Test TF-specific integrations
-      #   if: ${{ matrix.backend == 'tensorflow'}}
-      #   run: |
-      #     python integration_tests/tf_distribute_training_test.py
-      # - name: Test Torch-specific integrations
-      #   if: ${{ matrix.backend == 'torch'}}
-      #   run: |
-      #     pytest integration_tests/torch_workflow_test.py
-      # - name: Test with pytest
-      #   run: |
-      #     pytest keras --ignore keras/applications --cov=keras
-      #     coverage xml --omit='keras/applications/*' -o core-coverage.xml
+      - name: Test integrations
+        if: ${{ matrix.backend != 'numpy'}}
+        run: |
+          python integration_tests/import_test.py
+      - name: Test TF-specific integrations
+        if: ${{ matrix.backend == 'tensorflow'}}
+        run: |
+          python integration_tests/tf_distribute_training_test.py
+      - name: Test Torch-specific integrations
+        if: ${{ matrix.backend == 'torch'}}
+        run: |
+          pytest integration_tests/torch_workflow_test.py
       - name: Test with pytest
         run: |
-          pytest keras --ignore keras/applications -k test_speedup -s
+          pytest keras --ignore keras/applications --cov=keras
           coverage xml --omit='keras/applications/*' -o core-coverage.xml
-      # - name: Codecov keras
-      #   uses: codecov/codecov-action@v3
-      #   with:
-      #     env_vars: PYTHON,KERAS_BACKEND
-      #     flags: keras,keras-${{ matrix.backend }}
-      #     files: core-coverage.xml
-      #     fail_ci_if_error: false
+      - name: Codecov keras
+        uses: codecov/codecov-action@v3
+        with:
+          env_vars: PYTHON,KERAS_BACKEND
+          flags: keras,keras-${{ matrix.backend }}
+          files: core-coverage.xml
+          fail_ci_if_error: false
 
   format:
     name: Check the code format

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -63,18 +63,18 @@ jobs:
           flags: keras.applications,keras.applications-${{ matrix.backend }}
           files: apps-coverage.xml
           fail_ci_if_error: false
-      - name: Test integrations
-        if: ${{ matrix.backend != 'numpy'}}
-        run: |
-          python integration_tests/import_test.py
-      - name: Test TF-specific integrations
-        if: ${{ matrix.backend == 'tensorflow'}}
-        run: |
-          python integration_tests/tf_distribute_training_test.py
-      - name: Test Torch-specific integrations
-        if: ${{ matrix.backend == 'torch'}}
-        run: |
-          pytest integration_tests/torch_workflow_test.py
+      # - name: Test integrations
+      #   if: ${{ matrix.backend != 'numpy'}}
+      #   run: |
+      #     python integration_tests/import_test.py
+      # - name: Test TF-specific integrations
+      #   if: ${{ matrix.backend == 'tensorflow'}}
+      #   run: |
+      #     python integration_tests/tf_distribute_training_test.py
+      # - name: Test Torch-specific integrations
+      #   if: ${{ matrix.backend == 'torch'}}
+      #   run: |
+      #     pytest integration_tests/torch_workflow_test.py
       # - name: Test with pytest
       #   run: |
       #     pytest keras --ignore keras/applications --cov=keras

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -75,17 +75,21 @@ jobs:
         if: ${{ matrix.backend == 'torch'}}
         run: |
           pytest integration_tests/torch_workflow_test.py
+      # - name: Test with pytest
+      #   run: |
+      #     pytest keras --ignore keras/applications --cov=keras
+      #     coverage xml --omit='keras/applications/*' -o core-coverage.xml
       - name: Test with pytest
         run: |
-          pytest keras --ignore keras/applications --cov=keras
+          pytest keras --ignore keras/applications --cov=keras -k test_speedup -s
           coverage xml --omit='keras/applications/*' -o core-coverage.xml
-      - name: Codecov keras
-        uses: codecov/codecov-action@v3
-        with:
-          env_vars: PYTHON,KERAS_BACKEND
-          flags: keras,keras-${{ matrix.backend }}
-          files: core-coverage.xml
-          fail_ci_if_error: false
+      # - name: Codecov keras
+      #   uses: codecov/codecov-action@v3
+      #   with:
+      #     env_vars: PYTHON,KERAS_BACKEND
+      #     flags: keras,keras-${{ matrix.backend }}
+      #     files: core-coverage.xml
+      #     fail_ci_if_error: false
 
   format:
     name: Check the code format

--- a/keras/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/trainers/data_adapters/py_dataset_adapter_test.py
@@ -114,31 +114,35 @@ class PyDatasetAdapterTest(testing.TestCase, parameterized.TestCase):
             x,
             y,
             batch_size=4,
-            delay=0.2,
+            delay=0.5,
         )
         adapter = py_dataset_adapter.PyDatasetAdapter(
             no_speedup_py_dataset, shuffle=False
         )
+        gen = adapter.get_numpy_iterator()
         t0 = time.time()
-        for batch in adapter.get_numpy_iterator():
+        for batch in gen:
             pass
-        no_speed_up_time = time.time() - t0
+        no_speedup_time = time.time() - t0
 
         speedup_py_dataset = ExamplePyDataset(
             x,
             y,
             batch_size=4,
             workers=4,
-            use_multiprocessing=True,
+            # TODO: the github actions runner may have performance issue with
+            # multiprocessing
+            # use_multiprocessing=True,
             max_queue_size=8,
-            delay=0.2,
+            delay=0.5,
         )
         adapter = py_dataset_adapter.PyDatasetAdapter(
             speedup_py_dataset, shuffle=False
         )
+        gen = adapter.get_numpy_iterator()
         t0 = time.time()
-        for batch in adapter.get_numpy_iterator():
+        for batch in gen:
             pass
-        speed_up_time = time.time() - t0
+        speedup_time = time.time() - t0
 
-        self.assertLess(speed_up_time, no_speed_up_time)
+        self.assertLess(speedup_time, no_speedup_time)

--- a/keras/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/trainers/data_adapters/py_dataset_adapter_test.py
@@ -144,5 +144,7 @@ class PyDatasetAdapterTest(testing.TestCase, parameterized.TestCase):
         for batch in gen:
             pass
         speedup_time = time.time() - t0
+        print("\n!!!speedup test!!!")
+        print(speedup_time, no_speedup_time)
 
         self.assertLess(speedup_time, no_speedup_time)

--- a/keras/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/trainers/data_adapters/py_dataset_adapter_test.py
@@ -144,7 +144,5 @@ class PyDatasetAdapterTest(testing.TestCase, parameterized.TestCase):
         for batch in gen:
             pass
         speedup_time = time.time() - t0
-        print("\n!!!speedup test!!!")
-        print(speedup_time, no_speedup_time)
 
         self.assertLess(speedup_time, no_speedup_time)


### PR DESCRIPTION
I still saw the random failures of speed-up test in `py_dataset_adapter_test.py` after #18780 

The root cause might be the limited resouces (only 2 cpu for linux machine) of the runner to spawn multiple process in `PyDataset`:
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

```python
        ExamplePyDataset(
            x,
            y,
            batch_size=4,
            workers=4,
            use_multiprocessing=True,  # <---
            max_queue_size=8,
            delay=0.5,
        )
```

EDITED:
I have conducted 3 experiments on the runner and the results indicate that this issue should be fixed by this PR.
||backend|speed-up (sec)|no speed-up (sec)|
|-|-|-|-|
|1st|numpy|1.56|5.01|
|2nd|numpy|1.55|5.01|
|3rd|numpy|1.56|5.01|
|1st|jax|1.54|5.01|
|2nd|jax|1.57|5.01|
|3rd|jax|1.57|5.01|
|1st|tensorflow|1.58|5.01|
|2nd|tensorflow|1.54|5.01|
|3rd|tensorflow|1.58|5.01|
|1st|torch|1.53|5.01|
|2nd|torch|1.54|5.01|
|3rd|torch|1.52|5.01|

Runs:
- https://github.com/keras-team/keras/actions/runs/6886842509
- https://github.com/keras-team/keras/actions/runs/6886869800
- https://github.com/keras-team/keras/actions/runs/6886889355
