### PR TITLE
Custom Gradients

### DIFF
--- a/keras/backend/torch/core.py
+++ b/keras/backend/torch/core.py
@@ -453,21 +453,31 @@ class CustomGradientFunction(torch.autograd.Function):
     """
     CustomGradientFunction is a PyTorch autograd function enabling
     custom forward and backward passes for gradient computation.
+
+    Forward pass computation via:
+    `CustomGradientFunction.forward`
+
+    Args:
+        ctx: Context object.
+        forward_fn: Function to compute forward pass.
+        *args: Arguments for the forward pass.
+        **kwargs: Keyword arguments for the forward pass.
+
+    Returns:
+        torch.Tensor: Output of the forward pass.
+
+    Backward pass computation via
+    `CustomGradientFunction.backward`
+
+    Args:
+        ctx: Context object.
+        grad_output: Gradient with respect to the output.
+
+    Returns:
+        Tuple: Gradients with respect to the input arguments.
     """
     @staticmethod
     def forward(ctx, forward_fn, *args, **kwargs):
-        """
-        Forward pass computation.
-
-        Args:
-            ctx: Context object.
-            forward_fn: Function to compute forward pass.
-            *args: Arguments for the forward pass.
-            **kwargs: Keyword arguments for the forward pass.
-
-        Returns:
-            torch.Tensor: Output of the forward pass.
-        """
         ctx.forward_fn = forward_fn
         ctx.save_for_backward(*args)
         try:
@@ -479,16 +489,6 @@ class CustomGradientFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        """
-        Backward pass computation.
-
-        Args:
-            ctx: Context object.
-            grad_output: Gradient with respect to the output.
-
-        Returns:
-            Tuple: Gradients with respect to the input arguments.
-        """
         args = ctx.saved_tensors
         grad_fn = ctx.grad_fn
         if grad_fn is None:

--- a/keras/backend/torch/core.py
+++ b/keras/backend/torch/core.py
@@ -451,7 +451,8 @@ class custom_gradient:
 
 class CustomGradientFunction(torch.autograd.Function):
     """
-    CustomGradientFunction is a PyTorch autograd function enabling custom forward and backward passes for gradient computation.
+    CustomGradientFunction is a PyTorch autograd function enabling
+    custom forward and backward passes for gradient computation.
     """
     @staticmethod
     def forward(ctx, forward_fn, *args, **kwargs):

--- a/keras/backend/torch/core.py
+++ b/keras/backend/torch/core.py
@@ -436,8 +436,63 @@ def unstack(x, num=None, axis=0):
     return x.unbind(axis)
 
 
-def custom_gradient(fun):
-    # TODO: Support this function
-    raise NotImplementedError(
-        "`custom_gradient` is not supported with torch backend"
-    )
+class custom_gradient:
+    """
+    Decorator for custom gradients.
+
+    Args:
+        forward_fn: Function to compute forward pass.
+    """
+    def __init__(self, forward_fn):
+        self.forward_fn = forward_fn
+
+    def __call__(self, *args, **kwargs):
+        return CustomGradientFunction.apply(self.forward_fn, *args, **kwargs)
+
+class CustomGradientFunction(torch.autograd.Function):
+    """
+    Autograd function for custom gradients.
+    """
+    @staticmethod
+    def forward(ctx, forward_fn, *args, **kwargs):
+        """
+        Forward pass computation.
+
+        Args:
+            ctx: Context object.
+            forward_fn: Function to compute forward pass.
+            *args: Arguments for the forward pass.
+            **kwargs: Keyword arguments for the forward pass.
+
+        Returns:
+            torch.Tensor: Output of the forward pass.
+        """
+        ctx.forward_fn = forward_fn
+        ctx.save_for_backward(*args)
+        try:
+            output, ctx.grad_fn = forward_fn(*args, **kwargs)
+        except:
+            output = forward_fn(*args, **kwargs)
+            ctx.grad_fn = lambda *args, **kwargs: torch.full((), float('nan'))
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """
+        Backward pass computation.
+
+        Args:
+            ctx: Context object.
+            grad_output: Gradient with respect to the output.
+
+        Returns:
+            Tuple: Gradients with respect to the input arguments.
+        """
+        args = ctx.saved_tensors
+        grad_fn = ctx.grad_fn
+        if grad_fn is None:
+            raise ValueError("grad_fn must be provided for custom gradient")
+        grads = grad_fn(*args, upstream=grad_output)
+        if not isinstance(grads, tuple):
+            grads = (grads,)
+        return (None,) + grads

