### PR TITLE
Speed up `DataAdapter` tests by testing only the current backend.

### DIFF
--- a/keras/src/trainers/data_adapters/array_data_adapter_test.py
+++ b/keras/src/trainers/data_adapters/array_data_adapter_test.py
@@ -52,11 +52,10 @@ class TestArrayDataAdapter(testing.TestCase, parameterized.TestCase):
                 "scipy_sparse",
             ],
             array_dtype=["float32", "float64"],
-            iterator_type=["np", "tf", "jax", "torch"],
             shuffle=[False, "batch", True],
         )
     )
-    def test_basic_flow(self, array_type, array_dtype, iterator_type, shuffle):
+    def test_basic_flow(self, array_type, array_dtype, shuffle):
         x = self.make_array(array_type, (34, 4), array_dtype)
         y = self.make_array(array_type, (34, 2), "int32")
         xdim1 = 1 if array_type == "pandas_series" else 4
@@ -75,10 +74,10 @@ class TestArrayDataAdapter(testing.TestCase, parameterized.TestCase):
         self.assertEqual(adapter.has_partial_batch, True)
         self.assertEqual(adapter.partial_batch_size, 2)
 
-        if iterator_type == "np":
+        if backend.backend() == "numpy":
             it = adapter.get_numpy_iterator()
             expected_class = np.ndarray
-        elif iterator_type == "tf":
+        elif backend.backend() == "tensorflow":
             it = adapter.get_tf_dataset()
             if array_type == "tf_ragged":
                 expected_class = tf.RaggedTensor
@@ -88,13 +87,13 @@ class TestArrayDataAdapter(testing.TestCase, parameterized.TestCase):
                 expected_class = tf.SparseTensor
             else:
                 expected_class = tf.Tensor
-        elif iterator_type == "jax":
+        elif backend.backend() == "jax":
             it = adapter.get_jax_iterator()
             if array_type in ("tf_sparse", "jax_sparse", "scipy_sparse"):
                 expected_class = jax_sparse.JAXSparse
             else:
                 expected_class = jax.Array
-        elif iterator_type == "torch":
+        elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
 

--- a/keras/src/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter.py
@@ -342,11 +342,6 @@ def get_worker_id_queue():
     return _WORKER_ID_QUEUE
 
 
-def init_pool(seqs):
-    global _SHARED_SEQUENCES
-    _SHARED_SEQUENCES = seqs
-
-
 def get_index(uid, i):
     """Get the value from the PyDataset `uid` at index `i`.
 

--- a/keras/src/trainers/data_adapters/tf_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/tf_dataset_adapter_test.py
@@ -2,20 +2,18 @@ from unittest import mock
 
 import jax
 import numpy as np
+import pytest
 import tensorflow as tf
 import torch
 from absl.testing import parameterized
 
+from keras.src import backend
 from keras.src import testing
-from keras.src.testing.test_utils import named_product
 from keras.src.trainers.data_adapters import tf_dataset_adapter
 
 
 class TestTFDatasetAdapter(testing.TestCase, parameterized.TestCase):
-    @parameterized.named_parameters(
-        named_product(iterator_type=["np", "tf", "jax", "torch"])
-    )
-    def test_basic_flow(self, iterator_type):
+    def test_basic_flow(self):
         x = tf.random.normal((34, 4))
         y = tf.random.normal((34, 2))
         base_ds = tf.data.Dataset.from_tensor_slices((x, y)).batch(16)
@@ -26,16 +24,16 @@ class TestTFDatasetAdapter(testing.TestCase, parameterized.TestCase):
         self.assertEqual(adapter.has_partial_batch, None)
         self.assertEqual(adapter.partial_batch_size, None)
 
-        if iterator_type == "np":
+        if backend.backend() == "numpy":
             it = adapter.get_numpy_iterator()
             expected_class = np.ndarray
-        elif iterator_type == "tf":
+        elif backend.backend() == "tensorflow":
             it = adapter.get_tf_dataset()
             expected_class = tf.Tensor
-        elif iterator_type == "jax":
+        elif backend.backend() == "jax":
             it = adapter.get_jax_iterator()
             expected_class = jax.Array
-        elif iterator_type == "torch":
+        elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
 
@@ -258,10 +256,11 @@ class TestTFDatasetAdapter(testing.TestCase, parameterized.TestCase):
                 self.assertEqual(tuple(bx.shape), (2, 4))
                 self.assertEqual(tuple(by.shape), (2, 2))
 
-    @parameterized.named_parameters(
-        named_product(iterator_type=["np", "tf", "jax"])
+    @pytest.mark.skipif(
+        not backend.SUPPORTS_SPARSE_TENSORS and backend.backend() != "numpy",
+        reason="Backend does not support sparse tensors",
     )
-    def test_tf_sparse_tensors(self, iterator_type):
+    def test_tf_sparse_tensors(self):
         x = tf.SparseTensor(
             indices=[[0, 0], [1, 2]], values=[1.0, 2.0], dense_shape=(2, 4)
         )
@@ -271,13 +270,13 @@ class TestTFDatasetAdapter(testing.TestCase, parameterized.TestCase):
         base_ds = tf.data.Dataset.from_tensors((x, y))
         adapter = tf_dataset_adapter.TFDatasetAdapter(base_ds)
 
-        if iterator_type == "np":
+        if backend.backend() == "numpy":
             it = adapter.get_numpy_iterator()
             expected_class = np.ndarray
-        elif iterator_type == "tf":
+        elif backend.backend() == "tensorflow":
             it = adapter.get_tf_dataset()
             expected_class = tf.SparseTensor
-        elif iterator_type == "jax":
+        elif backend.backend() == "jax":
             it = adapter.get_jax_iterator()
             expected_class = jax.experimental.sparse.BCOO
 


### PR DESCRIPTION
There is no use case for using an iterator for a different backend than the current backend.