### PR TITLE
Implement tool for saved Keras model files inspection, diff and patching

### DIFF
--- a/keras/src/utils/model_tools.py
+++ b/keras/src/utils/model_tools.py
@@ -1,0 +1,303 @@
+"""Utilities related to model inspection and patching."""
+
+import io
+import json
+import base64
+import zipfile
+import matplotlib.pyplot as plt
+
+from difflib import unified_diff
+from IPython.display import display, HTML
+from diff_match_patch import diff_match_patch
+
+from keras.src.saving import load_model
+from keras.src.api_export import keras_export
+from keras.src.saving import deserialize_keras_object
+from keras.src.saving.saving_lib import H5IOStore
+
+_CONFIG_FILENAME = "config.json"
+_METADATA_FILENAME = "metadata.json"
+_VARS_FNAME = "model.weights"
+
+
+def load_model_config(model_path):
+    """ Auxiliar function.
+        Loads model and extract its JSON configuration."""
+    model = load_model(model_path)
+    return model.to_json()
+
+
+def compare_model_configs(config1_json, config2_json):
+    """ Auxiliar function.
+        Returns differences between two model configurations."""
+    config1 = json.loads(config1_json)
+    config2 = json.loads(config2_json)
+    if config1["config"]["name"]:
+        del config1["config"]["name"]
+    if config2["config"]["name"]:
+        del config2["config"]["name"]
+
+    config1_str = json.dumps(config1, indent=2)
+    config2_str = json.dumps(config2, indent=2)
+
+    diff = list(unified_diff(config1_str.splitlines(),
+                             config2_str.splitlines(),
+                             fromfile='model1',
+                             tofile='model2'
+                             )
+                )
+    return diff
+
+
+def diff_text(text1, text2):
+    """ Auxiliar function.
+        Returns highlighted differences between two texts."""
+    style1 = "background-color:rgba(212, 237, 218, 0.5); color:#155724;"
+    style2 = "background-color:rgba(248, 215, 218, 0.5); color:#721c24;"
+    dmp = diff_match_patch()
+    diffs = dmp.diff_main(text1, text2)
+    dmp.diff_cleanupSemantic(diffs)
+    highlighted1, highlighted2 = [], []
+    for (op, data) in diffs:
+        if op == 0:  # equal, no highlighting
+            highlighted1.append(data)
+            highlighted2.append(data)
+        elif op == 1:  # highlights with green color
+            highlighted2.append(f"<span style='{style1}'>{data}</span>")
+        elif op == -1:  # highlights with red color
+            highlighted1.append(f"<span style='{style2}'>{data}</span>")
+    return ''.join(highlighted1), ''.join(highlighted2)
+
+
+def render_differences(diff):
+    """ Auxiliar function.
+        Renders differences between two model configurations."""
+
+    base_style = "border:1px solid black; padding: 10px; text-align: left;"
+
+    html_output = ["<h3>Model Configuration Differences:</h3>",
+                   "<table style='width:100%; border-collapse:collapse;'>"]
+    html_output.append(f"<tr><th style='{base_style} width:50%;'>Model 1</th>\
+                        <th style='{base_style} width:50%;'>Model 2</th></tr>")
+
+    if diff:
+        text1_lines, text2_lines = [], []
+        for line in diff:
+            if line.startswith('- '):
+                text1_lines.append(line[2:])
+            elif line.startswith('+ '):
+                text2_lines.append(line[2:])
+        text1 = "\n".join(text1_lines)
+        text2 = "\n".join(text2_lines)
+        highlighted1, highlighted2 = diff_text(text1, text2)
+        html_output.append(f"<tr><td style='{base_style} vertical-align: top;'>\
+                           <pre>{highlighted1}</pre></td>")
+        html_output.append(f"<td style='{base_style} vertical-align: top;'> \
+                           <pre>{highlighted2}</pre></td></tr>")
+    else:
+        html_output.append(f"<tr><td colspan='2' style='{base_style}'> \
+                           No differences found</td></tr>")
+
+    html_output.append("</table>")
+    display(HTML(''.join(html_output)))
+
+
+@keras_export("keras.utils.compare_models")
+def compare_models(model1_path, model2_path):
+    """ Compares two models.
+        Shows them side by side with differences highlighted."""
+    config1_json = load_model_config(model1_path)
+    config2_json = load_model_config(model2_path)
+
+    diff = compare_model_configs(config1_json, config2_json)
+    render_differences(diff)
+
+
+def create_color_grid(weights):
+    """ Auxiliar function.
+        Create a heatmap of the weights."""
+
+    fig, ax = plt.subplots(figsize=(5, 5))
+    if weights.ndim > 2:
+        weights = weights.reshape(-1, weights.shape[-1])
+    if weights.ndim == 1:
+        cax = ax.imshow(weights.reshape(-1, 1), aspect='auto', cmap='viridis')
+    else:
+        cax = ax.matshow(weights, interpolation='nearest', cmap='viridis')
+        if weights.shape[0] / weights.shape[1] > 10 or \
+                weights.shape[1] / weights.shape[0] > 10:
+            ax.set_aspect('auto', 'datalim')
+        if weights.shape[0] == 1:
+            ax.set_yticks([])
+        if weights.shape[1] == 1:
+            ax.set_xticks([])
+
+    fig.colorbar(cax)
+    ax.set_title('Weights Heatmap')
+    ax.set_xlabel('Column')
+    ax.set_ylabel('Row')
+    ax.xaxis.set_label_position('top')
+    ax.xaxis.tick_top()
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png', bbox_inches='tight', pad_inches=1)
+    plt.close(fig)
+    buf.seek(0)
+    image_base64 = base64.b64encode(buf.read()).decode('utf-8')
+    return f'<img src="data:image/png;base64,{image_base64}" \
+                style="display:block;margin:auto;" />'
+
+
+@keras_export("keras.utils.inspect_file")
+def inspect_file(filepath, reference_model=None, custom_objects=None):
+    """ Inspects the contents of a Keras model or weights file."""
+
+    filepath = str(filepath)
+    html_output = []
+
+    if filepath.endswith(".keras"):
+        with zipfile.ZipFile(filepath, "r") as zf:
+            html_output.append(f"<h2>Keras model file '{filepath}'</h2>")
+
+            with zf.open(_CONFIG_FILENAME, "r") as f:
+                config = json.loads(f.read())
+                html_output.append(
+                    f"<p>Model: {config['class_name']} \
+                        name='{config['config']['name']}'</p>"
+                )
+            if reference_model is None:
+                reference_model = deserialize_keras_object(
+                    config, custom_objects=custom_objects
+                )
+
+            with zf.open(_METADATA_FILENAME, "r") as f:
+                metadata = json.loads(f.read())
+                html_output.append(f"<p>Saved with Keras \
+                                   {metadata['keras_version']}</p>")
+                html_output.append(f"<p>Date saved: \
+                                   {metadata['date_saved']}</p>")
+
+            archive = zipfile.ZipFile(filepath, "r")
+            weights_store = H5IOStore(
+                _VARS_FNAME + ".h5", archive=archive, mode="r"
+            )
+            html_output.append("<h3>Weights file:</h3>")
+            html_output.append(inspect_nested_dict(weights_store.h5_file))
+
+    elif filepath.endswith(".weights.h5"):
+        html_output.append(f"<h2>Keras weights file '{filepath}'</h2>")
+        weights_store = H5IOStore(filepath, mode="r")
+        html_output.append(inspect_nested_dict(weights_store.h5_file))
+
+    else:
+        raise ValueError(
+            "Invalid filename: expected a `.keras` or `.weights.h5` extension. "
+            f"Received: filepath={filepath}"
+        )
+
+    display(HTML(''.join(html_output)))
+
+
+def inspect_nested_dict(store):
+    """ Auxiliar function.
+        Inspect the contents of a nested dictionary."""
+
+    html_output = []
+    indent_style = "margin-left: 20px;"
+
+    for key in store.keys():
+        value = store[key]
+
+        if hasattr(value, "keys"):
+            skip = False
+            if (
+                list(value.keys()) == ["vars"]
+                and len(value["vars"].keys()) == 0
+            ):
+                skip = True
+            if key == "vars" and len(value.keys()) == 0:
+                skip = True
+            if not skip:
+                html_output.append(f"<details style='{indent_style}'>\
+                    <summary>{key}</summary>")
+                html_output.append(inspect_nested_dict(value))
+                html_output.append("</details>")
+        else:
+            w = value[()]
+            shape_info = f"{w.shape} {w.dtype}"
+            if w.ndim == 0:
+                html_output.append(f"<details style='{indent_style}'>\
+                    <summary>{key}: {shape_info}</summary></details>")
+            else:
+                color_grid = create_color_grid(w)
+                html_output.append(f"<details style='\
+                    {indent_style}'>\
+                        <summary>{key}: {shape_info}</summary>\
+                        {color_grid}\
+                    </details>")
+
+    return ''.join(html_output)
+
+
+@keras_export("keras.utils.change_layer_name")
+def change_layer_name(filepath):
+    """ Interactively changes the name of a layer in a Keras model."""
+
+    try:
+        model = load_model(filepath)
+    except Exception as e:
+        print(f"Error loading the model: {e}\n")
+        return
+
+    layers = model.layers
+    print("available layers: ")
+    for layer in layers:
+        print(layer.name)
+    found = False
+    layer_name = input("Enter the layer name you want to change: ")
+    for layer in layers:
+        if layer.name == layer_name:
+            found = True
+            new_name = input("Enter the new layer name: ")
+            layer.name = new_name
+    if not found:
+        print(f"Layer '{layer_name}' not found in the model.\n")
+        return
+    new_filepath = input("Enter the new file path to save the model: ")
+    if not new_filepath.endswith(".keras"):
+        new_filepath += ".keras"
+    model.save(new_filepath)
+
+    print(f"\nLayer name changed successfully. \
+        Model saved at '{new_filepath}'\n")
+
+
+@keras_export("keras.utils.patch_weight")
+def patch_weight(filepath, layer_name, weight_index, new_value, save_path):
+    """ Change the weight of a model in a specified layer at a given index."""
+
+    def change_weight(weights, weight_index, new_value):
+        element = weights
+        for index in weight_index[:-1]:
+            element = element[index]
+        element[weight_index[-1]] = new_value
+        return weights
+
+    if filepath.endswith(".keras"):
+        model = load_model(filepath)
+        try:
+            layer = model.get_layer(name=layer_name)
+        except ValueError:
+            print(f"Layer {layer_name} not found in the model.")
+            return
+
+        weights = layer.get_weights()
+        weights = change_weight(weights, weight_index, new_value)
+        layer.set_weights(weights)
+        model.save(save_path)
+        print(f"Model saved to {save_path}")
+    else:
+        raise ValueError(
+            "Invalid filename: expected a `.keras` or `.weights.h5` extension."
+            f"Received: filepath={filepath}"
+        )

