### PR TITLE
Support nested structures in while loops

### DIFF
--- a/keras/backend/jax/core.py
+++ b/keras/backend/jax/core.py
@@ -315,7 +315,8 @@ def while_loop(
     loop_vars,
     maximum_iterations=None,
 ):
-    loop_vars = tuple(loop_vars)
+    is_tuple = isinstance(loop_vars, (tuple, list))
+    loop_vars = tuple(loop_vars) if is_tuple else (loop_vars,)
     if maximum_iterations is not None:
         current_iter = 0
         loop_vars = loop_vars + (current_iter,)
@@ -325,7 +326,9 @@ def while_loop(
             return cond(*args[:-1]) & (args[-1] < maximum_iterations)
 
         def _body(args):
-            return tuple(body(*args[:-1])) + (args[-1] + 1,)
+            outputs = body(*args[:-1])
+            outputs = tuple(outputs) if is_tuple else (outputs,)
+            return outputs + (args[-1] + 1,)
 
     else:
 
@@ -333,12 +336,13 @@ def while_loop(
             return cond(*args)
 
         def _body(args):
-            return tuple(body(*args))
+            outputs = body(*args)
+            return tuple(outputs) if is_tuple else (outputs,)
 
     outputs = jax.lax.while_loop(_cond, _body, loop_vars)
     if maximum_iterations is not None:
         outputs = outputs[:-1]
-    return outputs
+    return outputs if is_tuple else outputs[0]
 
 
 def fori_loop(lower, upper, body_fun, init_val):

--- a/keras/backend/numpy/core.py
+++ b/keras/backend/numpy/core.py
@@ -203,14 +203,16 @@ def while_loop(
     iteration_check = (
         lambda iter: maximum_iterations is None or iter < maximum_iterations
     )
-    loop_vars = tuple([convert_to_tensor(v) for v in loop_vars])
+    is_tuple = isinstance(loop_vars, (tuple, list))
+    loop_vars = tuple(loop_vars) if is_tuple else (loop_vars,)
+    loop_vars = tree.map_structure(convert_to_tensor, loop_vars)
     while cond(*loop_vars) and iteration_check(current_iter):
         loop_vars = body(*loop_vars)
         if not isinstance(loop_vars, (list, tuple)):
             loop_vars = (loop_vars,)
         loop_vars = tuple(loop_vars)
         current_iter += 1
-    return loop_vars
+    return loop_vars if is_tuple else loop_vars[0]
 
 
 def fori_loop(lower, upper, body_fun, init_val):

--- a/keras/backend/tensorflow/core.py
+++ b/keras/backend/tensorflow/core.py
@@ -232,12 +232,20 @@ def while_loop(
     loop_vars,
     maximum_iterations=None,
 ):
-    return tf.while_loop(
+    is_tuple = isinstance(loop_vars, (tuple, list))
+    loop_vars = tuple(loop_vars) if is_tuple else (loop_vars,)
+
+    def _body(*args):
+        outputs = body(*args)
+        return tuple(outputs) if is_tuple else (outputs,)
+
+    outputs = tf.while_loop(
         cond,
-        body,
+        _body,
         loop_vars,
         maximum_iterations=maximum_iterations,
     )
+    return outputs if is_tuple else outputs[0]
 
 
 def fori_loop(lower, upper, body_fun, init_val):

--- a/keras/backend/torch/core.py
+++ b/keras/backend/torch/core.py
@@ -408,14 +408,16 @@ def while_loop(
     iteration_check = (
         lambda iter: maximum_iterations is None or iter < maximum_iterations
     )
-    loop_vars = tuple([convert_to_tensor(v) for v in loop_vars])
+    is_tuple = isinstance(loop_vars, (tuple, list))
+    loop_vars = tuple(loop_vars) if is_tuple else (loop_vars,)
+    loop_vars = tree.map_structure(convert_to_tensor, loop_vars)
     while cond(*loop_vars) and iteration_check(current_iter):
         loop_vars = body(*loop_vars)
         if not isinstance(loop_vars, (list, tuple)):
             loop_vars = (loop_vars,)
         loop_vars = tuple(loop_vars)
         current_iter += 1
-    return loop_vars
+    return loop_vars if is_tuple else loop_vars[0]
 
 
 def fori_loop(lower, upper, body_fun, init_val):

--- a/keras/ops/core.py
+++ b/keras/ops/core.py
@@ -235,11 +235,15 @@ def while_loop(
 
     Args:
         cond: A callable that represents the termination condition of the loop.
-            Must have the same number of args as `loop_vars`, and return a bool.
-        body: A callable that represents the loop body. Must have the same
-            number of args as `loop_vars`, and return a list/tuple of the same
-            length, shape and dtype as `loop_vars`.
-        loop_vars: A list/tuple of tensors, the loop variables.
+            Must accept a `loop_vars` like structure as an argument. If
+            `loop_vars` is a tuple or list, each element of `loop_vars` will be
+            passed positionally to the callable.
+        body: A callable that represents the loop body. Must accept a
+            `loop_vars` like structure as an argument, and return update value
+            with the same structure. If `loop_vars` is a tuple or list, each
+            element of `loop_vars` will be passed positionally to the callable.
+        loop_vars: An arbitrary nested structure of tensor state to persist
+            across loop iterations.
         maximum_iterations: Optional maximum number of iterations of the while
             loop to run. If provided, the `cond` output is AND-ed with an
             additional condition ensuring the number of iterations executed is
@@ -253,8 +257,14 @@ def while_loop(
     >>> i = 0
     >>> cond = lambda i: i < 10
     >>> body = lambda i: i + 1
-    >>> keras.ops.while_loop(cond, body, [i])[0]
+    >>> keras.ops.while_loop(cond, body, i)
     10
+
+    >>> x, y = 0, 1
+    >>> cond = lambda x, y: x < 10
+    >>> body = lambda x, y: (x + 1, y + 1)
+    >>> keras.ops.while_loop(cond, body, (x, y))
+    10, 11
     """
     return backend.core.while_loop(
         cond,

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import numpy as np
 import pytest
+import tree
 from absl.testing import parameterized
 
 from keras import backend
@@ -83,7 +84,7 @@ class CoreOpsStaticShapeTest(testing.TestCase):
             core.unstack(x, axis=axis)
 
 
-class CoreOpsCorrectnessTest(testing.TestCase):
+class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
     def test_scatter(self):
         # Test 1D
         indices = np.array([[1], [3], [4], [7]])
@@ -221,25 +222,85 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         outputs = core.slice_update(inputs, start_indices, updates)
         self.assertAllClose(outputs[1:3, 1:3, 2:4, 2:4], np.zeros([2, 2, 2, 2]))
 
-    def test_while_loop(self):
-        def cond(x, y):
-            return x[0, 0] < 10
+    @parameterized.named_parameters(
+        [
+            {
+                "testcase_name": "with_max",
+                "state": (np.array(0), np.array(1)),
+                "output": (np.array(5), np.array(6)),
+                "maximum_iterations": 5,
+            },
+            {
+                "testcase_name": "no_max",
+                "state": (np.array(0), np.array(1)),
+                "output": (np.array(10), np.array(11)),
+                "maximum_iterations": None,
+            },
+        ]
+    )
+    def test_while_loop_list_data(self, state, output, maximum_iterations):
+        def cond(*args):
+            return tree.flatten(args)[0] < 10
 
-        def body(x, y):
-            return x + 1, y + 1
+        def body(*args):
+            return tree.map_structure(lambda x: x + 1, args)
 
-        x = np.ones((2, 3))
-        y = np.ones((3, 2))
-        x, y = core.while_loop(cond, body, (x, y))
-        self.assertAllClose(x, np.ones((2, 3)) * 10)
-        self.assertAllClose(y, np.ones((3, 2)) * 10)
+        state = core.while_loop(
+            cond, body, state, maximum_iterations=maximum_iterations
+        )
+        tree.map_structure(self.assertAllClose, state, output)
 
-        # Test max iterations
-        x = np.ones((2, 3))
-        y = np.ones((3, 2))
-        x, y = core.while_loop(cond, body, (x, y), maximum_iterations=5)
-        self.assertAllClose(x, np.ones((2, 3)) * 6)
-        self.assertAllClose(y, np.ones((3, 2)) * 6)
+    @parameterized.named_parameters(
+        [
+            {
+                "testcase_name": "scalar_data_with_max",
+                "state": np.array(0),
+                "output": np.array(5),
+                "maximum_iterations": 5,
+            },
+            {
+                "testcase_name": "scalar_data_no_max",
+                "state": np.array(0),
+                "output": np.array(10),
+                "maximum_iterations": None,
+            },
+            {
+                "testcase_name": "nested_data_with_max",
+                "state": {
+                    "a": np.array(0),
+                    "b": (np.array(1), np.array(2)),
+                },
+                "output": {
+                    "a": np.array(5),
+                    "b": (np.array(6), np.array(7)),
+                },
+                "maximum_iterations": 5,
+            },
+            {
+                "testcase_name": "nested_data_no_max",
+                "state": {
+                    "a": np.array(0),
+                    "b": (np.array(1), np.array(2)),
+                },
+                "output": {
+                    "a": np.array(10),
+                    "b": (np.array(11), np.array(12)),
+                },
+                "maximum_iterations": None,
+            },
+        ]
+    )
+    def test_while_loop(self, state, output, maximum_iterations):
+        def cond(args):
+            return tree.flatten(args)[0] < 10
+
+        def body(args):
+            return tree.map_structure(lambda x: x + 1, args)
+
+        state = core.while_loop(
+            cond, body, state, maximum_iterations=maximum_iterations
+        )
+        tree.map_structure(self.assertAllClose, state, output)
 
     def test_fori_loop(self):
         def body_fun(i, x):


### PR DESCRIPTION
Previously, we had the following support for loop vars:
- jax and tensorflow support nest structures (dicts/tuples) in a tuples
- torch and numpy support only flat tuples

With this change, we support any nested structure. If loops vars is a loop or tuple, args as passed positionally.

Alternatively, we could:
- demand the toplevel be a tuple/list, with nested structure inside
- pass any structure through unaltered (never pass args positionally). this is the jax approach, and IMO it's the cleanest, but to get there we would need to break compat.