### PR TITLE
fix compute_output_shape in CategoryEncoding layer

### DIFF
--- a/keras/layers/preprocessing/category_encoding.py
+++ b/keras/layers/preprocessing/category_encoding.py
@@ -160,8 +160,19 @@ class CategoryEncoding(TFDataLayer):
             return self._count(inputs, count_weights=count_weights)
 
     def compute_output_shape(self, input_shape):
+        # Treat rank-0 inputs inconsistent with actual output .
+        if (input_shape is not None) & (len(input_shape) == 0):
+            # If output_mode == "multi_hot" return same shape .
+            if self.output_mode == "multi_hot":
+                return input_shape
+            # If output_mode == "one_hot" append num_tokens to shape .
+            # This is inline with actual output .
+            elif self.output_mode == "one_hot":
+                return (self.num_tokens,)
         if self.output_mode == "one_hot":
             if input_shape[-1] != 1:
+                return tuple(input_shape + (self.num_tokens,))
+            elif len(input_shape) == 1:
                 return tuple(input_shape + (self.num_tokens,))
             else:
                 return tuple(input_shape[:-1] + (self.num_tokens,))

--- a/keras/layers/preprocessing/category_encoding_test.py
+++ b/keras/layers/preprocessing/category_encoding_test.py
@@ -145,6 +145,16 @@ class CategoryEncodingTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual("float32", output.dtype)
         self.assertSparse(output, sparse)
 
+        # Test compute_output_shape
+        input_data = np.array((4))
+        layer = layers.CategoryEncoding(
+            num_tokens=num_tokens, output_mode="multi_hot", sparse=sparse
+        )
+        self.assertEqual(
+            layer(input_data).shape,
+            layer.compute_output_shape(input_data.shape),
+        )
+
     @parameterized.named_parameters(TEST_CASES)
     def test_one_hot(self, sparse):
         input_data = np.array([3, 2, 0, 1])
@@ -175,6 +185,24 @@ class CategoryEncodingTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(expected_output_shape, output.shape)
         self.assertEqual("float32", output.dtype)
         self.assertSparse(output, sparse)
+
+        # Test compute_output_shape
+        layer = layers.CategoryEncoding(
+            num_tokens=num_tokens, output_mode="one_hot", sparse=sparse
+        )
+        self.assertEqual(
+            layer(input_data).shape,
+            layer.compute_output_shape(input_data.shape),
+        )
+
+        input_data = np.array((4,))
+        layer = layers.CategoryEncoding(
+            num_tokens=num_tokens, output_mode="one_hot", sparse=sparse
+        )
+        self.assertEqual(
+            layer(input_data).shape,
+            layer.compute_output_shape(input_data.shape),
+        )
 
     @parameterized.named_parameters(TEST_CASES)
     def test_batched_one_hot(self, sparse):


### PR DESCRIPTION
Currently the `CategoryEncoding` layer outputs shape and its `compute_output_shape` method not rendering same outputs. The behaviour is same across all backends. Fixed three cases where there is difference.

Please note that the behaviour is different wrt Keras2 but same across all three backends with Keras3. Hence the fix is inline with Keras3 outputs and `compute_output_shape` function changed to match the actual output shapes.

The behaviour in Keras3 across all backends with and without fix replicated in the attached  [tf-gist,](https://colab.sandbox.google.com/gist/SuryanarayanaY/bfd84b3f37080f3ab9db8bf611bb4ac8/64392_keras3_tf_tested.ipynb) [torch-gist](https://colab.sandbox.google.com/gist/SuryanarayanaY/88d4237009aa344315cd5a0628dc707e/64392_keras3_torch_tested.ipynb) & [jax-gist](https://colab.sandbox.google.com/gist/SuryanarayanaY/319eacdfb1d36282cb67337dc33ff4e4/64392_keras3_jax_tested.ipynb#scrollTo=YFxh5gr40hTk) .

Might fix TF ticket #[64392](https://github.com/tensorflow/tensorflow/issues/64392).