### PR TITLE
Fix `output_shape` deserialization in Lambda Layer (#19776)

### DIFF
--- a/keras/src/layers/core/lambda_layer.py
+++ b/keras/src/layers/core/lambda_layer.py
@@ -215,7 +215,7 @@ class Lambda(Layer):
                 )
                 config["output_shape"] = fn
             else:
-                config["output_shape"] = (
+                config["output_shape"] = tuple(
                     serialization_lib.deserialize_keras_object(
                         fn_config, custom_objects=custom_objects
                     )

--- a/keras/src/layers/core/lambda_layer.py
+++ b/keras/src/layers/core/lambda_layer.py
@@ -214,12 +214,20 @@ class Lambda(Layer):
                     closure=inner_config["closure"],
                 )
                 config["output_shape"] = fn
-            else:
+            elif (
+                isinstance(fn_config, list)
+                and all(isinstance(e, (int, None)) for e in fn_config)
+            ):
                 config["output_shape"] = tuple(
                     serialization_lib.deserialize_keras_object(
                         fn_config, custom_objects=custom_objects
                     )
                 )
+            else:
+                config["output_shape"] = serialization_lib.deserialize_keras_object(
+                    fn_config, custom_objects=custom_objects
+                )
+
         if "arguments" in config:
             config["arguments"] = serialization_lib.deserialize_keras_object(
                 config["arguments"], custom_objects=custom_objects


### PR DESCRIPTION
The `output_shape` of a `keras.layers.Lambda` will be serialized as a list if it's originally a tuple.
After deserialization, it doesn't come back.  It works fine until a function call is made here:
https://github.com/keras-team/keras/blob/master/keras/src/layers/core/lambda_layer.py#L110