### PR TITLE
Update multiprocessing import in py_dataset_adapter.py

### DIFF
--- a/keras/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/trainers/data_adapters/py_dataset_adapter.py
@@ -1,4 +1,4 @@
-import multiprocessing
+import multiprocessing.dummy
 import queue
 import random
 import threading


### PR DESCRIPTION
Multiprocessing import needs to import multiprocessing.dummy.

This has worked up until now due to an import in tensorflow, which will soon no longer be available here.