### PR TITLE
Fix LSTM performance on TF Backend

### DIFF
--- a/keras/backend/tensorflow/rnn.py
+++ b/keras/backend/tensorflow/rnn.py
@@ -533,24 +533,6 @@ def _do_lstm_arguments_support_cudnn(
     )
 
 
-# Returns a TF symbolic tensor array and requires to be wrapped in
-# `tf.function`. But that causes regression of 20x for LSTM/GRU.
-# See GitHub issues #18397 and #18854
-# def _do_rnn_inputs_support_cudnn(mask, time_major):
-#     if tf.sysconfig.get_build_info()["is_rocm_build"]:
-#         if mask is not None:
-#             return tf.reduce_all(mask)
-#         return True
-#     if mask is None:
-#         return True
-#     if time_major:
-#         mask = tf.transpose(mask)
-#     return tf.logical_and(
-#         _is_sequence_right_padded(mask),
-#         tf.logical_not(_has_fully_masked_sequence(mask)),
-#     )
-
-
 def _is_sequence_right_padded(mask):
     """Check the mask tensor and see if it right padded.
 

--- a/keras/backend/tensorflow/rnn.py
+++ b/keras/backend/tensorflow/rnn.py
@@ -463,7 +463,7 @@ def gru(
         use_bias=bias is not None,
         reset_after=reset_after,
     )
-    if not cudnn_supported:
+    if not cudnn_supported or mask is not None:
         raise NotImplementedError
 
     from keras.backend.tensorflow import Variable
@@ -802,7 +802,7 @@ def lstm(
     cudnn_supported = cudnn_ok(
         activation, recurrent_activation, unroll, use_bias=bias is not None
     )
-    if not cudnn_supported:
+    if not cudnn_supported or mask is not None:
         raise NotImplementedError
 
     from keras.backend.tensorflow import Variable


### PR DESCRIPTION
Regression caused by #18610 
Fixes #18854 .  Also verified it doesn't re-introduce the masking issue - #18397

Wrapping check of `inputs_supported` in `tf.function` takes 200+ ms on each call.  Without this check LSTM layer returns results in 15ms/step for imdb keras.io example.  If we don't wrap it in `tf.function`, that causes masking issue since we are comparing python bool from `cudnn_supported` with TF symbolic tensor from `inputs_supported`.

This check on `inputs_supported` may not be necessary?

Colab testing the fix: https://colab.research.google.com/drive/1EFFINfOGp-htUvLZu_oK5aCzOWFNwTfS?usp=sharing