--- a/keras/src/utils/model_tools.py
+++ b/keras/src/utils/model_tools.py
@@ -1,206 +1,86 @@
-"""Utilities related to model inspection and patching."""
+"""Utilities related to model inspection, comparison and patching."""
 
+import base64
 import io
 import json
-import base64
+import os
 import zipfile
+
 import matplotlib.pyplot as plt
+import rich
+from IPython.display import HTML
+from IPython.display import display
 
-from difflib import unified_diff
-from IPython.display import display, HTML
-from diff_match_patch import diff_match_patch
-
-from keras.src.saving import load_model
 from keras.src.api_export import keras_export
 from keras.src.saving import deserialize_keras_object
+from keras.src.saving import load_model
 from keras.src.saving.saving_lib import H5IOStore
 
 _CONFIG_FILENAME = "config.json"
 _METADATA_FILENAME = "metadata.json"
 _VARS_FNAME = "model.weights"
+ANSI_RED = "\033[91m"
+ANSI_GREEN = "\033[92m"
+ANSI_BLUE = "\033[94m"
+ANSI_RESET = "\033[0m"
 
 
-def load_model_config(model_path):
-    """ Auxiliar function.
-        Loads model and extract its JSON configuration."""
-    model = load_model(model_path)
-    return model.to_json()
+def is_notebook():
+    """Auxiliar function.
+    Detects if the code is running in a Jupyter notebook."""
 
-
-def compare_model_configs(config1_json, config2_json):
-    """ Auxiliar function.
-        Returns differences between two model configurations."""
-    config1 = json.loads(config1_json)
-    config2 = json.loads(config2_json)
-    if config1["config"]["name"]:
-        del config1["config"]["name"]
-    if config2["config"]["name"]:
-        del config2["config"]["name"]
-
-    config1_str = json.dumps(config1, indent=2)
-    config2_str = json.dumps(config2, indent=2)
-
-    diff = list(unified_diff(config1_str.splitlines(),
-                             config2_str.splitlines(),
-                             fromfile='model1',
-                             tofile='model2'
-                             )
-                )
-    return diff
-
-
-def diff_text(text1, text2):
-    """ Auxiliar function.
-        Returns highlighted differences between two texts."""
-    style1 = "background-color:rgba(212, 237, 218, 0.5); color:#155724;"
-    style2 = "background-color:rgba(248, 215, 218, 0.5); color:#721c24;"
-    dmp = diff_match_patch()
-    diffs = dmp.diff_main(text1, text2)
-    dmp.diff_cleanupSemantic(diffs)
-    highlighted1, highlighted2 = [], []
-    for (op, data) in diffs:
-        if op == 0:  # equal, no highlighting
-            highlighted1.append(data)
-            highlighted2.append(data)
-        elif op == 1:  # highlights with green color
-            highlighted2.append(f"<span style='{style1}'>{data}</span>")
-        elif op == -1:  # highlights with red color
-            highlighted1.append(f"<span style='{style2}'>{data}</span>")
-    return ''.join(highlighted1), ''.join(highlighted2)
-
-
-def render_differences(diff):
-    """ Auxiliar function.
-        Renders differences between two model configurations."""
-
-    base_style = "border:1px solid black; padding: 10px; text-align: left;"
-
-    html_output = ["<h3>Model Configuration Differences:</h3>",
-                   "<table style='width:100%; border-collapse:collapse;'>"]
-    html_output.append(f"<tr><th style='{base_style} width:50%;'>Model 1</th>\
-                        <th style='{base_style} width:50%;'>Model 2</th></tr>")
-
-    if diff:
-        text1_lines, text2_lines = [], []
-        for line in diff:
-            if line.startswith('- '):
-                text1_lines.append(line[2:])
-            elif line.startswith('+ '):
-                text2_lines.append(line[2:])
-        text1 = "\n".join(text1_lines)
-        text2 = "\n".join(text2_lines)
-        highlighted1, highlighted2 = diff_text(text1, text2)
-        html_output.append(f"<tr><td style='{base_style} vertical-align: top;'>\
-                           <pre>{highlighted1}</pre></td>")
-        html_output.append(f"<td style='{base_style} vertical-align: top;'> \
-                           <pre>{highlighted2}</pre></td></tr>")
-    else:
-        html_output.append(f"<tr><td colspan='2' style='{base_style}'> \
-                           No differences found</td></tr>")
-
-    html_output.append("</table>")
-    display(HTML(''.join(html_output)))
-
-
-@keras_export("keras.utils.compare_models")
-def compare_models(model1_path, model2_path):
-    """ Compares two models.
-        Shows them side by side with differences highlighted."""
-    config1_json = load_model_config(model1_path)
-    config2_json = load_model_config(model2_path)
-
-    diff = compare_model_configs(config1_json, config2_json)
-    render_differences(diff)
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell == "ZMQInteractiveShell":
+            return True  # jupyter notebook
+        elif shell == "TerminalInteractiveShell":
+            return False  # terminal
+        else:
+            return False
+    except NameError:
+        return False
 
 
 def create_color_grid(weights):
