### PR TITLE
Fix `RandomBrightness`, Enhance `IndexLookup` Initialization and Expand Test Coverage for `Preprocessing Layers`

### DIFF
--- a/keras/layers/preprocessing/category_encoding_test.py
+++ b/keras/layers/preprocessing/category_encoding_test.py
@@ -260,3 +260,73 @@ class CategoryEncodingTest(testing.TestCase, parameterized.TestCase):
         for output in ds.take(1):
             output = output.numpy()
         self.assertAllClose(output, expected_output)
+
+    def test_category_encoding_without_num_tokens(self):
+        with self.assertRaisesRegex(
+            ValueError, r"num_tokens must be set to use this layer"
+        ):
+            layers.CategoryEncoding(output_mode="multi_hot")
+
+    def test_category_encoding_with_invalid_num_tokens(self):
+        # Test with zero which is an invalid number of tokens
+        with self.assertRaisesRegex(ValueError, r"`num_tokens` must be >= 1"):
+            layers.CategoryEncoding(num_tokens=0, output_mode="multi_hot")
+
+        # Also test with a negative number
+        with self.assertRaisesRegex(ValueError, r"`num_tokens` must be >= 1"):
+            layers.CategoryEncoding(num_tokens=-1, output_mode="multi_hot")
+
+    def test_category_encoding_with_unnecessary_count_weights(self):
+        layer = layers.CategoryEncoding(num_tokens=4, output_mode="multi_hot")
+        input_data = np.array([0, 1, 2, 3])
+        count_weights = np.array([0.1, 0.2, 0.3, 0.4])
+        with self.assertRaisesRegex(
+            ValueError, r"`count_weights` is not used when `output_mode`"
+        ):
+            layer(input_data, count_weights=count_weights)
+
+    def test_invalid_output_mode_raises_error(self):
+        with self.assertRaisesRegex(
+            ValueError, r"Unknown arg for output_mode: invalid_mode"
+        ):
+            layers.CategoryEncoding(num_tokens=4, output_mode="invalid_mode")
+
+    def test_encode_one_hot_single_sample(self):
+        layer = layers.CategoryEncoding(num_tokens=4, output_mode="one_hot")
+        input_array = np.array([1, 2, 3, 1])
+        expected_output = np.array(
+            [
+                [0, 1, 0, 0],
+                [0, 0, 1, 0],
+                [0, 0, 0, 1],
+                [0, 1, 0, 0],
+            ]
+        )
+        output = layer._encode(input_array)
+        self.assertAllClose(expected_output, output)
+
+    def test_encode_one_hot_batched_samples(self):
+        layer = layers.CategoryEncoding(num_tokens=4, output_mode="one_hot")
+        input_array = np.array([[3, 2, 0, 1], [3, 2, 0, 1]])
+        expected_output = np.array(
+            [
+                [[0, 0, 0, 1], [0, 0, 1, 0], [1, 0, 0, 0], [0, 1, 0, 0]],
+                [[0, 0, 0, 1], [0, 0, 1, 0], [1, 0, 0, 0], [0, 1, 0, 0]],
+            ]
+        )
+        output = layer._encode(input_array)
+        self.assertAllClose(expected_output, output)
+
+    def test_count_single_sample(self):
+        layer = layers.CategoryEncoding(num_tokens=4, output_mode="count")
+        input_array = np.array([1, 2, 3, 1])
+        expected_output = np.array([0, 2, 1, 1])
+        output = layer._count(input_array)
+        self.assertAllClose(expected_output, output)
+
+    def test_count_batched_samples(self):
+        layer = layers.CategoryEncoding(num_tokens=4, output_mode="count")
+        input_array = np.array([[1, 2, 3, 1], [0, 3, 1, 0]])
+        expected_output = np.array([[0, 2, 1, 1], [2, 1, 0, 1]])
+        output = layer._count(input_array)
+        self.assertAllClose(expected_output, output)

--- a/keras/layers/preprocessing/category_encoding_test.py
+++ b/keras/layers/preprocessing/category_encoding_test.py
@@ -268,11 +268,9 @@ class CategoryEncodingTest(testing.TestCase, parameterized.TestCase):
             layers.CategoryEncoding(output_mode="multi_hot")
 
     def test_category_encoding_with_invalid_num_tokens(self):
