### PR TITLE
Fix Adafactor when variables have 2 dimensions or more.

### DIFF
--- a/keras/optimizers/adafactor.py
+++ b/keras/optimizers/adafactor.py
@@ -106,7 +106,7 @@ class Adafactor(optimizer.Optimizer):
             else:
                 # Always factor the last 2 dimensions.
                 r_shape = var.shape[:-1]
-                c_shape = var.shape[:-2] + var.shape[-1]
+                c_shape = var.shape[:-2] + (var.shape[-1],)
                 self._r.append(
                     self.add_variable(
                         shape=r_shape,
@@ -177,7 +177,6 @@ class Adafactor(optimizer.Optimizer):
                 v, beta_2_t * v + (1 - beta_2_t) * regulated_grad_square
             )
 
-        # `convert_to_tensor` unifies the handling of sparse and dense grads.
         u_t = ops.divide(gradient, ops.sqrt(v))
         u_t_hat = ops.divide(
             u_t,

--- a/keras/optimizers/adafactor_test.py
+++ b/keras/optimizers/adafactor_test.py
@@ -20,13 +20,22 @@ class AdafactorTest(testing.TestCase):
         )
         self.run_class_serialization_test(optimizer)
 
-    def test_single_step(self):
+    def test_single_step_1d(self):
         optimizer = Adafactor(learning_rate=0.5)
         grads = np.array([1.0, 6.0, 7.0, 2.0])
         vars = backend.Variable([1.0, 2.0, 3.0, 4.0])
         optimizer.apply_gradients(zip([grads], [vars]))
         self.assertAllClose(
             vars, [-0.3693, 0.6307, 1.6307, 2.6307], rtol=1e-4, atol=1e-4
+        )
+
+    def test_single_step_2d(self):
+        optimizer = Adafactor(learning_rate=0.5)
+        grads = np.array([[1.0, 6.0], [7.0, 2.0]])
+        vars = backend.Variable([[1.0, 2.0], [3.0, 4.0]])
+        optimizer.apply_gradients(zip([grads], [vars]))
+        self.assertAllClose(
+            vars, [[0.7007, -0.0081], [1.2492, 3.4407]], rtol=1e-4, atol=1e-4
         )
 
     def test_weight_decay(self):


### PR DESCRIPTION
Adafactor would crash when using variables with 2 dimensions or more with most backends. It would work with the TensorFlow backend because `TensorShape` allows adding an int.