### PR TITLE
Add `hard_swish` to `ops.nn` and dtype tests for `hard_swish` and `hard_sigmoid`

### DIFF
--- a/keras/activations/activations.py
+++ b/keras/activations/activations.py
@@ -394,7 +394,7 @@ def hard_swish(x):
     - [A Howard, 2019](https://arxiv.org/abs/1905.02244)
     """
     x = backend.convert_to_tensor(x)
-    return x * ops.relu6(x + 3.0) * (1.0 / 6.0)
+    return ops.hard_swish(x)
 
 
 @keras_export("keras.activations.linear")

--- a/keras/backend/jax/nn.py
+++ b/keras/backend/jax/nn.py
@@ -64,6 +64,11 @@ def hard_sigmoid(x):
     return jnn.hard_sigmoid(x)
 
 
+def hard_swish(x):
+    x = convert_to_tensor(x)
+    return jnn.hard_swish(x)
+
+
 def elu(x, alpha=1.0):
     x = convert_to_tensor(x)
     return jnn.elu(x, alpha=alpha)

--- a/keras/backend/numpy/nn.py
+++ b/keras/backend/numpy/nn.py
@@ -51,6 +51,8 @@ def leaky_relu(x, negative_slope=0.2):
 
 
 def hard_sigmoid(x):
+    # python numbers will be promoted to float64 by np, so it's neccessary to
+    # first convert the python numbers to np scalars
     x = x / np.array(6.0, x.dtype) + np.array(0.5, x.dtype)
     return np.where(
         x <= 0.0,

--- a/keras/backend/numpy/nn.py
+++ b/keras/backend/numpy/nn.py
@@ -51,8 +51,16 @@ def leaky_relu(x, negative_slope=0.2):
 
 
 def hard_sigmoid(x):
-    x = (x / 6.0) + 0.5
-    return np.where(x <= 0.0, 0.0, np.where(x >= 1.0, 1.0, x))
+    x = x / np.array(6.0, x.dtype) + np.array(0.5, x.dtype)
+    return np.where(
+        x <= 0.0,
+        np.array(0.0, x.dtype),
+        np.where(x >= 1.0, np.array(1.0, x.dtype), x),
+    )
+
+
+def hard_swish(x):
+    return x * hard_sigmoid(x)
 
 
 def elu(x, alpha=1.0):

--- a/keras/backend/tensorflow/nn.py
+++ b/keras/backend/tensorflow/nn.py
@@ -55,6 +55,10 @@ def hard_sigmoid(x):
     return tf.clip_by_value(x, 0.0, 1.0)
 
 
+def hard_swish(x):
+    return x * hard_sigmoid(x)
+
+
 def elu(x, alpha=1.0):
     res = tf.nn.elu(x)
     if alpha == 1:

--- a/keras/backend/tensorflow/nn.py
+++ b/keras/backend/tensorflow/nn.py
@@ -9,6 +9,7 @@ from keras.backend.common.backend_utils import (
 )
 from keras.backend.config import epsilon
 from keras.backend.tensorflow.core import cast
+from keras.backend.tensorflow.core import convert_to_tensor
 
 
 def relu(x):
@@ -51,7 +52,8 @@ def leaky_relu(x, negative_slope=0.2):
 
 
 def hard_sigmoid(x):
-    x = x / 6.0 + 0.5
+    x = convert_to_tensor(x)
+    x = x / tf.constant(6.0, dtype=x.dtype) + tf.constant(0.5, dtype=x.dtype)
     return tf.clip_by_value(x, 0.0, 1.0)
 
 

--- a/keras/backend/torch/nn.py
+++ b/keras/backend/torch/nn.py
@@ -67,6 +67,11 @@ def hard_sigmoid(x):
     return tnn.hardsigmoid(x)
 
 
+def hard_swish(x):
+    x = convert_to_tensor(x)
+    return tnn.hardswish(x)
+
+
 def elu(x, alpha=1.0):
     x = convert_to_tensor(x)
     return tnn.elu(x, alpha)

--- a/keras/ops/nn.py
+++ b/keras/ops/nn.py
@@ -332,6 +332,44 @@ def hard_sigmoid(x):
     return backend.nn.hard_sigmoid(x)
 
 
+class HardSwish(Operation):
+    def call(self, x):
+        return backend.nn.hard_swish(x)
+
+    def compute_output_spec(self, x):
+        return KerasTensor(x.shape, dtype=x.dtype)
+
+
+@keras_export(["keras.ops.hard_swish", "keras.ops.nn.hard_swish"])
+def hard_swish(x):
+    """Hard swish activation function.
+
+    It is defined as:
+
+    - `0` if `if x < -3`
+    - `x` if `x > 3`
+    - `x * (x + 3) / 6` if `-3 <= x <= 3`
+
+    It's a faster, piecewise linear approximation of the swish activation.
+
+    Args:
+        x: Input tensor.
+
+    Returns:
+        A tensor with the same shape as `x`.
+
+    Example:
+
+    >>> x = keras.ops.convert_to_tensor([-3.0, -1.0, 0.0, 1.0, 3.0])
+    >>> keras.ops.hard_swish(x)
+    array([-0.0, -0.3333333, 0.0, 0.6666667, 3.0], shape=(5,), dtype=float32)
+
+    """
+    if any_symbolic_tensors((x,)):
+        return HardSwish().symbolic_call(x)
+    return backend.nn.hard_swish(x)
+
+
 class Elu(Operation):
     def __init__(self, alpha=1.0):
         super().__init__()

--- a/keras/ops/nn_test.py
+++ b/keras/ops/nn_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from absl.testing import parameterized
+from tensorflow.python.ops.numpy_ops import np_config
 
 from keras import backend
 from keras import layers
@@ -23,6 +24,9 @@ from keras.layers.pooling.max_pooling_test import np_maxpool2d
 from keras.ops import nn as knn
 from keras.ops import numpy as knp
 from keras.testing.test_utils import named_product
+
+# TODO: remove reliance on this (or alternatively, turn it on by default).
+np_config.enable_numpy_behavior()
 
 
 class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):

--- a/keras/ops/nn_test.py
+++ b/keras/ops/nn_test.py
@@ -7,7 +7,9 @@ from keras import layers
 from keras import losses
 from keras import models
 from keras import testing
+from keras.backend.common import standardize_dtype
 from keras.backend.common.keras_tensor import KerasTensor
+from keras.backend.common.variables import ALLOWED_DTYPES
 from keras.layers.convolutional.conv_test import np_conv1d
 from keras.layers.convolutional.conv_test import np_conv2d
 from keras.layers.convolutional.conv_test import np_conv3d
@@ -19,6 +21,8 @@ from keras.layers.pooling.average_pooling_test import np_avgpool2d
 from keras.layers.pooling.max_pooling_test import np_maxpool1d
 from keras.layers.pooling.max_pooling_test import np_maxpool2d
 from keras.ops import nn as knn
+from keras.ops import numpy as knp
+from keras.testing.test_utils import named_product
 
 
 class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):
@@ -57,6 +61,10 @@ class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):
     def test_hard_sigmoid(self):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.hard_sigmoid(x).shape, (None, 2, 3))
+
+    def test_hard_swish(self):
+        x = KerasTensor([None, 2, 3])
+        self.assertEqual(knn.hard_swish(x).shape, (None, 2, 3))
 
     def test_elu(self):
         x = KerasTensor([None, 2, 3])
@@ -579,6 +587,10 @@ class NNOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.hard_sigmoid(x).shape, (1, 2, 3))
 
+    def test_hard_swish(self):
+        x = KerasTensor([1, 2, 3])
+        self.assertEqual(knn.hard_swish(x).shape, (1, 2, 3))
+
     def test_elu(self):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.elu(x).shape, (1, 2, 3))
@@ -1011,6 +1023,13 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(
             knn.hard_sigmoid(x),
             [0.33333334, 0.5, 0.6666667, 0.8333334, 1.0],
+        )
+
+    def test_hard_swish(self):
+        x = np.array([-3, -2, -1, 0, 1, 2, 3], dtype=np.float32)
+        self.assertAllClose(
+            knn.hard_swish(x),
+            [-0.0, -0.333333, -0.333333, 0.0, 0.6666667, 1.6666667, 3.0],
         )
 
     def test_elu(self):
@@ -1735,3 +1754,56 @@ class TestLogitRecovery(testing.TestCase):
         model.compile(loss="binary_crossentropy", optimizer="sgd")
         out = model.evaluate(x, y)
         self.assertAllClose(out, 2.682124)
+
+
+class NNOpsDtypeTest(testing.TestCase, parameterized.TestCase):
+    """Test the dtype to verify that the behavior matches JAX."""
+
+    FLOAT_DTYPES = [x for x in ALLOWED_DTYPES if "float" in x]
+
+    def setUp(self):
+        from jax.experimental import enable_x64
+
+        self.jax_enable_x64 = enable_x64()
+        self.jax_enable_x64.__enter__()
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        self.jax_enable_x64.__exit__(None, None, None)
+        return super().tearDown()
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_hard_sigmoid(self, dtype):
+        import jax.nn as jnn
+        import jax.numpy as jnp
+
+        x = knp.ones((), dtype=dtype)
+        x_jax = jnp.ones((), dtype=dtype)
+        expected_dtype = standardize_dtype(jnn.hard_sigmoid(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knn.hard_sigmoid(x).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(knn.HardSigmoid().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_hard_swish(self, dtype):
+        import jax.nn as jnn
+        import jax.numpy as jnp
+
+        x = knp.ones((), dtype=dtype)
+        x_jax = jnp.ones((), dtype=dtype)
+        expected_dtype = standardize_dtype(jnn.hard_swish(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knn.hard_swish(x).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(knn.HardSwish().symbolic_call(x).dtype),
+            expected_dtype,
+        )


### PR DESCRIPTION
This PR:
- add `hard_swish` to `ops.nn` to ensure consistency for all activation functions in the codebase
- add dtype inference tests for `hard_sigmoid` and `hard_swish`

I plan to add more dtype inference tests for `ops.nn`.  I think we can focus on float types for these ops, as it's uncommon to use them with integer types.
Is it a good idea (adding more tests / skipping integer types for `ops.nn`)?