### PR TITLE
Fix `dtype` argument passed to `Layer` when it is a `FloatDTypePolicy` in config

### DIFF
--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -62,7 +62,7 @@ class DTypePolicy:
             name = dtype_policy().name
         self._name = name
         self._compute_dtype, self._variable_dtype = self._parse_name(name)
-        self._is_quantized = False
+        self._quantization_mode = None
 
     def _parse_name(self, name):
         """Parses a `DTypePolicy` name into a compute and variable dtype.
@@ -137,9 +137,14 @@ class DTypePolicy:
         return self._name
 
     @property
-    def is_quantized(self):
-        """Whether a quantized dtype policy."""
-        return self._is_quantized
+    def quantization_mode(self):
+        """The quantization mode of this policy.
+
+        Returns:
+            The quantization mode of this policy, as a string. If this policy is
+            not quantized, it will return `None`.
+        """
+        return self._quantization_mode
 
     def convert_input(self, x, autocast, dtype):
         """Converts the input dtype based on `autocast` and `dtype`.
@@ -218,16 +223,6 @@ class QuantizedDTypePolicy(DTypePolicy):
         self._name = name
         self._source_name = source_name
         self._quantization_mode = mode
-        self._is_quantized = True
-
-    @property
-    def quantization_mode(self):
-        """The quantization mode of this policy.
-
-        Returns:
-            The quantization mode of this policy, as a string.
-        """
-        return self._quantization_mode
 
     def __eq__(self, other):
         if super().__eq__(other) is False:

--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -23,7 +23,7 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
             config = super().get_config()
             dtype_policy_map = dtype_policies.DTypePolicyMap()
             for layer in self._flatten_layers():
-                if layer.dtype_policy.is_quantized:
+                if layer.dtype_policy.quantization_mode is not None:
                     dtype_policy_map[layer.path] = layer.dtype_policy
             if len(dtype_policy_map) > 0:
                 config.update({"dtype": dtype_policy_map})
@@ -86,16 +86,16 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
         return dtype_policies.get(self._default_policy)
 
     @property
-    def is_quantized(self):
-        return self.default_policy._is_quantized
-
-    @property
     def variable_dtype(self):
         return self.default_policy.variable_dtype
 
     @property
     def compute_dtype(self):
         return self.default_policy.compute_dtype
