### PR TITLE
Add support for sparse tensors with the JAX backend.

### DIFF
--- a/keras/backend/jax/core.py
+++ b/keras/backend/jax/core.py
@@ -1,6 +1,7 @@
 import types
 
 import jax
+import jax.experimental.sparse as jax_sparse
 import jax.numpy as jnp
 import ml_dtypes
 import numpy as np
@@ -13,9 +14,8 @@ from keras.backend.common import standardize_dtype
 from keras.backend.common.keras_tensor import KerasTensor
 from keras.backend.common.stateless_scope import StatelessScope
 from keras.backend.jax import distribution_lib
-from keras.utils.nest import pack_sequence_as
 
-SUPPORTS_SPARSE_TENSORS = False
+SUPPORTS_SPARSE_TENSORS = True
 
 
 class Variable(KerasVariable):
@@ -40,16 +40,14 @@ class Variable(KerasVariable):
         self._value = value
 
     def _convert_to_tensor(self, value, dtype=None):
-        return convert_to_tensor(value, dtype=dtype)
+        return convert_to_tensor(value, dtype=dtype, sparse=False)
 
     # Overload native accessor.
     def __jax_array__(self):
         return self.value
 
 
-def convert_to_tensor(x, dtype=None, sparse=None):
-    if sparse:
-        raise ValueError("`sparse=True` is not supported with jax backend")
+def convert_to_tensor(x, dtype=None, sparse=True):
     if dtype is not None:
         dtype = standardize_dtype(dtype)
     if isinstance(x, (jnp.ndarray, jax.Array)) and dtype == x.dtype:
@@ -62,6 +60,15 @@ def convert_to_tensor(x, dtype=None, sparse=None):
         if dtype and dtype != x.dtype:
             return x.value.astype(dtype)
         return x.value
+
+    if isinstance(x, jax_sparse.JAXSparse):
+        if sparse is not None and not sparse:
+            x = x.todense()
+        elif dtype and dtype != x.dtype:
+            return x.astype(dtype)
+        else:
+            return x
+
     if not is_tensor(x) and standardize_dtype(dtype) == "bfloat16":
         # Can't create bfloat16 arrays on the fly (e.g. from a h5 Dataset).
         # Instead we convert "as is" (to stored dtype) and cast.
@@ -70,13 +77,15 @@ def convert_to_tensor(x, dtype=None, sparse=None):
 
 
 def convert_to_numpy(x):
+    if isinstance(x, jax_sparse.JAXSparse):
+        x = x.todense()
     if is_tensor(x) and x.dtype == "bfloat16":
         return np.asarray(x, ml_dtypes.bfloat16)
     return np.asarray(x)
 
 
 def is_tensor(x):
-    if isinstance(x, jnp.ndarray):
+    if isinstance(x, (jnp.ndarray, jax_sparse.JAXSparse)):
         return True
     return False
 
@@ -91,10 +100,9 @@ def cast(x, dtype):
     return convert_to_tensor(x, dtype=dtype)
 
 
-# Shape / dtype inference util
+# Shape / dtype / sparseness inference util
 def compute_output_spec(fn, *args, **kwargs):
     with StatelessScope():
-        all_input_ktensors = []
         built_in_types = (type(None), int, float, str, bool, complex, bytes)
 
         # First, separate symbolic args from other args
@@ -109,27 +117,18 @@ def compute_output_spec(fn, *args, **kwargs):
                 static_args.append(arg)
             else:
                 maybe_symbolic_args.append(arg)
+        maybe_symbolic_args = tuple(maybe_symbolic_args)
         for k, v in kwargs.items():
             if isinstance(v, built_in_types):
                 static_kwargs[k] = v
             else:
                 maybe_symbolic_kwargs[k] = v
 
