### PR TITLE
Add `quantize` to Embedding

### DIFF
--- a/keras/layers/core/dense.py
+++ b/keras/layers/core/dense.py
@@ -331,6 +331,12 @@ class Dense(Layer):
     def quantize(self, mode):
         import gc
 
+        # Prevent quantization of the subclasses
+        if type(self) is not Dense:
+            raise NotImplementedError(
+                f"Layer {self.__class__.__name__} does not have a `quantize()` "
+                "method implemented."
+            )
         self._check_quantize_args(mode, self.compute_dtype)
         if mode == "int8":
             if backend.standardize_dtype(self._kernel.dtype) == "int8":

--- a/keras/layers/core/dense.py
+++ b/keras/layers/core/dense.py
@@ -344,9 +344,11 @@ class Dense(Layer):
             kernel_scale = ops.squeeze(kernel_scale, axis=0)
             self._tracker.unlock()
             self._untrack_variable(self._kernel)
+            kernel_shape = self._kernel.shape
+            del self._kernel
             self._kernel = self.add_weight(
                 name="kernel",
-                shape=self._kernel.shape,
+                shape=kernel_shape,
                 # Prevent adding a large constant to the computation graph
                 initializer=lambda shape, dtype: kernel_value,
                 dtype="int8",

--- a/keras/layers/core/dense_test.py
+++ b/keras/layers/core/dense_test.py
@@ -381,6 +381,15 @@ class DenseTest(testing.TestCase):
         ):
             layer.quantize("int8")
 
+    def test_quantize_on_subclass(self):
+        class MyDense(layers.Dense):
+            pass
+
+        layer = MyDense(units=16)
+        layer.build((None, 8))
+        with self.assertRaises(NotImplementedError):
+            layer.quantize("int8")
+
     def test_quantize_when_already_quantized(self):
         layer = layers.Dense(units=2)
         layer.build((None, 2))

--- a/keras/layers/core/dense_test.py
+++ b/keras/layers/core/dense_test.py
@@ -313,6 +313,8 @@ class DenseTest(testing.TestCase):
     def test_quantize_int8(self):
         layer = layers.Dense(units=16)
         layer.build((None, 8))
+        x = np.random.random((2, 8))
+        y_float = layer(x)
         layer.quantize("int8")
 
         # Verify weights dtype
@@ -322,9 +324,10 @@ class DenseTest(testing.TestCase):
             layer.variable_dtype,
         )
 
-        # Try eager call
-        x = np.random.random((2, 8))
-        _ = layer(x)
+        # Try eager call and verify output correctness
+        y_quantized = layer(x)
+        mse = ops.mean(ops.square(y_float - y_quantized))
+        self.assertLess(mse, 1e-3)  # A weak correctness test
 
         # Try saving and reloading the model
         model = models.Sequential([layer])

--- a/keras/layers/core/einsum_dense.py
+++ b/keras/layers/core/einsum_dense.py
@@ -424,7 +424,7 @@ class EinsumDense(Layer):
                 )
             # De-scale outputs
             x = ops.cast(x, self.compute_dtype)
-            x = ops.divide(x, ops.multiply(inputs_scale, self.kernel_scale))
+            x = ops.divide(x, ops.multiply(inputs_scale, kernel_scale))
             return x, grad_fn
 
         x = einsum_with_inputs_gradient(
@@ -433,8 +433,8 @@ class EinsumDense(Layer):
             ops.convert_to_tensor(self.kernel_scale),
         )
         if self.lora_enabled:
-            lora_kernel = ops.matmul(self.lora_kernel_a, self.lora_kernel_b)
-            lora_x = ops.einsum(self.equation, inputs, lora_kernel)
+            lora_x = ops.einsum(self.equation, inputs, self.lora_kernel_a)
+            lora_x = ops.matmul(lora_x, self.lora_kernel_b)
             x = ops.add(x, lora_x)
         if self.bias is not None:
             x += self.bias
