### PR TITLE
Linear algebra ops in `keras.ops.linalg`

### DIFF
--- a/keras/backend/jax/__init__.py
+++ b/keras/backend/jax/__init__.py
@@ -1,6 +1,7 @@
 from keras.backend.jax import core
 from keras.backend.jax import distribution_lib
 from keras.backend.jax import image
+from keras.backend.jax import linalg
 from keras.backend.jax import math
 from keras.backend.jax import nn
 from keras.backend.jax import numpy

--- a/keras/backend/jax/linalg.py
+++ b/keras/backend/jax/linalg.py
@@ -28,12 +28,12 @@ def inv(a):
     return jnp.linalg.inv(a)
 
 def lu_factor(x):
-    lu_fn = jsp.linalg.lu
+    lu_factor_fn = jsp.linalg.lu_factor
     if x.ndim > 2:
         for i in range(x.ndim - 2):
-            lu_fn = jax.vmap(lu_fn)
+            lu_factor_fn = jax.vmap(lu_factor_fn)
         
-    return lu_fn(x)    
+    return lu_factor_fn(x)    
     
 def norm(x, ord=None, axis=None, keepdims=False):
     x = convert_to_tensor(x)

--- a/keras/backend/jax/linalg.py
+++ b/keras/backend/jax/linalg.py
@@ -13,12 +13,15 @@ from keras.utils.module_utils import scipy
 def cholesky(a):
     out = jnp.linalg.cholesky(a)
     if jnp.any(jnp.isnan(out)):
-        raise ValueError("Cholesky decomposition failed. The input might not be a valid positive definite matrix.")
+        raise ValueError(
+            "Cholesky decomposition failed. The input might not be a valid positive definite matrix."
+        )
     return out
 
 
 def det(a):
     return jnp.linalg.det(a)
+
 
 def eig(x):
     return jnp.linalg.eig(x)
@@ -27,14 +30,16 @@ def eig(x):
 def inv(a):
     return jnp.linalg.inv(a)
 
+
 def lu_factor(x):
     lu_factor_fn = jsp.linalg.lu_factor
     if x.ndim > 2:
         for i in range(x.ndim - 2):
             lu_factor_fn = jax.vmap(lu_factor_fn)
-        
-    return lu_factor_fn(x)    
-    
+
+    return lu_factor_fn(x)
+
+
 def norm(x, ord=None, axis=None, keepdims=False):
     x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
@@ -61,6 +66,7 @@ def solve(a, b):
 
 def solve_triangular(a, b, lower=False):
     return jsp.linalg.solve_triangular(a, b, lower=lower)
+
 
 def svd(x, full_matrices=True, compute_uv=True):
     return jnp.linalg.svd(x, full_matrices=full_matrices, compute_uv=compute_uv)

--- a/keras/backend/jax/linalg.py
+++ b/keras/backend/jax/linalg.py
@@ -1,6 +1,6 @@
 import jax
 import jax.numpy as jnp
-import jax.scipy.linalg as jsl
+from jax.scipy.linalg import solve_triangular
 
 
 def cholesky(a):
@@ -15,13 +15,9 @@ def inv(a):
     return jnp.linalg.inv(a)
 
 
-def logdet(a):
-    return jnp.linalg.logdet(a)
-
-
 def solve(a, b):
     return jnp.linalg.solve(a, b)
 
 
 def solve_triangular(a, b, lower=False):
-    return jsl.solve_triangular(a, b, lower=lower)
+    return solve_triangular(a, b, lower=lower)

--- a/keras/backend/jax/linalg.py
+++ b/keras/backend/jax/linalg.py
@@ -1,18 +1,58 @@
 import jax
 import jax.numpy as jnp
-from jax.scipy.linalg import solve_triangular
+import jax.scipy as jsp
+
+from keras.backend import config
+from keras.backend import standardize_dtype
+from keras.backend.common import dtypes
+from keras.backend.jax.core import cast
+from keras.backend.jax.core import convert_to_tensor
+from keras.utils.module_utils import scipy
 
 
 def cholesky(a):
-    return jnp.linalg.cholesky(a)
+    out = jnp.linalg.cholesky(a)
+    if jnp.any(jnp.isnan(out)):
+        raise ValueError("Cholesky decomposition failed. The input might not be a valid positive definite matrix.")
+    return out
 
 
 def det(a):
     return jnp.linalg.det(a)
 
+def eig(x):
+    return jnp.linalg.eig(x)
+
 
 def inv(a):
     return jnp.linalg.inv(a)
+
+def lu_factor(x):
+    lu_fn = jsp.linalg.lu
+    if x.ndim > 2:
+        for i in range(x.ndim - 2):
+            lu_fn = jax.vmap(lu_fn)
+        
+    return lu_fn(x)    
+    
+def norm(x, ord=None, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "int64":
+        dtype = config.floatx()
+    else:
+        dtype = dtypes.result_type(x.dtype, float)
+    x = cast(x, dtype)
+    return jnp.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+
+
+def qr(x, mode="reduced"):
+    if mode not in {"reduced", "complete"}:
+        raise ValueError(
+            "`mode` argument value not supported. "
+            "Expected one of {'reduced', 'complete'}. "
+            f"Received: mode={mode}"
+        )
+    return jnp.linalg.qr(x, mode=mode)
 
 
 def solve(a, b):
@@ -20,4 +60,7 @@ def solve(a, b):
 
 
 def solve_triangular(a, b, lower=False):
-    return solve_triangular(a, b, lower=lower)
+    return jsp.linalg.solve_triangular(a, b, lower=lower)
+
+def svd(x, full_matrices=True, compute_uv=True):
+    return jnp.linalg.svd(x, full_matrices=full_matrices, compute_uv=compute_uv)

--- a/keras/backend/jax/linalg.py
+++ b/keras/backend/jax/linalg.py
@@ -1,0 +1,27 @@
+import jax
+import jax.numpy as jnp
+import jax.scipy.linalg as jsl
+
+
+def cholesky(a):
+    return jnp.linalg.cholesky(a)
+
+
+def det(a):
+    return jnp.linalg.det(a)
+
+
+def inv(a):
+    return jnp.linalg.inv(a)
+
+
+def logdet(a):
+    return jnp.linalg.logdet(a)
+
+
+def solve(a, b):
+    return jnp.linalg.solve(a, b)
+
+
+def solve_triangular(a, b, lower=False):
+    return jsl.solve_triangular(a, b, lower=lower)

--- a/keras/backend/numpy/__init__.py
+++ b/keras/backend/numpy/__init__.py
@@ -1,5 +1,6 @@
 from keras.backend.numpy import core
 from keras.backend.numpy import image
+from keras.backend.numpy import linalg
 from keras.backend.numpy import math
 from keras.backend.numpy import nn
 from keras.backend.numpy import numpy

--- a/keras/backend/numpy/linalg.py
+++ b/keras/backend/numpy/linalg.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy import linalg
+from scipy.linalg import solve_triangular
 
 
 def cholesky(a):
@@ -20,3 +20,7 @@ def inv(a):
 
 def solve(a, b):
     return np.linalg.solve(a, b)
+
+
+def solve_triangular(a, b, lower=False):
+    return solve_triangular(a, b, lower=lower)

--- a/keras/backend/numpy/linalg.py
+++ b/keras/backend/numpy/linalg.py
@@ -22,7 +22,17 @@ def inv(a):
     return np.linalg.inv(a)
 
 def lu_factor(a):
-    return sl.lu_factor(a)
+    if a.ndim == 2:
+        return sl.lu_factor(a)
+    
+    m, n = a.shape[-2:]
+    signature = "(m,n) -> (m,n), "
+    signature += "(m)" if m <= n else "(n)"
+    _lu_factor_gufunc = np.vectorize(
+        sl.lu_factor,
+        signature=signature,
+    )
+    return _lu_factor_gufunc(a)
 
 def norm(x, ord=None, axis=None, keepdims=False):
     x = convert_to_tensor(x)

--- a/keras/backend/numpy/linalg.py
+++ b/keras/backend/numpy/linalg.py
@@ -21,10 +21,11 @@ def eig(a):
 def inv(a):
     return np.linalg.inv(a)
 
+
 def lu_factor(a):
     if a.ndim == 2:
         return sl.lu_factor(a)
-    
+
     m, n = a.shape[-2:]
     signature = "(m,n) -> (m,n), "
     signature += "(m)" if m <= n else "(n)"
@@ -33,6 +34,7 @@ def lu_factor(a):
         signature=signature,
     )
     return _lu_factor_gufunc(a)
+
 
 def norm(x, ord=None, axis=None, keepdims=False):
     x = convert_to_tensor(x)
@@ -61,7 +63,7 @@ def solve(a, b):
 def solve_triangular(a, b, lower=False):
     if a.ndim == 2:
         return sl.solve_triangular(a, b, lower=lower)
