### PR TITLE
Add `training=False` behavior for float8-trained `Dense` and `EinsumDense`

### DIFF
--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -732,3 +732,16 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
                 reloaded_layer.non_trainable_weights,
                 len(model.non_trainable_weights),
             )
+
+    def test_quantize_float8_inference(self):
+        config = dict(units=16)
+        layer = layers.Dense(**config)
+        layer.build((None, 8))
+        layer.quantize("float8")
+
+        # Try calling with `training=False` and the result must match
+        # `training=True` because there is no update.
+        x = np.random.random((64, 8))
+        y_inference = layer(x, training=False)
+        y_training = layer(x, training=True)
+        self.assertAllClose(y_inference, y_training)

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -206,7 +206,7 @@ class EinsumDense(Layer):
     def compute_output_shape(self, _):
         return self.full_output_shape
 
-    def call(self, inputs):
+    def call(self, inputs, training=None):
         x = ops.einsum(self.equation, inputs, self.kernel)
         if self.bias is not None:
             x += self.bias
@@ -369,7 +369,7 @@ class EinsumDense(Layer):
                 f"Expected: {[v.name for v in all_vars]}"
             )
 
-    """Quantization-related (int8 and float8) methods"""
+    # Quantization-related (int8 and float8) methods
 
     QUANTIZATION_MODE_ERROR_TEMPLATE = (
         f"Invalid quantization mode. Expected one of "
@@ -488,11 +488,11 @@ class EinsumDense(Layer):
         self.outputs_grad_amax_history.overwrite_with_gradient = True
         self._is_quantized = True
 
-    def quantized_call(self, inputs):
+    def quantized_call(self, inputs, training=None):
         if self.dtype_policy.quantization_mode == "int8":
             return self._int8_call(inputs)
         elif self.dtype_policy.quantization_mode == "float8":
-            return self._float8_call(inputs)
+            return self._float8_call(inputs, training=training)
         else:
             mode = self.dtype_policy.quantization_mode
             raise NotImplementedError(
@@ -562,7 +562,7 @@ class EinsumDense(Layer):
             x = self.activation(x)
         return x
 
-    def _float8_call(self, inputs):
+    def _float8_call(self, inputs, training=None):
         if self.lora_enabled:
             raise NotImplementedError(
                 "Currently, `_float8_call` doesn't support LoRA"
@@ -570,18 +570,22 @@ class EinsumDense(Layer):
 
         @ops.custom_gradient
         def quantized_dequantize_inputs(inputs, scale, amax_history):
-            new_scale = quantizers.compute_float8_scale(
-                ops.max(amax_history, axis=0),
-                scale,
-                ops.cast(
-                    float(ml_dtypes.finfo("float8_e4m3fn").max), "float32"
-                ),
-            )
+            if training:
+                new_scale = quantizers.compute_float8_scale(
+                    ops.max(amax_history, axis=0),
+                    scale,
+                    ops.cast(
+                        float(ml_dtypes.finfo("float8_e4m3fn").max), "float32"
+                    ),
+                )
+                new_amax_history = quantizers.compute_float8_amax_history(
+                    inputs, amax_history
+                )
+            else:
+                new_scale = None
+                new_amax_history = None
             qdq_inputs = quantizers.quantize_and_dequantize(
                 inputs, scale, "float8_e4m3fn", self.compute_dtype
-            )
-            new_amax_history = quantizers.compute_float8_amax_history(
-                inputs, amax_history
             )
 
             def grad(*args, upstream=None, variables=None):

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -870,3 +870,20 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
                 reloaded_layer.non_trainable_weights,
                 len(model.non_trainable_weights),
             )
+
+    def test_quantize_float8_inference(self):
+        config = dict(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes="d",
+        )
+        layer = layers.EinsumDense(**config)
+        layer.build((None, 3))
+        layer.quantize("float8")
+
+        # Try calling with `training=False` and the result must match
+        # `training=True` because there is no update.
+        x = np.random.random((64, 3))
+        y_inference = layer(x, training=False)
+        y_training = layer(x, training=True)
+        self.assertAllClose(y_inference, y_training)


### PR DESCRIPTION
Related to #19671

This PR introduces `training=False` behavior for float8-trained `Dense` and `EinsumDense` layers.

We could eliminate `amax_history` and preprocess the weights to bypass the transpose op in compiled graph, but this would make the layers unrecoverable for further training. (We want to continue training in `fitting`)

Perhaps the post-processing could be considered as a future plan.