### PR TITLE
Attempt to add support for saving/loading bfloat16

### DIFF
--- a/keras/backend/tensorflow/core.py
+++ b/keras/backend/tensorflow/core.py
@@ -1,5 +1,7 @@
 import types
 
+import h5py
+import ml_dtypes
 import numpy as np
 import tensorflow as tf
 from tensorflow.compiler.tf2xla.python.xla import dynamic_update_slice
@@ -107,6 +109,10 @@ def convert_to_tensor(x, dtype=None, sparse=None):
     if dtype is not None:
         dtype = standardize_dtype(dtype)
     if not tf.is_tensor(x):
+        # h5py will handle bfloat16 as an opaque dtype.
+        # We assume any two byte void dtypes are in fact bfloat16 type.
+        if isinstance(x, h5py.Dataset) and x.dtype == np.dtype((np.void, 2)):
+            x = np.array(x, dtype=ml_dtypes.bfloat16)
         if dtype == "bool":
             # TensorFlow boolean conversion is stricter than other backends.
             # It does not allow ints. We convert without dtype and cast instead.

--- a/keras/layers/core/dense.py
+++ b/keras/layers/core/dense.py
@@ -188,7 +188,7 @@ class Dense(Layer):
         kernel_value = ops.convert_to_numpy(self.kernel)
         store["0"] = kernel_value
         if self.use_bias:
-            store["1"] = self.bias.numpy()
+            store["1"] = ops.convert_to_numpy(self.bias)
 
     def load_own_variables(self, store):
         if not self.lora_enabled:

--- a/keras/layers/core/einsum_dense.py
+++ b/keras/layers/core/einsum_dense.py
@@ -265,7 +265,7 @@ class EinsumDense(Layer):
         kernel_value = ops.convert_to_numpy(self.kernel)
         store["0"] = kernel_value
         if self.bias is not None:
-            store["1"] = self.bias.numpy()
+            store["1"] = ops.convert_to_numpy(self.bias)
 
     def load_own_variables(self, store):
         if not self.lora_enabled:

--- a/keras/layers/layer.py
+++ b/keras/layers/layer.py
@@ -26,6 +26,7 @@ from keras import backend
 from keras import constraints
 from keras import initializers
 from keras import mixed_precision
+from keras import ops
 from keras import regularizers
 from keras import utils
 from keras.api_export import keras_export
@@ -715,7 +716,7 @@ class Layer(BackendLayer, Operation):
                     x.dtype = self.input_dtype
                 return x
             elif hasattr(x, "__array__"):
-                return backend.convert_to_tensor(x, dtype=self.input_dtype)
+                return ops.convert_to_tensor(x, dtype=self.input_dtype)
             return x
 
         # Used to avoid expensive `tree` operations in the most common case.
@@ -1119,7 +1120,7 @@ class Layer(BackendLayer, Operation):
         """
         all_vars = self._trainable_variables + self._non_trainable_variables
         for i, v in enumerate(all_vars):
-            store[f"{i}"] = v.numpy()
+            store[f"{i}"] = ops.convert_to_numpy(v)
 
     def load_own_variables(self, store):
         """Loads the state of the layer.

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -9,6 +9,7 @@ pandas
 absl-py
 requests
 h5py
+ml-dtypes
 protobuf
 google
 tensorboard-plugin-profile

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "namex",
         "h5py",
         "dm-tree",
+        "ml-dtypes",
     ],
     # Supported Python versions
     python_requires=">=3.9",


### PR DESCRIPTION
Currently attempting to save or load weights in bfloat16 will fail. There may be better ways to do this, but the approach jax and tf seem to take is to use the `ml-dtypes` library to get a bfloat16 dtype that will work with numpy.

This is further compounded by the h5py format, which saves bfloat16 as a void type. This implementation currently just assumes any two byte void type is bfloat16, which seems a bit hacky. Quite possibly a better way to do this.