### PR TITLE
Fix bug in `model.export()` when inputs in a structure.

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1350,10 +1350,10 @@ class Layer(BackendLayer, Operation, KerasSaveable):
     def __setattr__(self, name, value):
         # Track Variables, Layers, Metrics, SeedGenerators.
         name, value = self._setattr_hook(name, value)
-        if hasattr(self, "_tracker"):
+        if name != "_tracker":
+            if not hasattr(self, "_tracker"):
+                self._initialize_tracker()
             value = self._tracker.track(value)
-        elif name != "_tracker":
-            self._initialize_tracker()
         return super().__setattr__(name, value)
 
     def _check_super_called(self):


### PR DESCRIPTION
The code computing the `call` signature was not going through the structure correctly.

Also tweaked tracking in `Layer` class:
- the first attribute set was not tracked.
- `TrackedDict` does not play nice with `jax2tf`/JAX so `_build_shapes_dict` is not tracked.