### PR TITLE
Fix print_fn for custom function

### DIFF
--- a/keras/utils/summary_utils.py
+++ b/keras/utils/summary_utils.py
@@ -360,7 +360,10 @@ def print_summary(
 
     # Output captured summary for non-interactive logging.
     if print_fn:
-        print_fn(console.end_capture(), line_break=False)
+        if print_fn is io_utils.print_msg:
+            print_fn(console.end_capture(), line_break=False)
+        else:
+            print_fn(console.end_capture())
 
 
 def get_layer_index_bound_by_layer_name(layers, layer_range=None):


### PR DESCRIPTION
When the `custom function` is passed as a `print_fn` the existing implementation will error out since `line_break` will not be provided in the custom function and it has no action for custom function.

This fix will check if the `print_fn` is from the below logic then pass the argument `line_break` else call `print_fn` without argument `line_break`

```
    if not print_fn and not io_utils.is_interactive_logging_enabled():
        print_fn = io_utils.print_msg
```
https://github.com/keras-team/keras/blob/6c591d7d34c3ffaa50e805fd75c83d9c2a23414f/keras/utils/summary_utils.py#L137C1-L138C38

Fixes: https://github.com/keras-team/keras/issues/19371