### PR TITLE
Add unit tests to `backend/common/dtypes_test.py`

### DIFF
--- a/keras/backend/common/dtypes_test.py
+++ b/keras/backend/common/dtypes_test.py
@@ -195,3 +195,16 @@ class DtypesTest(test_case.TestCase, parameterized.TestCase):
         result1 = dtypes._least_upper_bound("float32", "int32")
         result2 = dtypes._least_upper_bound("int32", "float32")
         self.assertEqual(result1, result2)
+
+    def test_least_upper_bound_single_element(self):
+        # Test for the scenario where LUB contains a single element
+        dtypes.LATTICE_UPPER_BOUNDS["test_dtype"] = {"test_dtype"}
+        self.assertEqual(dtypes._least_upper_bound("test_dtype"), "test_dtype")
+
+    def test_least_upper_bound_no_element(self):
+        # Test for the scenario where LUB contains no elements
+        dtypes.LATTICE_UPPER_BOUNDS["test_dtype"] = set()
+        with self.assertRaisesRegex(
+            ValueError, "no available implicit dtype promotion path"
+        ):
+            dtypes._least_upper_bound("test_dtype")

--- a/keras/backend/common/dtypes_test.py
+++ b/keras/backend/common/dtypes_test.py
@@ -208,7 +208,6 @@ class DtypesTest(test_case.TestCase, parameterized.TestCase):
             dtypes._least_upper_bound("test_dtype")
 
     def test_least_upper_bound_with_no_common_upper_bound(self):
-        # Modify the LATTICE_UPPER_BOUNDS to create a situation where no common upper bound exists
         with patch.dict(
             dtypes.LATTICE_UPPER_BOUNDS,
             {"test_dtype1": set(), "test_dtype2": set()},

--- a/keras/backend/common/dtypes_test.py
+++ b/keras/backend/common/dtypes_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from absl.testing import parameterized
 
 from keras import backend
@@ -128,3 +130,68 @@ class DtypesTest(test_case.TestCase, parameterized.TestCase):
             ValueError, "Invalid value for argument `dtype`. Expected one of"
         ):
             dtypes._respect_weak_type("invalid_dtype", True)
+
+    def test_invalid_dtype_in_least_upper_bound(self):
+        invalid_dtype = "non_existent_dtype"
+        with self.assertRaisesRegex(
+            ValueError, "is not a valid dtype for Keras type promotion"
+        ):
+            dtypes._least_upper_bound(invalid_dtype)
+
+    def test_empty_lub_in_least_upper_bound(self):
+        dtype1 = "float32"
+        dtype2 = "int32"
+        with patch.dict(
+            dtypes.LATTICE_UPPER_BOUNDS,
+            {"float32": set(), "int32": set()},
+            clear=True,
+        ):
+            with self.assertRaisesRegex(
+                ValueError, "no available implicit dtype promotion path"
+            ):
+                dtypes._least_upper_bound(dtype1, dtype2)
+
+    def test_valid_dtype_leading_to_single_lub_element(self):
+        self.assertEqual(
+            dtypes._least_upper_bound("float32", "int32"), "float32"
+        )
+
+    def test_valid_dtype_leading_to_keyerror_and_valueerror(self):
+        invalid_dtype = "non_existent_dtype"
+        with self.assertRaisesRegex(
+            ValueError, "is not a valid dtype for Keras type promotion"
+        ):
+            dtypes._least_upper_bound(invalid_dtype)
+
+    def test_resolve_weak_type_bool(self):
+        self.assertEqual(dtypes._resolve_weak_type("bool"), "bool")
+
+    def test_resolve_weak_type_int(self):
+        self.assertEqual(
+            dtypes._resolve_weak_type("int32", precision="32"), "int32"
+        )
+        self.assertEqual(
+            dtypes._resolve_weak_type("int64", precision="64"), "int64"
+        )
+
+    def test_resolve_weak_type_uint(self):
+        self.assertEqual(
+            dtypes._resolve_weak_type("uint32", precision="32"), "uint32"
+        )
+        self.assertEqual(
+            dtypes._resolve_weak_type("uint64", precision="64"), "uint64"
+        )
+
+    def test_resolve_weak_type_float(self):
+        self.assertEqual(
+            dtypes._resolve_weak_type("float32", precision="32"), "float32"
+        )
+        self.assertEqual(
+            dtypes._resolve_weak_type("float64", precision="64"), "float64"
+        )
+
+    def test_ill_formed_lattice_scenario_int_float(self):
+        # Test to ensure _least_upper_bound is order-independent.
+        result1 = dtypes._least_upper_bound("float32", "int32")
+        result2 = dtypes._least_upper_bound("int32", "float32")
+        self.assertEqual(result1, result2)

