### PR TITLE
Validate cropping arg value for -ve ints

### DIFF
--- a/keras/layers/reshaping/cropping2d.py
+++ b/keras/layers/reshaping/cropping2d.py
@@ -57,6 +57,11 @@ class Cropping2D(Layer):
         super().__init__(**kwargs)
         self.data_format = backend.standardize_data_format(data_format)
         if isinstance(cropping, int):
+            if cropping < 0:
+                raise ValueError(
+                    "`cropping` cannot be negative. "
+                    f"Received: cropping={cropping}."
+                )
             self.cropping = ((cropping, cropping), (cropping, cropping))
         elif hasattr(cropping, "__len__"):
             if len(cropping) != 2:

--- a/keras/layers/reshaping/cropping3d.py
+++ b/keras/layers/reshaping/cropping3d.py
@@ -62,6 +62,11 @@ class Cropping3D(Layer):
         super().__init__(**kwargs)
         self.data_format = backend.standardize_data_format(data_format)
         if isinstance(cropping, int):
+            if cropping < 0:
+                raise ValueError(
+                    "`cropping` cannot be negative. "
+                    f"Received: cropping={cropping}."
+                )
             self.cropping = (
                 (cropping, cropping),
                 (cropping, cropping),


### PR DESCRIPTION
The API Cropping2D has an argument cropping which can take either int or tuple of 2 tuple of ints.

If we provide -ve values when passed as tuple like `cropping = ( (-1,-1), (-1,-1) )` then this API raises exception like below which is intended.

> ValueError: The `1st entry of cropping` argument must be a tuple of 2 integers. Received 1st entry of cropping=(-1, -1), including values {-1} that do not satisfy `value >= 0`

However if we given -ve int value like `cropping = -1`, then there is no exception and generating unintended output.
Internally this -ve value being converted into tuple from below code.

https://github.com/keras-team/keras/blob/c3d269b308b40314e8e128a7116a7f3fdf0ca212/keras/layers/reshaping/cropping2d.py#L60

After converting to tuple there is no validation that this API currently doing for `tuple` input which is like below.
https://github.com/keras-team/keras/blob/c3d269b308b40314e8e128a7116a7f3fdf0ca212/keras/layers/reshaping/cropping2d.py#L67



Hence I am adding a simple validation for -ve values for cropping when passed as int.

Attached [gist](https://colab.sandbox.google.com/gist/SuryanarayanaY/546286afda9c021df731cfa762d39650/cropping2d_3d.ipynb) for above exercise 

This issue discussed in TF # [61255](https://github.com/tensorflow/tensorflow/issues/61255).