### PR TITLE
Update `alpha` broadcasting and put `beta` on device (https://github.com/keras-team/keras/pull/18926#discussion_r1423237034)

### DIFF
--- a/keras/backend/torch/random.py
+++ b/keras/backend/torch/random.py
@@ -194,8 +194,8 @@ def shuffle(x, axis=0, seed=None):
 def gamma(shape, alpha, dtype=None, seed=None):
     dtype = dtype or floatx()
     dtype = to_torch_dtype(dtype)
-    alpha = torch.ones(shape) * torch.tensor(alpha)
-    beta = torch.ones(shape)
+    alpha = torch.broadcast_to(convert_to_tensor(alpha), shape)
+    beta = torch.ones(shape, device=get_device())
     prev_rng_state = torch.random.get_rng_state()
     first_seed, second_seed = draw_seed(seed)
     torch.manual_seed(first_seed + second_seed)


### PR DESCRIPTION
Learning from the improvements proposed in the PR https://github.com/keras-team/keras/pull/18926, specifically https://github.com/keras-team/keras/pull/18926#discussion_r1423237034 I've updated the existing `gamma` function in the `torch/random.py` module to:
1. Use `torch.broadcast_to` instead of `torch.ones` to broadcast `alpha` to the `shape`
2. Explicitly specify `device` parameter when using `torch.ones`  for `beta` values.