### PR TITLE
Fix `isinstance` check for tuple input in `pack_x_y_sample_weight`

### DIFF
--- a/keras/trainers/data_adapters/data_adapter_utils.py
+++ b/keras/trainers/data_adapters/data_adapter_utils.py
@@ -100,7 +100,7 @@ def pack_x_y_sample_weight(x, y=None, sample_weight=None):
         # there is no ambiguity. This also makes NumPy and Dataset
         # consistent in that the user does not have to wrap their Dataset
         # data in an unnecessary tuple.
-        if not isinstance(x, tuple or list):
+        if not isinstance(x, (tuple, list)):
             return x
         else:
             return (x,)


### PR DESCRIPTION
Quite a simple fix:

`tuple or list` returns `tuple` so the current check amounts to `isinstance(x, tuple)` when clearly it is intended to also check for `list`.

You can quickly verify this with the following example in any interactive python shell:

```py3
>>> x = [1, 2, 3]
>>> isinstance(x, tuple or list)
False
>>> isinstance(x, (tuple, list))
True
```