### PR TITLE
Fix type check for input

### DIFF
--- a/keras/layers/merging/dot.py
+++ b/keras/layers/merging/dot.py
@@ -262,7 +262,7 @@ class Dot(Merge):
 
     def build(self, input_shape):
         # Used purely for shape validation.
-        if not isinstance(input_shape[0], tuple) or len(input_shape) != 2:
+        if not isinstance(input_shape[0], (tuple,list)) or len(input_shape) != 2:
             raise ValueError(
                 f"A `Dot` layer should be called on a list of 2 inputs. "
                 f"Received: input_shape={input_shape}"

--- a/keras/layers/merging/dot.py
+++ b/keras/layers/merging/dot.py
@@ -262,7 +262,10 @@ class Dot(Merge):
 
     def build(self, input_shape):
         # Used purely for shape validation.
-        if not isinstance(input_shape[0], (tuple,list)) or len(input_shape) != 2:
+        if (
+            not isinstance(input_shape[0], (tuple, list))
+            or len(input_shape) != 2
+        ):
             raise ValueError(
                 f"A `Dot` layer should be called on a list of 2 inputs. "
                 f"Received: input_shape={input_shape}"


### PR DESCRIPTION
Fixed the type checking for layers merging condition to accept list input as well.

For the initial `model.get_config()` `input_shape[0]` is a `tuple` 

```python
{'module': 'keras.layers',
  'class_name': 'Dot',
  'config': {'name': 'dot',
   'trainable': True,
   'dtype': 'float32',
   'axes': 1,
   'normalize': False},
  'registered_name': None,
  'build_config': {'input_shape': [(None, 10), (None, 10)]},
  'name': 'dot',
```

But the `input_shape[0]` type gets changed to `list` when the model is saved and loaded back.

```
{
            "module":"keras.layers",
            "class_name":"Dot",
            "config":{
               "name":"dot",
               "trainable":true,
               "dtype":"float32",
               "axes":1,
               "normalize":false
            },
            "registered_name":"None",
            "build_config":{
               "input_shape":[
                  [
                     "None",
                     10
                  ],
                  [
                     "None",
                     10
                  ]
               ]
            },
            "name":"dot", 
```

Fixes: https://github.com/keras-team/keras/issues/19305