### PR TITLE
`Metric.variables` is now recursive.

### DIFF
--- a/keras/src/metrics/metric.py
+++ b/keras/src/metrics/metric.py
@@ -209,9 +209,9 @@ class Metric(KerasSaveable):
 
     @property
     def variables(self):
-        variables = self._variables[:]
+        variables = list(self._variables)
         for metric in self._metrics:
-            variables.extend(metric._variables)
+            variables.extend(metric.variables)
         return variables
 
     def __call__(self, *args, **kwargs):

--- a/keras/src/metrics/metric_test.py
+++ b/keras/src/metrics/metric_test.py
@@ -161,6 +161,12 @@ class MetricTest(testing.TestCase):
         }
         self.assertEqual(len(metric.variables), 6)
 
+        # Two levels deep
+        metric = ExampleMetric(name="mse")
+        metric.submetric = ExampleMetric(name="submse")
+        metric.submetric.submetric = ExampleMetric(name="subsubmse")
+        self.assertEqual(len(metric.variables), 6)
+
     def test_serialization(self):
         self.run_class_serialization_test(
             ExampleMetric(name="mse"),


### PR DESCRIPTION
This allows it to surface variables from metrics nested at any depth.

Previously, metrics within metrics within metrics would not have their variables tracked in JAX, causing them to not be updated.