### PR TITLE
Fix for `_calculate_score_mask` in Attention Layer

### DIFF
--- a/keras/layers/attention/attention.py
+++ b/keras/layers/attention/attention.py
@@ -204,7 +204,7 @@ class Attention(Layer):
         else:
             # If not using causal mask, return the value mask as is,
             # or None if the value mask is not provided.
-            return v_mask if v_mask is not None else None
+            return v_mask
 
     def call(
         self,

--- a/keras/layers/attention/attention.py
+++ b/keras/layers/attention/attention.py
@@ -184,26 +184,27 @@ class Attention(Layer):
         return ops.matmul(weights, value), weights
 
     def _calculate_score_mask(self, scores, v_mask, use_causal_mask):
-        if v_mask is not None:
-            # Mask of shape [batch_size, 1, Tv].
-            v_mask = ops.expand_dims(v_mask, axis=-2)
-        if not use_causal_mask:
-            return v_mask
+        if use_causal_mask:
+            # Creates a lower triangular mask, so position i cannot attend to
+            # positions j > i. This prevents the flow of information from the
+            # future into the past.
+            score_shape = ops.shape(scores)
+            # causal_mask_shape = [1, Tq, Tv].
+            mask_shape = (1, score_shape[-2], score_shape[-1])
+            ones_mask = ops.ones(shape=mask_shape, dtype="int32")
+            row_index = ops.cumsum(ones_mask, axis=-2)
+            col_index = ops.cumsum(ones_mask, axis=-1)
+            causal_mask = ops.greater_equal(row_index, col_index)
 
-        # Creates a lower triangular mask, so position i cannot attend to
-        # positions j>i. This prevents the flow of information from the
-        # future into the past.
-        score_shape = ops.shape(scores)
-        # causal_mask_shape = [1, Tq, Tv].
-        mask_shape = (1, score_shape[-2], score_shape[-1])
-        ones_mask = ops.ones(shape=mask_shape, dtype="int32")
-        row_index = ops.cumsum(ones_mask, axis=-2)
-        col_index = ops.cumsum(ones_mask, axis=-1)
-        causal_mask = ops.greater_equal(row_index, col_index)
-
-        if v_mask is not None:
+            if v_mask is not None:
+                # Mask of shape [batch_size, 1, Tv].
+                v_mask = ops.expand_dims(v_mask, axis=-2)
+                return ops.logical_and(v_mask, causal_mask)
             return causal_mask
-        return ops.logical_and(v_mask, causal_mask)
+        else:
+            # If not using causal mask, return the value mask as is,
+            # or None if the value mask is not provided.
+            return v_mask if v_mask is not None else None
 
     def call(
         self,

--- a/keras/layers/attention/attention_test.py
+++ b/keras/layers/attention/attention_test.py
@@ -114,3 +114,106 @@ class AttentionTest(testing.TestCase):
         )
         self.assertNotAllClose(output1, output2)
         self.assertNotAllClose(scores1, scores2)
+
+    def test_attention_invalid_score_mode(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid value for argument score_mode. "
+            "Expected one of {'dot', 'concat'}",
+        ):
+            layers.Attention(score_mode="invalid_mode")
+
+    def test_attention_calculate_scores_with_scale(self):
+        query = np.random.random((2, 3, 4))
+        key = np.random.random((2, 4, 4))
+        layer = layers.Attention(use_scale=True, score_mode="dot")
+        layer.build(input_shape=[(2, 3, 4), (2, 4, 4)])
+        expected_scores = np.matmul(query, key.transpose((0, 2, 1)))
+        expected_scores *= layer.scale.numpy()
+        actual_scores = layer._calculate_scores(query, key).numpy()
+        self.assertAllClose(actual_scores, expected_scores, atol=1e-4)
+
+    def test_attention_calculate_score_mask_no_causal_no_vmask(self):
+        scores = np.random.random((2, 3, 4))
+        layer = layers.Attention()
+        mask = layer._calculate_score_mask(
+            scores, v_mask=None, use_causal_mask=False
+        )
+        self.assertIsNone(
+            mask,
+            "Mask should be None when no causal mask and no value mask "
+            "are used",
+        )
+
+    def test_attention_calculate_score_mask_with_causal_no_vmask(self):
+        scores = np.random.random((2, 3, 4))
+        layer = layers.Attention()
+
+        causal_mask = layer._calculate_score_mask(
+            scores, v_mask=None, use_causal_mask=True
+        )
+        expected_causal_mask = np.tril(
+            np.ones((1, scores.shape[1], scores.shape[2])), k=0
+        )
+        self.assertAllClose(
+            causal_mask.numpy(), expected_causal_mask, atol=1e-6
+        )
+
+    def test_attention_calculate_score_mask_with_causal_and_vmask(self):
+        scores = np.random.random((2, 3, 4))
+        layer = layers.Attention()
+        v_mask = np.array([[True, False, True, False]])
+
+        combined_mask = layer._calculate_score_mask(
+            scores, v_mask=v_mask, use_causal_mask=True
+        )
+        expected_causal_mask = np.tril(
+            np.ones((1, scores.shape[1], scores.shape[2])), k=0
+        )
+        expected_combined_mask = np.logical_and(
+            expected_causal_mask, v_mask[:, np.newaxis, :]
+        )
+        self.assertAllClose(
+            combined_mask.numpy(), expected_combined_mask, atol=1e-6
+        )
+
+    def test_attention_compute_mask_with_no_mask(self):
+        layer = layers.Attention()
+        dummy_inputs = [
+            np.random.random((2, 3, 4)),
+            np.random.random((2, 4, 4)),
+        ]
+        self.assertIsNone(
+            layer.compute_mask(inputs=dummy_inputs, mask=None),
+            "compute_mask should return None when mask is None",
+        )
+
+    def test_attention_compute_mask_with_first_element_none(self):
+        layer = layers.Attention()
+        dummy_inputs = [
+            np.random.random((2, 3, 4)),
+            np.random.random((2, 4, 4)),
+        ]
+        mask = [None, np.array([True, False, True])]
+        self.assertIsNone(
+            layer.compute_mask(inputs=dummy_inputs, mask=mask),
+            "compute_mask should return None when the first element is None",
+        )
+
+    def test_attention_compute_mask_with_valid_mask(self):
+        layer = layers.Attention()
+        dummy_inputs = [
+            np.random.random((2, 3, 4)),
+            np.random.random((2, 4, 4)),
+        ]
+        valid_mask = np.array([True, False, True])
+        mask = [valid_mask, np.array([False, True, False])]
+        computed_mask = layer.compute_mask(inputs=dummy_inputs, mask=mask)
+        self.assertIsNotNone(
+            computed_mask,
+            "compute_mask should not return None with a valid mask",
+        )
+        self.assertTrue(
+            np.array_equal(computed_mask.numpy(), valid_mask),
+            "compute_mask did not return the correct mask tensor",
+        )


### PR DESCRIPTION
**The Issue:**

In the previous implementation, if `v_mask` was set to `None` and `use_causal_mask` was `True`, the method encountered a `ValueError`. 

This issue arose because the method attempted to perform operations with a `None` value, which is not compatible with the expected tensor operations.





**The Enhancement:**

The modified implementation introduces a more robust handling mechanism for such scenarios:

1. Handling `None` for `v_mask` with Causal Mask: When `use_causal_mask` is `True`, the method now correctly generates a causal mask regardless of whether `v_mask` is `None`. 


3. Handling `None` for `v_mask` without Causal Mask: If `use_causal_mask` is `False`, and `v_mask` is `None`, the method safely returns `None`. 

