### PR TITLE
A few simplifications related to `ops.cond`.

### DIFF
--- a/keras/backend/jax/core.py
+++ b/keras/backend/jax/core.py
@@ -1,12 +1,9 @@
-import types
-
 import jax
 import jax.experimental.sparse as jax_sparse
 import jax.numpy as jnp
 import ml_dtypes
 import numpy as np
 import tree
-from jax.tree_util import Partial
 
 from keras.backend.common import KerasVariable
 from keras.backend.common import global_state
@@ -139,16 +136,6 @@ def compute_output_spec(fn, *args, **kwargs):
                             shape[i] = fill_value
                 jax_tensor = jax.ShapeDtypeStruct(shape, dtype=x.dtype)
                 return jax_tensor
-            if isinstance(x, types.FunctionType):
-
-                def _fn(*args, **kwargs):
-                    out = x(*args, **kwargs)
-                    out = convert_keras_tensor_to_jax(
-                        out, fill_value=fill_value
-                    )
-                    return out
-
-                return Partial(_fn)
             if isinstance(x, dict):
                 return {
                     k: convert_keras_tensor_to_jax(v, fill_value=fill_value)

--- a/keras/backend/tensorflow/core.py
+++ b/keras/backend/tensorflow/core.py
@@ -1,5 +1,3 @@
-import types
-
 import numpy as np
 import tensorflow as tf
 from tensorflow.compiler.tf2xla.python.xla import dynamic_update_slice
@@ -176,14 +174,6 @@ def compute_output_spec(fn, *args, **kwargs):
                         return tf.compat.v1.placeholder(
                             shape=x.shape, dtype=x.dtype
                         )
-                if isinstance(x, types.FunctionType):
-
-                    def _fn(*x_args, **x_kwargs):
-                        out = x(*x_args, **x_kwargs)
-                        out = convert_keras_tensor_to_tf(out)
-                        return out
-
-                    return _fn
                 return x
 
             args, kwargs = tf.nest.map_structure(

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -423,14 +423,6 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         f = ops.cond(False, lambda: None, lambda: None)
         self.assertEqual(f, None)
 
-        for val in [True, False]:
-            out = ops.cond(
-                val,
-                lambda: KerasTensor((16, 3)),
-                lambda: KerasTensor((16, 3)),
-            )
-            self.assertEqual((16, 3), out.shape)
-
         out = ops.cond(
             KerasTensor((), dtype="bool"),
             lambda: ops.ones((1, 3)),
@@ -440,16 +432,16 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
         out = ops.cond(
             KerasTensor((), dtype="bool"),
-            lambda: KerasTensor((3,)),
-            lambda: KerasTensor((3,)),
+            lambda: ops.ones((3,)),
+            lambda: ops.zeros((3,)),
         )
         self.assertEqual((3,), out.shape)
 
         with self.assertRaises(ValueError):
             ops.cond(
                 KerasTensor((), dtype="bool"),
-                lambda: KerasTensor((3,)),
-                lambda: KerasTensor((4,)),
+                lambda: ops.ones((3,)),
+                lambda: ops.zeros((4,)),
             )
 
     def test_unstack(self):


### PR DESCRIPTION
- Fixed an issue where an error resulting from using `ops.cond` was obscured by a different error caused by doing a symbolic call.
- Remove support for `KerasTensor` as return values for the functions passed to `ops.cond` as it is not a valid use case.
- Remove support for functions instead of tensors as inputs in `backend.compute_output_spec` as there is no use case for it.