### PR TITLE
Refactor `CompileLoss` to support nested `y_true` and `y_pred`

### DIFF
--- a/keras/src/losses/__init__.py
+++ b/keras/src/losses/__init__.py
@@ -2,6 +2,7 @@ import inspect
 
 from keras.src.api_export import keras_export
 from keras.src.losses.loss import Loss
+from keras.src.losses.losses import CTC
 from keras.src.losses.losses import BinaryCrossentropy
 from keras.src.losses.losses import BinaryFocalCrossentropy
 from keras.src.losses.losses import CategoricalCrossentropy
@@ -71,6 +72,8 @@ ALL_OBJECTS = {
     # Image segmentation
     Dice,
     Tversky,
+    # Sequence
+    CTC,
     # Probabilistic
     kl_divergence,
     poisson,
@@ -94,6 +97,8 @@ ALL_OBJECTS = {
     # Image segmentation
     dice,
     tversky,
+    # Sequence
+    ctc,
 }
 
 ALL_OBJECTS_DICT = {cls.__name__: cls for cls in ALL_OBJECTS}

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -11,9 +11,14 @@ from keras.src.utils.numerical_utils import normalize
 
 class LossFunctionWrapper(Loss):
     def __init__(
-        self, fn, reduction="sum_over_batch_size", name=None, **kwargs
+        self,
+        fn,
+        reduction="sum_over_batch_size",
+        name=None,
+        dtype=None,
+        **kwargs,
     ):
-        super().__init__(reduction=reduction, name=name)
+        super().__init__(reduction=reduction, name=name, dtype=dtype)
         self.fn = fn
         self._fn_kwargs = kwargs
 
@@ -22,10 +27,10 @@ class LossFunctionWrapper(Loss):
         return self.fn(y_true, y_pred, **self._fn_kwargs)
 
     def get_config(self):
-        base_config = super().get_config()
-        config = {"fn": serialization_lib.serialize_keras_object(self.fn)}
+        config = super().get_config()
+        config.update({"fn": serialization_lib.serialize_keras_object(self.fn)})
         config.update(serialization_lib.serialize_keras_object(self._fn_kwargs))
-        return {**base_config, **config}
+        return config
 
     @classmethod
     def from_config(cls, config):
@@ -52,9 +57,14 @@ class MeanSquaredError(LossFunctionWrapper):
     """
 
     def __init__(
-        self, reduction="sum_over_batch_size", name="mean_squared_error"
+        self,
+        reduction="sum_over_batch_size",
+        name="mean_squared_error",
+        dtype=None,
     ):
-        super().__init__(mean_squared_error, reduction=reduction, name=name)
+        super().__init__(
+            mean_squared_error, reduction=reduction, name=name, dtype=dtype
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -78,9 +88,14 @@ class MeanAbsoluteError(LossFunctionWrapper):
     """
 
     def __init__(
-        self, reduction="sum_over_batch_size", name="mean_absolute_error"
+        self,
+        reduction="sum_over_batch_size",
+        name="mean_absolute_error",
+        dtype=None,
     ):
-        super().__init__(mean_absolute_error, reduction=reduction, name=name)
+        super().__init__(
+            mean_absolute_error, reduction=reduction, name=name, dtype=dtype
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -107,9 +122,13 @@ class MeanAbsolutePercentageError(LossFunctionWrapper):
         self,
         reduction="sum_over_batch_size",
         name="mean_absolute_percentage_error",
+        dtype=None,
     ):
         super().__init__(
-            mean_absolute_percentage_error, reduction=reduction, name=name
+            mean_absolute_percentage_error,
+            reduction=reduction,
+            name=name,
+            dtype=dtype,
         )
 
     def get_config(self):
@@ -137,9 +156,13 @@ class MeanSquaredLogarithmicError(LossFunctionWrapper):
         self,
         reduction="sum_over_batch_size",
         name="mean_squared_logarithmic_error",
+        dtype=None,
     ):
         super().__init__(
-            mean_squared_logarithmic_error, reduction=reduction, name=name
+            mean_squared_logarithmic_error,
+            reduction=reduction,
+            name=name,
+            dtype=dtype,
         )
 
     def get_config(self):