-    
+
     _vectorized_solve_triangular = np.vectorize(
         lambda a, b: sl.solve_triangular(a, b, lower=lower),
         signature="(n,n),(n,m)->(n,m)",

--- a/keras/backend/numpy/linalg.py
+++ b/keras/backend/numpy/linalg.py
@@ -1,0 +1,22 @@
+import numpy as np
+from scipy import linalg
+
+
+def cholesky(a):
+    return np.linalg.cholesky(a)
+
+
+def det(a):
+    return np.linalg.det(a)
+
+
+def eig(a):
+    return np.linalg.eig(a)
+
+
+def inv(a):
+    return np.linalg.inv(a)
+
+
+def solve(a, b):
+    return np.linalg.solve(a, b)

--- a/keras/backend/tensorflow/__init__.py
+++ b/keras/backend/tensorflow/__init__.py
@@ -1,6 +1,7 @@
 from keras.backend.tensorflow import core
 from keras.backend.tensorflow import distribution_lib
 from keras.backend.tensorflow import image
+from keras.backend.tensorflow import linalg
 from keras.backend.tensorflow import math
 from keras.backend.tensorflow import nn
 from keras.backend.tensorflow import numpy

--- a/keras/backend/tensorflow/linalg.py
+++ b/keras/backend/tensorflow/linalg.py
@@ -2,7 +2,9 @@ import tensorflow as tf
 
 
 def cholesky(a):
-    return tf.linalg.cholesky(a)
+    out = tf.linalg.cholesky(a)
+    # tf.linalg.cholesky simply returns NaNs for non-positive definite matrices
+    return tf.debugging.check_numerics(out, "Cholesky")
 
 
 def det(a):
@@ -14,4 +16,12 @@ def inv(a):
 
 
 def solve(a, b):
+    # tensorflow.linalg.solve only supports same rank inputs
+    if tf.rank(b) == tf.rank(a) - 1:
+        b = tf.expand_dims(b, axis=-1)
+        return tf.squeeze(tf.linalg.solve(a, b), axis=-1)
     return tf.linalg.solve(a, b)
+
+
+def solve_triangular(a, b, lower=False):
+    return tf.linalg.triangular_solve(a, b, lower=lower)

--- a/keras/backend/tensorflow/linalg.py
+++ b/keras/backend/tensorflow/linalg.py
@@ -1,5 +1,11 @@
 import tensorflow as tf
+from tensorflow.experimental import numpy as tfnp
 
+from keras.backend import config
+from keras.backend import standardize_dtype
+from keras.backend.common import dtypes
+from keras.backend.tensorflow.core import cast
+from keras.backend.tensorflow.core import convert_to_tensor
 
 def cholesky(a):
     out = tf.linalg.cholesky(a)
@@ -11,8 +17,124 @@ def det(a):
     return tf.linalg.det(a)
 
 
+def eig(a):
+    return tf.linalg.eig(a)
+
+
 def inv(a):
     return tf.linalg.inv(a)
+
+
+def lu_factor(a):
+    lu, p = tf.linalg.lu(a)
+    return lu, p
+
+def norm(x, ord=None, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    x_shape = x.shape
+    ndim = x_shape.rank
+
+    if axis is None:
+        axis = tuple(range(ndim))
+    elif isinstance(axis, int):
+        axis = (axis,)
+
+    axis = axis[0] if len(axis) == 1 else axis
+    num_axes = 1 if isinstance(axis, int) else len(axis)
+
+    if num_axes == 1 and ord is None:
+        ord = "euclidean"
+    elif num_axes == 2 and ord is None:
+        ord = "fro"
+
+    if standardize_dtype(x.dtype) == "int64":
+        dtype = config.floatx()
+    else:
+        dtype = dtypes.result_type(x.dtype, float)
+    x = cast(x, dtype)
+
+    # Fast path to utilze `tf.linalg.norm`
+    if (num_axes == 1 and ord in ("euclidean", 1, 2, float("inf"))) or (
+        num_axes == 2 and ord in ("euclidean", "fro", 1, 2, float("inf"))
+    ):
+        return tf.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+
+    # Ref: jax.numpy.linalg.norm
+    if num_axes == 1 and ord not in ("fro", "nuc"):
+        if ord == float("-inf"):
+            return tf.math.reduce_min(
+                tf.math.abs(x), axis=axis, keepdims=keepdims
+            )
+        elif ord == 0:
+            return tf.math.reduce_sum(
+                tf.cast(tf.not_equal(x, 0), dtype=x.dtype),
+                axis=axis,
+                keepdims=keepdims,
+            )
+        else:
+            ord = convert_to_tensor(ord, dtype=x.dtype)
+            out = tf.math.reduce_sum(
+                tf.pow(tf.math.abs(x), ord), axis=axis, keepdims=keepdims
+            )
+            return tf.pow(out, 1.0 / ord)
+    elif num_axes == 2 and ord in ("nuc", float("-inf"), -2, -1):
+        row_axis, col_axis = axis[0], axis[1]
+        row_axis = row_axis + ndim if row_axis < 0 else row_axis
+        col_axis = col_axis + ndim if col_axis < 0 else col_axis
+        if ord == float("-inf"):
+            if not keepdims and row_axis > col_axis:
+                row_axis -= 1
+            x = tf.math.reduce_min(
+                tf.reduce_sum(tf.math.abs(x), axis=col_axis, keepdims=keepdims),
+                axis=row_axis,
+                keepdims=keepdims,
+            )
+        elif ord == -1:
+            if not keepdims and col_axis > row_axis:
+                col_axis -= 1
+            x = tf.math.reduce_min(
+                tf.reduce_sum(tf.math.abs(x), axis=row_axis, keepdims=keepdims),
+                axis=col_axis,
+                keepdims=keepdims,
+            )
+        else:
+            x = tfnp.moveaxis(x, axis, (-2, -1))
+            if ord == -2:
+                x = tf.math.reduce_min(
+                    tf.linalg.svd(x, compute_uv=False), axis=-1
+                )
+            else:
+                x = tf.math.reduce_sum(
+                    tf.linalg.svd(x, compute_uv=False), axis=-1
+                )
+            if keepdims:
+                x = tf.expand_dims(x, axis[0])
+                x = tf.expand_dims(x, axis[1])
+        return x
+
+    if num_axes == 1:
+        raise ValueError(
+            f"Invalid `ord` argument for vector norm. Received: ord={ord}"
+        )
+    elif num_axes == 2:
+        raise ValueError(
+            f"Invalid `ord` argument for matrix norm. Received: ord={ord}"
+        )
+    else:
+        raise ValueError(f"Invalid axis values. Received: axis={axis}")
+
+
+
+def qr(x, mode="reduced"):
+    if mode not in {"reduced", "complete"}:
+        raise ValueError(
+            "`mode` argument value not supported. "
+            "Expected one of {'reduced', 'complete'}. "
+            f"Received: mode={mode}"
+        )
+    if mode == "reduced":
+        return tf.linalg.qr(x)
+    return tf.linalg.qr(x, full_matrices=True)
 
 
 def solve(a, b):
@@ -24,4 +146,12 @@ def solve(a, b):
 
 
 def solve_triangular(a, b, lower=False):
+    if b.shape.ndims == a.shape.ndims - 1:
+        b = tf.expand_dims(b, axis=-1)
+        return tf.squeeze(tf.linalg.triangular_solve(a, b, lower=lower), axis=-1)
     return tf.linalg.triangular_solve(a, b, lower=lower)
+
+
+def svd(x, full_matrices=True, compute_uv=True):
+    s, u, v = tf.linalg.svd(x, full_matrices=full_matrices, compute_uv=compute_uv)
+    return u, s, tf.linalg.adjoint(v)

--- a/keras/backend/tensorflow/linalg.py
+++ b/keras/backend/tensorflow/linalg.py
@@ -7,6 +7,7 @@ from keras.backend.common import dtypes
 from keras.backend.tensorflow.core import cast
 from keras.backend.tensorflow.core import convert_to_tensor
 
+
 def cholesky(a):
     out = tf.linalg.cholesky(a)
     # tf.linalg.cholesky simply returns NaNs for non-positive definite matrices
@@ -27,7 +28,8 @@ def inv(a):
 
 def lu_factor(a):
     lu, p = tf.linalg.lu(a)
-    return lu, p
+    return lu, tf.math.invert_permutation(p)
+
 
 def norm(x, ord=None, axis=None, keepdims=False):
     x = convert_to_tensor(x)
@@ -124,7 +126,6 @@ def norm(x, ord=None, axis=None, keepdims=False):
         raise ValueError(f"Invalid axis values. Received: axis={axis}")
 
 
-
 def qr(x, mode="reduced"):
     if mode not in {"reduced", "complete"}:
         raise ValueError(
@@ -148,10 +149,14 @@ def solve(a, b):
 def solve_triangular(a, b, lower=False):
     if b.shape.ndims == a.shape.ndims - 1:
         b = tf.expand_dims(b, axis=-1)
-        return tf.squeeze(tf.linalg.triangular_solve(a, b, lower=lower), axis=-1)
+        return tf.squeeze(
+            tf.linalg.triangular_solve(a, b, lower=lower), axis=-1
+        )
     return tf.linalg.triangular_solve(a, b, lower=lower)
 
 
 def svd(x, full_matrices=True, compute_uv=True):
-    s, u, v = tf.linalg.svd(x, full_matrices=full_matrices, compute_uv=compute_uv)
+    s, u, v = tf.linalg.svd(
+        x, full_matrices=full_matrices, compute_uv=compute_uv
+    )
     return u, s, tf.linalg.adjoint(v)

--- a/keras/backend/tensorflow/linalg.py
+++ b/keras/backend/tensorflow/linalg.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def cholesky(a):
+    return tf.linalg.cholesky(a)
+
+
+def det(a):
+    return tf.linalg.det(a)
+
+
+def inv(a):
+    return tf.linalg.inv(a)
+
+
+def solve(a, b):
+    return tf.linalg.solve(a, b)

--- a/keras/backend/torch/__init__.py
+++ b/keras/backend/torch/__init__.py
@@ -16,6 +16,7 @@ we are doing the following to automate device placement if a GPU is available:
 
 from keras.backend.torch import core
 from keras.backend.torch import image
+from keras.backend.torch import linalg
 from keras.backend.torch import math
 from keras.backend.torch import nn
 from keras.backend.torch import numpy

--- a/keras/backend/torch/linalg.py
+++ b/keras/backend/torch/linalg.py
@@ -6,6 +6,7 @@ from keras.backend.common import dtypes
 from keras.backend.torch.core import cast
 from keras.backend.torch.core import convert_to_tensor
 
+
 def cholesky(x):
     return torch.cholesky(x)
 
@@ -17,12 +18,14 @@ def det(x):
 def eig(x):
     return torch.linalg.eig(x)
 
+
 def inv(x):
     return torch.linalg.inv(x)
 
+
 def lu_factor(x):
     LU, pivots = torch.linalg.lu_factor(x)
-    # torch retuns pivots with 1-based indexing 
+    # torch retuns pivots with 1-based indexing
     return LU, pivots - 1
 
 
@@ -45,6 +48,7 @@ def qr(x, mode="reduced"):
         )
     return torch.linalg.qr(x, mode=mode)
 
+
 def solve(a, b):
     return torch.linalg.solve(a, b)
 
@@ -52,11 +56,15 @@ def solve(a, b):
 def solve_triangular(a, b, lower=False):
     if b.ndim == a.ndim - 1:
         b = torch.unsqueeze(b, axis=-1)
-        return torch.linalg.solve_triangular(a, b, upper=not lower).squeeze(axis=-1)
+        return torch.linalg.solve_triangular(a, b, upper=not lower).squeeze(
+            axis=-1
+        )
     return torch.linalg.solve_triangular(a, b, upper=not lower)
 
 
 def svd(x, full_matrices=True, compute_uv=True):
     if not compute_uv:
-        raise NotImplementedError("compute_uv=False is not supported for torch backend.")
+        raise NotImplementedError(
+            "compute_uv=False is not supported for torch backend."
+        )
     return torch.linalg.svd(x, full_matrices=full_matrices)

--- a/keras/backend/torch/linalg.py
+++ b/keras/backend/torch/linalg.py
@@ -21,7 +21,9 @@ def inv(x):
     return torch.linalg.inv(x)
 
 def lu_factor(x):
-    return torch.linalg.lu_factor(x)
+    LU, pivots = torch.linalg.lu_factor(x)
+    # torch retuns pivots with 1-based indexing 
+    return LU, pivots - 1
 
 
 def norm(x, ord=None, axis=None, keepdims=False):

--- a/keras/backend/torch/linalg.py
+++ b/keras/backend/torch/linalg.py
@@ -22,3 +22,9 @@ def solve(a, b):
     a = convert_to_tensor(a)
     b = convert_to_tensor(b)
     return torch.linalg.solve(a, b)
+
+
+def solve_triangular(a, b, lower=False):
+    a = convert_to_tensor(a)
+    b = convert_to_tensor(b)
+    return torch.linalg.solve_triangular(a, b, upper=~lower)

--- a/keras/backend/torch/linalg.py
+++ b/keras/backend/torch/linalg.py
@@ -1,0 +1,24 @@
+import torch
+
+from keras.backend.torch.core import convert_to_tensor
+
+
+def cholesky(x):
+    x = convert_to_tensor(x)
+    return torch.cholesky(x)
+
+
+def det(x):
+    x = convert_to_tensor(x)
+    return torch.det(x)
+
+
+def inv(x):
+    x = convert_to_tensor(x)
+    return torch.linalg.inv(x)
+
+
+def solve(a, b):
+    a = convert_to_tensor(a)
+    b = convert_to_tensor(b)
+    return torch.linalg.solve(a, b)

--- a/keras/backend/torch/linalg.py
+++ b/keras/backend/torch/linalg.py
@@ -1,30 +1,60 @@
 import torch
 
+from keras.backend import config
+from keras.backend import standardize_dtype
+from keras.backend.common import dtypes
+from keras.backend.torch.core import cast
 from keras.backend.torch.core import convert_to_tensor
 
-
 def cholesky(x):
-    x = convert_to_tensor(x)
     return torch.cholesky(x)
 
 
 def det(x):
-    x = convert_to_tensor(x)
     return torch.det(x)
 
 
+def eig(x):
+    return torch.linalg.eig(x)
+
 def inv(x):
-    x = convert_to_tensor(x)
     return torch.linalg.inv(x)
 
+def lu_factor(x):
+    return torch.linalg.lu_factor(x)
+
+
+def norm(x, ord=None, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    if standardize_dtype(x.dtype) == "int64":
+        dtype = config.floatx()
+    else:
+        dtype = dtypes.result_type(x.dtype, float)
+    x = cast(x, dtype)
+    return torch.linalg.norm(x, ord=ord, dim=axis, keepdim=keepdims)
+
+
+def qr(x, mode="reduced"):
+    if mode not in {"reduced", "complete"}:
+        raise ValueError(
+            "`mode` argument value not supported. "
+            "Expected one of {'reduced', 'complete'}. "
+            f"Received: mode={mode}"
+        )
+    return torch.linalg.qr(x, mode=mode)
 
 def solve(a, b):
-    a = convert_to_tensor(a)
-    b = convert_to_tensor(b)
     return torch.linalg.solve(a, b)
 
 
 def solve_triangular(a, b, lower=False):
-    a = convert_to_tensor(a)
-    b = convert_to_tensor(b)
-    return torch.linalg.solve_triangular(a, b, upper=~lower)
+    if b.ndim == a.ndim - 1:
+        b = torch.unsqueeze(b, axis=-1)
+        return torch.linalg.solve_triangular(a, b, upper=not lower).squeeze(axis=-1)
+    return torch.linalg.solve_triangular(a, b, upper=not lower)
+
+
+def svd(x, full_matrices=True, compute_uv=True):
+    if not compute_uv:
+        raise NotImplementedError("compute_uv=False is not supported for torch backend.")
+    return torch.linalg.svd(x, full_matrices=full_matrices)

--- a/keras/ops/linalg.py
+++ b/keras/ops/linalg.py
@@ -45,7 +45,10 @@ def cholesky(x):
 def _cholesky(x):
     _assert_2d(x)
     _assert_square(x)
-    return backend.linalg.cholesky(x)
+    try:
+        return backend.linalg.cholesky(x)
+    except Exception as e:
+        raise LinalgError("Cholesky decomposition failed: " + str(e))
 
 
 class Det(Operation):
@@ -160,7 +163,7 @@ def _inv(x):
     return backend.linalg.inv(x)
 
 
-class LU(Operation):
+class Lu(Operation):
 
     def __init__(self):
         super().__init__()
@@ -176,11 +179,11 @@ class LU(Operation):
             KerasTensor(x.shape, x.dtype),
             KerasTensor(x.shape[:-1], x.dtype),
         )
-    
+
 
 @keras_export("keras.ops.linalg.lu")
 def lu(x):
-    """Computes the LU decomposition of a square matrix.
+    """Computes the lower-upper decomposition of a square matrix.
 
     Args:
         x: A tensor of shape (..., M, M).
@@ -193,7 +196,7 @@ def lu(x):
 
     """
     if any_symbolic_tensors((x,)):
-        return LU().symbolic_call(x)
+        return Lu().symbolic_call(x)
     return _lu(x)
 
 
@@ -246,7 +249,7 @@ def _solve(a, b):
 
 
 class SVD(Operation):
-    
+
     def __init__(self):
         super().__init__()
 
@@ -260,7 +263,7 @@ class SVD(Operation):
             KerasTensor(x.shape, x.dtype),
             KerasTensor(x.shape, x.dtype),
         )
-    
+
 
 @keras_export("keras.ops.linalg.svd")
 def svd(x):

--- a/keras/ops/linalg.py
+++ b/keras/ops/linalg.py
@@ -3,6 +3,8 @@ from keras.api_export import keras_export
 from keras.backend import KerasTensor
 from keras.backend import any_symbolic_tensors
 from keras.ops.operation import Operation
+from keras.ops.operation_utils import reduce_shape
+
 
 
 class LinalgError(ValueError):
@@ -43,6 +45,7 @@ def cholesky(x):
 
 
 def _cholesky(x):
+    x = backend.convert_to_tensor(x)
     _assert_2d(x)
     _assert_square(x)
     try:
@@ -82,6 +85,7 @@ def det(x):
 
 
 def _det(x):
+    x = backend.convert_to_tensor(x)
     _assert_2d(x)
     _assert_square(x)
     return backend.linalg.det(x)
@@ -122,6 +126,7 @@ def eig(x):
 
 
 def _eig(x):
+    x = backend.convert_to_tensor(x)
     _assert_2d(x)
     _assert_square(x)
     return backend.linalg.eig(x)
@@ -158,52 +163,52 @@ def inv(x):
 
 
 def _inv(x):
+    x = backend.convert_to_tensor(x)
     _assert_2d(x)
     _assert_square(x)
     return backend.linalg.inv(x)
 
 
-class Lu(Operation):
+class LuFactor(Operation):
 
     def __init__(self):
         super().__init__()
 
     def call(self, x):
-        return _lu(x)
+        return _lu_factor(x)
 
     def compute_output_spec(self, x):
         _assert_2d(x)
-        _assert_square(x)
+        batch_shape = x.shape[:-2]
+        m, n = x.shape[-2:]
+        k = min(m, n)
         return (
-            KerasTensor(x.shape, x.dtype),
-            KerasTensor(x.shape, x.dtype),
-            KerasTensor(x.shape[:-1], x.dtype),
+            KerasTensor(batch_shape + (m, n), x.dtype),
+            KerasTensor(batch_shape + (k,), x.dtype),
         )
 
 
-@keras_export("keras.ops.linalg.lu")
-def lu(x):
-    """Computes the lower-upper decomposition of a square matrix.
+@keras_export("keras.ops.linalg.lu_factor")
+def lu_factor(x):
+    """Computes the pivoted lower-upper decomposition of a square matrix.
 
     Args:
         x: A tensor of shape (..., M, M).
 
     Returns:
-        A tuple of three tensors: a tensor of shape (..., M, M) containing the
-        lower triangular matrix, a tensor of shape (..., M, M) containing the
-        upper triangular matrix and a tensor of shape (..., M) containing the
-        permutation indices.
-
+        A tuple of two tensors: a tensor of shape (..., M, M) containing the
+        lower-upper decomposition and a tensor of shape (..., K) containing the
+        pivot indices, with K = min(M, N).
     """
     if any_symbolic_tensors((x,)):
-        return Lu().symbolic_call(x)
-    return _lu(x)
+        return LuFactor().symbolic_call(x)
+    return _lu_factor(x)
 
 
-def _lu(x):
+def _lu_factor(x):
+    x = backend.convert_to_tensor(x)
     _assert_2d(x)
-    _assert_square(x)
-    return backend.linalg.lu(x)
+    return backend.linalg.lu_factor(x)
 
 
 class Norm(Operation):
@@ -391,7 +396,7 @@ def qr(x, mode="reduced"):
            [-0.5070925   0.2760267 ]
            [-0.8451542  -0.34503305]], shape=(3, 2), dtype=float32)
     """
-
+    x = backend.convert_to_tensor(x)
     if any_symbolic_tensors((x,)):
         return Qr(mode=mode).symbolic_call(x)
     return backend.linalg.qr(x, mode=mode)
@@ -441,27 +446,86 @@ def _solve(a, b):
     return backend.linalg.solve(a, b)
 
 
+class SolveTriangular(Operation):
+
+    def __init__(self, lower=False):
+        super().__init__()
+        self.lower = lower
+
+    def call(self, a, b):
+        return _solve_triangular(a, b, self.lower)
+
+    def compute_output_spec(self, a, b):
+        _assert_2d(a)
+        _assert_square(a)
+        _assert_1d(b)
+        _assert_a_b_compat(a, b)
+        return KerasTensor(b.shape, b.dtype)
+
+
+@keras_export("keras.ops.linalg.solve_triangular")
+def solve_triangular(a, b, lower=False):
+    """Solves a linear system of equations given by `a x = b`.
+
+    Args:
+        a: A tensor of shape (..., M, M) representing the coefficients matrix.
+        b: A tensor of shape (..., M) or (..., M, K) represeting the right-hand side or "dependent variable" matrix.
+
+    Returns:
+        A tensor of shape (..., M) or (..., M, K) representing the solution of the
+        linear system. Returned shape is identical to `b`.
+
+    """
+    if any_symbolic_tensors((a, b)):
+        return SolveTriangular(lower).symbolic_call(a, b)
+    return _solve_triangular(a, b, lower)
+
+
+def _solve_triangular(a, b, lower=False):
+    a = backend.convert_to_tensor(a)
+    b = backend.convert_to_tensor(b)
+    _assert_2d(a)
+    _assert_square(a)
+    _assert_1d(b)
+    _assert_a_b_compat(a, b)
+    return backend.linalg.solve_triangular(a, b, lower)
+
+
 
 
 class SVD(Operation):
 
-    def __init__(self):
+    def __init__(self, full_matrices=True, compute_uv=True):
         super().__init__()
+        self.full_matrices = full_matrices
+        self.compute_uv = compute_uv
 
     def call(self, x):
-        return _svd(x)
+        return _svd(x, self.full_matrices, self.compute_uv)
 
     def compute_output_spec(self, x):
         _assert_2d(x)
-        return (
-            KerasTensor(x.shape, x.dtype),
-            KerasTensor(x.shape, x.dtype),
-            KerasTensor(x.shape, x.dtype),
-        )
+        rows, columns = x.shape[-2:]
+        batches = x.shape[:-2]
+        s_shape = batches + (min(rows, columns),)
+        if self.full_matrices:
+            u_shape = batches + (rows, rows)
+            v_shape = batches + (columns, columns)
+        else:
+            u_shape = batches + (rows, min(rows, columns))
+            v_shape = batches + (min(rows, columns), columns)
+
+        if self.compute_uv:
+            return (
+                KerasTensor(u_shape, x.dtype),
+                KerasTensor(s_shape, x.dtype),
+                KerasTensor(v_shape, x.dtype),
+            )
+        return KerasTensor(s_shape, x.dtype)
 
 
 @keras_export("keras.ops.linalg.svd")
-def svd(x):
+def svd(x, full_matrices=True, compute_uv=True):
     """Computes the singular value decomposition of a matrix.
 
     Args:
@@ -475,14 +539,605 @@ def svd(x):
 
     """
     if any_symbolic_tensors((x,)):
-        return SVD().symbolic_call(x)
-    return _svd(x)
+        return SVD(full_matrices, compute_uv).symbolic_call(x)
+    return _svd(x, full_matrices, compute_uv)
 
 
-def _svd(x):
+def _svd(x, full_matrices=True, compute_uv=True):
     x = backend.convert_to_tensor(x)
     _assert_2d(x)
-    return backend.linalg.svd(x)
+    return backend.linalg.svd(x, full_matrices, compute_uv)
+
+
+
+
+def _assert_1d(*arrays):
+    for a in arrays:
+        if a.ndim < 1:
+            raise LinalgError(
+                f"{a.ndim}-dimensional array given. Array must be "
+                "at least one-dimensional"
+            )
+
+
+def _assert_2d(*arrays):
+    for a in arrays:
+        if a.ndim < 2:
+            raise LinalgError(
+                f"{a.ndim}-dimensional array given. Array must be "
+                "at least two-dimensional"
+            )
+
+
+def _assert_square(*arrays):
+    for a in arrays:
+        m, n = a.shape[-2:]
+        if m != n:
+            raise LinalgError("Last 2 dimensions of the array must be square")
+
+
+def _assert_a_b_compat(a, b):
+    if a.ndim == b.ndim:
+        if a.shape[-2] != b.shape[-2]:
+            raise LinalgError(
+                f"Incompatible shapes between `a` {a.shape} and `b` {b.shape}"
+            )
+    elif a.ndim == b.ndim - 1:
+        if a.shape[-1] != b.shape[-1]:
+            raise LinalgError(
+                f"Incompatible shapes between `a` {a.shape} and `b` {b.shape}"
+            )
+from keras import backend
+from keras.api_export import keras_export
+from keras.backend import KerasTensor
+from keras.backend import any_symbolic_tensors
+from keras.ops.operation import Operation
+from keras.ops.operation_utils import reduce_shape
+
+
+
+class LinalgError(ValueError):
+    """Generic exception raised by linalg operations.
+
+    Raised when a linear algebra-related condition prevents the correct
+    execution of the operation.
+    """
+
+
+class Cholesky(Operation):
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return _cholesky(x)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        _assert_square(x)
+        return KerasTensor(x.shape, x.dtype)
+
+
+@keras_export("keras.ops.linalg.cholesky")
+def cholesky(x):
+    """Computes the Cholesky decomposition of a positive semi-definite matrix.
+
+    Args:
+        x: A tensor or variable.
+
+    Returns:
+        A tensor.
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Cholesky().symbolic_call(x)
+    return _cholesky(x)
+
+
+def _cholesky(x):
+    x = backend.convert_to_tensor(x)
+    _assert_2d(x)
+    _assert_square(x)
+    try:
+        return backend.linalg.cholesky(x)
+    except Exception as e:
+        raise LinalgError("Cholesky decomposition failed: " + str(e))
+
+
+class Det(Operation):
+
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return _det(x)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        _assert_square(x)
+        return KerasTensor(x.shape[:-2], x.dtype)
+
+
+@keras_export("keras.ops.linalg.det")
+def det(x):
+    """Computes the determinant of a square tensor.
+
+    Args:
+        x: Input tensor of shape (..., M, M)
+
+    Returns:
+        A tensor of shape (...,) as the determinant of `x`.
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Det().symbolic_call(x)
+    return _det(x)
+
+
+def _det(x):
+    x = backend.convert_to_tensor(x)
+    _assert_2d(x)
+    _assert_square(x)
+    return backend.linalg.det(x)
+
+
+class Eig(Operation):
+
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return _eig(x)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        _assert_square(x)
+        return (
+            KerasTensor(x.shape[:-1], x.dtype),
+            KerasTensor(x.shape, x.dtype),
+        )
+
+
+@keras_export("keras.ops.linalg.eig")
+def eig(x):
+    """Computes the eigenvalues and eigenvectors of a square matrix.
+
+    Args:
+        x: A tensor of shape (..., M, M).
+
+    Returns:
+        A tuple of two tensors: a tensor of shape (..., M) containing the eigenvalues
+        and a tensor of shape (..., M, M) containing the eigenvectors.
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Eig().symbolic_call(x)
+    return _eig(x)
+
+
+def _eig(x):
+    x = backend.convert_to_tensor(x)
+    _assert_2d(x)
+    _assert_square(x)
+    return backend.linalg.eig(x)
+
+
+class Inv(Operation):
+
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return _inv(x)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        _assert_square(x)
+        return KerasTensor(x.shape, x.dtype)
+
+
+@keras_export("keras.ops.linalg.inv")
+def inv(x):
+    """Computes the inverse of a square tensor.
+
+    Args:
+        x: Input tensor of shape (..., M, M).
+
+    Returns:
+        A tensor of shape (..., M, M) representing the inverse of `x`.
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Inv().symbolic_call(x)
+    return _inv(x)
+
+
+def _inv(x):
+    x = backend.convert_to_tensor(x)
+    _assert_2d(x)
+    _assert_square(x)
+    return backend.linalg.inv(x)
+
+
+class LuFactor(Operation):
+
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return _lu_factor(x)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        batch_shape = x.shape[:-2]
+        m, n = x.shape[-2:]
+        k = min(m, n)
+        return (
+            KerasTensor(batch_shape + (m, n), x.dtype),
+            KerasTensor(batch_shape + (k,), x.dtype),
+        )
+
+
+@keras_export("keras.ops.linalg.lu_factor")
+def lu_factor(x):
+    """Computes the lower-upper decomposition of a square matrix.
+
+    Args:
+        x: A tensor of shape (..., M, M).
+
+    Returns:
+        A tuple of three tensors: a tensor of shape (..., M, M) containing the
+        lower triangular matrix, a tensor of shape (..., M, M) containing the
+        upper triangular matrix and a tensor of shape (..., M) containing the
+        permutation indices.
+
+    """
+    if any_symbolic_tensors((x,)):
+        return LuFactor().symbolic_call(x)
+    return _lu(x)
+
+
+def _lu_factor(x):
+    x = backend.convert_to_tensor(x)
+    _assert_2d(x)
+    return backend.linalg.lu_factor(x)
+
+
+class Norm(Operation):
+    def __init__(self, ord=None, axis=None, keepdims=False):
+        super().__init__()
+        if isinstance(ord, str):
+            if ord not in ("fro", "nuc"):
+                raise ValueError(
+                    "Invalid `ord` argument. "
+                    "Expected one of {'fro', 'nuc'} when using string. "
+                    f"Received: ord={ord}"
+                )
+        if isinstance(axis, int):
+            axis = [axis]
+        self.ord = ord
+        self.axis = axis
+        self.keepdims = keepdims
+
+    def compute_output_spec(self, x):
+        output_dtype = backend.standardize_dtype(x.dtype)
+        if "int" in output_dtype or output_dtype == "bool":
+            output_dtype = backend.floatx()
+        if self.axis is None:
+            axis = tuple(range(len(x.shape)))
+        else:
+            axis = self.axis
+        num_axes = len(axis)
+        if num_axes == 1 and isinstance(self.ord, str):
+            raise ValueError(
+                "Invalid `ord` argument for vector norm. "
+                f"Received: ord={self.ord}"
+            )
+        elif num_axes == 2 and self.ord not in (
+            None,
+            "fro",
+            "nuc",
+            float("inf"),
+            float("-inf"),
+            1,
+            -1,
+            2,
+            -2,
+        ):
+            raise ValueError(
+                "Invalid `ord` argument for matrix norm. "
+                f"Received: ord={self.ord}"
+            )
+        return KerasTensor(
+            reduce_shape(x.shape, axis=self.axis, keepdims=self.keepdims),
+            dtype=output_dtype,
+        )
+
+    def call(self, x):
+        x = backend.convert_to_tensor(x)
+        return backend.linalg.norm(
+            x, ord=self.ord, axis=self.axis, keepdims=self.keepdims
+        )
+
+
+@keras_export("keras.ops.linalg.norm")
+def norm(x, ord=None, axis=None, keepdims=False):
+    """Matrix or vector norm.
+
+    This function is able to return one of eight different matrix norms, or one
+    of an infinite number of vector norms (described below), depending on the
+    value of the `ord` parameter.
+
+    Args:
+        x: Input tensor.
+        ord: Order of the norm (see table under Notes). The default is `None`.
+        axis: If `axis` is an integer, it specifies the axis of `x` along which
+            to compute the vector norms. If `axis` is a 2-tuple, it specifies
+            the axes that hold 2-D matrices, and the matrix norms of these
+            matrices are computed.
+        keepdims: If this is set to `True`, the axes which are reduced are left
+            in the result as dimensions with size one.
+
+    Note:
+        For values of `ord < 1`, the result is, strictly speaking, not a
+        mathematical 'norm', but it may still be useful for various numerical
+        purposes. The following norms can be calculated:
+        - For matrices:
+            - `ord=None`: Frobenius norm
+            - `ord="fro"`: Frobenius norm
+            - `ord=nuc`: nuclear norm
+            - `ord=np.inf`: `max(sum(abs(x), axis=1))`
+            - `ord=-np.inf`: `min(sum(abs(x), axis=1))`
+            - `ord=0`: not supported
+            - `ord=1`: `max(sum(abs(x), axis=0))`
+            - `ord=-1`: `min(sum(abs(x), axis=0))`
+            - `ord=2`: 2-norm (largest sing. value)
+            - `ord=-2`: smallest singular value
+            - other: not supported
+        - For vectors:
+            - `ord=None`: 2-norm
+            - `ord="fro"`: not supported
+            - `ord=nuc`: not supported
+            - `ord=np.inf`: `max(abs(x))`
+            - `ord=-np.inf`: `min(abs(x))`
+            - `ord=0`: `sum(x != 0)`
+            - `ord=1`: as below
+            - `ord=-1`: as below
+            - `ord=2`: as below
+            - `ord=-2`: as below
+            - other: `sum(abs(x)**ord)**(1./ord)`
+
+    Returns:
+        Norm of the matrix or vector(s).
+
+    Example:
+
+    >>> x = keras.ops.reshape(keras.ops.arange(9, dtype="float32") - 4, (3, 3))
+    >>> keras.ops.linalg.norm(x)
+    7.7459664
+    """
+    if any_symbolic_tensors((x,)):
+        return Norm(ord=ord, axis=axis, keepdims=keepdims).symbolic_call(x)
+    x = backend.convert_to_tensor(x)
+    return backend.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+
+
+class Qr(Operation):
+    def __init__(self, mode="reduced"):
+        super().__init__()
+        if mode not in {"reduced", "complete"}:
+            raise ValueError(
+                "`mode` argument value not supported. "
+                "Expected one of {'reduced', 'complete'}. "
+                f"Received: mode={mode}"
+            )
+        self.mode = mode
+
+    def compute_output_spec(self, x):
+        if len(x.shape) < 2:
+            raise ValueError(
+                "Input should have rank >= 2. Received: "
+                f"input.shape = {x.shape}"
+            )
+        m = x.shape[-2]
+        n = x.shape[-1]
+        if m is None or n is None:
+            raise ValueError(
+                "Input should have its last 2 dimensions "
+                "fully-defined. Received: "
+                f"input.shape = {x.shape}"
+            )
+        k = min(m, n)
+        base = tuple(x.shape[:-2])
+        if self.mode == "reduced":
+            return (
+                KerasTensor(shape=base + (m, k), dtype=x.dtype),
+                KerasTensor(shape=base + (k, n), dtype=x.dtype),
+            )
+        # 'complete' mode.
+        return (
+            KerasTensor(shape=base + (m, m), dtype=x.dtype),
+            KerasTensor(shape=base + (m, n), dtype=x.dtype),
+        )
+
+    def call(self, x):
+        return backend.linalg.qr(x, mode=self.mode)
+
+
+@keras_export("keras.ops.linalg.qr")
+def qr(x, mode="reduced"):
+    """Computes the QR decomposition of a tensor.
+
+    Args:
+        x: Input tensor.
+        mode: A string specifying the mode of the QR decomposition.
+            - 'reduced': Returns the reduced QR decomposition. (default)
+            - 'complete': Returns the complete QR decomposition.
+
+    Returns:
+        A tuple containing two tensors. The first tensor represents the
+        orthogonal matrix Q, and the second tensor represents the upper
+        triangular matrix R.
+
+    Example:
+
+    >>> x = keras.ops.convert_to_tensor([[1., 2.], [3., 4.], [5., 6.]])
+    >>> q, r = qr(x)
+    >>> print(q)
+    array([[-0.16903079  0.897085]
+           [-0.5070925   0.2760267 ]
+           [-0.8451542  -0.34503305]], shape=(3, 2), dtype=float32)
+    """
+    if any_symbolic_tensors((x,)):
+        return Qr(mode=mode).symbolic_call(x)
+    x = backend.convert_to_tensor(x)
+    return backend.linalg.qr(x, mode=mode)
+
+
+class Solve(Operation):
+
+    def __init__(self):
+        super().__init__()
+
+    def call(self, a, b):
+        return _solve(a, b)
+
+    def compute_output_spec(self, a, b):
+        _assert_2d(a)
+        _assert_square(a)
+        _assert_1d(b)
+        _assert_a_b_compat(a, b)
+        return KerasTensor(b.shape, b.dtype)
+
+
+@keras_export("keras.ops.linalg.solve")
+def solve(a, b):
+    """Solves a linear system of equations given by `a x = b`.
+
+    Args:
+        a: A tensor of shape (..., M, M) representing the coefficients matrix.
+        b: A tensor of shape (..., M) or (..., M, K) represeting the right-hand side or "dependent variable" matrix.
+
+    Returns:
+        A tensor of shape (..., M) or (..., M, K) representing the solution of the
+        linear system. Returned shape is identical to `b`.
+
+    """
+    if any_symbolic_tensors((a, b)):
+        return Solve().symbolic_call(a, b)
+    return _solve(a, b)
+
+
+def _solve(a, b):
+    a = backend.convert_to_tensor(a)
+    b = backend.convert_to_tensor(b)
+    _assert_2d(a)
+    _assert_square(a)
+    _assert_1d(b)
+    _assert_a_b_compat(a, b)
+    return backend.linalg.solve(a, b)
+
+
+class SolveTriangular(Operation):
+
+    def __init__(self, lower=False):
+        super().__init__()
+        self.lower = lower
+
+    def call(self, a, b):
+        return _solve_triangular(a, b, self.lower)
+
+    def compute_output_spec(self, a, b):
+        _assert_2d(a)
+        _assert_square(a)
+        _assert_1d(b)
+        _assert_a_b_compat(a, b)
+        return KerasTensor(b.shape, b.dtype)
+
+
+@keras_export("keras.ops.linalg.solve_triangular")
+def solve_triangular(a, b, lower=False):
+    """Solves a linear system of equations given by `a x = b`.
+
+    Args:
+        a: A tensor of shape (..., M, M) representing the coefficients matrix.
+        b: A tensor of shape (..., M) or (..., M, K) represeting the right-hand side or "dependent variable" matrix.
+
+    Returns:
+        A tensor of shape (..., M) or (..., M, K) representing the solution of the
+        linear system. Returned shape is identical to `b`.
+
+    """
+    if any_symbolic_tensors((a, b)):
+        return SolveTriangular(lower).symbolic_call(a, b)
+    return _solve_triangular(a, b, lower)
+
+
+def _solve_triangular(a, b, lower=False):
+    a = backend.convert_to_tensor(a)
+    b = backend.convert_to_tensor(b)
+    _assert_2d(a)
+    _assert_square(a)
+    _assert_1d(b)
+    _assert_a_b_compat(a, b)
+    return backend.linalg.solve_triangular(a, b, lower)
+
+
+
+
+class SVD(Operation):
+
+    def __init__(self, full_matrices=True, compute_uv=True):
+        super().__init__()
+        self.full_matrices = full_matrices
+        self.compute_uv = compute_uv
+
+    def call(self, x):
+        return _svd(x, self.full_matrices, self.compute_uv)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        rows, columns = x.shape[-2:]
+        batches = x.shape[:-2]
+        s_shape = batches + (min(rows, columns),)
+        if self.full_matrices:
+            u_shape = batches + (rows, rows)
+            v_shape = batches + (columns, columns)
+        else:
+            u_shape = batches + (rows, min(rows, columns))
+            v_shape = batches + (min(rows, columns), columns)
+
+        if self.compute_uv:
+            return (
+                KerasTensor(u_shape, x.dtype),
+                KerasTensor(s_shape, x.dtype),
+                KerasTensor(v_shape, x.dtype),
+            )
+        return KerasTensor(s_shape, x.dtype)
+
+
+@keras_export("keras.ops.linalg.svd")
+def svd(x, full_matrices=True, compute_uv=True):
+    """Computes the singular value decomposition of a matrix.
+
+    Args:
+        x: A tensor of shape (..., M, N).
+
+    Returns:
+        A tuple of three tensors: a tensor of shape (..., M, M) containing the
+        left singular vectors, a tensor of shape (..., M, N) containing the
+        singular values and a tensor of shape (..., N, N) containing the
+        right singular vectors.
+
+    """
+    if any_symbolic_tensors((x,)):
+        return SVD(full_matrices, compute_uv).symbolic_call(x)
+    return _svd(x, full_matrices, compute_uv)
+
+
+def _svd(x, full_matrices=True, compute_uv=True):
+    x = backend.convert_to_tensor(x)
+    _assert_2d(x)
+    return backend.linalg.svd(x, full_matrices, compute_uv)
 
 
 

--- a/keras/ops/linalg.py
+++ b/keras/ops/linalg.py
@@ -38,6 +38,8 @@ def cholesky(x):
     Returns:
         A tensor.
 
+    Raises:
+        LinalgError: If `x` is not at least 2d or is not square.
     """
     if any_symbolic_tensors((x,)):
         return Cholesky().symbolic_call(x)
