### PR TITLE
Fixes Torch GPU Test for Binomial and Beta Distribution

### DIFF
--- a/keras/backend/torch/random.py
+++ b/keras/backend/torch/random.py
@@ -208,8 +208,8 @@ def gamma(shape, alpha, dtype=None, seed=None):
 def binomial(shape, counts, probabilities, dtype=None, seed=None):
     dtype = dtype or floatx()
     dtype = to_torch_dtype(dtype)
-    counts = torch.ones(shape) * convert_to_tensor(counts)
-    probabilities = torch.ones(shape) * convert_to_tensor(probabilities)
+    counts = torch.ones(shape, device=get_device()) * convert_to_tensor(counts)
+    probabilities = torch.ones(shape, device=get_device()) * convert_to_tensor(probabilities)
     prev_rng_state = torch.random.get_rng_state()
     first_seed, second_seed = draw_seed(seed)
     torch.manual_seed(first_seed + second_seed)
@@ -224,8 +224,8 @@ def binomial(shape, counts, probabilities, dtype=None, seed=None):
 def beta(shape, alpha, beta, dtype=None, seed=None):
     dtype = dtype or floatx()
     dtype = to_torch_dtype(dtype)
-    alpha = torch.ones(shape) * convert_to_tensor(alpha)
-    beta = torch.ones(shape) * convert_to_tensor(beta)
+    alpha = torch.ones(shape, device=get_device()) * convert_to_tensor(alpha)
+    beta = torch.ones(shape, device=get_device()) * convert_to_tensor(beta)
     prev_rng_state = torch.random.get_rng_state()
     first_seed, second_seed = draw_seed(seed)
     torch.manual_seed(first_seed + second_seed)

--- a/keras/backend/torch/random.py
+++ b/keras/backend/torch/random.py
@@ -208,10 +208,8 @@ def gamma(shape, alpha, dtype=None, seed=None):
 def binomial(shape, counts, probabilities, dtype=None, seed=None):
     dtype = dtype or floatx()
     dtype = to_torch_dtype(dtype)
-    counts = torch.ones(shape, device=get_device()) * convert_to_tensor(counts)
-    probabilities = torch.ones(shape, device=get_device()) * convert_to_tensor(
-        probabilities
-    )
+    counts = torch.broadcast_to(convert_to_tensor(counts), shape)
+    probabilities = torch.broadcast_to(convert_to_tensor(probabilities), shape)
     prev_rng_state = torch.random.get_rng_state()
     first_seed, second_seed = draw_seed(seed)
     torch.manual_seed(first_seed + second_seed)
@@ -226,8 +224,8 @@ def binomial(shape, counts, probabilities, dtype=None, seed=None):
 def beta(shape, alpha, beta, dtype=None, seed=None):
     dtype = dtype or floatx()
     dtype = to_torch_dtype(dtype)
-    alpha = torch.ones(shape, device=get_device()) * convert_to_tensor(alpha)
-    beta = torch.ones(shape, device=get_device()) * convert_to_tensor(beta)
+    alpha = torch.broadcast_to(convert_to_tensor(alpha), shape)
+    beta = torch.broadcast_to(convert_to_tensor(beta), shape)
     prev_rng_state = torch.random.get_rng_state()
     first_seed, second_seed = draw_seed(seed)
     torch.manual_seed(first_seed + second_seed)

--- a/keras/backend/torch/random.py
+++ b/keras/backend/torch/random.py
@@ -209,7 +209,9 @@ def binomial(shape, counts, probabilities, dtype=None, seed=None):
     dtype = dtype or floatx()
     dtype = to_torch_dtype(dtype)
     counts = torch.ones(shape, device=get_device()) * convert_to_tensor(counts)
-    probabilities = torch.ones(shape, device=get_device()) * convert_to_tensor(probabilities)
+    probabilities = torch.ones(shape, device=get_device()) * convert_to_tensor(
+        probabilities
+    )
     prev_rng_state = torch.random.get_rng_state()
     first_seed, second_seed = draw_seed(seed)
     torch.manual_seed(first_seed + second_seed)

--- a/keras/random/random_test.py
+++ b/keras/random/random_test.py
@@ -299,14 +299,15 @@ class RandomTest(testing.TestCase, parameterized.TestCase):
         # by the user for that event.
         # Hence, we do an element wise comparison between `counts` array
         # and the (generated) `values` array.
-        assert np.greater_equal(np.array(counts), np.array(values)).all()
+        values_np = ops.convert_to_numpy(values)
+        assert np.greater_equal(np.array(counts), values_np).all()
 
         # Following test computes the probabilities of each event
         # by dividing number of times an event occurs (which is the generated
         # value) by the corresponding value in the (total) counts array.
         # and then makes sure that the computed probabilities approximate
         # the input probabilities
-        generated_probabilities = np.array(values) / np.array(counts)
+        generated_probabilities = values_np / np.array(counts)
         probabilities = np.ones(shape) * np.array(probabilities)
         self.assertAllClose(
             probabilities, generated_probabilities, rtol=0.005, atol=0.005
@@ -342,8 +343,9 @@ class RandomTest(testing.TestCase, parameterized.TestCase):
         )
         self.assertEqual(ops.shape(values), shape)
         self.assertEqual(backend.standardize_dtype(values.dtype), dtype)
-        self.assertGreaterEqual(np.min(ops.convert_to_numpy(values)), b=0.0)
-        self.assertLessEqual(np.max(ops.convert_to_numpy(values)), b=1.0)
+        values_np = ops.convert_to_numpy(values)
+        self.assertGreaterEqual(np.min(values_np), b=0.0)
+        self.assertLessEqual(np.max(values_np), b=1.0)
 
         _alpha_is_an_array = False
         if isinstance(alpha, list):
@@ -357,12 +359,12 @@ class RandomTest(testing.TestCase, parameterized.TestCase):
         expected_mean = alpha / (alpha + beta)
 
         if _alpha_is_an_array:
-            actual_mean = np.mean(np.array(values), axis=0)
+            actual_mean = np.mean(values_np, axis=0)
             self.assertAllClose(
                 expected_mean.flatten(), actual_mean, atol=0.005, rtol=0.005
             )
         else:
-            actual_mean = np.mean(np.array(values).flatten())
+            actual_mean = np.mean(values_np.flatten())
             self.assertAlmostEqual(expected_mean, actual_mean, decimal=2)
 
         # Variance check:
@@ -372,7 +374,7 @@ class RandomTest(testing.TestCase, parameterized.TestCase):
             np.square(alpha + beta) * (alpha + beta + 1)
         )
         if _alpha_is_an_array:
-            actual_variance = np.var(np.array(values), axis=0)
+            actual_variance = np.var(values_np, axis=0)
             self.assertAllClose(
                 expected_variance.flatten(),
                 actual_variance,
@@ -380,7 +382,7 @@ class RandomTest(testing.TestCase, parameterized.TestCase):
                 rtol=0.005,
             )
         else:
-            actual_variance = np.var(np.array(values).flatten())
+            actual_variance = np.var(values_np.flatten())
             self.assertAlmostEqual(
                 expected_variance, actual_variance, decimal=2
             )


### PR DESCRIPTION
Fixes #18920 for Torch on GPU.  Move to Device before doing math with another tensor that's using `convert_to_tensor`.

