### PR TITLE
Fix `DynamicBackend`

### DIFF
--- a/keras/src/utils/backend_utils.py
+++ b/keras/src/utils/backend_utils.py
@@ -63,7 +63,7 @@ class DynamicBackend:
     def set_backend(self, backend):
         if backend not in ("tensorflow", "jax", "torch", "numpy"):
             raise ValueError(
-                "Avaiable backends are ('tensorflow', 'jax', 'torch' and "
+                "Available backends are ('tensorflow', 'jax', 'torch' and "
                 f"'numpy'). Received: backend={backend}"
             )
         self._backend = backend

--- a/keras/src/utils/backend_utils.py
+++ b/keras/src/utils/backend_utils.py
@@ -76,27 +76,22 @@ class DynamicBackend:
 
     def __getattr__(self, name):
         if self._backend == "tensorflow":
-            import keras.src.backend.tensorflow as tf_backend
-
-            return getattr(tf_backend, name)
+            module = importlib.import_module("keras.src.backend.tensorflow")
+            return getattr(module, name)
         if self._backend == "jax":
-            import keras.src.backend.jax as jax_backend
-
-            return getattr(jax_backend, name)
+            module = importlib.import_module("keras.src.backend.jax")
+            return getattr(module, name)
         if self._backend == "torch":
-            import keras.src.backend.torch as torch_backend
-
-            return getattr(torch_backend, name)
+            module = importlib.import_module("keras.src.backend.torch")
+            return getattr(module, name)
         if self._backend == "numpy":
-            # `import keras.src.backend.numpy as numpy_backend` will fail if
-            # `backend() == "numpy"``, so we reroute `keras.src.backend` for
-            # this.
             if backend_module.backend() == "numpy":
                 return getattr(backend_module, name)
             else:
-                import keras.src.backend.numpy as numpy_backend
-
-                return getattr(numpy_backend, name)
+                raise NotImplementedError(
+                    "Currently, we cannot dynamically import the numpy backend "
+                    "because it would disrupt the namespace of the import."
+                )
 
 
 @keras_export("keras.config.set_backend")

--- a/keras/src/utils/backend_utils.py
+++ b/keras/src/utils/backend_utils.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 from keras.src import backend as backend_module
-from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.backend.common import global_state
 
@@ -92,7 +91,7 @@ class DynamicBackend:
             # import keras.src.backend.numpy as numpy_backend will fail if
             # backend() == "numpy", so we reroute `keras.ops` for this.
             if backend_module.backend() == "numpy":
-                return getattr(ops, name)
+                return getattr(backend_module, name)
             else:
                 import keras.src.backend.numpy as numpy_backend
 

--- a/keras/src/utils/backend_utils.py
+++ b/keras/src/utils/backend_utils.py
@@ -88,8 +88,9 @@ class DynamicBackend:
 
             return getattr(torch_backend, name)
         if self._backend == "numpy":
-            # import keras.src.backend.numpy as numpy_backend will fail if
-            # backend() == "numpy", so we reroute `keras.ops` for this.
+            # `import keras.src.backend.numpy as numpy_backend` will fail if
+            # `backend() == "numpy"``, so we reroute `keras.src.backend` for
+            # this.
             if backend_module.backend() == "numpy":
                 return getattr(backend_module, name)
             else:

--- a/keras/src/utils/backend_utils_test.py
+++ b/keras/src/utils/backend_utils_test.py
@@ -24,7 +24,6 @@ class BackendUtilsTest(testing.TestCase, parameterized.TestCase):
                     NotImplementedError,
                     "Currently, we cannot dynamically import the numpy backend",
                 ):
-                    
                     y = dynamic_backend.numpy.log10(x)
             else:
                 y = dynamic_backend.numpy.log10(x)

--- a/keras/src/utils/backend_utils_test.py
+++ b/keras/src/utils/backend_utils_test.py
@@ -41,5 +41,5 @@ class BackendUtilsTest(testing.TestCase, parameterized.TestCase):
 
     def test_dynamic_backend_invalid_name(self):
         backend = backend_utils.DynamicBackend()
-        with self.assertRaisesRegex(ValueError, "Avaiable backends are"):
+        with self.assertRaisesRegex(ValueError, "Available backends are"):
             backend.set_backend("abc")

