### PR TITLE
Fix(preprocessing): resolve `ValueError` for `ngrams` tuple

### DIFF
--- a/keras/layers/preprocessing/text_vectorization.py
+++ b/keras/layers/preprocessing/text_vectorization.py
@@ -492,6 +492,10 @@ class TextVectorization(Layer):
             config["split"] = serialization_lib.deserialize_keras_object(
                 config["split"]
             )
+
+        if isinstance(config["ngrams"], list):
+            config["ngrams"] = tuple(config["ngrams"])
+
         return cls(**config)
 
     def set_vocabulary(self, vocabulary, idf_weights=None):

--- a/keras/layers/preprocessing/text_vectorization_test.py
+++ b/keras/layers/preprocessing/text_vectorization_test.py
@@ -1,11 +1,15 @@
+import os
+
 import numpy as np
 import pytest
 import tensorflow as tf
 from tensorflow import data as tf_data
 
+from keras import Sequential
 from keras import backend
 from keras import layers
 from keras import models
+from keras import saving
 from keras import testing
 
 
@@ -61,6 +65,21 @@ class TextVectorizationTest(testing.TestCase):
         output = layer(input_data)
         self.assertTrue(backend.is_tensor(output))
         self.assertAllClose(output, np.array([[4, 1, 3, 0], [1, 2, 0, 0]]))
+
+    def test_save_load_with_ngrams_flow(self):
+        input_data = np.array(["foo bar", "bar baz", "baz bada boom"])
+        model = Sequential(
+            [
+                layers.Input(dtype=tf.string, shape=(1,)),
+                layers.TextVectorization(ngrams=(1, 2)),
+            ]
+        )
+        model.layers[0].adapt(input_data)
+        output = model(input_data)
+        temp_filepath = os.path.join(self.get_temp_dir(), "model.keras")
+        model.save(temp_filepath)
+        model = saving.load_model(temp_filepath)
+        self.assertAllClose(output, model(input_data))
 
     def test_tf_data_compatibility(self):
         max_tokens = 5000

--- a/keras/layers/preprocessing/text_vectorization_test.py
+++ b/keras/layers/preprocessing/text_vectorization_test.py
@@ -66,11 +66,14 @@ class TextVectorizationTest(testing.TestCase):
         self.assertTrue(backend.is_tensor(output))
         self.assertAllClose(output, np.array([[4, 1, 3, 0], [1, 2, 0, 0]]))
 
+    @pytest.mark.skipif(
+        backend.backend() != "tensorflow", reason="Requires string input dtype"
+    )
     def test_save_load_with_ngrams_flow(self):
         input_data = np.array(["foo bar", "bar baz", "baz bada boom"])
         model = Sequential(
             [
-                layers.Input(dtype=tf.string, shape=(1,)),
+                layers.Input(dtype="string", shape=(1,)),
                 layers.TextVectorization(ngrams=(1, 2)),
             ]
         )


### PR DESCRIPTION
Resolves a deserialisation issue when `ngrams` is set to a tuple in `TextVectorization` layer. Closes #19180.