### PR TITLE
Fix gradient accumulation when using `overwrite_with_gradient` during float8 training

### DIFF
--- a/keras/src/backend/tensorflow/optimizer.py
+++ b/keras/src/backend/tensorflow/optimizer.py
@@ -196,11 +196,11 @@ class TFOptimizer(KerasAutoTrackable, base_optimizer.BaseOptimizer):
                 var, lambda a, b: a.assign(b), args=(average_var,)
             )
 
-    def _backend_increment_gradient_accumulators(self, grads):
+    def _backend_increment_gradient_accumulators(self, grads, acc_grads):
         def update_accumulator(var, grad):
             var.assign(var + grad)
 
-        accumulators = [v.value for v in self._accumulated_gradients]
+        accumulators = [v.value for v in acc_grads]
 
         def _distributed_tf_increment_grad_acc(
             distribution, grads, accumulators

--- a/keras/src/backend/torch/optimizers/torch_parallel_optimizer.py
+++ b/keras/src/backend/torch/optimizers/torch_parallel_optimizer.py
@@ -19,6 +19,6 @@ class TorchParallelOptimizer(BaseOptimizer):
         torch._foreach_mul_(acc_list, 0.0)
 
     @torch_utils.no_grad
-    def _backend_increment_gradient_accumulators(self, grads):
-        acc_list = [v.value for v in self._accumulated_gradients]
+    def _backend_increment_gradient_accumulators(self, grads, acc_grads):
+        acc_list = [v.value for v in acc_grads]
         torch._foreach_add_(acc_list, grads, alpha=1.0)

--- a/keras/src/optimizers/adadelta.py
+++ b/keras/src/optimizers/adadelta.py
@@ -49,6 +49,8 @@ class Adadelta(optimizer.Optimizer):
         use_ema=False,
         ema_momentum=0.99,
         ema_overwrite_frequency=None,
+        loss_scale_factor=None,
+        gradient_accumulation_steps=None,
         name="adadelta",
         **kwargs,
     ):
@@ -61,6 +63,8 @@ class Adadelta(optimizer.Optimizer):
             use_ema=use_ema,
             ema_momentum=ema_momentum,
             ema_overwrite_frequency=ema_overwrite_frequency,
+            loss_scale_factor=loss_scale_factor,
+            gradient_accumulation_steps=gradient_accumulation_steps,
             name=name,
             **kwargs,
         )

--- a/keras/src/optimizers/adafactor.py
+++ b/keras/src/optimizers/adafactor.py
@@ -56,6 +56,8 @@ class Adafactor(optimizer.Optimizer):
         use_ema=False,
         ema_momentum=0.99,
         ema_overwrite_frequency=None,
+        loss_scale_factor=None,
+        gradient_accumulation_steps=None,
         name="adafactor",
         **kwargs,
     ):
@@ -69,6 +71,8 @@ class Adafactor(optimizer.Optimizer):
             use_ema=use_ema,
             ema_momentum=ema_momentum,
             ema_overwrite_frequency=ema_overwrite_frequency,
+            loss_scale_factor=loss_scale_factor,
+            gradient_accumulation_steps=gradient_accumulation_steps,
             **kwargs,
         )
         self.beta_2_decay = beta_2_decay

--- a/keras/src/optimizers/adagrad.py
+++ b/keras/src/optimizers/adagrad.py
@@ -44,6 +44,8 @@ class Adagrad(optimizer.Optimizer):
         use_ema=False,
         ema_momentum=0.99,
         ema_overwrite_frequency=None,
+        loss_scale_factor=None,
+        gradient_accumulation_steps=None,
         name="adagrad",
         **kwargs,
     ):
@@ -56,6 +58,8 @@ class Adagrad(optimizer.Optimizer):
             use_ema=use_ema,
             ema_momentum=ema_momentum,
             ema_overwrite_frequency=ema_overwrite_frequency,
+            loss_scale_factor=loss_scale_factor,
+            gradient_accumulation_steps=gradient_accumulation_steps,
             name=name,
             **kwargs,
         )

