### PR TITLE
list insert requires index

### DIFF
--- a/keras/src/utils/tracking.py
+++ b/keras/src/utils/tracking.py
@@ -146,10 +146,10 @@ class TrackedList(list):
             self.tracker.track(value)
         super().append(value)
 
-    def insert(self, value):
+    def insert(self, index, value):
         if self.tracker:
             self.tracker.track(value)
-        super().insert(value)
+        super().insert(index, value)
 
     def extend(self, values):
         if self.tracker:


### PR DESCRIPTION
super() calls python's builtin list class.

As per Python docs: 
```python
list.insert(i, x)
```
"Insert an item at a given position. The first argument is the index of the element before which to insert, so a.insert(0, x) inserts at the front of the list, and a.insert(len(a), x) is equivalent to a.append(x)."

https://docs.python.org/3/tutorial/datastructures.html