### PR TITLE
Add pad_to_aspect_ratio arg to image_dataset_from_directory

### DIFF
--- a/keras/utils/image_dataset_utils.py
+++ b/keras/utils/image_dataset_utils.py
@@ -30,6 +30,7 @@ def image_dataset_from_directory(
     interpolation="bilinear",
     follow_links=False,
     crop_to_aspect_ratio=False,
+    pad_to_aspect_ratio=False,
     data_format=None,
     verbose=True,
 ):
@@ -113,6 +114,13 @@ def image_dataset_from_directory(
             return the largest possible window in the image
             (of size `image_size`) that matches the target aspect ratio. By
             default (`crop_to_aspect_ratio=False`), aspect ratio may not be
+            preserved.
+        pad_to_aspect_ratio: If `True`, resize the images without aspect
+            ratio distortion. When the original aspect ratio differs from the
+            target aspect ratio, the output image will be cropped so as to
+            return the largest possible window in the image
+            (of size `image_size`) that matches the target aspect ratio. By
+            default (`pad_to_aspect_ratio=False`), aspect ratio may not be
             preserved.
         data_format: If None uses keras.config.image_data_format()
             otherwise either 'channel_last' or 'channel_first'.
@@ -263,6 +271,7 @@ def image_dataset_from_directory(
             num_classes=len(class_names) if class_names else 0,
             interpolation=interpolation,
             crop_to_aspect_ratio=crop_to_aspect_ratio,
+            pad_to_aspect_ratio=pad_to_aspect_ratio,
             data_format=data_format,
         )
 
@@ -275,6 +284,7 @@ def image_dataset_from_directory(
             num_classes=len(class_names) if class_names else 0,
             interpolation=interpolation,
             crop_to_aspect_ratio=crop_to_aspect_ratio,
+            pad_to_aspect_ratio=pad_to_aspect_ratio,
             data_format=data_format,
         )
 
@@ -323,6 +333,7 @@ def image_dataset_from_directory(
             num_classes=len(class_names) if class_names else 0,
             interpolation=interpolation,
             crop_to_aspect_ratio=crop_to_aspect_ratio,
+            pad_to_aspect_ratio=pad_to_aspect_ratio,
             data_format=data_format,
         )
 
@@ -355,6 +366,7 @@ def paths_and_labels_to_dataset(
     interpolation,
     data_format,
     crop_to_aspect_ratio=False,
+    pad_to_aspect_ratio=False,
 ):
     """Constructs a dataset of images and labels."""
     # TODO(fchollet): consider making num_parallel_calls settable
@@ -365,6 +377,7 @@ def paths_and_labels_to_dataset(
         interpolation,
         data_format,
         crop_to_aspect_ratio,
+        pad_to_aspect_ratio,
     )
     img_ds = path_ds.map(
         lambda x: load_image(x, *args), num_parallel_calls=tf.data.AUTOTUNE
@@ -384,13 +397,30 @@ def load_image(
     interpolation,
     data_format,
     crop_to_aspect_ratio=False,
+    pad_to_aspect_ratio=False,
 ):
     """Load an image from a path and resize it."""
     img = tf.io.read_file(path)
     img = tf.image.decode_image(
         img, channels=num_channels, expand_animations=False
     )
-    if crop_to_aspect_ratio:
+    
+    if pad_to_aspect_ratio and crop_to_aspect_ratio:
+        raise ValueError(
+                'Only one of pad_to_aspect_ratio, crop_to_aspect_ratio can be set to True'
+            )
+    
+    if pad_to_aspect_ratio:
+        if data_format == "channels_first":
+            img = tf.transpose(img, (2, 0, 1))
+        
+        img = tf.image.resize_with_pad(
+            img, 
+            image_size[0], 
+            image_size[1], 
+            method=interpolation
+        )
+    elif crop_to_aspect_ratio:
         from keras.backend import tensorflow as tf_backend
 
         if data_format == "channels_first":

--- a/keras/utils/image_dataset_utils.py
+++ b/keras/utils/image_dataset_utils.py
@@ -117,7 +117,7 @@ def image_dataset_from_directory(
             preserved.
         pad_to_aspect_ratio: If `True`, resize the images without aspect
             ratio distortion. When the original aspect ratio differs from the
-            target aspect ratio, the output image will be cropped so as to
+            target aspect ratio, the output image will be padded so as to
             return the largest possible window in the image
             (of size `image_size`) that matches the target aspect ratio. By
             default (`pad_to_aspect_ratio=False`), aspect ratio may not be

--- a/keras/utils/image_dataset_utils.py
+++ b/keras/utils/image_dataset_utils.py
@@ -404,27 +404,22 @@ def load_image(
     img = tf.image.decode_image(
         img, channels=num_channels, expand_animations=False
     )
-    
+
     if pad_to_aspect_ratio and crop_to_aspect_ratio:
         raise ValueError(
-                'Only one of pad_to_aspect_ratio, crop_to_aspect_ratio can be set to True'
-            )
-    
+            "Only one of pad_to_aspect_ratio, crop_to_aspect_ratio can be set to True"
+        )
+
+    if data_format == "channels_first":
+        img = tf.transpose(img, (2, 0, 1))
+
     if pad_to_aspect_ratio:
-        if data_format == "channels_first":
-            img = tf.transpose(img, (2, 0, 1))
-        
         img = tf.image.resize_with_pad(
-            img, 
-            image_size[0], 
-            image_size[1], 
-            method=interpolation
+            img, image_size[0], image_size[1], method=interpolation
         )
     elif crop_to_aspect_ratio:
         from keras.backend import tensorflow as tf_backend
 
-        if data_format == "channels_first":
-            img = tf.transpose(img, (2, 0, 1))
         img = image_utils.smart_resize(
             img,
             image_size,
@@ -434,8 +429,7 @@ def load_image(
         )
     else:
         img = tf.image.resize(img, image_size, method=interpolation)
-        if data_format == "channels_first":
-            img = tf.transpose(img, (2, 0, 1))
+
     if data_format == "channels_last":
         img.set_shape((image_size[0], image_size[1], num_channels))
     else:

--- a/keras/utils/image_dataset_utils.py
+++ b/keras/utils/image_dataset_utils.py
@@ -410,16 +410,11 @@ def load_image(
             "Only one of pad_to_aspect_ratio, crop_to_aspect_ratio can be set to True"
         )
 
-    if data_format == "channels_first":
-        img = tf.transpose(img, (2, 0, 1))
-
-    if pad_to_aspect_ratio:
-        img = tf.image.resize_with_pad(
-            img, image_size[0], image_size[1], method=interpolation
-        )
-    elif crop_to_aspect_ratio:
+    if crop_to_aspect_ratio:
         from keras.backend import tensorflow as tf_backend
 
+        if data_format == "channels_first":
+            img = tf.transpose(img, (2, 0, 1))
         img = image_utils.smart_resize(
             img,
             image_size,
@@ -427,8 +422,16 @@ def load_image(
             data_format=data_format,
             backend_module=tf_backend,
         )
+    elif pad_to_aspect_ratio:
+        img = tf.image.resize_with_pad(
+            img, image_size[0], image_size[1], method=interpolation
+        )
+        if data_format == "channels_first":
+            img = tf.transpose(img, (2, 0, 1))
     else:
         img = tf.image.resize(img, image_size, method=interpolation)
+        if data_format == "channels_first":
+            img = tf.transpose(img, (2, 0, 1))
 
     if data_format == "channels_last":
         img.set_shape((image_size[0], image_size[1], num_channels))

--- a/keras/utils/image_dataset_utils.py
+++ b/keras/utils/image_dataset_utils.py
@@ -407,7 +407,8 @@ def load_image(
 
     if pad_to_aspect_ratio and crop_to_aspect_ratio:
         raise ValueError(
-            "Only one of pad_to_aspect_ratio, crop_to_aspect_ratio can be set to True"
+            "Only one of pad_to_aspect_ratio, crop_to_aspect_ratio"
+            " can be set to True"
         )
 
     if crop_to_aspect_ratio:

--- a/keras/utils/image_dataset_utils_test.py
+++ b/keras/utils/image_dataset_utils_test.py
@@ -369,7 +369,7 @@ class ImageDatasetFromDirectoryTest(testing.TestCase):
         batch = next(iter(dataset))
         self.assertLen(batch, 2)
         self.assertEqual(batch[0].shape, output_shape)
-        
+
     def test_image_dataset_from_directory_pad_to_aspect_ratio(self):
         directory = self._prepare_directory(num_classes=2, count=5)
         dataset = image_dataset_utils.image_dataset_from_directory(

--- a/keras/utils/image_dataset_utils_test.py
+++ b/keras/utils/image_dataset_utils_test.py
@@ -369,6 +369,22 @@ class ImageDatasetFromDirectoryTest(testing.TestCase):
         batch = next(iter(dataset))
         self.assertLen(batch, 2)
         self.assertEqual(batch[0].shape, output_shape)
+        
+    def test_image_dataset_from_directory_pad_to_aspect_ratio(self):
+        directory = self._prepare_directory(num_classes=2, count=5)
+        dataset = image_dataset_utils.image_dataset_from_directory(
+            directory,
+            batch_size=5,
+            image_size=(18, 18),
+            pad_to_aspect_ratio=True,
+        )
+        if backend.config.image_data_format() == "channels_last":
+            output_shape = [5, 18, 18, 3]
+        else:
+            output_shape = [5, 3, 18, 18]
+        batch = next(iter(dataset))
+        self.assertLen(batch, 2)
+        self.assertEqual(batch[0].shape, output_shape)
 
     def test_image_dataset_from_directory_errors(self):
         directory = self._prepare_directory(num_classes=3, count=5)


### PR DESCRIPTION
I'm not really sure how to do this but I've noticed that there is no easy way to use padding with image_dataset_from_directory. So I added an analogous argument to crop_to_aspect_ratio. I'm not sure about the behaviour when both padding and croping are set to true so I just raise an error.