### PR TITLE
Improved docs to bring in clarity.

### DIFF
--- a/keras/src/utils/torch_utils.py
+++ b/keras/src/utils/torch_utils.py
@@ -16,6 +16,9 @@ class TorchModuleWrapper(Layer):
     `torch.nn.Module` into a Keras layer, in particular by making its
     parameters trackable by Keras.
 
+    `TorchModuleWrapper` is only compatible with the torch backend and
+    cannot be used with TensorFlow or JAX backends.
+
     Args:
         module: `torch.nn.Module` instance. If it's a `LazyModule`
             instance, then its parameters must be initialized before

--- a/keras/src/utils/torch_utils.py
+++ b/keras/src/utils/torch_utils.py
@@ -16,8 +16,8 @@ class TorchModuleWrapper(Layer):
     `torch.nn.Module` into a Keras layer, in particular by making its
     parameters trackable by Keras.
 
-    `TorchModuleWrapper` is only compatible with the torch backend and
-    cannot be used with TensorFlow or JAX backends.
+    `TorchModuleWrapper` is only compatible with the PyTorch backend and
+    cannot be used with the TensorFlow or JAX backends.
 
     Args:
         module: `torch.nn.Module` instance. If it's a `LazyModule`


### PR DESCRIPTION
The PR consists of a tiny addition in docs to let the user know that `TorchModuleWrapper`, as the name sounds is not a Wrapper to Wrap any arbitrary code into Keras with any backend, but rather a different feature enabling integration of PyTorch custom layers to Keras when running PyTorch backends.

I'll try to write basic wrappers for actual code conversion if that is possible and try checking the extent by which complex models can be easily integrated into Keras, being backend invariant.

Thank You.