### PR TITLE
Fix for `JaxLayer` and `FlaxLayer` building in tracing scope.

### DIFF
--- a/keras/backend/jax/trainer.py
+++ b/keras/backend/jax/trainer.py
@@ -204,7 +204,7 @@ class JAXTrainer(base_trainer.Trainer):
 
     def make_train_function(self, force=False):
         if self.train_function is not None and not force:
-            return self.train_function
+            return
 
         def one_train_step(state, data):
             data = data[0]
@@ -236,7 +236,7 @@ class JAXTrainer(base_trainer.Trainer):
 
     def make_test_function(self, force=False):
         if self.test_function is not None and not force:
-            return self.test_function
+            return
 
         def one_test_step(state, data):
             data = data[0]

--- a/keras/utils/jax_layer_test.py
+++ b/keras/utils/jax_layer_test.py
@@ -327,6 +327,21 @@ class TestJaxLayer(testing.TestCase, parameterized.TestCase):
         output4 = model4.serve(x_test)
         self.assertAllClose(output1, output4)
 
+        # test subclass model building without a build method
+        class TestModel(models.Model):
+
+            def __init__(self, layer):
+                super().__init__()
+                self._layer = layer
+
+            def call(self, inputs):
+                return self._layer(inputs)
+
+        layer5 = layer_class(**layer_init_kwargs)
+        model5 = TestModel(layer5)
+        output5 = model5(x_test)
+        self.assertNotAllClose(output5, 0.0)
+
     @parameterized.named_parameters(
         {
             "testcase_name": "training_independent",


### PR DESCRIPTION
When building a sub-class model or layer that doesn't implement `build`, nested layers are first built in a tracing scope. This fix makes it so that the `JaxLayer` and `FlaxLayer` is built correctly the first time `build` is called in an eager scope.