### PR TITLE
Remove `PYTORCH_ENABLE_MPS_FALLBACK` flag requirement for mps

### DIFF
--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -21,7 +21,6 @@ SUPPORTS_SPARSE_TENSORS = False
 # check https://github.com/pytorch/pytorch/issues/77764.
 if (
     torch.backends.mps.is_available()
-    and os.getenv("PYTORCH_ENABLE_MPS_FALLBACK") == "1"
 ):
     DEFAULT_DEVICE = "mps"
 elif torch.cuda.is_available():

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -1,5 +1,4 @@
 import contextlib
-import os
 
 import ml_dtypes
 import numpy as np
@@ -19,9 +18,7 @@ SUPPORTS_SPARSE_TENSORS = False
 # Some operators such as 'aten::_foreach_mul_.Scalar'
 # are not currently implemented for the MPS device.
 # check https://github.com/pytorch/pytorch/issues/77764.
-if (
-    torch.backends.mps.is_available()
-):
+if torch.backends.mps.is_available():
     DEFAULT_DEVICE = "mps"
 elif torch.cuda.is_available():
     DEFAULT_DEVICE = "cuda"


### PR DESCRIPTION
Running with MPS used to require this flag since the feature was experimental. It has since graduated to stable in PyTorch (see https://pytorch.org/docs/stable/notes/mps.html).

We can go ahead and remove the flag check. Fix #19436.