### PR TITLE
Refactor dtypes and add float8_* dtypes

### DIFF
--- a/keras/backend/common/dtypes.py
+++ b/keras/backend/common/dtypes.py
@@ -17,8 +17,8 @@ INT_TYPES = (
 )
 FLOAT_TYPES = ("bfloat16", "float16", "float32", "float64")
 WEAK_TYPES = ("int", "float")
-# We need to separate float8 from float because there is no implicit conversions
-# from float8 dtypes to other dtypes.
+# We need to separate float8 from float because there are no implicit
+# conversions from float8 dtypes to other dtypes.
 # Ref: https://github.com/google/jax/issues/16705
 FLOAT8_TYPES = ("float8_e4m3fn", "float8_e5m2")
 

--- a/keras/backend/common/dtypes.py
+++ b/keras/backend/common/dtypes.py
@@ -1,17 +1,11 @@
 import functools
 
-from keras import backend
 from keras.api_export import keras_export
-from keras.backend.common.variables import ALLOWED_DTYPES
+from keras.backend import config
 from keras.backend.common.variables import standardize_dtype
 
-"""
-We adapted the type promotion lattice from JAX. Ref:
-https://github.com/google/jax/blob/main/jax/_src/dtypes.py
-"""
-
-BOOL_TYPES = ["bool"]
-INT_TYPES = [
+BOOL_TYPES = ("bool",)
+INT_TYPES = (
     "uint8",
     "uint16",
     "uint32",
@@ -20,9 +14,44 @@ INT_TYPES = [
     "int16",
     "int32",
     "int64",
-]
-FLOAT_TYPES = ["bfloat16", "float16", "float32", "float64"]
-WEAK_TYPES = ["int", "float"]
+)
+FLOAT_TYPES = ("bfloat16", "float16", "float32", "float64")
+WEAK_TYPES = ("int", "float")
+# We need to separate float8 from float because there is no implicit conversions
+# from float8 dtypes to other dtypes.
+# Ref: https://github.com/google/jax/issues/16705
+FLOAT8_TYPES = ("float8_e4m3fn", "float8_e5m2")
+
+# All supported dtypes in Keras
+ALLOWED_DTYPES = (
+    "float16",
+    "float32",
+    "float64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "bfloat16",
+    "bool",
+    "string",
+    "float8_e4m3fn",
+    "float8_e5m2",
+)
+PYTHON_DTYPES_MAP = {
+    bool: "bool",
+    int: "int64" if config.backend() == "tensorflow" else "int32",
+    float: "float32",
+    str: "string",
+    # special case for string value
+    "int": "int64" if config.backend() == "tensorflow" else "int32",
+}
+
+# We adapted the type promotion lattice from JAX. Ref:
+# https://github.com/google/jax/blob/main/jax/_src/dtypes.py
 
 
 def _type_promotion_lattice():
@@ -168,7 +197,7 @@ def _respect_weak_type(dtype, weak_type):
 @functools.lru_cache(maxsize=None)
 def _resolve_weak_type(dtype, precision="32"):
     """Resolve weak type by the precision of `backend.floatx()`."""
-    extended_allowed_dtypes = ALLOWED_DTYPES.union(WEAK_TYPES)
+    extended_allowed_dtypes = set(ALLOWED_DTYPES).union(WEAK_TYPES)
     if dtype not in extended_allowed_dtypes:
         raise ValueError(
             "Invalid value for argument `dtype`. Expected one of "
@@ -234,7 +263,7 @@ def _lattice_result_type(*args):
         out_weak_type = any(out_dtype is t for t in WEAK_TYPES)
 
     out_weak_type = (out_dtype != "bool") and out_weak_type
-    precision = backend.floatx()[-2:]
+    precision = config.floatx()[-2:]
     if out_weak_type:
         out_dtype = _resolve_weak_type(out_dtype, precision=precision)
     return out_dtype
@@ -270,7 +299,13 @@ def result_type(*dtypes):
     if len(dtypes) == 0:
         # If no dtypes provided, default to floatx, this matches
         # `ops.convert_to_tensor([])`
-        return backend.floatx()
+        return config.floatx()
+    for dtype in dtypes:
+        if dtype in FLOAT8_TYPES:
+            raise ValueError(
+                "There is no implicit conversions from float8 dtypes to others."
+                f" You must cast it internally. Received: {dtypes}"
+            )
     return _lattice_result_type(
-        *(backend.floatx() if arg is None else arg for arg in dtypes),
+        *(config.floatx() if arg is None else arg for arg in dtypes),
     )

--- a/keras/backend/common/variables.py
+++ b/keras/backend/common/variables.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from keras.api_export import keras_export
 from keras.backend import config
+from keras.backend.common import dtypes
 from keras.backend.common import global_state
 from keras.backend.common.name_scope import current_path
 from keras.backend.common.stateless_scope import get_stateless_scope
@@ -397,40 +398,13 @@ def initialize_all_variables():
     global_state.set_global_attribute("uninitialized_variables", [])
 
 
-ALLOWED_DTYPES = {
-    "float16",
-    "float32",
-    "float64",
-    "uint8",
-    "uint16",
-    "uint32",
-    "uint64",
-    "int8",
-    "int16",
-    "int32",
-    "int64",
-    "bfloat16",
-    "bool",
-    "string",
-}
-
-PYTHON_DTYPES_MAP = {
-    bool: "bool",
-    int: "int64" if config.backend() == "tensorflow" else "int32",
-    float: "float32",
-    str: "string",
-    # special case for string value
-    "int": "int64" if config.backend() == "tensorflow" else "int32",
-}
-
-
 @keras_export(
     ["keras.utils.standardize_dtype", "keras.backend.standardize_dtype"]
 )
 def standardize_dtype(dtype):
     if dtype is None:
         return config.floatx()
-    dtype = PYTHON_DTYPES_MAP.get(dtype, dtype)
+    dtype = dtypes.PYTHON_DTYPES_MAP.get(dtype, dtype)
     if hasattr(dtype, "name"):
         dtype = dtype.name
     elif hasattr(dtype, "__str__") and (
@@ -440,7 +414,7 @@ def standardize_dtype(dtype):
     elif hasattr(dtype, "__name__"):
         dtype = dtype.__name__
 
-    if dtype not in ALLOWED_DTYPES:
+    if dtype not in dtypes.ALLOWED_DTYPES:
         raise ValueError(f"Invalid dtype: {dtype}")
     return dtype
 

--- a/keras/backend/common/variables_test.py
+++ b/keras/backend/common/variables_test.py
@@ -4,7 +4,7 @@ from absl.testing import parameterized
 
 from keras import backend
 from keras import initializers
-from keras.backend.common.variables import ALLOWED_DTYPES
+from keras.backend.common import dtypes
 from keras.backend.common.variables import AutocastScope
 from keras.backend.common.variables import KerasVariable
 from keras.backend.common.variables import shape_equal
@@ -156,7 +156,7 @@ class VariablePropertiesTest(test_case.TestCase, parameterized.TestCase):
         self.assertEqual(backend.standardize_dtype(v.value.dtype), "float32")
 
     @parameterized.parameters(
-        *((dtype for dtype in ALLOWED_DTYPES if dtype != "string"))
+        *((dtype for dtype in dtypes.ALLOWED_DTYPES if dtype != "string"))
     )
     def test_standardize_dtype(self, dtype):
         """Tests standardize_dtype for all ALLOWED_DTYPES except string."""

--- a/keras/backend/torch/core.py
+++ b/keras/backend/torch/core.py
@@ -42,6 +42,8 @@ TORCH_DTYPES = {
     "int64": torch.int64,
     "bfloat16": torch.bfloat16,
     "bool": torch.bool,
+    "float8_e4m3fn": torch.float8_e4m3fn,
+    "float8_e5m2": torch.float8_e5m2,
 }
 
 

--- a/keras/ops/math_test.py
+++ b/keras/ops/math_test.py
@@ -7,8 +7,8 @@ from absl.testing import parameterized
 
 from keras import backend
 from keras import testing
+from keras.backend.common import dtypes
 from keras.backend.common.keras_tensor import KerasTensor
-from keras.backend.common.variables import ALLOWED_DTYPES
 from keras.ops import math as kmath
 
 
@@ -869,10 +869,10 @@ class MathDtypeTest(testing.TestCase, parameterized.TestCase):
     # resulting in different behavior between JAX and Keras. Currently, we
     # are skipping the test for uint64
     ALL_DTYPES = [
-        x for x in ALLOWED_DTYPES if x not in ["string", "uint64"]
+        x for x in dtypes.ALLOWED_DTYPES if x not in ["string", "uint64"]
     ] + [None]
-    INT_DTYPES = [x for x in ALLOWED_DTYPES if "int" in x and x != "uint64"]
-    FLOAT_DTYPES = [x for x in ALLOWED_DTYPES if "float" in x]
+    INT_DTYPES = [x for x in dtypes.INT_TYPES if x != "uint64"]
+    FLOAT_DTYPES = dtypes.FLOAT_TYPES
 
     if backend.backend() == "torch":
         # TODO: torch doesn't support uint16, uint32 and uint64

--- a/keras/ops/nn_test.py
+++ b/keras/ops/nn_test.py
@@ -9,9 +9,9 @@ from keras import losses
 from keras import models
 from keras import ops
 from keras import testing
+from keras.backend.common import dtypes
 from keras.backend.common import standardize_dtype
 from keras.backend.common.keras_tensor import KerasTensor
-from keras.backend.common.variables import ALLOWED_DTYPES
 from keras.layers.convolutional.conv_test import np_conv1d
 from keras.layers.convolutional.conv_test import np_conv2d
 from keras.layers.convolutional.conv_test import np_conv3d
@@ -1949,7 +1949,7 @@ class TestLogitRecovery(testing.TestCase):
 class NNOpsDtypeTest(testing.TestCase, parameterized.TestCase):
     """Test the dtype to verify that the behavior matches JAX."""
 
-    FLOAT_DTYPES = [x for x in ALLOWED_DTYPES if "float" in x]
+    FLOAT_DTYPES = dtypes.FLOAT_TYPES
 
     def setUp(self):
         from jax.experimental import enable_x64

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -11,9 +11,9 @@ from absl.testing import parameterized
 import keras
 from keras import backend
 from keras import testing
+from keras.backend.common import dtypes
 from keras.backend.common import standardize_dtype
 from keras.backend.common.keras_tensor import KerasTensor
-from keras.backend.common.variables import ALLOWED_DTYPES
 from keras.ops import numpy as knp
 from keras.testing.test_utils import named_product
 
@@ -4612,10 +4612,10 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     # resulting in different behavior between JAX and Keras. Currently, we
     # are skipping the test for uint64
     ALL_DTYPES = [
-        x for x in ALLOWED_DTYPES if x not in ["string", "uint64"]
+        x for x in dtypes.ALLOWED_DTYPES if x not in ["string", "uint64"]
     ] + [None]
-    INT_DTYPES = [x for x in ALLOWED_DTYPES if "int" in x and x != "uint64"]
-    FLOAT_DTYPES = [x for x in ALLOWED_DTYPES if "float" in x]
+    INT_DTYPES = [x for x in dtypes.INT_TYPES if x != "uint64"]
+    FLOAT_DTYPES = dtypes.FLOAT_TYPES
 
     if backend.backend() == "torch":
         # TODO: torch doesn't support uint16, uint32 and uint64
@@ -4625,6 +4625,8 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         INT_DTYPES = [
             x for x in INT_DTYPES if x not in ["uint16", "uint32", "uint64"]
         ]
+    # Remove float8 dtypes for the following tests
+    ALL_DTYPES = [x for x in ALL_DTYPES if x not in dtypes.FLOAT8_TYPES]
 
     def setUp(self):
         from jax.experimental import enable_x64
@@ -6247,7 +6249,7 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
                 [np.array([0, 1], "float32"), np.array([10, 20], "float32")],
             ],
             num=[0, 1, 5],
-            dtype=FLOAT_DTYPES + [None],
+            dtype=FLOAT_DTYPES + (None,),
         )
     )
     def test_linspace(self, start_and_stop, num, dtype):
@@ -6371,7 +6373,7 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
                 [np.array([0, 1], "float32"), np.array([10, 20], "float32")],
             ],
             num=[0, 1, 5],
-            dtype=FLOAT_DTYPES + [None],
+            dtype=FLOAT_DTYPES + (None,),
         )
     )
     def test_logspace(self, start_and_stop, num, dtype):


### PR DESCRIPTION
This PR:
- Centralizes the dtype-related variables into `keras.backend.common.dtypes`
- Uses `tuple` instead of `list` for dtype string initialization to prevent future overwriting.
- Introduces `float8_e4m3fn` and `float8_e5m2` for the upcoming fp8 training
- Adds a simple test for `ops.cast` of `float8_*`

It is worth noting that `dtypes.result_type` will intentionally fail when encountering `float8_*` because there are no implicit conversions from `float8_*` to other dtypes. (following the same rule as in JAX)
