### PR TITLE
Add `keras.ops.dtype`

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -13,6 +13,7 @@ from keras.src.ops.core import cond
 from keras.src.ops.core import convert_to_numpy
 from keras.src.ops.core import convert_to_tensor
 from keras.src.ops.core import custom_gradient
+from keras.src.ops.core import dtype
 from keras.src.ops.core import fori_loop
 from keras.src.ops.core import is_tensor
 from keras.src.ops.core import scan

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -13,6 +13,7 @@ from keras.src.ops.core import cond
 from keras.src.ops.core import convert_to_numpy
 from keras.src.ops.core import convert_to_tensor
 from keras.src.ops.core import custom_gradient
+from keras.src.ops.core import dtype
 from keras.src.ops.core import fori_loop
 from keras.src.ops.core import is_tensor
 from keras.src.ops.core import scan

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -599,8 +599,7 @@ def shape(x):
 
 @keras_export("keras.ops.dtype")
 def dtype(x):
-    """
-    Gets the dtype of the tensor input as a standardized string.
+    """Gets the dtype of the tensor input as a standardized string.
     Note that due to the standardization, the dtype will not compare equal
     to the backend-specific version of the dtype.
 

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -588,7 +588,7 @@ def shape(x):
 
     Example:
 
-    >>> x = keras.zeros((8, 12))
+    >>> x = keras.ops.zeros((8, 12))
     >>> keras.ops.shape(x)
     (8, 12)
     """

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -597,6 +597,29 @@ def shape(x):
     return backend.core.shape(x)
 
 
+@keras_export("keras.ops.dtype")
+def dtype(x):
+    """
+    Gets the dtype of the tensor input as a standardized string.
+    Note that due to the standardization, the dtype will not compare equal
+    to the backend-specific version of the dtype.
+
+    Args:
+        x: A tensor. This function will try to access the `dtype` attribute of
+            the input tensor.
+
+    Returns: A string indicating the dtype of the input tensor.
+
+    Example:
+
+    >>> x = keras.ops.zeros((8, 12))
+    >>> keras.ops.dtype(x)
+    'float32'
+
+    """
+    return backend.standardize_dtype(x.dtype)
+
+
 class Cast(Operation):
     def __init__(self, dtype):
         super().__init__()


### PR DESCRIPTION
This is strangely missing from the `ops` module. The current way to use `dtype`s would be to call `tensor.dtype` directly, but this is dangerous territory for a multi-backend library, and also confusing to users when the `ops` module specifically exists to avoid calling tensor methods directly.

Example use case:

```py3
x = keras.ops.zeros((32, 2))
t = keras.ops.full((keras.ops.shape(x)[0], 1), t, dtype=keras.ops.dtype(x))
```

Slightly nasty: the output from this will not compare equal to the actual dtype of the tensor for all backends:

```py3
# False for torch and tensorflow, True for numpy and jax
x = keras.ops.zeros(())
keras.ops.dtype(x) == x.dtype
```

However, I don't think this is an issue, as all use cases will either relate a dtype to a hard-coded value (where users can use a string) or one inferred from a tensor (where users can just call `ops.dtype` again):

```py3
assert keras.ops.dtype(x) == "float32"
assert keras.ops.dtype(x) == keras.ops.dtype(y)
```