### PR TITLE
Fix `get_file` when the HTTP response has no `Content-Length` header

### DIFF
--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -270,9 +270,9 @@ def get_file(
                 self.finished = False
 
             def __call__(self, block_num, block_size, total_size):
+                if total_size == -1:
+                    total_size = None
                 if not self.progbar:
-                    if total_size == -1:
-                        total_size = None
                     self.progbar = Progbar(total_size)
                 current = block_num * block_size
 


### PR DESCRIPTION
refer to:
https://github.com/python/cpython/blob/48f9d3e3faec5faaa4f7c9849fecd27eae4da213/Lib/urllib/request.py#L259-L264

Http response without a `Content-Length` header will cause `total_size = -1`

https://github.com/keras-team/keras/blob/efaaf85e19113400f23462cbafcef433cd95ad9c/keras/src/utils/file_utils.py#L279-L286

Line 280 is bypassed, so line 285 will be executed instead. `current` will be set to `self.progbar.target`, which is `None`.