@@ -77,6 +79,9 @@ def det(x):
 
     Returns:
         A tensor of shape (...,) as the determinant of `x`.
+
+    Raises:
+        LinalgError: If `x` is not at least 2d or is not square.
 
     """
     if any_symbolic_tensors((x,)):
@@ -119,6 +124,8 @@ def eig(x):
         A tuple of two tensors: a tensor of shape (..., M) containing the eigenvalues
         and a tensor of shape (..., M, M) containing the eigenvectors.
 
+    Raises:
+        LinalgError: If `x` is not at least 2d or is not square.
     """
     if any_symbolic_tensors((x,)):
         return Eig().symbolic_call(x)
@@ -155,6 +162,9 @@ def inv(x):
 
     Returns:
         A tensor of shape (..., M, M) representing the inverse of `x`.
+
+    Raises:
+        LinalgError: If `x` is not at least 2d or is not square.
 
     """
     if any_symbolic_tensors((x,)):
@@ -193,12 +203,15 @@ def lu_factor(x):
     """Computes the pivoted lower-upper decomposition of a square matrix.
 
     Args:
-        x: A tensor of shape (..., M, M).
+        x: A tensor of shape (..., M, N).
 
     Returns:
-        A tuple of two tensors: a tensor of shape (..., M, M) containing the
+        A tuple of two tensors: a tensor of shape (..., M, N) containing the
         lower-upper decomposition and a tensor of shape (..., K) containing the
         pivot indices, with K = min(M, N).
