### PR TITLE
Use Value dim shape for Attention compute_output_shape

### DIFF
--- a/keras/dtype_policies/dtype_policy.py
+++ b/keras/dtype_policies/dtype_policy.py
@@ -173,9 +173,6 @@ class FloatDTypePolicy(DTypePolicy):
             return "float16", "float32"
         elif name == "mixed_bfloat16":
             return "bfloat16", "float32"
-        elif name == "uint8":
-            dtype = backend.standardize_dtype(name)
-            return dtype, dtype
         try:
             dtype = backend.standardize_dtype(name)
             return dtype, dtype

--- a/keras/layers/attention/attention.py
+++ b/keras/layers/attention/attention.py
@@ -242,7 +242,8 @@ class Attention(Layer):
         return ops.convert_to_tensor(mask[0])
 
     def compute_output_shape(self, input_shape):
-        return input_shape[0]
+        # Return shape of value tensor
+        return input_shape[1]
 
     def _validate_inputs(self, inputs, mask=None):
         """Validates arguments of the call method."""

--- a/keras/layers/attention/attention.py
+++ b/keras/layers/attention/attention.py
@@ -242,8 +242,8 @@ class Attention(Layer):
         return ops.convert_to_tensor(mask[0])
 
     def compute_output_shape(self, input_shape):
-        # Return shape of value tensor
-        return input_shape[1]
+        """Returns shape of value tensor dim, but for query tensor length"""
+        return (*input_shape[0][:-1], input_shape[1][-1])
 
     def _validate_inputs(self, inputs, mask=None):
         """Validates arguments of the call method."""

--- a/keras/layers/attention/attention_test.py
+++ b/keras/layers/attention/attention_test.py
@@ -352,4 +352,9 @@ class AttentionTest(testing.TestCase):
         layer = layers.Attention()
         output = layer([query, value, key])
         self.assertAllEqual(output.shape, value.shape)
-        self.assertAllEqual(layer.compute_output_shape(input_shape=[query.shape, value.shape, key.shape]), value.shape)
+        self.assertAllEqual(
+            layer.compute_output_shape(
+                input_shape=[query.shape, value.shape, key.shape]
+            ),
+            value.shape,
+        )

--- a/keras/layers/attention/attention_test.py
+++ b/keras/layers/attention/attention_test.py
@@ -345,5 +345,11 @@ class AttentionTest(testing.TestCase):
 
     def test_attention_compute_output_shape(self):
         layer = layers.Attention()
-        input_shape = [(2, 8, 7), (2, 8, 5), (2, 8, 7)]  # Shapes of Q, V, K
-        self.assertAllEqual(layer.compute_output_shape(input_shape) == (2, 8, 5))
+
+        query = np.random.random((2, 3, 4))
+        value = np.random.random((2, 3, 5))
+        key = np.random.random((2, 3, 4))
+        layer = layers.Attention()
+        output = layer([query, value, key])
+        self.assertAllEqual(output.shape, value.shape)
+        self.assertAllEqual(layer.compute_output_shape(input_shape=[query.shape, value.shape, key.shape]), value.shape)

--- a/keras/layers/attention/attention_test.py
+++ b/keras/layers/attention/attention_test.py
@@ -342,3 +342,8 @@ class AttentionTest(testing.TestCase):
             computed_mask = layer.compute_mask(inputs=dummy_inputs, mask=mask)
             computed_mask = ops.convert_to_numpy(computed_mask)
             self.assertTrue(np.array_equal(computed_mask, valid_mask))
+
+    def test_attention_compute_output_shape(self):
+        layer = layers.Attention()
+        input_shape = [(2, 8, 7), (2, 8, 5), (2, 8, 7)]  # Shapes of Q, V, K
+        self.assertAllEqual(layer.compute_output_shape(input_shape) == (2, 8, 5))

--- a/keras/layers/attention/attention_test.py
+++ b/keras/layers/attention/attention_test.py
@@ -356,5 +356,5 @@ class AttentionTest(testing.TestCase):
             layer.compute_output_shape(
                 input_shape=[query.shape, value.shape, key.shape]
             ),
-            value.shape,
+            output.shape,
         )


### PR DESCRIPTION
Fixes #19257 by using Value dim shape for `compute_output_shape` of Attention layer.