### PR TITLE
Bug fix for TF backend using random zoom with flatten

### DIFF
--- a/keras/backend/tensorflow/image.py
+++ b/keras/backend/tensorflow/image.py
@@ -119,6 +119,7 @@ def affine_transform(
         interpolation=interpolation.upper(),
         fill_mode=fill_mode.upper(),
     )
+    affined = tf.ensure_shape(affined, image.shape)
 
     if data_format == "channels_first":
         affined = tf.transpose(affined, (0, 3, 1, 2))

--- a/keras/layers/preprocessing/random_zoom_test.py
+++ b/keras/layers/preprocessing/random_zoom_test.py
@@ -132,3 +132,15 @@ class RandomZoomTest(testing.TestCase, parameterized.TestCase):
         )(inputs)
         model = models.Model(inputs, outputs)
         model.predict(np.random.random((1, 6, 6, 3)))
+
+    def test_connect_with_flatten(self):
+        model = models.Sequential(
+            [
+                layers.RandomZoom((-0.5, 0.0), (-0.5, 0.0)),
+                layers.Flatten(),
+                layers.Dense(1, activation="relu"),
+            ],
+        )
+
+        model.compile(loss="mse")
+        model.fit(np.random.random((2, 2, 2, 1)), y=np.random.random((2,)))

--- a/keras/layers/preprocessing/random_zoom_test.py
+++ b/keras/layers/preprocessing/random_zoom_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from absl.testing import parameterized
 from tensorflow import data as tf_data
 
@@ -133,6 +134,10 @@ class RandomZoomTest(testing.TestCase, parameterized.TestCase):
         model = models.Model(inputs, outputs)
         model.predict(np.random.random((1, 6, 6, 3)))
 
+    @pytest.mark.skipif(
+        backend.backend() == "numpy",
+        reason="The NumPy backend does not implement fit.",
+    )
     def test_connect_with_flatten(self):
         model = models.Sequential(
             [


### PR DESCRIPTION
RandomZoom would lose the tensor shape when using with TF backend.
The multiple `None` dims would error out when used combined with the `Flatten` layer.

This PR simply adds back the shape in the underlying ops of TF backend.