### PR TITLE
pin torch < 2.3.0 (pre-release ver) to resolve 'Parameter' object has no attribute 'fget'

### DIFF
--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -3,7 +3,7 @@ tensorflow-cpu~=2.16.1  # Pin to TF 2.16
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0
+torch>=2.1.0, <2.3.0
 torchvision>=0.16.0
 
 # Jax with cuda support.

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -3,7 +3,7 @@ tensorflow[and-cuda]~=2.16.1  # Pin to TF 2.16
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0
+torch>=2.1.0, <2.3.0
 torchvision>=0.16.0
 
 # Jax cpu-only version (needed for testing).

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@
 tensorflow-cpu~=2.16.1  # Pin to TF 2.16
 
 # Torch.
+# TODO: Pin to < 2.3.0 (GitHub issue #19602)
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0
+torch>=2.1.0, <2.3.0
 torchvision>=0.16.0
 
 # Jax.


### PR DESCRIPTION
Fixes #19602 