### PR TITLE
Update CI to TF 2.16 RC0

### DIFF
--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,5 +1,5 @@
 # Tensorflow cpu-only version (needed for testing).
-tf-nightly-cpu==2.16.0.dev20240101  # Pin a working nightly until rc0.
+tensorflow-cpu==2.16.0rc0  # Pin to rc until TF 2.16 release
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,5 +1,5 @@
 # Tensorflow with cuda support.
-tensorflow[and-cuda]====2.16.0rc0  # Pin to rc until TF 2.16 release
+tensorflow[and-cuda]==2.16.0rc0  # Pin to rc until TF 2.16 release
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,5 +1,5 @@
 # Tensorflow with cuda support.
-tf-nightly[and-cuda]==2.16.0.dev20240101  # Pin a working nightly until rc0.
+tensorflow[and-cuda]====2.16.0rc0  # Pin to rc until TF 2.16 release
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,5 +1,5 @@
 # Tensorflow cpu-only version (needed for testing).
-tf-nightly-cpu==2.16.0.dev20240101  # Pin a working nightly until rc0.
+tensorflow-cpu==2.16.0rc0  # Pin to rc until TF 2.16 release
 
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu121

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Tensorflow.
-tf-nightly-cpu==2.16.0.dev20240101  # Pin a working nightly until rc0.
+tensorflow-cpu==2.16.0rc0  # Pin to rc until TF 2.16 release
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
Now that RC0 is released, pin to TF 2.16 RC0 instead of Nightly.

Spectral Norm test is failing on the Master as well for TF GPU Backend.