### PR TITLE
When monitor metric size >1 fallback to save_best_only=False in ModelCheckpoint

### DIFF
--- a/keras/callbacks/model_checkpoint.py
+++ b/keras/callbacks/model_checkpoint.py
@@ -246,6 +246,13 @@ class ModelCheckpoint(Callback):
                         "available, skipping.",
                         stacklevel=2,
                     )
+                elif len(current.numpy()) > 0:
+                    warnings.warn(
+                        f"Can save best model only when `monitor` is "
+                        f"a scalar value, got {current}. "
+                        f"Falling back to `save_best_only=False`. "
+                    )
+                    self.model.save(filepath, overwrite=True)
                 else:
                     if self.monitor_op(current, self.best):
                         if self.verbose > 0:


### PR DESCRIPTION
When we use `F1_score` with `average=None` as monitor for Model checkpoint and the model is of multi-class classification problem then the metric returns f1_score of each class. In such scenario if save_best_only=True passed to ModelCheckpoint then it will raise an error due to ambiguity. 

`ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`

If we set `save_best_only=False` which is default then there is no problem with model checkpointing. Hence I am proposing to fall back to `save_best_only=False` mode and display it as user warning for such case instead raising an exception.

Attached [gist](https://colab.research.google.com/gist/SuryanarayanaY/dd8a9494d77508b52f116d42dc68406b/f1_score_error_fix.ipynb) for the same with testing the fix.

May Fix the TF ticket #[61336](https://github.com/tensorflow/tensorflow/issues/61336).


