### PR TITLE
Add masking to BatchNormalization

### DIFF
--- a/keras/layers/normalization/batch_normalization.py
+++ b/keras/layers/normalization/batch_normalization.py
@@ -316,7 +316,7 @@ class BatchNormalization(Layer):
             self._reduction_axes,
             keepdims=True,
         )
-        mean = weighted_input_sum / (sum_of_weights + self.epsilon)
+        mean = weighted_input_sum / (sum_of_weights + backend.config.epsilon())
 
         difference = weighted_inputs - mean
         squared_difference = difference * difference
@@ -325,6 +325,6 @@ class BatchNormalization(Layer):
             self._reduction_axes,
             keepdims=True,
         )
-        variance = weighted_distsq / (sum_of_weights + self.epsilon)
+        variance = weighted_distsq / (sum_of_weights + backend.config.epsilon())
 
         return ops.squeeze(mean), ops.squeeze(variance)

--- a/keras/layers/normalization/batch_normalization.py
+++ b/keras/layers/normalization/batch_normalization.py
@@ -84,6 +84,12 @@ class BatchNormalization(Layer):
             - `training=False`: The layer will normalize its inputs using
             the mean and variance of its moving statistics, learned during
             training.
+        mask: Binary tensor of shape broadcastable to `inputs` tensor, with
+            True values indicating the positions for which mean and variance
+            should be computed. Masked elements of the current inputs are not
+            taken into account for mean and variance computation during
+            training. Any prior unmasked element values will be taken into
+            account until their momentum expires.
 
     Reference:
 
@@ -211,10 +217,9 @@ class BatchNormalization(Layer):
             inputs = ops.cast(inputs, "float32")
 
         if training and self.trainable:
-            mean, variance = ops.moments(
+            mean, variance = self._moments(
                 inputs,
-                axes=self._reduction_axes,
-                synchronized=self.synchronized,
+                mask,
             )
             moving_mean = ops.cast(self.moving_mean, inputs.dtype)
             moving_variance = ops.cast(self.moving_variance, inputs.dtype)
@@ -282,3 +287,57 @@ class BatchNormalization(Layer):
             "synchronized": self.synchronized,
         }
         return {**base_config, **config}
+
+    def _moments(self, inputs, mask):
+        if mask is None:
+            return ops.moments(
+                inputs,
+                axes=self._reduction_axes,
+                synchronized=self.synchronized,
+            )
+
+        mask_weights = ops.cast(
+            mask,
+            inputs.dtype,
+        )
+        mask_weights_broadcasted = ops.expand_dims(
+            mask_weights,
+            axis=-1,
+        )
+        weighted_inputs = mask_weights_broadcasted * inputs
+
+        weighted_input_sum = ops.sum(
+            weighted_inputs,
+            self._reduction_axes,
+            keepdims=True,
+        )
+        sum_of_weights = ops.sum(
+            mask_weights_broadcasted,
+            self._reduction_axes,
+            keepdims=True,
+        )
+        mean = self._divide_no_nan(weighted_input_sum, sum_of_weights)
+
+        difference = inputs - mean
+        squared_difference = difference * difference
+        weighted_distsq = ops.sum(
+            mask_weights_broadcasted * squared_difference,
+            self._reduction_axes,
+            keepdims=True,
+        )
+        variance = self._divide_no_nan(weighted_distsq, sum_of_weights)
+
+        return ops.squeeze(mean), ops.squeeze(variance)
+
+    def _divide_no_nan(self, x1, x2):
+        original_dtype = x1.dtype
+        x2_binary = ops.cast(x2, dtype="bool")
+        x2_mask = ops.cast(x2_binary, dtype=original_dtype)
+        x1_masked = x1 * x2_mask
+
+        x2_binary_inverted = ~x2_binary
+        x2_mask_inverted = ops.cast(x2_binary_inverted, original_dtype)
+        x2_masked = x2 + x2_mask_inverted
+
+        result = x1_masked / x2_masked
+        return result

--- a/keras/layers/normalization/batch_normalization_test.py
+++ b/keras/layers/normalization/batch_normalization_test.py
@@ -163,7 +163,7 @@ class BatchNormalizationTest(testing.TestCase, parameterized.TestCase):
 
         inputs = layers.Input((None, 2))
         masked = layers.Masking(mask_value=mask_value)(inputs)
-        normed = layers.BatchNormalization(momentum=0.0)(masked)
+        normed = layers.BatchNormalization(momentum=0.0, epsilon=1e-9)(masked)
         model = Model(inputs, normed)
         loss = MeanSquaredError()
         model.compile(
@@ -172,8 +172,8 @@ class BatchNormalizationTest(testing.TestCase, parameterized.TestCase):
             run_eagerly=run_eagerly,
         )
         model.fit(x=padded_data, y=padded_data, batch_size=10, epochs=5)
