### PR TITLE
Update `build` in `Dense` and `EinsumDense` for `QuantizedDTypePolicy`

### DIFF
--- a/keras/layers/core/dense.py
+++ b/keras/layers/core/dense.py
@@ -125,12 +125,12 @@ class Dense(Layer):
         else:
             self.bias = None
         self.input_spec = InputSpec(min_ndim=2, axes={-1: input_dim})
+        self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank)
         if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
             if self.bias is not None:
                 self.bias.trainable = False
-        self.built = True
 
     @property
     def kernel(self):

--- a/keras/layers/core/dense_test.py
+++ b/keras/layers/core/dense_test.py
@@ -310,6 +310,13 @@ class DenseTest(testing.TestCase):
         layer.build((None, 8))
         layer.quantize("int8")
 
+        # Verify weights dtype
+        self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
+        self.assertEqual(
+            backend.standardize_dtype(layer.kernel_scale.dtype),
+            layer.compute_dtype,
+        )
+
         # Try eager call
         x = np.random.random((2, 8))
         _ = layer(x)
@@ -336,6 +343,14 @@ class DenseTest(testing.TestCase):
         layer.quantize("int8")
         x = np.random.random((2, 8))
         _ = layer(x)
+
+        # Try building with quantized dtype policy
+        layer = layers.Dense(units=16, dtype="int8_from_mixed_bfloat16")
+        layer.build((None, 8))
+        self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
+        self.assertEqual(
+            backend.standardize_dtype(layer.kernel_scale.dtype), "bfloat16"
+        )
 
     @pytest.mark.requires_trainable_backend
     def test_quantize_dtype_argument(self):

--- a/keras/layers/core/dense_test.py
+++ b/keras/layers/core/dense_test.py
@@ -314,7 +314,7 @@ class DenseTest(testing.TestCase):
         self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
         self.assertEqual(
             backend.standardize_dtype(layer.kernel_scale.dtype),
-            layer.compute_dtype,
+            layer.variable_dtype,
         )
 
         # Try eager call
@@ -349,7 +349,7 @@ class DenseTest(testing.TestCase):
         layer.build((None, 8))
         self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
         self.assertEqual(
-            backend.standardize_dtype(layer.kernel_scale.dtype), "bfloat16"
+            backend.standardize_dtype(layer.kernel_scale.dtype), "float32"
         )
 
     @pytest.mark.requires_trainable_backend

--- a/keras/layers/core/einsum_dense.py
+++ b/keras/layers/core/einsum_dense.py
@@ -181,12 +181,12 @@ class EinsumDense(Layer):
             )
         else:
             self.bias = None
+        self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank)
         if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
             if self.bias is not None:
                 self.bias.trainable = False
-        self.built = True
 
     @property
     def kernel(self):

--- a/keras/layers/core/einsum_dense.py
+++ b/keras/layers/core/einsum_dense.py
@@ -153,16 +153,22 @@ class EinsumDense(Layer):
         )
         kernel_shape, bias_shape, full_output_shape = shape_data
         self.full_output_shape = tuple(full_output_shape)
-        self._kernel = self.add_weight(
-            name="kernel",
-            shape=tuple(kernel_shape),
-            initializer=self.kernel_initializer,
-            regularizer=self.kernel_regularizer,
-            constraint=self.kernel_constraint,
-            dtype=self.dtype,
-            trainable=True,
-        )
-
+        # `quantized_build` needs `self.input_spec`
+        self.input_spec = InputSpec(ndim=len(input_shape))
+        if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
+            self.quantized_build(
+                input_shape, mode=self.dtype_policy.quantization_mode
+            )
+        else:
+            self._kernel = self.add_weight(
+                name="kernel",
+                shape=tuple(kernel_shape),
+                initializer=self.kernel_initializer,
+                regularizer=self.kernel_regularizer,
+                constraint=self.kernel_constraint,
+                dtype=self.dtype,
+                trainable=True,
+            )
         if bias_shape is not None:
             self.bias = self.add_weight(
                 name="bias",
@@ -175,12 +181,12 @@ class EinsumDense(Layer):
             )
         else:
             self.bias = None