-    """ Auxiliar function.
-        Create a heatmap of the weights."""
+    """Auxiliar function.
+    Create a heatmap of the weights."""
 
     fig, ax = plt.subplots(figsize=(5, 5))
     if weights.ndim > 2:
         weights = weights.reshape(-1, weights.shape[-1])
     if weights.ndim == 1:
-        cax = ax.imshow(weights.reshape(-1, 1), aspect='auto', cmap='viridis')
+        cax = ax.imshow(weights.reshape(-1, 1), aspect="auto", cmap="viridis")
     else:
-        cax = ax.matshow(weights, interpolation='nearest', cmap='viridis')
-        if weights.shape[0] / weights.shape[1] > 10 or \
-                weights.shape[1] / weights.shape[0] > 10:
-            ax.set_aspect('auto', 'datalim')
+        cax = ax.matshow(weights, interpolation="nearest", cmap="viridis")
+        if (
+            weights.shape[0] / weights.shape[1] > 10
+            or weights.shape[1] / weights.shape[0] > 10
+        ):
+            ax.set_aspect("auto", "datalim")
         if weights.shape[0] == 1:
             ax.set_yticks([])
         if weights.shape[1] == 1:
             ax.set_xticks([])
 
     fig.colorbar(cax)
-    ax.set_title('Weights Heatmap')
-    ax.set_xlabel('Column')
-    ax.set_ylabel('Row')
-    ax.xaxis.set_label_position('top')
+    ax.set_title("Weights Heatmap")
+    ax.set_xlabel("Column")
+    ax.set_ylabel("Row")
+    ax.xaxis.set_label_position("top")
     ax.xaxis.tick_top()
 
     buf = io.BytesIO()
-    plt.savefig(buf, format='png', bbox_inches='tight', pad_inches=1)
+    plt.savefig(buf, format="png", bbox_inches="tight", pad_inches=1)
     plt.close(fig)
     buf.seek(0)
-    image_base64 = base64.b64encode(buf.read()).decode('utf-8')
+    image_base64 = base64.b64encode(buf.read()).decode("utf-8")
     return f'<img src="data:image/png;base64,{image_base64}" \
                 style="display:block;margin:auto;" />'
 
 
-@keras_export("keras.utils.inspect_file")
-def inspect_file(filepath, reference_model=None, custom_objects=None):
-    """ Inspects the contents of a Keras model or weights file."""
-
-    filepath = str(filepath)
-    html_output = []
-
-    if filepath.endswith(".keras"):
-        with zipfile.ZipFile(filepath, "r") as zf:
-            html_output.append(f"<h2>Keras model file '{filepath}'</h2>")
-
-            with zf.open(_CONFIG_FILENAME, "r") as f:
-                config = json.loads(f.read())
-                html_output.append(
-                    f"<p>Model: {config['class_name']} \
-                        name='{config['config']['name']}'</p>"
-                )
-            if reference_model is None:
-                reference_model = deserialize_keras_object(
-                    config, custom_objects=custom_objects
-                )
-
-            with zf.open(_METADATA_FILENAME, "r") as f:
-                metadata = json.loads(f.read())
-                html_output.append(f"<p>Saved with Keras \
-                                   {metadata['keras_version']}</p>")
-                html_output.append(f"<p>Date saved: \
-                                   {metadata['date_saved']}</p>")
-
-            archive = zipfile.ZipFile(filepath, "r")
-            weights_store = H5IOStore(
-                _VARS_FNAME + ".h5", archive=archive, mode="r"
-            )
-            html_output.append("<h3>Weights file:</h3>")
-            html_output.append(inspect_nested_dict(weights_store.h5_file))
-
-    elif filepath.endswith(".weights.h5"):
-        html_output.append(f"<h2>Keras weights file '{filepath}'</h2>")
-        weights_store = H5IOStore(filepath, mode="r")
-        html_output.append(inspect_nested_dict(weights_store.h5_file))
-
-    else:
-        raise ValueError(
-            "Invalid filename: expected a `.keras` or `.weights.h5` extension. "
-            f"Received: filepath={filepath}"
-        )
-
-    display(HTML(''.join(html_output)))
-
-
-def inspect_nested_dict(store):
-    """ Auxiliar function.
-        Inspect the contents of a nested dictionary."""
+def inspect_nested_dict_html(store):
+    """Auxiliar function.
+    Inspect the contents of a nested dictionary."""
 
     html_output = []
     indent_style = "margin-left: 20px;"
@@ -218,86 +98,358 @@ def inspect_nested_dict(store):
             if key == "vars" and len(value.keys()) == 0:
                 skip = True
             if not skip:
-                html_output.append(f"<details style='{indent_style}'>\
-                    <summary>{key}</summary>")
-                html_output.append(inspect_nested_dict(value))
+                html_output.append(
+                    f"<details style='{indent_style}'>\
+                    <summary>{key}</summary>"
+                )
+                html_output.append(inspect_nested_dict_html(value))
                 html_output.append("</details>")
         else:
             w = value[()]
             shape_info = f"{w.shape} {w.dtype}"
             if w.ndim == 0:
-                html_output.append(f"<details style='{indent_style}'>\
-                    <summary>{key}: {shape_info}</summary></details>")
+                html_output.append(
+                    f"<details style='{indent_style}'>\
+                    <summary>{key}: {shape_info}</summary></details>"
+                )
             else:
                 color_grid = create_color_grid(w)
-                html_output.append(f"<details style='\
+                html_output.append(
+                    f"<details style='\
                     {indent_style}'>\
                         <summary>{key}: {shape_info}</summary>\
                         {color_grid}\
-                    </details>")
+                    </details>"
+                )
 
-    return ''.join(html_output)
-
-
-@keras_export("keras.utils.change_layer_name")
-def change_layer_name(filepath):
-    """ Interactively changes the name of a layer in a Keras model."""
-
-    try:
-        model = load_model(filepath)
-    except Exception as e:
-        print(f"Error loading the model: {e}\n")
-        return
-
-    layers = model.layers
-    print("available layers: ")
-    for layer in layers:
-        print(layer.name)
-    found = False
-    layer_name = input("Enter the layer name you want to change: ")
-    for layer in layers:
-        if layer.name == layer_name:
-            found = True
-            new_name = input("Enter the new layer name: ")
-            layer.name = new_name
-    if not found:
-        print(f"Layer '{layer_name}' not found in the model.\n")
-        return
-    new_filepath = input("Enter the new file path to save the model: ")
-    if not new_filepath.endswith(".keras"):
-        new_filepath += ".keras"
-    model.save(new_filepath)
-
-    print(f"\nLayer name changed successfully. \
-        Model saved at '{new_filepath}'\n")
+    return "".join(html_output)
 
 
-@keras_export("keras.utils.patch_weight")
-def patch_weight(filepath, layer_name, weight_index, new_value, save_path):
-    """ Change the weight of a model in a specified layer at a given index."""
+def inspect_nested_dict_shell(store, indent=0):
+    """Auxiliar function.
+    Inspect the contents of a nested dictionary."""
 
