### PR TITLE
Fix incorrect usage of `quantize`

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -1,7 +1,6 @@
 import ml_dtypes
 
 from keras.src import activations
-from keras.src import backend
 from keras.src import constraints
 from keras.src import dtype_policies
 from keras.src import initializers
@@ -347,6 +346,7 @@ class Dense(Layer):
             initializer=kernel_scale_initializer,
             trainable=False,
         )
+        self._is_quantized = True
 
     def _float8_build(self):
         if not isinstance(
@@ -396,6 +396,7 @@ class Dense(Layer):
         self.kernel_amax_history.overwrite_with_gradient = True
         self.outputs_grad_scale.overwrite_with_gradient = True
         self.outputs_grad_amax_history.overwrite_with_gradient = True
+        self._is_quantized = True
 
     def quantized_call(self, inputs):
         if self.dtype_policy.quantization_mode == "int8":
@@ -539,6 +540,8 @@ class Dense(Layer):
                 f"Layer {self.__class__.__name__} does not have a `quantize()` "
                 "method implemented."
             )
+        if getattr(self, "_is_quantized", False):
+            raise ValueError("`quantize` can only be done once per layer.")
         self._check_quantize_args(mode, self.compute_dtype)
 
         # Set new dtype policy
@@ -552,8 +555,6 @@ class Dense(Layer):
 
         self._tracker.unlock()
         if mode == "int8":
-            if backend.standardize_dtype(self._kernel.dtype) == "int8":
-                raise ValueError("`quantize` can only be done once per layer.")
             # Configure `self.inputs_quantizer`
             self.inputs_quantizer = quantizers.AbsMaxQuantizer(axis=-1)
             # Quantize `self._kernel` to int8 and compute corresponding scale
@@ -572,8 +573,6 @@ class Dense(Layer):
                 lambda shape, dtype: kernel_scale,
             )
         elif mode == "float8":
-            if hasattr(self, "inputs_amax_history"):
-                raise ValueError("`quantize` can only be done once per layer.")
             self._float8_build()
         else:
             raise NotImplementedError(

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -540,8 +540,6 @@ class Dense(Layer):
                 f"Layer {self.__class__.__name__} does not have a `quantize()` "
                 "method implemented."
             )
-        if getattr(self, "_is_quantized", False):
-            raise ValueError("`quantize` can only be done once per layer.")
         self._check_quantize_args(mode, self.compute_dtype)
 
         # Set new dtype policy

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -422,7 +422,7 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
         layer.quantize(mode)
         for m in ["int8", "float8"]:
             with self.assertRaisesRegex(
-                ValueError, "`quantize` can only be done once per layer."
+                ValueError, "is already quantized with dtype_policy="
             ):
                 layer.quantize(m)
 
@@ -435,7 +435,7 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
         layer.build((None, 2))
         for m in ["int8", "float8"]:
             with self.assertRaisesRegex(
-                ValueError, "`quantize` can only be done once per layer."
+                ValueError, "is already quantized with dtype_policy="
             ):
                 layer.quantize(m)
 

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -420,10 +420,24 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
         layer = layers.Dense(units=2)
         layer.build((None, 2))
         layer.quantize(mode)
-        with self.assertRaisesRegex(
-            ValueError, "`quantize` can only be done once per layer."
-        ):
-            layer.quantize(mode)
+        for m in ["int8", "float8"]:
+            with self.assertRaisesRegex(
+                ValueError, "`quantize` can only be done once per layer."
+            ):
+                layer.quantize(m)
+
+    @parameterized.named_parameters(
+        ("int8", "int8_from_float32"),
+        ("float8", "float8_from_float32"),
+    )
+    def test_quantize_when_already_quantized_using_dtype_argument(self, mode):
+        layer = layers.Dense(units=2, dtype=mode)
+        layer.build((None, 2))
+        for m in ["int8", "float8"]:
+            with self.assertRaisesRegex(
+                ValueError, "`quantize` can only be done once per layer."
+            ):
+                layer.quantize(m)
 
     @parameterized.named_parameters(
         ("int8", "int8_from_float32", 3),

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -653,8 +653,6 @@ class EinsumDense(Layer):
                 f"Layer {self.__class__.__name__} does not have a `quantize()` "
                 "method implemented."
             )