@@ -177,9 +200,14 @@ class CosineSimilarity(LossFunctionWrapper):
         axis=-1,
         reduction="sum_over_batch_size",
         name="cosine_similarity",
+        dtype=None,
     ):
         super().__init__(
-            cosine_similarity, reduction=reduction, name=name, axis=axis
+            cosine_similarity,
+            reduction=reduction,
+            name=name,
+            dtype=dtype,
+            axis=axis,
         )
 
     def get_config(self):
@@ -217,8 +245,11 @@ class Huber(LossFunctionWrapper):
         delta=1.0,
         reduction="sum_over_batch_size",
         name="huber_loss",
+        dtype=None,
     ):
-        super().__init__(huber, name=name, reduction=reduction, delta=delta)
+        super().__init__(
+            huber, name=name, reduction=reduction, dtype=dtype, delta=delta
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -243,8 +274,10 @@ class LogCosh(LossFunctionWrapper):
         name: Optional name for the instance.
     """
 
-    def __init__(self, reduction="sum_over_batch_size", name="log_cosh"):
-        super().__init__(log_cosh, name=name, reduction=reduction)
+    def __init__(
+        self, reduction="sum_over_batch_size", name="log_cosh", dtype=None
+    ):
+        super().__init__(log_cosh, reduction=reduction, name=name, dtype=dtype)
 
     def get_config(self):
         return Loss.get_config(self)
@@ -270,8 +303,10 @@ class Hinge(LossFunctionWrapper):
         name: Optional name for the loss instance.
     """
 
-    def __init__(self, reduction="sum_over_batch_size", name="hinge"):
-        super().__init__(hinge, reduction=reduction, name=name)
+    def __init__(
+        self, reduction="sum_over_batch_size", name="hinge", dtype=None
+    ):
+        super().__init__(hinge, reduction=reduction, name=name, dtype=dtype)
 
     def get_config(self):
         return Loss.get_config(self)
@@ -297,8 +332,12 @@ class SquaredHinge(LossFunctionWrapper):
         name: Optional name for the loss instance.
     """
 
-    def __init__(self, reduction="sum_over_batch_size", name="squared_hinge"):
-        super().__init__(squared_hinge, reduction=reduction, name=name)
+    def __init__(
+        self, reduction="sum_over_batch_size", name="squared_hinge", dtype=None
+    ):
+        super().__init__(
+            squared_hinge, reduction=reduction, name=name, dtype=dtype
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -324,9 +363,14 @@ class CategoricalHinge(LossFunctionWrapper):
     """
 
     def __init__(
-        self, reduction="sum_over_batch_size", name="categorical_hinge"
+        self,
+        reduction="sum_over_batch_size",
+        name="categorical_hinge",
+        dtype=None,
     ):
-        super().__init__(categorical_hinge, reduction=reduction, name=name)
+        super().__init__(
+            categorical_hinge, reduction=reduction, name=name, dtype=dtype
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -353,8 +397,12 @@ class KLDivergence(LossFunctionWrapper):
         name: Optional name for the loss instance.
     """
 
-    def __init__(self, reduction="sum_over_batch_size", name="kl_divergence"):
-        super().__init__(kl_divergence, reduction=reduction, name=name)
+    def __init__(
+        self, reduction="sum_over_batch_size", name="kl_divergence", dtype=None
+    ):
+        super().__init__(
+            kl_divergence, reduction=reduction, name=name, dtype=dtype
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -377,8 +425,10 @@ class Poisson(LossFunctionWrapper):
         name: Optional name for the loss instance.
     """
 
-    def __init__(self, reduction="sum_over_batch_size", name="poisson"):
-        super().__init__(poisson, reduction=reduction, name=name)
+    def __init__(
+        self, reduction="sum_over_batch_size", name="poisson", dtype=None
+    ):
+        super().__init__(poisson, reduction=reduction, name=name, dtype=dtype)
 
     def get_config(self):
         return Loss.get_config(self)
@@ -473,11 +523,13 @@ class BinaryCrossentropy(LossFunctionWrapper):
         axis=-1,
         reduction="sum_over_batch_size",
         name="binary_crossentropy",
+        dtype=None,
     ):
         super().__init__(
             binary_crossentropy,
-            name=name,
             reduction=reduction,
+            name=name,
+            dtype=dtype,
             from_logits=from_logits,
             label_smoothing=label_smoothing,
             axis=axis,
@@ -638,14 +690,16 @@ class BinaryFocalCrossentropy(LossFunctionWrapper):
         axis=-1,
         reduction="sum_over_batch_size",
         name="binary_focal_crossentropy",
+        dtype=None,
     ):
         super().__init__(
             binary_focal_crossentropy,
+            reduction=reduction,
+            name=name,
+            dtype=dtype,
             apply_class_balancing=apply_class_balancing,
             alpha=alpha,
             gamma=gamma,
-            name=name,
-            reduction=reduction,
             from_logits=from_logits,
             label_smoothing=label_smoothing,
             axis=axis,
@@ -737,11 +791,13 @@ class CategoricalCrossentropy(LossFunctionWrapper):
         axis=-1,
         reduction="sum_over_batch_size",
         name="categorical_crossentropy",
+        dtype=None,
     ):
         super().__init__(
             categorical_crossentropy,
-            name=name,
             reduction=reduction,
+            name=name,
+            dtype=dtype,
             from_logits=from_logits,
             label_smoothing=label_smoothing,
             axis=axis,
@@ -870,14 +926,16 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
         axis=-1,
         reduction="sum_over_batch_size",
         name="categorical_focal_crossentropy",
+        dtype=None,
     ):
         """Initializes `CategoricalFocalCrossentropy` instance."""
         super().__init__(
             categorical_focal_crossentropy,
+            reduction=reduction,
+            name=name,
+            dtype=dtype,
             alpha=alpha,
             gamma=gamma,
-            name=name,
-            reduction=reduction,
             from_logits=from_logits,
             label_smoothing=label_smoothing,
             axis=axis,
@@ -963,11 +1021,13 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
         ignore_class=None,
         reduction="sum_over_batch_size",
         name="sparse_categorical_crossentropy",
+        dtype=None,
     ):
         super().__init__(
             sparse_categorical_crossentropy,
-            name=name,
             reduction=reduction,
+            name=name,
+            dtype=dtype,
             from_logits=from_logits,
             ignore_class=ignore_class,
         )
@@ -1897,12 +1957,9 @@ class CTC(LossFunctionWrapper):
         self,
         reduction="sum_over_batch_size",
         name="ctc",
+        dtype=None,
     ):