-        # Test with zero which is an invalid number of tokens
         with self.assertRaisesRegex(ValueError, r"`num_tokens` must be >= 1"):
             layers.CategoryEncoding(num_tokens=0, output_mode="multi_hot")
 
-        # Also test with a negative number
         with self.assertRaisesRegex(ValueError, r"`num_tokens` must be >= 1"):
             layers.CategoryEncoding(num_tokens=-1, output_mode="multi_hot")
 

--- a/keras/layers/preprocessing/hashing_test.py
+++ b/keras/layers/preprocessing/hashing_test.py
@@ -393,6 +393,43 @@ class HashingTest(testing.TestCase, parameterized.TestCase):
             expected, backend.convert_to_numpy(out_data).tolist()
         )
 
+    def test_hashing_invalid_num_bins(self):
+        # Test with `num_bins` set to None
+        with self.assertRaisesRegex(
+            ValueError,
+            "The `num_bins` for `Hashing` cannot be `None` or non-positive",
+        ):
+            layers.Hashing(num_bins=None)
+
+        # Test with `num_bins` set to 0
+        with self.assertRaisesRegex(
+            ValueError,
+            "The `num_bins` for `Hashing` cannot be `None` or non-positive",
+        ):
+            layers.Hashing(num_bins=0)
+
+    def test_hashing_invalid_output_mode(self):
+        # Test with an unsupported `output_mode`
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid value for argument `output_mode`. Expected one of",
+        ):
+            layers.Hashing(num_bins=3, output_mode="unsupported_mode")
+
+    def test_hashing_invalid_dtype_for_int_mode(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            'When `output_mode="int"`, `dtype` should be an integer type,',
+        ):
+            layers.Hashing(num_bins=3, output_mode="int", dtype="float32")
+
+    def test_hashing_sparse_with_int_mode(self):
+        # Test setting `sparse=True` with `output_mode='int'`
+        with self.assertRaisesRegex(
+            ValueError, "`sparse` may only be true if `output_mode` is"
+        ):
+            layers.Hashing(num_bins=3, output_mode="int", sparse=True)
+
 
 # TODO: support tf.RaggedTensor.
 # def test_hash_ragged_string_input_farmhash(self):

