### PR TITLE
Add Tensorflow support for variable `scatter_update` in optimizers.

### DIFF
--- a/keras/backend/tensorflow/optimizer.py
+++ b/keras/backend/tensorflow/optimizer.py
@@ -42,6 +42,15 @@ class TFOptimizer(base_optimizer.BaseOptimizer):
             "(as it is incompatible with tf.distribute)."
         )
 
+    def assign(self, variable, value):
+        if isinstance(variable, KerasVariable):
+            variable = variable.value
+        value = tf.cast(value, variable.dtype)
+        if isinstance(value, tf.IndexedSlices):
+            variable.scatter_update(value)
+        else:
+            variable.assign(value)
+
     def assign_add(self, variable, value):
         if isinstance(variable, KerasVariable):
             variable = variable.value


### PR DESCRIPTION
This should have been added along with `scatter_add` and `scatter_sub` as part of https://github.com/keras-team/keras/pull/18692 as it was added in the super class: https://github.com/keras-team/keras/blob/master/keras/optimizers/base_optimizer.py#L222

Fixes https://github.com/keras-team/keras/issues/19281