### PR TITLE
Bug Fix: Update Documentation for RaggedTensors in Input Layer

### DIFF
--- a/keras/layers/input_spec.py
+++ b/keras/layers/input_spec.py
@@ -56,6 +56,7 @@ class InputSpec:
         axes=None,
         allow_last_axis_squeeze=False,
         name=None,
+        ragged=None,
     ):
         self.dtype = (
             backend.standardize_dtype(dtype) if dtype is not None else None
@@ -87,6 +88,7 @@ class InputSpec:
                     "Axis {} is greater than the maximum "
                     "allowed value: {}".format(max_axis, max_dim)
                 )
+        self.ragged = ragged
 
     def __repr__(self):
         spec = [


### PR DESCRIPTION
Addressing issue #65399 in tensorflow, where the documentation for RaggedTensors in the Input layer was inconsistent, leading to a TypeError. The fix updates the input specification to accurately reflect the use of ragged tensors. This update aims to resolve the documented inconsistency.