--- a/keras/backend/common/dtypes_test.py
+++ b/keras/backend/common/dtypes_test.py
@@ -206,3 +206,15 @@ class DtypesTest(test_case.TestCase, parameterized.TestCase):
             ValueError, "no available implicit dtype promotion path"
         ):
             dtypes._least_upper_bound("test_dtype")
+
+    def test_least_upper_bound_with_no_common_upper_bound(self):
+        # Modify the LATTICE_UPPER_BOUNDS to create a situation where no common upper bound exists
+        with patch.dict(
+            dtypes.LATTICE_UPPER_BOUNDS,
+            {"test_dtype1": set(), "test_dtype2": set()},
+            clear=True,
+        ):
+            with self.assertRaisesRegex(
+                ValueError, "no available implicit dtype promotion path"
+            ):
+                dtypes._least_upper_bound("test_dtype1", "test_dtype2")

--- a/keras/backend/common/dtypes_test.py
+++ b/keras/backend/common/dtypes_test.py
@@ -190,19 +190,17 @@ class DtypesTest(test_case.TestCase, parameterized.TestCase):
             dtypes._resolve_weak_type("float64", precision="64"), "float64"
         )
 
-    def test_ill_formed_lattice_scenario_int_float(self):
+    def test_least_upper_bound_ensure_order_independence(self):
         # Test to ensure _least_upper_bound is order-independent.
         result1 = dtypes._least_upper_bound("float32", "int32")
         result2 = dtypes._least_upper_bound("int32", "float32")
         self.assertEqual(result1, result2)
 
     def test_least_upper_bound_single_element(self):
-        # Test for the scenario where LUB contains a single element
         dtypes.LATTICE_UPPER_BOUNDS["test_dtype"] = {"test_dtype"}
         self.assertEqual(dtypes._least_upper_bound("test_dtype"), "test_dtype")
 
     def test_least_upper_bound_no_element(self):
