### PR TITLE
Fix AttributeError in `_check_output_spec` Method of `keras.ops.core.Cond` Class" + Add tests

### DIFF
--- a/keras/ops/core.py
+++ b/keras/ops/core.py
@@ -541,9 +541,8 @@ class Cond(Operation):
         return true_fn_spec
 
     def _check_output_spec(self, true_fn_spec, false_fn_spec):
-        if true_fn_spec is None:
-            if false_fn_spec is not None:
-                return False
+        if true_fn_spec is None or false_fn_spec is None:
+            return true_fn_spec is None and false_fn_spec is None
         elif isinstance(true_fn_spec, dict):
             if not isinstance(false_fn_spec, dict):
                 return False

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -1,6 +1,5 @@
 import contextlib
 from unittest.mock import Mock
-from collections import namedtuple
 
 import numpy as np
 import pytest
@@ -606,20 +605,6 @@ class CoreOpsCallsTests(testing.TestCase):
         keras_loop_vars = [
             KerasTensor(v.shape, dtype=v.dtype) for v in loop_vars
         ]
-        while_loop = core.WhileLoop(
-            some_cond, some_body, maximum_iterations=None
-        )  # Replace with appropriate cond, body
-        output_specs = while_loop.compute_output_spec(keras_loop_vars)
-        for spec, var in zip(output_specs, keras_loop_vars):
-            self.assertEqual(spec.shape, var.shape)
-            self.assertEqual(spec.dtype, var.dtype)
-
-    def test_whileloop_compute_output_spec(self):
-        # Define loop variables with different shapes and data types
-        loop_vars = (np.random.rand(5, 5), np.random.randint(10, size=(3, 7)))
-        keras_loop_vars = [
-            KerasTensor(v.shape, dtype=v.dtype) for v in loop_vars
-        ]
         cond = lambda v: v[0] < 5
         body = lambda v: (v[0] + 1, v[1])
         while_loop = core.WhileLoop(cond, body, maximum_iterations=None)
@@ -659,16 +644,6 @@ class CoreOpsCallsTests(testing.TestCase):
         result = unstack.call(x)
         self.assertEqual(len(result), x.shape[axis])
         expected_shape = x.shape[:axis] + x.shape[axis + 1 :]
-        for tensor in result:
-            self.assertEqual(tensor.shape, expected_shape)
-
-    def test_unstack_basic_functionality(self):
-        x = np.random.rand(2, 3, 4)
-        axis = 1
-        unstack = core.Unstack(axis=axis)
-        result = unstack.call(x)
-        self.assertEqual(len(result), x.shape[axis])
-        expected_shape = x.shape[:axis] + x.shape[axis + 1 :]
         # Check that all tensors have the same shape
         if len(result) > 0:
             self.assertEqual(result[0].shape, expected_shape)
@@ -686,16 +661,6 @@ class CoreOpsCallsTests(testing.TestCase):
         # Check that the values are the same
         expected_values = x.astype(target_dtype)
         self.assertTrue(np.array_equal(result, expected_values))
-
-    def test_cond_check_output_spec_dict(self):
-        cond_op = core.Cond()
-        mock_spec = Mock(dtype="float32", shape=(2, 2))
-        self.assertTrue(
-            cond_op._check_output_spec(
-                {"a": mock_spec, "b": mock_spec},
-                {"a": mock_spec, "b": mock_spec},
-            )
-        )
 
     def test_cond_check_output_spec_list_tuple(self):
         cond_op = core.Cond()

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -615,11 +615,13 @@ class CoreOpsCallsTests(testing.TestCase):
         self.assertEqual(output_specs[1].dtype, keras_loop_vars[1].dtype)
 
     def test_stop_gradient_call(self):
-        variable = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        variable_np = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        variable = core.convert_to_tensor(variable_np)
         stop_gradient = core.StopGradient()
         result = stop_gradient.call(variable)
-        self.assertTrue(np.array_equal(result, variable))
-        self.assertEqual(result.dtype, variable.dtype)
+        result_np = core.convert_to_numpy(result)
+        self.assertTrue(np.array_equal(result_np, variable_np))
+        self.assertEqual(result_np.dtype, variable_np.dtype)
 
     def test_stop_gradient_compute_output_spec(self):
         variable = KerasTensor(shape=(3,), dtype=np.float32)
