### PR TITLE
Enhance Keras Ops Test Coverage for `Cond` and `Unstack` Operations

### DIFF
--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -933,3 +933,41 @@ class CoreOpsCallsTests(testing.TestCase):
 
         with self.assertRaisesRegex(ValueError, expected_regex):
             cond_op(pred, true_fn, false_fn)
+
+    def test_cond_output_spec_mismatch_in_tuple_elements(self):
+        cond_op = core.Cond()
+
+        def true_fn():
+            return (
+                KerasTensor(shape=(3, 3), dtype='float32'),
+                KerasTensor(shape=(4, 4), dtype='float32'),
+            )
+
+        def false_fn():
+            return (
+                KerasTensor(shape=(3, 3), dtype='float32'),
+                # Mismatched tuple
+                KerasTensor(shape=(2, 2), dtype='float32'),
+            )
+
+        pred = KerasTensor(shape=(), dtype='bool')
+        expected_regex = "should return outputs of the same kind"
+
+        with self.assertRaisesRegex(ValueError, expected_regex):
+            cond_op(pred, true_fn, false_fn)
+
+    def test_cond_output_spec_dtype_mismatch(self):
+        cond_op = core.Cond()
+
+        def true_fn():
+            return KerasTensor(shape=(3, 3), dtype='float32')
+
+        def false_fn():
+            # Mismatched dtype
+            return KerasTensor(shape=(3, 3), dtype='int32')
+
+        pred = KerasTensor(shape=(), dtype='bool')
+        expected_regex = "(struct, dtype and shape)"
+
+        with self.assertRaisesRegex(ValueError, expected_regex):
+            cond_op(pred, true_fn, false_fn)

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -912,50 +912,6 @@ class CoreOpsCallsTests(testing.TestCase):
         with self.assertRaisesRegex(ValueError, expected_regex):
             cond_op(pred, true_fn, false_fn)
 
-    def test_cond_output_spec_mismatch_true_fn_tuple_false_fn_not_tuple(self):
-        cond_op = core.Cond()
-
-        def true_fn():
-            return (
-                KerasTensor(shape=(3, 3), dtype="float32"),
-                KerasTensor(shape=(4, 4), dtype="float32"),
-            )
-
-        def false_fn():
-            # not a tuple to match the true_fn
-            return {
-                "a": KerasTensor(shape=(3, 3), dtype="float32"),
-                "b": KerasTensor(shape=(4, 4), dtype="float32"),
-            }
-
-        pred = KerasTensor(shape=(), dtype="bool")
-        expected_regex = "should return outputs of the same kind"
-
-        with self.assertRaisesRegex(ValueError, expected_regex):
-            cond_op(pred, true_fn, false_fn)
-
-    def test_cond_output_spec_mismatch_in_tuple_elements(self):
-        cond_op = core.Cond()
-
-        def true_fn():
-            return (
-                KerasTensor(shape=(3, 3), dtype="float32"),
-                KerasTensor(shape=(4, 4), dtype="float32"),
-            )
-
-        def false_fn():
-            return (
-                KerasTensor(shape=(3, 3), dtype="float32"),
-                # Mismatched tuple
-                KerasTensor(shape=(2, 2), dtype="float32"),
-            )
-
-        pred = KerasTensor(shape=(), dtype="bool")
-        expected_regex = "should return outputs of the same kind"
-
-        with self.assertRaisesRegex(ValueError, expected_regex):
-            cond_op(pred, true_fn, false_fn)
-
     def test_cond_output_spec_dtype_mismatch(self):
         cond_op = core.Cond()
 
@@ -1008,6 +964,58 @@ class CoreOpsCallsTests(testing.TestCase):
                 "a": KerasTensor(shape=(3, 3), dtype="float32"),
                 # Key 'b' has a mismatch in dtype
                 "b": KerasTensor(shape=(4, 4), dtype="int32"),
