### PR TITLE
Fix wrong gradients for torch batch_norm and moments

### DIFF
--- a/integration_tests/numerical_test.py
+++ b/integration_tests/numerical_test.py
@@ -36,10 +36,12 @@ def build_keras_model(keras_module, num_classes):
             keras_module.layers.Conv2D(
                 32, kernel_size=(3, 3), activation="relu"
             ),
+            keras_module.layers.BatchNormalization(),
             keras_module.layers.MaxPooling2D(pool_size=(2, 2)),
             keras_module.layers.Conv2D(
                 64, kernel_size=(3, 3), activation="relu"
             ),
+            keras_module.layers.BatchNormalization(scale=False, center=True),
             keras_module.layers.MaxPooling2D(pool_size=(2, 2)),
             keras_module.layers.Flatten(),
             keras_module.layers.Dense(num_classes, activation="softmax"),

--- a/keras/backend/torch/nn.py
+++ b/keras/backend/torch/nn.py
@@ -712,19 +712,22 @@ def batch_normalization(
     x = convert_to_tensor(x)
     mean = convert_to_tensor(mean)
     variance = convert_to_tensor(variance)
-    if offset is not None:
-        offset = convert_to_tensor(offset)
-    else:
-        offset = torch.zeros_like(mean)
-    if scale is not None:
-        scale = convert_to_tensor(scale)
-    else:
-        scale = torch.ones_like(variance)
 
     shape = [1] * len(x.shape)
     shape[axis] = mean.shape[0]
     mean = torch.reshape(mean, shape)
     variance = torch.reshape(variance, shape)
+
+    if offset is not None:
+        offset = convert_to_tensor(offset)
+        offset = torch.reshape(offset, shape)
+    else:
+        offset = torch.zeros_like(mean)
+    if scale is not None:
+        scale = convert_to_tensor(scale)
+        scale = torch.reshape(scale, shape)
+    else:
+        scale = torch.ones_like(variance)
 
     return (
         x.subtract(mean)

--- a/keras/backend/torch/nn.py
+++ b/keras/backend/torch/nn.py
@@ -684,7 +684,7 @@ def moments(x, axes, keepdims=False, synchronized=False):
     # gradient is zero.
     variance = torch.mean(
         torch.square(x), dim=axes, keepdim=True
-    ) - torch.square(mean.detach())
+    ) - torch.square(mean)
 
     if not keepdims:
         mean = torch.squeeze(mean, axes)
@@ -710,8 +710,8 @@ def batch_normalization(
     x, mean, variance, axis, offset=None, scale=None, epsilon=1e-3
 ):
     x = convert_to_tensor(x)
-    mean = convert_to_tensor(mean).detach()
-    variance = convert_to_tensor(variance).detach()
+    mean = convert_to_tensor(mean)
+    variance = convert_to_tensor(variance)
     if offset is not None:
         offset = convert_to_tensor(offset)
     else:
@@ -721,34 +721,16 @@ def batch_normalization(
     else:
         scale = torch.ones_like(variance)
 
-    def _batch_norm():
-        return tnn.batch_norm(
-            input=x,
-            running_mean=mean,
-            running_var=variance,
-            weight=scale,
-            bias=offset,
-            training=False,
-            eps=epsilon,
-        )
+    shape = [1] * len(x.shape)
+    shape[axis] = mean.shape[0]
+    mean = torch.reshape(mean, shape)
+    variance = torch.reshape(variance, shape)
 
-    if axis == 1:
-        return _batch_norm()
-
-    if axis < 0:
-        axis = len(x.shape) + axis
-
-    order = list(range(len(x.shape)))
-    order.pop(axis)
-    order.insert(1, axis)
-    x = x.permute(order)
-
-    x = _batch_norm()
-
-    order = list(range(len(x.shape)))
-    order.pop(1)
-    order.insert(axis, 1)
-    return x.permute(order)
+    return (
+        x.subtract(mean)
+        .mul_(variance.add(epsilon).rsqrt_().mul(scale))
+        .add_(offset)
+    )
 
 
 def ctc_loss(


### PR DESCRIPTION
Fix #19073

The deviation from the Keras 2 numerics is because of the following:
* The `moments` op used `mean.detach()`, which cut off the gradients for the mean, which is useful since it backprops to the inputs to the batch norm, from which the mean is computed from.
* The same reason that we should not detach the mean and variance in the `batch_normalization` op.

We had to change the torch `batch_normalization` op to a plain implementation instead of calling the fused op of `torch.nn.functional.batch_norm()` since it cannot run without calling `mean.detach()` and pass the detached mean to it, which cuts off the gradients.

In `torch.nn.BatchNorm2d`, the implementation is not mathematically equivalent to the Keras implementation. They call the fused op with `training=True`, and let the op manage the running mean and var completely.

In this PR, it also updates the `numerical_test.py` to catch the bug.

For performance and memory  concerns, it should be a little slower than the fused op, but not too much memory overhead since the implementation put the computes inplace whenever possible.