### PR TITLE
Fix EMA when using tensorflow backend

### DIFF
--- a/keras/backend/tensorflow/optimizer.py
+++ b/keras/backend/tensorflow/optimizer.py
@@ -179,8 +179,8 @@ class TFOptimizer(base_optimizer.BaseOptimizer):
                     average.assign(var)
 
                 tf.cond(
-                    self._ema_vars_initialized > 0,
+                    self._ema_vars_initialized,
                     lambda: _update_fn(var, average),
                     lambda: _assign_fn(var, average),
                 )
-            self._ema_vars_initialized.assign_add(True)
+            self._ema_vars_initialized.assign(True)

--- a/keras/optimizers/base_optimizer.py
+++ b/keras/optimizers/base_optimizer.py
@@ -139,22 +139,7 @@ class BaseOptimizer:
     def build(self, variables):
         if self.use_ema:
             self._model_variables_moving_average = []
-            # When using tensorflow backend, we must use `backend.Variable` in
-            # `self._update_model_variables_moving_average` to correctly
-            # initialize moving averages with the same value as
-            # `trainable_variables` during the first `self.apply`.
-            if backend.backend() == "tensorflow":
-                with backend.name_scope(self.name, caller=self):
-                    _ema_vars_initialized = backend.Variable(
-                        False,
-                        name="_ema_vars_initialized",
-                        dtype="bool",
-                        trainable=False,
-                    )
-                    self._track_variable(_ema_vars_initialized)
-                    self._ema_vars_initialized = _ema_vars_initialized
-            else:
-                self._ema_vars_initialized = False
+            self._ema_vars_initialized = False
         if self.gradient_accumulation_steps:
             self._accumulated_gradients = []
         for i, variable in enumerate(variables):

--- a/keras/optimizers/base_optimizer.py
+++ b/keras/optimizers/base_optimizer.py
@@ -140,10 +140,9 @@ class BaseOptimizer:
         if self.use_ema:
             self._model_variables_moving_average = []
             # When using tensorflow backend, we must use `backend.Variable` in
-            # `self._update_model_variables_moving_average`` to correctly
-            # initialize `self._model_variables_moving_average` with the same
-            # value as `trainable_variables` when the first `self.apply` is
-            # called.
+            # `self._update_model_variables_moving_average` to correctly
+            # initialize moving averages with the same value as
+            # `trainable_variables` during the first `self.apply`.
             if backend.backend() == "tensorflow":
                 with backend.name_scope(self.name, caller=self):
                     _ema_vars_initialized = backend.Variable(

--- a/keras/optimizers/base_optimizer.py
+++ b/keras/optimizers/base_optimizer.py
@@ -147,9 +147,9 @@ class BaseOptimizer:
             if backend.backend() == "tensorflow":
                 with backend.name_scope(self.name, caller=self):
                     _ema_vars_initialized = backend.Variable(
-                        0,
+                        False,
                         name="_ema_vars_initialized",
-                        dtype="int",
+                        dtype="bool",
                         trainable=False,
                     )
                     self._track_variable(_ema_vars_initialized)

--- a/keras/optimizers/optimizer_test.py
+++ b/keras/optimizers/optimizer_test.py
@@ -1,9 +1,13 @@
 import numpy as np
+import pytest
 
 from keras import backend
 from keras import constraints
+from keras import layers
+from keras import models
 from keras import optimizers
 from keras import testing
+from keras.utils import numerical_utils
 
 
 class OptimizerTest(testing.TestCase):
@@ -34,8 +38,33 @@ class OptimizerTest(testing.TestCase):
         )
         optimizer.apply_gradients([(grads, v)])
         self.assertAllClose(v, [[1.0, 2.0], [3.0, 4.0]])
+        self.assertAllClose(
+            optimizer._model_variables_moving_average[0],
+            [[1.9, 2.9], [3.9, 4.9]],
+        )
         optimizer.apply_gradients([(grads, v)])
         self.assertAllClose(v, [[1.71, 2.71], [3.71, 4.71]])
+        self.assertAllClose(
+            optimizer._model_variables_moving_average[0],
+            [[1.71, 2.71], [3.71, 4.71]],
+        )
+
+    @pytest.mark.requires_trainable_backend
+    def test_ema_with_model_fit(self):
+        x_train = np.ones((10, 3)).astype("float32")
+        y_train = np.zeros((10,)).astype("float32")
+        y_train = numerical_utils.to_categorical(y_train)
+        optimizer = optimizers.SGD(use_ema=True, ema_momentum=0.9999)
+        model = models.Sequential(
+            [layers.Dense(2, use_bias=False, kernel_initializer="ones")]
+        )
+        model.compile(loss="mse", optimizer=optimizer)
+        model.fit(x_train, y_train, batch_size=10, epochs=1)
+        self.assertAllClose(
+            model.trainable_variables[0].numpy(),
+            [[0.98, 0.98], [0.98, 0.98], [0.98, 0.98]],
+            atol=1e-5,
+        )
 
     def test_constraints_are_applied(self):
         v = backend.Variable(np.random.random((2, 2)) - 1.0)


### PR DESCRIPTION
Currently, the initial state of `_model_variables_moving_average` is INCORRECT when using tensorflow backend.
This bug will also cause the model weights become all zeros, regardless of the initializer used.

This PR fixes the bug by using `tf.cond` to overwrite `_update_model_variables_moving_average` in `TFOptimizer`.
The new test `test_ema_with_model_fit` can only be passed after this PR.
Before this PR, the trained model weights will be very small, even though they should be close to 1. (initialized by 1 and `ema_momentum=0.9999`)

Actually, the bug was identified during the implementation of the idea proposed in #18949