### PR TITLE
Show billions of parameters in model summary

### DIFF
--- a/keras/utils/summary_utils.py
+++ b/keras/utils/summary_utils.py
@@ -175,14 +175,14 @@ def print_summary(
                     break
 
     if sequential_like:
-        default_line_length = 84
-        positions = positions or [0.45, 0.84, 1.0]
+        default_line_length = 88
+        positions = positions or [0.45, 0.80, 1.0]
         # header names for the different log elements
         header = ["Layer (type)", "Output Shape", "Param #"]
         alignment = ["left", "left", "right"]
     else:
         default_line_length = 108
-        positions = positions or [0.3, 0.56, 0.70, 1.0]
+        positions = positions or [0.3, 0.56, 0.74, 1.0]
         # header names for the different log elements
         header = ["Layer (type)", "Output Shape", "Param #", "Connected to"]
         alignment = ["left", "left", "right", "left"]


### PR DESCRIPTION
Models are getting bigger! Let's adapt our summary so we can avoid ellipsizing summary for layers/sub-models with up to 10B parameters. In KerasNLP/KerasCV this comes up when we have a model that wraps a backbone, which can have billions of parameters. An ellipsized count is not readable, you can't tell the number of training digits. 

Not exactly sure on spacing. For sequential, I just made the whole summary 4 chars bigger (as the width is much smaller than functional anyway), For functional, I stole width from the `Connected to` column, as I would claim parameters count is more important.

Here's a quick demo:
https://colab.research.google.com/gist/mattdangerw/96bded8af054649caae8ec4cba8f0942/summaries.ipynb