### PR TITLE
support dict items in PyDataset

### DIFF
--- a/keras/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/trainers/data_adapters/py_dataset_adapter.py
@@ -209,13 +209,16 @@ class PyDatasetAdapter(DataAdapter):
         self._output_signature = tree.map_structure(get_tensor_spec, batch)
 
     def _standardize_batch(self, batch):
+        if isinstance(batch, dict):
+            return batch
         if isinstance(batch, np.ndarray):
             batch = (batch,)
         if isinstance(batch, list):
             batch = tuple(batch)
         if not isinstance(batch, tuple) or len(batch) not in {1, 2, 3}:
             raise ValueError(
-                "PyDataset.__getitem__() must return a tuple, either "
+                "PyDataset.__getitem__() must return a tuple or a dict. "
+                "If a tuple, it must be ordered either "
                 "(input,) or (inputs, targets) or "
                 "(inputs, targets, sample_weights). "
                 f"Received: {str(batch)[:100]}... of type {type(batch)}"

--- a/keras/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/trainers/data_adapters/py_dataset_adapter_test.py
@@ -39,6 +39,29 @@ class ExamplePyDataset(py_dataset_adapter.PyDataset):
         return batch_x, batch_y
 
 
+class DictPyDataset(py_dataset_adapter.PyDataset):
+    def __init__(
+        self, inputs, batch_size=32, **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.inputs = inputs
+        self.batch_size = batch_size
+
+    def __len__(self):
+        return math.ceil(len(self.inputs["x"]) / self.batch_size)
+
+    def __getitem__(self, idx):
+        # Return x, y for batch idx.
+        low = idx * self.batch_size
+        # Cap upper bound at array length; the last batch may be smaller
+        # if the total number of items is not a multiple of batch size.
+        high = min(low + self.batch_size, len(self.inputs["x"]))
+        batch_x = self.inputs["x"][low:high]
+        batch_y = self.inputs["y"][low:high]
+        batch = {"x": batch_x, "y": batch_y}
+        return batch
+
+
 class PyDatasetAdapterTest(testing.TestCase, parameterized.TestCase):
     @parameterized.parameters(
         [
@@ -146,3 +169,32 @@ class PyDatasetAdapterTest(testing.TestCase, parameterized.TestCase):
         speedup_time = time.time() - t0
 
         self.assertLess(speedup_time, no_speedup_time)
+
+    def test_dict_inputs(self):
+        inputs = {
+            "x": np.random.random((40, 4)),
+            "y": np.random.random((40, 2)),
+        }
+        py_dataset = DictPyDataset(inputs, batch_size=4)
+        adapter = py_dataset_adapter.PyDatasetAdapter(
+            py_dataset, shuffle=False
+        )
+        gen = adapter.get_numpy_iterator()
+        for batch in gen:
+            self.assertEqual(len(batch), 2)
+            bx, by = batch["x"], batch["y"]
+            self.assertIsInstance(bx, np.ndarray)
+            self.assertIsInstance(by, np.ndarray)
+            self.assertEqual(bx.dtype, by.dtype)
+            self.assertEqual(bx.shape, (4, 4))
+            self.assertEqual(by.shape, (4, 2))
+        
+        ds = adapter.get_tf_dataset()
+        for batch in ds:
+            self.assertEqual(len(batch), 2)
+            bx, by = batch["x"], batch["y"]
+            self.assertIsInstance(bx, tf.Tensor)
+            self.assertIsInstance(by, tf.Tensor)
+            self.assertEqual(bx.dtype, by.dtype)
+            self.assertEqual(tuple(bx.shape), (4, 4))
+            self.assertEqual(tuple(by.shape), (4, 2))


### PR DESCRIPTION
The second of two very small issues I ran into trying to run an existing code base on keras 3. This allows the `PyDataset.__getitem__` method to return a dict of tensors, which is a valid way to supply inputs as `Model(inputs={...})` and very convenient for formatting complex inputs. We could add checks in the case of a dict to make sure the batch is not deeply nested, and doesn't contain other invalid objects. This was just a minimal fix.