### PR TITLE
Introduce `DTypePolicyMap`

### DIFF
--- a/keras/api/_tf_keras/keras/dtype_policies/__init__.py
+++ b/keras/api/_tf_keras/keras/dtype_policies/__init__.py
@@ -11,3 +11,4 @@ from keras.src.dtype_policies.dtype_policy import DTypePolicy
 from keras.src.dtype_policies.dtype_policy import FloatDTypePolicy
 from keras.src.dtype_policies.dtype_policy import QuantizedDTypePolicy
 from keras.src.dtype_policies.dtype_policy import QuantizedFloat8DTypePolicy
+from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap

--- a/keras/api/dtype_policies/__init__.py
+++ b/keras/api/dtype_policies/__init__.py
@@ -11,3 +11,4 @@ from keras.src.dtype_policies.dtype_policy import DTypePolicy
 from keras.src.dtype_policies.dtype_policy import FloatDTypePolicy
 from keras.src.dtype_policies.dtype_policy import QuantizedDTypePolicy
 from keras.src.dtype_policies.dtype_policy import QuantizedFloat8DTypePolicy
+from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap

--- a/keras/src/dtype_policies/__init__.py
+++ b/keras/src/dtype_policies/__init__.py
@@ -98,11 +98,6 @@ def get(identifier):
             return _get_quantized_dtype_policy_by_str(identifier)
         else:
             return FloatDTypePolicy(identifier)
-    if isinstance(identifier, DTypePolicyMap):
-        raise TypeError(
-            "Cannot interpret `dtype` argument because it is a DTypePolicyMap. "
-            "You should pass a value from the DTypePolicyMap instead."
-        )
     try:
         return FloatDTypePolicy(backend.standardize_dtype(identifier))
     except:

--- a/keras/src/dtype_policies/__init__.py
+++ b/keras/src/dtype_policies/__init__.py
@@ -6,12 +6,14 @@ from keras.src.dtype_policies.dtype_policy import DTypePolicy
 from keras.src.dtype_policies.dtype_policy import FloatDTypePolicy
 from keras.src.dtype_policies.dtype_policy import QuantizedDTypePolicy
 from keras.src.dtype_policies.dtype_policy import QuantizedFloat8DTypePolicy
+from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
 
 ALL_OBJECTS = {
     DTypePolicy,
     FloatDTypePolicy,
     QuantizedDTypePolicy,
     QuantizedFloat8DTypePolicy,
+    DTypePolicyMap,
 }
 ALL_OBJECTS_DICT = {cls.__name__: cls for cls in ALL_OBJECTS}
 
@@ -96,6 +98,11 @@ def get(identifier):
             return _get_quantized_dtype_policy_by_str(identifier)
         else:
             return FloatDTypePolicy(identifier)
+    if isinstance(identifier, DTypePolicyMap):
+        raise TypeError(
+            "Cannot interpret `dtype` argument because it is a DTypePolicyMap. "
+            "You should pass a value from the DTypePolicyMap instead."
+        )
     try:
         return FloatDTypePolicy(backend.standardize_dtype(identifier))
     except:

--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -173,7 +173,19 @@ class DTypePolicy:
         return cls(**config)
 
     def __repr__(self):
-        return f'<FloatDTypePolicy "{self._name}">'
+        class_name = self.__class__.__name__
+        if class_name == "DTypePolicy":
+            class_name = "FloatDTypePolicy"
+        return f'<{class_name} "{self._name}">'
+
+    def __eq__(self, other):
+        if self.__class__ in (DTypePolicy, FloatDTypePolicy):
+            if type(other) not in (DTypePolicy, FloatDTypePolicy):
+                return False
+        else:
+            if type(other) is not self.__class__:
+                return False
+        return self._name == other._name
 
     def _should_cast(self, x, autocast, dtype):
         x_dtype = backend.standardize_dtype(x.dtype)
@@ -217,8 +229,13 @@ class QuantizedDTypePolicy(DTypePolicy):
         """
         return self._quantization_mode
 
-    def __repr__(self):
-        return f'<QuantizedDTypePolicy "{self._name}">'
+    def __eq__(self, other):
+        if super().__eq__(other) is False:
+            return False
+        return (
+            self._quantization_mode == other._quantization_mode
+            and self._source_name == other._source_name
+        )
 
     def get_config(self):
         return {
@@ -261,8 +278,10 @@ class QuantizedFloat8DTypePolicy(QuantizedDTypePolicy):
         """
         return self._amax_history_length
 
-    def __repr__(self):
-        return f'<QuantizedFloat8DTypePolicy "{self._name}">'
+    def __eq__(self, other):
+        if super().__eq__(other) is False:
+            return False
+        return self._amax_history_length == other._amax_history_length
 
     def get_config(self):
         config = super().get_config()

--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -8,7 +8,7 @@ from keras.src.dtype_policies import DTypePolicy
 
 @keras_export(["keras.dtype_policies.DTypePolicyMap"])
 class DTypePolicyMap(DTypePolicy, MutableMapping):
-    """A dict-like object that maps string to `DTypePolicy` instances.
+    """Dict-like object mapping layer paths to `DTypePolicy` instances.
 
     `DTypePolicyMap` can be used in `get_config` in layers and subclasses to
     support a complex configurations of dtype policies.
@@ -24,23 +24,20 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
             dtype_policy_map = dtype_policies.DTypePolicyMap()
             for layer in self._flatten_layers():
                 if layer.dtype_policy.is_quantized:
-                    dtype_policy_map[layer.name] = layer.dtype_policy
+                    dtype_policy_map[layer.path] = layer.dtype_policy
             if len(dtype_policy_map) > 0:
                 config.update({"dtype": dtype_policy_map})
             return config
     ```
 
-    Internally, `DTypePolicyMap` uses a string as key and a `DTypePolicy`
-    as value. There is a behavior difference between a normal Python dict and
-    this class. The string key will be treated as a regex when retrieving the
-    value. See the docstring of `get` for more details.
+    Internally, `DTypePolicyMap` uses a string as a key and a `DTypePolicy`
+    as the value. Typically, the key used for querying is the `Layer.path`.
+    However, it is also possible to set a regex as the key. See the docstring of
+    `get` for more details.
 
     See below for a usage example. You can define the naming schema
     of the `DTypePolicy`, and then retrieve the corresponding `DTypePolicy`
     instance.
-
-    In the normal case, the key to query is usually the `layer.name`, which
-    is the `name` of the layer.
 
     ```python
     dtype_policy_map = DTypePolicyMap()

--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -2,8 +2,8 @@ import re
 from collections.abc import MutableMapping
 
 from keras.src import dtype_policies
-from keras.src.dtype_policies import DTypePolicy
 from keras.src.api_export import keras_export
+from keras.src.dtype_policies import DTypePolicy
 
 
 @keras_export(["keras.dtype_policies.DTypePolicyMap"])
