### PR TITLE
fix bug for numerical difference in losses

### DIFF
--- a/keras/backend/jax/trainer.py
+++ b/keras/backend/jax/trainer.py
@@ -104,8 +104,8 @@ class JAXTrainer(base_trainer.Trainer):
                 for ref_v, v in zip(self.metrics_variables, metrics_variables)
             ]
         ) as scope:
-            self._update_loss_tracker(
-                unscaled_loss, tree.flatten(x)[0].shape[0]
+            self._loss_tracker.update_state(
+                unscaled_loss, sample_weight=tree.flatten(x)[0].shape[0]
             )
             logs = self.compute_metrics(x, y, y_pred, sample_weight)
 
@@ -148,8 +148,8 @@ class JAXTrainer(base_trainer.Trainer):
                 for ref_v, v in zip(self.metrics_variables, metrics_variables)
             ]
         ) as scope:
-            self._update_loss_tracker(
-                unscaled_loss, tree.flatten(x)[0].shape[0]
+            self._loss_tracker.update_state(
+                unscaled_loss, sample_weight=tree.flatten(x)[0].shape[0]
             )
             logs = self.compute_metrics(x, y, y_pred, sample_weight)
 

--- a/keras/backend/jax/trainer.py
+++ b/keras/backend/jax/trainer.py
@@ -104,7 +104,7 @@ class JAXTrainer(base_trainer.Trainer):
                 for ref_v, v in zip(self.metrics_variables, metrics_variables)
             ]
         ) as scope:
-            self._loss_tracker.update_state(unscaled_loss)
+            self._loss_tracker.update_state(unscaled_loss] * x.shape[0])
             logs = self.compute_metrics(x, y, y_pred, sample_weight)
 
         new_metrics_variables = []
@@ -146,7 +146,7 @@ class JAXTrainer(base_trainer.Trainer):
                 for ref_v, v in zip(self.metrics_variables, metrics_variables)
             ]
         ) as scope:
-            self._loss_tracker.update_state(unscaled_loss)
+            self._loss_tracker.update_state([unscaled_loss] * x.shape[0])
             logs = self.compute_metrics(x, y, y_pred, sample_weight)
 
         new_metrics_variables = []

--- a/keras/backend/jax/trainer.py
+++ b/keras/backend/jax/trainer.py
@@ -104,7 +104,9 @@ class JAXTrainer(base_trainer.Trainer):
                 for ref_v, v in zip(self.metrics_variables, metrics_variables)
             ]
         ) as scope:
-            self._loss_tracker.update_state(unscaled_loss] * x.shape[0])
+            self._update_loss_tracker(
+                unscaled_loss, tree.flatten(x)[0].shape[0]
+            )
             logs = self.compute_metrics(x, y, y_pred, sample_weight)
 
         new_metrics_variables = []
@@ -146,7 +148,9 @@ class JAXTrainer(base_trainer.Trainer):
                 for ref_v, v in zip(self.metrics_variables, metrics_variables)
             ]
         ) as scope:
-            self._loss_tracker.update_state([unscaled_loss] * x.shape[0])
+            self._update_loss_tracker(
+                unscaled_loss, tree.flatten(x)[0].shape[0]
+            )
             logs = self.compute_metrics(x, y, y_pred, sample_weight)
 
         new_metrics_variables = []

--- a/keras/backend/numpy/trainer.py
+++ b/keras/backend/numpy/trainer.py
@@ -31,7 +31,9 @@ class NumpyTrainer(base_trainer.Trainer):
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
-        self._update_loss_tracker(loss, tree.flatten(x)[0].shape[0])
+        self._loss_tracker.update_state(
+            loss, sample_weight=tree.flatten(x)[0].shape[0]
+        )
         return self.compute_metrics(x, y, y_pred, sample_weight=sample_weight)
 
     def predict_step(self, data):

--- a/keras/backend/numpy/trainer.py
+++ b/keras/backend/numpy/trainer.py
@@ -31,7 +31,7 @@ class NumpyTrainer(base_trainer.Trainer):
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
-        self._loss_tracker.update_state([loss] * x.shape[0])
+        self._update_loss_tracker(loss, tree.flatten(x)[0].shape[0])
         return self.compute_metrics(x, y, y_pred, sample_weight=sample_weight)
 
     def predict_step(self, data):