-        self.input_spec = InputSpec(ndim=len(input_shape))
-        self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank)
         if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
-            self.quantize(self.dtype_policy.quantization_mode)
+            if self.bias is not None:
+                self.bias.trainable = False
+        self.built = True
 
     @property
     def kernel(self):
@@ -197,57 +203,8 @@ class EinsumDense(Layer):
     def compute_output_shape(self, _):
         return self.full_output_shape
 
-    def get_config(self):
-        base_config = super().get_config()
-        config = {
-            "output_shape": self.partial_output_shape,
-            "equation": self.equation,
-            "activation": activations.serialize(self.activation),
-            "bias_axes": self.bias_axes,
-            "kernel_initializer": initializers.serialize(
-                self.kernel_initializer
-            ),
-            "bias_initializer": initializers.serialize(self.bias_initializer),
-            "kernel_regularizer": regularizers.serialize(
-                self.kernel_regularizer
-            ),
-            "bias_regularizer": regularizers.serialize(self.bias_regularizer),
-            "activity_regularizer": regularizers.serialize(
-                self.activity_regularizer
-            ),
-            "kernel_constraint": constraints.serialize(self.kernel_constraint),
-            "bias_constraint": constraints.serialize(self.bias_constraint),
-        }
-        if self.lora_rank:
-            config["lora_rank"] = self.lora_rank
-        return {**base_config, **config}
-
     def call(self, inputs):
         x = ops.einsum(self.equation, inputs, self.kernel)
-        if self.bias is not None:
-            x += self.bias
-        if self.activation is not None:
-            x = self.activation(x)
-        return x
-
-    def quantized_call(self, inputs):
-        if self.lora_enabled:
-            raise ValueError("`quantized_call` doesn't support lora weights")
-        inputs, inputs_scale = self.inputs_quantizer(inputs)
-        x = ops.einsum(self.equation, inputs, self.kernel)
-        # Deal with `inputs_scale`
-        inputs_scale = ops.transpose(inputs_scale, self._input_transpose_axes)
-        if self._input_expand_axes:
-            inputs_scale = ops.expand_dims(
-                inputs_scale, axis=self._input_expand_axes
-            )
-        if self._input_squeeze_axes:
-            inputs_scale = ops.squeeze(
-                inputs_scale, axis=self._input_squeeze_axes
-            )
-        # De-scale outputs
-        x = ops.cast(x, self.compute_dtype)
-        x = ops.divide(x, ops.multiply(inputs_scale, self.kernel_scale))
         if self.bias is not None:
             x += self.bias
         if self.activation is not None:
@@ -290,6 +247,118 @@ class EinsumDense(Layer):
         self.lora_enabled = True
         self.lora_rank = rank
 