-        self.assertAllEqual(model.layers[2].moving_mean.numpy(), [1.5, 5.0])
-        self.assertAllEqual(
+        self.assertAllClose(model.layers[2].moving_mean.numpy(), [1.5, 5.0])
+        self.assertAllClose(
             model.layers[2].moving_variance.numpy(), [0.25, 0.0]
         )
 

--- a/keras/layers/normalization/batch_normalization_test.py
+++ b/keras/layers/normalization/batch_normalization_test.py
@@ -163,7 +163,7 @@ class BatchNormalizationTest(testing.TestCase, parameterized.TestCase):
 
         inputs = layers.Input((None, 2))
         masked = layers.Masking(mask_value=mask_value)(inputs)
-        normed = layers.BatchNormalization(momentum=0.0, epsilon=1e-9)(masked)
+        normed = layers.BatchNormalization(momentum=0.0)(masked)
         model = Model(inputs, normed)
         loss = MeanSquaredError()
         model.compile(

--- a/keras/layers/normalization/batch_normalization_test.py
+++ b/keras/layers/normalization/batch_normalization_test.py
@@ -5,6 +5,8 @@ from absl.testing import parameterized
 from keras import backend
 from keras import layers
 from keras import testing
+from keras.losses import MeanSquaredError
+from keras.models import Model
 
 
 class BatchNormalizationTest(testing.TestCase, parameterized.TestCase):
@@ -112,6 +114,68 @@ class BatchNormalizationTest(testing.TestCase, parameterized.TestCase):
         training_out = layer(x, training=True)
         inference_out = layer(x, training=False)
         self.assertAllClose(inference_out, training_out)
+
+        # Masked result with no training should not differ
+        x[:, 1, :] = 0.0
+        unmasked_out = layer(x, training=False)
+        masked = layers.Masking()(x)
+        masked_out = layer(masked, training=False)
+        self.assertAllClose(unmasked_out, masked_out)
+
+        # Masked result should differ from unmasked result
+        unmasked_out = layer(x, training=False)
+        x[:, 1, :] = 0.0
+        masked = layers.Masking()(x)
+        masked_out = layer(masked, training=True)
+        self.assertNotAllClose(unmasked_out, masked_out)
+
+    @parameterized.product(
+        synchronized=(False, True)
+        if backend.backend == "tensorflow"
+        else (False,),
+    )
+    def test_input_fully_masked(self, synchronized):
+        norm = layers.BatchNormalization(
+            scale=False,
+            center=False,
+            synchronized=synchronized,
+        )
+        x = np.zeros((4, 5))
+        mask = np.zeros((4,), dtype=np.float32)
+        y = norm(x, mask=mask, training=True)
+        self.assertAllClose(y, np.zeros_like(x, dtype=np.float32))
+
+    @parameterized.product(run_eagerly=(True, False), mask_value=(0.0, 0.1, 1))
+    @pytest.mark.requires_trainable_backend
+    def test_bachnorm_ignore_masked_values(self, run_eagerly, mask_value):
+        padded_data = np.array(
+            [
+                [
+                    [1, 5],
+                    [2, 5],
+                    [mask_value, mask_value],
+                    [mask_value, mask_value],
+                ]
+                for _ in range(10)
+            ],
+            dtype="float32",
+        )
+
+        inputs = layers.Input((None, 2))
+        masked = layers.Masking(mask_value=mask_value)(inputs)
+        normed = layers.BatchNormalization(momentum=0.0)(masked)
+        model = Model(inputs, normed)
+        loss = MeanSquaredError()
+        model.compile(
+            "rmsprop",
+            loss=loss,
+            run_eagerly=run_eagerly,
+        )
+        model.fit(x=padded_data, y=padded_data, batch_size=10, epochs=5)
+        self.assertAllEqual(model.layers[2].moving_mean.numpy(), [1.5, 5.0])
+        self.assertAllEqual(
+            model.layers[2].moving_variance.numpy(), [0.25, 0.0]
+        )
 
     def test_trainable_behavior(self):
         layer = layers.BatchNormalization(axis=-1, momentum=0.8, epsilon=1e-7)


### PR DESCRIPTION
Proposed solution for the bug reported in https://github.com/keras-team/keras/issues/18759

Prior to this, masking was not effective in batch normalization layers. This approach pulls weighted_moments and divide_no_nan logic into batch_normalization using core operations so that masking will work with any back-end instead of just tensorflow.

Open to suggestions.