-    def change_weight(weights, weight_index, new_value):
-        element = weights
-        for index in weight_index[:-1]:
-            element = element[index]
-        element[weight_index[-1]] = new_value
-        return weights
+    output = []
+    indent_str = " " * (indent * 4)
+
+    for key in store.keys():
+        value = store[key]
+        if hasattr(value, "keys"):
+            skip = False
+            if (
+                list(value.keys()) == ["vars"]
+                and len(value["vars"].keys()) == 0
+            ):
+                skip = True
+            if key == "vars" and len(value.keys()) == 0:
+                skip = True
+            if not skip:
+                output.append(f"{ANSI_BLUE}{indent_str}{key}:{ANSI_RESET}")
+                output.append(inspect_nested_dict_shell(value, indent + 1))
+        else:
+            w = value[()]
+            shape_info = f"{w.shape} {w.dtype}"
+            output.append(
+                f"{ANSI_GREEN}{indent_str}{key}: \
+                          {shape_info}{ANSI_RESET}"
+            )
+    return "\n".join(output)
+
+
+@keras_export("keras.utils.inspect_file")
+def inspect_file(filepath, ref_model=None, cust_objs=None):
+    """Inspects the contents of a Keras model or weights file."""
+
+    filepath = str(filepath)
+    inNotebook = is_notebook()
+    output = []
 
     if filepath.endswith(".keras"):
-        model = load_model(filepath)
-        try:
-            layer = model.get_layer(name=layer_name)
-        except ValueError:
-            print(f"Layer {layer_name} not found in the model.")
-            return
+        if inNotebook:
+            output.append(f"<h2>Keras model file '{filepath}'</h2>")
+        else:
+            output.append(
+                f"{ANSI_BLUE}Keras model file \
+                          '{filepath}'{ANSI_RESET}"
+            )
 
-        weights = layer.get_weights()
-        weights = change_weight(weights, weight_index, new_value)
-        layer.set_weights(weights)
-        model.save(save_path)
-        print(f"Model saved to {save_path}")
+        with zipfile.ZipFile(filepath, "r") as zf:
+            with zf.open(_CONFIG_FILENAME, "r") as f:
+                config = json.loads(f.read())
+                if inNotebook:
+                    output.append(
+                        f"<p>Model: {config['class_name']} \
+                                  name='{config['config']['name']}'</p>"
+                    )
+                else:
+                    output.append(
+                        f"{ANSI_GREEN}Model: {config['class_name']} \
+                    name='{config['config']['name']}'{ANSI_RESET}"
+                    )
+            if ref_model is None:
+                ref_model = deserialize_keras_object(
+                    config, custom_objects=cust_objs
+                )
+
+            with zf.open(_METADATA_FILENAME, "r") as f:
+                metadata = json.loads(f.read())
+                if inNotebook:
+                    output.append(
+                        f"<p>Saved with Keras \
+                                  {metadata['keras_version']}</p>"
+                    )
+                    output.append(
+                        f"<p>Date saved:\
+                        {metadata['date_saved']}</p>"
+                    )
+                else:
+                    output.append(
+                        f"{ANSI_GREEN}Saved with Keras \
+                                  {metadata['keras_version']}{ANSI_RESET}"
+                    )
+                    output.append(
+                        f"{ANSI_GREEN}Date saved:\
+                        {metadata['date_saved']}{ANSI_RESET}"
+                    )
+
+            archive = zipfile.ZipFile(filepath, "r")
+            weights_store = H5IOStore(
+                _VARS_FNAME + ".h5", archive=archive, mode="r"
+            )
+            if inNotebook:
+                output.append("<h3>Weights file:</h3>")
+                output.append(inspect_nested_dict_html(weights_store.h5_file))
+            else:
+                output.append(f"{ANSI_BLUE}Weights file:{ANSI_RESET}")
+                output.append(inspect_nested_dict_shell(weights_store.h5_file))
+
+    elif filepath.endswith(".weights.h5"):
+        if inNotebook:
+            output.append(f"<h2>Keras weights file '{filepath}'</h2>")
+            weights_store = H5IOStore(filepath, mode="r")
+            output.append(inspect_nested_dict_html(weights_store.h5_file))
+        else:
+            output.append(
+                f"{ANSI_BLUE}Keras weights file \
+                '{filepath}'{ANSI_RESET}"
+            )
+            weights_store = H5IOStore(filepath, mode="r")
+            output.append(inspect_nested_dict_shell(weights_store.h5_file))
+
     else:
         raise ValueError(
-            "Invalid filename: expected a `.keras` or `.weights.h5` extension."
-            f"Received: filepath={filepath}"
+            f"Invalid filename: expected a\
+            `.keras` or `.weights.h5` extension.\
+                Received: filepath={filepath}"
         )
