### PR TITLE
Numpy backend requires torch

### DIFF
--- a/keras/backend/numpy/linalg.py
+++ b/keras/backend/numpy/linalg.py
@@ -3,7 +3,7 @@ import scipy.linalg as sl
 
 from keras.backend import standardize_dtype
 from keras.backend.common import dtypes
-from keras.backend.torch.core import convert_to_tensor
+from keras.backend.numpy.core import convert_to_tensor
 
 
 def cholesky(a):


### PR DESCRIPTION
A use of keras is to be able to run models with the numpy backend without have to install PyTorch. Since keras 3.0.5 this does not work.

This is due to #19143 by @frazane.

This PR fixes that, so that the numpy backend only requires the `numpy` and `jax[cpu]`.

### How to reproduce

Run anything with the numpy backend without having torch installed.

```
python3.11/site-packages/keras/src/backend/numpy/__init__.py:3: in <module>
    from keras.src.backend.numpy import linalg
python3.11/site-packages/keras/src/backend/numpy/linalg.py:6: in <module>
    from keras.src.backend.torch.core import convert_to_tensor
python3.11/site-packages/keras/src/backend/torch/__init__.py:17: in <module>
    from keras.src.backend.torch import core
python3.11/site-packages/keras/src/backend/torch/core.py:6: in <module>
    import torch
E   ModuleNotFoundError: No module named 'torch'
```
