### PR TITLE
Fix for `keras.metrics.Mean` when the sum of weights is negative.

### DIFF
--- a/keras/metrics/reduction_metrics.py
+++ b/keras/metrics/reduction_metrics.py
@@ -150,10 +150,11 @@ class Mean(Metric):
         self.count.assign(0)
 
     def result(self):
-        return self.total / (
-            ops.maximum(
-                ops.cast(self.count, dtype=self.dtype), backend.epsilon()
-            )
+        count = ops.cast(self.count, dtype=self.dtype)
+        return (
+            ops.sign(count)
+            * self.total
+            / ops.maximum(ops.abs(count), backend.epsilon())
         )
 
 

--- a/keras/metrics/reduction_metrics_test.py
+++ b/keras/metrics/reduction_metrics_test.py
@@ -62,6 +62,12 @@ class MeanTest(testing.TestCase):
         result = mean_obj.result()
         self.assertAllClose(result, 2.0, atol=1e-3)
 
+    def test_weighted_negative_weigts(self):
+        mean_obj = reduction_metrics.Mean(name="mean", dtype="float32")
+        mean_obj.update_state([1, 3, 5, 7], sample_weight=[-1, -1, 0, 0])
+        result = mean_obj.result()
+        self.assertAllClose(result, 2.0, atol=1e-3)
+
     def test_weighted_nd(self):
         mean_obj = reduction_metrics.Mean(name="mean", dtype="float32")
         mean_obj.update_state([[1, 3], [5, 7]], sample_weight=[[1, 1], [1, 0]])


### PR DESCRIPTION
The new behavior is similar to Keras 2 i.e. `tf.math.divide_no_nan`.