### PR TITLE
Fix bug in StringLokkup when vocab is a tensor

### DIFF
--- a/keras/src/layers/preprocessing/string_lookup.py
+++ b/keras/src/layers/preprocessing/string_lookup.py
@@ -316,6 +316,7 @@ class StringLookup(IndexLookup):
             raise ValueError(
                 "`sparse=True` can only be used with the " "TensorFlow backend."
             )
+        self.encoding = encoding
         super().__init__(
             max_tokens=max_tokens,
             num_oov_indices=num_oov_indices,
@@ -331,7 +332,6 @@ class StringLookup(IndexLookup):
             vocabulary_dtype="string",
             **kwargs,
         )
-        self.encoding = encoding
         self._convert_input_args = False
         self._allow_non_tensor_positional_args = True
         self.supports_jit = False

--- a/keras/src/layers/preprocessing/string_lookup_test.py
+++ b/keras/src/layers/preprocessing/string_lookup_test.py
@@ -5,6 +5,7 @@ from tensorflow import data as tf_data
 from keras.src import backend
 from keras.src import layers
 from keras.src import testing
+from keras.src.ops import convert_to_tensor
 
 
 class StringLookupTest(testing.TestCase):
@@ -79,3 +80,12 @@ class StringLookupTest(testing.TestCase):
         for output in ds.take(1):
             output = output.numpy()
         self.assertAllClose(output, np.array([2, 3, 0]))
+
+    def test_tensor_as_vocab(self):
+        vocab = convert_to_tensor(["a", "b", "c", "d"])
+        data = [["a", "c", "d"], ["d", "z", "b"]]
+        layer = layers.StringLookup(
+            vocabulary=vocab,
+        )
+        output = layer(data)
+        self.assertAllClose(output, np.array([[1, 3, 4], [4, 0, 2]]))

--- a/keras/src/layers/preprocessing/string_lookup_test.py
+++ b/keras/src/layers/preprocessing/string_lookup_test.py
@@ -81,9 +81,7 @@ class StringLookupTest(testing.TestCase):
             output = output.numpy()
         self.assertAllClose(output, np.array([2, 3, 0]))
 
-    @pytest.mark.skipif(
-        not backend.backend() == "tensorflow", reason="tf only"
-    )
+    @pytest.mark.skipif(not backend.backend() == "tensorflow", reason="tf only")
     def test_tensor_as_vocab(self):
         vocab = convert_to_tensor(["a", "b", "c", "d"])
         data = [["a", "c", "d"], ["d", "z", "b"]]

--- a/keras/src/layers/preprocessing/string_lookup_test.py
+++ b/keras/src/layers/preprocessing/string_lookup_test.py
@@ -81,6 +81,9 @@ class StringLookupTest(testing.TestCase):
             output = output.numpy()
         self.assertAllClose(output, np.array([2, 3, 0]))
 
+    @pytest.mark.skipif(
+        not backend.backend() == "tensorflow", reason="tf only"
+    )
     def test_tensor_as_vocab(self):
         vocab = convert_to_tensor(["a", "b", "c", "d"])
         data = [["a", "c", "d"], ["d", "z", "b"]]


### PR DESCRIPTION

Currently keras.layers.StringLookup fails when Vocabulary is a Tensor. This will raise below error.

`AttributeError: 'StringLookup' object has no attribute 'encoding'
`

This is self.encoding declared after super class constructor call. Fixed the same and added a test case.

Fixes #19770 

