### PR TITLE
[keras/saving/object_registration.py] Set `CustomObjectScope` dictionary arg type to `str` rather than `name`

### DIFF
--- a/keras/saving/object_registration.py
+++ b/keras/saving/object_registration.py
@@ -38,7 +38,8 @@ class CustomObjectScope:
     ```
 
     Args:
-        custom_objects: Dictionary of `{str: object}` pairs. Where the `str` key is the object name.
+        custom_objects: Dictionary of `{str: object}` pairs.
+            Where the `str` key is the object name.
     """
 
     def __init__(self, custom_objects):

--- a/keras/saving/object_registration.py
+++ b/keras/saving/object_registration.py
@@ -38,7 +38,7 @@ class CustomObjectScope:
     ```
 
     Args:
-        custom_objects: Dictionary of `{name: object}` pairs.
+        custom_objects: Dictionary of `{str: object}` pairs. Where the str key is the name.
     """
 
     def __init__(self, custom_objects):

--- a/keras/saving/object_registration.py
+++ b/keras/saving/object_registration.py
@@ -38,7 +38,7 @@ class CustomObjectScope:
     ```
 
     Args:
-        custom_objects: Dictionary of `{str: object}` pairs. Where the str key is the name.
+        custom_objects: Dictionary of `{str: object}` pairs. Where the `str` key is the object name.
     """
 
     def __init__(self, custom_objects):
@@ -73,7 +73,7 @@ custom_object_scope = CustomObjectScope
 def get_custom_objects():
     """Retrieves a live reference to the global dictionary of custom objects.
 
-    Custom objects set using using `custom_object_scope()` are not added to the
+    Custom objects set using `custom_object_scope()` are not added to the
     global dictionary of custom objects, and will not appear in the returned
     dictionary.
 


### PR DESCRIPTION
Found when converting/exposing your entire codebase:
```sh
$ python -m pip install python-cdd==0.0.99rc32  # Or a newer version!
$ python -m cdd exmod -m keras --emit sqlalchemy_hybrid -r -o build/keras 
# Replace `-m keras` with `-m keras.src.saving.object_registration.CustomObjectScope` to replicate just this bug
```

It fails because it parses out this:
```py
{   'doc': 'Dictionary of `{name: object}` pairs.',
    'typ': 'Mapping[name, object]'}
```

Instead of this:
```py
{   'doc': 'Dictionary of `{name: object}` pairs.',
    'typ': 'Mapping[str, object]'}
```

PS: Not sure if `object` is the best narrowing of the target type. If it's not tell me the right, e.g., `Callable`.

BTW: Sending this one-line one-file PR because when I tried whole codebase upgrade-to-non-adhoc-syntax it was not merged: #18786