-        if getattr(self, "_is_quantized", False):
-            raise ValueError("`quantize` can only be done once per layer.")
         self._check_quantize_args(mode, self.compute_dtype)
 
         # Set new dtype policy

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -5,7 +5,6 @@ import ml_dtypes
 import numpy as np
 
 from keras.src import activations
-from keras.src import backend
 from keras.src import constraints
 from keras.src import dtype_policies
 from keras.src import initializers
@@ -431,6 +430,7 @@ class EinsumDense(Layer):
             initializer=kernel_scale_initializer,
             trainable=False,
         )
+        self._is_quantized = True
 
     def _float8_build(self):
         if not isinstance(
@@ -480,6 +480,7 @@ class EinsumDense(Layer):
         self.kernel_amax_history.overwrite_with_gradient = True
         self.outputs_grad_scale.overwrite_with_gradient = True
         self.outputs_grad_amax_history.overwrite_with_gradient = True
+        self._is_quantized = True
 
     def quantized_call(self, inputs):
         if self.dtype_policy.quantization_mode == "int8":
@@ -652,6 +653,8 @@ class EinsumDense(Layer):
                 f"Layer {self.__class__.__name__} does not have a `quantize()` "
                 "method implemented."
             )
+        if getattr(self, "_is_quantized", False):
+            raise ValueError("`quantize` can only be done once per layer.")
         self._check_quantize_args(mode, self.compute_dtype)
 
         # Set new dtype policy
@@ -665,8 +668,6 @@ class EinsumDense(Layer):
 
         self._tracker.unlock()
         if mode == "int8":
-            if backend.standardize_dtype(self._kernel.dtype) == "int8":
-                raise ValueError("`quantize` can only be done once per layer.")
             (
                 self._input_reduced_axes,
                 self._kernel_reduced_axes,
@@ -709,8 +710,6 @@ class EinsumDense(Layer):
                 lambda shape, dtype: kernel_scale,
             )
         elif mode == "float8":
