### PR TITLE
Add `ops.math.norm`

### DIFF
--- a/keras/backend/jax/math.py
+++ b/keras/backend/jax/math.py
@@ -258,3 +258,7 @@ def solve(a, b):
     a = convert_to_tensor(a)
     b = convert_to_tensor(b)
     return jnp.linalg.solve(a, b)
+
+
+def norm(x, ord=None, axis=None, keepdims=False):
+    return jnp.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)

--- a/keras/backend/numpy/math.py
+++ b/keras/backend/numpy/math.py
@@ -312,3 +312,7 @@ def solve(a, b):
     a = convert_to_tensor(a)
     b = convert_to_tensor(b)
     return np.linalg.solve(a, b)
+
+
+def norm(x, ord=None, axis=None, keepdims=False):
+    return np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)

--- a/keras/backend/tensorflow/math.py
+++ b/keras/backend/tensorflow/math.py
@@ -1,4 +1,5 @@
 import tensorflow as tf
+from tensorflow.experimental import numpy as tfnp
 
 from keras.backend import standardize_dtype
 from keras.backend.tensorflow.core import convert_to_tensor
@@ -249,3 +250,120 @@ def solve(a, b):
     a = convert_to_tensor(a)
     b = convert_to_tensor(b)
     return tf.linalg.solve(a, b)