-        super().__init__(
-            ctc,
-            name=name,
-            reduction=reduction,
-        )
+        super().__init__(ctc, name=name, reduction=reduction, dtype=dtype)
 
     def get_config(self):
         return {
@@ -1996,11 +2053,13 @@ class Dice(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="dice",
         axis=None,
+        dtype=None,
     ):
         super().__init__(
             dice,
-            name=name,
             reduction=reduction,
+            name=name,
+            dtype=dtype,
             axis=axis,
         )
         self.axis = axis
@@ -2077,13 +2136,15 @@ class Tversky(LossFunctionWrapper):
         beta=0.5,
         reduction="sum_over_batch_size",
         name="tversky",
+        dtype=None,
     ):
         super().__init__(
             tversky,
+            reduction=reduction,
+            name=name,
+            dtype=dtype,
             alpha=alpha,
             beta=beta,
-            name=name,
-            reduction=reduction,
         )
         self.alpha = alpha
         self.beta = beta

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -474,9 +474,9 @@ class ModelTest(testing.TestCase, parameterized.TestCase):
         )
         # Fit the model to make sure compile_metrics are built
         with self.assertRaisesRegex(
-            ValueError,
-            "In the dict argument `loss`, "
-            "key 'output_c' does not correspond to any model output",
+            KeyError,
+            "in the `loss` argument, but they can't be found in the "
+            "model's output",
         ):
             model.fit(x, (y1, y2), batch_size=2, epochs=1, verbose=0)
 
