### PR TITLE
Correct the Error description in cropping layer APIs

### DIFF
--- a/keras/layers/reshaping/cropping1d.py
+++ b/keras/layers/reshaping/cropping1d.py
@@ -54,7 +54,7 @@ class Cropping1D(Layer):
             if length <= 0:
                 raise ValueError(
                     "`cropping` parameter of `Cropping1D` layer must be "
-                    "greater than the input length. Received: input_shape="
+                    "smaller than the input length. Received: input_shape="
                     f"{input_shape}, cropping={self.cropping}"
                 )
         else:
@@ -68,7 +68,7 @@ class Cropping1D(Layer):
         ):
             raise ValueError(
                 "`cropping` parameter of `Cropping1D` layer must be "
-                "greater than the input length. Received: inputs.shape="
+                "smaller than the input length. Received: inputs.shape="
                 f"{inputs.shape}, cropping={self.cropping}"
             )
         if self.cropping[1] == 0:

--- a/keras/layers/reshaping/cropping1d_test.py
+++ b/keras/layers/reshaping/cropping1d_test.py
@@ -64,7 +64,7 @@ class Cropping1DTest(testing.TestCase):
     def test_cropping_1d_errors_if_cropping_more_than_available(self):
         with self.assertRaisesRegex(
             ValueError,
-            "`cropping` parameter of `Cropping1D` layer must be greater than",
+            "`cropping` parameter of `Cropping1D` layer must be smaller than",
         ):
             input_layer = layers.Input(batch_shape=(3, 5, 7))
             layers.Cropping1D(cropping=(2, 3))(input_layer)
@@ -74,7 +74,7 @@ class Cropping1DTest(testing.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "`cropping` parameter of `Cropping1D` layer must be greater than",
+            "`cropping` parameter of `Cropping1D` layer must be smaller than",
         ):
             layer = layers.Cropping1D(cropping=(3, 3))
             _ = layer(inputs)

--- a/keras/layers/reshaping/cropping2d.py
+++ b/keras/layers/reshaping/cropping2d.py
@@ -91,7 +91,7 @@ class Cropping2D(Layer):
                 and sum(self.cropping[1]) >= input_shape[3]
             ):
                 raise ValueError(
-                    "Values in `cropping` argument should be greater than the "
+                    "Values in `cropping` argument should be smaller than the "
                     "corresponding spatial dimension of the input. Received: "
                     f"input_shape={input_shape}, cropping={self.cropping}"
                 )
@@ -114,7 +114,7 @@ class Cropping2D(Layer):
                 and sum(self.cropping[1]) >= input_shape[2]
             ):
                 raise ValueError(
-                    "Values in `cropping` argument should be greater than the "
+                    "Values in `cropping` argument should be smaller than the "
                     "corresponding spatial dimension of the input. Received: "
                     f"input_shape={input_shape}, cropping={self.cropping}"
                 )
@@ -139,7 +139,7 @@ class Cropping2D(Layer):
                 and sum(self.cropping[1]) >= inputs.shape[3]
             ):
                 raise ValueError(
-                    "Values in `cropping` argument should be greater than the "
+                    "Values in `cropping` argument should be smaller than the "
                     "corresponding spatial dimension of the input. Received: "
                     f"inputs.shape={inputs.shape}, cropping={self.cropping}"
                 )
@@ -176,7 +176,7 @@ class Cropping2D(Layer):
                 and sum(self.cropping[1]) >= inputs.shape[2]
             ):
                 raise ValueError(
-                    "Values in `cropping` argument should be greater than the "
+                    "Values in `cropping` argument should be smaller than the "
                     "corresponding spatial dimension of the input. Received: "
                     f"inputs.shape={inputs.shape}, cropping={self.cropping}"
                 )

--- a/keras/layers/reshaping/cropping2d_test.py
+++ b/keras/layers/reshaping/cropping2d_test.py
@@ -126,7 +126,7 @@ class Cropping2DTest(testing.TestCase, parameterized.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "Values in `cropping` argument should be greater than the "
+            "Values in `cropping` argument should be smaller than the "
             "corresponding spatial dimension of the input.",
         ):
             layer = layers.Cropping2D(

--- a/keras/layers/reshaping/cropping3d.py
+++ b/keras/layers/reshaping/cropping3d.py
@@ -107,7 +107,7 @@ class Cropping3D(Layer):
             spatial_dims[index] -= sum(self.cropping[index])
             if spatial_dims[index] <= 0:
                 raise ValueError(
-                    "Values in `cropping` argument should be greater than the "
+                    "Values in `cropping` argument should be smaller than the "
                     "corresponding spatial dimension of the input. Received: "
                     f"input_shape={input_shape}, cropping={self.cropping}"
                 )
@@ -129,7 +129,7 @@ class Cropping3D(Layer):
             spatial_dims[index] -= sum(self.cropping[index])
             if spatial_dims[index] <= 0:
                 raise ValueError(
-                    "Values in `cropping` argument should be greater than the "
+                    "Values in `cropping` argument should be smaller than the "
                     "corresponding spatial dimension of the input. Received: "
                     f"inputs.shape={inputs.shape}, cropping={self.cropping}"
                 )

--- a/keras/layers/reshaping/cropping3d_test.py
+++ b/keras/layers/reshaping/cropping3d_test.py
@@ -190,7 +190,7 @@ class Cropping3DTest(testing.TestCase, parameterized.TestCase):
             input_layer = layers.Input(batch_shape=shape)
 
         expected_error_msg = (
-            "Values in `cropping` argument should be greater than the"
+            "Values in `cropping` argument should be smaller than the"
         )
 
         with self.assertRaisesRegex(ValueError, expected_error_msg):


### PR DESCRIPTION
The cropping layer APIs like Cropping2D,Cropping3D and Cropping1D, have cropping parameter which should be smaller than the input(or image) size. This is validating like below.

https://github.com/keras-team/keras/blob/4a4a139c7aada9f4495620e5a1c5f7ef20d84395/keras/layers/reshaping/cropping2d.py#L94-L102

But the error description above states cropping should be `greater` than input which actually should be `smaller` than input. Reference [gist](https://colab.sandbox.google.com/gist/SuryanarayanaY/b27ecffe8781337f36dafa35dc7c5791/cropping_exception_error.ipynb) for demo.