### PR TITLE
Apply `backend.result_type` to `cumprod`, `cumsum`, `nonzero`, `power`, `take`, `take_along_axis`, `tensordot`, `tile`, `trace`, `transpose`, `tril`, `triu`, `vdot`, `vstack`, `where`

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -766,9 +766,7 @@ def divide(x1, x2):
 
 
 def true_divide(x1, x2):
-    x1 = convert_to_tensor(x1)
-    x2 = convert_to_tensor(x2)
-    return jnp.true_divide(x1, x2)
+    return divide(x1, x2)
 
 
 def power(x1, x2):

--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -731,7 +731,11 @@ def tile(x, repeats):
 
 
 def trace(x, offset=0, axis1=0, axis2=1):
-    return jnp.trace(x, offset=offset, axis1=axis1, axis2=axis2)
+    x = convert_to_tensor(x)
+    dtype = None
+    if standardize_dtype(x.dtype) == "bool":
+        dtype = "int32"
+    return jnp.trace(x, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype)
 
 
 def tri(N, M=None, k=0, dtype=None):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -476,12 +476,12 @@ def greater_equal(x1, x2):
 
 
 def hstack(xs):
-    xs = tree.map_structure(convert_to_tensor, xs)
-    dtypes_to_resolve = []
-    for x in xs:
-        dtypes_to_resolve.append(x.dtype)
-    dtype = dtypes.result_type(*dtypes_to_resolve)
-    xs = tree.map_structure(lambda x: x.astype(dtype), xs)
+    dtype_set = set([getattr(x, "dtype", type(x)) for x in xs])
+    if len(dtype_set) > 1:
+        dtype = dtypes.result_type(*dtype_set)
+        xs = tree.map_structure(
+            lambda x: convert_to_tensor(x).astype(dtype), xs
+        )
     return np.hstack(xs)
 
 
@@ -906,10 +906,21 @@ def triu(x, k=0):
 
 
 def vdot(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = x1.astype(dtype)
+    x2 = x2.astype(dtype)
     return np.vdot(x1, x2)
 
 
 def vstack(xs):
+    dtype_set = set([getattr(x, "dtype", type(x)) for x in xs])
+    if len(dtype_set) > 1:
+        dtype = dtypes.result_type(*dtype_set)
+        xs = tree.map_structure(
+            lambda x: convert_to_tensor(x).astype(dtype), xs
+        )
     return np.vstack(xs)
 
 
@@ -936,7 +947,7 @@ def divide(x1, x2):
 
 
 def true_divide(x1, x2):
-    return np.true_divide(x1, x2)
+    return divide(x1, x2)
 
 
 def power(x1, x2):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -889,7 +889,15 @@ def tile(x, repeats):
 def trace(x, offset=0, axis1=0, axis2=1):
     axis1 = tuple(axis1) if isinstance(axis1, list) else axis1
     axis2 = tuple(axis2) if isinstance(axis2, list) else axis2
-    return np.trace(x, offset=offset, axis1=axis1, axis2=axis2)
+    x = convert_to_tensor(x)
+    dtype = standardize_dtype(x.dtype)
+    if dtype == "int64":
+        dtype = "int64"
+    elif dtype == "uint32":
+        dtype = "uint32"
+    else:
+        dtype = dtypes.result_type(dtype, "int32")
+    return np.trace(x, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype)
 
 
 def tri(N, M=None, k=0, dtype=None):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -686,7 +686,7 @@ def ndim(x):
 
 
 def nonzero(x):
-    return np.nonzero(x)
+    return tuple(indices.astype("int32") for indices in np.nonzero(x))
 
 
 def not_equal(x1, x2):
@@ -926,6 +926,16 @@ def vstack(xs):
 
 def where(condition, x1, x2):
     if x1 is not None and x2 is not None:
+        if not isinstance(x1, (int, float)):
+            x1 = convert_to_tensor(x1)
+        if not isinstance(x2, (int, float)):
+            x2 = convert_to_tensor(x2)
+        dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)),
+            getattr(x2, "dtype", type(x2)),
+        )
+        x1 = convert_to_tensor(x1, dtype)
+        x2 = convert_to_tensor(x2, dtype)
         return np.where(condition, x1, x2)
     else:
         return np.where(condition)
