### PR TITLE
Remove reliance on Tensorflow enable_numpy_behavior for some ops.

### DIFF
--- a/keras/metrics/confusion_metrics_test.py
+++ b/keras/metrics/confusion_metrics_test.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 from absl import logging
 from absl.testing import parameterized
-from tensorflow.python.ops.numpy_ops import np_config
 
 from keras import layers
 from keras import metrics
@@ -12,10 +11,6 @@ from keras import models
 from keras import ops
 from keras import testing
 from keras.metrics import metrics_utils
-
-# TODO: remove reliance on this (or alternatively, turn it on by default).
-# This is no longer needed with tf-nightly.
-np_config.enable_numpy_behavior()
 
 
 class FalsePositivesTest(testing.TestCase):

--- a/keras/ops/nn_test.py
+++ b/keras/ops/nn_test.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 from absl.testing import parameterized
-from tensorflow.python.ops.numpy_ops import np_config
 
 from keras import backend
 from keras import layers
@@ -24,9 +23,6 @@ from keras.layers.pooling.max_pooling_test import np_maxpool2d
 from keras.ops import nn as knn
 from keras.ops import numpy as knp
 from keras.testing.test_utils import named_product
-
-# TODO: remove reliance on this (or alternatively, turn it on by default).
-np_config.enable_numpy_behavior()
 
 
 class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -1,10 +1,10 @@
 import contextlib
 import itertools
+import math
 
 import numpy as np
 import pytest
 from absl.testing import parameterized
-from tensorflow.python.ops.numpy_ops import np_config
 
 import keras
 from keras import backend
@@ -14,9 +14,6 @@ from keras.backend.common.keras_tensor import KerasTensor
 from keras.backend.common.variables import ALLOWED_DTYPES
 from keras.ops import numpy as knp
 from keras.testing.test_utils import named_product
-
-# TODO: remove reliance on this (or alternatively, turn it on by default).
-np_config.enable_numpy_behavior()
 
 
 class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
@@ -4013,7 +4010,8 @@ def create_sparse_tensor(x, indices_from=None, start=0, delta=2):
     if indices_from is not None:
         indices = indices_from.indices
     else:
-        flat_indices = np.arange(start, x.size, delta)
+        size = math.prod(x.shape)
+        flat_indices = np.arange(start, size, delta)
         indices = np.stack(np.where(np.ones_like(x)), axis=1)[flat_indices]
 
     if backend.backend() == "tensorflow":


### PR DESCRIPTION
https://github.com/keras-team/keras/issues/18947

Some ops would only work properly if `enable_numpy_behavior` was on. This reimplements these ops using standard tf operations.