+
+    final_output = "".join(output) if inNotebook else "\n".join(output)
+    if inNotebook:
+        display(HTML(final_output))
+    else:
+        print(final_output)
+
+
+def extract_relevant_info(model_path):
+    """Loads model and extracts its layer names,
+    number of weights, and sublayers."""
+    model = load_model(model_path)
+    model_info = []
+    for layer in model.layers:
+        config = layer.get_config()
+        name = layer.name
+        weights = layer.get_weights()
+        weights_info = [
+            {"shape": w.shape, "dtype": str(w.dtype)} for w in weights
+        ]
+        num_sublayers = len(config.get("layers", []))
+        model_info.append(
+            {
+                "name": name,
+                "num_weights": len(weights_info),
+                "num_sublayers": num_sublayers,
+                "weights": weights_info,
+            }
+        )
+    return model_info
+
+
+def compare_layers(model1_layers, model2_layers):
+    """Returns matching and different layers between two models."""
+    names1 = {layer["name"]: layer for layer in model1_layers}
+    names2 = {layer["name"]: layer for layer in model2_layers}
+    m1_layers, m2_layers = set(names1), set(names2)
+
+    set_added = m2_layers - m1_layers  # in model 2 but not in model 1
+    set_removed = m1_layers - m2_layers  # in model 1 but not in model 2
+    set_match = m1_layers & m2_layers  # common
+
+    added_layers = {name: names2[name] for name in set_added}
+    removed_layers = {name: names1[name] for name in set_removed}
+    matching_layers = {name: (names1[name], names2[name]) for name in set_match}
+
+    return added_layers, removed_layers, matching_layers
+
+
+def generate_layer_row(name, details1, details2):
+    """Helper function to generate a row for a layer with given details."""
+    return [name, details1, details2]
+
+
+def generate_weight_diff_rows(info1, info2):
+    """Helper function to generate weight difference rows."""
+    weight_diffs = []
+    for w1, w2 in zip(info1["weights"], info2["weights"]):
+        if w1["shape"] != w2["shape"] or w1["dtype"] != w2["dtype"]:
+            weight_diffs.append(
+                generate_layer_row(
+                    "\tShape:", f"{w1['shape']}", f"{w2['shape']}"
+                )
+            )
+            weight_diffs.append(
+                generate_layer_row(
+                    "\tDtype:", f"{w1['dtype']}", f"{w2['dtype']}"
+                )
+            )
+    return weight_diffs
+
+
+def render_differences(m1_name, m2_name, added, removed, matching):
+    """Renders differences and matching layers
+    between two lists of layer information."""
+    console = rich.console.Console()
+    table = rich.table.Table(show_header=True, header_style="bold turquoise2")
+    table.add_column("Layer Name", justify="left")
+    table.add_column(f"{m1_name} details", justify="left")
+    table.add_column(f"{m2_name} details", justify="left")
+
+    if added or removed:
+        table.add_row("Non matching Layers", "", "", style="bold red3")
+        if added:
+            for name, info in added.items():
+                table.add_row(
+                    name,
+                    "Absent",
+                    f"Weights: {info['num_weights']},\
+                    Sublayers: {info['num_sublayers']}",
+                )
+
+        if removed:
+            for name, info in removed.items():
+                table.add_row(
+                    name,
+                    f"Weights: {info['num_weights']},\
+                    Sublayers: {info['num_sublayers']}",
+                    "Absent",
+                )
+        table.add_row("", "", "")
+
+    if matching:
+        table.add_row("Matching Layers", "", "", style="bold chartreuse1")
+        for name, (info1, info2) in matching.items():
+            table.add_row("", "", "")
+            if (
+                info1["weights"] == info2["weights"]
+                and info1["num_sublayers"] == info2["num_sublayers"]
+            ):
+                table.add_row(
+                    name,
+                    f"Identical layer: \
+                    Weights: {info1['num_weights']}, \
+                        Sublayers: {info1['num_sublayers']}",
+                    "",
+                )
+            else:
+                table.add_row(
+                    name,
+                    f"Weights: {info1['num_weights']}, \
+                    Sublayers: {info1['num_sublayers']}",
+                    f"Weights:\
+                        {info2['num_weights']}, \
+                            Sublayers: {info2['num_sublayers']}",
+                )
+                weight_diff_rows = generate_weight_diff_rows(info1, info2)
+                for row in weight_diff_rows:
+                    table.add_row(*row)
+
+    console.print(table)
+
+
+@keras_export("keras.utils.compare_models")
+def compare_models(model1_path, model2_path):
+    """Compares two models. Shows them side by side with differences
+    highlighted."""
+    model1_name = os.path.basename(model1_path).replace(".keras", "")
+    model2_name = os.path.basename(model2_path).replace(".keras", "")
+
+    model1_info = extract_relevant_info(model1_path)
+    model2_info = extract_relevant_info(model2_path)
+
+    added, removed, matching = compare_layers(model1_info, model2_info)
+    render_differences(model1_name, model2_name, added, removed, matching)
+
+
+@keras_export(["keras.KerasFileEditor", "keras.utils.KerasFileEditor"])
+class KerasFileEditor:
+    def __init__(self, filepath):
+        self.filepath = filepath
+        try:
+            self.model = load_model(filepath)
+        except Exception as e:
+            print(f"Error loading the model: {e}")
+            self.model = None
+
+    def list_layer_paths(self):
+        """List all layer names in the model."""
+        if not self.model:
+            return
+        layers = self.model.layers
+        for layer in layers:
+            print(layer.name)
+
+    def layer_info(self, layer_name):
+        """Prints the weight structure for the specified layer."""
+        if not self.model:
+            return
+        try:
+            layer = self.model.get_layer(name=layer_name)
+            for weight in layer.weights:
+                print(weight.name, weight.shape)
+        except ValueError:
+            print(f"Layer '{layer_name}' not found in the model.")
+
+    def edit_layer(self, layer_name, new_name=None, new_vars=None):
+        """Edit the layer name and optionally update weights."""
+        if not self.model:
+            return
+        try:
+            layer = self.model.get_layer(name=layer_name)
+            if new_name:
+                layer.name = new_name  # Internal API to change the layer name
+            if new_vars:
+                if len(layer.weights) != len(new_vars):
+                    print(
+                        f"Number of new variables ({len(new_vars)}) does \
+                        not match the number of weights in the layer \
+                            ({len(layer.weights)})."
+                    )
+                    return
+                for weight, new_weight in zip(layer.weights, new_vars):
+                    if weight.shape != new_weight.shape:
+                        print(
+                            f"Shape mismatch: weight shape {weight.shape}, \
+                            new weight shape {new_weight.shape}."
+                        )
+                        return
+                    weight.assign(new_weight)
+        except ValueError:
+            print(f"Layer '{layer_name}' not found in the model.")
+
+    def write_out(self, new_filepath):
+        """Save the model to a new file."""
+        if not self.model:
+            return
+        if not new_filepath.endswith(".keras"):
+            new_filepath += ".keras"
+        self.model.save(new_filepath)
+        print(f"Model saved at '{new_filepath}'.")

