### PR TITLE
ArrayDataAdapter no longer converts to NumPy and supports sparse tens…

### DIFF
--- a/keras/backend/jax/core.py
+++ b/keras/backend/jax/core.py
@@ -47,21 +47,23 @@ class Variable(KerasVariable):
 def convert_to_tensor(x, dtype=None, sparse=True):
     if dtype is not None:
         dtype = standardize_dtype(dtype)
-    if isinstance(x, (jnp.ndarray, jax.Array)) and dtype == x.dtype:
+    if isinstance(x, (jnp.ndarray, jax.Array)) and (
+        dtype is None or x.dtype == dtype
+    ):
         # Skip the conversion early if the instance is already a JAX array.
         # This is important in the multi-process context since jax.array(x) for
         # an existing distributed jax array will raise error.
         return x
 
     if isinstance(x, Variable):
-        if dtype and dtype != x.dtype:
+        if dtype is not None and x.dtype != dtype:
             return x.value.astype(dtype)
         return x.value
 
     if isinstance(x, jax_sparse.JAXSparse):
         if sparse is not None and not sparse:
             x = x.todense()
-        elif dtype and dtype != x.dtype:
+        elif dtype is not None and x.dtype != dtype:
             return x.astype(dtype)
         else:
             return x

--- a/keras/backend/jax/trainer.py
+++ b/keras/backend/jax/trainer.py
@@ -12,6 +12,7 @@ from keras import optimizers as optimizers_module
 from keras.backend import distribution_lib as jax_distribution_lib
 from keras.distribution import distribution_lib
 from keras.trainers import trainer as base_trainer
+from keras.trainers.data_adapters import array_slicing
 from keras.trainers.data_adapters import data_adapter_utils
 from keras.trainers.epoch_iterator import EpochIterator
 from keras.utils import traceback_utils
@@ -330,7 +331,7 @@ class JAXTrainer(base_trainer.Trainer):
                 x,
                 y,
                 sample_weight,
-            ), validation_data = data_adapter_utils.train_validation_split(
+            ), validation_data = array_slicing.train_validation_split(
                 (x, y, sample_weight), validation_split=validation_split
             )
 

--- a/keras/backend/tensorflow/core.py
+++ b/keras/backend/tensorflow/core.py
@@ -129,6 +129,8 @@ def convert_to_numpy(x):
         x.set_shape(x_shape)
     elif isinstance(x, tf.IndexedSlices):
         x = tf.convert_to_tensor(x)
+    elif isinstance(x, tf.RaggedTensor):
+        x = x.to_tensor()
     return np.asarray(x)
 
 
@@ -161,7 +163,13 @@ def shape(x):
 
 def cast(x, dtype):
     dtype = standardize_dtype(dtype)
-    return tf.cast(x, dtype=dtype)
+    if isinstance(x, tf.SparseTensor):
+        x_shape = x.shape
+        x = tf.cast(x, dtype)
+        x.set_shape(x_shape)
+        return x
+    else:
+        return tf.cast(x, dtype=dtype)
 
 
 def compute_output_spec(fn, *args, **kwargs):

--- a/keras/backend/tensorflow/trainer.py
+++ b/keras/backend/tensorflow/trainer.py
@@ -10,6 +10,7 @@ from keras import callbacks as callbacks_module
 from keras import metrics as metrics_module
 from keras import optimizers as optimizers_module
 from keras.trainers import trainer as base_trainer
+from keras.trainers.data_adapters import array_slicing
 from keras.trainers.data_adapters import data_adapter_utils
 from keras.trainers.epoch_iterator import EpochIterator
 from keras.utils import traceback_utils
@@ -273,7 +274,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
                 x,
                 y,
                 sample_weight,
-            ), validation_data = data_adapter_utils.train_validation_split(
+            ), validation_data = array_slicing.train_validation_split(
                 (x, y, sample_weight), validation_split=validation_split
             )
 

--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -8,6 +8,7 @@ from keras import backend
 from keras import callbacks as callbacks_module
 from keras import optimizers as optimizers_module
 from keras.trainers import trainer as base_trainer
+from keras.trainers.data_adapters import array_slicing
 from keras.trainers.data_adapters import data_adapter_utils
 from keras.trainers.epoch_iterator import EpochIterator
 from keras.utils import traceback_utils
