### PR TITLE
Fix `ops.ctc_decode`

### DIFF
--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -593,7 +593,7 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
     output = convert_to_tensor(output)
     target_length = convert_to_tensor(target_length, "int32")
     output_length = convert_to_tensor(output_length, "int32")
-    batch_size, _, num_classes = output.shape
+    batch_size, max_input_length, num_classes = output.shape
     batch_size, max_label_length = target.shape
     log_epsilon = -1e5
 
@@ -610,7 +610,7 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
         return jnp.logical_not(elem_valid)
 
     target_paddings = _lengths_to_paddings(target_length, max_label_length)
-    output_paddings = _lengths_to_paddings(output_length, max_label_length)
+    output_paddings = _lengths_to_paddings(output_length, max_input_length)
     target_paddings = target_paddings.astype(output.dtype)
     output_paddings = output_paddings.astype(output.dtype)
 
@@ -690,12 +690,12 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
 
 def _ctc_greedy_decode(
     inputs,
-    sequence_length,
+    sequence_lengths,
     merge_repeated=True,
     mask_index=None,
 ):
     inputs = convert_to_tensor(inputs)
-    sequence_length = convert_to_tensor(sequence_length, dtype="int32")
+    sequence_lengths = convert_to_tensor(sequence_lengths, dtype="int32")
     batch_size, max_length, num_classes = inputs.shape
 
     if mask_index is None:
@@ -705,7 +705,7 @@ def _ctc_greedy_decode(
     scores = jnp.max(inputs, axis=-1)
 
     seqlen_mask = jnp.arange(max_length)[None, :]
-    seqlen_mask = seqlen_mask >= sequence_length[:, None]
+    seqlen_mask = seqlen_mask >= sequence_lengths[:, None]
 
     indices = jnp.where(seqlen_mask, mask_index, indices)
     scores = jnp.where(seqlen_mask, 0.0, scores)
@@ -715,16 +715,17 @@ def _ctc_greedy_decode(
         repeat_mask = jnp.pad(repeat_mask, ((0, 0), (1, 0)))
         indices = jnp.where(repeat_mask, mask_index, indices)
 
-    # We rearrange the indices by moving `mask_index` to the end of the array
+    # We set to -1 for blank labels
     invalid_mask = indices == mask_index
+    indices = jnp.where(invalid_mask, -1, indices)
+
+    # We rearrange the indices by moving `mask_index` to the end of the array
     order = jnp.expand_dims(jnp.arange(max_length), axis=0)  # [1, N]
     order = jnp.tile(order, (batch_size, 1))  # [B, N]
     order = jnp.where(invalid_mask, max_length, order)
     order = jnp.argsort(order, axis=-1)
     indices = jnp.take_along_axis(indices, order, axis=-1)
 
-    # We set to -1 for blank labels
-    indices = jnp.where(invalid_mask, -1, indices)
     scores = -jnp.sum(scores, axis=1)[:, None]
     indices = jnp.expand_dims(indices, axis=0)
     return indices, scores
@@ -732,17 +733,17 @@ def _ctc_greedy_decode(
 
 def _ctc_beam_search_decode(
     inputs,
-    sequence_length,
+    sequence_lengths,
     beam_width=100,
     top_paths=1,
     mask_index=None,
 ):
     inputs = convert_to_tensor(inputs)
-    sequence_length = convert_to_tensor(sequence_length)
+    sequence_lengths = convert_to_tensor(sequence_lengths)
 
     batch_size, max_seq_len, num_classes = inputs.shape
     inputs = jnn.log_softmax(inputs)
-    seqlen_mask = jnp.arange(max_seq_len)[None, :] >= sequence_length[:, None]
+    seqlen_mask = jnp.arange(max_seq_len)[None, :] >= sequence_lengths[:, None]
 
     if mask_index is None:
         mask_index = num_classes - 1
@@ -895,7 +896,7 @@ def _ctc_beam_search_decode(
 
 def ctc_decode(
     inputs,
-    sequence_length,
+    sequence_lengths,
     strategy="greedy",
     beam_width=100,
     top_paths=1,
@@ -909,14 +910,14 @@ def ctc_decode(
     if strategy == "greedy":
         return _ctc_greedy_decode(
             inputs,
-            sequence_length,
+            sequence_lengths,
             merge_repeated=merge_repeated,
             mask_index=mask_index,
         )
     elif strategy == "beam_search":
         return _ctc_beam_search_decode(
             inputs,
-            sequence_length,
+            sequence_lengths,
             beam_width=beam_width,
             top_paths=top_paths,
             mask_index=mask_index,

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -901,7 +901,7 @@ def ctc_decode(
     beam_width=100,
     top_paths=1,
     merge_repeated=True,
-    mask_index=None,
+    mask_index=0,
 ):
     inputs = convert_to_tensor(inputs)
     dtype = backend.result_type(inputs.dtype, "float32")

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -942,7 +942,7 @@ def ctc_decode(
     beam_width=100,
     top_paths=1,
     merge_repeated=True,
-    mask_index=None,
+    mask_index=0,
 ):
     inputs = convert_to_tensor(inputs)
     dtype = backend.result_type(inputs.dtype, "float32")

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -621,7 +621,7 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
     output = convert_to_tensor(output)
     target_length = convert_to_tensor(target_length, "int32")
     output_length = convert_to_tensor(output_length, "int32")
-    batch_size, _, num_classes = output.shape
+    batch_size, max_input_length, num_classes = output.shape
     batch_size, max_label_length = target.shape
     log_epsilon = -1e5
 
@@ -638,7 +638,7 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
         return np.logical_not(elem_valid)
 
     target_paddings = _lengths_to_paddings(target_length, max_label_length)
-    output_paddings = _lengths_to_paddings(output_length, max_label_length)
+    output_paddings = _lengths_to_paddings(output_length, max_input_length)
     target_paddings = target_paddings.astype(output.dtype)
     output_paddings = output_paddings.astype(output.dtype)
 
@@ -729,12 +729,12 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
 
 def _ctc_greedy_decode(
     inputs,
-    sequence_length,
+    sequence_lengths,
     merge_repeated=True,
     mask_index=None,
 ):
     inputs = convert_to_tensor(inputs)
-    sequence_length = convert_to_tensor(sequence_length, dtype="int32")
+    sequence_lengths = convert_to_tensor(sequence_lengths, dtype="int32")
     batch_size, max_length, num_classes = inputs.shape
 
     if mask_index is None:
@@ -744,7 +744,7 @@ def _ctc_greedy_decode(
     scores = np.max(inputs, axis=-1)
 
     seqlen_mask = np.arange(max_length)[None, :]
-    seqlen_mask = seqlen_mask >= sequence_length[:, None]
+    seqlen_mask = seqlen_mask >= sequence_lengths[:, None]
 
     indices = np.where(seqlen_mask, mask_index, indices)
     scores = np.where(seqlen_mask, 0.0, scores)
@@ -754,16 +754,17 @@ def _ctc_greedy_decode(
         repeat_mask = np.pad(repeat_mask, ((0, 0), (1, 0)))
         indices = np.where(repeat_mask, mask_index, indices)
 
-    # We rearrange the indices by moving `mask_index` to the end of the array
+    # We set to -1 for blank labels
     invalid_mask = indices == mask_index
+    indices = np.where(invalid_mask, -1, indices)
+
+    # We rearrange the indices by moving `mask_index` to the end of the array
     order = np.expand_dims(np.arange(max_length), axis=0)  # [1, N]
     order = np.tile(order, (batch_size, 1))  # [B, N]
     order = np.where(invalid_mask, max_length, order)
     order = np.argsort(order, axis=-1)
     indices = np.take_along_axis(indices, order, axis=-1)
 
-    # We set to -1 for blank labels
-    indices = np.where(invalid_mask, -1, indices)
     scores = -np.sum(scores, axis=1)[:, None]
     indices = np.expand_dims(indices, axis=0)
     return indices, scores
@@ -771,17 +772,17 @@ def _ctc_greedy_decode(
 
 def _ctc_beam_search_decode(
     inputs,
-    sequence_length,
+    sequence_lengths,
     beam_width=100,
     top_paths=1,
     mask_index=None,
 ):
     inputs = convert_to_tensor(inputs)
-    sequence_length = convert_to_tensor(sequence_length)
+    sequence_lengths = convert_to_tensor(sequence_lengths)
 
     batch_size, max_seq_len, num_classes = inputs.shape
     inputs = log_softmax(inputs, axis=-1)
-    seqlen_mask = np.arange(max_seq_len)[None, :] >= sequence_length[:, None]
+    seqlen_mask = np.arange(max_seq_len)[None, :] >= sequence_lengths[:, None]
 
     if mask_index is None:
         mask_index = num_classes - 1
@@ -936,7 +937,7 @@ def _ctc_beam_search_decode(
 
 def ctc_decode(
     inputs,
-    sequence_length,
+    sequence_lengths,
     strategy="greedy",
     beam_width=100,
     top_paths=1,
@@ -950,14 +951,14 @@ def ctc_decode(
     if strategy == "greedy":
         return _ctc_greedy_decode(
             inputs,
-            sequence_length,
+            sequence_lengths,
             merge_repeated=merge_repeated,
             mask_index=mask_index,
         )
     elif strategy == "beam_search":
         return _ctc_beam_search_decode(
             inputs,
-            sequence_length,
+            sequence_lengths,
             beam_width=beam_width,
             top_paths=top_paths,
             mask_index=mask_index,

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -802,7 +802,7 @@ def ctc_loss(
 
 def ctc_decode(
     inputs,
-    sequence_length,
+    sequence_lengths,
     strategy="greedy",
     beam_width=100,
     top_paths=1,
@@ -817,18 +817,18 @@ def ctc_decode(
     dtype = backend.result_type(inputs.dtype, "float32")
     inputs = tf.cast(inputs, dtype)
 
-    sequence_length = convert_to_tensor(sequence_length, dtype="int32")
+    sequence_lengths = convert_to_tensor(sequence_lengths, dtype="int32")
     if strategy == "greedy":
         (decoded, scores) = tf.nn.ctc_greedy_decoder(
             inputs=inputs,
-            sequence_length=sequence_length,
+            sequence_length=sequence_lengths,
             merge_repeated=merge_repeated,
             blank_index=mask_index,
         )
     elif strategy == "beam_search":
         (decoded, scores) = tf.nn.ctc_beam_search_decoder(
             inputs=inputs,
-            sequence_length=sequence_length,
+            sequence_length=sequence_lengths,
             beam_width=beam_width,
             top_paths=top_paths,
         )

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -857,6 +857,8 @@ def ctc_decode(
 
     # We need to recover the labels because we swapped the indices earlier
     if strategy == "beam_search" and mask_index is not None:
+        if mask_index < 0:
+            mask_index = mask_index + input_shape[-1]
         decoded_dense = tf.where(
             decoded_dense >= mask_index, decoded_dense + 1, decoded_dense
         )

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -807,7 +807,7 @@ def ctc_decode(
     beam_width=100,
     top_paths=1,
     merge_repeated=True,
-    mask_index=None,
+    mask_index=0,
 ):
     inputs = convert_to_tensor(inputs)
     input_shape = tf.shape(inputs)

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -826,7 +826,7 @@ def ctc_decode(
     beam_width=100,
     top_paths=1,
     merge_repeated=True,
-    mask_index=None,
+    mask_index=0,
 ):
     inputs = convert_to_tensor(inputs)
     dtype = backend.result_type(inputs.dtype, "float32")

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -775,12 +775,12 @@ def ctc_loss(
 
 def _ctc_greedy_decode(
     inputs,
-    sequence_length,
+    sequence_lengths,
     merge_repeated=True,
     mask_index=None,
 ):
     inputs = convert_to_tensor(inputs)
-    sequence_length = convert_to_tensor(sequence_length, dtype="int32")
+    sequence_lengths = convert_to_tensor(sequence_lengths, dtype="int32")
     batch_size, max_length, num_classes = inputs.shape
 
     if mask_index is None:
@@ -791,7 +791,7 @@ def _ctc_greedy_decode(
     scores = torch.max(inputs, axis=-1)[0]
 
     seqlen_mask = torch.arange(max_length, device=indices.device)[None, :]
-    seqlen_mask = seqlen_mask >= sequence_length[:, None]
+    seqlen_mask = seqlen_mask >= sequence_lengths[:, None]
 
     indices = torch.where(seqlen_mask, mask_index, indices)
     scores = torch.where(seqlen_mask, 0.0, scores)
@@ -801,8 +801,11 @@ def _ctc_greedy_decode(
         repeat = tnn.pad(repeat, (1, 0, 0, 0))
         indices = torch.where(repeat, mask_index, indices)
 
-    # We rearrange the indices by moving `mask_index` to the end of the array
+    # We set to -1 for blank labels
     invalid_mask = indices == mask_index
+    indices = torch.where(invalid_mask, -1, indices)
+
+    # We rearrange the indices by moving `mask_index` to the end of the array
     order = torch.unsqueeze(
         torch.arange(max_length, device=indices.device), dim=0
     )  # [1, N]
@@ -811,8 +814,6 @@ def _ctc_greedy_decode(
     order = torch.argsort(order, dim=-1)
     indices = torch.take_along_dim(indices, order, dim=-1)
 
-    # We set to -1 for blank labels
-    indices = torch.where(invalid_mask, -1, indices)
     scores = -torch.sum(scores, axis=1)[:, None]
     indices = torch.unsqueeze(indices, dim=0)
     return indices, scores
@@ -820,7 +821,7 @@ def _ctc_greedy_decode(
 
 def ctc_decode(
     inputs,
-    sequence_length,
+    sequence_lengths,
     strategy="greedy",
     beam_width=100,
     top_paths=1,
@@ -834,7 +835,7 @@ def ctc_decode(
     if strategy == "greedy":
         return _ctc_greedy_decode(
             inputs,
-            sequence_length,
+            sequence_lengths,
             merge_repeated=merge_repeated,
             mask_index=mask_index,
         )

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -1933,14 +1933,16 @@ def ctc(y_true, y_pred):
             f"Received: y_pred.shape={ops.shape(y_pred)}"
         )
 
-    batch_length = ops.cast(ops.shape(y_true)[0], dtype="int32")
-    input_length = ops.cast(ops.shape(y_pred)[1], dtype="int32")
-    label_length = ops.cast(ops.shape(y_true)[1], dtype="int32")
+    mask_index = 0
+    batch_length = ops.shape(y_pred)[0]
+    input_length = ops.shape(y_pred)[1]
     input_length = input_length * ops.ones((batch_length,), dtype="int32")
-    label_length = label_length * ops.ones((batch_length,), dtype="int32")
+    label_length = ops.cast(
+        ops.sum(y_true != mask_index, axis=-1), dtype="int32"
+    )
 
     return ops.ctc_loss(
-        y_true, y_pred, label_length, input_length, mask_index=0
+        y_true, y_pred, label_length, input_length, mask_index=mask_index
     )
 
 

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1387,7 +1387,7 @@ class CTCTest(testing.TestCase):
         logits = (np.arange(24).reshape((2, 4, 3)).astype("float32") - 12) / 100
         y_true = np.array(([[1, 2, 1, 0], [1, 2, 0, 2]]))
         output = losses.CTC()(y_true, logits)
-        self.assertAllClose(output, 4.389582)
+        self.assertAllClose(output, 2.448645)
 
 
 class DiceTest(testing.TestCase):

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -1973,7 +1973,7 @@ def ctc_decode(
         ).symbolic_call(inputs, sequence_lengths)
     return backend.nn.ctc_decode(
         inputs=inputs,
-        sequence_length=sequence_lengths,
+        sequence_lengths=sequence_lengths,
         strategy=strategy,
         beam_width=beam_width,
         top_paths=top_paths,

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -1880,7 +1880,7 @@ class CTCDecode(Operation):
         beam_width=100,
         top_paths=1,
         merge_repeated=True,
-        mask_index=None,
+        mask_index=0,
     ):
         super().__init__()
         self.strategy = strategy
@@ -1928,7 +1928,7 @@ def ctc_decode(
     beam_width=100,
     top_paths=1,
     merge_repeated=True,
-    mask_index=None,
+    mask_index=0,
 ):
     """Decodes the output of a CTC model.
 
@@ -1947,7 +1947,7 @@ def ctc_decode(
         merge_repeated: A boolean scalar, whether to merge repeated
             labels in the output. Defaults to `True`.
         mask_index: An integer scalar, the index of the mask character in
-            the vocabulary. Defaults to `None`.
+            the vocabulary. Defaults to `0`.
 
     Returns:
         A tuple containing:

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1963,7 +1963,7 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         )
         labels = np.array([[1, 2, -1], [2, -1, -1], [3, -1, -1]])
         score_labels = np.array([[-1.2], [-1.7], [-0.7]])
-        repeated_labels = np.array([[1, 2, 2], [0, 2, 0], [-1, -1, -1]])
+        repeated_labels = np.array([[1, 2, 2], [2, -1, -1], [3, -1, -1]])
 
         # Test strategy="greedy" and merge_repeated=True
         (decoded,), scores = knn.ctc_decode(
@@ -1981,6 +1981,7 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             sequence_lengths=[3, 3, 1],
             strategy="greedy",
             merge_repeated=False,
+            mask_index=0,
         )
         self.assertAllClose(decoded, repeated_labels)
         self.assertAllClose(scores, score_labels)
@@ -1990,15 +1991,15 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
         labels = np.array(
             [
-                [[2, -1, -1], [0, -1, -1], [-1, -1, -1]],
-                [[1, 2, -1], [0, 2, -1], [1, -1, -1]],
+                [[1, 2, -1], [2, -1, -1], [3, -1, -1]],
+                [[2, -1, -1], [3, -1, -1], [1, -1, -1]],
             ]
         )
         score_labels = np.array(
             [
-                [-2.32398787, -2.41500957],
-                [-2.237567, -2.428189],
-                [-1.0633859, -1.3633859],
+                [-2.426537, -2.435596],
+                [-2.127681, -2.182338],
+                [-1.063386, -1.363386],
             ]
         )
         beam_width = 4

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -2013,7 +2013,6 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             top_paths=top_paths,
             mask_index=0,
         )
-        print(decoded)
         self.assertAllClose(decoded, labels)
         self.assertAllClose(scores, score_labels)
 

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1946,30 +1946,31 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             [
                 [
                     [0.1, 0.4, 0.2, 0.4],
-                    [0.3, 0.3, 0.4, 0.2],
+                    [0.3, -0.3, 0.4, 0.2],
                     [0.3, 0.2, 0.4, 0.3],
                 ],
                 [
-                    [0.1, 0.4, 0.7, 0.2],
+                    [0.7, 0.4, 0.3, 0.2],
                     [0.3, 0.3, 0.4, 0.1],
-                    [0.2, 0.1, 0.1, 0.5],
+                    [0.6, -0.1, 0.1, 0.5],
                 ],
                 [
                     [0.1, 0.4, 0.2, 0.7],
-                    [0.3, 0.3, 0.2, 0.7],
+                    [0.3, 0.3, -0.2, 0.7],
                     [0.3, 0.2, 0.4, 0.1],
                 ],
             ]
         )
-        labels = np.array([[1, 2, -1], [2, -1, -1], [-1, -1, -1]])
-        score_labels = np.array([[-1.2], [-1.6], [-0.7]])
-        repeated_labels = np.array([[1, 2, 2], [2, 2, -1], [-1, -1, -1]])
+        labels = np.array([[1, 2, -1], [2, -1, -1], [3, -1, -1]])
+        score_labels = np.array([[-1.2], [-1.7], [-0.7]])
+        repeated_labels = np.array([[1, 2, 2], [0, 2, 0], [-1, -1, -1]])
 
         # Test strategy="greedy" and merge_repeated=True
         (decoded,), scores = knn.ctc_decode(
             inputs,
             sequence_lengths=[3, 3, 1],
             strategy="greedy",
+            mask_index=0,
         )
         self.assertAllClose(decoded, labels)
         self.assertAllClose(scores, score_labels)
@@ -1987,14 +1988,16 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         if backend.backend() == "torch":
             self.skipTest("torch doesn't support 'beam_search' strategy")
 
-        labels = [
-            np.array([[1, 2, -1], [2, -1, -1], [-1, -1, -1]]),
-            np.array([[2, -1, -1], [2, 0, -1], [1, -1, -1]]),
-        ]
+        labels = np.array(
+            [
+                [[2, -1, -1], [0, -1, -1], [-1, -1, -1]],
+                [[1, 2, -1], [0, 2, -1], [1, -1, -1]],
+            ]
+        )
         score_labels = np.array(
             [
-                [-2.33578291, -2.44335217],
-                [-2.22499622, -2.25768432],
+                [-2.32398787, -2.41500957],
+                [-2.237567, -2.428189],
                 [-1.0633859, -1.3633859],
             ]
         )
@@ -2008,9 +2011,10 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             strategy="beam_search",
             beam_width=beam_width,
             top_paths=top_paths,
+            mask_index=0,
         )
-        for i in range(top_paths):
-            self.assertAllClose(decoded[i], labels[i])
+        print(decoded)
+        self.assertAllClose(decoded, labels)
         self.assertAllClose(scores, score_labels)
 
     def test_normalize(self):


### PR DESCRIPTION
1. Compute `label_length` by counting non-`mask_index` elements in `losses.CTC`
2. Fix a bug in greedy decoding
3. Fix a bug where TF's beam search decoding didn't respect `mask_index`
4. Update the argument so that `mask_index` defaults to `0` which is consistent with `losses.CTC`

The unit tests have been updated.

I've also verified that this example will be compatible with Keras3 after the PR:
https://keras.io/examples/vision/handwriting_recognition/

|Backend|Training Speed|Validation Loss (at epoch=10)|
|-|-|-|
|tensorflow|~53ms/step|2.9052|
|jax|~9ms/step (super fast...)|2.9896|

- `tensorflow`, `ops.ctc_decode(strategy="beam_search")` at epoch=10:
![tf_beam_search](https://github.com/keras-team/keras/assets/20734616/73d9bc85-2600-4c95-a952-1ca8526a482a)

- `jax`, `ops.ctc_decode(strategy="greedy")` at epoch=10:
![inference](https://github.com/keras-team/keras/assets/20734616/0c526e46-a47d-4bc8-bfc3-95222e72bbe7)
