### PR TITLE
Fix for https://github.com/keras-team/keras/issues/18941

### DIFF
--- a/keras/backend/tensorflow/rnn.py
+++ b/keras/backend/tensorflow/rnn.py
@@ -90,7 +90,9 @@ def rnn(
 
     flattened_inputs = tree.flatten(inputs)
     time_steps = flattened_inputs[0].shape[0]
-    time_steps_t = tf.shape(flattened_inputs[0])[0]
+    time_steps_t = (
+        tf.shape(flattened_inputs[0])[0] if time_steps is None else time_steps
+    )
 
     for input_ in flattened_inputs:
         input_.shape.with_rank_at_least(3)


### PR DESCRIPTION
This allows the static shape to propagate in RNNs in the case when the number of time steps is fixed and known at build time.

Fixes #18941.