### PR TITLE
Add `normalize` ops

### DIFF
--- a/keras/ops/math.py
+++ b/keras/ops/math.py
@@ -200,7 +200,7 @@ def normalize(x, p=2.0, axis=1, eps=1e-12):
 
     Example:
 
-    >>> x = keras.ops.convert_to_tensor(([[1, 2, 3], [4, 5, 6]])
+    >>> x = keras.ops.convert_to_tensor([[1, 2, 3], [4, 5, 6]])
     >>> x_norm = keras.ops.math.normalize(x)
     >>> print(x_norm)
     array([[0.26726124 0.5345225  0.8017837 ]

--- a/keras/ops/math.py
+++ b/keras/ops/math.py
@@ -163,55 +163,6 @@ def top_k(x, k, sorted=True):
     return backend.math.top_k(x, k, sorted)
 
 
-class Normalize(Operation):
-    def __init__(self, p=2.0, axis=1, eps=1e-12):
-        super().__init__()
-        self.p = p
-        self.axis = axis
-        self.eps = eps
-
-    def compute_output_spec(self, x):
-        return KerasTensor(shape=x.shape)
-
-    def call(self, x):
-        return _normalize(x, self.p, self.axis, self.eps)
-
-
-def _normalize(x, p=2.0, axis=1, eps=1e-12):
-    x = backend.convert_to_tensor(x)
-    norm = backend.linalg.norm(x, ord=p, axis=axis, keepdims=True)
-    denom = backend.numpy.maximum(norm, eps)
-    return backend.numpy.divide(x, denom)
-
-
-@keras_export("keras.ops.normalize")
-def normalize(x, p=2.0, axis=1, eps=1e-12):
-    """Perform Lp normalization of a tensor over the specified axis.
-        v = v / max(||v||_p, epsilon)
-
-    Args:
-        x: Input tensor.
-        p: The exponent value in the norm formulation. Default: 2.
-        axis: The axis or axes along which to perform normalization. Default: 1.
-        eps: Small value to avoid division by zero. Default: 1e-12.
-
-    Returns:
-        The normalized array.
-
-    Example:
-
-    >>> x = keras.ops.convert_to_tensor([[1, 2, 3], [4, 5, 6]])
-    >>> x_norm = keras.ops.math.normalize(x)
-    >>> print(x_norm)
-    array([[0.26726124 0.5345225  0.8017837 ]
-           [0.45584232 0.5698029  0.68376344]], shape=(2, 3), dtype=float32)
-
-    """
-    if any_symbolic_tensors((x,)):
-        return Normalize(p, axis, eps).symbolic_call(x)
-    return _normalize(x, p, axis, eps)
-
-
 class InTopK(Operation):
     def __init__(self, k):
         super().__init__()

--- a/keras/ops/math.py
+++ b/keras/ops/math.py
@@ -163,6 +163,55 @@ def top_k(x, k, sorted=True):
     return backend.math.top_k(x, k, sorted)
 
 
+class Normalize(Operation):
+    def __init__(self, p=2.0, axis=1, eps=1e-12):
+        super().__init__()
+        self.p = p
+        self.axis = axis
+        self.eps = eps
+
+    def compute_output_spec(self, x):
+        return KerasTensor(shape=x.shape)
+
+    def call(self, x):
+        return _normalize(x, self.p, self.axis, self.eps)
+
+
+def _normalize(x, p=2.0, axis=1, eps=1e-12):
+    x = backend.convert_to_tensor(x)
+    norm = backend.linalg.norm(x, ord=p, axis=axis, keepdims=True)
+    denom = backend.numpy.maximum(norm, eps)
+    return backend.numpy.divide(x, denom)
+
+
+@keras_export("keras.ops.normalize")
+def normalize(x, p=2.0, axis=1, eps=1e-12):
+    """Perform Lp normalization of a tensor over the specified axis.
+        v = v / max(||v||_p, epsilon)
+
+    Args:
+        x: Input tensor.
+        p: The exponent value in the norm formulation. Default: 2.
+        axis: The axis or axes along which to perform normalization. Default: 1.
+        eps: Small value to avoid division by zero. Default: 1e-12.
+
+    Returns:
+        The normalized array.
+
+    Example:
+
+    >>> x = keras.ops.convert_to_tensor(([[1, 2, 3], [4, 5, 6]])
+    >>> x_norm = keras.ops.math.normalize(x)
+    >>> print(x_norm)
+    array([[0.26726124 0.5345225  0.8017837 ]
+           [0.45584232 0.5698029  0.68376344]], shape=(2, 3), dtype=float32)
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Normalize(p, axis, eps).symbolic_call(x)
+    return _normalize(x, p, axis, eps)
+
+
 class InTopK(Operation):
     def __init__(self, k):
         super().__init__()

--- a/keras/ops/nn.py
+++ b/keras/ops/nn.py
@@ -1840,3 +1840,57 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
     return backend.nn.ctc_loss(
         target, output, target_length, output_length, mask_index
     )
+
+
+class Normalize(Operation):
+    def __init__(self, p=2.0, axis=1, eps=1e-12):
+        super().__init__()
+        self.p = p
+        self.axis = axis
+        self.eps = eps
+
+    def compute_output_spec(self, x):
+        return KerasTensor(shape=x.shape)
+
+    def call(self, x):
+        return _normalize(x, self.p, self.axis, self.eps)
+
+
+@keras_export(
+    [
+        "keras.ops.normalize",
+        "keras.ops.nn.normalize",
+    ]
+)
+def normalize(x, p=2.0, axis=1, eps=1e-12):
+    """Perform Lp normalization of a tensor over the specified axis.
+        `v' = v / max(||v||_p, epsilon)`
+
+    Args:
+        x: Input tensor.
+        p: The exponent value in the norm formulation. Default: 2.
+        axis: The axis or axes along which to perform normalization. Default: 1.
+        eps: Small value to avoid division by zero. Default: 1e-12.
+
+    Returns:
+        The normalized array.
+
+    Example:
+
+    >>> x = keras.ops.convert_to_tensor([[1, 2, 3], [4, 5, 6]])
+    >>> x_norm = keras.ops.math.normalize(x)
+    >>> print(x_norm)
+    array([[0.26726124 0.5345225  0.8017837 ]
+           [0.45584232 0.5698029  0.68376344]], shape=(2, 3), dtype=float32)
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Normalize(p, axis, eps).symbolic_call(x)
+    return _normalize(x, p, axis, eps)
+
+
+def _normalize(x, p=2.0, axis=1, eps=1e-12):
+    x = backend.convert_to_tensor(x)
+    norm = backend.linalg.norm(x, ord=p, axis=axis, keepdims=True)
+    denom = backend.numpy.maximum(norm, eps)
+    return backend.numpy.divide(x, denom)

--- a/keras/ops/nn.py
+++ b/keras/ops/nn.py
@@ -1883,8 +1883,8 @@ def normalize(x, axis=-1, order=2):
 
     """
     if any_symbolic_tensors((x,)):
-        return Normalize(order, axis).symbolic_call(x)
-    return _normalize(x, order, axis)
+        return Normalize(axis, order).symbolic_call(x)
+    return _normalize(x, axis, order)
 
 
 def _normalize(x, axis=-1, order=2):

--- a/keras/ops/nn.py
+++ b/keras/ops/nn.py
@@ -1863,7 +1863,8 @@ class Normalize(Operation):
 )
 def normalize(x, axis=-1, order=2):
     """Perform Lp normalization of a tensor over the specified axis.
-        `v' = v / max(||v||_p, epsilon)`
+
+    It is defined as: `normalize(x) = x / max(norm(x), epsilon)`.
 
     Args:
         x: Input tensor.

--- a/keras/ops/nn.py
+++ b/keras/ops/nn.py
@@ -1843,9 +1843,9 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
 
 
 class Normalize(Operation):
-    def __init__(self, p=2.0, axis=1, eps=1e-12):
+    def __init__(self, order=2.0, axis=1, eps=1e-12):
         super().__init__()
-        self.p = p
+        self.p = order
         self.axis = axis
         self.eps = eps
 
@@ -1853,7 +1853,7 @@ class Normalize(Operation):
         return KerasTensor(shape=x.shape)
 
     def call(self, x):
-        return _normalize(x, self.p, self.axis, self.eps)
+        return _normalize(x, self.order, self.axis, self.eps)
 
 
 @keras_export(
@@ -1862,13 +1862,13 @@ class Normalize(Operation):
         "keras.ops.nn.normalize",
     ]
 )
-def normalize(x, p=2.0, axis=1, eps=1e-12):
+def normalize(x, order=2.0, axis=1, eps=1e-12):
     """Perform Lp normalization of a tensor over the specified axis.
         `v' = v / max(||v||_p, epsilon)`
 
     Args:
         x: Input tensor.
-        p: The exponent value in the norm formulation. Default: 2.
+        order: The exponent value in the norm formulation. Default: 2.
         axis: The axis or axes along which to perform normalization. Default: 1.
         eps: Small value to avoid division by zero. Default: 1e-12.
 
@@ -1885,8 +1885,8 @@ def normalize(x, p=2.0, axis=1, eps=1e-12):
 
     """
     if any_symbolic_tensors((x,)):
-        return Normalize(p, axis, eps).symbolic_call(x)
-    return _normalize(x, p, axis, eps)
+        return Normalize(order, axis, eps).symbolic_call(x)
+    return _normalize(x, order, axis, eps)
 
 
 def _normalize(x, p=2.0, axis=1, eps=1e-12):

--- a/keras/ops/nn_test.py
+++ b/keras/ops/nn_test.py
@@ -1852,6 +1852,37 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         result = knn.ctc_loss(labels, outputs, label_length, output_length)
         self.assertAllClose(result, np.array([3.4411672, 1.91680186]))
 
+    def test_normalize(self):
+        x = np.array([[1, 2, 3], [1, 2, 3]], dtype=np.float32)
+        self.assertAllClose(
+            knn.normalize(x, axis=None),
+            [
+                [0.18898225, 0.3779645, 0.56694674],
+                [0.18898225, 0.3779645, 0.56694674],
+            ],
+        )
+        self.assertAllClose(
+            knn.normalize(x, axis=0),
+            [
+                [0.70710677, 0.70710677, 0.70710677],
+                [0.70710677, 0.70710677, 0.70710677],
+            ],
+        )
+        self.assertAllClose(
+            knn.normalize(x, axis=-1),
+            [
+                [0.26726124, 0.53452247, 0.8017837],
+                [0.26726124, 0.53452247, 0.8017837],
+            ],
+        )
+        self.assertAllClose(
+            knn.normalize(x, order=3),
+            [
+                [0.30285344, 0.6057069, 0.9085603],
+                [0.30285344, 0.6057069, 0.9085603],
+            ],
+        )
+
 
 class TestLogitRecovery(testing.TestCase):
     def test_logit_recovery_binary_crossentropy(self):

--- a/keras/ops/nn_test.py
+++ b/keras/ops/nn_test.py
@@ -1053,6 +1053,10 @@ class NNOpsStaticShapeTest(testing.TestCase):
         y_lengths = KerasTensor([10], dtype="int32")
         self.assertEqual(knn.ctc_loss(x, y, x_lengths, y_lengths).shape, (10,))
 
+    def test_normalize(self):
+        x = KerasTensor([1, 2, 3])
+        self.assertEqual(knn.normalize(x).shape, (1, 2, 3))
+
 
 class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
     def test_relu(self):

--- a/keras/ops/nn_test.py
+++ b/keras/ops/nn_test.py
@@ -607,6 +607,10 @@ class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):
             scale=KerasTensor([3]),
         )
 
+    def test_normalize(self):
+        x = KerasTensor([None, 2, 3])
+        self.assertEqual(knn.normalize(x).shape, (None, 2, 3))
+
 
 class NNOpsStaticShapeTest(testing.TestCase):
     def test_relu(self):


### PR DESCRIPTION
$L_p$ Normalization is a popular operation available in both PyTorch and TensorFlow. Having it in Keras 3.0 would be a great addition. This PR will add the `normalize()` ops,

$$
v' = \frac{v}{\max(\lVert v \rVert_p, \epsilon)}
$$

This operation is widely used in the community; for example, `OpenAI-CLIP` or `Google-SigLIP` uses `l2_normalization` in their encoder embeddings.

## Ref:
* PyTorch: https://pytorch.org/docs/stable/_modules/torch/nn/functional.html#normalize
* TensorFlow: https://www.tensorflow.org/api_docs/python/tf/linalg/normalize