--- a/keras/backend/torch/core.py
+++ b/keras/backend/torch/core.py
@@ -451,7 +451,7 @@ class custom_gradient:
 
 class CustomGradientFunction(torch.autograd.Function):
     """
-    Autograd function for custom gradients.
+    CustomGradientFunction is a PyTorch autograd function enabling custom forward and backward passes for gradient computation.
     """
     @staticmethod
     def forward(ctx, forward_fn, *args, **kwargs):

--- a/keras/ops/core.py
+++ b/keras/ops/core.py
@@ -663,7 +663,7 @@ def custom_gradient(f):
         e = ops.exp(x)
 
         def grad(*args, upstream = None):
-            if upstream = None:
+            if upstream == None:
                 upstream, = args
                 
             return ops.multiply(upstream, 1.0 - 1.0 / ops.add(1, e))

--- a/keras/ops/core.py
+++ b/keras/ops/core.py
@@ -657,6 +657,7 @@ def custom_gradient(f):
 
     Example:
 
+    [Backend-invariant]
     ```python
     @ops.custom_gradient
     def log1pexp(x):
@@ -676,5 +677,29 @@ def custom_gradient(f):
     upon the backend being set. In JAX and TensorFlow backends, 
     it requires only one argument, whereas it might use `upstream` keyword 
     arguments in the case of PyTorch backend.
+
+    Example: When working with TensorFlow/JAX backend, `grad(upstream)`
+    is sufficient. In PyTorch `grad` function requires `*args` as well
+    as `upstream`, `def grad(*args, upstream)`. Follow the previous
+    example to use `@ops.custom_gradient` in all three backends.
+
+    [JAX, TensorFlow-specific backend example]
+    ```python
+    @ops.custom_gradient
+    def log1pexp(x):
+        e = ops.exp(x)
+        def grad(upstream=None):
+            return ops.multiply(upstream, 1.0 - 1.0 / ops.add(1, e))
+        return ops.log(1 + e), grad
+    ```
+    [PyTorch-specific backend example]
+    ```python
+    @ops.custom_gradient
+    def log1pexp(x):
+        e = ops.exp(x)
+        def grad(*args, upstream):
+            return ops.multiply(upstream, 1.0 - 1.0 / ops.add(1, e))
+        return ops.log(1 + e), grad
+    ```
     """
     return backend.core.custom_gradient(f)

--- a/keras/ops/core.py
+++ b/keras/ops/core.py
@@ -636,7 +636,7 @@ def custom_gradient(f):
     operations.
 
     Args:
-        forward_fn: Function `forward_fn(*args)` that returns a tuple
+        f: Function `f(*args)` that returns a tuple
             `(output, grad_fn)`, where:
             - `args` is a sequence of (nested structures of) tensor inputs to
                 the function.
@@ -651,8 +651,8 @@ def custom_gradient(f):
 
     Returns:
         A function `h(*args)` which returns the same value as
-        `forward_fn(*args)[0]` and whose gradient is determined by
-        `forward_fn(*args)[1]`.
+        `f(*args)[0]` and whose gradient is determined by
+        `f(*args)[1]`.
 
 
     Example:
@@ -672,9 +672,9 @@ def custom_gradient(f):
     ```
 
     Note that the grad function that returns gradient computations 
-    requires args as well as an upstream keyword argument, depending 
+    requires `args` as well as an `upstream` keyword argument, depending 
     upon the backend being set. In JAX and TensorFlow backends, 
