### PR TITLE
Wrap JAX export variables in TF variable, add test for JAX with TF function endpoint

### DIFF
--- a/keras/export/export_lib.py
+++ b/keras/export/export_lib.py
@@ -142,13 +142,28 @@ class ExportArchive:
         if isinstance(resource, Layer):
             # Variables in the lists below are actually part of the trackables
             # that get saved, because the lists are created in __init__.
-            self._tf_trackable.variables += resource.variables
-            self._tf_trackable.trainable_variables += (
-                resource.trainable_variables
-            )
-            self._tf_trackable.non_trainable_variables += (
-                resource.non_trainable_variables
-            )
+            if backend.backend() == "jax":
+                self._tf_trackable.variables += tf.nest.flatten(
+                    tf.nest.map_structure(tf.Variable, resource.variables)
+                )
+                self._tf_trackable.trainable_variables += tf.nest.flatten(
+                    tf.nest.map_structure(
+                        tf.Variable, resource.trainable_variables
+                    )
+                )
+                self._tf_trackable.non_trainable_variables += tf.nest.flatten(
+                    tf.nest.map_structure(
+                        tf.Variable, resource.non_trainable_variables
+                    )
+                )
+            else:
+                self._tf_trackable.variables += resource.variables
+                self._tf_trackable.trainable_variables += (
+                    resource.trainable_variables
+                )
+                self._tf_trackable.non_trainable_variables += (
+                    resource.non_trainable_variables
+                )
 
     def add_endpoint(self, name, fn, input_signature=None):
         """Register a new serving endpoint.

--- a/keras/export/export_lib_test.py
+++ b/keras/export/export_lib_test.py
@@ -56,6 +56,13 @@ class ExportArchiveTest(testing.TestCase):
         self.assertLen(export_archive.trainable_variables, 6)
         self.assertLen(export_archive.non_trainable_variables, 2)
 
+        # Assert `tf.Variable` regardless of backend
+        assert isinstance(export_archive.variables[0], tf.Variable)
+        assert isinstance(export_archive.trainable_variables[0], tf.Variable)
+        assert isinstance(
+            export_archive.non_trainable_variables[0], tf.Variable
+        )
+
         export_archive = export_lib.ExportArchive()
         export_archive.track(model)
         export_archive.add_endpoint(
@@ -113,6 +120,62 @@ class ExportArchiveTest(testing.TestCase):
         self.assertLen(revived_model.variables, 8)
         self.assertLen(revived_model.trainable_variables, 6)
         self.assertLen(revived_model.non_trainable_variables, 2)
+
+    @pytest.mark.skipif(
+        backend.backend() != "jax",
+        reason="This test is native to the JAX backend.",
+    )
+    def test_jax_endpoint_registration_tf_function(self):
+        model = get_model()
+        ref_input = np.random.normal(size=(3, 10))
+        model(ref_input)
+
+        # build a JAX function
+        def model_call(x):
+            return model(x)
+
+        from jax.experimental import jax2tf
+
+        # now, convert JAX function
+        converted_model_call = jax2tf.convert(
+            model_call,
+            native_serialization=True,
+            polymorphic_shapes=["(b, 10)"],
+        )
+
+        # you can now build a TF inference function
+        @tf.function(
+            input_signature=[tf.TensorSpec(shape=(None, 10), dtype=tf.float32)],
+            autograph=False,
+        )
+        def infer_fn(x):
+            return converted_model_call(x)
+
+        ref_output = infer_fn(ref_input)
+
+        # Export with TF inference function as endpoint
+        temp_filepath = os.path.join(self.get_temp_dir(), "my_model")
+        export_archive = export_lib.ExportArchive()
+        export_archive.track(model)
+        export_archive.add_endpoint("serve", infer_fn)
+        export_archive.write_out(temp_filepath)
+
+        # Reload and verify outputs
+        revived_model = tf.saved_model.load(temp_filepath)
+        self.assertFalse(hasattr(revived_model, "_tracked"))
+        self.assertAllClose(
+            ref_output, revived_model.serve(ref_input), atol=1e-6
+        )
+        self.assertLen(revived_model.variables, 8)
+        self.assertLen(revived_model.trainable_variables, 6)
+        self.assertLen(revived_model.non_trainable_variables, 2)
+
+        # Assert all variables wrapped as `tf.Variable`
+        assert isinstance(export_archive.variables[0], tf.Variable)
+        assert isinstance(export_archive.trainable_variables[0], tf.Variable)
+        assert isinstance(
+            export_archive.non_trainable_variables[0], tf.Variable
+        )
 
     def test_layer_export(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_layer")

--- a/keras/export/export_lib_test.py
+++ b/keras/export/export_lib_test.py
@@ -56,13 +56,6 @@ class ExportArchiveTest(testing.TestCase):
         self.assertLen(export_archive.trainable_variables, 6)
         self.assertLen(export_archive.non_trainable_variables, 2)
 
-        # Assert `tf.Variable` regardless of backend
-        assert isinstance(export_archive.variables[0], tf.Variable)
-        assert isinstance(export_archive.trainable_variables[0], tf.Variable)
-        assert isinstance(
-            export_archive.non_trainable_variables[0], tf.Variable
-        )
-
         export_archive = export_lib.ExportArchive()
         export_archive.track(model)
         export_archive.add_endpoint(


### PR DESCRIPTION
This PR makes sure the default variable collections are wrapped as TF variables on the JAX backend, preventing variables from being embedded as constants.

Additionally, I've added a basic test for registering a custom endpoint using jax2tf conversion from the JAX backend.