### PR TITLE
Fix `ops.shape()` for `tf.RaggedTensor`.

### DIFF
--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -148,14 +148,22 @@ def shape(x):
         return x.shape
     if not tf.is_tensor(x):
         x = tf.convert_to_tensor(x)
-    dynamic = tf.shape(x)
     if x.shape == tf.TensorShape(None):
         raise ValueError(
             "All tensors passed to `ops.shape` must have a statically known "
             f"rank. Received: x={x} with unknown rank."
         )
-    static = x.shape.as_list()
-    return tuple(dynamic[i] if s is None else s for i, s in enumerate(static))
+    shape = x.shape.as_list()
+    dynamic = tf.shape(x)
+    for i in range(len(shape)):
+        if shape[i] is None:
+            try:
+                shape[i] = dynamic[i]
+            except:
+                # With RaggedTensors, accessing a ragged dimension will fail,
+                # we leave it as None.
+                pass
+    return tuple(shape)
 
 
 def cast(x, dtype):

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -445,6 +445,19 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
         self.assertAllEqual(core.shape(x), (2, 3))
 
+    @pytest.mark.skipif(
+        backend.backend() != "tensorflow",
+        reason="Backend does not support ragged tensors.",
+    )
+    def test_shape_ragged(self):
+        import tensorflow as tf
+
+        x = tf.ragged.constant([[3, 1, 4, 1], [], [5, 9, 2], [6], []])
+        self.assertAllEqual(core.shape(x), (5, None))
+
+        x = tf.RaggedTensor.from_row_lengths(tf.zeros([15, 2]), [4, 5, 6])
+        self.assertAllEqual(core.shape(x), (3, None, 2))
+
     def test_convert_to_tensor(self):
         x = np.ones((2,))
         x = ops.convert_to_tensor(x)


### PR DESCRIPTION
With the TensorFlow backend, when passing a `RaggedTensor`, the dynamic shape returned by `tf.shape` is an object that raises an exception when a ragged dimension is accessed. We catch it and leave the dimension as `None`.