--- a/keras/src/optimizers/adam.py
+++ b/keras/src/optimizers/adam.py
@@ -54,6 +54,8 @@ class Adam(optimizer.Optimizer):
         use_ema=False,
         ema_momentum=0.99,
         ema_overwrite_frequency=None,
+        loss_scale_factor=None,
+        gradient_accumulation_steps=None,
         name="adam",
         **kwargs,
     ):
@@ -67,6 +69,8 @@ class Adam(optimizer.Optimizer):
             use_ema=use_ema,
             ema_momentum=ema_momentum,
             ema_overwrite_frequency=ema_overwrite_frequency,
+            loss_scale_factor=loss_scale_factor,
+            gradient_accumulation_steps=gradient_accumulation_steps,
             **kwargs,
         )
         self.beta_1 = beta_1

--- a/keras/src/optimizers/adamax.py
+++ b/keras/src/optimizers/adamax.py
@@ -63,6 +63,8 @@ class Adamax(optimizer.Optimizer):
         use_ema=False,
         ema_momentum=0.99,
         ema_overwrite_frequency=None,
+        loss_scale_factor=None,
+        gradient_accumulation_steps=None,
         name="adamax",
         **kwargs,
     ):
@@ -76,6 +78,8 @@ class Adamax(optimizer.Optimizer):
             use_ema=use_ema,
             ema_momentum=ema_momentum,
             ema_overwrite_frequency=ema_overwrite_frequency,
+            loss_scale_factor=loss_scale_factor,
+            gradient_accumulation_steps=gradient_accumulation_steps,
             **kwargs,
         )
         self.beta_1 = beta_1

--- a/keras/src/optimizers/adamw.py
+++ b/keras/src/optimizers/adamw.py
@@ -64,6 +64,8 @@ class AdamW(adam.Adam):
         use_ema=False,
         ema_momentum=0.99,
         ema_overwrite_frequency=None,
+        loss_scale_factor=None,
+        gradient_accumulation_steps=None,
         name="adamw",
         **kwargs,
     ):
@@ -81,6 +83,8 @@ class AdamW(adam.Adam):
             use_ema=use_ema,
             ema_momentum=ema_momentum,
             ema_overwrite_frequency=ema_overwrite_frequency,
+            loss_scale_factor=loss_scale_factor,
+            gradient_accumulation_steps=gradient_accumulation_steps,
             **kwargs,
         )
 

--- a/keras/src/optimizers/base_optimizer.py
+++ b/keras/src/optimizers/base_optimizer.py
@@ -622,6 +622,8 @@ class BaseOptimizer:
                     acc_g = self._accumulated_gradients[
                         self._get_variable_index(v)
                     ]
