### PR TITLE
Adding stop_evaluating and stop_predicting attributes for Callbacks

### DIFF
--- a/keras/backend/jax/trainer.py
+++ b/keras/backend/jax/trainer.py
@@ -579,6 +579,7 @@ class JAXTrainer(base_trainer.Trainer):
         self._record_training_state_sharding_spec()
 
         self.make_test_function()
+        self.stop_evaluating = False
         callbacks.on_test_begin()
         logs = None
         self.reset_metrics()
@@ -616,6 +617,8 @@ class JAXTrainer(base_trainer.Trainer):
                 "metrics_variables": metrics_variables,
             }
             callbacks.on_test_batch_end(step, self._pythonify_logs(logs))
+            if self.stop_evaluating:
+                break
 
         # Reattach state back to model.
         self.jax_state_sync()
@@ -667,6 +670,7 @@ class JAXTrainer(base_trainer.Trainer):
         self._record_training_state_sharding_spec()
 
         self.make_predict_function()
+        self.stop_predicting = False
         callbacks.on_predict_begin()
 
         def append_to_outputs(batch_outputs, outputs):
@@ -696,6 +700,8 @@ class JAXTrainer(base_trainer.Trainer):
             batch_outputs, state = self.predict_function(state, x)
             outputs = append_to_outputs(batch_outputs, outputs)
             callbacks.on_predict_batch_end(step, {"outputs": batch_outputs})
+            if self.stop_predicting:
+                break
         callbacks.on_predict_end()
         return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)
 

--- a/keras/backend/numpy/trainer.py
+++ b/keras/backend/numpy/trainer.py
@@ -195,6 +195,7 @@ class NumpyTrainer(base_trainer.Trainer):
             return outputs
 
         self.make_predict_function()
+        self.stop_predicting = False
         callbacks.on_predict_begin()
         outputs = None
         for step, data in epoch_iterator.enumerate_epoch(return_type="np"):
@@ -202,6 +203,8 @@ class NumpyTrainer(base_trainer.Trainer):
             batch_outputs = self.predict_function(data)
             outputs = append_to_outputs(batch_outputs, outputs)
             callbacks.on_predict_batch_end(step, {"outputs": batch_outputs})
+            if self.stop_predicting:
+                break
         callbacks.on_predict_end()
         return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)
 
@@ -257,6 +260,7 @@ class NumpyTrainer(base_trainer.Trainer):
             )
 
         self.make_test_function()
+        self.stop_evaluating = False
         callbacks.on_test_begin()
         logs = None
         self.reset_metrics()
@@ -264,6 +268,8 @@ class NumpyTrainer(base_trainer.Trainer):
             callbacks.on_test_batch_begin(step)
             logs = self.test_function(data)
             callbacks.on_test_batch_end(step, self._pythonify_logs(logs))
+            if self.stop_evaluating:
+                break
         logs = self.get_metrics_result()
         callbacks.on_test_end(logs)
 

--- a/keras/backend/tensorflow/trainer.py
+++ b/keras/backend/tensorflow/trainer.py
@@ -423,6 +423,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
             )
 
         self.make_test_function()
+        self.stop_evaluating = False
         callbacks.on_test_begin()
         logs = None
         self.reset_metrics()
@@ -431,6 +432,8 @@ class TensorFlowTrainer(base_trainer.Trainer):
                 callbacks.on_test_batch_begin(step)
                 logs = self.test_function(iterator)
                 callbacks.on_test_batch_end(step, self._pythonify_logs(logs))
+                if self.stop_evaluating:
+                    break
         logs = self.get_metrics_result()
         callbacks.on_test_end(logs)
 
@@ -498,6 +501,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
             return data
 
         self.make_predict_function()
+        self.stop_predicting = False
         callbacks.on_predict_begin()
         outputs = None
         with epoch_iterator.catch_stop_iteration():
@@ -507,6 +511,8 @@ class TensorFlowTrainer(base_trainer.Trainer):
                 batch_outputs = self.predict_function(data)
                 outputs = append_to_outputs(batch_outputs, outputs)
                 callbacks.on_predict_batch_end(step, {"outputs": batch_outputs})
+                if self.stop_predicting:
+                    break
         callbacks.on_predict_end()
         outputs = tree.map_structure_up_to(
             batch_outputs, potentially_ragged_concat, outputs

--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -426,6 +426,7 @@ class TorchTrainer(base_trainer.Trainer):
         self.eval()
 
         self.make_test_function()
+        self.stop_evaluating = False
         callbacks.on_test_begin()
         logs = None
         self.reset_metrics()
@@ -433,6 +434,8 @@ class TorchTrainer(base_trainer.Trainer):
             callbacks.on_test_batch_begin(step)
             logs = self.test_function(data)
             callbacks.on_test_batch_end(step, self._pythonify_logs(logs))
+            if self.stop_evaluating:
+                break
         logs = self.get_metrics_result()
         callbacks.on_test_end(logs)
 
@@ -484,6 +487,7 @@ class TorchTrainer(base_trainer.Trainer):
         self.eval()
 
         self.make_predict_function()
+        self.stop_predicting = False
         callbacks.on_predict_begin()
         outputs = None
         for step, data in epoch_iterator.enumerate_epoch():
@@ -491,6 +495,8 @@ class TorchTrainer(base_trainer.Trainer):
             batch_outputs = self.predict_function(data)
             outputs = append_to_outputs(batch_outputs, outputs)
             callbacks.on_predict_batch_end(step, {"outputs": batch_outputs})
+            if self.stop_predicting:
+                break
         callbacks.on_predict_end()
         outputs = tree.map_structure(backend.convert_to_numpy, outputs)
         return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)

