### PR TITLE
Add PSNR

### DIFF
--- a/keras/backend/jax/image.py
+++ b/keras/backend/jax/image.py
@@ -13,6 +13,26 @@ RESIZE_INTERPOLATIONS = (
     "bicubic",
 )
 
+def psnr(image1, image2, max_val, data_format="channels_last"):
+    if data_format == "channels_first":
+        if len(image1.shape) == 4:
+            image1 = jnp.transpose(image1, (0, 2, 3, 1))
+            image2 = jnp.transpose(image2, (0, 2, 3, 1))
+        elif len(image1.shape) == 3:
+            image1 = jnp.transpose(image1, (1, 2, 0))
+            image2 = jnp.transpose(image2, (1, 2, 0))
+        else:
+            raise ValueError(
+                "Invalid input rank: expected rank 3 (single image) "
+                "or rank 4 (batch of images). Received input with shape: "
+                f"image1.shape={image1.shape}"
+            )
+    max_val = jnp.float32(max_val)
+    image1 = image1.astype(jnp.float32)
+    image2 = image2.astype(jnp.float32)
+    mse = jnp.mean(jnp.square(image1 - image2), axis=(-3, -2, -1))
+    psnr = 20 * jnp.log10(max_val) - 10 * jnp.log10(mse)
+    return psnr
 
 def rgb_to_grayscale(image, data_format="channels_last"):
     if data_format == "channels_first":

--- a/keras/backend/jax/image.py
+++ b/keras/backend/jax/image.py
@@ -13,26 +13,23 @@ RESIZE_INTERPOLATIONS = (
     "bicubic",
 )
 
-def psnr(image1, image2, max_val, data_format="channels_last"):
-    if data_format == "channels_first":
-        if len(image1.shape) == 4:
-            image1 = jnp.transpose(image1, (0, 2, 3, 1))
-            image2 = jnp.transpose(image2, (0, 2, 3, 1))
-        elif len(image1.shape) == 3:
-            image1 = jnp.transpose(image1, (1, 2, 0))
-            image2 = jnp.transpose(image2, (1, 2, 0))
-        else:
-            raise ValueError(
-                "Invalid input rank: expected rank 3 (single image) "
-                "or rank 4 (batch of images). Received input with shape: "
-                f"image1.shape={image1.shape}"
-            )
+
+def psnr(image1, image2, max_val):
+    if image1.shape != image2.shape:
+        raise ValueError(
+            "Image shapes must match for PSNR calculation. "
+            f"Received shapes: image1.shape={image1.shape}, image2.shape={image2.shape}."
+        )
+
     max_val = jnp.float32(max_val)
     image1 = image1.astype(jnp.float32)
     image2 = image2.astype(jnp.float32)
     mse = jnp.mean(jnp.square(image1 - image2), axis=(-3, -2, -1))
-    psnr = 20 * jnp.log10(max_val) - 10 * jnp.log10(mse)
+    psnr = 20 * jnp.log(max_val) / jnp.log(10.0) - (10 / jnp.log(10)) * jnp.log(
+        mse
+    )
     return psnr
+
 
 def rgb_to_grayscale(image, data_format="channels_last"):
     if data_format == "channels_first":

--- a/keras/backend/jax/image.py
+++ b/keras/backend/jax/image.py
@@ -18,7 +18,8 @@ def psnr(image1, image2, max_val):
     if image1.shape != image2.shape:
         raise ValueError(
             "Image shapes must match for PSNR calculation. "
-            f"Received shapes: image1.shape={image1.shape}, image2.shape={image2.shape}."
+            f"Received shapes: image1.shape={image1.shape}, "
+            "image2.shape={image2.shape}. "
         )
 
     max_val = jnp.float32(max_val)

--- a/keras/backend/numpy/image.py
+++ b/keras/backend/numpy/image.py
@@ -17,7 +17,8 @@ def psnr(image1, image2, max_val):
     if image1.shape != image2.shape:
         raise ValueError(
             "Image shapes must match for PSNR calculation. "
-            f"Received shapes: image1.shape={image1.shape}, image2.shape={image2.shape}."
+            f"Received shapes: image1.shape={image1.shape}, "
+            "image2.shape={image2.shape}. "
         )
 
     max_val = np.float32(max_val)