--- a/keras/layers/preprocessing/index_lookup.py
+++ b/keras/layers/preprocessing/index_lookup.py
@@ -88,10 +88,10 @@ class IndexLookup(Layer):
 
     def __init__(
         self,
-        num_oov_indices,
-        mask_token,
-        oov_token,
-        vocabulary_dtype,
+        mask_token=None,
+        oov_token="[OOV]",
+        vocabulary_dtype="string",
+        num_oov_indices=1,
         max_tokens=None,
         vocabulary=None,
         idf_weights=None,

--- a/keras/layers/preprocessing/index_lookup.py
+++ b/keras/layers/preprocessing/index_lookup.py
@@ -88,17 +88,17 @@ class IndexLookup(Layer):
 
     def __init__(
         self,
+        max_tokens=None,
+        num_oov_indices=1,
         mask_token=None,
         oov_token="[OOV]",
-        vocabulary_dtype="string",
-        num_oov_indices=1,
-        max_tokens=None,
         vocabulary=None,
+        vocabulary_dtype="string",
         idf_weights=None,
         invert=False,
         output_mode="int",
-        sparse=False,
         pad_to_max_tokens=False,
+        sparse=False,
         name=None,
         **kwargs,
     ):

--- a/keras/layers/preprocessing/index_lookup.py
+++ b/keras/layers/preprocessing/index_lookup.py
@@ -88,17 +88,17 @@ class IndexLookup(Layer):
 
     def __init__(
         self,
-        max_tokens=None,
-        num_oov_indices=1,
-        mask_token=None,
-        oov_token="[OOV]",
+        max_tokens,
+        num_oov_indices,
+        mask_token,
+        oov_token,
+        vocabulary_dtype,
         vocabulary=None,
-        vocabulary_dtype="string",
         idf_weights=None,
         invert=False,
         output_mode="int",
-        pad_to_max_tokens=False,
         sparse=False,
+        pad_to_max_tokens=False,
         name=None,
         **kwargs,
     ):

--- a/keras/layers/preprocessing/index_lookup.py
+++ b/keras/layers/preprocessing/index_lookup.py
@@ -88,11 +88,11 @@ class IndexLookup(Layer):
 
     def __init__(
         self,
-        max_tokens,
         num_oov_indices,
         mask_token,
         oov_token,
         vocabulary_dtype,
+        max_tokens=None,
         vocabulary=None,
         idf_weights=None,
         invert=False,

--- a/keras/layers/preprocessing/index_lookup_test.py
+++ b/keras/layers/preprocessing/index_lookup_test.py
@@ -427,3 +427,163 @@ class IndexLookupLayerTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(list(output), [2, 3, 1])
         if backend.backend() != "torch":
             self.run_class_serialization_test(layer)
+
+    def test_max_tokens_less_than_two(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "If set, `max_tokens` must be greater than 1.",
+        ):
+            layers.IndexLookup(
+                max_tokens=1,
+                num_oov_indices=1,
+                mask_token=None,
+                oov_token=None,
+                vocabulary_dtype="int64",
+            )
+
+    def test_max_tokens_none_with_pad_to_max_tokens(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "If pad_to_max_tokens is True, must set `max_tokens`.",
+        ):
+            layers.IndexLookup(
+                num_oov_indices=1,
+                mask_token=None,
+                oov_token=None,
+                vocabulary_dtype="int64",
+                pad_to_max_tokens=True,
+            )
+
+    def test_negative_num_oov_indices(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "`num_oov_indices` must be greater than or equal to 0.",
+        ):
+            layers.IndexLookup(
+                max_tokens=10,
+                num_oov_indices=-1,
+                mask_token=None,
+                oov_token=None,
+                vocabulary_dtype="int64",
+            )
+
+    def test_invert_with_non_int_output_mode(self):
+        with self.assertRaisesRegex(
+            ValueError, r"`output_mode` must be `'int'` when `invert` is true."
+        ):
+            layers.IndexLookup(
+                num_oov_indices=1,
+                mask_token=None,
+                oov_token=None,
+                vocabulary_dtype="string",
+                invert=True,
+                output_mode="one_hot",  # Invalid combination
+            )
+
+    def test_sparse_true_with_int_output_mode(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            r"`sparse` may only be true if `output_mode` is `'one_hot'`",
+        ):
+            layers.IndexLookup(
+                num_oov_indices=1,
+                mask_token=None,
+                oov_token=None,
+                vocabulary_dtype="string",
+                sparse=True,
+                output_mode="int",  # Invalid combination
+            )
+
+    def test_idf_weights_set_with_non_tfidf_output_mode(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            r"`idf_weights` should only be set if `output_mode` is `'tf_idf'`",
+        ):
+            layers.IndexLookup(
+                num_oov_indices=1,
+                mask_token=None,
+                oov_token=None,
+                vocabulary_dtype="string",
+                idf_weights=[
+                    0.5,
+                    0.1,
+                    0.3,
+                ],  # Should not be set for non-TF-IDF modes
+                output_mode="int",
+            )
+
+    def test_unrecognized_kwargs(self):
+        with self.assertRaisesRegex(
+            ValueError, "Unrecognized keyword argument"
+        ):
+            layers.IndexLookup(
+                num_oov_indices=1,
+                mask_token=None,
+                oov_token=None,
+                vocabulary_dtype="string",
+                output_mode="int",
+                # This is an unrecognized argument
+                extra_arg=True,
+            )
+
+    def test_non_tf_idf_with_idf_weights(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "`idf_weights` should only be set if `output_mode` is",
+        ):
+            layers.IndexLookup(
+                num_oov_indices=1,
+                mask_token=None,
+                oov_token=None,
+                vocabulary_dtype="string",
+                output_mode="multi_hot",
+                idf_weights=[
+                    0.5,
+                    0.1,
+                    0.3,
+                ],  # idf_weights not valid for multi_hot mode
+            )
+
+    def test_vocabulary_file_does_not_exist(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Vocabulary file path/to/missing_vocab.txt does not exist",
+        ):
+            layers.IndexLookup(
+                num_oov_indices=1,
+                mask_token=None,
+                oov_token=None,
+                vocabulary_dtype="string",
+                output_mode="int",
+                # Nonexistent file path
+                vocabulary="path/to/missing_vocab.txt",
+            )
+
+    def test_repeated_tokens_in_vocabulary(self):
+        with self.assertRaisesRegex(
+            ValueError, "The passed vocabulary has at least one repeated term."
+        ):
+            layers.IndexLookup(
+                num_oov_indices=1,
+                mask_token=None,
+                oov_token=None,
+                vocabulary_dtype="string",
+                vocabulary=["token", "token", "unique"],
+            )
+
+    def test_mask_token_in_wrong_position(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Found reserved mask token at unexpected location in `vocabulary`.",
+        ):
+            layers.IndexLookup(
+                num_oov_indices=1,
+                mask_token="mask",
+                oov_token=None,
+                vocabulary_dtype="string",
+                vocabulary=[
+                    "token",
+                    "mask",
+                    "unique",
+                ],  # 'mask' should be at the start if included explicitly
+            )

--- a/keras/layers/preprocessing/index_lookup_test.py
+++ b/keras/layers/preprocessing/index_lookup_test.py
@@ -448,6 +448,7 @@ class IndexLookupLayerTest(testing.TestCase, parameterized.TestCase):
         ):
             layers.IndexLookup(
                 num_oov_indices=1,
+                max_tokens=None,
                 mask_token=None,
                 oov_token=None,
                 vocabulary_dtype="int64",
@@ -473,6 +474,7 @@ class IndexLookupLayerTest(testing.TestCase, parameterized.TestCase):
         ):
             layers.IndexLookup(
                 num_oov_indices=1,
+                max_tokens=None,
                 mask_token=None,
                 oov_token=None,
                 vocabulary_dtype="string",
@@ -487,6 +489,7 @@ class IndexLookupLayerTest(testing.TestCase, parameterized.TestCase):
         ):
             layers.IndexLookup(
                 num_oov_indices=1,
+                max_tokens=None,
                 mask_token=None,
                 oov_token=None,
                 vocabulary_dtype="string",
@@ -501,6 +504,7 @@ class IndexLookupLayerTest(testing.TestCase, parameterized.TestCase):
         ):
             layers.IndexLookup(
                 num_oov_indices=1,
+                max_tokens=None,
                 mask_token=None,
                 oov_token=None,
                 vocabulary_dtype="string",
@@ -518,6 +522,7 @@ class IndexLookupLayerTest(testing.TestCase, parameterized.TestCase):
         ):
             layers.IndexLookup(
                 num_oov_indices=1,
+                max_tokens=None,
                 mask_token=None,
                 oov_token=None,
                 vocabulary_dtype="string",
@@ -533,6 +538,7 @@ class IndexLookupLayerTest(testing.TestCase, parameterized.TestCase):
         ):
             layers.IndexLookup(
                 num_oov_indices=1,
+                max_tokens=None,
                 mask_token=None,
                 oov_token=None,
                 vocabulary_dtype="string",
@@ -551,6 +557,7 @@ class IndexLookupLayerTest(testing.TestCase, parameterized.TestCase):
         ):
             layers.IndexLookup(
                 num_oov_indices=1,
+                max_tokens=None,
                 mask_token=None,
                 oov_token=None,
                 vocabulary_dtype="string",
@@ -565,6 +572,7 @@ class IndexLookupLayerTest(testing.TestCase, parameterized.TestCase):
         ):
             layers.IndexLookup(
                 num_oov_indices=1,
+                max_tokens=None,
                 mask_token=None,
                 oov_token=None,
                 vocabulary_dtype="string",
@@ -578,6 +586,7 @@ class IndexLookupLayerTest(testing.TestCase, parameterized.TestCase):
         ):
             layers.IndexLookup(
                 num_oov_indices=1,
+                max_tokens=None,
                 mask_token="mask",
                 oov_token=None,
                 vocabulary_dtype="string",
@@ -598,6 +607,7 @@ class IndexLookupLayerTest(testing.TestCase, parameterized.TestCase):
             "output_mode": "multi_hot",
             "pad_to_max_tokens": False,
             "vocabulary_dtype": "string",
+            "max_tokens": None,
         }
         layer = layers.IndexLookup(**kwargs)
 

--- a/keras/layers/preprocessing/index_lookup_test.py
+++ b/keras/layers/preprocessing/index_lookup_test.py
@@ -587,3 +587,23 @@ class IndexLookupLayerTest(testing.TestCase, parameterized.TestCase):
                     "unique",
                 ],  # 'mask' should be at the start if included explicitly
             )
