### PR TITLE
Some Improvements in numpy api

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -823,12 +823,12 @@ def var(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
     # `jnp.var` does not handle low precision (e.g., float16) overflow
     # correctly, so we compute with float32 and cast back to the original type.
-    ori_dtype = standardize_dtype(x.dtype)
-    outputs = jnp.var(x, axis=axis, keepdims=keepdims, dtype=jnp.float32)
-    if "float" in ori_dtype:
-        return cast(outputs, ori_dtype)
-    else:
-        return cast(outputs, config.floatx())
+    compute_dtype = dtypes.result_type(x.dtype, "float32")
+    result_dtype = dtypes.result_type(x.dtype, float)
+    return cast(
+        jnp.var(x, axis=axis, keepdims=keepdims, dtype=compute_dtype),
+        result_dtype,
+    )
 
 
 def sum(x, axis=None, keepdims=False):

--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -130,6 +130,7 @@ def arange(start, stop=None, step=1, dtype=None):
 
 
 def arccos(x):
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         dtype = config.floatx()
     else:
@@ -139,6 +140,7 @@ def arccos(x):
 
 
 def arccosh(x):
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         dtype = config.floatx()
     else:
@@ -148,6 +150,7 @@ def arccosh(x):
 
 
 def arcsin(x):
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         dtype = config.floatx()
     else:
@@ -157,6 +160,7 @@ def arcsin(x):
 
 
 def arcsinh(x):
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         dtype = config.floatx()
     else:
@@ -166,6 +170,7 @@ def arcsinh(x):
 
 
 def arctan(x):
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         dtype = config.floatx()
     else:
@@ -184,6 +189,7 @@ def arctan2(x1, x2):
 
 
 def arctanh(x):
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         dtype = config.floatx()
     else:
@@ -235,6 +241,9 @@ def ceil(x):
 
 
 def clip(x, x_min, x_max):
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "bool":
+        x = cast(x, "int32")
     return jnp.clip(x, x_min, x_max)
 
 
@@ -255,6 +264,7 @@ def copy(x):
 
 
 def cos(x):
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         dtype = config.floatx()
     else:
@@ -264,6 +274,7 @@ def cos(x):
 
 
 def cosh(x):
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         dtype = config.floatx()
     else:
@@ -517,6 +528,7 @@ def median(x, axis=None, keepdims=False):
     # axis of jnp.median must be hashable
     if isinstance(axis, list):
         axis = tuple(axis)
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         x = cast(x, config.floatx())
 
@@ -644,6 +656,7 @@ def sign(x):
 
 
 def sin(x):
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         dtype = config.floatx()
     else:
@@ -653,6 +666,7 @@ def sin(x):
 
 
 def sinh(x):
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         dtype = config.floatx()
     else:
@@ -699,6 +713,7 @@ def take_along_axis(x, indices, axis=None):
 
 
 def tan(x):
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         dtype = config.floatx()
     else:
@@ -708,6 +723,7 @@ def tan(x):
 
 
 def tanh(x):
+    x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
         dtype = config.floatx()
     else:
@@ -804,12 +820,13 @@ def transpose(x, axes=None):
 
 
 def var(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
     # `jnp.var` does not handle low precision (e.g., float16) overflow
     # correctly, so we compute with float32 and cast back to the original type.
+    ori_dtype = standardize_dtype(x.dtype)
     outputs = jnp.var(x, axis=axis, keepdims=keepdims, dtype=jnp.float32)
-    dtype = getattr(x, "dtype", None)
-    if hasattr(dtype, "name") and "float" in dtype.name:
-        return cast(outputs, dtype)
+    if "float" in ori_dtype:
+        return cast(outputs, ori_dtype)
     else:
         return cast(outputs, config.floatx())
 

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -1012,7 +1012,12 @@ def transpose(x, axes=None):
 
 def var(x, axis=None, keepdims=False):
     axis = tuple(axis) if isinstance(axis, list) else axis
-    return np.var(x, axis=axis, keepdims=keepdims)
+    x = convert_to_tensor(x)
+    compute_dtype = dtypes.result_type(x.dtype, "float32")
+    result_dtype = dtypes.result_type(x.dtype, float)
+    return np.var(x, axis=axis, keepdims=keepdims, dtype=compute_dtype).astype(
+        result_dtype
+    )
 
 
 def sum(x, axis=None, keepdims=False):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -287,13 +287,15 @@ def ceil(x):
         dtype = config.floatx()
     else:
         dtype = dtypes.result_type(x.dtype, float)
-    return np.ceil(x).astype(dtype)
+    x = x.astype(dtype)
+    return np.ceil(x)
 
 
 def clip(x, x_min, x_max):
+    x = convert_to_tensor(x)
     dtype = standardize_dtype(x.dtype)
     if dtype == "bool":
-        dtype = "int64"
+        dtype = "int32"
     return np.clip(x, x_min, x_max).astype(dtype)
 
 
@@ -728,9 +730,7 @@ def prod(x, axis=None, keepdims=False, dtype=None):
     x = convert_to_tensor(x)
     if dtype is None:
         dtype = dtypes.result_type(x.dtype)
-        if dtype == "bool":
-            dtype = "int32"
-        elif dtype in ("int8", "int16"):
+        if dtype in ("bool", "int8", "int16"):
             dtype = "int32"
         elif dtype in ("uint8", "uint16"):
             dtype = "uint32"
@@ -891,11 +891,7 @@ def trace(x, offset=0, axis1=0, axis2=1):
     axis2 = tuple(axis2) if isinstance(axis2, list) else axis2
     x = convert_to_tensor(x)
     dtype = standardize_dtype(x.dtype)
-    if dtype == "int64":
-        dtype = "int64"
-    elif dtype == "uint32":
-        dtype = "uint32"
-    else:
+    if dtype not in ("int64", "uint32", "uint64"):
         dtype = dtypes.result_type(dtype, "int32")
     return np.trace(x, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype)
 

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -510,7 +510,7 @@ def ceil(x):
 def clip(x, x_min, x_max):
     dtype = standardize_dtype(x.dtype)
     if dtype == "bool":
-        x = tf.cast(x, "int64")
+        x = tf.cast(x, "int32")
     return tf.clip_by_value(x, x_min, x_max)
 
 
@@ -1407,11 +1407,7 @@ def tile(x, repeats):
 def trace(x, offset=0, axis1=0, axis2=1):
     x = convert_to_tensor(x)
     dtype = standardize_dtype(x.dtype)
-    if dtype == "int64":
-        dtype = "int64"
-    elif dtype == "uint32":
-        dtype = "uint32"
-    else:
+    if dtype not in ("int64", "uint32", "uint64"):
         dtype = dtypes.result_type(dtype, "int32")
     return tfnp.trace(x, offset=offset, axis1=axis1, axis2=axis2, dtype=dtype)
 

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -1563,7 +1563,13 @@ def transpose(x, axes=None):
 
 
 def var(x, axis=None, keepdims=False):
-    return tfnp.var(x, axis=axis, keepdims=keepdims)
+    x = convert_to_tensor(x)
+    compute_dtype = dtypes.result_type(x.dtype, "float32")
+    result_dtype = dtypes.result_type(x.dtype, float)
+    return tf.cast(
+        tfnp.var(x, axis=axis, keepdims=keepdims, dtype=compute_dtype),
+        result_dtype,
+    )
 
 
 def sum(x, axis=None, keepdims=False):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -1400,14 +1400,17 @@ def transpose(x, axes=None):
 
 
 def var(x, axis=None, keepdims=False):
-    x = convert_to_tensor(x)
-    if "float" not in standardize_dtype(x.dtype):
-        x = cast(x, config.floatx())
     if axis == [] or axis == ():
         # Torch handles the empty axis case differently from numpy.
-        return zeros_like(x)
+        return zeros_like(x, result_dtype)
+    x = convert_to_tensor(x)
+    compute_dtype = dtypes.result_type(x.dtype, "float32")
+    result_dtype = dtypes.result_type(x.dtype, float)
     # Bessel correction removed for numpy compatibility
-    return torch.var(x, dim=axis, keepdim=keepdims, correction=0)
+    x = cast(x, compute_dtype)
+    return cast(
+        torch.var(x, dim=axis, keepdim=keepdims, correction=0), result_dtype
+    )
 
 
 def sum(x, axis=None, keepdims=False):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -391,9 +391,11 @@ def clip(x, x_min, x_max):
     # TODO: torch.clip doesn't support float16 with cpu
     if get_device() == "cpu" and ori_dtype == "float16":
         x = cast(x, "float32")
+        return cast(torch.clip(x, min=x_min, max=x_max), "float16")
 
-    dtype = "int64" if ori_dtype == "bool" else ori_dtype
-    return cast(torch.clip(x, min=x_min, max=x_max), dtype=dtype)
+    if ori_dtype == "bool":
+        x = cast(x, "int32")
+    return torch.clip(x, min=x_min, max=x_max)
 
 
 def concatenate(xs, axis=0):
@@ -1290,9 +1292,7 @@ def tile(x, repeats):
 def trace(x, offset=None, axis1=None, axis2=None):
     x = convert_to_tensor(x)
     dtype = standardize_dtype(x.dtype)
-    if dtype == "int64":
-        dtype = "int64"
-    else:
+    if dtype != "int64":
         dtype = dtypes.result_type(dtype, "int32")
     return torch.sum(
         torch.diagonal(x, offset, axis1, axis2),
@@ -1380,7 +1380,7 @@ def square(x):
 
 def sqrt(x):
     x = convert_to_tensor(x)
-    if x.dtype == torch.int64:
+    if standardize_dtype(x.dtype) == "int64":
         x = cast(x, config.floatx())
     return torch.sqrt(x)
 
@@ -1400,9 +1400,9 @@ def transpose(x, axes=None):
 
 
 def var(x, axis=None, keepdims=False):
-    x = convert_to_tensor(x, dtype="float32")
-    # Conversion to float necessary for `torch.var`
-    x = cast(x, "float32") if x.dtype in TORCH_INT_TYPES else x
+    x = convert_to_tensor(x)
+    if "float" not in standardize_dtype(x.dtype):
+        x = cast(x, config.floatx())
     if axis == [] or axis == ():
         # Torch handles the empty axis case differently from numpy.
         return zeros_like(x)

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -5894,9 +5894,10 @@ class Var(Operation):
         return backend.numpy.var(x, axis=self.axis, keepdims=self.keepdims)
 
     def compute_output_spec(self, x):
+        output_dtype = backend.result_type(getattr(x, "dtype", type(x)), float)
         return KerasTensor(
             reduce_shape(x.shape, axis=self.axis, keepdims=self.keepdims),
-            dtype=x.dtype,
+            dtype=output_dtype,
         )
 
 

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -1428,7 +1428,7 @@ class Clip(Operation):
     def compute_output_spec(self, x):
         dtype = backend.standardize_dtype(x.dtype)
         if dtype == "bool":
-            dtype = "int64"
+            dtype = "int32"
         return KerasTensor(x.shape, dtype=dtype)
 
 
@@ -5255,11 +5255,7 @@ class Trace(Operation):
         x_shape[self.axis2] = -1
         output_shape = list(filter((-1).__ne__, x_shape))
         output_dtype = backend.standardize_dtype(x.dtype)
-        if output_dtype == "int64":
-            output_dtype = "int64"
-        elif output_dtype == "uint32":
-            output_dtype = "uint32"
-        else:
+        if output_dtype not in ("int64", "uint32", "uint64"):
             output_dtype = dtypes.result_type(output_dtype, "int32")
         return KerasTensor(output_shape, dtype=output_dtype)
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -5085,6 +5085,8 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         x = knp.ones((1,), dtype=dtype)
         x_jax = jnp.ones((1,), dtype=dtype)
         expected_dtype = standardize_dtype(jnp.clip(x_jax, -2, 2).dtype)
+        if dtype == "bool":
+            expected_dtype = "int32"
 
         self.assertEqual(
             standardize_dtype(knp.clip(x, -2, 2).dtype), expected_dtype

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -6971,6 +6971,22 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
                 knp.TrueDivide().symbolic_call(x1, x2).dtype, expected_dtype
             )
 
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_var(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((2,), dtype=dtype)
+        x_jax = jnp.ones((2,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.var(x_jax).dtype)
+        if dtype == "int64":
+            expected_dtype = backend.floatx()
+
+        self.assertEqual(standardize_dtype(knp.var(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Var().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
     @parameterized.named_parameters(
         named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
     )


### PR DESCRIPTION
This PR includes the following:
- Added `convert_to_tensor` in JAX's (inverse) trigonometric functions to ensure that x contains `dtype` attribute, as it is needed for dtype inference
- Applied `backend.result_type` to `var`
- Promoted dtype to int32 in `clip` instead of int64 when the incoming dtype is bool
- Fixed dtype conversion of `trace` as mentioned in https://github.com/keras-team/keras/pull/18831#discussion_r1406344825

<details>

- [x] abs
- [x] absolute
- [x] add
- [x] all
- [x] amax
- [x] amin
- [x] append
- [x] arange
- [x] arccos
- [x] arccosh
- [x] arcsin
- [x] arcsinh
- [x] arctan
- [x] arctan2
- [x] arctanh
- [x] argmax
- [x] argmin
- [x] argsort
- [x] array
- [x] average
- [x] bincount
- [x] broadcast_to
- [x] ceil
- [x] clip
- [x] concatenate
- [ ] conj  (Keras does not directly support complex data)
- [ ] conjugate  (Keras does not directly support complex data)
- [x] copy
- [x] cos
- [x] cosh
- [x] count_nonzero
- [x] cross
- [x] cumprod
- [x] cumsum
- [x] diag
- [x] diagonal
- [x] diff
- [x] digitize
- [x] divide
- [x] dot
- [x] einsum
- [x] empty
- [x] equal
- [x] exp
- [x] expand_dims
- [x] expm1
- [x] eye
- [x] flip
- [x] floor
- [x] full
- [x] full_like
- [x] greater
- [x] greater_equal
- [x] hstack
- [x] identity
- [ ] imag (Keras does not directly support complex data)
- [ ] interp (Keras lacks this op)
- [x] isclose
- [x] isfinite
- [x] isinf
- [x] isnan
- [x] less
- [x] less_equal
- [x] linspace
- [x] log
- [x] log10
- [x] log1p
- [x] log2
- [x] logaddexp
- [x] logical_and
- [x] logical_not
- [x] logical_or
- [x] logspace
- [x] matmul
- [x] max
- [x] maximum
- [x] mean
- [x] median
- [x] meshgrid
- [ ] mgrid (Keras lacks this op)
- [x] min
- [x] minimum
- [x] mod
- [x] moveaxis
- [x] multiply
- [x] nan_to_num
- [ ] ndim
- [x] nonzero
- [x] not_equal
- [x] ones
- [x] ones_like
- [x] outer
- [x] pad
- [ ] percentile (Keras lacks this op)
- [x] power
- [x] prod
- [x] quantile
- [x] ravel
- [ ] real (Keras does not directly support complex data)
- [ ] reciprocal (Keras lacks this op)
- [x] repeat
- [x] reshape
- [x] roll
- [x] round
- [x] sign
- [x] sin
- [x] sinh
- [ ] size
- [x] sort
- [x] split
- [x] sqrt
- [x] square
- [x] squeeze
- [x] stack
- [x] std
- [x] subtract
- [x] sum
- [x] swapaxes
- [x] take
- [x] take_along_axis
- [x] tan
- [x] tanh
- [x] tensordot
- [x] tile
- [x] trace
- [x] transpose
- [x] tri
- [x] tril
- [x] triu
- [x] true_divide
- [x] var
- [x] vdot
- [x] vstack
- [x] where
- [x] zeros
- [x] zeros_like

</details>