### PR TITLE
Fix the numerical_test by using `tf_keras` instead of `tensorflow.keras`

### DIFF
--- a/integration_tests/numerical_test.py
+++ b/integration_tests/numerical_test.py
@@ -1,7 +1,7 @@
 import keras  # isort: skip, keep it on top for torch test
 
 import numpy as np
-from tensorflow import keras as tf_keras
+import tf_keras
 
 NUM_CLASSES = 10
 


### PR DESCRIPTION
To ensure the `numerical_test`, compares between Keras 3 and Keras 2,
we use `tf_keras` for Keras 2.