### PR TITLE
add packaging requirement

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -17,3 +17,4 @@ rich
 build
 optree
 pytest-cov
+packaging

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "h5py",
         "optree",
         "ml-dtypes",
+        "packaging",
     ],
     # Supported Python versions
     python_requires=">=3.9",


### PR DESCRIPTION
## Motivation
When installing keras with `pip install -U keras` the [`packaging`](https://pypi.org/project/packaging/) package is not installed.
Its parsing features are however used with 
```python
from packaging.version import parse
```
in `keras/src/backend/torch/trainer.py` and `keras/src/utils/torch_utils.py`, which leads to a `ModuleNotFoundError`.

## Changes made
This PR adds the `packaging` package to `requirements-common.txt` and `setup.py`.