### PR TITLE
allow output_sequence_length when ragged is True

### DIFF
--- a/keras/layers/preprocessing/text_vectorization.py
+++ b/keras/layers/preprocessing/text_vectorization.py
@@ -123,7 +123,8 @@ class TextVectorization(Layer):
             have its time dimension padded or truncated to exactly
             `output_sequence_length` values, resulting in a tensor of shape
             `(batch_size, output_sequence_length)` regardless of how many tokens
-            resulted from the splitting step. Defaults to `None`.
+            resulted from the splitting step. Defaults to `None`. If `ragged`
+            is `True` then `output_sequence_length` may truncate the output.
         pad_to_max_tokens: Only valid in  `"multi_hot"`, `"count"`,
             and `"tf_idf"` modes. If `True`, the output will have
             its feature axis padded to `max_tokens` even if the number
@@ -313,13 +314,6 @@ class TextVectorization(Layer):
                 "`ragged` must not be true if `output_mode` is "
                 f"`'int'`. Received: ragged={ragged} and "
                 f"output_mode={output_mode}"
-            )
-
-        if ragged and output_sequence_length is not None:
-            raise ValueError(
-                "`output_sequence_length` must not be set if ragged "
-                f"is True. Received: ragged={ragged} and "
-                f"output_sequence_length={output_sequence_length}"
             )
 
         self._max_tokens = max_tokens

--- a/keras/layers/preprocessing/text_vectorization_test.py
+++ b/keras/layers/preprocessing/text_vectorization_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import tensorflow as tf
 import pytest
 from tensorflow import data as tf_data
 
@@ -104,3 +105,17 @@ class TextVectorizationTest(testing.TestCase):
             ]
         )
         model(backend.convert_to_tensor([["foo qux bar"], ["qux baz"]]))
+
+    @pytest.mark.skipif(
+        backend.backend() != "tensorflow", reason="Requires ragged tensors."
+    )
+    def test_ragged_tensor(self):
+        layer = layers.TextVectorization(
+            output_mode="int",
+            vocabulary=["baz", "bar", "foo"],
+            ragged=True,
+        )
+        input_data = [["foo baz baz bar"], ["foo baz bar"], ["foo baz"], ["foo"]]
+        output = layer(input_data)
+        assert isinstance(output, tf.RaggedTensor)
+        assert output.shape == (4,None)

--- a/keras/layers/preprocessing/text_vectorization_test.py
+++ b/keras/layers/preprocessing/text_vectorization_test.py
@@ -115,7 +115,12 @@ class TextVectorizationTest(testing.TestCase):
             vocabulary=["baz", "bar", "foo"],
             ragged=True,
         )
-        input_data = [["foo baz baz bar"], ["foo baz bar"], ["foo baz"], ["foo"]]
+        input_data = [
+            ["foo baz baz bar"],
+            ["foo baz bar"],
+            ["foo baz"],
+            ["foo"],
+        ]
         output = layer(input_data)
         assert isinstance(output, tf.RaggedTensor)
-        assert output.shape == (4,None)
+        assert output.shape == (4, None)

--- a/keras/layers/preprocessing/text_vectorization_test.py
+++ b/keras/layers/preprocessing/text_vectorization_test.py
@@ -1,6 +1,6 @@
 import numpy as np
-import tensorflow as tf
 import pytest
+import tensorflow as tf
 from tensorflow import data as tf_data
 
 from keras import backend


### PR DESCRIPTION
This PR fixes https://github.com/keras-team/keras/issues/18576 allowing ```output_sequence_length``` to be enabled even when ```ragged``` is ```True```.