### PR TITLE
Add more manual implementations for TF's `einsum`

### DIFF
--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -104,9 +104,13 @@ def einsum(subscripts, *operands, **kwargs):
         # `None`.
         if subscripts in [
             "a,b->ab",
+            "ab,b->a",
             "ab,bc->ac",
+            "ab,cb->ac",
             "abc,cd->abd",
+            "abcd,abde->abce",
             "abcd,abed->abce",
+            "abcd,acbe->adbe",
             "abcd,adbe->acbe",
             "abcd,aecd->acbe",
             "abcd,aecd->aceb",
@@ -127,9 +131,30 @@ def einsum(subscripts, *operands, **kwargs):
             if None in (b, c, d, e):
                 return False
             return True
+        elif subscripts == "abc,dec->abde":
+            _, b1, c1 = operands[0].shape
+            d2, e2, c2 = operands[1].shape
+            b, c, d, e = b1, c1 or c2, d2, e2
+            if None in (b, c, d, e):
+                return False
+            return True
         elif subscripts == "abcd,cde->abe":
             _, b1, c1, d1 = operands[0].shape
             c2, d2, e2 = operands[1].shape
+            b, c, d, e = b1, c1 or c2, d1 or d2, e2
+            if None in (b, c, d, e):
+                return False
+            return True
+        elif subscripts == "abcd,ced->abe":
+            _, b1, c1, d1 = operands[0].shape
+            c2, e2, d2 = operands[1].shape
+            b, c, d, e = b1, c1 or c2, d1 or d2, e2
+            if None in (b, c, d, e):
+                return False
+            return True
+        elif subscripts == "abcd,ecd->abe":
+            _, b1, c1, d1 = operands[0].shape
+            e2, c2, d2 = operands[1].shape
             b, c, d, e = b1, c1 or c2, d1 or d2, e2
             if None in (b, c, d, e):
                 return False
@@ -160,7 +185,14 @@ def einsum(subscripts, *operands, **kwargs):
             x = tf.expand_dims(x, axis=-1)
             y = tf.expand_dims(y, axis=0)
             return tf.matmul(x, y, output_type=output_type)
+        elif subscripts == "ab,b->a":
+            y = tf.expand_dims(y, axis=-1)
+            result = tf.matmul(x, y, output_type=output_type)
+            return tf.squeeze(result, axis=-1)
         elif subscripts == "ab,bc->ac":
+            return tf.matmul(x, y, output_type=output_type)
+        elif subscripts == "ab,cb->ac":
+            y = tf.transpose(y, [1, 0])
             return tf.matmul(x, y, output_type=output_type)
         elif subscripts == "abc,cd->abd":
             return tf.matmul(x, y, output_type=output_type)
@@ -179,9 +211,24 @@ def einsum(subscripts, *operands, **kwargs):
             y = tf.reshape(y, [c, -1])
             result = tf.matmul(x, y, output_type=output_type)
             return tf.reshape(result, [-1, b, d, e])
+        elif subscripts == "abc,dec->abde":
+            _, b1, c1 = x.shape
+            d2, e2, c2 = y.shape
+            b, c, d, e = b1, c1 or c2, d2, e2
+            y = tf.transpose(y, [2, 0, 1])  # cde
+            y = tf.reshape(y, [c, -1])
+            result = tf.matmul(x, y, output_type=output_type)
+            return tf.reshape(result, [-1, b, d, e])
+        elif subscripts == "abcd,abde->abce":
+            return tf.matmul(x, y, output_type=output_type)
         elif subscripts == "abcd,abed->abce":
             y = tf.transpose(y, [0, 1, 3, 2])
             return tf.matmul(x, y, output_type=output_type)
+        elif subscripts == "abcd,acbe->adbe":
+            x = tf.transpose(x, [0, 1, 3, 2])
+            y = tf.transpose(y, [0, 2, 1, 3])
+            result = tf.matmul(x, y, output_type=output_type)
+            return tf.transpose(result, [0, 2, 1, 3])
         elif subscripts == "abcd,adbe->acbe":
             y = tf.transpose(y, [0, 2, 1, 3])  # abde
             result = tf.matmul(x, y, output_type=output_type)  # abce
@@ -200,6 +247,22 @@ def einsum(subscripts, *operands, **kwargs):
             c2, d2, e2 = y.shape
             b, c, d, e = b1, c1 or c2, d1 or d2, e2
             x = tf.reshape(x, [-1, b, c * d])
+            y = tf.reshape(y, [-1, e])
+            return tf.matmul(x, y, output_type=output_type)
+        elif subscripts == "abcd,ced->abe":
+            _, b1, c1, d1 = x.shape
+            c2, e2, d2 = y.shape
+            b, c, d, e = b1, c1 or c2, d1 or d2, e2
+            x = tf.reshape(x, [-1, b, c * d])
+            y = tf.transpose(y, [0, 2, 1])
+            y = tf.reshape(y, [-1, e])
+            return tf.matmul(x, y, output_type=output_type)
+        elif subscripts == "abcd,ecd->abe":
+            _, b1, c1, d1 = x.shape
+            e2, c2, d2 = y.shape
+            b, c, d, e = b1, c1 or c2, d1 or d2, e2
+            x = tf.reshape(x, [-1, b, c * d])
+            y = tf.transpose(y, [1, 2, 0])
             y = tf.reshape(y, [-1, e])
             return tf.matmul(x, y, output_type=output_type)
         elif subscripts == "abcde,aebf->adbcf":

--- a/keras/backend/tensorflow/numpy.py
+++ b/keras/backend/tensorflow/numpy.py
@@ -108,6 +108,7 @@ def einsum(subscripts, *operands, **kwargs):
             "ab,bc->ac",
             "ab,cb->ac",
             "abc,cd->abd",
+            "abc,dc->abd",
             "abcd,abde->abce",
             "abcd,abed->abce",
             "abcd,acbe->adbe",
@@ -203,6 +204,9 @@ def einsum(subscripts, *operands, **kwargs):
             y = tf.reshape(y, [c, -1])
             result = tf.matmul(x, y, output_type=output_type)
             return tf.reshape(result, [-1, b, d, e])
+        elif subscripts == "abc,dc->abd":
+            y = tf.transpose(y, [1, 0])
+            return tf.matmul(x, y, output_type=output_type)
         elif subscripts == "abc,dce->abde":
             _, b1, c1 = x.shape
             d2, c2, e2 = y.shape

--- a/keras/layers/core/dense_test.py
+++ b/keras/layers/core/dense_test.py
@@ -372,7 +372,7 @@ class DenseTest(testing.TestCase):
     def test_quantize_on_unbuilt_layer(self):
         layer = layers.Dense(units=2)
         with self.assertRaisesRegex(
-            ValueError, "Cannot quantize on a layer that isn't yet built."
+            ValueError, "Cannot quantize a layer that isn't yet built."
         ):
             layer.quantize("int8")
 

--- a/keras/layers/core/einsum_dense_test.py
+++ b/keras/layers/core/einsum_dense_test.py
@@ -480,7 +480,7 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
             bias_axes="d",
         )
         with self.assertRaisesRegex(
-            ValueError, "Cannot quantize on a layer that isn't yet built."
+            ValueError, "Cannot quantize a layer that isn't yet built."
         ):
             layer.quantize("int8")
 

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -2173,9 +2173,23 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase, parameterized.TestCase):
             knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
         )
 
