### PR TITLE
Return regularization losses in stateless_call.

### DIFF
--- a/keras/layers/layer.py
+++ b/keras/layers/layer.py
@@ -1078,10 +1078,10 @@ class Layer(BackendLayer, Operation):
     def _get_regularization_losses(self):
         weight_regularization_losses = []
         for v in self.trainable_weights:
-            if backend.in_stateless_scope():
-                v = backend.get_stateless_scope().get_current_value(v)
             regularizer = getattr(v, "regularizer", None)
             if regularizer:
+                if backend.in_stateless_scope():
+                    v = backend.get_stateless_scope().get_current_value(v)
                 weight_regularization_losses.append(regularizer(v))
         return weight_regularization_losses
 

--- a/keras/layers/layer.py
+++ b/keras/layers/layer.py
@@ -966,6 +966,8 @@ class Layer(BackendLayer, Operation):
             state_mapping=mapping, collect_losses=return_losses
         ) as scope:
             outputs = self.call(*args, **kwargs)
+            for loss in self._get_regularization_losses():
+                scope.add_loss(loss)
 
         # Gather updated non-trainable variables
         non_trainable_variables = []
@@ -977,9 +979,7 @@ class Layer(BackendLayer, Operation):
                 non_trainable_variables.append(v)
 
         if return_losses:
-            losses = scope.losses[:]
-            losses.extend(self._get_regularization_losses())
-            return outputs, non_trainable_variables, losses
+            return outputs, non_trainable_variables, scope.losses[:]
         return outputs, non_trainable_variables
 
     def compute_output_spec(self, *args, **kwargs):
@@ -1562,4 +1562,3 @@ def is_shape_tuple(s):
 
 def might_have_unbuilt_state(layer):
     return any(not lr.built for lr in layer._layers)
-

--- a/keras/layers/layer.py
+++ b/keras/layers/layer.py
@@ -962,12 +962,13 @@ class Layer(BackendLayer, Operation):
         mapping = list(trainable_mapping) + list(non_trainable_mapping)
 
         # Call in stateless scope
+        losses = None
         with backend.StatelessScope(
             state_mapping=mapping, collect_losses=return_losses
         ) as scope:
             outputs = self.call(*args, **kwargs)
-            for loss in self._get_regularization_losses():
-                scope.add_loss(loss)
+            if return_losses:
+                losses = self.losses
 
         # Gather updated non-trainable variables
         non_trainable_variables = []
@@ -979,7 +980,7 @@ class Layer(BackendLayer, Operation):
                 non_trainable_variables.append(v)
 
         if return_losses:
-            return outputs, non_trainable_variables, scope.losses[:]
+            return outputs, non_trainable_variables, losses
         return outputs, non_trainable_variables
 
     def compute_output_spec(self, *args, **kwargs):

--- a/keras/layers/layer.py
+++ b/keras/layers/layer.py
@@ -1079,10 +1079,11 @@ class Layer(BackendLayer, Operation):
         weight_regularization_losses = []
         for v in self.trainable_weights:
             regularizer = getattr(v, "regularizer", None)
-            if regularizer:
-                if backend.in_stateless_scope():
-                    v = backend.get_stateless_scope().get_current_value(v)
-                weight_regularization_losses.append(regularizer(v))
+            if regularizer is None:
+                continue
+            if backend.in_stateless_scope():
+                v = backend.get_stateless_scope().get_current_value(v)
+            weight_regularization_losses.append(regularizer(v))
         return weight_regularization_losses
 
     @property

--- a/keras/layers/layer_test.py
+++ b/keras/layers/layer_test.py
@@ -581,6 +581,7 @@ class LayerTest(testing.TestCase):
                     shape=(),
                     initializer="zeros",
                     trainable=True,
+                    regularizer="l1",
                 )
                 self.built = True
 
@@ -632,6 +633,7 @@ class LayerTest(testing.TestCase):
             layer1.non_trainable_variables, non_trainable_variables
         ):
             self.assertAllClose(ref_v, v)
+        self.assertLen(losses, 2)
         for ref_loss, loss in zip(layer1.losses, losses):
             self.assertAllClose(ref_loss, loss)
 


### PR DESCRIPTION
Previously, those were not returned with "return_losses=True". In the same line, we now get the regularizer object from the respective module.