### PR TITLE
add get_config() to SeedGenerator

### DIFF
--- a/keras/random/seed_generator.py
+++ b/keras/random/seed_generator.py
@@ -90,7 +90,11 @@ class SeedGenerator:
         return new_seed_value
 
     def get_config(self):
-        return {"_initial_seed": self._initial_seed, "state": self.state}
+        return {"seed": self._initial_seed, "backend": self.backend}
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)
 
 
 def global_seed_generator():

--- a/keras/random/seed_generator.py
+++ b/keras/random/seed_generator.py
@@ -90,7 +90,7 @@ class SeedGenerator:
         return new_seed_value
 
     def get_config(self):
-        return {"seed": self._initial_seed, "backend": self.backend}
+        return {"seed": self._initial_seed}
 
     @classmethod
     def from_config(cls, config):

--- a/keras/random/seed_generator.py
+++ b/keras/random/seed_generator.py
@@ -89,6 +89,9 @@ class SeedGenerator:
             self.state.assign((seed_state + 1) * 5387 % 933199)
         return new_seed_value
 
+    def get_config(self):
+        return {"_initial_seed": self._initial_seed, "state": self.state}
+
 
 def global_seed_generator():
     if jax_utils.is_in_jax_tracing_scope():

--- a/keras/random/seed_generator_test.py
+++ b/keras/random/seed_generator_test.py
@@ -99,7 +99,7 @@ class SeedGeneratorTest(testing.TestCase):
         reconstructed_random_generator = random_generator.from_config(config)
 
         self.assertTrue(
-            self.config_equals(
+            SeedGeneratorTest.config_equals(
                 random_generator.get_config(),
                 reconstructed_random_generator.get_config(),
             )

--- a/keras/random/seed_generator_test.py
+++ b/keras/random/seed_generator_test.py
@@ -1,3 +1,5 @@
+import inspect
+
 import numpy as np
 import pytest
 
@@ -81,7 +83,24 @@ class SeedGeneratorTest(testing.TestCase):
     def test_seed_generator_serialization(self):
         random_generator = seed_generator.SeedGenerator(seed=42)
         config = random_generator.get_config()
-        self.assertAllInitParametersAreInConfig(random_generator, config)
+
+        def assertAllInitParametersAreInConfig(
+            self, seed_generator_cls, config
+        ):
+            excluded_name = ["args", "kwargs", "*"]
+            parameter_names = {
+                v
+                for v in inspect.signature(seed_generator_cls).parameters.keys()
+                if v not in excluded_name
+            }
+
+            intersection_with_config = {
+                v for v in config.keys() if v in parameter_names
+            }
+
+            self.assertSetEqual(parameter_names, intersection_with_config)
+
+        assertAllInitParametersAreInConfig(random_generator, config)
 
         reconstructed_random_generator = random_generator.from_config(config)
 

--- a/keras/random/seed_generator_test.py
+++ b/keras/random/seed_generator_test.py
@@ -1,5 +1,3 @@
-import inspect
-
 import numpy as np
 import pytest
 
@@ -81,26 +79,10 @@ class SeedGeneratorTest(testing.TestCase):
             traced_function()
 
     def test_seed_generator_serialization(self):
-        random_generator = seed_generator.SeedGenerator(seed=42)
+        seed = 42
+        random_generator = seed_generator.SeedGenerator(seed=seed)
         config = random_generator.get_config()
-
-        def assertAllInitParametersAreInConfig(
-            seed_generator_cls, config
-        ):
-            excluded_name = ["args", "kwargs", "*"]
-            parameter_names = {
-                v
-                for v in inspect.signature(seed_generator_cls).parameters.keys()
-                if v not in excluded_name
-            }
-
-            intersection_with_config = {
-                v for v in config.keys() if v in parameter_names
-            }
-
-            self.assertSetEqual(parameter_names, intersection_with_config)
-
-        assertAllInitParametersAreInConfig(random_generator, config)
+        self.assertEqual(config["seed"], seed)
 
         reconstructed_random_generator = random_generator.from_config(config)
 

--- a/keras/random/seed_generator_test.py
+++ b/keras/random/seed_generator_test.py
@@ -79,29 +79,5 @@ class SeedGeneratorTest(testing.TestCase):
             traced_function()
 
     def test_seed_generator_serialization(self):
-        seed = 42
-        random_generator = seed_generator.SeedGenerator(seed=seed)
-        config = random_generator.get_config()
-        self.assertEqual(config["seed"], seed)
-
-        reconstructed_random_generator = random_generator.from_config(config)
-
-        def config_equals(config1, config2):
-            # Both `config1` and `config2` are python dicts. So the first check
-            # is to see if both of them have same keys.
-            if config1.keys() != config2.keys():
-                return False
-
-            # Iterate over all keys of the configs and compare each entry.
-            for key in list(config1.keys()):
-                v1, v2 = config1[key], config2[key]
-                if not v1 == v2:
-                    return False
-            return True
-
-        self.assertTrue(
-            config_equals(
-                random_generator.get_config(),
-                reconstructed_random_generator.get_config(),
-            )
-        )
+        random_generator = seed_generator.SeedGenerator(seed=42)
+        self.run_class_serialization_test(random_generator)

--- a/keras/random/seed_generator_test.py
+++ b/keras/random/seed_generator_test.py
@@ -77,3 +77,30 @@ class SeedGeneratorTest(testing.TestCase):
             "When tracing a JAX function, you should only use seeded random",
         ):
             traced_function()
+
+    def config_equals(config1, config2):
+        # Both `config1` and `config2` are python dicts. So the first check is
+        # to see if both of them have same keys.
+        if config1.keys() != config2.keys():
+            return False
+
+        # Iterate over all keys of the configs and compare each entry.
+        for key in list(config1.keys()):
+            v1, v2 = config1[key], config2[key]
+            if not v1 == v2:
+                return False
+        return True
+
+    def test_seed_generator_serialization(self):
+        random_generator = seed_generator.SeedGenerator(seed=42)
+        config = random_generator.get_config()
+        self.assertAllInitParametersAreInConfig(random_generator, config)
+
+        reconstructed_random_generator = random_generator.from_config(config)
+
+        self.assertTrue(
+            self.config_equals(
+                random_generator.get_config(),
+                reconstructed_random_generator.get_config(),
+            )
+        )

--- a/keras/random/seed_generator_test.py
+++ b/keras/random/seed_generator_test.py
@@ -85,7 +85,7 @@ class SeedGeneratorTest(testing.TestCase):
         config = random_generator.get_config()
 
         def assertAllInitParametersAreInConfig(
-            self, seed_generator_cls, config
+            seed_generator_cls, config
         ):
             excluded_name = ["args", "kwargs", "*"]
             parameter_names = {

--- a/keras/random/seed_generator_test.py
+++ b/keras/random/seed_generator_test.py
@@ -78,19 +78,6 @@ class SeedGeneratorTest(testing.TestCase):
         ):
             traced_function()
 
-    def config_equals(config1, config2):
-        # Both `config1` and `config2` are python dicts. So the first check is
-        # to see if both of them have same keys.
-        if config1.keys() != config2.keys():
-            return False
-
-        # Iterate over all keys of the configs and compare each entry.
-        for key in list(config1.keys()):
-            v1, v2 = config1[key], config2[key]
-            if not v1 == v2:
-                return False
-        return True
-
     def test_seed_generator_serialization(self):
         random_generator = seed_generator.SeedGenerator(seed=42)
         config = random_generator.get_config()
@@ -98,8 +85,21 @@ class SeedGeneratorTest(testing.TestCase):
 
         reconstructed_random_generator = random_generator.from_config(config)
 
+        def config_equals(config1, config2):
+            # Both `config1` and `config2` are python dicts. So the first check
+            # is to see if both of them have same keys.
+            if config1.keys() != config2.keys():
+                return False
+
+            # Iterate over all keys of the configs and compare each entry.
+            for key in list(config1.keys()):
+                v1, v2 = config1[key], config2[key]
+                if not v1 == v2:
+                    return False
+            return True
+
         self.assertTrue(
-            SeedGeneratorTest.config_equals(
+            config_equals(
                 random_generator.get_config(),
                 reconstructed_random_generator.get_config(),
             )


### PR DESCRIPTION
KerasCV serialization tests were failing from 
```
TypeError: Cannot serialize object <keras.src.random.seed_generator.SeedGenerator object at 0x7fe3582b5610> of type <class 'keras.src.random.seed_generator.SeedGenerator'>. To be serializable, a class must implement the get_config() method.
```
https://github.com/keras-team/keras-cv/actions/runs/7175074758/job/19537736102?pr=2232