### PR TITLE
Fix one_hot for torch backend (MPS device)

### DIFF
--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -562,13 +562,14 @@ def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
     # Axis is the output axis. By default, PyTorch, outputs to last axis.
     # If axis is not last, change output to axis and shift remaining elements.
     x = convert_to_tensor(x, dtype=torch.long)
+    zero = convert_to_tensor(0, dtype=torch.long)
 
     # Torch one_hot does not natively handle negative values, so we add some
     # manual handling for negatives in the input to one_hot by using max(x, 0).
     # The output will have some invalid results, so we set them back to 0 using
     # `where` afterwards.
     output = tnn.one_hot(maximum(x, 0), num_classes)
-    output = where(expand_dims(x, axis=-1) >= 0, output, 0)
+    output = where(expand_dims(x, axis=-1) >= 0, output, zero)
     output = convert_to_tensor(output, dtype=dtype)
     dims = output.dim()
     if axis != -1 and axis != dims:


### PR DESCRIPTION
Hello,

As I was using an Apple M2 computer, I discovered a tiny bug in keras.ops.one_hot with the torch backend (on MPS device): the line `output = where(expand_dims(x, axis=-1) >= 0, output, 0)` raises the error "expected scalar type long long but found int", since in this setup the last "0" is automatically converted to an int (int32) instead of a long (int64), as opposed to  most backends/devices.

The proposed fix solves this issue (and still works with other backends/devices).