@@ -482,9 +482,11 @@ class EinsumDense(Layer):
                 )
             self._tracker.unlock()
             self._untrack_variable(self._kernel)
+            kernel_shape = self._kernel.shape
+            del self._kernel
             self._kernel = self.add_weight(
                 name="kernel",
-                shape=self._kernel.shape,
+                shape=kernel_shape,
                 # Prevent adding a large constant to the computation graph
                 initializer=lambda shape, dtype: kernel_value,
                 dtype="int8",

--- a/keras/layers/core/einsum_dense.py
+++ b/keras/layers/core/einsum_dense.py
@@ -445,6 +445,12 @@ class EinsumDense(Layer):
     def quantize(self, mode):
         import gc
 
+        # Prevent quantization of the subclasses
+        if type(self) is not EinsumDense:
+            raise NotImplementedError(
+                f"Layer {self.__class__.__name__} does not have a `quantize()` "
+                "method implemented."
+            )
         self._check_quantize_args(mode, self.compute_dtype)
         if mode == "int8":
             if backend.standardize_dtype(self._kernel.dtype) == "int8":

--- a/keras/layers/core/einsum_dense_test.py
+++ b/keras/layers/core/einsum_dense_test.py
@@ -489,6 +489,19 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
         ):
             layer.quantize("int8")
 
+    def test_quantize_on_subclass(self):
+        class MyEinsumDense(layers.EinsumDense):
+            pass
+
+        layer = MyEinsumDense(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes="d",
+        )
+        layer.build((None, 3))
+        with self.assertRaises(NotImplementedError):
+            layer.quantize("int8")
+
     def test_quantize_when_already_quantized(self):
         layer = layers.EinsumDense(
             equation="ab,bcd->acd",

--- a/keras/layers/core/embedding.py
+++ b/keras/layers/core/embedding.py
@@ -292,6 +292,12 @@ class Embedding(Layer):
     def quantize(self, mode):
         import gc
 
+        # Prevent quantization of the subclasses
+        if type(self) is not Embedding:
+            raise NotImplementedError(
+                f"Layer {self.__class__.__name__} does not have a `quantize()` "
+                "method implemented."
+            )
         self._check_quantize_args(mode, self.compute_dtype)
         if mode == "int8":
             if backend.standardize_dtype(self._embeddings.dtype) == "int8":

--- a/keras/layers/core/embedding.py
+++ b/keras/layers/core/embedding.py
@@ -1,8 +1,9 @@
-import numpy as np
-
+from keras import backend
 from keras import constraints
+from keras import dtype_policies
 from keras import initializers
 from keras import ops
+from keras import quantizers
 from keras import regularizers
 from keras.api_export import keras_export
 from keras.layers.layer import Layer
@@ -91,14 +92,19 @@ class Embedding(Layer):
         self.lora_enabled = False
 
     def build(self, input_shape=None):
-        self._embeddings = self.add_weight(
-            shape=(self.input_dim, self.output_dim),
-            initializer=self.embeddings_initializer,
-            name="embeddings",
-            regularizer=self.embeddings_regularizer,
-            constraint=self.embeddings_constraint,
-            trainable=True,
-        )
+        if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
+            self.quantized_build(
+                input_shape, mode=self.dtype_policy.quantization_mode
+            )
+        else:
+            self._embeddings = self.add_weight(
+                shape=(self.input_dim, self.output_dim),
+                initializer=self.embeddings_initializer,
+                name="embeddings",
+                regularizer=self.embeddings_regularizer,
+                constraint=self.embeddings_constraint,
+                trainable=True,
+            )
         self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank)
@@ -159,20 +165,39 @@ class Embedding(Layer):
         self.embeddings.trainable = False
         self._tracker.lock()
         self.lora_enabled = True
+        self.lora_rank = rank
 
     def save_own_variables(self, store):
