### PR TITLE
Fix regression in Reshape layer when using -1.

### DIFF
--- a/keras/layers/reshaping/reshape.py
+++ b/keras/layers/reshaping/reshape.py
@@ -54,16 +54,17 @@ class Reshape(Layer):
         )
 
     def build(self, input_shape):
-        self._sample_output_shape = (
-            operation_utils.compute_reshape_output_shape(
-                input_shape[1:], self.target_shape, "target_shape"
-            )
+        sample_output_shape = operation_utils.compute_reshape_output_shape(
+            input_shape[1:], self.target_shape, "target_shape"
+        )
+        self._resolved_target_shape = tuple(
+            -1 if d is None else d for d in sample_output_shape
         )
         self.built = True
 
     def call(self, inputs):
         return ops.reshape(
-            inputs, (ops.shape(inputs)[0],) + self._sample_output_shape
+            inputs, (ops.shape(inputs)[0],) + self._resolved_target_shape
         )
 
     def get_config(self):

--- a/keras/layers/reshaping/reshape_test.py
+++ b/keras/layers/reshaping/reshape_test.py
@@ -96,8 +96,16 @@ class ReshapeTest(testing.TestCase, parameterized.TestCase):
     def test_reshape_with_dynamic_batch_size_and_minus_one(self):
         input = KerasTensor((None, 6, 4))
         layer = layers.Reshape((-1, 8))
+        layer.build(input.shape)
         reshaped = backend.compute_output_spec(layer.__call__, input)
         self.assertEqual(reshaped.shape, (None, 3, 8))
+
+    def test_reshape_with_dynamic_dim_and_minus_one(self):
+        input = KerasTensor((4, 6, None, 3))
+        layer = layers.Reshape((-1, 3))
+        layer.build(input.shape)
+        reshaped = backend.compute_output_spec(layer.__call__, input)
+        self.assertEqual(reshaped.shape, (4, None, 3))
 
     def test_reshape_sets_static_shape(self):
         input_layer = layers.Input(batch_shape=(2, None))


### PR DESCRIPTION
PR https://github.com/keras-team/keras/pull/18792 broke the case when value for -1 cannot be calculated statically.