@@ -639,10 +641,12 @@ class CoreOpsCallsTests(testing.TestCase):
 
     def test_unstack_basic_functionality(self):
         x = np.random.rand(2, 3, 4)
+        x = core.convert_to_tensor(x)
         axis = 1
         unstack = core.Unstack(axis=axis)
         result = unstack.call(x)
         self.assertEqual(len(result), x.shape[axis])
+        result = core.convert_to_numpy(result)
         expected_shape = x.shape[:axis] + x.shape[axis + 1 :]
         # Check that all tensors have the same shape
         if len(result) > 0:
@@ -657,6 +661,7 @@ class CoreOpsCallsTests(testing.TestCase):
         target_dtype = np.int32
         cast = core.Cast(target_dtype)
         result = cast.call(x)
+        result = core.convert_to_numpy(result)
         self.assertEqual(result.dtype, target_dtype)
         # Check that the values are the same
         expected_values = x.astype(target_dtype)
@@ -728,4 +733,3 @@ class CoreOpsCallsTests(testing.TestCase):
                 (mock_spec,), (mock_spec, mock_spec_different)
             )
         )
-        

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -1,4 +1,6 @@
 import contextlib
+from unittest.mock import Mock
+from collections import namedtuple
 
 import numpy as np
 import pytest
@@ -505,3 +507,259 @@ class CoreOpsDtypeTest(testing.TestCase, parameterized.TestCase):
                 ),
                 expected_dtype,
             )
