### PR TITLE
Models and layers now return owned metrics recursively.

### DIFF
--- a/keras/layers/layer.py
+++ b/keras/layers/layer.py
@@ -636,14 +636,19 @@ class Layer(BackendLayer, Operation):
         return [v for v in self.weights if not v.trainable]
 
     @property
+    def metrics(self):
+        """List of all metrics."""
+        metrics = list(self._metrics)
+        for layer in self._layers:
+            metrics.extend(layer.metrics)
+        return metrics
+
+    @property
     def metrics_variables(self):
         """List of all metric variables."""
         vars = []
-        for metric in self._metrics:
+        for metric in self.metrics:
             vars.extend(metric.variables)
-        for layer in self._layers:
-            for metric in layer._metrics:
-                vars.extend(metric.variables)
         return vars
 
     def get_weights(self):

--- a/keras/trainers/trainer.py
+++ b/keras/trainers/trainer.py
@@ -242,7 +242,7 @@ class Trainer:
     @property
     def metrics(self):
         metrics = [self._loss_tracker] if self.compiled else []
-        metrics.extend(self._metrics[:])
+        metrics.extend(super().metrics)
         if self.compiled and self._compile_metrics is not None:
             metrics += [self._compile_metrics]
         return metrics
@@ -250,13 +250,6 @@ class Trainer:
     @property
     def metrics_names(self):
         return [m.name for m in self.metrics]
-
-    @property
-    def metrics_variables(self):
-        vars = []
-        for metric in self.metrics:
-            vars.extend(metric.variables)
-        return vars
 
     def reset_metrics(self):
         for m in self.metrics:


### PR DESCRIPTION
- added `Layer.metrics` to return all metrics owned by the layer and its sub-layers recursively.
- `Layer.metrics_variables` now returns variables from all metrics recursively, not just the layer and its direct sub-layers.
- `Model.metrics` now returns all metrics recursively, not just the model level metrics.
- `Model.metrics_variables` now returns variables from all metrics recursively, not just the model level metrics.
- added test coverage to test metrics and variables 2 levels deep.

This is consistent with the Keras 2 behavior and how `Model/Layer.variables` and `Model/Layer.weights` work.