### PR TITLE
Add sparse support to `ops.sum` and "sparse" option to `one_hot`, `mu…

### DIFF
--- a/keras/backend/common/variables_test.py
+++ b/keras/backend/common/variables_test.py
@@ -120,7 +120,6 @@ class VariablePropertiesTest(test_case.TestCase, parameterized.TestCase):
         )
         self.assertEqual(v.dtype, "float32")
         self.assertEqual(backend.standardize_dtype(v.value.dtype), "float32")
-        print("open scope")
         with AutocastScope("float16"):
             self.assertEqual(
                 backend.standardize_dtype(v.value.dtype), "float16"

--- a/keras/backend/numpy/nn.py
+++ b/keras/backend/numpy/nn.py
@@ -445,7 +445,9 @@ def conv_transpose(
     )
 
 
-def one_hot(x, num_classes, axis=-1, dtype="float32"):
+def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+    if sparse:
+        raise ValueError("Unsupported value `sparse=True` with numpy backend")
     x = convert_to_tensor(x)
     input_shape = x.shape
 
@@ -473,7 +475,9 @@ def one_hot(x, num_classes, axis=-1, dtype="float32"):
     return categorical
 
 
-def multi_hot(x, num_classes, axis=-1, dtype="float32"):
+def multi_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+    if sparse:
+        raise ValueError("Unsupported value `sparse=True` with numpy backend")
     x = convert_to_tensor(x)
     reduction_axis = 1 if len(x.shape) > 1 else 0
     outputs = np.max(

--- a/keras/backend/numpy/numpy.py
+++ b/keras/backend/numpy/numpy.py
@@ -260,7 +260,9 @@ def average(x, axis=None, weights=None):
     return np.average(x, weights=weights, axis=axis)
 
 
-def bincount(x, weights=None, minlength=0):
+def bincount(x, weights=None, minlength=0, sparse=False):
+    if sparse:
+        raise ValueError("Unsupported value `sparse=True` with numpy backend")
     x = convert_to_tensor(x)
     dtypes_to_resolve = [x.dtype]
     if weights is not None:

--- a/keras/backend/tensorflow/nn.py
+++ b/keras/backend/tensorflow/nn.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 
 import tensorflow as tf
@@ -444,19 +445,44 @@ def conv_transpose(
     )
 
 
-def one_hot(x, num_classes, axis=-1, dtype="float32"):
+def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
     x = convert_to_tensor(x)
+    if dtype is None:
+        dtype = "float32"
+    if sparse:
+        # We don't use `tf.sparse.bincount`, it doesn't handle negative indices
+        # and only support rank 1 and 2 tensors (`one_hot` adds a dimension).
+        if axis < 0:
+            axis = axis + len(x.shape) + 1
+        values_count = math.prod(x.shape)
+        values = tf.reshape(x, (values_count,))
+        # We deal with negative inputs by having zeros in the output although
+        # it's useless. It makes shapes static.
+        values = tf.cast(tf.greater_equal(values, 0), dtype=dtype)
+        indices = [tf.range(dim) for dim in x.shape]
+        indices = tf.meshgrid(*indices, indexing="ij")
+        indices.insert(axis, tf.maximum(x, 0))  # Deal with negative indices
+        indices = [tf.reshape(a, (values_count, 1)) for a in indices]
+        indices = [tf.cast(a, tf.int64) for a in indices]
+        indices = tf.concat(indices, axis=1)
+        shape = list(x.shape)
+        shape.insert(axis, num_classes)
+        return tf.SparseTensor(indices, values, shape)
     return tf.one_hot(x, num_classes, axis=axis, dtype=dtype)
 
 
-def multi_hot(x, num_classes, axis=-1, dtype="float32"):
+def multi_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
     x = convert_to_tensor(x)
     reduction_axis = 1 if len(x.shape) > 1 else 0
-    outputs = tf.reduce_max(
-        one_hot(cast(x, "int32"), num_classes, axis=axis, dtype=dtype),
-        axis=reduction_axis,
+    one_hot_outputs = one_hot(
+        cast(x, "int32"), num_classes, axis=axis, dtype=dtype, sparse=sparse
     )
-    return outputs
+    if sparse:
+        # We don't use `tf.sparse.bincount`, it doesn't handle negative indices.
+        return tf.sparse.reduce_max(
+            one_hot_outputs, axis=reduction_axis, output_is_sparse=True
+        )
+    return tf.reduce_max(one_hot_outputs, axis=reduction_axis)
 
 
 def _get_logits(output, from_logits, op_type, fn_name):

--- a/keras/backend/torch/nn.py
+++ b/keras/backend/torch/nn.py
@@ -552,7 +552,9 @@ def conv_transpose(
     return outputs
 
 
-def one_hot(x, num_classes, axis=-1, dtype="float32"):
+def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+    if sparse:
+        raise ValueError("Unsupported value `sparse=True` with torch backend")
     # Axis is the output axis. By default, PyTorch, outputs to last axis.
     # If axis is not last, change output to axis and shift remaining elements.
     x = convert_to_tensor(x, dtype=torch.long)
@@ -575,7 +577,9 @@ def one_hot(x, num_classes, axis=-1, dtype="float32"):
     return output
 
 
-def multi_hot(x, num_classes, axis=-1, dtype="float32"):
+def multi_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+    if sparse:
+        raise ValueError("Unsupported value `sparse=True` with torch backend")
     x = convert_to_tensor(x)
     reduction_axis = 1 if len(x.shape) > 1 else 0
     outputs = torch.amax(

--- a/keras/backend/torch/numpy.py
+++ b/keras/backend/torch/numpy.py
@@ -375,7 +375,9 @@ def average(x, axis=None, weights=None):
     return torch.mean(x, axis)
 
 
-def bincount(x, weights=None, minlength=0):
+def bincount(x, weights=None, minlength=0, sparse=False):
+    if sparse:
+        raise ValueError("Unsupported value `sparse=True` with torch backend")
     x = convert_to_tensor(x)
     dtypes_to_resolve = [x.dtype]
     if weights is not None:

--- a/keras/layers/merging/merging_test.py
+++ b/keras/layers/merging/merging_test.py
@@ -273,14 +273,12 @@ class MergingLayersTest(testing.TestCase, parameterized.TestCase):
 
             x1 = tf.SparseTensor([[0, 0], [1, 2]], [1.0, 2.0], (2, 3))
             x3 = tf.SparseTensor([[0, 0], [1, 1]], [4.0, 5.0], (2, 3))
-            sparse_class = tf.SparseTensor
         elif backend.backend() == "jax":
             import jax.experimental.sparse as jax_sparse
 
             # Use n_batch of 1 to be compatible with all ops.
             x1 = jax_sparse.BCOO(([[1.0, 2.0]], [[[0], [2]]]), shape=(2, 3))
             x3 = jax_sparse.BCOO(([[4.0, 5.0]], [[[0], [1]]]), shape=(2, 3))
-            sparse_class = jax_sparse.JAXSparse
         else:
             self.fail(f"Sparse is unsupported with backend {backend.backend()}")
 
@@ -292,5 +290,5 @@ class MergingLayersTest(testing.TestCase, parameterized.TestCase):
         # Merging a sparse tensor with a sparse tensor produces a sparse tensor
         x3_np = backend.convert_to_numpy(x3)
 
-        self.assertIsInstance(layer([x1, x3]), sparse_class)
+        self.assertSparse(layer([x1, x3]))
         self.assertAllClose(layer([x1, x3]), np_op(x1_np, x3_np, **init_kwargs))

--- a/keras/ops/core_test.py
+++ b/keras/ops/core_test.py
@@ -392,23 +392,21 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             import tensorflow as tf
 
             x = tf.SparseTensor([[0, 0], [1, 2]], [1.0, 2.0], (2, 3))
-            sparse_class = tf.SparseTensor
         elif backend.backend() == "jax":
             import jax.experimental.sparse as jax_sparse
 
             x = jax_sparse.BCOO(([1.0, 2.0], [[0, 0], [1, 2]]), shape=(2, 3))
-            sparse_class = jax_sparse.JAXSparse
         else:
             self.fail(f"Sparse is unsupported with backend {backend.backend()}")
 
         x_default = ops.convert_to_tensor(x)
-        self.assertIsInstance(x_default, sparse_class)
+        self.assertSparse(x_default)
         self.assertAllClose(x, x_default)
         x_sparse = ops.convert_to_tensor(x, sparse=True)
-        self.assertIsInstance(x_sparse, sparse_class)
+        self.assertSparse(x_sparse)
         self.assertAllClose(x, x_sparse)
         x_dense = ops.convert_to_tensor(x, sparse=False)
-        self.assertNotIsInstance(x_dense, sparse_class)
+        self.assertSparse(x_dense, False)
         self.assertAllClose(x, x_dense)
 
         x_numpy = ops.convert_to_numpy(x)

--- a/keras/ops/nn.py
+++ b/keras/ops/nn.py
@@ -1255,15 +1255,20 @@ def conv_transpose(
 
 
 class OneHot(Operation):
-    def __init__(self, num_classes, axis=-1, dtype=None):
+    def __init__(self, num_classes, axis=-1, dtype=None, sparse=False):
         super().__init__()
         self.num_classes = num_classes
         self.axis = axis
         self.dtype = dtype or backend.floatx()
+        self.sparse = sparse
 
     def call(self, x):
         return backend.nn.one_hot(
-            x, self.num_classes, axis=self.axis, dtype=self.dtype
+            x,
+            self.num_classes,
+            axis=self.axis,
+            dtype=self.dtype,
+            sparse=self.sparse,
         )
 
     def compute_output_spec(self, x):
@@ -1277,11 +1282,11 @@ class OneHot(Operation):
                 f"axis must be -1 or between [0, {len(x.shape)}), but "
                 f"received {self.axis}."
             )
-        return KerasTensor(x_shape, dtype=self.dtype)
+        return KerasTensor(x_shape, dtype=self.dtype, sparse=self.sparse)
 
 
 @keras_export(["keras.ops.one_hot", "keras.ops.nn.one_hot"])
-def one_hot(x, num_classes, axis=-1, dtype=None):
+def one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     """Converts integer tensor `x` into a one-hot tensor.
 
     The one-hot encoding is a representation where each integer value is
@@ -1297,6 +1302,8 @@ def one_hot(x, num_classes, axis=-1, dtype=None):
             `-1`, which represents the last axis.
         dtype: (Optional) Data type of the output tensor. If not
             provided, it defaults to the default data type of the backend.
+        sparse: Whether to return a sparse tensor; for backends that support
+            sparse tensors.
 
     Returns:
         Integer tensor: One-hot encoded tensor with the same shape as `x`
@@ -1314,9 +1321,15 @@ def one_hot(x, num_classes, axis=-1, dtype=None):
            [1. 0. 0. 0.]], shape=(4, 4), dtype=float32)
     """
     if any_symbolic_tensors((x,)):
-        return OneHot(num_classes, axis=axis, dtype=dtype).symbolic_call(x)
+        return OneHot(
+            num_classes, axis=axis, dtype=dtype, sparse=sparse
+        ).symbolic_call(x)
     return backend.nn.one_hot(
-        x, num_classes, axis=axis, dtype=dtype or backend.floatx()
+        x,
+        num_classes,
+        axis=axis,
+        dtype=dtype or backend.floatx(),
+        sparse=sparse,
     )
 
 
@@ -1558,16 +1571,17 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
 
 class MultiHot(Operation):
     def __init__(
-        self, num_classes=None, axis=-1, dtype=None, name=None, **kwargs
+        self, num_classes=None, axis=-1, dtype=None, sparse=False, **kwargs
     ):
         if num_classes is None and "num_tokens" in kwargs:
             num_classes = kwargs.pop("num_tokens")
         if num_classes is None:
             raise ValueError("Argument `num_classes` must be specified.")
-        super().__init__(name, **kwargs)
+        super().__init__(**kwargs)
         self.num_classes = num_classes
         self.axis = axis
         self.dtype = dtype or backend.floatx()
+        self.sparse = sparse
 
     def call(self, inputs):
         return backend.nn.multi_hot(
@@ -1594,7 +1608,7 @@ class MultiHot(Operation):
         else:
             x_shape = [x_shape[0]] + x_shape[2:]
 
-        return KerasTensor(x_shape, dtype=inputs.dtype)
+        return KerasTensor(x_shape, dtype=inputs.dtype, sparse=self.sparse)
 
 
 @keras_export(
@@ -1603,7 +1617,9 @@ class MultiHot(Operation):
         "keras.ops.nn.multi_hot",
     ]
 )
-def multi_hot(inputs, num_classes=None, axis=-1, dtype=None, **kwargs):
+def multi_hot(
+    inputs, num_classes=None, axis=-1, dtype=None, sparse=False, **kwargs
+):
     """Encodes integer labels as multi-hot vectors.
 
     This function encodes integer labels as multi-hot vectors, where each label
@@ -1616,6 +1632,8 @@ def multi_hot(inputs, num_classes=None, axis=-1, dtype=None, **kwargs):
             added. Defaults to `-1`, which corresponds to the last dimension.
         dtype: (optional) The data type of the resulting tensor. Default
             is backend's float type.
+        sparse: Whether to return a sparse tensor; for backends that support
+            sparse tensors.
 
     Returns:
         Tensor: The multi-hot encoded tensor.
@@ -1633,14 +1651,14 @@ def multi_hot(inputs, num_classes=None, axis=-1, dtype=None, **kwargs):
         raise ValueError("Argument `num_classes` must be specified.")
 
     if any_symbolic_tensors((inputs,)):
-        return MultiHot(num_classes, axis, dtype).symbolic_call(inputs)
+        return MultiHot(num_classes, axis, dtype, sparse).symbolic_call(inputs)
 
-    return backend.nn.multi_hot(inputs, num_classes, axis, dtype)
+    return backend.nn.multi_hot(inputs, num_classes, axis, dtype, sparse)
 
 
 class Moments(Operation):
-    def __init__(self, axes, keepdims=False, synchronized=False, name=None):
-        super().__init__(name)
+    def __init__(self, axes, keepdims=False, synchronized=False):
+        super().__init__()
         self.axes = axes
         self.keepdims = keepdims
         self.synchronized = synchronized
@@ -1709,8 +1727,8 @@ def moments(x, axes, keepdims=False, synchronized=False):
 
 
 class BatchNorm(Operation):
-    def __init__(self, axis, epsilon, name=None):
-        super().__init__(name)
+    def __init__(self, axis, epsilon):
+        super().__init__()
         self.axis = axis
         self.epsilon = epsilon
 

--- a/keras/ops/nn_test.py
+++ b/keras/ops/nn_test.py
@@ -202,6 +202,7 @@ class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(knn.multi_hot(x, 5).shape, (None, 1, 5))
         self.assertEqual(knn.multi_hot(x, 5, 1).shape, (None, 3, 1))
         self.assertEqual(knn.multi_hot(x, 5, 2).shape, (None, 5, 1))
+        self.assertSparse(knn.multi_hot(x, 5, sparse=True))
 
     @parameterized.product(dtype=["float32", "int32"])
     def test_multi_hot_dtype(self, dtype):
@@ -555,6 +556,7 @@ class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(knn.one_hot(x, 5).shape, (None, 3, 1, 5))
         self.assertEqual(knn.one_hot(x, 5, 1).shape, (None, 5, 3, 1))
         self.assertEqual(knn.one_hot(x, 5, 2).shape, (None, 3, 5, 1))
+        self.assertSparse(knn.one_hot(x, 5, sparse=True))
 
     @parameterized.product(dtype=["float32", "int32"])
     def test_one_hot_dtype(self, dtype):
@@ -1012,6 +1014,7 @@ class NNOpsStaticShapeTest(testing.TestCase):
         self.assertEqual(knn.one_hot(x, 5).shape, (2, 3, 1, 5))
         self.assertEqual(knn.one_hot(x, 5, 1).shape, (2, 5, 3, 1))
         self.assertEqual(knn.one_hot(x, 5, 2).shape, (2, 3, 5, 1))
+        self.assertSparse(knn.one_hot(x, 5, sparse=True))
 
     def test_binary_crossentropy(self):
         x1 = KerasTensor([2, 3, 1])
@@ -1552,54 +1555,63 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         )
         self.assertAllClose(outputs, expected)
 
-    def test_one_hot(self):
+    @parameterized.named_parameters(
+        [
+            {"testcase_name": "dense", "sparse": False},
+            {"testcase_name": "sparse", "sparse": True},
+        ]
+    )
+    def test_one_hot(self, sparse):
+        if sparse and not backend.SUPPORTS_SPARSE_TENSORS:
+            pytest.skip("Backend does not support sparse tensors")
         # Test 1D one-hot.
         indices_1d = np.array([0, 1, 2, 3])
-        self.assertAllClose(knn.one_hot(indices_1d, 4), np.eye(4)[indices_1d])
-        self.assertAllClose(
-            knn.one_hot(indices_1d, 4, axis=0),
-            np.eye(4)[indices_1d],
-        )
+        output_1d = knn.one_hot(indices_1d, 4, sparse=sparse)
+        self.assertAllClose(output_1d, np.eye(4)[indices_1d])
+        self.assertSparse(output_1d, sparse)
+        output_1d = knn.one_hot(indices_1d, 4, axis=0, sparse=sparse)
+        self.assertAllClose(output_1d, np.eye(4)[indices_1d])
+        self.assertSparse(output_1d, sparse)
 
         # Test 1D list one-hot.
         indices_1d = [0, 1, 2, 3]
-        self.assertAllClose(knn.one_hot(indices_1d, 4), np.eye(4)[indices_1d])
-        self.assertAllClose(
-            knn.one_hot(indices_1d, 4, axis=0),
-            np.eye(4)[indices_1d],
-        )
+        output_1d = knn.one_hot(indices_1d, 4, sparse=sparse)
+        self.assertAllClose(output_1d, np.eye(4)[indices_1d])
+        self.assertSparse(output_1d, sparse)
+        output_1d = knn.one_hot(indices_1d, 4, axis=0, sparse=sparse)
+        self.assertAllClose(output_1d, np.eye(4)[indices_1d])
+        self.assertSparse(output_1d, sparse)
 
         # Test 2D one-hot.
         indices_2d = np.array([[0, 1], [2, 3]])
-        self.assertAllClose(knn.one_hot(indices_2d, 4), np.eye(4)[indices_2d])
+        output_2d = knn.one_hot(indices_2d, 4, sparse=sparse)
+        self.assertAllClose(output_2d, np.eye(4)[indices_2d])
+        self.assertSparse(output_2d, sparse)
+        output_2d = knn.one_hot(indices_2d, 4, axis=2, sparse=sparse)
+        self.assertAllClose(output_2d, np.eye(4)[indices_2d])
+        self.assertSparse(output_2d, sparse)
+        output_2d = knn.one_hot(indices_2d, 4, axis=1, sparse=sparse)
         self.assertAllClose(
-            knn.one_hot(indices_2d, 4, axis=2),
-            np.eye(4)[indices_2d],
+            output_2d, np.transpose(np.eye(4)[indices_2d], (0, 2, 1))
         )
-        self.assertAllClose(
-            knn.one_hot(indices_2d, 4, axis=1),
-            np.transpose(np.eye(4)[indices_2d], (0, 2, 1)),
-        )
+        self.assertSparse(output_2d, sparse)
 
         # Test 1D one-hot with negative inputs
         indices_1d = np.array([0, -1, -1, 3])
+        output_1d = knn.one_hot(indices_1d, 4, sparse=sparse)
         self.assertAllClose(
-            knn.one_hot(indices_1d, 4),
+            output_1d,
             np.array(
                 [
                     [1, 0, 0, 0],
                     [0, 0, 0, 0],
                     [0, 0, 0, 0],
-                    [
-                        0,
-                        0,
-                        0,
-                        1,
-                    ],
+                    [0, 0, 0, 1],
                 ],
                 dtype=np.float32,
             ),
         )
+        self.assertSparse(output_1d, sparse)
 
     def test_binary_crossentropy(self):
         # Test with from_logits=False
@@ -1689,21 +1701,36 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         )
         self.assertAllClose(result, [0.001822, 0.000459, 0.169846])
 
-    def test_multi_hot(self):
+    @parameterized.named_parameters(
+        [
+            {"testcase_name": "dense", "sparse": False},
+            {"testcase_name": "sparse", "sparse": True},
+        ]
+    )
+    def test_multi_hot(self, sparse):
+        if sparse and not backend.SUPPORTS_SPARSE_TENSORS:
+            pytest.skip("Backend does not support sparse tensors")
+
         # Test 1D multi-hot.
         indices_1d = np.array([0, 1, 2, 3])
         expected_output_1d = np.array([1, 1, 1, 1])
-        self.assertAllClose(knn.multi_hot(indices_1d, 4), expected_output_1d)
+        output_1d = knn.multi_hot(indices_1d, 4, sparse=sparse)
+        self.assertAllClose(output_1d, expected_output_1d)
+        self.assertSparse(output_1d, sparse)
 
         # Test 2D multi-hot.
         indices_2d = np.array([[0, 1], [2, 3]])
         expected_output_2d = np.array([[1, 1, 0, 0], [0, 0, 1, 1]])
-        self.assertAllClose(knn.multi_hot(indices_2d, 4), expected_output_2d)
+        output_2d = knn.multi_hot(indices_2d, 4, sparse=sparse)
+        self.assertAllClose(output_2d, expected_output_2d)
+        self.assertSparse(output_2d, sparse)
 
         # Test 1D multi-hot with negative inputs
         indices_1d = np.array([0, -1, -1, 3])
         expected_output_1d = np.array([1, 0, 0, 1])
-        self.assertAllClose(knn.multi_hot(indices_1d, 4), expected_output_1d)
+        output_1d = knn.multi_hot(indices_1d, 4, sparse=sparse)
+        self.assertAllClose(output_1d, expected_output_1d)
+        self.assertSparse(output_1d, sparse)
 
     def test_moments(self):
         # Test 1D moments


### PR DESCRIPTION
…lti_hot`, `bincount` and `CategoryEncoding`.

`keras.ops.sum` now supports reducing sparse tensors with the TensorFlow and JAX backends.

The following now have a `sparse` argument to return a sparse tensor instead of a dense tensor with the TensorFlow and JAX backends:
- `keras.ops.nn.one_hot`
- `keras.ops.nn.multi_hot`
- `keras.ops.bincount`
- `keras.layers.CategoryEncoding`

Note that this argument does not exist in the Numpy API.

Fixes https://github.com/keras-team/keras/issues/19285

Also:
- added `assertSparse` in `TestCase` to make testing backend independent.
- use `backend.cast` instead of `tf.cast` with Tensorflow whenever the tensor might be sparse (otherwise the static shape is lost).