+
+
+class CoreOpsCallsTests(testing.TestCase):
+    def test_scatter_basic_call(self):
+        indices = np.array([[1, 0], [0, 1]])
+        values = np.array([10, 20])
+        shape = (2, 2)
+        scatter = core.Scatter()
+        result = scatter.call(indices, values, shape)
+        expected_output = np.array([[0, 20], [10, 0]])
+        self.assertAllClose(result.numpy(), expected_output)
+
+    def test_scatter_update_basic_call(self):
+        inputs = np.array([[0, 0], [0, 0]])
+        indices = np.array([[1, 0], [0, 1]])
+        updates = np.array([10, 20])
+        scatter_update = core.ScatterUpdate()
+        result = scatter_update.call(inputs, indices, updates)
+        expected_output = np.array([[0, 20], [10, 0]])
+        self.assertAllClose(result.numpy(), expected_output)
+
+    def test_slice_basic_call(self):
+        inputs = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        start_indices = np.array([1, 1])
+        shape = (2, 2)
+        slice_op = core.Slice()
+        result = slice_op.call(inputs, start_indices, shape)
+        expected_output = np.array([[5, 6], [8, 9]])
+        self.assertAllClose(result.numpy(), expected_output)
+
+    def test_slice_compute_output_spec(self):
+        inputs = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.float32)
+        start_indices = np.array([1, 1])
+        shape = (2, 2)
+        slice_op = core.Slice()
+        output_spec = slice_op.compute_output_spec(inputs, start_indices, shape)
+        self.assertEqual(output_spec.shape, shape)
+        self.assertEqual(output_spec.dtype, inputs.dtype)
+
+    def test_slice_with_symbolic_tensors(self):
+        inputs = KerasTensor(shape=(3, 3), dtype=np.float32)
+        start_indices = KerasTensor(shape=(2,), dtype=np.int32)
+        shape = (2, 2)
+        result = core.slice(inputs, start_indices, shape)
+        self.assertTrue(isinstance(result, KerasTensor))
+
+    def test_slice_with_non_symbolic_tensors(self):
+        inputs = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        start_indices = np.array([1, 1])
+        shape = (2, 2)
+        result = core.slice(inputs, start_indices, shape)
+        expected_output = np.array([[5, 6], [8, 9]])
+        self.assertAllClose(result, expected_output)
+
+    def test_slice_update_basic_call(self):
+        inputs = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        start_indices = np.array([1, 1])
+        updates = np.array([[10, 11], [12, 13]])
+        slice_update = core.SliceUpdate()
+        result = slice_update.call(inputs, start_indices, updates)
+        expected_output = np.array([[1, 2, 3], [4, 10, 11], [7, 12, 13]])
+        self.assertAllClose(result.numpy(), expected_output)
+
+    def test_while_loop_basic_functionality(self):
+        # Loop condition: continue if i < 5
+        cond = lambda i: i < 5
+        # Loop body: increment i by 1
+        body = lambda i: (i + 1,)
+        while_loop = core.WhileLoop(cond, body, maximum_iterations=None)
+        # Initial loop variable (i = 0)
+        loop_vars = (0,)
+        result = while_loop.call(loop_vars)
+        self.assertEqual(result[0], 5)
+
+    def test_while_loop_output_spec(self):
+        # Define dummy cond and body functions
+        cond = lambda x: True
+        body = lambda x: (x,)
+        while_loop = core.WhileLoop(cond, body, maximum_iterations=None)
+        loop_vars = (KerasTensor(shape=(10,), dtype=np.float32),)
+        output_spec = while_loop.compute_output_spec(loop_vars)
+        self.assertEqual(output_spec[0].shape, loop_vars[0].shape)
+        self.assertEqual(output_spec[0].dtype, loop_vars[0].dtype)
+
+    def test_while_loop_with_max_iterations(self):
+        # loop condition: continue if i < 10
+        cond = lambda i: i < 10
+        # loop body: increment i by 1
+        body = lambda i: (i + 1,)
+        while_loop = core.WhileLoop(cond, body, maximum_iterations=5)
+        result = while_loop.call((0,))
+        self.assertEqual(result[0], 5)
+
+    def test_whileloop_compute_output_spec(self):
+        # Define loop variables with different shapes and data types
+        loop_vars = (np.random.rand(5, 5), np.random.randint(10, size=(3, 7)))
+        keras_loop_vars = [
+            KerasTensor(v.shape, dtype=v.dtype) for v in loop_vars
+        ]
+        while_loop = core.WhileLoop(
+            some_cond, some_body, maximum_iterations=None
+        )  # Replace with appropriate cond, body
+        output_specs = while_loop.compute_output_spec(keras_loop_vars)
+        for spec, var in zip(output_specs, keras_loop_vars):
+            self.assertEqual(spec.shape, var.shape)
+            self.assertEqual(spec.dtype, var.dtype)
+
+    def test_whileloop_compute_output_spec(self):
+        # Define loop variables with different shapes and data types
+        loop_vars = (np.random.rand(5, 5), np.random.randint(10, size=(3, 7)))
+        keras_loop_vars = [
+            KerasTensor(v.shape, dtype=v.dtype) for v in loop_vars
+        ]
+        cond = lambda v: v[0] < 5
+        body = lambda v: (v[0] + 1, v[1])
+        while_loop = core.WhileLoop(cond, body, maximum_iterations=None)
+        output_specs = while_loop.compute_output_spec(keras_loop_vars)
+        self.assertEqual(output_specs[0].shape, keras_loop_vars[0].shape)
+        self.assertEqual(output_specs[0].dtype, keras_loop_vars[0].dtype)
+        self.assertEqual(output_specs[1].shape, keras_loop_vars[1].shape)
+        self.assertEqual(output_specs[1].dtype, keras_loop_vars[1].dtype)
+
+    def test_stop_gradient_call(self):
+        variable = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        stop_gradient = core.StopGradient()
+        result = stop_gradient.call(variable)
+        self.assertTrue(np.array_equal(result, variable))
+        self.assertEqual(result.dtype, variable.dtype)
+
+    def test_stop_gradient_compute_output_spec(self):
+        variable = KerasTensor(shape=(3,), dtype=np.float32)
+        stop_gradient = core.StopGradient()
+        output_spec = stop_gradient.compute_output_spec(variable)
+        self.assertEqual(output_spec.shape, variable.shape)
+        self.assertEqual(output_spec.dtype, variable.dtype)
+
+    def test_fori_loop_basic_functionality(self):
+        lower = 0
+        upper = 5
+        body_fun = lambda index, val: val + 1
+        fori_loop = core.ForiLoop(lower, upper, body_fun)
+        init_val = 0
+        result = fori_loop.call(init_val)
+        self.assertEqual(result, upper)
+
+    def test_unstack_basic_functionality(self):
+        x = np.random.rand(2, 3, 4)
+        axis = 1
+        unstack = core.Unstack(axis=axis)
+        result = unstack.call(x)
+        self.assertEqual(len(result), x.shape[axis])
+        expected_shape = x.shape[:axis] + x.shape[axis + 1 :]
+        for tensor in result:
+            self.assertEqual(tensor.shape, expected_shape)
+
+    def test_unstack_basic_functionality(self):
+        x = np.random.rand(2, 3, 4)
+        axis = 1
+        unstack = core.Unstack(axis=axis)
+        result = unstack.call(x)
+        self.assertEqual(len(result), x.shape[axis])
+        expected_shape = x.shape[:axis] + x.shape[axis + 1 :]
+        # Check that all tensors have the same shape
+        if len(result) > 0:
+            self.assertEqual(result[0].shape, expected_shape)
+        if len(result) > 1:
+            self.assertEqual(result[1].shape, expected_shape)
+        if len(result) > 2:
+            self.assertEqual(result[2].shape, expected_shape)
+
+    def test_cast_basic_functionality(self):
+        x = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        target_dtype = np.int32
+        cast = core.Cast(target_dtype)
+        result = cast.call(x)
+        self.assertEqual(result.dtype, target_dtype)
+        # Check that the values are the same
+        expected_values = x.astype(target_dtype)
+        self.assertTrue(np.array_equal(result, expected_values))
+
+    def test_cond_check_output_spec_dict(self):
+        cond_op = core.Cond()
+        mock_spec = Mock(dtype="float32", shape=(2, 2))
+        self.assertTrue(
+            cond_op._check_output_spec(
+                {"a": mock_spec, "b": mock_spec},
+                {"a": mock_spec, "b": mock_spec},
+            )
+        )
+
+    def test_cond_check_output_spec_list_tuple(self):
+        cond_op = core.Cond()
+        mock_spec = Mock(dtype="float32", shape=(2, 2))
+        self.assertTrue(
+            cond_op._check_output_spec(
+                [mock_spec, mock_spec], [mock_spec, mock_spec]
+            )
+        )
+
+    def test_cond_check_output_spec_other_types(self):
+        cond_op = core.Cond()
+        # Create mock objects with dtype and shape attributes
+        mock_spec1 = Mock(dtype="float32", shape=(2, 2))
+        mock_spec2 = Mock(dtype="float32", shape=(2, 2))
+        self.assertTrue(cond_op._check_output_spec(mock_spec1, mock_spec2))
+
+    def test_cond_check_output_spec_none(self):
+        cond_op = core.Cond()
+        self.assertTrue(cond_op._check_output_spec(None, None))
+        self.assertFalse(
+            cond_op._check_output_spec(
+                None, Mock(dtype="float32", shape=(2, 2))
+            )
+        )
+        self.assertFalse(
+            cond_op._check_output_spec(
+                Mock(dtype="float32", shape=(2, 2)), None
+            )
+        )
+
+    def test_cond_check_output_spec_dict(self):
+        cond_op = core.Cond()
+        mock_spec = Mock(dtype="float32", shape=(2, 2))
+        self.assertTrue(
+            cond_op._check_output_spec({"a": mock_spec}, {"a": mock_spec})
+        )
+        self.assertFalse(
+            cond_op._check_output_spec({"a": mock_spec}, {"b": mock_spec})
+        )
+        self.assertFalse(
+            cond_op._check_output_spec(
+                {"a": mock_spec}, {"a": mock_spec, "b": mock_spec}
+            )
+        )
+
+    def test_cond_check_output_spec_list(self):
+        cond_op = core.Cond()
+        mock_spec = Mock(dtype="float32", shape=(2, 2))
+        mock_spec_different = Mock(dtype="int32", shape=(3, 3))
+        self.assertTrue(cond_op._check_output_spec([mock_spec], [mock_spec]))
+        self.assertFalse(
+            cond_op._check_output_spec(
+                [mock_spec], [mock_spec, mock_spec_different]
+            )
+        )
+
+    def test_cond_check_output_spec_tuple(self):
+        cond_op = core.Cond()
+        mock_spec = Mock(dtype="float32", shape=(2, 2))
+        mock_spec_different = Mock(dtype="int32", shape=(3, 3))
+        self.assertTrue(cond_op._check_output_spec((mock_spec,), (mock_spec,)))
+        self.assertFalse(
+            cond_op._check_output_spec(
+                (mock_spec,), (mock_spec, mock_spec_different)
+            )
+        )

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -571,15 +571,13 @@ class CoreOpsCallsTests(testing.TestCase):
 
     def test_while_loop_basic_functionality(self):
         # Loop condition: continue if i < 5