--- a/keras/backend/numpy/trainer.py
+++ b/keras/backend/numpy/trainer.py
@@ -31,7 +31,7 @@ class NumpyTrainer(base_trainer.Trainer):
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
-        self._loss_tracker.update_state(loss)
+        self._loss_tracker.update_state([loss] * x.shape[0])
         return self.compute_metrics(x, y, y_pred, sample_weight=sample_weight)
 
     def predict_step(self, data):

--- a/keras/backend/tensorflow/trainer.py
+++ b/keras/backend/tensorflow/trainer.py
@@ -60,7 +60,9 @@ class TensorFlowTrainer(base_trainer.Trainer):
             loss = self.compute_loss(
                 x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
             )
-            self._update_loss_tracker(loss, tf.shape(tree.flatten(x)[0])[0])
+            self._loss_tracker.update_state(
+                loss, sample_weight=tf.shape(tree.flatten(x)[0])[0]
+            )
             if self.optimizer is not None:
                 loss = self.optimizer.scale_loss(loss)
 
@@ -85,7 +87,9 @@ class TensorFlowTrainer(base_trainer.Trainer):
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
-        self._update_loss_tracker(loss, tf.shape(tree.flatten(x)[0])[0])
+        self._loss_tracker.update_state(
+            loss, sample_weight=tf.shape(tree.flatten(x)[0])[0]
+        )
         return self.compute_metrics(x, y, y_pred, sample_weight=sample_weight)
 
     def predict_step(self, data):

--- a/keras/backend/tensorflow/trainer.py
+++ b/keras/backend/tensorflow/trainer.py
@@ -60,7 +60,9 @@ class TensorFlowTrainer(base_trainer.Trainer):
             loss = self.compute_loss(
                 x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
             )
-            self._loss_tracker.update_state(loss)
+            self._loss_tracker.update_state(
+                tf.repeat(loss, repeats=tf.shape(x)[0])
+            )
             if self.optimizer is not None:
                 loss = self.optimizer.scale_loss(loss)
 
@@ -85,7 +87,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
-        self._loss_tracker.update_state(loss)
+        self._loss_tracker.update_state(tf.repeat(loss, repeats=tf.shape(x)[0]))
         return self.compute_metrics(x, y, y_pred, sample_weight=sample_weight)
 
     def predict_step(self, data):

--- a/keras/backend/tensorflow/trainer.py
+++ b/keras/backend/tensorflow/trainer.py
@@ -60,9 +60,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
             loss = self.compute_loss(
                 x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
             )
-            self._loss_tracker.update_state(
-                tf.repeat(loss, repeats=tf.shape(x)[0])
-            )
+            self._update_loss_tracker(loss, tf.shape(tree.flatten(x)[0])[0])
             if self.optimizer is not None:
                 loss = self.optimizer.scale_loss(loss)
 
@@ -87,7 +85,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
-        self._loss_tracker.update_state(tf.repeat(loss, repeats=tf.shape(x)[0]))
+        self._update_loss_tracker(loss, tf.shape(tree.flatten(x)[0])[0])
         return self.compute_metrics(x, y, y_pred, sample_weight=sample_weight)
 
     def predict_step(self, data):

--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -52,7 +52,7 @@ class TorchTrainer(base_trainer.Trainer):
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
-        self._loss_tracker.update_state([loss] * x.shape[0])
+        self._update_loss_tracker(loss, tree.flatten(x)[0].shape[0])
         if self.optimizer is not None:
             loss = self.optimizer.scale_loss(loss)
 
@@ -86,7 +86,7 @@ class TorchTrainer(base_trainer.Trainer):
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
-        self._loss_tracker.update_state([loss] * x.shape[0])
+        self._update_loss_tracker(loss, tree.flatten(x)[0].shape[0])
         return self.compute_metrics(x, y, y_pred, sample_weight=sample_weight)
 
     def predict_step(self, data):

--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -52,7 +52,9 @@ class TorchTrainer(base_trainer.Trainer):
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
-        self._update_loss_tracker(loss, tree.flatten(x)[0].shape[0])
+        self._loss_tracker.update_state(
+            loss, sample_weight=tree.flatten(x)[0].shape[0]
+        )
         if self.optimizer is not None:
             loss = self.optimizer.scale_loss(loss)
 
@@ -86,7 +88,9 @@ class TorchTrainer(base_trainer.Trainer):
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
-        self._update_loss_tracker(loss, tree.flatten(x)[0].shape[0])
+        self._loss_tracker.update_state(
+            loss, sample_weight=tree.flatten(x)[0].shape[0]
+        )
         return self.compute_metrics(x, y, y_pred, sample_weight=sample_weight)
 
     def predict_step(self, data):

