### PR TITLE
Unwrap variable values in all stateless calls.

### DIFF
--- a/keras/backend/common/stateless_scope.py
+++ b/keras/backend/common/stateless_scope.py
@@ -53,7 +53,10 @@ class StatelessScope:
                     "all keys in argument `mapping` must be KerasVariable "
                     f"instances. Received instead: {k}"
                 )
-            v = backend.convert_to_tensor(v, dtype=k.dtype)
+            if isinstance(v, KerasVariable):
+                v = backend.cast(v.value, dtype=k.dtype)
+            else:
+                v = backend.convert_to_tensor(v, dtype=k.dtype)
             if k.shape != v.shape:
                 raise ValueError(
                     "Invalid variable value in StatelessScope: "

--- a/keras/backend/tensorflow/core.py
+++ b/keras/backend/tensorflow/core.py
@@ -111,7 +111,12 @@ def convert_to_tensor(x, dtype=None, sparse=None):
             x = tf.convert_to_tensor(x)
             return tf.cast(x, dtype)
         return tf.convert_to_tensor(x, dtype=dtype)
-    elif dtype is not None:
+    elif dtype is not None and not x.dtype == dtype:
+        if isinstance(x, tf.SparseTensor):
+            x_shape = x.shape
+            x = tf.cast(x, dtype)
+            x.set_shape(x_shape)
+            return x
         return tf.cast(x, dtype=dtype)
     else:
         return x


### PR DESCRIPTION
When variables are passed to stateless calls (`stateless_call`, `stateless_update`, `stateless_apply`), unwrap them to extract their value so that the mapping from variable to value in `StatelessScope` points to a value. This is to prevent an infinite recursion when performing operations (e.g. `__add__`) in a stateless scope.

Also fix issue where casting a `tf.SparseTensor` would lose the shape. The optimization in `ops.cast` is what revealed the stateless calls bug.