-        # cond = lambda i: i < 5
         def cond(i):
             return i < 5
+
         # Loop body: increment i by 1
-        # body = lambda i: (i + 1,)
-        
         def body(i):
             return (i + 1,)
-        
+
         while_loop = core.WhileLoop(cond, body, maximum_iterations=None)
         # Initial loop variable (i = 0)
         loop_vars = (0,)
@@ -588,13 +586,12 @@ class CoreOpsCallsTests(testing.TestCase):
 
     def test_while_loop_output_spec(self):
         # Define dummy cond and body functions
-        # cond = lambda x: True
         def cond(x):
             return True
-        # body = lambda x: (x,)
-        
+
         def body(x):
             return (x,)
+
         while_loop = core.WhileLoop(cond, body, maximum_iterations=None)
         loop_vars = (KerasTensor(shape=(10,), dtype=np.float32),)
         output_spec = while_loop.compute_output_spec(loop_vars)
@@ -603,14 +600,12 @@ class CoreOpsCallsTests(testing.TestCase):
 
     def test_while_loop_with_max_iterations(self):
         # loop condition: continue if i < 10
-        # cond = lambda i: i < 10
         def cond(i):
             return i < 10
-        # loop body: increment i by 1
-        # body = lambda i: (i + 1,)
-        
+
         def body(i):
             return (i + 1,)
