### PR TITLE
fix variable name when add in init function

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -507,7 +507,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
             else:
                 initializer = "zeros"
         initializer = initializers.get(initializer)
-        with self._open_name_scope():
+        with backend.name_scope(self.name, caller=self):
             variable = backend.Variable(
                 initializer=initializer,
                 shape=shape,


### PR DESCRIPTION
i am debugging a variable naming issue that i found out when upgrading from v3.0.1 -> v3.3.3. the situation i observed is that the variable name random "restarts" in nested layers and i am able to root cause to https://github.com/keras-team/keras/commit/b53b4d being the culprit when keras is trying to fix another naming issue for lora.

with the ability to cache `_parent_path` on the first `name_scope` open with `current_path()`, the `_parent_path` will be set to empty string when `self.add_weight()` is being called in init function since the scope name stack will always be empty when construct layers. then, during build, since `_parent_path` is being set to an empty string resulted name will only contain the immediate layer name and thus causing the variable name to restart.

here is a snippet that explains what the current behavior and what's the ideal behavior:

```
import keras

class A(keras.layers.Layer):

    def __init__(self):
        super().__init__()
        self.b = B()
        self.c = C()

    def call(self, input):
        return self.c(self.b(input))


class B(keras.layers.Layer):
    def __init__(self):
        super().__init__()
        self.c = C()
        self.var_b = self.add_weight(
            shape=(1, ),
            name="var_b",
        )

    def call(self, input):
        return self.c(input) + self.var_b
        

class C(keras.layers.Layer):
    def __init__(self):
        super().__init__()
        self.var_c = self.add_weight(
            shape=(1, ),
            name="var_c",
        )
        self.dense = keras.layers.Dense(units=5)

    def call(self, input):
        return self.dense(input + self.var_c)

input = keras.Input(shape=(10, ), batch_size=8)

output = A()(input)
model = keras.Model(input, output)
print("Model A")
for var in model.variables:
    print(var)
```

above snippet will return

```
Model A
<KerasVariable shape=(1,), dtype=float32, path=b/var_b>
<KerasVariable shape=(1,), dtype=float32, path=c/var_c>
<KerasVariable shape=(10, 5), dtype=float32, path=c/dense/kernel>
<KerasVariable shape=(5,), dtype=float32, path=c/dense/bias>
<KerasVariable shape=(1,), dtype=float32, path=c_1/var_c>
<KerasVariable shape=(5, 5), dtype=float32, path=c_1/dense_1/kernel>
<KerasVariable shape=(5,), dtype=float32, path=c_1/dense_1/bias>
```

but the expectation would be `a/b/c/dense/kernel`, `a/b/c/dense/bias`, `a/c_1/dense_1/kernel`, `a/c_1/dense_1/bias` instead of missing `a/b` in the name path.

changing above snippet to creating variables in build matches the expectation. snippet:

```
class Ap(keras.layers.Layer):

    def __init__(self):
        super().__init__()
        self.b = Bp()
        self.c = Cp()

    def call(self, input):
        return self.c(self.b(input))


class Bp(keras.layers.Layer):
    def __init__(self):
        super().__init__()
        self.c = Cp()

    def build(self, _):
        self.var_b = self.add_weight(
            shape=(1, ),
            name="var_b",
        )

    def call(self, input):
        return self.c(input) + self.var_b
        

class Cp(keras.layers.Layer):
    def __init__(self):
        super().__init__()
        self.dense = keras.layers.Dense(units=5)

    def build(self, _):
        self.var_c = self.add_weight(
            shape=(1, ),
            name="var_c",
        )

    def call(self, input):
        return self.dense(input + self.var_c)

input = keras.Input(shape=(10, ), batch_size=8)
print("Model Ap")
output = Ap()(input)
model = keras.Model(input, output)
for var in model.variables:
    print(var)
```

output:

```
Model Ap
<KerasVariable shape=(1,), dtype=float32, path=ap/bp/var_b>
<KerasVariable shape=(1,), dtype=float32, path=ap/bp/cp/var_c>
<KerasVariable shape=(10, 5), dtype=float32, path=ap/bp/cp/dense/kernel>
<KerasVariable shape=(5,), dtype=float32, path=ap/bp/cp/dense/bias>
<KerasVariable shape=(1,), dtype=float32, path=ap/cp_1/var_c>
<KerasVariable shape=(5, 5), dtype=float32, path=ap/cp_1/dense_1/kernel>
<KerasVariable shape=(5,), dtype=float32, path=ap/cp_1/dense_1/bias>
```

there are two options to sort of solving the issue:
1. stop allowing `add_weight` in init function. but i think this would be a disruptive changes that could potentially break many existing code?
2. take a compromise where all variables add in init function will result in `layer/var` and variables add in build will result in `parent_layer/layer/var` and document the behavior. this option will still support the lora use case and still allow `add_weight` to be called in init function.

current pr implements option 2.