### PR TITLE
Change Conv layers Doc string wrt padding.

### DIFF
--- a/keras/layers/convolutional/base_conv.py
+++ b/keras/layers/convolutional/base_conv.py
@@ -37,8 +37,8 @@ class BaseConv(Layer):
             incompatible with `dilation_rate > 1`.
         padding: string, either `"valid"` or `"same"` (case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input.
+            the left/right or up/down of the input. . When `padding="same"` and
+            `strides=1`, the output has the same size as the input.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape `(batch, steps, features)`

--- a/keras/layers/convolutional/base_conv.py
+++ b/keras/layers/convolutional/base_conv.py
@@ -37,7 +37,7 @@ class BaseConv(Layer):
             incompatible with `dilation_rate > 1`.
         padding: string, either `"valid"` or `"same"` (case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input. . When `padding="same"` and
+            the left/right or up/down of the input. When `padding="same"` and
             `strides=1`, the output has the same size as the input.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`

--- a/keras/layers/convolutional/base_depthwise_conv.py
+++ b/keras/layers/convolutional/base_depthwise_conv.py
@@ -49,8 +49,8 @@ class BaseDepthwiseConv(Layer):
             `strides > 1` is incompatible with `dilation_rate > 1`.
         padding: string, either `"valid"` or `"same"` (case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input.
+            the left/right or up/down of the input. When `padding="same"` and
+            `strides=1`, the output has the same size as the input.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape `(batch, steps, features)`

--- a/keras/layers/convolutional/base_separable_conv.py
+++ b/keras/layers/convolutional/base_separable_conv.py
@@ -37,8 +37,8 @@ class BaseSeparableConv(Layer):
             `stride value != 1` is incompatible with `dilation_rate != 1`.
         padding: string, either `"valid"` or `"same"` (case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input.
+            the left/right or up/down of the input. When `padding="same"` and
+            `strides=1`, the output has the same size as the input.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape `(batch, steps, features)`

--- a/keras/layers/convolutional/conv1d.py
+++ b/keras/layers/convolutional/conv1d.py
@@ -23,11 +23,11 @@ class Conv1D(BaseConv):
             `dilation_rate > 1`.
         padding: string, `"valid"`, `"same"` or `"causal"`(case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input. `"causal"` results in causal
-            (dilated) convolutions, e.g. `output[t]` does not depend on
-            `input[t+1:]`. Useful when modeling temporal data where the model
-            should not violate the temporal order.
+            the left/right or up/down of the input. When `padding="same"` and
+            `strides=1`, the output has the same size as the input.
+            `"causal"` results in causal(dilated) convolutions, e.g. `output[t]`
+            does not depend on`input[t+1:]`. Useful when modeling temporal data
+            where the model should not violate the temporal order.
             See [WaveNet: A Generative Model for Raw Audio, section2.1](
             https://arxiv.org/abs/1609.03499).
         data_format: string, either `"channels_last"` or `"channels_first"`.

--- a/keras/layers/convolutional/conv2d.py
+++ b/keras/layers/convolutional/conv2d.py
@@ -22,8 +22,8 @@ class Conv2D(BaseConv):
             `dilation_rate > 1`.
         padding: string, either `"valid"` or `"same"` (case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input.
+            the left/right or up/down of the input. When `padding="same"` and
+            `strides=1`, the output has the same size as the input.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape

--- a/keras/layers/convolutional/conv2d_transpose.py
+++ b/keras/layers/convolutional/conv2d_transpose.py
@@ -27,8 +27,8 @@ class Conv2DTranspose(BaseConvTranspose):
             `dilation_rate > 1`.
         padding: string, either `"valid"` or `"same"` (case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input.
+            the left/right or up/down of the input. When `padding="same"` and
+            `strides=1`, the output has the same size as the input.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape

--- a/keras/layers/convolutional/conv3d.py
+++ b/keras/layers/convolutional/conv3d.py
@@ -22,8 +22,8 @@ class Conv3D(BaseConv):
             `dilation_rate > 1`.
         padding: string, either `"valid"` or `"same"` (case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input.
+            the left/right or up/down of the input. When `padding="same"` and
+            `strides=1`, the output has the same size as the input.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape

--- a/keras/layers/convolutional/conv3d_transpose.py
+++ b/keras/layers/convolutional/conv3d_transpose.py
@@ -27,8 +27,8 @@ class Conv3DTranspose(BaseConvTranspose):
             `dilation_rate > 1`.
         padding: string, either `"valid"` or `"same"` (case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input.
+            the left/right or up/down of the input. When `padding="same"` and
+            `strides=1`, the output has the same size as the input.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape

--- a/keras/layers/convolutional/depthwise_conv1d.py
+++ b/keras/layers/convolutional/depthwise_conv1d.py
@@ -33,8 +33,8 @@ class DepthwiseConv1D(BaseDepthwiseConv):
             `dilation_rate > 1`.
         padding: string, either `"valid"` or `"same"` (case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input.
+            the left/right or up/down of the input. When `padding="same"` and
+            `strides=1`, the output has the same size as the input.
         depth_multiplier: The number of depthwise convolution output channels
             for each input channel. The total number of depthwise convolution
             output channels will be equal to `input_channel * depth_multiplier`.

--- a/keras/layers/convolutional/depthwise_conv2d.py
+++ b/keras/layers/convolutional/depthwise_conv2d.py
@@ -33,8 +33,8 @@ class DepthwiseConv2D(BaseDepthwiseConv):
             `dilation_rate > 1`.
         padding: string, either `"valid"` or `"same"` (case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input.
+            the left/right or up/down of the input. When `padding="same"` and
+            `strides=1`, the output has the same size as the input.
         depth_multiplier: The number of depthwise convolution output channels
             for each input channel. The total number of depthwise convolution
             output channels will be equal to `input_channel * depth_multiplier`.

--- a/keras/layers/convolutional/separable_conv1d.py
+++ b/keras/layers/convolutional/separable_conv1d.py
@@ -28,8 +28,8 @@ class SeparableConv1D(BaseSeparableConv):
             incompatible with `dilation_rate > 1`.
         padding: string, either `"valid"` or `"same"` (case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input.
+            the left/right or up/down of the input. When `padding="same"` and
+            `strides=1`, the output has the same size as the input.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape `(batch, steps, features)`

--- a/keras/layers/convolutional/separable_conv2d.py
+++ b/keras/layers/convolutional/separable_conv2d.py
@@ -28,8 +28,8 @@ class SeparableConv2D(BaseSeparableConv):
             incompatible with `dilation_rate > 1`.
         padding: string, either `"valid"` or `"same"` (case-insensitive).
             `"valid"` means no padding. `"same"` results in padding evenly to
-            the left/right or up/down of the input such that output has the same
-            height/width dimension as the input.
+            the left/right or up/down of the input. When `padding="same"` and
+            `strides=1`, the output has the same size as the input.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape `(batch, steps, features)`


### PR DESCRIPTION
"Updating the args documentation of padding='same' for all convolutional layers.

Reference issue #15703.

Reference PRs #15771 closed due to stale.

The documentation for padding in all conv layers listed above states that, "" ""same"" results in padding with zeros evenly to the left/right or up/down of the input such that output has the same height/width dimension as the input."". This seems incorrect as it is true only when `strides=1`. Hence update the same.