### PR TITLE
Adds psutil deps for CI Log Reader

### DIFF
--- a/.kokoro/github/ubuntu/gpu/build.sh
+++ b/.kokoro/github/ubuntu/gpu/build.sh
@@ -20,6 +20,8 @@ nvcc --version
 
 cd "src/github/keras"
 pip install -U pip setuptools
+# psutil is used by background log reader
+pip install -U psutil
 
 if [ "$KERAS_BACKEND" == "tensorflow" ]
 then


### PR DESCRIPTION
`psutil` gets installed as part of general requirements.txt. But sometimes, it takes a while to install all dependencies and background log reader starts its job. When it happens, it causes the CI to fail since `psutil` is not yet installed. So, install `psutil` in the beginning so we don't have this failures that occur sometimes.

```
Downloading tf_nightly-2.16.0.dev20240209-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (589.8 MB)
Downloading nvidia_cublas_cu12-12.3.4.1-py3-none-manylinux1_x86_64.whl (412.6 MB)
Downloading nvidia_cuda_cupti_cu12-12.3.101-py3-none-manylinux1_x86_64.whl (14.0 MB)
Downloading nvidia_cuda_nvcc_cu12-12.3.107-py3-none-manylinux1_x86_64.whl (22.0 MB)
Downloading nvidia_cuda_nvrtc_cu12-12.3.107-py3-none-manylinux1_x86_64.whl (24.9 MB)
Downloading nvidia_cuda_runtime_cu12-12.3.101-py3-none-manylinux1_x86_64.whl (867 kB)
Downloading nvidia_cudnn_cu12-8.9.7.29-py3-none-manylinux1_x86_64.whl (704.7 MB)
Traceback (most recent call last):
  File "/tmpfs/kokoro_log_reader.py", line 13, in <module>
    import psutil
ModuleNotFoundError: No module named 'psutil'
```