### PR TITLE
Add `dtype` argument to all losses and export `CTC`

### DIFF
--- a/keras/src/losses/__init__.py
+++ b/keras/src/losses/__init__.py
@@ -2,6 +2,7 @@ import inspect
 
 from keras.src.api_export import keras_export
 from keras.src.losses.loss import Loss
+from keras.src.losses.losses import CTC
 from keras.src.losses.losses import BinaryCrossentropy
 from keras.src.losses.losses import BinaryFocalCrossentropy
 from keras.src.losses.losses import CategoricalCrossentropy
@@ -71,6 +72,8 @@ ALL_OBJECTS = {
     # Image segmentation
     Dice,
     Tversky,
+    # Sequence
+    CTC,
     # Probabilistic
     kl_divergence,
     poisson,
@@ -94,6 +97,8 @@ ALL_OBJECTS = {
     # Image segmentation
     dice,
     tversky,
+    # Sequence
+    ctc,
 }
 
 ALL_OBJECTS_DICT = {cls.__name__: cls for cls in ALL_OBJECTS}

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -11,9 +11,14 @@ from keras.src.utils.numerical_utils import normalize
 
 class LossFunctionWrapper(Loss):
     def __init__(
-        self, fn, reduction="sum_over_batch_size", name=None, **kwargs
+        self,
+        fn,
+        reduction="sum_over_batch_size",
+        name=None,
+        dtype=None,
+        **kwargs,
     ):
-        super().__init__(reduction=reduction, name=name)
+        super().__init__(name=name, reduction=reduction, dtype=dtype)
         self.fn = fn
         self._fn_kwargs = kwargs
 
@@ -22,10 +27,10 @@ class LossFunctionWrapper(Loss):
         return self.fn(y_true, y_pred, **self._fn_kwargs)
 
     def get_config(self):
-        base_config = super().get_config()
-        config = {"fn": serialization_lib.serialize_keras_object(self.fn)}
+        config = super().get_config()
+        config.update({"fn": serialization_lib.serialize_keras_object(self.fn)})
         config.update(serialization_lib.serialize_keras_object(self._fn_kwargs))
-        return {**base_config, **config}
+        return config
 
     @classmethod
     def from_config(cls, config):
@@ -49,12 +54,21 @@ class MeanSquaredError(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
     def __init__(
-        self, reduction="sum_over_batch_size", name="mean_squared_error"
+        self,
+        reduction="sum_over_batch_size",
+        name="mean_squared_error",
+        dtype=None,
     ):
-        super().__init__(mean_squared_error, reduction=reduction, name=name)
+        super().__init__(
+            mean_squared_error, name=name, reduction=reduction, dtype=dtype
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -75,12 +89,21 @@ class MeanAbsoluteError(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
     def __init__(
-        self, reduction="sum_over_batch_size", name="mean_absolute_error"
+        self,
+        reduction="sum_over_batch_size",
+        name="mean_absolute_error",
+        dtype=None,
     ):
-        super().__init__(mean_absolute_error, reduction=reduction, name=name)
+        super().__init__(
+            mean_absolute_error, name=name, reduction=reduction, dtype=dtype
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -101,15 +124,23 @@ class MeanAbsolutePercentageError(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
     def __init__(
         self,
         reduction="sum_over_batch_size",
         name="mean_absolute_percentage_error",
+        dtype=None,
     ):
         super().__init__(
-            mean_absolute_percentage_error, reduction=reduction, name=name
+            mean_absolute_percentage_error,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
         )
 
     def get_config(self):
@@ -131,15 +162,23 @@ class MeanSquaredLogarithmicError(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
     def __init__(
         self,
         reduction="sum_over_batch_size",
         name="mean_squared_logarithmic_error",
+        dtype=None,
     ):
         super().__init__(
-            mean_squared_logarithmic_error, reduction=reduction, name=name
+            mean_squared_logarithmic_error,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
         )
 
     def get_config(self):
@@ -170,6 +209,10 @@ class CosineSimilarity(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
     def __init__(
@@ -177,9 +220,14 @@ class CosineSimilarity(LossFunctionWrapper):
         axis=-1,
         reduction="sum_over_batch_size",
         name="cosine_similarity",
+        dtype=None,
     ):
         super().__init__(
-            cosine_similarity, reduction=reduction, name=name, axis=axis
+            cosine_similarity,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            axis=axis,
         )
 
     def get_config(self):
@@ -210,6 +258,10 @@ class Huber(LossFunctionWrapper):
             `"sum_over_batch_size"` or `None`. Defaults to
             `"sum_over_batch_size"`.
         name: Optional name for the instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
     def __init__(
@@ -217,8 +269,11 @@ class Huber(LossFunctionWrapper):
         delta=1.0,
         reduction="sum_over_batch_size",
         name="huber_loss",
+        dtype=None,
     ):
-        super().__init__(huber, name=name, reduction=reduction, delta=delta)
+        super().__init__(
+            huber, name=name, reduction=reduction, dtype=dtype, delta=delta
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -241,10 +296,16 @@ class LogCosh(LossFunctionWrapper):
             `"sum_over_batch_size"` or `None`. Defaults to
             `"sum_over_batch_size"`.
         name: Optional name for the instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
-    def __init__(self, reduction="sum_over_batch_size", name="log_cosh"):
-        super().__init__(log_cosh, name=name, reduction=reduction)
+    def __init__(
+        self, reduction="sum_over_batch_size", name="log_cosh", dtype=None
+    ):
+        super().__init__(log_cosh, name=name, reduction=reduction, dtype=dtype)
 
     def get_config(self):
         return Loss.get_config(self)
@@ -268,10 +329,16 @@ class Hinge(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
-    def __init__(self, reduction="sum_over_batch_size", name="hinge"):
-        super().__init__(hinge, reduction=reduction, name=name)
+    def __init__(
+        self, reduction="sum_over_batch_size", name="hinge", dtype=None
+    ):
+        super().__init__(hinge, name=name, reduction=reduction, dtype=dtype)
 
     def get_config(self):
         return Loss.get_config(self)
@@ -295,10 +362,18 @@ class SquaredHinge(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
-    def __init__(self, reduction="sum_over_batch_size", name="squared_hinge"):
-        super().__init__(squared_hinge, reduction=reduction, name=name)
+    def __init__(
+        self, reduction="sum_over_batch_size", name="squared_hinge", dtype=None
+    ):
+        super().__init__(
+            squared_hinge, name=name, reduction=reduction, dtype=dtype
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -321,12 +396,21 @@ class CategoricalHinge(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
     def __init__(
-        self, reduction="sum_over_batch_size", name="categorical_hinge"
+        self,
+        reduction="sum_over_batch_size",
+        name="categorical_hinge",
+        dtype=None,
     ):
-        super().__init__(categorical_hinge, reduction=reduction, name=name)
+        super().__init__(
+            categorical_hinge, name=name, reduction=reduction, dtype=dtype
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -351,10 +435,18 @@ class KLDivergence(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
-    def __init__(self, reduction="sum_over_batch_size", name="kl_divergence"):
-        super().__init__(kl_divergence, reduction=reduction, name=name)
+    def __init__(
+        self, reduction="sum_over_batch_size", name="kl_divergence", dtype=None
+    ):
+        super().__init__(
+            kl_divergence, name=name, reduction=reduction, dtype=dtype
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -375,10 +467,16 @@ class Poisson(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
-    def __init__(self, reduction="sum_over_batch_size", name="poisson"):
-        super().__init__(poisson, reduction=reduction, name=name)
+    def __init__(
+        self, reduction="sum_over_batch_size", name="poisson", dtype=None
+    ):
+        super().__init__(poisson, name=name, reduction=reduction, dtype=dtype)
 
     def get_config(self):
         return Loss.get_config(self)
@@ -413,6 +511,10 @@ class BinaryCrossentropy(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
 
     Examples:
 
@@ -473,11 +575,13 @@ class BinaryCrossentropy(LossFunctionWrapper):
         axis=-1,
         reduction="sum_over_batch_size",
         name="binary_crossentropy",
+        dtype=None,
     ):
         super().__init__(
             binary_crossentropy,
             name=name,
             reduction=reduction,
+            dtype=dtype,
             from_logits=from_logits,
             label_smoothing=label_smoothing,
             axis=axis,
@@ -543,6 +647,10 @@ class BinaryFocalCrossentropy(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
 
     Examples:
 
@@ -638,14 +746,16 @@ class BinaryFocalCrossentropy(LossFunctionWrapper):
         axis=-1,
         reduction="sum_over_batch_size",
         name="binary_focal_crossentropy",
+        dtype=None,
     ):
         super().__init__(
             binary_focal_crossentropy,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
             apply_class_balancing=apply_class_balancing,
             alpha=alpha,
             gamma=gamma,
-            name=name,
-            reduction=reduction,
             from_logits=from_logits,
             label_smoothing=label_smoothing,
             axis=axis,
@@ -694,6 +804,10 @@ class CategoricalCrossentropy(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
 
     Examples:
 
@@ -737,11 +851,13 @@ class CategoricalCrossentropy(LossFunctionWrapper):
         axis=-1,
         reduction="sum_over_batch_size",
         name="categorical_crossentropy",
+        dtype=None,
     ):
         super().__init__(
             categorical_crossentropy,
             name=name,
             reduction=reduction,
+            dtype=dtype,
             from_logits=from_logits,
             label_smoothing=label_smoothing,
             axis=axis,
@@ -825,6 +941,10 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
 
     Examples:
 
@@ -870,14 +990,16 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
         axis=-1,
         reduction="sum_over_batch_size",
         name="categorical_focal_crossentropy",
+        dtype=None,
     ):
         """Initializes `CategoricalFocalCrossentropy` instance."""
         super().__init__(
             categorical_focal_crossentropy,
-            alpha=alpha,
-            gamma=gamma,
             name=name,
             reduction=reduction,
+            dtype=dtype,
+            alpha=alpha,
+            gamma=gamma,
             from_logits=from_logits,
             label_smoothing=label_smoothing,
             axis=axis,
@@ -923,6 +1045,10 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
         name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
 
     Examples:
 
@@ -963,11 +1089,13 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
         ignore_class=None,
         reduction="sum_over_batch_size",
         name="sparse_categorical_crossentropy",
+        dtype=None,
     ):
         super().__init__(
             sparse_categorical_crossentropy,
             name=name,
             reduction=reduction,
+            dtype=dtype,
             from_logits=from_logits,
             ignore_class=ignore_class,
         )
@@ -1235,7 +1363,7 @@ def mean_absolute_percentage_error(y_true, y_pred):
     """
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.convert_to_tensor(y_true, dtype=y_pred.dtype)
-    epsilon = ops.convert_to_tensor(backend.epsilon())
+    epsilon = ops.convert_to_tensor(backend.epsilon(), dtype=y_pred.dtype)
     y_true, y_pred = squeeze_or_expand_to_same_rank(y_true, y_pred)
     diff = ops.abs((y_true - y_pred) / ops.maximum(ops.abs(y_true), epsilon))
     return 100.0 * ops.mean(diff, axis=-1)
@@ -1364,7 +1492,7 @@ def huber(y_true, y_pred, delta=1.0):
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.convert_to_tensor(y_true, dtype=y_pred.dtype)
     y_true, y_pred = squeeze_or_expand_to_same_rank(y_true, y_pred)
-    delta = ops.convert_to_tensor(delta)
+    delta = ops.convert_to_tensor(delta, dtype=y_pred.dtype)
     error = ops.subtract(y_pred, y_true)
     abs_error = ops.abs(error)
     half = ops.convert_to_tensor(0.5, dtype=abs_error.dtype)
@@ -1511,7 +1639,7 @@ def poisson(y_true, y_pred):
     """
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.convert_to_tensor(y_true, dtype=y_pred.dtype)
-    epsilon = ops.convert_to_tensor(backend.epsilon())
+    epsilon = ops.convert_to_tensor(backend.epsilon(), dtype=y_pred.dtype)
     return ops.mean(y_pred - y_true * ops.log(y_pred + epsilon), axis=-1)
 
 
@@ -1885,24 +2013,23 @@ class CTC(LossFunctionWrapper):
     """CTC (Connectionist Temporal Classification) loss.
 
     Args:
-        y_true: A tensor of shape `(batch_size, target_max_length)` containing
-            the true labels in integer format. `0` always represents
-            the blank/mask index and should not be used for classes.
-        y_pred: A tensor of shape `(batch_size, output_max_length, num_classes)`
-            containing logits (the output of your model).
-            They should *not* be normalized via softmax.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`.
+            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+        name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
     """
 
     def __init__(
         self,
         reduction="sum_over_batch_size",
         name="ctc",
+        dtype=None,
     ):
-        super().__init__(
-            ctc,
-            name=name,
-            reduction=reduction,
-        )
+        super().__init__(ctc, name=name, reduction=reduction, dtype=dtype)
 
     def get_config(self):
         return {
@@ -1959,8 +2086,16 @@ class Dice(LossFunctionWrapper):
     ```
 
     Args:
-        y_true: tensor of true targets.
-        y_pred: tensor of predicted targets.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`.
+            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+        name: Optional name for the loss instance.
+        axis: Tuple for which dimensions the loss is calculated. Defaults to
+            `None`.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
 
     Returns:
         Dice loss value.
@@ -1996,11 +2131,13 @@ class Dice(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="dice",
         axis=None,
+        dtype=None,
     ):
         super().__init__(
             dice,
             name=name,
             reduction=reduction,
+            dtype=dtype,
             axis=axis,
         )
         self.axis = axis
@@ -2058,10 +2195,18 @@ class Tversky(LossFunctionWrapper):
     Dice Loss.
 
     Args:
-        y_true: tensor of true targets.
-        y_pred: tensor of predicted targets.
-        alpha: coefficient controlling incidence of false positives.
-        beta: coefficient controlling incidence of false negatives.
+        alpha: The coefficient controlling incidence of false positives.
+            Defaults to `0.5`.
+        beta: The coefficient controlling incidence of false negatives.
+            Defaults to `0.5`.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`.
+            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+        name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`).
 
     Returns:
         Tversky loss value.
@@ -2077,13 +2222,15 @@ class Tversky(LossFunctionWrapper):
         beta=0.5,
         reduction="sum_over_batch_size",
         name="tversky",
+        dtype=None,
     ):
         super().__init__(
             tversky,
-            alpha=alpha,
-            beta=beta,
             name=name,
             reduction=reduction,
+            dtype=dtype,
+            alpha=alpha,
+            beta=beta,
         )
         self.alpha = alpha
         self.beta = beta

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -78,6 +78,13 @@ class MeanSquaredErrorTest(testing.TestCase):
         loss = mse_obj(y_true, y_pred, sample_weight=2.3)
         self.assertAlmostEqual(loss, 227.69998)
 
+    def test_dtype_arg(self):
+        mse_obj = losses.MeanSquaredError(dtype="bfloat16")
+        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
+        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
+        loss = mse_obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
+
 
 class MeanAbsoluteErrorTest(testing.TestCase):
     def test_config(self):
@@ -146,6 +153,13 @@ class MeanAbsoluteErrorTest(testing.TestCase):
         loss = mae_obj(y_true, y_pred, sample_weight=2.3)
         self.assertAlmostEqual(loss, 25.29999)
 
+    def test_dtype_arg(self):
+        mae_obj = losses.MeanAbsoluteError(dtype="bfloat16")
+        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
+        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
+        loss = mae_obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
+
 
 class MeanAbsolutePercentageErrorTest(testing.TestCase):
     def test_config(self):
@@ -207,6 +221,13 @@ class MeanAbsolutePercentageErrorTest(testing.TestCase):
         loss = mape_obj(y_true, y_pred, sample_weight=2.3)
         self.assertAlmostEqual(loss, [621.8518, 352.6666])
 
+    def test_dtype_arg(self):
+        mape_obj = losses.MeanAbsolutePercentageError(dtype="bfloat16")
+        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
+        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
+        loss = mape_obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
+
 
 class MeanSquaredLogarithmicErrorTest(testing.TestCase):
     def test_config(self):
@@ -254,6 +275,13 @@ class MeanSquaredLogarithmicErrorTest(testing.TestCase):
         y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
         loss = msle_obj(y_true, y_pred, sample_weight=0)
         self.assertAlmostEqual(loss, 0.0, 3)
+
+    def test_dtype_arg(self):
+        msle_obj = losses.MeanSquaredLogarithmicError(dtype="bfloat16")
+        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
+        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
+        loss = msle_obj(y_true, y_pred, sample_weight=2.3)
+        self.assertDType(loss, "bfloat16")
 
 
 class HingeTest(testing.TestCase):
@@ -309,6 +337,13 @@ class HingeTest(testing.TestCase):
         loss = hinge_obj(y_true, y_pred, sample_weight=sample_weight)
         self.assertEqual(loss, 0.0)
 
+    def test_dtype_arg(self):
+        hinge_obj = losses.Hinge(dtype="bfloat16")
+        y_true = np.array([[0.0, 1.0], [0.0, 0.0]])
+        y_pred = np.array([[0.6, 0.4], [0.4, 0.6]])
+        loss = hinge_obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
+
 
 class SquaredHingeTest(testing.TestCase):
     def test_unweighted(self):
@@ -363,6 +398,13 @@ class SquaredHingeTest(testing.TestCase):
         loss = hinge_obj(y_true, y_pred, sample_weight=sample_weight)
         self.assertEqual(loss, 0.0)
 
+    def test_dtype_arg(self):
+        hinge_obj = losses.SquaredHinge(dtype="bfloat16")
+        y_true = np.array([[0.0, 1.0], [0.0, 0.0]])
+        y_pred = np.array([[0.6, 0.4], [0.4, 0.6]])
+        loss = hinge_obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
+
 
 class CategoricalHingeTest(testing.TestCase):
     def test_unweighted(self):
@@ -416,6 +458,13 @@ class CategoricalHingeTest(testing.TestCase):
         hinge_obj = losses.CategoricalHinge()
         loss = hinge_obj(y_true, y_pred, sample_weight=sample_weight)
         self.assertEqual(loss, 0.0)
+
+    def test_dtype_arg(self):
+        hinge_obj = losses.CategoricalHinge(dtype="bfloat16")
+        y_true = np.array([[0.0, 1.0], [0.0, 0.0]])
+        y_pred = np.array([[0.6, 0.4], [0.4, 0.6]])
+        loss = hinge_obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
 
 
 class CosineSimilarityTest(testing.TestCase):
@@ -498,6 +547,12 @@ class CosineSimilarityTest(testing.TestCase):
         loss = cosine_obj(self.y_true, self.y_pred)
         expected_loss = -np.mean(self.expected_loss)
         self.assertAlmostEqual(loss, expected_loss, 3)
+
+    def test_dtype_arg(self):
+        self.setup()
+        cosine_obj = losses.CosineSimilarity(dtype="bfloat16")
+        loss = cosine_obj(self.y_true, self.y_pred)
+        self.assertDType(loss, "bfloat16")
 
 
 class HuberLossTest(testing.TestCase):
@@ -605,11 +660,11 @@ class HuberLossTest(testing.TestCase):
         )
         self.assertAlmostEqual(loss, actual_loss, 3)
 
-    def test_loss_with_non_default_dtype(self):
-        # Test case for GitHub issue:
-        # https://github.com/tensorflow/tensorflow/issues/39004
-        # TODO
-        pass
+    def test_dtype_arg(self):
+        self.setup()
+        h_obj = losses.Huber(dtype="bfloat16")
+        loss = h_obj(self.y_true, self.y_pred)
+        self.assertDType(loss, "bfloat16")
 
 
 class LogCoshTest(testing.TestCase):
@@ -702,6 +757,12 @@ class LogCoshTest(testing.TestCase):
         )
         self.assertAlmostEqual(loss, 0.0, 3)
 
+    def test_dtype_arg(self):
+        self.setup()
+        logcosh_obj = losses.LogCosh(dtype="bfloat16")
+        loss = logcosh_obj(self.y_true, self.y_pred)
+        self.assertDType(loss, "bfloat16")
+
 
 class KLDivergenceTest(testing.TestCase):
     def setup(self):
@@ -782,6 +843,12 @@ class KLDivergenceTest(testing.TestCase):
         k_obj = losses.KLDivergence()
         loss = k_obj(self.y_true, self.y_pred, sample_weight=0)
         self.assertAlmostEqual(loss, 0.0, 3)
+
+    def test_dtype_arg(self):
+        self.setup()
+        k_obj = losses.KLDivergence(dtype="bfloat16")
+        loss = k_obj(self.y_true, self.y_pred)
+        self.assertDType(loss, "bfloat16")
 
 
 class PoissonTest(testing.TestCase):
@@ -869,6 +936,12 @@ class PoissonTest(testing.TestCase):
         poisson_obj = losses.Poisson()
         loss = poisson_obj(self.y_true, self.y_pred, sample_weight=0)
         self.assertAlmostEqual(loss, 0.0, 3)
+
+    def test_dtype_arg(self):
+        self.setup()
+        poisson_obj = losses.Poisson(dtype="bfloat16")
+        loss = poisson_obj(self.y_true, self.y_pred)
+        self.assertDType(loss, "bfloat16")
 
 
 class BinaryCrossentropyTest(testing.TestCase):
@@ -973,6 +1046,19 @@ class BinaryCrossentropyTest(testing.TestCase):
         cce_obj = losses.BinaryCrossentropy()
         with self.assertRaisesRegex(ValueError, "must have the same shape"):
             cce_obj(y_true, y_pred)
+
+    @pytest.mark.skipif(
+        backend.backend() == "torch",
+        reason="Torch doesn't support bfloat16 for BinaryCrossentropy",
+    )
+    def test_dtype_arg(self):
+        y_true = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype="float32")
+        y_pred = np.array(
+            [[0.9, 0.1, 0.2], [0.3, 0.8, 0.1], [0.1, 0.2, 0.7]], dtype="float32"
+        )
+        bce_obj = losses.BinaryCrossentropy(dtype="bfloat16")
+        loss = bce_obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
 
 
 class CategoricalCrossentropyTest(testing.TestCase):
@@ -1089,6 +1175,16 @@ class CategoricalCrossentropyTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "must have the same shape"):
             cce_obj(y_true, y_pred)
 
+    def test_dtype_arg(self):
+        y_true = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype="int64")
+        y_pred = np.array(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            dtype="float32",
+        )
+        cce_obj = losses.CategoricalCrossentropy(dtype="bfloat16")
+        loss = cce_obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
+
 
 class SparseCategoricalCrossentropyTest(testing.TestCase):
     def test_config(self):
@@ -1189,6 +1285,16 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
         loss = cce_obj(y_true, logits)
         self.assertAllClose([[0.0, 1.480129]], loss)
 
+    def test_dtype_arg(self):
+        y_true = np.array([[0], [1], [2]], dtype="int64")
+        y_pred = np.array(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            dtype="float32",
+        )
+        cce_obj = losses.SparseCategoricalCrossentropy(dtype="bfloat16")
+        loss = cce_obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
+
 
 class BinaryFocalCrossentropyTest(testing.TestCase):
     def test_config(self):
@@ -1281,6 +1387,19 @@ class BinaryFocalCrossentropyTest(testing.TestCase):
         )
         loss = obj(y_true, y_pred)
         self.assertAllClose(loss, (0.515547, 0.020513))
+
+    @pytest.mark.skipif(
+        backend.backend() == "torch",
+        reason="Torch doesn't support bfloat16 for BinaryFocalCrossentropy",
+    )
+    def test_dtype_arg(self):
+        y_true = np.asarray([1, 0, 1, 0]).reshape([2, 2])
+        y_pred = np.asarray([0.9, 0.8, 0.7, 0.2], dtype=np.float32).reshape(
+            [2, 2]
+        )
+        obj = losses.BinaryFocalCrossentropy(dtype="bfloat16")
+        loss = obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
 
 
 class CategoricalFocalCrossentropyTest(testing.TestCase):
@@ -1381,20 +1500,31 @@ class CategoricalFocalCrossentropyTest(testing.TestCase):
         expected_value = 0.06685
         self.assertAlmostEqual(loss, expected_value, 3)
 
+    def test_dtype_arg(self):
+        logits = np.array([[4.9, -0.5, 2.05]])
+        y_true = np.array([[1, 0, 0]])
+        cce_obj = losses.CategoricalFocalCrossentropy(
+            from_logits=True, dtype="bfloat16"
+        )
+        loss = cce_obj(y_true, logits)
+        self.assertDType(loss, "bfloat16")
+
 
 class CTCTest(testing.TestCase):
     def test_config(self):
         self.run_class_serialization_test(losses.CTC(name="myctc"))
 
-    @pytest.mark.skipif(
-        backend.backend() == "numpy",
-        reason="Numpy does not support CTC loss",
-    )
     def test_correctness(self):
         logits = (np.arange(24).reshape((2, 4, 3)).astype("float32") - 12) / 100
         y_true = np.array(([[1, 2, 1, 0], [1, 2, 0, 2]]))
         output = losses.CTC()(y_true, logits)
         self.assertAllClose(output, 2.448645)
+
+    def test_dtype_arg(self):
+        logits = (np.arange(24).reshape((2, 4, 3)).astype("float32") - 12) / 100
+        y_true = np.array(([[1, 2, 1, 0], [1, 2, 0, 2]]))
+        output = losses.CTC(dtype="bfloat16")(y_true, logits)
+        self.assertDType(output, "bfloat16")
 
 
 class DiceTest(testing.TestCase):
@@ -1426,6 +1556,12 @@ class DiceTest(testing.TestCase):
         )
         output = losses.Dice(axis=(1, 2, 3), reduction=None)(y_true, y_pred)
         self.assertAllClose(output, [0.5, 0.75757575])
+
+    def test_dtype_arg(self):
+        y_true = np.array(([[1, 2], [1, 2]]))
+        y_pred = np.array(([[4, 1], [6, 1]]))
+        output = losses.Dice(dtype="bfloat16")(y_true, y_pred)
+        self.assertDType(output, "bfloat16")
 
 
 class TverskyTest(testing.TestCase):
@@ -1463,3 +1599,9 @@ class TverskyTest(testing.TestCase):
         )
         output = losses.Tversky(alpha=0.2, beta=0.8)(y_true, y_pred)
         self.assertAllClose(output, 0.7916667)
+
+    def test_dtype_arg(self):
+        y_true = np.array(([[1, 2], [1, 2]]))
+        y_pred = np.array(([[4, 1], [6, 1]]))
+        output = losses.Tversky(dtype="bfloat16")(y_true, y_pred)
+        self.assertDType(output, "bfloat16")


### PR DESCRIPTION
This PR allows users to set the `dtype` for `Loss`. Previously, it was only configurable via `keras.backend.set_floatx()`.