### PR TITLE
Reintroduce the option for autocasting to individual weights

### DIFF
--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -12,7 +12,13 @@ from keras.utils.naming import auto_name
 
 class KerasVariable:
     def __init__(
-        self, initializer, shape=None, dtype=None, trainable=True, name=None
+        self,
+        initializer,
+        shape=None,
+        dtype=None,
+        trainable=True,
+        autocast=True,
+        name=None,
     ):
         name = name or auto_name(self.__class__.__name__)
         if not isinstance(name, str) or "/" in name:
@@ -34,6 +40,7 @@ class KerasVariable:
         self._regularizer = None
         self._constraint = None
         self._trainable = trainable
+        self._autocast = autocast
         if isinstance(initializer, str):
             from keras import initializers
 
@@ -107,7 +114,7 @@ class KerasVariable:
 
     def _maybe_autocast(self, value):
         autocast_scope = get_autocast_scope()
-        if autocast_scope is not None:
+        if self._autocast and autocast_scope is not None:
             return autocast_scope.maybe_cast(value)
         return value
 
@@ -157,7 +164,11 @@ class KerasVariable:
     @property
     def dtype(self):
         autocast_scope = get_autocast_scope()
-        if autocast_scope is not None and is_float_dtype(self._dtype):
+        if (
+            self._autocast
+            and autocast_scope is not None
+            and is_float_dtype(self._dtype)
+        ):
             return autocast_scope.dtype
         return self._dtype
 

--- a/keras/backend/common/variables_test.py
+++ b/keras/backend/common/variables_test.py
@@ -139,6 +139,22 @@ class VariablePropertiesTest(test_case.TestCase, parameterized.TestCase):
         with AutocastScope("float16"):
             self.assertEqual(backend.standardize_dtype(v.value.dtype), "int32")
 
+        # Test autocast argument
+        v = backend.Variable(
+            initializer=initializers.RandomNormal(),
+            shape=(2, 2),
+            dtype="float32",
+            autocast=False,
+        )
+        self.assertEqual(v.dtype, "float32")
+        self.assertEqual(backend.standardize_dtype(v.value.dtype), "float32")
+        with AutocastScope("float16"):
+            self.assertEqual(
+                backend.standardize_dtype(v.value.dtype),
+                "float32",  # ignore AutocastScope
+            )
+        self.assertEqual(backend.standardize_dtype(v.value.dtype), "float32")
+
     @parameterized.parameters(
         *((dtype for dtype in ALLOWED_DTYPES if dtype != "string"))
     )

--- a/keras/layers/layer.py
+++ b/keras/layers/layer.py
@@ -424,6 +424,7 @@ class Layer(BackendLayer, Operation):
         initializer,
         dtype=None,
         trainable=True,
+        autocast=True,
         regularizer=None,
         constraint=None,
         name=None,
@@ -437,6 +438,7 @@ class Layer(BackendLayer, Operation):
             initializer=initializer,
             dtype=dtype,
             trainable=trainable,
+            autocast=autocast,
             regularizer=regularizer,
             constraint=constraint,
             name=name,
@@ -448,6 +450,7 @@ class Layer(BackendLayer, Operation):
         initializer=None,
         dtype=None,
         trainable=True,
+        autocast=True,
         regularizer=None,
         constraint=None,
         name=None,
@@ -455,29 +458,28 @@ class Layer(BackendLayer, Operation):
         """Add a weight variable to the layer.
 
         Args:
-            shape: Shape tuple for the variable.
-                Must be fully-defined (no `None` entries).
-                Defaults to `()` (scalar) if unspecified.
-            initializer: Initializer object to use to
-                populate the initial variable value,
-                or string name of a built-in initializer
-                (e.g. `"random_normal"`). If unspecified,
-                defaults to `"glorot_uniform"`
-                for floating-point variables and to `"zeros"`
+            shape: Shape tuple for the variable. Must be fully-defined
+                (no `None` entries). Defaults to `()` (scalar) if unspecified.
+            initializer: Initializer object to use to populate the initial
+                variable value, or string name of a built-in initializer
+                (e.g. `"random_normal"`). If unspecified, defaults to
+                `"glorot_uniform"` for floating-point variables and to `"zeros"`
                 for all other types (e.g. int, bool).
-            dtype: Dtype of the variable to create,
-                e.g. `"float32"`. If unspecified,
-                defaults to the layer's
-                variable dtype (which itself defaults to
-                `"float32"` if unspecified).
-            trainable: Boolean, whether the variable should
-                be trainable via backprop or whether its
-                updates are managed manually.
-            constraint: Contrainst object to call on the
-                variable after any optimizer update,
-                or string name of a built-in constraint.
-            name: String name of the variable. Useful
-                for debugging purposes.
+            dtype: Dtype of the variable to create, e.g. `"float32"`. If
+                unspecified, defaults to the layer's variable dtype
+                (which itself defaults to `"float32"` if unspecified).
+            trainable: Boolean, whether the variable should be trainable via
+                backprop or whether its updates are managed manually. Defaults
+                to `True`.
+            autocast: Boolean, whether to autocast the variable when accessing
+                it. Defaults to `True`.
+            regularizer: Regularizer object to call to apply penalty on the
+                weight. These penalties are summed into the loss function
+                during optimization. Defaults to `None`.
+            constraint: Contrainst object to call on the variable after any
+                optimizer update, or string name of a built-in constraint.
+                Defaults to `None`.
+            name: String name of the variable. Useful for debugging purposes.
         """
         self._check_super_called()
         if shape is None:
@@ -498,6 +500,7 @@ class Layer(BackendLayer, Operation):
                 shape=shape,
                 dtype=dtype,
                 trainable=trainable,
+                autocast=autocast,
                 name=name,
             )
         # Will be added to layer.losses

--- a/keras/layers/normalization/layer_normalization.py
+++ b/keras/layers/normalization/layer_normalization.py
@@ -158,6 +158,7 @@ class LayerNormalization(Layer):
                 regularizer=self.gamma_regularizer,
                 constraint=self.gamma_constraint,
                 trainable=True,
+                autocast=False,
             )
         else:
             self.gamma = None
@@ -170,6 +171,7 @@ class LayerNormalization(Layer):
                 regularizer=self.beta_regularizer,
                 constraint=self.beta_constraint,
                 trainable=True,
+                autocast=False,
             )
         else:
             self.beta = None


### PR DESCRIPTION
Individual autocasting to the wieghts is possible to configure in Keras2 using the option called `experimental_autocast`
https://github.com/keras-team/tf-keras/blob/master/tf_keras/engine/base_layer.py#L608

In fact, this missing feature could lead to inconsistent behavior for `BatcnNormalization` and `LayerNormalization` between Keras2 and Keras3.

This PR is also related to the upcoming fp8 training.
(`amax_history` and `scale` are set and utilized in `float32` if I'm not mistaken)

cc @kaixih