### PR TITLE
Fix loading nested Functional models from config

### DIFF
--- a/keras/models/functional.py
+++ b/keras/models/functional.py
@@ -553,6 +553,10 @@ def functional_from_config(cls, config, custom_objects=None):
     def get_tensor(layer_name, node_index, tensor_index):
         assert layer_name in created_layers
         layer = created_layers[layer_name]
+        if issubclass(layer.__class__, Functional):
+            # Functional models start with a pre-existing node
+            # linking their input to output.
+            node_index -= 1
         layer_output_tensors = layer._inbound_nodes[node_index].output_tensors
         return layer_output_tensors[tensor_index]
 


### PR DESCRIPTION
This PR addresses issue #19326 

During investigation I found that this bug does not just occur with a shared model structure, but with *any* model that contains nested Functional models.

The below code (and [linked gist](https://colab.research.google.com/drive/1nNCflPuHmNzlO-P8RwrT9-vSmcuqKwsD?usp=sharing)) demonstrate a simpler reproducible example:

```py

import os

from keras import Input, Model
from keras.saving import load_model
from keras.layers import Dense

# Model 1 definition
input1 = Input((5, ), name="input1")
dense1 = Dense(3, name="dense1")(input1)
model1 = Model(input1, dense1, name="model1")

# Model 2 definition
input2 = Input((3, ), name="input2")
dense2 = Dense(3, name="dense2")(input2)
model2 = Model(input2, dense2, name="model2")

# Define outputs through the 2 models
outputs = model2(model1(input1))

# Nest the models
model = Model(input1, outputs)
print(model.summary())

model.save("test.keras")
test = load_model("test.keras")  # Fails with index out of range error

```

The implemented fix does the reverse of [`get_config()`](https://github.com/keras-team/keras/blob/b267f939b70970e38eec20e3977a1bf41cec8cdd/keras/models/functional.py#L374) where the `kept_nodes` are incremented by `1` if the operation is a `Functional` Model.

When loading, the `node_index` is decremented by 1 if the layer is a `Functional` Model.

This fixes the issue and loads the model successfully. In addition, when comparing the `get_config()` of the saved and loaded models, they match.

Whilst this fix works, I am not 100% sure that it is the correct approach. Initially I was looking to amend the saving function, however, I since discovered that Keras 2 + Keras 3 (beyond some syntactical changes) stored the `output_layers` in the same way (with a node index of `1` when the number of outputs had a `len()` of `0`), so for backwards compatibility reasons, I focused the fix on the loading function.

If this fix looks good, please let me know and I will implement a unit test. Advice on the best approach for the test would be appreciated. Initially I was looking to compare the original config with the loaded config, but due to conversions of tuples to lists, the config would require iterating. It may be enough just to make sure models structured this way load without a failure. Please let me know.