### PR TITLE
support numpy int dtypes in shapes

### DIFF
--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -419,7 +419,7 @@ def standardize_shape(shape):
         if not is_int_dtype(type(e)):
             raise ValueError(
                 f"Cannot convert '{shape}' to a shape. "
-                f"Found invalid entry '{e}'. "
+                f"Found invalid entry '{e}' of type '{type(e)}'. "
             )
         if e < 0:
             raise ValueError(

--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -389,6 +389,8 @@ def standardize_dtype(dtype):
         "torch" in str(dtype) or "jax.numpy" in str(dtype)
     ):
         dtype = str(dtype).split(".")[-1]
+    elif hasattr(dtype, "__name__"):
+        dtype = dtype.__name__
 
     if dtype not in ALLOWED_DTYPES:
         raise ValueError(f"Invalid dtype: {dtype}")
@@ -414,7 +416,7 @@ def standardize_shape(shape):
         if config.backend() == "jax" and str(e) == "b":
             # JAX2TF tracing represents `None` dimensions as `b`
             continue
-        if not isinstance(e, int):
+        if not is_int_dtype(type(e)):
             raise ValueError(
                 f"Cannot convert '{shape}' to a shape. "
                 f"Found invalid entry '{e}'. "

--- a/keras/layers/core/input_layer_test.py
+++ b/keras/layers/core/input_layer_test.py
@@ -131,3 +131,12 @@ class InputLayerTest(testing.TestCase, parameterized.TestCase):
         layer = InputLayer(shape=(32,))
         output = layer.call()
         self.assertIsNone(output)
+
+    def test_numpy_shape(self):
+        # non-python int type shapes should be ok
+        InputLayer(shape=(np.int64(32),))
+        # float should still raise
+        with self.assertRaisesRegex(
+            ValueError, "Cannot convert"
+        ):
+            InputLayer(shape=(np.float64(32),))


### PR DESCRIPTION
One of two very small issues I ran into trying to run an existing code base on keras 3. This allows passing a tuple of numpy (or any other valid) int types to `Input(shape=...)`. I am preloading some data to generate the model shape on the fly, and the lib I'm using to wrangle that data happens to output shape as numpy ints.