@@ -193,7 +194,7 @@ class TorchTrainer(base_trainer.Trainer):
                 x,
                 y,
                 sample_weight,
-            ), validation_data = data_adapter_utils.train_validation_split(
+            ), validation_data = array_slicing.train_validation_split(
                 (x, y, sample_weight), validation_split=validation_split
             )
 

--- a/keras/trainers/data_adapters/array_slicing.py
+++ b/keras/trainers/data_adapters/array_slicing.py
@@ -1,0 +1,512 @@
+import collections
+import math
+
+import numpy as np
+
+from keras import backend
+from keras.trainers.data_adapters import data_adapter_utils
+from keras.utils import tree
+
+try:
+    import pandas
+except ImportError:
+    pandas = None
+
+
+# Leave jax, tf, and torch arrays off this list. Instead we will use
+# `__array__` to detect these types. Doing so allows us to avoid importing a
+# backend framework we are not currently using just to do type-checking.
+ARRAY_TYPES = (np.ndarray,)
+if pandas:
+    ARRAY_TYPES = ARRAY_TYPES + (pandas.Series, pandas.DataFrame)
+
+
+class Sliceable:
+    """`Sliceable` wrapping a tensor.
+
+    A `Sliceable` implements the subscript operator to slice or index against
+    the first dimension of the array. It also has conversion methods for each
+    one of the backends.
+
+    Args:
+        array: the native array or tensor to wrap.
+
+    Attributes:
+        shape: the shape of the full dense native array.
+    """
+
+    def __init__(self, array):
+        self.array = array
+
+    def __getitem__(self, indices):
+        """Select elements in the 0th dimension.
+
+        Args:
+            indices: the indices to select. Only needs to support one dimension,
+                the 0th dimension. Should support a `slice` or a list, tuple,
+                `np.array` or 1D tensor.
+        Returns: A slice of `self.array`.
+        """
+        return self.array[indices]
+
+    @classmethod
+    def cast(cls, x, dtype):
+        """Cast a tensor to a different dtype.
+
+        Only called on a full array as provided by the user.
+
+        Args:
+            x: the tensor to cast.
+        Returns: the cast tensor.
+        """
+        return x.astype(dtype)
+
+    @classmethod
+    def convert_to_numpy(cls, x):
+        """Convert a tensor to a NumPy array.
+
+        Only called after slicing using `__getitem__`.
+
+        Args:
+            x: the tensor to convert.
+        Returns: the converted tensor.
+        """
+        return x
+
+    @classmethod
+    def convert_to_tf_dataset_compatible(cls, x):
+        """Convert a tensor to something compatible with `tf.data.Dataset`.
+
+        This can be a NumPy array, `tf.Tensor` or any other type of tensor that
+        `tf.data.Dataset.from_tensors` can consume.
+        Only called on a full array as provided by the user.
+
+        Args:
+            x: the tensor to convert.
+        Returns: converted version tensor.
+        """
+        return x
+
+    @classmethod
+    def convert_to_jax_compatible(cls, x):
+        """Convert a tensor to something that the JAX backend can consume.
+
+        This can be a `JAX` array, NumPy array or any other type of tensor that
+        `keras.backend.jax.core.convert_to_tensor()` can consume.
+        Only called after slicing using `__getitem__`.
+        Used to convert sparse tensors and densify ragged tensors.
+
+        Args:
+            x: the tensor to convert.
+        Returns: the converted tensor.
+        """
+        return x
+
+    @classmethod
+    def convert_to_torch_compatible(cls, x):
+        """Convert a tensor to something that the Torch backend can consume.
+
+        This can be a Torch tensor, NumPy array or any other type of tensor that
+        `keras.backend.torch.core.convert_to_tensor()` can consume.
+        Only called after slicing using `__getitem__`.
+        Used to densify sparse tensors and ragged tensors.
+
+        Args:
+            x: the tensor to convert.
+        Returns: the converted tensor.
+        """
+        return x
+
+
+class NumpySliceable(Sliceable):
+    pass
+
+
+class TensorflowSliceable(Sliceable):
+    def __getitem__(self, indices):
+        from keras.utils.module_utils import tensorflow as tf
+
+        if isinstance(indices, slice):
+            return self.array[indices]
+        else:
+            return tf.gather(self.array, indices, axis=0)
+
+    @classmethod
+    def cast(cls, x, dtype):
+        from keras.backend.tensorflow.core import cast
+
+        return cast(x, dtype)
+
+    @classmethod
+    def convert_to_numpy(cls, x):
+        from keras.backend.tensorflow.core import convert_to_numpy
+
+        return convert_to_numpy(x)
+
+
+class TensorflowRaggedSliceable(TensorflowSliceable):
+    @classmethod
+    def convert_to_jax_compatible(cls, x):
+        return x.to_tensor()
+
+    @classmethod
+    def convert_to_torch_compatible(cls, x):
+        return x.to_tensor()
+
+
+class TensorflowSparseSliceable(TensorflowSliceable):
+    def __init__(self, array):
+        super().__init__(to_tensorflow_sparse_wrapper(array))
+
+    @property
+    def shape(self):
+        return self.array.sparse.shape
+
+    def __getitem__(self, indices):
+        return slice_tensorflow_sparse_wrapper(self.array, indices)
+
+    @classmethod
+    def convert_to_tf_dataset_compatible(cls, x):
+        return to_tensorflow_sparse_wrapper(x)
+
+    @classmethod
+    def convert_to_jax_compatible(cls, x):
+        return data_adapter_utils.tf_sparse_to_jax_sparse(x)
+
+    @classmethod
+    def convert_to_torch_compatible(cls, x):
+        from keras.utils.module_utils import tensorflow as tf
+
+        return tf.sparse.to_dense(x)
+
+
+class JaxSliceable(Sliceable):
+    def __getitem__(self, indices):
+        return self.array[indices, ...]
+
+    @classmethod
+    def convert_to_numpy(cls, x):
+        from keras.backend.jax.core import convert_to_numpy
+
+        return convert_to_numpy(x)
+
+
+class JaxSparseSliceable(JaxSliceable):
+    @classmethod
+    def convert_to_tf_dataset_compatible(cls, array):
+        return to_tensorflow_sparse_wrapper(
+            data_adapter_utils.jax_sparse_to_tf_sparse(array)
+        )
+
+    @classmethod
+    def convert_to_torch_compatible(cls, x):
+        return x.todense()
+
+
+class TorchSliceable(Sliceable):
+    @classmethod
+    def cast(cls, x, dtype):
+        from keras.backend.torch.core import cast
+
+        return cast(x, dtype)
+
+    @classmethod
+    def convert_to_numpy(cls, x):
+        from keras.backend.torch.core import convert_to_numpy
+
+        return convert_to_numpy(x)
+
+
+class PandasSliceable(Sliceable):
+    def __getitem__(self, indices):
+        return self.array.iloc[indices]
+
+    @classmethod
+    def convert_to_numpy(cls, x):
+        return x.to_numpy()
+
+    @classmethod
+    def convert_to_tf_dataset_compatible(cls, x):
+        return cls.convert_to_numpy(x)
+
+    @classmethod
+    def convert_to_jax_compatible(cls, x):
+        return cls.convert_to_numpy(x)
+
+    @classmethod
+    def convert_to_torch_compatible(cls, x):
+        return cls.convert_to_numpy(x)
+
+
+class PandasDataFrameSliceable(PandasSliceable):
+    pass
+
+
+class PandasSeriesSliceable(PandasSliceable):
+    @classmethod
+    def convert_to_numpy(cls, x):
+        return np.expand_dims(x.to_numpy(), axis=-1)
+
+
+class ScipySparseSliceable(Sliceable):
+    def __init__(self, array):
+        # The COO representation is not indexable / sliceable and does not lend
+        # itself to it. Use the CSR representation instead, which is sliceable.
+        super().__init__(array.tocsr())
+
+    @classmethod
+    def convert_to_numpy(cls, x):
+        return x.todense()
+
+    @classmethod
+    def convert_to_tf_dataset_compatible(cls, x):
+        return to_tensorflow_sparse_wrapper(
+            data_adapter_utils.scipy_sparse_to_tf_sparse(x)
+        )
+
+    @classmethod
+    def convert_to_jax_compatible(cls, x):
+        return data_adapter_utils.scipy_sparse_to_jax_sparse(x)
+
+    @classmethod
+    def convert_to_torch_compatible(cls, x):
+        return x.todense()
+
+
+# `tf.SparseTensor` does not support indexing or `tf.gather`. The COO
+# representation it uses does not lend itself to indexing. We add some
+# intermediary tensors to ease the indexing and slicing. We put both indices and
+# values in `RaggedTensor`s where each row corresponds to a row in the sparse
+# tensor. This is because the number of values per row is not fixed.
+# `RaggedTensor`s do support indexing and `tf.gather`, although on CPU only.
+# We then reconstruct a `SparseTensor` from extracted rows. In theory, there is
+# no duplication of data for the indices and values, only the addition of row
+# splits for the ragged representation.
+# `TensorflowSparseWrapper` is a named tuple which combines the original
+# `SparseTensor` (used for the shape) and the ragged representations of indices
+# and values for indexing / slicing. We use a named tuple and not a `Sliceable`
+# to be able to ingest it in `tf.data.Dataset.from_tensors()` and map it.
+
+TensorflowSparseWrapper = collections.namedtuple(
+    "TensorflowSparseWrapper", ["sparse", "ragged_indices", "ragged_values"]
+)
+
+
+def to_tensorflow_sparse_wrapper(sparse):
+    from keras.utils.module_utils import tensorflow as tf
+
+    row_ids = sparse.indices[:, 0]
+    row_splits = tf.experimental.RowPartition.from_value_rowids(
+        row_ids
+    ).row_splits()
+
+    ragged_indices = tf.cast(
+        tf.RaggedTensor.from_row_splits(sparse.indices, row_splits), tf.int64
+    )
+    ragged_values = tf.RaggedTensor.from_row_splits(sparse.values, row_splits)
+    return TensorflowSparseWrapper(sparse, ragged_indices, ragged_values)
+
+
+def slice_tensorflow_sparse_wrapper(sparse_wrapper, indices):
+    from keras.utils.module_utils import tensorflow as tf
+
+    if isinstance(indices, slice):
+        sparse_indices = sparse_wrapper.ragged_indices[indices]
+        sparse_values = sparse_wrapper.ragged_values[indices]
+        batch_dim = indices.stop - indices.start
+    else:
+        sparse_indices = tf.gather(sparse_wrapper.ragged_indices, indices)
+        sparse_values = tf.gather(sparse_wrapper.ragged_values, indices)
+        if isinstance(indices, list):
+            batch_dim = len(indices)
+        else:
+            batch_dim = indices.shape[0]
+            if batch_dim is None:
+                batch_dim = tf.shape(indices)[0]
+
+    row_ids = sparse_indices.value_rowids()
+    sparse_indices = sparse_indices.flat_values[:, 1:]  # remove first value
+    sparse_indices = tf.concat(
+        [tf.expand_dims(row_ids, -1), sparse_indices], axis=1
+    )
+
+    sparse_values = sparse_values.flat_values
+    sparse_shape = (batch_dim,) + tuple(
+        sparse_wrapper.sparse.shape.as_list()[1:]
+    )
+    return tf.SparseTensor(sparse_indices, sparse_values, sparse_shape)
+
+
+def can_slice_array(x):
+    return (
+        x is None
+        or isinstance(x, ARRAY_TYPES)
+        or data_adapter_utils.is_tensorflow_tensor(x)
+        or data_adapter_utils.is_jax_array(x)
+        or data_adapter_utils.is_torch_tensor(x)
+        or data_adapter_utils.is_scipy_sparse(x)
+        or hasattr(x, "__array__")
+    )
+
+
+def convert_to_sliceable(arrays, target_backend=None):
+    """Convert a structure of arrays into `Sliceable` instances
+
+    Args:
+        arrays: the arrays to convert.
+        target_backend: the target backend for the output:
+            - `None` indicates that `arrays` will be wrapped into `Sliceable`s
+              as-is without using a different representation. This is used by
+              `train_validation_split()`.
+            - `tensorflow` indicates that
+              `Sliceable.convert_to_tf_dataset_compatible` will be called. The
+              returned structure therefore contains arrays, not `Sliceable`s.
+            - `numpy`, `jax` or `torch` indices that the arrays will eventually
+              be converted to this backend type after slicing. In this case,
+              the intermediary `Sliceable`s may use a different representation
+              from the input `arrays` for better performance.
+    Returns: the same structure with `Sliceable` instances or arrays.
+    """
+
+    def convert_single_array(x):
+        if x is None:
+            return x
+
+        # Step 1. Determine which Sliceable class to use.
+        if isinstance(x, np.ndarray):
+            sliceable_class = NumpySliceable
+        elif data_adapter_utils.is_tensorflow_tensor(x):
+            if data_adapter_utils.is_tensorflow_ragged(x):
+                sliceable_class = TensorflowRaggedSliceable
+            elif data_adapter_utils.is_tensorflow_sparse(x):
+                sliceable_class = TensorflowSparseSliceable
+            else:
+                sliceable_class = TensorflowSliceable
+        elif data_adapter_utils.is_jax_array(x):
+            if data_adapter_utils.is_jax_sparse(x):
+                sliceable_class = JaxSparseSliceable
+            else:
+                sliceable_class = JaxSliceable
+        elif data_adapter_utils.is_torch_tensor(x):
+            sliceable_class = TorchSliceable
+        elif pandas is not None and isinstance(x, pandas.DataFrame):
+            sliceable_class = PandasDataFrameSliceable
+        elif pandas is not None and isinstance(x, pandas.Series):
+            sliceable_class = PandasSeriesSliceable
+        elif data_adapter_utils.is_scipy_sparse(x):
+            sliceable_class = ScipySparseSliceable
+        elif hasattr(x, "__array__"):
+            x = np.asarray(x)
+            sliceable_class = NumpySliceable
+        else:
+            raise ValueError(
+                "Expected a NumPy array, tf.Tensor, tf.RaggedTensor, "
+                "tf.SparseTensor, jax.np.ndarray, "
+                "jax.experimental.sparse.JAXSparse, torch.Tensor, "
+                "Pandas Dataframe, or Pandas Series. Received invalid input: "
+                f"{x} (of type {type(x)})"
+            )
+
+        # Step 2. Normalize floats to floatx.
+        def is_non_floatx_float(dtype):
+            return (
+                not dtype == object
+                and backend.is_float_dtype(dtype)
+                and not backend.standardize_dtype(dtype) == backend.floatx()
+            )
+
+        cast_dtype = None
+        if pandas is not None and isinstance(x, pandas.DataFrame):
+            if any(is_non_floatx_float(d) for d in x.dtypes.values):
+                cast_dtype = backend.floatx()
+        else:
+            if is_non_floatx_float(x.dtype):
+                cast_dtype = backend.floatx()
+
+        if cast_dtype is not None:
+            x = sliceable_class.cast(x, cast_dtype)
+
+        # Step 3. Apply target backend specific logic and optimizations.
+        if target_backend is None:
+            return sliceable_class(x)
+
+        if target_backend == "tensorflow":
+            return sliceable_class.convert_to_tf_dataset_compatible(x)
+
+        # With dense arrays, with JAX as either input or output, it is faster to
+        # use NumPy as an intermediary representation, so wrap input array in a
+        # NumPy array, which should not use extra memory. For the input case,
+        # see https://github.com/google/jax/issues/1276 for an explanation of
+        # why slicing a NumPy array is faster than slicing a JAX array.
+        if sliceable_class == JaxSliceable or (
+            target_backend == "jax"
+            and sliceable_class in (TensorflowSliceable, TorchSliceable)
+        ):
+            x = np.asarray(x)
+            sliceable_class = NumpySliceable
+
+        return sliceable_class(x)
+
+    return tree.map_structure(convert_single_array, arrays)
+
+
+def train_validation_split(arrays, validation_split):
+    """Split arrays into train and validation subsets in deterministic order.
+
+    The last part of data will become validation data.
+
+    Args:
+        arrays: Tensors to split. Allowed inputs are arbitrarily nested
+            structures of Tensors and NumPy arrays.
+        validation_split: Float between 0 and 1. The proportion of the dataset
+            to include in the validation split. The rest of the dataset will be
+            included in the training split.
+
+    Returns:
+        `(train_arrays, validation_arrays)`
+    """
+
+    flat_arrays = tree.flatten(arrays)
+    unsplitable = [type(t) for t in flat_arrays if not can_slice_array(t)]
+    if unsplitable:
+        raise ValueError(
+            "Argument `validation_split` is only supported "
+            "for tensors or NumPy arrays."
+            f"Found incompatible type in the input: {unsplitable}"
+        )
+
+    if all(t is None for t in flat_arrays):
+        return arrays, arrays
+
+    first_non_none = None
+    for t in flat_arrays:
+        if t is not None:
+            first_non_none = t
+            break
+
+    # Assumes all arrays have the same batch shape or are `None`.
+    batch_dim = int(first_non_none.shape[0])
+    split_at = int(math.floor(batch_dim * (1.0 - validation_split)))
+
+    if split_at == 0 or split_at == batch_dim:
+        raise ValueError(
+            f"Training data contains {batch_dim} samples, which is not "
+            "sufficient to split it into a validation and training set as "
+            f"specified by `validation_split={validation_split}`. Either "
+            "provide more data, or a different value for the "
+            "`validation_split` argument."
+        )
+
+    def _split(t, start, end):
+        if t is None:
+            return t
+        return t[start:end]
+
+    sliceables = convert_to_sliceable(arrays)
+    train_arrays = tree.map_structure(
+        lambda x: _split(x, start=0, end=split_at), sliceables
+    )
+    val_arrays = tree.map_structure(
+        lambda x: _split(x, start=split_at, end=batch_dim), sliceables
+    )
+    return train_arrays, val_arrays