-        if not self.lora_enabled:
-            return super().save_own_variables(store)
-
-        embeddings_value = self.embeddings
+        # Do nothing if the layer isn't yet built
+        if not self.built:
+            return
+        # The keys of the `store` will be saved as determined because the
+        # default ordering will change after quantization
+        embeddings_value, embeddings_scale = (
+            self._get_embeddings_with_merged_lora()
+        )
         store["0"] = embeddings_value
+        if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
+            store["1"] = embeddings_scale
 
     def load_own_variables(self, store):
         if not self.lora_enabled:
-            return super().load_own_variables(store)
+            self._check_load_own_variables(store)
+        # Do nothing if the layer isn't yet built
+        if not self.built:
+            return
+        # The keys of the `store` will be saved as determined because the
+        # default ordering will change after quantization
         self._embeddings.assign(store["0"])
-        self.lora_embeddings_a.assign(np.zeros(self.lora_embeddings_a.shape))
-        self.lora_embeddings_b.assign(np.zeros(self.lora_embeddings_b.shape))
+        if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
+            self.embeddings_scale.assign(store["1"])
+        if self.lora_enabled:
+            self.lora_embeddings_a.assign(
+                ops.zeros(self.lora_embeddings_a.shape)
+            )
+            self.lora_embeddings_b.assign(
+                ops.zeros(self.lora_embeddings_b.shape)
+            )
 
     def get_config(self):
         base_config = super().get_config()
@@ -196,3 +221,141 @@ class Embedding(Layer):
         if self.lora_rank:
             config["lora_rank"] = self.lora_rank
         return {**base_config, **config}
