### PR TITLE
Exclude benchmarks directory from distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,8 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development",
     ],
-    packages=find_packages(include=("keras", "keras.*",), exclude=("*_test.py", "benchmarks")),
+    packages=find_packages(
+        include=("keras", "keras.*",),
+        exclude=("*_test.py", "benchmarks"),
+    ),
 )

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,5 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development",
     ],
-    packages=find_packages(exclude=("*_test.py",)),
+    packages=find_packages(include=("keras", "keras.*",), exclude=("*_test.py", "benchmarks")),
 )

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "Topic :: Software Development",
     ],
     packages=find_packages(
-        include=("keras", "keras.*",),
+        include=("keras", "keras.*"),
         exclude=("*_test.py", "benchmarks"),
     ),
 )


### PR DESCRIPTION
Otherwise it seems like it is dragged into the distribution.

At least it does in our release process at conda-forge


xref: https://github.com/conda-forge/keras-feedstock/issues/91