+
+    @property
+    def quantization_mode(self):
+        return self.default_policy.quantization_mode
 
     def __getitem__(self, key):
         """Retrieves the corresponding `DTypePolicy` by the string key.

--- a/keras/src/dtype_policies/dtype_policy_test.py
+++ b/keras/src/dtype_policies/dtype_policy_test.py
@@ -113,13 +113,13 @@ class FloatDTypePolicyTest(test_case.TestCase, parameterized.TestCase):
         self.assertEqual(policy.variable_dtype, "float32")
         self.assertEqual(policy.compute_dtype, "float16")
         self.assertEqual(policy.name, "mixed_float16")
-        self.assertFalse(policy.is_quantized)
+        self.assertIsNone(policy.quantization_mode)
 
         policy = FloatDTypePolicy("mixed_float16")
         self.assertEqual(policy.variable_dtype, "float32")
         self.assertEqual(policy.compute_dtype, "float16")
         self.assertEqual(policy.name, "mixed_float16")
-        self.assertFalse(policy.is_quantized)
+        self.assertIsNone(policy.quantization_mode)
 
     def test_properties_uint8(self):
         """Test properties for 'uint8'."""
@@ -365,7 +365,7 @@ class QuantizedDTypePolicyTest(test_case.TestCase, parameterized.TestCase):
         self.assertEqual(policy.variable_dtype, "float32")
         self.assertEqual(policy.compute_dtype, "bfloat16")
         self.assertEqual(policy.name, "int8_from_mixed_bfloat16")
-        self.assertTrue(policy.is_quantized)
+        self.assertEqual(policy.quantization_mode, "int8")
 
         # Test float8
         policy = QuantizedFloat8DTypePolicy(
@@ -374,7 +374,7 @@ class QuantizedDTypePolicyTest(test_case.TestCase, parameterized.TestCase):
         self.assertEqual(policy.variable_dtype, "float32")
         self.assertEqual(policy.compute_dtype, "bfloat16")
         self.assertEqual(policy.name, "float8_from_mixed_bfloat16")
-        self.assertTrue(policy.is_quantized)
+        self.assertEqual(policy.quantization_mode, "float8")
         self.assertEqual(policy.amax_history_length, 1024)
 
         # Test float8 with amax_history_length

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -559,7 +559,7 @@ class Dense(Layer):
         self._tracker.lock()
 
         # Set new dtype policy
-        if not self.dtype_policy.is_quantized:
+        if self.dtype_policy.quantization_mode is None:
             policy = dtype_policies.get(f"{mode}_from_{self.dtype_policy.name}")
             self.dtype_policy = policy
 
@@ -567,7 +567,7 @@ class Dense(Layer):
         gc.collect()
 
     def _get_kernel_with_merged_lora(self):
-        if self.dtype_policy.is_quantized:
+        if self.dtype_policy.quantization_mode is not None:
             kernel_value = self._kernel
             kernel_scale = self.kernel_scale
             if self.lora_enabled:

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -475,7 +475,7 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
             NotImplementedError, "Invalid quantization mode."
         ):
             # Explicitly set quantization_mode
-            layer._dtype_policy.quantization_mode = mode
+            layer._dtype_policy._quantization_mode = mode
             layer.quantized_call(x)
         self.assertEqual(layer.dtype_policy, original_dtype_policy)
 

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -697,7 +697,7 @@ class EinsumDense(Layer):
         self._tracker.lock()
 
         # Set new dtype policy
-        if not self.dtype_policy.is_quantized:
+        if self.dtype_policy.quantization_mode is None:
             policy = dtype_policies.get(f"{mode}_from_{self.dtype_policy.name}")
             self.dtype_policy = policy
 
@@ -705,7 +705,7 @@ class EinsumDense(Layer):
         gc.collect()
 
     def _get_kernel_with_merged_lora(self):
-        if self.dtype_policy.is_quantized:
+        if self.dtype_policy.quantization_mode is not None:
             kernel_value = self._kernel
             kernel_scale = self.kernel_scale
             if self.lora_enabled:

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -599,7 +599,7 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
             NotImplementedError, "Invalid quantization mode."
         ):
             # Explicitly set quantization_mode
-            layer._dtype_policy.quantization_mode = mode
+            layer._dtype_policy._quantization_mode = mode
             layer.quantized_call(x)
         self.assertEqual(layer.dtype_policy, original_dtype_policy)
 

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -376,7 +376,7 @@ class Embedding(Layer):
         self._tracker.lock()
 
         # Set new dtype policy
-        if not self.dtype_policy.is_quantized:
+        if self.dtype_policy.quantization_mode is None:
             policy = dtype_policies.get(f"{mode}_from_{self.dtype_policy.name}")
             self.dtype_policy = policy
 
@@ -384,7 +384,7 @@ class Embedding(Layer):
         gc.collect()
 
     def _get_embeddings_with_merged_lora(self):
-        if self.dtype_policy.is_quantized:
+        if self.dtype_policy.quantization_mode is not None:
             embeddings_value = self._embeddings
             embeddings_scale = self.embeddings_scale
             if self.lora_enabled:

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -367,7 +367,7 @@ class EmbeddingTest(test_case.TestCase, parameterized.TestCase):
             NotImplementedError, "Invalid quantization mode."
         ):
             # Explicitly set quantization_mode
-            layer._dtype_policy.quantization_mode = mode
+            layer._dtype_policy._quantization_mode = mode
             layer.quantized_call(x)
         self.assertEqual(layer.dtype_policy, original_dtype_policy)
 

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -994,6 +994,46 @@ class LayerTest(testing.TestCase):
         reloaded = pickle.loads(pickle.dumps(layer))
         self.assertEqual(layer.get_config(), reloaded.get_config())
 
+    def test_serialize_dtype(self):
+        assertIsNone = self.assertIsNone
+        assertIsNotNone = self.assertIsNotNone
+
+        class AssertionDense(layers.Dense):
+            def __init__(self, *args, **kwargs):
+                dtype = kwargs["dtype"]
+                if isinstance(dtype, str):
+                    # `dtype` is a plain string, it should be the `name` from a
+                    # `FloatDTypePolicy`
+                    dtype = dtype_policies.get(dtype)
+                    assertIsNone(dtype.quantization_mode)
+                else:
+                    # `dtype` is a DTypePolicy instance, it should be an
+                    # instance of `QuantizedDTypePolicy`
+                    assertIsNotNone(dtype.quantization_mode)
+                super().__init__(*args, **kwargs)
+
+        # Test floating dtype serialization
+        layer = layers.Dense(2, dtype="bfloat16")
+        config = layer.get_config()
+        self.assertIn("dtype", config)
+        self.assertEqual(
+            config["dtype"],
+            dtype_policies.serialize(
+                dtype_policies.FloatDTypePolicy("bfloat16")
+            ),
+        )
+        AssertionDense.from_config(config)  # Assertion inside
+
+        # Test quantized dtype serialization
+        layer = layers.Dense(2, dtype="int8_from_bfloat16")
+        config = layer.get_config()
+        self.assertIn("dtype", config)
+        self.assertEqual(
+            config["dtype"],
+            dtype_policies.serialize(dtype_policies.get("int8_from_bfloat16")),
+        )
+        AssertionDense.from_config(config)  # Assertion inside
+
     def test_serialize_activity_regularizer(self):
         layer = layers.Dense(2, activity_regularizer="l2")
         config = layer.get_config()

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -107,7 +107,7 @@ class Operation:
         if dtype is not None and isinstance(dtype, dtype_policies.DTypePolicy):
             # For backward compatibility, we use a str (`name`) for
             # `FloatDTypePolicy`
-            if not dtype.is_quantized:
+            if dtype.quantization_mode is None:
                 kwargs["dtype"] = dtype.name
             # Otherwise, use `dtype_policies.serialize`
             else:
@@ -221,7 +221,15 @@ class Operation:
         # directly interact with the instance of `DTypePolicy`.
         if "dtype" in config and isinstance(config["dtype"], dict):
             config = config.copy()
-            config["dtype"] = dtype_policies.deserialize(config["dtype"])
+            policy = dtype_policies.deserialize(config["dtype"])
+            if (
+                not isinstance(policy, dtype_policies.DTypePolicyMap)
+                and policy.quantization_mode is None
+            ):
+                # For backward compatibility, we use a str (`name`) for
+                # `FloatDTypePolicy`
+                policy = policy.name
+            config["dtype"] = policy
         try:
             return cls(**config)
         except Exception as e:


### PR DESCRIPTION
This PR is a small but important fix.

We should ensure that the `dtype` argument passed to `Layer` is a str when it is a `FloatDTypePolicy` in config for backward compatibility.
Otherwise, it will break the downstream project like KerasNLP. (Currently, master branch should break it.)

EDITED:
It would be a good idea to replace `is_quantized` with `quantization_mode` in `DTypePolicy`.
Now, `quantization_mode` returns `None` if the policy is not quantized. This behavior matches `Layer`.
