### PR TITLE
Refactor `axis` logic across all backends and add support for multiple axes in `expand_dims` and `squeeze`

### DIFF
--- a/keras/backend/common/backend_utils.py
+++ b/keras/backend/common/backend_utils.py
@@ -1,3 +1,4 @@
+import operator
 import warnings
 
 
@@ -255,3 +256,34 @@ def compute_conv_transpose_output_shape(
     else:
         output_shape = [input_shape[0], filters] + output_shape
     return output_shape
+
+
+def canonicalize_axis(axis, num_dims):
+    """Canonicalize an axis in [-num_dims, num_dims) to [0, num_dims)."""
+    axis = operator.index(axis)
+    if not -num_dims <= axis < num_dims:
+        raise ValueError(
+            f"axis={axis} is out of bounds for array of dimension={num_dims}."
+        )
+    if axis < 0:
+        axis = axis + num_dims
+    return axis
+
+
+def standardize_axis_for_numpy(axis):
+    """Standardize an axis to tuple if it is a list for numpy backend."""
+    return tuple(axis) if isinstance(axis, list) else axis
+
+
+def to_tuple_or_list(value):
+    """Convert the given value to a tuple or list."""
+    if value is None:
+        return value
+    if not isinstance(value, (int, tuple, list)):
+        raise ValueError(
+            "`value` must be integer, tuple or list. "
+            f"Received: value={value}"
+        )
+    if isinstance(value, int):
+        return (value,)
+    return value

--- a/keras/backend/common/backend_utils.py
+++ b/keras/backend/common/backend_utils.py
@@ -263,7 +263,8 @@ def canonicalize_axis(axis, num_dims):
     axis = operator.index(axis)
     if not -num_dims <= axis < num_dims:
         raise ValueError(
-            f"axis={axis} is out of bounds for array of dimension={num_dims}."
+            f"axis {axis} is out of bounds for an array with dimension "
+            f"{num_dims}."
         )
     if axis < 0:
         axis = axis + num_dims
@@ -271,17 +272,17 @@ def canonicalize_axis(axis, num_dims):
 
 
 def standardize_axis_for_numpy(axis):
-    """Standardize an axis to tuple if it is a list for numpy backend."""
+    """Standardize an axis to a tuple if it is a list in the numpy backend."""
     return tuple(axis) if isinstance(axis, list) else axis
 
 
 def to_tuple_or_list(value):
-    """Convert the given value to a tuple or list."""
+    """Convert the non-`None` value to either a tuple or a list."""
     if value is None:
         return value
     if not isinstance(value, (int, tuple, list)):
         raise ValueError(
-            "`value` must be integer, tuple or list. "
+            "`value` must be an integer, tuple or list. "
             f"Received: value={value}"
         )
     if isinstance(value, int):

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -4,6 +4,7 @@ import tree
 from keras.backend import config
 from keras.backend import standardize_dtype
 from keras.backend.common import dtypes
+from keras.backend.common.backend_utils import standardize_axis_for_numpy
 from keras.backend.numpy.core import convert_to_tensor
 
 
@@ -82,7 +83,7 @@ def multiply(x1, x2):
 
 
 def mean(x, axis=None, keepdims=False):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     x = convert_to_tensor(x)
     ori_dtype = standardize_dtype(x.dtype)
     if "int" in ori_dtype or ori_dtype == "bool":
@@ -93,7 +94,7 @@ def mean(x, axis=None, keepdims=False):
 
 
 def max(x, axis=None, keepdims=False, initial=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.max(x, axis=axis, keepdims=keepdims, initial=initial)
 
 
@@ -116,27 +117,27 @@ def abs(x):
 
 
 def all(x, axis=None, keepdims=False):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.all(x, axis=axis, keepdims=keepdims)
 
 
 def any(x, axis=None, keepdims=False):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.any(x, axis=axis, keepdims=keepdims)
 
 
 def amax(x, axis=None, keepdims=False):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.amax(x, axis=axis, keepdims=keepdims)
 
 
 def amin(x, axis=None, keepdims=False):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.amin(x, axis=axis, keepdims=keepdims)
 
 
 def append(x1, x2, axis=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
     dtype = dtypes.result_type(x1.dtype, x2.dtype)
@@ -227,17 +228,17 @@ def arctanh(x):
 
 
 def argmax(x, axis=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.argmax(x, axis=axis).astype("int32")
 
 
 def argmin(x, axis=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.argmin(x, axis=axis).astype("int32")
 
 
 def argsort(x, axis=-1):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.argsort(x, axis=axis).astype("int32")
 
 
@@ -246,7 +247,7 @@ def array(x, dtype=None):
 
 
 def average(x, axis=None, weights=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     x = convert_to_tensor(x)
     dtypes_to_resolve = [x.dtype, float]
     if weights is not None:
@@ -311,7 +312,7 @@ def clip(x, x_min, x_max):
 
 
 def concatenate(xs, axis=0):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     dtype_set = set([getattr(x, "dtype", type(x)) for x in xs])
     if len(dtype_set) > 1:
         dtype = dtypes.result_type(*dtype_set)
@@ -354,14 +355,14 @@ def cosh(x):
 
 
 def count_nonzero(x, axis=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     # np.count_nonzero will return python int when axis=None, so we need
     # to convert_to_tensor
     return convert_to_tensor(np.count_nonzero(x, axis=axis)).astype("int32")
 
 
 def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
     dtype = dtypes.result_type(x1.dtype, x2.dtype)
@@ -378,7 +379,7 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
 
 
 def cumprod(x, axis=None, dtype=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     dtype = dtypes.result_type(dtype or x.dtype)
     if dtype == "bool":
         dtype = "int32"
@@ -386,7 +387,7 @@ def cumprod(x, axis=None, dtype=None):
 
 
 def cumsum(x, axis=None, dtype=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     dtype = dtypes.result_type(dtype or x.dtype)
     if dtype == "bool":
         dtype = "int32"
@@ -398,14 +399,9 @@ def diag(x, k=0):
 
 
 def diagonal(x, offset=0, axis1=0, axis2=1):
-    axis1 = tuple(axis1) if isinstance(axis1, list) else axis1
-    axis2 = tuple(axis2) if isinstance(axis2, list) else axis2
-    return np.diagonal(
-        x,
-        offset=offset,
-        axis1=axis1,
-        axis2=axis2,
-    )
+    axis1 = standardize_axis_for_numpy(axis1)
+    axis2 = standardize_axis_for_numpy(axis2)
+    return np.diagonal(x, offset=offset, axis1=axis1, axis2=axis2)
 
 
 def diff(a, n=1, axis=-1):
@@ -443,7 +439,7 @@ def exp(x):
 
 
 def expand_dims(x, axis):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.expand_dims(x, axis)
 
 
@@ -456,7 +452,7 @@ def expm1(x):
 
 
 def flip(x, axis=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.flip(x, axis=axis)
 
 
@@ -534,7 +530,7 @@ def less_equal(x1, x2):
 def linspace(
     start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0
 ):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     if dtype is None:
         dtypes_to_resolve = [
             getattr(start, "dtype", type(start)),
@@ -657,7 +653,7 @@ def meshgrid(*x, indexing="xy"):
 
 
 def min(x, axis=None, keepdims=False, initial=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.min(x, axis=axis, keepdims=keepdims, initial=initial)
 
 
@@ -737,7 +733,7 @@ def pad(x, pad_width, mode="constant", constant_values=None):
 
 
 def prod(x, axis=None, keepdims=False, dtype=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     x = convert_to_tensor(x)
     if dtype is None:
         dtype = dtypes.result_type(x.dtype)
@@ -749,7 +745,7 @@ def prod(x, axis=None, keepdims=False, dtype=None):
 
 
 def quantile(x, q, axis=None, method="linear", keepdims=False):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     x = convert_to_tensor(x)
 
     ori_dtype = standardize_dtype(x.dtype)
@@ -818,17 +814,17 @@ def size(x):
 
 
 def sort(x, axis=-1):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.sort(x, axis=axis)
 
 
 def split(x, indices_or_sections, axis=0):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.split(x, indices_or_sections, axis=axis)
 
 
 def stack(x, axis=0):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     dtype_set = set([getattr(a, "dtype", type(a)) for a in x])
     if len(dtype_set) > 1:
         dtype = dtypes.result_type(*dtype_set)
@@ -837,7 +833,7 @@ def stack(x, axis=0):
 
 
 def std(x, axis=None, keepdims=False):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     x = convert_to_tensor(x)
     ori_dtype = standardize_dtype(x.dtype)
     if "int" in ori_dtype or ori_dtype == "bool":
@@ -850,12 +846,12 @@ def swapaxes(x, axis1, axis2):
 
 
 def take(x, indices, axis=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.take(x, indices, axis=axis)
 
 
 def take_along_axis(x, indices, axis=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.take_along_axis(x, indices, axis=axis)
 
 
@@ -898,8 +894,8 @@ def tile(x, repeats):
 
 
 def trace(x, offset=0, axis1=0, axis2=1):
-    axis1 = tuple(axis1) if isinstance(axis1, list) else axis1
-    axis2 = tuple(axis2) if isinstance(axis2, list) else axis2
+    axis1 = standardize_axis_for_numpy(axis1)
+    axis2 = standardize_axis_for_numpy(axis2)
     x = convert_to_tensor(x)
     dtype = standardize_dtype(x.dtype)
     if dtype not in ("int64", "uint32", "uint64"):
@@ -1027,7 +1023,7 @@ def sqrt(x):
 
 
 def squeeze(x, axis=None):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     return np.squeeze(x, axis=axis)
 
 
@@ -1037,7 +1033,7 @@ def transpose(x, axes=None):
 
 
 def var(x, axis=None, keepdims=False):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     x = convert_to_tensor(x)
     compute_dtype = dtypes.result_type(x.dtype, "float32")
     result_dtype = dtypes.result_type(x.dtype, float)
@@ -1047,7 +1043,7 @@ def var(x, axis=None, keepdims=False):
 
 
 def sum(x, axis=None, keepdims=False):
-    axis = tuple(axis) if isinstance(axis, list) else axis
+    axis = standardize_axis_for_numpy(axis)
     dtype = standardize_dtype(x.dtype)
     # follow jax's rule
     if dtype in ("bool", "int8", "int16"):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -601,7 +601,12 @@ def exp(x):
 
 def expand_dims(x, axis):
     x = convert_to_tensor(x)
-    return torch.unsqueeze(x, dim=axis)
+    axis = to_tuple_or_list(axis)
+    out_ndim = len(x.shape) + len(axis)
+    axis = sorted([canonicalize_axis(a, out_ndim) for a in axis])
+    for a in axis:
+        x = torch.unsqueeze(x, dim=a)
+    return x
 
 
 def expm1(x):

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -6,6 +6,8 @@ import torch
 from keras.backend import KerasTensor
 from keras.backend import config
 from keras.backend.common import dtypes
+from keras.backend.common.backend_utils import canonicalize_axis
+from keras.backend.common.backend_utils import to_tuple_or_list
 from keras.backend.common.variables import standardize_dtype
 from keras.backend.torch.core import cast
 from keras.backend.torch.core import convert_to_tensor
@@ -119,8 +121,7 @@ def mean(x, axis=None, keepdims=False):
     if axis == () or axis == []:
         # Torch handles the empty axis case differently from numpy.
         return x
-    elif isinstance(axis, int):
-        axis = (axis,)  # see [NB] below
+    axis = to_tuple_or_list(axis)  # see [NB] below
 
     ori_dtype = standardize_dtype(x.dtype)
     # torch.mean only supports floating point inputs
@@ -208,8 +209,7 @@ def all(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
     if axis is None:
         return cast(torch.all(x), "bool")
-    if not isinstance(axis, (list, tuple)):
-        axis = (axis,)
+    axis = to_tuple_or_list(axis)
     for a in axis:
         # `torch.all` does not handle multiple axes.
         x = torch.all(x, dim=a, keepdim=keepdims)
@@ -220,8 +220,7 @@ def any(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
     if axis is None:
         return cast(torch.any(x), "bool")
-    if not isinstance(axis, (list, tuple)):
-        axis = (axis,)
+    axis = to_tuple_or_list(axis)
     for a in axis:
         # `torch.any` does not handle multiple axes.
         x = torch.any(x, dim=a, keepdim=keepdims)
@@ -617,8 +616,7 @@ def flip(x, axis=None):
     x = convert_to_tensor(x)
     if axis is None:
         axis = tuple(range(x.ndim))
-    if isinstance(axis, int):
-        axis = (axis,)
+    axis = to_tuple_or_list(axis)
     return torch.flip(x, dims=axis)
 
 
@@ -892,7 +890,7 @@ def median(x, axis=None, keepdims=False):
         y = reshape(x, [-1])
     else:
         # transpose
-        axis = list(map(lambda a: a if a >= 0 else a + x.ndim, axis))
+        axis = [canonicalize_axis(a, x.ndim) for a in axis]
         other_dims = sorted(set(range(x.ndim)).difference(axis))
         perm = other_dims + list(axis)
         x_permed = torch.permute(x, dims=perm)
@@ -1072,8 +1070,7 @@ def prod(x, axis=None, keepdims=False, dtype=None):
         compute_dtype = "float32"
     if axis is None:
         return cast(torch.prod(x, dtype=to_torch_dtype(compute_dtype)), dtype)
-    if not isinstance(axis, (list, tuple)):
-        axis = (axis,)
+    axis = to_tuple_or_list(axis)
     for a in axis:
         # `torch.prod` does not handle multiple axes.
         x = cast(
@@ -1086,11 +1083,9 @@ def prod(x, axis=None, keepdims=False, dtype=None):
 
 
 def quantile(x, q, axis=None, method="linear", keepdims=False):
-    if isinstance(axis, int):
-        axis = [axis]
-
     x = convert_to_tensor(x)
     q = convert_to_tensor(q)
+    axis = to_tuple_or_list(axis)
 
     compute_dtype = dtypes.result_type(x.dtype, "float32")
     result_dtype = dtypes.result_type(x.dtype, float)
@@ -1105,7 +1100,7 @@ def quantile(x, q, axis=None, method="linear", keepdims=False):
         y = reshape(x, [-1])
     else:
         # transpose
-        axis = list(map(lambda a: a if a >= 0 else a + x.ndim, axis))
+        axis = [canonicalize_axis(a, x.ndim) for a in axis]
         other_dims = sorted(set(range(x.ndim)).difference(axis))
         perm = other_dims + list(axis)
         x_permed = torch.permute(x, dims=perm)
@@ -1266,8 +1261,7 @@ def take(x, indices, axis=None):
         x = torch.reshape(x, (-1,))
         axis = 0
     if axis is not None:
-        # make sure axis is non-negative
-        axis = len(x.shape) + axis if axis < 0 else axis
+        axis = canonicalize_axis(axis, x.ndim)
         shape = x.shape[:axis] + indices.shape + x.shape[axis + 1 :]
         # ravel the `indices` since `index_select` expects `indices`
         # to be a vector (1-D tensor).

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -151,6 +151,7 @@ from keras.api_export import keras_export
 from keras.backend import KerasTensor
 from keras.backend import any_symbolic_tensors
 from keras.backend.common import dtypes
+from keras.backend.common.backend_utils import to_tuple_or_list
 from keras.ops import operation_utils
 from keras.ops.operation import Operation
 from keras.ops.operation_utils import broadcast_shapes
@@ -2499,10 +2500,10 @@ def exp(x):
 class ExpandDims(Operation):
     def __init__(self, axis):
         super().__init__()
-        if isinstance(axis, list):
+        if not isinstance(axis, (int, tuple, list)):
             raise ValueError(
                 "The `axis` argument to `expand_dims` should be an integer, "
-                f"but received a list: {axis}."
+                f"tuple or list. Received axis={axis}"
             )
         self.axis = axis
 
@@ -5740,16 +5741,19 @@ class Squeeze(Operation):
     def compute_output_spec(self, x):
         input_shape = list(x.shape)
         sparse = getattr(x, "sparse", False)
-        if self.axis is None:
+        axis = to_tuple_or_list(self.axis)
+        if axis is None:
             output_shape = list(filter((1).__ne__, input_shape))
             return KerasTensor(output_shape, dtype=x.dtype, sparse=sparse)
         else:
-            if input_shape[self.axis] != 1:
-                raise ValueError(
-                    f"Cannot squeeze axis {self.axis}, because the dimension "
-                    "is not 1."
-                )
-            del input_shape[self.axis]
+            for a in axis:
+                if input_shape[a] != 1:
+                    raise ValueError(
+                        f"Cannot squeeze axis {a}, because the dimension "
+                        "is not 1."
+                    )
+            for a in sorted(axis, reverse=True):
+                del input_shape[a]
             return KerasTensor(input_shape, dtype=x.dtype, sparse=sparse)
 
 

--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -151,6 +151,7 @@ from keras.api_export import keras_export
 from keras.backend import KerasTensor
 from keras.backend import any_symbolic_tensors
 from keras.backend.common import dtypes
+from keras.backend.common.backend_utils import canonicalize_axis
 from keras.backend.common.backend_utils import to_tuple_or_list
 from keras.ops import operation_utils
 from keras.ops.operation import Operation
@@ -5752,6 +5753,7 @@ class Squeeze(Operation):
                         f"Cannot squeeze axis {a}, because the dimension "
                         "is not 1."
                     )
+            axis = [canonicalize_axis(a, len(input_shape)) for a in axis]
             for a in sorted(axis, reverse=True):
                 del input_shape[a]
             return KerasTensor(input_shape, dtype=x.dtype, sparse=sparse)

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -2,6 +2,7 @@ import contextlib
 import functools
 import itertools
 import math
+import warnings
 
 import numpy as np
 import pytest
@@ -4012,7 +4013,7 @@ class NumpyArrayCreateOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.Arange()(3, 7, 2), np.arange(3, 7, 2))
 
         self.assertEqual(standardize_dtype(knp.arange(3).dtype), "int32")
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             knp.arange(3, dtype="int")
         self.assertEqual(len(record), 0)
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -929,6 +929,13 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
             x = KerasTensor((None, 1))
             knp.squeeze(x, axis=0)
 
+        # Multiple axes
+        x = KerasTensor((None, 1, 1, 1))
+        self.assertEqual(knp.squeeze(x, (1, 2)).shape, (None, 1))
+        self.assertEqual(knp.squeeze(x, (-1, -2)).shape, (None, 1))
+        self.assertEqual(knp.squeeze(x, (1, 2, 3)).shape, (None,))
+        self.assertEqual(knp.squeeze(x, (-1, 1)).shape, (None, 1))
+
     def test_transpose(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.transpose(x).shape, (3, None))
@@ -1142,6 +1149,11 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.expand_dims(x, 0).shape, (1, None, 3))
         self.assertEqual(knp.expand_dims(x, 1).shape, (None, 1, 3))
         self.assertEqual(knp.expand_dims(x, -2).shape, (None, 1, 3))
+
+        # Multiple axes
+        self.assertEqual(knp.expand_dims(x, (1, 2)).shape, (None, 1, 1, 3))
+        self.assertEqual(knp.expand_dims(x, (-1, -2)).shape, (None, 3, 1, 1))
+        self.assertEqual(knp.expand_dims(x, (-1, 1)).shape, (None, 1, 3, 1))
 
     def test_expm1(self):
         x = KerasTensor((None, 3))
@@ -1479,6 +1491,13 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
         with self.assertRaises(ValueError):
             knp.squeeze(x, axis=0)
 
+        # Multiple axes
+        x = KerasTensor((2, 1, 1, 1))
+        self.assertEqual(knp.squeeze(x, (1, 2)).shape, (2, 1))
+        self.assertEqual(knp.squeeze(x, (-1, -2)).shape, (2, 1))
+        self.assertEqual(knp.squeeze(x, (1, 2, 3)).shape, (2,))
+        self.assertEqual(knp.squeeze(x, (-1, 1)).shape, (2, 1))
+
     def test_transpose(self):
         x = KerasTensor((2, 3))
         self.assertEqual(knp.transpose(x).shape, (3, 2))
@@ -1649,6 +1668,11 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
         self.assertEqual(knp.expand_dims(x, 0).shape, (1, 2, 3, 4))
         self.assertEqual(knp.expand_dims(x, 1).shape, (2, 1, 3, 4))
         self.assertEqual(knp.expand_dims(x, -2).shape, (2, 3, 1, 4))
+
+        # Multiple axes
+        self.assertEqual(knp.expand_dims(x, (1, 2)).shape, (2, 1, 1, 3, 4))
+        self.assertEqual(knp.expand_dims(x, (-1, -2)).shape, (2, 3, 4, 1, 1))
+        self.assertEqual(knp.expand_dims(x, (-1, 1)).shape, (2, 1, 3, 4, 1))
 
     def test_expm1(self):
         x = KerasTensor((2, 3))
@@ -2852,6 +2876,18 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(knp.Squeeze()(x), np.squeeze(x))
         self.assertAllClose(knp.Squeeze(axis=0)(x), np.squeeze(x, axis=0))
 
+        # Multiple axes
+        x = np.ones([2, 1, 1, 1])
+        self.assertAllClose(knp.squeeze(x, (1, 2)), np.squeeze(x, (1, 2)))
+        self.assertAllClose(knp.squeeze(x, (-1, -2)), np.squeeze(x, (-1, -2)))
+        self.assertAllClose(knp.squeeze(x, (1, 2, 3)), np.squeeze(x, (1, 2, 3)))
+        self.assertAllClose(knp.squeeze(x, (-1, 1)), np.squeeze(x, (-1, 1)))
+
+        self.assertAllClose(knp.Squeeze((1, 2))(x), np.squeeze(x, (1, 2)))
+        self.assertAllClose(knp.Squeeze((-1, -2))(x), np.squeeze(x, (-1, -2)))
+        self.assertAllClose(knp.Squeeze((1, 2, 3))(x), np.squeeze(x, (1, 2, 3)))
+        self.assertAllClose(knp.Squeeze((-1, 1))(x), np.squeeze(x, (-1, 1)))
+
     def test_transpose(self):
         x = np.ones([1, 2, 3, 4, 5])
         self.assertAllClose(knp.transpose(x), np.transpose(x))
@@ -3290,6 +3326,27 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(knp.ExpandDims(0)(x), np.expand_dims(x, 0))
         self.assertAllClose(knp.ExpandDims(1)(x), np.expand_dims(x, 1))
         self.assertAllClose(knp.ExpandDims(-2)(x), np.expand_dims(x, -2))
+
+        # Multiple axes
+        self.assertAllClose(
+            knp.expand_dims(x, (1, 2)), np.expand_dims(x, (1, 2))
+        )
+        self.assertAllClose(
+            knp.expand_dims(x, (-1, -2)), np.expand_dims(x, (-1, -2))
+        )
+        self.assertAllClose(
+            knp.expand_dims(x, (-1, 1)), np.expand_dims(x, (-1, 1))
+        )
+
+        self.assertAllClose(
+            knp.ExpandDims((1, 2))(x), np.expand_dims(x, (1, 2))
+        )
+        self.assertAllClose(
+            knp.ExpandDims((-1, -2))(x), np.expand_dims(x, (-1, -2))
+        )
+        self.assertAllClose(
+            knp.ExpandDims((-1, 1))(x), np.expand_dims(x, (-1, 1))
+        )
 
     def test_expm1(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])

--- a/keras/ops/operation_utils.py
+++ b/keras/ops/operation_utils.py
@@ -4,6 +4,8 @@ import numpy as np
 import tree
 
 from keras.api_export import keras_export
+from keras.backend.common.backend_utils import canonicalize_axis
+from keras.backend.common.backend_utils import to_tuple_or_list
 
 
 def broadcast_shapes(shape1, shape2):
@@ -55,7 +57,7 @@ def compute_expand_dims_output_shape(input_shape, axis):
 
     Args:
         input_shape: Input shape.
-        axis: int for the axis to expand.
+        axis: int or sequence of ints for the axis to expand.
 
     Returns:
         Tuple of ints: The output shape after the `expand_dims` operation.
@@ -63,9 +65,14 @@ def compute_expand_dims_output_shape(input_shape, axis):
     input_shape = list(input_shape)
     if axis is None:
         axis = len(input_shape)
-    elif axis < 0:
-        axis = len(input_shape) + 1 + axis
-    return tuple(input_shape[:axis] + [1] + input_shape[axis:])
+    axis = to_tuple_or_list(axis)
+    out_ndim = len(axis) + len(input_shape)
+    axis = [canonicalize_axis(a, out_ndim) for a in axis]
+    shape_iter = iter(input_shape)
+    new_shape = [
+        1 if ax in axis else next(shape_iter) for ax in range(out_ndim)
+    ]
+    return tuple(new_shape)
 
 
 def compute_pooling_output_shape(

--- a/keras/ops/operation_utils_test.py
+++ b/keras/ops/operation_utils_test.py
@@ -18,6 +18,23 @@ class OperationUtilsTest(testing.TestCase):
         inputs = input_layer.Input(shape=(10,))
         self.assertIs(operation_utils.get_source_inputs(inputs)[0], inputs)
 
+    def test_compute_expand_dims_output_shape(self):
+        input_shape = (2, 3, 4)
+        axis = -1
+        output_shape = operation_utils.compute_expand_dims_output_shape(
+            input_shape, axis
+        )
+        expected_output_shape = (2, 3, 4, 1)
+        self.assertEqual(output_shape, expected_output_shape)
+
+        input_shape = (2, 3, 4)
+        axis = (1, -1)
+        output_shape = operation_utils.compute_expand_dims_output_shape(
+            input_shape, axis
+        )
+        expected_output_shape = (2, 1, 3, 4, 1)
+        self.assertEqual(output_shape, expected_output_shape)
+
     def test_compute_pooling_output_shape(self):
         input_shape = (1, 4, 4, 1)
         pool_size = (2, 2)


### PR DESCRIPTION
In this PR:
- Introduces `canonicalize_axis`, `standardize_axis_for_numpy` and `to_tuple_or_list` and utilizes them to standardize the code across all backends
- Add support for multiple axes in `expand_dims` and `squeeze` (especially in tensorflow and torch)

(BTW, this PR will further help to reduce the redundancy of quantization computation)

EDITD:
`pytest.warns(None)` has been replaced by `warnings.catch_warnings(record=True)` as suggested in https://github.com/scipy/scipy/issues/15186
This should fix the failed unit tests.