+
+    def _check_load_own_variables(self, store):
+        all_vars = self._trainable_variables + self._non_trainable_variables
+        if len(store.keys()) != len(all_vars):
+            if len(all_vars) == 0 and not self.built:
+                raise ValueError(
+                    f"Layer '{self.name}' was never built "
+                    "and thus it doesn't have any variables. "
+                    f"However the weights file lists {len(store.keys())} "
+                    "variables for this layer.\n"
+                    "In most cases, this error indicates that either:\n\n"
+                    "1. The layer is owned by a parent layer that "
+                    "implements a `build()` method, but calling the "
+                    "parent's `build()` method did NOT create the state of "
+                    f"the child layer '{self.name}'. A `build()` method "
+                    "must create ALL state for the layer, including "
+                    "the state of any children layers.\n\n"
+                    "2. You need to implement "
+                    "the `def build_from_config(self, config)` method "
+                    f"on layer '{self.name}', to specify how to rebuild "
+                    "it during loading. "
+                    "In this case, you might also want to implement the "
+                    "method that generates the build config at saving time, "
+                    "`def get_build_config(self)`. "
+                    "The method `build_from_config()` is meant "
+                    "to create the state "
+                    "of the layer (i.e. its variables) upon deserialization.",
+                )
+            raise ValueError(
+                f"Layer '{self.name}' expected {len(all_vars)} variables, "
+                "but received "
+                f"{len(store.keys())} variables during loading. "
+                f"Expected: {[v.name for v in all_vars]}"
+            )
+
+    """Quantization-related methods"""
+
+    def quantized_build(self, input_shape, mode):
+        if mode == "int8":
+            self.inputs_quantizer = quantizers.AbsMaxQuantizer(axis=-1)
+            self._embeddings = self.add_weight(
+                name="embeddings",
+                shape=(self.input_dim, self.output_dim),
+                initializer="zeros",
+                dtype="int8",
+                trainable=False,
+            )
+            self.embeddings_scale = self.add_weight(
+                name="embeddings_scale",
+                shape=(self.output_dim,),
+                initializer="ones",
+                trainable=False,
+            )
+
+    def quantized_call(self, inputs):
+        # We cannot update quantized self._embeddings, so the custom gradient is
+        # not needed
+        if backend.standardize_dtype(inputs.dtype) not in ("int32", "int64"):
+            inputs = ops.cast(inputs, "int32")
+        # De-scale embeddings
+        embeddings = ops.divide(self._embeddings, self.embeddings_scale)
+        outputs = ops.take(embeddings, inputs, axis=0)
+        if self.lora_enabled:
+            lora_outputs = ops.take(self.lora_embeddings_a, inputs, axis=0)
+            lora_outputs = ops.matmul(lora_outputs, self.lora_embeddings_b)
+            outputs = ops.add(outputs, lora_outputs)
+        return outputs
+
+    def quantize(self, mode):
+        import gc
+
+        self._check_quantize_args(mode, self.compute_dtype)
+        if mode == "int8":
+            if backend.standardize_dtype(self._embeddings.dtype) == "int8":
+                raise ValueError("`quantize` can only be done once per layer.")
+            # Configure `self.inputs_quantizer`
+            self.inputs_quantizer = quantizers.AbsMaxQuantizer(axis=-1)
+            # Quantize `self._embeddings` to int8 and compute corresponding
+            # scale
+            embeddings_value, embeddings_scale = quantizers.abs_max_quantize(
+                self._embeddings, axis=0
+            )
+            embeddings_scale = ops.squeeze(embeddings_scale, axis=0)
+            self._tracker.unlock()
+            self._untrack_variable(self._embeddings)
+            del self._embeddings
+            self._embeddings = self.add_weight(
+                name="embeddings",
+                shape=(self.input_dim, self.output_dim),
+                # Prevent adding a large constant to the computation graph
+                initializer=lambda shape, dtype: embeddings_value,
+                dtype="int8",
+                trainable=False,
+            )
+            self.embeddings_scale = self.add_weight(
+                name="embeddings_scale",
+                shape=(self.output_dim,),
+                # Prevent adding a large constant to the computation graph
+                initializer=lambda shape, dtype: embeddings_scale,
+                trainable=False,
+            )
+            self._tracker.lock()
+        else:
+            NotImplementedError(
+                "Invalid quantization mode. Expected 'int8'. "
+                f"Received: mode={mode}"
+            )
+
+        # Set new dtype policy
+        if not isinstance(
+            self.dtype_policy, dtype_policies.QuantizedDTypePolicy
+        ):
+            quantized_dtype = f"{mode}_from_{self.dtype_policy.name}"
+            self.dtype_policy = dtype_policies.get(quantized_dtype)
+
+        # Release memory manually because sometimes the backend doesn't
+        gc.collect()
+
+    def _get_embeddings_with_merged_lora(self):
+        if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
+            embeddings_value = self._embeddings
+            embeddings_scale = self.embeddings_scale
+            if self.lora_enabled:
+                # Dequantize & quantize to merge lora weights into embeddings
+                # Note that this is a lossy compression
+                embeddings_value = ops.divide(
+                    embeddings_value, embeddings_scale
+                )
+                embeddings_value = ops.add(
+                    embeddings_value,
+                    ops.matmul(self.lora_embeddings_a, self.lora_embeddings_b),
+                )
+                embeddings_value, embeddings_scale = (
+                    quantizers.abs_max_quantize(embeddings_value, axis=0)
+                )
+                embeddings_scale = ops.squeeze(embeddings_scale, axis=0)
+            return embeddings_value, embeddings_scale
+        return self.embeddings, None

--- a/keras/layers/core/embedding.py
+++ b/keras/layers/core/embedding.py
@@ -280,9 +280,12 @@ class Embedding(Layer):
         # not needed
         if backend.standardize_dtype(inputs.dtype) not in ("int32", "int64"):
             inputs = ops.cast(inputs, "int32")
-        # De-scale embeddings
-        embeddings = ops.divide(self._embeddings, self.embeddings_scale)
-        outputs = ops.take(embeddings, inputs, axis=0)
+        outputs = ops.take(self._embeddings, inputs, axis=0)
+        # De-scale outputs
+        outputs = ops.cast(outputs, self.compute_dtype)
+        outputs = ops.divide(
+            outputs, ops.expand_dims(self.embeddings_scale, axis=0)
+        )
         if self.lora_enabled:
             lora_outputs = ops.take(self.lora_embeddings_a, inputs, axis=0)
             lora_outputs = ops.matmul(lora_outputs, self.lora_embeddings_b)