@@ -951,6 +961,16 @@ def true_divide(x1, x2):
 
 
 def power(x1, x2):
+    if not isinstance(x1, (int, float)):
+        x1 = convert_to_tensor(x1)
+    if not isinstance(x2, (int, float)):
+        x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(
+        getattr(x1, "dtype", type(x1)),
+        getattr(x2, "dtype", type(x2)),
+    )
+    x1 = convert_to_tensor(x1, dtype)
+    x2 = convert_to_tensor(x2, dtype)
     return np.power(x1, x2)
 
 

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -366,12 +366,18 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
 
 def cumprod(x, axis=None, dtype=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    return np.cumprod(x, axis=axis, dtype=dtype or x.dtype)
+    dtype = dtypes.result_type(dtype or x.dtype)
+    if dtype == "bool":
+        dtype = "int32"
+    return np.cumprod(x, axis=axis, dtype=dtype)
 
 
 def cumsum(x, axis=None, dtype=None):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    return np.cumsum(x, axis=axis, dtype=dtype or x.dtype)
+    dtype = dtypes.result_type(dtype or x.dtype)
+    if dtype == "bool":
+        dtype = "int32"
+    return np.cumsum(x, axis=axis, dtype=dtype)
 
 
 def diag(x, k=0):
@@ -864,6 +870,11 @@ def tanh(x):
 
 def tensordot(x1, x2, axes=2):
     axes = tuple(axes) if isinstance(axes, list) else axes
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = x1.astype(dtype)
+    x2 = x2.astype(dtype)
     return np.tensordot(x1, x2, axes=axes)
 
 

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -590,11 +590,17 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
 
 
 def cumprod(x, axis=None, dtype=None):
-    return tfnp.cumprod(x, axis=axis, dtype=dtype or x.dtype)
+    dtype = dtypes.result_type(dtype or x.dtype)
+    if dtype == "bool":
+        dtype = "int32"
+    return tfnp.cumprod(x, axis=axis, dtype=dtype)
 
 
 def cumsum(x, axis=None, dtype=None):
-    return tfnp.cumsum(x, axis=axis, dtype=dtype or x.dtype)
+    dtype = dtypes.result_type(dtype or x.dtype)
+    if dtype == "bool":
+        dtype = "int32"
+    return tfnp.cumsum(x, axis=axis, dtype=dtype)
 
 
 def diag(x, k=0):
@@ -1366,7 +1372,14 @@ def tanh(x):
 
 
 def tensordot(x1, x2, axes=2):
-    return tfnp.tensordot(x1, x2, axes=axes)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    result_dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    # TODO: tfnp.tensordot only supports float types
+    compute_dtype = dtypes.result_type(result_dtype, float)
+    x1 = tf.cast(x1, compute_dtype)
+    x2 = tf.cast(x2, compute_dtype)
+    return tf.cast(tfnp.tensordot(x1, x2, axes=axes), dtype=result_dtype)
 
 
 @sparse.elementwise_unary

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -1405,7 +1405,15 @@ def tile(x, repeats):
 
 
 def trace(x, offset=0, axis1=0, axis2=1):
-    return tfnp.trace(x, offset=offset, axis1=axis1, axis2=axis2)
+    x = convert_to_tensor(x)
+    dtype = standardize_dtype(x.dtype)
+    if dtype == "int64":
+        dtype = "int64"
+    elif dtype == "uint32":
+        dtype = "uint32"
+    else:
+        dtype = dtypes.result_type(dtype, "int32")
+    return tfnp.trace(x, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype)
 
 
 def tri(N, M=None, k=0, dtype=None):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -1289,7 +1289,18 @@ def tile(x, repeats):
 
 def trace(x, offset=None, axis1=None, axis2=None):
     x = convert_to_tensor(x)
-    return torch.sum(torch.diagonal(x, offset, axis1, axis2), dim=-1)
+    dtype = standardize_dtype(x.dtype)
+    if dtype == "int64":
+        dtype = "int64"
+    elif dtype == "uint32":
+        dtype = "uint32"
+    else:
+        dtype = dtypes.result_type(dtype, "int32")
+    return torch.sum(
+        torch.diagonal(x, offset, axis1, axis2),
+        dim=-1,
+        dtype=to_torch_dtype(dtype),
+    )
 
 
 def tri(N, M=None, k=0, dtype=None):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -1292,8 +1292,6 @@ def trace(x, offset=None, axis1=None, axis2=None):
     dtype = standardize_dtype(x.dtype)
     if dtype == "int64":
         dtype = "int64"
-    elif dtype == "uint32":
-        dtype = "uint32"
     else:
         dtype = dtypes.result_type(dtype, "int32")
     return torch.sum(

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -1307,8 +1307,19 @@ def triu(x, k=0):
 
 
 def vdot(x1, x2):
-    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
-    return torch.vdot(x1, x2)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    result_dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    # TODO: torch.vdot only supports float types
+    compute_dtype = dtypes.result_type(result_dtype, float)
+
+    # TODO: torch.vdot doesn't support float16 with cpu
+    if get_device() == "cpu" and compute_dtype == "float16":
+        compute_dtype = "float32"
+
+    x1 = cast(x1, compute_dtype)
+    x2 = cast(x2, compute_dtype)
+    return cast(torch.vdot(x1, x2), result_dtype)
 
 
 def vstack(xs):
@@ -1335,8 +1346,7 @@ def divide(x1, x2):
 
 
 def true_divide(x1, x2):
-    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
-    return torch.true_divide(x1, x2)
+    return divide(x1, x2)
 
 
 def power(x1, x2):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -944,7 +944,7 @@ def ndim(x):
 
 def nonzero(x):
     x = convert_to_tensor(x)
-    return torch.nonzero(x).T
+    return tuple(cast(indices, "int32") for indices in torch.nonzero(x).T)
 
 
 def not_equal(x1, x2):
@@ -1254,6 +1254,9 @@ def tensordot(x1, x2, axes=2):
     result_dtype = dtypes.result_type(x1.dtype, x2.dtype)
     # TODO: torch.tensordot only supports float types
     compute_dtype = dtypes.result_type(result_dtype, float)
+    # TODO: torch.tensordot doesn't support float16 with cpu
+    if get_device() == "cpu" and compute_dtype == "float16":
+        compute_dtype = "float32"
     x1 = cast(x1, compute_dtype)
     x2 = cast(x2, compute_dtype)
     # torch only handles dims=((0,), (1,)), numpy accepts axes=(0, 1).

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -5255,8 +5255,12 @@ class Trace(Operation):
         x_shape[self.axis2] = -1
         output_shape = list(filter((-1).__ne__, x_shape))
         output_dtype = backend.standardize_dtype(x.dtype)
-        if output_dtype != "uint32" and "int" in output_dtype:
-            output_dtype = "int32"
+        if output_dtype == "int64":
+            output_dtype = "int64"
+        elif output_dtype == "uint32":
+            output_dtype = "uint32"
+        else:
+            output_dtype = dtypes.result_type(output_dtype, "int32")
         return KerasTensor(output_shape, dtype=output_dtype)
 
 

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -5473,7 +5473,10 @@ class Where(Operation):
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(condition_shape, x1_shape)
         output_shape = broadcast_shapes(output_shape, x2_shape)
-        output_dtype = getattr(x1, "dtype", "int")
+        output_dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1) if x1 is not None else "int"),
+            getattr(x2, "dtype", type(x2) if x2 is not None else "int"),
+        )
         return KerasTensor(output_shape, dtype=output_dtype)
 
 
