### PR TITLE
Add workflow test for multiple unknown JAX dimensions

### DIFF
--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -420,11 +420,12 @@ def standardize_dtype(dtype):
     dtype = PYTHON_DTYPES_MAP.get(dtype, dtype)
     if hasattr(dtype, "name"):
         dtype = dtype.name
-    elif hasattr(dtype, "__str__"):
-        if "_DimExpr" in str(dtype):
-            return config.floatx()
-        if "torch" in str(dtype) or "jax.numpy" in str(dtype):
-            dtype = str(dtype).split(".")[-1]
+    elif hasattr(dtype, "__str__") and (
+        "torch" in str(dtype) or "jax.numpy" in str(dtype)
+    ):
+        dtype = str(dtype).split(".")[-1]
+    elif hasattr(dtype, "__str__") and "_DimExpr" in str(dtype):
+        return config.floatx()
     elif hasattr(dtype, "__name__"):
         dtype = dtype.__name__
 

--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -420,10 +420,11 @@ def standardize_dtype(dtype):
     dtype = PYTHON_DTYPES_MAP.get(dtype, dtype)
     if hasattr(dtype, "name"):
         dtype = dtype.name
-    elif hasattr(dtype, "__str__") and (
-        "torch" in str(dtype) or "jax.numpy" in str(dtype)
-    ):
-        dtype = str(dtype).split(".")[-1]
+    elif hasattr(dtype, "__str__"):
+        if "_DimExpr" in str(dtype):
+            return config.floatx()
+        if "torch" in str(dtype) or "jax.numpy" in str(dtype):
+            dtype = str(dtype).split(".")[-1]
     elif hasattr(dtype, "__name__"):
         dtype = dtype.__name__
 
@@ -453,7 +454,7 @@ def standardize_shape(shape):
     for e in shape:
         if e is None:
             continue
-        if config.backend() == "jax" and str(e) == "b":
+        if config.backend() == "jax" and "_DimExpr" in str(type(e)):
             # JAX2TF tracing represents `None` dimensions as `b`
             continue
         if not is_int_dtype(type(e)):

--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -455,7 +455,7 @@ def standardize_shape(shape):
         if e is None:
             continue
         if config.backend() == "jax" and "_DimExpr" in str(type(e)):
-            # JAX2TF tracing represents `None` dimensions as `b`
+            # JAX2TF tracing uses JAX-native dimension expressions
             continue
         if not is_int_dtype(type(e)):
             raise ValueError(

--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -424,8 +424,6 @@ def standardize_dtype(dtype):
         "torch" in str(dtype) or "jax.numpy" in str(dtype)
     ):
         dtype = str(dtype).split(".")[-1]
-    elif hasattr(dtype, "__str__") and "_DimExpr" in str(dtype):
-        return config.floatx()
     elif hasattr(dtype, "__name__"):
         dtype = dtype.__name__
 

--- a/keras/backend/common/variables_test.py
+++ b/keras/backend/common/variables_test.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import numpy as np
 import pytest
 from absl.testing import parameterized

--- a/keras/backend/common/variables_test.py
+++ b/keras/backend/common/variables_test.py
@@ -614,13 +614,6 @@ class VariableBinaryOperationsTest(test_case.TestCase):
         ):
             standardize_dtype(invalid_dtype)
 
-    @patch("keras.backend.config.backend", return_value="jax")
-    def test_jax_backend_b_dimension(self, mock_backend):
-        """Test 'b' dimension handling with JAX backend."""
-        shape = (3, "b", 5)
-        standardized_shape = standardize_shape(shape)
-        self.assertEqual(standardized_shape, shape)
-
     def test_negative_shape_entry(self):
         """Test negative shape entry."""
         shape = (3, -1, 5)

--- a/keras/export/export_lib_test.py
+++ b/keras/export/export_lib_test.py
@@ -181,7 +181,6 @@ class ExportArchiveTest(testing.TestCase):
     )
     def test_jax_multi_unknown_endpoint_registration(self):
         window_size = 100