+
+
+def norm(x, ord=None, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    x_shape = x.shape
+    ndim = x_shape.rank
+
+    if ord is None:
+        ord = "euclidean"
+
+    if axis is None:
+        axis = tuple(range(ndim))
+    elif isinstance(axis, int):
+        axis = [axis]
+
+    num_axes = len(axis)
+    axis = axis[0] if len(axis) == 1 else axis
+
+    # Fast path to utilze `tf.linalg.norm`
+    if (num_axes == 1 and ord in ("euclidean", 2)) or (
+        num_axes == 2 and ord in ("euclidean", "fro")
+    ):
+        return tf.linalg.norm(x, axis=axis, keepdims=keepdims)
+
+    # Ref: jax.numpy.linalg.norm
+    if num_axes == 1 and ord not in ("euclidean", 2):
+        if ord == float("-inf"):
+            return tf.math.reduce_min(
+                tf.math.abs(x), axis=axis, keepdims=keepdims
+            )
+        elif ord == 0:
+            return tf.math.reduce_sum(
+                tf.cast(tf.not_equal(x, 0), dtype=x.dtype),
+                axis=axis,
+                keepdims=keepdims,
+            )
+        elif ord == 1:
+            return tf.math.reduce_sum(
+                tf.math.abs(x), axis=axis, keepdims=keepdims
+            )
+        elif ord == float("inf"):
+            return tf.math.reduce_max(
+                tf.math.abs(x), axis=axis, keepdims=keepdims
+            )
+        else:
+            ord = convert_to_tensor(ord, dtype=x.dtype)
+            out = tf.math.reduce_sum(
+                tf.pow(tf.math.abs(x), ord), axis=axis, keepdims=keepdims
+            )
+            return tf.pow(out, 1.0 / ord)
+    elif num_axes == 2 and ord in (
+        "nuc",
+        float("-inf"),
+        -2,
+        -1,
+        1,
+        2,
+        float("inf"),
+    ):
+        row_axis, col_axis = axis[0], axis[1]
+        row_axis = row_axis + ndim if row_axis < 0 else row_axis
+        col_axis = col_axis + ndim if col_axis < 0 else col_axis
+        if ord == float("-inf"):
+            if not keepdims and row_axis > col_axis:
+                row_axis -= 1
+            x = tf.math.reduce_min(
+                tf.reduce_sum(tf.math.abs(x), axis=col_axis, keepdims=keepdims),
+                axis=row_axis,
+                keepdims=keepdims,
+            )
+        elif ord == -1:
+            if not keepdims and col_axis > row_axis:
+                col_axis -= 1
+            x = tf.math.reduce_min(
+                tf.reduce_sum(tf.math.abs(x), axis=row_axis, keepdims=keepdims),
+                axis=col_axis,
+                keepdims=keepdims,
+            )
+        elif ord == 1:
+            if not keepdims and col_axis > row_axis:
+                col_axis -= 1
+            x = tf.math.reduce_max(
+                tf.reduce_sum(tf.math.abs(x), axis=row_axis, keepdims=keepdims),
+                axis=col_axis,
+                keepdims=keepdims,
+            )
+        elif ord == float("inf"):
+            if not keepdims and row_axis > col_axis:
+                row_axis -= 1
+            x = tf.math.reduce_max(
+                tf.reduce_sum(tf.math.abs(x), axis=col_axis, keepdims=keepdims),
+                axis=row_axis,
+                keepdims=keepdims,
+            )
+        elif ord in ("nuc", 2, -2):
+            x = tfnp.moveaxis(x, axis, (-2, -1))
+            if ord == 2:
+                x = tf.math.reduce_max(
+                    tf.linalg.svd(x, compute_uv=False), axis=-1
+                )
+            elif ord == -2:
+                x = tf.math.reduce_min(
+                    tf.linalg.svd(x, compute_uv=False), axis=-1
+                )
+            else:
+                x = tf.math.reduce_sum(
+                    tf.linalg.svd(x, compute_uv=False), axis=-1
+                )
+            if keepdims:
+                x = tf.expand_dims(x, axis[0])
+                x = tf.expand_dims(x, axis[1])
+        return x
+
+    raise ValueError(
+        "Failed to compute norm of x. "
+        f"Received: ord={ord}, axis={axis}, keepdims={keepdims}"
+    )

--- a/keras/backend/torch/math.py
+++ b/keras/backend/torch/math.py
@@ -419,3 +419,8 @@ def solve(a, b):
     a = convert_to_tensor(a)
     b = convert_to_tensor(b)
     return torch.linalg.solve(a, b)
+
+
+def norm(x, ord=None, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    return torch.linalg.norm(x, ord=ord, dim=axis, keepdim=keepdims)

--- a/keras/ops/math_test.py
+++ b/keras/ops/math_test.py
@@ -281,6 +281,16 @@ class MathOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):
         x = KerasTensor([None, 3])
         self.assertEqual(kmath.rsqrt(x).shape, (None, 3))
 
+    def test_norm(self):
+        x = KerasTensor((None, 3))
+        self.assertEqual(kmath.norm(x).shape, ())
+
+        x = KerasTensor((None, 3, 3))
+        self.assertEqual(kmath.norm(x, axis=1).shape, (None, 3))
+        self.assertEqual(
+            kmath.norm(x, axis=1, keepdims=True).shape, (None, 1, 3)
+        )
+
 
 class MathOpsStaticShapeTest(testing.TestCase):
     @pytest.mark.skipif(
@@ -424,6 +434,10 @@ class MathOpsStaticShapeTest(testing.TestCase):
         x2 = KerasTensor((2, 2), dtype="float32")
         outputs = kmath.solve(x1, x2)
         self.assertEqual(outputs.shape, (2, 2))
+
+    def test_norm(self):
+        x = KerasTensor((2, 3))
+        self.assertEqual(kmath.norm(x).shape, ())
 
 
 class MathOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
@@ -877,6 +891,38 @@ class MathOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         x2 = np.array([[2, 4], [8, 10]], dtype="float32")
         output = kmath.solve(x1, x2)
         expected_result = np.array([[2, 0], [0, 2]], dtype="float32")
+        self.assertAllClose(output, expected_result)
+
+    @parameterized.product(
+        ord=[None, "fro", "nuc", -np.inf, -2, -1, 1, 2, np.inf],
+        axis=[None, (0, 1), (0, 2)],
+        keepdims=[False, True],
+    )
+    def test_norm_matrices(self, ord, axis, keepdims):
+        if axis is None:
+            x = np.random.random((6, 7))
+        else:
+            x = np.random.random((5, 6, 7))
+        output = kmath.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+        expected_result = np.linalg.norm(
+            x, ord=ord, axis=axis, keepdims=keepdims
+        )
+        self.assertAllClose(output, expected_result)
+
+    @parameterized.product(
+        ord=[None, -np.inf, -2, -1, 0, 1, 2, np.inf, -3.5, 3.5],
+        axis=[None, 1, -1],
+        keepdims=[False, True],
+    )
+    def test_norm_vectors(self, ord, axis, keepdims):
+        if axis is None:
+            x = np.random.random((5,))
+        else:
+            x = np.random.random((5, 6))
+        output = kmath.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+        expected_result = np.linalg.norm(
+            x, ord=ord, axis=axis, keepdims=keepdims
+        )
         self.assertAllClose(output, expected_result)
 
 


### PR DESCRIPTION
Related to #19070 

The `norm` in jax and torch is the same as numpy's `norm`.
However, significant modifications are required for tensorflow to match the output of the other backends.