+
+    Raises:
+        LinalgError: If `x` is not at least 2d.
     """
     if any_symbolic_tensors((x,)):
         return LuFactor().symbolic_call(x)
@@ -438,6 +451,10 @@ def solve(a, b):
         A tensor of shape (..., M) or (..., M, K) representing the solution of the
         linear system. Returned shape is identical to `b`.
 
+    Raises:
+        LinalgError: If `a` or `b` are not at least 2d, `a` is not square or
+            the last dimension of `a` and `b` are incompatible.
+
     """
     if any_symbolic_tensors((a, b)):
         return Solve().symbolic_call(a, b)
@@ -483,6 +500,9 @@ def solve_triangular(a, b, lower=False):
         A tensor of shape (..., M) or (..., M, K) representing the solution of the
         linear system. Returned shape is identical to `b`.
 
+    Raises:
+        LinalgError: If `a` or `b` are not at least 2d, `a` is not square or
+            the last dimension of `a` and `b` are incompatible.
     """
     if any_symbolic_tensors((a, b)):
         return SolveTriangular(lower).symbolic_call(a, b)
@@ -545,6 +565,8 @@ def svd(x, full_matrices=True, compute_uv=True):
         singular values and a tensor of shape (..., N, N) containing the
         right singular vectors.
 
+    Raises:
+        LinalgError: If `x` is not at least 2d.
     """
     if any_symbolic_tensors((x,)):
         return SVD(full_matrices, compute_uv).symbolic_call(x)

--- a/keras/ops/linalg.py
+++ b/keras/ops/linalg.py
@@ -208,6 +208,14 @@ def lu_factor(x):
 def _lu_factor(x):
     x = backend.convert_to_tensor(x)
     _assert_2d(x)
+    if backend.backend() == "tensorflow":
+        try:
+            _assert_square(x)
+        except LinalgError as e:
+            raise LinalgError(
+                "LU decomposition failed: " + str(e) + ". "
+                "LU decomposition is only supported for square matrices in TensorFlow."
+            )
     return backend.linalg.lu_factor(x)
 
 
@@ -793,12 +801,20 @@ def lu_factor(x):
     """
     if any_symbolic_tensors((x,)):
         return LuFactor().symbolic_call(x)
-    return _lu(x)
+    return _lu_factor(x)
 
 
 def _lu_factor(x):
     x = backend.convert_to_tensor(x)
     _assert_2d(x)
+    if backend.backend() == "tensorflow":
+        try:
+            _assert_square(x)
+        except LinalgError as e:
+            raise LinalgError(
+                "LU decomposition failed: " + str(e) + ". "
+                "LU decomposition is only supported for square matrices in TensorFlow."
+            )
     return backend.linalg.lu_factor(x)
 
 

--- a/keras/ops/linalg.py
+++ b/keras/ops/linalg.py
@@ -211,7 +211,8 @@ def lu_factor(x):
         pivot indices, with K = min(M, N).
 
     Raises:
-        LinalgError: If `x` is not at least 2d.
+        LinalgError: If `x` is not at least 2d or (with tensorflow backend)
+            is not square.
     """
     if any_symbolic_tensors((x,)):
         return LuFactor().symbolic_call(x)

--- a/keras/ops/linalg.py
+++ b/keras/ops/linalg.py
@@ -6,7 +6,6 @@ from keras.ops.operation import Operation
 from keras.ops.operation_utils import reduce_shape
 
 
