### PR TITLE
Propagate kwargs through `keras.ops.isclose`

### DIFF
--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -598,10 +598,10 @@ def imag(x):
     return jnp.imag(x)
 
 
-def isclose(x1, x2):
+def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    return jnp.isclose(x1, x2)
+    return jnp.isclose(x1, x2, rtol, atol, equal_nan)
 
 
 @sparse.densifying_unary

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -505,8 +505,8 @@ def imag(x):
     return np.imag(x)
 
 
-def isclose(x1, x2):
-    return np.isclose(x1, x2)
+def isclose(x1, x2, **kwargs):
+    return np.isclose(x1, x2, **kwargs)
 
 
 def isfinite(x):

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -505,8 +505,8 @@ def imag(x):
     return np.imag(x)
 
 
-def isclose(x1, x2, **kwargs):
-    return np.isclose(x1, x2, **kwargs)
+def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
+    return np.isclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
 
 def isfinite(x):

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -506,7 +506,7 @@ def imag(x):
 
 
 def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
-    return np.isclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan)
+    return np.isclose(x1, x2, rtol, atol, equal_nan)
 
 
 def isfinite(x):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1250,18 +1250,8 @@ def imag(x):
     return tf.math.imag(x)
 
 
-def isclose(x1, x2):
-    x1 = convert_to_tensor(x1)
-    x2 = convert_to_tensor(x2)
-    dtype = dtypes.result_type(x1.dtype, x2.dtype)
-    x1 = tf.cast(x1, dtype)
-    x2 = tf.cast(x2, dtype)
-    if "float" in dtype:
-        # atol defaults to 1e-08
-        # rtol defaults to 1e-05
-        return tf.abs(x1 - x2) <= (1e-08 + 1e-05 * tf.abs(x2))
-    else:
-        return tf.equal(x1, x2)
+def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
+    return tf.experimental.numpy.isclose(x1, x2, rtol, atol, equal_nan)
 
 
 @sparse.densifying_unary(True)

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.ops.linalg.sparse import sparse_csr_matrix_ops
+from tensorflow.python.ops.math_ops import is_nan
 
 from keras.src import tree
 from keras.src.backend import config
@@ -1251,7 +1252,18 @@ def imag(x):
 
 
 def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
-    return tf.experimental.numpy.isclose(x1, x2, rtol, atol, equal_nan)
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = tf.cast(x1, dtype)
+    x2 = tf.cast(x2, dtype)
+    if "float" in dtype:
+        result = tf.abs(x1 - x2) <= (atol + rtol * tf.abs(x2))
+        if equal_nan:
+            result = result | (is_nan(x1) & is_nan(x2))
+        return result
+    else:
+        return tf.equal(x1, x2)
 
 
 @sparse.densifying_unary(True)

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -697,13 +697,13 @@ def imag(x):
     return torch.imag(x)
 
 
-def isclose(x1, x2):
+def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
     result_dtype = dtypes.result_type(x1.dtype, x2.dtype)
     x1 = cast(x1, result_dtype)
     x2 = cast(x2, result_dtype)
-    return torch.isclose(x1, x2)
+    return torch.isclose(x1, x2, rtol, atol, equal_nan)
 
 
 def isfinite(x):

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2804,7 +2804,9 @@ class Isclose(Operation):
     def call(self, x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
         return backend.numpy.isclose(x1, x2, rtol, atol, equal_nan)
 
-    def compute_output_spec(self, x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
+    def compute_output_spec(
+            self, x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False
+    ):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2802,7 +2802,7 @@ def imag(x):
 
 class Isclose(Operation):
     def call(self, x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
-        return backend.numpy.isclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan)
+        return backend.numpy.isclose(x1, x2, rtol, atol, equal_nan)
 
     def compute_output_spec(self, x1, x2):
         x1_shape = getattr(x1, "shape", [])

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2804,7 +2804,7 @@ class Isclose(Operation):
     def call(self, x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
         return backend.numpy.isclose(x1, x2, rtol, atol, equal_nan)
 
-    def compute_output_spec(self, x1, x2):
+    def compute_output_spec(self, x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2801,8 +2801,8 @@ def imag(x):
 
 
 class Isclose(Operation):
-    def call(self, x1, x2, **kwargs):
-        return backend.numpy.isclose(x1, x2, **kwargs)
+    def call(self, x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
+        return backend.numpy.isclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
     def compute_output_spec(self, x1, x2):
         x1_shape = getattr(x1, "shape", [])

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2805,7 +2805,7 @@ class Isclose(Operation):
         return backend.numpy.isclose(x1, x2, rtol, atol, equal_nan)
 
     def compute_output_spec(
-            self, x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False
+        self, x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False
     ):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2820,6 +2820,9 @@ def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
     Args:
         x1: First input tensor.
         x2: Second input tensor.
+        rtol: Relative tolerance.
+        atol: Absolute tolerance.
+        equal_nan: If `True`, element-wise NaNs are considered equal.
 
     Returns:
         Output boolean tensor.

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2801,8 +2801,8 @@ def imag(x):
 
 
 class Isclose(Operation):
-    def call(self, x1, x2):
-        return backend.numpy.isclose(x1, x2)
+    def call(self, x1, x2, **kwargs):
+        return backend.numpy.isclose(x1, x2, **kwargs)
 
     def compute_output_spec(self, x1, x2):
         x1_shape = getattr(x1, "shape", [])

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2812,7 +2812,7 @@ class Isclose(Operation):
 
 
 @keras_export(["keras.ops.isclose", "keras.ops.numpy.isclose"])
-def isclose(x1, x2):
+def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
     """Return whether two tensors are element-wise almost equal.
 
     Args:
@@ -2823,8 +2823,8 @@ def isclose(x1, x2):
         Output boolean tensor.
     """
     if any_symbolic_tensors((x1, x2)):
-        return Isclose().symbolic_call(x1, x2)
-    return backend.numpy.isclose(x1, x2)
+        return Isclose().symbolic_call(x1, x2, rtol, atol, equal_nan)
+    return backend.numpy.isclose(x1, x2, rtol, atol, equal_nan)
 
 
 class Isfinite(Operation):


### PR DESCRIPTION
This allows passing `atol` and `rtol`. Should work under all backends.

I haven't found my way around the test suite yet. Is there a good place to implement a unit test for this?