### PR TITLE
Update python example of kl_divergence

### DIFF
--- a/keras/losses/losses.py
+++ b/keras/losses/losses.py
@@ -1461,7 +1461,7 @@ def kl_divergence(y_true, y_pred):
     Example:
 
     >>> y_true = np.random.randint(0, 2, size=(2, 3)).astype(np.float32)
-    >>> y_pred = np.random.random(size=(2, 3))
+    >>> y_pred = np.random.random(size=(2, 3)).astype(np.float32)
     >>> loss = keras.losses.kl_divergence(y_true, y_pred)
     >>> assert loss.shape == (2,)
     >>> y_true = ops.clip(y_true, 1e-7, 1)


### PR DESCRIPTION
Current Python example in `kl_divergence` fails with TypeError.Updated the same to fix this.



> TypeError: `x` and `y` must have the same dtype, got tf.float32 != tf.float64.