+    def save_own_variables(self, store):
+        if not self.lora_enabled:
+            return super().save_own_variables(store)
+
+        kernel_value = self.kernel
+        store["0"] = kernel_value
+        if self.bias is not None:
+            store["1"] = self.bias
+
+    def load_own_variables(self, store):
+        if not self.lora_enabled:
+            return super().load_own_variables(store)
+        self._kernel.assign(store["0"])
+        if self.bias is not None:
+            self.bias.assign(store["1"])
+        self.lora_kernel_a.assign(np.zeros(self.lora_kernel_a.shape))
+        self.lora_kernel_b.assign(np.zeros(self.lora_kernel_b.shape))
+
+    def get_config(self):
+        base_config = super().get_config()
+        config = {
+            "output_shape": self.partial_output_shape,
+            "equation": self.equation,
+            "activation": activations.serialize(self.activation),
+            "bias_axes": self.bias_axes,
+            "kernel_initializer": initializers.serialize(
+                self.kernel_initializer
+            ),
+            "bias_initializer": initializers.serialize(self.bias_initializer),
+            "kernel_regularizer": regularizers.serialize(
+                self.kernel_regularizer
+            ),
+            "bias_regularizer": regularizers.serialize(self.bias_regularizer),
+            "activity_regularizer": regularizers.serialize(
+                self.activity_regularizer
+            ),
+            "kernel_constraint": constraints.serialize(self.kernel_constraint),
+            "bias_constraint": constraints.serialize(self.bias_constraint),
+        }
+        if self.lora_rank:
+            config["lora_rank"] = self.lora_rank
+        return {**base_config, **config}
+
+    """Quantization-related methods"""
+
+    def quantized_build(self, input_shape, mode):
+        shape_data = _analyze_einsum_string(
+            self.equation,
+            self.bias_axes,
+            input_shape,
+            self.partial_output_shape,
+        )
+        kernel_shape, _, _ = shape_data
+        if mode == "int8":
+            (
+                self._input_reduced_axes,
+                self._kernel_reduced_axes,
+                self._input_transpose_axes,
+                self._kernel_transpose_axes,
+                self._input_expand_axes,
+                self._kernel_expand_axes,
+                self._input_squeeze_axes,
+                self._kernel_squeeze_axes,
+            ) = _analyze_quantization_info(self.equation, self.input_spec.ndim)
+            self.inputs_quantizer = quantizers.AbsMaxQuantizer(axis=-1)
+            self._kernel = self.add_weight(
+                name="kernel",
+                shape=kernel_shape,
+                initializer="zeros",
+                dtype="int8",
+                trainable=False,
+            )
+            kernel_scale_shape = np.array(kernel_shape)
+            kernel_scale_shape[self._kernel_reduced_axes] = 1
+            kernel_scale_shape = kernel_scale_shape[self._kernel_transpose_axes]
+            kernel_scale_shape = kernel_scale_shape.tolist()
+            for a in self._kernel_expand_axes:
+                kernel_scale_shape.insert(a, 1)
+            for a in self._kernel_squeeze_axes:
+                kernel_scale_shape.pop(a)
+            self.kernel_scale = self.add_weight(
+                name="kernel_scale",
+                shape=kernel_scale_shape,
+                initializer="zeros",
+                dtype=self.compute_dtype,
+                trainable=False,
+            )
+
+    def quantized_call(self, inputs):
+        if self.lora_enabled:
+            raise ValueError("`quantized_call` doesn't support lora weights")
+        inputs, inputs_scale = self.inputs_quantizer(inputs)
+        x = ops.einsum(self.equation, inputs, self.kernel)
+        # Deal with `inputs_scale`
+        inputs_scale = ops.transpose(inputs_scale, self._input_transpose_axes)
+        if self._input_expand_axes:
+            inputs_scale = ops.expand_dims(
+                inputs_scale, axis=self._input_expand_axes
+            )
+        if self._input_squeeze_axes:
+            inputs_scale = ops.squeeze(
+                inputs_scale, axis=self._input_squeeze_axes
+            )
+        # De-scale outputs
+        x = ops.cast(x, self.compute_dtype)
+        x = ops.divide(x, ops.multiply(inputs_scale, self.kernel_scale))
+        if self.bias is not None:
+            x += self.bias
+        if self.activation is not None:
+            x = self.activation(x)
+        return x
+
     def quantize(self, mode):
         self._check_quantize_args(mode, self.compute_dtype)
         if mode == "int8":
@@ -297,11 +366,6 @@ class EinsumDense(Layer):
                 raise ValueError("`quantize` can only be done once per layer.")
             # Merge lora-related parameters to make use of fully int8 kernel
             self._merge_lora_into_kernel()
