### PR TITLE
Fix torch distributed training

### DIFF
--- a/keras/src/backend/torch/layer.py
+++ b/keras/src/backend/torch/layer.py
@@ -1,3 +1,6 @@
+from typing import Iterator
+from typing import Tuple
+
 import torch
 
 from keras.src.backend.common.stateless_scope import in_stateless_scope
@@ -13,15 +16,23 @@ class TorchLayer(torch.nn.Module):
         self._track_variables()
 
     def _track_variables(self):
-        # Index given to ParameterDict must be a string
+        # set torch_params attribute will have module automatically track
+        # parameters.
         self.torch_params = torch.nn.ParameterDict(
-            {str(id(variable)): variable.value for variable in self.variables}
+            {variable.path: variable.value for variable in self.variables}
         )
 
-    def parameters(self, recurse=True):
+    def named_parameters(
+        self,
+        prefix: str = "",
+        recurse: bool = True,
+        remove_duplicate: bool = True,
+    ) -> Iterator[Tuple[str, torch.nn.Parameter]]:
         if not hasattr(self, "torch_params"):
             self._track_variables()
-        return torch.nn.Module.parameters(self, recurse=recurse)
+        return torch.nn.Module.named_parameters(
+            self, prefix, recurse, remove_duplicate
+        )
 
     def forward(self, *args, **kwargs):
         return Operation.__call__(self, *args, **kwargs)
@@ -42,13 +53,9 @@ class TorchLayer(torch.nn.Module):
 
     def _post_track_variable(self, variable):
         if hasattr(self, "torch_params"):
-            # Index given to ParameterDict must be a string
-            key = str(id(variable))
-            if key not in self.torch_params:
-                self.torch_params[key] = variable.value
+            if variable.path not in self.torch_params:
+                self.torch_params[variable.path] = variable.value
 
     def _post_untrack_variable(self, variable):
         if hasattr(self, "torch_params"):
-            # Index given to ParameterDict must be a string
-            key = str(id(variable))
-            self.torch_params.pop(key)
+            self.torch_params.pop(variable.path)

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -10,6 +10,7 @@ from keras.src import metrics
 from keras.src import models
 from keras.src import ops
 from keras.src import testing
+from keras.src.backend.common import global_state
 
 
 class LayerTest(testing.TestCase):
@@ -1023,6 +1024,12 @@ class LayerTest(testing.TestCase):
         variable_paths = set(v.path for v in layer.variables)
         self.assertTrue("inner_layer/inner" in variable_paths)
         self.assertTrue("inner_inner_layer/inner" in variable_paths)
+        if backend.backend() == "torch":
+            parameter_names = set(
+                param_name.replace("torch_params.", "")
+                for param_name, _ in layer.named_parameters()
+            )
+            self.assertSetEqual(variable_paths, parameter_names)
 
     def test_custom_layer_add_weight_in_build_name(self):
         class TrainingLayer(layers.Layer):
@@ -1074,3 +1081,152 @@ class LayerTest(testing.TestCase):
             "training_layer/inner_layer/inner_inner_layer/inner"
             in variable_paths
         )