-            if hasattr(self, "inputs_amax_history"):
-                raise ValueError("`quantize` can only be done once per layer.")
             self._float8_build()
         else:
             raise NotImplementedError(

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -508,15 +508,34 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
     def test_quantize_when_already_quantized(self, mode):
         layer = layers.EinsumDense(
             equation="ab,bcd->acd",
-            output_shape=(8, 32),
+            output_shape=(8, 16),
             bias_axes="d",
         )
         layer.build((None, 3))
         layer.quantize(mode)
-        with self.assertRaisesRegex(
-            ValueError, "`quantize` can only be done once per layer."
-        ):
-            layer.quantize(mode)
+        for m in ["int8", "float8"]:
+            with self.assertRaisesRegex(
+                ValueError, "`quantize` can only be done once per layer."
+            ):
+                layer.quantize(m)
+
+    @parameterized.named_parameters(
+        ("int8", "int8_from_float32"),
+        ("float8", "float8_from_float32"),
+    )
+    def test_quantize_when_already_quantized_using_dtype_argument(self, mode):
+        layer = layers.EinsumDense(
+            equation="ab,bcd->acd",
+            output_shape=(8, 16),
+            bias_axes="d",
+            dtype=mode,
+        )
+        layer.build((None, 3))
+        for m in ["int8", "float8"]:
+            with self.assertRaisesRegex(
+                ValueError, "`quantize` can only be done once per layer."
+            ):
+                layer.quantize(m)
 
     @parameterized.named_parameters(
         ("int8", "int8_from_float32", 3),

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -515,7 +515,7 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
         layer.quantize(mode)
         for m in ["int8", "float8"]:
             with self.assertRaisesRegex(
-                ValueError, "`quantize` can only be done once per layer."
+                ValueError, "is already quantized with dtype_policy="
             ):
                 layer.quantize(m)
 
@@ -533,7 +533,7 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
         layer.build((None, 3))
         for m in ["int8", "float8"]:
             with self.assertRaisesRegex(
-                ValueError, "`quantize` can only be done once per layer."
+                ValueError, "is already quantized with dtype_policy="
             ):
                 layer.quantize(m)
 

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -362,8 +362,6 @@ class Embedding(Layer):
                 f"Layer {self.__class__.__name__} does not have a `quantize()` "
                 "method implemented."
             )
-        if getattr(self, "_is_quantized", False):
-            raise ValueError("`quantize` can only be done once per layer.")
         self._check_quantize_args(mode, self.compute_dtype)
 
         # Set new dtype policy

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -314,7 +314,7 @@ class EmbeddingTest(test_case.TestCase, parameterized.TestCase):
         layer.build()
         layer.quantize("int8")
         with self.assertRaisesRegex(
-            ValueError, "`quantize` can only be done once per layer."
+            ValueError, "is already quantized with dtype_policy="
         ):
             layer.quantize("int8")
 
@@ -322,7 +322,7 @@ class EmbeddingTest(test_case.TestCase, parameterized.TestCase):
         layer = layers.Embedding(10, 16, dtype="int8_from_float32")
         layer.build()
         with self.assertRaisesRegex(
-            ValueError, "`quantize` can only be done once per layer."
+            ValueError, "is already quantized with dtype_policy="
         ):
             layer.quantize("int8")
 

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -318,6 +318,14 @@ class EmbeddingTest(test_case.TestCase, parameterized.TestCase):
         ):
             layer.quantize("int8")
 
+    def test_quantize_when_already_quantized_using_dtype_argument(self):
+        layer = layers.Embedding(10, 16, dtype="int8_from_float32")
+        layer.build()
+        with self.assertRaisesRegex(
+            ValueError, "`quantize` can only be done once per layer."
+        ):
+            layer.quantize("int8")
+
     @parameterized.named_parameters(
         ("int8", "int8_from_float32", 2),
     )

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1143,6 +1143,12 @@ class Layer(BackendLayer, Operation):
                 f"Layer '{self.name}' (of type '{self.__class__.__name__}') "
                 "is not built yet."
             )
+        if getattr(self, "_is_quantized", False):
+            raise ValueError(
+                f"'{self.name}' is already quantized with "
+                f"dtype_policy={self.dtype_policy.name}. "
+                f"Received: mode={mode}"
+            )
         if mode not in dtype_policies.QUANTIZATION_MODES:
             raise ValueError(
                 "Invalid quantization mode. "

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1145,8 +1145,8 @@ class Layer(BackendLayer, Operation):
             )
         if getattr(self, "_is_quantized", False):
             raise ValueError(
-                f"'{self.name}' is already quantized with "
-                f"dtype_policy={self.dtype_policy.name}. "
+                f"Layer '{self.name}' is already quantized with "
+                f"dtype_policy='{self.dtype_policy.name}'. "
                 f"Received: mode={mode}"
             )
         if mode not in dtype_policies.QUANTIZATION_MODES:


### PR DESCRIPTION
This PR prevents incorrect usage of `quantize` on the layer with different quantization modes.

```python
from keras import layers
from keras import models

model = models.Sequential([layers.Input(shape=[16]), layers.Dense(32)])
model.quantize("int8")
model.quantize("float8")  # <- will succeed with the current codebase

```

This PR also replaces the original error msg with a more informative one:

```bash
ValueError: Layer 'dense' is already quantized with dtype_policy='int8_from_float32'. Received: mode=float8
```