### PR TITLE
Added constant_values support to pad

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -583,8 +583,11 @@ def outer(x1, x2):
     return jnp.outer(x1, x2)
 
 
-def pad(x, pad_width, mode="constant"):
-    return jnp.pad(x, pad_width, mode=mode)
+def pad(x, pad_width, mode="constant", constant_values=0):
+    kwargs = {}
+    if mode == "constant":
+        kwargs["constant_values"] = constant_values
+    return jnp.pad(x, pad_width, mode=mode, **kwargs)
 
 
 def prod(x, axis=None, keepdims=False, dtype=None):

--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -583,9 +583,15 @@ def outer(x1, x2):
     return jnp.outer(x1, x2)
 
 
-def pad(x, pad_width, mode="constant", constant_values=0):
+def pad(x, pad_width, mode="constant", constant_values=None):
     kwargs = {}
-    if mode == "constant":
+    if constant_values is not None:
+        if mode != "constant":
+            raise ValueError(
+                "Argument 'constant_values' can only be "
+                "provided when mode == 'constant'. "
+                f"Received mode '{mode}'"
+            )
         kwargs["constant_values"] = constant_values
     return jnp.pad(x, pad_width, mode=mode, **kwargs)
 

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -676,8 +676,11 @@ def outer(x1, x2):
     return np.outer(x1, x2)
 
 
-def pad(x, pad_width, mode="constant"):
-    return np.pad(x, pad_width, mode=mode)
+def pad(x, pad_width, mode="constant", constant_values=0):
+    kwargs = {}
+    if mode == "constant":
+        kwargs["constant_values"] = constant_values
+    return np.pad(x, pad_width, mode=mode, **kwargs)
 
 
 def prod(x, axis=None, keepdims=False, dtype=None):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -676,9 +676,15 @@ def outer(x1, x2):
     return np.outer(x1, x2)
 
 
-def pad(x, pad_width, mode="constant", constant_values=0):
+def pad(x, pad_width, mode="constant", constant_values=None):
     kwargs = {}
-    if mode == "constant":
+    if constant_values is not None:
+        if mode != "constant":
+            raise ValueError(
+                "Argument 'constant_values' can only be "
+                "provided when mode == 'constant'. "
+                f"Received mode '{mode}'"
+            )
         kwargs["constant_values"] = constant_values
     return np.pad(x, pad_width, mode=mode, **kwargs)
 

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -1030,8 +1030,8 @@ def outer(x1, x2):
     return tfnp.outer(x1, x2)
 
 
-def pad(x, pad_width, mode="constant"):
-    return tfnp.pad(x, pad_width, mode=mode)
+def pad(x, pad_width, mode="constant", constant_values=0):
+    return tfnp.pad(x, pad_width, mode=mode, constant_values=constant_values)
 
 
 def prod(x, axis=None, keepdims=False, dtype=None):

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -1030,8 +1030,17 @@ def outer(x1, x2):
     return tfnp.outer(x1, x2)
 
 
-def pad(x, pad_width, mode="constant", constant_values=0):
-    return tfnp.pad(x, pad_width, mode=mode, constant_values=constant_values)
+def pad(x, pad_width, mode="constant", constant_values=None):
+    kwargs = {}
+    if constant_values is not None:
+        if mode != "constant":
+            raise ValueError(
+                "Argument 'constant_values' can only be "
+                "provided when mode == 'constant'. "
+                f"Received mode '{mode}'"
+            )
+        kwargs["constant_values"] = constant_values
+    return tfnp.pad(x, pad_width, mode=mode, **kwargs)
 
 
 def prod(x, axis=None, keepdims=False, dtype=None):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -927,7 +927,7 @@ def outer(x1, x2):
     return torch.outer(x1.flatten(), x2.flatten())
 
 
-def pad(x, pad_width, mode="constant"):
+def pad(x, pad_width, mode="constant", constant_values=0):
     x = convert_to_tensor(x)
     pad_sum = []
     pad_width = list(pad_width)[::-1]  # torch uses reverse order
@@ -942,8 +942,9 @@ def pad(x, pad_width, mode="constant"):
     if mode == "symmetric":
         mode = "replicate"
     if mode == "constant":
-        return torch.nn.functional.pad(x, pad=pad_sum, mode=mode)
-
+        return torch.nn.functional.pad(
+            x, pad=pad_sum, mode=mode, value=constant_values
+        )
     # TODO: reflect and symmetric padding are implemented for padding the
     # last 3 dimensions of a 4D or 5D input tensor, the last 2 dimensions of a
     # 3D or 4D input tensor, or the last dimension of a 2D or 3D input tensor.

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -927,7 +927,16 @@ def outer(x1, x2):
     return torch.outer(x1.flatten(), x2.flatten())
 
 
-def pad(x, pad_width, mode="constant", constant_values=0):
+def pad(x, pad_width, mode="constant", constant_values=None):
+    kwargs = {}
+    if constant_values is not None:
+        if mode != "constant":
+            raise ValueError(
+                "Argument 'constant_values' can only be "
+                "provided when mode == 'constant'. "
+                f"Received mode '{mode}'"
+            )
+        kwargs["value"] = constant_values
     x = convert_to_tensor(x)
     pad_sum = []
     pad_width = list(pad_width)[::-1]  # torch uses reverse order