-        inference_window_size = None
 
         X = np.random.random((1024, window_size, 1))
         Y = np.random.random((1024, window_size, 1))

--- a/keras/export/export_lib_test.py
+++ b/keras/export/export_lib_test.py
@@ -76,7 +76,7 @@ class ExportArchiveTest(testing.TestCase):
 
     @pytest.mark.skipif(
         backend.backend() != "tensorflow",
-        reason="Registering a tf.function endpoint is only in TF backend.",
+        reason="This test is native to the TF backend.",
     )
     def test_endpoint_registration_tf_function(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
@@ -174,6 +174,81 @@ class ExportArchiveTest(testing.TestCase):
         assert isinstance(
             export_archive.non_trainable_variables[0], tf.Variable
         )
+
+    @pytest.mark.skipif(
+        backend.backend() != "jax",
+        reason="This test is native to the JAX backend.",
+    )
+    def test_jax_multi_unknown_endpoint_registration(self):
+        window_size = 100
+        inference_window_size = None
+
+        X = np.random.random((1024, window_size, 1))
+        Y = np.random.random((1024, window_size, 1))
+
+        model = models.Sequential(
+            [
+                layers.Dense(128, activation="relu"),
+                layers.Dense(64, activation="relu"),
+                layers.Dense(1, activation="relu"),
+            ]
+        )
+
+        model.compile(optimizer="adam", loss="mse")
+
+        model.fit(X, Y, batch_size=32)
+
+        # build a JAX function
+        def model_call(x):
+            return model(x)
+
+        from jax import default_backend as jax_device
+        from jax.experimental import jax2tf
+
+        native_jax_compatible = not (
+            jax_device() == "gpu"
+            and len(tf.config.list_physical_devices("GPU")) == 0
+        )
+        # now, convert JAX function
+        converted_model_call = jax2tf.convert(
+            model_call,
+            native_serialization=native_jax_compatible,
+            polymorphic_shapes=["(b, t, 1)"],
+        )
+
+        # you can now build a TF inference function
+        @tf.function(
+            input_signature=[
+                tf.TensorSpec(shape=(None, None, 1), dtype=tf.float32)
+            ],
+            autograph=False,
+        )
+        def infer_fn(x):
+            return converted_model_call(x)
+
+        ref_input = np.random.random((1024, window_size, 1))
+        ref_output = infer_fn(ref_input)
+
+        # Export with TF inference function as endpoint
+        temp_filepath = os.path.join(self.get_temp_dir(), "my_model")
+        export_archive = export_lib.ExportArchive()
+        export_archive.track(model)
+        export_archive.add_endpoint("serve", infer_fn)
+        export_archive.write_out(temp_filepath)
+
+        # Reload and verify outputs
+        revived_model = tf.saved_model.load(temp_filepath)
+        self.assertFalse(hasattr(revived_model, "_tracked"))
+        self.assertAllClose(
+            ref_output, revived_model.serve(ref_input), atol=1e-6
+        )
+        self.assertLen(revived_model.variables, 6)
+        self.assertLen(revived_model.trainable_variables, 6)
+        self.assertLen(revived_model.non_trainable_variables, 0)
+
+        # Assert all variables wrapped as `tf.Variable`
+        assert isinstance(export_archive.variables[0], tf.Variable)
+        assert isinstance(export_archive.trainable_variables[0], tf.Variable)
 
     def test_layer_export(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_layer")


### PR DESCRIPTION
This PR additionally special-cases JAX dimension expressions (at tracing time) from being blocked by dtype and shape standardization in Keras.

**NOTE:** The test for unknown JAX dimensions in shape and dtype standardization is not reproducible outside of the export API. (This is because SavedModel export triggers JAX tracing, which produces the JAX _DimExpr for which we special-case.) As a result, I have deleted the associated test, as it is covered in `export_lib_test.py`.