### PR TITLE
Fix dropout for recurrent dropout

### DIFF
--- a/keras/layers/rnn/dropout_rnn_cell.py
+++ b/keras/layers/rnn/dropout_rnn_cell.py
@@ -35,7 +35,7 @@ class DropoutRNNCell:
         if self._recurrent_dropout_mask is None and self.recurrent_dropout > 0:
             ones = ops.ones_like(step_input)
             self._recurrent_dropout_mask = backend.random.dropout(
-                ones, rate=self.dropout, seed=self.seed_generator
+                ones, rate=self.recurrent_dropout, seed=self.seed_generator
             )
         return self._recurrent_dropout_mask
 


### PR DESCRIPTION
Fix typo for the the `recurrent dropout` implementation to use `recurrent_dropout` instead of `dropout`.

recurrent_dropout has no effect in the below usage as per existing implementation.

`layer = keras.layers.SimpleRNN(10, recurrent_dropout=0.5)` 

Fixes: https://github.com/keras-team/keras/issues/19395