### PR TITLE
fix seed value when seed=0

### DIFF
--- a/keras/initializers/random_initializers.py
+++ b/keras/initializers/random_initializers.py
@@ -47,7 +47,7 @@ class RandomNormal(Initializer):
         self.mean = mean
         self.stddev = stddev
         self._init_seed = seed
-        self.seed = seed or random.make_default_seed()
+        self.seed = seed if seed is not None else random.make_default_seed()
         super().__init__()
 
     def __call__(self, shape, dtype=None):
@@ -107,7 +107,7 @@ class TruncatedNormal(Initializer):
         self.mean = mean
         self.stddev = stddev
         self._init_seed = seed
-        self.seed = seed or random.make_default_seed()
+        self.seed = seed if seed is not None else random.make_default_seed()
         super().__init__()
 
     def __call__(self, shape, dtype=None):
@@ -164,7 +164,7 @@ class RandomUniform(Initializer):
         self.minval = minval
         self.maxval = maxval
         self._init_seed = seed
-        self.seed = seed or random.make_default_seed()
+        self.seed = seed if seed is not None else random.make_default_seed()
         super().__init__()
 
     def __call__(self, shape, dtype=None):
@@ -268,7 +268,7 @@ class VarianceScaling(Initializer):
         self.mode = mode
         self.distribution = distribution
         self._init_seed = seed
-        self.seed = seed or random.make_default_seed()
+        self.seed = seed if seed is not None else random.make_default_seed()
 
     def __call__(self, shape, dtype=None):
         scale = self.scale
@@ -669,7 +669,7 @@ class OrthogonalInitializer(Initializer):
     def __init__(self, gain=1.0, seed=None):
         self.gain = gain
         self._init_seed = seed
-        self.seed = seed or random.make_default_seed()
+        self.seed = seed if seed is not None else random.make_default_seed()
 
     def __call__(self, shape, dtype=None):
         if len(shape) < 2:

--- a/keras/layers/preprocessing/random_crop.py
+++ b/keras/layers/preprocessing/random_crop.py
@@ -48,7 +48,9 @@ class RandomCrop(TFDataLayer):
         super().__init__(name=name, **kwargs)
         self.height = height
         self.width = width
-        self.seed = seed or backend.random.make_default_seed()
+        self.seed = (
+            seed if seed is not None else backend.random.make_default_seed()
+        )
         self.generator = SeedGenerator(seed)
         self.data_format = backend.standardize_data_format(data_format)
 


### PR DESCRIPTION
This fixes edge case scenario when `seed=0`.

According to the existing implementation for `seed=0`, `self.seed = seed or random.make_default_seed()` evaluates to 
`0 or random.make_default_seed()` which forces the seed value from  `random.make_default_seed()` and invalidate this logic for `0` input.

Fixes: https://github.com/keras-team/keras/issues/19361