### PR TITLE
Fix bugs with `Mean`, `Accuracy` and `BinaryAccuracy` metrics.

### DIFF
--- a/keras/src/metrics/accuracy_metrics.py
+++ b/keras/src/metrics/accuracy_metrics.py
@@ -9,10 +9,7 @@ def accuracy(y_true, y_pred):
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.convert_to_tensor(y_true, dtype=y_pred.dtype)
     y_true, y_pred = squeeze_or_expand_to_same_rank(y_true, y_pred)
-    return ops.mean(
-        ops.cast(ops.equal(y_true, y_pred), dtype=backend.floatx()),
-        axis=-1,
-    )
+    return ops.cast(ops.equal(y_true, y_pred), dtype=backend.floatx())
 
 
 @keras_export("keras.metrics.Accuracy")
@@ -69,10 +66,7 @@ def binary_accuracy(y_true, y_pred, threshold=0.5):
     y_true, y_pred = squeeze_or_expand_to_same_rank(y_true, y_pred)
     threshold = ops.cast(threshold, y_pred.dtype)
     y_pred = ops.cast(y_pred > threshold, y_true.dtype)
-    return ops.mean(
-        ops.cast(ops.equal(y_true, y_pred), dtype=backend.floatx()),
-        axis=-1,
-    )
+    return ops.cast(ops.equal(y_true, y_pred), dtype=backend.floatx())
 
 
 @keras_export("keras.metrics.BinaryAccuracy")

--- a/keras/src/metrics/accuracy_metrics_test.py
+++ b/keras/src/metrics/accuracy_metrics_test.py
@@ -41,6 +41,33 @@ class AccuracyTest(testing.TestCase):
         result = acc_obj.result()
         self.assertAllClose(result, 0.5, atol=1e-3)
 
+    def test_weighted_rank_1(self):
+        acc_obj = accuracy_metrics.Accuracy(name="accuracy", dtype="float32")
+        y_true = np.array([1, 2, 3, 4])
+        y_pred = np.array([0, 2, 3, 4])
+        sample_weight = np.array([1, 1, 0, 0])
+        acc_obj.update_state(y_true, y_pred, sample_weight=sample_weight)
+        result = acc_obj.result()
+        self.assertAllClose(result, 0.5, atol=1e-3)
+
+    def test_weighted_nd_weights(self):
+        acc_obj = accuracy_metrics.Accuracy(name="accuracy", dtype="float32")
+        y_true = np.array([[1, 2], [3, 4]])
+        y_pred = np.array([[0, 2], [3, 4]])
+        sample_weight = np.array([[1, 0], [0, 1]])
+        acc_obj.update_state(y_true, y_pred, sample_weight=sample_weight)
+        result = acc_obj.result()
+        self.assertAllClose(result, 0.5, atol=1e-3)
+
+    def test_weighted_nd_broadcast_weights(self):
+        acc_obj = accuracy_metrics.Accuracy(name="accuracy", dtype="float32")
+        y_true = np.array([[1, 2], [3, 4]])
+        y_pred = np.array([[0, 2], [3, 4]])
+        sample_weight = np.array([[1, 0]])
+        acc_obj.update_state(y_true, y_pred, sample_weight=sample_weight)
+        result = acc_obj.result()
+        self.assertAllClose(result, 0.5, atol=1e-3)
+
 
 class BinaryAccuracyTest(testing.TestCase):
     def test_config(self):
@@ -94,6 +121,39 @@ class BinaryAccuracyTest(testing.TestCase):
         bin_acc_obj.update_state(y_true, y_pred, sample_weight=sample_weight)
         result = bin_acc_obj.result()
         self.assertAllClose(result, 0.5, atol=1e-3)
