### PR TITLE
added dtype arg to cumsum/cumprod, fixes inconsistency bug

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -287,12 +287,12 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
     )
 
 
-def cumprod(x, axis=None):
-    return jnp.cumprod(x, axis=axis)
+def cumprod(x, axis=None, dtype=None):
+    return jnp.cumprod(x, axis=axis, dtype=dtype)
 
 
-def cumsum(x, axis=None):
-    return jnp.cumsum(x, axis=axis)
+def cumsum(x, axis=None, dtype=None):
+    return jnp.cumsum(x, axis=axis, dtype=dtype)
 
 
 def diag(x, k=0):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -345,14 +345,14 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
     )
 
 
-def cumprod(x, axis=None):
+def cumprod(x, axis=None, dtype=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    return np.cumprod(x, axis=axis)
+    return np.cumprod(x, axis=axis, dtype=dtype or x.dtype)
 
 
-def cumsum(x, axis=None):
+def cumsum(x, axis=None, dtype=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    return np.cumsum(x, axis=axis)
+    return np.cumsum(x, axis=axis, dtype=dtype or x.dtype)
 
 
 def diag(x, k=0):

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -574,12 +574,12 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
     )
 
 
-def cumprod(x, axis=None):
-    return tfnp.cumprod(x, axis=axis)
+def cumprod(x, axis=None, dtype=None):
+    return tfnp.cumprod(x, axis=axis, dtype=dtype or x.dtype)
 
 
-def cumsum(x, axis=None):
-    return tfnp.cumsum(x, axis=axis)
+def cumsum(x, axis=None, dtype=None):
+    return tfnp.cumsum(x, axis=axis, dtype=dtype or x.dtype)
 
 
 def diag(x, k=0):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -463,7 +463,9 @@ def cumprod(x, axis=None, dtype=None):
     if axis is None:
         x = x.flatten()
         axis = 0
-    return torch.cumprod(x, dim=axis, dtype=dtype or x.dtype)
+    return torch.cumprod(
+        x, dim=axis, dtype=x.dtype if dtype is None else to_torch_dtype(dtype)
+    )
 
 
 def cumsum(x, axis=None, dtype=None):
@@ -471,7 +473,9 @@ def cumsum(x, axis=None, dtype=None):
     if axis is None:
         x = x.flatten()
         axis = 0
-    return torch.cumsum(x, dim=axis, dtype=dtype or x.dtype)
+    return torch.cumsum(
+        x, dim=axis, dtype=x.dtype if dtype is None else to_torch_dtype(dtype)
+    )
 
 
 def diag(x, k=0):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -458,20 +458,20 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=-1):
     return cast(torch.cross(x1, x2, dim=axis), result_dtype)
 
 
-def cumprod(x, axis=None):
+def cumprod(x, axis=None, dtype=None):
     x = convert_to_tensor(x)
     if axis is None:
         x = x.flatten()
         axis = 0
-    return torch.cumprod(x, dim=axis)
+    return torch.cumprod(x, dim=axis, dtype=dtype or x.dtype)
 
 
-def cumsum(x, axis=None):
+def cumsum(x, axis=None, dtype=None):
     x = convert_to_tensor(x)
     if axis is None:
         x = x.flatten()
         axis = 0
-    return torch.cumsum(x, dim=axis)
+    return torch.cumsum(x, dim=axis, dtype=dtype or x.dtype)
 
 
 def diag(x, k=0):

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -1779,12 +1779,13 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
 
 
 class Cumprod(Operation):
-    def __init__(self, axis=None):
+    def __init__(self, axis=None, dtype=None):
         super().__init__()
         self.axis = axis
+        self.dtype = dtype
 
     def call(self, x):
-        return backend.numpy.cumprod(x, axis=self.axis)
+        return backend.numpy.cumprod(x, axis=self.axis, dtype=self.dtype)
 
     def compute_output_spec(self, x):
         if self.axis is None:
@@ -1792,34 +1793,35 @@ class Cumprod(Operation):
                 output_shape = (None,)
             else:
                 output_shape = (int(np.prod(x.shape)),)
-            return KerasTensor(output_shape, dtype="int32")
-        return KerasTensor(x.shape, dtype=x.dtype)
+        else:
+            output_shape = x.shape
+        return KerasTensor(output_shape, self.dtype or x.dtype)
 
 
 @keras_export(["keras.ops.cumprod", "keras.ops.numpy.cumprod"])
-def cumprod(x, axis=None):
+def cumprod(x, axis=None, dtype=None):
     """Return the cumulative product of elements along a given axis.
 
     Args:
         x: Input tensor.
         axis: Axis along which the cumulative product is computed.
             By default the input is flattened.
+        dtype: dtype of returned tensor. Defaults to x.dtype.
 
     Returns:
         Output tensor.
     """
