### PR TITLE
Correct keras.ops.take behaviour with axis=None

### DIFF
--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -1217,9 +1217,12 @@ def swapaxes(x, axis1, axis2):
 def take(x, indices, axis=None):
     x = convert_to_tensor(x)
     indices = convert_to_tensor(indices).long()
-    if x.ndim == 2 and (axis is None or axis == 0):
+    if x.ndim == 2 and axis == 0:
         # This case is equivalent to embedding lookup.
         return torch.nn.functional.embedding(indices, x)
+    if axis is None:
+        x = torch.reshape(x, (-1,))
+        axis = 0
     if axis is not None:
         # make sure axis is non-negative
         axis = len(x.shape) + axis if axis < 0 else axis

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -2476,6 +2476,12 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase, parameterized.TestCase):
             knp.take(x, indices, axis=-2),
             np.take(x, indices, axis=-2),
         )
+        # test with axis=None & x.ndim=2
+        x = np.array(([1, 2], [3, 4]))
+        indices = np.array([2, 3])
+        self.assertAllClose(
+            knp.take(x, indices, axis=None), np.take(x, indices, axis=None)
+        )
 
     @parameterized.named_parameters(
         named_product(


### PR DESCRIPTION
At present the behaviour of  API `keras.ops.take` with Torch backend is different and incorrect compared to TF and Jax.

This is specifically when input `x.ndim=2` and `axis = None` where x is not flattened by default with axis=None.

Hence changed the implementation and added test case to verify.

Shall fix #18984