### PR TITLE
Ensure the same rule applies for np arrays in autocasting

### DIFF
--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -165,7 +165,6 @@ class DTypePolicy:
         return cls(**config)
 
     def _should_cast(self, x, autocast, dtype):
-        # Note: we don't convert integers to floats even when `autocast=True`
         x_dtype = backend.standardize_dtype(x.dtype)
         if autocast and backend.is_float_dtype(x_dtype) and x_dtype != dtype:
             return True

--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -136,9 +136,9 @@ class DTypePolicy:
     def convert_input(self, x, autocast, dtype):
         """Converts the input dtype based on `autocast` and `dtype`.
 
-        Note that `x` can be a tensor, symbolic tensor or numpy array. This
+        Note that `x` can be a tensor, symbolic tensor or numpy array, and this
         method will keep integer inputs untouched and only apply casting to
-        on floats.
+        floats.
         """
 
         dtype = backend.standardize_dtype(dtype)

--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -134,6 +134,13 @@ class DTypePolicy:
         return self._name
 
     def convert_input(self, x, autocast, dtype):
+        """Converts the input dtype based on `autocast` and `dtype`.
+
+        Note that `x` can be a tensor, symbolic tensor or numpy array. This
+        method will keep integer inputs untouched and only apply casting to
+        on floats.
+        """
+
         dtype = backend.standardize_dtype(dtype)
         if backend.is_tensor(x):
             if self._should_cast(x, autocast, dtype):

--- a/keras/src/layers/normalization/spectral_normalization_test.py
+++ b/keras/src/layers/normalization/spectral_normalization_test.py
@@ -25,7 +25,7 @@ class SpectralNormalizationTest(testing.TestCase):
         self.run_layer_test(
             layers.SpectralNormalization,
             init_kwargs={"layer": layers.Embedding(10, 4)},
-            input_data=np.random.randint(10, size=(10,)),
+            input_data=np.random.randint(10, size=(10,)).astype("float32"),
             expected_output_shape=(10, 4),
             expected_num_trainable_weights=1,
             expected_num_non_trainable_weights=1,

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -105,12 +105,13 @@ class TestCase(unittest.TestCase):
         else:
             # If x is a python number
             x_dtype = backend.standardize_dtype(type(x))
+        standardized_dtype = backend.standardize_dtype(dtype)
         default_msg = (
             "The dtype of x does not match the expected one. "
             f"Received: x.dtype={x_dtype} and dtype={dtype}"
         )
         msg = msg or default_msg
-        self.assertEqual(x_dtype, dtype, msg=msg)
+        self.assertEqual(x_dtype, standardized_dtype, msg=msg)
 
     def run_class_serialization_test(self, instance, custom_objects=None):
         from keras.src.saving import custom_object_scope

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -99,6 +99,19 @@ class TestCase(unittest.TestCase):
                 f"Backend {backend.backend()} does not support sparse tensors",
             )
 
+    def assertDType(self, x, dtype, msg=None):
+        if hasattr(x, "dtype"):
+            x_dtype = backend.standardize_dtype(x.dtype)
+        else:
+            # If x is a python number
+            x_dtype = backend.standardize_dtype(type(x))
+        default_msg = (
+            "The dtype of x does not match the expected one. "
+            f"Received: x.dtype={x_dtype} and dtype={dtype}"
+        )
+        msg = msg or default_msg
+        self.assertEqual(x_dtype, dtype, msg=msg)
+
     def run_class_serialization_test(self, instance, custom_objects=None):
         from keras.src.saving import custom_object_scope
         from keras.src.saving import deserialize_keras_object


### PR DESCRIPTION
Fix #19629

1. Ensure the same rule applies for np arrays in autocasting (`self.dtype_policy.convert_input`)
2. Introduce `self.assertDType` in `TestCase` (should be useful for any dtype checks)