### PR TITLE
Use  `convert_to_tensor` when moving to device for numpy

### DIFF
--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -508,10 +508,7 @@ class TorchEpochIterator(EpochIterator):
         return super()._get_iterator(return_type)
 
     def _prefetch_numpy_data(self, data):
-        def to_device(d):
-            return torch.as_tensor(d, device=get_device())
-
-        return tree.map_structure(to_device, data)
+        return tree.map_structure(backend.convert_to_tensor, data)
 
     def _prefetch_numpy_iterator(self, numpy_iterator):
         """Prefetch batches on device.

--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -10,7 +10,6 @@ from packaging.version import parse
 from keras import backend
 from keras import callbacks as callbacks_module
 from keras import optimizers as optimizers_module
-from keras.backend.torch.core import get_device
 from keras.trainers import data_adapters
 from keras.trainers import trainer as base_trainer
 from keras.trainers.data_adapters import data_adapter_utils


### PR DESCRIPTION
PR #18991 update to `trainer.py` caused regression in keras-cv test - 
```
    def to_device(d):
>       return torch.as_tensor(d, device=get_device())
```
E       UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/torch/csrc/utils/tensor_numpy.cpp:212.)

/opt/miniconda3/envs/keras-cv3/lib/python3.9/site-packages/keras/src/backend/torch/trainer.py:512: UserWarning
================================================= short test summary info =================================================
FAILED keras_cv/callbacks/pycoco_callback_test.py::PyCOCOCallbackTest::test_model_fit_retinanet - UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writ...
**

To fix this, changed to `backend.convert_to_tensor` that also converts numpy dtypes to appropriate torch types when converting numpy array to torch tensor instead of using the base `torch.as_tensor`.

Tested and verified locally that this change fixes the failing keras-cv test for torch backend.

FYI: @james77777778 