### PR TITLE
Update jax random shuffle API

### DIFF
--- a/keras/backend/jax/random.py
+++ b/keras/backend/jax/random.py
@@ -83,7 +83,7 @@ def dropout(inputs, rate, noise_shape=None, seed=None):
 
 def shuffle(x, axis=0, seed=None):
     seed = jax_draw_seed(seed)
-    return jax.random.shuffle(seed, x, axis)
+    return jax.random.permutation(seed, x, axis, independent=True)
 
 
 def gamma(shape, alpha, dtype=None, seed=None):


### PR DESCRIPTION
jax.random.shuffle API is deprecated and is replaced with [jax.random.permutation](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.permutation.html).

Fixes: https://github.com/keras-team/keras/issues/19271