### PR TITLE
Re-introduce `tf_utils.ensure_tensor` in preprocessing layers.

### DIFF
--- a/keras/src/layers/preprocessing/hashed_crossing.py
+++ b/keras/src/layers/preprocessing/hashed_crossing.py
@@ -4,6 +4,7 @@ from keras.src.layers.layer import Layer
 from keras.src.utils import argument_validation
 from keras.src.utils import backend_utils
 from keras.src.utils import numerical_utils
+from keras.src.utils import tf_utils
 from keras.src.utils.module_utils import tensorflow as tf
 
 
@@ -138,7 +139,7 @@ class HashedCrossing(Layer):
         from keras.src.backend import tensorflow as tf_backend
 
         self._check_at_least_two_inputs(inputs)
-        inputs = [tf_backend.convert_to_tensor(x) for x in inputs]
+        inputs = [tf_utils.ensure_tensor(x) for x in inputs]
         self._check_input_shape_and_type(inputs)
 
         # Uprank to rank 2 for the cross_hashed op.

--- a/keras/src/layers/preprocessing/hashing.py
+++ b/keras/src/layers/preprocessing/hashing.py
@@ -3,6 +3,7 @@ from keras.src.api_export import keras_export
 from keras.src.layers.layer import Layer
 from keras.src.utils import backend_utils
 from keras.src.utils import numerical_utils
+from keras.src.utils import tf_utils
 from keras.src.utils.module_utils import tensorflow as tf
 
 
@@ -211,7 +212,7 @@ class Hashing(Layer):
     def call(self, inputs):
         from keras.src.backend import tensorflow as tf_backend
 
-        inputs = tf_backend.convert_to_tensor(inputs)
+        inputs = tf_utils.ensure_tensor(inputs)
         if self.output_mode == "one_hot" and inputs.shape[-1] == 1:
             # One hot only unpranks if the final dimension is not 1.
             inputs = tf_backend.numpy.squeeze(inputs, axis=-1)

--- a/keras/src/layers/preprocessing/text_vectorization.py
+++ b/keras/src/layers/preprocessing/text_vectorization.py
@@ -8,6 +8,7 @@ from keras.src.layers.preprocessing.string_lookup import StringLookup
 from keras.src.saving import serialization_lib
 from keras.src.utils import argument_validation
 from keras.src.utils import backend_utils
+from keras.src.utils import tf_utils
 from keras.src.utils.module_utils import tensorflow as tf
 
 
@@ -412,8 +413,6 @@ class TextVectorization(Layer):
                 repeating dataset, you must specify the `steps` argument. This
                 argument is not supported with array inputs or list inputs.
         """
-        from keras.src.backend import tensorflow as tf_backend
-
         self.reset_state()
         if isinstance(data, tf.data.Dataset):
             if steps is not None:
@@ -421,7 +420,7 @@ class TextVectorization(Layer):
             for batch in data:
                 self.update_state(batch)
         else:
-            data = tf_backend.convert_to_tensor(data, dtype="string")
+            data = tf_utils.ensure_tensor(data, dtype="string")
             if data.shape.rank == 1:
                 # A plain list of strings
                 # is treated as as many documents
@@ -520,9 +519,7 @@ class TextVectorization(Layer):
         self._lookup_layer.set_vocabulary(vocabulary, idf_weights=idf_weights)
 
     def _preprocess(self, inputs):
-        from keras.src.backend import tensorflow as tf_backend
-
-        inputs = tf_backend.convert_to_tensor(inputs, dtype=tf.string)
+        inputs = tf_utils.ensure_tensor(inputs, dtype=tf.string)
         if self._standardize in ("lower", "lower_and_strip_punctuation"):
             inputs = tf.strings.lower(inputs)
         if self._standardize in (

--- a/keras/src/utils/tf_utils.py
+++ b/keras/src/utils/tf_utils.py
@@ -1,3 +1,4 @@
+from keras.src import backend
 from keras.src.utils.module_utils import tensorflow as tf
 
 
@@ -25,3 +26,15 @@ def get_tensor_spec(t, dynamic_batch=False, name=None):
     shape = tf.TensorShape(shape_list)
     spec._shape = shape
     return spec
+
+
+def ensure_tensor(inputs, dtype=None):
+    """Ensures the input is a Tensor, SparseTensor or RaggedTensor."""
+    if not isinstance(inputs, (tf.Tensor, tf.SparseTensor, tf.RaggedTensor)):
+        if backend.backend() == "torch" and backend.is_tensor(inputs):
+            # Plain `np.asarray()` conversion fails with PyTorch.
+            inputs = backend.convert_to_numpy(inputs)
+        inputs = tf.convert_to_tensor(inputs, dtype)
+    if dtype is not None and inputs.dtype != dtype:
+        inputs = tf.cast(inputs, dtype)
+    return inputs


### PR DESCRIPTION
It turns out `tf_backend.convert_to_tensor` does not support on-GPU Torch tensors. This also removes the need for some late import.