### PR TITLE
Update `DTypePolicy` and add support for hardware-accelerated int8 `ops.matmul`

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -55,6 +55,14 @@ def subtract(x1, x2):
 def matmul(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
+    # When both x1 and x2 are of int8, specifying `preferred_element_type` as
+    # int32 to enable hardware-accelerated matmul
+    x1_dtype = standardize_dtype(x1.dtype)
+    x2_dtype = standardize_dtype(x2.dtype)
+    if x1_dtype == "int8" and x2_dtype == "int8":
+        preferred_element_type = "int32"
+    else:
+        preferred_element_type = None
     if isinstance(x1, jax_sparse.JAXSparse) or isinstance(
         x2, jax_sparse.JAXSparse
     ):
@@ -68,9 +76,11 @@ def matmul(x1, x2):
             x2 = jax_sparse.bcoo_update_layout(
                 x2, n_batch=len(x2.shape) - 2, on_inefficient="warn"
             )
-        return matmul.sparse_matmul(x1, x2)
+        return matmul.sparse_matmul(
+            x1, x2, preferred_element_type=preferred_element_type
+        )
 
-    return jnp.matmul(x1, x2)
+    return jnp.matmul(x1, x2, preferred_element_type=preferred_element_type)
 
 
 def multiply(x1, x2):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -52,7 +52,14 @@ def subtract(x1, x2):
 def matmul(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    # When both x1 and x2 are of int8, we cast the outputs to int32 to align
+    # with jax
+    x1_dtype = standardize_dtype(x1.dtype)
+    x2_dtype = standardize_dtype(x2.dtype)
+    if x1_dtype == "int8" and x2_dtype == "int8":
+        dtype = "int32"
+    else:
+        dtype = dtypes.result_type(x1.dtype, x2.dtype)
     return np.matmul(x1, x2).astype(dtype)
 
 

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -46,7 +46,15 @@ def subtract(x1, x2):
 def matmul(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    result_dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    # When both x1 and x2 are of int8, we cast the outputs to int32 to align
+    # with jax
+    # TODO: Support hardware-accelerated matmul
+    x1_dtype = standardize_dtype(x1.dtype)
+    x2_dtype = standardize_dtype(x2.dtype)
+    if x1_dtype == "int8" and x2_dtype == "int8":
+        result_dtype = "int32"
+    else:
+        result_dtype = dtypes.result_type(x1.dtype, x2.dtype)
     compute_dtype = result_dtype
 
     # TODO: torch.matmul doesn't support bool

--- a/keras/dtype_policies/dtype_policy.py
+++ b/keras/dtype_policies/dtype_policy.py
@@ -1,4 +1,5 @@
 from keras import backend
+from keras import ops
 from keras.api_export import keras_export
 from keras.backend.common import global_state
 
@@ -132,7 +133,33 @@ class DTypePolicy:
         return self._name
 
     def __repr__(self):
-        return f'<DTypePolicy "{self._name}">'
+        return (
+            f'<DTypePolicy "{self._name}", '
+            f'variable_dtype="{self._variable_dtype}, "'
+            f'compute_dtype="{self._compute_dtype}">'
+        )
+
+    def convert_input(self, x, autocast, dtype):
+        dtype = backend.standardize_dtype(dtype)
+        if backend.is_tensor(x):
+            if (
+                autocast
+                and backend.is_float_dtype(x.dtype)
+                and x.dtype != dtype
+            ):
+                x = backend.cast(x, dtype=dtype)
+            return x
+        elif backend.is_keras_tensor(x):
+            if (
+                autocast
+                and backend.is_float_dtype(x.dtype)
+                and x.dtype != dtype
+            ):
+                x.dtype = dtype
+            return x
+        elif hasattr(x, "__array__"):
+            return ops.convert_to_tensor(x, dtype=dtype)
+        return x
 
     def get_config(self):
         return {"name": self.name}

--- a/keras/layers/layer.py
+++ b/keras/layers/layer.py
@@ -27,7 +27,6 @@ from keras import backend
 from keras import constraints
 from keras import dtype_policies
 from keras import initializers
-from keras import ops
 from keras import regularizers
 from keras import utils
 from keras.api_export import keras_export
@@ -700,25 +699,9 @@ class Layer(BackendLayer, Operation):
         #####################################
         # 1. Convert any array arguments to tensors of correct dtype.
         def maybe_convert(x):
-            if backend.is_tensor(x):
-                if (
-                    self.autocast
-                    and backend.is_float_dtype(x.dtype)
-                    and x.dtype != self.input_dtype
-                ):
-                    x = backend.cast(x, dtype=self.input_dtype)
-                return x
-            elif isinstance(x, backend.KerasTensor):
-                if (
-                    self.autocast
-                    and backend.is_float_dtype(x.dtype)
-                    and x.dtype != self.input_dtype
-                ):
-                    x.dtype = self.input_dtype
-                return x
-            elif hasattr(x, "__array__"):
-                return ops.convert_to_tensor(x, dtype=self.input_dtype)
-            return x
+            return self.dtype_policy.convert_input(
+                x, self.autocast, self.input_dtype
+            )
 
         # Used to avoid expensive `tree` operations in the most common case.
         if (

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -3513,10 +3513,12 @@ class Matmul(Operation):
         x1_sparse = getattr(x1, "sparse", True)
         x2_sparse = getattr(x2, "sparse", True)
         output_sparse = x1_sparse and x2_sparse
-        dtype = dtypes.result_type(
-            getattr(x1, "dtype", type(x1)),
-            getattr(x2, "dtype", type(x2)),
-        )
+        x1_dtype = backend.standardize_dtype(getattr(x1, "dtype", type(x1)))
+        x2_dtype = backend.standardize_dtype(getattr(x2, "dtype", type(x2)))
+        if x1_dtype == "int8" and x2_dtype == "int8":
+            dtype = "int32"
+        else:
+            dtype = dtypes.result_type(x1_dtype, x2_dtype)
         return KerasTensor(output_shape, dtype=dtype, sparse=output_sparse)
 
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4593,17 +4593,28 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
             )
 
     @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+        named_product(
+            dtypes=list(itertools.combinations(ALL_DTYPES, 2))
+            + [("int8", "int8")]
+        )
     )
     def test_matmul(self, dtypes):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = knp.ones((1,), dtype=dtype1)
-        x2 = knp.ones((1,), dtype=dtype2)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.matmul(x1_jax, x2_jax).dtype)
+        x1 = knp.ones((1, 1), dtype=dtype1)
+        x2 = knp.ones((1, 1), dtype=dtype2)
+        x1_jax = jnp.ones((1, 1), dtype=dtype1)
+        x2_jax = jnp.ones((1, 1), dtype=dtype2)
+        if dtype1 == "int8" and dtype2 == "int8":
+            preferred_element_type = "int32"
+        else:
+            preferred_element_type = None
+        expected_dtype = standardize_dtype(
+            jnp.matmul(
+                x1_jax, x2_jax, preferred_element_type=preferred_element_type
+            ).dtype
+        )
 
         self.assertEqual(
             standardize_dtype(knp.matmul(x1, x2).dtype), expected_dtype


### PR DESCRIPTION
- Utilize the new `convert_input` of `DTypePolicy` for `Layer` to convert input dtype
- Add support for int8 matmul

This PR is a preparation of the upcoming quantized_int8 dtype policy.

The performance report:

```bash
JAX:
TOPS/TFLOPS
===================================
dim    |     int8     fp16     fp32
-----------------------------------
256    |     4.59     5.67     4.35
512    |    23.49    16.79    11.55
1024   |    61.11    42.38    23.96
2048   |   136.63    56.98    27.26
4096   |   150.83    61.12    29.47
===================================

Tensorflow:
TOPS/TFLOPS
===================================
dim    |     int8     fp16     fp32
-----------------------------------
256    |     1.10     1.37     1.27
512    |     7.57     8.67     6.82
1024   |    33.27    32.62    20.65
2048   |   110.02    54.65    26.96
4096   |   147.46    60.98    29.38
===================================
```

Benchmark script is adopted from https://github.com/tensorflow/tensorflow/issues/59530

```python
import time

from keras import backend
from keras import ops
from keras import random


def int8_linear_layer(x, params):
    # read in x and w as pre-quantized int8 tensors
    y = ops.matmul(x, params["w"])

    # add bias and apply activation in fp32
    y = ops.cast(y, "float32")
    y = y + params["b"]
    y = ops.relu(y)

    # quantize and store output as int8
    y = ops.round(y / params["s"])
    y = ops.clip(y, -128, 127)
    y = ops.cast(y, "int8")
    return y


def fp_linear_layer(x, params):
    return ops.relu(ops.matmul(x, params["w"]) + params["b"])


def linear_layer(x, params):
    if backend.standardize_dtype(params["w"].dtype) == "int8":
        return int8_linear_layer(x, params)
    else:
        return fp_linear_layer(x, params)


def network(x, network_params):
    for layer_params in network_params:
        x = linear_layer(x, layer_params)
    return x[0, 0]


def benchmark(dim, dtype, n_layers=32, iters=200):
    """Benchmarks the throughput of a linear layer.

    matmul + bias + act (+ quantization)

    To drown out data transfer costs and other overheads, each run performs a
    forward pass of a network consisting of `n_layers` of linear layers in
    series.

    The full network is run for `iters` iterations to compute the throughput in
    TFLOPS/TOPS.
    """

    # create input tensor for network
    if dtype == "int8":
        x = random.uniform([dim, dim], minval=-127, maxval=127, dtype="float32")
        x = ops.cast(x, "int8")
    else:
        x = random.uniform([dim, dim], dtype=dtype)

    # create weight + bias (+ quant scale) tensors for each layer
    network_params = []
    for i in range(n_layers):
        if dtype == "int8":
            w = random.uniform(
                [dim, dim], minval=-127, maxval=127, dtype="float32"
            )
            w = ops.cast(w, "int8")
            b = random.normal([dim], dtype="float32")
            s = random.normal([], dtype="float32")
            layer_params = {"w": w, "b": b, "s": s}
        else:
            w = random.uniform([dim, dim], dtype=dtype)
            b = random.uniform([dim], dtype=dtype)
            layer_params = {"w": w, "b": b}
        network_params.append(layer_params)

    # jit
    if backend.backend() == "tensorflow":
        import tensorflow as tf

        jit_network = tf.function(network, jit_compile=True)
    elif backend.backend() == "jax":
        import jax

        jit_network = jax.jit(network)

    # warmup
    for _ in range(10):
        _ = ops.convert_to_numpy(jit_network(x, network_params))

    times = []
    for _ in range(iters):
        t0 = time.time()
        _ = ops.convert_to_numpy(jit_network(x, network_params))
        elapsed_time = time.time() - t0  # in ms
        times.append(elapsed_time)

    avg_time = sum(times) / len(times)
    tflops = (n_layers * 2 * dim**3) / avg_time * 1e-12
    return tflops


if __name__ == "__main__":
    # not used, just triggers tensorflow/xla initial log dump
    benchmark(256, "float16")

    print("\nTOPS/TFLOPS")
    cols = f"{'dim':<6} | {'int8':>8} {'fp16':>8} {'fp32':>8}"
    print("=" * len(cols) + "\n" + cols + "\n" + "-" * len(cols))
    for dim in [256, 512, 1024, 2048, 4096]:
        int8_time = benchmark(dim, "int8")
        fp16_time = benchmark(dim, "float16")
        fp32_time = benchmark(dim, "float32")
        print(
            f"{dim:<6} | {int8_time:>8.2f} {fp16_time:>8.2f} {fp32_time:>8.2f}"
        )
    print("=" * len(cols))
```