### PR TITLE
Fix `dtype` serialization

### DIFF
--- a/keras/src/dtype_policies/__init__.py
+++ b/keras/src/dtype_policies/__init__.py
@@ -87,9 +87,7 @@ def get(identifier):
 
     if identifier is None:
         return dtype_policy.dtype_policy()
-    if isinstance(
-        identifier, (DTypePolicy, FloatDTypePolicy, QuantizedDTypePolicy)
-    ):
+    if isinstance(identifier, DTypePolicy):
         return identifier
     if isinstance(identifier, dict):
         return deserialize(identifier)

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -104,10 +104,10 @@ class Operation:
         arg_names = inspect.getfullargspec(cls.__init__).args
         kwargs.update(dict(zip(arg_names[1 : len(args) + 1], args)))
 
-        # Explicitly serialize `dtype` into dict to support _auto_config
+        # Explicitly serialize `dtype` to support auto_config
         dtype = kwargs.get("dtype", None)
         if dtype is not None and isinstance(dtype, dtype_policies.DTypePolicy):
-            # For backward compatibility, we use a plain string (`name`) for
+            # For backward compatibility, we use a str (`name`) for
             # `FloatDTypePolicy`
             if not dtype.is_quantized:
                 kwargs["dtype"] = dtype.name
@@ -210,7 +210,7 @@ class Operation:
 
         ```python
         if "dtype" in config and isinstance(config["dtype"], dict):
-            config["dtype"] = dtype_policies.deserialize(config["dtype"])
+            policy = dtype_policies.deserialize(config["dtype"])
         ```
 
         Args:

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -105,10 +105,15 @@ class Operation:
         kwargs.update(dict(zip(arg_names[1 : len(args) + 1], args)))
 
         # Explicitly serialize `dtype` into dict to support _auto_config
-        if "dtype" in kwargs and isinstance(
-            kwargs["dtype"], dtype_policies.DTypePolicy
-        ):
-            kwargs["dtype"] = dtype_policies.serialize(kwargs["dtype"])
+        dtype = kwargs.get("dtype", None)
+        if dtype is not None and isinstance(dtype, dtype_policies.DTypePolicy):
+            # For backward compatibility, we use a plain string (`name`) for
+            # `FloatDTypePolicy`
+            if not dtype.is_quantized:
+                kwargs["dtype"] = dtype.name
+            # Otherwise, use `dtype_policies.serialize`
+            else:
+                kwargs["dtype"] = dtype_policies.serialize(dtype)
 
         # For safety, we only rely on auto-configs for a small set of
         # serializable types.


### PR DESCRIPTION
We should use `dtype_policies.serialize` to serialize the `DTypePolicy` in `Operation`. A simple test has been added to verify this.
A note has been added in `from_config` to indicate that when overriding `from_config`, users should deserialize the `dtype` if needed.