-
 class LinalgError(ValueError):
     """Generic exception raised by linalg operations.
 
@@ -520,8 +519,6 @@ def _solve_triangular(a, b, lower=False):
     return backend.linalg.solve_triangular(a, b, lower)
 
 
-
-
 class SVD(Operation):
 
     def __init__(self, full_matrices=True, compute_uv=True):
@@ -580,8 +577,6 @@ def _svd(x, full_matrices=True, compute_uv=True):
     return backend.linalg.svd(x, full_matrices, compute_uv)
 
 
-
-
 def _assert_1d(*arrays):
     for a in arrays:
         if a.ndim < 1:
@@ -618,13 +613,14 @@ def _assert_a_b_compat(a, b):
             raise LinalgError(
                 f"Incompatible shapes between `a` {a.shape} and `b` {b.shape}"
             )
+
+
 from keras import backend
 from keras.api_export import keras_export
 from keras.backend import KerasTensor
 from keras.backend import any_symbolic_tensors
 from keras.ops.operation import Operation
 from keras.ops.operation_utils import reduce_shape
-
 
 
 class LinalgError(ValueError):
@@ -1121,8 +1117,6 @@ def _solve_triangular(a, b, lower=False):
     return backend.linalg.solve_triangular(a, b, lower)
 
 
-
-
 class SVD(Operation):
 
     def __init__(self, full_matrices=True, compute_uv=True):
@@ -1177,8 +1171,6 @@ def _svd(x, full_matrices=True, compute_uv=True):
     x = backend.convert_to_tensor(x)
     _assert_2d(x)
     return backend.linalg.svd(x, full_matrices, compute_uv)
-
-
 
 
 def _assert_1d(*arrays):

--- a/keras/ops/linalg.py
+++ b/keras/ops/linalg.py
@@ -206,6 +206,197 @@ def _lu(x):
     return backend.linalg.lu(x)
 
 
+class Norm(Operation):
+    def __init__(self, ord=None, axis=None, keepdims=False):
+        super().__init__()
+        if isinstance(ord, str):
+            if ord not in ("fro", "nuc"):
+                raise ValueError(
+                    "Invalid `ord` argument. "
+                    "Expected one of {'fro', 'nuc'} when using string. "
+                    f"Received: ord={ord}"
+                )
+        if isinstance(axis, int):
+            axis = [axis]
+        self.ord = ord
+        self.axis = axis
+        self.keepdims = keepdims
+
+    def compute_output_spec(self, x):
+        output_dtype = backend.standardize_dtype(x.dtype)
+        if "int" in output_dtype or output_dtype == "bool":
+            output_dtype = backend.floatx()
+        if self.axis is None:
+            axis = tuple(range(len(x.shape)))
+        else:
+            axis = self.axis
+        num_axes = len(axis)
+        if num_axes == 1 and isinstance(self.ord, str):
+            raise ValueError(
+                "Invalid `ord` argument for vector norm. "
+                f"Received: ord={self.ord}"
+            )
+        elif num_axes == 2 and self.ord not in (
+            None,
+            "fro",
+            "nuc",
+            float("inf"),
+            float("-inf"),
+            1,
+            -1,
+            2,
+            -2,
+        ):
+            raise ValueError(
+                "Invalid `ord` argument for matrix norm. "
+                f"Received: ord={self.ord}"
+            )
+        return KerasTensor(
+            reduce_shape(x.shape, axis=self.axis, keepdims=self.keepdims),
+            dtype=output_dtype,
+        )
+
+    def call(self, x):
+        x = backend.convert_to_tensor(x)
+        return backend.linalg.norm(
+            x, ord=self.ord, axis=self.axis, keepdims=self.keepdims
+        )
+
+
+@keras_export("keras.ops.linalg.norm")
+def norm(x, ord=None, axis=None, keepdims=False):
+    """Matrix or vector norm.
+
+    This function is able to return one of eight different matrix norms, or one
+    of an infinite number of vector norms (described below), depending on the
+    value of the `ord` parameter.
+
+    Args:
+        x: Input tensor.
+        ord: Order of the norm (see table under Notes). The default is `None`.
+        axis: If `axis` is an integer, it specifies the axis of `x` along which
+            to compute the vector norms. If `axis` is a 2-tuple, it specifies
+            the axes that hold 2-D matrices, and the matrix norms of these
+            matrices are computed.
+        keepdims: If this is set to `True`, the axes which are reduced are left
+            in the result as dimensions with size one.
+
+    Note:
+        For values of `ord < 1`, the result is, strictly speaking, not a
+        mathematical 'norm', but it may still be useful for various numerical
+        purposes. The following norms can be calculated:
+        - For matrices:
+            - `ord=None`: Frobenius norm
+            - `ord="fro"`: Frobenius norm
+            - `ord=nuc`: nuclear norm
+            - `ord=np.inf`: `max(sum(abs(x), axis=1))`
+            - `ord=-np.inf`: `min(sum(abs(x), axis=1))`
+            - `ord=0`: not supported
+            - `ord=1`: `max(sum(abs(x), axis=0))`
+            - `ord=-1`: `min(sum(abs(x), axis=0))`
+            - `ord=2`: 2-norm (largest sing. value)
+            - `ord=-2`: smallest singular value
+            - other: not supported
+        - For vectors:
+            - `ord=None`: 2-norm
+            - `ord="fro"`: not supported
+            - `ord=nuc`: not supported
+            - `ord=np.inf`: `max(abs(x))`
+            - `ord=-np.inf`: `min(abs(x))`
+            - `ord=0`: `sum(x != 0)`
+            - `ord=1`: as below
+            - `ord=-1`: as below
+            - `ord=2`: as below
+            - `ord=-2`: as below
+            - other: `sum(abs(x)**ord)**(1./ord)`
+
+    Returns:
+        Norm of the matrix or vector(s).
+
+    Example:
+
+    >>> x = keras.ops.reshape(keras.ops.arange(9, dtype="float32") - 4, (3, 3))
+    >>> keras.ops.linalg.norm(x)
+    7.7459664
+    """
+    if any_symbolic_tensors((x,)):
+        return Norm(ord=ord, axis=axis, keepdims=keepdims).symbolic_call(x)
+    x = backend.convert_to_tensor(x)
+    return backend.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+
+
+class Qr(Operation):
+    def __init__(self, mode="reduced"):
+        super().__init__()
+        if mode not in {"reduced", "complete"}:
+            raise ValueError(
+                "`mode` argument value not supported. "
+                "Expected one of {'reduced', 'complete'}. "
+                f"Received: mode={mode}"
+            )
+        self.mode = mode
+
+    def compute_output_spec(self, x):
+        if len(x.shape) < 2:
+            raise ValueError(
+                "Input should have rank >= 2. Received: "
+                f"input.shape = {x.shape}"
+            )
+        m = x.shape[-2]
+        n = x.shape[-1]
+        if m is None or n is None:
+            raise ValueError(
+                "Input should have its last 2 dimensions "
+                "fully-defined. Received: "
+                f"input.shape = {x.shape}"
+            )
+        k = min(m, n)
+        base = tuple(x.shape[:-2])
+        if self.mode == "reduced":
+            return (
+                KerasTensor(shape=base + (m, k), dtype=x.dtype),
+                KerasTensor(shape=base + (k, n), dtype=x.dtype),
+            )
+        # 'complete' mode.
+        return (
+            KerasTensor(shape=base + (m, m), dtype=x.dtype),
+            KerasTensor(shape=base + (m, n), dtype=x.dtype),
+        )
+
+    def call(self, x):
+        return backend.linalg.qr(x, mode=self.mode)
+
+
+@keras_export("keras.ops.linalg.qr")
+def qr(x, mode="reduced"):
+    """Computes the QR decomposition of a tensor.
+
+    Args:
+        x: Input tensor.
+        mode: A string specifying the mode of the QR decomposition.
+            - 'reduced': Returns the reduced QR decomposition. (default)
+            - 'complete': Returns the complete QR decomposition.
+
+    Returns:
+        A tuple containing two tensors. The first tensor represents the
+        orthogonal matrix Q, and the second tensor represents the upper
+        triangular matrix R.
+
+    Example:
+
+    >>> x = keras.ops.convert_to_tensor([[1., 2.], [3., 4.], [5., 6.]])
+    >>> q, r = qr(x)
+    >>> print(q)
+    array([[-0.16903079  0.897085]
+           [-0.5070925   0.2760267 ]
+           [-0.8451542  -0.34503305]], shape=(3, 2), dtype=float32)
+    """
+
+    if any_symbolic_tensors((x,)):
+        return Qr(mode=mode).symbolic_call(x)
+    return backend.linalg.qr(x, mode=mode)
+
+
 class Solve(Operation):
 
     def __init__(self):
@@ -241,11 +432,15 @@ def solve(a, b):
 
 
 def _solve(a, b):
+    a = backend.convert_to_tensor(a)
+    b = backend.convert_to_tensor(b)
     _assert_2d(a)
     _assert_square(a)
     _assert_1d(b)
     _assert_a_b_compat(a, b)
     return backend.linalg.solve(a, b)
+
+
 
 
 class SVD(Operation):
@@ -285,8 +480,11 @@ def svd(x):
 
 
 def _svd(x):
+    x = backend.convert_to_tensor(x)
     _assert_2d(x)
     return backend.linalg.svd(x)
+
+
 
 
 def _assert_1d(*arrays):

--- a/keras/ops/linalg.py
+++ b/keras/ops/linalg.py
@@ -1,0 +1,324 @@
+from keras import backend
+from keras.api_export import keras_export
+from keras.backend import KerasTensor
+from keras.backend import any_symbolic_tensors
+from keras.ops.operation import Operation
+
+
+class LinalgError(ValueError):
+    """Generic exception raised by linalg operations.
+
+    Raised when a linear algebra-related condition prevents the correct
+    execution of the operation.
+    """
+
+
+class Cholesky(Operation):
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return _cholesky(x)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        _assert_square(x)
+        return KerasTensor(x.shape, x.dtype)
+
+
+@keras_export("keras.ops.linalg.cholesky")
+def cholesky(x):
+    """Computes the Cholesky decomposition of a positive semi-definite matrix.
+
+    Args:
+        x: A tensor or variable.
+
+    Returns:
+        A tensor.
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Cholesky().symbolic_call(x)
+    return _cholesky(x)
+
+
+def _cholesky(x):
+    _assert_2d(x)
+    _assert_square(x)
+    return backend.linalg.cholesky(x)
+
+
+class Det(Operation):
+
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return _det(x)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        _assert_square(x)
+        return KerasTensor(x.shape[:-2], x.dtype)
+
+
+@keras_export("keras.ops.linalg.det")
+def det(x):
+    """Computes the determinant of a square tensor.
+
+    Args:
+        x: Input tensor of shape (..., M, M)
+
+    Returns:
+        A tensor of shape (...,) as the determinant of `x`.
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Det().symbolic_call(x)
+    return _det(x)
+
+
+def _det(x):
+    _assert_2d(x)
+    _assert_square(x)
+    return backend.linalg.det(x)
+
+
+class Eig(Operation):
+
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return _eig(x)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        _assert_square(x)
+        return (
+            KerasTensor(x.shape[:-1], x.dtype),
+            KerasTensor(x.shape, x.dtype),
+        )
+
+
+@keras_export("keras.ops.linalg.eig")
+def eig(x):
+    """Computes the eigenvalues and eigenvectors of a square matrix.
+
+    Args:
+        x: A tensor of shape (..., M, M).
+
+    Returns:
+        A tuple of two tensors: a tensor of shape (..., M) containing the eigenvalues
+        and a tensor of shape (..., M, M) containing the eigenvectors.
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Eig().symbolic_call(x)
+    return _eig(x)
+
+
+def _eig(x):
+    _assert_2d(x)
+    _assert_square(x)
+    return backend.linalg.eig(x)
+
+
+class Inv(Operation):
+
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return _inv(x)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        _assert_square(x)
+        return KerasTensor(x.shape, x.dtype)
+
+
+@keras_export("keras.ops.linalg.inv")
+def inv(x):
+    """Computes the inverse of a square tensor.
+
+    Args:
+        x: Input tensor of shape (..., M, M).
+
+    Returns:
+        A tensor of shape (..., M, M) representing the inverse of `x`.
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Inv().symbolic_call(x)
+    return _inv(x)
+
+
+def _inv(x):
+    _assert_2d(x)
+    _assert_square(x)
+    return backend.linalg.inv(x)
+
+
+class LU(Operation):
+
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return _lu(x)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        _assert_square(x)
+        return (
+            KerasTensor(x.shape, x.dtype),
+            KerasTensor(x.shape, x.dtype),
+            KerasTensor(x.shape[:-1], x.dtype),
+        )
+    
+
+@keras_export("keras.ops.linalg.lu")
+def lu(x):
+    """Computes the LU decomposition of a square matrix.
+
+    Args:
+        x: A tensor of shape (..., M, M).
+
+    Returns:
+        A tuple of three tensors: a tensor of shape (..., M, M) containing the
+        lower triangular matrix, a tensor of shape (..., M, M) containing the
+        upper triangular matrix and a tensor of shape (..., M) containing the
+        permutation indices.
+
+    """
+    if any_symbolic_tensors((x,)):
+        return LU().symbolic_call(x)
+    return _lu(x)
+
+
+def _lu(x):
+    _assert_2d(x)
+    _assert_square(x)
+    return backend.linalg.lu(x)
+
+
+class Solve(Operation):
+
+    def __init__(self):
+        super().__init__()
+
+    def call(self, a, b):
+        return _solve(a, b)
+
+    def compute_output_spec(self, a, b):
+        _assert_2d(a)
+        _assert_square(a)
+        _assert_1d(b)
+        _assert_a_b_compat(a, b)
+        return KerasTensor(b.shape, b.dtype)
+
+
+@keras_export("keras.ops.linalg.solve")
+def solve(a, b):
+    """Solves a linear system of equations given by `a x = b`.
+
+    Args:
+        a: A tensor of shape (..., M, M) representing the coefficients matrix.
+        b: A tensor of shape (..., M) or (..., M, K) represeting the right-hand side or "dependent variable" matrix.
+
+    Returns:
+        A tensor of shape (..., M) or (..., M, K) representing the solution of the
+        linear system. Returned shape is identical to `b`.
+
+    """
+    if any_symbolic_tensors((a, b)):
+        return Solve().symbolic_call(a, b)
+    return _solve(a, b)
+
+
+def _solve(a, b):
+    _assert_2d(a)
+    _assert_square(a)
+    _assert_1d(b)
+    _assert_a_b_compat(a, b)
+    return backend.linalg.solve(a, b)
+
+
+class SVD(Operation):
+    
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return _svd(x)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        return (
+            KerasTensor(x.shape, x.dtype),
+            KerasTensor(x.shape, x.dtype),
+            KerasTensor(x.shape, x.dtype),
+        )
+    
+
+@keras_export("keras.ops.linalg.svd")
+def svd(x):
+    """Computes the singular value decomposition of a matrix.
+
+    Args:
+        x: A tensor of shape (..., M, N).
+
+    Returns:
+        A tuple of three tensors: a tensor of shape (..., M, M) containing the
+        left singular vectors, a tensor of shape (..., M, N) containing the
+        singular values and a tensor of shape (..., N, N) containing the
+        right singular vectors.
+
+    """
+    if any_symbolic_tensors((x,)):
+        return SVD().symbolic_call(x)
+    return _svd(x)
+
+
+def _svd(x):
+    _assert_2d(x)
+    return backend.linalg.svd(x)
+
+
+def _assert_1d(*arrays):
+    for a in arrays:
+        if a.ndim < 1:
+            raise LinalgError(
+                f"{a.ndim}-dimensional array given. Array must be "
+                "at least one-dimensional"
+            )
+
+
+def _assert_2d(*arrays):
+    for a in arrays:
+        if a.ndim < 2:
+            raise LinalgError(
+                f"{a.ndim}-dimensional array given. Array must be "
+                "at least two-dimensional"
+            )
+
+
+def _assert_square(*arrays):
+    for a in arrays:
+        m, n = a.shape[-2:]
+        if m != n:
+            raise LinalgError("Last 2 dimensions of the array must be square")
+
+
+def _assert_a_b_compat(a, b):
+    if a.ndim == b.ndim:
+        if a.shape[-2] != b.shape[-2]:
+            raise LinalgError(
+                f"Incompatible shapes between `a` {a.shape} and `b` {b.shape}"
+            )
+    elif a.ndim == b.ndim - 1:
+        if a.shape[-1] != b.shape[-1]:
+            raise LinalgError(
+                f"Incompatible shapes between `a` {a.shape} and `b` {b.shape}"
+            )

--- a/keras/ops/linalg_test.py
+++ b/keras/ops/linalg_test.py
@@ -1,15 +1,10 @@
-import math
 
 import numpy as np
-import pytest
-import scipy.signal
 from absl.testing import parameterized
 
 from keras import backend
 from keras import testing
-from keras.backend.common import standardize_dtype
 from keras.backend.common.keras_tensor import KerasTensor
-from keras.backend.common.variables import ALLOWED_DTYPES
 from keras.ops import linalg
 from keras.testing.test_utils import named_product
 
@@ -41,6 +36,20 @@ class LinalgOpsDynamicShapeTest(testing.TestCase):
         with self.assertRaises(ValueError):
             linalg.det(x)
 
+    def test_eig(self):
+        x = KerasTensor([None, 20, 20])
+        w, v = linalg.eig(x)
+        self.assertEqual(w.shape, (None, 20))
+        self.assertEqual(v.shape, (None, 20, 20))
+
+        x = KerasTensor([None, None, 20])
+        with self.assertRaises(linalg.LinalgError):
+            linalg.eig(x)
+
+        x = KerasTensor([None, 20, 15])
+        with self.assertRaises(linalg.LinalgError):
+            linalg.eig(x)
+
     def test_inv(self):
         x = KerasTensor([None, 20, 20])
         out = linalg.inv(x)
@@ -53,6 +62,47 @@ class LinalgOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor([None, 20, 15])
         with self.assertRaises(ValueError):
             linalg.inv(x)
+
+
+    def test_lu_factor(self):
+        x = KerasTensor([None, 4, 3])
+        lu, p = linalg.lu_factor(x)
+        self.assertEqual(lu.shape, (None, 4, 3))
+        self.assertEqual(p.shape, (None, 3))
+
+        x = KerasTensor([None, 2, 3])
+        lu, p = linalg.lu_factor(x)
+        self.assertEqual(lu.shape, (None, 2, 3))
+        self.assertEqual(p.shape, (None, 2))
+
+
+    def test_norm(self):
+        x = KerasTensor((None, 3))
+        self.assertEqual(linalg.norm(x).shape, ())
+
+        x = KerasTensor((None, 3, 3))
+        self.assertEqual(linalg.norm(x, axis=1).shape, (None, 3))
+        self.assertEqual(
+            linalg.norm(x, axis=1, keepdims=True).shape, (None, 1, 3)
+        )
+
+
+    def test_qr(self):
+        x = KerasTensor((None, 4, 3), dtype="float32")
+        q, r = linalg.qr(x, mode="reduced")
+        qref, rref = np.linalg.qr(np.ones((2, 4, 3)), mode="reduced")
+        qref_shape = (None,) + qref.shape[1:]
+        rref_shape = (None,) + rref.shape[1:]
+        self.assertEqual(q.shape, qref_shape)
+        self.assertEqual(r.shape, rref_shape)
+
+        q, r = linalg.qr(x, mode="complete")
+        qref, rref = np.linalg.qr(np.ones((2, 4, 3)), mode="complete")
+        qref_shape = (None,) + qref.shape[1:]
+        rref_shape = (None,) + rref.shape[1:]
+        self.assertEqual(q.shape, qref_shape)
+        self.assertEqual(r.shape, rref_shape)
+
 
     def test_solve(self):
         a = KerasTensor([None, 20, 20])
@@ -80,45 +130,140 @@ class LinalgOpsDynamicShapeTest(testing.TestCase):
         with self.assertRaises(ValueError):
             linalg.solve(a, b)
 
+    def test_solve_triangular(self):
+        a = KerasTensor([None, 20, 20])
+        b = KerasTensor([None, 20, 5])
+        out = linalg.solve_triangular(a, b)
+        self.assertEqual(out.shape, (None, 20, 5))
+
+        a = KerasTensor([None, 20, 20])
+        b = KerasTensor([None, 20])
+        out = linalg.solve_triangular(a, b)
+        self.assertEqual(out.shape, (None, 20))
+
+        a = KerasTensor([None, 20, 20])
+        b = KerasTensor([None, 20, 5])
+        out = linalg.solve_triangular(a, b, lower=True)
+        self.assertEqual(out.shape, (None, 20, 5))
+
+        a = KerasTensor([None, 20, 20])
+        b = KerasTensor([None, 20])
+        out = linalg.solve_triangular(a, b, lower=True)
+        self.assertEqual(out.shape, (None, 20))
+
+        a = KerasTensor([None, 20, 15])
+        b = KerasTensor([None, 20, 5])
+        with self.assertRaises(linalg.LinalgError):
+            linalg.solve_triangular(a, b)
+
+        a = KerasTensor([None, 20, 20])
+        b = KerasTensor([None, None, 5])
+        with self.assertRaises(linalg.LinalgError):
+            linalg.solve_triangular(a, b)
+
+
+    def test_svd(self):
+        x = KerasTensor((None, 3, 2))
+        u, s, v = linalg.svd(x)
+        self.assertEqual(u.shape, (None, 3, 3))
+        self.assertEqual(s.shape, (None, 2))
+        self.assertEqual(v.shape, (None, 2, 2))
+
+        u, s, v = linalg.svd(x, full_matrices=False)
+        self.assertEqual(u.shape, (None, 3, 2))
+        self.assertEqual(s.shape, (None, 2))
+        self.assertEqual(v.shape, (None, 2, 2))
+
+        s = linalg.svd(x, compute_uv=False)
+        self.assertEqual(s.shape, (None, 2))
+
 
 class LinalgOpsStaticShapeTest(testing.TestCase):
     def test_cholesky(self):
-        x = KerasTensor([10, 20, 20])
+        x = KerasTensor([4, 3, 3])
         out = linalg.cholesky(x)
-        self.assertEqual(out.shape, (10, 20, 20))
+        self.assertEqual(out.shape, (4, 3, 3))
 
         x = KerasTensor([10, 20, 15])
         with self.assertRaises(ValueError):
             linalg.cholesky(x)
 
     def test_det(self):
-        x = KerasTensor([10, 20, 20])
+        x = KerasTensor([4, 3, 3])
         out = linalg.det(x)
-        self.assertEqual(out.shape, (10,))
+        self.assertEqual(out.shape, (4,))
 
         x = KerasTensor([10, 20, 15])
         with self.assertRaises(ValueError):
             linalg.det(x)
 
+    def test_eig(self):
+        x = KerasTensor([4, 3, 3])
+        w, v = linalg.eig(x)
+        self.assertEqual(w.shape, (4, 3))
+        self.assertEqual(v.shape, (4, 3, 3))
+
+        x = KerasTensor([10, 20, 15])
+        with self.assertRaises(linalg.LinalgError):
+            linalg.eig(x)
+
+
     def test_inv(self):
-        x = KerasTensor([10, 20, 20])
+        x = KerasTensor([4, 3, 3])
         out = linalg.inv(x)
-        self.assertEqual(out.shape, (10, 20, 20))
+        self.assertEqual(out.shape, (4, 3, 3))
 
         x = KerasTensor([10, 20, 15])
         with self.assertRaises(ValueError):
             linalg.inv(x)
 
-    def test_solve(self):
-        a = KerasTensor([10, 20, 20])
-        b = KerasTensor([10, 20, 5])
-        out = linalg.solve(a, b)
-        self.assertEqual(out.shape, (10, 20, 5))
+    def test_lu_factor(self):
+        x = KerasTensor([10, 4, 3])
+        lu, p = linalg.lu_factor(x)
+        self.assertEqual(lu.shape, (10, 4, 3))
+        self.assertEqual(p.shape, (10, 3))
 
-        a = KerasTensor([10, 20, 20])
-        b = KerasTensor([10, 20])
+        x = KerasTensor([10, 2, 3])
+        lu, p = linalg.lu_factor(x)
+        self.assertEqual(lu.shape, (10, 2, 3))
+        self.assertEqual(p.shape, (10, 2))
+
+
+    def test_norm(self):
+        x = KerasTensor((10, 3))
+        self.assertEqual(linalg.norm(x).shape, ())
+
+        x = KerasTensor((10, 3, 3))
+        self.assertEqual(linalg.norm(x, axis=1).shape, (10, 3))
+        self.assertEqual(
+            linalg.norm(x, axis=1, keepdims=True).shape, (10, 1, 3)
+        )
+
+    def test_qr(self):
+        x = KerasTensor((4, 3), dtype="float32")
+        q, r = linalg.qr(x, mode="reduced")
+        qref, rref = np.linalg.qr(np.ones((4, 3)), mode="reduced")
+        self.assertEqual(q.shape, qref.shape)
+        self.assertEqual(r.shape, rref.shape)
+
+        q, r = linalg.qr(x, mode="complete")
+        qref, rref = np.linalg.qr(np.ones((4, 3)), mode="complete")
+        self.assertEqual(q.shape, qref.shape)
+        self.assertEqual(r.shape, rref.shape)
+
+        with self.assertRaises(ValueError):
+            linalg.qr(x, mode="invalid")
+
+    def test_solve(self):
+        a = KerasTensor([4, 3, 3])
+        b = KerasTensor([4, 3, 5])
         out = linalg.solve(a, b)
-        self.assertEqual(out.shape, (10, 20))
+        self.assertEqual(out.shape, (4, 3, 5))
+
+        a = KerasTensor([4, 3, 3])
+        b = KerasTensor([4, 3])
+        out = linalg.solve(a, b)
+        self.assertEqual(out.shape, (4, 3))
 
         a = KerasTensor([10, 20, 15])
         b = KerasTensor([10, 20, 5])
@@ -130,35 +275,148 @@ class LinalgOpsStaticShapeTest(testing.TestCase):
         with self.assertRaises(ValueError):
             linalg.solve(a, b)
 
+    def test_solve_triangular(self):
+        a = KerasTensor([4, 3, 3])
+        b = KerasTensor([4, 3, 5])
+        out = linalg.solve_triangular(a, b)
+        self.assertEqual(out.shape, (4, 3, 5))
 
-class LinalgOpsCorrectnessTest(testing.TestCase):
+        a = KerasTensor([4, 3, 3])
+        b = KerasTensor([4, 3])
+        out = linalg.solve_triangular(a, b)
+        self.assertEqual(out.shape, (4, 3))
+
+        a = KerasTensor([10, 20, 15])
+        b = KerasTensor([10, 20, 5])
+        with self.assertRaises(ValueError):
+            linalg.solve_triangular(a, b)
+
+    def test_svd(self):
+        x = KerasTensor((10, 3, 2))
+        u, s, v = linalg.svd(x)
+        self.assertEqual(u.shape, (10, 3, 3))
+        self.assertEqual(s.shape, (10, 2))
+        self.assertEqual(v.shape, (10, 2, 2))
+
+        u, s, v = linalg.svd(x, full_matrices=False)
+        self.assertEqual(u.shape, (10, 3, 2))
+        self.assertEqual(s.shape, (10, 2))
+        self.assertEqual(v.shape, (10, 2, 2))
+
+        s = linalg.svd(x, compute_uv=False)
+        self.assertEqual(s.shape, (10, 2))
+
+
+class LinalgOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
     def test_cholesky(self):
-        x = np.random.rand(10, 20, 20)
+        x = np.random.rand(4, 3, 3).astype("float32")
         with self.assertRaises(linalg.LinalgError):
             linalg.cholesky(x)
-
-        x_psd = x @ x.transpose((0, 2, 1))
+        x_psd = x @ x.transpose((0, 2, 1)) + 1e-5 * np.eye(3)
         out = linalg.cholesky(x_psd)
-        np.testing.assert_allclose(out, np.linalg.cholesky(x_psd))
+        self.assertAllClose(out, np.linalg.cholesky(x_psd), atol=1e-4)
 
     def test_det(self):
-        x = np.random.rand(10, 20, 20)
+        x = np.random.rand(4, 3, 3)
         out = linalg.det(x)
-        np.testing.assert_allclose(out, np.linalg.det(x))
+        self.assertAllClose(out, np.linalg.det(x), atol=1e-5)
+
+    def test_eig(self):
+        x = np.random.rand(4, 3, 3)
+        x = x @ x.transpose((0, 2, 1))
+        w, v = linalg.eig(x)
+        w_ref, v_ref = np.linalg.eig(x)
+        self.assertAllClose(w, w_ref, atol=1e-3)
 
     def test_inv(self):
-        x = np.random.rand(10, 20, 20)
+        x = np.random.rand(4, 3, 3)
         out = linalg.inv(x)
-        np.testing.assert_allclose(out, np.linalg.inv(x))
+        self.assertAllClose(out, np.linalg.inv(x), atol=1e-5)
+
+
+    def test_lu_factor(self):
+        from scipy.linalg import lu_factor
+        # 2d-case
+        x = np.random.rand(3, 3)
+        lu, p = linalg.lu_factor(x)
+        lu_ref, p_ref = lu_factor(x)
+        self.assertAllClose(lu, lu_ref, atol=1e-5)
+        self.assertAllClose(p, p_ref, atol=1e-5)
+
+        # batched case
+        x = np.random.rand(4, 3, 3)
+        lu, p = linalg.lu_factor(x)
+        for i in range(4):
+            lu_ref, p_ref = lu_factor(x[i])
+            self.assertAllClose(lu[i], lu_ref, atol=1e-5)
+            self.assertAllClose(p[i], p_ref, atol=1e-5)        
+
+    @parameterized.named_parameters(
+        named_product(
+            ord=[None, "fro", "nuc", -np.inf, -2, -1, 0, 1, 2, np.inf, 3],
+            axis=[None, 1, -1],
+            keepdims=[False, True],
+        )
+    )
+    def test_norm_vectors(self, ord, axis, keepdims):
+        if axis is None:
+            x = np.random.random((5,))
+        else:
+            x = np.random.random((5, 6))
+        if ord in ("fro", "nuc"):
+            error = RuntimeError if backend.backend() == "torch" else ValueError
+            with self.assertRaises(error):
+                linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+            return
+        output = linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+        expected_result = np.linalg.norm(
+            x, ord=ord, axis=axis, keepdims=keepdims
+        )
+        self.assertAllClose(output, expected_result)
+
+    def test_qr(self):
+        x = np.random.random((4, 5))
+        q, r = linalg.qr(x, mode="reduced")
+        qref, rref = np.linalg.qr(x, mode="reduced")
+        self.assertAllClose(qref, q)
+        self.assertAllClose(rref, r)
+
+        q, r = linalg.qr(x, mode="complete")
+        qref, rref = np.linalg.qr(x, mode="complete")
+        self.assertAllClose(qref, q)
+        self.assertAllClose(rref, r)
+
 
     def test_solve(self):
-        a = np.random.rand(10, 20, 20)
-        b = np.random.rand(10, 20, 5)
-        out = linalg.solve(a, b)
-        np.testing.assert_allclose(out, np.linalg.solve(a, b))
+        x1 = np.array([[1, 2], [4, 5]], dtype="float32")
+        x2 = np.array([[2, 4], [8, 10]], dtype="float32")
+        output = linalg.solve(x1, x2)
+        expected_result = np.array([[2, 0], [0, 2]], dtype="float32")
+        self.assertAllClose(output, expected_result)
 
-        a = np.random.rand(10, 20, 20)
-        b = np.random.rand(10, 20)
-        out = linalg.solve(a, b)
-        np.testing.assert_allclose(out, np.linalg.solve(a, b))
+    def test_solve_triangular(self):
+        
+        # 2d-case
+        x1 = np.array([[1, 2], [0, 5]], dtype="float32")
+        x2 = np.array([2, 10], dtype="float32")
+        output = linalg.solve_triangular(x1, x2, lower=True)
+        expected_result = np.array([2, 2], dtype="float32")
+        self.assertAllClose(output, expected_result)
+
+        output = linalg.solve_triangular(x1, x2, lower=False)
+        expected_result = np.array([-2, 2], dtype="float32")
+        self.assertAllClose(output, expected_result)
+
+        # batched case
+        x1 = np.array([[[1, 2], [0, 5]], [[1, 2], [0, 5]]], dtype="float32")
+        x2 = np.array([[2, 10], [2, 10]], dtype="float32")
+        output = linalg.solve_triangular(x1, x2, lower=True)
+        expected_result = np.array([[2, 2], [2, 2]], dtype="float32")
+        self.assertAllClose(output, expected_result)
+
+    def test_svd(self):
+        x = np.random.rand(4, 30, 20)
+        u, s, vh = linalg.svd(x)
+        x_reconstructed = (u[...,:,:s.shape[-1]] * s[...,None,:]) @ vh[..., :s.shape[-1],:]
+        self.assertAllClose(x_reconstructed, x, atol=1e-4)

--- a/keras/ops/linalg_test.py
+++ b/keras/ops/linalg_test.py
@@ -135,8 +135,12 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
 
     def test_cholesky(self):
         x = np.random.rand(10, 20, 20)
-        out = linalg.cholesky(x)
-        np.testing.assert_allclose(out, np.linalg.cholesky(x))
+        with self.assertRaises(linalg.LinalgError):
+            linalg.cholesky(x)
+
+        x_psd = x @ x.transpose((0, 2, 1))
+        out = linalg.cholesky(x_psd)
+        np.testing.assert_allclose(out, np.linalg.cholesky(x_psd))
 
     def test_det(self):
         x = np.random.rand(10, 20, 20)

--- a/keras/ops/linalg_test.py
+++ b/keras/ops/linalg_test.py
@@ -1,0 +1,160 @@
+import math
+
+import numpy as np
+import pytest
+import scipy.signal
+from absl.testing import parameterized
+
+from keras import backend
+from keras import testing
+from keras.backend.common import standardize_dtype
+from keras.backend.common.keras_tensor import KerasTensor
+from keras.backend.common.variables import ALLOWED_DTYPES
+from keras.ops import linalg
+from keras.testing.test_utils import named_product
+
+
+class LinalgOpsDynamicShapeTest(testing.TestCase):
+    def test_cholesky(self):
+        x = KerasTensor([None, 20, 20])
+        out = linalg.cholesky(x)
+        self.assertEqual(out.shape, (None, 20, 20))
+
+        x = KerasTensor([None, None, 20])
+        with self.assertRaises(ValueError):
+            linalg.cholesky(x)
+
+        x = KerasTensor([None, 20, 15])
+        with self.assertRaises(ValueError):
+            linalg.cholesky(x)
+
+    def test_det(self):
+        x = KerasTensor([None, 20, 20])
+        out = linalg.det(x)
+        self.assertEqual(out.shape, (None,))
+
+        x = KerasTensor([None, None, 20])
+        with self.assertRaises(ValueError):
+            linalg.det(x)
+
+        x = KerasTensor([None, 20, 15])
+        with self.assertRaises(ValueError):
+            linalg.det(x)
+
+    def test_inv(self):
+        x = KerasTensor([None, 20, 20])
+        out = linalg.inv(x)
+        self.assertEqual(out.shape, (None, 20, 20))
+
+        x = KerasTensor([None, None, 20])
+        with self.assertRaises(ValueError):
+            linalg.inv(x)
+
+        x = KerasTensor([None, 20, 15])
+        with self.assertRaises(ValueError):
+            linalg.inv(x)
+
+    def test_solve(self):
+        a = KerasTensor([None, 20, 20])
+        b = KerasTensor([None, 20, 5])
+        out = linalg.solve(a, b)
+        self.assertEqual(out.shape, (None, 20, 5))
+
+        a = KerasTensor([None, 20, 20])
+        b = KerasTensor([None, 20])
+        out = linalg.solve(a, b)
+        self.assertEqual(out.shape, (None, 20))
+
+        a = KerasTensor([None, None, 20])
+        b = KerasTensor([None, 20, 5])
+        with self.assertRaises(ValueError):
+            linalg.solve(a, b)
+
+        a = KerasTensor([None, 20, 15])
+        b = KerasTensor([None, 20, 5])
+        with self.assertRaises(ValueError):
+            linalg.solve(a, b)
+
+        a = KerasTensor([None, 20, 20])
+        b = KerasTensor([None, None, 5])
+        with self.assertRaises(ValueError):
+            linalg.solve(a, b)
+
+
+class LinalgOpsStaticShapeTest(testing.TestCase):
+    def test_cholesky(self):
+        x = KerasTensor([10, 20, 20])
+        out = linalg.cholesky(x)
+        self.assertEqual(out.shape, (10, 20, 20))
+
+        x = KerasTensor([10, 20, 15])
+        with self.assertRaises(ValueError):
+            linalg.cholesky(x)
+
+    def test_det(self):
+        x = KerasTensor([10, 20, 20])
+        out = linalg.det(x)
+        self.assertEqual(out.shape, (10,))
+
+        x = KerasTensor([10, 20, 15])
+        with self.assertRaises(ValueError):
+            linalg.det(x)
+
+    def test_inv(self):
+        x = KerasTensor([10, 20, 20])
+        out = linalg.inv(x)
+        self.assertEqual(out.shape, (10, 20, 20))
+
+        x = KerasTensor([10, 20, 15])
+        with self.assertRaises(ValueError):
+            linalg.inv(x)
+
+    def test_solve(self):
+        a = KerasTensor([10, 20, 20])
+        b = KerasTensor([10, 20, 5])
+        out = linalg.solve(a, b)
+        self.assertEqual(out.shape, (10, 20, 5))
+
+        a = KerasTensor([10, 20, 20])
+        b = KerasTensor([10, 20])
+        out = linalg.solve(a, b)
+        self.assertEqual(out.shape, (10, 20))
+
+        a = KerasTensor([10, 20, 15])
+        b = KerasTensor([10, 20, 5])
+        with self.assertRaises(ValueError):
+            linalg.solve(a, b)
+
+        a = KerasTensor([20, 20])
+        b = KerasTensor([])
+        with self.assertRaises(ValueError):
+            linalg.solve(a, b)
+
+
+class LinalgOpsCorrectnessTest(testing.TestCase):
+
+    def test_cholesky(self):
+        x = np.random.rand(10, 20, 20)
+        out = linalg.cholesky(x)
+        np.testing.assert_allclose(out, np.linalg.cholesky(x))
+
+    def test_det(self):
+        x = np.random.rand(10, 20, 20)
+        out = linalg.det(x)
+        np.testing.assert_allclose(out, np.linalg.det(x))
+
+    def test_inv(self):
+        x = np.random.rand(10, 20, 20)
+        out = linalg.inv(x)
+        np.testing.assert_allclose(out, np.linalg.inv(x))
+
+    def test_solve(self):
+        a = np.random.rand(10, 20, 20)
+        b = np.random.rand(10, 20, 5)
+        out = linalg.solve(a, b)
+        np.testing.assert_allclose(out, np.linalg.solve(a, b))
+
+        a = np.random.rand(10, 20, 20)
+        b = np.random.rand(10, 20)
+        out = linalg.solve(a, b)
+        np.testing.assert_allclose(out, np.linalg.solve(a, b))

--- a/keras/ops/math.py
+++ b/keras/ops/math.py
@@ -1,5 +1,7 @@
 """Commonly used math operations not included in NumPy."""
 
+import warnings
+
 from keras import backend
 from keras.api_export import keras_export
 from keras.backend import KerasTensor
@@ -310,6 +312,10 @@ def qr(x, mode="reduced"):
            [-0.5070925   0.2760267 ]
            [-0.8451542  -0.34503305]], shape=(3, 2), dtype=float32)
     """
