### PR TITLE
Fix for TF XLA compilation error for `SpectralNormalization`.

### DIFF
--- a/keras/layers/normalization/spectral_normalization_test.py
+++ b/keras/layers/normalization/spectral_normalization_test.py
@@ -9,10 +9,6 @@ from keras import testing
 
 class SpectralNormalizationTest(testing.TestCase):
     @pytest.mark.requires_trainable_backend
-    @pytest.mark.skipif(
-        backend.backend() == "tensorflow",
-        reason="TODO: test fails on GPU. XLA related.",
-    )
     def test_basic_spectralnorm(self):
         self.run_layer_test(
             layers.SpectralNormalization,

--- a/keras/ops/linalg.py
+++ b/keras/ops/linalg.py
@@ -294,7 +294,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
         - For matrices:
             - `ord=None`: Frobenius norm
             - `ord="fro"`: Frobenius norm
-            - `ord=nuc`: nuclear norm
+            - `ord="nuc"`: nuclear norm
             - `ord=np.inf`: `max(sum(abs(x), axis=1))`
             - `ord=-np.inf`: `min(sum(abs(x), axis=1))`
             - `ord=0`: not supported
@@ -306,7 +306,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
         - For vectors:
             - `ord=None`: 2-norm
             - `ord="fro"`: not supported
-            - `ord=nuc`: not supported
+            - `ord="nuc"`: not supported
             - `ord=np.inf`: `max(abs(x))`
             - `ord=-np.inf`: `min(abs(x))`
             - `ord=0`: `sum(x != 0)`

--- a/keras/ops/linalg_test.py
+++ b/keras/ops/linalg_test.py
@@ -398,19 +398,45 @@ class LinalgOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
     @parameterized.named_parameters(
         named_product(
+            ndim=[1, 2],
             ord=[None, "fro", "nuc", -np.inf, -2, -1, 0, 1, 2, np.inf, 3],
-            axis=[None, 1, -1],
+            axis=[None, 1, -1, (0, 1)],
             keepdims=[False, True],
         )
     )
-    def test_norm_vectors(self, ord, axis, keepdims):
-        if axis is None:
+    def test_norm(self, ndim, ord, axis, keepdims):
+        if ndim == 1:
             x = np.random.random((5,))
         else:
             x = np.random.random((5, 6))
-        if ord in ("fro", "nuc"):
-            error = RuntimeError if backend.backend() == "torch" else ValueError
-            with self.assertRaises(error):
+
+        vector_norm = (ndim == 1) or isinstance(axis, int)
+
+        axis_out_of_bounds = ndim == 1 and (
+            axis == 1 or isinstance(axis, tuple)
+        )
+        expected_error = None
+        # when an out of bounds axis triggers an IndexError on torch is complex
+        if (
+            axis_out_of_bounds
+            and (not isinstance(axis, tuple) or ord is None)
+            and ord not in ("fro", "nuc")
+        ):
+            expected_error = IndexError
+        elif (
+            axis_out_of_bounds
+            or (vector_norm and isinstance(axis, tuple))  # inv. axis for vector
+            or (vector_norm and ord in ("fro", "nuc"))  # invalid ord for vector
+            or (not vector_norm and ord in (0, 3))  # invalid ord for matrix
+        ):
+            expected_error = RuntimeError
+
+        if expected_error is not None:
+            # Non-torch backends always throw a ValueError
+            expected_error = (
+                expected_error if backend.backend() == "torch" else ValueError
+            )
+            with self.assertRaises(expected_error):
                 linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
             return
         output = linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)


### PR DESCRIPTION
- On the Tensorflow backend, reimplemented all cases for `ops.linalg.norm` instead of sometimes relying on `tf.linalg.norm`. `tf.linalg.norm` sometimes fails to compile on XLA or returns tensors with no shape. Note that there is not special op used by `tf.linalg.norm`.
- Added more test cases for `ops.linalg.norm`:
  - vector norms are now also tested with 2 dimensional inputs
  - axis as a tuple of 2 values is tested
  - many more cases of invalid combinations of rank / ord / axis are verified