### PR TITLE
Fix bug in broadcast_to Op with Jax backend when keras variable as input

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -10,7 +10,7 @@ from keras.backend.common.variables import standardize_dtype
 from keras.backend.jax import sparse
 from keras.backend.jax.core import cast
 from keras.backend.jax.core import convert_to_tensor
-from keras.ops import convert_to_numpy
+from keras.ops import convert_to_tensor
 
 
 @sparse.elementwise_binary_union(linear=True, use_sparsify=True)
@@ -323,7 +323,7 @@ def average(x, axis=None, weights=None):
 
 
 def broadcast_to(x, shape):
-    x = convert_to_numpy(x)
+    x = convert_to_tensor(x)
     return jnp.broadcast_to(x, shape)
 
 

--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -10,6 +10,8 @@ from keras.backend.common.variables import standardize_dtype
 from keras.backend.jax import sparse
 from keras.backend.jax.core import cast
 from keras.backend.jax.core import convert_to_tensor
+from keras.ops import convert_to_numpy
+
 
 
 @sparse.elementwise_binary_union(linear=True, use_sparsify=True)
@@ -322,6 +324,7 @@ def average(x, axis=None, weights=None):
 
 
 def broadcast_to(x, shape):
+    x = convert_to_numpy(x)
     return jnp.broadcast_to(x, shape)
 
 

--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -13,7 +13,6 @@ from keras.backend.jax.core import convert_to_tensor
 from keras.ops import convert_to_numpy
 
 
-
 @sparse.elementwise_binary_union(linear=True, use_sparsify=True)
 def add(x1, x2):
     x1 = convert_to_tensor(x1)

--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -10,7 +10,6 @@ from keras.backend.common.variables import standardize_dtype
 from keras.backend.jax import sparse
 from keras.backend.jax.core import cast
 from keras.backend.jax.core import convert_to_tensor
-from keras.ops import convert_to_tensor
 
 
 @sparse.elementwise_binary_union(linear=True, use_sparsify=True)


### PR DESCRIPTION
The `broadcast_to` Op with Jax backend expects Array as input and fails when it is a Tensor like `tf.Tensor` or a `KerasVariable`.

I am proposing to explicit conversion to numpy array before passing it to `jax.numpy.broadcast_to`.

Shall fixes #19116 .