### PR TITLE
[keras/dtype_policies/dtype_policy.py] Document acceptable arguments to the `DTypePolicy` `__new__` call

### DIFF
--- a/keras/dtype_policies/dtype_policy.py
+++ b/keras/dtype_policies/dtype_policy.py
@@ -21,7 +21,13 @@ class DTypePolicy:
     `keras.config.set_dtype_policy`.
 
     Args:
-        name: The policy name, which determines the compute and variable dtypes.
+        name: ```Literal['bfloat16', 'bool', 'complex128', 'complex64',
+                         'double', 'float16', 'float32', 'float64', 'half',
+                         'int16', 'int32', 'int64', 'int8', 'mixed_bfloat16',
+                         'mixed_float16', 'qint16', 'qint32', 'qint8',
+                         'quint16', 'quint8', 'resource', 'uint16', 'uint32',
+                         'uint64', 'uint8', 'variant']```.
+            The policy name, which determines the compute and variable dtypes.
             Can be any dtype name, such as `"float32"` or `"float64"`,
             which causes both the compute and variable dtypes
             will be that dtype.


### PR DESCRIPTION
Found when converting/exposing your entire codebase:
```sh
$ python -m pip install python-cdd==0.0.99rc46  # Or a newer version!
$ python -m cdd exmod -m keras --emit sqlalchemy_hybrid -r -o build/keras 
# Replace `-m keras` with `-m keras.dtype_policies.dtype_policy` to replicate just this bug
```

It fails because it parses out this:
```py
{   'doc': 'The policy name, which determines the compute and variable dtypes. Can be any dtype name, such as `"float32"` or `"float64"`, which causes both the compute and variable dtypes will be that dtype. Can also be the string `"mixed_float16"` or `"mixed_bfloat16"`, which causes the compute dtype to be `float16` or `bfloat16` and the variable dtype to be `float32`.',
    'typ': ''Union[Literal["float32", "float64"], str]''}
```

Instead of this:
```py
{   'doc': <omit for brevity>,
    'typ': "Literal['bfloat16', 'bool', 'complex128', 'complex64', 'double', 'float16', 'float32', 'float64', 'half', 'int16', 'int32', 'int64', 'int8', 'mixed_bfloat16', 'mixed_float16', 'qint16', 'qint32', 'qint8', 'quint16', 'quint8', 'resource', 'uint16', 'uint32', 'uint64', 'uint8', 'variant']"}
```

Parsed from https://www.tensorflow.org/api_docs/python/tf/dtypes @ v2.15.0.post1.

BTW: Sending this five-line one-file PR because when I tried whole codebase upgrade-to-non-adhoc-syntax it was not merged: #18786