### PR TITLE
Apply `backend.result_type` to `einsum`, `expand_dims`, `flip`, `floor`, `full_like`, `hstack`, `is*`, `meshgrid` and `moveaxis`

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -353,6 +353,9 @@ def flip(x, axis=None):
 
 
 def floor(x):
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "int64":
+        x = cast(x, config.floatx())
     return jnp.floor(x)
 
 

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -451,6 +451,12 @@ def greater_equal(x1, x2):
 
 
 def hstack(xs):
+    xs = tree.map_structure(convert_to_tensor, xs)
+    dtypes_to_resolve = []
+    for x in xs:
+        dtypes_to_resolve.append(x.dtype)
+    dtype = dtypes.result_type(*dtypes_to_resolve)
+    xs = tree.map_structure(lambda x: x.astype(dtype), xs)
     return np.hstack(xs)
 
 

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -729,6 +729,13 @@ def imag(x):
 
 
 def isclose(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    # TODO: tfnp.isclose lack support of bfloat16 dtype promotion
+    if standardize_dtype(x1.dtype) == "bfloat16":
+        x1 = tf.cast(x1, "float32")
+    if standardize_dtype(x2.dtype) == "bfloat16":
+        x2 = tf.cast(x2, "float32")
     return tfnp.isclose(x1, x2)
 
 
@@ -737,7 +744,9 @@ def isfinite(x):
 
 
 def isinf(x):
-    return tfnp.isinf(x)
+    # TODO: tfnp.isinf will get python bool when input is a scalar, so we
+    # need the extra `convert_to_tensor`
+    return convert_to_tensor(tfnp.isinf(x))
 
 
 def isnan(x):

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -75,7 +75,7 @@ def einsum(subscripts, *operands, **kwargs):
 
     dtypes_to_resolve = []
     for x in operands:
-        dtypes_to_resolve.append(getattr(x, "dtype", type(x)))
+        dtypes_to_resolve.append(x.dtype)
     result_dtype = dtypes.result_type(*dtypes_to_resolve)
     compute_dtype = result_dtype
     # TODO: tfnp.einsum doesn't support integer dtype with gpu
@@ -509,7 +509,8 @@ def concatenate(xs, axis=0):
                 tf.sparse.to_dense(x) if isinstance(x, tf.SparseTensor) else x
                 for x in xs
             ]
-    dtype_set = set([getattr(x, "dtype", type(x)) for x in xs])
+    xs = tf.nest.map_structure(convert_to_tensor, xs)
+    dtype_set = set([x.dtype for x in xs])
     if len(dtype_set) > 1:
         dtype = dtypes.result_type(*dtype_set)
         xs = tf.nest.map_structure(lambda x: tf.cast(x, dtype), xs)
@@ -730,7 +731,7 @@ def hstack(xs):
     xs = tf.nest.map_structure(convert_to_tensor, xs)
     dtypes_to_resolve = []
     for x in xs:
-        dtypes_to_resolve.append(getattr(x, "dtype", type(x)))
+        dtypes_to_resolve.append(x.dtype)
     dtype = dtypes.result_type(*dtypes_to_resolve)
     xs = tf.nest.map_structure(lambda x: tf.cast(x, dtype), xs)
     return tfnp.hstack(xs)

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -85,7 +85,7 @@ def einsum(subscripts, *operands, **kwargs):
     operands = tf.nest.map_structure(
         lambda x: tf.cast(x, compute_dtype), operands
     )
