### PR TITLE
 Add dependabot to update GHA and Python deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      python:
+        patterns:
+          - "*"


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras/issues/18833.

This PR sets up dependabot to update the GitHub Actions used in workflows and the pinned Python dependencies in the requirements files.

Dependabot is set up to send a single monthly PR updating all the dependencies in each ecosystem at once. As a preview, here are the PRs I received on my fork:
- https://github.com/pnacht/keras/pull/1 updating the GitHub Actions
- https://github.com/pnacht/keras/pull/2 updating the Python dependencies

For the Python dependencies, it:
- updates the patch-version-pinned `torch` and `torchvision` in `requirements-torch-cuda.txt`
- It also updates `tf-nightly` and `tf-nightly-cpu` to the latest nightly build. If you'd rather not have this update automatically (due to potential breakages), let me know and I'll modify the config to skip these dependencies.

If you prefer, let me know and I can incorporate the version bumps to this PR so you don't get dependabot PRs immediately after merging this one.