### PR TITLE
Tweaks to TensofFlow support for SparseTensor/IndexedSlices.

### DIFF
--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -807,6 +807,7 @@ def isclose(x1, x2):
     return tfnp.isclose(x1, x2)
 
 
+@sparse.densifying_unary(True)
 def isfinite(x):
     return tfnp.isfinite(x)
 
@@ -824,7 +825,7 @@ def isnan(x):
 def less(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    # tfnp handles the casting internally during comparision, but it lacks
+    # tfnp handles the casting internally during comparison, but it lacks
     # support for bfloat16. Therefore we explicitly cast to the same dtype.
     dtype = dtypes.result_type(x1.dtype, x2.dtype)
     x1 = tf.cast(x1, dtype)
@@ -1021,7 +1022,6 @@ def minimum(x1, x2):
     return tfnp.minimum(x1, x2)
 
 
-@sparse.elementwise_division
 def mod(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
@@ -1640,7 +1640,6 @@ def eye(N, M=None, k=0, dtype=None):
     return tfnp.eye(N, M=M, k=k, dtype=dtype)
 
 
-@sparse.elementwise_division
 def floor_divide(x1, x2):
     return tfnp.floor_divide(x1, x2)
 

--- a/keras/backend/tensorflow/sparse.py
+++ b/keras/backend/tensorflow/sparse.py
@@ -355,7 +355,7 @@ def elementwise_unary(func):
       `tf.SparseTensor` or `tf.IndexedSlices`, the indices of the result must be
       the same. Therefore:
         - Reduction operations are not supported (e.g. `mean`).
-        - Operation for which the result may be dense (e.g. `reciprocal`), or
+        - Operations for which the result may be dense (e.g. `reciprocal`), or
           the sparse indices depend on the inputs are not supported (e.g.
           `clip`). This implies that `func(0)` must be 0.
 
@@ -631,8 +631,8 @@ def elementwise_division(func):
     """Decorator to add support for `tf.SparseTensor` and `tf.IndexedSlices` to
     element-wise binary division and related operators.
 
-    This decorator is designed for operations related to the division of the
-    two operands (e.g. `divide`, `mod`). It accepts `tf.SparseTensor` and
+    This decorator is designed for operations related to the division of two
+    operands (e.g. `divide`). It accepts `tf.SparseTensor` and
     `tf.IndexedSlices` for both the dividend and the divisor, but handles them
     differently based on whether they are the dividend or the divisor.
 

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -3831,12 +3831,7 @@ class Mod(Operation):
         )
         if output_dtype == "bool":
             output_dtype = "int32"
-        x1_sparse = getattr(x1, "sparse", False)
-        x2_sparse = getattr(x2, "sparse", False)
-        output_sparse = x1_sparse and not x2_sparse
-        return KerasTensor(
-            output_shape, dtype=output_dtype, sparse=output_sparse
-        )
+        return KerasTensor(output_shape, dtype=output_dtype)
 
 
 @keras_export(["keras.ops.mod", "keras.ops.numpy.mod"])
@@ -5972,10 +5967,7 @@ class FloorDivide(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        x1_sparse = getattr(x1, "sparse", False)
-        x2_sparse = getattr(x2, "sparse", False)
-        output_sparse = x1_sparse and not x2_sparse
-        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
+        return KerasTensor(output_shape, dtype=x1.dtype)
 
 
 @keras_export(["keras.ops.floor_divide", "keras.ops.numpy.floor_divide"])

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4082,6 +4082,7 @@ class SparseTest(testing.TestCase, parameterized.TestCase):
         "cos",
         "cosh",
         "exp",
+        "isfinite",
         "log",
         "log10",
         "log2",
@@ -4138,10 +4139,8 @@ class SparseTest(testing.TestCase, parameterized.TestCase):
         ("maximum", union_sparseness),
         ("minimum", union_sparseness),
         ("multiply", intersection_sparseness),
-        ("mod", division_sparseness),
         ("divide", division_sparseness),
         ("true_divide", division_sparseness),
-        ("floor_divide", division_sparseness),
     ]
     BINARY_OPS_TESTS = [
         {
@@ -4270,9 +4269,6 @@ class SparseTest(testing.TestCase, parameterized.TestCase):
     def test_binary_correctness_sparse_tensor(
         self, x, y, op_function, op_class, np_op, op_sparseness, dtype
     ):
-        if dtype == "int32" and op_function.__name__ in ("floor_divide", "mod"):
-            self.skipTest(f"{op_function.__name__} does not support integers")
-
         x = backend.cast(x, dtype)
         y = backend.cast(y, dtype)
         expected_result = np_op(
@@ -4294,9 +4290,6 @@ class SparseTest(testing.TestCase, parameterized.TestCase):
     def test_binary_correctness_indexed_slices(
         self, x, y, op_function, op_class, np_op, op_sparseness, dtype
     ):
-        if dtype == "int32" and op_function.__name__ in ("floor_divide", "mod"):
-            self.skipTest(f"{op_function.__name__} does not support integers")
-
         x = backend.cast(x, dtype)
         y = backend.cast(y, dtype)
         expected_result = np_op(


### PR DESCRIPTION
This is in preparation for JAX support of sparse tensors.

Added explicit support for `ops.isfinite`. This op is used by optimizers (`LossScaleOptimizer`) with sparse gradients. Somehow, `tf.isfinite` works out of the box with `tf.IndexedSlices` but this change makes the support explicit.

Removed support for `ops.mod` and `ops.floor_divide`. These ops are not used with sparse tensors in any context right now; support was incomplete with TensorFlow and there is no support for them in JAX for JAXSparse tensors.