--- a/keras/trainers/data_adapters/generator_data_adapter.py
+++ b/keras/trainers/data_adapters/generator_data_adapter.py
@@ -1,7 +1,5 @@
 import itertools
 
-import numpy as np
-
 from keras import backend
 from keras.trainers.data_adapters import data_adapter_utils
 from keras.trainers.data_adapters.data_adapter import DataAdapter
@@ -44,8 +42,8 @@ class GeneratorDataAdapter(DataAdapter):
                 return tf.RaggedTensorSpec(shape=shape, dtype=dtype)
             if (
                 isinstance(x, tf.SparseTensor)
-                or is_scipy_sparse(x)
-                or is_jax_sparse(x)
+                or data_adapter_utils.is_scipy_sparse(x)
+                or data_adapter_utils.is_jax_sparse(x)
             ):
                 return tf.SparseTensorSpec(shape=shape, dtype=dtype)
             else:
@@ -62,10 +60,10 @@ class GeneratorDataAdapter(DataAdapter):
         from keras.backend.jax.core import convert_to_tensor
 
         def convert_to_jax(x):
-            if is_scipy_sparse(x):
-                return scipy_sparse_to_jax_sparse(x)
-            elif is_tf_sparse(x):
-                return tf_sparse_to_jax_sparse(x)
+            if data_adapter_utils.is_scipy_sparse(x):
+                return data_adapter_utils.scipy_sparse_to_jax_sparse(x)
+            elif data_adapter_utils.is_tensorflow_sparse(x):
+                return data_adapter_utils.tf_sparse_to_jax_sparse(x)
             return convert_to_tensor(x)
 
         for batch in self.generator:
@@ -75,10 +73,10 @@ class GeneratorDataAdapter(DataAdapter):
         from keras.utils.module_utils import tensorflow as tf
 
         def convert_to_tf(x):
-            if is_scipy_sparse(x):
-                x = scipy_sparse_to_tf_sparse(x)
-            elif is_jax_sparse(x):
-                x = jax_sparse_to_tf_sparse(x)
+            if data_adapter_utils.is_scipy_sparse(x):
+                x = data_adapter_utils.scipy_sparse_to_tf_sparse(x)
+            elif data_adapter_utils.is_jax_sparse(x):
+                x = data_adapter_utils.jax_sparse_to_tf_sparse(x)
             return x
 
         def get_tf_iterator():
@@ -110,58 +108,3 @@ class GeneratorDataAdapter(DataAdapter):
 def peek_and_restore(generator):
     element = next(generator)
     return element, itertools.chain([element], generator)
-
-
-def is_scipy_sparse(x):
-    return x.__class__.__module__.startswith("scipy.sparse") and hasattr(
-        x, "tocoo"
-    )
-
-
-def is_tf_sparse(x):
-    return (
-        x.__class__.__name__ == "SparseTensor"
-        and x.__class__.__module__.startswith("tensorflow")
-    )
-
-
-def is_jax_sparse(x):
-    return x.__class__.__module__.startswith("jax.experimental.sparse")
-
-
-def scipy_sparse_to_tf_sparse(x):
-    from keras.utils.module_utils import tensorflow as tf
-
-    coo = x.tocoo()
-    indices = np.concatenate(
-        (np.expand_dims(coo.row, 1), np.expand_dims(coo.col, 1)),
-        axis=1,
-    )
-    return tf.SparseTensor(indices, coo.data, coo.shape)
-
-
-def scipy_sparse_to_jax_sparse(x):
-    import jax.experimental.sparse as jax_sparse
-
-    coo = x.tocoo()
-    indices = np.concatenate(
-        (np.expand_dims(coo.row, 1), np.expand_dims(coo.col, 1)),
-        axis=1,
-    )
-    return jax_sparse.BCOO((coo.data, indices), shape=coo.shape)
-
-
-def tf_sparse_to_jax_sparse(x):
-    import jax.experimental.sparse as jax_sparse
-
-    from keras.backend.tensorflow.core import convert_to_numpy
-
-    values = convert_to_numpy(x.values)
-    indices = convert_to_numpy(x.indices)
-    return jax_sparse.BCOO((values, indices), shape=x.shape)
-
-
-def jax_sparse_to_tf_sparse(x):
-    from keras.utils.module_utils import tensorflow as tf
-
-    return tf.SparseTensor(x.indices, x.data, x.shape)

