### PR TITLE
Set dtype policy for uint8

### DIFF
--- a/keras/dtype_policies/__init__.py
+++ b/keras/dtype_policies/__init__.py
@@ -14,7 +14,7 @@ def get(identifier):
     if isinstance(identifier, dict):
         return serialization_lib.deserialize_keras_object(identifier)
     if isinstance(identifier, str):
-        if "int8" in identifier:
+        if identifier.startswith("int8"):
             return QuantizedDTypePolicy(identifier)
         else:
             return FloatDTypePolicy(identifier)

--- a/keras/dtype_policies/dtype_policy.py
+++ b/keras/dtype_policies/dtype_policy.py
@@ -174,7 +174,7 @@ class FloatDTypePolicy(DTypePolicy):
         elif name == "mixed_bfloat16":
             return "bfloat16", "float32"
         elif name == "uint8":
-            dtype = backend.standardize_dtype(None)
+            dtype = backend.standardize_dtype(name)
             return dtype, dtype
         try:
             dtype = backend.standardize_dtype(name)
@@ -253,7 +253,7 @@ def set_dtype_policy(policy):
     """
     if not isinstance(policy, DTypePolicy):
         if isinstance(policy, str):
-            if "int8" in policy:
+            if policy.startswith("int8"):
                 policy = QuantizedDTypePolicy(policy)
             else:
                 policy = FloatDTypePolicy(policy)

--- a/keras/dtype_policies/dtype_policy.py
+++ b/keras/dtype_policies/dtype_policy.py
@@ -64,7 +64,7 @@ class DTypePolicy:
         # For backwards compatibility
         # TODO: We should consider deprecating this behavior
         if cls is __class__:
-            if "int8" in name:
+            if name.startswith("int8"):
                 return QuantizedDTypePolicy(name)
             return FloatDTypePolicy(name)
         return super().__new__(cls)
@@ -173,6 +173,9 @@ class FloatDTypePolicy(DTypePolicy):
             return "float16", "float32"
         elif name == "mixed_bfloat16":
             return "bfloat16", "float32"
+        elif name == "uint8":
+            dtype = backend.standardize_dtype(None)
+            return dtype, dtype
         try:
             dtype = backend.standardize_dtype(name)
             return dtype, dtype

--- a/keras/dtype_policies/dtype_policy_test.py
+++ b/keras/dtype_policies/dtype_policy_test.py
@@ -1,3 +1,4 @@
+from keras import backend
 from keras.dtype_policies.dtype_policy import DTypePolicy
 from keras.dtype_policies.dtype_policy import FloatDTypePolicy
 from keras.dtype_policies.dtype_policy import QuantizedDTypePolicy
@@ -102,6 +103,13 @@ class FloatDTypePolicyTest(test_case.TestCase):
         self.assertEqual(policy.variable_dtype, "float32")
         self.assertEqual(policy.compute_dtype, "float16")
         self.assertEqual(policy.name, "mixed_float16")
+
+    def test_properties_uint8(self):
+        """Test properties for 'uint8'."""
+        policy = FloatDTypePolicy("uint8")
+        self.assertEqual(policy.compute_dtype, backend.floatx())
+        self.assertEqual(policy.variable_dtype, backend.floatx())
+        self.assertEqual(policy.name, "uint8")
 
     def test_repr(self):
         """Test __repr__ method."""

--- a/keras/dtype_policies/dtype_policy_test.py
+++ b/keras/dtype_policies/dtype_policy_test.py
@@ -1,4 +1,3 @@
-from keras import backend
 from keras.dtype_policies.dtype_policy import DTypePolicy
 from keras.dtype_policies.dtype_policy import FloatDTypePolicy
 from keras.dtype_policies.dtype_policy import QuantizedDTypePolicy
@@ -107,8 +106,8 @@ class FloatDTypePolicyTest(test_case.TestCase):
     def test_properties_uint8(self):
         """Test properties for 'uint8'."""
         policy = FloatDTypePolicy("uint8")
-        self.assertEqual(policy.compute_dtype, backend.floatx())
-        self.assertEqual(policy.variable_dtype, backend.floatx())
+        self.assertEqual(policy.compute_dtype, "uint8")
+        self.assertEqual(policy.variable_dtype, "uint8")
         self.assertEqual(policy.name, "uint8")
 
     def test_repr(self):


### PR DESCRIPTION
Fixes issue for KerasCV where we use `uint8` for dtype.  Set to `FloatDtypePolicy` to get past the quantization dtype policy error. Tested locally with KerasCV to verify the fix.