### PR TITLE
Fix the doc bug in channels_last shape in conv2d_transpose.py

### DIFF
--- a/keras/layers/convolutional/conv2d_transpose.py
+++ b/keras/layers/convolutional/conv2d_transpose.py
@@ -32,7 +32,7 @@ class Conv2DTranspose(BaseConvTranspose):
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape
-            `(batch_size, channels, height, width)`
+            `(batch_size, height, width, channels)`
             while `"channels_first"` corresponds to inputs with shape
             `(batch_size, channels, height, width)`. It defaults to the
             `image_data_format` value found in your Keras config file at


### PR DESCRIPTION
Fixed the doc bug in channels_last shape description from

`(batch_size, channels, height, width)` 
to 
`(batch_size, height, width, channels)`

to avoid confusion among users.

Fixes #18910 