+
         while_loop = core.WhileLoop(cond, body, maximum_iterations=5)
         result = while_loop.call((0,))
         self.assertEqual(result[0], 5)
@@ -621,14 +616,13 @@ class CoreOpsCallsTests(testing.TestCase):
         keras_loop_vars = [
             KerasTensor(v.shape, dtype=v.dtype) for v in loop_vars
         ]
-        # cond = lambda v: v[0] < 5
-        
+
         def cond(v):
             return v[0] < 5
-        # body = lambda v: (v[0] + 1, v[1])
-        
+
         def body(v):
             return (v[0] + 1, v[1])
+
         while_loop = core.WhileLoop(cond, body, maximum_iterations=None)
         output_specs = while_loop.compute_output_spec(keras_loop_vars)
         self.assertEqual(output_specs[0].shape, keras_loop_vars[0].shape)
@@ -655,10 +649,10 @@ class CoreOpsCallsTests(testing.TestCase):
     def test_fori_loop_basic_functionality(self):
         lower = 0
         upper = 5
-        # body_fun = lambda index, val: val + 1
-        
+
         def body_fun(index, val):
             return val + 1
+
         fori_loop = core.ForiLoop(lower, upper, body_fun)
         init_val = 0
         result = fori_loop.call(init_val)

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -571,9 +571,15 @@ class CoreOpsCallsTests(testing.TestCase):
 
     def test_while_loop_basic_functionality(self):
         # Loop condition: continue if i < 5
-        cond = lambda i: i < 5
+        # cond = lambda i: i < 5
+        def cond(i):
+            return i < 5
         # Loop body: increment i by 1
-        body = lambda i: (i + 1,)
+        # body = lambda i: (i + 1,)
+        
+        def body(i):
+            return (i + 1,)
+        
         while_loop = core.WhileLoop(cond, body, maximum_iterations=None)
         # Initial loop variable (i = 0)
         loop_vars = (0,)
@@ -582,8 +588,13 @@ class CoreOpsCallsTests(testing.TestCase):
 
     def test_while_loop_output_spec(self):
         # Define dummy cond and body functions
-        cond = lambda x: True
-        body = lambda x: (x,)
+        # cond = lambda x: True
+        def cond(x):
+            return True
+        # body = lambda x: (x,)
+        
+        def body(x):
+            return (x,)
         while_loop = core.WhileLoop(cond, body, maximum_iterations=None)
         loop_vars = (KerasTensor(shape=(10,), dtype=np.float32),)
         output_spec = while_loop.compute_output_spec(loop_vars)
@@ -592,9 +603,14 @@ class CoreOpsCallsTests(testing.TestCase):
 
     def test_while_loop_with_max_iterations(self):
         # loop condition: continue if i < 10
-        cond = lambda i: i < 10
+        # cond = lambda i: i < 10
+        def cond(i):
+            return i < 10
         # loop body: increment i by 1
