### PR TITLE
Cast avg to float in progbar

### DIFF
--- a/keras/utils/progbar.py
+++ b/keras/utils/progbar.py
@@ -164,6 +164,7 @@ class Progbar:
                             self._values[k][0] / max(1, self._values[k][1])
                         )
                     )
+                    avg = float(avg)
                     if abs(avg) > 1e-3:
                         info += f" {avg:.4f}"
                     else:


### PR DESCRIPTION
We need to explicitly cast `avg` to float otherwise, training has some issues with the torch backend when the default dtype is `bfloat16`.