### PR TITLE
Change PReLU operation

### DIFF
--- a/keras/layers/activations/prelu.py
+++ b/keras/layers/activations/prelu.py
@@ -2,10 +2,10 @@ from keras import activations
 from keras import constraints
 from keras import initializers
 from keras import regularizers
+from keras import ops
 from keras.api_export import keras_export
 from keras.layers.input_spec import InputSpec
 from keras.layers.layer import Layer
-from keras.utils.module_utils import tensorflow as tf
 
 
 @keras_export("keras.layers.PReLU")
@@ -76,7 +76,7 @@ class PReLU(Layer):
     def call(self, inputs):
         pos = activations.relu(inputs)
         neg = -self.alpha * activations.relu(-inputs)
-        neg = tf.where(tf.math.is_nan(neg), tf.zeros_like(neg), neg)
+        neg = ops.where(ops.isnan(neg), ops.zeros_like(neg), neg)
         return pos + neg
 
     def get_config(self):

--- a/keras/layers/activations/prelu.py
+++ b/keras/layers/activations/prelu.py
@@ -5,6 +5,7 @@ from keras import regularizers
 from keras.api_export import keras_export
 from keras.layers.input_spec import InputSpec
 from keras.layers.layer import Layer
+from keras.utils.module_utils import tensorflow as tf
 
 
 @keras_export("keras.layers.PReLU")
@@ -75,6 +76,7 @@ class PReLU(Layer):
     def call(self, inputs):
         pos = activations.relu(inputs)
         neg = -self.alpha * activations.relu(-inputs)
+        neg = tf.where(tf.math.is_nan(neg), tf.zeros_like(neg), neg)
         return pos + neg
 
     def get_config(self):

--- a/keras/layers/activations/prelu_test.py
+++ b/keras/layers/activations/prelu_test.py
@@ -37,3 +37,31 @@ class PReLUTest(testing.TestCase):
         prelu_layer.alpha.assign(weights)
         ref_out = np_prelu(inputs, weights)
         self.assertAllClose(prelu_layer(inputs), ref_out)
+
+    def test_prelu_inf_weight_pos(self):
+        input = np.random.rand(1)
+        prelu_layer = prelu.PReLU(
+            alpha_initializer="glorot_uniform",
+            alpha_regularizer="l1",
+            alpha_constraint="non_neg",
+        )
+        prelu_layer.build(input.shape)
+
+        weight = np.inf
+        prelu_layer.alpha.assign(weight)
+        #for a positive input, the output should be the same as the input
+        self.assertAllClose(prelu_layer(input), input)
+
+    def test_prelu_inf_weight_neg(self):
+        input = -np.random.rand(1)
+        prelu_layer = prelu.PReLU(
+            alpha_initializer="glorot_uniform",
+            alpha_regularizer="l1",
+            alpha_constraint="non_neg",
+        )
+        prelu_layer.build(input.shape)
+
+        weight = np.inf
+        prelu_layer.alpha.assign(weight)
+        #for a negative input, the output should be weight * input (which is -inf)
+        self.assertAllClose(prelu_layer(input), -np.inf)


### PR DESCRIPTION
fix [tensorflow#63823](https://github.com/tensorflow/tensorflow/issues/63823)

The added line creates a new tensor equal to "neg" but with all NaN replaced by zeros.
This change is needed so that PReLU doesn't return NaN when using infinite weight just like in this issue mentioned.

Also added 2 new tests to verify the solution.