-        body = lambda i: (i + 1,)
+        # body = lambda i: (i + 1,)
+        
+        def body(i):
+            return (i + 1,)
         while_loop = core.WhileLoop(cond, body, maximum_iterations=5)
         result = while_loop.call((0,))
         self.assertEqual(result[0], 5)
@@ -605,8 +621,14 @@ class CoreOpsCallsTests(testing.TestCase):
         keras_loop_vars = [
             KerasTensor(v.shape, dtype=v.dtype) for v in loop_vars
         ]
-        cond = lambda v: v[0] < 5
-        body = lambda v: (v[0] + 1, v[1])
+        # cond = lambda v: v[0] < 5
+        
+        def cond(v):
+            return v[0] < 5
+        # body = lambda v: (v[0] + 1, v[1])
+        
+        def body(v):
+            return (v[0] + 1, v[1])
         while_loop = core.WhileLoop(cond, body, maximum_iterations=None)
         output_specs = while_loop.compute_output_spec(keras_loop_vars)
         self.assertEqual(output_specs[0].shape, keras_loop_vars[0].shape)
@@ -633,7 +655,10 @@ class CoreOpsCallsTests(testing.TestCase):
     def test_fori_loop_basic_functionality(self):
         lower = 0
         upper = 5
-        body_fun = lambda index, val: val + 1
+        # body_fun = lambda index, val: val + 1
+        
+        def body_fun(index, val):
+            return val + 1
         fori_loop = core.ForiLoop(lower, upper, body_fun)
         init_val = 0
         result = fori_loop.call(init_val)

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -516,7 +516,7 @@ class CoreOpsCallsTests(testing.TestCase):
         scatter = core.Scatter()
         result = scatter.call(indices, values, shape)
         expected_output = np.array([[0, 20], [10, 0]])
-        self.assertAllClose(result.numpy(), expected_output)
+        self.assertAllClose(core.convert_to_numpy(result), expected_output)
 
     def test_scatter_update_basic_call(self):
         inputs = np.array([[0, 0], [0, 0]])
@@ -525,7 +525,7 @@ class CoreOpsCallsTests(testing.TestCase):
         scatter_update = core.ScatterUpdate()
         result = scatter_update.call(inputs, indices, updates)
         expected_output = np.array([[0, 20], [10, 0]])
-        self.assertAllClose(result.numpy(), expected_output)
+        self.assertAllClose(core.convert_to_numpy(result), expected_output)
 
     def test_slice_basic_call(self):
         inputs = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -534,7 +534,7 @@ class CoreOpsCallsTests(testing.TestCase):
         slice_op = core.Slice()
         result = slice_op.call(inputs, start_indices, shape)
         expected_output = np.array([[5, 6], [8, 9]])
-        self.assertAllClose(result.numpy(), expected_output)
+        self.assertAllClose(core.convert_to_numpy(result), expected_output)
 
     def test_slice_compute_output_spec(self):
         inputs = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.float32)
@@ -567,7 +567,7 @@ class CoreOpsCallsTests(testing.TestCase):
         slice_update = core.SliceUpdate()
         result = slice_update.call(inputs, start_indices, updates)
         expected_output = np.array([[1, 2, 3], [4, 10, 11], [7, 12, 13]])
-        self.assertAllClose(result.numpy(), expected_output)
+        self.assertAllClose(core.convert_to_numpy(result), expected_output)
 
     def test_while_loop_basic_functionality(self):
         # Loop condition: continue if i < 5
@@ -728,3 +728,4 @@ class CoreOpsCallsTests(testing.TestCase):
                 (mock_spec,), (mock_spec, mock_spec_different)
             )
         )
+        


### PR DESCRIPTION
While adding tests for `keras/ops/core.py`, I caught a bug in the `_check_output_spec` method 

Previously, the method would raise an `AttributeError` when trying to access the `dtype` attribute of `false_fn_spec` if it was `None`.

The fix involves adding a check at the beginning of the `_check_output_spec` method to return `True` only if both `true_fn_spec` and `false_fn_spec` are `None`. If only one of them is `None`, the function will return `False`, preventing the `AttributeError`.

The updated unit tests in `core_test.py` confirm that the fix works as expected. All tests now pass successfully.