+    warnings.warn(
+        "`keras.ops.qr` is deprecated. Please use `keras.ops.linalg.qr` instead.",
+        DeprecationWarning,
+    )
 
     if any_symbolic_tensors((x,)):
         return Qr(mode=mode).symbolic_call(x)
@@ -1026,6 +1032,10 @@ def solve(a, b):
     >>> keras.ops.solve(x1, x2)
     array([[2, 0], [0, 2]], dtype="float32")
     """
+    warnings.warn(
+        "`keras.ops.solve` is deprecated. Please use `keras.ops.linalg.solve` instead.",
+        DeprecationWarning,
+    )
     if any_symbolic_tensors((a, b)):
         return Solve().symbolic_call(a, b)
     a = backend.convert_to_tensor(a)
@@ -1146,6 +1156,10 @@ def norm(x, ord=None, axis=None, keepdims=False):
     >>> keras.ops.norm(x)
     7.7459664
     """
+    warnings.warn(
+        "`keras.ops.norm` is deprecated. Please use `keras.ops.linalg.norm` instead.",
+        DeprecationWarning,
+    )
     if any_symbolic_tensors((x,)):
         return Norm(ord=ord, axis=axis, keepdims=keepdims).symbolic_call(x)
     x = backend.convert_to_tensor(x)


### PR DESCRIPTION
Introduces a linear algebra module in Keras' backend-agnostic ops, with some of the most widely used methods. Closes #19062  

The following ops are implemented and are available under the `keras.ops.linalg` namespace: `cholesky`, `det`, `eig`, `inv`, `lu_factor`, `norm`, `qr`, `solve`, `solve_triangular`, `svd`.  A deprecation warning is raised for `norm`, `qr` and `solve` in the `keras.ops.math` module.


