### PR TITLE
ops/numpy.py: support key as list in GetItem

### DIFF
--- a/keras/ops/numpy.py
+++ b/keras/ops/numpy.py
@@ -2707,6 +2707,8 @@ class GetItem(Operation):
             remaining_key = [key]
         elif isinstance(key, tuple):
             remaining_key = list(key)
+        elif isinstance(key, list):
+            remaining_key = key.copy()
         else:
             raise ValueError(
                 f"Unsupported key type for array slice. Recieved: `{key}`"

--- a/keras/saving/serialization_lib_test.py
+++ b/keras/saving/serialization_lib_test.py
@@ -94,6 +94,19 @@ class SerializationLibTest(testing.TestCase):
         self.assertEqual(layer.trainable, restored.trainable)
         self.assertEqual(layer.compute_dtype, restored.compute_dtype)
 
+    def test_numpy_get_item_layer(self):
+        def tuples_to_lists_str(x):
+            return str(x).replace("(", "[").replace(")", "]")
+
+        input = keras.layers.Input(shape=(2,))
+        layer = input[:, 1]
+        model = keras.Model(input, layer)
+        serialized, _, reserialized = self.roundtrip(model)
+        # Anticipate JSON roundtrip mapping tuples to lists:
+        serialized_str = tuples_to_lists_str(serialized)
+        reserialized_str = tuples_to_lists_str(reserialized)
+        self.assertEqual(serialized_str, reserialized_str)
+
     def test_tensors_and_shapes(self):
         x = ops.random.normal((2, 2), dtype="float64")
         obj = {"x": x}


### PR DESCRIPTION
Please take a look, I had trouble loading a model that did things like this:

    kernel_output = keras.layers.Concatenate()(
      [ 
        kernel(input[:, 2*other:2*other+2] - input[:, 2*ref:2*ref+2]) 
        for ref in range(n)
        for other in range(n) 
        if other != ref 
      ])