+                    # `ops.maximum` is utilized for gradient accumulation for
+                    # `overwrite_with_gradient=True` variables
                     new_g_acc = ops.cond(
                         is_update_step,
                         lambda: ops.zeros(g.shape, dtype=g.dtype),

--- a/keras/src/optimizers/base_optimizer.py
+++ b/keras/src/optimizers/base_optimizer.py
@@ -1,8 +1,6 @@
 import re
 import warnings
 
-import numpy as np
-
 from keras.src import backend
 from keras.src import initializers
 from keras.src import ops
@@ -375,27 +373,31 @@ class BaseOptimizer:
             is_update_step = (
                 self.iterations + 1
             ) % self.gradient_accumulation_steps == 0
+            # `trainable_variables` might have been filtered in previous
+            # processing steps, so we need to ensure the correct mapping between
+            # `self._accumulated_gradients` and `trainable_variables`
+            acc_grads = [
+                self._accumulated_gradients[self._get_variable_index(v)]
+                for v in trainable_variables
+            ]
 
-            def _update_step_fn(self, grads, trainable_variables):
+            def _update_step_fn(grads, trainable_variables):
                 # Run update step with accumulated grads + reset accumulators
                 steps = self.gradient_accumulation_steps
                 grads = [
-                    (grads[i] + self._accumulated_gradients[i]) / steps
-                    for i in range(len(grads))
+                    (g + acc_g) / steps for g, acc_g in zip(grads, acc_grads)
                 ]
                 self._backend_update_step(
                     grads, trainable_variables, self.learning_rate
                 )
                 self._backend_reset_gradient_accumulators()
 
-            def _grad_accumulation_fn(self, grads):
-                # Update gradient accumulators
-                self._backend_increment_gradient_accumulators(grads)
-
             ops.cond(
                 is_update_step,
-                lambda: _update_step_fn(self, grads, trainable_variables),
-                lambda: _grad_accumulation_fn(self, grads),
+                lambda: _update_step_fn(grads, trainable_variables),
+                lambda: self._backend_increment_gradient_accumulators(
+                    grads, acc_grads
+                ),
             )
         else:
             # Run udpate step.
@@ -434,14 +436,11 @@ class BaseOptimizer:
 
     def _backend_reset_gradient_accumulators(self):
         for g_acc in self._accumulated_gradients:
-            g_acc.assign(np.zeros(g_acc.shape, dtype=g_acc.dtype))
+            g_acc.assign(ops.zeros(g_acc.shape, dtype=g_acc.dtype))
 
-    def _backend_increment_gradient_accumulators(self, grads):
-        new_g_accs = [
-            (grads[i] + self._accumulated_gradients[i])
-            for i in range(len(grads))
-        ]
-        for n_g_acc, g_acc in zip(new_g_accs, self._accumulated_gradients):
+    def _backend_increment_gradient_accumulators(self, grads, acc_grads):
+        new_g_accs = [(g + acc_g) for g, acc_g in zip(grads, acc_grads)]
+        for n_g_acc, g_acc in zip(new_g_accs, acc_grads):
             g_acc.assign(n_g_acc)
 
     def stateless_apply(self, optimizer_variables, grads, trainable_variables):
@@ -616,7 +615,30 @@ class BaseOptimizer:
         for i in range(len(filtered_grads) - 1, -1, -1):
             g, v = filtered_grads[i], filtered_vars[i]
             if v.overwrite_with_gradient:
-                v.assign(g)
+                if self.gradient_accumulation_steps:
+                    # Utilize a stateless manner for JAX compatibility
+                    steps = self.gradient_accumulation_steps
+                    is_update_step = (self.iterations + 1) % steps == 0
+                    acc_g = self._accumulated_gradients[
+                        self._get_variable_index(v)
+                    ]
+                    new_g_acc = ops.cond(
+                        is_update_step,
+                        lambda: ops.zeros(g.shape, dtype=g.dtype),
+                        lambda: ops.maximum(g, acc_g),
+                    )
+                    new_g = ops.cond(
+                        is_update_step,
+                        lambda: ops.maximum(g, acc_g),
+                        lambda: g,
+                    )
+                    new_v = ops.cond(
+                        is_update_step, lambda: new_g, lambda: v.value
+                    )
+                    v.assign(new_v)
+                    acc_g.assign(new_g_acc)
+                else:
+                    v.assign(g)
                 filtered_grads.pop(i)
                 filtered_vars.pop(i)
         return filtered_grads, filtered_vars

--- a/keras/src/optimizers/ftrl.py
+++ b/keras/src/optimizers/ftrl.py
@@ -91,6 +91,8 @@ class Ftrl(optimizer.Optimizer):
         use_ema=False,
         ema_momentum=0.99,
         ema_overwrite_frequency=None,
+        loss_scale_factor=None,
+        gradient_accumulation_steps=None,
         name="ftrl",
         **kwargs,
     ):
@@ -104,6 +106,8 @@ class Ftrl(optimizer.Optimizer):
             use_ema=use_ema,
             ema_momentum=ema_momentum,
             ema_overwrite_frequency=ema_overwrite_frequency,
+            loss_scale_factor=loss_scale_factor,
+            gradient_accumulation_steps=gradient_accumulation_steps,
             **kwargs,
         )
 

--- a/keras/src/optimizers/lion.py
+++ b/keras/src/optimizers/lion.py
@@ -53,6 +53,8 @@ class Lion(optimizer.Optimizer):
         use_ema=False,
         ema_momentum=0.99,
         ema_overwrite_frequency=None,
