### PR TITLE
Support `torch._int_mm` in torch's `ops.matmul`

### DIFF
--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -43,27 +43,28 @@ def subtract(x1, x2):
     return torch.subtract(x1, x2)
 
 
-def _enable_int_mm(x1, x2):
+def _can_use_int_matmul(x1, x2):
     # torch._int_mm only accepts the following conditions:
-    # 1. both inputs must have int8 dtype
-    # 2. both inputs must be 2d
-    # 3. x1.shape must be [>16, >= 16 and a multiplier of 8]
-    # 4. x2.shape must be [>= 16 and a multiplier of 8, multiplier of 8]
+    # 1. cuda
+    # 2. both inputs must have int8 dtype
+    # 3. both inputs must be 2d
+    # 4. x1.shape must be [>16, >= 16 and a multiplier of 8]
+    # 5. x2.shape must be [>= 16 and a multiplier of 8, multiplier of 8]
     if get_device() != "cuda":
         return False
     x1_dtype = standardize_dtype(x1.dtype)
     x2_dtype = standardize_dtype(x2.dtype)
-    if x1_dtype == "int8" and x2_dtype == "int8":
-        x1_shape = x1.shape
-        x2_shape = x2.shape
-        if x1.ndim != 2 or x2.ndim != 2:
-            return False
-        if x1_shape[0] <= 16 or x1_shape[1] < 16 or x1_shape[1] % 8 != 0:
-            return False
-        if x2_shape[0] < 16 or x2_shape[0] % 8 != 0 or x2_shape[1] % 8 != 0:
-            return False
-        return True
-    return False
+    if x1_dtype != "int8" or x2_dtype != "int8":
+        return False
+    x1_shape = x1.shape
+    x2_shape = x2.shape
+    if x1.ndim != 2 or x2.ndim != 2:
+        return False
+    if x1_shape[0] <= 16 or x1_shape[1] < 16 or x1_shape[1] % 8 != 0:
+        return False
+    if x2_shape[0] < 16 or x2_shape[0] % 8 != 0 or x2_shape[1] % 8 != 0:
+        return False
+    return True
 
 
 def matmul(x1, x2):
@@ -72,10 +73,8 @@ def matmul(x1, x2):
 
     # Shortcut for torch._int_mm
     # TODO: Loosen the restriction of the usage of torch._int_mm
-    # TODO: torch._int_mm is not a public api. We should replace it with public
-    # api
-    enable_int_mm = _enable_int_mm(x1, x2)
-    if enable_int_mm:
+    # TODO: We should replace torch._int_mm with the public api if possible
+    if _can_use_int_matmul(x1, x2):
         return torch._int_mm(x1, x2)
 
     x1_dtype = standardize_dtype(x1.dtype)

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -43,12 +43,41 @@ def subtract(x1, x2):
     return torch.subtract(x1, x2)
 
 
+def _enable_int_mm(x1, x2):
+    # torch._int_mm only accepts the following conditions:
+    # 1. both inputs must have int8 dtype
+    # 2. both inputs must be 2d
+    # 3. x1.shape must be [>16, >= 16 and a multiplier of 8]
+    # 4. x2.shape must be [>= 16 and a multiplier of 8, multiplier of 8]
+    if get_device() != "cuda":
+        return False
+    x1_dtype = standardize_dtype(x1.dtype)
+    x2_dtype = standardize_dtype(x2.dtype)
+    if x1_dtype == "int8" and x2_dtype == "int8":
+        x1_shape = x1.shape
+        x2_shape = x2.shape
+        if x1.ndim != 2 or x2.ndim != 2:
+            return False
+        if x1_shape[0] <= 16 or x1_shape[1] < 16 or x1_shape[1] % 8 != 0:
+            return False
+        if x2_shape[0] < 16 or x2_shape[0] % 8 != 0 or x2_shape[1] % 8 != 0:
+            return False
+        return True
+    return False
+
+
 def matmul(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    # When both x1 and x2 are of int8, we cast the outputs to int32 to align
-    # with jax
-    # TODO: Support hardware-accelerated matmul
+
+    # Shortcut for torch._int_mm
+    # TODO: Loosen the restriction of the usage of torch._int_mm
+    # TODO: torch._int_mm is not a public api. We should replace it with public
+    # api
+    enable_int_mm = _enable_int_mm(x1, x2)
+    if enable_int_mm:
+        return torch._int_mm(x1, x2)
+
     x1_dtype = standardize_dtype(x1.dtype)
     x2_dtype = standardize_dtype(x2.dtype)
     if x1_dtype == "int8" and x2_dtype == "int8":

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4607,10 +4607,12 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = knp.ones((1, 1), dtype=dtype1)
-        x2 = knp.ones((1, 1), dtype=dtype2)
-        x1_jax = jnp.ones((1, 1), dtype=dtype1)
-        x2_jax = jnp.ones((1, 1), dtype=dtype2)
+        # The shape of the matrix needs to meet the requirements of
+        # torch._int_mm to test hardware-accelerated matmul
+        x1 = knp.ones((17, 16), dtype=dtype1)
+        x2 = knp.ones((16, 8), dtype=dtype2)
+        x1_jax = jnp.ones((17, 16), dtype=dtype1)
+        x2_jax = jnp.ones((16, 8), dtype=dtype2)
         if dtype1 == "int8" and dtype2 == "int8":
             preferred_element_type = "int32"
         else:


### PR DESCRIPTION
I just discovered a private api `torch._int_mm` for performing int8xint8->int32 matmul
However, it comes with strict conditions to perform:
1. both inputs must have int8 dtype
2. both inputs must be 2d
3. x1.shape must be [>16, >= 16 and a multiplier of 8]
4. x2.shape must be [>= 16 and a multiplier of 8, multiplier of 8]

Nevertheless, it could still be valuable to include.

The performance report (using the code from #19137 )

```python
    # compile `network` by following
    elif backend.backend() == "torch":
        import torch

        torch.set_float32_matmul_precision("high")
        jit_network = torch.compile(network)
```

```bash
TOPS/TFLOPS
===================================
dim    |     int8     fp16     fp32
-----------------------------------
256    |     0.23     0.51     0.49
512    |     1.52     3.26     3.21
1024   |    11.98    25.34    22.25
2048   |    31.96    47.59    26.30
4096   |    33.22    55.90    27.76
===================================
```
The performance of int8 matmul in torch is not as robust as that in jax and tf.