### PR TITLE
Convert return type imdb.load_data to np array

### DIFF
--- a/keras/src/datasets/imdb.py
+++ b/keras/src/datasets/imdb.py
@@ -135,8 +135,8 @@ def load_data(
         xs = [[w for w in x if skip_top <= w < num_words] for x in xs]
 
     idx = len(x_train)
-    x_train, y_train = xs[:idx], labels[:idx]
-    x_test, y_test = xs[idx:], labels[idx:]
+    x_train, y_train = np.array(xs[:idx], dtype="object"), labels[:idx]
+    x_test, y_test = np.array(xs[idx:], dtype="object"), labels[idx:]
     return (x_train, y_train), (x_test, y_test)
 
 


### PR DESCRIPTION
Convert return type imdb.load_data to Numpy array. Currently X_train and X-test returned as list. Tested [gist](https://colab.sandbox.google.com/gist/SuryanarayanaY/f8132ac0b80cadf0c65ed4f74ee092c3/19596.ipynb).

Fixes #19596 