### PR TITLE
Make batch norm mask shape error more descriptive

### DIFF
--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -219,7 +219,8 @@ class BatchNormalization(Layer):
             if len(mask.shape) != len(inputs.shape) - 1:
                 # Raise a value error
                 raise ValueError(
-                    "The mask provided should be one dimension less than the inputs."
+                    "The mask provided should be one dimension less than the inputs. "
+                    f"Received: mask.shape={mask.shape}, inputs.shape={inputs.shape}"
                 )
 
         input_dtype = standardize_dtype(inputs.dtype)

--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -214,6 +214,14 @@ class BatchNormalization(Layer):
         return input_shape
 
     def call(self, inputs, training=None, mask=None):
+        # Check if the mask has one less dimension than the inputs.
+        if mask is not None:
+            if len(mask.shape) != len(inputs.shape) - 1:
+                # Raise a value error
+                raise ValueError(
+                    "The mask provided should be one dimension less than the inputs."
+                )
+
         input_dtype = standardize_dtype(inputs.dtype)
         if input_dtype in ("float16", "bfloat16"):
             # BN is prone to overflowing for float16/bfloat16 inputs, so we opt


### PR DESCRIPTION
This PR fixes #19818 by adding a more descriptive message to the mask mismatch exception in batch normalization.

Before:
![image](https://github.com/keras-team/keras/assets/60848863/5303a7b4-618b-484e-832f-e8b319877af5)


After (Highlighted for clarity):
![image](https://github.com/keras-team/keras/assets/60848863/c88256f4-2b02-445b-bc7e-744e051ff958)
