### PR TITLE
Fix masking in merge layers.

### DIFF
--- a/keras/src/layers/merging/concatenate.py
+++ b/keras/src/layers/merging/concatenate.py
@@ -145,11 +145,15 @@ class Concatenate(Merge):
                 masks.append(ops.ones_like(input_i, dtype="bool"))
             elif mask_i.ndim < input_i.ndim:
                 # Mask is smaller than the input, expand it
-                masks.append(ops.expand_dims(mask_i, axis=-1))
+                masks.append(
+                    ops.broadcast_to(
+                        ops.expand_dims(mask_i, axis=-1), ops.shape(input_i)
+                    )
+                )
             else:
                 masks.append(mask_i)
         concatenated = ops.concatenate(masks, axis=self.axis)
-        return ops.all(concatenated, axis=-1, keepdims=False)
+        return ops.any(concatenated, axis=-1, keepdims=False)
 
     def get_config(self):
         config = {"axis": self.axis}

--- a/keras/src/layers/merging/maximum.py
+++ b/keras/src/layers/merging/maximum.py
@@ -31,10 +31,7 @@ class Maximum(Merge):
     """
 
     def _merge_function(self, inputs):
-        output = inputs[0]
-        for i in range(1, len(inputs)):
-            output = ops.maximum(output, inputs[i])
-        return output
+        return self._apply_merge_op_and_or_mask(ops.maximum, inputs)
 
 
 @keras_export("keras.layers.maximum")

--- a/keras/src/layers/merging/merging_test.py
+++ b/keras/src/layers/merging/merging_test.py
@@ -125,14 +125,14 @@ class MergingLayersTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(res.shape, expected_output_shape)
         self.assertAllClose(res, x3, atol=1e-4)
         self.assertIsNone(layer.compute_mask([input_1, input_2], [None, None]))
+        self.assertIsNone(layer.compute_mask([x1, x2], [None, None]))
         if not skip_mask_test:
+            mask1 = np.ones(input_shape[:-1], dtype=np.bool_)
+            mask2 = np.ones(input_shape[:-1], dtype=np.bool_)
             self.assertTrue(
                 np.all(
                     backend.convert_to_numpy(
-                        layer.compute_mask(
-                            [input_1, input_2],
-                            [backend.Variable(x1), backend.Variable(x2)],
-                        )
+                        layer.compute_mask([x1, x2], [mask1, mask2])
                     )
                 )
             )
@@ -233,6 +233,111 @@ class MergingLayersTest(testing.TestCase, parameterized.TestCase):
         b = np.random.random(b_shape)
         c = layers.Dot(axes=(-2, -1))([a, b])
         self.assertEqual(backend.standardize_shape(c.shape), (1, 2, 1, 2))
+
+    def test_add_with_mask(self):
+        mask = layers.Masking()
+        x1 = mask(backend.convert_to_tensor([[[0, 0], [1, 2], [0, 0], [3, 4]]]))
+        x2 = backend.convert_to_tensor([[[0, 0], [0, 0], [1, 2], [3, 4]]])
+
+        output = layers.Add()([x1, x2])
+        self.assertAllClose(output, [[[0, 0], [1, 2], [1, 2], [6, 8]]])
+        self.assertIsNone(getattr(output, "_keras_mask", None))
+
+        x2 = mask(x2)
+        output = layers.Add()([x1, x2])
+        self.assertAllClose(output, [[[0, 0], [1, 2], [1, 2], [6, 8]]])
+        self.assertAllClose(output._keras_mask, [[0, 1, 1, 1]])
+
+    def test_subtract_with_mask(self):
+        mask = layers.Masking()
+        x1 = mask(backend.convert_to_tensor([[[0, 0], [1, 2], [0, 0], [3, 4]]]))
+        x2 = backend.convert_to_tensor([[[0, 0], [0, 0], [1, 2], [3, 4]]])
+
+        output = layers.Subtract()([x1, x2])
+        self.assertAllClose(output, [[[0, 0], [1, 2], [-1, -2], [0, 0]]])
+        self.assertIsNone(getattr(output, "_keras_mask", None))
+
+        x2 = mask(x2)
+        output = layers.Subtract()([x1, x2])
+        self.assertAllClose(output, [[[0, 0], [1, 2], [-1, -2], [0, 0]]])
+        self.assertAllClose(output._keras_mask, [[0, 1, 1, 1]])
+
+    def test_average_with_mask(self):
+        mask = layers.Masking()
+        x1 = mask(backend.convert_to_tensor([[[0, 0], [1, 2], [0, 0], [3, 4]]]))
+        x2 = backend.convert_to_tensor([[[0, 0], [0, 0], [1, 2], [3, 4]]])
+
+        output = layers.Average()([x1, x2])
+        self.assertAllClose(output, [[[0, 0], [0.5, 1], [0.5, 1], [3, 4]]])
+        self.assertIsNone(getattr(output, "_keras_mask", None))
+
+        x2 = mask(x2)
+        output = layers.Average()([x1, x2])
+        self.assertAllClose(output, [[[0, 0], [0.5, 1], [0.5, 1], [3, 4]]])
+        self.assertAllClose(output._keras_mask, [[0, 1, 1, 1]])
+
+    def test_multiply_with_mask(self):
+        mask = layers.Masking()
+        x1 = mask(backend.convert_to_tensor([[[0, 0], [1, 2], [0, 0], [3, 4]]]))
+        x2 = backend.convert_to_tensor([[[0, 0], [0, 0], [1, 2], [3, 4]]])
+
+        output = layers.Multiply()([x1, x2])
+        self.assertAllClose(output, [[[0, 0], [0, 0], [1, 2], [9, 16]]])
+        self.assertIsNone(getattr(output, "_keras_mask", None))
+
+        x2 = mask(x2)
+        output = layers.Multiply()([x1, x2])
+        self.assertAllClose(output, [[[0, 0], [1, 2], [1, 2], [9, 16]]])
+        self.assertAllClose(output._keras_mask, [[0, 1, 1, 1]])
+
+    def test_maximum_with_mask(self):
+        mask = layers.Masking()
+        x1 = mask(
+            backend.convert_to_tensor([[[0, 0], [-1, -2], [0, 0], [-3, -4]]])
+        )
+        x2 = backend.convert_to_tensor([[[0, 0], [0, 0], [-1, -2], [-3, -4]]])
+
+        output = layers.Maximum()([x1, x2])
+        self.assertAllClose(output, [[[0, 0], [0, 0], [-1, -2], [-3, -4]]])
+        self.assertIsNone(getattr(output, "_keras_mask", None))
+
+        x2 = mask(x2)
+        output = layers.Maximum()([x1, x2])
+        self.assertAllClose(output, [[[0, 0], [-1, -2], [-1, -2], [-3, -4]]])
+        self.assertAllClose(output._keras_mask, [[0, 1, 1, 1]])
+
+    def test_minimum_with_mask(self):
+        mask = layers.Masking()
+        x1 = mask(backend.convert_to_tensor([[[0, 0], [1, 2], [0, 0], [3, 4]]]))
+        x2 = backend.convert_to_tensor([[[0, 0], [0, 0], [1, 2], [3, 4]]])
+
+        output = layers.Minimum()([x1, x2])
+        self.assertAllClose(output, [[[0, 0], [0, 0], [1, 2], [3, 4]]])
+        self.assertIsNone(getattr(output, "_keras_mask", None))
+
+        x2 = mask(x2)
+        output = layers.Minimum()([x1, x2])
+        self.assertAllClose(output, [[[0, 0], [1, 2], [1, 2], [3, 4]]])
+        self.assertAllClose(output._keras_mask, [[0, 1, 1, 1]])
+
+    def test_concatenate_with_mask(self):
+        mask = layers.Masking()
+        x1 = mask(backend.convert_to_tensor([[[0, 0], [1, 2], [0, 0], [3, 4]]]))
+        x2 = backend.convert_to_tensor([[[0, 0], [0, 0], [1, 2], [3, 4]]])
+
+        output = layers.Concatenate(axis=1)([x1, x2])
+        self.assertAllClose(
+            output,
+            [[[0, 0], [1, 2], [0, 0], [3, 4], [0, 0], [0, 0], [1, 2], [3, 4]]],
+        )
+        self.assertAllClose(output._keras_mask, [[0, 1, 0, 1, 1, 1, 1, 1]])
+
+        output = layers.Concatenate(axis=2)([x1, x2])
+        self.assertAllClose(
+            output,
+            [[[0, 0, 0, 0], [1, 2, 0, 0], [0, 0, 1, 2], [3, 4, 3, 4]]],
+        )
+        self.assertAllClose(output._keras_mask, [[1, 1, 1, 1]])
 
     @parameterized.named_parameters(TEST_PARAMETERS)
     @pytest.mark.skipif(

--- a/keras/src/layers/merging/minimum.py
+++ b/keras/src/layers/merging/minimum.py
@@ -31,10 +31,7 @@ class Minimum(Merge):
     """
 
     def _merge_function(self, inputs):