+
+    def test_ensure_known_vocab_size_without_vocabulary(self):
+        kwargs = {
+            "num_oov_indices": 1,
+            # Assume empty string or some default token is valid.
+            "mask_token": "",
+            # Assume [OOV] or some default token is valid.
+            "oov_token": "[OOV]",
+            "output_mode": "multi_hot",
+            "pad_to_max_tokens": False,
+            "vocabulary_dtype": "string",
+        }
+        layer = layers.IndexLookup(**kwargs)
+
+        # Try calling the layer without setting the vocabulary.
+        with self.assertRaisesRegex(
+            RuntimeError, "When using `output_mode=multi_hot` and"
+        ):
+            input_data = ["sample", "data"]
+            layer(input_data)

--- a/keras/layers/preprocessing/random_brightness.py
+++ b/keras/layers/preprocessing/random_brightness.py
@@ -80,12 +80,12 @@ class RandomBrightness(TFDataLayer):
     def _set_value_range(self, value_range):
         if not isinstance(value_range, (tuple, list)):
             raise ValueError(
-                self.value_range_VALIDATION_ERROR
+                self._VALUE_RANGE_VALIDATION_ERROR
                 + f"Received: value_range={value_range}"
             )
         if len(value_range) != 2:
             raise ValueError(
-                self.value_range_VALIDATION_ERROR
+                self._VALUE_RANGE_VALIDATION_ERROR
                 + f"Received: value_range={value_range}"
             )
         self.value_range = sorted(value_range)

