### PR TITLE
Check if softmax activation is used correctly

### DIFF
--- a/keras/models/functional.py
+++ b/keras/models/functional.py
@@ -679,15 +679,18 @@ def deserialize_node(node_data, created_layers):
 
 
 def _check_output_activation_softmax(output_layers):
-    """
-    Checks if the output activation is softmax and the applied axis has only
-    one unit.
-    Args:
-        output_layers: A dictionary of output layers with their names as keys
-            and the layers as values.
+    """Ensures output activation is suitable for Sequential and Functional models.
+
+    Verifies the output layer's activation function is softmax and confirms that
+    the axis of application leads to a singular unit output.
+
+    Parameters:
+        output_layers (dict): A mapping of output layer names to their respective layer
+            instances.
+
     Raises:
-        ValueError: If the output activation is softmax and the applied axis
-            will make the model output 1.0 for all inputs.
+        ValueError: Triggered when the softmax activation results in a constant model
+            output of 1.0 across all inputs.
     """
 
     # remove all the layers except Dense, and BaseConv

--- a/keras/models/functional.py
+++ b/keras/models/functional.py
@@ -7,7 +7,8 @@ import tree
 from keras import backend
 from keras import ops
 from keras.backend.common import global_state
-from keras.layers import Softmax, Dense
+from keras.layers import Dense
+from keras.layers import Softmax
 from keras.layers.convolutional.base_conv import BaseConv
 from keras.layers.input_spec import InputSpec
 from keras.layers.layer import Layer
@@ -165,9 +166,10 @@ class Functional(Function, Model):
         self.output_names = [x.name for x in output_layers]
 
         if validate_softmax:
-            layer_output_mapping = {layer.name:layer for layer in output_layers}
+            layer_output_mapping = {
+                layer.name: layer for layer in output_layers
+            }
             _check_output_activation_softmax(layer_output_mapping)
-
 
     def _lock_state(self):
         # Unlike other layers, we allow Functional state to be mutable after
@@ -689,7 +691,11 @@ def _check_output_activation_softmax(output_layers):
     """
 
     # remove all the layers except Dense, and BaseConv
-    output_layers = {k: v for k, v in output_layers.items() if isinstance(v, (Dense, BaseConv))}
+    output_layers = {
+        k: v
+        for k, v in output_layers.items()
+        if isinstance(v, (Dense, BaseConv))
+    }
 
     for layer_name, layer in output_layers.items():
 

--- a/keras/models/functional.py
+++ b/keras/models/functional.py
@@ -811,15 +811,17 @@ def clone_graph_nodes(inputs, outputs):
 
 
 def _check_output_activation_softmax(output_layers):
-    """Ensures output activation is suitable for Sequential and Functional models.
+    """Ensures output activation is suitable.
+
     Verifies the output layer's activation function is softmax and confirms that
     the axis of application leads to a singular unit output.
+
     Parameters:
-        output_layers (dict): A mapping of output layer names to their respective layer
+        output_layers: A mapping of output layer names to their respective layer
             instances.
     Raises:
