### PR TITLE
Fix keys of `save_own_variables` and `load_own_variables`

### DIFF
--- a/keras/src/layers/convolutional/base_conv.py
+++ b/keras/src/layers/convolutional/base_conv.py
@@ -307,9 +307,11 @@ class BaseConv(Layer):
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
-        store["0"] = self.kernel
+        target_variables = [self.kernel]
         if self.use_bias:
-            store["1"] = self.bias
+            target_variables.append(self.bias)
+        for i, variable in enumerate(target_variables):
+            store[str(i)] = variable
 
     def load_own_variables(self, store):
         if not self.lora_enabled:
@@ -317,9 +319,11 @@ class BaseConv(Layer):
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
-        self._kernel.assign(store["0"])
+        target_variables = [self._kernel]
         if self.use_bias:
-            self.bias.assign(store["1"])
+            target_variables.append(self.bias)
+        for i, variable in enumerate(target_variables):
+            variable.assign(store[str(i)])
         if self.lora_enabled:
             self.lora_kernel_a.assign(ops.zeros(self.lora_kernel_a.shape))
             self.lora_kernel_b.assign(ops.zeros(self.lora_kernel_b.shape))

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -257,24 +257,26 @@ class EinsumDense(Layer):
         # The keys of the `store` will be saved as determined because the
         # default ordering will change after quantization
         kernel_value, kernel_scale = self._get_kernel_with_merged_lora()
-        store["0"] = kernel_value
+        target_variables = [kernel_value]
         if self.bias is not None:
-            store["1"] = self.bias
+            target_variables.append(self.bias)
         if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
             mode = self.dtype_policy.quantization_mode
             if mode == "int8":
-                store["2"] = kernel_scale
+                target_variables.append(kernel_scale)
             elif mode == "float8":
-                store["2"] = self.inputs_scale
-                store["3"] = self.inputs_amax_history
-                store["4"] = self.kernel_scale
-                store["5"] = self.kernel_amax_history
-                store["6"] = self.outputs_grad_scale
-                store["7"] = self.outputs_grad_amax_history
+                target_variables.append(self.inputs_scale)
+                target_variables.append(self.inputs_amax_history)
+                target_variables.append(self.kernel_scale)
+                target_variables.append(self.kernel_amax_history)
+                target_variables.append(self.outputs_grad_scale)
+                target_variables.append(self.outputs_grad_amax_history)
             else:
                 raise NotImplementedError(
                     self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode)
                 )
+        for i, variable in enumerate(target_variables):
+            store[str(i)] = variable
 
     def load_own_variables(self, store):
         if not self.lora_enabled:
@@ -284,24 +286,26 @@ class EinsumDense(Layer):
             return
         # The keys of the `store` will be saved as determined because the
         # default ordering will change after quantization
-        self._kernel.assign(store["0"])
+        target_variables = [self._kernel]
         if self.bias is not None:
-            self.bias.assign(store["1"])
+            target_variables.append(self.bias)
         if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
             mode = self.dtype_policy.quantization_mode
             if mode == "int8":
-                self.kernel_scale.assign(store["2"])
+                target_variables.append(self.kernel_scale)
             elif mode == "float8":
-                self.inputs_scale.assign(store["2"])
-                self.inputs_amax_history.assign(store["3"])
-                self.kernel_scale.assign(store["4"])
-                self.kernel_amax_history.assign(store["5"])
-                self.outputs_grad_scale.assign(store["6"])
-                self.outputs_grad_amax_history.assign(store["7"])
+                target_variables.append(self.inputs_scale)
+                target_variables.append(self.inputs_amax_history)
+                target_variables.append(self.kernel_scale)
+                target_variables.append(self.kernel_amax_history)
+                target_variables.append(self.outputs_grad_scale)
+                target_variables.append(self.outputs_grad_amax_history)
             else:
                 raise NotImplementedError(
                     self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode)
                 )
+        for i, variable in enumerate(target_variables):
+            variable.assign(store[str(i)])
         if self.lora_enabled:
             self.lora_kernel_a.assign(ops.zeros(self.lora_kernel_a.shape))
             self.lora_kernel_b.assign(ops.zeros(self.lora_kernel_b.shape))


### PR DESCRIPTION
Consider following script:

```python
import keras

layer = keras.layers.Dense(4, use_bias=False)
layer.build([None, 2])
layer.quantize("int8")

store = {}
layer.save_own_variables(store)
print(list(store.keys()))

```

With the current codebase, we will get `['0', '2']`.

This PR updates the logic to strictly increments the key numbers. (`['0', '1']`)

This change will prevent a potential bug when adding quantization techniques to downstream projects such as
`keras_nlp.layers.ReversibleEmbedding`