### PR TITLE
Fix for rendering issues with Keras Layers API Documentation (Convolution and Pooling layers)

### DIFF
--- a/keras/src/layers/convolutional/conv1d.py
+++ b/keras/src/layers/convolutional/conv1d.py
@@ -63,12 +63,14 @@ class Conv1D(BaseConv):
             bias after being updated by an `Optimizer`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         A 3D tensor with shape: `(batch_shape, steps, channels)`
     - If `data_format="channels_first"`:
         A 3D tensor with shape: `(batch_shape, channels, steps)`
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         A 3D tensor with shape: `(batch_shape, new_steps, filters)`
     - If `data_format="channels_first"`:

--- a/keras/src/layers/convolutional/conv1d_transpose.py
+++ b/keras/src/layers/convolutional/conv1d_transpose.py
@@ -57,12 +57,14 @@ class Conv1DTranspose(BaseConvTranspose):
             bias after being updated by an `Optimizer`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         A 3D tensor with shape: `(batch_shape, steps, channels)`
     - If `data_format="channels_first"`:
         A 3D tensor with shape: `(batch_shape, channels, steps)`
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         A 3D tensor with shape: `(batch_shape, new_steps, filters)`
     - If `data_format="channels_first"`:

--- a/keras/src/layers/convolutional/conv2d.py
+++ b/keras/src/layers/convolutional/conv2d.py
@@ -59,12 +59,14 @@ class Conv2D(BaseConv):
             bias after being updated by an `Optimizer`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         A 4D tensor with shape: `(batch_size, height, width, channels)`
     - If `data_format="channels_first"`:
         A 4D tensor with shape: `(batch_size, channels, height, width)`
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         A 4D tensor with shape: `(batch_size, new_height, new_width, filters)`
     - If `data_format="channels_first"`:

--- a/keras/src/layers/convolutional/conv2d_transpose.py
+++ b/keras/src/layers/convolutional/conv2d_transpose.py
@@ -59,12 +59,14 @@ class Conv2DTranspose(BaseConvTranspose):
             bias after being updated by an `Optimizer`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         A 4D tensor with shape: `(batch_size, height, width, channels)`
     - If `data_format="channels_first"`:
         A 4D tensor with shape: `(batch_size, channels, height, width)`
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         A 4D tensor with shape: `(batch_size, new_height, new_width, filters)`
     - If `data_format="channels_first"`:

--- a/keras/src/layers/convolutional/conv3d.py
+++ b/keras/src/layers/convolutional/conv3d.py
@@ -59,6 +59,7 @@ class Conv3D(BaseConv):
             bias after being updated by an `Optimizer`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         5D tensor with shape:
         `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
@@ -67,6 +68,7 @@ class Conv3D(BaseConv):
         `(batch_size, channels, spatial_dim1, spatial_dim2, spatial_dim3)`
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         5D tensor with shape:
         `(batch_size, new_spatial_dim1, new_spatial_dim2, new_spatial_dim3,

--- a/keras/src/layers/convolutional/conv3d_transpose.py
+++ b/keras/src/layers/convolutional/conv3d_transpose.py
@@ -59,6 +59,7 @@ class Conv3DTranspose(BaseConvTranspose):
             bias after being updated by an `Optimizer`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         5D tensor with shape:
         `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
@@ -67,6 +68,7 @@ class Conv3DTranspose(BaseConvTranspose):
         `(batch_size, channels, spatial_dim1, spatial_dim2, spatial_dim3)`
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         5D tensor with shape:
         `(batch_size, new_spatial_dim1, new_spatial_dim2, new_spatial_dim3,

--- a/keras/src/layers/convolutional/depthwise_conv1d.py
+++ b/keras/src/layers/convolutional/depthwise_conv1d.py
@@ -67,12 +67,14 @@ class DepthwiseConv1D(BaseDepthwiseConv):
             bias after being updated by an `Optimizer`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         A 3D tensor with shape: `(batch_shape, steps, channels)`
     - If `data_format="channels_first"`:
         A 3D tensor with shape: `(batch_shape, channels, steps)`
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         A 3D tensor with shape:
         `(batch_shape, new_steps, channels * depth_multiplier)`

--- a/keras/src/layers/convolutional/depthwise_conv2d.py
+++ b/keras/src/layers/convolutional/depthwise_conv2d.py
@@ -68,12 +68,14 @@ class DepthwiseConv2D(BaseDepthwiseConv):
             bias after being updated by an `Optimizer`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         A 4D tensor with shape: `(batch_size, height, width, channels)`
     - If `data_format="channels_first"`:
         A 4D tensor with shape: `(batch_size, channels, height, width)`
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         A 4D tensor with shape:
         `(batch_size, new_height, new_width, channels * depth_multiplier)`

--- a/keras/src/layers/convolutional/separable_conv1d.py
+++ b/keras/src/layers/convolutional/separable_conv1d.py
@@ -70,12 +70,14 @@ class SeparableConv1D(BaseSeparableConv):
             bias after being updated by an `Optimizer`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         A 3D tensor with shape: `(batch_shape, steps, channels)`
     - If `data_format="channels_first"`:
         A 3D tensor with shape: `(batch_shape, channels, steps)`
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         A 3D tensor with shape: `(batch_shape, new_steps, filters)`
     - If `data_format="channels_first"`:

--- a/keras/src/layers/convolutional/separable_conv2d.py
+++ b/keras/src/layers/convolutional/separable_conv2d.py
@@ -71,12 +71,14 @@ class SeparableConv2D(BaseSeparableConv):
             bias after being updated by an `Optimizer`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         A 4D tensor with shape: `(batch_size, height, width, channels)`
     - If `data_format="channels_first"`:
         A 4D tensor with shape: `(batch_size, channels, height, width)`
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         A 4D tensor with shape: `(batch_size, new_height, new_width, filters)`
     - If `data_format="channels_first"`:

--- a/keras/src/layers/pooling/average_pooling1d.py
+++ b/keras/src/layers/pooling/average_pooling1d.py
@@ -31,12 +31,14 @@ class AveragePooling1D(BasePooling):
             If you never set it, then it will be `"channels_last"`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         3D tensor with shape `(batch_size, steps, features)`.
     - If `data_format="channels_first"`:
         3D tensor with shape `(batch_size, features, steps)`.
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         3D tensor with shape `(batch_size, downsampled_steps, features)`.
     - If `data_format="channels_first"`:

--- a/keras/src/layers/pooling/average_pooling2d.py
+++ b/keras/src/layers/pooling/average_pooling2d.py
@@ -40,12 +40,14 @@ class AveragePooling2D(BasePooling):
             `"channels_last"`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         4D tensor with shape `(batch_size, height, width, channels)`.
     - If `data_format="channels_first"`:
         4D tensor with shape `(batch_size, channels, height, width)`.
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         4D tensor with shape
         `(batch_size, pooled_height, pooled_width, channels)`.

--- a/keras/src/layers/pooling/average_pooling3d.py
+++ b/keras/src/layers/pooling/average_pooling3d.py
@@ -33,6 +33,7 @@ class AveragePooling3D(BasePooling):
             will be `"channels_last"`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         5D tensor with shape:
         `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
@@ -41,6 +42,7 @@ class AveragePooling3D(BasePooling):
         `(batch_size, channels, spatial_dim1, spatial_dim2, spatial_dim3)`
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         5D tensor with shape:
         `(batch_size, pooled_dim1, pooled_dim2, pooled_dim3, channels)`

--- a/keras/src/layers/pooling/max_pooling1d.py
+++ b/keras/src/layers/pooling/max_pooling1d.py
@@ -32,12 +32,14 @@ class MaxPooling1D(BasePooling):
             If you never set it, then it will be `"channels_last"`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         3D tensor with shape `(batch_size, steps, features)`.
     - If `data_format="channels_first"`:
         3D tensor with shape `(batch_size, features, steps)`.
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         3D tensor with shape `(batch_size, downsampled_steps, features)`.
     - If `data_format="channels_first"`:

--- a/keras/src/layers/pooling/max_pooling2d.py
+++ b/keras/src/layers/pooling/max_pooling2d.py
@@ -40,12 +40,14 @@ class MaxPooling2D(BasePooling):
             `"channels_last"`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         4D tensor with shape `(batch_size, height, width, channels)`.
     - If `data_format="channels_first"`:
         4D tensor with shape `(batch_size, channels, height, width)`.
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         4D tensor with shape
         `(batch_size, pooled_height, pooled_width, channels)`.

--- a/keras/src/layers/pooling/max_pooling3d.py
+++ b/keras/src/layers/pooling/max_pooling3d.py
@@ -33,6 +33,7 @@ class MaxPooling3D(BasePooling):
             will be `"channels_last"`.
 
     Input shape:
+
     - If `data_format="channels_last"`:
         5D tensor with shape:
         `(batch_size, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
@@ -41,6 +42,7 @@ class MaxPooling3D(BasePooling):
         `(batch_size, channels, spatial_dim1, spatial_dim2, spatial_dim3)`
 
     Output shape:
+    
     - If `data_format="channels_last"`:
         5D tensor with shape:
         `(batch_size, pooled_dim1, pooled_dim2, pooled_dim3, channels)`


### PR DESCRIPTION
This change adds an extra newline character after the `Input shape:` and `Output shape:` sections for docstrings with nested bullet points. This ensures the correct markdown translation on the keras.io website for the convolution and pooling layers which have these bullet points right after these section headings. 

**Screeenshot of issue for MaxPooling2D from the keras.io website:**
![Screenshot from 2024-05-06 22-26-15](https://github.com/keras-team/keras/assets/32600304/df70cdd2-61a5-4821-ad07-197979fd00f4)

The markdown translation logic in the keras-io repo for docstrings requires an additional \n character. Some layers such as the ConvLSTM and GlobalAveragePooling already do this correctly in their docstrings. This change replicates the correct structure for the docstrings of the pooling and conv layers which have this rendering issue

**Screenshot of MaxPooling2D after the fix:**
![Screenshot from 2024-05-06 22-35-38](https://github.com/keras-team/keras/assets/32600304/551c31bf-69c6-4872-b152-dbaa8459aea9)
