### PR TITLE
Faster in_top_k implementation for Jax backend

### DIFF
--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -40,11 +40,11 @@ def top_k(x, k, sorted=True):
 
 
 def in_top_k(targets, predictions, k):
-    targets = targets[..., None]
-    topk_values = top_k(predictions, k)[0]
-    targets_values = jnp.take_along_axis(predictions, targets, axis=-1)
-    mask = targets_values >= topk_values
-    return jnp.any(mask, axis=1)
+    preds_at_label = jnp.take_along_axis(
+        predictions, jnp.expand_dims(targets, axis=-1), axis=-1
+    )
+    rank = jnp.sum(jnp.greater_equal(predictions, preds_at_label), axis=-1)
+    return jnp.less_equal(rank, k)
 
 
 def logsumexp(x, axis=None, keepdims=False):

--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -43,7 +43,7 @@ def in_top_k(targets, predictions, k):
     preds_at_label = jnp.take_along_axis(
         predictions, jnp.expand_dims(targets, axis=-1), axis=-1
     )
-    rank = jnp.sum(jnp.greater_equal(predictions, preds_at_label), axis=-1)
+    rank = 1 + jnp.sum(jnp.greater(predictions, preds_at_label), axis=-1)
     return jnp.less_equal(rank, k)
 
 


### PR DESCRIPTION
Microbenchmarks are here [1]. Seems to be faster on CPU, GPU, TPU. Also XLA is sometimes able to dedup everything before k is referenced when it's called multiple times with different ks. This results in nice gains for retrieval applications with multiple top k metrics.

[1] https://gist.github.com/Hilly12/85460873d9786924159f2377f320df48