-
-            if self.input_spec is None:
-                raise ValueError(
-                    f"Cannot quantize {self.name} that isn't yet built."
-                )
             (
                 self._input_reduced_axes,
                 self._kernel_reduced_axes,
@@ -375,24 +439,6 @@ class EinsumDense(Layer):
             self.lora_kernel_b = self._untrack_variable(self.lora_kernel_b)
             self._tracker.lock()
             self.lora_rank = None
-
-    def save_own_variables(self, store):
-        if not self.lora_enabled:
-            return super().save_own_variables(store)
-
-        kernel_value = self.kernel
-        store["0"] = kernel_value
-        if self.bias is not None:
-            store["1"] = self.bias
-
-    def load_own_variables(self, store):
-        if not self.lora_enabled:
-            return super().load_own_variables(store)
-        self._kernel.assign(store["0"])
-        if self.bias is not None:
-            self.bias.assign(store["1"])
-        self.lora_kernel_a.assign(np.zeros(self.lora_kernel_a.shape))
-        self.lora_kernel_b.assign(np.zeros(self.lora_kernel_b.shape))
 
 
 def _analyze_einsum_string(equation, bias_axes, input_shape, output_shape):

--- a/keras/layers/core/einsum_dense.py
+++ b/keras/layers/core/einsum_dense.py
@@ -323,9 +323,9 @@ class EinsumDense(Layer):
             kernel_scale_shape[self._kernel_reduced_axes] = 1
             kernel_scale_shape = kernel_scale_shape[self._kernel_transpose_axes]
             kernel_scale_shape = kernel_scale_shape.tolist()
-            for a in self._kernel_expand_axes:
+            for a in sorted(self._kernel_expand_axes):
                 kernel_scale_shape.insert(a, 1)
-            for a in self._kernel_squeeze_axes:
+            for a in sorted(self._kernel_squeeze_axes, reverse=True):
                 kernel_scale_shape.pop(a)
             self.kernel_scale = self.add_weight(
                 name="kernel_scale",

--- a/keras/layers/core/einsum_dense.py
+++ b/keras/layers/core/einsum_dense.py
@@ -330,8 +330,7 @@ class EinsumDense(Layer):
             self.kernel_scale = self.add_weight(
                 name="kernel_scale",
                 shape=kernel_scale_shape,
-                initializer="zeros",
-                dtype=self.compute_dtype,
+                initializer="ones",
                 trainable=False,
             )
 
@@ -411,7 +410,6 @@ class EinsumDense(Layer):
                 shape=kernel_scale.shape,
                 # Prevent adding a large constant to the computation graph
                 initializer=lambda shape, dtype: kernel_scale,
-                dtype=self.compute_dtype,
                 trainable=False,
             )
             if self.bias is not None:

--- a/keras/layers/core/einsum_dense_test.py
+++ b/keras/layers/core/einsum_dense_test.py
@@ -387,7 +387,7 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
         self.assertEqual(
             backend.standardize_dtype(layer.kernel_scale.dtype),
-            layer.compute_dtype,
+            layer.variable_dtype,
         )
 
         # Try eager call
@@ -431,7 +431,7 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
         layer.build((1, 8, 2, 4, 32))
         self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
         self.assertEqual(
-            backend.standardize_dtype(layer.kernel_scale.dtype), "bfloat16"
+            backend.standardize_dtype(layer.kernel_scale.dtype), "float32"
         )
         layer = layers.EinsumDense(
             equation="a,b->ab",  # Test expand

--- a/keras/layers/core/einsum_dense_test.py
+++ b/keras/layers/core/einsum_dense_test.py
@@ -423,15 +423,25 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
 
         # Try building with quantized dtype policy
         layer = layers.EinsumDense(
-            equation="ab,bcd->acd",
-            output_shape=(8, 32),
+            equation="abcde,afce->acdbf",
+            output_shape=(2, 4, 8, 16),
             bias_axes="d",
             dtype="int8_from_mixed_bfloat16",
         )
-        layer.build((None, 3))
+        layer.build((1, 8, 2, 4, 32))
         self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
         self.assertEqual(
             backend.standardize_dtype(layer.kernel_scale.dtype), "bfloat16"
+        )
+        layer = layers.EinsumDense(
+            equation="a,b->ab",
+            output_shape=(4,),
+            dtype="int8_from_float32",
+        )
+        layer.build((None,))
+        self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
+        self.assertEqual(
+            backend.standardize_dtype(layer.kernel_scale.dtype), "float32"
         )
 
     @pytest.mark.requires_trainable_backend


### PR DESCRIPTION
This PR updates the logic in `build` to directly add int8 weights if `dtype_policy` is a QuantizedDTypePolicy

Additionally, I have moved the logic about quantization to the bottom of the class.