### PR TITLE
Return a tuple from `ops.shape` with the Torch backend.

### DIFF
--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -234,7 +234,8 @@ def is_tensor(x):
 
 
 def shape(x):
-    return x.shape
+    # Convert from `torch.Size` to plain tuple.
+    return tuple(x.shape)
 
 
 def cast(x, dtype):

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -338,10 +338,12 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(x, y)
 
     def test_shape(self):
-        x = np.ones((2, 3, 7, 1))
+        x = ops.ones((2, 3, 7, 1))
+        self.assertEqual(core.shape(x).__class__, tuple)
         self.assertAllEqual(core.shape(x), (2, 3, 7, 1))
 
         x = KerasTensor((None, 3, None, 1))
+        self.assertEqual(core.shape(x).__class__, tuple)
         self.assertAllEqual(core.shape(x), (None, 3, None, 1))
 
     @pytest.mark.skipif(


### PR DESCRIPTION
With Torch, `x.shape` returns a `torch.Size`, which is a subclass of `tuple` but can cause different behaviors. In particular `convert_to_tensor` does not work on `torch.Size`.

This fixes https://github.com/keras-team/keras/issues/18900