### PR TITLE
Standardize docstring

### DIFF
--- a/keras/callbacks/tensorboard.py
+++ b/keras/callbacks/tensorboard.py
@@ -90,8 +90,6 @@ class TensorBoard(Callback):
 
     Examples:
 
-    Basic usage:
-
     ```python
     tensorboard_callback = keras.callbacks.TensorBoard(log_dir="./logs")
     model.fit(x_train, y_train, epochs=2, callbacks=[tensorboard_callback])

--- a/keras/layers/convolutional/conv1d.py
+++ b/keras/layers/convolutional/conv1d.py
@@ -80,7 +80,7 @@ class Conv1D(BaseConv):
     Raises:
         ValueError: when both `strides > 1` and `dilation_rate > 1`.
 
-    Examples:
+    Example:
 
     >>> # The inputs are 128-length vectors with 10 timesteps, and the
     >>> # batch size is 4.

--- a/keras/layers/convolutional/conv1d_transpose.py
+++ b/keras/layers/convolutional/conv1d_transpose.py
@@ -81,7 +81,7 @@ class Conv1DTranspose(BaseConvTranspose):
     - [Deconvolutional Networks](
         https://www.matthewzeiler.com/mattzeiler/deconvolutionalnetworks.pdf)
 
-    Examples:
+    Example:
 
     >>> x = np.random.rand(4, 10, 128)
     >>> y = keras.layers.Conv1DTranspose(32, 3, 2, activation='relu')(x)

--- a/keras/layers/convolutional/conv2d.py
+++ b/keras/layers/convolutional/conv2d.py
@@ -76,7 +76,7 @@ class Conv2D(BaseConv):
     Raises:
         ValueError: when both `strides > 1` and `dilation_rate > 1`.
 
-    Examples:
+    Example:
 
     >>> x = np.random.rand(4, 10, 10, 128)
     >>> y = keras.layers.Conv2D(32, 3, activation='relu')(x)

--- a/keras/layers/convolutional/conv2d_transpose.py
+++ b/keras/layers/convolutional/conv2d_transpose.py
@@ -83,7 +83,7 @@ class Conv2DTranspose(BaseConvTranspose):
     - [Deconvolutional Networks](
         https://www.matthewzeiler.com/mattzeiler/deconvolutionalnetworks.pdf)
 
-    Examples:
+    Example:
 
     >>> x = np.random.rand(4, 10, 8, 128)
     >>> y = keras.layers.Conv2DTranspose(32, 2, 2, activation='relu')(x)

--- a/keras/layers/convolutional/conv3d.py
+++ b/keras/layers/convolutional/conv3d.py
@@ -82,7 +82,7 @@ class Conv3D(BaseConv):
     Raises:
         ValueError: when both `strides > 1` and `dilation_rate > 1`.
 
-    Examples:
+    Example:
 
     >>> x = np.random.rand(4, 10, 10, 10, 128)
     >>> y = keras.layers.Conv3D(32, 3, activation='relu')(x)

--- a/keras/layers/convolutional/conv3d_transpose.py
+++ b/keras/layers/convolutional/conv3d_transpose.py
@@ -88,7 +88,7 @@ class Conv3DTranspose(BaseConvTranspose):
     - [Deconvolutional Networks](
         https://www.matthewzeiler.com/mattzeiler/deconvolutionalnetworks.pdf)
 
-    Examples:
+    Example:
 
     >>> x = np.random.rand(4, 10, 8, 12, 128)
     >>> y = keras.layers.Conv3DTranspose(32, 2, 2, activation='relu')(x)

--- a/keras/layers/convolutional/depthwise_conv1d.py
+++ b/keras/layers/convolutional/depthwise_conv1d.py
@@ -87,7 +87,7 @@ class DepthwiseConv1D(BaseDepthwiseConv):
     Raises:
         ValueError: when both `strides > 1` and `dilation_rate > 1`.
 
-    Examples:
+    Example:
 
     >>> x = np.random.rand(4, 10, 12)
     >>> y = keras.layers.DepthwiseConv1D(3, 3, 2, activation='relu')(x)

--- a/keras/layers/convolutional/depthwise_conv2d.py
+++ b/keras/layers/convolutional/depthwise_conv2d.py
@@ -88,7 +88,7 @@ class DepthwiseConv2D(BaseDepthwiseConv):
     Raises:
         ValueError: when both `strides > 1` and `dilation_rate > 1`.
 
-    Examples:
+    Example:
 
     >>> x = np.random.rand(4, 10, 10, 12)
     >>> y = keras.layers.DepthwiseConv2D(3, 3, activation='relu')(x)

--- a/keras/layers/convolutional/separable_conv1d.py
+++ b/keras/layers/convolutional/separable_conv1d.py
@@ -85,7 +85,7 @@ class SeparableConv1D(BaseSeparableConv):
         A 3D tensor representing
         `activation(separable_conv1d(inputs, kernel) + bias)`.
 
-    Examples:
+    Example:
 
     >>> x = np.random.rand(4, 10, 12)
     >>> y = keras.layers.SeparableConv1D(3, 4, 3, 2, activation='relu')(x)

--- a/keras/layers/convolutional/separable_conv2d.py
+++ b/keras/layers/convolutional/separable_conv2d.py
@@ -86,7 +86,7 @@ class SeparableConv2D(BaseSeparableConv):
         A 4D tensor representing
         `activation(separable_conv2d(inputs, kernel) + bias)`.
 
-    Examples:
+    Example:
 
     >>> x = np.random.rand(4, 10, 10, 12)
     >>> y = keras.layers.SeparableConv2D(3, 4, 3, 2, activation='relu')(x)

--- a/keras/layers/merging/dot.py
+++ b/keras/layers/merging/dot.py
@@ -29,7 +29,7 @@ def batch_dot(x, y, axes=None):
         `y` has been summed over.
         (`dot_axes[1]` = 2) `output_shape` = `(100, 30)`
 
-    Examples:
+    Example:
 
     >>> x_batch = np.ones(shape=(32, 20, 1))
     >>> y_batch = np.ones(shape=(32, 30, 20))
@@ -209,7 +209,7 @@ class Dot(Merge):
     inputs. e.g. with `axes=(1, 2)`, the dot product of `x`, and `y`
     will result in a tensor with shape `(2, 5, 10)`
 
-    Examples:
+    Example:
 
     >>> x = np.arange(10).reshape(1, 5, 2)
     >>> y = np.arange(10, 20).reshape(1, 2, 5)

--- a/keras/layers/preprocessing/random_brightness.py
+++ b/keras/layers/preprocessing/random_brightness.py
@@ -41,7 +41,7 @@ class RandomBrightness(TFDataLayer):
         the valid range of RGB colors, and
         rescaled based on the `value_range` if needed.
 
-    Sample usage:
+    Example:
 
     ```python
     random_bright = keras.layers.RandomBrightness(factor=0.2)

