### PR TITLE
switch tensorflow for macOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Tensorflow.
-tensorflow-cpu~=2.16.1  # Pin to TF 2.16
+tensorflow-cpu~=2.16.1;sys_platform != 'darwin'  # Pin to TF 2.16
+tensorflow~=2.16.1;sys_platform == 'darwin'
 
 # Torch.
 # TODO: Pin to < 2.3.0 (GitHub issue #19602)


### PR DESCRIPTION
`tensorflow-cpu` is not available for macOS, hence switch to `tensorflow`