### PR TITLE
Update nn.py to use jnp.add rather than + operand.

### DIFF
--- a/keras/backend/jax/nn.py
+++ b/keras/backend/jax/nn.py
@@ -546,7 +546,7 @@ def batch_normalization(
         offset = jnp.reshape(offset, shape)
         res = res + offset
 
-    return x * inv + res
+    return jnp.add(x * inv, res)
 
 
 def ctc_loss(


### PR DESCRIPTION
Ref: https://jax.readthedocs.io/en/latest/notebooks/thinking_in_jax.html#numpy-lax-xla-jax-api-layering

`jax.numpy` implicitly promotes arguments to allow operations of mixed data types, while `jax.lax` does not. If using `jax.lax` directly, it is advised to do explicit type promotion. Because the core functions in nn.py are the backbone for various model edge cases, it is better to use a safer operand.