--- a/keras/layers/reshaping/cropping1d.py
+++ b/keras/layers/reshaping/cropping1d.py
@@ -10,7 +10,7 @@ class Cropping1D(Layer):
 
     It crops along the time dimension (axis 1).
 
-    Examples:
+    Example:
 
     >>> input_shape = (2, 3, 2)
     >>> x = np.arange(np.prod(input_shape)).reshape(input_shape)

--- a/keras/layers/reshaping/cropping2d.py
+++ b/keras/layers/reshaping/cropping2d.py
@@ -11,7 +11,7 @@ class Cropping2D(Layer):
 
     It crops along spatial dimensions, i.e. height and width.
 
-    Examples:
+    Example:
 
     >>> input_shape = (2, 28, 28, 3)
     >>> x = np.arange(np.prod(input_shape)).reshape(input_shape)

--- a/keras/layers/reshaping/cropping3d.py
+++ b/keras/layers/reshaping/cropping3d.py
@@ -9,7 +9,7 @@ from keras.utils import argument_validation
 class Cropping3D(Layer):
     """Cropping layer for 3D data (e.g. spatial or spatio-temporal).
 
-    Examples:
+    Example:
 
     >>> input_shape = (2, 28, 28, 10, 3)
     >>> x = np.arange(np.prod(input_shape)).reshape(input_shape)

--- a/keras/layers/reshaping/up_sampling1d.py
+++ b/keras/layers/reshaping/up_sampling1d.py
@@ -10,7 +10,7 @@ class UpSampling1D(Layer):
 
     Repeats each temporal step `size` times along the time axis.
 
-    Examples:
+    Example:
 
     >>> input_shape = (2, 2, 3)
     >>> x = np.arange(np.prod(input_shape)).reshape(input_shape)

--- a/keras/layers/reshaping/up_sampling2d.py
+++ b/keras/layers/reshaping/up_sampling2d.py
@@ -14,7 +14,7 @@ class UpSampling2D(Layer):
     (specified by the `interpolation` argument). Use `interpolation=nearest`
     to repeat the rows and columns of the data.
 
-    Examples:
+    Example:
 
     >>> input_shape = (2, 2, 1, 3)
     >>> x = np.arange(np.prod(input_shape)).reshape(input_shape)

--- a/keras/layers/reshaping/zero_padding1d.py
+++ b/keras/layers/reshaping/zero_padding1d.py
@@ -9,7 +9,7 @@ from keras.utils import argument_validation
 class ZeroPadding1D(Layer):
     """Zero-padding layer for 1D input (e.g. temporal sequence).
 
