### PR TITLE
Disable Dependabot auto-update for JAX GPU

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,6 @@ updates:
       python:
         patterns:
           - "*"
+    ignore:
+        # TODO: ignore all updates for JAX GPU due to cuda version issue
+      - dependency-name: "jax[cuda12_pip]"


### PR DESCRIPTION
Disable AutoUpdate of JAX GPU by Dependabot.
Followup to #19161. 