+            }
+
+        pred = KerasTensor(shape=(), dtype="bool")
+        expected_regex = "should return outputs of the same kind"
+
+        with self.assertRaisesRegex(ValueError, expected_regex):
+            cond_op(pred, true_fn, false_fn)
+
+    @pytest.mark.skipif(
+        backend.backend() == "jax",
+        reason="Incompatibilities with JAX's symbolic tensors",
+    )
+    def test_cond_output_spec_mismatch_in_tuple_elements(self):
+        cond_op = core.Cond()
+
+        def true_fn():
+            return (
+                KerasTensor(shape=(3, 3), dtype="float32"),
+                KerasTensor(shape=(4, 4), dtype="float32"),
+            )
+
+        def false_fn():
+            return (
+                KerasTensor(shape=(3, 3), dtype="float32"),
+                # Mismatched tuple
+                KerasTensor(shape=(2, 2), dtype="float32"),
+            )
+
+        pred = KerasTensor(shape=(), dtype="bool")
+        expected_regex = "should return outputs of the same kind"
+
+        with self.assertRaisesRegex(ValueError, expected_regex):
+            cond_op(pred, true_fn, false_fn)
+
+    @pytest.mark.skipif(
+        backend.backend() == "jax",
+        reason="Incompatibilities with JAX's symbolic tensors",
+    )
+    def test_cond_output_spec_mismatch_true_fn_tuple_false_fn_not_tuple(self):
+        cond_op = core.Cond()
+
+        def true_fn():
+            return (
+                KerasTensor(shape=(3, 3), dtype="float32"),
+                KerasTensor(shape=(4, 4), dtype="float32"),
+            )
+
+        def false_fn():
+            # not a tuple to match the true_fn
+            return {
+                "a": KerasTensor(shape=(3, 3), dtype="float32"),
+                "b": KerasTensor(shape=(4, 4), dtype="float32"),
             }
 
         pred = KerasTensor(shape=(), dtype="bool")

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -814,3 +814,19 @@ class CoreOpsCallsTests(testing.TestCase):
                 (mock_spec,), (mock_spec, mock_spec_different)
             )
         )
+
+    def test_unstack_with_negative_axis_first_tensor(self):
+        x = np.random.rand(4, 3, 2)
+        x_tensor = ops.convert_to_tensor(x)
+        negative_axis = -1
+        result = ops.unstack(x_tensor, axis=negative_axis)
+        expected_shape = (4, 3)
+        self.assertAllEqual(result[0].shape, expected_shape)
+
+    def test_unstack_with_negative_axis_second_tensor(self):
+        x = np.random.rand(4, 3, 2)
+        x_tensor = ops.convert_to_tensor(x)
+        negative_axis = -1
+        result = ops.unstack(x_tensor, axis=negative_axis)
+        expected_shape = (4, 3)
+        self.assertAllEqual(result[1].shape, expected_shape)

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -939,18 +939,18 @@ class CoreOpsCallsTests(testing.TestCase):
 
         def true_fn():
             return (
-                KerasTensor(shape=(3, 3), dtype='float32'),
-                KerasTensor(shape=(4, 4), dtype='float32'),
+                KerasTensor(shape=(3, 3), dtype="float32"),
+                KerasTensor(shape=(4, 4), dtype="float32"),
             )
 
         def false_fn():
             return (
-                KerasTensor(shape=(3, 3), dtype='float32'),
+                KerasTensor(shape=(3, 3), dtype="float32"),
                 # Mismatched tuple
-                KerasTensor(shape=(2, 2), dtype='float32'),
+                KerasTensor(shape=(2, 2), dtype="float32"),
             )
 
-        pred = KerasTensor(shape=(), dtype='bool')
+        pred = KerasTensor(shape=(), dtype="bool")
         expected_regex = "should return outputs of the same kind"
 
         with self.assertRaisesRegex(ValueError, expected_regex):
@@ -960,14 +960,58 @@ class CoreOpsCallsTests(testing.TestCase):
         cond_op = core.Cond()
 
         def true_fn():
-            return KerasTensor(shape=(3, 3), dtype='float32')
+            return KerasTensor(shape=(3, 3), dtype="float32")
 
         def false_fn():
             # Mismatched dtype
-            return KerasTensor(shape=(3, 3), dtype='int32')
+            return KerasTensor(shape=(3, 3), dtype="int32")
 
-        pred = KerasTensor(shape=(), dtype='bool')
+        pred = KerasTensor(shape=(), dtype="bool")
         expected_regex = "(struct, dtype and shape)"
