### PR TITLE
Fix code formatting error in docstring

### DIFF
--- a/keras/src/layers/preprocessing/hashed_crossing.py
+++ b/keras/src/layers/preprocessing/hashed_crossing.py
@@ -14,7 +14,7 @@ class HashedCrossing(Layer):
 
     This layer performs crosses of categorical features using the "hashing
     trick". Conceptually, the transformation can be thought of as:
-    `hash(concatenate(features)) % num_bins.
+    `hash(concatenate(features)) % num_bins`.
 
     This layer currently only performs crosses of scalar inputs and batches of
     scalar inputs. Valid input shapes are `(batch_size, 1)`, `(batch_size,)` and


### PR DESCRIPTION
This pull request is a minor documentation fix, so I don't create an issue for this.

For some reason, there is an unclosed backtick the in layer.HashedClossing docstring and this breaks the code formatting of the online documentation.

Before fix:
<img width="721" alt="Screen Shot 2024-06-16 at 8 42 05 PM" src="https://github.com/keras-team/keras/assets/459169/2feb6b7d-3420-452a-a8dd-f635577cfb74">

After fix:
<img width="720" alt="Screen Shot 2024-06-16 at 8 43 10 PM" src="https://github.com/keras-team/keras/assets/459169/2855292a-2923-4dd2-92c6-cb80626d77a8">
