### PR TITLE
Fix for layers.Reshape when using -1 and a dynamic batch size.

### DIFF
--- a/keras/layers/reshaping/reshape.py
+++ b/keras/layers/reshaping/reshape.py
@@ -53,8 +53,18 @@ class Reshape(Layer):
             shape=output_shape, dtype=inputs.dtype, sparse=inputs.sparse
         )
 
+    def build(self, input_shape):
+        self._sample_output_shape = (
+            operation_utils.compute_reshape_output_shape(
+                input_shape[1:], self.target_shape, "target_shape"
+            )
+        )
+        self.built = True
+
     def call(self, inputs):
-        return ops.reshape(inputs, (ops.shape(inputs)[0],) + self.target_shape)
+        return ops.reshape(
+            inputs, (ops.shape(inputs)[0],) + self._sample_output_shape
+        )
 
     def get_config(self):
         config = {"target_shape": self.target_shape}

--- a/keras/layers/reshaping/reshape_test.py
+++ b/keras/layers/reshaping/reshape_test.py
@@ -4,6 +4,7 @@ from absl.testing import parameterized
 from keras import backend
 from keras import layers
 from keras import testing
+from keras.backend.common.keras_tensor import KerasTensor
 
 
 class ReshapeTest(testing.TestCase, parameterized.TestCase):
@@ -91,6 +92,12 @@ class ReshapeTest(testing.TestCase, parameterized.TestCase):
         input_layer = layers.Input(shape=(2, 4))
         reshaped = layers.Reshape((8,))(input_layer)
         self.assertEqual(reshaped.shape, (None, 8))
+
+    def test_reshape_with_dynamic_batch_size_and_minus_one(self):
+        input = KerasTensor((None, 6, 4))
+        layer = layers.Reshape((-1, 8))
+        reshaped = backend.compute_output_spec(layer.__call__, input)
+        self.assertEqual(reshaped.shape, (None, 3, 8))
 
     def test_reshape_sets_static_shape(self):
         input_layer = layers.Input(batch_shape=(2, None))


### PR DESCRIPTION
When using `-1` for one of the dimensions and a dynamic batch size, with the Tensorflow backend, in non eager mode, this would result in Tensors with a `None` dimension where the `-1` was. This is because the `reshape` op does not treat the batch size specially and therefore has no way to determine what goes to the batch dimension vs. the `-1` dimension.

To fix this, we resolve the `-1` to an actual number at build time since the layer knows that the batch dimension is untouched.

Note that this bug would not affect the JAX and PyTorch backends because we inject a fake batch size when needed.