### PR TITLE
Fix model.trainable_variables with Embedding layer when trainable=False

### DIFF
--- a/keras/layers/core/embedding.py
+++ b/keras/layers/core/embedding.py
@@ -103,7 +103,7 @@ class Embedding(Layer):
                 name="embeddings",
                 regularizer=self.embeddings_regularizer,
                 constraint=self.embeddings_constraint,
-                trainable=True,
+                trainable=self.trainable,
             )
         self.built = True
         if self.lora_rank:
@@ -173,9 +173,10 @@ class Embedding(Layer):
             return
         # The keys of the `store` will be saved as determined because the
         # default ordering will change after quantization
-        embeddings_value, embeddings_scale = (
-            self._get_embeddings_with_merged_lora()
-        )
+        (
+            embeddings_value,
+            embeddings_scale,
+        ) = self._get_embeddings_with_merged_lora()
         store["0"] = embeddings_value
         if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
             store["1"] = embeddings_scale
@@ -362,9 +363,10 @@ class Embedding(Layer):
                     embeddings_value,
                     ops.matmul(self.lora_embeddings_a, self.lora_embeddings_b),
                 )
-                embeddings_value, embeddings_scale = (
-                    quantizers.abs_max_quantize(embeddings_value, axis=0)
-                )
+                (
+                    embeddings_value,
+                    embeddings_scale,
+                ) = quantizers.abs_max_quantize(embeddings_value, axis=0)
                 embeddings_scale = ops.squeeze(embeddings_scale, axis=0)
             return embeddings_value, embeddings_scale
         return self.embeddings, None

--- a/keras/layers/core/embedding_test.py
+++ b/keras/layers/core/embedding_test.py
@@ -114,6 +114,14 @@ class EmbeddingTest(test_case.TestCase):
         layer.build((None, 2))
         self.assertIsInstance(layer.embeddings.constraint, constraints.NonNeg)
 
+    # Test model.trainable_variables when trainable=False in Embedding
+    def test_model_trainable_weights(self):
+        input_layer = layers.Input(shape=(1,))
+        layer = layers.Embedding(3, 2, trainable=False)
+        embedded = layer(input_layer)
+        model = models.Model(inputs=input_layer, outputs=embedded)
+        assert len(model.trainable_variables) == 0
+
     @pytest.mark.requires_trainable_backend
     def test_enable_lora(self):
         layer = layers.Embedding(10, 16)


### PR DESCRIPTION
Fix model.trainable_variables with Embedding layer when trainable=False.

Currently when Embedding layer set trainable=False the model still shows the params as trainable_variables.

This creates confusion when we print model.summary().

Proposed a fix along with Testcase.

Might fix #19398 & #19432