### PR TITLE
only save to temp directories in tests

### DIFF
--- a/keras/saving/saving_lib_test.py
+++ b/keras/saving/saving_lib_test.py
@@ -809,7 +809,9 @@ class SavingBattleTest(testing.TestCase):
             def call(self, x):
                 return self.dense(x)
 
-        temp_filepath = "normal_model.weights.h5"
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "normal_model.weights.h5"
+        )
         model_a = NormalModel()
         model_a(np.random.random((2, 2)))
         model_a.save_weights(temp_filepath)


### PR DESCRIPTION
When running tests locally, it would add an untracked file to git.
So changing it to use a temporary directory.