### PR TITLE
Let backend determine the data format by setting `data_format=None`

### DIFF
--- a/keras/layers/pooling/average_pooling2d.py
+++ b/keras/layers/pooling/average_pooling2d.py
@@ -91,7 +91,7 @@ class AveragePooling2D(BasePooling):
         pool_size,
         strides=None,
         padding="valid",
-        data_format="channels_last",
+        data_format=None,
         name=None,
         **kwargs
     ):

--- a/keras/layers/pooling/average_pooling3d.py
+++ b/keras/layers/pooling/average_pooling3d.py
@@ -67,7 +67,7 @@ class AveragePooling3D(BasePooling):
         pool_size,
         strides=None,
         padding="valid",
-        data_format="channels_last",
+        data_format=None,
         name=None,
         **kwargs
     ):

--- a/keras/layers/pooling/base_global_pooling.py
+++ b/keras/layers/pooling/base_global_pooling.py
@@ -1,4 +1,4 @@
-from keras.backend import image_data_format
+from keras import backend
 from keras.layers.input_spec import InputSpec
 from keras.layers.layer import Layer
 
@@ -11,9 +11,7 @@ class BaseGlobalPooling(Layer):
     ):
         super().__init__(**kwargs)
 
-        self.data_format = (
-            image_data_format() if data_format is None else data_format
-        )
+        self.data_format = backend.standardize_data_format(data_format)
         self.keepdims = keepdims
         self.input_spec = InputSpec(ndim=pool_dimensions + 2)
 

--- a/keras/layers/reshaping/up_sampling2d.py
+++ b/keras/layers/reshaping/up_sampling2d.py
@@ -70,7 +70,7 @@ class UpSampling2D(Layer):
         self, size=(2, 2), data_format=None, interpolation="nearest", **kwargs
     ):
         super().__init__(**kwargs)
-        self.data_format = backend.config.standardize_data_format(data_format)
+        self.data_format = backend.standardize_data_format(data_format)
         self.size = argument_validation.standardize_tuple(size, 2, "size")
         self.interpolation = interpolation.lower()
         self.input_spec = InputSpec(ndim=4)

--- a/keras/layers/reshaping/up_sampling3d.py
+++ b/keras/layers/reshaping/up_sampling3d.py
@@ -55,7 +55,7 @@ class UpSampling3D(Layer):
 
     def __init__(self, size=(2, 2, 2), data_format=None, **kwargs):
         super().__init__(**kwargs)
-        self.data_format = backend.config.standardize_data_format(data_format)
+        self.data_format = backend.standardize_data_format(data_format)
         self.size = argument_validation.standardize_tuple(size, 3, "size")
         self.input_spec = InputSpec(ndim=5)
 


### PR DESCRIPTION
I have found the inconsistency in `data_format` across these layers while building a model zoo library.

This PR should improve the UX for developers who want to support both `channels_last` and `channels_first` for their models.
