### PR TITLE
Make example in documentation more obvious

### DIFF
--- a/keras/src/layers/reshaping/permute.py
+++ b/keras/src/layers/reshaping/permute.py
@@ -14,7 +14,7 @@ class Permute(Layer):
     Args:
         dims: Tuple of integers. Permutation pattern does not include the
             batch dimension. Indexing starts at 1.
-            For instance, `(2, 1)` permutes the first and second dimensions
+            For instance, `(1, 3, 2)` permutes the second and third dimensions
             of the input.
 
     Input shape:


### PR DESCRIPTION
By adding a third column in `dims` in the example, we avoid the misconception that the tuple could mean the exchange of the given pair, i.e. `(2, 3)` meaning to exchange the second and third column.