### PR TITLE
Fix for JAX exported model not updating non-trainable variables.

### DIFF
--- a/keras/src/export/export_lib_test.py
+++ b/keras/src/export/export_lib_test.py
@@ -93,7 +93,43 @@ class ExportArchiveTest(testing.TestCase, parameterized.TestCase):
         revived_model = tf.saved_model.load(temp_filepath)
         self.assertEqual(ref_output.shape, revived_model.serve(ref_input).shape)
         # Test with a different batch size
-        revived_model.serve(tf.random.normal((6, 10)))
+        input = tf.random.normal((6, 10))
+        output1 = revived_model.serve(input)
+        output2 = revived_model.serve(input)
+        # Verify RNG seeding works and produces random outputs
+        self.assertNotAllClose(output1, output2)
+
+    @parameterized.named_parameters(
+        named_product(model_type=["sequential", "functional", "subclass"])
+    )
+    def test_model_with_non_trainable_state_export(self, model_type):
+
+        class StateLayer(layers.Layer):
+            def __init__(self):
+                super().__init__()
+                self.counter = self.add_variable(
+                    (), "zeros", "int32", trainable=False
+                )
+
+            def call(self, inputs):
+                self.counter.assign_add(1)
+                return ops.array(inputs), ops.array(self.counter.value)
+
+        temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
+        model = get_model(model_type, layer_list=[StateLayer()])
+        model(tf.random.normal((3, 10)))
+
+        export_lib.export_model(model, temp_filepath)
+        revived_model = tf.saved_model.load(temp_filepath)
+
+        # The non-trainable counter is expected to increment
+        input = tf.random.normal((6, 10))
+        output1, counter1 = revived_model.serve(input)
+        self.assertAllClose(output1, input)
+        self.assertAllClose(counter1, 2)
+        output2, counter2 = revived_model.serve(input)
+        self.assertAllClose(output2, input)
+        self.assertAllClose(counter2, 3)
 
     @parameterized.named_parameters(
         named_product(struct_type=["tuple", "array", "dict"])


### PR DESCRIPTION
Modification of non-trainable variables were not reflected in the `tf.Variable`s for exported JAX models. In particular, this caused random functions to use the same seed on every call.

This change binds the non-trainable variables of the model in the exported function.