### PR TITLE
Add a constraint to BaseConv to make sure `groups` are positive

### DIFF
--- a/keras/layers/convolutional/base_conv.py
+++ b/keras/layers/convolutional/base_conv.py
@@ -104,7 +104,7 @@ class BaseConv(Layer):
         )
         self.rank = rank
         self.filters = filters
-        self.groups = groups or 1
+        self.groups = groups
         self.kernel_size = standardize_tuple(kernel_size, rank, "kernel_size")
         self.strides = standardize_tuple(strides, rank, "strides")
         self.dilation_rate = standardize_tuple(
@@ -127,6 +127,12 @@ class BaseConv(Layer):
             raise ValueError(
                 "Invalid value for argument `filters`. Expected a strictly "
                 f"positive value. Received filters={self.filters}."
+            )
+
+        if self.groups <= 0:
+            raise ValueError(
+                "The number of groups must be a positive integer. "
+                f"Received groups={self.groups}."
             )
 
         if self.filters is not None and self.filters % self.groups != 0:

--- a/keras/layers/convolutional/conv_test.py
+++ b/keras/layers/convolutional/conv_test.py
@@ -503,6 +503,10 @@ class ConvBasicTest(testing.TestCase, parameterized.TestCase):
                 filters=2, kernel_size=(2, 2), strides=2, dilation_rate=(2, 1)
             )
 
+        # `groups` is not strictly positive.
+        with self.assertRaises(ValueError):
+            layers.Conv2D(filters=5, kernel_size=(2, 2), groups=0)
+
         # `filters` cannot be divided by `groups`.
         with self.assertRaises(ValueError):
             layers.Conv2D(filters=5, kernel_size=(2, 2), groups=2)


### PR DESCRIPTION
I think it's better to have a check for `groups` parameter in BaseConv and throwing an error if it's not valid.

For example:

```python
c1 = keras.layers.Conv2D(1, 3, activation='relu', groups = -1)(keras.random.normal((1, 10, 10, 3)))
```

This will give:
```python
[/usr/local/lib/python3.10/dist-packages/keras/src/backend/common/variables.py](https://localhost:8080/#) in standardize_shape(shape)
    429             )
    430         if e < 0:
--> 431             raise ValueError(
    432                 f"Cannot convert '{shape}' to a shape. "
    433                 "Negative dimensions are not allowed."

ValueError: Cannot convert '(3, 3, -3, 2)' to a shape. Negative dimensions are not allowed.
```

which can be improved by checking the `groups` argument in layer construction.