### PR TITLE
Bug fix, model.evaluate return metrics in order.

### DIFF
--- a/keras/trainers/trainer.py
+++ b/keras/trainers/trainer.py
@@ -865,7 +865,14 @@ class Trainer:
 
     def _flatten_metrics_in_order(self, logs):
         """Turns `logs` dict into a list as per key order of `metrics_names`."""
-        metric_names = [m.name for m in self.metrics]
+        metric_names = []
+        for metric in self.metrics:
+            if isinstance(metric, CompileMetrics):
+                metric_names += [
+                    sub_metric.name for sub_metric in metric.metrics
+                ]
+            else:
+                metric_names.append(metric.name)
         results = []
         for name in metric_names:
             if name in logs:

--- a/keras/trainers/trainer_test.py
+++ b/keras/trainers/trainer_test.py
@@ -1046,6 +1046,28 @@ class TestTrainer(testing.TestCase, parameterized.TestCase):
             sorted(list(eval_out_2.keys())), ["loss", "mean_absolute_error"]
         )
 
+    def test_evaluate_return_list_respect_metrics_order(self):
+        def metrics_zero(y_true, y_pred):
+            return 0.0
+
+        def metrics_one(y_true, y_pred):
+            return 1.0
+
+        model = ExampleModel(units=3)
+        model.compile(
+            optimizer="sgd", loss="mse", metrics=[metrics_zero, metrics_one]
+        )
+        eval_out = model.evaluate(np.ones((3, 2)), np.ones((3, 3)))
+        self.assertEqual(eval_out[1], 0.0)
+        self.assertEqual(eval_out[2], 1.0)
+
+        model.compile(
+            optimizer="sgd", loss="mse", metrics=[metrics_one, metrics_zero]
+        )
+        eval_out = model.evaluate(np.ones((3, 2)), np.ones((3, 3)))
+        self.assertEqual(eval_out[1], 1.0)
+        self.assertEqual(eval_out[2], 0.0)
+
     @pytest.mark.requires_trainable_backend
     def test_nested_inputs(self):
         model = ListModel(units=2)


### PR DESCRIPTION
Related to #19267.
Before this fix, when returning a list from `model.evaluate()`, it would always sort the value by the metric names,
not respecting the order of the metrics configed by the user in `model.compile()`.

Added a test to ensure the behavior.
Before the fix, the test fails.
After the fix, the test passes.