@@ -5649,7 +5652,10 @@ class Power(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        output_dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)), getattr(x2, "dtype", type(x2))
+        )
+        return KerasTensor(output_shape, dtype=output_dtype)
 
 
 @keras_export(["keras.ops.power", "keras.ops.numpy.power"])

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -1795,7 +1795,10 @@ class Cumprod(Operation):
                 output_shape = (int(np.prod(x.shape)),)
         else:
             output_shape = x.shape
-        return KerasTensor(output_shape, self.dtype or x.dtype)
+        output_dtype = backend.standardize_dtype(self.dtype or x.dtype)
+        if output_dtype == "bool":
+            output_dtype = "int32"
+        return KerasTensor(output_shape, output_dtype)
 
 
 @keras_export(["keras.ops.cumprod", "keras.ops.numpy.cumprod"])
@@ -1831,7 +1834,10 @@ class Cumsum(Operation):
                 output_shape = (int(np.prod(x.shape)),)
         else:
             output_shape = x.shape
-        return KerasTensor(output_shape, self.dtype or x.dtype)
+        output_dtype = backend.standardize_dtype(self.dtype or x.dtype)
+        if output_dtype == "bool":
+            output_dtype = "int32"
+        return KerasTensor(output_shape, output_dtype)
 
 
 @keras_export(["keras.ops.cumsum", "keras.ops.numpy.cumsum"])