--- a/keras/src/utils/model_tools_test.py
+++ b/keras/src/utils/model_tools_test.py
@@ -1,0 +1,161 @@
+import unittest
+import os
+
+from unittest.mock import patch
+
+from keras.src.optimizers import Adam
+from keras.src.layers import Dense, Input
+from keras.src.models import Model
+
+from keras.src.saving import load_model
+from keras.src.saving.saving_lib import save_model
+from keras.src.utils import model_tools
+
+
+class DiffModelsTest(unittest.TestCase):
+
+    def setUp(self):
+        ref_name = 'reference_model.keras'
+        diff_name = 'diff_model.keras'
+        self.reference_model_path = os.path.join(os.getcwd(), ref_name)
+        self.diff_model_path = os.path.join(os.getcwd(), diff_name)
+
+    def tearDown(self):
+        if os.path.exists(self.reference_model_path):
+            os.remove(self.reference_model_path)
+        if os.path.exists(self.diff_model_path):
+            os.remove(self.diff_model_path)
+
+    def create_reference_model(self, units, name):
+        input_layer = Input(shape=(20,), name='input')
+        x = Dense(units, activation='relu', name='dense_1')(input_layer)
+        x = Dense(5, activation='relu', name='dense_2')(x)
+        output_layer = Dense(1, activation='sigmoid', name='output')(x)
+        model = Model(inputs=input_layer, outputs=output_layer, name=name)
+        model.compile(optimizer='adam', loss='binary_crossentropy')
+        return model
+
+    @patch('keras.src.utils.model_tools.display')
+    def test_equal_models(self, mock_display):
+        model1 = self.create_reference_model(10, 'reference_model')
+        save_model(model1, self.reference_model_path)
+        model2 = self.create_reference_model(10, 'reference_model')
+        save_model(model2, self.diff_model_path)
+
+        model_tools.compare_models(self.reference_model_path,
+                                   self.diff_model_path)
+        display_args = mock_display.call_args[0][0].data
+        # no differences between equal models
+        self.assertIn("No differences found", display_args)
+
+    @patch('keras.src.utils.model_tools.display')
+    def test_missing_layer_models(self, mock_display):
+        style1 = "background-color:rgba(248, 215, 218, 0.5); color:#721c24;"
+        style2 = "background-color:rgba(212, 237, 218, 0.5); color:#155724;"
+        model1 = self.create_reference_model(10, 'reference_model')
+        save_model(model1, self.reference_model_path)
+
+        input_layer = Input(shape=(20,), name='input')
+        x = Dense(10, activation='relu', name='dense_1')(input_layer)
+        x = Dense(5, activation='relu', name='dense_2')(x)
+        x = Dense(3, activation='relu', name='extra_layer')(x)  # extra layer
+        output_layer = Dense(1, activation='sigmoid', name='output')(x)
+        model2 = Model(inputs=input_layer, outputs=output_layer,
+                       name='diff_model')
+        model2.compile(optimizer=Adam(), loss='binary_crossentropy')
+        save_model(model2, self.diff_model_path)
+        model_tools.compare_models(self.reference_model_path,
+                                   self.diff_model_path)
+        display_args = mock_display.call_args[0][0].data
+        # output layer (model in the left) is highlighted in red
+        self.assertIn(f'"name": "<span style=\'{style1}\'>output"',
+                      display_args)
+        # extra_layer (model in the right) is highlighted in green
+        self.assertIn(f'"name": "<span style=\'{style2}\'>extra_layer"',
+                      display_args)
+        self.assertIn('"units": 1,', display_args)
+        self.assertIn('"units": 3,', display_args)
+        self.assertIn('"activation": "sigmoid"', display_args)
+        self.assertIn('"activation": "relu"', display_args)
+
+
+class InspectModelsTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_filepath = os.path.join(os.getcwd(), "my_model.keras")
+
+    def tearDown(self):
+        if os.path.exists(self.temp_filepath):
+            os.remove(self.temp_filepath)
+
+    @patch('keras.src.utils.model_tools.display')
+    def test_inspect_keras_model(self, mock_display):
+        inputs = Input(shape=(4,))
+        outputs = Dense(1)(inputs)
+        model = Model(inputs, outputs)
+        model.save(self.temp_filepath)
+
+        model_tools.inspect_file(self.temp_filepath)
+        display_args = mock_display.call_args[0][0].data
+        display_args.replace('\n', '')
+        self.assertIn("Keras model file", display_args)
+        self.assertIn("Model: Functional", display_args)
+        self.assertIn("name='functional_1'", display_args)
+        self.assertIn("Saved with Keras", display_args)
+        self.assertIn("Weights file:", display_args)
+        self.assertIn("dense", display_args)
+        self.assertIn("0: (4, 1) float32", display_args)
+        self.assertIn("1: (1,) float32", display_args)
+
+
+class TestModelPatching(unittest.TestCase):
+    def setUp(self):
+        input_layer = Input(shape=(20,), name='input')
+        x = Dense(10, activation='relu', name='dense_1')(input_layer)
+        output_layer = Dense(1, activation='sigmoid', name='output')(x)
+        self.model = Model(inputs=input_layer, outputs=output_layer,
+                           name='test_model')
+        self.model.compile(optimizer='adam', loss='binary_crossentropy')
+
+        self.model_path = 'test_model.keras'
+        save_model(self.model, self.model_path)
+
+        self.patched_model_path = 'patched_model.keras'
+
+    def tearDown(self):
+        if os.path.exists(self.model_path):
+            os.remove(self.model_path)
+        if os.path.exists(self.patched_model_path):
+            os.remove(self.patched_model_path)
+
+    def test_patch_weight(self):
+        weight_index = (0, 0, 1)
+        new_value = 0.5
+
+        original_weights = self.model.get_layer(name='dense_1').get_weights()
+        original_weight_value = original_weights[0][0][1]
+
+        model_tools.patch_weight(self.model_path, 'dense_1', weight_index,
+                                 new_value, self.patched_model_path)
+
+        patched_model = load_model(self.patched_model_path)
+        patched_weights = patched_model.get_layer(name='dense_1').get_weights()
+        print("patched_weights: ", patched_weights[0][0][1])
+        patched_weight_value = patched_weights[0][0][1]
+
+        self.assertNotEqual(original_weight_value, patched_weight_value)
+        self.assertEqual(patched_weight_value, new_value)
+
+    # we use the decorator to mock the input function
+    @patch('builtins.input', side_effect=[
+            'dense_1',
+            'renamed_dense_1',
+            'patched_model.keras'
+        ])
+    def test_change_layer_name(self, mock_input):
+        model_tools.change_layer_name(self.model_path)
+
+        patched_model = load_model(self.patched_model_path)
+        layer_names = [layer.name for layer in patched_model.layers]
+        self.assertIn('renamed_dense_1', layer_names)
+        self.assertNotIn('dense_1', layer_names)

--- a/keras/src/utils/model_tools_test.py
+++ b/keras/src/utils/model_tools_test.py
@@ -1,82 +1,181 @@
-import unittest
+import contextlib
 import os
-
+import tempfile
+import unittest
+from io import StringIO
 from unittest.mock import patch
 
-from keras.src.optimizers import Adam
-from keras.src.layers import Dense, Input
-from keras.src.models import Model
+import numpy as np
 
+from keras.src.layers import Conv2D
+from keras.src.layers import Dense
+from keras.src.layers import Dropout
+from keras.src.layers import Flatten
+from keras.src.layers import Input
+from keras.src.models import Model
 from keras.src.saving import load_model
-from keras.src.saving.saving_lib import save_model
 from keras.src.utils import model_tools
 
 
-class DiffModelsTest(unittest.TestCase):
+class TestModelComparison(unittest.TestCase):
+    """Tests for the model comparison functions.
+    Contains four unit tests:
+    - test_identical_models: Tests the comparison of two identical models.
+    - test_structural_difference: Tests the comparison of two models with
+    structural differences.
+    - test_missing_layers: Tests the comparison of two models
+    with missing layers.
+    - test_significant_differences: Tests the comparison of two models
+    with significant differences.
+    """
 
     def setUp(self):
-        ref_name = 'reference_model.keras'
-        diff_name = 'diff_model.keras'
-        self.reference_model_path = os.path.join(os.getcwd(), ref_name)
-        self.diff_model_path = os.path.join(os.getcwd(), diff_name)
+        self.temp_dir = tempfile.TemporaryDirectory()
 
     def tearDown(self):
-        if os.path.exists(self.reference_model_path):
-            os.remove(self.reference_model_path)
-        if os.path.exists(self.diff_model_path):
-            os.remove(self.diff_model_path)
+        self.temp_dir.cleanup()
 
-    def create_reference_model(self, units, name):
-        input_layer = Input(shape=(20,), name='input')
-        x = Dense(units, activation='relu', name='dense_1')(input_layer)
-        x = Dense(5, activation='relu', name='dense_2')(x)
-        output_layer = Dense(1, activation='sigmoid', name='output')(x)
-        model = Model(inputs=input_layer, outputs=output_layer, name=name)
-        model.compile(optimizer='adam', loss='binary_crossentropy')
-        return model
+    def create_model(self, path, units1, units2, extra_layer=False):
+        input_layer = Input(shape=(20,), name="input")
+        x = Dense(units1, activation="relu", name="dense_1")(input_layer)
+        x = Dense(units2, activation="relu", name="dense_2")(x)
+        if extra_layer:
+            x = Dense(3, activation="relu", name="extra_layer")(x)
+        output_layer = Dense(1, activation="sigmoid", name="output")(x)
+        model = Model(inputs=input_layer, outputs=output_layer)
+        model.save(path)
 
-    @patch('keras.src.utils.model_tools.display')
-    def test_equal_models(self, mock_display):
-        model1 = self.create_reference_model(10, 'reference_model')
-        save_model(model1, self.reference_model_path)
-        model2 = self.create_reference_model(10, 'reference_model')
-        save_model(model2, self.diff_model_path)
+    def create_complex_model(self, path, layers):
+        input_layer = Input(shape=(64, 64, 3), name="input")
+        x = input_layer
+        for layer in layers:
+            x = layer(x)
+        output_layer = Dense(10, activation="softmax", name="output")(x)
+        model = Model(inputs=input_layer, outputs=output_layer)
+        model.save(path)
 
