### PR TITLE
Enable int8xint8->int32 `einsum`

### DIFF
--- a/keras/backend/jax/numpy.py
+++ b/keras/backend/jax/numpy.py
@@ -42,6 +42,14 @@ def bincount(x, weights=None, minlength=0):
 
 def einsum(subscripts, *operands, **kwargs):
     operands = [convert_to_tensor(x) for x in operands]
+    # When all operands are of int8, specifying `preferred_element_type` as
+    # int32 to enable hardware-accelerated einsum
+    dtypes = list(set(standardize_dtype(x.dtype) for x in operands))
+    if len(dtypes) == 1 and dtypes[0] == "int8":
+        preferred_element_type = "int32"
+    else:
+        preferred_element_type = None
+    kwargs["preferred_element_type"] = preferred_element_type
     return jnp.einsum(subscripts, *operands, **kwargs)
 
 

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -1,6 +1,8 @@
 import builtins
 import collections
+import functools
 import math
+import string
 import warnings
 
 import numpy as np
@@ -75,22 +77,105 @@ def bincount(x, weights=None, minlength=0):
     )
 
 
+@functools.lru_cache(512)
+def _normalize_einsum_subscripts(subscripts):
+    # string.ascii_letters
+    mapping = {}
+    normalized_subscripts = ""
+    for c in subscripts:
+        if c in string.ascii_letters:
+            if c not in mapping:
+                mapping[c] = string.ascii_letters[len(mapping)]
+            normalized_subscripts += mapping[c]
+        else:
+            normalized_subscripts += c
+    return normalized_subscripts
+
+
 def einsum(subscripts, *operands, **kwargs):
     operands = tf.nest.map_structure(convert_to_tensor, operands)
+    subscripts = _normalize_einsum_subscripts(subscripts)
 
-    dtypes_to_resolve = []
-    for x in operands:
-        dtypes_to_resolve.append(x.dtype)
-    result_dtype = dtypes.result_type(*dtypes_to_resolve)
-    compute_dtype = result_dtype
-    # TODO: tf.einsum doesn't support integer dtype with gpu
-    if "int" in compute_dtype:
-        compute_dtype = config.floatx()
+    def is_valid_for_custom_ops(subscripts, *operands):
+        # Check that `subscripts` is supported and the shape of operands is not
+        # `None`
+        if subscripts == "abcde,afce->acdbf":
+            _, b1, c1, d1, e1 = operands[0].shape
+            _, f2, c2, e2 = operands[1].shape
+            b, c, d, e, f = b1, c1 or c2, d1, e1 or e2, f2
+            if None in (b, c, d, e, f):
+                return False
+            return True
+        elif subscripts == "abc,dce->abde":
+            _, b1, c1 = operands[0].shape
+            d2, c2, e2 = operands[1].shape
+            b, c, d, e = b1, c1 or c2, d2, e2
+            if None in (b, c, d, e):
+                return False
+            return True
+        else:
+            # Defaults to `False`
+            return False
 
