### PR TITLE
Fixed layer.losses such that it recurses into sublayer losses

### DIFF
--- a/keras/layers/layer.py
+++ b/keras/layers/layer.py
@@ -1076,7 +1076,7 @@ class Layer(BackendLayer, Operation):
         """List of scalar losses added via `add_loss()` during layer call."""
         losses = self._get_own_losses()
         for layer in self._layers:
-            losses.extend(layer._get_own_losses())
+            losses.extend(layer.losses)
         weight_regularization_losses = []
         for v in self.trainable_weights:
             if backend.in_stateless_scope():

--- a/keras/layers/layer_test.py
+++ b/keras/layers/layer_test.py
@@ -328,6 +328,12 @@ class LayerTest(testing.TestCase):
         self.assertLen(model.losses, 1)
         self.assertAllClose(model.losses[0], 1.0)
 
+        # It works recursively in nested models
+        model = models.Sequential([model])
+        model(np.ones((1,)))
+        self.assertLen(model.losses, 1)
+        self.assertAllClose(model.losses[0], 1.0)
+
     def test_training_arg_value_resolution(self):
         # Check that even if `training` is not passed
         # to an inner layer, the outer value gets propagated


### PR DESCRIPTION
Fixes a bug in the current implementation whereby layers only look 1-child deep for layer losses.