-    return tf.cast(tfnp.einsum(subscripts, *operands, **kwargs), result_dtype)
+    return tf.cast(tf.einsum(subscripts, *operands, **kwargs), result_dtype)
 
 
 @sparse.elementwise_binary_union(sparse.sparse_subtract)

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -625,13 +625,9 @@ def imag(x):
 def isclose(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    x1_dtype = standardize_dtype(x1.dtype)
-    x2_dtype = standardize_dtype(x2.dtype)
-    result_dtype = dtypes.result_type(x1_dtype, x2_dtype)
-    if x1_dtype != result_dtype:
-        x1 = cast(x1, result_dtype)
-    if x2_dtype != result_dtype:
-        x2 = cast(x2, result_dtype)
+    result_dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = cast(x1, result_dtype)
+    x2 = cast(x2, result_dtype)
     return torch.isclose(x1, x2)
 
 

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -609,13 +609,15 @@ def imag(x):
 
 
 def isclose(x1, x2):
-    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
-    if x1.dtype != x2.dtype:
-        result_dtype = torch.result_type(x1, x2)
-        if x1.dtype != result_dtype:
-            x1 = cast(x1, result_dtype)
-        else:
-            x2 = cast(x2, result_dtype)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    x1_dtype = standardize_dtype(x1.dtype)
+    x2_dtype = standardize_dtype(x2.dtype)
+    result_dtype = dtypes.result_type(x1_dtype, x2_dtype)
+    if x1_dtype != result_dtype:
+        x1 = cast(x1, result_dtype)
+    if x2_dtype != result_dtype:
+        x2 = cast(x2, result_dtype)
     return torch.isclose(x1, x2)
 
 

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -548,6 +548,12 @@ def flip(x, axis=None):
 
 def floor(x):
     x = convert_to_tensor(x)
+    dtype = (
+        config.floatx()
+        if standardize_dtype(x.dtype) == "int64"
+        else dtypes.result_type(x.dtype, float)
+    )
+    x = cast(x, dtype)
     return torch.floor(x)
 
 
@@ -565,6 +571,7 @@ def full(shape, fill_value, dtype=None):
 
 
 def full_like(x, fill_value, dtype=None):
+    dtype = dtype or x.dtype
     return full(shape=x.shape, fill_value=fill_value, dtype=dtype)
 
 

--- a/keras/backend/torch/random.py
+++ b/keras/backend/torch/random.py
@@ -196,6 +196,10 @@ def gamma(shape, alpha, dtype=None, seed=None):
     dtype = to_torch_dtype(dtype)
     alpha = torch.ones(shape) * torch.tensor(alpha)
     beta = torch.ones(shape)
-    # TODO: seed / generator not supported
+    prev_rng_state = torch.random.get_rng_state()
+    first_seed, second_seed = draw_seed(seed)
+    torch.manual_seed(first_seed + second_seed)
     gamma_distribution = torch.distributions.gamma.Gamma(alpha, beta)
-    return gamma_distribution.sample().type(dtype)
+    sample = gamma_distribution.sample().type(dtype)
+    torch.random.set_rng_state(prev_rng_state)
+    return sample

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -2944,7 +2944,7 @@ class Isclose(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        return KerasTensor(output_shape, dtype="bool")
 
 
 @keras_export(["keras.ops.isclose", "keras.ops.numpy.isclose"])

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -3744,7 +3744,9 @@ class Meshgrid(Operation):
         tmp = output_shape[0]
         output_shape[0] = output_shape[1]
         output_shape[1] = tmp
-        return [KerasTensor(output_shape) for _ in range(len(x))]
+        return [
+            KerasTensor(output_shape, dtype=xi.dtype) for _ in range(len(x))
+        ]
 
 
 @keras_export(["keras.ops.meshgrid", "keras.ops.numpy.meshgrid"])

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -2344,11 +2344,10 @@ class Einsum(Operation):
         output_shape = expanded_operands_shapes[0]
         for shape in expanded_operands_shapes[1:]:
             output_shape = broadcast_shapes(output_shape, shape)
-        dtype = None
+        dtypes_to_resolve = []
         for x in operands:
-            if hasattr(x, "dtype"):
-                dtype = x.dtype
-                break
+            dtypes_to_resolve.append(getattr(x, "dtype", type(x)))
+        dtype = dtypes.result_type(*dtypes_to_resolve)
         return KerasTensor(output_shape, dtype=dtype)
 
 
@@ -2629,7 +2628,12 @@ class Floor(Operation):
 
     def compute_output_spec(self, x):
         sparse = getattr(x, "sparse", False)
-        return KerasTensor(x.shape, dtype=x.dtype, sparse=sparse)
+        dtype = (
+            backend.floatx()
+            if backend.standardize_dtype(x.dtype) == "int64"
+            else dtypes.result_type(x.dtype, float)
+        )
+        return KerasTensor(x.shape, dtype=dtype, sparse=sparse)
 
 
 @keras_export(["keras.ops.floor", "keras.ops.numpy.floor"])
@@ -2678,6 +2682,7 @@ class FullLike(Operation):
         return backend.numpy.full_like(x, fill_value, dtype=dtype)
 
     def compute_output_spec(self, x, fill_value, dtype=None):
+        dtype = dtype or x.dtype
         return KerasTensor(x.shape, dtype=dtype)
 
 
@@ -2843,6 +2848,7 @@ class Hstack(Operation):
     def compute_output_spec(self, xs):
         first_shape = xs[0].shape
         total_size_on_axis = 0
+        dtypes_to_resolve = []
         for x in xs:
             if not shape_equal(x.shape, first_shape, axis=[1], allow_none=True):
                 raise ValueError(
@@ -2855,9 +2861,11 @@ class Hstack(Operation):
                 total_size_on_axis = None
             else:
                 total_size_on_axis += x.shape[1]
+            dtypes_to_resolve.append(getattr(x, "dtype", type(x)))
         output_shape = list(first_shape)
         output_shape[1] = total_size_on_axis
-        return KerasTensor(output_shape)
+        dtype = dtypes.result_type(*dtypes_to_resolve)
+        return KerasTensor(output_shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.hstack", "keras.ops.numpy.hstack"])

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -5647,7 +5647,26 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             expected_dtype,
         )
 
-    # TODO: test_meshgrid
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_meshgrid(self, dtype):
+        import jax.numpy as jnp
+
+        if dtype == "bool":
+            self.skipTest("meshgrid doesn't support bool dtype")
+        elif dtype is None:
+            dtype = backend.floatx()
+        x = knp.array([1, 2, 3], dtype=dtype)
+        y = knp.array([4, 5, 6], dtype=dtype)
+        x_jax = jnp.array([1, 2, 3], dtype=dtype)
+        y_jax = jnp.array([4, 5, 6], dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.meshgrid(x_jax, y_jax)[0].dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.meshgrid(x, y)[0].dtype), expected_dtype
+        )
+        self.assertEqual(
+            knp.Meshgrid().symbolic_call(x, y)[0].dtype, expected_dtype
+        )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_min(self, dtype):
@@ -5700,6 +5719,21 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(
             standardize_dtype(knp.Mod().symbolic_call(x1, x2).dtype),
             expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_moveaxis(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1, 1, 1), dtype=dtype)
+        x_jax = jnp.ones((1, 1, 1), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.moveaxis(x_jax, -2, -1).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.moveaxis(x, -2, -1).dtype), expected_dtype
+        )
+        self.assertEqual(
+            knp.Moveaxis(-2, -1).symbolic_call(x).dtype, expected_dtype
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -5259,6 +5259,71 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(
         named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
     )
+    def test_isclose(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((), dtype=dtype1)
+        x2 = knp.ones((), dtype=dtype2)
+        x1_jax = jnp.ones((), dtype=dtype1)
+        x2_jax = jnp.ones((), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.isclose(x1_jax, x2_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.isclose(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Isclose().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_isfinite(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((), dtype=dtype)
+        x_jax = jnp.ones((), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.isfinite(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.isfinite(x).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Isfinite().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_isinf(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((), dtype=dtype)
+        x_jax = jnp.ones((), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.isinf(x_jax).dtype)
+
+        self.assertEqual(standardize_dtype(knp.isinf(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Isinf().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_isnan(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((), dtype=dtype)
+        x_jax = jnp.ones((), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.isnan(x_jax).dtype)
+
+        self.assertEqual(standardize_dtype(knp.isnan(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Isnan().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
     def test_less(self, dtypes):
         import jax.numpy as jnp
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4608,8 +4608,6 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             standardize_dtype(knp.Any().symbolic_call(x).dtype), expected_dtype
         )
 
-    # TODO: test_einsum
-
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_argmax(self, dtype):
         import jax.numpy as jnp
@@ -4969,6 +4967,33 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         )
         self.assertEqual(knp.Dot().symbolic_call(x1, x2).dtype, expected_dtype)
 
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_einsum(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1, 1, 1), dtype=dtype1)
+        x2 = knp.ones((1, 1, 1), dtype=dtype2)
+        x1_jax = jnp.ones((1, 1, 1), dtype=dtype1)
+        x2_jax = jnp.ones((1, 1, 1), dtype=dtype2)
+        subscripts = "ijk,lkj->il"
+        expected_dtype = standardize_dtype(
+            jnp.einsum(subscripts, x1_jax, x2_jax).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(knp.einsum(subscripts, x1, x2).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(
+                knp.Einsum(subscripts).symbolic_call(x1, x2).dtype
+            ),
+            expected_dtype,
+        )
+
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_empty(self, dtype):
         import jax.numpy as jnp
@@ -5023,6 +5048,22 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_expand_dims(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.expand_dims(x_jax, -1).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.expand_dims(x, -1).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.ExpandDims(-1).symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_expm1(self, dtype):
         import jax.numpy as jnp
 
@@ -5067,6 +5108,38 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_flip(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.flip(x_jax, -1).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.flip(x, -1).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Flip(-1).symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_floor(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.floor(x_jax).dtype)
+        if dtype == "int64":
+            expected_dtype = backend.floatx()
+
+        self.assertEqual(standardize_dtype(knp.floor(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Floor().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_full(self, dtype):
         import jax.numpy as jnp
 
@@ -5082,6 +5155,22 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             standardize_dtype(
                 knp.Full().symbolic_call((), 0, dtype=dtype).dtype
             ),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_full_like(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.full_like(x_jax, 0).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.full_like(x, 0).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.FullLike().symbolic_call(x, 0).dtype),
             expected_dtype,
         )
 
@@ -5126,6 +5215,27 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knp.GreaterEqual().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_hstack(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1, 1), dtype=dtype1)
+        x2 = knp.ones((1, 1), dtype=dtype2)
+        x1_jax = jnp.ones((1, 1), dtype=dtype1)
+        x2_jax = jnp.ones((1, 1), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.hstack([x1_jax, x2_jax]).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.hstack([x1, x2]).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Hstack().symbolic_call([x1, x2]).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
In addition to the applying `backend.result_type`:
- Remove TODO strings in tf's numpy api because there is no particular preference for using tfnp over plain TF APIs (https://github.com/keras-team/keras/pull/18787#pullrequestreview-1734998900)
- Try the best to prevent incorrect bfloat16 promotion

Currently, the status of ops applied `backend.result_type` is as follows (has fully covered A-M):

<details>

- [x] abs
- [x] absolute
- [x] add
- [x] all
- [x] amax
- [x] amin
- [x] append
- [x] arange
- [x] arccos
- [x] arccosh
- [x] arcsin
- [x] arcsinh
- [x] arctan
- [x] arctan2
- [x] arctanh
- [x] argmax
- [x] argmin
- [x] argsort
- [x] array
- [x] average
- [x] bincount
- [x] broadcast_to
- [x] ceil
- [x] clip
- [x] concatenate
- [ ] conj  (Keras does not directly support complex data)
- [ ] conjugate  (Keras does not directly support complex data)
- [x] copy
- [x] cos
- [x] cosh
- [x] count_nonzero
- [x] cross
- [ ] cumprod  (left for #18734)
- [ ] cumsum (left for #18734)
- [x] diag
- [x] diagonal
- [x] diff
- [x] digitize
- [x] divide
- [x] dot
- [x] einsum
- [x] empty
- [x] equal
- [x] exp
- [x] expand_dims
- [x] expm1
- [x] eye
- [x] flip
- [x] floor
- [x] full
- [x] full_like
- [x] greater
- [x] greater_equal
- [x] hstack
- [x] identity
- [ ] imag (Keras does not directly support complex data)
- [ ] interp (Keras lacks this op)
- [x] isclose
- [x] isfinite
- [x] isinf
- [x] isnan
- [x] less
- [x] less_equal
- [x] linspace
- [x] log
- [x] log10
- [x] log1p
- [x] log2
- [x] logaddexp
- [x] logical_and
- [x] logical_not
- [x] logical_or
- [x] logspace
- [x] matmul
- [x] max
- [x] maximum
- [x] mean
- [x] median
- [x] meshgrid
- [ ] mgrid (Keras lacks this op)
- [x] min
- [x] minimum
- [x] mod
- [x] moveaxis
- [x] multiply
- [x] nan_to_num
- [ ] ndim
- [ ] nonzero
- [x] not_equal
- [x] ones
- [ ] ones_like
- [ ] outer
- [ ] pad
- [ ] percentile
- [ ] power
- [ ] prod
- [x] quantile
- [ ] ravel
- [ ] real
- [ ] reciprocal
- [ ] repeat
- [ ] reshape
- [ ] roll
- [ ] round
- [ ] sign
- [x] sin
- [x] sinh
- [ ] size
- [ ] sort
- [ ] split
- [x] sqrt
- [ ] square
- [ ] squeeze
- [ ] stack
- [ ] std
- [x] subtract
- [x] sum
- [ ] swapaxes
- [ ] take
- [ ] take_along_axis
- [x] tan
- [x] tanh
- [ ] tensordot
- [ ] tile
- [ ] trace
- [ ] transpose
- [x] tri
- [ ] tril
- [ ] triu
- [ ] true_divide
- [ ] vdot
- [ ] vstack
- [ ] where
- [x] zeros
- [ ] zeros_like

</details>