--- a/keras/utils/dataset_utils.py
+++ b/keras/utils/dataset_utils.py
@@ -248,6 +248,8 @@ def _get_next_sample(
     Yields:
         data_sample: The next sample.
     """
+    from keras.trainers.data_adapters.data_adapter_utils import is_torch_tensor
+
     try:
         dataset_iterator = iter(dataset_iterator)
         first_sample = next(dataset_iterator)
@@ -291,16 +293,6 @@ def _get_next_sample(
                     )
                     data_size_warning_flag = False
         yield sample
-
-
-def is_torch_tensor(value):
-    if hasattr(value, "__class__"):
-        for parent in value.__class__.__mro__:
-            if parent.__name__ == "Tensor" and str(parent.__module__).endswith(
-                "torch"
-            ):
-                return True
-    return False
 
 
 def is_torch_dataset(dataset):

--- a/keras/utils/tree.py
+++ b/keras/utils/tree.py
@@ -19,6 +19,10 @@ def map_structure_up_to(shallow_structure, func, *structures, **kwargs):
     )
 
 
+def traverse(func, structure, top_down=True):
+    return tree.traverse(func, structure, top_down=top_down)
+
+
 def assert_same_structure(a, b, check_types=True):
     return tree.assert_same_structure(a, b, check_types=check_types)
 


### PR DESCRIPTION
…ors.

Instead, the passed arrays can be sliced or indexed in their native format.
- This addresses https://github.com/keras-team/keras/issues/18408 and improves performance, especially with Tensorflow and Torch. It improves TF -> TF and Torch -> Torch, but also TF -> Torch and Torch -> TF.
- This allows the support of sparse tensors (`tf.SparseTensor`, `jax.experimental.sparse.BCOO` and `scipy.sparse`). These sparse tensors are sliced as sparse and the iterators yield sparse tensors in the requested format (either TF or JAX).
- The `validation_split` argument of `Model.fit()` can now be used with anything supported by `ArrayDataAdapter`, in particular, sparse tensors are now supported.

In summary, `ArrayDataAdapter` now supports:
- native Python arrays
- NumPy arrays
- Tensorflow tensors, ragged tensors, sparse tensors (new)
- JAX arrays and BCOO sparse tensors (new)
- pandas DataFrames
- pandas Series
- scipy sparse matrices (new)

Also:
- Fixed bug where batch level shuffling would shuffle inconsistently the different arrays (in particular inputs and labels) when using a TF dataset or a NumPy iterator.
- Fixed bug where `tf.RaggedTensor`s would only work when using a TF dataset.
- Fixed bug where `tf.RaggedTensor`s would not work when doing batch level shuffling.
- Added a workaround for a bug where `tf.cast`ing a `tf.SparseTensor` would lose the static shape.
- Added test coverage for `tf.RaggedTensor`s and `pandas.Series`.
- Added verification in tests that inputs and labels are shuffled consistently.