### PR TITLE
Fix a crash with PyTorch backend when using `weighted_metrics` with a GPU.

### DIFF
--- a/keras/metrics/reduction_metrics.py
+++ b/keras/metrics/reduction_metrics.py
@@ -10,7 +10,7 @@ def reduce_to_samplewise_values(values, sample_weight, reduce_fn, dtype):
     mask = getattr(values, "_keras_mask", None)
     values = ops.cast(values, dtype=dtype)
     if sample_weight is not None:
-        sample_weight = ops.cast(sample_weight, dtype=dtype)
+        sample_weight = ops.convert_to_tensor(sample_weight, dtype=dtype)
         if mask is not None:
             sample_weight = losses.loss.apply_mask(
                 sample_weight, mask, dtype=dtype, reduction="sum"


### PR DESCRIPTION
This patch makes sure the `sample_weights` are on the default device. Before, it can happen that `sample_weights` are on CPU while values are on GPU (unless the `sample_weights` were moved to GPU by a dataloader, for example).

Note that the `y_true` are moved to the default device already during metric computation; for example https://github.com/keras-team/keras/blob/d4f23eac3a9469646a070129d723a532fdb07090/keras/metrics/accuracy_metrics.py#L9-L10 or https://github.com/keras-team/keras/blob/d4f23eac3a9469646a070129d723a532fdb07090/keras/metrics/f_score_metrics.py#L159-L160

I understand that a corresponding issue, reproducible example and a suitable test would be the ideal way to proceed, but unfortunately, my current time constraints only allow me to create this pull-request.