--- a/keras/backend/numpy/image.py
+++ b/keras/backend/numpy/image.py
@@ -12,26 +12,21 @@ RESIZE_INTERPOLATIONS = (
     "bicubic",
 )
 
-def psnr(image1, image2, max_val, data_format="channels_last"):
-    if data_format == "channels_first":
-        if len(image1.shape) == 4:
-            image1 = np.transpose(image1, (0, 2, 3, 1))
-            image2 = np.transpose(image2, (0, 2, 3, 1))
-        elif len(image1.shape) == 3:
-            image1 = np.transpose(image1, (1, 2, 0))
-            image2 = np.transpose(image2, (1, 2, 0))
-        else:
-            raise ValueError(
-                "Invalid input rank: expected rank 3 (single image) "
-                "or rank 4 (batch of images). Received input with shape: "
-                f"image1.shape={image1.shape}"
-            )
+
+def psnr(image1, image2, max_val):
+    if image1.shape != image2.shape:
+        raise ValueError(
+            "Image shapes must match for PSNR calculation. "
+            f"Received shapes: image1.shape={image1.shape}, image2.shape={image2.shape}."
+        )
+
     max_val = np.float32(max_val)
     image1 = image1.astype(np.float32)
     image2 = image2.astype(np.float32)
     mse = np.mean(np.square(image1 - image2), axis=(-3, -2, -1))
-    psnr = 20 * np.log10(max_val) - 10 * np.log10(mse)
+    psnr = 20 * np.log(max_val) / np.log(10.0) - (10 / np.log(10)) * np.log(mse)
     return psnr
+
 
 def rgb_to_grayscale(image, data_format="channels_last"):
     if data_format == "channels_first":

--- a/keras/backend/numpy/image.py
+++ b/keras/backend/numpy/image.py
@@ -12,6 +12,26 @@ RESIZE_INTERPOLATIONS = (
     "bicubic",
 )
 
+def psnr(image1, image2, max_val, data_format="channels_last"):
+    if data_format == "channels_first":
+        if len(image1.shape) == 4:
+            image1 = np.transpose(image1, (0, 2, 3, 1))
+            image2 = np.transpose(image2, (0, 2, 3, 1))
+        elif len(image1.shape) == 3:
+            image1 = np.transpose(image1, (1, 2, 0))
+            image2 = np.transpose(image2, (1, 2, 0))
+        else:
+            raise ValueError(
+                "Invalid input rank: expected rank 3 (single image) "
+                "or rank 4 (batch of images). Received input with shape: "
+                f"image1.shape={image1.shape}"
+            )
+    max_val = np.float32(max_val)
+    image1 = image1.astype(np.float32)
+    image2 = image2.astype(np.float32)
+    mse = np.mean(np.square(image1 - image2), axis=(-3, -2, -1))
+    psnr = 20 * np.log10(max_val) - 10 * np.log10(mse)
+    return psnr
 
 def rgb_to_grayscale(image, data_format="channels_last"):
     if data_format == "channels_first":

--- a/keras/backend/tensorflow/image.py
+++ b/keras/backend/tensorflow/image.py
@@ -2,8 +2,8 @@ import functools
 import itertools
 import operator
 
-import tensorflow as tf
 import numpy as np
+import tensorflow as tf
 
 from keras.backend.tensorflow.core import convert_to_tensor
 

--- a/keras/backend/tensorflow/image.py
+++ b/keras/backend/tensorflow/image.py
@@ -20,7 +20,8 @@ def psnr(image1, image2, max_val):
     if image1.shape != image2.shape:
         raise ValueError(
             "Image shapes must match for PSNR calculation. "
-            f"Received shapes: image1.shape={image1.shape}, image2.shape={image2.shape}."
+            f"Received shapes: image1.shape={image1.shape}, "
+            "image2.shape={image2.shape}. "
         )
     max_val = tf.cast(max_val, tf.float32)
     image1 = tf.cast(image1, tf.float32)

--- a/keras/backend/tensorflow/image.py
+++ b/keras/backend/tensorflow/image.py
@@ -14,6 +14,22 @@ RESIZE_INTERPOLATIONS = (
     "bicubic",
 )
 