-        model_tools.compare_models(self.reference_model_path,
-                                   self.diff_model_path)
-        display_args = mock_display.call_args[0][0].data
-        # no differences between equal models
-        self.assertIn("No differences found", display_args)
+    def test_identical_models(self):
+        model1_path = os.path.join(self.temp_dir.name, "model1.keras")
+        model2_path = os.path.join(self.temp_dir.name, "model2.keras")
+        self.create_model(model1_path, 10, 5)
+        self.create_model(model2_path, 10, 5)
 
-    @patch('keras.src.utils.model_tools.display')
-    def test_missing_layer_models(self, mock_display):
-        style1 = "background-color:rgba(248, 215, 218, 0.5); color:#721c24;"
-        style2 = "background-color:rgba(212, 237, 218, 0.5); color:#155724;"
-        model1 = self.create_reference_model(10, 'reference_model')
-        save_model(model1, self.reference_model_path)
+        console_output = StringIO()
+        with contextlib.redirect_stdout(console_output):
+            model_tools.compare_models(model1_path, model2_path)
 
-        input_layer = Input(shape=(20,), name='input')
-        x = Dense(10, activation='relu', name='dense_1')(input_layer)
-        x = Dense(5, activation='relu', name='dense_2')(x)
-        x = Dense(3, activation='relu', name='extra_layer')(x)  # extra layer
-        output_layer = Dense(1, activation='sigmoid', name='output')(x)
-        model2 = Model(inputs=input_layer, outputs=output_layer,
-                       name='diff_model')
-        model2.compile(optimizer=Adam(), loss='binary_crossentropy')
-        save_model(model2, self.diff_model_path)
-        model_tools.compare_models(self.reference_model_path,
-                                   self.diff_model_path)
-        display_args = mock_display.call_args[0][0].data
-        # output layer (model in the left) is highlighted in red
-        self.assertIn(f'"name": "<span style=\'{style1}\'>output"',
-                      display_args)
-        # extra_layer (model in the right) is highlighted in green
-        self.assertIn(f'"name": "<span style=\'{style2}\'>extra_layer"',
-                      display_args)
-        self.assertIn('"units": 1,', display_args)
-        self.assertIn('"units": 3,', display_args)
-        self.assertIn('"activation": "sigmoid"', display_args)
-        self.assertIn('"activation": "relu"', display_args)
+        output = console_output.getvalue()
+
+        self.assertIn("Matching Layers", output)
+        self.assertIn("input", output)
+        self.assertIn("Identical layer:", output)
+        self.assertIn("Weights: 0", output)
+        self.assertIn("Sublayers: 0", output)
+        self.assertIn("dense_1", output)
+        self.assertIn("Identical layer:", output)
+        self.assertIn("output", output)
+        self.assertIn("Identical layer:", output)
+        self.assertIn("dense_2", output)
+        self.assertIn("Identical layer:", output)
+        self.assertNotIn("Non matching Layers", output)
+
+    def test_structural_difference(self):
+        model1_path = os.path.join(self.temp_dir.name, "model1.keras")
+        model2_path = os.path.join(self.temp_dir.name, "model2.keras")
+        self.create_model(model1_path, 10, 5)
+        self.create_model(model2_path, 12, 5)
+
+        console_output = StringIO()
+        with contextlib.redirect_stdout(console_output):
+            model_tools.compare_models(model1_path, model2_path)
+
+        output = console_output.getvalue()
+        self.assertIn("Matching Layers", output)
+        self.assertIn("input", output)
+        self.assertIn("Identical layer:", output)
+        self.assertIn("dense_1", output)
+        self.assertIn("Shape:", output)
+        self.assertIn("(20, 10)", output)
+        self.assertIn("(20, 12)", output)
+        self.assertIn("Dtype:", output)
+        self.assertIn("float32", output)
+        self.assertIn("float32", output)
+
+    def test_missing_layers(self):
+        model1_path = os.path.join(self.temp_dir.name, "model1.keras")
+        model2_path = os.path.join(self.temp_dir.name, "model2.keras")
+        self.create_model(model1_path, 10, 5)
+        self.create_model(model2_path, 10, 5, extra_layer=True)
+
+        console_output = StringIO()
+        with contextlib.redirect_stdout(console_output):
+            model_tools.compare_models(model1_path, model2_path)
+
+        output = console_output.getvalue()
+        self.assertIn("Non matching Layers", output)
+        self.assertIn("extra_layer", output)
+
+        self.assertIn("input", output)
+        self.assertIn("Identical layer:", output)
+        self.assertIn("Weights: 0", output)
+        self.assertIn("Sublayers: 0", output)
+        self.assertIn("dense_1", output)
+        self.assertIn("Identical layer:", output)
+        self.assertIn("Weights: 2", output)
+        self.assertIn("Sublayers: 0", output)
+
+    def test_significant_differences(self):
+        model1_path = os.path.join(self.temp_dir.name, "model1.keras")
+        model2_path = os.path.join(self.temp_dir.name, "model2.keras")
+
+        model1_layers = [
+            Conv2D(32, (3, 3), activation="relu", name="conv_1"),
+            Conv2D(64, (3, 3), activation="relu", name="conv_2"),
+            Flatten(name="flatten"),
+            Dense(128, activation="relu", name="dense_1"),
+        ]
+        model2_layers = [
+            Conv2D(32, (5, 5), activation="relu", name="conv_1"),
+            Conv2D(128, (3, 3), activation="relu", name="conv_2"),
+            Conv2D(64, (3, 3), activation="relu", name="conv_3"),
+            Dropout(0.5, name="dropout"),
+            Flatten(name="flatten"),
+            Dense(256, activation="relu", name="dense_1"),
+        ]
+
+        self.create_complex_model(model1_path, model1_layers)
+        self.create_complex_model(model2_path, model2_layers)
+
+        console_output = StringIO()
+        with contextlib.redirect_stdout(console_output):
+            model_tools.compare_models(model1_path, model2_path)
+
+        output = console_output.getvalue()
+        self.assertIn("Non matching Layers", output)
+        self.assertIn("conv_3", output)
+        self.assertIn("dropout", output)
+
+        self.assertIn("Matching Layers", output)
+        self.assertIn("dense_1", output)
+        self.assertIn("Shape:", output)
+        self.assertIn("(230400, 128)", output)
+        self.assertIn("(200704, 256)", output)
+        self.assertIn("Dtype:", output)
+        self.assertIn("float32", output)
+        self.assertIn("float32", output)
+
+        self.assertIn("conv_2", output)
+        self.assertIn("Shape:", output)
+        self.assertIn("(3, 3, 32, 64)", output)
+        self.assertIn("(3, 3, 32, 128)", output)
+        self.assertIn("Dtype:", output)
+        self.assertIn("float32", output)
+        self.assertIn("float32", output)
+
+        self.assertIn("flatten", output)
+        self.assertIn("Identical layer:", output)
+        self.assertIn("Weights: 0", output)
+        self.assertIn("Sublayers: 0", output)
 
 
 class InspectModelsTest(unittest.TestCase):
@@ -88,19 +187,41 @@ class InspectModelsTest(unittest.TestCase):
         if os.path.exists(self.temp_filepath):
             os.remove(self.temp_filepath)
 