+        if backend.backend() == "torch":
+            parameter_names = set(
+                param_name.replace("torch_params.", "")
+                for param_name, _ in layer.named_parameters()
+            )
+            self.assertSetEqual(variable_paths, parameter_names)
+
+    def test_layer_variable_tracking_correct(self):
+        class TrainingLayer(layers.Layer):
+            def __init__(self):
+                super().__init__()
+                self.post_build_modify_layer = PostBuildModifyLayer()
+
+            def call(self, input):
+                return self.post_build_modify_layer(input)
+
+        class PostBuildModifyLayer(layers.Layer):
+
+            def call(self, input):
+                return self.var + input
+
+            def build(self, _):
+                self.var = self.add_weight(
+                    shape=(2,),
+                    name="var",
+                )
+
+            def post_build_add(self):
+                self._tracker.unlock()
+                self.additional_var = self.add_weight(
+                    shape=(2,),
+                    name="var2",
+                )
+                self._tracker.lock()
+
+            def post_build_remove(self):
+                self._tracker.unlock()
+                self._untrack_variable(self.var)
+                del self.var
+                self._tracker.lock()
+
+        layer = TrainingLayer()
+        output = layer(backend.KerasTensor((4, 2)))
+
+        self.assertEqual(output.shape, (4, 2))
+        self.assertEqual(len(layer.variables), 1)
+        self.assertEqual(
+            layer.variables[0].path,
+            "training_layer/post_build_modify_layer/var",
+        )
+        if backend.backend() == "torch":
+            parameter_names = [pname for pname, _ in layer.named_parameters()]
+            self.assertEqual(len(parameter_names), 1)
+            self.assertEqual(
+                parameter_names[0],
+                "torch_params.training_layer/post_build_modify_layer/var",
+            )
+
+        layer.post_build_modify_layer.post_build_add()
+        self.assertEqual(len(layer.variables), 2)
+        self.assertEqual(
+            layer.variables[0].path,
+            "training_layer/post_build_modify_layer/var",
+        )
+        self.assertEqual(
+            layer.variables[1].path,
+            "training_layer/post_build_modify_layer/var2",
+        )
+        if backend.backend() == "torch":
+            # TODO (haohuanw, fchollet): Needs further discussion on how to 
+            # properly manage torch params. Post build modification cannot 
+            # propagate to parent torch params.
+            parameter_names = [pname for pname, _ in layer.named_parameters()]
+            # Below check should have 2 parameters instead of 1.
+            self.assertEqual(len(parameter_names), 1)
+            self.assertEqual(
+                parameter_names[0],
+                "torch_params.training_layer/post_build_modify_layer/var",
+            )
+
+            parameter_names = [
+                pname
+                for pname, _ in layer.post_build_modify_layer.named_parameters()
+            ]
+            self.assertEqual(len(parameter_names), 2)
+            self.assertEqual(
+                parameter_names[0],
+                "torch_params.training_layer/post_build_modify_layer/var",
+            )
+            self.assertEqual(
+                parameter_names[1],
+                "torch_params.training_layer/post_build_modify_layer/var2",
+            )
+
+        layer.post_build_modify_layer.post_build_remove()
+        self.assertEqual(len(layer.variables), 1)
+        self.assertEqual(
+            layer.variables[0].path,
+            "training_layer/post_build_modify_layer/var2",
+        )
+        if backend.backend() == "torch":
+            # TODO (haohuanw, fchollet): Needs further discussion on how to 
+            # properly manage torch params. Post build modification cannot 
+            # propagate to parent torch params.
+            parameter_names = [pname for pname, _ in layer.named_parameters()]
+            # Below check should have 1 parameters instead of 2, torch_params
+            # in parent layer is wrong.
+            self.assertEqual(len(parameter_names), 2)
+            self.assertEqual(
+                parameter_names[0],
+                "post_build_modify_layer.torch_params.training_layer/"
+                "post_build_modify_layer/var2",
+            )
+            self.assertEqual(
+                parameter_names[1],
+                "torch_params.training_layer/post_build_modify_layer/var",
+            )
+
+            parameter_names = [
+                pname
+                for pname, _ in layer.post_build_modify_layer.named_parameters()
+            ]
+            self.assertEqual(len(parameter_names), 1)
+            self.assertEqual(
+                parameter_names[0],
+                "torch_params.training_layer/post_build_modify_layer/var2",
+            )
+
+    @pytest.mark.skipif(backend.backend() != "torch", reason="Torch only test.")
+    def test_torch_params_create_deterministic(self):
+        class MyLayer(layers.Layer):
+            def __init__(self):
+                super().__init__()
+                self.w1 = self.add_weight()
+                self.w2 = self.add_weight(dtype="int32", trainable=False)
+                self.w3 = self.add_weight(dtype="bool", trainable=False)
+                self.w4 = self.add_weight(
+                    dtype="int32", shape=(2, 2), trainable=False
+                )
+                self.w5 = self.add_weight(initializer="ones", shape=(2, 2))
+
+        layer1 = MyLayer()
+        layer1.build(None)
+        layer1_names = list(pname for pname, _ in layer1.named_parameters())
+        global_state.clear_session()
+        layer2 = MyLayer()
+        layer2.build(None)
+        layer2_names = list(pname for pname, _ in layer2.named_parameters())
+        self.assertListEqual(layer1_names, layer2_names)


### PR DESCRIPTION
this pr fixes a regression observed in torch distributed training with v3.3.3. when wrapping keras model with DDP, it resulted in errors like below:

```
[rank1]:   File "/home/hwang/.cache/bazel/_bazel_hwang/456a88c8103b63576563cc0e1d65d843/execroot/nuro/bazel-out/k8-opt/bin/learning/behavior/lambda_model/mpi_run.runfiles/nuro/external/pypi__torch_2_3_0_cu121_x86_64/torch/nn/parallel/distributed.py", line 798, in __init__
[rank1]:     _verify_param_shape_across_processes(self.process_group, parameters)
[rank1]:   File "/home/hwang/.cache/bazel/_bazel_hwang/456a88c8103b63576563cc0e1d65d843/execroot/nuro/bazel-out/k8-opt/bin/learning/behavior/lambda_model/mpi_run.runfiles/nuro/external/pypi__torch_2_3_0_cu121_x86_64/torch/distributed/utils.py", line 269, in _verify_param_shape_across_processes
[rank1]:     return dist._verify_params_across_processes(process_group, tensors, logger)
[rank1]: RuntimeError: [1]: params[142] in this process with sizes [4, 64] appears not to match sizes of the same param in process 0.
```

and i am able to root cause the issue being `torch_layer.torch_params` is not returned in deterministic order in params dict since the key is generated with python `id` from https://github.com/keras-team/keras/pull/19495/files and it won't be the same across processes.

this pr attempts to fix with following changes:

1. changing to `variable.path` instead of `id(variable)`. `variable.path` is a good alternative since i believe it will be unique.
2. instead of overriding `parameters()` change to overriding `named_parameters()` for torch module since i found torch api tends to call `named_parameters` more: https://github.com/pytorch/pytorch/blob/main/torch/nn/parallel/distributed.py#L698 and `parameters` directly calls `named_parameters`

what hasn't fixed: i think `post_track_variable` and `post_untrack_variable` doesn't solve all the torch module tracking issues since it won't be able to update parent layer's `torch_params`. `LayerTest::test_layer_variable_tracking_correct` has a more detailed example.

thoughts: i think the main challenge for torch backend is that there are 2 variable tracking system, one in torch module (`_parameters`) and one in keras tracker; and there are some stateful operations for changing the layer like enable lora / quantize. some ideas i have to fix it:

1. introduce an explicit "model.lock()" api and user only allow to use torch specific apis (eg. calling `parameters()`) after the model is locked.
2. always generate parameters on the fly through `self.variables`. this might work but will break if `torch.module` starts to cache additional or specific things.
