### PR TITLE
Remove aliases for multi_head_attention layers

### DIFF
--- a/keras/layers/attention/multi_head_attention.py
+++ b/keras/layers/attention/multi_head_attention.py
@@ -264,22 +264,6 @@ class MultiHeadAttention(Layer):
         self._output_dense.build(tuple(output_dense_input_shape))
         self.built = True
 
-    @property
-    def query_dense(self):
-        return self._query_dense
-
-    @property
-    def key_dense(self):
-        return self._key_dense
-
-    @property
-    def value_dense(self):
-        return self._value_dense
-
-    @property
-    def output_dense(self):
-        return self._output_dense
-
     def _get_common_kwargs_for_sublayer(self):
         common_kwargs = dict(
             kernel_regularizer=self._kernel_regularizer,

--- a/keras/layers/attention/multi_head_attention_test.py
+++ b/keras/layers/attention/multi_head_attention_test.py
@@ -303,9 +303,9 @@ class MultiHeadAttentionTest(testing.TestCase, parameterized.TestCase):
             use_bias=False,
         )
         layer.build(query.shape, key.shape, value.shape)
-        layer.query_dense.enable_lora(2)
-        layer.key_dense.enable_lora(2)
-        layer.value_dense.enable_lora(2)
+        layer._query_dense.enable_lora(2)
+        layer._key_dense.enable_lora(2)
+        layer._value_dense.enable_lora(2)
 
         self.assertLen(layer.trainable_variables, 7)
         self.assertLen(layer.non_trainable_variables, 3)


### PR DESCRIPTION
These aliases, when combined with the saving change below, breaks all saving involving the MultiHeadAttention layer and .keras style weights. https://github.com/keras-team/keras/blob/f97e3c7963c3c82e6a8bcea49e20ad6063054ed7/keras/saving/saving_lib.py#L290-L294

We either need to remove these alises, or change the linked saving logic. Basically, old saved model weights path would be to the private variable, new loading expects at a public attr without the underscore.