-    Examples:
+    Example:
 
     >>> input_shape = (2, 2, 3)
     >>> x = np.arange(np.prod(input_shape)).reshape(input_shape)

--- a/keras/layers/reshaping/zero_padding2d.py
+++ b/keras/layers/reshaping/zero_padding2d.py
@@ -13,7 +13,7 @@ class ZeroPadding2D(Layer):
     This layer can add rows and columns of zeros at the top, bottom, left and
     right side of an image tensor.
 
-    Examples:
+    Example:
 
     >>> input_shape = (1, 1, 2, 2)
     >>> x = np.arange(np.prod(input_shape)).reshape(input_shape)

--- a/keras/layers/reshaping/zero_padding3d.py
+++ b/keras/layers/reshaping/zero_padding3d.py
@@ -10,7 +10,7 @@ from keras.utils import argument_validation
 class ZeroPadding3D(Layer):
     """Zero-padding layer for 3D data (spatial or spatio-temporal).
 
-    Examples:
+    Example:
 
     >>> input_shape = (1, 1, 2, 2, 3)
     >>> x = np.arange(np.prod(input_shape)).reshape(input_shape)

--- a/keras/layers/rnn/stacked_rnn_cells.py
+++ b/keras/layers/rnn/stacked_rnn_cells.py
@@ -14,7 +14,7 @@ class StackedRNNCells(Layer):
     Args:
       cells: List of RNN cell instances.
 
-    Examples:
+    Example:
 
     ```python
     batch_size = 3

--- a/keras/metrics/accuracy_metrics.py
+++ b/keras/metrics/accuracy_metrics.py
@@ -31,7 +31,7 @@ class Accuracy(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Examples:
 
     >>> m = keras.metrics.Accuracy()
     >>> m.update_state([[1], [2], [3], [4]], [[0], [2], [3], [4]])
@@ -93,7 +93,7 @@ class BinaryAccuracy(reduction_metrics.MeanMetricWrapper):
         threshold: (Optional) Float representing the threshold for deciding
         whether prediction values are 1 or 0.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.BinaryAccuracy()
     >>> m.update_state([[1], [1], [0], [0]], [[0.98], [1], [0], [0.6]])
@@ -192,7 +192,7 @@ class CategoricalAccuracy(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.CategoricalAccuracy()
     >>> m.update_state([[0, 0, 1], [0, 1, 0]], [[0.1, 0.9, 0.8],
@@ -281,7 +281,7 @@ class SparseCategoricalAccuracy(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.SparseCategoricalAccuracy()
     >>> m.update_state([[2], [1]], [[0.1, 0.6, 0.3], [0.05, 0.95, 0]])
@@ -352,7 +352,7 @@ class TopKCategoricalAccuracy(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.TopKCategoricalAccuracy(k=1)
     >>> m.update_state([[0, 0, 1], [0, 1, 0]],
@@ -430,7 +430,7 @@ class SparseTopKCategoricalAccuracy(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.SparseTopKCategoricalAccuracy(k=1)
     >>> m.update_state([2, 1], [[0.1, 0.9, 0.8], [0.05, 0.95, 0]])

--- a/keras/metrics/confusion_metrics.py
+++ b/keras/metrics/confusion_metrics.py
@@ -97,7 +97,7 @@ class FalsePositives(_ConfusionMatrixConditionCount):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Examples:
 
     >>> m = keras.metrics.FalsePositives()
     >>> m.update_state([0, 1, 0, 0], [0, 0, 1, 1])
@@ -141,7 +141,7 @@ class FalseNegatives(_ConfusionMatrixConditionCount):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.FalseNegatives()
     >>> m.update_state([0, 1, 1, 1], [0, 1, 0, 0])
@@ -185,7 +185,7 @@ class TrueNegatives(_ConfusionMatrixConditionCount):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.TrueNegatives()
     >>> m.update_state([0, 1, 0, 0], [1, 1, 0, 0])
@@ -229,7 +229,7 @@ class TruePositives(_ConfusionMatrixConditionCount):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.TruePositives()
     >>> m.update_state([0, 1, 1, 1], [1, 0, 1, 1])
@@ -291,7 +291,7 @@ class Precision(Metric):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.Precision()
     >>> m.update_state([0, 1, 1, 1], [1, 0, 1, 1])
@@ -449,7 +449,7 @@ class Recall(Metric):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.Recall()
     >>> m.update_state([0, 1, 1, 1], [1, 0, 1, 1])
@@ -710,7 +710,7 @@ class SensitivityAtSpecificity(SensitivitySpecificityBase):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.SensitivityAtSpecificity(0.5)
     >>> m.update_state([0, 0, 0, 1, 1], [0, 0.3, 0.8, 0.3, 0.8])
@@ -814,7 +814,7 @@ class SpecificityAtSensitivity(SensitivitySpecificityBase):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.SpecificityAtSensitivity(0.5)
     >>> m.update_state([0, 0, 0, 1, 1], [0, 0.3, 0.8, 0.3, 0.8])
@@ -909,7 +909,7 @@ class PrecisionAtRecall(SensitivitySpecificityBase):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.PrecisionAtRecall(0.5)
     >>> m.update_state([0, 0, 0, 1, 1], [0, 0.3, 0.8, 0.3, 0.8])
@@ -999,7 +999,7 @@ class RecallAtPrecision(SensitivitySpecificityBase):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.RecallAtPrecision(0.8)
     >>> m.update_state([0, 0, 1, 1], [0, 0.5, 0.3, 0.9])
@@ -1155,7 +1155,7 @@ class AUC(Metric):
         when using a keras loss, the `from_logits` constructor argument of the
         loss should match the AUC `from_logits` constructor argument.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.AUC(num_thresholds=3)
     >>> m.update_state([0, 0, 1, 1], [0, 0.5, 0.3, 0.9])

--- a/keras/metrics/hinge_metrics.py
+++ b/keras/metrics/hinge_metrics.py
@@ -16,7 +16,7 @@ class Hinge(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Examples:
 
     >>> m = keras.metrics.Hinge()
     >>> m.update_state([[0, 1], [0, 0]], [[0.6, 0.4], [0.4, 0.6]])
@@ -49,7 +49,7 @@ class SquaredHinge(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.SquaredHinge()
     >>> m.update_state([[0, 1], [0, 0]], [[0.6, 0.4], [0.4, 0.6]])
@@ -79,7 +79,7 @@ class CategoricalHinge(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
     >>> m = keras.metrics.CategoricalHinge()
     >>> m.update_state([[0, 1], [0, 0]], [[0.6, 0.4], [0.4, 0.6]])
     >>> m.result().numpy()

--- a/keras/metrics/iou_metrics.py
+++ b/keras/metrics/iou_metrics.py
@@ -186,8 +186,6 @@ class IoU(_IoUBase):
 
     Examples:
 
-    Standalone usage:
-
     >>> # cm = [[1, 1],
     >>> #        [1, 1]]
     >>> # sum_row = [2, 2], sum_col = [2, 2], true_positives = [1, 1]
@@ -338,9 +336,9 @@ class BinaryIoU(IoU):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.BinaryIoU(target_class_ids=[0, 1], threshold=0.3)
     >>> m.update_state([0, 1, 0, 1], [0.1, 0.2, 0.4, 0.7])
@@ -459,9 +457,9 @@ class MeanIoU(IoU):
             is used to determine each sample's most likely associated label.
         axis: (Optional) The dimension containing the logits. Defaults to `-1`.
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> # cm = [[1, 1],
     >>> #        [1, 1]]
@@ -572,9 +570,9 @@ class OneHotIoU(IoU):
             is used to determine each sample's most likely associated label.
         axis: (Optional) The dimension containing the logits. Defaults to `-1`.
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> y_true = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0], [1, 0, 0]])
     >>> y_pred = np.array([[0.2, 0.3, 0.5], [0.1, 0.2, 0.7], [0.5, 0.3, 0.1],
@@ -688,9 +686,9 @@ class OneHotMeanIoU(MeanIoU):
             associated label.
         axis: (Optional) The dimension containing the logits. Defaults to `-1`.
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> y_true = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0], [1, 0, 0]])
     >>> y_pred = np.array([[0.2, 0.3, 0.5], [0.1, 0.2, 0.7], [0.5, 0.3, 0.1],

--- a/keras/metrics/metric.py
+++ b/keras/metrics/metric.py
@@ -14,7 +14,7 @@ class Metric:
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Example:
 
     ```python
     m = SomeMetric(...)

--- a/keras/metrics/probabilistic_metrics.py
+++ b/keras/metrics/probabilistic_metrics.py
@@ -22,7 +22,7 @@ class KLDivergence(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Standalone usage:
+    Examples:
 
     >>> m = keras.metrics.KLDivergence()
     >>> m.update_state([[0, 1], [0, 0]], [[0.6, 0.4], [0.4, 0.6]])
@@ -65,9 +65,9 @@ class Poisson(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.Poisson()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]])
@@ -115,9 +115,9 @@ class BinaryCrossentropy(reduction_metrics.MeanMetricWrapper):
             e.g. `label_smoothing=0.2` means that we will use
             a value of 0.1 for label "0" and 0.9 for label "1".
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.BinaryCrossentropy()
     >>> m.update_state([[0, 1], [0, 0]], [[0.6, 0.4], [0.4, 0.6]])
@@ -191,9 +191,9 @@ class CategoricalCrossentropy(reduction_metrics.MeanMetricWrapper):
         axis: (Optional) Defaults to `-1`.
             The dimension along which entropy is computed.
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> # EPSILON = 1e-7, y = y_true, y` = y_pred
     >>> # y` = clip_ops.clip_by_value(output, EPSILON, 1. - EPSILON)
@@ -278,9 +278,9 @@ class SparseCategoricalCrossentropy(reduction_metrics.MeanMetricWrapper):
         axis: (Optional) Defaults to `-1`.
             The dimension along which entropy is computed.
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> # y_true = one_hot(y_true) = [[0, 1, 0], [0, 0, 1]]
     >>> # logits = log(y_pred)

--- a/keras/metrics/regression_metrics.py
+++ b/keras/metrics/regression_metrics.py
@@ -60,8 +60,6 @@ class MeanAbsoluteError(reduction_metrics.MeanMetricWrapper):
 
     Examples:
 
-    Standalone usage:
-
     >>> m = keras.metrics.MeanAbsoluteError()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]])
     >>> m.result()
@@ -105,9 +103,9 @@ class MeanAbsolutePercentageError(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.MeanAbsolutePercentageError()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]])
@@ -152,9 +150,9 @@ class MeanSquaredLogarithmicError(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.MeanSquaredLogarithmicError()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]])
@@ -199,9 +197,9 @@ class RootMeanSquaredError(reduction_metrics.Mean):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.RootMeanSquaredError()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]])
@@ -272,9 +270,9 @@ class CosineSimilarity(reduction_metrics.MeanMetricWrapper):
         axis: (Optional) Defaults to `-1`. The dimension along which the cosine
             similarity is computed.
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> # l2_norm(y_true) = [[0., 1.], [1./1.414, 1./1.414]]
     >>> # l2_norm(y_pred) = [[1., 0.], [1./1.414, 1./1.414]]
@@ -325,9 +323,9 @@ class LogCoshError(reduction_metrics.MeanMetricWrapper):
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
-    Examples:
+    Example:
 
-    Standalone usage:
+    Example:
 
     >>> m = keras.metrics.LogCoshError()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]])

--- a/keras/models/cloning.py
+++ b/keras/models/cloning.py
@@ -48,9 +48,7 @@ def clone_model(model, input_tensors=None, clone_function=None):
         differently from the original model if a custom `clone_function`
         modifies the layer.
 
-    Examples:
-
-    Basic usage:
+    Example:
 
     ```python
     # Create a test Sequential model.

--- a/keras/models/model.py
+++ b/keras/models/model.py
@@ -563,7 +563,7 @@ class Model(Trainer, Layer):
 def model_from_json(json_string, custom_objects=None):
     """Parses a JSON model configuration string and returns a model instance.
 
