### PR TITLE
Remove `convert_to_numpy` in confusion metrics and fix `ops.nonzero` …

### DIFF
--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1007,7 +1007,7 @@ def ndim(x):
 
 def nonzero(x):
     x = convert_to_tensor(x)
-    return tuple(cast(indices, "int32") for indices in torch.nonzero(x).T)
+    return cast(torch.nonzero(x).T, "int32")
 
 
 def not_equal(x1, x2):

--- a/keras/src/metrics/confusion_metrics.py
+++ b/keras/src/metrics/confusion_metrics.py
@@ -664,10 +664,7 @@ class SensitivitySpecificityBase(Metric):
         Returns:
             maximal dependent value, if no value satisfies the constraint 0.0.
         """
-        feasible = backend.convert_to_numpy(
-            ops.nonzero(predicate(constrained, self.value))
-        )
-
+        feasible = ops.nonzero(predicate(constrained, self.value))
         feasible_exists = ops.greater(ops.size(feasible), 0)
         max_dependent = ops.max(ops.take(dependent, feasible), initial=0)
 


### PR DESCRIPTION
…for torch.

- Removed the use of `convert_to_numpy` confusion metrics as it prevents jit compilation.
- Fixed Torch implementation of `ops.nonzero`, it was returning a tuple of one tensor instead of just the tensor.

The `convert_to_numpy` call was presumably a workaround for the second issue.