### PR TITLE
Fix type annotation for `Model`, `Sequential` and `Functional`

### DIFF
--- a/keras/models/functional.py
+++ b/keras/models/functional.py
@@ -1,5 +1,6 @@
 import copy
 import inspect
+import typing
 import warnings
 
 from keras import backend
@@ -93,6 +94,9 @@ class Functional(Function, Model):
         trainable: Boolean, optional. If the model's variables should be
             trainable.
     """
+
+    def __new__(cls, *args, **kwargs):
+        return typing.cast(Functional, super().__new__(cls))
 
     @tracking.no_automatic_dependency_tracking
     def __init__(self, inputs, outputs, name=None, **kwargs):

--- a/keras/models/model.py
+++ b/keras/models/model.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import typing
 import warnings
 
 from keras import backend
@@ -27,7 +28,7 @@ else:
 
 
 @keras_export(["keras.Model", "keras.models.Model"])
-class Model(Trainer, Layer):
+class Model(Trainer, base_trainer.Trainer, Layer):
     """A model grouping layers into an object with training/inference features.
 
     There are three ways to instantiate a `Model`:
@@ -138,7 +139,7 @@ class Model(Trainer, Layer):
             from keras.models import functional
 
             return functional.Functional(*args, **kwargs)
-        return super().__new__(cls)
+        return typing.cast(Model, super().__new__(cls))
 
     def __init__(self, *args, **kwargs):
         Trainer.__init__(self)
@@ -599,11 +600,3 @@ def inject_functional_model_class(cls):
     cls.__new__(cls)
 
     return cls
-
-
-Model.fit.__doc__ = base_trainer.Trainer.fit.__doc__
-Model.predict.__doc__ = base_trainer.Trainer.predict.__doc__
-Model.evaluate.__doc__ = base_trainer.Trainer.evaluate.__doc__
-Model.train_on_batch.__doc__ = base_trainer.Trainer.train_on_batch.__doc__
-Model.test_on_batch.__doc__ = base_trainer.Trainer.test_on_batch.__doc__
-Model.predict_on_batch.__doc__ = base_trainer.Trainer.predict_on_batch.__doc__

--- a/keras/models/sequential.py
+++ b/keras/models/sequential.py
@@ -1,5 +1,6 @@
 import copy
 import inspect
+import typing
 
 from keras.api_export import keras_export
 from keras.backend.common import global_state
@@ -59,6 +60,9 @@ class Sequential(Model):
     model.fit(x, y, batch_size=32, epochs=10)
     ```
     """
+
+    def __new__(cls, *args, **kwargs):
+        return typing.cast(Sequential, super().__new__(cls))
 
     def __init__(self, layers=None, trainable=True, name=None):
         super().__init__(trainable=trainable, name=name)


### PR DESCRIPTION
Fixes #19152 (credit to @marcelo-souzaf)
Related to #19453 

This PR addresses incorrect type annotations for `Model`, `Sequential` and `Functional`
The root cause is the overridden `__new__`

I'm using VSCode to demonstrate:

|Class|Before|After|
|-|-|-|
|`Model`| ![3](https://github.com/keras-team/keras/assets/20734616/c52628ea-62cc-493a-a270-3c974f4825bd) | ![6](https://github.com/keras-team/keras/assets/20734616/df1f0a74-5996-4362-8609-43d4da551103) |
|`Sequential`| ![1](https://github.com/keras-team/keras/assets/20734616/844bf74c-da49-4f95-b8f8-ba241e00299c) | ![4](https://github.com/keras-team/keras/assets/20734616/57489cd2-c7c6-4c6a-a477-e96712f5518e) |
|`Functional`| ![2](https://github.com/keras-team/keras/assets/20734616/b62ed5ca-13a0-42e3-88dd-6a840f25004d) | ![5](https://github.com/keras-team/keras/assets/20734616/9a476329-9ad9-4dae-8a0d-c1bff0129387) |

`add` from `Sequential`:
![7](https://github.com/keras-team/keras/assets/20734616/ea51c9de-c0c5-440e-8cf6-4fe92ba8ea23)

