### PR TITLE
Fix `ops.split` in torch and tensorflow

### DIFF
--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -1331,7 +1331,21 @@ def sort(x, axis=-1):
 
 
 def split(x, indices_or_sections, axis=0):
-    return tfnp.split(x, indices_or_sections, axis=axis)
+    if not isinstance(indices_or_sections, int):
+        # `tf.split` requires `num_or_size_splits`, so we need to convert
+        # `indices_or_sections` to the appropriate format.
+        # The following implementation offers better compatibility for the
+        # tensor argument `indices_or_sections` than original `tfnp.split`.
+        total_size = x.shape[axis]
+        indices_or_sections = convert_to_tensor(indices_or_sections)
+        start_size = indices_or_sections[0:1]
+        end_size = total_size - indices_or_sections[-1:]
+        num_or_size_splits = tf.concat(
+            [start_size, tfnp.diff(indices_or_sections), end_size], axis=0
+        )
+    else:
+        num_or_size_splits = indices_or_sections
+    return tf.split(x, num_or_size_splits, axis=axis)
 
 
 def stack(x, axis=0):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -1168,15 +1168,15 @@ def sort(x, axis=-1):
 def split(x, indices_or_sections, axis=0):
     x = convert_to_tensor(x)
     dim = x.shape[axis]
-    if isinstance(indices_or_sections, (list, tuple)):
-        idxs = convert_to_tensor(indices_or_sections)
-        start_size = indices_or_sections[0]
-        end_size = dim - indices_or_sections[-1]
-        chunk_sizes = (
-            [start_size]
-            + torch.diff(idxs).type(torch.int).tolist()
-            + [end_size]
+    if not isinstance(indices_or_sections, int):
+        indices_or_sections = convert_to_tensor(indices_or_sections)
+        start_size = indices_or_sections[0:1]
+        end_size = dim - indices_or_sections[-1:]
+        chunk_sizes = torch.concat(
+            [start_size, torch.diff(indices_or_sections), end_size], dim=0
         )
+        # torch.split doesn't support tensor input for `split_size_or_sections`
+        chunk_sizes = chunk_sizes.tolist()
     else:
         if dim % indices_or_sections != 0:
             raise ValueError(

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -3740,6 +3740,37 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(len(knp.split(x, 2)), 2)
         self.assertEqual(len(knp.Split(2)(x)), 2)
 
+        # test indices_or_sections as tensor
+        x = knp.array([[1, 2, 3], [3, 2, 1]])
+        indices_or_sections = knp.array([1, 2])
+        x_np = np.array([[1, 2, 3], [3, 2, 1]])
+        indices_or_sections_np = np.array([1, 2])
+        self.assertAllClose(
+            knp.split(x, indices_or_sections, axis=1),
+            np.split(x_np, indices_or_sections_np, axis=1),
+        )
+
+    @pytest.mark.skipif(
+        backend.backend() != "tensorflow",
+        reason="Only test tensorflow backend",
+    )
+    def test_split_with_jit_in_tf(self):
+        import tensorflow as tf
+
+        x = knp.array([[1, 2, 3], [3, 2, 1]])
+        indices = knp.array([1, 2])
+        x_np = np.array([[1, 2, 3], [3, 2, 1]])
+        indices_np = np.array([1, 2])
+
+        @tf.function(jit_compile=True)
+        def fn(x, indices, axis):
+            return knp.split(x, indices, axis=axis)
+
+        self.assertAllClose(
+            fn(x, indices, axis=1),
+            np.split(x_np, indices_np, axis=1),
+        )
+
     def test_sqrt(self):
         x = np.array([[1, 4, 9], [16, 25, 36]], dtype="float32")
         ref_y = np.sqrt(x)


### PR DESCRIPTION
It's a common use case to use a tensor to split another tensor.

This PR addresses the incompatibility issue of using a tensor input as `indices_or_sections` in `ops.split` for tensorflow and torch.

It is worth noting that I have implemented a more robust solution for tensorflow backend, supporting XLA compilation for tensor input of `indices_or_sections`.
The corresponding test `test_split_with_jit_in_tf` has been added.