@@ -5124,6 +5130,10 @@ class Tensordot(Operation):
     def compute_output_spec(self, x1, x2):
         x1_shape = list(getattr(x1, "shape", []))
         x2_shape = list(getattr(x2, "shape", []))
+        dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)),
+            getattr(x2, "dtype", type(x2)),
+        )
         if not isinstance(self.axes, int):
             x1_select_shape = [x1_shape[ax] for ax in self.axes[0]]
             x2_select_shape = [x2_shape[ax] for ax in self.axes[1]]
@@ -5144,14 +5154,14 @@ class Tensordot(Operation):
             x2_shape = list(filter((-1).__ne__, x2_shape))
 
             output_shape = x1_shape + x2_shape
-            return KerasTensor(output_shape, dtype=x1.dtype)
+            return KerasTensor(output_shape, dtype=dtype)
 
         if self.axes <= 0:
             output_shape = x1_shape + x2_shape
         else:
             output_shape = x1_shape[: -self.axes] + x2_shape[self.axes :]
 
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        return KerasTensor(output_shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.tensordot", "keras.ops.numpy.tensordot"])

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -6754,6 +6754,38 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_tile(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.tile(x_jax, [1]).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.tile(x, [1]).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Tile([1]).symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_transpose(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1, 1), dtype=dtype)
+        x_jax = jnp.ones((1, 1), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.transpose(x_jax, [1, 0]).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.transpose(x, [1, 0]).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Transpose([1, 0]).symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_tri(self, dtype):
         import jax.numpy as jnp
 
@@ -6766,6 +6798,107 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(
             standardize_dtype(knp.Tri().symbolic_call(3, dtype=dtype).dtype),
             expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_tril(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1, 1), dtype=dtype)
+        x_jax = jnp.ones((1, 1), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.tril(x_jax, 0).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.tril(x, 0).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Tril(0).symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_triu(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1, 1), dtype=dtype)
+        x_jax = jnp.ones((1, 1), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.triu(x_jax, 0).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.triu(x, 0).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Triu(0).symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_true_divide(self, dtypes):
+        import jax.experimental
+        import jax.numpy as jnp
+
+        # We have to disable x64 for jax since jnp.divide doesn't respect
+        # JAX_DEFAULT_DTYPE_BITS=32 in `./conftest.py`. We also need to downcast
+        # the expected dtype from 64 bit to 32 bit when using jax backend.
+        with jax.experimental.disable_x64():
+            dtype1, dtype2 = dtypes
+            x1 = knp.ones((1,), dtype=dtype1)
+            x2 = knp.ones((1,), dtype=dtype2)
+            x1_jax = jnp.ones((1,), dtype=dtype1)
+            x2_jax = jnp.ones((1,), dtype=dtype2)
+            expected_dtype = standardize_dtype(
+                jnp.true_divide(x1_jax, x2_jax).dtype
+            )
+            if "float64" in (dtype1, dtype2):
+                expected_dtype = "float64"
+            if backend.backend() == "jax":
+                expected_dtype = expected_dtype.replace("64", "32")
+
+            self.assertEqual(
+                standardize_dtype(knp.true_divide(x1, x2).dtype), expected_dtype
+            )
+            self.assertEqual(
+                knp.TrueDivide().symbolic_call(x1, x2).dtype, expected_dtype
+            )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_vdot(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1,), dtype=dtype1)
+        x2 = knp.ones((1,), dtype=dtype2)
+        x1_jax = jnp.ones((1,), dtype=dtype1)
+        x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.vdot(x1_jax, x2_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.vdot(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(knp.Vdot().symbolic_call(x1, x2).dtype, expected_dtype)
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_vstack(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1,), dtype=dtype1)
+        x2 = knp.ones((1,), dtype=dtype2)
+        x1_jax = jnp.ones((1,), dtype=dtype1)
+        x2_jax = jnp.ones((1,), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.vstack([x1_jax, x2_jax]).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.vstack([x1, x2]).dtype), expected_dtype
+        )
+        self.assertEqual(
+            knp.Vstack().symbolic_call([x1, x2]).dtype, expected_dtype
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4745,8 +4745,6 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             standardize_dtype(knp.Any().symbolic_call(x).dtype), expected_dtype
         )
 
-    # TODO: test_einsum
-
     @parameterized.named_parameters(
         named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
     )
@@ -6243,6 +6241,19 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             expected_dtype,
         )
 
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_nonzero(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.nonzero(x_jax)[0].dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.nonzero(x)[0].dtype), expected_dtype
+        )
+        # TODO: verify Nonzero
+
     @parameterized.named_parameters(
         named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
     )
