### PR TITLE
raise exception on unknown padding for conv

### DIFF
--- a/keras/ops/operation_utils.py
+++ b/keras/ops/operation_utils.py
@@ -219,6 +219,11 @@ def compute_conv_output_shape(
                 )
     elif padding == "same" or padding == "causal":
         output_spatial_shape = np.floor((spatial_shape - 1) / strides) + 1
+    else:
+        raise ValueError(
+            "`padding` must be either `'valid'` or `'same'`. Received "
+            f"{padding}."
+        )
     output_spatial_shape = [int(i) for i in output_spatial_shape]
     for i in none_dims:
         output_spatial_shape[i] = None


### PR DESCRIPTION
Currently, the operation util `compute_conv_output_shape`, doesn't throw an exception given an unknown type of `padding`. Conv layers dependent on this util throw an unknown exception

`UnboundLocalError: local variable 'output_spatial_shape' referenced before assignment`

To reproduce:
```
import keras
from keras import layers
layer = layers.Conv2D(64, kernel_size=(3, 3),
                          strides=(3, 3),
                          padding=(1, 1), use_bias=True)

inputs = keras.random.uniform((1, 224, 224, 3))
out = layer(inputs)
```

Which can be fixed using this patch.