--- a/keras/backend/torch/trainer.py
+++ b/keras/backend/torch/trainer.py
@@ -52,7 +52,7 @@ class TorchTrainer(base_trainer.Trainer):
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
-        self._loss_tracker.update_state(loss)
+        self._loss_tracker.update_state([loss] * x.shape[0])
         if self.optimizer is not None:
             loss = self.optimizer.scale_loss(loss)
 
@@ -86,7 +86,7 @@ class TorchTrainer(base_trainer.Trainer):
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
-        self._loss_tracker.update_state(loss)
+        self._loss_tracker.update_state([loss] * x.shape[0])
         return self.compute_metrics(x, y, y_pred, sample_weight=sample_weight)
 
     def predict_step(self, data):

--- a/keras/trainers/trainer.py
+++ b/keras/trainers/trainer.py
@@ -336,6 +336,18 @@ class Trainer:
             total_loss = ops.sum(losses)
         return total_loss
 
+    def _update_loss_tracker(self, loss, num_samples):
+        """Update the loss tracker.
+
+        Args:
+            loss: A scalar. The averaged loss value for the batch.
+            num_samples: Integer. The number of samples in the batch.
+        """
+        # The sample weight here is not the one passed to fit() or evaluate().
+        # It is only used for counting the total number of samples to average
+        # the loss.
+        self._loss_tracker.update_state(loss, sample_weight=num_samples)
+
     def compute_metrics(self, x, y, y_pred, sample_weight=None):
         """Update metric states and collect all metrics to be returned.
 

--- a/keras/trainers/trainer.py
+++ b/keras/trainers/trainer.py
@@ -336,18 +336,6 @@ class Trainer:
             total_loss = ops.sum(losses)
         return total_loss
 
-    def _update_loss_tracker(self, loss, num_samples):
-        """Update the loss tracker.
-
-        Args:
-            loss: A scalar. The averaged loss value for the batch.
-            num_samples: Integer. The number of samples in the batch.
-        """
-        # The sample weight here is not the one passed to fit() or evaluate().
-        # It is only used for counting the total number of samples to average
-        # the loss.
-        self._loss_tracker.update_state(loss, sample_weight=num_samples)
-
     def compute_metrics(self, x, y, y_pred, sample_weight=None):
         """Update metric states and collect all metrics to be returned.
 

--- a/keras/trainers/trainer_test.py
+++ b/keras/trainers/trainer_test.py
@@ -587,6 +587,26 @@ class TestTrainer(testing.TestCase, parameterized.TestCase):
         self.assertEqual(step_count.test_count, 3)
 
     @pytest.mark.requires_trainable_backend
+    def test_fit_with_different_batch_size_same_loss(self):
+        x = np.random.rand(100, 4)
+        y = np.ones((100, 1))
+        model = ExampleModel(units=1)
+        model.trainable = False
+        model.compile(loss="mse")
+        loss1 = model.fit(x, y, batch_size=80).history["loss"]
+        loss2 = model.fit(x, y, batch_size=100).history["loss"]
+        self.assertAllClose(loss1, loss2)
+
+    def test_evaluate_with_different_batch_size_same_loss(self):
+        x = np.random.rand(100, 4)
+        y = np.ones((100, 1))
+        model = ExampleModel(units=1)
+        model.compile(loss="mse")
+        loss1 = model.evaluate(x, y, batch_size=80)
+        loss2 = model.evaluate(x, y, batch_size=100)
+        self.assertAllClose(loss1, loss2)
+
+    @pytest.mark.requires_trainable_backend
     def test_adds_loss_scaling_optimizer(self):
         model = TrainingTestingLayer(dtype="mixed_float16")
         model.compile(optimizer="rmsprop", loss="mse")


### PR DESCRIPTION
Related to #19267 .
This fixes one of the numerical differences between Keras 3 & Keras 2.

The loss was averaged across multi batches without considering whether it is a full batch or not.
The last batch contains less examples, should be averaged dividing the actual number of samples..

Used `sample_weights` argument in `Mean.update_state()`.
So the `Mean` class would average it considering the number of samples.

Extracted a backend agnostic function to avoid confusion to the readers as it is not the same as the `sample_weights` set by the user.

Added 2 tests, which fail before the change, but succeed after the change.