### PR TITLE
All DataAdapters can now create a native iterator for each backend.

### DIFF
--- a/keras/backend/jax/core.py
+++ b/keras/backend/jax/core.py
@@ -61,11 +61,11 @@ def convert_to_tensor(x, dtype=None, sparse=None):
         if dtype and dtype != x.dtype:
             return x.value.astype(dtype)
         return x.value
-    return jnp.array(x, dtype=dtype)
+    return jnp.asarray(x, dtype=dtype)
 
 
 def convert_to_numpy(x):
-    return np.array(x)
+    return np.asarray(x)
 
 
 def is_tensor(x):

--- a/keras/backend/jax/trainer.py
+++ b/keras/backend/jax/trainer.py
@@ -904,11 +904,10 @@ def _distribute_data(data):
 
 
 class JAXEpochIterator(EpochIterator):
-    def _get_iterator(self, return_type="auto"):
-        if return_type in ("np", "auto"):
-            # enable prefetching when using numpy_iterator
-            return self._prefetch_numpy_iterator(super()._get_iterator("np"))
-        return super()._get_iterator(return_type)
+    def _get_iterator(self):
+        return self._prefetch_numpy_iterator(
+            self.data_adapter.get_jax_iterator()
+        )
 
     def _prefetch_numpy_iterator(self, numpy_iterator):
         """Shard and prefetch batches on device.

--- a/keras/backend/numpy/trainer.py
+++ b/keras/backend/numpy/trainer.py
@@ -198,7 +198,7 @@ class NumpyTrainer(base_trainer.Trainer):
         self.stop_predicting = False
         callbacks.on_predict_begin()
         outputs = None
-        for step, data in epoch_iterator.enumerate_epoch(return_type="np"):
+        for step, data in epoch_iterator.enumerate_epoch():
             callbacks.on_predict_batch_begin(step)
             batch_outputs = self.predict_function(data)
             outputs = append_to_outputs(batch_outputs, outputs)
@@ -242,7 +242,7 @@ class NumpyTrainer(base_trainer.Trainer):
 
         if not all(layer.built for layer in self._flatten_layers()):
             # Build the model on one batch of data.
-            for _, data in epoch_iterator.enumerate_epoch(return_type="np"):
+            for _, data in epoch_iterator.enumerate_epoch():
                 data_batch = data[0]
                 self._symbolic_build(data_batch)
                 break
@@ -264,7 +264,7 @@ class NumpyTrainer(base_trainer.Trainer):
         callbacks.on_test_begin()
         logs = None
         self.reset_metrics()
-        for step, data in epoch_iterator.enumerate_epoch(return_type="np"):
+        for step, data in epoch_iterator.enumerate_epoch():
             callbacks.on_test_batch_begin(step)
             logs = self.test_function(data)
             callbacks.on_test_batch_end(step, self._pythonify_logs(logs))

--- a/keras/backend/tensorflow/core.py
+++ b/keras/backend/tensorflow/core.py
@@ -126,7 +126,7 @@ def convert_to_numpy(x):
         x.set_shape(x_shape)
     elif isinstance(x, tf.IndexedSlices):
         x = tf.convert_to_tensor(x)
-    return np.array(x)
+    return np.asarray(x)
 
 
 def is_tensor(x):

--- a/keras/backend/tensorflow/trainer.py
+++ b/keras/backend/tensorflow/trainer.py
@@ -629,13 +629,16 @@ class TFEpochIterator(EpochIterator):
     def __init__(self, distribute_strategy=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._distribute_strategy = distribute_strategy
-        dataset = self.data_adapter.get_tf_dataset()
+        dataset = self._get_iterator()
         if not isinstance(dataset, tf.distribute.DistributedDataset):
             dataset = self._distribute_strategy.experimental_distribute_dataset(
                 dataset
             )
         self._distributed_dataset = dataset
         self._steps_seen = 0
+
+    def _get_iterator(self):
+        return self.data_adapter.get_tf_dataset()
 
     def enumerate_epoch(self):
         if self.steps_per_epoch:

--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -1,5 +1,3 @@
-import collections
-import itertools
 import warnings
 
 import numpy as np
@@ -10,7 +8,6 @@ from packaging.version import parse
 from keras import backend
 from keras import callbacks as callbacks_module
 from keras import optimizers as optimizers_module
-from keras.trainers import data_adapters
 from keras.trainers import trainer as base_trainer
 from keras.trainers.data_adapters import data_adapter_utils
 from keras.trainers.epoch_iterator import EpochIterator
@@ -496,40 +493,5 @@ class TorchTrainer(base_trainer.Trainer):
 
 
 class TorchEpochIterator(EpochIterator):
-    def _get_iterator(self, return_type="auto"):
-        if return_type == "auto" and isinstance(
-            self.data_adapter, data_adapters.TorchDataLoaderAdapter
-        ):
-            return self.data_adapter.get_torch_dataloader()
-        elif return_type in ("np", "auto"):
-            # enable prefetching when using numpy_iterator
-            return self._prefetch_numpy_iterator(super()._get_iterator("np"))
-        return super()._get_iterator(return_type)
-
-    def _prefetch_numpy_data(self, data):
-        return tree.map_structure(backend.convert_to_tensor, data)
-
-    def _prefetch_numpy_iterator(self, numpy_iterator):
-        """Prefetch batches on device.
-
-        The idea has been borrowed from
-        `torchtnt.utils.data.CudaDataPrefetcher`
-
-        This utility takes an iterator and returns a new iterator which fills an
-        on device prefetch buffer. Eager prefetching can improve the performance
-        of training loops significantly by overlapping compute and data
-        transfer.
-        """
-        queue = collections.deque()
-
-        # If you're training on GPUs, 2 is generally the best choice because
-        # this guarantees that you can overlap a training step on GPU with a
-        # data prefetch step on CPU.
-        def enqueue(n=2):
-            for data in itertools.islice(numpy_iterator, n):
-                queue.append(self._prefetch_numpy_data(data))
-
-        enqueue(n=2)  # TODO: should we make `n` configurable?
-        while queue:
-            yield queue.popleft()
-            enqueue(1)
+    def _get_iterator(self):
+        return self.data_adapter.get_torch_dataloader()

--- a/keras/layers/normalization/batch_normalization_test.py
+++ b/keras/layers/normalization/batch_normalization_test.py
@@ -92,8 +92,10 @@ class BatchNormalizationTest(testing.TestCase, parameterized.TestCase):
         broadcast_shape = [1] * len(input_shape)
         broadcast_shape[axis] = input_shape[axis]
         out = backend.convert_to_numpy(out)
-        out -= np.reshape(backend.convert_to_numpy(layer.beta), broadcast_shape)
-        out /= np.reshape(
+        out = out - np.reshape(
+            backend.convert_to_numpy(layer.beta), broadcast_shape
+        )
+        out = out / np.reshape(
             backend.convert_to_numpy(layer.gamma), broadcast_shape
         )
 
@@ -200,8 +202,12 @@ class BatchNormalizationTest(testing.TestCase, parameterized.TestCase):
             out = layer(x, training=True)
 
         out = backend.convert_to_numpy(out)
-        out -= np.reshape(backend.convert_to_numpy(layer.beta), (1, 1, 1, 3))
-        out /= np.reshape(backend.convert_to_numpy(layer.gamma), (1, 1, 1, 3))
+        out = out - np.reshape(
+            backend.convert_to_numpy(layer.beta), (1, 1, 1, 3)
+        )
+        out = out / np.reshape(
+            backend.convert_to_numpy(layer.gamma), (1, 1, 1, 3)
+        )
 
         self.assertAllClose(np.mean(out, axis=(0, 1, 2)), 0.0, atol=1e-3)
         self.assertAllClose(np.std(out, axis=(0, 1, 2)), 1.0, atol=1e-3)

--- a/keras/trainers/data_adapters/data_adapter.py
+++ b/keras/trainers/data_adapters/data_adapter.py
@@ -7,7 +7,8 @@ class DataAdapter(object):
     """
 
     def get_numpy_iterator(self):
