### PR TITLE
Provide write permission to action for cache management.

### DIFF
--- a/.github/workflows/stale-issue-pr.yaml
+++ b/.github/workflows/stale-issue-pr.yaml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      actions: write
     steps:
       - name: Awaiting response issues
         uses: actions/stale@v9


### PR DESCRIPTION
With latest version of stale. Cache management is required actions write permission to update the cahce in next run.