### PR TITLE
( Fix issue #19303) Ensure `MultiHeadAttention` returns `attention scores` as a tuple when `return_attention_scores=True

### DIFF
--- a/keras/layers/attention/multi_head_attention.py
+++ b/keras/layers/attention/multi_head_attention.py
@@ -475,8 +475,9 @@ class MultiHeadAttention(Layer):
         attention_output = self._output_dense(attention_output)
 
         if return_attention_scores:
-            return attention_output, attention_scores
-        return attention_output
+            return (attention_output, attention_scores)
+        else:
+            return attention_output
 
     def _compute_attention_mask(
         self,

--- a/keras/layers/attention/multi_head_attention_test.py
+++ b/keras/layers/attention/multi_head_attention_test.py
@@ -417,4 +417,3 @@ class MultiHeadAttentionTest(testing.TestCase, parameterized.TestCase):
 
         self.assertEqual(output.shape, (2, 8, 16))
         self.assertEqual(attention_scores.shape, (2, num_heads, 8, 4))
-

--- a/keras/layers/attention/multi_head_attention_test.py
+++ b/keras/layers/attention/multi_head_attention_test.py
@@ -363,3 +363,58 @@ class MultiHeadAttentionTest(testing.TestCase, parameterized.TestCase):
         new_model.save_weights(temp_filepath)
         model.load_weights(temp_filepath)
         self.assertAllClose(model.predict(x), new_model.predict(x))
+
+    def test_return_attention_scores_true(self):
+        """Test that the layer returns attention scores along with outputs."""
+        num_heads = 2
+        key_dim = 2
+
+        # Generate dummy input data
+        query = np.random.random((2, 8, 16)).astype(np.float32)
+        value = np.random.random((2, 4, 16)).astype(np.float32)
+
+        # Initialize the MultiHeadAttention layer
+        layer = layers.MultiHeadAttention(num_heads=num_heads, key_dim=key_dim)
+
+        # Call the layer with return_attention_scores=True
+        output, attention_scores = layer(
+            query, value, return_attention_scores=True
+        )
+
+        # Check the shape of the outputs
+        self.assertEqual(output.shape, (2, 8, 16))
+        self.assertEqual(attention_scores.shape, (2, num_heads, 8, 4))
+
+    def test_return_attention_scores_true_and_tuple(self):
+        num_heads = 2
+        key_dim = 2
+
+        query = np.random.random((2, 8, 16)).astype(np.float32)
+        value = np.random.random((2, 4, 16)).astype(np.float32)
+
+        layer = layers.MultiHeadAttention(num_heads=num_heads, key_dim=key_dim)
+
+        outputs = layer(query, value, return_attention_scores=True)
+
+        # Check that outputs is a tuple
+        self.assertIsInstance(
+            outputs, tuple, "Expected the outputs to be a tuple"
+        )
+
+    def test_return_attention_scores_true_tuple_then_unpack(self):
+        num_heads = 2
+        key_dim = 2
+
+        query = np.random.random((2, 8, 16)).astype(np.float32)
+        value = np.random.random((2, 4, 16)).astype(np.float32)
+
+        layer = layers.MultiHeadAttention(num_heads=num_heads, key_dim=key_dim)
+
+        outputs = layer(query, value, return_attention_scores=True)
+
+        # Unpack the outputs
+        output, attention_scores = outputs
+
+        self.assertEqual(output.shape, (2, 8, 16))
+        self.assertEqual(attention_scores.shape, (2, num_heads, 8, 4))
+

--- a/keras/layers/attention/multi_head_attention_test.py
+++ b/keras/layers/attention/multi_head_attention_test.py
@@ -417,3 +417,36 @@ class MultiHeadAttentionTest(testing.TestCase, parameterized.TestCase):
 
         self.assertEqual(output.shape, (2, 8, 16))
         self.assertEqual(attention_scores.shape, (2, num_heads, 8, 4))
+
+    def test_return_attention_scores_true_and_tuple_with_keras_input(self):
+        num_heads = 2
+        key_dim = 2
+
+        # Define the input shapes using keras.Input for symbolic tensors
+        query_input = layers.Input(shape=(3, 5))
+        value_input = layers.Input(shape=(3, 5))
+
+        # Initialize the MultiHeadAttention layer
+        layer = layers.MultiHeadAttention(num_heads=num_heads, key_dim=key_dim)
+
+        # Call the layer on the inputs with return_attention_scores=True
+        unpack = layer(query_input, value_input, return_attention_scores=True)
+
+        attention_output, attention_scores = unpack
+
+        # Create a model to be able to run the computation graph
+        model = models.Model(
+            inputs=[query_input, value_input],
+            outputs=[attention_output, attention_scores],
+        )
+
+        # Generate dummy data to pass through the model
+        query_data = np.random.random((2, 3, 5)).astype(np.float32)
+        value_data = np.random.random((2, 3, 5)).astype(np.float32)
+
+        # Run the model to get the output and scores
+        output, scores = model.predict([query_data, value_data])
+
+        # Check the shapes of the outputs
+        self.assertEqual(output.shape, (2, 3, 5))
+        self.assertEqual(scores.shape, (2, num_heads, 3, 3))


### PR DESCRIPTION
This PR fixes an issue ( #19303 ) where the `MultiHeadAttention` layer did not return attention scores as a tuple when `return_attention_scores=True` was specified, contrary to the expected behavior. 


Tests have been added to validate the expected behavior.


