### PR TITLE
[keras/applications/mobilenet.py] `_conv_block` & `_depthwise_conv_block` now conformed to 'Google style docstrings' format

### DIFF
--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -360,7 +360,8 @@ def _depthwise_conv_block(
             all spatial dimensions. Specifying any stride value != 1 is
             incompatible with specifying any `dilation_rate` value != 1.
         block_id: Integer, a unique identification designating the block number.
-            # Input shape
+
+    # Input shape
         4D tensor with shape: `(batch, channels, rows, cols)` if
             data_format='channels_first'
         or 4D tensor with shape: `(batch, rows, cols, channels)` if

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -297,7 +297,7 @@ def _conv_block(inputs, filters, alpha, kernel=(3, 3), strides=(1, 1)):
             incompatible with specifying any `dilation_rate`
             value != 1.
 
-    Input shape
+    Input shape:
         4D tensor with shape: `(samples, channels, rows, cols)` if
             data_format='channels_first'
         or 4D tensor with shape: `(samples, rows, cols, channels)` if
@@ -361,7 +361,7 @@ def _depthwise_conv_block(
             incompatible with specifying any `dilation_rate` value != 1.
         block_id: Integer, a unique identification designating the block number.
 
-    Input shape
+    Input shape:
         4D tensor with shape: `(batch, channels, rows, cols)` if
             data_format='channels_first'
         or 4D tensor with shape: `(batch, rows, cols, channels)` if

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -295,7 +295,9 @@ def _conv_block(inputs, filters, alpha, kernel=(3, 3), strides=(1, 1)):
             Can be a single integer to specify the same value for all
             spatial dimensions. Specifying any stride value != 1 is
             incompatible with specifying any `dilation_rate`
-            value != 1. # Input shape
+            value != 1.
+
+    # Input shape
         4D tensor with shape: `(samples, channels, rows, cols)` if
             data_format='channels_first'
         or 4D tensor with shape: `(samples, rows, cols, channels)` if

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -297,7 +297,7 @@ def _conv_block(inputs, filters, alpha, kernel=(3, 3), strides=(1, 1)):
             incompatible with specifying any `dilation_rate`
             value != 1.
 
-    # Input shape
+    Input shape
         4D tensor with shape: `(samples, channels, rows, cols)` if
             data_format='channels_first'
         or 4D tensor with shape: `(samples, rows, cols, channels)` if
@@ -361,7 +361,7 @@ def _depthwise_conv_block(
             incompatible with specifying any `dilation_rate` value != 1.
         block_id: Integer, a unique identification designating the block number.
 
-    # Input shape
+    Input shape
         4D tensor with shape: `(batch, channels, rows, cols)` if
             data_format='channels_first'
         or 4D tensor with shape: `(batch, rows, cols, channels)` if


### PR DESCRIPTION
Found when converting/exposing your entire codebase:
```sh
$ python -m pip install python-cdd==0.0.99rc20  # Or a newer version!
$ python -m cdd exmod -m keras --emit class -r -o build/keras 
# Replace `-m keras` with `-m keras.applications.mobilenet` to replicate just this bug
```

Which failed to re-`ast.parse` the output because it produces:
```py
class _conv_block(object):
    """
    Adds an initial convolution layer (with batch normalization and relu6).
    
    :cvar inputs: Input tensor of shape `(rows, cols, 3)` (with `channels_last` data format) or (3, rows, cols) (with `channels_first` data format). It should have exactly 3 inputs channels, and width and height should be no smaller than 32. E.g. `(224, 224, 3)` would be one valid value.
    :cvar filters: Integer, the dimensionality of the output space (i.e. the number of output filters in the convolution).
    :cvar alpha: controls the width of the network. - If `alpha` < 1.0, proportionally decreases the number of filters in each layer. - If `alpha` > 1.0, proportionally increases the number of filters in each layer. - If `alpha` = 1, default number of filters from the paper are used at each layer.
    :cvar kernel: An integer or tuple/list of 2 integers, specifying the width and height of the 2D convolution window. Can be a single integer to specify the same value for all spatial dimensions.
    :cvar strides: An integer or tuple/list of 2 integers, specifying the strides of the convolution along the width and height. Can be a single integer to specify the same value for all spatial dimensions. Specifying any stride value != 1 is incompatible with specifying any `dilation_rate` value != 1. # Input shape
    :cvar 4D tensor with shape: `(samples, filters, new_rows, new_cols)` if data_format='channels_first'
    :cvar or 4D tensor with shape: `(samples, new_rows, new_cols, filters)` if data_format='channels_last'. `rows` and `cols` values might have changed due to stride.
    :cvar return_type: Output tensor of block."""
    inputs = None
    filters = None
    alpha = None
    kernel: int = (3, 3)
    strides: int = (1, 1)
    4D tensor with shape = None
    or 4D tensor with shape = None
    return_type: str = "```layers.ReLU(6.0, name='conv1_relu')(x)```"
```

…so this PR changes the function to have a docstring that is compliant with the Google docstring format.

PS: As you can see my library is still a WiP; but at least it's finding issues within your codebase as I develop! :robot: 