### PR TITLE
Adds initial support for an MLX backend

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        backend: [tensorflow, jax, torch, numpy]
+        backend: [tensorflow, jax, torch, numpy, mlx]
     name: Run tests
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/config/mlx/keras.json
+++ b/.github/workflows/config/mlx/keras.json
@@ -1,0 +1,7 @@
+{
+    "floatx": "float32",
+    "epsilon": 1e-07,
+    "backend": "mlx",
+    "image_data_format": "channels_last"
+}
+

--- a/integration_tests/import_test.py
+++ b/integration_tests/import_test.py
@@ -8,6 +8,7 @@ BACKEND_REQ = {
     "tensorflow": "tensorflow",
     "torch": "torch torchvision",
     "jax": "jax jaxlib",
+    "mlx": "mlx",
 }
 
 

--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -387,7 +387,7 @@ def standardize_dtype(dtype):
     if hasattr(dtype, "name"):
         dtype = dtype.name
     elif hasattr(dtype, "__str__") and (
-        "torch" in str(dtype) or "jax.numpy" in str(dtype)
+        "torch" in str(dtype) or "jax.numpy" in str(dtype) or "mlx" in str(dtype)
     ):
         dtype = str(dtype).split(".")[-1]
     elif hasattr(dtype, "__name__"):

--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -387,7 +387,9 @@ def standardize_dtype(dtype):
     if hasattr(dtype, "name"):
         dtype = dtype.name
     elif hasattr(dtype, "__str__") and (
-        "torch" in str(dtype) or "jax.numpy" in str(dtype) or "mlx" in str(dtype)
+        "torch" in str(dtype)
+        or "jax.numpy" in str(dtype)
+        or "mlx" in str(dtype)
     ):
         dtype = str(dtype).split(".")[-1]
     elif hasattr(dtype, "__name__"):

--- a/keras/backend/mlx/__init__.py
+++ b/keras/backend/mlx/__init__.py
@@ -19,3 +19,7 @@ from keras.backend.mlx.core import shape
 from keras.backend.mlx.core import stop_gradient
 from keras.backend.mlx.core import to_mlx_dtype
 from keras.backend.mlx.core import vectorized_map
+from keras.backend.mlx.rnn import cudnn_ok
+from keras.backend.mlx.rnn import gru
+from keras.backend.mlx.rnn import lstm
+from keras.backend.mlx.rnn import rnn

--- a/keras/backend/mlx/__init__.py
+++ b/keras/backend/mlx/__init__.py
@@ -1,0 +1,16 @@
+"""MLX backend APIs."""
+
+from keras.backend.mlx import core
+from keras.backend.mlx import random
+from keras.backend.mlx.core import SUPPORTS_SPARSE_TENSORS
+from keras.backend.mlx.core import Variable
+from keras.backend.mlx.core import cast
+from keras.backend.mlx.core import compute_output_spec
+from keras.backend.mlx.core import cond
+from keras.backend.mlx.core import convert_to_numpy
+from keras.backend.mlx.core import convert_to_tensor
+from keras.backend.mlx.core import is_tensor
+from keras.backend.mlx.core import scatter
+from keras.backend.mlx.core import shape
+from keras.backend.mlx.core import stop_gradient
+from keras.backend.mlx.core import vectorized_map

--- a/keras/backend/mlx/__init__.py
+++ b/keras/backend/mlx/__init__.py
@@ -1,6 +1,7 @@
 """MLX backend APIs."""
 
 from keras.backend.mlx import core
+from keras.backend.mlx import nn
 from keras.backend.mlx import numpy
 from keras.backend.mlx import random
 from keras.backend.mlx.core import SUPPORTS_SPARSE_TENSORS

--- a/keras/backend/mlx/__init__.py
+++ b/keras/backend/mlx/__init__.py
@@ -1,6 +1,8 @@
 """MLX backend APIs."""
 
 from keras.backend.mlx import core
+from keras.backend.mlx import image
+from keras.backend.mlx import math
 from keras.backend.mlx import nn
 from keras.backend.mlx import numpy
 from keras.backend.mlx import random

--- a/keras/backend/mlx/__init__.py
+++ b/keras/backend/mlx/__init__.py
@@ -1,6 +1,7 @@
 """MLX backend APIs."""
 
 from keras.backend.mlx import core
+from keras.backend.mlx import numpy
 from keras.backend.mlx import random
 from keras.backend.mlx.core import SUPPORTS_SPARSE_TENSORS
 from keras.backend.mlx.core import Variable
@@ -13,4 +14,5 @@ from keras.backend.mlx.core import is_tensor
 from keras.backend.mlx.core import scatter
 from keras.backend.mlx.core import shape
 from keras.backend.mlx.core import stop_gradient
+from keras.backend.mlx.core import to_mlx_dtype
 from keras.backend.mlx.core import vectorized_map

--- a/keras/backend/mlx/core.py
+++ b/keras/backend/mlx/core.py
@@ -83,6 +83,7 @@ def convert_to_tensor(x, dtype=None, sparse=None):
         return mx.array(x, dtype=mlx_dtype)
 
     if isinstance(x, list):
+
         def to_scalar_list(x):
             if isinstance(x, list):
                 return [to_scalar_list(xi) for xi in x]
@@ -93,6 +94,7 @@ def convert_to_tensor(x, dtype=None, sparse=None):
                     return x.tolist()
             else:
                 return x
+
         return mx.array(to_scalar_list(x), dtype=mlx_dtype)
 
     return mx.array(x, dtype=mlx_dtype)
@@ -254,6 +256,7 @@ def fori_loop(lower, upper, body_fun, init_val):
     for i in range(lower, upper):
         val = body_fun(i, val)
     return val
+
 
 def stop_gradient(variable):
     return mx.stop_gradient(variable)

--- a/keras/backend/mlx/core.py
+++ b/keras/backend/mlx/core.py
@@ -80,6 +80,7 @@ def convert_to_tensor(x, dtype=None, sparse=None):
     if isinstance(x, np.ndarray):
         if x.dtype == np.int64:
             x = x.astype(np.int32)
+        x = x.astype(standardize_dtype(x.dtype))
         return mx.array(x, dtype=mlx_dtype)
 
     if isinstance(x, list):
@@ -186,7 +187,6 @@ def vectorized_map(function, elements):
 
 
 def scatter(indices, values, shape):
-    # TODO: Expose mlx scatter to make this more efficient
     indices = convert_to_tensor(indices)
     values = convert_to_tensor(values)
     zeros = mx.zeros(shape, dtype=values.dtype)

--- a/keras/backend/mlx/core.py
+++ b/keras/backend/mlx/core.py
@@ -3,12 +3,9 @@ import numpy as np
 import tree
 
 from keras.backend.common import KerasVariable
-from keras.backend.common import global_state
 from keras.backend.common import standardize_dtype
-from keras.backend.common.dtypes import result_type
 from keras.backend.common.keras_tensor import KerasTensor
 from keras.backend.common.stateless_scope import StatelessScope
-from keras.backend.config import floatx
 from keras.utils.nest import pack_sequence_as
 
 SUPPORTS_SPARSE_TENSORS = False
@@ -99,7 +96,7 @@ def convert_to_tensor(x, dtype=None, sparse=None):
 
 
 def convert_to_tensors(*xs):
-    ys = [None]*len(xs)
+    ys = [None] * len(xs)
     dtype = None
     for i, x in enumerate(xs):
         if not isinstance(x, (int, float, bool)):

--- a/keras/backend/mlx/core.py
+++ b/keras/backend/mlx/core.py
@@ -1,5 +1,8 @@
 import mlx.core as mx
 
+import numpy as np
+import tree
+
 from keras.backend.common import KerasVariable
 from keras.backend.common import global_state
 from keras.backend.common import standardize_dtype
@@ -22,7 +25,7 @@ MLX_DTYPES = {
     "int8": mx.int8,
     "int16": mx.int16,
     "int32": mx.int32,
-    "int64": mx.int64,
+    "int64": mx.int32,  # we only support int64 on cpu
     "bfloat16": mx.bfloat16,
     "bool": mx.bool_,
 }
@@ -48,7 +51,11 @@ class Variable(KerasVariable):
         return convert_to_tensor(value, dtype=dtype)
 
     def __mlx_array__(self):
-        return self._value
+        return self.value
+
+    @property
+    def shape(self):
+        return list(self._shape)
 
     def __array__(self, dtype=None):
         value = convert_to_numpy(self._value)
@@ -105,7 +112,7 @@ def compute_output_spec(fn, *args, **kwargs):
                 for i, e in enumerate(shape):
                     if e is None:
                         shape[i] = fill_value
-            return mlx.ones(shape, dtype=MLX_DTYPES[x.dtype])
+            return mx.ones(shape, dtype=MLX_DTYPES[x.dtype])
         return x
 
     def convert_mlx_to_keras_tensor(x):

--- a/keras/backend/mlx/core.py
+++ b/keras/backend/mlx/core.py
@@ -24,10 +24,11 @@ MLX_DTYPES = {
     "uint8": mx.uint8,
     "uint16": mx.uint16,
     "uint32": mx.uint32,
+    "uint64": mx.uint64,  # some things may not be well supported
     "int8": mx.int8,
     "int16": mx.int16,
     "int32": mx.int32,
-    "int64": mx.int32,  # we only support int64 on cpu
+    "int64": mx.int64,  # some things may not be well supported
     "bfloat16": mx.bfloat16,
     "bool": mx.bool_,
 }

--- a/keras/backend/mlx/core.py
+++ b/keras/backend/mlx/core.py
@@ -73,9 +73,12 @@ def convert_to_tensor(x, dtype=None, sparse=None):
             return x
         return x.astype(mlx_dtype)
     if isinstance(x, Variable):
-        if dtype and dtype != x.dtype:
+        if dtype and standardize_dtype(dtype) != x.dtype:
             return x.value.astype(mlx_dtype)
         return x.value
+    if isinstance(x, np.ndarray):
+        if x.dtype == np.int64:
+            x = x.astype(np.int32)
     return mx.array(x, dtype=mlx_dtype)
 
 

--- a/keras/backend/mlx/core.py
+++ b/keras/backend/mlx/core.py
@@ -11,6 +11,10 @@ from keras.backend.common.stateless_scope import StatelessScope
 from keras.backend.config import floatx
 from keras.utils.nest import pack_sequence_as
 
