### PR TITLE
default value for input_shape when include_top is provided has False.

### DIFF
--- a/keras/applications/nasnet.py
+++ b/keras/applications/nasnet.py
@@ -384,6 +384,8 @@ def NASNetMobile(
             "at this time due to an outstanding bug. "
             "If interested, please open a PR."
         )
+    if (include_top == False) and (input_shape == None):
+        input_shape = (224, 224, 3)
     return NASNet(
         input_shape,
         penultimate_filters=1056,


### PR DESCRIPTION
This was the issue raised at the time of `Keras 3 code base` migration from `keras-team/keras-core` to `keras-team/keras`. I was told to recreate the pull request if the issue is not fixed after the migration.

issue was: keras-team/tf-keras#142