-        # Second, identify all ktensors
-        def index_all_ktensors(x):
-            if isinstance(x, KerasTensor):
-                all_input_ktensors.append(x)
-            return x
-
-        # Third, find out if there are dynamic shapes
-        maybe_symbolic_args, maybe_symbolic_kwargs = tree.map_structure(
-            index_all_ktensors, (maybe_symbolic_args, maybe_symbolic_kwargs)
-        )
-        none_count = 0
-        for x in all_input_ktensors:
-            for d in x.shape:
-                if d is None:
-                    none_count += 1
+        # Second, find out if there are dynamic shapes
+        has_none = False
+        for x in tree.flatten((maybe_symbolic_args, maybe_symbolic_kwargs)):
+            if isinstance(x, KerasTensor) and any(d is None for d in x.shape):
+                has_none = True
 
         def convert_keras_tensor_to_jax(x, fill_value=None):
             if isinstance(x, KerasTensor):
@@ -163,6 +162,22 @@ def compute_output_spec(fn, *args, **kwargs):
             return x
 
         def wrapped_fn(*args, **kwargs):
+
+            # Turn inputs that are sparse to BCOO tensors
+            def to_bcoo_if_sparse(x, maybe_symbolic_x):
+                if (
+                    isinstance(maybe_symbolic_x, KerasTensor)
+                    and maybe_symbolic_x.sparse
+                ):
+                    return jax_sparse.BCOO.fromdense(x, nse=1)
+                return x
+
+            args, kwargs = tree.map_structure(
+                to_bcoo_if_sparse,
+                (args, kwargs),
+                (maybe_symbolic_args, maybe_symbolic_kwargs),
+            )
+
             rec_args = []
             idx_static = 0
             idx_sym = 0
@@ -179,8 +194,8 @@ def compute_output_spec(fn, *args, **kwargs):
             with StatelessScope():
                 return fn(*rec_args, **kwargs, **static_kwargs)
 
-        jax_out = None
-        if none_count:
+        output_spec = None
+        if has_none:
             try:
                 ms_args_1, ms_kwargs_1 = tree.map_structure(
                     lambda x: convert_keras_tensor_to_jax(x, fill_value=83),
@@ -198,24 +213,35 @@ def compute_output_spec(fn, *args, **kwargs):
                     *ms_args_2, **ms_kwargs_2
                 )
 
-                flat_out_1 = tree.flatten(jax_out_1)
-                flat_out_2 = tree.flatten(jax_out_2)
+                def merge_shapes(shape1, shape2):
+                    return tuple(
+                        [
+                            d1 if d1 == d2 else None
+                            for d1, d2 in zip(shape1, shape2)
+                        ]
+                    )
 
-                flat_out = []
-                for x1, x2 in zip(flat_out_1, flat_out_2):
+                def convert_jax_specs_to_keras_tensor(x1, x2):
                     if isinstance(x1, jax.ShapeDtypeStruct):
                         if not isinstance(x2, jax.ShapeDtypeStruct):
                             raise ValueError("Indeterministic output ordering.")