-    it requires only one argument, whereas it might use upstream keyword 
+    it requires only one argument, whereas it might use `upstream` keyword 
     arguments in the case of PyTorch backend.
     """
     return backend.core.custom_gradient(f)

--- a/keras/ops/core.py
+++ b/keras/ops/core.py
@@ -635,24 +635,25 @@ def custom_gradient(f):
     a more efficient or numerically stable gradient for a sequence of
     operations.
 
-    Note that `custom_gradient` only supports TensorFlow and JAX backends.
-
     Args:
-        f: Function `f(*x)` that returns a tuple `(y, grad_fn)` where:
-            - `x` is a sequence of (nested structures of) tensor inputs to the
-                function.
-            - `y` is a (nested structure of) tensor outputs of applying
-                operations in `f` to `x`.
-            - `grad_fn` is a function with the signature `g(*grad_ys)` which
-                returns a list of tensors the same size as (flattened) `x`: the
-                derivatives of tensors in `y` with respect to the tensors in
-                `x`. `grad_ys` is a sequence of tensors the same size as
-                (flattened) `y` holding the initial value gradients for each
-                tensor in `y`.
+        forward_fn: Function `forward_fn(*args)` that returns a tuple
+            `(output, grad_fn)`, where:
+            - `args` is a sequence of (nested structures of) tensor inputs to
+                the function.
+            - `output` is a (nested structure of) tensor outputs of applying
+                operations in `forward_fn` to `args`.
+            - `grad_fn` is a function with the signature `grad_fn(*args,
+                upstream)` which returns a tuple of tensors the same size as
+                (flattened) `args`: the derivatives of tensors in `output` with
+                respect to the tensors in `args`. `upstream` is a tensor or
+                sequence of tensors holding the initial value gradients for each
+                tensor in `output`.
 
     Returns:
-        A function `h(x)` which returns the same value as `f(x)[0]` and whose
-        gradient is determined by `f(x)[1]`.
+        A function `h(*args)` which returns the same value as
+        `forward_fn(*args)[0]` and whose gradient is determined by
+        `forward_fn(*args)[1]`.
+
 
     Example:
 
@@ -661,10 +662,19 @@ def custom_gradient(f):
     def log1pexp(x):
         e = ops.exp(x)
 
-        def grad(upstream):
+        def grad(*args, upstream = None):
+            if upstream = None:
+                upstream, = args
+                
             return ops.multiply(upstream, 1.0 - 1.0 / ops.add(1, e))
 
         return ops.log(1 + e), grad
     ```
+
+    Note that the grad function that returns gradient computations 
+    requires args as well as an upstream keyword argument, depending 
+    upon the backend being set. In JAX and TensorFlow backends, 
+    it requires only one argument, whereas it might use upstream keyword 
+    arguments in the case of PyTorch backend.
     """
     return backend.core.custom_gradient(f)

--- a/keras/ops/core.py
+++ b/keras/ops/core.py
@@ -662,7 +662,7 @@ def custom_gradient(f):
     def log1pexp(x):
         e = ops.exp(x)
 
-        def grad(*args, upstream = None):
+        def grad(*args, upstream=None):
             if upstream == None:
                 upstream, = args
                 

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -542,7 +542,7 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             dz_dx = jax.grad(log1pexp_nan)(x)
             self.assertEqual(ops.convert_to_numpy(dy_dx), 1.0)
             self.assertTrue(ops.isnan(dz_dx))
-        elif backend.backend() == "pytorch":
+        elif backend.backend() == "torch":
             import torch
 
             z = log1pexp(x)

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -512,7 +512,9 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         def log1pexp(x):
             e = ops.exp(x)
 
-            def grad(upstream):
+            def grad(*args, upstream = None):
+                if upstream == None:
+                    upstream, = args
                 return ops.multiply(upstream, 1.0 - 1.0 / ops.add(1, e))
 
             return ops.log(1 + e), grad

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -545,6 +545,7 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         elif backend.backend() == "torch":
             import torch
 
+            x = torch.tensor(100.0, requires_grad = True) # x = ops.convert_to_tensor(100.0) is NOT supported Yet!
             z = log1pexp(x)
             z.sum().backward()
             self.assertEqual(ops.convert_to_numpy(x.grad), 1.0)

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -501,7 +501,7 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertFalse(ops.is_tensor([1, 2, 3]))
 
     @pytest.mark.skipif(
-        backend.backend() not in ("tensorflow", "jax", "pytorch"),
+        backend.backend() not in ("tensorflow", "jax", "torch"),
         reason=f"{backend.backend()} doesn't support `custom_gradient`.",
     )
 


### PR DESCRIPTION
With little bit of tweaking of the syntax, now its possible to have custom gradients for all three - JAX, PyTorch and TensorFlow.

Sorry if I don't know, tho I added the unit tests, I don't know how to run to test it.

Example of syntax:

Here's the rough notebook testing it:
 - https://colab.research.google.com/gist/abhaskumarsinha/5486857bacd9adb78a32ed29aee3f580/keras-autograd.ipynb
 - https://colab.research.google.com/drive/1PbnHsZMWBLHXzOtrzwTLc6GQMAO_EwZb?usp=sharing

I believe custom addition of function and their custom gradient definitions would enable the users to implement complex layers and operations even if that isn't available in other frameworks. It could also help them work with custom data structures like - complex numbers, non metric spaces or probabilistic spaces.

Example Syntax:

```
@keras.ops.custom_gradient
def fun(x):
    z = x * x
    def grad(*args, upstream=None):
        if upstream is None:
            # tf.custom_gradient convention
            upstream, = args
        return upstream * x * 10
    return z, grad

x = torch.tensor([2.0], requires_grad = True)
z = fun(x)
z.sum().backward()
x.grad

```

Only difference is that grad function accepts two arguments (one keyword) in the case of PyTorch and one argument in the case of TensorFlow or Jax. So additional

```
def grad(*args, upstream = None):
     if upstream == None:
          upstream, = args
```

doesn't hurt more.

Thank You.