-    Usage:
+    Example:
 
     >>> model = keras.Sequential([
     ...     keras.layers.Dense(5, input_shape=(3,)),

--- a/keras/optimizers/rmsprop.py
+++ b/keras/optimizers/rmsprop.py
@@ -35,7 +35,7 @@ class RMSprop(optimizer.Optimizer):
             expensive in terms of computation and memory. Defaults to `False`.
         {{base_optimizer_keyword_args}}
 
-    Usage:
+    Example:
 
     >>> opt = keras.optimizers.RMSprop(learning_rate=0.1)
     >>> var1 = keras.backend.Variable(10.0)

--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -782,7 +782,7 @@ class CosineDecayRestarts(LearningRateSchedule):
     restart is performed. Each new warm restart runs for `t_mul` times more
     steps and with `m_mul` times initial learning rate as the new learning rate.
 
-    Example usage:
+    Example:
     ```python
     first_decay_steps = 1000
     lr_decayed_fn = (

--- a/keras/trainers/data_adapters/data_adapter_utils.py
+++ b/keras/trainers/data_adapters/data_adapter_utils.py
@@ -16,7 +16,7 @@ def unpack_x_y_sample_weight(data):
     This utility makes it easy to support data of the form `(x,)`,
     `(x, y)`, or `(x, y, sample_weight)`.
 
-    Standalone usage:
+    Example:
 
     >>> features_batch = ops.ones((10, 5))
     >>> labels_batch = ops.zeros((10, 5))
@@ -57,7 +57,7 @@ def pack_x_y_sample_weight(x, y=None, sample_weight=None):
     This is a convenience utility for packing data into the tuple formats
     that `Model.fit()` uses.
 
-    Standalone usage:
+    Example:
 
     >>> x = ops.ones((10, 1))
     >>> data = pack_x_y_sample_weight(x)

--- a/keras/utils/backend_utils.py
+++ b/keras/utils/backend_utils.py
@@ -43,7 +43,7 @@ class TFGraphScope:
 class DynamicBackend:
     """A class that can be used to switch from one backend to another.
 
-    Usage:
+    Example:
 
     ```python
     backend = DynamicBackend("tensorflow")

--- a/keras/utils/image_utils.py
+++ b/keras/utils/image_utils.py
@@ -41,7 +41,7 @@ if pil_image_resampling is not None:
 def array_to_img(x, data_format=None, scale=True, dtype=None):
     """Converts a 3D NumPy array to a PIL Image instance.
 
-    Usage:
+    Example:
 
     ```python
     from PIL import Image
@@ -116,7 +116,7 @@ def array_to_img(x, data_format=None, scale=True, dtype=None):
 def img_to_array(img, data_format=None, dtype=None):
     """Converts a PIL Image instance to a NumPy array.
 
-    Usage:
+    Example:
 
     ```python
     from PIL import Image
@@ -194,7 +194,7 @@ def load_img(
 ):
     """Loads an image into PIL format.
 
-    Usage:
+    Example:
 
     ```python
     image = keras.utils.load_img(image_path)

--- a/keras/utils/torch_utils.py
+++ b/keras/utils/torch_utils.py
@@ -23,7 +23,7 @@ class TorchModuleWrapper(Layer):
             it once).
         name: The name of the layer (string).
 
-    Examples:
+    Example:
 
     Here's an example of how the `TorchModuleWrapper` can be used with vanilla
     PyTorch modules.

--- a/keras/utils/tracking.py
+++ b/keras/utils/tracking.py
@@ -41,7 +41,7 @@ class Tracker:
     still get tracked. This is done by wrapping these
     collections into an equivalent, tracking-aware object.
 
-    Usage:
+    Example:
 
     ```python
     def __init__(self):


### PR DESCRIPTION
Standardize the docstring format to use `Example:` or `Examples:`