### PR TITLE
Fix torch.tile for int

### DIFF
--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1359,6 +1359,8 @@ def round(x, decimals=0):
 def tile(x, repeats):
     if is_tensor(repeats):
         repeats = tuple(repeats.int().numpy())
+    if isinstance(repeats, int):
+        repeats = (repeats,)
     x = convert_to_tensor(x)
     return torch.tile(x, dims=repeats)
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -5047,6 +5047,8 @@ class Tile(Operation):
     def compute_output_spec(self, x):
         x_shape = list(x.shape)
         repeats = self.repeats
+        if isinstance(repeats, int):
+            repeats = [repeats]
         if len(x_shape) > len(repeats):
             repeats = [1] * (len(x_shape) - len(repeats)) + repeats
         else:

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1445,6 +1445,7 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
 
     def test_tile(self):
         x = KerasTensor((None, 3))
+        self.assertEqual(knp.tile(x, 2).shape, (None, 6))
         self.assertEqual(knp.tile(x, [2]).shape, (None, 6))
         self.assertEqual(knp.tile(x, [1, 2]).shape, (None, 6))
         self.assertEqual(knp.tile(x, [2, 1, 2]).shape, (2, None, 6))
@@ -1969,6 +1970,7 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
 
     def test_tile(self):
         x = KerasTensor((2, 3))
+        self.assertEqual(knp.tile(x, 2).shape, (2, 6))
         self.assertEqual(knp.tile(x, [2]).shape, (2, 6))
         self.assertEqual(knp.tile(x, [1, 2]).shape, (2, 6))
         self.assertEqual(knp.tile(x, [2, 1, 2]).shape, (2, 2, 6))
@@ -4119,6 +4121,7 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
     def test_tile(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
+        self.assertAllClose(knp.tile(x, 2), np.tile(x, 2))
         self.assertAllClose(knp.tile(x, [2, 3]), np.tile(x, [2, 3]))
         self.assertAllClose(knp.Tile([2, 3])(x), np.tile(x, [2, 3]))
 


### PR DESCRIPTION
Currently when int is given as input for dims in the ops.tile for torch backend, it throws an error `TypeError: tile(): argument 'dims' must be tuple of ints, not int`
Fixes: https://github.com/keras-team/keras/issues/19877