### PR TITLE
Enable `Sequential` and `Functional` model to be used as a submodel

### DIFF
--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -182,7 +182,8 @@ class Functional(Function, Model):
         return super().compute_output_spec(inputs)
 
     def compute_output_shape(self, input_shape):
-        return self.output_shape
+        # From Function
+        return super().compute_output_shape(input_shape)
 
     def build(self, input_shape):
         self.built = True

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -181,6 +181,9 @@ class Functional(Function, Model):
         # From Function
         return super().compute_output_spec(inputs)
 
+    def compute_output_shape(self, input_shape):
+        return self.output_shape
+
     def build(self, input_shape):
         self.built = True
 

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -118,13 +118,13 @@ class FunctionalTest(testing.TestCase):
         out_val = model(in_val)
         self.assertEqual(out_val.shape, (2, 4))
 
-    def test_basic_flow_as_submodel(self):
+    def test_basic_flow_as_a_submodel(self):
         # Build submodel
         submodel_inputs = Input([4])
         submodel_outputs = layers.Flatten()(submodel_inputs)
         submodel = Model(submodel_inputs, submodel_outputs)
 
-        inputs = Input((3, 4))
+        inputs = Input((None, 4))
         outputs = layers.TimeDistributed(submodel)(inputs)
         model = Model(inputs=inputs, outputs=outputs)
 

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -118,6 +118,20 @@ class FunctionalTest(testing.TestCase):
         out_val = model(in_val)
         self.assertEqual(out_val.shape, (2, 4))
 
+    def test_basic_flow_as_submodel(self):
+        # Build submodel
+        submodel_inputs = Input([4])
+        submodel_outputs = layers.Flatten()(submodel_inputs)
+        submodel = Model(submodel_inputs, submodel_outputs)
+
+        inputs = Input((3, 4))
+        outputs = layers.TimeDistributed(submodel)(inputs)
+        model = Model(inputs=inputs, outputs=outputs)
+
+        x = np.random.random((2, 3, 4))
+        y = model(x)
+        self.assertEqual(y.shape, (2, 3, 4))
+
     @pytest.mark.requires_trainable_backend
     def test_named_input_dict_io(self):
         input_a = Input(shape=(3,), batch_size=2, name="a")

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -254,7 +254,7 @@ class Sequential(Model):
 
     def compute_output_shape(self, input_shape):
         if self._functional:
-            return self._functional.output_shape
+            return self._functional.compute_output_shape(input_shape)
         # Direct application
         for layer in self.layers:
             output_shape = layer.compute_output_shape(input_shape)

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -252,6 +252,15 @@ class Sequential(Model):
             inputs = outputs
         return outputs
 
+    def compute_output_shape(self, input_shape):
+        if self._functional:
+            return self._functional.output_shape
+        # Direct application
+        for layer in self.layers:
+            output_shape = layer.compute_output_shape(input_shape)
+            input_shape = output_shape
+        return output_shape
+
     @property
     def input_shape(self):
         if self._functional:

--- a/keras/src/models/sequential_test.py
+++ b/keras/src/models/sequential_test.py
@@ -8,6 +8,7 @@ from keras.src import layers
 from keras.src import testing
 from keras.src.layers.core.input_layer import Input
 from keras.src.models.functional import Functional
+from keras.src.models.model import Model
 from keras.src.models.sequential import Sequential
 
 
@@ -134,6 +135,34 @@ class SequentialTest(testing.TestCase):
         x = np.random.random((3, 2))
         y = model(x)
         self.assertEqual(y.shape, (3, 4))
+
+    def test_basic_flow_as_submodel(self):
+        # Test `built=False`
+        inputs = Input((3, 4))
+        nested_model = Sequential()
+        nested_model.add(layers.Flatten())
+        self.assertFalse(nested_model.built)
+
+        outputs = layers.TimeDistributed(nested_model)(inputs)
+        model = Model(inputs=inputs, outputs=outputs)
+
+        x = np.random.random((2, 3, 4))
+        y = model(x)
+        self.assertEqual(y.shape, (2, 3, 4))
+
+        # Test `built=True`
+        inputs = Input((3, 4))
+        nested_model = Sequential()
+        nested_model.add(layers.Input([4]))
+        nested_model.add(layers.Flatten())
+        self.assertTrue(nested_model.built)
+
+        outputs = layers.TimeDistributed(nested_model)(inputs)
+        model = Model(inputs=inputs, outputs=outputs)
+
+        x = np.random.random((2, 3, 4))
+        y = model(x)
+        self.assertEqual(y.shape, (2, 3, 4))
 
     def test_dict_inputs(self):
         class DictLayer(layers.Layer):

--- a/keras/src/models/sequential_test.py
+++ b/keras/src/models/sequential_test.py
@@ -137,12 +137,13 @@ class SequentialTest(testing.TestCase):
         self.assertEqual(y.shape, (3, 4))
 
     def test_basic_flow_as_submodel(self):
-        inputs = Input((3, 4))
-        nested_model = Sequential()
-        nested_model.add(layers.Flatten())
-        self.assertFalse(nested_model.built)
+        # Build submodel
+        submodel = Sequential()
+        submodel.add(layers.Flatten())
+        self.assertFalse(submodel.built)
 