--- a/keras/layers/core/embedding_test.py
+++ b/keras/layers/core/embedding_test.py
@@ -8,6 +8,7 @@ from keras import constraints
 from keras import layers
 from keras import models
 from keras import saving
+from keras.export import export_lib
 from keras.testing import test_case
 
 
@@ -152,7 +153,7 @@ class EmbeddingTest(test_case.TestCase):
         model.save(temp_filepath)
 
         new_model = saving.load_model(temp_filepath)
-        self.assertFalse(new_model.layers[0].lora_enabled)
+        self.assertTrue(new_model.layers[0].lora_enabled)
         self.assertAllClose(model.predict(x), new_model.predict(x))
 
         # Try saving and reloading the model's weights only
@@ -213,3 +214,169 @@ class EmbeddingTest(test_case.TestCase):
         layer.enable_lora(rank=2)
         with self.assertRaisesRegex(ValueError, "lora is already enabled"):
             layer.enable_lora(rank=2)
+
+    def test_quantize_int8(self):
+        layer = layers.Embedding(10, 16)
+        layer.build()
+        layer.quantize("int8")
+
+        # Verify weights dtype
+        self.assertEqual(
+            backend.standardize_dtype(layer._embeddings.dtype), "int8"
+        )
+        self.assertEqual(
+            backend.standardize_dtype(layer.embeddings_scale.dtype),
+            layer.variable_dtype,
+        )
+
+        # Try eager call
+        x = np.random.randint(0, 9, size=(64, 3))
+        _ = layer(x)
+
+        # Try saving and reloading the model
+        model = models.Sequential([layer])
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "quantized_model.keras"
+        )
+        model.save(temp_filepath)
+        new_model = saving.load_model(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try saving and reloading the model's weights only
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "quantized_model.weights.h5"
+        )
+        model.save_weights(temp_filepath)
+
+        # Try lora
+        layer = layers.Embedding(10, 16)
+        layer.build()
+        layer.enable_lora(4)
+        layer.quantize("int8")
+        _ = layer(x)
+
+        # Try building with quantized dtype policy
+        layer = layers.Embedding(10, 16, dtype="int8_from_mixed_bfloat16")
+        layer.build()
+        self.assertEqual(
+            backend.standardize_dtype(layer._embeddings.dtype), "int8"
+        )
+        self.assertEqual(
+            backend.standardize_dtype(layer.embeddings_scale.dtype), "float32"
+        )
+
+    @pytest.mark.requires_trainable_backend
+    def test_quantize_dtype_argument(self):
+        self.run_layer_test(
+            layers.Embedding,
+            {
+                "input_dim": 4,
+                "output_dim": 3,
+                "dtype": "int8_from_mixed_bfloat16",
+            },
+            input_shape=(2,),
+            input_dtype="int32",
+            expected_output_shape=(2, 3),
+            expected_num_trainable_weights=0,
+            expected_num_non_trainable_weights=2,
+            expected_num_seed_generators=0,
+            expected_num_losses=0,
+            supports_masking=False,
+        )
+
+    def test_quantize_on_unbuilt_layer(self):
+        layer = layers.Embedding(10, 16)
+        with self.assertRaisesRegex(
+            ValueError, "Cannot quantize a layer that isn't yet built."
+        ):
+            layer.quantize("int8")
+
+    def test_quantize_when_already_quantized(self):
+        layer = layers.Embedding(10, 16)
+        layer.build()
+        layer.quantize("int8")
+        with self.assertRaisesRegex(
+            ValueError, "`quantize` can only be done once per layer."
+        ):
+            layer.quantize("int8")
+
+    @pytest.mark.requires_trainable_backend
+    def test_quantize_when_lora_enabled(self):
+        config = dict(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes=None,
+        )
+        layer = layers.EinsumDense(**config)
+        layer.build((None, 3))
+        layer.enable_lora(2)
+        layer.quantize("int8")
+        self.assertLen(layer.trainable_weights, 2)
+        self.assertLen(layer.non_trainable_weights, 2)
+
+        # Try calling fit()
+        init_lora_a_kernel_value = layer.lora_kernel_a.numpy()
+        init_lora_b_kernel_value = layer.lora_kernel_b.numpy()
+        x = np.random.random((64, 3))
+        y = np.random.random((64, 8, 32))
+        model = models.Sequential([layer])
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(x, y, epochs=2)
+
+        final_lora_a_kernel_value = layer.lora_kernel_a.numpy()
+        final_lora_b_kernel_value = layer.lora_kernel_b.numpy()
+        diff_a = np.max(
+            np.abs(init_lora_a_kernel_value - final_lora_a_kernel_value)
+        )
+        diff_b = np.max(
+            np.abs(init_lora_b_kernel_value - final_lora_b_kernel_value)
+        )
+        self.assertGreater(diff_a, 0.0)
+        self.assertGreater(diff_b, 0.0)
+
+        # Try saving and reloading the model
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "quantized_lora_model.keras"
+        )
+        model.save(temp_filepath)
+        new_model = saving.load_model(temp_filepath)
+        self.assertTrue(new_model.layers[0].lora_enabled)
+        self.assertAllClose(model.predict(x), new_model.predict(x), atol=0.5)
+
+        # Try saving and reloading the model's weights only
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "quantized_lora_model.weights.h5"
+        )
+        model.save_weights(temp_filepath)
+        new_model = models.Sequential([layers.EinsumDense(**config)])
+        new_model.build((None, 3))
+        new_model.quantize("int8")
+        new_model.load_weights(temp_filepath)
+        self.assertFalse(new_model.layers[0].lora_enabled)
+        self.assertAllClose(model.predict(x), new_model.predict(x), atol=0.5)
+
+        # Try loading a normal checkpoint into a lora model
+        new_model.save_weights(temp_filepath)
+        model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x), atol=0.5)
+
+        # Test export and TFSMLayer reloading when using tensorflow backend
+        if backend.backend() == "tensorflow":
+            import tensorflow as tf
+
+            temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
+            ref_input = tf.random.normal((32, 3))
+            ref_output = model(ref_input)
+            export_lib.export_model(model, temp_filepath)
+            reloaded_layer = export_lib.TFSMLayer(temp_filepath)
+            self.assertAllClose(
+                reloaded_layer(ref_input), ref_output, atol=1e-7
+            )
+            self.assertLen(reloaded_layer.weights, len(model.weights))
+            self.assertLen(
+                reloaded_layer.trainable_weights, len(model.trainable_weights)
+            )
+            self.assertLen(
+                reloaded_layer.non_trainable_weights,
+                len(model.non_trainable_weights),
+            )

--- a/keras/layers/core/embedding_test.py
+++ b/keras/layers/core/embedding_test.py
@@ -291,6 +291,14 @@ class EmbeddingTest(test_case.TestCase):
         ):
             layer.quantize("int8")
 
+    def test_quantize_on_subclass(self):
+        class MyEmbedding(layers.Embedding):
+            pass
+
+        layer = MyEmbedding(10, 16)
+        with self.assertRaises(NotImplementedError):
+            layer.quantize("int8")
+
     def test_quantize_when_already_quantized(self):
         layer = layers.Embedding(10, 16)
         layer.build()


### PR DESCRIPTION
This PR includes:
1. Add `quantize` to Embedding layer
2. Prevent quantization of subclasses for Dense, EinsumDense and Embedding
3. Improve `quantized_call` for training speed in EinsumDense

|model|quantized|`compute_dtype`|training speed (before/this pr)|peak memory usage (before/this pr)|
|-|-|-|-|-|
|GPT2|int8|float32|112ms / 106ms|3.994GB / 4.066GB|
|GPT2|int8|bfloat16|88ms / 82ms|2.745GB / 2.728GB|

