### PR TITLE
Improve `Model.summary`

### DIFF
--- a/keras/src/utils/summary_utils_test.py
+++ b/keras/src/utils/summary_utils_test.py
@@ -40,3 +40,37 @@ class SummaryUtilsTest(testing.TestCase, parameterized.TestCase):
                 self.assertNotIn("Optimizer params", summary_content)
         except ImportError:
             pass
+
+    def test_print_model_summary_custom_build(self):
+        class MyModel(models.Model):
+            def __init__(self):
+                super().__init__()
+                self.dense1 = layers.Dense(4, activation="relu")
+                self.dense2 = layers.Dense(2, activation="softmax")
+                self.unbuilt_dense = layers.Dense(1)
+
+            def build(self, input_shape):
+                self.dense1.build(input_shape)
+                input_shape = self.dense1.compute_output_shape(input_shape)
+                self.dense2.build(input_shape)
+
+            def call(self, inputs):
+                x = self.dense1(inputs)
+                return self.dense2(x)
+
+        model = MyModel()
+        model.build((None, 2))
+
+        summary_content = []
+
+        def print_to_variable(text, line_break=False):
+            summary_content.append(text)
+
+        summary_utils.print_summary(model, print_fn=print_to_variable)
+        summary_content = "\n".join(summary_content)
+        self.assertIn("(None, 4)", summary_content)  # dense1
+        self.assertIn("(None, 2)", summary_content)  # dense2
+        self.assertIn("?", summary_content)  # unbuilt_dense
+        self.assertIn("Total params: 22", summary_content)
+        self.assertIn("Trainable params: 22", summary_content)
+        self.assertIn("Non-trainable params: 0", summary_content)


### PR DESCRIPTION
Fix #19535 

Besides `layer._inbound_nodes`, we can also use `layer._build_shape_dict` to get the output shapes.

With this PR, we can try our best to show the output shape of the custom model subclassed from `keras.Model`

```python
import keras


class MyModel(keras.Model):
    def __init__(self):
        super().__init__()
        self.dense1 = keras.layers.Dense(4, activation="relu")
        self.dense2 = keras.layers.Dense(2, activation="softmax")
        self.unbuilt_dense = keras.layers.Dense(1)

    def build(self, input_shape):
        self.dense1.build(input_shape)
        input_shape = self.dense1.compute_output_shape(input_shape)
        self.dense2.build(input_shape)

    def call(self, inputs):
        x = self.dense1(inputs)
        return self.dense2(x)


m = MyModel()
m.build((None, 2))
m.summary()

```

```bash
Model: "my_model"
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃ Layer (type)                         ┃ Output Shape                ┃         Param # ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ dense (Dense)                        │ (None, 4)                   │              12 │
├──────────────────────────────────────┼─────────────────────────────┼─────────────────┤
│ dense_1 (Dense)                      │ (None, 2)                   │              10 │
├──────────────────────────────────────┼─────────────────────────────┼─────────────────┤
│ dense_2 (Dense)                      │ ?                           │     0 (unbuilt) │
└──────────────────────────────────────┴─────────────────────────────┴─────────────────┘
 Total params: 22 (88.00 B)
 Trainable params: 22 (88.00 B)
 Non-trainable params: 0 (0.00 B)
```

The corresponding test has been added.