-        """Get a Python iterable for the DataAdapter, that yields NumPy arrays.
+        """Get a Python iterable for the `DataAdapter`, that yields NumPy
+        arrays.
 
         Returns:
             A Python iterator.
@@ -25,6 +26,22 @@ class DataAdapter(object):
             A `tf.data.Dataset`. Caller might use the dataset in different
             context, e.g. iter(dataset) in eager to get the value directly, or
             in graph mode, provide the iterator tensor to Keras model function.
+        """
+        raise NotImplementedError
+
+    def get_jax_iterator(self):
+        """Get a Python iterable for the `DataAdapter`, that yields JAX arrays.
+
+        Returns:
+            A Python iterator.
+        """
+        raise NotImplementedError
+
+    def get_torch_dataloader(self):
+        """Get a Torch `DataLoader` for the `DataAdapter`.
+
+        Returns:
+            A Torch `DataLoader`.
         """
         raise NotImplementedError
 

--- a/keras/trainers/data_adapters/generator_data_adapter_test.py
+++ b/keras/trainers/data_adapters/generator_data_adapter_test.py
@@ -1,11 +1,15 @@
 import math
 
+import jax
 import numpy as np
 import scipy
 import tensorflow as tf
+import torch
 from absl.testing import parameterized
+from jax import numpy as jnp
 
 from keras import testing
+from keras.testing.test_utils import named_product
 from keras.trainers.data_adapters import generator_data_adapter
 
 
@@ -25,18 +29,31 @@ def example_generator(x, y, sample_weight=None, batch_size=32):
 
 
 class GeneratorDataAdapterTest(testing.TestCase, parameterized.TestCase):
-    @parameterized.parameters(
-        [
-            (True,),
-            (False,),
-        ]
+    @parameterized.named_parameters(
+        named_product(
+            [
+                {"testcase_name": "use_weight", "use_sample_weight": True},
+                {"testcase_name": "no_weight", "use_sample_weight": False},
+            ],
+            generator_type=["np", "tf", "jax", "torch"],
+            iterator_type=["np", "tf", "jax", "torch"],
+        )
     )
-    def test_basic_flow(self, use_sample_weight):
-        x = np.random.random((64, 4))
-        y = np.array([[i, i] for i in range(64)], dtype="float64")
-        if use_sample_weight:
-            sw = np.random.random((64,))
-        else:
+    def test_basic_flow(self, use_sample_weight, generator_type, iterator_type):
+        x = np.random.random((34, 4)).astype("float32")
+        y = np.array([[i, i] for i in range(34)], dtype="float32")
+        sw = np.random.random((34,)).astype("float32")
+        if generator_type == "tf":
+            x, y, sw = tf.constant(x), tf.constant(y), tf.constant(sw)
+        elif generator_type == "jax":
+            x, y, sw = jnp.array(x), jnp.array(y), jnp.array(sw)
+        elif generator_type == "torch":
+            x, y, sw = (
+                torch.as_tensor(x),
+                torch.as_tensor(y),
+                torch.as_tensor(sw),
+            )
+        if not use_sample_weight:
             sw = None
         make_generator = example_generator(
             x,
@@ -44,53 +61,46 @@ class GeneratorDataAdapterTest(testing.TestCase, parameterized.TestCase):
             sample_weight=sw,
             batch_size=16,
         )
+
         adapter = generator_data_adapter.GeneratorDataAdapter(make_generator())
+        if iterator_type == "np":
+            it = adapter.get_numpy_iterator()
+            expected_class = np.ndarray
+        elif iterator_type == "tf":
+            it = adapter.get_tf_dataset()
+            expected_class = tf.Tensor
+        elif iterator_type == "jax":
+            it = adapter.get_jax_iterator()
+            expected_class = jax.Array
+        elif iterator_type == "torch":
+            it = adapter.get_torch_dataloader()
+            expected_class = torch.Tensor
 
-        gen = adapter.get_numpy_iterator()
         sample_order = []
-        for batch in gen:
+        for i, batch in enumerate(it):
             if use_sample_weight:
                 self.assertEqual(len(batch), 3)
                 bx, by, bsw = batch
             else:
                 self.assertEqual(len(batch), 2)
                 bx, by = batch
-
-            self.assertIsInstance(bx, np.ndarray)
-            self.assertIsInstance(by, np.ndarray)
+            self.assertIsInstance(bx, expected_class)
+            self.assertIsInstance(by, expected_class)
             self.assertEqual(bx.dtype, by.dtype)
-            self.assertEqual(bx.shape, (16, 4))
-            self.assertEqual(by.shape, (16, 2))
-            if use_sample_weight:
-                self.assertIsInstance(bsw, np.ndarray)
-            for i in range(by.shape[0]):
-                sample_order.append(by[i, 0])
-        self.assertAllClose(sample_order, list(range(64)))
-
-        adapter = generator_data_adapter.GeneratorDataAdapter(
-            make_generator(),
-        )
-        ds = adapter.get_tf_dataset()
-        sample_order = []
-        for batch in ds:
-            if use_sample_weight:
-                self.assertEqual(len(batch), 3)
-                bx, by, bsw = batch
+            self.assertContainsExactSubsequence(str(bx.dtype), "float32")
+            if i < 2:
+                self.assertEqual(bx.shape, (16, 4))
+                self.assertEqual(by.shape, (16, 2))
             else:
-                self.assertEqual(len(batch), 2)
-                bx, by = batch
-            self.assertIsInstance(bx, tf.Tensor)
-            self.assertIsInstance(by, tf.Tensor)
-            self.assertEqual(bx.dtype, by.dtype)
-            self.assertEqual(tuple(bx.shape), (16, 4))
-            self.assertEqual(tuple(by.shape), (16, 2))
+                self.assertEqual(bx.shape, (2, 4))
+                self.assertEqual(by.shape, (2, 2))
             if use_sample_weight:
-                self.assertIsInstance(bsw, tf.Tensor)
+                self.assertIsInstance(bsw, expected_class)
             for i in range(by.shape[0]):
                 sample_order.append(by[i, 0])
-        self.assertAllClose(sample_order, list(range(64)))
+        self.assertAllClose(sample_order, list(range(34)))
 
-    def test_tf_sparse_tensors(self):
+    def test_tf_sparse_tensors_with_tf_dataset(self):
         def generate_tf():
             for i in range(4):
                 x = tf.SparseTensor(
@@ -115,7 +125,7 @@ class GeneratorDataAdapterTest(testing.TestCase, parameterized.TestCase):
             self.assertEqual(bx.shape, (2, 4))
             self.assertEqual(by.shape, (2, 2))
 
-    def test_scipy_sparse_tensors(self):
+    def test_scipy_sparse_tensors_with_tf_dataset(self):
         def generate_scipy():
             for i in range(4):
                 x = scipy.sparse.coo_matrix(

--- a/keras/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/trainers/data_adapters/py_dataset_adapter_test.py
@@ -1,11 +1,14 @@
 import math
 import time
 
+import jax
 import numpy as np
 import tensorflow as tf
+import torch
 from absl.testing import parameterized
 
 from keras import testing
+from keras.testing.test_utils import named_product
 from keras.trainers.data_adapters import py_dataset_adapter
 from keras.utils.rng_utils import set_random_seed
 
@@ -61,22 +64,51 @@ class DictPyDataset(py_dataset_adapter.PyDataset):
 
 
 class PyDatasetAdapterTest(testing.TestCase, parameterized.TestCase):
-    @parameterized.parameters(
-        [
-            (True, 2, True, 10),
-            (False, 2, True, 10),
-            (True, 2, False, 10),
-            (False, 2, False, 10),
-            (True, 0, False, 0),
-            (False, 0, False, 0),
-        ]
+    @parameterized.named_parameters(
+        named_product(
+            [
+                {
+                    "testcase_name": "multi_on",
+                    "workers": 2,
+                    "use_multiprocessing": True,
+                    "max_queue_size": 10,
+                },
+                {
+                    "testcase_name": "multi_off",
+                    "workers": 2,
+                    "use_multiprocessing": False,
+                    "max_queue_size": 10,
+                },
+                {
+                    "testcase_name": "multi_off_zero",
+                    "workers": 0,
+                    "use_multiprocessing": False,
+                    "max_queue_size": 0,
+                },
+            ],
+            shuffle=[True, False],
+            dataset_type=["np", "tf", "jax", "torch"],
+            iterator_type=["np", "tf", "jax", "torch"],
+        )
     )
     def test_basic_flow(
-        self, shuffle, workers, use_multiprocessing, max_queue_size
+        self,
+        shuffle,
+        workers,
+        use_multiprocessing,
+        max_queue_size,
+        dataset_type,
+        iterator_type,
     ):
         set_random_seed(1337)
-        x = np.random.random((64, 4))
-        y = np.array([[i, i] for i in range(64)], dtype="float64")
+        x = np.random.random((64, 4)).astype("float32")
+        y = np.array([[i, i] for i in range(64)], dtype="float32")
+        if dataset_type == "tf":
+            x, y = tf.constant(x), tf.constant(y)
+        elif dataset_type == "jax":
+            x, y = jax.numpy.array(x), jax.numpy.array(y)
+        elif dataset_type == "torch":
+            x, y = torch.as_tensor(x), torch.as_tensor(y)
         py_dataset = ExamplePyDataset(
             x,
             y,
@@ -89,37 +121,33 @@ class PyDatasetAdapterTest(testing.TestCase, parameterized.TestCase):
             py_dataset, shuffle=shuffle
         )
 
-        gen = adapter.get_numpy_iterator()
+        if iterator_type == "np":
+            it = adapter.get_numpy_iterator()
+            expected_class = np.ndarray
+        elif iterator_type == "tf":
+            it = adapter.get_tf_dataset()
+            expected_class = tf.Tensor
+        elif iterator_type == "jax":
+            it = adapter.get_jax_iterator()
+            expected_class = jax.Array
+        elif iterator_type == "torch":
+            it = adapter.get_torch_dataloader()
+            expected_class = torch.Tensor
+
         sample_order = []
-        for batch in gen:
+        for batch in it:
             self.assertEqual(len(batch), 2)
             bx, by = batch
-            self.assertIsInstance(bx, np.ndarray)
-            self.assertIsInstance(by, np.ndarray)
+            self.assertIsInstance(bx, expected_class)
+            self.assertIsInstance(by, expected_class)
             self.assertEqual(bx.dtype, by.dtype)
+            self.assertContainsExactSubsequence(str(bx.dtype), "float32")
             self.assertEqual(bx.shape, (16, 4))
             self.assertEqual(by.shape, (16, 2))
             for i in range(by.shape[0]):
                 sample_order.append(by[i, 0])
         if shuffle:
-            self.assertFalse(sample_order == list(range(64)))
-        else:
-            self.assertAllClose(sample_order, list(range(64)))
-
-        ds = adapter.get_tf_dataset()
-        sample_order = []
-        for batch in ds:
-            self.assertEqual(len(batch), 2)
-            bx, by = batch
-            self.assertIsInstance(bx, tf.Tensor)
-            self.assertIsInstance(by, tf.Tensor)
-            self.assertEqual(bx.dtype, by.dtype)
-            self.assertEqual(tuple(bx.shape), (16, 4))
-            self.assertEqual(tuple(by.shape), (16, 2))
-            for i in range(by.shape[0]):
-                sample_order.append(by[i, 0])
-        if shuffle:
-            self.assertFalse(sample_order == list(range(64)))
+            self.assertNotAllClose(sample_order, list(range(64)))
         else:
             self.assertAllClose(sample_order, list(range(64)))
 

--- a/keras/trainers/data_adapters/tf_dataset_adapter_test.py
+++ b/keras/trainers/data_adapters/tf_dataset_adapter_test.py
@@ -1,14 +1,21 @@
 from unittest import mock
 
+import jax
 import numpy as np
 import tensorflow as tf
+import torch
+from absl.testing import parameterized
 
 from keras import testing
+from keras.testing.test_utils import named_product
 from keras.trainers.data_adapters import tf_dataset_adapter
 
 
-class TestTFDatasetAdapter(testing.TestCase):
-    def test_basic_flow(self):
+class TestTFDatasetAdapter(testing.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(
+        named_product(iterator_type=["np", "tf", "jax", "torch"])
+    )
+    def test_basic_flow(self, iterator_type):
         x = tf.random.normal((34, 4))
         y = tf.random.normal((34, 2))
         base_ds = tf.data.Dataset.from_tensor_slices((x, y)).batch(16)
@@ -19,34 +26,32 @@ class TestTFDatasetAdapter(testing.TestCase):
         self.assertEqual(adapter.has_partial_batch, None)
         self.assertEqual(adapter.partial_batch_size, None)
 
-        gen = adapter.get_numpy_iterator()
-        for i, batch in enumerate(gen):
+        if iterator_type == "np":
+            it = adapter.get_numpy_iterator()
+            expected_class = np.ndarray
+        elif iterator_type == "tf":
+            it = adapter.get_tf_dataset()
+            expected_class = tf.Tensor
+        elif iterator_type == "jax":
+            it = adapter.get_jax_iterator()
+            expected_class = jax.Array
+        elif iterator_type == "torch":
+            it = adapter.get_torch_dataloader()
+            expected_class = torch.Tensor
+
+        for i, batch in enumerate(it):
             self.assertEqual(len(batch), 2)
             bx, by = batch
-            self.assertIsInstance(bx, np.ndarray)
-            self.assertIsInstance(by, np.ndarray)
+            self.assertIsInstance(bx, expected_class)
+            self.assertIsInstance(by, expected_class)
             self.assertEqual(bx.dtype, by.dtype)
-            self.assertEqual(bx.dtype, "float32")
+            self.assertContainsExactSubsequence(str(bx.dtype), "float32")
             if i < 2:
                 self.assertEqual(bx.shape, (16, 4))
                 self.assertEqual(by.shape, (16, 2))
             else:
                 self.assertEqual(bx.shape, (2, 4))
                 self.assertEqual(by.shape, (2, 2))
-        ds = adapter.get_tf_dataset()
-        for i, batch in enumerate(ds):
-            self.assertEqual(len(batch), 2)
-            bx, by = batch
-            self.assertIsInstance(bx, tf.Tensor)
-            self.assertIsInstance(by, tf.Tensor)
-            self.assertEqual(bx.dtype, by.dtype)
-            self.assertEqual(bx.dtype, "float32")
-            if i < 2:
-                self.assertEqual(tuple(bx.shape), (16, 4))
-                self.assertEqual(tuple(by.shape), (16, 2))
-            else:
-                self.assertEqual(tuple(bx.shape), (2, 4))
-                self.assertEqual(tuple(by.shape), (2, 2))
 
     def _test_class_weights(self, target_encoding="int"):
         x = np.random.random((4, 2))

--- a/keras/trainers/data_adapters/torch_data_loader_adapter_test.py
+++ b/keras/trainers/data_adapters/torch_data_loader_adapter_test.py
@@ -1,28 +1,25 @@
+import jax
 import numpy as np
-import pytest
 import tensorflow as tf
+import torch
+from absl.testing import parameterized
 
-from keras import backend
 from keras import testing
+from keras.testing.test_utils import named_product
 from keras.trainers.data_adapters.torch_data_loader_adapter import (
     TorchDataLoaderAdapter,
 )
 
 
-@pytest.mark.skipif(
-    backend.backend() != "torch",
-    reason="Backend does not support TorchDataLoaderAdapter.",
-)
-class TestTorchDataLoaderAdapter(testing.TestCase):
-    def test_basic_dataloader(self):
-        import torch
-        from torch.utils.data import DataLoader
-        from torch.utils.data import TensorDataset
-
+class TestTorchDataLoaderAdapter(testing.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(
+        named_product(iterator_type=["np", "tf", "jax", "torch"])
+    )
+    def test_basic_dataloader(self, iterator_type):
         x = torch.normal(2, 3, size=(34, 4))
         y = torch.normal(1, 3, size=(34, 2))
-        base_ds = TensorDataset(x, y)
-        base_dataloader = DataLoader(base_ds, batch_size=16)
+        base_ds = torch.utils.data.TensorDataset(x, y)
+        base_dataloader = torch.utils.data.DataLoader(base_ds, batch_size=16)
         adapter = TorchDataLoaderAdapter(base_dataloader)
 
         self.assertEqual(adapter.num_batches, 3)
@@ -30,47 +27,29 @@ class TestTorchDataLoaderAdapter(testing.TestCase):
         self.assertEqual(adapter.has_partial_batch, True)
         self.assertEqual(adapter.partial_batch_size, 2)
 
-        gen = adapter.get_numpy_iterator()
-        for i, batch in enumerate(gen):
+        if iterator_type == "np":
+            it = adapter.get_numpy_iterator()
+            expected_class = np.ndarray
+        elif iterator_type == "tf":
+            it = adapter.get_tf_dataset()
+            expected_class = tf.Tensor
+        elif iterator_type == "jax":
+            it = adapter.get_jax_iterator()
+            expected_class = jax.Array
+        elif iterator_type == "torch":
+            it = adapter.get_torch_dataloader()
+            expected_class = torch.Tensor
+
+        for i, batch in enumerate(it):
             self.assertEqual(len(batch), 2)
             bx, by = batch
-            self.assertIsInstance(bx, np.ndarray)
-            self.assertIsInstance(by, np.ndarray)
+            self.assertIsInstance(bx, expected_class)
+            self.assertIsInstance(by, expected_class)
             self.assertEqual(bx.dtype, by.dtype)
-            self.assertEqual(bx.dtype, "float32")
+            self.assertContainsExactSubsequence(str(bx.dtype), "float32")
             if i < 2:
                 self.assertEqual(bx.shape, (16, 4))
                 self.assertEqual(by.shape, (16, 2))
             else:
                 self.assertEqual(bx.shape, (2, 4))
                 self.assertEqual(by.shape, (2, 2))
-
-        ds = adapter.get_torch_dataloader()
-        for i, batch in enumerate(ds):
-            self.assertEqual(len(batch), 2)
-            bx, by = batch
-            self.assertIsInstance(bx, torch.Tensor)
-            self.assertIsInstance(by, torch.Tensor)
-            self.assertEqual(bx.dtype, by.dtype)
-            self.assertEqual(bx.dtype, torch.float32)
-            if i < 2:
-                self.assertEqual(tuple(bx.shape), (16, 4))
-                self.assertEqual(tuple(by.shape), (16, 2))
-            else:
-                self.assertEqual(tuple(bx.shape), (2, 4))
-                self.assertEqual(tuple(by.shape), (2, 2))
-
-        ds = adapter.get_tf_dataset()
-        for i, batch in enumerate(ds):
-            self.assertEqual(len(batch), 2)
-            bx, by = batch
-            self.assertIsInstance(bx, tf.Tensor)
-            self.assertIsInstance(by, tf.Tensor)
-            self.assertEqual(bx.dtype, by.dtype)
-            self.assertEqual(bx.dtype, tf.float32)
-            if i < 2:
-                self.assertEqual(tuple(bx.shape), (16, 4))
-                self.assertEqual(tuple(by.shape), (16, 2))
-            else:
-                self.assertEqual(tuple(bx.shape), (2, 4))
-                self.assertEqual(tuple(by.shape), (2, 2))

--- a/keras/trainers/epoch_iterator_test.py
+++ b/keras/trainers/epoch_iterator_test.py
@@ -9,7 +9,7 @@ from keras.trainers import epoch_iterator
 
 
 class TestEpochIterator(testing.TestCase):
-    def _test_basic_flow(self, return_type):
+    def test_basic_flow(self):
         x = np.random.random((100, 16))
         y = np.random.random((100, 4))
         sample_weight = np.random.random((100,))
@@ -23,21 +23,12 @@ class TestEpochIterator(testing.TestCase):
             shuffle=shuffle,
         )
         steps_seen = []
-        for step, batch in iterator.enumerate_epoch(return_type=return_type):
+        for step, batch in iterator.enumerate_epoch():
             batch = batch[0]
             steps_seen.append(step)
             self.assertEqual(len(batch), 3)
-            if return_type == "np":
-                self.assertIsInstance(batch[0], np.ndarray)
-            else:
-                self.assertIsInstance(batch[0], tf.Tensor)
+            self.assertIsInstance(batch[0], np.ndarray)
         self.assertEqual(steps_seen, [0, 1, 2, 3, 4, 5, 6])
-
-    def test_basic_flow_np(self):
-        self._test_basic_flow("np")
-
-    def test_basic_flow_tf(self):
-        self._test_basic_flow("tf")
 
     def test_insufficient_data(self):
         batch_size = 8
@@ -97,7 +88,7 @@ class TestEpochIterator(testing.TestCase):
             torch_dataset, batch_size=8, shuffle=True
         )
         iterator = epoch_iterator.EpochIterator(torch_dataloader)
-        for _, batch in iterator.enumerate_epoch(return_type="np"):
+        for _, batch in iterator.enumerate_epoch():
             batch = batch[0]
             self.assertEqual(batch[0].shape, (8, 2))
             self.assertEqual(batch[1].shape, (8, 1))
@@ -180,14 +171,3 @@ class TestEpochIterator(testing.TestCase):
         x = "unsupported_data"
         with self.assertRaisesRegex(ValueError, "Unrecognized data type"):
             _ = epoch_iterator.EpochIterator(x=x)
-
-    def test_invalid_return_type_in_get_iterator(self):
-        x = np.random.random((100, 16))
-        y = np.random.random((100, 4))
-        epoch_iter = epoch_iterator.EpochIterator(x=x, y=y)
-
-        with self.assertRaisesRegex(
-            ValueError,
-            "Argument `return_type` must be one of `{'np', 'tf', 'auto'}`",
-        ):
-            _ = epoch_iter._get_iterator("unsupported")


### PR DESCRIPTION
- Added `get_jax_iterator` and `get_torch_dataloader` to all `DataAdapter`s.
- `GeneratorDataAdapter` and `PyDatasetAdapter` can now consume tensors from any backend (added support for JAX and Torch). As a result, any combination of input format is supported by these two `DataAdapter`s.
- Made `DataAdapter`s unit tests similar.
- Fixed gap where `shuffle="batch"` was not implemented (used a global shuffle) for the numpy iterator.
- `GeneratorDataAdapter` no longer peeks twice at the first element.
- Removed the concept of `return_type` in `EpochIterator` since it is now always "auto".
- Each backend has a subclass of `EpochIterator` (this is not new), which is now in charge of retrieving the correct iterator for the backend.
- This prevents the double conversion that was happening in some cases (e.g. `TFDatasetAdapter` from `tf.Tensor` to numpy to JAX or Torch). Note that `ArrayDataAdapter` still needs some work to not have double conversions.
- The optimization of using `np.asarray` instead of `np.array` was moved from the `DataAdapter`s to the backend's `convert_to_numpy` since that is what is now used by the `DataAdapter`s.
- Also fixes https://github.com/keras-team/keras/issues/19038 .