### PR TITLE
Raise error when inputs and mask don't have same shape in Softmax

### DIFF
--- a/keras/src/layers/activations/softmax.py
+++ b/keras/src/layers/activations/softmax.py
@@ -50,6 +50,12 @@ class Softmax(Layer):
 
     def call(self, inputs, mask=None):
         if mask is not None:
+            if mask.shape != inputs.shape:
+                raise ValueError(
+                    "`mask` and `inputs` must have same shape. "
+                    f"Got inputs shape: {inputs.shape} and "
+                    f"mask shape: {mask.shape}"
+                )
             adder = (
                 1.0 - backend.cast(mask, inputs.dtype)
             ) * _large_negative_number(inputs.dtype)


### PR DESCRIPTION
Currently keras.layers.Softmax not having check to verify inputs and mask shape same or not. As per documnetation the mask should be A boolean mask of the same shape as inputs.

But Its generating output even though mask shape is not same as that of inputs.

Hence proposing a check to raise exception when inputs and mask don't have same shape.

Fixes #19722 .