-        # Test for the scenario where LUB contains no elements
         dtypes.LATTICE_UPPER_BOUNDS["test_dtype"] = set()
         with self.assertRaisesRegex(
             ValueError, "no available implicit dtype promotion path"


### PR DESCRIPTION
This pull request aims to introduce additional unit tests for the `keras.backend.common.dtypes` module, with a focus on the `_resolve_weak_type`  and the `_least_upper_bound`. 

In the process of enhancing the test suite, particularly for `_least_upper_bound`, I encountered specific challenges that I wish to report and seek assistance with.


While enhancing the test suite for the `_least_upper_bound` , I encountered challenges in creating test for 


```python
    else:
        # If we get here, it means the lattice is ill-formed.
        raise ValueError(
            f"Internal Type Promotion error: {nodes} do not have a unique "
            f"least upper bound on the specified lattice; options are {LUB}. "
            "This is an unexpected error in Keras's internal logic; "
            "please report it to the maintainers."
        )
```
https://github.com/keras-team/keras/blob/master/keras%2Fbackend%2Fcommon%2Fdtypes.py#L129-L136

Despite varied approaches, the test suite consistently failed to simulate the conditions leading to an ill-formed lattice and thus did not trigger the intended exception.

```python
=========================================================== FAILURES ============================================================
_________________________________ DtypesTest.test_ill_formed_lattice_leading_to_internal_error __________________________________
ValueError: Input dtypes ('test_dtype1',) have no available implicit dtype promotion path. Try explicitly casting inputs to the desired output type.

During handling of the above exception, another exception occurred:

self = <keras.backend.common.dtypes_test.DtypesTest testMethod=test_ill_formed_lattice_leading_to_internal_error>

    def test_ill_formed_lattice_leading_to_internal_error(self):
        # Mocking a scenario where LATTICE_UPPER_BOUNDS has multiple valid upper bounds for a dtype without a unique least upper bound
        with patch.dict(
            dtypes.LATTICE_UPPER_BOUNDS,
            {
                "test_dtype1": {"test_dtype2", "test_dtype3"},
                "test_dtype2": {"test_dtype4"},
                "test_dtype3": {"test_dtype4"},
                "test_dtype4": set()
            },
            clear=True,
        ):
>           with self.assertRaisesRegex(ValueError, "Internal Type Promotion error"):
E           AssertionError: "Internal Type Promotion error" does not match "Input dtypes ('test_dtype1',) have no available implicit dtype promotion path. Try explicitly casting inputs to the desired output type."

keras/backend/common/dtypes_test.py:222: AssertionError
==================================================== short test summary info ====================================================
FAILED keras/backend/common/dtypes_test.py::DtypesTest::test_ill_formed_lattice_leading_to_internal_error - AssertionError: "Internal Type Promotion error" does not match "Input dtypes ('test_dtype1',) have no available implicit dty...
```

```python
=========================================================== FAILURES ============================================================
_________________________________ DtypesTest.test_ill_formed_lattice_leading_to_internal_error __________________________________
ValueError: Input dtypes ('test_dtype1',) have no available implicit dtype promotion path. Try explicitly casting inputs to the desired output type.

During handling of the above exception, another exception occurred:

self = <keras.backend.common.dtypes_test.DtypesTest testMethod=test_ill_formed_lattice_leading_to_internal_error>

    def test_ill_formed_lattice_leading_to_internal_error(self):
        # Mocking a scenario where LATTICE_UPPER_BOUNDS has multiple valid upper bounds for a dtype
        with patch.dict(
            dtypes.LATTICE_UPPER_BOUNDS,
            {
                "test_dtype1": {"test_dtype2", "test_dtype3"},
                "test_dtype2": {"test_dtype3"},
                "test_dtype3": set()
            },
            clear=True,
        ):
>           with self.assertRaisesRegex(ValueError, "Internal Type Promotion error"):
E           AssertionError: "Internal Type Promotion error" does not match "Input dtypes ('test_dtype1',) have no available implicit dtype promotion path. Try explicitly casting inputs to the desired output type."

keras/backend/common/dtypes_test.py:221: AssertionError
==================================================== short test summary info ====================================================
FAILED keras/backend/common/dtypes_test.py::DtypesTest::test_ill_formed_lattice_leading_to_internal_error - AssertionError: "Internal Type Promotion error" does not match "Input dtypes ('test_dtype1',) have no available implicit dty...
================================================= 1 failed, 261 passed in 3.40s ============================
```

```python
=========================================================== FAILURES ============================================================
_________________________________ DtypesTest.test_ill_formed_lattice_leading_to_internal_error __________________________________

self = <keras.backend.common.dtypes_test.DtypesTest testMethod=test_ill_formed_lattice_leading_to_internal_error>

    def test_ill_formed_lattice_leading_to_internal_error(self):
        original_lattice_function = dtypes._type_promotion_lattice
    
        def mock_lattice():
            return {
                "test_dtype1": {"test_dtype2", "test_dtype3"},
                "test_dtype2": {"ambiguous_dtype"},
                "test_dtype3": {"ambiguous_dtype"},
                "ambiguous_dtype": set(),
            }
    
        dtypes._type_promotion_lattice = mock_lattice
        dtypes.LATTICE_UPPER_BOUNDS = dtypes._make_lattice_upper_bounds()
    
        try:
>           with self.assertRaisesRegex(ValueError, "Internal Type Promotion error"):
E           AssertionError: ValueError not raised

keras/backend/common/dtypes_test.py:225: AssertionError
==================================================== short test summary info ====================================================
FAILED keras/backend/common/dtypes_test.py::DtypesTest::test_ill_formed_lattice_leading_to_internal_error - AssertionError: ValueError not raised
```



Given the complexity of this scenario and the intricate dependencies within the `_least_upper_bound` function, I am seeking suggestions or insights . Any guidance on creating an effective test for this branch or alternative approaches to handle this edge case would be greatly appreciated.