+        subscripts = "ab,b->a"
+        x = np.arange(6).reshape([2, 3]).astype("float32")
+        y = np.arange(3).reshape([3]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
         subscripts = "ab,bc->ac"
         x = np.arange(6).reshape([2, 3]).astype("float32")
         y = np.arange(12).reshape([3, 4]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "ab,cb->ac"
+        x = np.arange(6).reshape([2, 3]).astype("float32")
+        y = np.arange(12).reshape([4, 3]).astype("float32")
         self.assertAllClose(
             knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
         )
@@ -2201,9 +2215,30 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase, parameterized.TestCase):
             knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
         )
 
+        subscripts = "abc,dec->abde"
+        x = np.arange(24).reshape([2, 3, 4]).astype("float32")
+        y = np.arange(120).reshape([5, 6, 4]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abcd,abde->abce"
+        x = np.arange(120).reshape([2, 3, 4, 5]).astype("float32")
+        y = np.arange(180).reshape([2, 3, 5, 6]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
         subscripts = "abcd,abed->abce"
         x = np.arange(120).reshape([2, 3, 4, 5]).astype("float32")
         y = np.arange(180).reshape([2, 3, 6, 5]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abcd,acbe->adbe"
+        x = np.arange(120).reshape([2, 3, 4, 5]).astype("float32")
+        y = np.arange(144).reshape([2, 4, 3, 6]).astype("float32")
         self.assertAllClose(
             knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
         )
@@ -2232,6 +2267,20 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase, parameterized.TestCase):
         subscripts = "abcd,cde->abe"
         x = np.arange(120).reshape([2, 3, 4, 5]).astype("float32")
         y = np.arange(120).reshape([4, 5, 6]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abcd,ced->abe"
+        x = np.arange(120).reshape([2, 3, 4, 5]).astype("float32")
+        y = np.arange(120).reshape([4, 6, 5]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
+        subscripts = "abcd,ecd->abe"
+        x = np.arange(120).reshape([2, 3, 4, 5]).astype("float32")
+        y = np.arange(120).reshape([6, 4, 5]).astype("float32")
         self.assertAllClose(
             knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
         )
@@ -5668,15 +5717,23 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         dtype1, dtype2 = dtypes
         for subscripts in [
             "a,b->ab",
+            "ab,b->a",
             "ab,bc->ac",
+            "ab,cb->ac",
             "abc,cd->abd",
             "abc,cde->abde",
+            "abc,dc->abd",
             "abc,dce->abde",
+            "abc,dec->abde",
+            "abcd,abde->abce",
             "abcd,abed->abce",
+            "abcd,acbe->adbe",
             "abcd,adbe->acbe",
             "abcd,aecd->acbe",
             "abcd,aecd->aceb",
             "abcd,cde->abe",
+            "abcd,ced->abe",
+            "abcd,ecd->abe",
             "abcde,aebf->adbcf",
             "abcde,afce->acdbf",
         ]:

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -2208,6 +2208,13 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase, parameterized.TestCase):
             knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
         )
 
+        subscripts = "abc,dc->abd"
+        x = np.arange(24).reshape([2, 3, 4]).astype("float32")
+        y = np.arange(20).reshape([5, 4]).astype("float32")
+        self.assertAllClose(
+            knp.einsum(subscripts, x, y), np.einsum(subscripts, x, y)
+        )
+
         subscripts = "abc,dce->abde"
         x = np.arange(24).reshape([2, 3, 4]).astype("float32")
         y = np.arange(120).reshape([5, 4, 6]).astype("float32")


### PR DESCRIPTION
We need these new subscripts to utilize int8,int8->int32 `einsum` for backprop in #19356 

```python
                inputs_grad = ops.einsum(
                    # self._custom_gradient_equation is '{output_spec},{weight_spec}->{input_spec}'
                    self._custom_gradient_equation, upstream, float_kernel
                )
```

To find out all of these subscripts:

```python
import re

from keras.backend.tensorflow.numpy import _normalize_einsum_subscripts

currently_supported_subscripts = [
    "a,b->ab",
    "ab,bc->ac",
    "abc,cd->abd",
    "abcd,abed->abce",
    "abcd,adbe->acbe",
    "abcd,aecd->acbe",
    "abcd,aecd->aceb",
    "abc,cde->abde",
    "abc,dce->abde",
    "abcd,cde->abe",
    "abcde,aebf->adbcf",
    "abcde,afce->acdbf",
]


def custom_gradient_subscripts(equation):
    dot_replaced_string = re.sub(r"\.\.\.", "0", equation)
    split_string = re.match(
        "([a-zA-Z]+),([a-zA-Z]+)->([a-zA-Z]+)", dot_replaced_string
    )
    if split_string is not None:
        input_spec = split_string.group(1)
        weight_spec = split_string.group(2)
        output_spec = split_string.group(3)
    return f"{output_spec},{weight_spec}->{input_spec}"


possible_subscripts = []
for s in currently_supported_subscripts:
    t = _normalize_einsum_subscripts(custom_gradient_subscripts(s))
    possible_subscripts.append(t)

supported_subscripts = set(currently_supported_subscripts)
possible_subscripts = set(possible_subscripts)
missing_subscripts = possible_subscripts - supported_subscripts
print(sorted(missing_subscripts))

# ['ab,b->a', 'ab,cb->ac', 'abc,dc->abd', 'abc,dec->abde', 'abcd,abde->abce',
# 'abcd,acbe->adbe', 'abcd,ced->abe', 'abcd,ecd->abe']

```