@@ -64,18 +64,15 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
     """
 
     def __init__(self, default_policy=None, policy_map=None):
+        if isinstance(default_policy, DTypePolicyMap):
+            raise ValueError("`default_policy` cannot be a `DTypePolicyMap`.")
         if policy_map is not None and not isinstance(policy_map, dict):
             raise TypeError(
                 "If specified, `policy_map` must be a dict. "
                 f"Received: policy_map={policy_map} of type {type(policy_map)}"
             )
-        # Don't allow nesting maps. Should we?
-        if isinstance(default_policy, DTypePolicyMap):
-            default_policy = default_policy.default_policy
         self._default_policy_arg = default_policy
         self._default_policy = dtype_policies.get(default_policy)
-        if isinstance(self._default_policy, DTypePolicyMap):
-            self._default_policy = self._default_policy.default_policy
         self._policy_map = policy_map or dict()
 
     @property

--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -2,11 +2,12 @@ import re
 from collections.abc import MutableMapping
 
 from keras.src import dtype_policies
+from keras.src.dtype_policies import DTypePolicy
 from keras.src.api_export import keras_export
 
 
 @keras_export(["keras.dtype_policies.DTypePolicyMap"])
-class DTypePolicyMap(MutableMapping):
+class DTypePolicyMap(DTypePolicy, MutableMapping):
     """A dict-like object that maps string to `DTypePolicy` instances.
 
     `DTypePolicyMap` can be used in `get_config` in layers and subclasses to
@@ -76,6 +77,10 @@ class DTypePolicyMap(MutableMapping):
         self._policy_map = policy_map or dict()
 
     @property
+    def name(self):
+        return "map_" + self.default_policy._name
+
+    @property
     def default_policy(self):
         """The default dtype policy.
 
@@ -83,6 +88,18 @@ class DTypePolicyMap(MutableMapping):
         will be `keras.config.dtype_policy()`.
         """
         return dtype_policies.get(self._default_policy)