-    operands = tf.nest.map_structure(
-        lambda x: tf.cast(x, compute_dtype), operands
-    )
-    return tf.cast(tf.einsum(subscripts, *operands, **kwargs), result_dtype)
+    def use_custom_ops(subscripts, *operands, output_type):
+        # Replace tf.einsum with custom ops to utilize hardware-accelerated
+        # matmul
+        if subscripts == "abcde,afce->acdbf":
+            x = operands[0]
+            y = operands[1]
+            _, b1, c1, d1, e1 = x.shape
+            _, f2, c2, e2 = y.shape
+            b, c, d, e, f = b1, c1 or c2, d1, e1 or e2, f2
+            x = tf.transpose(x, [0, 2, 3, 1, 4])  # acdbe
+            x = tf.reshape(x, [-1, c, d * b, e])  # ac(b*d)e
+            y = tf.transpose(y, [0, 2, 3, 1])  # acef
+            result = tf.matmul(x, y, output_type=output_type)
+            return tf.reshape(result, [-1, c, d, b, f])
+        elif subscripts == "abc,dce->abde":
+            x = operands[0]
+            y = operands[1]
+            _, b1, c1 = x.shape
+            d2, c2, e2 = y.shape
+            b, c, d, e = b1, c1 or c2, d2, e2
+            x = tf.reshape(x, [-1, c])
+            y = tf.transpose(y, [1, 0, 2])
+            y = tf.reshape(y, [c, -1])
+            result = tf.matmul(x, y, output_type=output_type)
+            return tf.reshape(result, [-1, b, d, e])
+        else:
+            raise NotImplementedError
+
+    dtypes_to_resolve = list(set(standardize_dtype(x.dtype) for x in operands))
+    # When operands are of int8, we cast the result to int32 to align with
+    # the behavior of jax.
+    if len(dtypes_to_resolve) == 1 and dtypes_to_resolve[0] == "int8":
+        compute_dtype = "int8"
+        result_dtype = "int32"
+        output_type = "int32"
+    else:
+        result_dtype = dtypes.result_type(*dtypes_to_resolve)
+        compute_dtype = result_dtype
+        output_type = None
+
+    # TODO: Remove the condition once `tf.einsum` supports int8xint8->int32
+    if is_valid_for_custom_ops(subscripts, *operands) and not kwargs:
+        # TODO: tf.matmul doesn't support integer dtype if not specifying
+        # output_type="int32"
+        if "int" in compute_dtype and output_type is None:
+            compute_dtype = config.floatx()
+        operands = tf.nest.map_structure(
+            lambda x: tf.cast(x, compute_dtype), operands
+        )
+        result = use_custom_ops(subscripts, *operands, output_type=output_type)
+    else:
+        # TODO: tf.einsum doesn't support integer dtype with gpu
+        if "int" in compute_dtype:
+            compute_dtype = config.floatx()
+        operands = tf.nest.map_structure(
+            lambda x: tf.cast(x, compute_dtype), operands
+        )
+        result = tf.einsum(subscripts, *operands, **kwargs)
+    return tf.cast(result, result_dtype)
 
 
 @sparse.elementwise_binary_union(sparse.sparse_subtract)

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -29,6 +29,13 @@ def add(x1, x2):
 
 def einsum(subscripts, *operands, **kwargs):
     operands = [convert_to_tensor(operand) for operand in operands]
+    # When all operands are of int8, we cast the result to int32 to align with
+    # the behavior of jax.
+    dtypes_to_resolve = list(set(standardize_dtype(x.dtype) for x in operands))
+    if len(dtypes_to_resolve) == 1 and dtypes_to_resolve[0] == "int8":
+        # prevent overflow
+        operands = [cast(operand, "int32") for operand in operands]
+        return cast(torch.einsum(subscripts, *operands), "int32")
     return torch.einsum(subscripts, *operands)
 
 
@@ -43,38 +50,37 @@ def subtract(x1, x2):
     return torch.subtract(x1, x2)
 
 