@@ -492,9 +492,9 @@ class ModelTest(testing.TestCase, parameterized.TestCase):
         )
         # Fit the model to make sure compile_metrics are built
         with self.assertRaisesRegex(
-            ValueError,
-            "In the dict argument `loss`, "
-            "key 'output_a' does not correspond to any model output",
+            KeyError,
+            "in the `loss` argument, but they can't be found in the "
+            "model's output",
         ):
             model.fit(x, (y1, y2), batch_size=2, epochs=1, verbose=0)
 
@@ -537,9 +537,9 @@ class ModelTest(testing.TestCase, parameterized.TestCase):
         )
         # Fit the model to make sure compile_metrics are built
         with self.assertRaisesRegex(
-            ValueError,
-            "In the dict argument `loss`, "
-            "key 'output_c' does not correspond to any model output",
+            KeyError,
+            "in the `loss` argument, but they can't be found in the "
+            "model's output",
         ):
             model.fit(x, (y1, y2), batch_size=2, epochs=1, verbose=0)
 
@@ -583,8 +583,7 @@ class ModelTest(testing.TestCase, parameterized.TestCase):
         # Fit the model to make sure compile_metrics are built
         with self.assertRaisesRegex(
             ValueError,
-            "when providing the `loss` argument as a list, "
-            "it should have as many entries as the model has outputs",
+            "When providing the `loss` argument, it should match the specs ",
         ):
             model.fit(x, (y1, y2), batch_size=2, epochs=1, verbose=0)
 

--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -1,4 +1,3 @@
-from keras.src import backend
 from keras.src import losses as losses_module
 from keras.src import metrics as metrics_module
 from keras.src import ops
@@ -429,209 +428,212 @@ class CompileLoss(losses_module.Loss):
         self.output_names = output_names
         super().__init__(name="compile_loss", reduction=reduction)
 
-    def build(self, y_true, y_pred):
-        if self.output_names:
-            output_names = self.output_names
-        elif isinstance(y_pred, dict):
-            output_names = sorted(list(y_pred.keys()))
-        elif isinstance(y_pred, (list, tuple)):
-            num_outputs = len(y_pred)
-            if all(hasattr(x, "_keras_history") for x in y_pred):
-                output_names = [x._keras_history.operation.name for x in y_pred]
-            else:
-                output_names = None
-        else:
-            output_names = None
-            num_outputs = 1
-        if output_names:
-            num_outputs = len(output_names)
+        # Inferred by `y_pred` and `output_names`
+        self.inferred_output_names = None
 
-        y_pred = self._flatten_y(y_pred)
+    def build(self, y_true, y_pred):
         loss = self._user_loss
         loss_weights = self._user_loss_weights
-        flat_losses = []
-        flat_loss_weights = []
-
-        if isinstance(loss, dict):
-            for name in loss.keys():
-                if name not in output_names:
-                    raise ValueError(
-                        "In the dict argument `loss`, key "
-                        f"'{name}' does not correspond to any model output. "
-                        f"Received:\nloss={loss}"
-                    )
-        if num_outputs == 1:
-            if isinstance(loss, dict):
-                loss = tree.flatten(loss)
-            if isinstance(loss, list) and len(loss) == 1:
-                loss = loss[0]
-            if not is_function_like(loss):
-                raise ValueError(
-                    "When there is only a single output, the `loss` argument "
-                    "must be a callable. "
-                    f"Received instead:\nloss={loss} of type {type(loss)}"
-                )
-            if isinstance(y_pred, list) and len(y_pred) == 1:
-                y_pred = y_pred[0]
+        output_names = self._get_y_pred_output_names(y_pred)
+        inferred_output_names = output_names or self.output_names
 
         if is_function_like(loss) and tree.is_nested(y_pred):
             # The model has multiple outputs but only one loss fn
             # was provided. Broadcast loss to all outputs.
             loss = tree.map_structure(lambda x: loss, y_pred)
 