-                        shape = list(x1.shape)
-                        for i, e in enumerate(x2.shape):
-                            if e != shape[i]:
-                                shape[i] = None
-                        flat_out.append(
-                            jax.ShapeDtypeStruct(shape, dtype=x1.dtype)
+                        return KerasTensor(
+                            merge_shapes(x1.shape, x2.shape), dtype=x1.dtype
+                        )
+                    elif isinstance(x1, jax_sparse.BCOO):
+                        if not isinstance(x2, jax_sparse.BCOO):
+                            raise ValueError("Indeterministic output ordering.")
+                        return KerasTensor(
+                            merge_shapes(x1.shape, x2.shape),
+                            dtype=x1.dtype,
+                            sparse=True,
                         )
                     else:
-                        flat_out.append(x1)
-                jax_out = pack_sequence_as(jax_out_1, flat_out)
+                        return x1
+
+                output_spec = tree.map_structure(
+                    convert_jax_specs_to_keras_tensor, jax_out_1, jax_out_2
+                )
             except Exception as e:
                 if "[JAX RNG]" in str(e):
                     raise e
@@ -230,7 +256,7 @@ def compute_output_spec(fn, *args, **kwargs):
                 # The error message will be much easier to understand.
                 pass
 
-        if jax_out is None:
+        if output_spec is None:
             maybe_symbolic_args, maybe_symbolic_kwargs = tree.map_structure(
                 convert_keras_tensor_to_jax,
                 (maybe_symbolic_args, maybe_symbolic_kwargs),
@@ -239,15 +265,18 @@ def compute_output_spec(fn, *args, **kwargs):
                 *maybe_symbolic_args, **maybe_symbolic_kwargs
             )
 
-        def convert_jax_spec_to_keras_tensor(x):
-            if isinstance(x, jax.ShapeDtypeStruct):
-                return KerasTensor(x.shape, x.dtype)
-            return x
+            def convert_jax_spec_to_keras_tensor(x):
+                if isinstance(x, jax.ShapeDtypeStruct):
+                    return KerasTensor(x.shape, x.dtype)
+                elif isinstance(x, jax_sparse.BCOO):
+                    return KerasTensor(x.shape, x.dtype, sparse=True)
+                return x
 
-        output_shape = tree.map_structure(
-            convert_jax_spec_to_keras_tensor, jax_out
-        )
-    return output_shape
+            output_spec = tree.map_structure(
+                convert_jax_spec_to_keras_tensor, jax_out
+            )
+
+    return output_spec
 
 
 def cond(pred, true_fn, false_fn):

--- a/keras/backend/jax/sparse.py
+++ b/keras/backend/jax/sparse.py
@@ -1,0 +1,328 @@
+import functools
+
+import jax.experimental.sparse as jax_sparse
+import jax.numpy as jnp
+
+from keras.utils import jax_utils
+
+
+def axis_shape_dims_for_broadcast_in_dim(axis, input_shape, insert_dims):
+    """Turn the `axis` argument to the arguments needed by `broadcast_in_dim`.
+
+    Args:
+        axis: single int or a tuple of ints for the axis argument. The list of
+          dimensions to reduce or insert.
+        input_shape: the shape of the input as a tuple ints.
+        insert_dims: `False` turns dimensions in `axis` to 1s (use case:
+          reduction along `axis` with `keep_dims=True`). `True`, inserts 1s
+          according to `axis` (use case: `expand_dims`).
+    Returns:
+        A tuple of three lists
+        - The canonical value for `axis`: always a list, negative values have
+          been resolved and values are sorted in ascending order.
+        - The output shape: `input_shape` with 1s at the indices in `axis`, for
+          use as the `shape` argument of `broadcast_in_dim`.
+        - The broadcast dimensions: list of dimensions not in `axis`, for use as
+          the `broadcast_dimensions` argument of `broadcast_in_dim`.
+    """
+    if axis is None:
+        raise ValueError("Received `None` value for `axis`")
+    if isinstance(axis, int):
+        axis = (axis,)
+    # Check uniqueness.
+    if len(set(axis)) != len(axis):
+        raise ValueError(f"Repeated axis in `axis`: {axis}")
+    result_dims = len(input_shape)
+    if insert_dims:
+        result_dims += len(axis)
+
+    # Resolve negative values.
+    canonical_axis = []
+    for a in axis:
+        if not -result_dims <= a < result_dims:
+            raise ValueError(
+                f"In `axis`, axis {a} is out of bounds for array "
+                f"of dimension {result_dims}"
+            )
+        if a < 0:
+            a = a + result_dims
+        canonical_axis.append(a)
+
+    # Check uniqueness again after resolving negative values.
+    if len(set(canonical_axis)) != len(canonical_axis):
+        raise ValueError(f"Repeated axis in `axis`: {canonical_axis}")
+    canonical_axis = sorted(canonical_axis)
+
+    # Compute output shape.
+    output_shape = list(input_shape)
+    for i in canonical_axis:
+        if insert_dims:
+            output_shape.insert(i, 1)
+        else:
+            output_shape[i] = 1
+    broadcast_dims = [i for i in range(result_dims) if i not in canonical_axis]
+    return canonical_axis, output_shape, broadcast_dims
+
+
+def bcoo_add_indices(x1, x2, sum_duplicates):
+    """Add the indices of `x2` to `x1` with zero values.
+
+    Args:
+        x1: `BCOO` tensor to add indices to.
+        x2: `BCOO` tensor to take the indices to add to x1.
+        sum_duplicates: if `True` calls `bcoo_sum_duplicates` on the output.
+    Returns:
+        a `BCOO` tensor equal to `x1` but with extra zeros at indices in `x2`
+        that were missing in `x1`.
+    """
+    x2_zeros = jnp.zeros(x2.data.shape, x1.data.dtype)
+    concat_axis = len(x1.indices.shape) - 2
+    output_indices = jnp.concatenate([x1.indices, x2.indices], axis=concat_axis)
+    output_data = jnp.concatenate([x1.data, x2_zeros], axis=concat_axis)
+    output = jax_sparse.BCOO((output_data, output_indices), shape=x1.shape)
+    if sum_duplicates:
+        output = jax_sparse.bcoo_sum_duplicates(output)
+    return output
+
+
+def densifying_unary(func):
+    """Decorator to add support for `JAXSparse` tensors (including `BCOO`) to a
+    non-zero-preserving element-wise unary operator.
+
+    There are requirements on the operator for this decorator to work correctly:
+
+    - The operator must be element-wise
+    - The operator must be unary (one input tensor and one output tensor)
+    - The operator must return a tensor of the same shape.
+
+    Additional arguments to the function (besides the input tensor) are
+    supported. The returned result is a dense tensor.
+
+    Args:
+        func: The unary operator to wrap.
+    Returns:
+        Wrapped function that supports `JAXSparse` tensors.
+    """
+
+    @functools.wraps(func)
+    def sparse_wrapper(x, *args, **kwargs):
+        if isinstance(x, jax_sparse.JAXSparse):
+            x = x.todense()
+        return func(x, *args, **kwargs)
+
+    return sparse_wrapper
+
+
+def elementwise_unary(linear):
+    """Decorator to add support for `BCOO` sparse tensors to a zero-preserving
+    element-wise unary operator.
+
+    There are requirements on the operator for this decorator to work correctly:
+
+    - The operator must be element-wise
+    - The operator must be unary (one input tensor and one output tensor)
+    - The operator must return a tensor of the same shape, and if it is a
+      `BCOO` tensor, the indices of the result must be the same. Therefore:
+        - Reduction operations are not supported (e.g. `mean`).
+        - Operations for which the result may be dense (e.g. `reciprocal`), or
+          the sparse indices depend on the inputs are not supported (e.g.
+          `clip`). This implies that `func(0)` must be 0.
+
+    Additional arguments to the function (besides the input tensor) are
+    supported as long as they cannot change the indices of the result. For
+    instance,`round` is supported, but `clip` is not supported as
+    `clip(x, 1.0, 2.0)` would always return a dense tensor.
+
+    Note that if an input sparse tensor contains zero values, the indices and
+    the zero values are preserved.
+
+    Args:
+        linear: if `True`, means that the operation is such that
+            `op(a + b) == op(a) + op(b)`.
+    Returns:
+        Wrapped function that supports `BCOO` sparse tensors.
+    """
+
+    def wrap_elementwise_unary(func):
+        @functools.wraps(func)
+        def sparse_wrapper(x, *args, **kwargs):
+            if isinstance(x, jax_sparse.BCOO):
+                if not linear and not x.unique_indices:
+                    x = jax_sparse.bcoo_sum_duplicates(x)
+                return jax_sparse.BCOO(
+                    (func(x.data, *args, **kwargs), x.indices), shape=x.shape
+                )
+            else:
+                return func(x, *args, **kwargs)
+
+        return sparse_wrapper
+
+    return wrap_elementwise_unary
+
+
+def elementwise_binary_union(linear, use_sparsify):
+    """Decorator to add support for `JAXSparse` tensors (including `BCOO`) to an
+    element-wise binary operator such that the indices present in the result are
+    are the union of the indices in the two operand.
+
+    The primary use case for this is the `add` and `subtract` operators.
+
+    There are requirements on the operator for this decorator to work correctly:
+
+    - The operator must be element-wise.
+    - The operator must be binary (two input tensors and one output tensor).
+    - Both inputs must be of the same shape or one input must be a scalar.
+    - The output must be of the same shape as the (non scalar) inputs.
+    - The indices of the output must be the union of the indices of the inputs.
+      This implies that func(0, 0) must be 0. As a result, if one operand is
+      dense or a scalar, then the result will be dense.
+
+    Additional arguments to the function (besides the input tensors) are not
+    supported.
+
+    Note that if the result of the operation is zero at some indices, including
+    because the operands were zero at these indices, the zeros and indices are
+    preserved.
+
+    The `BCOO` format is the only supported one in all cases. Other formats are
+    not supported when `use_sparsify` is `False`.
+
+    Args:
+        use_sparsify: indicates that the JAX `sparsify` transform supports this
+            operation.
+        linear: if `True`, mean that the operation is such that
+            `op(a + b, c) == op(a, c) + op(b, c)` and
+            `op(a, c + d) == op(a, c) + op(a, d)`.
+    Returns:
+        Wrapped function that supports `JAXSparse`.
+    """
+
+    def wrap_elementwise_binary_union(func):
+        sparse_func = jax_sparse.sparsify(func) if use_sparsify else None
+
+        @functools.wraps(func)
+        def sparse_wrapper(x1, x2):
+            if isinstance(x1, jax_sparse.JAXSparse):
+                if isinstance(x2, jax_sparse.JAXSparse):
+                    # x1 and x2 are sparse.
+                    # The way we use `sparsify` it cannot know that the indices
+                    # are the same, so we optimize this case here.
+                    if (
+                        x1.indices is x2.indices
+                        and isinstance(x1, jax_sparse.BCOO)
+                        and isinstance(x2, jax_sparse.BCOO)
+                    ):
+                        if not linear and not x1.unique_indices:
+                            x1 = jax_sparse.bcoo_sum_duplicates(x1)
+                            x2 = jax_sparse.bcoo_sum_duplicates(x2)
+                        return jax_sparse.BCOO(
+                            (func(x1.data, x2.data), x1.indices),
+                            shape=x1.shape,
+                            indices_sorted=x1.indices_sorted,
+                            unique_indices=x1.unique_indices,
+                        )
+                    elif use_sparsify:
+                        return sparse_func(x1, x2)
+                    elif isinstance(x1, jax_sparse.BCOO) and isinstance(
+                        x2, jax_sparse.BCOO
+                    ):
+                        x1 = bcoo_add_indices(x1, x2, sum_duplicates=not linear)
+                        x2 = bcoo_add_indices(x2, x1, sum_duplicates=not linear)
+                        return jax_sparse.BCOO(
+                            (func(x1.data, x2.data), x1.indices),
+                            shape=x1.shape,
+                            indices_sorted=True,
+                            unique_indices=True,
+                        )
+                    else:
+                        ValueError(
+                            "Unsupported sparse format: "
+                            f"{x1.__class__} and {x2.__class__}"
+                        )
+                else:
+                    # x1 is sparse, x2 is dense, densify x2.
+                    x1 = x1.todense()
+            elif isinstance(x2, jax_sparse.JAXSparse):
+                # x1 is dense, x2 is sparse, densify x2.
+                x2 = x2.todense()
+            return func(x1, x2)
+
+        return sparse_wrapper
+
+    return wrap_elementwise_binary_union
+
+
+def elementwise_division(func):
+    """Decorator to add support for `BCOO` sparse tensors to element-wise binary
+    division and related operators.
+
+    This decorator is designed for operations related to the division of two
+    two operands (e.g. `divide`). It accepts `BCOO` tensors for both the
+    dividend and the divisor, but handles them differently based on whether they
+    are the dividend or the divisor.
+
+    - If the divisor is sparse, it is densified and the result is dense because
+      the result contains Inf or Nan outside of the indices of the dividend.
+    - If the dividend is sparse and the divisor is dense, it finds occurrences
+      of zeros and NaNs in the divisor. The result may therefore have more
+      indices than there were in the dividend to return correct values where the
+      divisor was zero or NaN.
+    - If the dividend is sparse and the divisor is a scalar, it does the
+      division element-wise. Note that the result is incorrectly sparse if the
+      scalar divisor is zero.
+
+    Args:
+        func: The function to wrap.
+    Returns:
+        Wrapped function that supports `BCOO` sparse tensors.
+    """
+    sparse_func = jax_sparse.sparsify(func)
+
+    @functools.wraps(func)
+    def sparse_wrapper(x1, x2):
+        if isinstance(x1, jax_sparse.JAXSparse):
+            if isinstance(x2, jax_sparse.JAXSparse):
+                # x1 is sparse and x2 is sparse.
+                # Divisor is sparse, meaning we're doing divisions by zero
+                # outside of x2.indices, so the result is dense. Densify both.
+                x1 = x1.todense()
+                x2 = x2.todense()
+            elif isinstance(x1, jax_sparse.BCOO):
+                if not hasattr(x2, "shape") or len(x2.shape) == 0:
+                    # x1 is sparse BCOO, x2 is scalar, apply func element-wise.
+                    return jax_sparse.BCOO(
+                        (func(x1.data, x2), x1.indices),
+                        shape=x1.shape,
+                        indices_sorted=x1.indices_sorted,
+                        unique_indices=x1.unique_indices,
+                    )
+                else:
+                    # x1 is sparse BCOO, x2 is dense.
+                    if not jax_utils.is_in_jax_tracing_scope(x2):
+                        # Find zeros and nans in x2 and add indices to x1.
+                        # 1. Create a dense mask for zeros and nans.
+                        x2_zeros_and_nans = jnp.equal(x2, 0)
+                        if not jnp.issubdtype(x2.dtype, jnp.integer):
+                            x2_zeros_and_nans = jnp.logical_or(
+                                x2_zeros_and_nans, jnp.isnan(x2)
+                            )
+                        # 2. Make it a BCOO of True values.
+                        x2_zeros_and_nans = jax_sparse.bcoo_fromdense(
+                            x2_zeros_and_nans,
+                            n_batch=x1.n_batch,
+                            n_dense=x1.n_dense,
+                            index_dtype=x1.indices.dtype,
+                        )
+                        # 3. Add the indices to x1.
+                        x1 = bcoo_add_indices(
+                            x1, x2_zeros_and_nans, sum_duplicates=True
+                        )
+                    return sparse_func(x1, x2)
+            else:
+                raise ValueError(f"Unsupported sparse format: {x1.__class__}")
+        elif isinstance(x2, jax_sparse.JAXSparse):
+            # x1 is dense, x2 is sparse, densify x2
+            x2 = x2.todense()
+        return func(x1, x2)
+
+    return sparse_wrapper

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -1716,11 +1716,14 @@ def sqrt(x):
 def squeeze(x, axis=None):
     if isinstance(x, tf.SparseTensor):
         static_shape = x.shape.as_list()
-        if axis is not None and static_shape[axis] != 1:
-            raise ValueError(
-                f"Cannot squeeze axis {axis}, because the "
-                "dimension is not 1."
-            )
+        if axis is not None:
+            if static_shape[axis] != 1:
+                raise ValueError(
+                    f"Cannot squeeze axis {axis}, because the "
+                    "dimension is not 1."
+                )
+            if axis < 0:
+                axis += len(static_shape)
         dynamic_shape = tf.shape(x)
         new_shape = []
         gather_indices = []

--- a/keras/backend/tests/compute_output_spec_test.py
+++ b/keras/backend/tests/compute_output_spec_test.py
@@ -63,7 +63,7 @@ class ComputeOutputSpecTest(unittest.TestCase):
             self.assertEqual(y.shape, (None, 3, 3))
             self.assertTrue(y.sparse)
 
-        def three_args_2_kwarg_sparse_fn(x1, x2, x3=None):
+        def three_args_sparse_fn(x1, x2, x3=None):
             y0 = ops.add(x1, x2)  # sparse, sparse
             y1 = ops.concatenate([x1, x2], axis=0)  # sparse, sparse
             y2 = ops.divide(x1, x3)  # sparse, dense
@@ -75,9 +75,7 @@ class ComputeOutputSpecTest(unittest.TestCase):
         x1 = KerasTensor(shape=(None, 3, 3), sparse=True)
         x2 = KerasTensor(shape=(None, 3, 3), sparse=True)
         x3 = KerasTensor(shape=(None, 3, 3), sparse=False)
-        ys = backend.compute_output_spec(
-            three_args_2_kwarg_sparse_fn, x1, x2, x3=x3
-        )
+        ys = backend.compute_output_spec(three_args_sparse_fn, x1, x2, x3=x3)
         for y in ys:
             self.assertEqual(y.shape, (None, 3, 3))
             self.assertTrue(y.sparse)
@@ -97,23 +95,20 @@ class ComputeOutputSpecTest(unittest.TestCase):
             self.assertEqual(y.shape, (None, 3, 3))
             self.assertFalse(y.sparse)
 
-        def three_args_2_kwarg_dense_fn(x1, x2, x3=None):
-            y0 = ops.add(x1, x3)  # sparse, dense
-            y1 = ops.add(x3, x1)  # dense, sparse
-            y2 = ops.concatenate([x1, x3], axis=0)  # sparse, dense
-            y3 = ops.matmul(x1, x3)  # sparse, dense
-            y4 = ops.matmul(x3, x1)  # dense, sparse
-            indices = KerasTensor((3,), "int64", sparse=True)
-            y5 = ops.take(x3, indices=indices, axis=1)  # dense, sparse
-            y6 = ops.divide(x1, x2)
+        def three_args_dense_fn(x1, x2, x3=None):
+            y0 = ops.add(x1, x2)  # sparse, dense
+            y1 = ops.add(x2, x1)  # dense, sparse
+            y2 = ops.concatenate([x1, x2], axis=0)  # sparse, dense
+            y3 = ops.matmul(x1, x2)  # sparse, dense
+            y4 = ops.matmul(x2, x1)  # dense, sparse
+            y5 = ops.take(x2, indices=x3, axis=1)  # dense, sparse
+            y6 = ops.divide(x1, x1)  # sparse, sparse
             return (y0, y1, y2, y3, y4, y5, y6)
 
         x1 = KerasTensor(shape=(None, 3, 3), sparse=True)
-        x2 = KerasTensor(shape=(None, 3, 3), sparse=True)
-        x3 = KerasTensor(shape=(None, 3, 3), sparse=False)
-        ys = backend.compute_output_spec(
-            three_args_2_kwarg_dense_fn, x1, x2, x3=x3
-        )
+        x2 = KerasTensor(shape=(None, 3, 3), sparse=False)
+        x3 = KerasTensor(shape=(3,), dtype="int64", sparse=True)
+        ys = backend.compute_output_spec(three_args_dense_fn, x1, x2, x3=x3)
         for y in ys:
             self.assertEqual(y.shape, (None, 3, 3))
             self.assertFalse(y.sparse)

--- a/keras/layers/core/identity.py
+++ b/keras/layers/core/identity.py
@@ -1,4 +1,7 @@
+import tree
+
 from keras.api_export import keras_export
+from keras.backend import KerasTensor
 from keras.layers.layer import Layer
 
 
@@ -16,3 +19,12 @@ class Identity(Layer):
 
     def call(self, inputs):
         return inputs
+
+    def compute_output_shape(self, input_shape):
+        return input_shape
+
+    def compute_output_spec(self, inputs):
+        return tree.map_structure(
+            lambda x: KerasTensor(x.shape, dtype=x.dtype, sparse=x.sparse),
+            inputs,
+        )

--- a/keras/layers/reshaping/flatten_test.py
+++ b/keras/layers/reshaping/flatten_test.py
@@ -30,13 +30,23 @@ class FlattenTest(testing.TestCase, parameterized.TestCase):
             np.reshape(np.transpose(inputs, (0, 2, 3, 1)), (-1, 5 * 5 * 3))
         )
         if sparse:
-            import tensorflow as tf
+            if backend.backend() == "tensorflow":
+                import tensorflow as tf
 
-            inputs = tf.sparse.from_dense(inputs)
-            expected_output_channels_last = tf.sparse.from_dense(
+                dense_to_sparse = tf.sparse.from_dense
+            elif backend.backend() == "jax":
+                import jax.experimental.sparse as jax_sparse
+
+                dense_to_sparse = jax_sparse.BCOO.fromdense
+            else:
+                self.fail(
+                    f"Sparse is unsupported with backend {backend.backend()}"
+                )
+            inputs = dense_to_sparse(inputs)
+            expected_output_channels_last = dense_to_sparse(
                 expected_output_channels_last
             )
-            expected_output_channels_first = tf.sparse.from_dense(
+            expected_output_channels_first = dense_to_sparse(
                 expected_output_channels_first
             )
 

--- a/keras/layers/reshaping/permute_test.py
+++ b/keras/layers/reshaping/permute_test.py
@@ -27,10 +27,20 @@ class PermuteTest(testing.TestCase, parameterized.TestCase):
             np.transpose(inputs, axes=(0, 3, 1, 2))
         )
         if sparse:
-            import tensorflow as tf
+            if backend.backend() == "tensorflow":
+                import tensorflow as tf
 
-            inputs = tf.sparse.from_dense(inputs)
-            expected_output = tf.sparse.from_dense(expected_output)
+                inputs = tf.sparse.from_dense(inputs)
+                expected_output = tf.sparse.from_dense(expected_output)
+            elif backend.backend() == "jax":
+                import jax.experimental.sparse as jax_sparse
+
+                inputs = jax_sparse.BCOO.fromdense(inputs)
+                expected_output = jax_sparse.BCOO.fromdense(expected_output)
+            else:
+                self.fail(
+                    f"Backend {backend.backend()} does not support sparse"
+                )
 
         self.run_layer_test(
             layers.Permute,

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -5776,9 +5776,11 @@ class Mean(Operation):
             result_dtype = compute_dtype
         else:
             result_dtype = ori_dtype
+        sparse = getattr(x, "sparse", False)
         return KerasTensor(
             reduce_shape(x.shape, axis=self.axis, keepdims=self.keepdims),
             dtype=result_dtype,
+            sparse=sparse,
         )
 
 

--- a/keras/utils/jax_utils.py
+++ b/keras/utils/jax_utils.py
@@ -1,9 +1,10 @@
 from keras import backend
 
 
-def is_in_jax_tracing_scope():
+def is_in_jax_tracing_scope(x=None):
     if backend.backend() == "jax":
-        x = backend.numpy.ones(())
+        if x is None:
+            x = backend.numpy.ones(())
         if x.__class__.__name__ == "DynamicJaxprTracer":
             return True
     return False


### PR DESCRIPTION
Add support for sparse tensors with the JAX backend.

This is experimental since JAX support for sparse tensors itself is experimental.

This support has the following limitation:
- Only the BCOO format is fully supported and tested. Other formats are untested and only supported for some use cases.
- Not all combinations of `n_batch`, `n_sparse` and `n_dense` are supported. What is tested is:
  - all sparse (equivalent to `tf.SparseTensor`)
  - `n_sparse == 1` and the rest is dense (equivalent to `tf.IndexedSlices`)
- The the embedding layer / the `take` op is not optimized (densifies inputs).
- Gradients obtained from sparse inputs are not sparse.

Also:
- Fixed a bug with TensorFlow sparse support for `squeeze` when `axis` is negative.
- `run_layer_test` can now take a tuple of input shapes.