-    if any_symbolic_tensors((x,)):
-        return Cumprod(axis=axis).symbolic_call(x)
-    return backend.numpy.cumprod(x, axis=axis)
+    return Cumprod(axis=axis, dtype=dtype)(x)
 
 
 class Cumsum(Operation):
-    def __init__(self, axis=None):
+    def __init__(self, axis=None, dtype=None):
         super().__init__()
         self.axis = axis
+        self.dtype = dtype
 
     def call(self, x):
-        return backend.numpy.cumsum(x, axis=self.axis)
+        return backend.numpy.cumsum(x, axis=self.axis, dtype=self.dtype)
 
     def compute_output_spec(self, x):
         if self.axis is None:
@@ -1827,25 +1829,25 @@ class Cumsum(Operation):
                 output_shape = (None,)
             else:
                 output_shape = (int(np.prod(x.shape)),)
-            return KerasTensor(output_shape, dtype="int32")
-        return KerasTensor(x.shape, dtype=x.dtype)
+        else:
+            output_shape = x.shape
+        return KerasTensor(output_shape, self.dtype or x.dtype)
 
 
 @keras_export(["keras.ops.cumsum", "keras.ops.numpy.cumsum"])
-def cumsum(x, axis=None):
+def cumsum(x, axis=None, dtype=None):
     """Returns the cumulative sum of elements along a given axis.
 
     Args:
         x: Input tensor.
         axis: Axis along which the cumulative sum is computed.
             By default the input is flattened.
+        dtype: dtype of returned tensor. Defaults to x.dtype.
 
     Returns:
         Output tensor.
     """
-    if any_symbolic_tensors((x,)):
-        return Cumsum(axis=axis).symbolic_call(x)
-    return backend.numpy.cumsum(x, axis=axis)
+    return Cumsum(axis=axis, dtype=dtype)(x)
 
 
 class Diag(Operation):

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -3172,48 +3172,34 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             np.count_nonzero(x, axis=1),
         )
 
-    def test_cumprod(self):
+    @parameterized.product(
+        axis=[None, 0, 1, -1],
+        dtype=[None, "int32", "float32"],
+    )
+    def test_cumprod(self, axis, dtype):
         x = np.array([[1, 2, 3], [3, 2, 1]])
-        self.assertAllClose(knp.cumprod(x), np.cumprod(x))
         self.assertAllClose(
-            knp.cumprod(x, axis=0),
-            np.cumprod(x, axis=0),
+            knp.cumprod(x, axis=axis, dtype=dtype),
+            np.cumprod(x, axis=axis, dtype=dtype or x.dtype),
         )
         self.assertAllClose(
-            knp.cumprod(x, axis=None),
-            np.cumprod(x, axis=None),
-        )
-
-        self.assertAllClose(knp.Cumprod()(x), np.cumprod(x))
-        self.assertAllClose(
-            knp.Cumprod(axis=0)(x),
-            np.cumprod(x, axis=0),
-        )
-        self.assertAllClose(
-            knp.Cumprod(axis=None)(x),
-            np.cumprod(x, axis=None),
+            knp.Cumprod(axis=axis, dtype=dtype)(x),
+            np.cumprod(x, axis=axis, dtype=dtype or x.dtype),
         )
 
-    def test_cumsum(self):
+    @parameterized.product(
+        axis=[None, 0, 1, -1],
+        dtype=[None, "int32", "float32"],
+    )
+    def test_cumsum(self, axis, dtype):
         x = np.array([[1, 2, 3], [3, 2, 1]])
-        self.assertAllClose(knp.cumsum(x), np.cumsum(x))
         self.assertAllClose(
-            knp.cumsum(x, axis=0),
-            np.cumsum(x, axis=0),
+            knp.cumsum(x, axis=axis, dtype=dtype),
+            np.cumsum(x, axis=axis, dtype=dtype or x.dtype),
         )
         self.assertAllClose(
-            knp.cumsum(x, axis=1),
-            np.cumsum(x, axis=1),
-        )
-
-        self.assertAllClose(knp.Cumsum()(x), np.cumsum(x))
-        self.assertAllClose(
-            knp.Cumsum(axis=0)(x),
-            np.cumsum(x, axis=0),
-        )
-        self.assertAllClose(
-            knp.Cumsum(axis=1)(x),
-            np.cumsum(x, axis=1),
+            knp.Cumsum(axis=axis, dtype=dtype)(x),
+            np.cumsum(x, axis=axis, dtype=dtype or x.dtype),
         )
 
     def test_diag(self):


### PR DESCRIPTION
Addresses #18730 . I've adopted the jax convention of defaulting dtype to the original in the case of ints, rather than integer type promotion as is the numpy/tensorflow/torch approach.