### PR TITLE
Fix output shape for channels_first

### DIFF
--- a/keras/layers/reshaping/up_sampling2d.py
+++ b/keras/layers/reshaping/up_sampling2d.py
@@ -140,11 +140,8 @@ class UpSampling2D(Layer):
         Returns:
             A tensor.
         """
-        if data_format == "channels_first":
-            rows, cols = 2, 3
-        elif data_format == "channels_last":
-            rows, cols = 1, 2
-        else:
+        rows, cols = 1, 2
+        if data_format not in {"channels_last", "channels_first"}:
             raise ValueError(f"Invalid `data_format` argument: {data_format}")
 
         if data_format == "channels_first":

--- a/keras/layers/reshaping/up_sampling2d.py
+++ b/keras/layers/reshaping/up_sampling2d.py
@@ -140,7 +140,6 @@ class UpSampling2D(Layer):
         Returns:
             A tensor.
         """
-        rows, cols = 1, 2
         if data_format not in {"channels_last", "channels_first"}:
             raise ValueError(f"Invalid `data_format` argument: {data_format}")
 
@@ -160,8 +159,8 @@ class UpSampling2D(Layer):
             # will be traced as a symbolic variable (specifically
             # a `FakeTensor`) which does not have a `tolist()` method.
             new_shape = (
-                x.shape[rows] * height_factor,
-                x.shape[cols] * width_factor,
+                x.shape[1] * height_factor,
+                x.shape[2] * width_factor,
             )
             x = ops.image.resize(x, new_shape, interpolation=interpolation)
         if data_format == "channels_first":


### PR DESCRIPTION
When the `data_format` is `"channels_first"` the rows and columns are mentioned as `2,3` but this logic will not hold good when the input is transposed like below, which results in input to have `rows,col as 1,2` always for both `channel_first` and `channel_last` 
https://github.com/keras-team/keras/blob/5bc8488c0ea3f43c70c70ebca919093cd56066eb/keras/layers/reshaping/up_sampling2d.py#L150-L151


This fixes the incorrect shape computation of `new_shape` when the `interpolation` is not `"nearest"`

Fixes: https://github.com/keras-team/keras/issues/19261
Fixes: https://github.com/keras-team/keras/issues/19153

Working Gist by subclassing layer. https://colab.sandbox.google.com/gist/sachinprasadhs/3b9ea7d2b3bbb4f31c9b2eacce86cf2c/upsampling.ipynb