### PR TITLE
Make `ops.abs` and `ops.absolute` consistent between backends.

### DIFF
--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -223,10 +223,8 @@ def absolute(x):
     return jnp.absolute(x)
 
 
-@sparse.elementwise_unary(linear=False)
 def abs(x):
-    x = convert_to_tensor(x)
-    return jnp.absolute(x)
+    return absolute(x)
 
 
 def all(x, axis=None, keepdims=False):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -615,6 +615,7 @@ def zeros(shape, dtype=None):
 
 @sparse.elementwise_unary
 def absolute(x):
+    x = convert_to_tensor(x)
     # uintx and bool are always non-negative
     dtype = standardize_dtype(x.dtype)
     if "uint" in dtype or dtype == "bool":
@@ -622,7 +623,6 @@ def absolute(x):
     return tf.abs(x)
 
 
-@sparse.elementwise_unary
 def abs(x):
     return absolute(x)
 
@@ -2405,4 +2405,4 @@ def correlate(x1, x2, mode="valid"):
 
 
 def select(condlist, choicelist, default=0):
-    return tfnp.select(condlist, choicelist, default=default)
+    return tf.experimental.numpy.select(condlist, choicelist, default=default)

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -201,15 +201,15 @@ def zeros_like(x, dtype=None):
 
 
 def absolute(x):
-    return abs(x)
-
-
-def abs(x):
     x = convert_to_tensor(x)
     # bool are always non-negative
     if standardize_dtype(x.dtype) == "bool":
         return x
     return torch.abs(x)
+
+
+def abs(x):
+    return absolute(x)
 
 
 def all(x, axis=None, keepdims=False):


### PR DESCRIPTION
- The TensorFlow implementation was missing `convert_to_tensor`
- The sparse annotation was unnecessarily applied twice
- Now `abs` calls `absolute` in all backends

Also fixed TensorFlow `ops.select`.