-        ValueError: Triggered when the softmax activation results in a constant model
-            output of 1.0 across all inputs.
+        ValueError: Triggered when the softmax activation results in a constant
+            model output of 1.0 across all inputs.
     """
 
     # remove all the layers except Dense, and BaseConv
@@ -862,6 +864,7 @@ def _check_output_activation_softmax(output_layers):
                     "think that the error is raised due to an incorrect check, "
                     "please file an issue on "
                     "https://github.com/keras-team/keras/issues. You can "
-                    "disable this check by setting `validate_output_activation=False` "
-                    "when constructing the model."
+                    "disable this check by setting "
+                    "`validate_output_activation=False` when constructing the "
+                    "model."
                 )

--- a/keras/models/functional_test.py
+++ b/keras/models/functional_test.py
@@ -94,7 +94,7 @@ class FunctionalTest(testing.TestCase):
         outputs = layers.Dense(4)(x)
 
         with self.assertRaisesRegex(
-                ValueError, "all values in the dict must be KerasTensors"
+            ValueError, "all values in the dict must be KerasTensors"
         ):
             model = Functional({"aa": [input_a], "bb": input_b}, outputs)
 
@@ -295,7 +295,7 @@ class FunctionalTest(testing.TestCase):
         outputs = layers.Dense(2)(inputs)
         model = Functional(inputs, outputs)
         with self.assertRaisesRegex(
-                ValueError, r"expected shape=\(None, 4\), found shape=\(2, 3\)"
+            ValueError, r"expected shape=\(None, 4\), found shape=\(2, 3\)"
         ):
             model(np.zeros((2, 3)))
         with self.assertRaisesRegex(ValueError, "expected 1 input"):
@@ -310,7 +310,7 @@ class FunctionalTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "expected 2 input"):
             model(np.zeros((2, 3)))
         with self.assertRaisesRegex(
-                ValueError, r"expected shape=\(None, 4\), found shape=\(2, 3\)"
+            ValueError, r"expected shape=\(None, 4\), found shape=\(2, 3\)"
         ):
             model([np.zeros((2, 3)), np.zeros((2, 4))])
 
@@ -319,7 +319,7 @@ class FunctionalTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "expected 2 input"):
             model(np.zeros((2, 3)))
         with self.assertRaisesRegex(
-                ValueError, r"expected shape=\(None, 4\), found shape=\(2, 3\)"
+            ValueError, r"expected shape=\(None, 4\), found shape=\(2, 3\)"
         ):
             model({"a": np.zeros((2, 3)), "b": np.zeros((2, 4))})
 
@@ -330,8 +330,8 @@ class FunctionalTest(testing.TestCase):
         model = Functional(inputs, outputs)
         model.input_spec = InputSpec(shape=(None, 4, 3))
         with self.assertRaisesRegex(
-                ValueError,
-                r"expected shape=\(None, 4, 3\), found shape=\(2, 3, 3\)",
+            ValueError,
+            r"expected shape=\(None, 4, 3\), found shape=\(2, 3, 3\)",
         ):
             model(np.zeros((2, 3, 3)))
         model(np.zeros((2, 4, 3)))
@@ -346,8 +346,8 @@ class FunctionalTest(testing.TestCase):
             x = layers.Dense(1, activation=activation)(inputs)
 
             with self.assertRaisesRegex(
-                    ValueError,
-                    "has a single unit output, but the activation is softmax.*",
+                ValueError,
+                "has a single unit output, but the activation is softmax.*",
             ):
                 Model(inputs, x)
 
@@ -358,8 +358,8 @@ class FunctionalTest(testing.TestCase):
             y = layers.Dense(1, activation=activation)(inputs)
 
             with self.assertRaisesRegex(
-                    ValueError,
-                    "has a single unit output, but the activation is softmax.*",
+                ValueError,
+                "has a single unit output, but the activation is softmax.*",
             ):
                 Model(inputs, [x, y])
 
@@ -372,7 +372,7 @@ class FunctionalTest(testing.TestCase):
             x = layers.Dense(1, activation=activation)(inputs[0])
             y = layers.Dense(1, activation=activation)(inputs[1])
             with self.assertRaisesRegex(
-                    ValueError,
-                    "has a single unit output, but the activation is softmax.*",
+                ValueError,
+                "has a single unit output, but the activation is softmax.*",
             ):
                 Model(inputs, [x, y])

--- a/keras/models/sequential.py
+++ b/keras/models/sequential.py
@@ -61,7 +61,13 @@ class Sequential(Model):
     ```
     """
 
-    def __init__(self, layers=None, trainable=True, name=None, validate_output_activation=True):
+    def __init__(
+        self,
+        layers=None,
+        trainable=True,
+        name=None,
+        validate_output_activation=True,
+    ):
         super().__init__(trainable=trainable, name=name)
         self._functional = None
         self._layers = []
