### PR TITLE
Fix compute_output_shape in  bidirectional.py

### DIFF
--- a/keras/layers/rnn/bidirectional.py
+++ b/keras/layers/rnn/bidirectional.py
@@ -186,12 +186,8 @@ class Bidirectional(Wrapper):
 
         if self.return_state:
             if self.merge_mode is None:
-                return (
-                    tuple(output_shape) + state_shape + state_shape
-                )
-            return (
-                tuple([output_shape]) + (state_shape) + (state_shape)
-            )
+                return tuple(output_shape) + state_shape + state_shape
+            return tuple([output_shape]) + (state_shape) + (state_shape)
         return tuple(output_shape)
 
     def call(

--- a/keras/layers/rnn/bidirectional.py
+++ b/keras/layers/rnn/bidirectional.py
@@ -187,7 +187,7 @@ class Bidirectional(Wrapper):
         if self.return_state:
             if self.merge_mode is None:
                 return output_shape + state_shape + copy.copy(state_shape)
-            return [output_shape] + state_shape + copy.copy(state_shape)
+            return [output_shape] + [state_shape] + [copy.copy(state_shape)]
         return output_shape
 
     def call(

--- a/keras/layers/rnn/bidirectional.py
+++ b/keras/layers/rnn/bidirectional.py
@@ -186,9 +186,13 @@ class Bidirectional(Wrapper):
 
         if self.return_state:
             if self.merge_mode is None:
-                return output_shape + state_shape + copy.copy(state_shape)
-            return [output_shape] + [state_shape] + [copy.copy(state_shape)]
-        return output_shape
+                return (
+                    tuple(output_shape) + state_shape + copy.copy(state_shape)
+                )
+            return (
+                tuple([output_shape]) + (state_shape) + (copy.copy(state_shape))
+            )
+        return tuple(output_shape)
 
     def call(
         self,

--- a/keras/layers/rnn/bidirectional.py
+++ b/keras/layers/rnn/bidirectional.py
@@ -182,15 +182,15 @@ class Bidirectional(Wrapper):
             output_shape[-1] *= 2
             output_shape = tuple(output_shape)
         elif self.merge_mode is None:
-            output_shape = [output_shape, copy.copy(output_shape)]
+            output_shape = [output_shape, output_shape]
 
         if self.return_state:
             if self.merge_mode is None:
                 return (
-                    tuple(output_shape) + state_shape + copy.copy(state_shape)
+                    tuple(output_shape) + state_shape + state_shape
                 )
             return (
-                tuple([output_shape]) + (state_shape) + (copy.copy(state_shape))
+                tuple([output_shape]) + (state_shape) + (state_shape)
             )
         return tuple(output_shape)
 

--- a/keras/layers/rnn/bidirectional_test.py
+++ b/keras/layers/rnn/bidirectional_test.py
@@ -234,3 +234,29 @@ class SimpleRNNTest(testing.TestCase):
             np.array([[0.2501858, 0.2501858], [0.941473, 0.941473]]),
             c2,
         )
+
+    @pytest.mark.requires_trainable_backend
+    def test_output_shape(self):
+        x = np.array([[[101, 202], [303, 404]]])
+        for merge_mode in ["ave", "concat", "mul", "sum", None]:
+            sub_layer = layers.LSTM(2, return_state=True)
+            layer = layers.Bidirectional(sub_layer, merge_mode=merge_mode)
+            output = layer(x)
+            output_shape = layer.compute_output_shape(x.shape)
+            for out, shape in zip(output, output_shape):
+                self.assertEqual(out.shape, shape)
+
+        for merge_mode in ["concat", "ave", "mul", "sum"]:
+            sub_layer = layers.LSTM(2, return_state=False)
+            layer = layers.Bidirectional(sub_layer, merge_mode=merge_mode)
+            output = layer(x)
+            output_shape = layer.compute_output_shape(x.shape)
+            self.assertEqual(output.shape, output_shape)
+
+        # return_state=False & merge_mode=None
+        sub_layer = layers.LSTM(2, return_state=False)
+        layer = layers.Bidirectional(sub_layer, merge_mode=None)
+        output = layer(x)
+        output_shape = layer.compute_output_shape(x.shape)
+        for out, shape in zip(output, output_shape):
+            self.assertEqual(out.shape, shape)


### PR DESCRIPTION
The `compute_output_shape` trying to add list and tuples of shapes while calculating the output_shape with `return_state=True` and `merge_mode='concat'`. This will cause the TypeError like below.

```
TypeError: Exception encountered when calling Bidirectional.call().
can only concatenate list (not "tuple") to list
```
May Fixes #19328 