+# Monkey patch mx.array.shape to return tuples
+mx.array._og_shape = mx.array.shape
+mx.array.shape = property(lambda a: tuple(a._og_shape))
+
 SUPPORTS_SPARSE_TENSORS = False
 
 MLX_DTYPES = {
@@ -50,10 +54,6 @@ class Variable(KerasVariable):
 
     def __mlx_array__(self):
         return self.value
-
-    @property
-    def shape(self):
-        return list(self._shape)
 
     def __array__(self, dtype=None):
         value = convert_to_numpy(self._value)

--- a/keras/backend/mlx/core.py
+++ b/keras/backend/mlx/core.py
@@ -47,6 +47,9 @@ class Variable(KerasVariable):
     def _convert_to_tensor(self, value, dtype=None):
         return convert_to_tensor(value, dtype=dtype)
 
+    def __mlx_array__(self):
+        return self._value
+
     def __array__(self, dtype=None):
         value = convert_to_numpy(self._value)
         if dtype:

--- a/keras/backend/mlx/core.py
+++ b/keras/backend/mlx/core.py
@@ -1,0 +1,234 @@
+import mlx.core as mx
+
+from keras.backend.common import KerasVariable
+from keras.backend.common import global_state
+from keras.backend.common import standardize_dtype
+from keras.backend.common.dtypes import result_type
+from keras.backend.common.keras_tensor import KerasTensor
+from keras.backend.common.stateless_scope import StatelessScope
+from keras.backend.config import floatx
+from keras.utils.nest import pack_sequence_as
+
+
+SUPPORTS_SPARSE_TENSORS = False
+
+MLX_DTYPES = {
+    "float16": mx.float16,
+    "float32": mx.float32,
+    "float64": None,  # mlx does not support float64
+    "uint8": mx.uint8,
+    "uint16": mx.uint16,
+    "uint32": mx.uint32,
+    "int8": mx.int8,
+    "int16": mx.int16,
+    "int32": mx.int32,
+    "int64": mx.int64,
+    "bfloat16": mx.bfloat16,
+    "bool": mx.bool_,
+}
+
+
+def to_mlx_dtype(dtype):
+    if isinstance(dtype, mx.Dtype):
+        return dtype
+    standardized_dtype = MLX_DTYPES.get(standardize_dtype(dtype), None)
+    if standardized_dtype is None:
+        raise ValueError(f"Unsupported dtype for MLX: {dtype}")
+    return standardized_dtype
+
+
+class Variable(KerasVariable):
+    def _initialize(self, value):
+        self._value = convert_to_tensor(value, dtype=self._dtype)
+
+    def _direct_assign(self, value):
+        self._value = value
+
+    def _convert_to_tensor(self, value, dtype=None):
+        return convert_to_tensor(value, dtype=dtype)
+
+    def __array__(self, dtype=None):
+        value = convert_to_numpy(self._value)
+        if dtype:
+            return value.astype(dtype)
+        return value
+
+
+def convert_to_tensor(x, dtype=None, sparse=None):
+    if sparse:
+        raise ValueError("`sparse=True` is not supported with mlx backend")
+    mlx_dtype = to_mlx_dtype(dtype) if dtype is not None else None
+    if is_tensor(x):
+        if dtype is None:
+            return x
+        return x.astype(mlx_dtype)
+    if isinstance(x, Variable):
+        if dtype and dtype != x.dtype:
+            return x.value.astype(mlx_dtype)
+        return x.value
+    return mx.array(x, dtype=mlx_dtype)
+
+
+def convert_to_numpy(x):
+    # Performs a copy. If we want 0-copy we can pass copy=False
+    return np.array(x)
+
+
+def is_tensor(x):
+    return isinstance(x, mx.array)
+
+
+def shape(x):
+    return tuple(x.shape)
+
+
+def cast(x, dtype):
+    return convert_to_tensor(x, dtype=dtype)
+
+
+# Shape / dtype inference util
+def compute_output_spec(fn, *args, **kwargs):
+    def has_none_shape(x):
+        """Check for if a `KerasTensor` has dynamic shape."""
+        if isinstance(x, KerasTensor):
+            return None in x.shape
+        return False
+
+    def convert_keras_tensor_to_mlx(x, fill_value=None):
+        """Convert `KerasTensor`s to `mlx.array`s."""
+        if isinstance(x, KerasTensor):
+            shape = list(x.shape)
+            if fill_value:
+                for i, e in enumerate(shape):
+                    if e is None:
+                        shape[i] = fill_value
+            return mlx.ones(shape, dtype=MLX_DTYPES[x.dtype])
+        return x
+
+    def convert_mlx_to_keras_tensor(x):
+        """Convert `mlx.array`s to `KerasTensor`s."""
+        if is_tensor(x):
+            return KerasTensor(x.shape, standardize_dtype(x.dtype))
+        return x
+
+    def symbolic_call(fn, args, kwargs, fill_value):
+        """Call `fn` to infer output shape and dtype."""
+        arr_args, arr_kwargs = tree.map_structure(
+            lambda x: convert_keras_tensor_to_mlx(x, fill_value),
+            (args, kwargs),
+        )
+        return fn(*arr_args, **arr_kwargs)
+
+    with StatelessScope():
+        outputs = symbolic_call(fn, args, kwargs, fill_value=83)
+
+        none_in_shape = any(map(has_none_shape, tree.flatten((args, kwargs))))
+        if none_in_shape:
+            outputs_1 = outputs
+            outputs_2 = symbolic_call(fn, args, kwargs, fill_value=89)
+
+            flat_out_1 = tree.flatten(outputs_1)
+            flat_out_2 = tree.flatten(outputs_2)
+
+            flat_out = []
+            for x1, x2 in zip(flat_out_1, flat_out_2):
+                shape = list(x1.shape)
+                for i, e in enumerate(x2.shape):
+                    if e != shape[i]:
+                        shape[i] = None
+                flat_out.append(KerasTensor(shape, standardize_dtype(x1.dtype)))
+            outputs = pack_sequence_as(outputs_1, flat_out)
+
+        output_spec = tree.map_structure(convert_mlx_to_keras_tensor, outputs)
+    return output_spec
+
+
+def cond(pred, true_fn, false_fn):
+    # TODO: How should we avoid evaluating pred in case we are tracing?
+    if pred:
+        return true_fn()
+    return false_fn()
+
+
+def vectorized_map(function, elements):
+    return mx.vmap(function)(elements)
+
+
+def scatter(indices, values, shape):
+    # TODO: Expose mlx scatter to make this more efficient
+    indices = convert_to_tensor(indices)
+    values = convert_to_tensor(values)
+    zeros = mx.zeros(shape, dtype=values.dtype)
+    indices = tuple(indices[..., i] for i in range(indices.shape[-1]))
+    zeros[indices] = values
+
+    return zeros
+
+
+def scatter_update(inputs, indices, updates):
+    inputs = convert_to_tensor(inputs)
+    indices = convert_to_tensor(indices)
+    updates = convert_to_tensor(updates)
+    indices = tuple(indices[..., i] for i in range(indices.shape[-1]))
+    inputs[indices] = updates
+
+    return inputs
+
+
+def slice(inputs, start_indices, shape):
+    inputs = convert_to_tensor(inputs)
+
+    python_slice = __builtins__["slice"]
+    slices = tuple(
+        python_slice(start_index, start_index + length)
+        for start_index, length in zip(start_indices, shape)
+    )
+    return inputs[slices]
+
+
+def slice_update(inputs, start_indices, updates):
+    inputs = convert_to_tensor(inputs)
+    updates = convert_to_tensor(updates)
+
+    python_slice = __builtins__["slice"]
+    slices = (
+        python_slice(start_index, start_index + update_length)
+        for start_index, update_length in zip(start_indices, updates.shape)
+    )
+    inputs[slices] = updates
+    return inputs
+
+
+def while_loop(
+    cond,
+    body,
+    loop_vars,
+    maximum_iterations=None,
+):
+    # TODO: How should we avoid evaluating cond when tracing?
+    current_iter = 0
+    iteration_check = (
+        lambda iter: maximum_iterations is None or iter < maximum_iterations
+    )
+    loop_vars = tuple([convert_to_tensor(v) for v in loop_vars])
+    while cond(*loop_vars) and iteration_check(current_iter):
+        loop_vars = body(*loop_vars)
+        if not isinstance(loop_vars, (list, tuple)):
+            loop_vars = (loop_vars,)
+        loop_vars = tuple(loop_vars)
+        current_iter += 1
+    return loop_vars
+
+
+def fori_loop(lower, upper, body_fun, init_val):
+    val = init_val
+    for i in range(lower, upper):
+        val = body_fun(i, val)
+    return val
+
+def stop_gradient(variable):
+    return mx.stop_gradient(variable)
+
+
+def unstack(x, num=None, axis=0):
+    return x.split(axis=axis)

--- a/keras/backend/mlx/core.py
+++ b/keras/backend/mlx/core.py
@@ -1,5 +1,4 @@
 import mlx.core as mx
-
 import numpy as np
 import tree
 
@@ -11,7 +10,6 @@ from keras.backend.common.keras_tensor import KerasTensor
 from keras.backend.common.stateless_scope import StatelessScope
 from keras.backend.config import floatx
 from keras.utils.nest import pack_sequence_as
-
 
 SUPPORTS_SPARSE_TENSORS = False
 

--- a/keras/backend/mlx/image.py
+++ b/keras/backend/mlx/image.py
@@ -89,7 +89,8 @@ def _extract_coordinates(
     empty_slices = (slice(None),) * start_axis
     for items in itertools.product(*indices):
         indices, validities, weights = zip(*items)
-        contribution = src[*empty_slices, *indices]
+        index = empty_slices + indices
+        contribution = src[index]
 
         # Check if we need to replace some with fill value
         if check_validity:

--- a/keras/backend/mlx/image.py
+++ b/keras/backend/mlx/image.py
@@ -1,0 +1,324 @@
+import functools
+import itertools
+import operator
+
+import mlx.core as mx
+
+from keras.backend.mlx.core import convert_to_tensor
+
+
+def _mirror_index_fixer(index, size):
+    s = size - 1  # Half-wavelength of triangular wave
+    # Scaled, integer-valued version of the triangular wave |x - round(x)|
+    return mx.abs((index + s) % (2 * s) - s)
+
+
+def _reflect_index_fixer(index, size):
+    return mx.floor_divide(
+        _mirror_index_fixer(2 * index + 1, 2 * size + 1) - 1, 2
+    )
+
+
+_INDEX_FIXERS = {
+    # we need to take care of out-of-bound indices in torch
+    "constant": lambda index, size: mx.clip(index, 0, size - 1),
+    "nearest": lambda index, size: mx.clip(index, 0, size - 1),
+    "wrap": lambda index, size: index % size,
+    "mirror": _mirror_index_fixer,
+    "reflect": _reflect_index_fixer,
+}
+
+
+def _is_integer(a):
+    # Should we add bool?
+    return a.dtype in (
+        mx.int32,
+        mx.uint32,
+        mx.int64,
+        mx.uint64,
+        mx.int16,
+        mx.uint16,
+        mx.int8,
+        mx.uint8,
+    )
+
+
+def _nearest_indices_and_weights(coordinate):
+    coordinate = coordinate if _is_integer(coordinate) else mx.round(coordinate)
+    index = coordinate.astype(mx.int32)
+    return [(index, 1)]
+
+
+def _linear_indices_and_weights(coordinate):
+    lower = mx.floor(coordinate)
+    upper_weight = coordinate - lower
+    lower_weight = 1 - upper_weight
+    index = lower.astype(mx.int32)
+    return [(index, lower_weight), (index + 1, upper_weight)]
+
+
+def _extract_coordinates(
+    src,
+    coordinates,
+    interpolation_function,
+    index_fixer,
+    fill_value=0,
+    check_validity=True,
+    start_axis=0,
+):
+    def _expand(x):
+        if not isinstance(x, mx.array):
+            return x
+        return x.reshape(*x.shape, *([1] * (src.ndim - x.ndim)))
+
+    indices = []
+    for ci, size in zip(coordinates, src.shape[start_axis:]):
+        indices.append(
+            [
+                (
+                    index_fixer(index, size),
+                    _expand(mx.logical_and((0 <= index), (index < size))),
+                    _expand(weight),
+                )
+                for index, weight in interpolation_function(ci)
+            ]
+        )
+
+    outputs = []
+    empty_slices = (slice(None),) * start_axis
+    for items in itertools.product(*indices):
+        indices, validities, weights = zip(*items)
+        contribution = src[*empty_slices, *indices]
+
+        # Check if we need to replace some with fill value
+        if check_validity:
+            all_valid = functools.reduce(operator.and_, validities)
+            contribution = mx.where(all_valid, contribution, fill_value)
+
+        # Multiply with the weight if it isn't 1.0
+        weight = functools.reduce(operator.mul, weights)
+        if not (isinstance(weight, (float, int)) and weight == 1):
+            contribution = contribution * weight
+
+        outputs.append(contribution)
+
+    result = functools.reduce(operator.add, outputs)
+    if _is_integer(src) and not _is_integer(result):
+        result = mx.round(result)
+
+    return result.astype(src.dtype)
+
+
+def map_coordinates(
+    input, coordinates, order, fill_mode="constant", fill_value=0.0
+):
+    input_arr = convert_to_tensor(input)
+    coordinate_arrs = [convert_to_tensor(c) for c in coordinates]
+    # skip tensor creation as possible
+    if isinstance(fill_value, (int, float)) and _is_integer(input_arr):
+        fill_value = int(fill_value)
+
+    if len(coordinates) != len(input_arr.shape):
+        raise ValueError(
+            "coordinates must be a sequence of length input.shape, but "
+            f"{len(coordinates)} != {len(input_arr.shape)}"
+        )
+
+    index_fixer = _INDEX_FIXERS.get(fill_mode)
+    if index_fixer is None:
+        raise ValueError(
+            "Invalid value for argument `fill_mode`. Expected one of "
+            f"{set(_INDEX_FIXERS.keys())}. Received: fill_mode={fill_mode}"
+        )
+
+    if order == 0:
+        interp_fun = _nearest_indices_and_weights
+    elif order == 1:
+        interp_fun = _linear_indices_and_weights
+    else:
+        raise NotImplementedError("map_coordinates currently requires order<=1")
+
+    return _extract_coordinates(
+        src=input,
+        coordinates=coordinate_arrs,
+        interpolation_function=interp_fun,
+        index_fixer=index_fixer,
+        fill_value=fill_value,
+        check_validity=fill_mode == "constant",
+        start_axis=0,
+    )
+
+
+AFFINE_TRANSFORM_INTERPOLATIONS = {
+    "nearest": _nearest_indices_and_weights,
+    "bilinear": _linear_indices_and_weights,
+}
+AFFINE_TRANSFORM_FILL_MODES = {
+    "constant",
+    "nearest",
+    "wrap",
+    "mirror",
+    "reflect",
+}
+
+
+def _affine_transform(
+    src,
+    transform,
+    target_size,
+    interpolation_function,
+    index_fixer,
+    fill_value=0,
+    check_validity=True,
+):
+    y_target = mx.arange(target_size[0]).reshape(1, -1, 1)
+    x_target = mx.arange(target_size[1]).reshape(1, 1, -1)
+    a0, a1, a2, b0, b1, b2, c0, c1 = [
+        t.reshape(-1, 1, 1)
+        for t in transform.T.reshape(-1).reshape(8, -1).split(8)
+    ]
+    # TODO: Should we ignore c0 and c1 as the docs say they are only used in
+    #       the tf backend?
+    k = c0 * x_target + c1 * y_target + 1
+    x_src = (a0 * x_target + a1 * y_target + a2) / k
+    y_src = (b0 * x_target + b1 * y_target + b2) / k
+
+    # not batched
+    if src.ndim == 3:
+        indices = [y_src.squeeze(0), x_src.squeeze(0)]
+
+    # batched
+    else:
+        indices = [
+            mx.arange(len(src)).reshape(-1, 1, 1),
+            y_src,
+            x_src,
+        ]
+
+    return _extract_coordinates(
+        src=src,
+        coordinates=indices,
+        interpolation_function=interpolation_function,
+        index_fixer=index_fixer,
+        fill_value=fill_value,
+        check_validity=check_validity,
+        start_axis=0,
+    )
+
+
+def affine_transform(
+    image,
+    transform,
+    interpolation="bilinear",
+    fill_mode="constant",
+    fill_value=0,
+    data_format="channels_last",
+):
+    if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS.keys():
+        raise ValueError(
+            "Invalid value for argument `interpolation`. Expected of one "
+            f"{set(AFFINE_TRANSFORM_INTERPOLATIONS.keys())}. Received: "
+            f"interpolation={interpolation}"
+        )
+    if fill_mode not in AFFINE_TRANSFORM_FILL_MODES:
+        raise ValueError(
+            "Invalid value for argument `fill_mode`. Expected of one "
+            f"{AFFINE_TRANSFORM_FILL_MODES}. Received: fill_mode={fill_mode}"
+        )
+
+    image = convert_to_tensor(image)
+    transform = convert_to_tensor(transform)
+
+    if image.ndim not in (3, 4):
+        raise ValueError(
+            "Invalid image rank: expected rank 3 (single image) "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"image.shape={image.shape}"
+        )
+    if transform.ndim not in (1, 2):
+        raise ValueError(
+            "Invalid transform rank: expected rank 1 (single transform) "
+            "or rank 2 (batch of transforms). Received input with shape: "
+            f"transform.shape={transform.shape}"
+        )
+
+    if data_format == "channels_first":
+        image = (
+            image.transpose(0, 2, 3, 1)
+            if image.ndim == 4
+            else image.transpose(1, 2, 0)
+        )
+
+    result = _affine_transform(
+        src=image,
+        transform=transform,
+        target_size=image.shape[:2] if image.ndim == 3 else image.shape[1:3],
+        interpolation_function=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
+        index_fixer=_INDEX_FIXERS[fill_mode],
+        fill_value=fill_value,
+        check_validity=fill_mode == "constant",
+    )
+
+    if data_format == "channels_first":
+        result = (
+            result.transpose(0, 3, 1, 2)
+            if image.ndim == 4
+            else image.transpose(2, 0, 1)
+        )
+
+    return result
+
+
+def resize(
+    image,
+    size,
+    interpolation="bilinear",
+    antialias=False,
+    data_format="channels_last",
+):
+    if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS.keys():
+        raise ValueError(
+            "Invalid value for argument `interpolation`. Expected of one "
+            f"{set(AFFINE_TRANSFORM_INTERPOLATIONS.keys())}. Received: "
+            f"interpolation={interpolation}"
+        )
+
+    size = tuple(size)
+    image = convert_to_tensor(image)
+
+    if image.ndim not in (3, 4):
+        raise ValueError(
+            "Invalid input rank: expected rank 3 (single image) "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"image.shape={image.shape}"
+        )
+
+    # Change to channels_last
+    if data_format == "channels_first":
+        image = (
+            image.transpose(0, 2, 3, 1)
+            if image.ndim == 4
+            else image.transpose(1, 2, 0)
+        )
+
+    *_, H, W, C = image.shape
+    transform = mx.array([H/size[0], 0, 0, 0, W/size[1], 0, 0, 0])
+    result = _affine_transform(
+        src=image,
+        transform=transform,
+        target_size=size,
+        interpolation_function=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
+        index_fixer=_INDEX_FIXERS["constant"],
+        fill_value=0,
+        check_validity=False
+    )
+
+    # Change back to channels_first
+    if data_format == "channels_first":
+        result = (
+            result.transpose(0, 3, 1, 2)
+            if image.ndim == 4
+            else image.transpose(2, 0, 1)
+        )
+
+    return result

--- a/keras/backend/mlx/image.py
+++ b/keras/backend/mlx/image.py
@@ -277,8 +277,10 @@ def resize(
     antialias=False,
     data_format="channels_last",
 ):
-    if antialias == True:
-        raise NotImplementedError("Antialiasing not implemented for the MLX backend")
+    if antialias:
+        raise NotImplementedError(
+            "Antialiasing not implemented for the MLX backend"
+        )
 
     if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS.keys():
         raise ValueError(
@@ -306,7 +308,7 @@ def resize(
         )
 
     *_, H, W, C = image.shape
-    transform = mx.array([H/size[0], 0, 0, 0, W/size[1], 0, 0, 0])
+    transform = mx.array([H / size[0], 0, 0, 0, W / size[1], 0, 0, 0])
     result = _affine_transform(
         src=image,
         transform=transform,
@@ -314,7 +316,7 @@ def resize(
         interpolation_function=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
         index_fixer=_INDEX_FIXERS["constant"],
         fill_value=0,
-        check_validity=False
+        check_validity=False,
     )
 
     # Change back to channels_first

--- a/keras/backend/mlx/image.py
+++ b/keras/backend/mlx/image.py
@@ -5,6 +5,7 @@ import operator
 import mlx.core as mx
 
 from keras.backend.mlx.core import convert_to_tensor
+from keras.backend.mlx.core import to_mlx_dtype
 
 
 def _mirror_index_fixer(index, size):
@@ -31,7 +32,7 @@ _INDEX_FIXERS = {
 
 def _is_integer(a):
     # Should we add bool?
-    return a.dtype in (
+    return to_mlx_dtype(a.dtype) in (
         mx.int32,
         mx.uint32,
         mx.int64,
@@ -139,7 +140,7 @@ def map_coordinates(
         raise NotImplementedError("map_coordinates currently requires order<=1")
 
     return _extract_coordinates(
-        src=input,
+        src=input_arr,
         coordinates=coordinate_arrs,
         interpolation_function=interp_fun,
         index_fixer=index_fixer,
@@ -263,7 +264,7 @@ def affine_transform(
         result = (
             result.transpose(0, 3, 1, 2)
             if image.ndim == 4
-            else image.transpose(2, 0, 1)
+            else result.transpose(2, 0, 1)
         )
 
     return result
@@ -276,6 +277,9 @@ def resize(
     antialias=False,
     data_format="channels_last",
 ):
+    if antialias == True:
+        raise NotImplementedError("Antialiasing not implemented for the MLX backend")
+
     if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS.keys():
         raise ValueError(
             "Invalid value for argument `interpolation`. Expected of one "
@@ -318,7 +322,7 @@ def resize(
         result = (
             result.transpose(0, 3, 1, 2)
             if image.ndim == 4
-            else image.transpose(2, 0, 1)
+            else result.transpose(2, 0, 1)
         )
 
     return result

--- a/keras/backend/mlx/layer.py
+++ b/keras/backend/mlx/layer.py
@@ -1,0 +1,2 @@
+class MLXLayer:
+    pass

--- a/keras/backend/mlx/math.py
+++ b/keras/backend/mlx/math.py
@@ -1,0 +1,98 @@
+import math
+
+import mlx.core as mx
+
+from keras.backend.jax.core import convert_to_tensor
+
+
+def segment_sum(data, segment_ids, num_segments=None, sorted=False):
+    raise NotImplementedError("segment_sum is not implemented for mlx")
+
+
+def segment_max(data, segment_ids, num_segments=None, sorted=False):
+    raise NotImplementedError("segment_max is not implemented for mlx")
+
+
+def top_k(x, k, sorted=True):
+    x = convert_to_tensor(x)
+    indices = mx.argpartition(mx.negative(x), k, axis=-1)[..., :k]
+    values = mx.take_along_axis(x, indices, axis=-1)
+    return values, indices
+
+
+def in_top_k(targets, predictions, k):
+    targets = convert_to_tensor(targets)
+    predictions = convert_to_tensor(predictions)
+    targets = targets[..., None]
+    topk_values = top_k(predictions, k)[0]
+    targets_values = mx.take_along_axis(predictions, targets, axis=-1)
+    mask = targets_values >= topk_values
+    return mx.any(mask, axis=-1)
+
+
+def logsumexp(x, axis=None, keepdims=False):
+    return mx.logsumexp(x, axis, keepdims)
+
+
+def qr(x, mode="reduced"):
+    raise NotImplementedError("QR decomposition not supported in mlx yet")
+
+
+def extract_sequences(x, sequence_length, sequence_stride):
+    x = convert_to_tensor(x)
+
+    *batch_shape, signal_length = x.shape
+    frames = (signal_length - sequence_length) // sequence_stride + 1
+    N = math.prod(batch_shape)
+    x = mx.as_strided(
+        x,
+        shape=(N, frames, sequence_length),
+        strides=(signal_length, sequence_stride, 1),
+    )
+    return x.reshape(*batch_shape, frames, sequence_length)
+
+
+def fft(x):
+    raise NotImplementedError("fft not yet implemented in mlx")
+
+
+def fft2(x):
+    raise NotImplementedError("fft not yet implemented in mlx")
+
+
+def rfft(x, fft_length=None):
+    raise NotImplementedError("fft not yet implemented in mlx")
+
+
+def irfft(x, fft_length=None):
+    raise NotImplementedError("fft not yet implemented in mlx")
+
+
+def stft(
+    x, sequence_length, sequence_stride, fft_length, window="hann", center=True
+):
+    raise NotImplementedError("fft not yet implemented in mlx")
+
+
+def istft(
+    x,
+    sequence_length,
+    sequence_stride,
+    fft_length,
+    length=None,
+    window="hann",
+    center=True,
+):
+    raise NotImplementedError("fft not yet implemented in mlx")
+
+
+def rsqrt(x):
+    return mx.rsqrt(x)
+
+
+def erf(x):
+    return mx.erf(x)
+
+
+def solve(a, b):
+    raise NotImplementedError("Linear system solving not yet implemented in mlx")

--- a/keras/backend/mlx/math.py
+++ b/keras/backend/mlx/math.py
@@ -95,4 +95,6 @@ def erf(x):
 
 
 def solve(a, b):
-    raise NotImplementedError("Linear system solving not yet implemented in mlx")
+    raise NotImplementedError(
+        "Linear system solving not yet implemented in mlx"
+    )

--- a/keras/backend/mlx/math.py
+++ b/keras/backend/mlx/math.py
@@ -2,7 +2,7 @@ import math
 
 import mlx.core as mx
 
-from keras.backend.jax.core import convert_to_tensor
+from keras.backend.mlx.core import convert_to_tensor
 
 
 def segment_sum(data, segment_ids, num_segments=None, sorted=False):

--- a/keras/backend/mlx/nn.py
+++ b/keras/backend/mlx/nn.py
@@ -266,7 +266,7 @@ def binary_crossentropy(target, output, from_logits=False):
         return nn.binary_cross_entropy(output, target, reduction="none")
     else:
         output = mx.minimum(mx.maximum(output, epsilon()), 1 - epsilon())
-        return -targets * mx.log(output) - (1 - targets) * mx.log(1 - output)
+        return -target * mx.log(output) - (1 - target) * mx.log(1 - output)
 
 
 def moments(x, axes, keepdims=False, synchronized=False):

--- a/keras/backend/mlx/nn.py
+++ b/keras/backend/mlx/nn.py
@@ -1,0 +1,48 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from keras.backend.mlx.core import convert_to_tensor
+from keras.backend.mlx.numpy import clip
+from keras.backend.config import epsilon
+
+
+def relu(x):
+    x = convert_to_tensor(x)
+    return nn.relu(x)
+
+
+def sigmoid(x):
+    x = convert_to_tensor(x)
+    return mx.sigmoid(x)
+
+
+def softmax(x, axis=-1):
+    x = convert_to_tensor(x)
+    return mx.softmax(x, axis=axis)
+
+
+def categorical_crossentropy(target, output, from_logits=False, axis=-1):
+    target = convert_to_tensor(target)
+    output = convert_to_tensor(output)
+
+    if target.shape != output.shape:
+        raise ValueError(
+            "Arguments `target` and `output` must have the same shape. "
+            "Received: "
+            f"target.shape={target.shape}, output.shape={output.shape}"
+        )
+    if len(target.shape) < 1:
+        raise ValueError(
+            "Arguments `target` and `output` must be at least rank 1. "
+            "Received: "
+            f"target.shape={target.shape}, output.shape={output.shape}"
+        )
+
+    if from_logits:
+        log_prob = output - mx.logsumexp(output, axis=axis)
+    else:
+        output = output / output.sum(axis=axis, keepdims=True)
+        output = clip(output, epsilon(), 1-epsilon())
+        log_prob = mx.log(output)
+
+    return -(target * log_prob).sum(axis=axis)

--- a/keras/backend/mlx/nn.py
+++ b/keras/backend/mlx/nn.py
@@ -1,8 +1,9 @@
 import mlx.core as mx
 import mlx.nn as nn
 
+from keras.backend import standardize_dtype
 from keras.backend.config import epsilon
-from keras.backend.mlx.core import convert_to_tensor
+from keras.backend.mlx.core import convert_to_tensor, to_mlx_dtype
 from keras.backend.mlx.numpy import clip
 
 
@@ -11,14 +12,166 @@ def relu(x):
     return nn.relu(x)
 
 
+def relu6(x):
+    x = convert_to_tensor(x)
+    return nn.relu6(x)
+
+
 def sigmoid(x):
     x = convert_to_tensor(x)
     return mx.sigmoid(x)
 
 
+def tanh(x):
+    x = convert_to_tensor(x)
+    return mx.tanh(x)
+
+
+def softplus(x):
+    x = convert_to_tensor(x)
+    return nn.softplus(x)
+
+
+def softsign(x):
+    x = convert_to_tensor(x)
+    return x / (1 + mx.abs(x))
+
+
+def silu(x, beta=1.0):
+    x = convert_to_tensor(x)
+    if beta == 1:
+        return nn.silu(x)
+    else:
+        return x * mx.sigmoid(beta * x)
+
+
+def log_sigmoid(x):
+    x = convert_to_tensor(x)
+    return mx.log_sigmoid(x)
+
+
+def leaky_relu(x, negative_slope=0.2):
+    x = convert_to_tensor(x)
+    return nn.leaky_relu(x, negative_slope=negative_slope)
+
+
+def hard_sigmoid(x):
+    x = convert_to_tensor(x)
+    return mx.maximum(0, mx.minimum(1, x / 6 + 0.5))
+
+
+def hard_silu(x):
+    x = convert_to_tensor(x)
+    xclipped = mx.minimum(mx.maximum(x, -3), 3)
+    return x * (xclipped + 3) / 6
+
+
+def elu(x, alpha=1.0):
+    x = convert_to_tensor(x)
+    xneg = mx.minimum(x, 0)
+    xpos = mx.maximum(x, 0)
+    if alpha != 1:
+        xneg = alpha * (mx.exp(xneg) - 1)
+    else:
+        xneg = mx.exp(xneg) - 1
+    return xneg + xpos
+
+
+def selu(x):
+    x = convert_to_tensor(x)
+    a = 1.6732631921768188
+    scale = 1.0507009873554805
+    xneg = mx.minimum(x, 0)
+    xpos = mx.maximum(x, 0)
+    return scale * (xpos + a * (mx.exp(xneg) - 1))
+
+
+def gelu(x, approximate=True):
+    x = convert_to_tensor(x)
+
+    def gelu_tanh_approx(x):
+        return (
+            0.5 * x * (1 + mx.tanh(0.7978846 * (x + 0.044715 * x * x.square())))
+        )
+
+    f = gelu_tanh_approx if approximate else nn.gelu
+    return f(x)
+
+
 def softmax(x, axis=-1):
     x = convert_to_tensor(x)
     return mx.softmax(x, axis=axis)
+
+
+def log_softmax(x, axis=-1):
+    x = convert_to_tensor(x)
+    return x - mx.logsumexp(x, axis=axis, keepdims=True)
+
+
+def max_pool(inputs, pool_size, strides=None, padding="valid", data_format=None):
+    raise NotImplementedError("MLX backend doesn't support max pooling yet")
+
+
+def average_pool(inputs, pool_size, strides=None, padding="valid", data_format=None):
+    raise NotImplementedError("MLX backend doesn't support average pooling yet")
+
+
+def conv(inputs, kernel, strides=1, padding="valid", data_format=None, dilation_rate=1):
+    raise NotImplementedError("MLX backend doesn't support conv yet")
+
+def depthwise_conv(
+    inputs,
+    kernel,
+    strides=1,
+    padding="valid",
+    data_format=None,
+    dilation_rate=1,
+):
+    raise NotImplementedError("MLX backend doesn't support depthwise conv yet")
+
+
+def separable_conv(
+    inputs,
+    depthwise_kernel,
+    pointwise_kernel,
+    strides=1,
+    padding="valid",
+    data_format=None,
+    dilation_rate=1,
+):
+    raise NotImplementedError("MLX backend doesn't support separable conv yet")
+
+
+def conv_transpose(
+    inputs,
+    kernel,
+    strides=1,
+    padding="valid",
+    output_padding=None,
+    data_format=None,
+    dilation_rate=1,
+):
+    raise NotImplementedError("MLX backend doesn't support conv transpose yet")
+
+
+def one_hot(x, num_classes, axis=-1, dtype="float32"):
+    x = convert_to_tensor(x, dtype=mx.int32)
+    dtype = to_mlx_dtype(standardize_dtype(dtype))
+
+    # TODO: Make this faster by instantiating 0s and using x as indices to
+    #       write the 1s (basically using scatter)
+    output = mx.eye(num_classes, dtype=dtype)[x]
+
+    if axis != -1 and axis != output.ndim:
+        output = mx.moveaxis(output, -1, axis)
+
+    return output
+
+
+def multi_hot(x, num_classes, axis=-1, dtype="float32"):
+    x = convert_to_tensor(x)
+    reduction_axis = 1 if x.ndim > 1 else 0
+    return one_hot(x, num_classes, axis=axis, dtype=dtype).max(axis=reduction_axis)
 
 
 def categorical_crossentropy(target, output, from_logits=False, axis=-1):
@@ -46,3 +199,104 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
         log_prob = mx.log(output)
 
     return -(target * log_prob).sum(axis=axis)
+
+
+def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
+    target = convert_to_tensor(target, dtype=mx.int32)
+    output = convert_to_tensor(output)
+
+    if axis != -1:
+        raise ValueError("Only axis=-1 is supported in sparse_categorical_crossentropy")
+
+    if target.ndim == output.ndim and target.shape[-1] == 1:
+        target = target.squeeze(-1)
+
+    if len(output.shape) < 1:
+        raise ValueError(
+            "Argument `output` must be at least rank 1. "
+            "Received: "
+            f"output.shape={output.shape}"
+        )
+    if target.shape != output.shape[:-1]:
+        raise ValueError(
+            "Arguments `target` and `output` must have the same shape "
+            "up until the last dimension: "
+            f"target.shape={target.shape}, output.shape={output.shape}"
+        )
+
+    if from_logits:
+        log_prob = output - mx.logsumexp(output, axis=-1, keepdims=True)
+    else:
+        output = output / output.sum(axis=-1, keepdims=True)
+        output = mx.minimum(mx.maximum(output, epsilon()), 1 - epsilon())
+        log_prob = mx.log(output)
+
+    return -mx.take_along_axis(log_prob, target[..., None], axis=-1).squeeze(-1)
+
+
+def binary_crossentropy(target, output, from_logits=False):
+    target = convert_to_tensor(target)
+    output = convert_to_tensor(output)
+
+    if target.shape != output.shape:
+        raise ValueError(
+            "Arguments `target` and `output` must have the same shape. "
+            "Received: "
+            f"target.shape={target.shape}, output.shape={output.shape}"
+        )
+
+    if from_logits:
+        return nn.binary_cross_entropy(output, target, reduction="none")
+    else:
+        output = mx.minimum(mx.maximum(output, epsilon()), 1 - epsilon())
+        return -targets * mx.log(output) - (1 - targets) * mx.log(1 - output)
+
+
+def moments(x, axes, keepdims=False, synchronized=False):
+    if synchronized:
+        raise NotImplementedError(
+            "Argument synchronized=True is not supported with MLX."
+        )
+
+    x = convert_to_tensor(x)
+
+    # The dynamic range of float16 is too limited for statistics. As a
+    # workaround, we simply perform the operations on float32 and convert back
+    # to float16
+    need_cast = False
+    ori_dtype = x.dtype
+    if ori_dtype == mx.float16:
+        need_cast = True
+        x = x.astype(mx.float32)
+
+    mean = mx.mean(x, axis=axes, keepdims=True)
+    variance = (
+        x.square().mean(axis=axes, keepdims=True) - mx.stop_gradient(mean.square())
+    )
+
+    if not keepdims:
+        mean = mean.squeeze(axes)
+        variance = variance.squeeze(axes)
+
+    if need_cast:
+        # TODO: Clip as is done in the pytorch backend
+        mean = mean.astype(ori_dtype)
+        variance = variance.astype(ori_dtype)
+
+    return mean, variance
+
+
+def batch_normalization(
+    x, mean, variance, axis, offset=None, scale=None, epsilon=1e-3
+):
+    raise NotImplementedError("MLX backend doesn't support batch normalization yet.")
+
+
+def ctc_loss(
+    target,
+    output,
+    target_length,
+    output_length,
+    mask_index=0,
+):
+    raise NotImplementedError("MLX backend doesn't support the ctc loss yet.")

--- a/keras/backend/mlx/nn.py
+++ b/keras/backend/mlx/nn.py
@@ -1,9 +1,9 @@
 import mlx.core as mx
 import mlx.nn as nn
 
+from keras.backend.config import epsilon
 from keras.backend.mlx.core import convert_to_tensor
 from keras.backend.mlx.numpy import clip
-from keras.backend.config import epsilon
 
 
 def relu(x):

--- a/keras/backend/mlx/nn.py
+++ b/keras/backend/mlx/nn.py
@@ -287,9 +287,7 @@ def moments(x, axes, keepdims=False, synchronized=False):
         x = x.astype(mx.float32)
 
     mean = mx.mean(x, axis=axes, keepdims=True)
-    variance = x.square().mean(axis=axes, keepdims=True) - mx.stop_gradient(
-        mean.square()
-    )
+    variance = x.square().mean(axis=axes, keepdims=True) - mean.square()
 
     if not keepdims:
         mean = mean.squeeze(axes)

--- a/keras/backend/mlx/nn.py
+++ b/keras/backend/mlx/nn.py
@@ -3,7 +3,8 @@ import mlx.nn as nn
 
 from keras.backend import standardize_dtype
 from keras.backend.config import epsilon
-from keras.backend.mlx.core import convert_to_tensor, to_mlx_dtype
+from keras.backend.mlx.core import convert_to_tensor
+from keras.backend.mlx.core import to_mlx_dtype
 from keras.backend.mlx.numpy import clip
 
 
@@ -108,16 +109,28 @@ def log_softmax(x, axis=-1):
     return x - mx.logsumexp(x, axis=axis, keepdims=True)
 
 
-def max_pool(inputs, pool_size, strides=None, padding="valid", data_format=None):
+def max_pool(
+    inputs, pool_size, strides=None, padding="valid", data_format=None
+):
     raise NotImplementedError("MLX backend doesn't support max pooling yet")
 
 
-def average_pool(inputs, pool_size, strides=None, padding="valid", data_format=None):
+def average_pool(
+    inputs, pool_size, strides=None, padding="valid", data_format=None
+):
     raise NotImplementedError("MLX backend doesn't support average pooling yet")
 
 
-def conv(inputs, kernel, strides=1, padding="valid", data_format=None, dilation_rate=1):
+def conv(
+    inputs,
+    kernel,
+    strides=1,
+    padding="valid",
+    data_format=None,
+    dilation_rate=1,
+):
     raise NotImplementedError("MLX backend doesn't support conv yet")
+
 
 def depthwise_conv(
     inputs,
@@ -171,7 +184,9 @@ def one_hot(x, num_classes, axis=-1, dtype="float32"):
 def multi_hot(x, num_classes, axis=-1, dtype="float32"):
     x = convert_to_tensor(x)
     reduction_axis = 1 if x.ndim > 1 else 0
-    return one_hot(x, num_classes, axis=axis, dtype=dtype).max(axis=reduction_axis)
+    return one_hot(x, num_classes, axis=axis, dtype=dtype).max(
+        axis=reduction_axis
+    )
 
 
 def categorical_crossentropy(target, output, from_logits=False, axis=-1):
@@ -195,7 +210,7 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
         log_prob = output - mx.logsumexp(output, axis=axis)
     else:
         output = output / output.sum(axis=axis, keepdims=True)
-        output = clip(output, epsilon(), 1-epsilon())
+        output = clip(output, epsilon(), 1 - epsilon())
         log_prob = mx.log(output)
 
     return -(target * log_prob).sum(axis=axis)
@@ -206,7 +221,9 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
     output = convert_to_tensor(output)
 
     if axis != -1:
-        raise ValueError("Only axis=-1 is supported in sparse_categorical_crossentropy")
+        raise ValueError(
+            "Only axis=-1 is supported in sparse_categorical_crossentropy"
+        )
 
     if target.ndim == output.ndim and target.shape[-1] == 1:
         target = target.squeeze(-1)
@@ -270,8 +287,8 @@ def moments(x, axes, keepdims=False, synchronized=False):
         x = x.astype(mx.float32)
 
     mean = mx.mean(x, axis=axes, keepdims=True)
-    variance = (
-        x.square().mean(axis=axes, keepdims=True) - mx.stop_gradient(mean.square())
+    variance = x.square().mean(axis=axes, keepdims=True) - mx.stop_gradient(
+        mean.square()
     )
 
     if not keepdims:
@@ -289,7 +306,9 @@ def moments(x, axes, keepdims=False, synchronized=False):
 def batch_normalization(
     x, mean, variance, axis, offset=None, scale=None, epsilon=1e-3
 ):
-    raise NotImplementedError("MLX backend doesn't support batch normalization yet.")
+    raise NotImplementedError(
+        "MLX backend doesn't support batch normalization yet."
+    )
 
 
 def ctc_loss(

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -219,7 +219,8 @@ def broadcast_to(x, shape):
 
 
 def ceil(x):
-    raise NotImplementedError("The MLX backend doesn't support ceil yet")
+    x = convert_to_tensor(x)
+    return mx.ceil(x)
 
 
 def clip(x, x_min, x_max):
@@ -949,7 +950,7 @@ def sum(x, axis=None, keepdims=False):
 
 
 def eye(N, M=None, k=None, dtype=None):
-    dtype = to_torch_dtype(dtype or config.floatx())
+    dtype = to_mlx_dtype(dtype or config.floatx())
     M = N if M is None else M
     k = 0 if k is None else k
     diag_length = builtins.max(N, M)
@@ -958,9 +959,10 @@ def eye(N, M=None, k=None, dtype=None):
 
 
 def floor_divide(x1, x2):
-    raise NotImplementedError(
-        "The MLX backend doesn't support floor_divide yet."
-    )
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+
+    return mx.floor(x1 // x2)
 
 
 def logical_xor(x1, x2):

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -2,6 +2,7 @@ import math
 
 import mlx.core as mx
 
+from keras.backend import config
 from keras.backend import standardize_dtype
 from keras.backend.mlx.core import cast, convert_to_tensor, to_mlx_dtype
 

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -1,12 +1,13 @@
-import math
 import builtins
 
 import mlx.core as mx
 
 from keras.backend import config
+from keras.backend import result_type
 from keras.backend import standardize_dtype
 from keras.backend.mlx.core import cast
-from keras.backend.mlx.core import convert_to_tensor, convert_to_tensors
+from keras.backend.mlx.core import convert_to_tensor
+from keras.backend.mlx.core import convert_to_tensors
 from keras.backend.mlx.core import to_mlx_dtype
 
 
@@ -36,7 +37,6 @@ def multiply(x1, x2):
 
 def mean(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
-    ori_dtype = standardize_dtype(x.dtype)
 
     # TODO: decide if we need special low precision handling
 
@@ -119,7 +119,7 @@ def arange(start, stop=None, step=1, dtype=None):
         ]
         if stop is not None:
             dtypes_to_resolve.append(getattr(stop, "dtype", type(stop)))
-        dtype = dtypes.result_type(*dtypes_to_resolve)
+        dtype = result_type(*dtypes_to_resolve)
     dtype = standardize_dtype(dtype)
     return mx.arange(start, stop, step=step, dtype=dtype)
 
@@ -181,7 +181,7 @@ def average(x, axis=None, weights=None):
     if weights is not None:
         weights = convert_to_tensor(weights)
         dtypes_to_resolve.append(weights.dtype)
-    dtype = dtypes.result_type(*dtypes_to_resolve)
+    dtype = result_type(*dtypes_to_resolve)
     x = cast(x, dtype)
 
     # Early exit
@@ -467,7 +467,7 @@ def imag(x):
 def isclose(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    result_dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    result_dtype = result_type(x1.dtype, x2.dtype)
     x1 = cast(x1, result_dtype)
     x2 = cast(x2, result_dtype)
 
@@ -607,8 +607,8 @@ def min(x, axis=None, keepdims=False, initial=None):
 
 
 def minimum(x1, x2):
-    x1 = convert_to_tensor(x1, dtype)
-    x2 = convert_to_tensor(x2, dtype)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
     return mx.minimum(x1, x2)
 
 
@@ -782,7 +782,7 @@ def std(x, axis=None, keepdims=False):
 def swapaxes(x, axis1, axis2):
     x = convert_to_tensor(x)
     axes = list(range(x.ndim))
-    axes[axis1], axes[axes2] = axes[axis2], axes[axis1]
+    axes[axis1], axes[axis2] = axes[axis2], axes[axis1]
     return x.transpose(axes)
 
 

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -290,9 +290,10 @@ def _diagonal_indices(H, W, k):
         idx1 = mx.arange(0, N)
         idx2 = mx.arange(k, k + N)
     elif k < 0:
-        N = min(H + k, W)
-        idx1 = mx.arange(-k, N)
-        idx2 = mx.arange(-k, -k + N)
+        k = -k
+        N = min(H - k, W)
+        idx1 = mx.arange(k, k + N)
+        idx2 = mx.arange(0, N)
     return idx1, idx2
 
 
@@ -510,7 +511,7 @@ def linspace(
     start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0
 ):
     if axis != 0:
-        raise ValueError(
+        raise NotImplementedError(
             "MLX doesn't support linspace with an `axis` argument. "
             f"Received axis={axis}"
         )
@@ -570,7 +571,7 @@ def logical_or(x1, x2):
 
 def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
     if axis != 0:
-        raise ValueError(
+        raise NotImplementedError(
             "MLX logspace does not support an `axis` argument. "
             f"Received axis={axis}"
         )
@@ -675,7 +676,7 @@ def outer(x1, x2):
 
 def pad(x, pad_width, mode="constant", constant_values=None):
     if mode != "constant":
-        raise ValueError(
+        raise NotImplementedError(
             "MLX pad supports only `mode == 'constant'`"
             f"Received: mode={mode}"
         )
@@ -896,7 +897,7 @@ def vstack(xs):
 def where(condition, x1, x2):
     # TODO: Trivial to implement with masking but it would be incorrect for
     #       instance in the presence of nans or infs
-    raise ValueError("The MLX backend doesn't support where yet")
+    raise NotImplementedError("The MLX backend doesn't support where yet")
 
 
 def divide(x1, x2):

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -1,0 +1,964 @@
+import math
+
+import mlx.core as mx
+
+from keras.backend.mlx.core import cast, convert_to_tensor, to_mlx_dtype
+
+
+def add(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return mx.add(x1, x2)
+
+
+def einsum(subscripts, *operands, **kwargs):
+    raise NotImplementedError()
+
+
+def subtract(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return mx.subtract(x1, x2)
+
+
+def matmul(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return mx.matmul(x1, x2)
+
+
+def multiply(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return mx.multiply(x1, x2)
+
+
+def mean(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    ori_dtype = standardize_dtype(x.dtype)
+
+    #TODO: decide if we need special low precision handling
+
+    return mx.mean(x, axis=axis, keepdims=keepdims)
+
+
+def max(x, axis=None, keepdims=False, initial=None):
+    x = convert_to_tensor(x)
+    if 0 in x.shape:
+        if initial is None:
+            raise ValueError("Cannot compute the max of an empty tensor.")
+        elif keepdims:
+            return mx.full((1,) * len(x.shape), initial)
+        else:
+            return mx.array(initial)
+
+    result = mx.max(x, axis=axis, keepdims=keepdims)
+    if initial is not None:
+        result = mx.maximum(result, initial)
+
+    return result
+
+
+def ones(shape, dtype=None):
+    dtype = to_mlx_dtype(dtype or config.floatx())
+    return mx.ones(shape, dtype=dtype)
+
+
+def zeros(shape, dtype=None):
+    dtype = to_mlx_dtype(dtype or config.floatx())
+    return mx.zeros(shape, dtype=dtype)
+
+
+def zeros_like(x, dtype=None):
+    x = convert_to_tensor(x)
+    dtype = to_mlx_dtype(dtype or x.dtype)
+    return mx.zeros(x.shape, dtype=dtype)
+
+
+def absolute(x):
+    x = convert_to_tensor(x)
+    return mx.abs(x)
+
+
+def abs(x):
+    return absolute(x)
+
+
+def all(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    return mx.all(x, axis=axis, keepdims=keepdims)
+
+
+def any(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    return mx.any(x, axis=axis, keepdims=keepdims)
+
+
+def amax(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    return mx.max(x, axis=axis, keepdims=keepdims)
+
+
+def amin(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    return mx.min(x, axis=axis, keepdims=keepdims)
+
+
+def append(x1, x2, axis=None):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return mx.concatenate([x1, x2], axis=axis)
+
+
+def arange(start, stop=None, step=1, dtype=None):
+    if dtype is None:
+        dtypes_to_resolve = [
+            getattr(start, "dtype", type(start)),
+            getattr(step, "dtype", type(step)),
+        ]
+        if stop is not None:
+            dtypes_to_resolve.append(getattr(stop, "dtype", type(stop)))
+        dtype = dtypes.result_type(*dtypes_to_resolve)
+    dtype = standardize_dtype(dtype)
+    return mx.arange(start, stop, step=step, dtype=dtype)
+
+
+def arccos(x):
+    x = convert_to_tensor(x)
+    return mx.arccos(x)
+
+
+def arccosh(x):
+    x = convert_to_tensor(x)
+    return mx.arccosh(x)
+
+
+def arcsin(x):
+    x = convert_to_tensor(x)
+    return mx.arcsin(x)
+
+
+def arcsinh(x):
+    x = convert_to_tensor(x)
+    return mx.arcsinh(x)
+
+
+def arctan(x):
+    x = convert_to_tensor(x)
+    return mx.arctan(x)
+
+
+def arctan2(x1, x2):
+    raise NotImplementedError("The MLX backend doesn't support arctan2 yet")
+
+
+def arctanh(x):
+    x = convert_to_tensor(x)
+    return mx.arctanh(x)
+
+
+def argmax(x, axis=None):
+    x = convert_to_tensor(x)
+    return mx.argmax(x, axis=axis)
+
+
+def argmin(x, axis=None):
+    return mx.argmin(x, axis=axis)
+
+
+def argsort(x, axis=-1):
+    return mx.argsort(x, axis=axis)
+
+
+def array(x, dtype=None):
+    return convert_to_tensor(x, dtype=dtype)
+
+
+def average(x, axis=None, weights=None):
+    x = convert_to_tensor(x)
+    dtypes_to_resolve = [x.dtype, float]
+    if weights is not None:
+        weights = convert_to_tensor(weights)
+        dtypes_to_resolve.append(weights.dtype)
+    dtype = dtypes.result_type(*dtypes_to_resolve)
+    x = cast(x, dtype)
+
+    # Early exit
+    if axis == () or axis == []:
+        return x
+
+    # Weighted average
+    if weights is not None:
+        weights = cast(weights, dtype)
+        if len(weights.shape) < len(x.shape):
+            s = [1] * len(x.shape)
+            s[axis] = x.shape[axis]
+            weights = weights.reshape(s)
+
+        # TODO: mean(a * b) / mean(b) is more numerically stable in case a is
+        #       large
+        return mx.sum(mx.multiply(x, weights), axis=axis) / mx.sum(weights, axis=axis)
+
+    # Plain average
+    return mx.mean(x, axis=axis)
+
+
+def bincount(x, weights=None, minlength=0):
+    raise NotImplementedError("The MLX backend doesn't support bincount yet")
+
+
+def broadcast_to(x, shape):
+    x = convert_to_tensor(x)
+    return mx.broadcast_to(x, shape)
+
+
+def ceil(x):
+    raise NotImplementedError("The MLX backend doesn't support ceil yet")
+
+
+def clip(x, x_min, x_max):
+    x = convert_to_tensor(x)
+    x_min = convert_to_tensor(x_min)
+    x_max = convert_to_tensor(x_max)
+    return mx.maximum(x_min, mx.minimum(x, x_max))
+
+
+def concatenate(xs, axis=0):
+    xs = [convert_to_tensor(xi) for xi in xs]
+    return mx.concatenate(xs, axis=axis)
+
+
+def conjugate(x):
+    raise NotImplementedError("The MLX backend doesn't support conjugate yet")
+
+
+def conj(x):
+    return conjugate(x)
+
+
+def copy(x):
+    raise NotImplementedError("The MLX backend doesn't support copy yet")
+
+
+def cos(x):
+    x = convert_to_tensor(x)
+    return mx.cos(x)
+
+
+def cosh(x):
+    x = convert_to_tensor(x)
+    return mx.cosh(x)
+
+
+def count_nonzero(x, axis=None):
+    x = convert_to_tensor(x)
+    return (x != 0).astype(mx.int32).sum(axis=axis)
+
+
+def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
+    # TODO: Write it inline if necessary
+    raise NotImplementedError("The MLX backend doesn't support cross product yet")
+
+
+def cumprod(x, axis=None, dtype=None):
+    x = convert_to_tensor(x)
+    if dtype is not None:
+        x = cast(x, dtype)
+    return mx.cumprod(x, axis=axis)
+
+
+def cumsum(x, axis=None, dtype=None):
+    x = convert_to_tensor(x)
+    if dtype is not None:
+        x = cast(x, dtype)
+    return mx.cumsum(x, axis=axis)
+
+
+def _diagonal_indices(H, W, k):
+    if k >= 0:
+        N = min(W - k, H)
+        idx1 = mx.arange(0, N)
+        idx2 = mx.arange(k, k+N)
+    elif k < 0:
+        N = min(H + k, W)
+        idx1 = mx.arange(-k, N)
+        idx2 = mx.arange(-k, -k+N)
+    return idx1, idx2
+
+
+def diag(x, k=0):
+    x = convert_to_tensor(x)
+
+    if len(x.shape) == 2:
+        return x[_diagonal_indices(*x.shape, k)]
+
+    elif len(x.shape) == 1:
+        N = x.shape[0] + abs(k)
+        zeros = mx.zeros((N, N))
+        zeros[_diagonal_indices(N, N, k)] = x
+        return zeros
+
+    else:
+        raise ValueError("Input must be 1d or 2d")
+
+
+def diagonal(x, offset=0, axis1=0, axis2=1):
+    x = convert_to_tensor(x)
+
+    ndim = x.ndim
+    axis1 = (ndim + axis1) % ndim
+    axis2 = (ndim + axis2) % ndim
+
+    max_axis = builtins.max(axis1, axis2)
+    indices = [slice(None) for _ in range(max_axis+1)]
+    indices[axis1], indices[axis2] = _diagonal_indices(x.shape[axis1], x.shape[axis2], offset)
+
+    return x[indices]
+
+
+def diff(x, n=1, axis=-1):
+    x = convert_to_tensor(x)
+    ndim = x.ndim
+    axis = (ndim + axis) % ndim
+    indices = [slice(None) for _ in range(axis)]
+    index_a = indices + [slice(None, -1)]
+    index_b = indices + [slice(1)]
+
+    y = x
+    for i in range(n):
+        y = y[index_b] - y[index_a]
+    return y
+
+
+def digitize(x, bins):
+    # TODO: This is quite inefficient but we don't have natice support yet
+    x = convert_to_tensor(x)
+    bins = convert_to_tensor(bins)
+
+    return (x[..., None] >= bins).sum(axis=-1)
+
+
+def dot(x, y):
+    x = convert_to_tensor(x)
+    y = convert_to_tensor(y)
+
+    ndimx = x.ndim
+    ndimy = y.ndim
+
+    if ndimx == ndimy == 1:
+        return (x[None] @ y[:, None]).reshape()
+
+    if ndimx == ndimy == 2:
+        return x @ y
+
+    if ndimx == 0 or ndimy == 0:
+        return x * y
+
+    if ndimy == 1:
+        r = x @ y
+        return r.squeeze(-1)
+
+    if ndimy >= 2:
+        x = x.reshape(x.shape + [1] * ndimy-1)
+        r = x @ y
+        return r.squeeze(-2)
+
+    raise RuntimeError("This should be unreachable")
+
+
+def empty(shape, dtype=None):
+    dtype = to_mlx_dtype(dtype or config.floatx())
+    return mx.zeros(shape, dtype=dtype)
+
+
+def equal(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return mx.equal(x1, x2)
+
+
+def exp(x):
+    x = convert_to_tensor(x)
+    ori_dtype = standardize_dtype(x.dtype)
+    if "int" in ori_dtype or ori_dtype == "bool":
+        x = cast(x, config.floatx())
+    return mx.exp(x)
+
+
+def expand_dims(x, axis):
+    x = convert_to_tensor(x)
+    return mx.expand_dims(x, axis=axis)
+
+
+def expm1(x):
+    # TODO: Add the numerically stable version
+    x = convert_to_tensor(x)
+    return mx.exp(x) - 1
+
+
+def flip(x, axis=None):
+    x = convert_to_tensor(x)
+    if axis is None:
+        axis = tuple(range(x.ndim))
+    if isinstance(axis, int):
+        axis = (axis,)
+    indices = [slice(None)] * len(x.shape)
+    for ax in axis:
+        indices[ax] = slice(None, None, -1)
+
+    return x[indices]
+
+
+def floor(x):
+    # TODO: This is not a proper floor we need a floor
+    x = convert_to_tensor(x)
+    dtype = (
+        config.floatx()
+        if standardize_dtype(x.dtype) == "int64"
+        else dtypes.result_type(x.dtype, float)
+    )
+    x = x.astype(mx.int64)
+    x = cast(x, dtype)
+    return x
+
+
+def full(shape, fill_value, dtype=None):
+    dtype = to_mlx_dtype(dtype)
+    fill_value = convert_to_tensor(fill_value, dtype=dtype)
+    return mx.full(shape, fill_value)
+
+
+def full_like(x, fill_value, dtype=None):
+    dtype = dtype or x.dtype
+    return full(shape=x.shape, fill_value=fill_value, dtype=dtype)
+
+
+def greater(x1, x2):
+    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    return mx.greater(x1, x2)
+
+
+def greater_equal(x1, x2):
+    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    return mx.greater_equal(x1, x2)
+
+
+def hstack(xs):
+    xs = [convert_to_tensor(x) for x in xs]
+    if xs[0].ndim == 1:
+        return mx.concatenate(xs, axis=0)
+    else:
+        return mx.concatenate(xs, axis=1)
+
+
+def identity(n, dtype=None):
+    dtype = to_mlx_dtype(dtype or config.floatx())
+
+    zeros = mx.zeros((n, n), dtype=dtype)
+    idx = mx.arange(n)
+    zeros[idx, idx] = 1
+
+    return zeros
+
+
+def imag(x):
+    raise NotImplementedError("MLX doesn't support imag yet")
+
+
+def isclose(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    result_dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = cast(x1, result_dtype)
+    x2 = cast(x2, result_dtype)
+
+    rtol = 1e-5
+    atol = 1e-8
+    return absolute(x1 - x2) <= (atol + rtol * absolute(x2))
+
+
+def isfinite(x):
+    x = convert_to_tensor(x)
+    return True - (isinf(x) + isnan(x))
+
+
+def isinf(x):
+    x = convert_to_tensor(x)
+    return mx.abs(x) == float("inf")
+
+
+def isnan(x):
+    x = convert_to_tensor(x)
+    return x != x
+
+
+def less(x1, x2):
+    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    return mx.less(x1, x2)
+
+
+def less_equal(x1, x2):
+    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    return mx.less_equal(x1, x2)
+
+
+def linspace(
+    start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0
+):
+    if axis != 0:
+        raise ValueError(
+            "MLX doesn't support linspace with an `axis` argument. "
+            f"Received axis={axis}"
+        )
+    start = convert_to_tensor(start)
+    stop = convert_to_tensor(stop)
+    zero_one = mx.arange(num) / ((num-1) if endpoint else num)
+    direction = stop - start
+    zero_one = zero_one.reshape([-1] + [1]*direction.ndim)
+    rs = zero_one * direction[None] + start[None]
+
+    if retstep:
+        return rs, rs[1] - rs[0]
+    else:
+        return rs
+
+
+def log(x):
+    x = convert_to_tensor(x)
+    return mx.log(x)
+
+
+def log10(x):
+    x = convert_to_tensor(x)
+    return mx.log10(x)
+
+
+def log1p(x):
+    x = convert_to_tensor(x)
+    return mx.log1p(x)
+
+
+def log2(x):
+    x = convert_to_tensor(x)
+    return mx.log2(x)
+
+
+def logaddexp(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return mx.logaddexp(x1, x2)
+
+
+def logical_and(x1, x2):
+    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    return x1.astype(mx.bool_) * x2.astype(mx.bool_)
+
+
+def logical_not(x):
+    x = convert_to_tensor(x)
+    return True - x.astype(mx.bool_)
+
+
+def logical_or(x1, x2):
+    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    return x1.astype(mx.bool_) + x2.astype(mx.bool_)
+
+
+def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
+    if axis != 0:
+        raise ValueError(
+            "MLX logspace does not support an `axis` argument. "
+            f"Received axis={axis}"
+        )
+    points = linspace(start, stop, num, endpoint=endpoint)
+    return mx.power(base, points)
+
+
+def maximum(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return mx.maximum(x1, x2)
+
+
+def median(x, axis=None, keepdims=False):
+    # TODO: Maybe implement via sort?
+    raise NotImplementedError("The MLX backend doesn't support median yet")
+
+
+def meshgrid(*x, indexing="xy"):
+    # TODO: Implement inline like linspace
+    raise NotImplementedError("The MLX backend doesn't support meshgrid yet")
+
+
+def min(x, axis=None, keepdims=False, initial=None):
+    x = convert_to_tensor(x)
+    if 0 in x.shape:
+        if initial is None:
+            raise ValueError("Cannot compute the min of an empty tensor.")
+        elif keepdims:
+            return mx.full((1,) * len(x.shape), initial)
+        else:
+            return mx.tensor(initial)
+
+    result = mx.min(x, axis=axis, keepdims=keepdims)
+    if initial is not None:
+        result = mx.minimum(result, initial)
+
+    return result
+
+
+def minimum(x1, x2):
+    x1 = convert_to_tensor(x1, dtype)
+    x2 = convert_to_tensor(x2, dtype)
+    return mx.minimum(x1, x2)
+
+
+def mod(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return mx.remainder(x1, x2)
+
+
+def moveaxis(x, source, destination):
+    x = convert_to_tensor(x)
+
+    if not isinstance(source, (list, tuple)):
+        source = [source]
+    if not isinstance(destination, (list, tuple)):
+        destination = [destination]
+
+    ndim = x.ndim
+    axes = list(range(ndim))
+    for s, d in zip(source, destination):
+        s = (ndim + s) % ndim
+        d = (ndim + d) % ndim
+        axes.insert(d, axes.pop(s))
+
+    return mx.transpose(x, axes)
+
+
+def nan_to_num(x):
+    raise NotImplementedError("The MLX backend doesn't support nan_to_num yet")
+
+
+def ndim(x):
+    x = convert_to_tensor(x)
+    return x.ndim
+
+
+def nonzero(x):
+    raise NotImplementedError("The MLX backend doesn't support nonzero yet")
+
+
+def not_equal(x1, x2):
+    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    return x1 != x2
+
+
+def ones_like(x, dtype=None):
+    x = convert_to_tensor(x)
+    dtype = to_mlx_dtype(dtype or x.dtype)
+    return mx.ones(x.shape, dtype=dtype)
+
+
+def outer(x1, x2):
+    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    x1 = x1.reshape(-1)
+    x2 = x2.reshape(-1)
+
+    return x1[:, None] * x2[None, :]
+
+
+def pad(x, pad_width, mode="constant", constant_values=None):
+    if mode != "constant":
+        raise ValueError(
+            "MLX pad supports only `mode == 'constant'`"
+            f"Received: mode={mode}"
+        )
+
+    x = convert_to_tensor(x)
+    return mx.pad(x, pad_width, constant_values=constant_values)
+
+
+def prod(x, axis=None, keepdims=False, dtype=None):
+    x = convert_to_tensor(x)
+    if dtype is not None:
+        x = cast(x, dtype)
+    return mx.prod(x, axis=axis, keepdims=keepdims)
+
+
+def quantile(x, q, axis=None, method="linear", keepdims=False):
+    raise NotImplementedError("MLX doesn't support quantile yet")
+
+
+def ravel(x):
+    x = convert_to_tensor(x)
+    return x.reshape(-1)
+
+
+def real(x):
+    raise NotImplementedError("MLX doesn't support real yet")
+
+
+def reciprocal(x):
+    x = convert_to_tensor(x)
+    return mx.reciprocal(x)
+
+
+def repeat(x, repeats, axis=None):
+    x = convert_to_tensor(x)
+
+    if axis is None:
+        x = x.reshape(-1)
+        axis = 0
+
+    shape = x.shape
+    shape.insert(axis+1, 1)
+    x = x.reshape(shape)
+    shape[axis+1] = repeats
+    x = mx.broadcast_to(x, shape)
+    shape.pop(axis+1)
+    shape[axis] *= repeats
+    x = x.reshape(shape)
+
+    return x
+
+
+def reshape(x, new_shape):
+    if not isinstance(new_shape, (list, tuple)):
+        new_shape = (new_shape,)
+    x = convert_to_tensor(x)
+    return mx.reshape(x, new_shape)
+
+
+def roll(x, shift, axis=None):
+    # TODO: Implement using concatenate
+    raise NotImplementedError("The MLX backend doesn't support roll yet")
+
+
+def sign(x):
+    x = convert_to_tensor(x)
+    return mx.sign(x)
+
+
+def sin(x):
+    x = convert_to_tensor(x)
+    return mx.sin(x)
+
+
+def sinh(x):
+    x = convert_to_tensor(x)
+    return mx.sinh(x)
+
+
+def size(x):
+    x = convert_to_tensor(x)
+    return x.size
+
+
+def sort(x, axis=-1):
+    x = convert_to_tensor(x)
+    return mx.sort(x, axis=axis)
+
+
+def split(x, indices_or_sections, axis=0):
+    x = convert_to_tensor(x)
+    return mx.split(x, indices_or_sections, axis=axis)
+
+
+def stack(xs, axis=0):
+    xs = [convert_to_tensor(x) for x in xs]
+    xs = [x.unsqueeze(axis) for x in xs]
+    return mx.concatenate(xs, axis=axis)
+
+
+def std(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    return mx.sqrt(mx.var(x, axis=axis, keepdims=keepdims))
+
+
+def swapaxes(x, axis1, axis2):
+    x = convert_to_tensor(x)
+    axes = list(range(x.ndim))
+    axes[axis1], axes[axes2] = axes[axis2], axes[axis1]
+    return x.transpose(axes)
+
+
+def take(x, indices, axis=None):
+    x = convert_to_tensor(x)
+    indices = convert_to_tensor(indices)
+    return mx.take(x, indices, axis=axis)
+
+
+def take_along_axis(x, indices, axis=None):
+    x = convert_to_tensor(x)
+    indices = convert_to_tensor(indices)
+    return mx.take_along_axis(x, indices, axis=axis)
+
+
+def tan(x):
+    x = convert_to_tensor(x)
+    return mx.tan(x)
+
+
+def tanh(x):
+    x = convert_to_tensor(x)
+    return mx.tanh(x)
+
+
+def tensordot(x1, x2, axes=2):
+    raise NotImplementedError("The MLX backend doesn't support tensordot yet")
+
+
+def round(x, decimals=0):
+    raise NotImplementedError("The MLX backend doesn't support round yet")
+
+
+def tile(x, repeats):
+    x = convert_to_tensor(x)
+    ndim = x.ndim
+    if not isinstance(repeats, (tuple, list)):
+        repeats = [repeats]
+
+    if ndim > len(repeats):
+        repeats = [1] * (ndim - len(repeats))
+    elif ndim < len(repeats):
+        shape = [1] * (len(repeats) - ndim) + x.shape
+        x = x.reshape(shape)
+
+    shape = []
+    for s in x.shape:
+        shape.append(s)
+        shape.append(1)
+    x = x.reshape(shape)
+    for i, r in enumerate(repeats):
+        shape[2*i] = r
+    x = mx.broadcast_to(x, shape)
+    final_shape = []
+    for i in range(len(shape) // 2):
+        final_shape.append(shape[i] * shape[i + 1])
+    x = x.reshape(final_shape)
+
+    return x
+
+
+def trace(x, offset=None, axis1=None, axis2=None):
+    x = convert_to_tensor(x)
+    return diagonal(x, offset, axis1, axis2).sum(-1)
+
+
+def tri(N, M=None, k=0, dtype=None):
+    dtype = to_mlx_dtype(dtype or config.floatx())
+    M = M or N
+    x = mx.ones((N, M), dtype=dtype)
+
+    return tril(x, k=k)
+
+
+def tril(x, k=0):
+    x = convert_to_tensor(x)
+
+    idx_y = mx.arange(x.shape[-2])
+    idx_x = mx.arange(x.shape[-1])
+    mask = idx_y[:, None] >= idx_x[None] - k
+
+    return x * mask
+
+
+def triu(x, k=0):
+    x = convert_to_tensor(x)
+
+    idx_y = mx.arange(x.shape[-2])
+    idx_x = mx.arange(x.shape[-1])
+    mask = idx_y[:, None] <= idx_x[None] - k
+
+    return x * mask
+
+
+def vdot(x1, x2):
+    raise NotImplementedError("The MLX backend doesn't support vdot yet")
+
+
+def vstack(xs):
+    xs = [convert_to_tensor(x) for x in xs]
+    if xs[0].ndim == 1:
+        xs = [x[None] for x in xs]
+    return mx.concatenate(xs, axis=0)
+
+
+def where(condition, x1, x2):
+    # TODO: Trivial to implement with masking but it would be incorrect for
+    #       instance in the presence of nans or infs
+    raise ValueError("The MLX backend doesn't support where yet")
+
+
+def divide(x1, x2):
+    if not isinstance(x1, (int, float)):
+        x1 = convert_to_tensor(x1)
+    if not isinstance(x2, (int, float)):
+        x2 = convert_to_tensor(x2)
+    return mx.divide(x1, x2)
+
+
+def true_divide(x1, x2):
+    return divide(x1, x2)
+
+
+def power(x1, x2):
+    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    return mx.power(x1, x2)
+
+
+def negative(x):
+    x = convert_to_tensor(x)
+    return mx.negative(x)
+
+
+def square(x):
+    x = convert_to_tensor(x)
+    return mx.square(x)
+
+
+def sqrt(x):
+    x = convert_to_tensor(x)
+    return mx.sqrt(x)
+
+
+def squeeze(x, axis=None):
+    x = convert_to_tensor(x)
+    return mx.squeeze(x, axis=axis)
+
+
+def transpose(x, axes=None):
+    x = convert_to_tensor(x)
+    return mx.transpose(x, axes)
+
+
+def var(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    return mx.var(x, axis=axis, keepdims=keepdims)
+
+
+def sum(x, axis=None, keepdims=False):
+    if isinstance(x, (list, tuple)):
+        x = stack(x)
+    x = convert_to_tensor(x)
+    return mx.sum(x, axis=axis, keepdims=keepdims)
+
+
+def eye(N, M=None, k=None, dtype=None):
+    dtype = to_torch_dtype(dtype or config.floatx())
+    M = N if M is None else M
+    k = 0 if k is None else k
+    diag_length = builtins.max(N, M)
+    diag = mx.ones(diag_length, dtype=dtype)
+    return diag(diag, diagonal=k)[:N, :M]
+
+
+def floor_divide(x1, x2):
+    raise NotImplementedError("The MLX backend doesn't support floor_divide yet.")
+
+
+def logical_xor(x1, x2):
+    x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
+    return x1.astype(mx.bool_) - x2.astype(mx.bool_)

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -4,7 +4,9 @@ import mlx.core as mx
 
 from keras.backend import config
 from keras.backend import standardize_dtype
-from keras.backend.mlx.core import cast, convert_to_tensor, to_mlx_dtype
+from keras.backend.mlx.core import cast
+from keras.backend.mlx.core import convert_to_tensor
+from keras.backend.mlx.core import to_mlx_dtype
 
 
 def add(x1, x2):

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -1,4 +1,5 @@
 import math
+import builtins
 
 import mlx.core as mx
 
@@ -679,8 +680,11 @@ def pad(x, pad_width, mode="constant", constant_values=None):
             f"Received: mode={mode}"
         )
 
+    if isinstance(pad_width, mx.array):
+        pad_width = pad_width.tolist()
+
     x = convert_to_tensor(x)
-    return mx.pad(x, pad_width, constant_values=constant_values)
+    return mx.pad(x, pad_width, constant_values=constant_values or 0)
 
 
 def prod(x, axis=None, keepdims=False, dtype=None):
@@ -953,9 +957,7 @@ def eye(N, M=None, k=None, dtype=None):
     dtype = to_mlx_dtype(dtype or config.floatx())
     M = N if M is None else M
     k = 0 if k is None else k
-    diag_length = builtins.max(N, M)
-    diag = mx.ones(diag_length, dtype=dtype)
-    return diag(diag, diagonal=k)[:N, :M]
+    return mx.eye(N, M, k)
 
 
 def floor_divide(x1, x2):

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -412,16 +412,8 @@ def flip(x, axis=None):
 
 
 def floor(x):
-    # TODO: This is not a proper floor we need a floor
     x = convert_to_tensor(x)
-    dtype = (
-        config.floatx()
-        if standardize_dtype(x.dtype) == "int64"
-        else dtypes.result_type(x.dtype, float)
-    )
-    x = x.astype(mx.int64)
-    x = cast(x, dtype)
-    return x
+    return mx.floor(x)
 
 
 def full(shape, fill_value, dtype=None):

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -6,13 +6,12 @@ import mlx.core as mx
 from keras.backend import config
 from keras.backend import standardize_dtype
 from keras.backend.mlx.core import cast
-from keras.backend.mlx.core import convert_to_tensor
+from keras.backend.mlx.core import convert_to_tensor, convert_to_tensors
 from keras.backend.mlx.core import to_mlx_dtype
 
 
 def add(x1, x2):
-    x1 = convert_to_tensor(x1)
-    x2 = convert_to_tensor(x2)
+    x1, x2 = convert_to_tensors(x1, x2)
     return mx.add(x1, x2)
 
 
@@ -21,20 +20,17 @@ def einsum(subscripts, *operands, **kwargs):
 
 
 def subtract(x1, x2):
-    x1 = convert_to_tensor(x1)
-    x2 = convert_to_tensor(x2)
+    x1, x2 = convert_to_tensors(x1, x2)
     return mx.subtract(x1, x2)
 
 
 def matmul(x1, x2):
-    x1 = convert_to_tensor(x1)
-    x2 = convert_to_tensor(x2)
+    x1, x2 = convert_to_tensors(x1, x2)
     return mx.matmul(x1, x2)
 
 
 def multiply(x1, x2):
-    x1 = convert_to_tensor(x1)
-    x2 = convert_to_tensor(x2)
+    x1, x2 = convert_to_tensors(x1, x2)
     return mx.multiply(x1, x2)
 
 
@@ -225,14 +221,12 @@ def ceil(x):
 
 
 def clip(x, x_min, x_max):
-    x = convert_to_tensor(x)
-    x_min = convert_to_tensor(x_min)
-    x_max = convert_to_tensor(x_max)
+    x, x_min, x_max = convert_to_tensors(x, x_min, x_max)
     return mx.maximum(x_min, mx.minimum(x, x_max))
 
 
 def concatenate(xs, axis=0):
-    xs = [convert_to_tensor(xi) for xi in xs]
+    xs = convert_to_tensors(*xs)
     return mx.concatenate(xs, axis=axis)
 
 

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -41,7 +41,7 @@ def mean(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
     ori_dtype = standardize_dtype(x.dtype)
 
-    #TODO: decide if we need special low precision handling
+    # TODO: decide if we need special low precision handling
 
     return mx.mean(x, axis=axis, keepdims=keepdims)
 
@@ -201,7 +201,9 @@ def average(x, axis=None, weights=None):
 
         # TODO: mean(a * b) / mean(b) is more numerically stable in case a is
         #       large
-        return mx.sum(mx.multiply(x, weights), axis=axis) / mx.sum(weights, axis=axis)
+        return mx.sum(mx.multiply(x, weights), axis=axis) / mx.sum(
+            weights, axis=axis
+        )
 
     # Plain average
     return mx.mean(x, axis=axis)
@@ -261,7 +263,9 @@ def count_nonzero(x, axis=None):
 
 def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
     # TODO: Write it inline if necessary
-    raise NotImplementedError("The MLX backend doesn't support cross product yet")
+    raise NotImplementedError(
+        "The MLX backend doesn't support cross product yet"
+    )
 
 
 def cumprod(x, axis=None, dtype=None):
@@ -282,11 +286,11 @@ def _diagonal_indices(H, W, k):
     if k >= 0:
         N = min(W - k, H)
         idx1 = mx.arange(0, N)
-        idx2 = mx.arange(k, k+N)
+        idx2 = mx.arange(k, k + N)
     elif k < 0:
         N = min(H + k, W)
         idx1 = mx.arange(-k, N)
-        idx2 = mx.arange(-k, -k+N)
+        idx2 = mx.arange(-k, -k + N)
     return idx1, idx2
 
 
@@ -314,8 +318,10 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
     axis2 = (ndim + axis2) % ndim
 
     max_axis = builtins.max(axis1, axis2)
-    indices = [slice(None) for _ in range(max_axis+1)]
-    indices[axis1], indices[axis2] = _diagonal_indices(x.shape[axis1], x.shape[axis2], offset)
+    indices = [slice(None) for _ in range(max_axis + 1)]
+    indices[axis1], indices[axis2] = _diagonal_indices(
+        x.shape[axis1], x.shape[axis2], offset
+    )
 
     return x[indices]
 
@@ -363,7 +369,7 @@ def dot(x, y):
         return r.squeeze(-1)
 
     if ndimy >= 2:
-        x = x.reshape(x.shape + [1] * ndimy-1)
+        x = x.reshape(x.shape + [1] * ndimy - 1)
         r = x @ y
         return r.squeeze(-2)
 
@@ -508,9 +514,9 @@ def linspace(
         )
     start = convert_to_tensor(start)
     stop = convert_to_tensor(stop)
-    zero_one = mx.arange(num) / ((num-1) if endpoint else num)
+    zero_one = mx.arange(num) / ((num - 1) if endpoint else num)
     direction = stop - start
-    zero_one = zero_one.reshape([-1] + [1]*direction.ndim)
+    zero_one = zero_one.reshape([-1] + [1] * direction.ndim)
     rs = zero_one * direction[None] + start[None]
 
     if retstep:
@@ -709,11 +715,11 @@ def repeat(x, repeats, axis=None):
         axis = 0
 
     shape = x.shape
-    shape.insert(axis+1, 1)
+    shape.insert(axis + 1, 1)
     x = x.reshape(shape)
-    shape[axis+1] = repeats
+    shape[axis + 1] = repeats
     x = mx.broadcast_to(x, shape)
-    shape.pop(axis+1)
+    shape.pop(axis + 1)
     shape[axis] *= repeats
     x = x.reshape(shape)
 
@@ -828,7 +834,7 @@ def tile(x, repeats):
         shape.append(1)
     x = x.reshape(shape)
     for i, r in enumerate(repeats):
-        shape[2*i] = r
+        shape[2 * i] = r
     x = mx.broadcast_to(x, shape)
     final_shape = []
     for i in range(len(shape) // 2):
@@ -952,7 +958,9 @@ def eye(N, M=None, k=None, dtype=None):
 
 
 def floor_divide(x1, x2):
-    raise NotImplementedError("The MLX backend doesn't support floor_divide yet.")
+    raise NotImplementedError(
+        "The MLX backend doesn't support floor_divide yet."
+    )
 
 
 def logical_xor(x1, x2):

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -2,6 +2,7 @@ import math
 
 import mlx.core as mx
 
+from keras.backend import standardize_dtype
 from keras.backend.mlx.core import cast, convert_to_tensor, to_mlx_dtype
 
 
@@ -768,7 +769,7 @@ def split(x, indices_or_sections, axis=0):
 
 def stack(xs, axis=0):
     xs = [convert_to_tensor(x) for x in xs]
-    xs = [x.unsqueeze(axis) for x in xs]
+    xs = [mx.expand_dims(x, axis) for x in xs]
     return mx.concatenate(xs, axis=axis)
 
 

--- a/keras/backend/mlx/random.py
+++ b/keras/backend/mlx/random.py
@@ -99,6 +99,7 @@ def binomial(shape, counts, probabilities, dtype=None, seed=None):
         "Sampling from a Binomial distribution is not implemented in mlx"
     )
 
+
 def beta(shape, alpha, beta, dtype=None, seed=None):
     raise NotImplementedError(
         "Sampling from a Beta distribution is not implemented in mlx"

--- a/keras/backend/mlx/random.py
+++ b/keras/backend/mlx/random.py
@@ -84,9 +84,11 @@ def dropout(inputs, rate, noise_shape=None, seed=None):
 def shuffle(x, axis=0, seed=None):
     seed = mlx_draw_seed(seed)
     order = mx.argsort(mx.random.uniform(shape=(x.shape[axis],), key=seed))
-    index = [slice(None)]*axis + [order]
+    index = [slice(None)] * axis + [order]
     return x[index]
 
 
 def gamma(shape, alpha, dtype=None, seed=None):
-    raise NotImplementedError("Sampling from Gamma distribution is not implemented in mlx")
+    raise NotImplementedError(
+        "Sampling from Gamma distribution is not implemented in mlx"
+    )

--- a/keras/backend/mlx/random.py
+++ b/keras/backend/mlx/random.py
@@ -92,3 +92,14 @@ def gamma(shape, alpha, dtype=None, seed=None):
     raise NotImplementedError(
         "Sampling from Gamma distribution is not implemented in mlx"
     )
+
+
+def binomial(shape, counts, probabilities, dtype=None, seed=None):
+    raise NotImplementedError(
+        "Sampling from a Binomial distribution is not implemented in mlx"
+    )
+
+def beta(shape, alpha, beta, dtype=None, seed=None):
+    raise NotImplementedError(
+        "Sampling from a Beta distribution is not implemented in mlx"
+    )

--- a/keras/backend/mlx/random.py
+++ b/keras/backend/mlx/random.py
@@ -1,0 +1,92 @@
+import mlx.core as mx
+
+from keras.backend.config import floatx
+from keras.backend.mlx.core import to_mlx_dtype
+from keras.random.seed_generator import SeedGenerator
+from keras.random.seed_generator import draw_seed
+from keras.random.seed_generator import make_default_seed
+
+
+def mlx_draw_seed(seed):
+    if isinstance(seed, mx.array):
+        return seed
+    else:
+        return draw_seed(seed)
+
+
+def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
+    dtype = dtype or floatx()
+    dtype = to_mlx_dtype(dtype)
+    seed = mlx_draw_seed(seed)
+    sample = mx.random.normal(shape=shape, dtype=dtype, key=seed)
+    return sample * stddev + mean
+
+
+def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
+    dtype = dtype or floatx()
+    dtype = to_mlx_dtype(dtype)
+    seed = mlx_draw_seed(seed)
+    return mx.random.uniform(
+        low=minval, high=maxval, shape=shape, dtype=dtype, key=seed
+    )
+
+
+def categorical(logits, num_samples, dtype="int32", seed=None):
+    seed = mlx_draw_seed(seed)
+    output = mx.random.categorical(logits, num_samples=num_samples, key=seed)
+    return output.astype(to_mlx_dtype(dtype))
+
+
+def randint(shape, minval, maxval, dtype="int32", seed=None):
+    seed = mlx_draw_seed(seed)
+    dtype = to_mlx_dtype(dtype)
+
+    return mx.random.randint(
+        low=minval, high=maxval, shape=shape, dtype=dtype, key=seed
+    )
+
+
+def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
+    dtype = dtype or floatx()
+    dtype = to_mlx_dtype(dtype)
+    seed = mlx_draw_seed(seed)
+    sample = mx.random.truncated_normal(
+        lower=-2.0, upper=2.0, shape=shape, dtype=dtype, key=seed
+    )
+    return sample * stddev + mean
+
+
+def _get_concrete_noise_shape(inputs, noise_shape):
+    if noise_shape is None:
+        return inputs.shape
+
+    concrete_inputs_shape = inputs.shape
+    concrete_noise_shape = []
+    for i, value in enumerate(noise_shape):
+        concrete_noise_shape.append(
+            concrete_inputs_shape[i] if value is None else value
+        )
+    return concrete_noise_shape
+
+
+def dropout(inputs, rate, noise_shape=None, seed=None):
+    seed = mlx_draw_seed(seed)
+    keep_prob = 1.0 - rate
+    # The `noise_shape` may contain `None` so we need to convert it
+    # into a concrete shape before passing it on to jax.
+    noise_shape = _get_concrete_noise_shape(inputs, noise_shape)
+    mask = mx.random.bernoulli(p=keep_prob, shape=noise_shape, key=seed)
+    mask = mx.broadcast_to(mask, inputs.shape)
+
+    return mask * (inputs / keep_prob)
+
+
+def shuffle(x, axis=0, seed=None):
+    seed = mlx_draw_seed(seed)
+    order = mx.argsort(mx.random.uniform(shape=(x.shape[axis],), key=seed))
+    index = [slice(None)]*axis + [order]
+    return x[index]
+
+
+def gamma(shape, alpha, dtype=None, seed=None):
+    raise NotImplementedError("Sampling from Gamma distribution is not implemented in mlx")

--- a/keras/backend/mlx/rnn.py
+++ b/keras/backend/mlx/rnn.py
@@ -1,3 +1,6 @@
+import mlx.core as mx
+
+
 def rnn(
     step_function,
     inputs,
@@ -27,5 +30,4 @@ def gru(*args, **kwargs):
 
 
 def unstack(x, axis=0):
-    slices = (slice(None),) * axis
-    return [x[*slices, i] for i in range(x.shape[axis])]
+    return mx.split(x, axis=axis)

--- a/keras/backend/mlx/rnn.py
+++ b/keras/backend/mlx/rnn.py
@@ -1,0 +1,43 @@
+import contextlib
+
+import tree
+import mlx.core as mx
+
+from keras.backend import standardize_dtype
+from keras.backend.common import stateless_scope
+from keras.backend.mlx.core import to_mlx_dtype
+from keras.utils.nest import pack_sequence_as
+
+
+def rnn(
+    step_function,
+    inputs,
+    initial_states,
+    go_backwards=False,
+    mask=None,
+    constants=None,
+    unroll=False,
+    input_length=None,
+    time_major=False,
+    zero_output_for_mask=False,
+    return_all_outputs=True,
+):
+    raise NotImplementedError("rnn not yet implemented in mlx")
+
+
+def cudnn_ok(*args, **kwargs):
+    return False
+
+
+def lstm(*args, **kwargs):
+    raise NotImplementedError("lstm not yet implemented in mlx")
+
+
+def gru(*args, **kwargs):
+    raise NotImplementedError("gru not yet implemented in mlx")
+
+
+def unstack(x, axis=0):
+    slices = (slice(None),) * axis
+    return [x[*slices, i] for i in range(x.shape[axis])]
+

--- a/keras/backend/mlx/rnn.py
+++ b/keras/backend/mlx/rnn.py
@@ -1,14 +1,3 @@
-import contextlib
-
-import tree
-import mlx.core as mx
-
-from keras.backend import standardize_dtype
-from keras.backend.common import stateless_scope
-from keras.backend.mlx.core import to_mlx_dtype
-from keras.utils.nest import pack_sequence_as
-
-
 def rnn(
     step_function,
     inputs,
@@ -40,4 +29,3 @@ def gru(*args, **kwargs):
 def unstack(x, axis=0):
     slices = (slice(None),) * axis
     return [x[*slices, i] for i in range(x.shape[axis])]
-

--- a/keras/backend/mlx/trainer.py
+++ b/keras/backend/mlx/trainer.py
@@ -1,0 +1,808 @@
+
+import mlx.core as mx
+
+from keras import backend
+from keras import callbacks as callbacks_module
+from keras import ops
+from keras import optimizers as optimizers_module
+from keras.backend.common import standardize_dtype
+from keras.backend.common.keras_tensor import KerasTensor
+from keras.backend.mlx.core import is_tensor
+from keras.trainers import epoch_iterator
+from keras.trainers import trainer as base_trainer
+from keras.trainers.data_adapters import data_adapter_utils
+from keras.trainers.epoch_iterator import EpochIterator
+from keras.utils import traceback_utils
+
+
+class MLXTrainer(base_trainer.Trainer):
+    def __init__(self):
+        super().__init__()
+        self.train_function = None
+        self.test_function = None
+        self.predict_function = None
+
+    def mlx_state_sync(self):
+        if not getattr(self, "_mlx_state", None):
+            return
+
+        trainable_variables = self._mlx_state.get("trainable_variables", None)
+        non_trainable_variables = self._mlx_state.get(
+            "non_trainable_variables", None
+        )
+        optimizer_variables = self._mlx_state.get("optimizer_variables", None)
+        metrics_variables = self._mlx_state.get("metrics_variables", None)
+        if trainable_variables:
+            for ref_v, v in zip(self.trainable_variables, trainable_variables):
+                ref_v.assign(v)
+        if non_trainable_variables:
+            for ref_v, v in zip(
+                self.non_trainable_variables, non_trainable_variables
+            ):
+                ref_v.assign(v)
+        if optimizer_variables:
+            for ref_v, v in zip(self.optimizer.variables, optimizer_variables):
+                ref_v.assign(v)
+        if metrics_variables:
+            for ref_v, v in zip(self.metrics_variables, metrics_variables):
+                ref_v.assign(v)
+
+    def _purge_model_variables(
+        self,
+        trainable_variables=True,
+        non_trainable_variables=True,
+        optimizer_variables=True,
+        metric_variables=True,
+    ):
+        """Remove all the model variables so they can be garbage collected and
+        the memory reclaimed by MLX.
+
+        Very similar to JAX we have a stateless training function and keeping
+        an extra reference to the model weights means the memory cannot be
+        reclaimed by MLX.
+
+        When finished updating the model variables by training, then we can
+        reattach them to the model with `mlx_state_sync()`.
+        """
+        if trainable_variables:
+            for v in self.trainable_variables:
+                v._value = None
+        if non_trainable_variables:
+            for v in self.non_trainable_variables:
+                v._value = None
+        if optimizer_variables:
+            for v in self.optimizer.variables:
+                v._value = None
+        if metric_variables:
+            for v in self.metrics_variables:
+                v._value = None
+
+    def compute_loss_and_updates(
+        self,
+        trainable_variables,
+        non_trainable_variables,
+        x,
+        y,
+        sample_weight,
+        training=False,
+        optimizer_variables=None,
+    ):
+        """Similar to the jax trainer, this method is stateless and is intended
+        for use with mx.value_and_grad ."""
+        kwargs = {}
+        if self._call_has_training_arg:
+            kwargs["training"] = training
+        y_pred, non_trainable_variables, losses = self.stateless_call(
+            trainable_variables,
+            non_trainable_variables,
+            x,
+            return_losses=True,
+            **kwargs,
+        )
+
+        trainable_mapping = zip(self.trainable_variables, trainable_variables)
+        with backend.StatelessScope(state_mapping=trainable_mapping):
+            # Note that this is needed for the regularization loss, which need
+            # the latest value of train/non-trainable variables.
+            loss = self.compute_loss(
+                x, y, y_pred, sample_weight, allow_empty=True
+            )
+        if losses:
+            loss += ops.sum(losses)
+        unscaled_loss = loss
+        if training and self.optimizer is not None:
+            # Scale loss with a StatelessScope, to use an update scale variable.
+            mapping = list(zip(self.optimizer.variables, optimizer_variables))
+            with backend.StatelessScope(state_mapping=mapping):
+                loss = self.optimizer.scale_loss(loss)
+        return loss, unscaled_loss, y_pred, non_trainable_variables
+
+    def train_step(self, state, data):
+        (
+            trainable_variables,
+            non_trainable_variables,
+            optimizer_variables,
+            metrics_variables,
+        ) = state
+        x, y, sample_weight = data_adapter_utils.unpack_x_y_sample_weight(data)
+        grad_fn = mx.value_and_grad(self.compute_loss_and_updates)
+
+        (loss, unscaled_loss, y_pred, non_trainable_variables), grads = grad_fn(
+            trainable_variables,
+            non_trainable_variables,
+            x,
+            y,
+            sample_weight,
+            training=True,
+            optimizer_variables=optimizer_variables,
+        )
+
+        (
+            trainable_variables,
+            optimizer_variables,
+        ) = self.optimizer.stateless_apply(
+            optimizer_variables, grads, trainable_variables
+        )
+
+        with backend.StatelessScope(
+            state_mapping=[
+                (ref_v, v)
+                for ref_v, v in zip(self.metrics_variables, metrics_variables)
+            ]
+        ) as scope:
+            self._loss_tracker.update_state(unscaled_loss)
+            logs = self.compute_metrics(x, y, y_pred, sample_weight)
+
+        new_metrics_variables = []
+        for ref_v in self.metrics_variables:
+            new_v = scope.get_current_value(ref_v)
+            if new_v is None:
+                new_v = ref_v.value
+            new_metrics_variables.append(new_v)
+        metrics_variables = new_metrics_variables
+
+        state = (
+            trainable_variables,
+            non_trainable_variables,
+            optimizer_variables,
+            metrics_variables,
+        )
+        return logs, state
+
+    def test_step(self, state, data):
+        (
+            trainable_variables,
+            non_trainable_variables,
+            metrics_variables,
+        ) = state
+        x, y, sample_weight = data_adapter_utils.unpack_x_y_sample_weight(data)
+        loss, unscaled_loss, y_pred, non_trainable_variables = self.compute_loss_and_updates(
+            trainable_variables,
+            non_trainable_variables,
+            x,
+            y,
+            sample_weight,
+            training=False,
+        )
+
+        with backend.StatelessScope(
+            state_mapping=[
+                (ref_v, v)
+                for ref_v, v in zip(self.metrics_variables, metrics_variables)
+            ]
+        ) as scope:
+            self._loss_tracker.update_state(unscaled_loss)
+            logs = self.compute_metrics(x, y, y_pred, sample_weight)
+
+        new_metrics_variables = []
+        for ref_v in self.metrics_variables:
+            new_v = scope.get_current_value(ref_v)
+            if new_v is None:
+                new_v = ref_v.value
+            new_metrics_variables.append(new_v)
+        metrics_variables = new_metrics_variables
+
+        state = (
+            trainable_variables,
+            non_trainable_variables,
+            metrics_variables,
+        )
+        return logs, state
+
+    def predict_step(self, state, data):
+        trainable_variables, non_trainable_variables = state
+        kwargs = {}
+        if self._call_has_training_arg:
+            kwargs["training"] = False
+
+        x, _, _ = data_adapter_utils.unpack_x_y_sample_weight(data)
+        outputs, non_trainable_variables = self.stateless_call(
+            trainable_variables, non_trainable_variables, x, **kwargs
+        )
+        return outputs, (trainable_variables, non_trainable_variables)
+
+    def make_train_function(self, force=False):
+        if self.train_function is not None and not force:
+            return self.train_function
+
+        def one_train_step(state, data):
+            data = data[0]
+            return self.train_step(state, data)
+
+        def multi_train_steps(state, data):
+            for single_step_data in data:
+                logs, state = one_train_step(state, [single_step_data])
+            return logs, state
+
+        if self.steps_per_execution > 1:
+            train_step = multi_train_steps
+        else:
+            train_step = one_train_step
+
+        self.train_function = train_step
+
+    def make_test_function(self, force=False):
+        if self.test_function is not None and not force:
+            return self.test_function
+
+        def one_test_step(state, data):
+            data = data[0]
+            return self.test_step(state, data)
+
+        def multi_test_steps(state, data):
+            for single_step_data in data:
+                logs, state = one_test_step(state, [single_step_data])
+            return logs, state
+
+        if self.steps_per_execution > 1:
+            test_step = multi_test_steps
+        else:
+            test_step = one_test_step
+
+        self.test_function = test_step
+
+    def make_predict_function(self, force=False):
+        if self.predict_function is not None and not force:
+            return self.predict_function
+
+        def one_predict_step(state, data):
+            data = data[0]
+            return self.predict_step(state, data)
+
+        def multi_predict_steps(state, data):
+            outputs, state = one_predict_step(state, data[:1])
+
+            for single_step_data in data[1:]:
+                step_outputs, state = one_predict_step(
+                    state,
+                    [single_step_data],
+                )
+                outputs = tree.map_structure(
+                    lambda t1, t2: mx.concatenate([t1, t2]),
+                    outputs,
+                    step_outputs,
+                )
+            return outputs, state
+
+        if self.steps_per_execution > 1:
+            predict_step = multi_predict_steps
+        else:
+            predict_step = one_predict_step
+
+        self.predict_function = predict_step
+
+    def _symbolic_build(self, data_batch):
+        model_unbuilt = not all(layer.built for layer in self._flatten_layers())
+        compile_metrics_unbuilt = (
+            self._compile_metrics is not None
+            and not self._compile_metrics.built
+        )
+        if model_unbuilt or compile_metrics_unbuilt:
+            # Create symbolic tensors matching an input batch.
+
+            def to_symbolic_input(v):
+                if is_tensor(v):
+                    return KerasTensor(v.shape, standardize_dtype(v.dtype))
+                return v
+
+            data_batch = tree.map_structure(to_symbolic_input, data_batch)
+            (
+                x,
+                y,
+                sample_weight,
+            ) = data_adapter_utils.unpack_x_y_sample_weight(data_batch)
+            # Build all model state with `backend.compute_output_spec`.
+            try:
+                y_pred = backend.compute_output_spec(self, x)
+            except Exception as e:
+                raise RuntimeError(
+                    "Unable to automatically build the model. "
+                    "Please build it yourself before calling "
+                    "fit/evaluate/predict. "
+                    "A model is 'built' when its variables have "
+                    "been created and its `self.built` attribute "
+                    "is True. Usually, calling the model on a batch "
+                    "of data is the right way to build it.\n"
+                    "Exception encountered:\n"
+                    f"'{e}'"
+                )
+            if compile_metrics_unbuilt:
+                # Build all metric state with `backend.compute_output_spec`.
+                backend.compute_output_spec(
+                    self.compute_metrics,
+                    x,
+                    y,
+                    y_pred,
+                    sample_weight=sample_weight,
+                )
+        if self.optimizer is not None and not self.optimizer.built:
+            # Build optimizer
+            self.optimizer.build(self.trainable_variables)
+        self._post_build()
+
+    @traceback_utils.filter_traceback
+    def fit(
+        self,
+        x=None,
+        y=None,
+        batch_size=None,
+        epochs=1,
+        verbose="auto",
+        callbacks=None,
+        validation_split=0.0,
+        validation_data=None,
+        shuffle=True,
+        class_weight=None,
+        sample_weight=None,
+        initial_epoch=0,
+        steps_per_epoch=None,
+        validation_steps=None,
+        validation_batch_size=None,
+        validation_freq=1,
+    ):
+        if not self.compiled:
+            raise ValueError(
+                "You must call `compile()` before calling `fit()`."
+            )
+
+        # TODO: respect compiled trainable state
+        self._eval_epoch_iterator = None
+        if validation_split and validation_data is None:
+            # Create the validation data using the training data. Only supported
+            # for TF/numpy/jax arrays.
+            (
+                x,
+                y,
+                sample_weight,
+            ), validation_data = data_adapter_utils.train_validation_split(
+                (x, y, sample_weight), validation_split=validation_split
+            )
+
+        if validation_data:
+            (
+                val_x,
+                val_y,
+                val_sample_weight,
+            ) = data_adapter_utils.unpack_x_y_sample_weight(validation_data)
+
+        # Create an iterator that yields batches for one epoch.
+        epoch_iterator = EpochIterator(
+            x=x,
+            y=y,
+            sample_weight=sample_weight,
+            batch_size=batch_size,
+            steps_per_epoch=steps_per_epoch,
+            shuffle=shuffle,
+            class_weight=class_weight,
+            steps_per_execution=self.steps_per_execution,
+        )
+
+        needs_building = (
+            not all(layer.built for layer in self._flatten_layers())
+            or not self.optimizer.built
+            or (
+                self._compile_metrics is not None
+                and not self._compile_metrics.built
+            )
+        )
+        if needs_building:
+            # Build the model on one batch of data.
+            for _, data in epoch_iterator.enumerate_epoch():
+                data_batch = data[0]
+                self._symbolic_build(data_batch)
+                break
+
+        # Container that configures and calls callbacks.
+        if not isinstance(callbacks, callbacks_module.CallbackList):
+            callbacks = callbacks_module.CallbackList(
+                callbacks,
+                add_history=True,
+                add_progbar=verbose != 0,
+                verbose=verbose,
+                epochs=epochs,
+                steps=epoch_iterator.num_batches,
+                model=self,
+            )
+
+        self.stop_training = False
+        self.make_train_function()
+        callbacks.on_train_begin()
+
+        for epoch in range(initial_epoch, epochs):
+            self.reset_metrics()
+            callbacks.on_epoch_begin(epoch)
+
+            trainable_variables = [v.value for v in self.trainable_variables]
+            non_trainable_variables = [
+                v.value for v in self.non_trainable_variables
+            ]
+            optimizer_variables = [v.value for v in self.optimizer.variables]
+            metrics_variables = [v.value for v in self.metrics_variables]
+
+            self._purge_model_variables()
+            for step, data in epoch_iterator.enumerate_epoch():
+                # Callbacks
+                callbacks.on_train_batch_begin(step)
+
+                # Train step
+                state = (
+                    trainable_variables,
+                    non_trainable_variables,
+                    optimizer_variables,
+                    metrics_variables,
+                )
+                logs, state = self.train_function(state, data)
+                (
+                    trainable_variables,
+                    non_trainable_variables,
+                    optimizer_variables,
+                    metrics_variables,
+                ) = state
+
+                # Setting _mlx_state enables callbacks to force a state sync
+                # if they need to.
+                self._mlx_state = {
+                    "trainable_variables": trainable_variables,
+                    "non_trainable_variables": non_trainable_variables,
+                    "optimizer_variables": optimizer_variables,
+                    "metrics_variables": metrics_variables,
+                }
+
+                # Callbacks
+                callbacks.on_train_batch_end(step, self._pythonify_logs(logs))
+                if self.stop_training:
+                    break
+
+            # Reattach state to model variables.
+            self.mlx_state_sync()
+
+            # Override with model metrics instead of last step logs
+            epoch_logs = self.get_metrics_result()
+
+            # Run validation.
+            if validation_data and self._should_eval(epoch, validation_freq):
+                # Create EpochIterator for evaluation and cache it.
+                if getattr(self, "_eval_epoch_iterator", None) is None:
+                    self._eval_epoch_iterator = EpochIterator(
+                        x=val_x,
+                        y=val_y,
+                        sample_weight=val_sample_weight,
+                        batch_size=validation_batch_size or batch_size,
+                        steps_per_execution=self.steps_per_execution,
+                        steps_per_epoch=validation_steps,
+                        shuffle=False,
+                    )
+                val_logs = self.evaluate(
+                    x=val_x,
+                    y=val_y,
+                    sample_weight=val_sample_weight,
+                    batch_size=validation_batch_size or batch_size,
+                    steps=validation_steps,
+                    callbacks=callbacks,
+                    return_dict=True,
+                    _use_cached_eval_dataset=True,
+                )
+                val_logs = {
+                    "val_" + name: val for name, val in val_logs.items()
+                }
+                epoch_logs.update(val_logs)
+
+            callbacks.on_epoch_end(epoch, epoch_logs)
+            training_logs = epoch_logs
+            if self.stop_training:
+                break
+
+        if (
+            isinstance(self.optimizer, optimizers_module.Optimizer)
+            and epochs > 0
+        ):
+            self.optimizer.finalize_variable_values(self.trainable_weights)
+
+        # If _eval_epoch_iterator exists, delete it after all epochs are done.
+        if getattr(self, "_eval_epoch_iterator", None) is not None:
+            del self._eval_epoch_iterator
+        callbacks.on_train_end(logs=training_logs)
+        self._mlx_state = None
+        return self.history
+
+    @traceback_utils.filter_traceback
+    def evaluate(
+        self,
+        x=None,
+        y=None,
+        batch_size=None,
+        verbose="auto",
+        sample_weight=None,
+        steps=None,
+        callbacks=None,
+        return_dict=False,
+        **kwargs,
+    ):
+        # TODO: respect compiled trainable state
+        use_cached_eval_dataset = kwargs.pop("_use_cached_eval_dataset", False)
+        if kwargs:
+            raise ValueError(f"Arguments not recognized: {kwargs}")
+
+        if use_cached_eval_dataset:
+            epoch_iterator = self._eval_epoch_iterator
+        else:
+            # Create an iterator that yields batches of input/target data.
+            epoch_iterator = EpochIterator(
+                x=x,
+                y=y,
+                sample_weight=sample_weight,
+                batch_size=batch_size,
+                steps_per_epoch=steps,
+                shuffle=False,
+                steps_per_execution=self.steps_per_execution,
+            )
+
+        if not all(layer.built for layer in self._flatten_layers()):
+            # Build the model on one batch of data.
+            for _, data in epoch_iterator.enumerate_epoch():
+                data_batch = data[0]
+                self._symbolic_build(data_batch)
+                break
+
+        # Container that configures and calls callbacks.
+        if not isinstance(callbacks, callbacks_module.CallbackList):
+            callbacks = callbacks_module.CallbackList(
+                callbacks,
+                add_history=True,
+                add_progbar=verbose != 0,
+                verbose=verbose,
+                epochs=1,
+                steps=epoch_iterator.num_batches,
+                model=self,
+            )
+
+        self.make_test_function()
+        self.stop_evaluating = False
+        callbacks.on_test_begin()
+        logs = None
+        self.reset_metrics()
+
+        trainable_variables = [v.value for v in self.trainable_variables]
+        non_trainable_variables = [
+            v.value for v in self.non_trainable_variables
+        ]
+        metrics_variables = [v.value for v in self.metrics_variables]
+
+        self._purge_model_variables(optimizer_variables=False)
+        for step, data in epoch_iterator.enumerate_epoch():
+            callbacks.on_test_batch_begin(step)
+
+            state = (
+                trainable_variables,
+                non_trainable_variables,
+                metrics_variables,
+            )
+            logs, state = self.test_function(state, data)
+            (
+                trainable_variables,
+                non_trainable_variables,
+                metrics_variables,
+            ) = state
+
+            self._mlx_state = {
+                # I wouldn't recommend modifying non-trainable model state
+                # during evaluate(), but it's allowed.
+                "trainable_variables": trainable_variables,
+                "non_trainable_variables": non_trainable_variables,
+                "metrics_variables": metrics_variables,
+            }
+            callbacks.on_test_batch_end(step, self._pythonify_logs(logs))
+            if self.stop_evaluating:
+                break
+
+        self.mlx_state_sync()
+        logs = self.get_metrics_result()
+        callbacks.on_test_end(logs)
+        self._mlx_state = None
+
+        if return_dict:
+            return logs
+        return self._flatten_metrics_in_order(logs)
+
+    @traceback_utils.filter_traceback
+    def predict(
+        self, x, batch_size=None, verbose="auto", steps=None, callbacks=None
+    ):
+        # Create an iterator that yields batches of input data.
+        epoch_iterator = EpochIterator(
+            x=x,
+            batch_size=batch_size,
+            steps_per_epoch=steps,
+            shuffle=False,
+            steps_per_execution=self.steps_per_execution,
+        )
+
+        # Container that configures and calls callbacks.
+        if not isinstance(callbacks, callbacks_module.CallbackList):
+            callbacks = callbacks_module.CallbackList(
+                callbacks,
+                add_history=True,
+                add_progbar=verbose != 0,
+                verbose=verbose,
+                epochs=1,
+                steps=epoch_iterator.num_batches,
+                model=self,
+            )
+
+        def append_to_outputs(batch_outputs, outputs):
+            if outputs is None:
+                outputs = tree.map_structure(
+                    lambda batch_output: [batch_output],
+                    batch_outputs,
+                )
+            else:
+                tree.map_structure_up_to(
+                    batch_outputs,
+                    lambda output, batch_output: output.append(batch_output),
+                    outputs,
+                    batch_outputs,
+                )
+            return outputs
+
+        self.make_predict_function()
+        self.stop_predicting = False
+        callbacks.on_predict_begin()
+
+        trainable_variables = [v.value for v in self.trainable_variables]
+        non_trainable_variables = [
+            v.value for v in self.non_trainable_variables
+        ]
+        state = (trainable_variables, non_trainable_variables)
+
+        outputs = None
+        for step, data in epoch_iterator.enumerate_epoch():
+            callbacks.on_predict_batch_begin(step)
+            batch_outputs, state = self.predict_function(state, x)
+            outputs = append_to_outputs(batch_outputs, outputs)
+            callbacks.on_predict_batch_end(step, {"outputs": batch_outputs})
+            if self.stop_predicting:
+                break
+        callbacks.on_predict_end()
+        outputs = tree.map_structure(backend.convert_to_numpy, outputs)  # TODO: This copies but we could avoid it
+        return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)
+
+    def train_on_batch(
+        self,
+        x,
+        y=None,
+        sample_weight=None,
+        class_weight=None,
+        return_dict=False,
+    ):
+        self._assert_compile_called("train_on_batch")
+        if class_weight is not None:
+            if sample_weight is not None:
+                raise ValueError(
+                    "Arguments `sample_weight` and `class_weight` "
+                    "cannot be specified at the same time. "
+                    f"Received: sample_weight={sample_weight}, "
+                    f"class_weight={class_weight}"
+                )
+            sample_weight = data_adapter_utils.class_weight_to_sample_weights(
+                y, class_weight
+            )
+
+        data = (x, y, sample_weight)
+
+        # Maybe build model
+        self._symbolic_build(data)
+        self.make_train_function()
+
+        trainable_variables = [v.value for v in self.trainable_variables]
+        non_trainable_variables = [
+            v.value for v in self.non_trainable_variables
+        ]
+        optimizer_variables = [v.value for v in self.optimizer.variables]
+        metrics_variables = [v.value for v in self.metrics_variables]
+        # TODO: Why not purge model state?
+        state = (
+            trainable_variables,
+            non_trainable_variables,
+            optimizer_variables,
+            metrics_variables,
+        )
+        logs, state = self.train_function(state, [data])
+
+        # State sync
+        (
+            trainable_variables,
+            non_trainable_variables,
+            optimizer_variables,
+            metrics_variables,
+        ) = state
+        self._mlx_state = {
+            "trainable_variables": trainable_variables,
+            "non_trainable_variables": non_trainable_variables,
+            "optimizer_variables": optimizer_variables,
+            "metrics_variables": metrics_variables,
+        }
+        self.mlx_state_sync()
+
+        logs = tree.map_structure(lambda x: np.array(x), logs)
+        if return_dict:
+            return logs
+        return self._flatten_metrics_in_order(logs)
+
+    def test_on_batch(
+        self,
+        x,
+        y=None,
+        sample_weight=None,
+        return_dict=False,
+    ):
+        self._assert_compile_called("test_on_batch")
+
+        data = (x, y, sample_weight)
+
+        # Maybe build model
+        self._symbolic_build(data)
+        self.make_test_function()
+
+        # Test step
+        trainable_variables = [v.value for v in self.trainable_variables]
+        non_trainable_variables = [
+            v.value for v in self.non_trainable_variables
+        ]
+        metrics_variables = [v.value for v in self.metrics_variables]
+        # TODO: Why not purge model state?
+        state = (
+            trainable_variables,
+            non_trainable_variables,
+            metrics_variables,
+        )
+        logs, state = self.test_function(state, [data])
+
+        # State sync
+        trainable_variables, non_trainable_variables, metrics_variables = state
+        self._mlx_state = {
+            "trainable_variables": trainable_variables,
+            "non_trainable_variables": non_trainable_variables,
+            "metrics_variables": metrics_variables,
+        }
+        self.mlx_state_sync()
+
+        logs = self.test_function([data])
+        logs = tree.map_structure(lambda x: np.array(x), logs)
+        if return_dict:
+            return logs
+        return self._flatten_metrics_in_order(logs)
+
+    def predict_on_batch(self, x):
+        self.make_predict_function()
+        trainable_variables = [v.value for v in self.trainable_variables]
+        non_trainable_variables = [
+            v.value for v in self.non_trainable_variables
+        ]
+        state = (trainable_variables, non_trainable_variables)
+        batch_outputs, state = self.predict_function(state, [(x,)])
+
+        # TODO: This copies but we could avoid it
+        batch_outputs = tree.map_structure(
+            backend.convert_to_numpy, batch_outputs
+        )
+        return batch_outputs

--- a/keras/backend/mlx/trainer.py
+++ b/keras/backend/mlx/trainer.py
@@ -9,7 +9,6 @@ from keras import optimizers as optimizers_module
 from keras.backend.common import standardize_dtype
 from keras.backend.common.keras_tensor import KerasTensor
 from keras.backend.mlx.core import is_tensor
-from keras.trainers import epoch_iterator
 from keras.trainers import trainer as base_trainer
 from keras.trainers.data_adapters import data_adapter_utils
 from keras.trainers.epoch_iterator import EpochIterator

--- a/keras/backend/mlx/trainer.py
+++ b/keras/backend/mlx/trainer.py
@@ -153,8 +153,6 @@ class MLXTrainer(base_trainer.Trainer):
             with backend.StatelessScope(state_mapping=mapping):
                 loss = self.optimizer.scale_loss(loss)
 
-        mx.simplify(loss)
-
         return loss, unscaled_loss, y_pred, non_trainable_variables
 
     def train_step(self, state, data):
@@ -190,7 +188,6 @@ class MLXTrainer(base_trainer.Trainer):
             ) = self.optimizer.stateless_apply(
                 optimizer_variables, grads, trainable_variables
             )
-            mx.simplify(loss, trainable_variables, optimizer_variables)
         else:
             (
                 loss,

--- a/keras/layers/layer.py
+++ b/keras/layers/layer.py
@@ -51,6 +51,8 @@ elif backend.backend() == "torch":
     from keras.backend.torch.layer import TorchLayer as BackendLayer
 elif backend.backend() == "numpy":
     from keras.backend.numpy.layer import NumpyLayer as BackendLayer
+elif backend.backend() == "mlx":
+    from keras.backend.mlx.layer import MLXLayer as BackendLayer
 else:
     raise RuntimeError(
         f"Backend '{backend.backend()}' must implement a layer mixin class."

--- a/keras/models/model.py
+++ b/keras/models/model.py
@@ -23,6 +23,8 @@ elif backend.backend() == "torch":
     from keras.backend.torch.trainer import TorchTrainer as Trainer
 elif backend.backend() == "numpy":
     from keras.backend.numpy.trainer import NumpyTrainer as Trainer
+elif backend.backend() == "mlx":
+    from keras.backend.mlx.trainer import MLXTrainer as Trainer
 else:
     raise RuntimeError(
         f"Backend '{backend.backend()}' must implement the Trainer class."

--- a/keras/trainers/trainer_test.py
+++ b/keras/trainers/trainer_test.py
@@ -26,6 +26,8 @@ elif backend.backend() == "tensorflow":
     from keras.backend.tensorflow.trainer import TensorFlowTrainer as Trainer
 elif backend.backend() == "numpy":
     from keras.backend.numpy.trainer import NumpyTrainer as Trainer
+elif backend.backend() == "mlx":
+    from keras.backend.mlx.trainer import MLXTrainer as Trainer
 else:
     raise ImportError(f"Invalid backend: {backend.backend()}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ jax[cpu]
 # MLX
 pybind11[global]
 cmake
-mlx @ git+https://github.com/ml-explore/mlx.git@v0.0.9
+mlx
 
 # Common deps.
 -r requirements-common.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,10 @@ torchvision>=0.16.0
 # Jax.
 jax[cpu]
 
+# MLX
+pybind11[global]
+cmake
+mlx @ git+https://github.com/ml-explore/mlx.git@v0.0.9
+
 # Common deps.
 -r requirements-common.txt


### PR DESCRIPTION
This PR adds an MLX (https://github.com/ml-explore/mlx) backend as mentioned also in #18901 .

A lot of things are still missing but my initial goal was to be able to pass the trainer and backend tests as well as train a small MLP. The backend is implemented by porting things either from the Jax backend or the PyTorch backend where appropriate.

The following is an excerpt from the MNIST training example that runs fine with the MLX backend on my M2 air.
```python
model = keras.Sequential(
    [
        keras.Input(shape=input_shape),
        layers.Dense(1024, activation="relu"),
        layers.Dense(1024, activation="relu"),
        layers.Dense(num_classes, activation="softmax"),
    ]
)

model.summary()

model.compile(loss="categorical_crossentropy", optimizer="adam", metrics=["accuracy"])
model.fit(x_train, y_train, batch_size=batch_size, epochs=epochs, validation_split=0.1)
```