### PR TITLE
Fix example code in embedding.py

### DIFF
--- a/keras/layers/core/embedding.py
+++ b/keras/layers/core/embedding.py
@@ -20,7 +20,7 @@ class Embedding(Layer):
     Example:
 
     >>> model = keras.Sequential()
-    >>> model.add(keras.layers.Embedding(1000, 64, input_length=10))
+    >>> model.add(keras.layers.Embedding(1000, 64))
     >>> # The model will take as input an integer matrix of size (batch,
     >>> # input_length), and the largest integer (i.e. word index) in the input
     >>> # should be no larger than 999 (vocabulary size).


### PR DESCRIPTION
The python example in `Embedding` layer class uses Keras2 code snippet that has  `input_length` arg. This will raise an below with keras3. 


`Unrecognized 'input_length' keyword arguments passed to Embedding 
`

In keras3 we don't need this arg as it will automatically inferred from the input passed. Alternatively we can pass `input_shape`as kwarg. I proceeded with first approach.

Fixes #19282.