### PR TITLE
Add pickle support for Keras model

### DIFF
--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -1,9 +1,10 @@
 import inspect
+import io
 import json
 import typing
 import warnings
-import io
 
+import keras.src.saving.saving_lib as saving_lib
 from keras.src import backend
 from keras.src import utils
 from keras.src.api_export import keras_export
@@ -13,8 +14,6 @@ from keras.src.saving import saving_api
 from keras.src.trainers import trainer as base_trainer
 from keras.src.utils import summary_utils
 from keras.src.utils import traceback_utils
-import keras.src.saving.saving_lib as saving_lib
-
 
 if backend.backend() == "tensorflow":
     from keras.src.backend.tensorflow.trainer import (

--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -355,7 +355,7 @@ class Model(Trainer, base_trainer.Trainer, Layer):
     # saving format -- it should only be supported for use with distributed
     # computing frameworks.
     @classmethod
-    def _depickle_model(cls, bytesio):
+    def _unpickle_model(cls, bytesio):
         # pickle is not safe regardless of what you do.
         return saving_lib._load_model_from_fileobj(
             bytesio, custom_objects=None, compile=True, safe_mode=False
@@ -370,7 +370,7 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         buf = io.BytesIO()
         saving_lib._save_model_to_fileobj(self, buf, "h5")
         return (
-            self._depickle_model,
+            self._unpickle_model,
             (buf,),
         )
 

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -142,7 +142,6 @@ class ModelTest(testing.TestCase, parameterized.TestCase):
         # self.assertAllClose fails for some dtypes, so we use np
         self.assertAllClose(np.array(pred_reloaded), np.array(pred))
 
-
     @parameterized.named_parameters(
         ("single_output_1", _get_model_single_output, None),
         ("single_output_2", _get_model_single_output, "list"),

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -174,11 +174,11 @@ class ModelTest(testing.TestCase, parameterized.TestCase):
 
         reloaded_pickle = pickle.loads(pickle.dumps(model))
         # self.assertAllClose fails for some dtypes
-        
+
         pred_reloaded = reloaded_pickle.predict(x)
         pred = model.predict(x)
         if isinstance(pred, dict):
-            for key in pred: 
+            for key in pred:
                 np.testing.assert_allclose(pred_reloaded[key], pred[key])
         else:
             np.testing.assert_allclose(pred_reloaded, pred)

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -1,3 +1,5 @@
+import pickle
+
 import numpy as np
 import pytest
 from absl.testing import parameterized
@@ -9,7 +11,6 @@ from keras.src.layers.core.input_layer import Input
 from keras.src.models.functional import Functional
 from keras.src.models.model import Model
 from keras.src.models.model import model_from_json
-import pickle
 
 
 def _get_model():
@@ -173,10 +174,11 @@ class ModelTest(testing.TestCase, parameterized.TestCase):
         self.assertListEqual(hist_keys, ref_keys)
 
         reloaded_pickle = pickle.loads(pickle.dumps(model))
-        # self.assertAllClose fails for some dtypes
 
         pred_reloaded = reloaded_pickle.predict(x)
         pred = model.predict(x)
+
+        # self.assertAllClose fails for some dtypes, so we use np
         if isinstance(pred, dict):
             for key in pred:
                 np.testing.assert_allclose(pred_reloaded[key], pred[key])

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -139,7 +139,6 @@ class ModelTest(testing.TestCase, parameterized.TestCase):
         pred_reloaded = reloaded_pickle.predict(x)
         pred = model.predict(x)
 
-        # self.assertAllClose fails for some dtypes, so we use np
         self.assertAllClose(np.array(pred_reloaded), np.array(pred))
 
     @parameterized.named_parameters(


### PR DESCRIPTION
https://github.com/keras-team/keras/issues/19554

Implements some basic unit tests for pickling on top of one of the existing parameterized tests.  I think this gets pretty good coverage across cases.

There might be some weird edge cases where reloading fails, but I think this is fine in that pickling isn't really useful as  a long term storage solution - just a short term way to transfer some info between workers.

Open to ideas about better approaches here - this is just the best I could come up with.