### PR TITLE
Don't mutate passed config dict in Operation.from_config()

### DIFF
--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -205,6 +205,7 @@ class Operation:
             An operation instance.
         """
         if "dtype" in config and isinstance(config["dtype"], dict):
+            config = config.copy()
             config["dtype"] = dtype_policies.deserialize(config["dtype"])
         try:
             return cls(**config)


### PR DESCRIPTION
As of #19728, Operation.from_config() has been overriding the dtype field in the passed config dict.

There doesn't seem to be an explicit contract that from_config doesn't modify the config argument, but this seems to be the case in practice, and this behaviour has broken some code on an internal repo.