### PR TITLE
Text Vectorization Preprocessing Layer - Fixes

### DIFF
--- a/keras/layers/preprocessing/category_encoding.py
+++ b/keras/layers/preprocessing/category_encoding.py
@@ -1,4 +1,3 @@
-from keras import backend
 from keras.api_export import keras_export
 from keras.layers.preprocessing.tf_data_layer import TFDataLayer
 from keras.utils import backend_utils
@@ -150,10 +149,4 @@ class CategoryEncoding(TFDataLayer):
 
     def call(self, inputs):
         outputs = self._encode(inputs)
-
-        if (
-            self.backend._backend != "tensorflow"
-            and not backend_utils.in_tf_graph()
-        ):
-            outputs = backend.convert_to_tensor(outputs)
-        return outputs
+        return backend_utils.convert_tf_tensor(outputs)

--- a/keras/layers/preprocessing/hashed_crossing.py
+++ b/keras/layers/preprocessing/hashed_crossing.py
@@ -170,12 +170,7 @@ class HashedCrossing(Layer):
             sparse=self.sparse,
             dtype=self.compute_dtype,
         )
-        if (
-            backend.backend() != "tensorflow"
-            and not backend_utils.in_tf_graph()
-        ):
-            outputs = backend.convert_to_tensor(outputs, dtype=self.dtype)
-        return outputs
+        return backend_utils.convert_tf_tensor(outputs, dtype=self.dtype)
 
     def get_config(self):
         return {

--- a/keras/layers/preprocessing/hashing.py
+++ b/keras/layers/preprocessing/hashing.py
@@ -226,12 +226,7 @@ class Hashing(Layer):
             sparse=self.sparse,
             dtype=self.dtype,
         )
-        if (
-            backend.backend() != "tensorflow"
-            and not backend_utils.in_tf_graph()
-        ):
-            outputs = backend.convert_to_tensor(outputs)
-        return outputs
+        return backend_utils.convert_tf_tensor(outputs)
 
     def _hash_values_to_bins(self, values):
         """Converts a non-sparse tensor of values to bin indices."""

--- a/keras/layers/preprocessing/integer_lookup.py
+++ b/keras/layers/preprocessing/integer_lookup.py
@@ -403,9 +403,4 @@ class IntegerLookup(IndexLookup):
         ):
             inputs = tf.convert_to_tensor(backend.convert_to_numpy(inputs))
         outputs = super().call(inputs)
-        if (
-            backend.backend() != "tensorflow"
-            and not backend_utils.in_tf_graph()
-        ):
-            outputs = backend.convert_to_tensor(outputs)
-        return outputs
+        return backend_utils.convert_tf_tensor(outputs)

--- a/keras/layers/preprocessing/string_lookup.py
+++ b/keras/layers/preprocessing/string_lookup.py
@@ -390,10 +390,6 @@ class StringLookup(IndexLookup):
             if not isinstance(inputs, (np.ndarray, list, tuple)):
                 inputs = tf.convert_to_tensor(backend.convert_to_numpy(inputs))
         outputs = super().call(inputs)
-        if (
-            not tf_inputs
-            and backend.backend() != "tensorflow"
-            and not backend_utils.in_tf_graph()
-        ):
-            outputs = backend.convert_to_tensor(outputs)
+        if not tf_inputs:
+            outputs = backend_utils.convert_tf_tensor(outputs)
         return outputs

--- a/keras/layers/preprocessing/text_vectorization_test.py
+++ b/keras/layers/preprocessing/text_vectorization_test.py
@@ -119,6 +119,23 @@ class TextVectorizationTest(testing.TestCase):
         output = layer(input_data)
         self.assertIsInstance(output, tf.RaggedTensor)
         self.assertEqual(output.shape, (3, None))
+        self.assertEqual(output.to_list(), [[4, 1, 3], [1, 2], [4]])
+
+    @pytest.mark.skipif(
+        backend.backend() != "tensorflow", reason="Requires ragged tensors."
+    )
+    def test_ragged_tensor_output_length(self):
+        layer = layers.TextVectorization(
+            output_mode="int",
+            vocabulary=["baz", "bar", "foo"],
+            ragged=True,
+            output_sequence_length=2,
+        )
+        input_data = [["foo qux bar"], ["qux baz"], ["foo"]]
+        output = layer(input_data)
+        self.assertIsInstance(output, tf.RaggedTensor)
+        self.assertEqual(output.shape, (3, None))
+        self.assertEqual(output.to_list(), [[4, 1], [1, 2], [4]])
 
     @pytest.mark.skipif(
         backend.backend() == "tensorflow",

--- a/keras/utils/backend_utils.py
+++ b/keras/utils/backend_utils.py
@@ -15,6 +15,12 @@ def in_tf_graph():
     return False
 
 
+def convert_tf_tensor(outputs, dtype=None):
+    if backend_module.backend() != "tensorflow" and not in_tf_graph():
+        outputs = backend_module.convert_to_tensor(outputs, dtype=dtype)
+    return outputs
+
+
 class TFGraphScope:
     def __init__(self):
         self._original_value = global_state.get_global_attribute(


### PR DESCRIPTION
Fixes - 
1. TextVectorization layer: local variable 'outputs' referenced before assignment error on some instances in the call method of TextVectorization. 
2. allow output_sequence_length when ragged is True - #18576 

Abstracted repeated use of `convert_to_tensor` on preprocessing layer outputs for non-TF backends into common utility in backend.

FYI: @SasankYadati.  I had made the change for issue #1 independently and then noticed that you had similar issue in #18980, so combined that issue also into this PR.  Hope that's OK.