-def _can_use_int_matmul(x1, x2):
-    # torch._int_mm only accepts the following conditions:
-    # 1. cuda
-    # 2. both inputs must have int8 dtype
-    # 3. both inputs must be 2d
-    # 4. x1.shape must be [>16, >= 16 and a multiplier of 8]
-    # 5. x2.shape must be [>= 16 and a multiplier of 8, multiplier of 8]
-    if get_device() != "cuda":
-        return False
-    x1_dtype = standardize_dtype(x1.dtype)
-    x2_dtype = standardize_dtype(x2.dtype)
-    if x1_dtype != "int8" or x2_dtype != "int8":
-        return False
-    x1_shape = x1.shape
-    x2_shape = x2.shape
-    if x1.ndim != 2 or x2.ndim != 2:
-        return False
-    if x1_shape[0] <= 16 or x1_shape[1] < 16 or x1_shape[1] % 8 != 0:
-        return False
-    if x2_shape[0] < 16 or x2_shape[0] % 8 != 0 or x2_shape[1] % 8 != 0:
-        return False
-    return True
-
-
 def matmul(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
 
+    def can_use_int_matmul(x1, x2):
+        # torch._int_mm only accepts the following conditions:
+        # 1. cuda
+        # 2. both inputs must have int8 dtype
+        # 3. both inputs must be 2d
+        # 4. x1.shape must be [>16, >= 16 and a multiplier of 8]
+        # 5. x2.shape must be [>= 16 and a multiplier of 8, multiplier of 8]
+        if get_device() != "cuda":
+            return False
+        x1_dtype = standardize_dtype(x1.dtype)
+        x2_dtype = standardize_dtype(x2.dtype)
+        if x1_dtype != "int8" or x2_dtype != "int8":
+            return False
+        x1_shape = x1.shape
+        x2_shape = x2.shape
+        if x1.ndim != 2 or x2.ndim != 2:
+            return False
+        if x1_shape[0] <= 16 or x1_shape[1] < 16 or x1_shape[1] % 8 != 0:
+            return False
+        if x2_shape[0] < 16 or x2_shape[0] % 8 != 0 or x2_shape[1] % 8 != 0:
+            return False
+        return True
+
     # Shortcut for torch._int_mm
     # TODO: Loosen the restriction of the usage of torch._int_mm
     # TODO: We should replace torch._int_mm with the public api if possible
-    if _can_use_int_matmul(x1, x2):
+    if can_use_int_matmul(x1, x2):
         return torch._int_mm(x1, x2)
 
     x1_dtype = standardize_dtype(x1.dtype)

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -2318,10 +2318,16 @@ class Einsum(Operation):
         output_shape = expanded_operands_shapes[0]
         for shape in expanded_operands_shapes[1:]:
             output_shape = broadcast_shapes(output_shape, shape)
-        dtypes_to_resolve = []
-        for x in operands:
-            dtypes_to_resolve.append(getattr(x, "dtype", type(x)))
-        dtype = dtypes.result_type(*dtypes_to_resolve)
+        dtypes_to_resolve = list(
+            set(
+                backend.standardize_dtype(getattr(x, "dtype", type(x)))
+                for x in operands
+            )
+        )
+        if len(dtypes_to_resolve) == 1 and dtypes_to_resolve[0] == "int8":
+            dtype = "int32"
+        else:
+            dtype = dtypes.result_type(*dtypes_to_resolve)
         return KerasTensor(output_shape, dtype=dtype)
 
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -2137,20 +2137,81 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(knp.Einsum(",ijk")(5, y), np.einsum(",ijk", 5, y))
 
     def test_einsum_with_custom_ops(self):
-        # abcde,afce->acdbf
-        x = np.arange(720).reshape([2, 3, 4, 5, 6]).astype("float32")
-        y = np.arange(336).reshape([2, 7, 4, 6]).astype("float32")
+        subscripts = "a,b->ab"
+        x = np.arange(2).reshape([2]).astype("float32")
+        y = np.arange(3).reshape([3]).astype("float32")
         self.assertAllClose(
-            knp.einsum("abcde,afce->acdbf", x, y),
-            np.einsum("abcde,afce->acdbf", x, y),
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
         )
 
-        # abc,dce->abde
+        subscripts = "abc,cd->abd"
+        x = np.arange(24).reshape([2, 3, 4]).astype("float32")
+        y = np.arange(20).reshape([4, 5]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abc,cde->abde"
+        x = np.arange(24).reshape([2, 3, 4]).astype("float32")
+        y = np.arange(120).reshape([4, 5, 6]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abc,dce->abde"
         x = np.arange(24).reshape([2, 3, 4]).astype("float32")
         y = np.arange(120).reshape([5, 4, 6]).astype("float32")
         self.assertAllClose(
-            knp.einsum("abc,dce->abde", x, y),
-            np.einsum("abc,dce->abde", x, y),
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abcd,abed->abce"
+        x = np.arange(120).reshape([2, 3, 4, 5]).astype("float32")
+        y = np.arange(180).reshape([2, 3, 6, 5]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abcd,adbe->acbe"
+        x = np.arange(120).reshape([2, 3, 4, 5]).astype("float32")
+        y = np.arange(180).reshape([2, 5, 3, 6]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abcd,aecd->acbe"
+        x = np.arange(120).reshape([2, 3, 4, 5]).astype("float32")
+        y = np.arange(240).reshape([2, 6, 4, 5]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abcd,aecd->aceb"
+        x = np.arange(120).reshape([2, 3, 4, 5]).astype("float32")
+        y = np.arange(240).reshape([2, 6, 4, 5]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abcd,cde->abe"
+        x = np.arange(120).reshape([2, 3, 4, 5]).astype("float32")
+        y = np.arange(120).reshape([4, 5, 6]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abcde,aebf->adbcf"
+        x = np.arange(720).reshape([2, 3, 4, 5, 6]).astype("float32")
+        y = np.arange(252).reshape([2, 6, 3, 7]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abcde,afce->acdbf"
+        x = np.arange(720).reshape([2, 3, 4, 5, 6]).astype("float32")
+        y = np.arange(336).reshape([2, 7, 4, 6]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
         )
 
     def test_full_like(self):
@@ -5477,16 +5538,24 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_einsum(self, dtypes):
         import jax.numpy as jnp
 
+        def get_input_shapes(subscripts):
+            x1_labels = subscripts.split(",")[0]
+            x2_labels = subscripts.split("->")[0][len(x1_labels) + 1 :]
+            x1_shape = [1] * len(x1_labels)
+            x2_shape = [1] * len(x2_labels)
+            return x1_shape, x2_shape
+
         dtype1, dtype2 = dtypes
-        x1 = knp.ones((1, 1, 1), dtype=dtype1)
-        x2 = knp.ones((1, 1, 1), dtype=dtype2)
-        x1_jax = jnp.ones((1, 1, 1), dtype=dtype1)
-        x2_jax = jnp.ones((1, 1, 1), dtype=dtype2)
+        subscripts = "ijk,lkj->il"
+        x1_shape, x2_shape = get_input_shapes(subscripts)
+        x1 = knp.ones(x1_shape, dtype=dtype1)
+        x2 = knp.ones(x2_shape, dtype=dtype2)
+        x1_jax = jnp.ones(x1_shape, dtype=dtype1)
+        x2_jax = jnp.ones(x2_shape, dtype=dtype2)
         if dtype1 == "int8" and dtype2 == "int8":
             preferred_element_type = "int32"
         else:
             preferred_element_type = None
-        subscripts = "ijk,lkj->il"
         expected_dtype = standardize_dtype(
             jnp.einsum(
                 subscripts,
@@ -5509,51 +5578,47 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
 
         # Test custom implementation of einsum for tensorflow
         if backend.backend() == "tensorflow":
-            subscripts = "abc,dce->abde"
-            expected_dtype = standardize_dtype(
-                jnp.einsum(
-                    subscripts,
-                    x1_jax,
-                    x2_jax,
-                    preferred_element_type=preferred_element_type,
-                ).dtype
-            )
+            for subscripts in [
+                "a,b->ab",
+                "abc,cd->abd",
+                "abc,cde->abde",
+                "abc,dce->abde",
+                "abcd,abed->abce",
+                "abcd,adbe->acbe",
+                "abcd,aecd->acbe",
+                "abcd,aecd->aceb",
+                "abcd,cde->abe",
+                "abcde,aebf->adbcf",
+                "abcde,afce->acdbf",
+            ]:
+                x1_shape, x2_shape = get_input_shapes(subscripts)
+                x1 = knp.ones(x1_shape, dtype=dtype1)
+                x2 = knp.ones(x2_shape, dtype=dtype2)
+                x1_jax = jnp.ones(x1_shape, dtype=dtype1)
+                x2_jax = jnp.ones(x2_shape, dtype=dtype2)
+                if dtype1 == "int8" and dtype2 == "int8":
+                    preferred_element_type = "int32"
+                else:
+                    preferred_element_type = None
+                expected_dtype = standardize_dtype(
+                    jnp.einsum(
+                        subscripts,
+                        x1_jax,
+                        x2_jax,
+                        preferred_element_type=preferred_element_type,
+                    ).dtype
+                )
 
-            self.assertEqual(
-                standardize_dtype(knp.einsum(subscripts, x1, x2).dtype),
-                expected_dtype,
-            )
-            self.assertEqual(
-                standardize_dtype(
-                    knp.Einsum(subscripts).symbolic_call(x1, x2).dtype
-                ),
-                expected_dtype,
-            )
-
-            subscripts = "abcde,afce->acdbf"
-            x1 = knp.ones((1, 1, 1, 1, 1), dtype=dtype1)
-            x2 = knp.ones((1, 1, 1, 1), dtype=dtype2)
-            x1_jax = jnp.ones((1, 1, 1, 1, 1), dtype=dtype1)
-            x2_jax = jnp.ones((1, 1, 1, 1), dtype=dtype2)
-            expected_dtype = standardize_dtype(
-                jnp.einsum(
-                    subscripts,
-                    x1_jax,
-                    x2_jax,
-                    preferred_element_type=preferred_element_type,
-                ).dtype
-            )
-
-            self.assertEqual(
-                standardize_dtype(knp.einsum(subscripts, x1, x2).dtype),
-                expected_dtype,
-            )
-            self.assertEqual(
-                standardize_dtype(
-                    knp.Einsum(subscripts).symbolic_call(x1, x2).dtype
-                ),
-                expected_dtype,
-            )
+                self.assertEqual(
+                    standardize_dtype(knp.einsum(subscripts, x1, x2).dtype),
+                    expected_dtype,
+                )
+                self.assertEqual(
+                    standardize_dtype(
+                        knp.Einsum(subscripts).symbolic_call(x1, x2).dtype
+                    ),
+                    expected_dtype,
+                )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_empty(self, dtype):


### PR DESCRIPTION
jax:
use `preferred_element_type="int32"` to enable int8xint8->int32 in `einsum`

tf:
add custom ops for 2 subscripts below to replace `tf.einsum` with `tf.matmul` in order to enable int8xint8->int32 format:
- "abcde,afce->acdbf"
- "abc,dce->abde"

other backends:
just align the dtype conversion with jax and tf.

However, I'm not sure how to benchmark them, and currently, I don't see much improvement by using int8 `einsum` compared to float32/bfloat16 `einsum` in jax and tf backends.
