### PR TITLE
bug fix in scatter update for jax backend

### DIFF
--- a/keras/backend/jax/core.py
+++ b/keras/backend/jax/core.py
@@ -265,6 +265,7 @@ def scatter(indices, values, shape):
 
 
 def scatter_update(inputs, indices, updates):
+    inputs = jnp.array(inputs)
     indices = jnp.array(indices)
     indices = jnp.transpose(indices)
     inputs = inputs.at[tuple(indices)].set(updates)

--- a/keras/backend/jax/core.py
+++ b/keras/backend/jax/core.py
@@ -267,7 +267,7 @@ def scatter(indices, values, shape):
 def scatter_update(inputs, indices, updates):
     indices = jnp.array(indices)
     indices = jnp.transpose(indices)
-    inputs[tuple(indices)] = updates
+    inputs = inputs.at[tuple(indices)].set(updates)
     return inputs
 
 

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -150,6 +150,7 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         indices = [[1, 1], [2, 2]]
         updates = np.array([[0, 1, 2, 3], [3, 2, 1, 0]], dtype=np.float64)
         outputs = core.scatter_update(inputs, indices, updates)
+        self.assertTrue(ops.is_tensor(outputs))
         self.assertAllClose(outputs[1, 1, :], [0, 1, 2, 3])
         self.assertAllClose(outputs[2, 2, :], [3, 2, 1, 0])
 


### PR DESCRIPTION
`ops.scatter_update` throws an exception with the JAX backend. 

To reproduce:
```
import os
os.environ['KERAS_BACKEND'] = 'jax'

from keras import ops

adjacency_matrix = ops.zeros((12))
indices = [[0],[1], [3]]
updates = ops.ones(shape=(3))
adjacency_matrix = ops.scatter_update(adjacency_matrix, indices, updates)
```

This patch can fix this error.