-    @patch('keras.src.utils.model_tools.display')
-    def test_inspect_keras_model(self, mock_display):
+    def create_simple_model(self):
         inputs = Input(shape=(4,))
         outputs = Dense(1)(inputs)
         model = Model(inputs, outputs)
         model.save(self.temp_filepath)
 
+    def test_inspect_keras_model_shell(self):
+        with patch(
+            "keras.src.utils.model_tools.is_notebook", return_value=False
+        ):
+            self.create_simple_model()
+
+            console_output = StringIO()
+            with contextlib.redirect_stdout(console_output):
+                model_tools.inspect_file(self.temp_filepath)
+
+            output = console_output.getvalue().replace("\n", "")
+            self.assertIn("Keras model file", output)
+            self.assertIn("Model: Functional", output)
+            self.assertIn("Saved with Keras", output)
+            self.assertIn("Weights file:", output)
+            self.assertIn("dense", output)
+            self.assertIn("(4, 1) float32", output)
+            self.assertIn("(1,) float32", output)
+
+    @patch("keras.src.utils.model_tools.is_notebook", return_value=True)
+    @patch("keras.src.utils.model_tools.display")
+    def test_inspect_keras_model_notebook(self, mock_display, mock_is_notebook):
+        self.create_simple_model()
+
         model_tools.inspect_file(self.temp_filepath)
         display_args = mock_display.call_args[0][0].data
-        display_args.replace('\n', '')
+        display_args = display_args.replace("\n", "")
         self.assertIn("Keras model file", display_args)
         self.assertIn("Model: Functional", display_args)
-        self.assertIn("name='functional_1'", display_args)
         self.assertIn("Saved with Keras", display_args)
         self.assertIn("Weights file:", display_args)
         self.assertIn("dense", display_args)
@@ -108,54 +229,81 @@ class InspectModelsTest(unittest.TestCase):
         self.assertIn("1: (1,) float32", display_args)
 
 
-class TestModelPatching(unittest.TestCase):
+class TestKerasFileEditor(unittest.TestCase):
     def setUp(self):
-        input_layer = Input(shape=(20,), name='input')
-        x = Dense(10, activation='relu', name='dense_1')(input_layer)
-        output_layer = Dense(1, activation='sigmoid', name='output')(x)
-        self.model = Model(inputs=input_layer, outputs=output_layer,
-                           name='test_model')
-        self.model.compile(optimizer='adam', loss='binary_crossentropy')
-
-        self.model_path = 'test_model.keras'
-        save_model(self.model, self.model_path)
-
-        self.patched_model_path = 'patched_model.keras'
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.filepath = os.path.join(self.temp_dir.name, "test_model.keras")
+        self.editor = None
+        self.create_model()
 
     def tearDown(self):
-        if os.path.exists(self.model_path):
-            os.remove(self.model_path)
-        if os.path.exists(self.patched_model_path):
-            os.remove(self.patched_model_path)
+        self.temp_dir.cleanup()
 
-    def test_patch_weight(self):
-        weight_index = (0, 0, 1)
-        new_value = 0.5
+    def create_model(self):
+        inputs = Input(shape=(4,), name="input")
+        x = Dense(3, activation="relu", name="dense_1")(inputs)
+        outputs = Dense(1, activation="sigmoid", name="output")(x)
+        model = Model(inputs=inputs, outputs=outputs)
+        model.save(self.filepath)
+        self.editor = model_tools.KerasFileEditor(self.filepath)
 
-        original_weights = self.model.get_layer(name='dense_1').get_weights()
-        original_weight_value = original_weights[0][0][1]
+    def test_initialization(self):
+        self.assertIsNotNone(self.editor.model)
+        self.assertEqual(self.editor.filepath, self.filepath)
 
-        model_tools.patch_weight(self.model_path, 'dense_1', weight_index,
-                                 new_value, self.patched_model_path)
+    def test_list_layer_paths(self):
+        with patch("builtins.print") as mocked_print:
+            self.editor.list_layer_paths()
+            mocked_print.assert_any_call("input")
+            mocked_print.assert_any_call("dense_1")
+            mocked_print.assert_any_call("output")
 
-        patched_model = load_model(self.patched_model_path)
-        patched_weights = patched_model.get_layer(name='dense_1').get_weights()
-        print("patched_weights: ", patched_weights[0][0][1])
-        patched_weight_value = patched_weights[0][0][1]
+    def test_layer_info(self):
+        with patch("builtins.print") as mocked_print:
+            self.editor.layer_info("dense_1")
+            mocked_print.assert_any_call("kernel", (4, 3))
+            mocked_print.assert_any_call("bias", (3,))
 
-        self.assertNotEqual(original_weight_value, patched_weight_value)
-        self.assertEqual(patched_weight_value, new_value)
+    def test_edit_layer_name(self):
+        new_name = "new_dense_1"
+        self.editor.edit_layer("dense_1", new_name=new_name)
+        self.assertEqual(
+            self.editor.model.get_layer(name=new_name).name, new_name
+        )
 
-    # we use the decorator to mock the input function
-    @patch('builtins.input', side_effect=[
-            'dense_1',
-            'renamed_dense_1',
-            'patched_model.keras'
-        ])
-    def test_change_layer_name(self, mock_input):
-        model_tools.change_layer_name(self.model_path)
+    def test_edit_layer_weights(self):
+        layer_name = "dense_1"
+        layer = self.editor.model.get_layer(name=layer_name)
+        new_weights = [np.ones_like(w) for w in layer.get_weights()]
+        self.editor.edit_layer(layer_name, new_vars=new_weights)
 
-        patched_model = load_model(self.patched_model_path)
-        layer_names = [layer.name for layer in patched_model.layers]
-        self.assertIn('renamed_dense_1', layer_names)
-        self.assertNotIn('dense_1', layer_names)
+        updated_layer = self.editor.model.get_layer(name=layer_name)
+        for original, updated in zip(new_weights, updated_layer.get_weights()):
+            np.testing.assert_array_equal(original, updated)
+
+    def test_edit_layer_mismatch_weights(self):
+        layer_name = "dense_1"
+        layer = self.editor.model.get_layer(name=layer_name)
+        new_weights = [np.ones_like(layer.get_weights()[0])]
+
+        with patch("builtins.print") as mocked_print:
+            self.editor.edit_layer(layer_name, new_vars=new_weights)
+            mocked_print.assert_called_with(
+                "Number of new variables (1) does \
+                        not match the number of weights in the layer \
+                            (2)."
+            )
+
+    def test_write_out(self):
+        new_filepath = os.path.join(self.temp_dir.name, "new_model.keras")
+        self.editor.write_out(new_filepath)
+        self.assertTrue(os.path.exists(new_filepath))
+
+        loaded_model = load_model(new_filepath)
+        self.assertEqual(
+            len(loaded_model.layers), len(self.editor.model.layers)
+        )
+        for layer_orig, layer_loaded in zip(
+            self.editor.model.layers, loaded_model.layers
+        ):
+            self.assertEqual(layer_orig.name, layer_loaded.name)


### PR DESCRIPTION
It consists of three sub features, that allow:
Visualization of the contents of .keras and .weights.h5 files in a notebook, where you can further expand the contents up until the weights of the file. Diff of a model compared to a reference model, being presented side by side with the differences highlighted. Patching a model, where it is possible to change a layer's name and changing a specified weight of a model.

Please let us know if this is what you had in mind.

closes #19705