@@ -196,8 +202,11 @@ class Sequential(Model):
                     )
                 raise e
         outputs = x
-        self._functional = Functional(inputs=inputs, outputs=outputs,
-                                      validate_output_activation=self.validate_output_activation)
+        self._functional = Functional(
+            inputs=inputs,
+            outputs=outputs,
+            validate_output_activation=self.validate_output_activation,
+        )
         self.built = True
 
     def call(self, inputs, training=None, mask=None):

--- a/keras/models/sequential.py
+++ b/keras/models/sequential.py
@@ -61,10 +61,11 @@ class Sequential(Model):
     ```
     """
 
-    def __init__(self, layers=None, trainable=True, name=None):
+    def __init__(self, layers=None, trainable=True, name=None, validate_output_activation=True):
         super().__init__(trainable=trainable, name=name)
         self._functional = None
         self._layers = []
+        self.validate_output_activation = validate_output_activation
         if layers:
             for layer in layers:
                 self.add(layer, rebuild=False)
@@ -195,7 +196,8 @@ class Sequential(Model):
                     )
                 raise e
         outputs = x
-        self._functional = Functional(inputs=inputs, outputs=outputs)
+        self._functional = Functional(inputs=inputs, outputs=outputs,
+                                      validate_output_activation=self.validate_output_activation)
         self.built = True
 
     def call(self, inputs, training=None, mask=None):

--- a/keras/models/sequential_test.py
+++ b/keras/models/sequential_test.py
@@ -6,9 +6,9 @@ from keras import layers
 from keras import testing
 from keras.layers import Softmax
 from keras.layers.core.input_layer import Input
-from keras.ops.nn import softmax as softmax_op
 from keras.models.functional import Functional
 from keras.models.sequential import Sequential
+from keras.ops.nn import softmax as softmax_op
 
 
 @pytest.mark.requires_trainable_backend
@@ -261,7 +261,7 @@ class SequentialTest(testing.TestCase):
 
         model.add(BadLayer())
         with self.assertRaisesRegex(
-                ValueError, "can only have a single positional"
+            ValueError, "can only have a single positional"
         ):
             model.build((None, 2))
 
@@ -269,8 +269,8 @@ class SequentialTest(testing.TestCase):
 
         for activation in ["softmax", softmax_op, Softmax()]:
             with self.assertRaisesRegex(
-                    ValueError,
-                    "has a single unit output, but the activation is softmax.*",
+                ValueError,
+                "has a single unit output, but the activation is softmax.*",
             ):
                 Sequential(
                     [
@@ -290,19 +290,23 @@ class SequentialTest(testing.TestCase):
 
     def test_model_output_softmax_activation_conv(self):
 
-        input_config = {"Conv1D": (10, 2),
-                        "Conv2D": (10, 10, 2),
-                        "Conv3D": (10, 10, 10, 2)}
+        input_config = {
+            "Conv1D": (10, 2),
+            "Conv2D": (10, 10, 2),
+            "Conv3D": (10, 10, 10, 2),
+        }
 
         for layer in [layers.Conv1D, layers.Conv2D, layers.Conv3D]:
             for activation in ["softmax", softmax_op, Softmax()]:
                 with self.assertRaisesRegex(
-                        ValueError,
-                        "has a single unit output, but the activation is softmax.*",
+                    ValueError,
+                    "has a single unit output, but the activation is softmax.*",
                 ):
                     Sequential(
                         [
-                            layers.InputLayer(shape=input_config[layer.__name__]),
+                            layers.InputLayer(
+                                shape=input_config[layer.__name__]
+                            ),
                             layer(1, 3, activation=activation),
                         ]
                     )


### PR DESCRIPTION
Feature request was made in #18909 

This is a utility function to check if the usage of softmax makes sense (new users make this mistake a lot). Applying softmax on a single neuron will make the model output ones everytime, there are too many Stackoverflow posts about this.

This applies for any other layers (Conv2D etc.) where the applied axis (axis=-1 default) of softmax has only one unit.