### PR TITLE
Fix descrepancies in Conv Module docstrings regarding data_format

### DIFF
--- a/keras/layers/convolutional/conv2d.py
+++ b/keras/layers/convolutional/conv2d.py
@@ -27,7 +27,7 @@ class Conv2D(BaseConv):
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape
-            `(batch_size, channels, height, width)`
+            `(batch_size, height, width, channels)`
             while `"channels_first"` corresponds to inputs with shape
             `(batch_size, channels, height, width)`. It defaults to the
             `image_data_format` value found in your Keras config file at

--- a/keras/layers/convolutional/conv3d.py
+++ b/keras/layers/convolutional/conv3d.py
@@ -29,7 +29,7 @@ class Conv3D(BaseConv):
             corresponds to inputs with shape
             `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
             while `"channels_first"` corresponds to inputs with shape
-            `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`.
+            `(batch_size, channels, spatial_dim1, spatial_dim2, spatial_dim3)`.
             It defaults to the `image_data_format` value found in your Keras
             config file at `~/.keras/keras.json`. If you never set it, then it
             will be `"channels_last"`.

--- a/keras/layers/convolutional/conv3d_transpose.py
+++ b/keras/layers/convolutional/conv3d_transpose.py
@@ -34,7 +34,7 @@ class Conv3DTranspose(BaseConvTranspose):
             corresponds to inputs with shape
             `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
             while `"channels_first"` corresponds to inputs with shape
-            `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`.
+            `(batch_size, channels, spatial_dim1, spatial_dim2, spatial_dim3)`.
             It defaults to the `image_data_format` value found in your Keras
             config file at `~/.keras/keras.json`. If you never set it, then it
             will be `"channels_last"`.

--- a/keras/layers/convolutional/depthwise_conv2d.py
+++ b/keras/layers/convolutional/depthwise_conv2d.py
@@ -40,10 +40,11 @@ class DepthwiseConv2D(BaseDepthwiseConv):
             output channels will be equal to `input_channel * depth_multiplier`.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
+            corresponds to inputs with shape `(batch, height, width, channels)`
             while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
+            `(batch, channels, height, width)`. It defaults to the
+            `image_data_format` value found in your Keras config file
+            at `~/.keras/keras.json`.
             If you never set it, then it will be `"channels_last"`.
         dilation_rate: int or tuple/list of 2 integers, specifying the dilation
             rate to use for dilated convolution.

--- a/keras/layers/convolutional/separable_conv2d.py
+++ b/keras/layers/convolutional/separable_conv2d.py
@@ -32,10 +32,11 @@ class SeparableConv2D(BaseSeparableConv):
             `strides=1`, the output has the same size as the input.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
-            corresponds to inputs with shape `(batch, steps, features)`
+            corresponds to inputs with shape `(batch, height, width, channels)`
             while `"channels_first"` corresponds to inputs with shape
-            `(batch, features, steps)`. It defaults to the `image_data_format`
-            value found in your Keras config file at `~/.keras/keras.json`.
+            `(batch, channels, height, width)`. It defaults to the
+            `image_data_format` value found in your Keras config file
+            at `~/.keras/keras.json`.
             If you never set it, then it will be `"channels_last"`.
         dilation_rate: int or tuple/list of 2 integers, specifying the dilation
             rate to use for dilated convolution. If only one int is specified,


### PR DESCRIPTION
Stumbled upon some inconsistencies in the docs for conv layers, e.g. Conv2d, which currently states

> `"channels_last"` corresponds to inputs with shape `(batch_size, channels, height, width)`

which seems wrong, especially since a bit further down, it mentions

> Input Shape: If `data_format="channels_last"`: A 4D tensor with shape: `(batch_size, height, width, channels)`

Similar inconsisties exist for other conv layers, namely conv3d, conv3d_transpose, depthwise_conv2d, separable_conv2d.

So here's a simple Doc Fix to get the documentation for the `data_format` argument to conv layers in line with the expected input shape.