### PR TITLE
EarlyStopping: Restore best weights after the last epoch

### DIFF
--- a/keras/callbacks/early_stopping.py
+++ b/keras/callbacks/early_stopping.py
@@ -176,7 +176,7 @@ class EarlyStopping(Callback):
             return
 
         # Only check after the first epoch.
-        if self.wait >= self.patience and epoch > 0:
+        if (self.wait >= self.patience or epoch == self.params["epochs"] - 1) and epoch > 0:
             self.stopped_epoch = epoch
             self.model.stop_training = True
             if self.restore_best_weights and self.best_weights is not None:


### PR DESCRIPTION
This fixes:
https://github.com/tensorflow/tensorflow/issues/35634
https://github.com/keras-team/keras/issues/12511