+
+        with self.assertRaisesRegex(ValueError, expected_regex):
+            cond_op(pred, true_fn, false_fn)
+
+    def test_cond_output_spec_mismatch_in_dict_shapes(self):
+        cond_op = core.Cond()
+
+        def true_fn():
+            return {
+                "a": KerasTensor(shape=(3, 3), dtype="float32"),
+                "b": KerasTensor(shape=(4, 4), dtype="float32"),
+            }
+
+        def false_fn():
+            return {
+                "a": KerasTensor(shape=(3, 3), dtype="float32"),
+                # Key 'b' has a mismatch in shape
+                "b": KerasTensor(shape=(2, 2), dtype="float32"),
+            }
+
+        pred = KerasTensor(shape=(), dtype="bool")
+        expected_regex = "should return outputs of the same kind"
+
+        with self.assertRaisesRegex(ValueError, expected_regex):
+            cond_op(pred, true_fn, false_fn)
+
+    def test_cond_output_spec_mismatch_in_dict_dtypes(self):
+        cond_op = core.Cond()
+
+        def true_fn():
+            return {
+                "a": KerasTensor(shape=(3, 3), dtype="float32"),
+                "b": KerasTensor(shape=(4, 4), dtype="float32"),
+            }
+
+        def false_fn():
+            return {
+                "a": KerasTensor(shape=(3, 3), dtype="float32"),
+                # Key 'b' has a mismatch in dtype
+                "b": KerasTensor(shape=(4, 4), dtype="int32"),
+            }
+
+        pred = KerasTensor(shape=(), dtype="bool")
+        expected_regex = "should return outputs of the same kind"
 
         with self.assertRaisesRegex(ValueError, expected_regex):
             cond_op(pred, true_fn, false_fn)


### PR DESCRIPTION
This PR introduces tests aimed at enhancing coverage for 
`keras/ops/core.py`,
the `Cond` operation's output specification checks and the handling of negative axes by the `Unstack` operation.

The untested lines were identified through [Codecov's coverage report](https://app.codecov.io/gh/keras-team/keras/blob/master/keras%2Fops%2Fcore.py).

Please note thatI have that added 2 tests with 

```Python
    @pytest.mark.skipif(backend.backend() == "jax", reason="Incompatibilities with JAX's symbolic tensors")
```

to skip tests incompatible with JAX's handling of symbolic tensors. 

```Python
    @pytest.mark.skipif(backend.backend() == "jax", reason="Incompatibilities with JAX's symbolic tensors")
    def test_cond_output_spec_mismatch_in_tuple_elements(self):
        cond_op = core.Cond()

        def true_fn():
            return (
                KerasTensor(shape=(3, 3), dtype="float32"),
                KerasTensor(shape=(4, 4), dtype="float32"),
            )

        def false_fn():
            return (
                KerasTensor(shape=(3, 3), dtype="float32"),
                # Mismatched tuple
                KerasTensor(shape=(2, 2), dtype="float32"),
            )

        pred = KerasTensor(shape=(), dtype="bool")
        expected_regex = "should return outputs of the same kind"

        with self.assertRaisesRegex(ValueError, expected_regex):
            cond_op(pred, true_fn, false_fn)

    @pytest.mark.skipif(backend.backend() == "jax", reason="Incompatibilities with JAX's symbolic tensors")
    def test_cond_output_spec_mismatch_true_fn_tuple_false_fn_not_tuple(self):
        cond_op = core.Cond()

        def true_fn():
            return (
                KerasTensor(shape=(3, 3), dtype="float32"),
                KerasTensor(shape=(4, 4), dtype="float32"),
            )

        def false_fn():
            # not a tuple to match the true_fn
            return {
                "a": KerasTensor(shape=(3, 3), dtype="float32"),
                "b": KerasTensor(shape=(4, 4), dtype="float32"),
            }

        pred = KerasTensor(shape=(), dtype="bool")
        expected_regex = "should return outputs of the same kind"

        with self.assertRaisesRegex(ValueError, expected_regex):
            cond_op(pred, true_fn, false_fn)

```



Is this the best way to avoid tests failing specifically due to JAX compatibility issues? Or should we strive to write tests that are suitable for all backends? Like using `unittest.mock` ?
