### PR TITLE
Change implementation of numpy.min() of torch backend

### DIFF
--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -892,9 +892,7 @@ def min(x, axis=None, keepdims=False, initial=None):
     if axis is None:
         result = torch.min(x)
     else:
-        if isinstance(axis, list):
-            axis = axis[-1]
-        result = torch.min(x, dim=axis, keepdim=keepdims)
+        result = amin(x, axis=axis, keepdims=keepdims)
 
     if isinstance(getattr(result, "values", None), torch.Tensor):
         result = result.values

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -3429,6 +3429,12 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(knp.min(x), np.min(x))
         self.assertAllClose(knp.Min()(x), np.min(x))
 
+        self.assertAllClose(knp.min(x, axis=(0, 1)), np.min(x, (0, 1)))
+        self.assertAllClose(knp.Min((0, 1))(x), np.min(x, (0, 1)))
+        
+        self.assertAllClose(knp.min(x, axis=()), np.min(x, axis=()))
+        self.assertAllClose(knp.Min(())(x), np.min(x, axis=()))
+        
         self.assertAllClose(knp.min(x, 0), np.min(x, 0))
         self.assertAllClose(knp.Min(0)(x), np.min(x, 0))
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -3431,10 +3431,10 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
         self.assertAllClose(knp.min(x, axis=(0, 1)), np.min(x, (0, 1)))
         self.assertAllClose(knp.Min((0, 1))(x), np.min(x, (0, 1)))
-        
+
         self.assertAllClose(knp.min(x, axis=()), np.min(x, axis=()))
         self.assertAllClose(knp.Min(())(x), np.min(x, axis=()))
-        
+
         self.assertAllClose(knp.min(x, 0), np.min(x, 0))
         self.assertAllClose(knp.Min(0)(x), np.min(x, 0))
 


### PR DESCRIPTION
The implementation of min() with torch backend is not working properly. For eg if list of axis passed the reduction is not happening. Changed the implementation like torch.numpy.max function which is working fine.

Attached https://colab.research.google.com/gist/SuryanarayanaY/9b28fd5fa5837d11d660550caa13eea0/19064.ipynb for demo of same.

Fizes #19064 