### PR TITLE
Fix `CategoryEncoding` generates output with 1 additional dimension in all backends except NumPy (#19724)

### DIFF
--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -448,10 +448,6 @@ def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
     x = convert_to_tensor(x)
     input_shape = x.shape
 
-    # Shrink the last dimension if the shape is (..., 1).
-    if input_shape and input_shape[-1] == 1 and len(input_shape) > 1:
-        input_shape = tuple(input_shape[:-1])
-
     x = x.reshape(-1)
     if not num_classes:
         num_classes = np.max(x) + 1

--- a/keras/src/layers/preprocessing/category_encoding_test.py
+++ b/keras/src/layers/preprocessing/category_encoding_test.py
@@ -195,6 +195,16 @@ class CategoryEncodingTest(testing.TestCase, parameterized.TestCase):
             layer.compute_output_shape(input_data.shape),
         )
 
+        # Test compute_output_shape with 1 extra dimension
+        input_data = np.array([[3], [2], [0], [1]])
+        layer = layers.CategoryEncoding(
+            num_tokens=num_tokens, output_mode="one_hot", sparse=sparse
+        )
+        self.assertEqual(
+            layer(input_data).shape,
+            layer.compute_output_shape(input_data.shape),
+        )
+
         input_data = np.array((4,))
         layer = layers.CategoryEncoding(
             num_tokens=num_tokens, output_mode="one_hot", sparse=sparse

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1650,6 +1650,15 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         )
         self.assertSparse(output_2d, sparse)
 
+        # Test 1D one-hot with 1 extra dimension.
+        indices_1d = np.array([[0], [1], [2], [3]])
+        output_1d = knn.one_hot(indices_1d, 4, sparse=sparse)
+        self.assertAllClose(output_1d, np.eye(4)[indices_1d])
+        self.assertSparse(output_1d, sparse)
+        output_1d = knn.one_hot(indices_1d, 4, axis=0, sparse=sparse)
+        self.assertAllClose(output_1d, np.eye(4)[indices_1d].swapaxes(1, 2))
+        self.assertSparse(output_1d, sparse)
+
         # Test 1D one-hot with negative inputs
         indices_1d = np.array([0, -1, -1, 3])
         output_1d = knn.one_hot(indices_1d, 4, sparse=sparse)

--- a/keras/src/utils/numerical_utils.py
+++ b/keras/src/utils/numerical_utils.py
@@ -75,7 +75,11 @@ def to_categorical(x, num_classes=None):
     if backend.is_tensor(x):
         input_shape = backend.core.shape(x)
         # Shrink the last dimension if the shape is (..., 1).
-        if input_shape is not None and len(input_shape) > 1 and input_shape[-1] == 1:
+        if (
+            input_shape is not None
+            and len(input_shape) > 1
+            and input_shape[-1] == 1
+        ):
             newshape = tuple(input_shape[:-1])
             x = backend.numpy.reshape(x, newshape)
         return backend.nn.one_hot(x, num_classes)
@@ -137,7 +141,11 @@ def encode_categorical_inputs(
     elif output_mode == "one_hot":
         input_shape = backend_module.core.shape(inputs)
         # Shrink the last dimension if the shape is (..., 1).
-        if input_shape is not None and len(input_shape) > 1 and input_shape[-1] == 1:
+        if (
+            input_shape is not None
+            and len(input_shape) > 1
+            and input_shape[-1] == 1
+        ):
             newshape = tuple(input_shape[:-1])
             inputs = backend_module.numpy.reshape(inputs, newshape)
         return backend_module.nn.one_hot(

--- a/keras/src/utils/numerical_utils.py
+++ b/keras/src/utils/numerical_utils.py
@@ -74,7 +74,7 @@ def to_categorical(x, num_classes=None):
     """
     if backend.is_tensor(x):
         input_shape = backend.core.shape(x)
-         # Shrink the last dimension if the shape is (..., 1).
+        # Shrink the last dimension if the shape is (..., 1).
         if input_shape is not None and len(input_shape) > 1 and input_shape[-1] == 1:
             newshape = tuple(input_shape[:-1])
             x = backend.numpy.reshape(x, newshape)
@@ -136,7 +136,7 @@ def encode_categorical_inputs(
         )
     elif output_mode == "one_hot":
         input_shape = backend_module.core.shape(inputs)
-         # Shrink the last dimension if the shape is (..., 1).
+        # Shrink the last dimension if the shape is (..., 1).
         if input_shape is not None and len(input_shape) > 1 and input_shape[-1] == 1:
             newshape = tuple(input_shape[:-1])
             inputs = backend_module.numpy.reshape(inputs, newshape)

--- a/keras/src/utils/numerical_utils.py
+++ b/keras/src/utils/numerical_utils.py
@@ -73,6 +73,11 @@ def to_categorical(x, num_classes=None):
     [0. 0. 0. 0.]
     """
     if backend.is_tensor(x):
+        input_shape = backend.core.shape(x)
+         # Shrink the last dimension if the shape is (..., 1).
+        if input_shape is not None and len(input_shape) > 1 and input_shape[-1] == 1:
+            newshape = tuple(input_shape[:-1])
+            x = backend.numpy.reshape(x, newshape)
         return backend.nn.one_hot(x, num_classes)
     x = np.array(x, dtype="int64")
     input_shape = x.shape
@@ -130,6 +135,11 @@ def encode_categorical_inputs(
             inputs, depth, dtype=dtype, sparse=sparse
         )
     elif output_mode == "one_hot":
+        input_shape = backend_module.core.shape(inputs)
+         # Shrink the last dimension if the shape is (..., 1).
+        if input_shape is not None and len(input_shape) > 1 and input_shape[-1] == 1:
+            newshape = tuple(input_shape[:-1])
+            inputs = backend_module.numpy.reshape(inputs, newshape)
         return backend_module.nn.one_hot(
             inputs, depth, dtype=dtype, sparse=sparse
         )


### PR DESCRIPTION
Make the behavior consistent across all backends.