### PR TITLE
Add `_untrack_variable` to `Layer` and explicitly define `constraint` and `regularizer` to `KerasVariable`

### DIFF
--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -187,8 +187,9 @@ class KerasVariable:
 
         if value is not None and not isinstance(value, Regularizer):
             raise ValueError(
-                "The object to be assigned must be the subclass of "
-                f"`Regularizer` or `None`. Received: {type(value)}"
+                "Invalid value for attribute `regularizer`. Expected an "
+                "instance of `keras.regularizers.Regularizer`, or `None`. "
+                f"Received: regularizer={value}"
             )
         self._regularizer = value
 
@@ -202,8 +203,9 @@ class KerasVariable:
 
         if value is not None and not isinstance(value, Constraint):
             raise ValueError(
-                "The object to be assigned must be the subclass of "
-                f"`Constraint` or `None`. Received: {type(value)}"
+                "Invalid value for attribute `constraint`. Expected an "
+                "instance of `keras.constraints.Constraint`, or `None`. "
+                f"Received: constraint={value}"
             )
         self._constraint = value
 

--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -31,6 +31,8 @@ class KerasVariable:
         self._dtype = dtype
         self._shape = None
         self._initializer = None
+        self._regularizer = None
+        self._constraint = None
         self._trainable = trainable
         if isinstance(initializer, str):
             from keras import initializers
@@ -174,6 +176,36 @@ class KerasVariable:
     @trainable.setter
     def trainable(self, value):
         self._trainable = value
+
+    @property
+    def regularizer(self):
+        return self._regularizer
+
+    @regularizer.setter
+    def regularizer(self, value):
+        from keras.regularizers import Regularizer
+
+        if value is not None and not isinstance(value, Regularizer):
+            raise ValueError(
+                "The object to be assigned must be the subclass of "
+                f"`Regularizer` or `None`. Received: {type(value)}"
+            )
+        self._regularizer = value
+
+    @property
+    def constraint(self):
+        return self._constraint
+
+    @constraint.setter
+    def constraint(self, value):
+        from keras.constraints import Constraint
+
+        if value is not None and not isinstance(value, Constraint):
+            raise ValueError(
+                "The object to be assigned must be the subclass of "
+                f"`Constraint` or `None`. Received: {type(value)}"
+            )
+        self._constraint = value
 
     def __repr__(self):
         return (

--- a/keras/layers/core/dense.py
+++ b/keras/layers/core/dense.py
@@ -164,7 +164,7 @@ class Dense(Layer):
                 "lora is already enabled. "
                 "This can only be done once per layer."
             )
-        self._tracker.locked = False
+        self._tracker.unlock()
         self.lora_kernel_a = self.add_weight(
             name="lora_kernel_a",
             shape=(self.kernel.shape[0], rank),
@@ -178,7 +178,7 @@ class Dense(Layer):
             regularizer=self.kernel_regularizer,
         )
         self.kernel.trainable = False
-        self._tracker.locked = True
+        self._tracker.lock()
         self.lora_enabled = True
 
     def save_own_variables(self, store):

--- a/keras/layers/core/einsum_dense.py
+++ b/keras/layers/core/einsum_dense.py
@@ -240,8 +240,7 @@ class EinsumDense(Layer):
                 "lora is already enabled. "
                 "This can only be done once per layer."
             )
-
-        self._tracker.locked = False
+        self._tracker.unlock()
         self.lora_kernel_a = self.add_weight(
             name="lora_kernel_a",
             shape=(self.kernel.shape[:-1] + (rank,)),
@@ -255,7 +254,7 @@ class EinsumDense(Layer):
             regularizer=self.kernel_regularizer,
         )
         self.kernel.trainable = False
-        self._tracker.locked = True
+        self._tracker.lock()
         self.lora_enabled = True
 
     def save_own_variables(self, store):

--- a/keras/layers/core/embedding.py
+++ b/keras/layers/core/embedding.py
@@ -143,7 +143,7 @@ class Embedding(Layer):
                 "lora is already enabled. "
                 "This can only be done once per layer."
             )
-        self._tracker.locked = False
+        self._tracker.unlock()
         self.lora_embeddings_a = self.add_weight(
             name="lora_embeddings_a",
             shape=(self.embeddings.shape[0], rank),
@@ -157,7 +157,7 @@ class Embedding(Layer):
             regularizer=self.embeddings_regularizer,
         )
         self.embeddings.trainable = False
-        self._tracker.locked = True
+        self._tracker.lock()
         self.lora_enabled = True
 
     def save_own_variables(self, store):

--- a/keras/layers/layer.py
+++ b/keras/layers/layer.py
@@ -509,16 +509,6 @@ class Layer(BackendLayer, Operation):
         self._track_variable(variable)
         return variable
 
-    def remove_weight(self, variable):
-        """Remove a weight variable from the layer.
-
-        Args:
-            variable: The variable to be removed.
-        """
-        self._check_super_called()
-        self._untrack_variable(variable)
-        return None
-
     @property
     def trainable(self):
         """Settable boolean, whether this layer should be trainable or not."""

