### PR TITLE
Adjust confusion metrics to handle division by zero the same as Keras 2.

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -90,7 +90,7 @@ def multiply(x1, x2):
         if isinstance(x2, jax_sparse.BCOO):
             # x1 is sparse, x2 is sparse.
             if x1.indices is x2.indices:
-                # `bcoo_multiply_sparse`` will not detect that the indices are
+                # `bcoo_multiply_sparse` will not detect that the indices are
                 # the same, optimize this case here.
                 if not x1.unique_indices:
                     x1 = jax_sparse.bcoo_sum_duplicates(x1)
@@ -957,7 +957,12 @@ def divide(x1, x2):
     return jnp.divide(x1, x2)
 
 
-@sparse.elementwise_division
+def divide_no_nan(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return jnp.where(x2 == 0, 0, jnp.divide(x1, x2))
+
+
 def true_divide(x1, x2):
     return divide(x1, x2)
 

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -967,6 +967,21 @@ def divide(x1, x2):
     return np.divide(x1, x2)
 
 
+def divide_no_nan(x1, x2):
+    if not isinstance(x1, (int, float)):
+        x1 = convert_to_tensor(x1)
+    if not isinstance(x2, (int, float)):
+        x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(
+        getattr(x1, "dtype", type(x1)),
+        getattr(x2, "dtype", type(x2)),
+        float,
+    )
+    x1 = convert_to_tensor(x1, dtype)
+    x2 = convert_to_tensor(x2, dtype)
+    return np.where(x2 == 0, 0, np.divide(x1, x2))
+
+
 def true_divide(x1, x2):
     return divide(x1, x2)
 

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -1681,7 +1681,21 @@ def divide(x1, x2):
     return tf.divide(x1, x2)
 
 
-@sparse.elementwise_division
+def divide_no_nan(x1, x2):
+    if not isinstance(x1, (int, float)):
+        x1 = convert_to_tensor(x1)
+    if not isinstance(x2, (int, float)):
+        x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(
+        getattr(x1, "dtype", type(x1)),
+        getattr(x2, "dtype", type(x2)),
+        float,
+    )
+    x1 = convert_to_tensor(x1, dtype)
+    x2 = convert_to_tensor(x2, dtype)
+    return tf.math.divide_no_nan(x1, x2)
+
+
 def true_divide(x1, x2):
     return divide(x1, x2)
 

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -1366,6 +1366,14 @@ def divide(x1, x2):
     return torch.divide(x1, x2)
 
 
+def divide_no_nan(x1, x2):
+    if not isinstance(x1, (int, float)):
+        x1 = convert_to_tensor(x1)
+    if not isinstance(x2, (int, float)):
+        x2 = convert_to_tensor(x2)
+    return torch.where(x2 == 0, 0, torch.divide(x1, x2))
+
+
 def true_divide(x1, x2):
     return divide(x1, x2)
 

--- a/keras/metrics/confusion_metrics_test.py
+++ b/keras/metrics/confusion_metrics_test.py
@@ -1386,6 +1386,16 @@ class AUCTest(testing.TestCase):
         expected_result = 2.416 / 7 + 4 / 7
         self.assertAllClose(result, expected_result, 1e-3)
 
+    def test_weighted_pr_interpolation_negative_weights(self):
+        auc_obj = metrics.AUC(num_thresholds=self.num_thresholds, curve="PR")
+        sample_weight = [-1, -2, -3, -4]
+        result = auc_obj(self.y_true, self.y_pred, sample_weight=sample_weight)
+
+        # Divisor in auc formula is max(tp[1:]+fn[1:], 0), which is all zeros
+        # because the all values in tp and fn are negative, divide_no_nan will
+        # produce all zeros.
+        self.assertAllClose(result, 0.0, 1e-3)
+
     def test_invalid_num_thresholds(self):
         with self.assertRaisesRegex(
             ValueError, "Argument `num_thresholds` must be an integer > 1"

--- a/keras/metrics/reduction_metrics.py
+++ b/keras/metrics/reduction_metrics.py
@@ -1,4 +1,3 @@
-from keras import backend
 from keras import initializers
 from keras import losses
 from keras import ops
@@ -150,11 +149,8 @@ class Mean(Metric):
         self.count.assign(0)
 
     def result(self):
-        count = ops.cast(self.count, dtype=self.dtype)
-        return (
-            ops.sign(count)
-            * self.total
-            / ops.maximum(ops.abs(count), backend.epsilon())
+        return ops.divide_no_nan(
+            self.total, ops.cast(self.count, dtype=self.dtype)
         )
 
 

--- a/keras/metrics/reduction_metrics_test.py
+++ b/keras/metrics/reduction_metrics_test.py
@@ -62,7 +62,7 @@ class MeanTest(testing.TestCase):
         result = mean_obj.result()
         self.assertAllClose(result, 2.0, atol=1e-3)
 
-    def test_weighted_negative_weigts(self):
+    def test_weighted_negative_weights(self):
         mean_obj = reduction_metrics.Mean(name="mean", dtype="float32")
         mean_obj.update_state([1, 3, 5, 7], sample_weight=[-1, -1, 0, 0])
         result = mean_obj.result()

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -5540,6 +5540,43 @@ def divide(x1, x2):
     return backend.numpy.divide(x1, x2)
 
 
+class DivideNoNan(Operation):
+    def call(self, x1, x2):
+        return backend.numpy.divide_no_nan(x1, x2)
+
+    def compute_output_spec(self, x1, x2):
+        x1_shape = getattr(x1, "shape", [])
+        x2_shape = getattr(x2, "shape", [])
+        output_shape = broadcast_shapes(x1_shape, x2_shape)
+        output_dtype = dtypes.result_type(
+            getattr(x1, "dtype", type(x1)),
+            getattr(x2, "dtype", type(x2)),
+            float,
+        )
+        x1_sparse = getattr(x1, "sparse", False)
+        x2_sparse = getattr(x2, "sparse", False)
+        output_sparse = x1_sparse and not x2_sparse
+        return KerasTensor(
+            output_shape, dtype=output_dtype, sparse=output_sparse
+        )
+
+
+@keras_export(["keras.ops.divide_no_nan", "keras.ops.numpy.divide_no_nan"])
+def divide_no_nan(x1, x2):
+    """Safe element-wise division which returns 0 where the denominator is 0.
+
+    Args:
+        x1: First input tensor.
+        x2: Second input tensor.
+
+    Returns:
+        The quotient `x1/x2`, element-wise, with zero where x2 is zero.
+    """
+    if any_symbolic_tensors((x1, x2)):
+        return DivideNoNan().symbolic_call(x1, x2)
+    return backend.numpy.divide_no_nan(x1, x2)
+
+
 class TrueDivide(Operation):
     def call(self, x1, x2):
         return backend.numpy.true_divide(x1, x2)


### PR DESCRIPTION
- Added `divide_no_nan` op.
- Also used ops consistently in `confusion_metrics.py`.