+
+    @property
+    def is_quantized(self):
+        return self.default_policy._is_quantized
+
+    @property
+    def variable_dtype(self):
+        return self.default_policy.variable_dtype
+
+    @property
+    def compute_dtype(self):
+        return self.default_policy.compute_dtype
 
     def __getitem__(self, key):
         """Retrieves the corresponding `DTypePolicy` by the string key.

--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -1,0 +1,199 @@
+import re
+from collections.abc import MutableMapping
+
+from keras.src import dtype_policies
+from keras.src.api_export import keras_export
+
+
+@keras_export(["keras.dtype_policies.DTypePolicyMap"])
+class DTypePolicyMap(MutableMapping):
+    """A dict-like object that maps string to `DTypePolicy` instances.
+
+    `DTypePolicyMap` can be used in `get_config` in layers and subclasses to
+    support a complex configurations of dtype policies.
+
+    For example, we can modify `get_config` in `layers.MultiHeadAttention` as
+    follows to support the mixing of dtype policies, such as quantization.
+
+    ```python
+    @keras.saving.register_keras_serializable("MyPackage")
+    class MyMultiHeadAttention(keras.layers.MultiHeadAttention):
+        def get_config(self):
+            config = super().get_config()
+            dtype_policy_map = dtype_policies.DTypePolicyMap()
+            for layer in self._flatten_layers():
+                if layer.dtype_policy.is_quantized:
+                    dtype_policy_map[layer.name] = layer.dtype_policy
+            if len(dtype_policy_map) > 0:
+                config.update({"dtype": dtype_policy_map})
+            return config
+    ```
+
+    Internally, `DTypePolicyMap` uses a string as key and a `DTypePolicy`
+    as value. There is a behavior difference between a normal Python dict and
+    this class. The string key will be treated as a regex when retrieving the
+    value. See the docstring of `get` for more details.
+
+    See below for a usage example. You can define the naming schema
+    of the `DTypePolicy`, and then retrieve the corresponding `DTypePolicy`
+    instance.
+
+    In the normal case, the key to query is usually the `layer.name`, which
+    is the `name` of the layer.
+
+    ```python
+    dtype_policy_map = DTypePolicyMap()
+    dtype_policy_map["layer/dense_0"] = FloatDTypePolicy("bfloat16")
+    dtype_policy_map["layer/dense_1"] = QuantizedDTypePolicy("int8", "bfloat16")
+
+    policy_0 = dtype_policy_map["layer/dense_0"]
+    policy_1 = dtype_policy_map["layer/dense_1"]
+    policy_2 = dtype_policy_map["layer/dense_2"]  # No hit
+    assert policy_0 == FloatDTypePolicy("bfloat16")
+    assert policy_1 == QuantizedDTypePolicy("int8", "bfloat16")
+    assert policy_2 == keras.config.dtype_policy()
+    ```
+
+    Args:
+        default_policy: An optional `DTypePolicy` instance specifying the
+            default dtype policy. If not specified, the value will default to
+            `keras.config.dtype_policy()`.
+        policy_map: An optional dict that maps string to `DTypePolicy`
+            instances. Defaults to `None`
+    """
+
+    def __init__(self, default_policy=None, policy_map=None):
+        if policy_map is not None and not isinstance(policy_map, dict):
+            raise TypeError(
+                "If specified, `policy_map` must be a dict. "
+                f"Received: policy_map={policy_map} of type {type(policy_map)}"
+            )
+        # `default_policy=None` enables us to defer to
+        # `keras.config.dtype_policy()` during loading.
+        if default_policy is not None:
+            default_policy = dtype_policies.get(default_policy)
+        self._default_policy = default_policy
+        self._policy_map = policy_map or dict()
+
+    @property
+    def default_policy(self):
+        """The default dtype policy.
+
+        If `default_policy` is not specified in the constructor, this property
+        will be `keras.config.dtype_policy()`.
+        """
+        return dtype_policies.get(self._default_policy)
+
+    def __getitem__(self, key):
+        """Retrieves the corresponding `DTypePolicy` by the string key.
+
+        When there isn't an exact match, all the existing keys in the map
+        will be treated as a regex and map against the input key again. When
+        there are multiple matches for the regex, an `ValueError` will be
+        raised. Returns `self.default_policy` if there isn't any match found.
+
+        Args:
+            key: String key to query a `DTypePolicy`.
+
+        Returns:
+            Corresponding `DTypePolicy` based on the query.
+        """
+        if key in self._policy_map:
+            return self._policy_map[key]
+
+        matching_keys = []
+        for k in self._policy_map:
+            if re.search(k, key):
+                matching_keys.append(k)
+        if len(matching_keys) > 1:
+            raise ValueError(
+                f"Path '{key}' matches multiple dtype policy "
+                f"specification keys: {matching_keys}. Please make "
+                "sure each path only matches at most "
+                "one dtype policy specification key in the DTypePolicyMap."
+            )
+        elif len(matching_keys) == 1:
+            return self._policy_map[matching_keys[0]]
+        return self.default_policy
+
+    def __setitem__(self, key, policy):
+        """Insert `DTypePolicy` to the `DTypePolicyMap`.
+
+        Args:
+            key: String key for the `DTypePolicy`.
+            policy: The `DTypePolicy`.
+        """
+        if key in self._policy_map:
+            raise ValueError(
+                f"{key} already exist in the DTypePolicyMap with "
+                f"value {self._policy_map[key]}. Please make sure to "
+                "not use duplicated keys."
+            )
+        try:
+            policy = dtype_policies.get(policy)
+        except Exception:
+            raise ValueError(
+                "Cannot interpret the assigned value by "
+                "`keras.dtype_policies.get`. "
+                f"Received: {policy} of type {type(policy)}"
+            )
+        self._policy_map[key] = policy
+
+    def __delitem__(self, key):
+        # Let the dict to handle the key missing error
+        return self._policy_map.pop(key)
+
+    def __contains__(self, key):
+        return key in self._policy_map
+
+    def get_config(self):
+        from keras.src.saving import serialization_lib
+
+        policy_map = self._policy_map
+        if self._default_policy is None:
+            # `self._default_policy=None` enables us to defer to
+            # `keras.config.dtype_policy()` during loading.
+            # To support this feature, we can set `_name` and `_source_name` to
+            # `None` in `FloatDTypePolicy` and `QuantizedDTypePolicy`,
+            # respectively.
+            for policy in policy_map.values():
+                if isinstance(policy, dtype_policies.QuantizedDTypePolicy):
+                    policy._name = None
+                    policy._source_name = None
+                elif isinstance(policy, dtype_policies.DTypePolicy):
+                    policy._name = None
+        return {
+            "default_policy": self._default_policy,
+            "policy_map": serialization_lib.serialize_keras_object(policy_map),
+        }
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        from keras.src.saving import serialization_lib
+
+        config = config.copy()
+        config["policy_map"] = serialization_lib.deserialize_keras_object(
+            config["policy_map"], custom_objects=custom_objects
+        )
+        return cls(**config)
+
+    def __len__(self):
+        return len(self._policy_map)
+
+    def __iter__(self):
+        return iter(self._policy_map)
+
+    def __repr__(self):
+        default_policy = (
+            self._default_policy.name
+            if self._default_policy is not None
+            else None
+        )
+        mapping = []
+        for k, v in self._policy_map.items():
+            mapping.append((k, v.name))
+        return (
+            f"<DTypePolicyMap at {hex(id(self))} "
+            f"default_policy={default_policy}, "
+            f"mapping={mapping}>"
+        )

--- a/keras/src/dtype_policies/dtype_policy_map_test.py
+++ b/keras/src/dtype_policies/dtype_policy_map_test.py
@@ -45,8 +45,8 @@ class DTypePolicyMapTest(testing.TestCase):
                 config = super().get_config()
                 dtype_policy_map = DTypePolicyMap()
                 for layer in self._flatten_layers():
-                    if layer.dtype_policy.is_quantized:
-                        dtype_policy_map[layer.name] = layer.dtype_policy
+                    if layer.quantization_mode is not None:
+                        dtype_policy_map[layer.path] = layer.dtype_policy
                 if len(dtype_policy_map) > 0:
                     config.update({"dtype": dtype_policy_map})
                 return config

--- a/keras/src/dtype_policies/dtype_policy_map_test.py
+++ b/keras/src/dtype_policies/dtype_policy_map_test.py
@@ -328,7 +328,7 @@ class DTypePolicyMapTest(testing.TestCase):
         )
         repr_str = repr(dtype_policy_map)
         self.assertTrue("DTypePolicyMap" in repr_str)
-        self.assertTrue("default_policy=None" in repr_str)
+        self.assertTrue("default_policy" in repr_str)
         self.assertTrue(
             "mapping=[('layer/dense_0', 'mixed_bfloat16')]" in repr_str
         )

--- a/keras/src/dtype_policies/dtype_policy_map_test.py
+++ b/keras/src/dtype_policies/dtype_policy_map_test.py
@@ -1,0 +1,347 @@
+import numpy as np
+import pytest
+
+from keras.src import dtype_policies
+from keras.src import layers
+from keras.src import models
+from keras.src import saving
+from keras.src import testing
+from keras.src.dtype_policies.dtype_policy import dtype_policy
+from keras.src.dtype_policies.dtype_policy import set_dtype_policy
+from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
+
+
+class DTypePolicyMapTest(testing.TestCase):
+    def setUp(self):
+        super().setUp()
+        self._global_dtype_policy = dtype_policy()
+
+    def tearDown(self):
+        super().tearDown()
+        set_dtype_policy(self._global_dtype_policy)
+
+    @pytest.mark.requires_trainable_backend
+    def test_basic_usage(self):
+        # Create a subclass that might contain mixing dtype policies for
+        # sublayers.
+        # It is important to ensure that `dtype` is passed to sublayers and
+        # that each sublayer has a unique `name`.
+        @saving.register_keras_serializable()
+        class Subclass(layers.Layer):
+            def __init__(self, dtype=None, name="subclass", **kwargs):
+                super().__init__(dtype=dtype, name=name, **kwargs)
+                self.dense = layers.Dense(8, dtype=dtype, name=f"{name}_dense")
+                self.bn = layers.BatchNormalization(
+                    dtype=dtype, name=f"{name}_bn"
+                )
+                self.relu = layers.ReLU(dtype=dtype, name=f"{name}_relu")
+
+            def call(self, inputs, training=None):
+                return self.relu(self.bn(self.dense(inputs), training=training))
+
+            def get_config(self):
+                # Typically, we only need to record the quantized policy for
+                # `DTypePolicyMap`
+                config = super().get_config()
+                dtype_policy_map = DTypePolicyMap()
+                for layer in self._flatten_layers():
+                    if layer.dtype_policy.is_quantized:
+                        dtype_policy_map[layer.name] = layer.dtype_policy
+                if len(dtype_policy_map) > 0:
+                    config.update({"dtype": dtype_policy_map})
+                return config
+
+        # Instantiate the model
+        inputs = layers.Input([4])
+        outputs = Subclass()(inputs)
+        model = models.Model(inputs, outputs)
+
+        # Quantize the model to make mixing of dtype policies in sublayers
+        model.quantize("int8")
+        for layer in model._flatten_layers():
+            if isinstance(layer, layers.Dense):
+                self.assertEqual(
+                    layer.dtype_policy,
+                    dtype_policies.QuantizedDTypePolicy("int8"),
+                )
+            elif isinstance(layer, layers.BatchNormalization):
+                self.assertEqual(
+                    layer.dtype_policy, dtype_policies.FloatDTypePolicy()
+                )
+            elif isinstance(layer, layers.ReLU):
+                self.assertEqual(
+                    layer.dtype_policy, dtype_policies.FloatDTypePolicy()
+                )
+
+        # Verify the output after saving and loading
+        x = np.random.uniform(size=[16, 4])
+        temp_dir = self.get_temp_dir()
+        y = model(x, training=False)
+        model.save(f"{temp_dir}/model.keras")
+        reloaded_model = saving.load_model(f"{temp_dir}/model.keras")
+        reloaded_y = reloaded_model(x, training=False)
+        self.assertAllClose(y, reloaded_y)
+
+    def test_add(self):
+        dtype_policy_map = DTypePolicyMap()
+        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+            "bfloat16"
+        )
+        dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
+            "int8", "mixed_bfloat16"
+        )
+        dtype_policy_map["layer/dense_2"] = (
+            dtype_policies.QuantizedFloat8DTypePolicy("float8", "mixed_float16")
+        )
+
+        self.assertLen(dtype_policy_map, 3)
+
+        policy = dtype_policy_map["layer/dense_0"]
+        self.assertIsInstance(policy, dtype_policies.FloatDTypePolicy)
+        self.assertEqual(policy.name, "bfloat16")
+
+        policy = dtype_policy_map["layer/dense_1"]
+        self.assertIsInstance(policy, dtype_policies.QuantizedDTypePolicy)
+        self.assertEqual(policy._source_name, "mixed_bfloat16")
+        self.assertEqual(policy.quantization_mode, "int8")
+
+        policy = dtype_policy_map["layer/dense_2"]
+        self.assertIsInstance(policy, dtype_policies.QuantizedFloat8DTypePolicy)
+        self.assertEqual(policy._source_name, "mixed_float16")
+        self.assertEqual(policy.quantization_mode, "float8")
+
+        with self.assertRaisesRegex(
+            ValueError, "layer/dense_0 already exist in the DTypePolicyMap"
+        ):
+            dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+                "float32"
+            )
+
+        with self.assertRaisesRegex(
+            ValueError, "Cannot interpret the assigned value."
+        ):
+            dtype_policy_map["layer/dense_3"] = 123
+
+    def test_get(self):
+        dtype_policy_map = DTypePolicyMap()
+        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+            "bfloat16"
+        )
+        dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
+            "int8", "mixed_bfloat16"
+        )
+        dtype_policy_map["layer/dense_2"] = (
+            dtype_policies.QuantizedFloat8DTypePolicy("float8", "mixed_float16")
+        )
+
+        self.assertEqual(
+            dtype_policy_map["layer/dense_0"],
+            dtype_policies.FloatDTypePolicy("bfloat16"),
+        )
+        self.assertEqual(
+            dtype_policy_map["layer/dense_1"],
+            dtype_policies.QuantizedDTypePolicy("int8", "mixed_bfloat16"),
+        )
+        self.assertEqual(
+            dtype_policy_map["layer/dense_2"],
+            dtype_policies.QuantizedFloat8DTypePolicy(
+                "float8", "mixed_float16"
+            ),
+        )
+
+        self.assertNotEqual(
+            dtype_policy_map["layer/dense_2"],
+            dtype_policies.QuantizedFloat8DTypePolicy("float8", "bfloat16"),
+        )
+
+        # No hit
+        self.assertEqual(
+            dtype_policy_map["layer/batch_normalization"],
+            dtype_policy_map.default_policy,
+        )
+
+        # It will cause a ValueError in the case of one-to-many.
+        dtype_policy_map["dense"] = dtype_policies.FloatDTypePolicy("float32")
+        dtype_policy_map["dense_1"] = dtype_policies.FloatDTypePolicy("float32")
+        with self.assertRaisesRegex(
+            ValueError, "Path 'dense_10' matches multiple dtype policy"
+        ):
+            dtype_policy_map["dense_10"]
+
+    def test_delete(self):
+        dtype_policy_map = DTypePolicyMap()
+        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+            "bfloat16"
+        )
+        dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
+            "int8", "mixed_bfloat16"
+        )
+
+        self.assertEqual(
+            dtype_policy_map.pop("layer/dense_0"),
+            dtype_policies.FloatDTypePolicy("bfloat16"),
+        )
+        with self.assertRaises(KeyError):
+            dtype_policy_map.pop("layer/dense_0")
+
+        # Test `del`, causing no hit
+        del dtype_policy_map["layer/dense_1"]
+        self.assertEqual(
+            dtype_policy_map["layer/dense_1"], dtype_policy_map.default_policy
+        )
+
+        self.assertLen(dtype_policy_map, 0)
+
+    def test_len(self):
+        dtype_policy_map = DTypePolicyMap()
+        self.assertLen(dtype_policy_map, 0)
+
+        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+            "bfloat16"
+        )
+        dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
+            "int8", "mixed_bfloat16"
+        )
+        self.assertLen(dtype_policy_map, 2)
+
+    def test_iter(self):
+        dtype_policy_map = DTypePolicyMap()
+        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+            "bfloat16"
+        )
+        dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
+            "int8", "mixed_bfloat16"
+        )
+
+        self.assertEqual(
+            list(dtype_policy_map.keys()), ["layer/dense_0", "layer/dense_1"]
+        )
+
+        keys = []
+        values = []
+        for k, v in dtype_policy_map.items():
+            keys.append(k)
+            values.append(v)
+        self.assertEqual(keys, ["layer/dense_0", "layer/dense_1"])
+        self.assertEqual(
+            values,
+            [
+                dtype_policies.FloatDTypePolicy("bfloat16"),
+                dtype_policies.QuantizedDTypePolicy("int8", "mixed_bfloat16"),
+            ],
+        )
+
+    def test_in(self):
+        dtype_policy_map = DTypePolicyMap()
+        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+            "bfloat16"
+        )
+        dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
+            "int8", "mixed_bfloat16"
+        )
+
+        self.assertTrue("layer/dense_0" in dtype_policy_map)
+        self.assertTrue("layer/dense_1" in dtype_policy_map)
+        self.assertFalse("layer/dense_2" in dtype_policy_map)
+
+    def test_default_policy(self):
+        # Test default_policy is set to `"float32"`
+        dtype_policy_map = DTypePolicyMap(default_policy="mixed_bfloat16")
+        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+            "mixed_bfloat16"
+        )
+        dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
+            "int8", "mixed_bfloat16"
+        )
+        config = dtype_policy_map.get_config()
+        dtype_policy_map = DTypePolicyMap.from_config(config)
+        self.assertEqual(
+            dtype_policy_map["layer/dense_0"],
+            dtype_policies.FloatDTypePolicy("mixed_bfloat16"),
+        )
+        self.assertEqual(
+            dtype_policy_map["layer/dense_1"],
+            dtype_policies.QuantizedDTypePolicy("int8", "mixed_bfloat16"),
+        )
+        # No hit, defers to `dtype_policy_map.default_policy`
+        self.assertEqual(
+            dtype_policy_map["layer/dense_2"], dtype_policy_map.default_policy
+        )
+
+        # Test that default_policy defers to `keras.config.dtype_policy()`
+        # during loading
+        set_dtype_policy("bfloat16")
+        dtype_policy_map = DTypePolicyMap()
+        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+            "mixed_bfloat16"
+        )
+        dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
+            "int8", "mixed_bfloat16"
+        )
+        config = dtype_policy_map.get_config()
+        dtype_policy_map = DTypePolicyMap.from_config(config)
+        self.assertEqual(
+            dtype_policy_map["layer/dense_0"],
+            dtype_policies.FloatDTypePolicy("bfloat16"),
+        )
+        self.assertEqual(
+            dtype_policy_map["layer/dense_1"],
+            dtype_policies.QuantizedDTypePolicy("int8", "bfloat16"),
+        )
+        # No hit, defers to `dtype_policy_map.default_policy` which is
+        # `keras.config.dtype_policy()`
+        self.assertEqual(
+            dtype_policy_map["layer/dense_2"], dtype_policy_map.default_policy
+        )
+        self.assertEqual(
+            dtype_policy_map["layer/dense_2"], dtype_policies.get("bfloat16")
+        )
+
+    def test_serialization(self):
+        dtype_policy_map = DTypePolicyMap(default_policy="mixed_bfloat16")
+        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+            "mixed_bfloat16"
+        )
+        dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
+            "int8", "mixed_bfloat16"
+        )
+
+        config = dtype_policies.serialize(dtype_policy_map)
+        reloaded_dtype_policy_map = dtype_policies.deserialize(config)
+        self.assertEqual(
+            dtype_policy_map.default_policy,
+            reloaded_dtype_policy_map.default_policy,
+        )
+        for k, v in dtype_policy_map.items():
+            self.assertEqual(reloaded_dtype_policy_map[k], v)
+
+        # Test that config remains intact during deserialization
+        config = dtype_policy_map.get_config()
+        original_config = config.copy()
+        DTypePolicyMap.from_config(config)
+        self.assertDictEqual(config, original_config)
+
+    def test_repr(self):
+        dtype_policy_map = DTypePolicyMap()
+        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+            "mixed_bfloat16"
+        )
+        repr_str = repr(dtype_policy_map)
+        self.assertTrue("DTypePolicyMap" in repr_str)
+        self.assertTrue("default_policy=None" in repr_str)
+        self.assertTrue(
+            "mapping=[('layer/dense_0', 'mixed_bfloat16')]" in repr_str
+        )
+
+    def test_invalid_policy_map(self):
+        with self.assertRaisesRegex(
+            TypeError, "If specified, `policy_map` must be a dict."
+        ):
+            DTypePolicyMap(policy_map=123)
+
+        with self.assertRaisesRegex(
+            TypeError, "If specified, `policy_map` must be a dict."
+        ):
+            DTypePolicyMap(
+                policy_map=dtype_policies.FloatDTypePolicy("mixed_bfloat16")
+            )

--- a/keras/src/dtype_policies/dtype_policy_test.py
+++ b/keras/src/dtype_policies/dtype_policy_test.py
@@ -225,6 +225,19 @@ class FloatDTypePolicyTest(test_case.TestCase, parameterized.TestCase):
             repr(copied_policy), '<FloatDTypePolicy "mixed_float16">'
         )
 
+    def test_eq(self):
+        policy = DTypePolicy("mixed_bfloat16")
+
+        # Test True
+        self.assertEqual(policy, DTypePolicy("mixed_bfloat16"))
+        self.assertEqual(policy, FloatDTypePolicy("mixed_bfloat16"))
+
+        # Test False
+        self.assertNotEqual(policy, "mixed_float16")
+        self.assertNotEqual(
+            policy, QuantizedDTypePolicy("int8", "mixed_bfloat16")
+        )
+
 
 class QuantizedDTypePolicyTest(test_case.TestCase, parameterized.TestCase):
     def setUp(self):
@@ -492,6 +505,19 @@ class QuantizedDTypePolicyTest(test_case.TestCase, parameterized.TestCase):
         self.assertEqual(policy.name, reloaded_policy.name)
         self.assertEqual(
             policy.amax_history_length, reloaded_policy.amax_history_length
+        )
+
+    def test_eq(self):
+        policy = QuantizedDTypePolicy("int8", "mixed_bfloat16")
+
+        # Test True
+        self.assertEqual(policy, QuantizedDTypePolicy("int8", "mixed_bfloat16"))
+
+        # Test False
+        self.assertNotEqual(policy, "mixed_bfloat16")
+        self.assertNotEqual(policy, DTypePolicy("mixed_bfloat16"))
+        self.assertNotEqual(
+            policy, QuantizedFloat8DTypePolicy("float8", "mixed_bfloat16")
         )
 
     @parameterized.named_parameters(

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -216,9 +216,6 @@ class MultiHeadAttention(Layer):
         einsum_equation, bias_axes, output_rank = _build_proj_equation(
             query_rank - 1, bound_dims=1, output_dims=2
         )
-        print("dtype_policy", self.dtype_policy)
-        print("path", self.path)
-        print(self._get_common_kwargs_for_sublayer()["dtype"])
         self._query_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -292,7 +292,7 @@ class MultiHeadAttention(Layer):
             activity_regularizer=self._activity_regularizer,
             kernel_constraint=self._kernel_constraint,
             bias_constraint=self._bias_constraint,
-            dtype=self.dtype_argument,
+            dtype=self.dtype_policy,
         )
         # Create new clone of kernel/bias initializer, so that we don't reuse
         # the initializer instance, which could lead to same init value since

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -292,7 +292,7 @@ class MultiHeadAttention(Layer):
             activity_regularizer=self._activity_regularizer,
             kernel_constraint=self._kernel_constraint,
             bias_constraint=self._bias_constraint,
-            dtype=self.dtype_policy,
+            dtype=self.dtype_argument,
         )
         # Create new clone of kernel/bias initializer, so that we don't reuse
         # the initializer instance, which could lead to same init value since

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -216,6 +216,9 @@ class MultiHeadAttention(Layer):
         einsum_equation, bias_axes, output_rank = _build_proj_equation(
             query_rank - 1, bound_dims=1, output_dims=2
         )
+        print("dtype_policy", self.dtype_policy)
+        print("path", self.path)
+        print(self._get_common_kwargs_for_sublayer()["dtype"])
         self._query_dense = EinsumDense(
             einsum_equation,
             output_shape=_get_output_shape(

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -560,10 +560,8 @@ class Dense(Layer):
 
         # Set new dtype policy
         if not self.dtype_policy.is_quantized:
-            quantized_dtype = f"{mode}_from_{self.dtype_policy.name}"
-            # We set the internal `self._dtype_policy` instead of using the
-            # setter to avoid double `quantize` call
-            self._dtype_policy = dtype_policies.get(quantized_dtype)
+            policy = dtype_policies.get(f"{mode}_from_{self.dtype_policy.name}")
+            self.dtype_policy = policy
 
         # Release memory manually because sometimes the backend doesn't
         gc.collect()

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -101,13 +101,9 @@ class Dense(Layer):
 
     def build(self, input_shape):
         input_dim = input_shape[-1]
-        # We use `self._dtype_policy` to check to avoid issues in torch dynamo
-        is_quantized = self._dtype_policy.is_quantized
-        if is_quantized:
-            self.quantized_build(
-                input_shape, mode=self.dtype_policy.quantization_mode
-            )
-        if not is_quantized or self.dtype_policy.quantization_mode != "int8":
+        if self.quantization_mode:
+            self.quantized_build(input_shape, mode=self.quantization_mode)
+        if self.quantization_mode != "int8":
             # If the layer is quantized to int8, `self._kernel` will be added
             # in `self._int8_build`. Therefore, we skip it here.
             self._kernel = self.add_weight(
@@ -203,11 +199,10 @@ class Dense(Layer):
         target_variables = [kernel_value]
         if self.use_bias:
             target_variables.append(self.bias)
-        if self.dtype_policy.is_quantized:
-            mode = self.dtype_policy.quantization_mode
-            if mode == "int8":
+        if self.quantization_mode is not None:
+            if self.quantization_mode == "int8":
                 target_variables.append(kernel_scale)
-            elif mode == "float8":
+            elif self.quantization_mode == "float8":
                 target_variables.append(self.inputs_scale)
                 target_variables.append(self.inputs_amax_history)
                 target_variables.append(self.kernel_scale)
@@ -215,9 +210,7 @@ class Dense(Layer):
                 target_variables.append(self.outputs_grad_scale)
                 target_variables.append(self.outputs_grad_amax_history)
             else:
-                raise NotImplementedError(
-                    self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-                )
+                raise self._quantization_mode_error(self.quantization_mode)
         for i, variable in enumerate(target_variables):
             store[str(i)] = variable
 
@@ -232,11 +225,10 @@ class Dense(Layer):
         target_variables = [self._kernel]
         if self.use_bias:
             target_variables.append(self.bias)
-        if self.dtype_policy.is_quantized:
-            mode = self.dtype_policy.quantization_mode
-            if mode == "int8":
+        if self.quantization_mode is not None:
+            if self.quantization_mode == "int8":
                 target_variables.append(self.kernel_scale)
-            elif mode == "float8":
+            elif self.quantization_mode == "float8":
                 target_variables.append(self.inputs_scale)
                 target_variables.append(self.inputs_amax_history)
                 target_variables.append(self.kernel_scale)
@@ -244,9 +236,7 @@ class Dense(Layer):
                 target_variables.append(self.outputs_grad_scale)
                 target_variables.append(self.outputs_grad_amax_history)
             else:
-                raise NotImplementedError(
-                    self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-                )
+                raise self._quantization_mode_error(self.quantization_mode)
         for i, variable in enumerate(target_variables):
             variable.assign(store[str(i)])
         if self.lora_enabled:
@@ -310,11 +300,12 @@ class Dense(Layer):
 
     # Quantization-related (int8 and float8) methods
 
-    QUANTIZATION_MODE_ERROR_TEMPLATE = (
-        f"Invalid quantization mode. Expected one of "
-        f"{dtype_policies.QUANTIZATION_MODES}. "
-        "Received: quantization_mode={mode}"
-    )
+    def _quantization_mode_error(self, mode):
+        return NotImplementedError(
+            "Invalid quantization mode. Expected one of "
+            f"{dtype_policies.QUANTIZATION_MODES}. "
+            f"Received: quantization_mode={mode}"
+        )
 
     def quantized_build(self, input_shape, mode):
         if mode == "int8":
@@ -324,9 +315,7 @@ class Dense(Layer):
         elif mode == "float8":
             self._float8_build()
         else:
-            raise NotImplementedError(
-                self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-            )
+            raise self._quantization_mode_error(mode)
 
     def _int8_build(
         self,
@@ -402,15 +391,12 @@ class Dense(Layer):
         self._is_quantized = True
 
     def quantized_call(self, inputs, training=None):
-        if self.dtype_policy.quantization_mode == "int8":
+        if self.quantization_mode == "int8":
             return self._int8_call(inputs)
-        elif self.dtype_policy.quantization_mode == "float8":
+        elif self.quantization_mode == "float8":
             return self._float8_call(inputs, training=training)
         else:
-            mode = self.dtype_policy.quantization_mode
-            raise NotImplementedError(
-                self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-            )
+            raise self._quantization_mode_error(self.quantization_mode)
 
     def _int8_call(self, inputs):
         @ops.custom_gradient
@@ -569,9 +555,7 @@ class Dense(Layer):
         elif mode == "float8":
             self._float8_build()
         else:
-            raise NotImplementedError(
-                self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-            )
+            raise self._quantization_mode_error(mode)
         self._tracker.lock()
 
         # Set new dtype policy

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -156,12 +156,9 @@ class EinsumDense(Layer):
         # `self._int8_build` needs `self.input_spec`
         self.input_spec = InputSpec(ndim=len(input_shape))
         # We use `self._dtype_policy` to check to avoid issues in torch dynamo
-        is_quantized = self._dtype_policy.is_quantized
-        if is_quantized:
-            self.quantized_build(
-                input_shape, mode=self.dtype_policy.quantization_mode
-            )
-        if not is_quantized or self.dtype_policy.quantization_mode != "int8":
+        if self.quantization_mode is not None:
+            self.quantized_build(input_shape, mode=self.quantization_mode)
+        if self.quantization_mode != "int8":
             # If the layer is quantized to int8, `self._kernel` will be added
             # in `self._int8_build`. Therefore, we skip it here.
             self._kernel = self.add_weight(
@@ -258,11 +255,10 @@ class EinsumDense(Layer):
         target_variables = [kernel_value]
         if self.bias is not None:
             target_variables.append(self.bias)
-        if self.dtype_policy.is_quantized:
-            mode = self.dtype_policy.quantization_mode
-            if mode == "int8":
+        if self.quantization_mode is not None:
+            if self.quantization_mode == "int8":
                 target_variables.append(kernel_scale)
-            elif mode == "float8":
+            elif self.quantization_mode == "float8":
                 target_variables.append(self.inputs_scale)
                 target_variables.append(self.inputs_amax_history)
                 target_variables.append(self.kernel_scale)
@@ -270,9 +266,7 @@ class EinsumDense(Layer):
                 target_variables.append(self.outputs_grad_scale)
                 target_variables.append(self.outputs_grad_amax_history)
             else:
-                raise NotImplementedError(
-                    self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-                )
+                raise self._quantization_mode_error(self.quantization_mode)
         for i, variable in enumerate(target_variables):
             store[str(i)] = variable
 
@@ -287,11 +281,10 @@ class EinsumDense(Layer):
         target_variables = [self._kernel]
         if self.bias is not None:
             target_variables.append(self.bias)
-        if self.dtype_policy.is_quantized:
-            mode = self.dtype_policy.quantization_mode
-            if mode == "int8":
+        if self.quantization_mode is not None:
+            if self.quantization_mode == "int8":
                 target_variables.append(self.kernel_scale)
-            elif mode == "float8":
+            elif self.quantization_mode == "float8":
                 target_variables.append(self.inputs_scale)
                 target_variables.append(self.inputs_amax_history)
                 target_variables.append(self.kernel_scale)
@@ -299,9 +292,7 @@ class EinsumDense(Layer):
                 target_variables.append(self.outputs_grad_scale)
                 target_variables.append(self.outputs_grad_amax_history)
             else:
-                raise NotImplementedError(
-                    self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-                )
+                raise self._quantization_mode_error(self.quantization_mode)
         for i, variable in enumerate(target_variables):
             variable.assign(store[str(i)])
         if self.lora_enabled:
@@ -369,11 +360,12 @@ class EinsumDense(Layer):
 
     # Quantization-related (int8 and float8) methods
 
-    QUANTIZATION_MODE_ERROR_TEMPLATE = (
-        f"Invalid quantization mode. Expected one of "
-        f"{dtype_policies.QUANTIZATION_MODES}. "
-        "Received: quantization_mode={mode}"
-    )
+    def _quantization_mode_error(self, mode):
+        return NotImplementedError(
+            "Invalid quantization mode. Expected one of "
+            f"{dtype_policies.QUANTIZATION_MODES}. "
+            f"Received: quantization_mode={mode}"
+        )
 
     def quantized_build(self, input_shape, mode):
         if mode == "int8":
@@ -388,9 +380,7 @@ class EinsumDense(Layer):
         elif mode == "float8":
             self._float8_build()
         else:
-            raise NotImplementedError(
-                self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-            )
+            raise self._quantization_mode_error(mode)
 
     def _int8_build(
         self,
@@ -488,15 +478,12 @@ class EinsumDense(Layer):
         self._is_quantized = True
 
     def quantized_call(self, inputs, training=None):
-        if self.dtype_policy.quantization_mode == "int8":
+        if self.quantization_mode == "int8":
             return self._int8_call(inputs)
-        elif self.dtype_policy.quantization_mode == "float8":
+        elif self.quantization_mode == "float8":
             return self._float8_call(inputs, training=training)
         else:
-            mode = self.dtype_policy.quantization_mode
-            raise NotImplementedError(
-                self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-            )
+            raise self._quantization_mode_error(self.quantization_mode)
 
     def _int8_call(self, inputs):
         @ops.custom_gradient
@@ -706,9 +693,7 @@ class EinsumDense(Layer):
         elif mode == "float8":
             self._float8_build()
         else:
-            raise NotImplementedError(
-                self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-            )
+            raise self._quantization_mode_error(mode)
         self._tracker.lock()
 
         # Set new dtype policy

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -698,10 +698,8 @@ class EinsumDense(Layer):
 
         # Set new dtype policy
         if not self.dtype_policy.is_quantized:
-            quantized_dtype = f"{mode}_from_{self.dtype_policy.name}"
-            # We set the internal `self._dtype_policy` instead of using the
-            # setter to avoid double `quantize` call
-            self._dtype_policy = dtype_policies.get(quantized_dtype)
+            policy = dtype_policies.get(f"{mode}_from_{self.dtype_policy.name}")
+            self.dtype_policy = policy
 
         # Release memory manually because sometimes the backend doesn't
         gc.collect()

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -111,15 +111,9 @@ class Embedding(Layer):
     def build(self, input_shape=None):
         if self.built:
             return
-        # We use `self._dtype_policy` to check to avoid issues in torch dynamo
-        is_quantized = isinstance(
-            self._dtype_policy, dtype_policies.QuantizedDTypePolicy
-        )
-        if is_quantized:
-            self.quantized_build(
-                input_shape, mode=self.dtype_policy.quantization_mode
-            )
-        if not is_quantized or self.dtype_policy.quantization_mode != "int8":
+        if self.quantization_mode is not None:
+            self.quantized_build(input_shape, mode=self.quantization_mode)
+        if self.quantization_mode != "int8":
             self._embeddings = self.add_weight(
                 shape=(self.input_dim, self.output_dim),
                 initializer=self.embeddings_initializer,
@@ -200,14 +194,11 @@ class Embedding(Layer):
             self._get_embeddings_with_merged_lora()
         )
         target_variables = [embeddings_value]
-        if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
-            mode = self.dtype_policy.quantization_mode
-            if mode == "int8":
+        if self.quantization_mode is not None:
+            if self.quantization_mode == "int8":
                 target_variables.append(embeddings_scale)
             else:
-                raise NotImplementedError(
-                    self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-                )
+                raise self._quantization_mode_error(self.quantization_mode)
         for i, variable in enumerate(target_variables):
             store[str(i)] = variable
 
@@ -220,14 +211,11 @@ class Embedding(Layer):
         # The keys of the `store` will be saved as determined because the
         # default ordering will change after quantization
         target_variables = [self._embeddings]
-        if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
-            mode = self.dtype_policy.quantization_mode
-            if mode == "int8":
+        if self.quantization_mode is not None:
+            if self.quantization_mode == "int8":
                 target_variables.append(self.embeddings_scale)
             else:
-                raise NotImplementedError(
-                    self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-                )
+                raise self._quantization_mode_error(self.quantization_mode)
         for i, variable in enumerate(target_variables):
             variable.assign(store[str(i)])
         if self.lora_enabled:
@@ -297,18 +285,17 @@ class Embedding(Layer):
 
     """Quantization-related (int8) methods"""
 
-    QUANTIZATION_MODE_ERROR_TEMPLATE = (
-        "Invalid quantization mode. Expected 'int8'. "
-        "Received: quantization_mode={mode}"
-    )
+    def _quantization_mode_error(self, mode):
+        return NotImplementedError(
+            "Invalid quantization mode. Expected 'int8'. "
+            f"Received: quantization_mode={mode}"
+        )
 
     def quantized_build(self, input_shape, mode):
         if mode == "int8":
             self._int8_build()
         else:
-            raise NotImplementedError(
-                self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-            )
+            raise self._quantization_mode_error(mode)
 
     def _int8_build(
         self,
@@ -334,13 +321,10 @@ class Embedding(Layer):
         self._is_quantized = True
 
     def quantized_call(self, inputs):
-        if self.dtype_policy.quantization_mode == "int8":
+        if self.quantization_mode == "int8":
             return self._int8_call(inputs)
         else:
-            mode = self.dtype_policy.quantization_mode
-            raise NotImplementedError(
-                self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-            )
+            raise self._quantization_mode_error(self.quantization_mode)
 
     def _int8_call(self, inputs):
         # We cannot update quantized self._embeddings, so the custom gradient is
@@ -388,9 +372,7 @@ class Embedding(Layer):
                 lambda shape, dtype: embeddings_scale,
             )
         else:
-            raise NotImplementedError(
-                self.QUANTIZATION_MODE_ERROR_TEMPLATE.format(mode=mode)
-            )
+            raise self._quantization_mode_error(mode)
         self._tracker.lock()
 
         # Set new dtype policy

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -376,19 +376,15 @@ class Embedding(Layer):
         self._tracker.lock()
 
         # Set new dtype policy
-        if not isinstance(
-            self.dtype_policy, dtype_policies.QuantizedDTypePolicy
-        ):
-            quantized_dtype = f"{mode}_from_{self.dtype_policy.name}"
-            # We set the internal `self._dtype_policy` instead of using the
-            # setter to avoid double `quantize` call
-            self._dtype_policy = dtype_policies.get(quantized_dtype)
+        if not self.dtype_policy.is_quantized:
+            policy = dtype_policies.get(f"{mode}_from_{self.dtype_policy.name}")
+            self.dtype_policy = policy
 
         # Release memory manually because sometimes the backend doesn't
         gc.collect()
 
     def _get_embeddings_with_merged_lora(self):
-        if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
+        if self.dtype_policy.is_quantized:
             embeddings_value = self._embeddings
             embeddings_scale = self.embeddings_scale
             if self.lora_enabled:

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -507,7 +507,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
             else:
                 initializer = "zeros"
         initializer = initializers.get(initializer)
-        with self._open_name_scope():
+        with backend.name_scope(self.name, caller=self):
             variable = backend.Variable(
                 initializer=initializer,
                 shape=shape,

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -678,6 +678,16 @@ class Layer(BackendLayer, Operation, KerasSaveable):
             variable.assign(value)
 
     @property
+    def dtype_argument(self):
+        """Passed dtype argument to the constructor of the layer.
+
+        This property might be a `str` (like `"float32"`), a serialized
+        `DTypePolicy` config or a `DTypePolicyMap`. This property should only
+        be used internally.
+        """
+        return self._dtype_argument
+
+    @property
     def dtype_policy(self):
         return self._dtype_policy
 

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -975,6 +975,18 @@ class LayerTest(testing.TestCase):
         self.assertEqual(layer.dtype_policy.name, "mixed_float16")
         self.assertEqual(layer.dtype_policy.compute_dtype, "float16")
         self.assertEqual(layer.dtype_policy.variable_dtype, "float32")
+        # Set with DTypePolicyMap
+        dtype_policy_map = dtype_policies.DTypePolicyMap()
+        layer = layers.Dense(2, dtype=dtype_policy_map)
+        layer.build([None, 1])
+        layer.dtype_policy = "mixed_bfloat16"
+        self.assertIsInstance(
+            layer._dtype_policy, dtype_policies.DTypePolicyMap
+        )
+        self.assertEqual(
+            layer._dtype_policy[layer.path],
+            dtype_policies.FloatDTypePolicy("mixed_bfloat16"),
+        )
 
     def test_pickle_layer(self):
         layer = layers.Dense(2)

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -23,7 +23,11 @@ class Operation:
                 "cannot contain character `/`. "
                 f"Received: name={name} (of type {type(name)})"
             )
-        self._dtype_policy = dtype_policies.get(dtype)
+        if isinstance(dtype, dtype_policies.DTypePolicyMap):
+            self._dtype_policy = dtype_policies.get(dtype[name])
+        else:
+            self._dtype_policy = dtype_policies.get(dtype)
+        self._dtype_argument = dtype
         self.name = name
         self._inbound_nodes = []
         self._outbound_nodes = []

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -23,11 +23,7 @@ class Operation:
                 "cannot contain character `/`. "
                 f"Received: name={name} (of type {type(name)})"
             )
-        if isinstance(dtype, dtype_policies.DTypePolicyMap):
-            self._dtype_policy = dtype_policies.get(dtype[name])
-        else:
-            self._dtype_policy = dtype_policies.get(dtype)
-        self._dtype_argument = dtype
+        self._dtype_policy = dtype_policies.get(dtype)
         self.name = name
         self._inbound_nodes = []
         self._outbound_nodes = []

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -28,6 +28,14 @@ class Operation:
         self._inbound_nodes = []
         self._outbound_nodes = []
 
+    @property
+    def dtype_policy(self):
+        if isinstance(self._dtype_policy, dtype_policies.DTypePolicyMap):
+            policy = self._dtype_policy.default_policy
+        else:
+            policy = self._dtype_policy
+        return policy
+
     @traceback_utils.filter_traceback
     def __call__(self, *args, **kwargs):
         if traceback_utils.is_traceback_filtering_enabled():
@@ -36,7 +44,7 @@ class Operation:
                 call_fn = self.symbolic_call
             else:
                 if isinstance(
-                    self._dtype_policy, dtype_policies.QuantizedDTypePolicy
+                    self.dtype_policy, dtype_policies.QuantizedDTypePolicy
                 ):
                     call_fn = self.quantized_call
                 else:
@@ -50,7 +58,7 @@ class Operation:
         # Plain flow.
         if any_symbolic_tensors(args, kwargs):
             return self.symbolic_call(*args, **kwargs)
-        if isinstance(self._dtype_policy, dtype_policies.QuantizedDTypePolicy):
+        if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
             return self.quantized_call(*args, **kwargs)
         else:
             return self.call(*args, **kwargs)

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -28,14 +28,6 @@ class Operation:
         self._inbound_nodes = []
         self._outbound_nodes = []
 
-    @property
-    def dtype_policy(self):
-        if isinstance(self._dtype_policy, dtype_policies.DTypePolicyMap):
-            policy = self._dtype_policy.default_policy
-        else:
-            policy = self._dtype_policy
-        return policy
-
     @traceback_utils.filter_traceback
     def __call__(self, *args, **kwargs):
         if traceback_utils.is_traceback_filtering_enabled():
@@ -43,9 +35,7 @@ class Operation:
             if any_symbolic_tensors(args, kwargs):
                 call_fn = self.symbolic_call
             else:
-                if isinstance(
-                    self.dtype_policy, dtype_policies.QuantizedDTypePolicy
-                ):
+                if getattr(self, "quantization_mode", None) is not None:
                     call_fn = self.quantized_call
                 else:
                     call_fn = self.call
@@ -58,7 +48,7 @@ class Operation:
         # Plain flow.
         if any_symbolic_tensors(args, kwargs):
             return self.symbolic_call(*args, **kwargs)
-        if isinstance(self.dtype_policy, dtype_policies.QuantizedDTypePolicy):
+        if getattr(self, "quantization_mode", None) is not None:
             return self.quantized_call(*args, **kwargs)
         else:
             return self.call(*args, **kwargs)


### PR DESCRIPTION
ORIGINAL FROM #19783
Sorry for the inconvenience.

I have tried to implement the idea mentioned by @mattdangerw :
https://github.com/keras-team/keras-nlp/pull/1612

I think this idea is clean and only requires some small changes to support mixing dtype policies into subclasses.

In general, `DTypePolicyMap` is similar to `LayoutMap` as it contains a dict to record the (layer name, policy) pair.
The limitations / overheads of using `DTypePolicyMap`:
- Each layer must have a unique name (`auto_name` might fail)
- Some extra logic needs to be added in `get_config` for the top class (ex: `Backbone` in KerasCV and KerasNLP)

The basic usage  (adding quantization support for `MultiHeadAttention`):

<details>

```python
import keras
from keras import dtype_policies
from keras import ops
import numpy as np

@keras.saving.register_keras_serializable("MyPackage")
class MyMultiHeadAttention(keras.layers.MultiHeadAttention):
    def get_config(self):
        config = super().get_config()
        # `default_policy=None` enables us to defer to
        # `keras.config.dtype_policy` during loading.
        dtype_policy_map = dtype_policies.DTypePolicyMap(default_policy=None)
        for layer in self._flatten_layers():
            if layer.dtype_policy.is_quantized:
                dtype_policy_map[layer.name] = layer.dtype_policy
        if len(dtype_policy_map) > 0:
            config.update({"dtype": dtype_policy_map})
        return config


query = keras.Input(shape=[4, 6])
value = keras.Input(shape=[4, 6])
outputs = MyMultiHeadAttention(2, 4, name="my_mha")(query, value)
model = keras.Model([query, value], outputs)

x_query = keras.random.uniform([2, 4, 6])
x_value = keras.random.uniform([2, 4, 6])
print(f"Saving stage, global policy: {keras.config.dtype_policy()}")
model.quantize("int8")
for layer in model._flatten_layers(include_self=False, recursive=True):
    print(layer.name, layer.dtype_policy)
model.save("model.keras")
y = model([x_query, x_value])

keras.config.set_dtype_policy("mixed_bfloat16")
print(f"Loading stage, global policy: {keras.config.dtype_policy()}")
new_model = keras.models.load_model("model.keras")
for layer in new_model._flatten_layers(include_self=False, recursive=True):
    print(layer.name, layer.dtype_policy)
ref_y = new_model([x_query, x_value])

np.testing.assert_allclose(
    ops.convert_to_numpy(y),
    ops.convert_to_numpy(ops.cast(ref_y, "float32")),
    atol=1e-2,
)

```

</details>

Outputs:
```bash
Saving stage, global policy: <FloatDTypePolicy "float32">
input_layer <FloatDTypePolicy "float32">
input_layer_1 <FloatDTypePolicy "float32">
my_mha <FloatDTypePolicy "float32">
attention_output <QuantizedDTypePolicy "int8_from_float32">
dropout <FloatDTypePolicy "float32">
softmax <FloatDTypePolicy "float32">
value <QuantizedDTypePolicy "int8_from_float32">
key <QuantizedDTypePolicy "int8_from_float32">
query <QuantizedDTypePolicy "int8_from_float32">

Loading stage, global policy: <FloatDTypePolicy "bfloat16">
input_layer <FloatDTypePolicy "mixed_bfloat16">
input_layer_1 <FloatDTypePolicy "mixed_bfloat16">
my_mha <FloatDTypePolicy "mixed_bfloat16">
attention_output <QuantizedDTypePolicy "int8_from_mixed_bfloat16">
dropout_1 <FloatDTypePolicy "mixed_bfloat16">
softmax_1 <FloatDTypePolicy "mixed_bfloat16">
value <QuantizedDTypePolicy "int8_from_mixed_bfloat16">
key <QuantizedDTypePolicy "int8_from_mixed_bfloat16">
query <QuantizedDTypePolicy "int8_from_mixed_bfloat16">
```

Some updates:
- A high-level description has been added, as suggested by @mattdangerw 
- An internal property, `dtype_argument`, has been introduced to store the passed argument. `dtype_argument` can be further utilized in `build` (e.g., in `MultiHeadAttention`).