-        output = inputs[0]
-        for i in range(1, len(inputs)):
-            output = ops.minimum(output, inputs[i])
-        return output
+        return self._apply_merge_op_and_or_mask(ops.minimum, inputs)
 
 
 @keras_export("keras.layers.minimum")

--- a/keras/src/layers/merging/multiply.py
+++ b/keras/src/layers/merging/multiply.py
@@ -31,9 +31,29 @@ class Multiply(Merge):
     """
 
     def _merge_function(self, inputs):
-        output = inputs[0]
-        for i in range(1, len(inputs)):
-            output = ops.multiply(output, inputs[i])
+        masks = [getattr(x, "_keras_mask", None) for x in inputs]
+        has_output_mask = all(mask is not None for mask in masks)
+        output = None
+        output_mask = None
+
+        for x, mask in zip(inputs, masks):
+            if mask is not None:
+                mask = ops.broadcast_to(ops.expand_dims(mask, -1), ops.shape(x))
+                # Replace 0s with 1s outside of mask.
+                x = ops.where(mask, x, ops.cast(1, x.dtype))
+                if has_output_mask:
+                    output_mask = (
+                        mask
+                        if output_mask is None
+                        else ops.logical_or(output_mask, mask)
+                    )
+            output = x if output is None else ops.multiply(output, x)
+
+        if has_output_mask:
+            # Replace 1s with 0s outside of mask per standard masking rules.
+            output = ops.where(output_mask, output, ops.cast(0, output.dtype))
+            output_mask = ops.any(output_mask, axis=-1, keepdims=False)
+            output._keras_mask = output_mask
         return output
 
 


### PR DESCRIPTION
- Fixed bug where base `Layer` class was not handling masking with input structures correctly, which affected all merge layers.
- Fixed bug where the zeros outside of the mask were still used to compute the output of the merge layer (affected `Maximum`, `Minimum` and `Multiply`).
- Fixed bug where the output mask was not computed correctly (affected all merge layers).
- Fixed bug where `Concatenate` layer was not broadcasting the mask correctly.

Fixes https://github.com/keras-team/keras/issues/18416