### PR TITLE
[keras/ops/numpy.py] Use a more standard docstring format for `meshgrid`

### DIFF
--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -3714,8 +3714,8 @@ def meshgrid(*x, indexing="xy"):
 
     Args:
         x: 1-D tensors representing the coordinates of a grid.
-        indexing: Cartesian (`"xy"`, default) or matrix (`"ij"`) indexing
-            of output.
+        indexing: `"xy"` or `"ij"`. "xy" is cartesian; `"ij"` is matrix
+            indexing of output. Defaults to `"xy"`.
 
     Returns:
         Sequence of N tensors.


### PR DESCRIPTION
Found when converting/exposing your entire codebase:
```sh
$ python -m pip install python-cdd==0.0.99rc22  # Or a newer version!
$ python -m cdd exmod -m keras --emit sqlalchemy_hybrid -r -o build/keras 
# Replace `-m keras` with `-m keras.ops` to replicate just this bug
```

It fails because it parses out this:
```py
{   'default': 'xy',
    'doc': 'Cartesian (`"xy"`, default) or matrix (`"ij"`) indexing of output.',
    'typ': 'Literal["xy"]'}
```

Instead of this:
```py
{   'default': 'xy',
    'doc': 'Cartesian (`"xy"`, default) or matrix (`"ij"`) indexing of output.',
    'typ': 'Literal["xy", "ij"]'}
```

BTW: Sending this two-line one-file PR because when I tried whole codebase upgrade-to-non-adhoc-syntax it was not merged: #18786