--- a/keras/src/utils/backend_utils_test.py
+++ b/keras/src/utils/backend_utils_test.py
@@ -1,0 +1,45 @@
+import numpy as np
+from absl.testing import parameterized
+
+from keras.src import testing
+from keras.src.utils import backend_utils
+
+
+class BackendUtilsTest(testing.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(
+        ("numpy", "numpy"),
+        ("jax", "jax"),
+        ("tensorflow", "tensorflow"),
+        ("torch", "torch"),
+    )
+    def test_dynamic_backend(self, name):
+        backend = backend_utils.DynamicBackend()
+        x = np.random.uniform(size=[1, 2, 3])
+
+        if name == "numpy":
+            backend.set_backend(name)
+            y = backend.numpy.log10(x)
+            self.assertIsInstance(y, np.ndarray)
+        elif name == "jax":
+            import jax
+
+            backend.set_backend(name)
+            y = backend.numpy.log10(x)
+            self.assertIsInstance(y, jax.Array)
+        elif name == "tensorflow":
+            import tensorflow as tf
+
+            backend.set_backend(name)
+            y = backend.numpy.log10(x)
+            self.assertIsInstance(y, tf.Tensor)
+        elif name == "torch":
+            import torch
+
+            backend.set_backend(name)
+            y = backend.numpy.log10(x)
+            self.assertIsInstance(y, torch.Tensor)
+
+    def test_dynamic_backend_invalid_name(self):
+        backend = backend_utils.DynamicBackend()
+        with self.assertRaisesRegex(ValueError, "Avaiable backends are"):
+            backend.set_backend("abc")

--- a/keras/src/utils/backend_utils_test.py
+++ b/keras/src/utils/backend_utils_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 from absl.testing import parameterized
 
+from keras.src import backend
 from keras.src import testing
 from keras.src.utils import backend_utils
 
@@ -13,33 +14,41 @@ class BackendUtilsTest(testing.TestCase, parameterized.TestCase):
         ("torch", "torch"),
     )
     def test_dynamic_backend(self, name):
-        backend = backend_utils.DynamicBackend()
+        dynamic_backend = backend_utils.DynamicBackend()
         x = np.random.uniform(size=[1, 2, 3])
 
         if name == "numpy":
-            backend.set_backend(name)
-            y = backend.numpy.log10(x)
-            self.assertIsInstance(y, np.ndarray)
+            dynamic_backend.set_backend(name)
+            if backend.backend() != "numpy":
+                with self.assertRaisesRegex(
+                    NotImplementedError,
+                    "Currently, we cannot dynamically import the numpy backend",
+                ):
+                    
+                    y = dynamic_backend.numpy.log10(x)
+            else:
+                y = dynamic_backend.numpy.log10(x)
+                self.assertIsInstance(y, np.ndarray)
         elif name == "jax":
             import jax
 
-            backend.set_backend(name)
-            y = backend.numpy.log10(x)
+            dynamic_backend.set_backend(name)
+            y = dynamic_backend.numpy.log10(x)
             self.assertIsInstance(y, jax.Array)
         elif name == "tensorflow":
             import tensorflow as tf
 
-            backend.set_backend(name)
-            y = backend.numpy.log10(x)
+            dynamic_backend.set_backend(name)
+            y = dynamic_backend.numpy.log10(x)
             self.assertIsInstance(y, tf.Tensor)
         elif name == "torch":
             import torch
 
-            backend.set_backend(name)
-            y = backend.numpy.log10(x)
+            dynamic_backend.set_backend(name)
+            y = dynamic_backend.numpy.log10(x)
             self.assertIsInstance(y, torch.Tensor)
 
     def test_dynamic_backend_invalid_name(self):
-        backend = backend_utils.DynamicBackend()
+        dynamic_backend = backend_utils.DynamicBackend()
         with self.assertRaisesRegex(ValueError, "Available backends are"):
-            backend.set_backend("abc")
+            dynamic_backend.set_backend("abc")


### PR DESCRIPTION
We should trigger an error when attempting to perform numpy's ops in a non-numpy backend via `DynamicBackend`. The current codebase disregards `self._backend` and defaults to use `keras.src.backend.*`.
