### PR TITLE
Add `JAXEpochIterator` and speed up `get_numpy_iterator`

### DIFF
--- a/keras/backend/jax/trainer.py
+++ b/keras/backend/jax/trainer.py
@@ -1,3 +1,5 @@
+import collections
+import itertools
 from functools import partial
 
 import jax
@@ -336,7 +338,7 @@ class JAXTrainer(base_trainer.Trainer):
             ) = data_adapter_utils.unpack_x_y_sample_weight(validation_data)
 
         # Create an iterator that yields batches for one epoch.
-        epoch_iterator = EpochIterator(
+        epoch_iterator = JAXEpochIterator(
             x=x,
             y=y,
             sample_weight=sample_weight,
@@ -389,7 +391,6 @@ class JAXTrainer(base_trainer.Trainer):
                     optimizer_variables,
                     metrics_variables,
                 )
-                data = self._distribute_data(data)
                 logs, state = self.train_function(state, data)
                 (
                     trainable_variables,
@@ -426,9 +427,9 @@ class JAXTrainer(base_trainer.Trainer):
 
             # Run validation.
             if validation_data and self._should_eval(epoch, validation_freq):
-                # Create EpochIterator for evaluation and cache it.
+                # Create JAXEpochIterator for evaluation and cache it.
                 if getattr(self, "_eval_epoch_iterator", None) is None:
-                    self._eval_epoch_iterator = EpochIterator(
+                    self._eval_epoch_iterator = JAXEpochIterator(
                         x=val_x,
                         y=val_y,
                         sample_weight=val_sample_weight,
@@ -493,7 +494,7 @@ class JAXTrainer(base_trainer.Trainer):
             epoch_iterator = self._eval_epoch_iterator
         else:
             # Create an iterator that yields batches of input/target data.
-            epoch_iterator = EpochIterator(
+            epoch_iterator = JAXEpochIterator(
                 x=x,
                 y=y,
                 sample_weight=sample_weight,
@@ -539,7 +540,6 @@ class JAXTrainer(base_trainer.Trainer):
                 non_trainable_variables,
                 metrics_variables,
             )
-            data = self._distribute_data(data)
             logs, state = self.test_function(state, data)
             (
                 trainable_variables,
@@ -579,7 +579,7 @@ class JAXTrainer(base_trainer.Trainer):
         self, x, batch_size=None, verbose="auto", steps=None, callbacks=None
     ):
         # Create an iterator that yields batches of input data.
-        epoch_iterator = EpochIterator(
+        epoch_iterator = JAXEpochIterator(
             x=x,
             batch_size=batch_size,
             steps_per_epoch=steps,
@@ -636,7 +636,6 @@ class JAXTrainer(base_trainer.Trainer):
         outputs = None
         for step, x in epoch_iterator.enumerate_epoch(return_type="np"):
             callbacks.on_predict_batch_begin(step)
-            x = self._distribute_data(x)
             batch_outputs, state = self.predict_function(state, x)
             outputs = append_to_outputs(batch_outputs, outputs)
             callbacks.on_predict_batch_end(step, {"outputs": batch_outputs})
@@ -666,7 +665,7 @@ class JAXTrainer(base_trainer.Trainer):
                 y, class_weight
             )
         data = (x, y, sample_weight)
-        data = self._distribute_data(data)
+        data = _distribute_data(data)
 
         # Maybe build model
         self._symbolic_build(data_batch=data)
@@ -719,7 +718,7 @@ class JAXTrainer(base_trainer.Trainer):
         self._assert_compile_called("test_on_batch")
 
         data = (x, y, sample_weight)
-        data = self._distribute_data(data)
+        data = _distribute_data(data)
         # Maybe build model
         self._symbolic_build(data_batch=data)
         self._record_training_state_sharding_spec()
@@ -794,18 +793,6 @@ class JAXTrainer(base_trainer.Trainer):
         if metrics_variables:
             for ref_v, v in zip(self.metrics_variables, metrics_variables):
                 ref_v.assign(v)
-
-    def _distribute_data(self, data):
-        distribution = distribution_lib.distribution()
-        if distribution is not None:
-
-            def distribute_single_value(d):
-                layout = distribution.get_data_layout(d.shape)
-                return jax_distribution_lib.distribute_data_input(d, layout)
-
-            return jax.tree_util.tree_map(distribute_single_value, data)
-        else:
-            return data
 
     def _record_training_state_sharding_spec(self):
         self._trainable_variable_shardings = [
@@ -901,3 +888,51 @@ class JAXTrainer(base_trainer.Trainer):
         if metric_variables:
             for v in self.metrics_variables:
                 v._value = None
+
+
+def _distribute_data(data):
+    distribution = distribution_lib.distribution()
+    if distribution is not None:
+
+        def distribute_single_value(d):
+            layout = distribution.get_data_layout(d.shape)
+            return jax_distribution_lib.distribute_data_input(d, layout)
+
+        return jax.tree_util.tree_map(distribute_single_value, data)
+    else:
+        return data
+
+
+class JAXEpochIterator(EpochIterator):
+    def _get_iterator(self, return_type="np"):
+        if return_type == "np":
+            return self._prefetch_numpy_iterator(
+                super()._get_iterator(return_type)
+            )
+        else:
+            return super()._get_iterator(return_type)
+
+    def _prefetch_numpy_iterator(self, numpy_iterator):
+        """Shard and prefetch batches on device.
+
+        Most of the implementation has been borrowed from
+        `flax.jax_utils.prefetch_to_device`
+
+        This utility takes an iterator and returns a new iterator which fills an
+        on device prefetch buffer. Eager prefetching can improve the performance
+        of training loops significantly by overlapping compute and data
+        transfer.
+        """
+        queue = collections.deque()
+
+        # If you're training on GPUs, 2 is generally the best choice because
+        # this guarantees that you can overlap a training step on GPU with a
+        # data prefetch step on CPU.
+        def enqueue(n=2):
+            for data in itertools.islice(numpy_iterator, n):
+                queue.append(_distribute_data(data))
+
+        enqueue(2)  # TODO: should we make `n` configurable?
+        while queue:
+            yield queue.popleft()
+            enqueue(1)

--- a/keras/backend/jax/trainer.py
+++ b/keras/backend/jax/trainer.py
@@ -906,11 +906,13 @@ def _distribute_data(data):
 class JAXEpochIterator(EpochIterator):
     def _get_iterator(self, return_type="np"):
         if return_type == "np":
-            return self._prefetch_to_device(super()._get_iterator(return_type))
+            return self._prefetch_numpy_iterator(
+                super()._get_iterator(return_type)
+            )
         else:
             return super()._get_iterator(return_type)
 
-    def _prefetch_to_device(self, numpy_iterator):
+    def _prefetch_numpy_iterator(self, numpy_iterator):
         """Shard and prefetch batches on device.
 
         Most of the implementation has been borrowed from

--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -209,7 +209,7 @@ class TorchTrainer(base_trainer.Trainer):
             ) = data_adapter_utils.unpack_x_y_sample_weight(validation_data)
 
         # Create an iterator that yields batches for one epoch.
-        epoch_iterator = EpochIterator(
+        epoch_iterator = TorchEpochIterator(
             x=x,
             y=y,
             sample_weight=sample_weight,

--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -1,3 +1,5 @@
+import collections
+import itertools
 import warnings
 
 import numpy as np
@@ -8,8 +10,8 @@ from packaging.version import parse
 from keras import backend
 from keras import callbacks as callbacks_module
 from keras import optimizers as optimizers_module
+from keras.backend.torch.core import get_device
 from keras.trainers import data_adapters
-from keras.trainers import epoch_iterator
 from keras.trainers import trainer as base_trainer
 from keras.trainers.data_adapters import data_adapter_utils
 from keras.trainers.epoch_iterator import EpochIterator
@@ -263,9 +265,9 @@ class TorchTrainer(base_trainer.Trainer):
 
             # Run validation.
             if validation_data and self._should_eval(epoch, validation_freq):
-                # Create EpochIterator for evaluation and cache it.
+                # Create TorchEpochIterator for evaluation and cache it.
                 if getattr(self, "_eval_epoch_iterator", None) is None:
-                    self._eval_epoch_iterator = EpochIterator(
+                    self._eval_epoch_iterator = TorchEpochIterator(
                         x=val_x,
                         y=val_y,
                         sample_weight=val_sample_weight,
@@ -328,7 +330,7 @@ class TorchTrainer(base_trainer.Trainer):
             epoch_iterator = self._eval_epoch_iterator
         else:
             # Create an iterator that yields batches of input/target data.
-            epoch_iterator = EpochIterator(
+            epoch_iterator = TorchEpochIterator(
                 x=x,
                 y=y,
                 sample_weight=sample_weight,
@@ -494,11 +496,49 @@ class TorchTrainer(base_trainer.Trainer):
         return batch_outputs
 
 
-class TorchEpochIterator(epoch_iterator.EpochIterator):
+class TorchEpochIterator(EpochIterator):
     def _get_iterator(self, return_type="auto"):
         if return_type == "auto" and isinstance(
             self.data_adapter, data_adapters.TorchDataLoaderAdapter
         ):
             return self.data_adapter.get_torch_dataloader()
+        else:
+            # defaults to `np` if not `TorchDataLoaderAdapter`
+            return_type = "np"
 
+        if return_type == "np":
+            return self._prefetch_numpy_iterator(
+                super()._get_iterator(return_type)
+            )
         return super()._get_iterator(return_type)
+
+    def _prefetch_numpy_data(self, data):
+        def to_device(d):
+            return torch.as_tensor(d, device=get_device())
+
+        return tree.map_structure(to_device, data)
+
+    def _prefetch_numpy_iterator(self, numpy_iterator):
+        """Prefetch batches on device.
+
+        The idea has been borrowed from
+        `torchtnt.utils.data.CudaDataPrefetcher`
+
+        This utility takes an iterator and returns a new iterator which fills an
+        on device prefetch buffer. Eager prefetching can improve the performance
+        of training loops significantly by overlapping compute and data
+        transfer.
+        """
+        queue = collections.deque()
+
+        # If you're training on GPUs, 2 is generally the best choice because
+        # this guarantees that you can overlap a training step on GPU with a
+        # data prefetch step on CPU.
+        def enqueue(n=2):
+            for data in itertools.islice(numpy_iterator, n):
+                queue.append(self._prefetch_numpy_data(data))
+
+        enqueue(n=2)  # TODO: should we make `n` configurable?
+        while queue:
+            yield queue.popleft()
+            enqueue(1)

--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -502,14 +502,9 @@ class TorchEpochIterator(EpochIterator):
             self.data_adapter, data_adapters.TorchDataLoaderAdapter
         ):
             return self.data_adapter.get_torch_dataloader()
-        else:
-            # defaults to `np` if not `TorchDataLoaderAdapter`
-            return_type = "np"
-
-        if return_type == "np":
-            return self._prefetch_numpy_iterator(
-                super()._get_iterator(return_type)
-            )
+        elif return_type in ("np", "auto"):
+            # enable prefetching when using numpy_iterator
+            return self._prefetch_numpy_iterator(super()._get_iterator("np"))
         return super()._get_iterator(return_type)
 
     def _prefetch_numpy_data(self, data):

--- a/keras/trainers/data_adapters/tf_dataset_adapter.py
+++ b/keras/trainers/data_adapters/tf_dataset_adapter.py
@@ -1,3 +1,4 @@
+import numpy as np
 import tree
 
 from keras.trainers.data_adapters import data_adapter_utils
@@ -41,7 +42,8 @@ class TFDatasetAdapter(DataAdapter):
         def convert_to_numpy(x):
             if isinstance(x, tf.SparseTensor):
                 x = tf.sparse.to_dense(x)
-            return x.numpy()
+            # shared memory using `np.asarray`
+            return np.asarray(x)
 
         for batch in self._dataset:
             yield tree.map_structure(convert_to_numpy, batch)

--- a/keras/trainers/data_adapters/torch_data_loader_adapter.py
+++ b/keras/trainers/data_adapters/torch_data_loader_adapter.py
@@ -1,3 +1,4 @@
+import numpy as np
 import tree
 
 from keras.trainers.data_adapters.data_adapter import DataAdapter
@@ -22,7 +23,10 @@ class TorchDataLoaderAdapter(DataAdapter):
 
     def get_numpy_iterator(self):
         for batch in self._dataloader:
-            yield tuple(tree.map_structure(lambda x: x.cpu().numpy(), batch))
+            # shared memory using `np.asarray`
+            yield tuple(
+                tree.map_structure(lambda x: np.asarray(x.cpu()), batch)
+            )
 
     def get_torch_dataloader(self):
         return self._dataloader


### PR DESCRIPTION
There are two major improvements:
1. Utilize shared memory to convert tensor to numpy (`TFDatasetAdapter` and `TorchDataLoaderAdapter`)
2. Introduce `JAXEpochIterator` with prefetching to achieve speed-up
3. Add prefetching to `TorchEpochIterator` to achieve speed-up

The result:
JAX:
|Methods|Training speed||
|-|-|-|
|Current implementation|147ms/step||
|`np.asarray`|137ms/step|-6.8%|
|`np.asarray` + prefetching|128ms/step|-12.3%|

Torch:
|Methods|Training speed||
|-|-|-|
|Current implementation|223ms/step||
|`np.asarray`|214ms/step|-4.0%|
|`np.asarray` + prefetching|203ms/step|-9.0%|

The standalone script (tested with RTX4070):

```python
import numpy as np

# isort: off
import torch  # noqa:F401 dummy import to prevent segmentation fault
import tensorflow as tf

# isort: on


import keras
from keras import backend
from keras import layers
from keras import losses
from keras import optimizers


class TestModel(keras.Model):
    def __init__(self, num_layers=4, **kwargs):
        super().__init__(**kwargs)
        self.num_layers = num_layers
        self.convs = []
        for _ in range(num_layers):
            self.convs.append(
                layers.Conv2D(32, 3, padding="same", activation="relu")
            )
        self.pool = layers.GlobalAveragePooling2D()
        self.fatten = layers.Flatten()
        self.dense = layers.Dense(1)

    def call(self, x):
        for i in range(self.num_layers):
            x = self.convs[i](x)
        x = self.pool(x)
        x = self.fatten(x)
        x = self.dense(x)
        return x


x = np.random.random((1024, 416, 416, 3)).astype("float32")
y = np.random.random((1024, 1)).astype("float32")


def preprocess(x, y):
    x = tf.image.random_brightness(x, 0.2)
    x = tf.image.random_contrast(x, 0.2, 0.5)
    x = tf.image.random_saturation(x, 0.2, 0.5)
    x = tf.image.rgb_to_hsv(x)
    x = tf.image.hsv_to_rgb(x)
    return x, y


train_dataset = tf.data.Dataset.from_tensor_slices((x, y))
train_dataset = train_dataset.batch(32)
train_dataset = train_dataset.map(
    preprocess, num_parallel_calls=tf.data.AUTOTUNE
)
train_dataset = train_dataset.prefetch(tf.data.AUTOTUNE)

model = TestModel(num_layers=4)
model.compile(
    optimizer=optimizers.SGD(learning_rate=0.001),
    loss=losses.MeanSquaredError(),
    jit_compile=False if backend.backend() == "torch" else True,
)
model.fit(train_dataset, epochs=3)

```

Ref:
- https://github.com/google/flax/blob/85dfad242e56098849dbf05e7e4657b3a40820f9/examples/imagenet/train.py#L193
- https://flax.readthedocs.io/en/latest/api_reference/flax.jax_utils.html#flax.jax_utils.prefetch_to_device