-        # Iterate over all possible loss formats:
-        # plain function, list/tuple, dict
-        if is_function_like(loss):
-            flat_losses.append(get_loss(loss, y_true, y_pred))
-            if loss_weights:
-                if not isinstance(loss_weights, float):
-                    raise ValueError(
-                        "When there is only a single output, the "
-                        "`loss_weights` argument "
-                        "must be a Python float. "
-                        f"Received instead: loss_weights={loss_weights} of "
-                        f"type {type(loss_weights)}"
-                    )
-                flat_loss_weights.append(loss_weights)
-            else:
-                flat_loss_weights.append(1.0)
-        elif isinstance(loss, (list, tuple)):
-            loss = tree.flatten(loss)
-            if len(loss) != len(y_pred):
-                raise ValueError(
-                    "For a model with multiple outputs, "
-                    "when providing the `loss` argument as a list, "
-                    "it should have as many entries as the model has outputs. "
-                    f"Received:\nloss={loss}\nof length {len(loss)} "
-                    f"whereas the model has {len(y_pred)} outputs."
-                )
-            if not all(is_function_like(e) for e in loss):
-                raise ValueError(
-                    "For a model with multiple outputs, "
-                    "when providing the `loss` argument as a list, "
-                    "each list entry should be a callable (the loss function "
-                    "corresponding to that output). "
-                    f"Received: loss={loss}"
-                )
-            flat_losses = [
-                get_loss(fn, y_true, y_pred) for fn in loss if fn is not None
-            ]
-            if loss_weights:
-                if not isinstance(loss_weights, (list, tuple)):
-                    raise ValueError(
-                        "If the `loss` argument is provided as a list/tuple, "
-                        "the `loss_weight` argument should also be provided as "
-                        "a list/tuple, of equal length. "
-                        f"Received: loss_weights={loss_weights}"
-                    )
-                if len(loss_weights) != len(y_pred):
-                    raise ValueError(
-                        "For a model with multiple outputs, "
-                        "when providing the `loss_weights` argument as a list, "
-                        "it should have as many entries as the model has "
-                        f"outputs. Received: loss_weights={loss_weights} of "
-                        f"length {len(loss_weights)} whereas the model has "
-                        f"{len(y_pred)} outputs."
-                    )
-                if not all(isinstance(e, (int, float)) for e in loss_weights):
-                    raise ValueError(
-                        "For a model with multiple outputs, when providing "
-                        "the `loss_weights` argument as a list, "
-                        "each list entry should be a Python int or float (the "
-                        "weighting coefficient corresponding to the loss for "
-                        f"that output). Received: loss_weights={loss_weights}"
-                    )
-                flat_loss_weights = list(loss_weights)
-            else:
-                flat_loss_weights = [1.0 for _ in loss]
-        elif isinstance(loss, dict):
-            if output_names is None:
+        # Check and filter the keys.
+        if isinstance(loss, dict):
+            if inferred_output_names is None:
                 raise ValueError(
                     "Argument `loss` can only be provided as a dict "
                     "when the model also returns a dict of outputs. "
                     f"Received loss={loss}"
                 )
