### PR TITLE
Fix jax2tf device incompatiblity for Export

### DIFF
--- a/keras/export/export_lib.py
+++ b/keras/export/export_lib.py
@@ -469,10 +469,12 @@ class ExportArchive:
         ):
             logging.warning(
                 "JAX backend is using GPU for export, but installed "
-                "TF package cannot access GPU. To use JAX-native serialization "
-                "for high-performance export and serving, please install "
-                "tensorflow-gpu and ensure CUDA version compatiblity between "
-                "your JAX and TF installations."
+                "TF package cannot access GPU, so reloading the model with "
+                "the TF runtime in the same environment will not work. "
+                "To use JAX-native serialization for high-performance export "
+                "and serving, please install `tensorflow-gpu` and ensure "
+                "CUDA version compatiblity between your JAX and TF "
+                "installations."
             )
             return False
         else:

--- a/keras/export/export_lib.py
+++ b/keras/export/export_lib.py
@@ -1,5 +1,7 @@
 """Library for exporting inference-only Keras models/layers."""
 
+from absl import logging
+
 from keras import backend
 from keras.api_export import keras_export
 from keras.layers import Layer
@@ -441,10 +443,15 @@ class ExportArchive:
     def _convert_jax2tf_function(self, fn, input_signature):
         from jax.experimental import jax2tf
 
+        native_serialization = self._check_device_compatible()
         shapes = []
         for spec in input_signature:
             shapes.append(self._spec_to_poly_shape(spec))
-        return jax2tf.convert(fn, polymorphic_shapes=shapes)
+        return jax2tf.convert(
+            fn,
+            polymorphic_shapes=shapes,
+            native_serialization=native_serialization,
+        )
 
     def _spec_to_poly_shape(self, spec):
         if isinstance(spec, (dict, list)):
@@ -452,6 +459,24 @@ class ExportArchive:
         spec_shape = spec.shape
         spec_shape = str(spec_shape).replace("None", "b")
         return spec_shape
+
+    def _check_device_compatible(self):
+        from jax import default_backend as jax_device
+
+        if (
+            jax_device() == "gpu"
+            and len(tf.config.list_physical_devices("GPU")) == 0
+        ):
+            logging.warning(
+                "JAX backend is using GPU for export, but installed "
+                "TF package cannot access GPU. To use JAX-native serialization "
+                "for high-performance export and serving, please install "
+                "tensorflow-gpu and ensure CUDA version compatiblity between "
+                "your JAX and TF installations."
+            )
+            return False
+        else:
+            return True
 
 
 def export_model(model, filepath):


### PR DESCRIPTION
This PR checks whether the installed packages for JAX and TF both can access the GPU when JAX with GPU is being used for export.

If TF is CPU-only, the export API will prevent the usage of JAX-native serialization, allowing cross-device compatibility, but at the expense of performant serving from the exported artifact.