### PR TITLE
Refactor CTC APIs

### DIFF
--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -893,11 +893,16 @@ def ctc_decode(
             merge_repeated=merge_repeated,
             mask_index=mask_index,
         )
-    else:
+    elif strategy == "beam_search":
         return _ctc_beam_search_decode(
             inputs,
             sequence_length,
             beam_width=beam_width,
             top_paths=top_paths,
             mask_index=mask_index,
+        )
+    else:
+        raise ValueError(
+            f"Invalid strategy {strategy}. Supported values are "
+            "'greedy' and 'beam_search'."
         )

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -3,12 +3,10 @@ import numpy as np
 from jax import lax
 from jax import numpy as jnp
 
-from keras.src.backend import standardize_data_format
-from keras.src.backend import standardize_dtype
+from keras.src import backend
 from keras.src.backend.common.backend_utils import (
     compute_conv_transpose_padding_args_for_jax,
 )
-from keras.src.backend.config import epsilon
 from keras.src.backend.numpy.core import cast
 from keras.src.backend.numpy.core import convert_to_tensor
 from keras.src.backend.numpy.core import is_tensor
@@ -191,7 +189,7 @@ def max_pool(
     padding="valid",
     data_format=None,
 ):
-    data_format = standardize_data_format(data_format)
+    data_format = backend.standardize_data_format(data_format)
     num_spatial_dims = inputs.ndim - 2
     pool_size = _convert_to_spatial_operand(
         pool_size, num_spatial_dims, data_format
@@ -210,7 +208,7 @@ def average_pool(
     padding,
     data_format=None,
 ):
-    data_format = standardize_data_format(data_format)
+    data_format = backend.standardize_data_format(data_format)
     num_spatial_dims = inputs.ndim - 2
     pool_size = _convert_to_spatial_operand(
         pool_size, num_spatial_dims, data_format
@@ -276,7 +274,7 @@ def conv(
     data_format=None,
     dilation_rate=1,
 ):
-    data_format = standardize_data_format(data_format)
+    data_format = backend.standardize_data_format(data_format)
     num_spatial_dims = inputs.ndim - 2
     dimension_numbers = _convert_to_lax_conv_dimension_numbers(
         num_spatial_dims,
@@ -328,7 +326,7 @@ def depthwise_conv(
     data_format=None,
     dilation_rate=1,
 ):
-    data_format = standardize_data_format(data_format)
+    data_format = backend.standardize_data_format(data_format)
     num_spatial_dims = inputs.ndim - 2
     dimension_numbers = _convert_to_lax_conv_dimension_numbers(
         num_spatial_dims,
@@ -376,7 +374,7 @@ def separable_conv(
     data_format=None,
     dilation_rate=1,
 ):
-    data_format = standardize_data_format(data_format)
+    data_format = backend.standardize_data_format(data_format)
     depthwise_conv_output = depthwise_conv(
         inputs,
         depthwise_kernel,
@@ -404,7 +402,7 @@ def conv_transpose(
     data_format=None,
     dilation_rate=1,
 ):
-    data_format = standardize_data_format(data_format)
+    data_format = backend.standardize_data_format(data_format)
     num_spatial_dims = inputs.ndim - 2
     padding_values = compute_conv_transpose_padding_args_for_jax(
         input_shape=inputs.shape,
@@ -508,7 +506,7 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
         log_prob = log_softmax(output, axis=axis)
     else:
         output = output / np.sum(output, axis, keepdims=True)
-        output = np.clip(output, epsilon(), 1.0 - epsilon())
+        output = np.clip(output, backend.epsilon(), 1.0 - backend.epsilon())
         log_prob = np.log(output)
     return -np.sum(target * log_prob, axis=axis)
 
@@ -535,7 +533,7 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
         log_prob = log_softmax(output, axis=axis)
     else:
         output = output / np.sum(output, axis, keepdims=True)
-        output = np.clip(output, epsilon(), 1.0 - epsilon())
+        output = np.clip(output, backend.epsilon(), 1.0 - backend.epsilon())
         log_prob = np.log(output)
     target = one_hot(target, output.shape[axis], axis=axis)
     return -np.sum(target * log_prob, axis=axis)
@@ -555,7 +553,7 @@ def binary_crossentropy(target, output, from_logits=False):
     if from_logits:
         output = sigmoid(output)
 
-    output = np.clip(output, epsilon(), 1.0 - epsilon())
+    output = np.clip(output, backend.epsilon(), 1.0 - backend.epsilon())
     bce = target * np.log(output)
     bce += (1.0 - target) * np.log(1.0 - output)
     return -bce
@@ -571,7 +569,7 @@ def moments(x, axes, keepdims=False, synchronized=False):
     # workaround, we simply perform the operations on float32 and convert back
     # to float16
     need_cast = False
-    ori_dtype = standardize_dtype(x.dtype)
+    ori_dtype = backend.standardize_dtype(x.dtype)
     if ori_dtype == "float16":
         need_cast = True
         x = cast(x, "float32")
@@ -617,6 +615,309 @@ def batch_normalization(
     return x * inv + res
 
 
+def ctc_loss(
+    target,
+    output,
+    target_length,
+    output_length,
+    mask_index=0,
+):
+    target = convert_to_tensor(target)
+    output = convert_to_tensor(output)
+    batch_size, _, _ = output.shape
+    batch_size, max_target_length = target.shape
+
+    output = output.transpose((1, 0, 2))
+    target = target.transpose((1, 0)).astype("int32")
+
+    # Ensure that the dtype promotion behavior matchs that of `tf.nn.ctc_loss`
+    dtype = backend.result_type(output.dtype, "float32")
+    output = output.astype(dtype)
+
+    logits = log_softmax(output, axis=-1)
+    mgrid_t, mgrid_b = np.meshgrid(
+        np.arange(max_target_length), np.arange(batch_size)
+    )
+    logprobs_emit = logits[mgrid_t, mgrid_b, target[:, :, None]]
+    logprobs_mask = logits[:, :, mask_index]
+
+    logit_paddings = np.array(
+        np.arange(max_target_length) < output_length[:, None],
+        dtype=output.dtype,
+    )
+
+    repeat = np.array(target[1:] == target[:-1])
+    repeat = np.pad(repeat, ((0, 1), (0, 0))).transpose((1, 0))
+
+    _logepsilon = -100000.0
+
+    def _iterate(prev, x):
+        prev_mask, prev_emit = prev
+        logprob_mask, logprob_emit, pad = x
+
+        prev_mask_orig = prev_mask
+        prev_mask[:, 1:] = np.logaddexp(
+            prev_mask[:, 1:], prev_emit + _logepsilon * repeat
+        )
+        emit = np.logaddexp(
+            prev_mask[:, :-1] + logprob_emit, prev_emit + logprob_emit
+        )
+
+        mask = prev_mask + logprob_mask[:, None]
+        mask[:, 1:] = np.logaddexp(
+            mask[:, 1:],
+            prev_emit + logprob_mask[:, None] + _logepsilon * (1 - repeat),
+        )
+
+        pad = pad[:, None]
+        emit = emit * pad + prev_emit * (1 - pad)
+        mask = mask * pad + prev_mask_orig * (1 - pad)
+
+        return (mask, emit), (mask, emit)
+
+    mask_init = np.full(
+        (batch_size, max_target_length + 1),
+        _logepsilon,
+        dtype=logits.dtype,
+    )
+    mask_init[:, 0] = 0.0
+    emit_init = np.full(
+        (batch_size, max_target_length), _logepsilon, dtype=logits.dtype
+    )
+
+    def np_scan(f, init, xs):
+        carry = init
+        ys = []
+        for x in zip(*xs):
+            carry, y = f(carry, x)
+            ys.append(y)
+        result = []
+        for i in range(len(ys[0])):
+            result.append(np.stack([y[i] for y in ys]))
+        return carry, result
+
+    _, (alphas_mask, alphas_emit) = np_scan(
+        _iterate,
+        [mask_init, emit_init],
+        [logprobs_mask, logprobs_emit, logit_paddings.transpose()],
+    )
+
+    last_alpha_mask = alphas_mask[-1]
+    last_alpha_mask[:, 1:] = np.logaddexp(
+        alphas_mask[-1, :, 1:], alphas_emit[-1]
+    )
+    return -last_alpha_mask[np.arange(batch_size), target_length]
+
+
+def _ctc_greedy_decode(
+    inputs,
+    sequence_length,
+    merge_repeated=True,
+    mask_index=None,
+):
+    inputs = convert_to_tensor(inputs)
+    sequence_length = convert_to_tensor(sequence_length, dtype="int32")
+
+    if mask_index is None:
+        mask_index = inputs.shape[-1] - 1
+
+    indices = np.argmax(inputs, axis=-1)
+    scores = np.max(inputs, axis=-1)
+
+    seqlen_mask = np.arange(inputs.shape[1])[None, :]
+    seqlen_mask = seqlen_mask >= sequence_length[:, None]
+
+    if merge_repeated:
+        repeat = indices[:, 1:] == indices[:, :-1]
+        repeat = np.pad(repeat, ((0, 0), (1, 0)))
+
+        indices = np.where(repeat, mask_index, indices)
+    else:
+        repeat = np.zeros_like(indices, dtype=bool)
+
+    indices = np.where(seqlen_mask, mask_index, indices)
+    indices = [batch[batch != mask_index] for batch in indices]
+    max_len = max(len(batch) for batch in indices)
+    indices = np.array(
+        [np.pad(batch, (0, max_len - len(batch))) for batch in indices]
+    )
+
+    scores = np.where(seqlen_mask, 0.0, scores)
+    scores = -np.sum(scores, axis=1)[:, None]
+
+    return [indices], scores
+
+
+def _ctc_beam_search_decode(
+    inputs,
+    sequence_length,
+    beam_width=100,
+    top_paths=1,
+    mask_index=None,
+):
+    inputs = convert_to_tensor(inputs)
+    sequence_length = convert_to_tensor(sequence_length)
+
+    batch_size, max_seq_len, num_classes = inputs.shape
+    inputs = log_softmax(inputs, axis=-1)
+    seqlen_mask = np.arange(max_seq_len)[None, :] >= sequence_length[:, None]
+
+    if mask_index is None:
+        mask_index = num_classes - 1
+
+    # This is a workaround for the fact that np.argsort does not support
+    # the order parameter which is used to break ties when scores are equal.
+    # For compatibility with the tensorflow implementation, we flip the inputs
+    # and the mask_index, and then flip the classes back to the correct indices
+    inputs = np.flip(inputs, axis=2)
+    mask_index = num_classes - mask_index - 1
+
+    _pad = -1
+
+    init_paths = np.full(
+        (batch_size, 2 * beam_width, max_seq_len), _pad, dtype=np.int32
+    )
+
+    num_init_paths = np.min(np.array([num_classes, beam_width]))
+    max_classes = np.argsort(inputs[:, 0], axis=1)[:, -num_init_paths:]
+    init_classes = np.where(max_classes == mask_index, _pad, max_classes)
+    init_paths[:, :num_init_paths, 0] = init_classes
+
+    init_scores = np.full((batch_size, 2 * beam_width), -np.inf)
+    init_scores[:, :num_init_paths] = np.take_along_axis(
+        inputs[:, 0], max_classes, axis=1
+    )
+    init_masked = init_paths[:, :, 0] == _pad
+
+    def _extend_paths(paths, scores, masked, x):
+        paths = np.repeat(paths, num_classes, axis=0)
+        scores = np.repeat(scores, num_classes)
+        masked = np.repeat(masked, num_classes)
+
+        path_tail_index = np.argmax(paths == _pad, axis=1)
+        paths_arange = np.arange(2 * beam_width * num_classes)
+        path_tails = paths[paths_arange, path_tail_index - 1]
+        path_tails = np.where(path_tail_index == 0, _pad, path_tails)
+
+        classes = np.arange(num_classes)
+        classes[mask_index] = _pad
+        classes = np.tile(classes, 2 * beam_width)
+
+        prev_masked = masked
+        masked = classes == _pad
+
+        masked_repeat = ~prev_masked & (path_tails == classes)
+        classes = np.where(masked_repeat, _pad, classes)
+        paths[paths_arange, path_tail_index] = classes
+
+        x = np.tile(x, 2 * beam_width)
+        scores = scores + x
+
+        return paths, scores, masked
+
+    def _merge_scores(unique_inverse, scores):
+        scores_max = np.max(scores)
+        scores_exp = np.exp(scores - scores_max)
+        scores = np.zeros_like(scores)
+        for i, u in enumerate(unique_inverse):
+            scores[u] += scores_exp[i]
+        scores = np.log(scores) + scores_max
+        return scores
+
+    def _prune_paths(paths, scores, masked):
+        paths, unique_inverse = np.unique(paths, return_inverse=True, axis=0)
+        pad_size = (2 * num_classes * beam_width) - len(paths)
+        if pad_size > 0:
+            paths = np.pad(paths, [[0, pad_size], [0, 0]], constant_values=_pad)
+        paths = paths[: 2 * num_classes * beam_width]
+        if len(unique_inverse.shape) >= 2:
+            unique_inverse = np.squeeze(unique_inverse, axis=1)
+
+        emit_scores = np.where(masked, -np.inf, scores)
+        mask_scores = np.where(masked, scores, -np.inf)
+
+        emit_scores = _merge_scores(unique_inverse, emit_scores)
+        mask_scores = _merge_scores(unique_inverse, mask_scores)
+
+        total_scores = np.logaddexp(emit_scores, mask_scores)
+        top_indices = np.argsort(total_scores, kind="stable")[-beam_width:]
+
+        paths = paths[top_indices]
+        emit_scores = emit_scores[top_indices]
+        mask_scores = mask_scores[top_indices]
+
+        paths = np.tile(paths, (2, 1))
+        scores = np.concatenate([emit_scores, mask_scores])
+        masked = np.concatenate(
+            [np.zeros(beam_width, bool), np.ones(beam_width, bool)]
+        )
+
+        return paths, scores, masked
+
+    def _decode_step(paths, scores, masked, x):
+        paths, scores, masked = _extend_paths(paths, scores, masked, x)
+        paths, scores, masked = _prune_paths(paths, scores, masked)
+        return paths, scores, masked
+
+    def _step(prev, x):
+        paths, scores, masked = prev
+        x, seqlen_mask = x
+        if not seqlen_mask:
+            paths, scores, masked = _decode_step(paths, scores, masked, x)
+        return (paths, scores, masked), None
+
+    def _decode_batch(
+        init_paths, init_scores, init_masked, inputs, seqlen_mask
+    ):
+        def np_scan_only_carry(f, init, xs):
+            carry = init
+            for x in zip(*xs):
+                carry, y = f(carry, x)
+            return carry, None
+
+        (paths, scores, masked), _ = np_scan_only_carry(
+            _step,
+            (init_paths, init_scores, init_masked),
+            (inputs[1:], seqlen_mask[1:]),
+        )
+
+        paths, unique_inverse = np.unique(paths, return_inverse=True, axis=0)
+        pad_size = (2 * num_classes * beam_width) - len(paths)
+        if pad_size > 0:
+            paths = np.pad(paths, [[0, pad_size], [0, 0]], constant_values=_pad)
+        paths = paths[: 2 * num_classes * beam_width]
+        if len(unique_inverse.shape) >= 2:
+            unique_inverse = np.squeeze(unique_inverse, axis=1)
+        scores = _merge_scores(unique_inverse, scores)
+
+        top_indices = np.argsort(scores)[-top_paths:][::-1]
+        paths = paths[top_indices]
+        scores = scores[top_indices]
+
+        return paths, scores
+
+    results = [
+        _decode_batch(p, s, m, i, sm)
+        for p, s, m, i, sm in zip(
+            init_paths, init_scores, init_masked, inputs, seqlen_mask
+        )
+    ]
+    paths = np.stack([r[0] for r in results])
+    scores = np.stack([r[1] for r in results])
+
+    # convert classes back to the correct indices
+    paths = np.where(paths == _pad, _pad, num_classes - paths - 1)
+
+    lengths = np.argmax(paths == _pad, axis=2)
+    lengths = np.max(lengths, axis=0)
+    paths = np.where(paths == _pad, 0, paths)
+
+    paths = paths.transpose((1, 0, 2))
+    paths = [path[:, :length] for path, length in zip(paths, lengths)]
+
+    return paths, scores
+
+
 def ctc_decode(
     inputs,
     sequence_length,
@@ -626,6 +927,18 @@ def ctc_decode(
     merge_repeated=True,
     mask_index=None,
 ):
-    raise NotImplementedError(
-        "NumPy backend does not yet support CTC decoding."
-    )
+    if strategy == "greedy":
+        return _ctc_greedy_decode(
+            inputs,
+            sequence_length,
+            merge_repeated=merge_repeated,
+            mask_index=mask_index,
+        )
+    else:
+        return _ctc_beam_search_decode(
+            inputs,
+            sequence_length,
+            beam_width=beam_width,
+            top_paths=top_paths,
+            mask_index=mask_index,
+        )

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -934,11 +934,16 @@ def ctc_decode(
             merge_repeated=merge_repeated,
             mask_index=mask_index,
         )
-    else:
+    elif strategy == "beam_search":
         return _ctc_beam_search_decode(
             inputs,
             sequence_length,
             beam_width=beam_width,
             top_paths=top_paths,
             mask_index=mask_index,
+        )
+    else:
+        raise ValueError(
+            f"Invalid strategy {strategy}. Supported values are "
+            "'greedy' and 'beam_search'."
         )

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -1,7 +1,6 @@
 import jax
 import numpy as np
 from jax import lax
-from jax import numpy as jnp
 
 from keras.src import backend
 from keras.src.backend.common.backend_utils import (
@@ -198,7 +197,7 @@ def max_pool(
     strides = _convert_to_spatial_operand(
         strides, num_spatial_dims, data_format
     )
-    return _pool(inputs, -jnp.inf, lax.max, pool_size, strides, padding)
+    return _pool(inputs, -np.inf, lax.max, pool_size, strides, padding)
 
 
 def average_pool(
@@ -231,7 +230,7 @@ def average_pool(
             (a if b != 1 else 1) for (a, b) in zip(inputs.shape, pool_size)
         ]
         window_counts = _pool(
-            jnp.ones(shape, inputs.dtype),
+            np.ones(shape, inputs.dtype),
             0.0,
             lax.add,
             pool_size,
@@ -348,7 +347,7 @@ def depthwise_conv(
     feature_group_count = (
         inputs.shape[-1] if data_format == "channels_last" else inputs.shape[1]
     )
-    kernel = jnp.reshape(
+    kernel = np.reshape(
         kernel if is_tensor(kernel) else kernel.numpy(),
         kernel.shape[:-2] + (1, feature_group_count * kernel.shape[-1]),
     )
@@ -615,75 +614,91 @@ def batch_normalization(
     return x * inv + res
 
 
-def ctc_loss(
-    target,
-    output,
-    target_length,
-    output_length,
-    mask_index=0,
-):
-    target = convert_to_tensor(target)
+def ctc_loss(target, output, target_length, output_length, mask_index=0):
+    # Ref: https://github.com/google-deepmind/optax
+    # optax.ctc_loss_with_forward_probs
+    target = convert_to_tensor(target, dtype="int32")
     output = convert_to_tensor(output)
-    batch_size, _, _ = output.shape
-    batch_size, max_target_length = target.shape
-
-    output = output.transpose((1, 0, 2))
-    target = target.transpose((1, 0)).astype("int32")
+    target_length = convert_to_tensor(target_length, "int32")
+    output_length = convert_to_tensor(output_length, "int32")
+    batch_size, _, num_classes = output.shape
+    batch_size, max_label_length = target.shape
+    log_epsilon = -1e5
 
     # Ensure that the dtype promotion behavior matchs that of `tf.nn.ctc_loss`
     dtype = backend.result_type(output.dtype, "float32")
     output = output.astype(dtype)
 
-    logits = log_softmax(output, axis=-1)
-    mgrid_t, mgrid_b = np.meshgrid(
-        np.arange(max_target_length), np.arange(batch_size)
-    )
-    logprobs_emit = logits[mgrid_t, mgrid_b, target[:, :, None]]
-    logprobs_mask = logits[:, :, mask_index]
-
-    logit_paddings = np.array(
-        np.arange(max_target_length) < output_length[:, None],
-        dtype=output.dtype,
-    )
-
-    repeat = np.array(target[1:] == target[:-1])
-    repeat = np.pad(repeat, ((0, 1), (0, 0))).transpose((1, 0))
-
-    _logepsilon = -100000.0
-
-    def _iterate(prev, x):
-        prev_mask, prev_emit = prev
-        logprob_mask, logprob_emit, pad = x
-
-        prev_mask_orig = prev_mask
-        prev_mask[:, 1:] = np.logaddexp(
-            prev_mask[:, 1:], prev_emit + _logepsilon * repeat
+    def _lengths_to_paddings(lengths, max_length):
+        indices = np.arange(max_length).reshape(
+            (1,) * lengths.ndim + (max_length,)
         )
-        emit = np.logaddexp(
-            prev_mask[:, :-1] + logprob_emit, prev_emit + logprob_emit
+        lengths = np.expand_dims(lengths, axis=-1)
+        elem_valid = indices < lengths
+        return np.logical_not(elem_valid)
+
+    target_paddings = _lengths_to_paddings(target_length, max_label_length)
+    output_paddings = _lengths_to_paddings(output_length, max_label_length)
+    target_paddings = target_paddings.astype(output.dtype)
+    output_paddings = output_paddings.astype(output.dtype)
+
+    logprobs = log_softmax(output, axis=-1)
+    label_lengths = max_label_length - np.sum(target_paddings, axis=1).astype(
+        np.int32
+    )
+
+    # repeat[b, n] == 1.0 when label[b, n] == label[b, n+1].
+    repeat = (target[:, :-1] == target[:, 1:]).astype(np.float32)
+    repeat = np.pad(repeat, ((0, 0), (0, 1)))
+
+    logprobs_phi = logprobs[:, :, mask_index : mask_index + 1]  # [B, T, 1]
+    logprobs_phi = np.transpose(logprobs_phi, (1, 0, 2))  # [T, B, 1]
+
+    _one_hot = one_hot(target, num_classes=num_classes)  # [B, N, K]
+    logprobs_emit = np.einsum("btk,bnk->btn", logprobs, _one_hot)
+    logprobs_emit = np.transpose(logprobs_emit, (1, 0, 2))  # [T, B, N]
+
+    # [B, N]
+    logalpha_phi_init = (
+        np.ones((batch_size, max_label_length + 1), dtype=output.dtype)
+        * log_epsilon
+    )
+    logalpha_phi_init[:, 0] = 0.0
+    logalpha_emit_init = (
+        np.ones((batch_size, max_label_length), dtype=output.dtype)
+        * log_epsilon
+    )
+
+    def update_phi_score(phi, added_score):
+        # Update `phi[:, 1:]`` with adding `added_score` in log space.
+        return np.concatenate(
+            [phi[:, :1], np.logaddexp(phi[:, 1:], added_score)], axis=-1
         )
 
-        mask = prev_mask + logprob_mask[:, None]
-        mask[:, 1:] = np.logaddexp(
-            mask[:, 1:],
-            prev_emit + logprob_mask[:, None] + _logepsilon * (1 - repeat),
+    def loop_body(prev, x):
+        prev_phi, prev_emit = prev
+        # emit-to-phi epsilon transition, except if the next label is repetition
+        prev_phi_orig = prev_phi
+        prev_phi = update_phi_score(prev_phi, prev_emit + log_epsilon * repeat)
+
+        logprob_emit, logprob_phi, pad = x
+
+        # phi-to-emit transition
+        next_emit = np.logaddexp(
+            prev_phi[:, :-1] + logprob_emit, prev_emit + logprob_emit
+        )
+        # self-loop transition
+        next_phi = prev_phi + logprob_phi
+        # emit-to-phi blank transition only when the next label is repetition
+        next_phi = update_phi_score(
+            next_phi, prev_emit + logprob_phi + log_epsilon * (1.0 - repeat)
         )
 
-        pad = pad[:, None]
-        emit = emit * pad + prev_emit * (1 - pad)
-        mask = mask * pad + prev_mask_orig * (1 - pad)
+        pad = pad.reshape((batch_size, 1))
+        next_emit = pad * prev_emit + (1.0 - pad) * next_emit
+        next_phi = pad * prev_phi_orig + (1.0 - pad) * next_phi
 
-        return (mask, emit), (mask, emit)
-
-    mask_init = np.full(
-        (batch_size, max_target_length + 1),
-        _logepsilon,
-        dtype=logits.dtype,
-    )
-    mask_init[:, 0] = 0.0
-    emit_init = np.full(
-        (batch_size, max_target_length), _logepsilon, dtype=logits.dtype
-    )
+        return (next_phi, next_emit), (next_phi, next_emit)
 
     def np_scan(f, init, xs):
         carry = init
@@ -696,17 +711,20 @@ def ctc_loss(
             result.append(np.stack([y[i] for y in ys]))
         return carry, result
 
-    _, (alphas_mask, alphas_emit) = np_scan(
-        _iterate,
-        [mask_init, emit_init],
-        [logprobs_mask, logprobs_emit, logit_paddings.transpose()],
+    xs = (logprobs_emit, logprobs_phi, output_paddings.transpose((1, 0)))
+    _, (logalpha_phi, logalpha_emit) = np_scan(
+        loop_body, (logalpha_phi_init, logalpha_emit_init), xs
     )
 
-    last_alpha_mask = alphas_mask[-1]
-    last_alpha_mask[:, 1:] = np.logaddexp(
-        alphas_mask[-1, :, 1:], alphas_emit[-1]
-    )
-    return -last_alpha_mask[np.arange(batch_size), target_length]
+    # last row needs to be updated with the last epsilon transition
+    logalpha_phi_last = update_phi_score(logalpha_phi[-1], logalpha_emit[-1])
+    logalpha_phi[-1] = logalpha_phi_last
+
+    # extract per_seq_loss
+    # [B, N+1]
+    _one_hot = one_hot(label_lengths, num_classes=max_label_length + 1)
+    per_seq_loss = -np.einsum("bn,bn->b", logalpha_phi_last, _one_hot)
+    return per_seq_loss
 
 
 def _ctc_greedy_decode(

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -3,12 +3,10 @@ import warnings
 
 import tensorflow as tf
 
-from keras.src.backend import standardize_data_format
-from keras.src.backend import standardize_dtype
+from keras.src import backend
 from keras.src.backend.common.backend_utils import (
     compute_conv_transpose_output_shape,
 )
-from keras.src.backend.config import epsilon
 from keras.src.backend.tensorflow.core import cast
 from keras.src.backend.tensorflow.core import convert_to_tensor
 
@@ -75,30 +73,7 @@ def selu(x):
 
 def gelu(x, approximate=True):
     x = convert_to_tensor(x)
-    # we need to explicitly implement gelu because bfloat16 will trigger
-    # DTypePromotionError when using enable_numpy_behavior()
-    if approximate:
-        coeff = tf.constant(0.044715, x.dtype)
-        return (
-            tf.constant(0.5, x.dtype)
-            * x
-            * (
-                tf.constant(1.0, x.dtype)
-                + tf.math.tanh(
-                    tf.constant(0.7978845608028654, x.dtype)
-                    * (x + coeff * tf.pow(x, 3))
-                )
-            )
-        )
-    else:
-        return (
-            tf.constant(0.5, x.dtype)
-            * x
-            * (
-                tf.constant(1.0, x.dtype)
-                + tf.math.erf(x / tf.constant(1.4142135623730951, x.dtype))
-            )
-        )
+    return tf.nn.gelu(x, approximate=approximate)
 
 
 def softmax(x, axis=-1):
@@ -162,7 +137,7 @@ def max_pool(
     padding="valid",
     data_format=None,
 ):
-    data_format = standardize_data_format(data_format)
+    data_format = backend.standardize_data_format(data_format)
     strides = pool_size if strides is None else strides
     padding = padding.upper()
     tf_data_format = _convert_data_format("channels_last", len(inputs.shape))
@@ -190,7 +165,7 @@ def average_pool(
     padding="valid",
     data_format=None,
 ):
-    data_format = standardize_data_format(data_format)
+    data_format = backend.standardize_data_format(data_format)
     strides = pool_size if strides is None else strides
     padding = padding.upper()
     tf_data_format = _convert_data_format("channels_last", len(inputs.shape))
@@ -268,7 +243,7 @@ def conv(
     def _conv_xla():
         return _conv()
 
-    data_format = standardize_data_format(data_format)
+    data_format = backend.standardize_data_format(data_format)
     if data_format == "channels_last":
         channels = inputs.shape[-1]
     else:
@@ -288,7 +263,7 @@ def depthwise_conv(
     data_format=None,
     dilation_rate=1,
 ):
-    data_format = standardize_data_format(data_format)
+    data_format = backend.standardize_data_format(data_format)
     num_spatial_dims = len(inputs.shape) - 2
     if num_spatial_dims > 2:
         raise ValueError(
@@ -351,7 +326,7 @@ def separable_conv(
     data_format=None,
     dilation_rate=1,
 ):
-    data_format = standardize_data_format(data_format)
+    data_format = backend.standardize_data_format(data_format)
     num_spatial_dims = len(inputs.shape) - 2
     if num_spatial_dims > 2:
         raise ValueError(
@@ -414,7 +389,7 @@ def conv_transpose(
     data_format=None,
     dilation_rate=1,
 ):
-    data_format = standardize_data_format(data_format)
+    data_format = backend.standardize_data_format(data_format)
     tf_data_format = _convert_data_format(data_format, len(inputs.shape))
     kernel_size = kernel.shape[:-2]
     filters = kernel.shape[-2]
@@ -597,7 +572,9 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
     output = output / tf.reduce_sum(output, axis, keepdims=True)
 
     # Compute cross entropy from probabilities.
-    output = tf.clip_by_value(output, epsilon(), 1.0 - epsilon())
+    output = tf.clip_by_value(
+        output, backend.epsilon(), 1.0 - backend.epsilon()
+    )
     return -tf.reduce_sum(target * tf.math.log(output), axis)
 
 
@@ -653,7 +630,9 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
             )
 
     if not from_logits:
-        output = tf.clip_by_value(output, epsilon(), 1 - epsilon())
+        output = tf.clip_by_value(
+            output, backend.epsilon(), 1 - backend.epsilon()
+        )
         output = tf.math.log(output)
 
     result = tf.nn.sparse_softmax_cross_entropy_with_logits(
@@ -702,7 +681,9 @@ def binary_crossentropy(target, output, from_logits=False):
         )
 
     # Compute cross entropy from probabilities.
-    output = tf.clip_by_value(output, epsilon(), 1.0 - epsilon())
+    output = tf.clip_by_value(
+        output, backend.epsilon(), 1.0 - backend.epsilon()
+    )
     bce = target * tf.math.log(output)
     bce += (1 - target) * tf.math.log(1 - output)
     return -bce
@@ -713,7 +694,7 @@ def moments(x, axes, keepdims=False, synchronized=False):
     # workaround, we simply perform the operations on float32 and convert back
     # to float16
     need_cast = False
-    ori_dtype = standardize_dtype(x.dtype)
+    ori_dtype = backend.standardize_dtype(x.dtype)
     if ori_dtype in ("float16", "bfloat16"):
         need_cast = True
         x = cast(x, "float32")
@@ -797,11 +778,18 @@ def ctc_loss(
     output_length,
     mask_index=0,
 ):
-    target = tf.convert_to_tensor(target)
+    target = convert_to_tensor(target)
+    output = convert_to_tensor(output)
     target = tf.cast(target, dtype="int32")
-    output = tf.convert_to_tensor(output)
-    output = tf.cast(output, dtype="float32")
-    return tf.nn.ctc_loss(
+
+    # `tf.nn.ctc_loss` will internally cast to float32 when the input is float16
+    # or bfloat16. Additionally, it will raise an error when the input is
+    # float64. As a result, we perform the casting externally and add support
+    # for float64.
+    result_dtype = backend.result_type(output.dtype, "float32")
+    compute_dtype = "float32" if result_dtype == "float64" else result_dtype
+    output = tf.cast(output, compute_dtype)
+    loss = tf.nn.ctc_loss(
         labels=target,
         logits=output,
         label_length=target_length,
@@ -809,6 +797,7 @@ def ctc_loss(
         blank_index=mask_index,
         logits_time_major=False,
     )
+    return tf.cast(loss, result_dtype)
 
 
 def ctc_decode(

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -1893,7 +1893,7 @@ class CTC(LossFunctionWrapper):
     def __init__(
         self,
         reduction="sum_over_batch_size",
-        name="sparse_categorical_crossentropy",
+        name="ctc",
     ):
         super().__init__(
             ctc,

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -1908,11 +1908,14 @@ def ctc_decode(
 
     Returns:
         A tuple containing:
-
-        - A list of decoded sequences.
-        - A list of the negative of the sum of the probability logits
-        (if strategy is `"greedy"`) or the log probability (if strategy is
-        `"beam_search"`) for each sequence.
+        - A list of decoded sequences. Each decoded sequence has shape
+            `(batch_size, max_length)`. Note that: `-1` indicates the blank
+            label.
+        - If `strategy="greedy"`, a tensor of shape `(batch_size, 1)`
+            representing the negative of the sum of the probability logits. If
+            `strategy="beam_seatch"`, a tensor of shape
+            `(batch_size, top_paths)` representing the log probability for each
+            sequence.
     """
 
     if any_symbolic_tensors((inputs, sequence_lengths)):

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -1912,8 +1912,8 @@ def ctc_decode(
             `(batch_size, max_length)`. Note that: `-1` indicates the blank
             label.
         - If `strategy="greedy"`, a tensor of shape `(batch_size, 1)`
-            representing the negative of the sum of the probability logits. If
-            `strategy="beam_seatch"`, a tensor of shape
+            representing the negative of the sum of the probability logits for
+            each sequence. If `strategy="beam_seatch"`, a tensor of shape
             `(batch_size, top_paths)` representing the log probability for each
             sequence.
     """

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -1810,8 +1810,8 @@ def batch_normalization(
     )
 
 
-class CtcLoss(Operation):
-    def __init__(self, mask_index):
+class CTCLoss(Operation):
+    def __init__(self, mask_index=0):
         super().__init__()
         self.mask_index = mask_index
 
@@ -1838,8 +1838,8 @@ class CtcLoss(Operation):
         self._check_shape_first_dim(
             "output_length", output_length.shape, "output", output.shape
         )
-
-        return KerasTensor((target.shape[0],), dtype=target.dtype)
+        dtype = backend.result_type(output.dtype, "float32")
+        return KerasTensor((target.shape[0],), dtype=dtype)
 
 
 @keras_export(
@@ -1865,7 +1865,7 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
     """
 
     if any_symbolic_tensors((target, output, target_length, output_length)):
-        return CtcLoss(mask_index).symbolic_call(
+        return CTCLoss(mask_index).symbolic_call(
             target, output, target_length, output_length
         )
     return backend.nn.ctc_loss(

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -1873,6 +1873,48 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
     )
 
 
+class CTCDecode(Operation):
+    def __init__(
+        self,
+        strategy="greedy",
+        beam_width=100,
+        top_paths=1,
+        merge_repeated=True,
+        mask_index=None,
+    ):
+        super().__init__()
+        self.strategy = strategy
+        self.beam_width = beam_width
+        self.top_paths = top_paths
+        self.merge_repeated = merge_repeated
+        self.mask_index = mask_index
+
+    def call(self, inputs, sequence_lengths):
+        return backend.nn.ctc_decode(
+            inputs,
+            sequence_lengths,
+            strategy=self.strategy,
+            beam_width=self.beam_width,
+            top_paths=self.top_paths,
+            merge_repeated=self.merge_repeated,
+            mask_index=self.mask_index,
+        )
+
+    def compute_output_spec(self, inputs, sequence_lengths):
+        inputs_shape = inputs.shape
+        if self.strategy == "greedy":
+            top_paths = 1
+        else:
+            top_paths = self.top_paths
+        dtype = backend.result_type(inputs.dtype, "float32")
+        return (
+            KerasTensor(
+                (top_paths, inputs_shape[0], inputs_shape[1]), dtype="int32"
+            ),
+            KerasTensor((inputs_shape[0], top_paths), dtype=dtype),
+        )
+
+
 @keras_export(
     [
         "keras.ops.ctc_decode",
@@ -1882,7 +1924,7 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
 def ctc_decode(
     inputs,
     sequence_lengths,
-    strategy,
+    strategy="greedy",
     beam_width=100,
     top_paths=1,
     merge_repeated=True,
@@ -1892,7 +1934,8 @@ def ctc_decode(
 
     Args:
         inputs: A tensor of shape `(batch_size, max_length, num_classes)`
-            containing the logits (output of the model).
+            containing the logits (the output of the model).
+            They should *not* be normalized via softmax.
         sequence_lengths: A tensor of shape `(batch_size,)` containing the
             sequence lengths for the batch.
         strategy: A string for the decoding strategy. Supported values are
@@ -1908,9 +1951,11 @@ def ctc_decode(
 
     Returns:
         A tuple containing:
-        - A list of decoded sequences. Each decoded sequence has shape
-            `(batch_size, max_length)`. Note that: `-1` indicates the blank
-            label.
+        - The tensor representing the list of decoded sequences. If
+            `strategy="greedy"`, the shape is `(1, batch_size, max_length)`. If
+            `strategy="beam_seatch"`, the shape is
+            `(top_paths, batch_size, max_length)`. Note that: `-1` indicates the
+            blank label.
         - If `strategy="greedy"`, a tensor of shape `(batch_size, 1)`
             representing the negative of the sum of the probability logits for
             each sequence. If `strategy="beam_seatch"`, a tensor of shape
@@ -1919,12 +1964,13 @@ def ctc_decode(
     """
 
     if any_symbolic_tensors((inputs, sequence_lengths)):
-        raise NotImplementedError(
-            "CTC decoding is not supported with KerasTensors. Use it "
-            "inside the call() method of a Layer or the predict_step "
-            "method of a model."
-        )
-
+        return CTCDecode(
+            strategy=strategy,
+            beam_width=beam_width,
+            top_paths=top_paths,
+            merge_repeated=merge_repeated,
+            mask_index=mask_index,
+        ).symbolic_call(inputs, sequence_lengths)
     return backend.nn.ctc_decode(
         inputs=inputs,
         sequence_length=sequence_lengths,

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1915,9 +1915,9 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
                 ],
             ]
         )
-        labels = np.array([[1, 2], [2, 0], [0, 0]])
+        labels = np.array([[1, 2, -1], [2, -1, -1], [-1, -1, -1]])
         score_labels = np.array([[-1.2], [-1.6], [-0.7]])
-        repeated_labels = np.array([[1, 2, 2], [2, 2, 0], [0, 0, 0]])
+        repeated_labels = np.array([[1, 2, 2], [2, 2, -1], [-1, -1, -1]])
 
         # Test strategy="greedy" and merge_repeated=True
         (decoded,), scores = knn.ctc_decode(
@@ -1942,8 +1942,8 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             self.skipTest("torch doesn't support 'beam_search' strategy")
 
         labels = [
-            np.array([[1, 2], [2, 0], [0, 0]]),
-            np.array([[2, 0], [2, 0], [1, 0]]),
+            np.array([[1, 2, -1], [2, -1, -1], [-1, -1, -1]]),
+            np.array([[2, -1, -1], [2, 0, -1], [1, -1, -1]]),
         ]
         score_labels = np.array(
             [

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1917,12 +1917,25 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         )
         labels = np.array([[1, 2], [2, 0], [0, 0]])
         score_labels = np.array([[-1.2], [-1.6], [-0.7]])
+        repeated_labels = np.array([[1, 2, 2], [2, 2, 0], [0, 0, 0]])
 
+        # Test strategy="greedy" and merge_repeated=True
         (decoded,), scores = knn.ctc_decode(
-            inputs, sequence_lengths=[3, 3, 1], strategy="greedy"
+            inputs,
+            sequence_lengths=[3, 3, 1],
+            strategy="greedy",
         )
-
         self.assertAllClose(decoded, labels)
+        self.assertAllClose(scores, score_labels)
+
+        # Test strategy="greedy" and merge_repeated=False
+        (decoded,), scores = knn.ctc_decode(
+            inputs,
+            sequence_lengths=[3, 3, 1],
+            strategy="greedy",
+            merge_repeated=False,
+        )
+        self.assertAllClose(decoded, repeated_labels)
         self.assertAllClose(scores, score_labels)
 
         if backend.backend() == "torch":
@@ -1939,10 +1952,10 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
                 [-1.0633859, -1.3633859],
             ]
         )
-
         beam_width = 4
         top_paths = 2
 
+        # Test strategy="beam_search"
         decoded, scores = knn.ctc_decode(
             inputs,
             sequence_lengths=[3, 3, 1],
@@ -1950,7 +1963,6 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             beam_width=beam_width,
             top_paths=top_paths,
         )
-
         for i in range(top_paths):
             self.assertAllClose(decoded[i], labels[i])
         self.assertAllClose(scores, score_labels)


### PR DESCRIPTION
This PR:
- Ensure dtype inference for `ctc_loss` across all backends
- Add `ctc_loss` to numpy backend
- Add `ctc_decode` (including both `"greedy"` and `"beam_search"` strategies) to numpy backend
- Add `"greedy"` strategy for `ctc_decode` to torch backend
- Reduce the number of import lines by using `keras.src.backend`

Furthermore, we can simply utilize `tf.nn.gelu` instead of a custom implementation since we have already removed the usage of `enable_numpy_behavior`