### PR TITLE
Fix JAX GPU CI Cuda error by fixing JAX version

### DIFF
--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -7,7 +7,8 @@ torch>=2.1.0
 torchvision>=0.16.0
 
 # Jax with cuda support.
+# TODO: 0.4.24 has an updated Cuda version breaks Jax CI.
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[cuda12_pip]
+jax[cuda12_pip]==0.4.23
 
 -r requirements-common.txt


### PR DESCRIPTION
Fix the JAX version for GPU CI.  Added a TODO to see if the cuda version can be updated.
Log: https://source.cloud.google.com/results/invocations/c60e0c47-9e68-42ce-b67e-2f685ab476c9/log