@@ -942,9 +951,7 @@ def pad(x, pad_width, mode="constant", constant_values=0):
     if mode == "symmetric":
         mode = "replicate"
     if mode == "constant":
-        return torch.nn.functional.pad(
-            x, pad=pad_sum, mode=mode, value=constant_values
-        )
+        return torch.nn.functional.pad(x, pad=pad_sum, mode=mode, **kwargs)
     # TODO: reflect and symmetric padding are implemented for padding the
     # last 3 dimensions of a 4D or 5D input tensor, the last 2 dimensions of a
     # 3D or 4D input tensor, or the last dimension of a 2D or 3D input tensor.

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -4191,7 +4191,7 @@ class Pad(Operation):
                 pad_width[i] = (pw[0], pw[0])
         return pad_width
 
-    def call(self, x, constant_values=0):
+    def call(self, x, constant_values=None):
         return backend.numpy.pad(
             x,
             pad_width=self.pad_width,
@@ -4199,7 +4199,7 @@ class Pad(Operation):
             constant_values=constant_values,
         )
 
-    def compute_output_spec(self, x, constant_values=0):
+    def compute_output_spec(self, x, constant_values=None):
         output_shape = list(x.shape)
         if len(self.pad_width) == 1:
             pad_width = [self.pad_width[0] for _ in range(len(output_shape))]
@@ -4220,7 +4220,7 @@ class Pad(Operation):
 
 
 @keras_export(["keras.ops.pad", "keras.ops.numpy.pad"])
-def pad(x, pad_width, mode="constant", constant_values=0):
+def pad(x, pad_width, mode="constant", constant_values=None):
     """Pad a tensor.
 
     Args:
@@ -4236,7 +4236,9 @@ def pad(x, pad_width, mode="constant", constant_values=0):
             `"maximum"`, `"mean"`, `"median"`, `"minimum"`,
             `"reflect"`, `"symmetric"`, `"wrap"`, `"empty"`,
             `"circular"`. Defaults to`"constant"`.
-        constant_values: value to pad with if `mode=="constant"`.
+        constant_values: value to pad with if `mode == "constant"`.
+            Defaults to `0`. A `ValueError` is raised if not None and
+            `mode != "constant"`.
 
     Note:
         Torch backend only supports modes `"constant"`, `"reflect"`,

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -4191,10 +4191,15 @@ class Pad(Operation):
                 pad_width[i] = (pw[0], pw[0])
         return pad_width
 
-    def call(self, x):
-        return backend.numpy.pad(x, pad_width=self.pad_width, mode=self.mode)
+    def call(self, x, constant_values=0):
+        return backend.numpy.pad(
+            x,
+            pad_width=self.pad_width,
+            mode=self.mode,
+            constant_values=constant_values,
+        )
 
-    def compute_output_spec(self, x):
+    def compute_output_spec(self, x, constant_values=0):
         output_shape = list(x.shape)
         if len(self.pad_width) == 1:
             pad_width = [self.pad_width[0] for _ in range(len(output_shape))]
@@ -4215,7 +4220,7 @@ class Pad(Operation):
 
 
 @keras_export(["keras.ops.pad", "keras.ops.numpy.pad"])
-def pad(x, pad_width, mode="constant"):
+def pad(x, pad_width, mode="constant", constant_values=0):
     """Pad a tensor.
 
     Args:
@@ -4231,6 +4236,7 @@ def pad(x, pad_width, mode="constant"):
             `"maximum"`, `"mean"`, `"median"`, `"minimum"`,
             `"reflect"`, `"symmetric"`, `"wrap"`, `"empty"`,
             `"circular"`. Defaults to`"constant"`.
+        constant_values: value to pad with if `mode=="constant"`.
 
     Note:
         Torch backend only supports modes `"constant"`, `"reflect"`,
