### PR TITLE
[WIP] Fix the variable init issue for tf optimizers.

### DIFF
--- a/integration_tests/tf_distribute_training_test.py
+++ b/integration_tests/tf_distribute_training_test.py
@@ -49,6 +49,7 @@ def test_model_fit():
             ),
             loss=losses.MeanSquaredError(),
             metrics=[metrics.MeanSquaredError()],
+            jit_compile=True,
         )
         history = model.fit(
             x,

--- a/keras/backend/tensorflow/optimizer.py
+++ b/keras/backend/tensorflow/optimizer.py
@@ -33,7 +33,6 @@ class TFOptimizer(base_optimizer.BaseOptimizer):
             return super().add_variable_from_reference(
                 reference_variable, name=name, initializer=initializer
             )
-
     def add_variable(self, shape, initializer="zeros", dtype=None, name=None):
         with tf.init_scope():
             return super().add_variable(shape, initializer, dtype, name)

--- a/keras/backend/tensorflow/optimizer.py
+++ b/keras/backend/tensorflow/optimizer.py
@@ -33,7 +33,7 @@ class TFOptimizer(base_optimizer.BaseOptimizer):
             return super().add_variable_from_reference(
                 reference_variable, name=name, initializer=initializer
             )
-        
+
     def add_variable(self, shape, initializer="zeros", dtype=None, name=None):
         with tf.init_scope():
             return super().add_variable(shape, initializer, dtype, name)

--- a/keras/backend/tensorflow/optimizer.py
+++ b/keras/backend/tensorflow/optimizer.py
@@ -33,6 +33,10 @@ class TFOptimizer(base_optimizer.BaseOptimizer):
             return super().add_variable_from_reference(
                 reference_variable, name=name, initializer=initializer
             )
+        
+    def add_variable(self, shape, initializer="zeros", dtype=None, name=None):
+        with tf.init_scope():
+            return super().add_variable(shape, initializer, dtype, name)
 
     def stateless_apply(self, optimizer_variables, grads, trainable_variables):
         # This is mainly due to the interaction with tf.distribute.Strategy,

--- a/keras/trainers/trainer.py
+++ b/keras/trainers/trainer.py
@@ -222,10 +222,6 @@ class Trainer:
                 # Disable XLA on CPU-only machines.
                 return False
 
-            if self._distribute_strategy:
-                # Disable XLA with tf.distribute
-                return False
-
         if model_supports_jit(self):
             return True
         return False


### PR DESCRIPTION
This was preventing the training function to run with jit_compile = True with distribution strategy. 

See https://github.com/keras-team/keras/issues/19005 for more details.