--- a/keras/layers/layer.py
+++ b/keras/layers/layer.py
@@ -515,11 +515,8 @@ class Layer(BackendLayer, Operation):
         Args:
             variable: The variable to be removed.
         """
-        previous_lock_state = self._tracker.locked
-        self._tracker.unlock()
-        self._tracker.untrack(variable)
-        if previous_lock_state is True:
-            self._tracker.lock()
+        self._check_super_called()
+        self._untrack_variable(variable)
         return None
 
     @property
@@ -1169,6 +1166,13 @@ class Layer(BackendLayer, Operation):
             self._tracker.add_to_store("trainable_variables", variable)
         else:
             self._tracker.add_to_store("non_trainable_variables", variable)
+
+    def _untrack_variable(self, variable):
+        previous_lock_state = self._tracker.locked
+        self._tracker.unlock()
+        self._tracker.untrack(variable)
+        if previous_lock_state is True:
+            self._tracker.lock()
 
     def add_metric(self):
         # Permanently disabled

--- a/keras/layers/layer_test.py
+++ b/keras/layers/layer_test.py
@@ -855,3 +855,27 @@ class LayerTest(testing.TestCase):
         self.assertEqual(layer.w5.shape, (2, 2))
         self.assertEqual(layer.w5.dtype, "float32")
         self.assertAllClose(backend.convert_to_numpy(layer.w5), np.ones((2, 2)))
+
+    def test_remove_weight(self):
+        class MyLayer(layers.Layer):
+            def __init__(self):
+                super().__init__()
+                self.w = self.add_weight()
+
+            def custom_remove_w(self):
+                self.w = self.remove_weight(self.w)
+
+            def custom_change_dtype(self):
+                self.w = self.remove_weight(self.w)
+                self.w = self.add_weight(initializer="zeros", dtype="int8")
+
+        layer = MyLayer()
+        self.assertEqual(len(layer.weights), 1)
+        layer.custom_remove_w()
+        self.assertEqual(len(layer.weights), 0)
+        self.assertEqual(layer.w, None)
+
+        layer = MyLayer()
+        self.assertEqual(layer.w.dtype, "float32")
+        layer.custom_change_dtype()
+        self.assertEqual(layer.w.dtype, "int8")

--- a/keras/layers/layer_test.py
+++ b/keras/layers/layer_test.py
@@ -867,7 +867,9 @@ class LayerTest(testing.TestCase):
 
             def custom_change_dtype(self):
                 self.w = self.remove_weight(self.w)
-                self.w = self.add_weight(initializer="zeros", dtype="int8")
+                self.w = self.add_weight(
+                    initializer="zeros", dtype="int8", trainable=False
+                )
 
         layer = MyLayer()
         self.assertEqual(len(layer.weights), 1)
@@ -877,5 +879,7 @@ class LayerTest(testing.TestCase):
 
         layer = MyLayer()
         self.assertEqual(layer.w.dtype, "float32")
+        self.assertEqual(layer.w.trainable, True)
         layer.custom_change_dtype()
         self.assertEqual(layer.w.dtype, "int8")
+        self.assertEqual(layer.w.trainable, False)

--- a/keras/layers/layer_test.py
+++ b/keras/layers/layer_test.py
@@ -863,10 +863,10 @@ class LayerTest(testing.TestCase):
                 self.w = self.add_weight()
 
             def custom_remove_w(self):
-                self.w = self.remove_weight(self.w)
+                self.w = self._untrack_variable(self.w)
 
             def custom_change_dtype(self):
-                self.w = self.remove_weight(self.w)
+                self.w = self._untrack_variable(self.w)
                 self.w = self.add_weight(
                     initializer="zeros", dtype="int8", trainable=False
                 )

--- a/keras/optimizers/base_optimizer.py
+++ b/keras/optimizers/base_optimizer.py
@@ -330,7 +330,7 @@ class BaseOptimizer:
             self._backend_apply_gradients(grads, trainable_variables)
             # Apply variable constraints after applying gradients.
             for variable in trainable_variables:
-                if getattr(variable, "constraint", None) is not None:
+                if variable.constraint is not None:
                     variable.assign(variable.constraint(variable))
 
     def _backend_apply_gradients(self, grads, trainable_variables):

--- a/keras/utils/tracking.py
+++ b/keras/utils/tracking.py
@@ -95,9 +95,13 @@ class Tracker:
                 self.stored_ids[store_name].remove(id(value))
                 python_utils.remove_by_id(self.config[store_name][1], value)
 
-    def lock(self, msg):
+    def lock(self, msg=None):
         self.locked = True
-        self._lock_violation_msg = msg
+        if msg is not None:
+            self._lock_violation_msg = msg
+
+    def unlock(self):
+        self.locked = False
 
     def add_to_store(self, store_name, value):
         if self.locked:


### PR DESCRIPTION
`_untrack_variable` is necessary when performing in-place operations on variables, such as changing the dtype.
A unit test is also included.

I think it would be beneficial to expose `constraint` and `regularizer` for `KerasVariable`:
- This prevents improper assignment to these attrs, which could lead to runtime error (and may be challenging to debug).
- This should enhance the development UX.

This PR is also a preparation for adding `quantize` to `Layer` and `Quantizer` classes for `KerasVariable`.