--- a/keras/trainers/trainer_test.py
+++ b/keras/trainers/trainer_test.py
@@ -1131,11 +1131,11 @@ class TestTrainer(testing.TestCase, parameterized.TestCase):
                 y = np.ones((2, 3))
                 yield (x,) if method == "predict" else (x, y)
 
-        for stop_count in (5, 7):
-            stopper = Stopper(stop_count)
+        stop_count = 5
+        stopper = Stopper(stop_count)
 
-            getattr(model, method)(
-                infinite_gen(),
-                callbacks=[stopper],
-            )
-            self.assertEqual(stopper.counter, stop_count)
+        getattr(model, method)(
+            infinite_gen(),
+            callbacks=[stopper],
+        )
+        self.assertEqual(stopper.counter, stop_count)

--- a/keras/trainers/trainer_test.py
+++ b/keras/trainers/trainer_test.py
@@ -1010,9 +1010,7 @@ class TestTrainer(testing.TestCase, parameterized.TestCase):
 
     @pytest.mark.requires_trainable_backend
     def test_recompile(self):
-        inputs = layers.Input((2,))
-        outputs = layers.Dense(3)(inputs)
-        model = keras.Model(inputs, outputs)
+        model = ExampleModel(3)
         model.compile(
             optimizer="sgd", loss="mse", metrics=["mean_squared_error"]
         )
@@ -1072,9 +1070,7 @@ class TestTrainer(testing.TestCase, parameterized.TestCase):
         # Test that you can pass an infinite generator to `validation_data`
         # arg of fit() as well as a `validation_steps` argument and that
         # validation only runs for the correct number of steps.
-        inputs = layers.Input((2,))
-        outputs = layers.Dense(3)(inputs)
-        model = keras.Model(inputs, outputs)
+        model = ExampleModel(3)
         model.compile(optimizer="sgd", loss="mse", metrics=["mse"])
 
         class Recorder(keras.callbacks.Callback):

--- a/keras/trainers/trainer_test.py
+++ b/keras/trainers/trainer_test.py
@@ -1010,7 +1010,7 @@ class TestTrainer(testing.TestCase, parameterized.TestCase):
 
     @pytest.mark.requires_trainable_backend
     def test_recompile(self):
-        model = ExampleModel(3)
+        model = ExampleModel(units=3)
         model.compile(
             optimizer="sgd", loss="mse", metrics=["mean_squared_error"]
         )
@@ -1070,7 +1070,7 @@ class TestTrainer(testing.TestCase, parameterized.TestCase):
         # Test that you can pass an infinite generator to `validation_data`
         # arg of fit() as well as a `validation_steps` argument and that
         # validation only runs for the correct number of steps.
-        model = ExampleModel(3)
+        model = ExampleModel(units=3)
         model.compile(optimizer="sgd", loss="mse", metrics=["mse"])
 
         class Recorder(keras.callbacks.Callback):
@@ -1111,7 +1111,7 @@ class TestTrainer(testing.TestCase, parameterized.TestCase):
     )
     @pytest.mark.requires_trainable_backend
     def test_stop_loop(self, method, method_gerund, on_end_name):
-        model = ExampleModel(3)
+        model = ExampleModel(units=3)
         model.compile(optimizer="sgd", loss="mse", metrics=["mse"])
 
         class Stopper(keras.callbacks.Callback):


### PR DESCRIPTION
### Summary

This pull request introduces the `stop_evaluating` and `stop_predicting` attributes available for callbacks, allowing users to halt the evaluation and prediction loops.

### Motivation

The existing `stop_training` attribute makes it possible to interrupt the training loop based on custom criteria in callbacks. However, similar capabilities are not available for the evaluation and prediction loops. The introduction of `stop_evaluating` and `stop_predicting` attributes extends this functionality, allowing users to use callbacks to stop these loops.

### Changes Made

1. **Added `stop_evaluating` attribute:**
   - Enables users to interrupt the evaluation loop based by marking is as `True` in a callback.
   
2. **Added `stop_predicting` attribute:**
   - Provides the ability to halt the prediction loop based by marking is as `True` in a callback.

### Example Usage

```python
import keras


class TimeOutCallback(keras.callbacks.Callback):
    """Stop evaluation loop after a certain amount of time."""

    def __init__(self, timeout: int) -> None:
        """Initialize the callback."""
        super().__init__()
        self.timeout = timeout

    def on_test_begin(self, logs: dict[str, Any] | None = None) -> None:
        """Initialize the stopping time."""
        self.stopping_time = time.time() + self.timeout

    def on_test_batch_end(self, epoch: int, logs: dict[str, Any] | None = None) -> None:
        """Stop evaluation if the timeout has been reached."""
        if time.time() > self.stopping_time:
            self.model.stop_evaluating = True
```