### PR TITLE
Fix inconsistent behavior of `losses.sparse_categorical_crossentropy`…

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -1711,6 +1711,9 @@ def sparse_categorical_crossentropy(
     array([0.0513, 2.303], dtype=float32)
     """
 
+    if len(y_true.shape) == len(y_pred.shape) and y_true.shape[-1] == 1:
+        y_true = ops.squeeze(y_true, axis=-1)
+
     if ignore_class is not None:
         res_shape = ops.shape(y_pred)[:-1]
         valid_mask = ops.not_equal(y_true, ops.cast(ignore_class, y_pred.dtype))

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1181,6 +1181,13 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
         loss = cce_obj(y_true, logits)
         self.assertAllClose([[0.0, 1.48012]], loss, 3)
 
+        y_true = np.array([[[-1], [2]]])
+        logits = np.array([[[0.854, 0.698, 0.598], [0.088, 0.86, 0.018]]])
+        cce_obj = losses.SparseCategoricalCrossentropy(
+            from_logits=True, ignore_class=-1, reduction=None
+        )
+        loss = cce_obj(y_true, logits)
+        self.assertAllClose([[0.0, 1.48012]], loss, 3)
 
 class BinaryFocalCrossentropyTest(testing.TestCase):
     def test_config(self):

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1189,6 +1189,7 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
         loss = cce_obj(y_true, logits)
         self.assertAllClose([[0.0, 1.48012]], loss, 3)
 
+
 class BinaryFocalCrossentropyTest(testing.TestCase):
     def test_config(self):
         self.run_class_serialization_test(

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1055,7 +1055,7 @@ class CategoricalCrossentropyTest(testing.TestCase):
             from_logits=True, reduction=None
         )
         loss = cce_obj(y_true, logits)
-        self.assertAllClose((0.001822, 0.000459, 0.169846), loss, 3)
+        self.assertAllClose((0.001822, 0.000459, 0.169846), loss)
 
     def test_label_smoothing(self):
         logits = np.array([[100.0, -100.0, -100.0]])
@@ -1170,7 +1170,7 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
             from_logits=True, reduction=None
         )
         loss = cce_obj(y_true, logits)
-        self.assertAllClose((0.001822, 0.000459, 0.169846), loss, 3)
+        self.assertAllClose((0.001822, 0.000459, 0.169846), loss)
 
     def test_ignore_class(self):
         y_true = np.array([[-1, 2]])
@@ -1179,7 +1179,7 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
             from_logits=True, ignore_class=-1, reduction=None
         )
         loss = cce_obj(y_true, logits)
-        self.assertAllClose([[0.0, 1.48012]], loss, 3)
+        self.assertAllClose([[0.0, 1.480129]], loss)
 
         y_true = np.array([[[-1], [2]]])
         logits = np.array([[[0.854, 0.698, 0.598], [0.088, 0.86, 0.018]]])
@@ -1187,7 +1187,7 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
             from_logits=True, ignore_class=-1, reduction=None
         )
         loss = cce_obj(y_true, logits)
-        self.assertAllClose([[0.0, 1.48012]], loss, 3)
+        self.assertAllClose([[0.0, 1.480129]], loss)
 
 
 class BinaryFocalCrossentropyTest(testing.TestCase):
@@ -1280,7 +1280,7 @@ class BinaryFocalCrossentropyTest(testing.TestCase):
             reduction=None,
         )
         loss = obj(y_true, y_pred)
-        self.assertAllClose(loss, (0.5155, 0.0205), 3)
+        self.assertAllClose(loss, (0.515547, 0.020513))
 
 
 class CategoricalFocalCrossentropyTest(testing.TestCase):
@@ -1366,7 +1366,6 @@ class CategoricalFocalCrossentropyTest(testing.TestCase):
         self.assertAllClose(
             (1.5096224e-09, 2.4136547e-11, 1.0360638e-03),
             loss,
-            3,
         )
 
     def test_label_smoothing(self):


### PR DESCRIPTION
… with and without `ignore_class`

All backends remove trailing dimension of size 1 from `target`. 
In `losses`, if `ignore_class` is not None, the preprocessing before calling the backend's `sparse_categorical_crossentropy` ignores this situation.

https://github.com/keras-team/keras/blob/26abe697a8802de40cb2761fc98b843fe1b2d5f6/keras/src/backend/jax/nn.py#L487-L491

Fixes #19825