### PR TITLE
update the namex version requirements

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,4 +1,4 @@
-namex
+namex>=0.0.8
 black>=22
 flake8
 isort


### PR DESCRIPTION
The new `api_gen.py` requires namex to be at `0.0.8`.
It errors out with `0.0.7`.