### PR TITLE
identify, implement and test missing functions in MLX backend

### DIFF
--- a/keras/backend/mlx/math.py
+++ b/keras/backend/mlx/math.py
@@ -35,6 +35,7 @@ def logsumexp(x, axis=None, keepdims=False):
 
 
 def qr(x, mode="reduced"):
+    # TODO https://ml-explore.github.io/mlx/build/html/python/linalg.html
     raise NotImplementedError("QR decomposition not supported in mlx yet")
 
 
@@ -53,18 +54,22 @@ def extract_sequences(x, sequence_length, sequence_stride):
 
 
 def fft(x):
+    # TODO: https://ml-explore.github.io/mlx/build/html/python/fft.html#fft
     raise NotImplementedError("fft not yet implemented in mlx")
 
 
 def fft2(x):
+    # TODO: https://ml-explore.github.io/mlx/build/html/python/fft.html#fft
     raise NotImplementedError("fft not yet implemented in mlx")
 
 
 def rfft(x, fft_length=None):
+    # TODO: https://ml-explore.github.io/mlx/build/html/python/fft.html#fft
     raise NotImplementedError("fft not yet implemented in mlx")
 
 
 def irfft(x, fft_length=None):
+    # TODO: https://ml-explore.github.io/mlx/build/html/python/fft.html#fft
     raise NotImplementedError("fft not yet implemented in mlx")
 
 

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -604,12 +604,9 @@ def median(x, axis=None, keepdims=False):
 
 
 def meshgrid(*x, indexing="xy"):
-    # TODO: https://ml-explore.github.io/mlx/build/html/python/
-    # _autosummary/mlx.core.meshgrid.html
-    # https://github.com/ml-explore/mlx/blob/
-    # #85c8a91a279923189d0eeddd926a1015370bf4f8/python/tests/test_ops.py#L1470
-
-    raise NotImplementedError("The MLX backend doesn't support meshgrid yet")
+    # TODO: test with and without
+    # x = [convert_to_tensor(xi) for xi in x]
+    return mx.meshgrid(*x, indexing=indexing)
 
 
 def min(x, axis=None, keepdims=False, initial=None):
@@ -832,19 +829,14 @@ def tanh(x):
 
 
 def tensordot(x1, x2, axes=2):
-    # TODO: https://ml-explore.github.io/mlx/build/html/python/_autosummary
-    # /mlx.core.tensordot.html#mlx-core-tensordot
-    # https://github.com/ml-explore/mlx/blob/
-    # 85c8a91a279923189d0eeddd926a1015370bf4f8/python/tests/test_ops.py#L1865
-    raise NotImplementedError("The MLX backend doesn't support tensordot yet")
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return mx.tensordot(x1, x2, axes=axes)
 
 
 def round(x, decimals=0):
-    # TODO: https://ml-explore.github.io/mlx/build/html
-    # /python/_autosummary/mlx.core.round.html#mlx.core.round
-    # https://github.com/ml-explore/mlx/blob/
-    # 85c8a91a279923189d0eeddd926a1015370bf4f8/python/tests/test_ops.py#L483
-    raise NotImplementedError("The MLX backend doesn't support round yet")
+    x = convert_to_tensor(x)
+    return mx.round(x, decimals=decimals)
 
 
 def tile(x, repeats):

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -580,8 +580,27 @@ def maximum(x1, x2):
 
 
 def median(x, axis=None, keepdims=False):
-    # TODO: Maybe implement via sort?
-    raise NotImplementedError("The MLX backend doesn't support median yet")
+    x = mx.array(x)
+    x = mx.sort(x, axis=axis)
+    if axis is None:
+        axis = 0
+    n = x.shape[axis]
+    m = n - 1
+    if n % 2 == 0:
+        index1 = [slice(None)] * x.ndim
+        index1[axis] = m // 2
+        index2 = [slice(None)] * x.ndim
+        index2[axis] = (m + 1) // 2
+        median = (x[tuple(index1)] + x[tuple(index2)]) / 2.0
+    else:
+        index = [slice(None)] * x.ndim
+        index[axis] = n // 2
+        median = x[tuple(index)]
+    if keepdims:
+        median_shape = list(median.shape)
+        median_shape.insert(axis, 1)
+        median = median.reshape(median_shape)
+    return median
 
 
 def meshgrid(*x, indexing="xy"):

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -585,7 +585,11 @@ def median(x, axis=None, keepdims=False):
 
 
 def meshgrid(*x, indexing="xy"):
-    # TODO: Implement inline like linspace
+    # TODO: https://ml-explore.github.io/mlx/build/html/python/
+    # _autosummary/mlx.core.meshgrid.html
+    # https://github.com/ml-explore/mlx/blob/
+    # #85c8a91a279923189d0eeddd926a1015370bf4f8/python/tests/test_ops.py#L1470
+
     raise NotImplementedError("The MLX backend doesn't support meshgrid yet")
 
 
@@ -809,10 +813,18 @@ def tanh(x):
 
 
 def tensordot(x1, x2, axes=2):
+    # TODO: https://ml-explore.github.io/mlx/build/html/python/_autosummary
+    # /mlx.core.tensordot.html#mlx-core-tensordot
+    # https://github.com/ml-explore/mlx/blob/
+    # 85c8a91a279923189d0eeddd926a1015370bf4f8/python/tests/test_ops.py#L1865
     raise NotImplementedError("The MLX backend doesn't support tensordot yet")
 
 
 def round(x, decimals=0):
+    # TODO: https://ml-explore.github.io/mlx/build/html
+    # /python/_autosummary/mlx.core.round.html#mlx.core.round
+    # https://github.com/ml-explore/mlx/blob/
+    # 85c8a91a279923189d0eeddd926a1015370bf4f8/python/tests/test_ops.py#L483
     raise NotImplementedError("The MLX backend doesn't support round yet")
 
 

--- a/keras/backend/mlx/numpy.py
+++ b/keras/backend/mlx/numpy.py
@@ -604,8 +604,7 @@ def median(x, axis=None, keepdims=False):
 
 
 def meshgrid(*x, indexing="xy"):
-    # TODO: test with and without
-    # x = [convert_to_tensor(xi) for xi in x]
+    x = [convert_to_tensor(xi) for xi in x]
     return mx.meshgrid(*x, indexing=indexing)
 
 


### PR DESCRIPTION
identify, implement, and test missing functions in the MLX backend.
at `keras/backend/mlx/math.py` and `keras/backend/mlx/numpy.py`
 
 

 I have added [mlx.core.meshgrid]( https://ml-explore.github.io/mlx/build/html/python/_autosummary/mlx.core.meshgrid.html#mlx.core.meshgrid
)
 
I have added [mlx.core.tensordot]( https://ml-explore.github.io/mlx/build/html/python/_autosummary/mlx.core.tensordot.html#mlx-core-tensordot) 
 
 
 I have added [mlx.core.round](https://ml-explore.github.io/mlx/build/html/python/_autosummary/mlx.core.round.html#mlx.core.round)
 
 
I have added some as TODOs.  I will be happy to address them later.

I have implemented and tested median
https://colab.research.google.com/drive/1QAnbnRQB-njkbMm8s852Go6LcOQH3ihN?usp=sharing


WIP almost done..

keras/backend/mlx/nn.py:conv
keras/backend/mlx/nn.py:depthwise_conv
keras/backend/mlx/nn.py:separable_conv
keras/backend/mlx/nn.py:conv_transpose