+def psnr(image1, image2, max_val, data_format="channels_last"):
+    if data_format == "channels_first":
+        if len(image1.shape) == 4:
+            image1 = tf.transpose(image1, (0, 2, 3, 1))
+            image2 = tf.transpose(image2, (0, 2, 3, 1))
+        elif len(image1.shape) == 3:
+            image1 = tf.transpose(image1, (1, 2, 0))
+            image2 = tf.transpose(image2, (1, 2, 0))
+        else:
+            raise ValueError(
+                "Invalid input rank: expected rank 3 (single image) "
+                "or rank 4 (batch of images). Received input with shape: "
+                f"image1.shape={image1.shape}"
+            )
+    psnr = tf.image.psnr(image1, image2, max_val, name=None)
+    return psnr
 
 def rgb_to_grayscale(image, data_format="channels_last"):
     if data_format == "channels_first":

--- a/keras/backend/torch/image.py
+++ b/keras/backend/torch/image.py
@@ -14,7 +14,7 @@ UNSUPPORTED_INTERPOLATIONS = (
 )
 
 
-def psnr_pt(image1, image2, max_val):
+def psnr(image1, image2, max_val):
     if image1.shape != image2.shape:
         raise ValueError(
             "Image shapes must match for PSNR calculation. "

--- a/keras/backend/torch/image.py
+++ b/keras/backend/torch/image.py
@@ -18,7 +18,8 @@ def psnr_pt(image1, image2, max_val):
     if image1.shape != image2.shape:
         raise ValueError(
             "Image shapes must match for PSNR calculation. "
-            f"Received shapes: image1.shape={image1.shape}, image2.shape={image2.shape}."
+            f"Received shapes: image1.shape={image1.shape}, "
+            "image2.shape={image2.shape}. "
         )
     image1, image2 = convert_to_tensor(image1), convert_to_tensor(image2)
     max_val = convert_to_tensor(max_val)

--- a/keras/backend/torch/image.py
+++ b/keras/backend/torch/image.py
@@ -21,9 +21,9 @@ def psnr(image1, image2, max_val):
             f"Received shapes: image1.shape={image1.shape}, "
             "image2.shape={image2.shape}. "
         )
-    image1, image2 = convert_to_tensor(image1), convert_to_tensor(image2)
-    max_val = convert_to_tensor(max_val)
-    mse = torch.mean((image1 - image2) ** 2)
+    image1, image2 = convert_to_tensor(image1).float(), convert_to_tensor(image2).float()
+    max_val = convert_to_tensor(max_val).float()
+    mse = torch.mean((image1 - image2) ** 2, (-3, -2, -1))
     psnr = 20 * torch.log10(max_val) - 10 * torch.log10(mse)
     return psnr
 

--- a/keras/backend/torch/image.py
+++ b/keras/backend/torch/image.py
@@ -21,7 +21,10 @@ def psnr(image1, image2, max_val):
             f"Received shapes: image1.shape={image1.shape}, "
             "image2.shape={image2.shape}. "
         )
-    image1, image2 = convert_to_tensor(image1).float(), convert_to_tensor(image2).float()
+    image1, image2 = (
+        convert_to_tensor(image1).float(),
+        convert_to_tensor(image2).float(),
+    )
     max_val = convert_to_tensor(max_val).float()
     mse = torch.mean((image1 - image2) ** 2, (-3, -2, -1))
     psnr = 20 * torch.log10(max_val) - 10 * torch.log10(mse)

--- a/keras/backend/torch/image.py
+++ b/keras/backend/torch/image.py
@@ -13,6 +13,21 @@ UNSUPPORTED_INTERPOLATIONS = (
     "lanczos5",
 )
 
+def psnr(image1, image2, max_val=224, data_format="channel_last"):
+    image1, image2 = convert_to_tensor(image1), convert_to_tensor(image2)
+    max_val = convert_to_tensor(max_val)
+
+    if data_format == 'channel_last':
+        if len(image1.shape) == 4:
+            image1 = image1.permute(0, 2, 3, 1)
+            image2 = image2.permute(0, 2, 3, 1)
+        elif len(image1.shape) == 3:
+            image1 = image1.permute((2, 0, 1))
+            image2 = image2.permute((2, 0, 1))
+
+    mse = torch.mean((image1 - image2) ** 2)
+    psnr = 20 * torch.log10(max_val) - 10 * torch.log10(mse)
+    return psnr
 
 def rgb_to_grayscale(image, data_format="channel_last"):
     try:

--- a/keras/backend/torch/image.py
+++ b/keras/backend/torch/image.py
@@ -13,21 +13,19 @@ UNSUPPORTED_INTERPOLATIONS = (
     "lanczos5",
 )
 
-def psnr(image1, image2, max_val=224, data_format="channel_last"):
+
+def psnr_pt(image1, image2, max_val):
+    if image1.shape != image2.shape:
+        raise ValueError(
+            "Image shapes must match for PSNR calculation. "
+            f"Received shapes: image1.shape={image1.shape}, image2.shape={image2.shape}."
+        )
     image1, image2 = convert_to_tensor(image1), convert_to_tensor(image2)
     max_val = convert_to_tensor(max_val)
-
-    if data_format == 'channel_last':
-        if len(image1.shape) == 4:
-            image1 = image1.permute(0, 2, 3, 1)
-            image2 = image2.permute(0, 2, 3, 1)
-        elif len(image1.shape) == 3:
-            image1 = image1.permute((2, 0, 1))
-            image2 = image2.permute((2, 0, 1))
-
     mse = torch.mean((image1 - image2) ** 2)
     psnr = 20 * torch.log10(max_val) - 10 * torch.log10(mse)
     return psnr
+
 
 def rgb_to_grayscale(image, data_format="channel_last"):
     try:

--- a/keras/ops/image_test.py
+++ b/keras/ops/image_test.py
@@ -6,13 +6,18 @@ import scipy.ndimage
 import tensorflow as tf
 from absl.testing import parameterized
 
-from keras import backend
+from keras import backend, utils
 from keras import testing
 from keras.backend.common.keras_tensor import KerasTensor
 from keras.ops import image as kimage
 
 
 class ImageOpsDynamicShapeTest(testing.TestCase):
+    def test_psnr(self):
+        """Load 2 images and check psnr values
+        ref: https://github.com/tensorflow/tensorflow/blob/5bc9d26649cca274750ad3625bd93422617eed4b/tensorflow/python/ops/image_ops_test.py#L5694
+        """
+
     def test_rgb_to_grayscale(self):
         x = KerasTensor([None, 20, 20, 3])
         out = kimage.rgb_to_grayscale(x)

--- a/keras/ops/image_test.py
+++ b/keras/ops/image_test.py
@@ -74,8 +74,8 @@ class ImageOpsDynamicShapeTest(testing.TestCase):
 
 class ImageOpsStaticShapeTest(testing.TestCase):
     def test_psnr(self):
-        x1 = KerasTensor([None, 20, 20, 3])
-        x2 = KerasTensor([None, 20, 20, 3])
+        x1 = KerasTensor([20, 20, 3])
+        x2 = KerasTensor([20, 20, 3])
         out = kimage.psnr(x1, x2, max_val=224)
         self.assertEqual(out.shape, ())
 

--- a/keras/ops/image_test.py
+++ b/keras/ops/image_test.py
@@ -224,7 +224,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             max_val=224,
         )
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=0.3)
+        self.assertAllClose(ref_out, out, atol=1e-4)
 
         # Batched case
         x1 = np.random.random((2, 3, 50, 50)) * 255
@@ -240,7 +240,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             max_val=224,
         )
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=0.3)
+        self.assertAllClose(ref_out, out, atol=1e-4)
 
     @parameterized.parameters(
         [

--- a/keras/ops/image_test.py
+++ b/keras/ops/image_test.py
@@ -216,12 +216,12 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         out = kimage.psnr(
             x1,
             x2,
-            max_val=224,
+            max_val=255,
         )
         ref_out = tf.image.psnr(
             x1,
             x2,
-            max_val=224,
+            max_val=255,
         )
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
         self.assertAllClose(ref_out, out, atol=1e-4)
@@ -232,12 +232,12 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         out = kimage.psnr(
             x1,
             x2,
-            max_val=224,
+            max_val=255,
         )
         ref_out = tf.image.psnr(
             x1,
             x2,
-            max_val=224,
+            max_val=255,
         )
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
         self.assertAllClose(ref_out, out, atol=1e-4)


### PR DESCRIPTION
question: How to add tests for this functionality? should we load 2 images using `keras.utils` and compare the psnr values?

Here's PSNR values in different backends on sample images I used on colab:

```python
Tensorflow: 60.896583557128906
Numpy: 60.89658856391907
JAX: 60.89658737182617
Torch: 60.89658960237466
````

@fchollet 