### PR TITLE
Remove prints from image dataset from directory

### DIFF
--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -503,6 +503,7 @@ def index_directory(
     shuffle=True,
     seed=None,
     follow_links=False,
+    verbose=True,
 ):
     """List all files in `directory`, with their labels.
 
@@ -529,6 +530,7 @@ def index_directory(
             If set to False, sorts the data in alphanumeric order.
         seed: Optional random seed for shuffling.
         follow_links: Whether to visits subdirectories pointed to by symlinks.
+        verbose: Whether the function prints number of files found and classes. Default: True
 
     Returns:
         tuple (file_paths, labels, class_names).
@@ -610,14 +612,14 @@ def index_directory(
                 f"in directory {directory}."
             )
         class_names = [str(label) for label in sorted(set(labels))]
-
-    if labels is None:
-        io_utils.print_msg(f"Found {len(filenames)} files.")
-    else:
-        io_utils.print_msg(
-            f"Found {len(filenames)} files belonging "
-            f"to {len(class_names)} classes."
-        )
+    if verbose:
+        if labels is None:
+            io_utils.print_msg(f"Found {len(filenames)} files.")
+        else:
+            io_utils.print_msg(
+                f"Found {len(filenames)} files belonging "
+                f"to {len(class_names)} classes."
+            )
     pool.close()
     pool.join()
     file_paths = [tf.io.gfile.join(directory, fname) for fname in filenames]

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -530,7 +530,8 @@ def index_directory(
             If set to False, sorts the data in alphanumeric order.
         seed: Optional random seed for shuffling.
         follow_links: Whether to visits subdirectories pointed to by symlinks.
-        verbose: Whether the function prints number of files found and classes. Default: True
+        verbose: Whether the function prints number of files found and classes.
+            Default: True
 
     Returns:
         tuple (file_paths, labels, class_names).

--- a/keras/utils/image_dataset_utils.py
+++ b/keras/utils/image_dataset_utils.py
@@ -31,6 +31,7 @@ def image_dataset_from_directory(
     follow_links=False,
     crop_to_aspect_ratio=False,
     data_format=None,
+    verbose=True,
 ):
     """Generates a `tf.data.Dataset` from image files in a directory.
 
@@ -115,6 +116,7 @@ def image_dataset_from_directory(
             preserved.
         data_format: If None uses keras.config.image_data_format()
             otherwise either 'channel_last' or 'channel_first'.
+        verbose: Whether the function prints number of files found and classes. Default: True
 
     Returns:
 
@@ -217,6 +219,7 @@ def image_dataset_from_directory(
         shuffle=shuffle,
         seed=seed,
         follow_links=follow_links,
+        verbose=verbose,
     )
 
     if label_mode == "binary" and len(class_names) != 2:

--- a/keras/utils/image_dataset_utils.py
+++ b/keras/utils/image_dataset_utils.py
@@ -116,7 +116,8 @@ def image_dataset_from_directory(
             preserved.
         data_format: If None uses keras.config.image_data_format()
             otherwise either 'channel_last' or 'channel_first'.
-        verbose: Whether the function prints number of files found and classes. Default: True
+        verbose: Whether the function prints number of files found and classes.
+            Default: True
 
     Returns:
 


### PR DESCRIPTION
I added a verbose arg to `index_directory` function in utils/dataset_utils.py and to `image_dataset_from_directory` function  in utils/image_dataset_utils.py to control/remove prints when using `image_dataset_from_directory.`