+        loss_scale_factor=None,
+        gradient_accumulation_steps=None,
         name="lion",
         **kwargs,
     ):
@@ -66,6 +68,8 @@ class Lion(optimizer.Optimizer):
             use_ema=use_ema,
             ema_momentum=ema_momentum,
             ema_overwrite_frequency=ema_overwrite_frequency,
+            loss_scale_factor=loss_scale_factor,
+            gradient_accumulation_steps=gradient_accumulation_steps,
             **kwargs,
         )
         self.beta_1 = beta_1

--- a/keras/src/optimizers/nadam.py
+++ b/keras/src/optimizers/nadam.py
@@ -49,6 +49,8 @@ class Nadam(optimizer.Optimizer):
         use_ema=False,
         ema_momentum=0.99,
         ema_overwrite_frequency=None,
+        loss_scale_factor=None,
+        gradient_accumulation_steps=None,
         name="nadam",
         **kwargs,
     ):
@@ -62,6 +64,8 @@ class Nadam(optimizer.Optimizer):
             use_ema=use_ema,
             ema_momentum=ema_momentum,
             ema_overwrite_frequency=ema_overwrite_frequency,
+            loss_scale_factor=loss_scale_factor,
+            gradient_accumulation_steps=gradient_accumulation_steps,
             **kwargs,
         )
         self.beta_1 = beta_1

--- a/keras/src/optimizers/rmsprop.py
+++ b/keras/src/optimizers/rmsprop.py
@@ -63,7 +63,9 @@ class RMSprop(optimizer.Optimizer):
         global_clipnorm=None,
         use_ema=False,
         ema_momentum=0.99,
-        ema_overwrite_frequency=100,
+        ema_overwrite_frequency=None,
+        loss_scale_factor=None,
+        gradient_accumulation_steps=None,
         name="rmsprop",
         **kwargs,
     ):
@@ -76,6 +78,8 @@ class RMSprop(optimizer.Optimizer):
             use_ema=use_ema,
             ema_momentum=ema_momentum,
             ema_overwrite_frequency=ema_overwrite_frequency,
+            loss_scale_factor=loss_scale_factor,
+            gradient_accumulation_steps=gradient_accumulation_steps,
             name=name,
             **kwargs,
         )

--- a/keras/src/optimizers/sgd.py
+++ b/keras/src/optimizers/sgd.py
@@ -52,6 +52,8 @@ class SGD(optimizer.Optimizer):
         use_ema=False,
         ema_momentum=0.99,
         ema_overwrite_frequency=None,
+        loss_scale_factor=None,
+        gradient_accumulation_steps=None,
         name="SGD",
         **kwargs,
     ):
@@ -65,6 +67,8 @@ class SGD(optimizer.Optimizer):
             use_ema=use_ema,
             ema_momentum=ema_momentum,
             ema_overwrite_frequency=ema_overwrite_frequency,
+            loss_scale_factor=loss_scale_factor,
+            gradient_accumulation_steps=gradient_accumulation_steps,
             **kwargs,
         )
         if not isinstance(momentum, float) or momentum < 0 or momentum > 1:


### PR DESCRIPTION
Ref implementation:
https://github.com/google/flax/pull/3623

We should use `ops.maximum` for gradient accumulation with `overwrite_with_gradient=True` variables.

This PR also fixes a potential bug in gradient accumulation where directly using `self._accumulated_gradients` may mismatch with the filtered `grads` in the code path.

The new test `test_overwrite_with_gradient_with_gradient_accumulation` can only pass after the changes.

EDITED:

Fix all optimizers arguments hint by including `loss_scale_factor` and `gradient_accumulation_steps`:
|Before|After|
|-|-|
|![before1](https://github.com/keras-team/keras/assets/20734616/bf3f4690-870e-46f9-87f9-416b8da6416c)|![before](https://github.com/keras-team/keras/assets/20734616/96c2d87b-0711-4277-8b53-b78532ce64ce)|