-        outputs = layers.TimeDistributed(nested_model)(inputs)
+        inputs = Input((3, 4))
+        outputs = layers.TimeDistributed(submodel)(inputs)
         model = Model(inputs=inputs, outputs=outputs)
 
         x = np.random.random((2, 3, 4))

--- a/keras/src/models/sequential_test.py
+++ b/keras/src/models/sequential_test.py
@@ -136,13 +136,13 @@ class SequentialTest(testing.TestCase):
         y = model(x)
         self.assertEqual(y.shape, (3, 4))
 
-    def test_basic_flow_as_submodel(self):
+    def test_basic_flow_as_a_submodel(self):
         # Build submodel
         submodel = Sequential()
         submodel.add(layers.Flatten())
         self.assertFalse(submodel.built)
 
-        inputs = Input((3, 4))
+        inputs = Input((None, 4))
         outputs = layers.TimeDistributed(submodel)(inputs)
         model = Model(inputs=inputs, outputs=outputs)
 

--- a/keras/src/models/sequential_test.py
+++ b/keras/src/models/sequential_test.py
@@ -137,25 +137,10 @@ class SequentialTest(testing.TestCase):
         self.assertEqual(y.shape, (3, 4))
 
     def test_basic_flow_as_submodel(self):
-        # Test `built=False`
         inputs = Input((3, 4))
         nested_model = Sequential()
         nested_model.add(layers.Flatten())
         self.assertFalse(nested_model.built)
-
-        outputs = layers.TimeDistributed(nested_model)(inputs)
-        model = Model(inputs=inputs, outputs=outputs)
-
-        x = np.random.random((2, 3, 4))
-        y = model(x)
-        self.assertEqual(y.shape, (2, 3, 4))
-
-        # Test `built=True`
-        inputs = Input((3, 4))
-        nested_model = Sequential()
-        nested_model.add(layers.Input([4]))
-        nested_model.add(layers.Flatten())
-        self.assertTrue(nested_model.built)
 
         outputs = layers.TimeDistributed(nested_model)(inputs)
         model = Model(inputs=inputs, outputs=outputs)
@@ -300,3 +285,8 @@ class SequentialTest(testing.TestCase):
             ValueError, "can only have a single positional"
         ):
             model.build((None, 2))
+
+    def test_compute_output_shape(self):
+        layer = Sequential([layers.Dense(4), layers.Dense(8)])
+        output_shape = layer.compute_output_shape((1, 2))
+        self.assertEqual(output_shape, (1, 8))

--- a/keras/src/ops/function.py
+++ b/keras/src/ops/function.py
@@ -118,6 +118,20 @@ class Function(Operation):
             inputs, operation_fn=lambda op: op.compute_output_spec
         )
 
+    def compute_output_shape(self, input_shape):
+        # Wrap `input_shape` into the structure of KerasTensor to utilize
+        # `compute_output_spec`.
+        input_shape_struct = tree.map_shape_structure(
+            lambda x: KerasTensor(shape=x), input_shape
+        )
+        # Ensure that dtype and sparse settings are the same as self._inputs,
+        # because we only care about the shape in this function.
+        for x, x_ref in zip(tree.flatten(input_shape_struct), self._inputs):
+            x.dtype = x_ref.dtype
+            x.sparse = x_ref.sparse
+        output_spec = self.compute_output_spec(input_shape_struct)
+        return tree.map_structure(lambda x: x.shape, output_spec)
+
     def call(self, inputs):
         """Computes output tensors for new inputs."""
         self._assert_input_compatibility(inputs)

--- a/keras/src/ops/function_test.py
+++ b/keras/src/ops/function_test.py
@@ -55,6 +55,11 @@ class FunctionTest(testing.TestCase):
         self.assertIsInstance(out, keras_tensor.KerasTensor)
         self.assertEqual(out.shape, (4, 3))
 
+        # Test with compute_output_shape
+        out = fn.compute_output_shape((4, 3))
+        self.assertIsInstance(out, tuple)
+        self.assertEqual(out, (4, 3))
+
         # Test with call
         out = fn(keras_tensor.KerasTensor((4, 3)))
         self.assertIsInstance(out, keras_tensor.KerasTensor)

--- a/keras/src/ops/function_test.py
+++ b/keras/src/ops/function_test.py
@@ -56,9 +56,9 @@ class FunctionTest(testing.TestCase):
         self.assertEqual(out.shape, (4, 3))
 
         # Test with compute_output_shape
-        out = fn.compute_output_shape((4, 3))
+        out = fn.compute_output_shape((None, 3))
         self.assertIsInstance(out, tuple)
-        self.assertEqual(out, (4, 3))
+        self.assertEqual(out, (None, 3))
 
         # Test with call
         out = fn(keras_tensor.KerasTensor((4, 3)))


### PR DESCRIPTION
Fix #19792

As titled.

To enable this, we can simply add `compute_output_shape` to `Sequential` and `Functional`.
The added unit test verifies this.

(I also encountered this issue when building the project https://github.com/james77777778/keras-image-models)