### PR TITLE
Fix TensorShape bug in tensorflow backend

### DIFF
--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -6,6 +6,7 @@ from keras.backend.common import global_state
 from keras.backend.common.name_scope import current_path
 from keras.backend.common.stateless_scope import get_stateless_scope
 from keras.backend.common.stateless_scope import in_stateless_scope
+from keras.utils.module_utils import tensorflow as tf
 from keras.utils.naming import auto_name
 
 
@@ -404,9 +405,10 @@ def standardize_shape(shape):
         if not hasattr(shape, "__iter__"):
             raise ValueError(f"Cannot convert '{shape}' to a shape.")
         if config.backend() == "tensorflow":
-            # `shape` should be `tf.TensorShape` and may contain `Dimension` objects.
-            # We need to convert the items in it to either int or `None`
-            shape = shape.as_list()
+            if isinstance(shape, tf.TensorShape):
+                # `tf.TensorShape` may contain `Dimension` objects.
+                # We need to convert the items in it to either int or `None`
+                shape = shape.as_list()
         shape = tuple(shape)
 
     if config.backend() == "torch":

--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -403,6 +403,10 @@ def standardize_shape(shape):
             raise ValueError("Undefined shapes are not supported.")
         if not hasattr(shape, "__iter__"):
             raise ValueError(f"Cannot convert '{shape}' to a shape.")
+        if config.backend() == "tensorflow":
+            # `shape` should be `tf.TensorShape` and may contain `Dimension` objects.
+            # We need to convert the items in it to either int or `None`
+            shape = shape.as_list()
         shape = tuple(shape)
 
     if config.backend() == "torch":


### PR DESCRIPTION
This fix is using TensorShape's [as_list() method](https://www.tensorflow.org/api_docs/python/tf/TensorShape#as_list) to prevent downstream issues whenever TensorShape contains Dimension objects (which sometimes happen for legacy reasons).

This ensures that the resulting shape will only contain int/None items (and no Dimension objects) in any case.