### PR TITLE
Fix the device conversion logic for keras.distribute.list_devices()

### DIFF
--- a/keras/backend/jax/distribution_lib.py
+++ b/keras/backend/jax/distribution_lib.py
@@ -26,7 +26,7 @@ def list_devices(device_type=None):
     """
     device_type = device_type.lower() if device_type else None
     jax_devices = jax.devices(backend=device_type)
-    return [f"{device.device_kind}:{device.id}" for device in jax_devices]
+    return [f"{device.platform}:{device.id}" for device in jax_devices]
 
 
 def distribute_variable(value, layout):

--- a/keras/backend/jax/distribution_lib_test.py
+++ b/keras/backend/jax/distribution_lib_test.py
@@ -37,6 +37,15 @@ class JaxDistributionLibTest(testing.TestCase):
         self.assertEqual(len(distribution_lib.list_devices("cpu")), 8)
         self.assertEqual(len(distribution_lib.list_devices("cpu")), 8)
 
+    def test_device_conversion(self):
+        devices = distribution_lib.list_devices("cpu")
+        jax_devices = jax.devices("cpu")
+
+        for d, jax_d in zip(devices, jax_devices):
+            converted_jax_device = backend_dlib._to_jax_device(d)
+            self.assertIsInstance(converted_jax_device, jax.Device)
+            self.assertEqual(jax_d, converted_jax_device)
+
     @mock.patch.object(jax.distributed, "initialize", return_value=None)
     def test_initialize_with_all_job_addresses(self, mock_jax_initialze):
         backend_dlib.initialize("10.0.0.1:1234,10.0.0.2:2345", 2, 0)


### PR DESCRIPTION
The https://github.com/keras-team/keras/commit/3d147bed1e7e25ff84b129374784aaf2aabe1ae8 was using the jax.Device.device_kind incorrectly. The jax.Device.device_kind will contain extra information like "tpu v3" or "Tesla V100-SXM2-16GB", which can't be used to parse the type. We should use `platform` instead.

Also adding tests to cover the device conversion logic.

Please also see internal cl in cl/584064211  for tpu in single and multi-process test.