### PR TITLE
Remove versioning restrictions for export from JAX backend

### DIFF
--- a/keras/export/export_lib.py
+++ b/keras/export/export_lib.py
@@ -91,16 +91,6 @@ class ExportArchive:
                 "The export API is only compatible with JAX and TF backends."
             )
 
-        # TODO(nkovela): Make JAX version checking programatic.
-        if backend.backend() == "jax":
-            from jax import __version__ as jax_v
-
-            if jax_v > "0.4.15":
-                raise ValueError(
-                    "The export API is only compatible with JAX version 0.4.15 "
-                    f"and prior. Your JAX version: {jax_v}"
-                )
-
     @property
     def variables(self):
         return self._tf_trackable.variables

--- a/keras/export/export_lib_test.py
+++ b/keras/export/export_lib_test.py
@@ -1,6 +1,5 @@
 """Tests for inference-only model/layer exporting utilities."""
 import os
-import sys
 
 import numpy as np
 import pytest
@@ -28,10 +27,6 @@ def get_model():
 @pytest.mark.skipif(
     backend.backend() not in ("tensorflow", "jax"),
     reason="Export only currently supports the TF and JAX backends.",
-)
-@pytest.mark.skipif(
-    backend.backend() == "jax" and sys.modules["jax"].__version__ > "0.4.15",
-    reason="The export API is only compatible with JAX version <= 0.4.15.",
 )
 class ExportArchiveTest(testing.TestCase):
     def test_standard_model_export(self):
@@ -540,18 +535,6 @@ class ExportArchiveTest(testing.TestCase):
         self.assertAllClose(
             ref_output, revived_model.serve(ref_input), atol=1e-6
         )
-
-
-@pytest.mark.skipif(
-    backend.backend() != "jax" or sys.modules["jax"].__version__ <= "0.4.15",
-    reason="This test is for invalid JAX versions, i.e. versions > 0.4.15.",
-)
-class VersionTest(testing.TestCase):
-    def test_invalid_jax_version(self):
-        with self.assertRaisesRegex(
-            ValueError, "only compatible with JAX version"
-        ):
-            _ = export_lib.ExportArchive()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Previously, JAX release 0.4.16 was incompatible with stable TF versions. However, this has recently been fixed, and JAX export can now be used again.