### PR TITLE
Dense layer docstring typo fix

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -17,7 +17,7 @@ class Dense(Layer):
     """Just your regular densely-connected NN layer.
 
     `Dense` implements the operation:
-    `output = activation(dot(input, kernel) + bias)`
+    `output = activation(matmul(input, kernel) + bias)`
     where `activation` is the element-wise activation function
     passed as the `activation` argument, `kernel` is a weights matrix
     created by the layer, and `bias` is a bias vector created by the layer


### PR DESCRIPTION
**Dense layer does matmul(matrix multiplication) for tensors with rank <= 2, not dot product.** 

It can be easily checked in the code, the call method of the dense layer class has:
`x = ops.matmul(inputs, self.kernel)`
not 
`output = activation(dot(input, kernel) + bias)`
as in the docstring

It can also be checked by passing rank<=2 inputs of different [-1] dimension to dense layers with variable number of units, which is only possible if dense layers are doing matmul and not dot for rank<=2 tensors.