### PR TITLE
Making extract_patches compatible with images of dtype float16 along with float32

### DIFF
--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -548,7 +548,7 @@ def _extract_patches(
     if not strides:
         strides = size
     out_dim = patch_h * patch_w * channels_in
-    kernel = backend.numpy.eye(out_dim)
+    kernel = backend.numpy.eye(out_dim, dtype=image.dtype)
     kernel = backend.numpy.reshape(
         kernel, (patch_h, patch_w, channels_in, out_dim)
     )


### PR DESCRIPTION
Error when an image of dtype `float16` is used in `nn.ops.image.extract_patches`
[Colab link](https://colab.research.google.com/drive/1y41vpFs6Cd4NHmSY6IRmU53PXgl_SAFE?usp=sharing)
Fixed it.