--- a/keras/layers/preprocessing/random_brightness_test.py
+++ b/keras/layers/preprocessing/random_brightness_test.py
@@ -58,3 +58,59 @@ class RandomBrightnessTest(testing.TestCase):
         ds = tf_data.Dataset.from_tensor_slices(input_data).batch(2).map(layer)
         for output in ds.take(1):
             output.numpy()
+
+    def test_value_range_incorrect_type(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "The `value_range` argument should be a list of two numbers.*",
+        ):
+            layers.RandomBrightness(factor=0.1, value_range="incorrect_type")
+
+    def test_value_range_incorrect_length(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "The `value_range` argument should be a list of two numbers.*",
+        ):
+            layers.RandomBrightness(factor=0.1, value_range=[10])
+
+    def test_set_factor_incorrect_length(self):
+        layer = layers.RandomBrightness(factor=0.5)
+        with self.assertRaisesRegex(
+            ValueError, "The `factor` argument should be a number.*"
+        ):
+            layer._set_factor([0.1])  # Only one element in list
+
+    def test_set_factor_incorrect_type(self):
+        layer = layers.RandomBrightness(factor=0.5)
+        with self.assertRaisesRegex(
+            ValueError, "The `factor` argument should be a number.*"
+        ):
+            layer._set_factor(
+                "invalid_type"
+            )  # Passing a string instead of a number or a list/tuple of numbers
+
+    def test_factor_range_below_lower_bound(self):
+        with self.assertRaisesRegex(
+            ValueError, "The `factor` argument should be a number.*"
+        ):
+            # Passing a value less than -1.0
+            layers.RandomBrightness(factor=-1.1)
+
+    def test_factor_range_above_upper_bound(self):
+        with self.assertRaisesRegex(
+            ValueError, "The `factor` argument should be a number.*"
+        ):
+            # Passing a value more than 1.0
+            layers.RandomBrightness(factor=1.1)
+
+    def test_randomly_adjust_brightness_input_incorrect_rank(self):
+        layer = layers.RandomBrightness(factor=0.1)
+        wrong_rank_input = np.random.rand(10, 10)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Expected the input image to be rank 3 or 4.",
+        ):
+            layer(
+                wrong_rank_input, training=True
+            )  # Call the method that triggers the error


### PR DESCRIPTION
1: 

In this PR , I have added tests for keras/layers/preprocessing:

`keras/layers/preprocessing/category_encoding_test.py`
`keras/layers/preprocessing/hashing_test.py`
`keras/layers/preprocessing/index_lookup_test.py`
`keras/layers/preprocessing/normalization_test.py`

---

2 :

This PR corrects the error attribute names in the `RandomBrightness` layer, changing `_value_range_VALIDATION_ERROR` to `_VALUE_RANGE_VALIDATION_ERROR`. This ensures that the proper error messages are displayed when `value_range` parameter validations fail.

---