### PR TITLE
Fix `MapCoordinates` class and Add Tests for Uncovered Areas in `keras/ops/image.py`

### DIFF
--- a/keras/ops/image.py
+++ b/keras/ops/image.py
@@ -515,7 +515,7 @@ def _extract_patches(
 
 
 class MapCoordinates(Operation):
-    def __init__(self, order, fill_mode="constant", fill_value=0):
+    def __init__(self, order=1, fill_mode="constant", fill_value=0):
         super().__init__()
         self.order = order
         self.fill_mode = fill_mode


### PR DESCRIPTION
This PR addresses a 

`TypeError: MapCoordinates.__init__() missing 1 required positional argument: 'order'`

 in `MapCoordinates` by adding a default `order=1` in the constructor. 
 
Also,tests for uncovered areas in `ops/image.py` are also included for better coverage.
 
 ---
 
 **Note:**
 
We default to `order=1` for linear interpolation, which is generally more commonly used in many applications  and preferred choice due to its smoother results than order=0 (nearest neighbor).

 ---
 
**Changes Made:**
- Added default `order=1` to `MapCoordinates` constructor.
- Included tests for uncovered areas in `ops/image.py`.

 