@@ -4244,9 +4250,7 @@ def pad(x, pad_width, mode="constant"):
     Returns:
         Padded tensor.
     """
-    if any_symbolic_tensors((x,)):
-        return Pad(pad_width, mode=mode).symbolic_call(x)
-    return backend.numpy.pad(x, pad_width, mode=mode)
+    return Pad(pad_width, mode=mode)(x, constant_values=constant_values)
 
 
 class Prod(Operation):

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -3555,22 +3555,37 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
                 "int32",
             ],
             mode=["constant", "reflect", "symmetric"],
-            constant_values=[0, 2],
+            constant_values=[None, 0, 2],
         )
     )
     def test_pad(self, dtype, mode, constant_values):
         # 2D
-        kwargs = {}
-        if mode == "constant":
-            kwargs["constant_values"] = constant_values
         x = np.ones([2, 3], dtype=dtype)
         pad_width = ((1, 1), (1, 1))
+
+        if mode != "constant":
+            if constant_values is not None:
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "Argument 'constant_values' can only be "
+                    "provided when mode == 'constant'",
+                ):
+                    knp.pad(
+                        x, pad_width, mode=mode, constant_values=constant_values
+                    )
+                return
+            # constant_values is None
+            kwargs = {}
+        else:
+            # mode is constant
+            kwargs = {"constant_values": constant_values or 0}
+
         self.assertAllClose(
-            knp.pad(x, pad_width, mode=mode, **kwargs),
+            knp.pad(x, pad_width, mode=mode, constant_values=constant_values),
             np.pad(x, pad_width, mode=mode, **kwargs),
         )
         self.assertAllClose(
-            knp.Pad(pad_width, mode=mode)(x, **kwargs),
+            knp.Pad(pad_width, mode=mode)(x, constant_values=constant_values),
             np.pad(x, pad_width, mode=mode, **kwargs),
         )
 
@@ -3578,11 +3593,11 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         x = np.ones([2, 3, 4, 5, 6], dtype=dtype)
         pad_width = ((0, 0), (0, 0), (2, 3), (1, 1), (1, 1))
         self.assertAllClose(
-            knp.pad(x, pad_width, mode=mode, **kwargs),
+            knp.pad(x, pad_width, mode=mode, constant_values=constant_values),
             np.pad(x, pad_width, mode=mode, **kwargs),
         )
         self.assertAllClose(
-            knp.Pad(pad_width, mode=mode)(x, **kwargs),
+            knp.Pad(pad_width, mode=mode)(x, constant_values=constant_values),
             np.pad(x, pad_width, mode=mode, **kwargs),
         )
 
@@ -3595,11 +3610,11 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         x = np.ones([2, 3, 4, 5, 6], dtype=dtype)
         pad_width = ((1, 1), (2, 1), (3, 2), (4, 3), (5, 4))
         self.assertAllClose(
-            knp.pad(x, pad_width, mode=mode, **kwargs),
+            knp.pad(x, pad_width, mode=mode, constant_values=constant_values),
             np.pad(x, pad_width, mode=mode, **kwargs),
         )
         self.assertAllClose(
-            knp.Pad(pad_width, mode=mode)(x, **kwargs),
+            knp.Pad(pad_width, mode=mode)(x, constant_values=constant_values),
             np.pad(x, pad_width, mode=mode, **kwargs),
         )
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -3555,27 +3555,35 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
                 "int32",
             ],
             mode=["constant", "reflect", "symmetric"],
+            constant_values=[0, 2],
         )
     )
-    def test_pad(self, dtype, mode):
+    def test_pad(self, dtype, mode, constant_values):
         # 2D
+        kwargs = {}
+        if mode == "constant":
+            kwargs["constant_values"] = constant_values
         x = np.ones([2, 3], dtype=dtype)
         pad_width = ((1, 1), (1, 1))
         self.assertAllClose(
-            knp.pad(x, pad_width, mode=mode), np.pad(x, pad_width, mode=mode)
+            knp.pad(x, pad_width, mode=mode, **kwargs),
+            np.pad(x, pad_width, mode=mode, **kwargs),
         )
         self.assertAllClose(
-            knp.Pad(pad_width, mode=mode)(x), np.pad(x, pad_width, mode=mode)
+            knp.Pad(pad_width, mode=mode)(x, **kwargs),
+            np.pad(x, pad_width, mode=mode, **kwargs),
         )
 
         # 5D (pad last 3D)
         x = np.ones([2, 3, 4, 5, 6], dtype=dtype)
         pad_width = ((0, 0), (0, 0), (2, 3), (1, 1), (1, 1))
         self.assertAllClose(
-            knp.pad(x, pad_width, mode=mode), np.pad(x, pad_width, mode=mode)
+            knp.pad(x, pad_width, mode=mode, **kwargs),
+            np.pad(x, pad_width, mode=mode, **kwargs),
         )
         self.assertAllClose(
-            knp.Pad(pad_width, mode=mode)(x), np.pad(x, pad_width, mode=mode)
+            knp.Pad(pad_width, mode=mode)(x, **kwargs),
+            np.pad(x, pad_width, mode=mode, **kwargs),
         )
 
         # 5D (pad arbitrary dimensions)
@@ -3587,10 +3595,12 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         x = np.ones([2, 3, 4, 5, 6], dtype=dtype)
         pad_width = ((1, 1), (2, 1), (3, 2), (4, 3), (5, 4))
         self.assertAllClose(
-            knp.pad(x, pad_width, mode=mode), np.pad(x, pad_width, mode=mode)
+            knp.pad(x, pad_width, mode=mode, **kwargs),
+            np.pad(x, pad_width, mode=mode, **kwargs),
         )
         self.assertAllClose(
-            knp.Pad(pad_width, mode=mode)(x), np.pad(x, pad_width, mode=mode)
+            knp.Pad(pad_width, mode=mode)(x, **kwargs),
+            np.pad(x, pad_width, mode=mode, **kwargs),
         )
 
     def test_prod(self):


### PR DESCRIPTION
Added `constant_values` kwarg to `ops.pad`. This argument is ignored if `mode != 'constant'`, which is different to `numpy` which raises.