### PR TITLE
Fix JAX export support of `TFDataLayer`.

### DIFF
--- a/keras/src/layers/preprocessing/tf_data_layer.py
+++ b/keras/src/layers/preprocessing/tf_data_layer.py
@@ -3,6 +3,7 @@ from keras.src import tree
 from keras.src.layers.layer import Layer
 from keras.src.random.seed_generator import SeedGenerator
 from keras.src.utils import backend_utils
+from keras.src.utils import jax_utils
 from keras.src.utils import tracking
 
 
@@ -20,8 +21,11 @@ class TFDataLayer(Layer):
         self._allow_non_tensor_positional_args = True
 
     def __call__(self, inputs, **kwargs):
-        if backend_utils.in_tf_graph() and not isinstance(
-            inputs, keras.KerasTensor
+        sample_input = tree.flatten(inputs)[0]
+        if (
+            not isinstance(sample_input, keras.KerasTensor)
+            and backend_utils.in_tf_graph()
+            and not jax_utils.is_in_jax_tracing_scope(sample_input)
         ):
             # We're in a TF graph, e.g. a tf.data pipeline.
             self.backend.set_backend("tensorflow")

--- a/keras/src/utils/jax_utils.py
+++ b/keras/src/utils/jax_utils.py
@@ -5,6 +5,7 @@ def is_in_jax_tracing_scope(x=None):
     if backend.backend() == "jax":
         if x is None:
             x = backend.numpy.ones(())
-        if x.__class__.__name__ == "DynamicJaxprTracer":
-            return True
+        for c in x.__class__.__mro__:
+            if c.__name__ == "Tracer" and c.__module__.startswith("jax"):
+                return True
     return False


### PR DESCRIPTION
During export, the `tf.function` wrapping the `jax2tf` function is traced. In this scenario, we're in a JAX tracing scope within a Tensorflow graph. `TFDataLayer` now detects this correctly.

Also improved `jax_utils.is_in_jax_tracing_scope()`: there are multiple tracer array classes that all extend `jax._src.core.Tracer`.