### PR TITLE
Changes to auto mode in EarlyStopping callback

### DIFF
--- a/keras/callbacks/early_stopping.py
+++ b/keras/callbacks/early_stopping.py
@@ -107,7 +107,11 @@ class EarlyStopping(Callback):
                 or self.monitor.endswith("auc")
             ):
                 self.monitor_op = ops.greater
-            elif monitor.endswith("loss"):
+            elif (
+                self.monitor.endswith("loss")
+                or self.monitor.endswith("mse")
+                or self.monitor.endswith("error")
+            ):
                 self.monitor_op = ops.less
             else:
                 raise ValueError(

--- a/keras/callbacks/early_stopping.py
+++ b/keras/callbacks/early_stopping.py
@@ -107,8 +107,13 @@ class EarlyStopping(Callback):
                 or self.monitor.endswith("auc")
             ):
                 self.monitor_op = ops.greater
-            else:
+            elif monitor.endswith("loss"):
                 self.monitor_op = ops.less
+            else:
+                raise ValueError(
+                    f"For the given metric {self.monitor}, "
+                    "user has to define the `mode`. "
+                )
 
         if self.monitor_op == ops.greater:
             self.min_delta *= 1


### PR DESCRIPTION
In current implementation of EarlyStopping callback, If the argument mode is not mentioned in either min or max it fall backs to auto mode. In auto mode if the monitored metric name not ends with 'acc' or 'accuracy' ot 'auc' then the mode will fall back to mode= 'min' which is problematic. For example if the monitored metric is 'TruePositive' or 'FalsePositive' for both cases it will monitor whether the metric is decreasing or not by minimum change configured in callback.This makes callback not useful at all for this cases.

Similarly there are metrics in [TF-ranking](https://www.tensorflow.org/ranking/api_docs/python/tfr/keras/metrics), which by default fall to min mode if user left the mode to auto.

Relevant issues from [TF-Forum](https://discuss.tensorflow.org/t/confusion-in-earlystopping-mode-argument/14080) and [SO](https://stackoverflow.com/questions/69744405/tensorflow-earlystopping-stops-too-early).

IMO, its better to leave the metrics `mode` to be defined by user. Otherwise we need to list all the metrics that should have higher value(like `accuracy`) and lower values(like `loss`) to efficiently use this auto mode. This may be problematic for custom metrics.

Maybe we can leave a warning/exception to the user if metrics other than 'acc' or 'accuracy' ot 'auc' or used as monitored metric something like below.