### PR TITLE
Fix `test_case.run_layer` which was not training with `training=True`.

### DIFF
--- a/keras/layers/regularization/alpha_dropout.py
+++ b/keras/layers/regularization/alpha_dropout.py
@@ -77,9 +77,9 @@ class AlphaDropout(Layer):
 
     def _get_concrete_noise_shape(self, inputs, noise_shape):
         if noise_shape is None:
-            return inputs.shape
+            return ops.shape(inputs)
 
-        concrete_inputs_shape = inputs.shape
+        concrete_inputs_shape = ops.shape(inputs)
         concrete_noise_shape = []
         for i, value in enumerate(noise_shape):
             concrete_noise_shape.append(

--- a/keras/layers/rnn/rnn.py
+++ b/keras/layers/rnn/rnn.py
@@ -392,7 +392,9 @@ class RNN(Layer):
 
         # Prepopulate the dropout state so that the inner_loop is stateless
         # this is particularly important for JAX backend.
-        self._maybe_config_dropout_masks(self.cell, sequences, initial_state)
+        self._maybe_config_dropout_masks(
+            self.cell, sequences[:, 0, :], initial_state
+        )
 
         last_output, outputs, states = self.inner_loop(
             sequences=sequences,
@@ -426,18 +428,22 @@ class RNN(Layer):
         return output
 
     def _maybe_config_dropout_masks(self, cell, input_sequence, input_state):
-        step_input = input_sequence[:, 0, :]
         state = (
             input_state[0]
             if isinstance(input_state, (list, tuple))
             else input_state
         )
         if isinstance(cell, DropoutRNNCell):
-            cell.get_dropout_mask(step_input)
+            cell.get_dropout_mask(input_sequence)
             cell.get_recurrent_dropout_mask(state)
         if isinstance(cell, StackedRNNCells):
             for c, s in zip(cell.cells, input_state):
                 self._maybe_config_dropout_masks(c, input_sequence, s)
+                # Replicate the behavior of `StackedRNNCells.call` to compute
+                # the inputs for the next cell.
+                s = list(s) if tree.is_nested(s) else [s]
+                cell_call_fn = c.__call__ if callable(c) else c.call
+                input_sequence, _ = cell_call_fn(input_sequence, s)
 
     def _maybe_reset_dropout_masks(self, cell):
         if isinstance(cell, DropoutRNNCell):

--- a/keras/testing/test_case.py
+++ b/keras/testing/test_case.py
@@ -320,8 +320,8 @@ class TestCase(unittest.TestCase):
                     super().__init__()
                     self.layer = layer
 
-                def call(self, x):
-                    return self.layer(x)
+                def call(self, x, training=False):
+                    return self.layer(x, training=training)
 
             model = TestModel(layer)
 


### PR DESCRIPTION
Added the training argument to `TestModel.call` so that `training=True` is actually passed to the layer during the training test.

This uncovered some issues:
- `SpectralNormalization` had an `if` that should have been a `ops.cond`. https://github.com/keras-team/keras/issues/19183
- `AlphaDropout` should have been using `ops.shape`.
- The dropout mask for `StackedRNNCells` was not constructed with the correct size.