+
+    def test_weighted_rank_1(self):
+        bin_acc_obj = accuracy_metrics.BinaryAccuracy(
+            name="binary_accuracy", dtype="float32"
+        )
+        y_true = np.array([1, 1, 0, 0])
+        y_pred = np.array([0.98, 1, 0, 0.6])
+        sample_weight = np.array([1, 0, 0, 1])
+        bin_acc_obj.update_state(y_true, y_pred, sample_weight=sample_weight)
+        result = bin_acc_obj.result()
+        self.assertAllClose(result, 0.5, atol=1e-3)
+
+    def test_weighted_nd_weights(self):
+        bin_acc_obj = accuracy_metrics.BinaryAccuracy(
+            name="binary_accuracy", dtype="float32"
+        )
+        y_true = np.array([[1, 1], [0, 0]])
+        y_pred = np.array([[0.98, 1], [0, 0.6]])
+        sample_weight = np.array([[1, 0], [0, 1]])
+        bin_acc_obj.update_state(y_true, y_pred, sample_weight=sample_weight)
+        result = bin_acc_obj.result()
+        self.assertAllClose(result, 0.5, atol=1e-3)
+
+    def test_weighted_nd_broadcast_weights(self):
+        bin_acc_obj = accuracy_metrics.BinaryAccuracy(
+            name="binary_accuracy", dtype="float32"
+        )
+        y_true = np.array([[1, 1], [0, 0]])
+        y_pred = np.array([[0.98, 1], [0, 0.6]])
+        sample_weight = np.array([[1, 0]])
+        bin_acc_obj.update_state(y_true, y_pred, sample_weight=sample_weight)
+        result = bin_acc_obj.result()
+        self.assertAllClose(result, 1.0, atol=1e-3)
 
     def test_threshold(self):
         bin_acc_obj_1 = accuracy_metrics.BinaryAccuracy(

--- a/keras/src/metrics/reduction_metrics.py
+++ b/keras/src/metrics/reduction_metrics.py
@@ -22,15 +22,18 @@ def reduce_to_samplewise_values(values, sample_weight, reduce_fn, dtype):
         values, sample_weight = losses.loss.squeeze_or_expand_to_same_rank(
             values, sample_weight
         )
-        # Reduce values to same ndim as weight array
+        # Reduce values to same ndim as weight array.
         weight_ndim = len(sample_weight.shape)
         values_ndim = len(values.shape)
         if values_ndim > weight_ndim:
             values = reduce_fn(
                 values, axis=list(range(weight_ndim, values_ndim))
             )
+        # Broadcast sample_weight. It doesn't change the multiplication below
+        # but changes the sample_weight reduction applied later.
+        sample_weight = ops.broadcast_to(sample_weight, values.shape)
         values = values * sample_weight
-        if values_ndim > 1:
+        if weight_ndim > 1:
             sample_weight = reduce_fn(
                 sample_weight, axis=list(range(1, weight_ndim))
             )
@@ -38,7 +41,6 @@ def reduce_to_samplewise_values(values, sample_weight, reduce_fn, dtype):
     values_ndim = len(values.shape)
     if values_ndim > 1:
         values = reduce_fn(values, axis=list(range(1, values_ndim)))
-        return values, sample_weight
     return values, sample_weight
 
 
@@ -82,7 +84,7 @@ class Sum(Metric):
         values, _ = reduce_to_samplewise_values(
             values, sample_weight, reduce_fn=ops.sum, dtype=self.dtype
         )
-        self.total.assign(self.total + ops.sum(values))
+        self.total.assign_add(ops.sum(values))
 
     def reset_state(self):
         self.total.assign(0.0)
@@ -138,14 +140,14 @@ class Mean(Metric):
         values, sample_weight = reduce_to_samplewise_values(
             values, sample_weight, reduce_fn=ops.mean, dtype=self.dtype
         )
-        self.total.assign(self.total + ops.sum(values))
-        if len(values.shape) >= 1:
+        self.total.assign_add(ops.sum(values))
+        if sample_weight is not None:
+            num_samples = ops.sum(sample_weight)
+        elif len(values.shape) >= 1:
             num_samples = ops.shape(values)[0]
         else:
             num_samples = 1
-        if sample_weight is not None:
-            num_samples = ops.sum(sample_weight)
-        self.count.assign(self.count + ops.cast(num_samples, dtype=self.dtype))
+        self.count.assign_add(ops.cast(num_samples, dtype=self.dtype))
 
     def reset_state(self):
         self.total.assign(0.0)

--- a/keras/src/metrics/reduction_metrics_test.py
+++ b/keras/src/metrics/reduction_metrics_test.py
@@ -36,6 +36,12 @@ class SumTest(testing.TestCase):
         result = sum_obj.result()
         self.assertAllClose(result, 9.0, atol=1e-3)
 
+    def test_weighted_nd_broadcast(self):
+        sum_obj = reduction_metrics.Sum(name="sum", dtype="float32")
+        sum_obj.update_state([[1, 3], [5, 7]], sample_weight=[[1, 0]])
+        result = sum_obj.result()
+        self.assertAllClose(result, 6.0, atol=1e-3)
+
 
 class MeanTest(testing.TestCase):
     def test_config(self):
@@ -71,6 +77,12 @@ class MeanTest(testing.TestCase):
     def test_weighted_nd(self):
         mean_obj = reduction_metrics.Mean(name="mean", dtype="float32")
         mean_obj.update_state([[1, 3], [5, 7]], sample_weight=[[1, 1], [1, 0]])
+        result = mean_obj.result()
+        self.assertAllClose(result, 3.0, atol=1e-3)
+
+    def test_weighted_nd_broadcast(self):
+        mean_obj = reduction_metrics.Mean(name="mean", dtype="float32")
+        mean_obj.update_state([[1, 3], [5, 7]], sample_weight=[[1, 0]])
         result = mean_obj.result()
         self.assertAllClose(result, 3.0, atol=1e-3)
 
@@ -127,3 +139,17 @@ class MetricWrapperTest(testing.TestCase):
         sample_weight = np.array([1.0, 1.5, 2.0, 2.5])
         result = mse_obj(y_true, y_pred, sample_weight=sample_weight)
         self.assertAllClose(0.54285, result, atol=1e-5)
+
+    def test_weighted_broadcast(self):
+        mse_obj = reduction_metrics.MeanMetricWrapper(
+            fn=mse, name="mse", dtype="float32"
+        )
+        y_true = np.array(
+            [[0, 1, 0, 1, 0], [0, 0, 1, 1, 1], [1, 1, 1, 1, 0], [0, 0, 0, 0, 1]]
+        )
+        y_pred = np.array(
+            [[0, 0, 1, 1, 0], [1, 1, 1, 1, 1], [0, 1, 0, 1, 0], [1, 1, 1, 1, 1]]
+        )
+        sample_weight = np.array([[1.0, 0.0, 0.5, 0.0, 1.0]])
+        result = mse_obj(y_true, y_pred, sample_weight=sample_weight)
+        self.assertAllClose(0.45, result, atol=1e-5)


### PR DESCRIPTION
- `reduce_to_samplewise_values` would not reduce `sample_weights` correctly because the number of dimensions of `values` was checked.
- `reduce_to_samplewise_values` needs to explicitely broadcast `sample_weights`. Before, it was implicitly broadcast in the multiplication with `values`. However, the explicit broadcast is needed for the computation of `num_samples` for the averaging to be correct. This causes a bug when `sample_weights` is of rank 2 or more and a broadcast happens when doing the multiplication. This logic existed in `tf_keras`: https://github.com/keras-team/tf-keras/blob/master/tf_keras/metrics/base_metric.py#L508
- `Accuracy` and `BinaryAccuracy` were doing a mean reduction too early, before multiplying by `sample_weights`. This matters when the rank of `sample_weights` is the same as `y_true` and `y_pred`.