### PR TITLE
Workaround for Tensorflow unit test crash on GPU.

### DIFF
--- a/keras/backend/tensorflow/core.py
+++ b/keras/backend/tensorflow/core.py
@@ -9,6 +9,7 @@ from keras.backend.common.keras_tensor import KerasTensor
 from keras.backend.common.name_scope import name_scope as base_name_scope
 from keras.backend.common.stateless_scope import StatelessScope
 from keras.backend.common.stateless_scope import in_stateless_scope
+from keras.backend.tensorflow.sparse import sparse_to_dense
 from keras.utils import tree
 from keras.utils.naming import auto_name
 
@@ -100,9 +101,7 @@ class Variable(
 
 def convert_to_tensor(x, dtype=None, sparse=None):
     if isinstance(x, tf.SparseTensor) and sparse is not None and not sparse:
-        x_shape = x.shape
-        x = tf.sparse.to_dense(x)
-        x.set_shape(x_shape)
+        x = sparse_to_dense(x)
     if dtype is not None:
         dtype = standardize_dtype(dtype)
     if not tf.is_tensor(x):
@@ -124,9 +123,7 @@ def convert_to_tensor(x, dtype=None, sparse=None):
 
 def convert_to_numpy(x):
     if isinstance(x, tf.SparseTensor):
-        x_shape = x.shape
-        x = tf.sparse.to_dense(x)
-        x.set_shape(x_shape)
+        x = sparse_to_dense(x)
     elif isinstance(x, tf.IndexedSlices):
         x = tf.convert_to_tensor(x)
     elif isinstance(x, tf.RaggedTensor):

--- a/keras/ops/numpy_test.py
+++ b/keras/ops/numpy_test.py
@@ -4585,9 +4585,6 @@ class SparseTest(testing.TestCase, parameterized.TestCase):
         self.assertSameSparseness(op_class()(x), x)
 
     @parameterized.named_parameters(OTHER_UNARY_OPS_TESTS)
-    @pytest.mark.skipif(
-        testing.tensorflow_uses_gpu(), reason="Temporary, XLA error"
-    )
     def test_other_unary_sparse_correctness(
         self, op_function, op_class, np_op, init_kwargs, op_kwargs, input_shape
     ):

--- a/keras/trainers/data_adapters/array_slicing.py
+++ b/keras/trainers/data_adapters/array_slicing.py
@@ -175,9 +175,9 @@ class TensorflowSparseSliceable(TensorflowSliceable):
 
     @classmethod
     def convert_to_torch_compatible(cls, x):
-        from keras.utils.module_utils import tensorflow as tf
+        from keras.backend.tensorflow import sparse as tf_sparse
 
-        return tf.sparse.to_dense(x)
+        return tf_sparse.sparse_to_dense(x)
 
 
 class JaxSliceable(Sliceable):


### PR DESCRIPTION
What was crashing was `tf.sparse.to_dense`, which was called by `convert_to_numpy`, which was called by `assertAllClose`.

Special handling is needed on GPU to densify sparse tensors that represent a scalar.

Also found a simpler way to create empty (i.e. with 0 dimensions) tensors.