### PR TITLE
Fixed formatting that preventing error message from printing.

### DIFF
--- a/keras/ops/operation.py
+++ b/keras/ops/operation.py
@@ -168,10 +168,10 @@ class Operation:
 
             def get_config(self):
                 config = super().get_config()
-                config.update({
+                config.update({{
                     "arg1": self.arg1,
                     "arg2": self.arg2,
-                })
+                }})
                 return config"""
                 )
             )


### PR DESCRIPTION
Because it is an f-string, curly braces need to be escaped.