### PR TITLE
Add TFDatasetAdapter and GeneratorDataAdapter sparse support for JAX.

### DIFF
--- a/keras/trainers/data_adapters/generator_data_adapter_test.py
+++ b/keras/trainers/data_adapters/generator_data_adapter_test.py
@@ -1,6 +1,7 @@
 import math
 
 import jax
+import jax.experimental.sparse as jax_sparse
 import numpy as np
 import scipy
 import tensorflow as tf
@@ -100,48 +101,39 @@ class GeneratorDataAdapterTest(testing.TestCase, parameterized.TestCase):
                 sample_order.append(by[i, 0])
         self.assertAllClose(sample_order, list(range(34)))
 
-    def test_tf_sparse_tensors_with_tf_dataset(self):
-        def generate_tf():
-            for i in range(4):
-                x = tf.SparseTensor(
-                    indices=[[0, 0], [1, 2]],
-                    values=[1.0, 2.0],
-                    dense_shape=(2, 4),
-                )
-                y = tf.SparseTensor(
-                    indices=[[0, 0], [1, 1]],
-                    values=[3.0, 4.0],
-                    dense_shape=(2, 2),
-                )
+    @parameterized.named_parameters(
+        named_product(
+            generator_type=["tf", "jax", "scipy"], iterator_type=["tf", "jax"]
+        )
+    )
+    def test_scipy_sparse_tensors(self, generator_type, iterator_type):
+        if generator_type == "tf":
+            x = tf.SparseTensor([[0, 0], [1, 2]], [1.0, 2.0], (2, 4))
+            y = tf.SparseTensor([[0, 0], [1, 1]], [3.0, 4.0], (2, 2))
+        elif generator_type == "jax":
+            x = jax_sparse.BCOO(([1.0, 2.0], [[0, 0], [1, 2]]), shape=(2, 4))
+            y = jax_sparse.BCOO(([3.0, 4.0], [[0, 0], [1, 1]]), shape=(2, 2))
+        elif generator_type == "scipy":
+            x = scipy.sparse.coo_matrix(([1.0, 2.0], ([0, 1], [0, 2])), (2, 4))
+            y = scipy.sparse.coo_matrix(([3.0, 4.0], ([0, 1], [0, 1])), (2, 2))
+
+        def generate():
+            for _ in range(4):
                 yield x, y
 
-        adapter = generator_data_adapter.GeneratorDataAdapter(generate_tf())
-        ds = adapter.get_tf_dataset()
-        for batch in ds:
+        adapter = generator_data_adapter.GeneratorDataAdapter(generate())
+
+        if iterator_type == "tf":
+            it = adapter.get_tf_dataset()
+            expected_class = tf.SparseTensor
+        elif iterator_type == "jax":
+            it = adapter.get_jax_iterator()
+            expected_class = jax_sparse.BCOO
+
+        for batch in it:
             self.assertEqual(len(batch), 2)
             bx, by = batch
-            self.assertIsInstance(bx, tf.SparseTensor)
-            self.assertIsInstance(by, tf.SparseTensor)
-            self.assertEqual(bx.shape, (2, 4))
-            self.assertEqual(by.shape, (2, 2))
-
-    def test_scipy_sparse_tensors_with_tf_dataset(self):
-        def generate_scipy():
-            for i in range(4):
-                x = scipy.sparse.coo_matrix(
-                    ([1.0, 2.0], ([0, 1], [0, 2])), shape=[2, 4]
-                )
-                y = scipy.sparse.coo_matrix(
-                    ([3.0, 4.0], ([0, 1], [0, 1])), shape=[2, 2]
-                )
-                yield x, y
-
-        adapter = generator_data_adapter.GeneratorDataAdapter(generate_scipy())
-        ds = adapter.get_tf_dataset()
-        for batch in ds:
-            self.assertEqual(len(batch), 2)
-            bx, by = batch
-            self.assertIsInstance(bx, tf.SparseTensor)
-            self.assertIsInstance(by, tf.SparseTensor)
+            self.assertIsInstance(bx, expected_class)
+            self.assertIsInstance(by, expected_class)
             self.assertEqual(bx.shape, (2, 4))
             self.assertEqual(by.shape, (2, 2))


### PR DESCRIPTION
- `TFDatasetAdapter.get_jax_iterator()` now converts `tf.SparseTensor`s to JAX `BCOO`s.
- `GeneratorDataAdapter` can now take `tf.SparseTensor`s, JAX `BCOO`s or `scipy.sparse` tensors and output either `tf.SparseTensor`s or JAX `BCOO`s.