-            for name in loss.keys():
-                if isinstance(loss[name], list) and len(loss[name]) == 1:
-                    loss[name] = loss[name][0]
-                if not is_function_like(loss[name]):
-                    raise ValueError(
-                        "For a model with multiple outputs, "
-                        "when providing the `loss` argument as a dict, "
-                        "each dict entry should be a callable (the loss "
-                        "function corresponding to that output). "
-                        f"At key '{name}', received invalid type:\n{loss[name]}"
+        filtered_y_pred_keys = []
+        filtered_y_true_keys = []
+        if isinstance(loss, dict):
+            loss_keys = set(loss.keys())
+            if inferred_output_names is not None:
+                y_pred_keys = set(inferred_output_names)
+                if len(loss_keys - y_pred_keys) > 0:
+                    raise KeyError(
+                        f"There are keys: {list(loss_keys - y_pred_keys)} in "
+                        "the `loss` argument, but they can't be found in "
+                        "the model's output (`y_pred`)."
                     )
-            for name, yt, yp in zip(output_names, y_true, y_pred):
-                if name in loss:
-                    if loss[name]:
-                        flat_losses.append(get_loss(loss[name], yt, yp))
-                    else:
-                        flat_losses.append(None)
-                else:
-                    flat_losses.append(None)
-            if loss_weights:
-                if not isinstance(loss_weights, dict):
-                    raise ValueError(
-                        "If the `loss` argument is provided as a dict, "
-                        "the `loss_weight` argument should also be provided as "
-                        f"a dict. Received: loss_weights={loss_weights}"
+                filtered_y_pred_keys.extend(list(y_pred_keys - loss_keys))
+            if isinstance(y_true, dict):
+                y_true_keys = set(y_true.keys())
+                if len(loss_keys - y_true_keys) > 0:
+                    raise KeyError(
+                        f"There are keys: {list(loss_keys - y_true_keys)} in "
+                        "the `loss` argument, but they can't be found in "
+                        "`y` (`y_true`)."
                     )
-                for name in loss_weights.keys():
-                    if name not in output_names:
-                        raise ValueError(
-                            "In the dict argument `loss_weights`, key "
-                            f"'{name}' does not correspond to any model "
-                            f"output. Received: loss_weights={loss_weights}"
-                        )
-                    if not isinstance(loss_weights[name], float):
-                        raise ValueError(
-                            "For a model with multiple outputs, "
-                            "when providing the `loss_weights` argument as a "
-                            "dict, each dict entry should be a Python float "
-                            "(the weighting coefficient corresponding to the "
-                            f"loss for that output). At key '{name}', "
-                            f"received invalid type:\n{loss_weights[name]}"
-                        )
-                for name in output_names:
-                    if name in loss_weights:
-                        flat_loss_weights.append(loss_weights[name])
-                    else:
-                        flat_loss_weights.append(1.0)
-            else:
-                flat_loss_weights = [1.0 for _ in flat_losses]
+                filtered_y_true_keys.extend(list(y_true_keys - loss_keys))
+        filtered_y_pred_keys = set(filtered_y_pred_keys)
+        filtered_y_true_keys = set(filtered_y_true_keys)
+
+        # Filter unused inputs.
+        y_true, y_pred = self._filter_unused_inputs(
+            y_true,
+            y_pred,
+            filtered_y_true_keys,
+            filtered_y_pred_keys,
+            self.inferred_output_names,
+        )
+
+        # `loss` could be a plain function (or a `Loss` instance), a list, a
+        # nested list, or a dict. However, in `call`, we want to iterate over
+        # all losses, so we flatten them into a list regardless of their
+        # original structure.
+        flat_losses = tree.flatten(loss)
+        if loss_weights is None:
+            flat_loss_weights = [None] * len(flat_losses)
+        else:
+            flat_loss_weights = tree.flatten(loss_weights)
+            for loss_weight in flat_loss_weights:
+                if not isinstance(loss_weight, (int, float, type(None))):
+                    raise TypeError(
+                        "When providing the `loss_weights` argument, each "
+                        "element should be a Python int, float (the weighting "
+                        "coefficient corresponding to the loss for that "
+                        "output) or `None`."
+                        f"Received: loss_weights={loss_weights}"
+                    )
+            if len(flat_loss_weights) != len(flat_losses):
+                raise ValueError(
+                    "When providing the `loss_weights` argument, it should "
+                    "have equal length of `loss` argument. "
+                    f"Received: loss_weights length={len(flat_loss_weights)}, "
+                    f"loss legnth={len(flat_losses)}"
+                )
+
+        # After flattening losses, we need to flatten `y_true` and `y_pred` as
+        # well. First, we get the `y_true_spec` and `y_pred_spec` in flat form
+        # from `flat_losses`, then pack them into the correct structure.
+        flat_y_true_specs, flat_y_pred_specs = self._get_flat_specs(flat_losses)
+        try:
+            y_trues = tree.pack_sequence_as(
+                flat_y_true_specs, tree.flatten(y_true)
+            )
+            y_preds = tree.pack_sequence_as(
+                flat_y_pred_specs, tree.flatten(y_pred)
+            )
+        except Exception:
+            raise ValueError(
+                "When providing the `loss` argument, it should match the specs "
+                "of `y` (`y_true`) and the model's output (`y_pred`). Received:"
+                f" y_true={y_true}, flat_y_true_specs={flat_y_true_specs},"
+                f" y_pred={y_pred}, flat_y_pred_specs={flat_y_pred_specs}, "
+            )
+
+        # Get the real loss instances.
+        flat_losses = [
+            get_loss(identifier, y_true, y_pred)
+            for identifier, y_true, y_pred in zip(flat_losses, y_trues, y_preds)
+        ]
+
         self.flat_losses = flat_losses
         self.flat_loss_weights = flat_loss_weights
+        self.flat_y_true_specs = flat_y_true_specs
+        self.flat_y_pred_specs = flat_y_pred_specs
+        self.filtered_y_true_keys = filtered_y_true_keys
+        self.filtered_y_pred_keys = filtered_y_pred_keys
+        self.inferred_output_names = inferred_output_names
         self.built = True
+
+    def _get_y_pred_output_names(self, y_pred):
+        if isinstance(y_pred, dict):
+            output_names = sorted(y_pred.keys())
+        else:
+            y_pred = tree.flatten(y_pred)
+            if all(hasattr(x, "_keras_history") for x in y_pred):
+                output_names = [x._keras_history.operation.name for x in y_pred]
+            else:
+                output_names = None
+        return output_names
+
+    def _filter_unused_inputs(
+        self,
+        y_true,
+        y_pred,
+        filtered_y_true_keys,
+        filtered_y_pred_keys,
+        output_names,
+    ):
+        if len(filtered_y_true_keys) > 0:
+            if isinstance(y_true, dict):
+                for k in filtered_y_true_keys:
+                    y_true.pop(k)
+        if len(filtered_y_pred_keys) > 0:
+            if isinstance(y_pred, dict):
+                for k in filtered_y_pred_keys:
+                    y_pred.pop(k)
+            elif output_names is not None:
+                y_pred = []
+                for x, output_name in zip(tree.flatten(y_pred), output_names):
+                    if output_name not in filtered_y_pred_keys:
+                        y_pred.append(x)
+        return y_true, y_pred
+
+    def _get_flat_specs(self, flat_losses):
+        y_true_specs = []
+        y_pred_specs = []
+        for loss in flat_losses:
+            # Every `Loss` instance has the specs.
+            if isinstance(loss, losses_module.Loss):
+                y_true_specs.append(loss.y_true_spec)
+                y_pred_specs.append(loss.y_pred_spec)
+            else:
+                # Pick one of crossentropy loss functions to infer the specs.
+                if str(loss).lower() in ("crossentropy", "ce"):
+                    bce = losses_module.BinaryCrossentropy()
+                    y_true_specs.append(bce.y_true_spec)
+                    y_pred_specs.append(bce.y_pred_spec)
+                # Get the loss instance, then the specs.
+                else:
+                    loss_obj = losses_module.get(loss)
+                    if not isinstance(loss_obj, losses_module.Loss):
+                        loss_obj = losses_module.LossFunctionWrapper(loss_obj)
+                    y_true_specs.append(loss_obj.y_true_spec)
+                    y_pred_specs.append(loss_obj.y_pred_spec)
+        return y_true_specs, y_pred_specs
 
     def __call__(self, y_true, y_pred, sample_weight=None):
         with ops.name_scope(self.name):
             return self.call(y_true, y_pred, sample_weight)
 
-    def _flatten_y(self, y):
-        if isinstance(y, dict) and self.output_names:
-            result = []
-            for name in self.output_names:
-                if name in y:
-                    result.append(y[name])
-            return result
-        return tree.flatten(y)
-
     def call(self, y_true, y_pred, sample_weight=None):
         if not self.built:
             self.build(y_true, y_pred)
 
-        y_true = self._flatten_y(y_true)
-        y_pred = self._flatten_y(y_pred)
+        # Filter unused inputs.
+        y_true, y_pred = self._filter_unused_inputs(
+            y_true,
+            y_pred,
+            self.filtered_y_true_keys,
+            self.filtered_y_pred_keys,
+            self.inferred_output_names,
+        )
 
+        # Pack the inputs.
+        y_true = tree.pack_sequence_as(
+            self.flat_y_true_specs, tree.flatten(y_true)
+        )
+        y_pred = tree.pack_sequence_as(
+            self.flat_y_pred_specs, tree.flatten(y_pred)
+        )
         if sample_weight is not None:
-            sample_weight = self._flatten_y(sample_weight)
+            sample_weight = tree.flatten(sample_weight)
             # For multi-outputs, repeat sample weights for n outputs.
             if len(sample_weight) < len(y_true):
                 sample_weight = [sample_weight[0] for _ in range(len(y_true))]
         else:
             sample_weight = [None for _ in y_true]
 
+        # Iterate all losses in flat form.
         loss_values = []
         for loss, y_t, y_p, loss_weight, sample_weight in zip(
             self.flat_losses,
@@ -641,9 +643,11 @@ class CompileLoss(losses_module.Loss):
             sample_weight,
         ):
             if loss:
-                value = loss_weight * ops.cast(
-                    loss(y_t, y_p, sample_weight), dtype=backend.floatx()
+                value = ops.cast(
+                    loss(y_t, y_p, sample_weight), dtype=self.dtype
                 )
+                if loss_weight is not None:
+                    value = ops.multiply(value, loss_weight)
                 loss_values.append(value)
         if loss_values:
             total_loss = sum(loss_values)


### PR DESCRIPTION
Fix #19855 

I think current implementation of `CompileLoss` restricts many possibility for custom loss:
1. It strictly require `y_true` and `y_pred` to be single tensor
2. It enforces the number of losses to match the number of the model's outputs in `Functional` model instead of the actual number of pairs of (`y_true`, `y_pred`)

Additionally, there are many pitfalls that can cause `CompileLoss` to malfunction.  #19855

So, I have refactored `CompileLoss` by introducing the concept of `y_true_spec` and `y_pred_spec`.
The idea behind is to utilize `tree` and the specs to automatically pack `y_true` and `y_pred` for `CompileLoss.build` and `CompileLoss.call`.

For backward compatibility, they default to a plain `"tensor"` structure. If someone needs a nested structure for `y_true` or `y_pred`, they can use the newly introduced `Loss.set_specs` to set `y_true_spec` and `y_pred_spec`.

Tests have been added to verify this new behavior.
- `test_custom_loss_with_list_y_true`: `y_true` as a list
- `test_custom_loss_with_nested_dict`: `y_true` as a dict with a list and `y_pred` as a dict of dict

Additionally, the missing `dtype` in all losses has been corrected.