@@ -6323,6 +6334,70 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
                     knp.Pad(pad_width, mode).symbolic_call(x).dtype
                 ),
                 expected_dtype,
+            )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_power(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x = knp.ones((1,), dtype=dtype1)
+        power = knp.ones((1,), dtype2)
+        x_jax = jnp.ones((1,), dtype=dtype1)
+        power_jax = jnp.ones((1,), dtype2)
+        expected_dtype = standardize_dtype(jnp.power(x_jax, power_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.power(x, power).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Power().symbolic_call(x, power).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_power_python_types(self, dtype):
+        import jax.experimental
+        import jax.numpy as jnp
+
+        # We have to disable x64 for jax since jnp.power doesn't respect
+        # JAX_DEFAULT_DTYPE_BITS=32 in `./conftest.py`. We also need to downcast
+        # the expected dtype from 64 bit to 32 bit when using jax backend.
+        with jax.experimental.disable_x64():
+            x = knp.ones((1,), dtype=dtype)
+            x_jax = jnp.ones((1,), dtype=dtype)
+
+            # python int
+            expected_dtype = standardize_dtype(jnp.power(x_jax, 1).dtype)
+            if dtype == "float64":
+                expected_dtype = "float64"
+            elif dtype == "int64":
+                expected_dtype = "int64"
+            if backend.backend() == "jax":
+                expected_dtype = expected_dtype.replace("64", "32")
+
+            self.assertEqual(
+                standardize_dtype(knp.power(x, 1).dtype), expected_dtype
+            )
+            self.assertEqual(
+                knp.Power().symbolic_call(x, 1).dtype, expected_dtype
+            )
+
+            # python float
+            expected_dtype = standardize_dtype(jnp.power(x_jax, 1.0).dtype)
+            if dtype == "float64":
+                expected_dtype = "float64"
+            if backend.backend() == "jax":
+                expected_dtype = expected_dtype.replace("64", "32")
+
+            self.assertEqual(
+                standardize_dtype(knp.power(x, 1.0).dtype), expected_dtype
+            )
+            self.assertEqual(
+                knp.Power().symbolic_call(x, 1.0).dtype, expected_dtype
             )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
@@ -6839,7 +6914,7 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         import jax.experimental
         import jax.numpy as jnp
 
-        # We have to disable x64 for jax since jnp.divide doesn't respect
+        # We have to disable x64 for jax since jnp.true_divide doesn't respect
         # JAX_DEFAULT_DTYPE_BITS=32 in `./conftest.py`. We also need to downcast
         # the expected dtype from 64 bit to 32 bit when using jax backend.
         with jax.experimental.disable_x64():
@@ -6900,6 +6975,82 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(
             knp.Vstack().symbolic_call([x1, x2]).dtype, expected_dtype
         )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_where(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        condition = knp.ones((10,), dtype="bool")
+        x1 = knp.ones((10,), dtype=dtype1)
+        x2 = knp.ones((10,), dtype=dtype2)
+        condition_jax = jnp.ones((10,), dtype="bool")
+        x1_jax = jnp.ones((10,), dtype=dtype1)
+        x2_jax = jnp.ones((10,), dtype=dtype2)
+        expected_dtype = standardize_dtype(
+            jnp.where(condition_jax, x1_jax, x2_jax).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(knp.where(condition, x1, x2).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            knp.Where().symbolic_call(condition, x1, x2).dtype, expected_dtype
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_where_python_types(self, dtype):
+        import jax.experimental
+        import jax.numpy as jnp
+
+        # We have to disable x64 for jax since jnp.power doesn't respect
+        # JAX_DEFAULT_DTYPE_BITS=32 in `./conftest.py`. We also need to downcast
+        # the expected dtype from 64 bit to 32 bit when using jax backend.
+        with jax.experimental.disable_x64():
+            condition = knp.ones((10,), dtype="bool")
+            x = knp.ones((10,), dtype=dtype)
+            condition_jax = jnp.ones((10,), dtype="bool")
+            x_jax = jnp.ones((10,), dtype=dtype)
+
+            # python int
+            expected_dtype = standardize_dtype(
+                jnp.where(condition_jax, x_jax, 1).dtype
+            )
+            if dtype == "float64":
+                expected_dtype = "float64"
+            elif dtype == "int64":
+                expected_dtype = "int64"
+            if backend.backend() == "jax":
+                expected_dtype = expected_dtype.replace("64", "32")
+
+            self.assertEqual(
+                standardize_dtype(knp.where(condition, x, 1).dtype),
+                expected_dtype,
+            )
+            self.assertEqual(
+                knp.Where().symbolic_call(condition, x, 1).dtype, expected_dtype
+            )
+
+            # python float
+            expected_dtype = standardize_dtype(
+                jnp.where(condition_jax, x_jax, 1.0).dtype
+            )
+            if dtype == "float64":
+                expected_dtype = "float64"
+            if backend.backend() == "jax":
+                expected_dtype = expected_dtype.replace("64", "32")
+
+            self.assertEqual(
+                standardize_dtype(knp.where(condition, x, 1.0).dtype),
+                expected_dtype,
+            )
+            self.assertEqual(
+                knp.Where().symbolic_call(condition, x, 1.0).dtype,
+                expected_dtype,
+            )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_zeros_like(self, dtype):

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -5198,6 +5198,36 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_cumprod(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.cumprod(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.cumprod(x).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Cumprod().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_cumsum(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.cumsum(x_jax).dtype)
+
+        self.assertEqual(standardize_dtype(knp.cumsum(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Cumsum().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_diag(self, dtype):
         import jax.numpy as jnp
 
@@ -6630,6 +6660,46 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_take(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.take(x_jax, 0).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.take(x, 0).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Take().symbolic_call(x, 0).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_take_along_axis(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        indices = knp.zeros((1,), dtype="int32")
+        x_jax = jnp.ones((1,), dtype=dtype)
+        indices_jax = jnp.zeros((1,), dtype="int32")
+        expected_dtype = standardize_dtype(
+            jnp.take_along_axis(x_jax, indices_jax, 0).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(knp.take_along_axis(x, indices, 0).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(
+                knp.TakeAlongAxis(0).symbolic_call(x, indices).dtype
+            ),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_tan(self, dtype):
         import jax.numpy as jnp
 
@@ -6659,6 +6729,28 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(
             standardize_dtype(knp.Tanh().symbolic_call(x).dtype),
             expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_tensordot(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1, 1), dtype=dtype1)
+        x2 = knp.ones((1, 1), dtype=dtype2)
+        x1_jax = jnp.ones((1, 1), dtype=dtype1)
+        x2_jax = jnp.ones((1, 1), dtype=dtype2)
+        expected_dtype = standardize_dtype(
+            jnp.tensordot(x1_jax, x2_jax, 2).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(knp.tensordot(x1, x2, 2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            knp.Tensordot(2).symbolic_call(x1, x2).dtype, expected_dtype
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))


### PR DESCRIPTION
This PR should be the final one for `ops.numpy` dtype inference. Now, all ops (excluding `ndim`, `size` and complex-related ones) have consistent dtype inference across all backends!

<details>

- [x] abs
- [x] absolute
- [x] add
- [x] all
- [x] amax
- [x] amin
- [x] append
- [x] arange
- [x] arccos
- [x] arccosh
- [x] arcsin
- [x] arcsinh
- [x] arctan
- [x] arctan2
- [x] arctanh
- [x] argmax
- [x] argmin
- [x] argsort
- [x] array
- [x] average
- [x] bincount
- [x] broadcast_to
- [x] ceil
- [x] clip
- [x] concatenate
- [ ] conj  (Keras does not directly support complex data)
- [ ] conjugate  (Keras does not directly support complex data)
- [x] copy
- [x] cos
- [x] cosh
- [x] count_nonzero
- [x] cross
- [x] cumprod
- [x] cumsum
- [x] diag
- [x] diagonal
- [x] diff
- [x] digitize
- [x] divide
- [x] dot
- [x] einsum
- [x] empty
- [x] equal
- [x] exp
- [x] expand_dims
- [x] expm1
- [x] eye
- [x] flip
- [x] floor
- [x] full
- [x] full_like
- [x] greater
- [x] greater_equal
- [x] hstack
- [x] identity
- [ ] imag (Keras does not directly support complex data)
- [ ] interp (Keras lacks this op)
- [x] isclose
- [x] isfinite
- [x] isinf
- [x] isnan
- [x] less
- [x] less_equal
- [x] linspace
- [x] log
- [x] log10
- [x] log1p
- [x] log2
- [x] logaddexp
- [x] logical_and
- [x] logical_not
- [x] logical_or
- [x] logspace
- [x] matmul
- [x] max
- [x] maximum
- [x] mean
- [x] median
- [x] meshgrid
- [ ] mgrid (Keras lacks this op)
- [x] min
- [x] minimum
- [x] mod
- [x] moveaxis
- [x] multiply
- [x] nan_to_num
- [ ] ndim
- [x] nonzero
- [x] not_equal
- [x] ones
- [x] ones_like
- [x] outer
- [x] pad
- [ ] percentile (Keras lacks this op)
- [x] power
- [x] prod
- [x] quantile
- [x] ravel
- [ ] real (Keras does not directly support complex data)
- [ ] reciprocal (Keras lacks this op)
- [x] repeat
- [x] reshape
- [x] roll
- [x] round
- [x] sign
- [x] sin
- [x] sinh
- [ ] size
- [x] sort
- [x] split
- [x] sqrt
- [x] square
- [x] squeeze
- [x] stack
- [x] std
- [x] subtract
- [x] sum
- [x] swapaxes
- [x] take
- [x] take_along_axis
- [x] tan
- [x] tanh
- [x] tensordot
- [x] tile
- [x] trace
- [x] transpose
- [x] tri
- [x] tril
- [x] triu
- [x] true_divide
- [x] vdot
- [x] vstack
- [x] where
- [x] zeros
- [x] zeros_like

</details>
