### PR TITLE
tweak torch parameter registration mechanism

### DIFF
--- a/keras/src/backend/torch/layer.py
+++ b/keras/src/backend/torch/layer.py
@@ -8,19 +8,85 @@ from keras.src.ops.operation import Operation
 
 
 class TorchLayer(torch.nn.Module):
+    """Adaptation layer to make sure keras.layers.Layer works well with
+    torch.nn.Module. Currently, the main modification are on parameter/module
+    tracking and pointing torch.nn.Module.forward() to the right keras call.
+
+    Module tracking:
+      All sublayers are tracked as modules in Module._modules. All module level
+    api with recurse=True should work properly just like a torch.nn.Module.
+
+    Variable tracking:
+      Since keras has a different variable tracking mechanism, unlike modules,
+    Modules._parameter doesn't automatically tracks variables created for torch
+    layers.
+      This is currently manually populated through _track_torch_params() that
+    does following work:
+        1. Populate all sublayers torch params by calling _track_torch_params()
+        2. Create a single torch.nn.ParameterList() parameter with trainable,
+           non trainable and seed generator states belongs to the current layer.
+      Since keras also allows untrack / track object post build, eg.
+    Dense.enable_lora(), Dense.quantization(); _untrack_torch_params() is added
+    that allows refresh the parameters expose to torch module. A re-populate
+    will trigger every time when Layer._track_variable() and
+    Layer._untrack_variable() is called.
+
+    Few additional points that user should be aware of:
+    1. When torch backend is enabled KerasVariable.value is torch.nn.Parameter,
+       this is not visible to torch since it is separately tracked in keras
+       tracker.
+    2. When torch parameter is exposed with _track_torch_params(), no copy is
+       made to the torch parameter in keras tracker; so both keras tracker and
+       torch module sees the same object it is just present in 2 different
+       member variables. This also means any modification to keras variable,
+       for instance, setting trainable is automatically populated to torch
+       parameters.
+    3. Since keras creates variables in a deterministic order, resulted torch
+       parameter list will also in deterministic order with the order of
+       trainable->non_trainable->seed_generator_states. Changing variable from
+       trainable to non trainable won't move keras variable from one tracker to
+       the another, so does the final populated torch_params.
+    4. It is recommended for user to alternate variables through keras variable
+       apis instead of alternate with torch_params since it is simpler with the
+       keras variable api and it is backend agnostic.
+    5. Any torch module operation should in theory works; for example
+       state_dict() and load_state_dict() works if you want a more torch way of
+       saving variables.
+    6. Although not recommended, but you can use below code snippet to find the
+       corresponding parameter in torch_params from a keras variable:
+       parameters = [(pname, p) for pname, p in layer.named_parameters() \
+                      if id(p) == id(variable.value)]
+    """
+
     def _post_build(self):
         # Do not track variables when in a stateless scope.
         # The variables are not initialized.
         if in_stateless_scope():
             return
-        self._track_variables()
+        self._track_torch_params()
 
-    def _track_variables(self):
+    def _track_torch_params(self):
+        for layer in self._layers:
+            layer._track_torch_params()
+        if self._torch_params_tracked():
+            return
+        torch_params = []
+        for v in self._trainable_variables + self._non_trainable_variables:
+            torch_params.append(v.value)
+        for sg in self._seed_generators:
+            torch_params.append(sg.state.value)
+
         # set torch_params attribute will have module automatically track
         # parameters.
-        self.torch_params = torch.nn.ParameterDict(
-            {variable.path: variable.value for variable in self.variables}
-        )
+        self.torch_params = torch.nn.ParameterList(torch_params)
+
+    def _untrack_torch_params(self):
+        for layer in self._layers:
+            layer._untrack_torch_params()
+        del self.torch_params
+
+    def _torch_params_tracked(self):
+        return hasattr(self, "torch_params")
 
     def named_parameters(
         self,
@@ -28,8 +94,11 @@ class TorchLayer(torch.nn.Module):
         recurse: bool = True,
         remove_duplicate: bool = True,
     ) -> Iterator[Tuple[str, torch.nn.Parameter]]:
-        if not hasattr(self, "torch_params"):
-            self._track_variables()
+        if not self._torch_params_tracked():
+            raise RuntimeError(
+                "Torch parameters are not tracked yet. "
+                "Did you forget to call build()?"
+            )
         return torch.nn.Module.named_parameters(
             self, prefix, recurse, remove_duplicate
         )
@@ -51,11 +120,12 @@ class TorchLayer(torch.nn.Module):
                 value = TorchModuleWrapper(value)
         return name, value
 
-    def _post_track_variable(self, variable):
-        if hasattr(self, "torch_params"):
-            if variable.path not in self.torch_params:
-                self.torch_params[variable.path] = variable.value
+    def _post_track_variable(self, _):
+        if self._torch_params_tracked():
+            self._untrack_torch_params()
+            self._track_torch_params()
 
-    def _post_untrack_variable(self, variable):
-        if hasattr(self, "torch_params"):
-            self.torch_params.pop(variable.path)
+    def _post_untrack_variable(self, _):
+        if self._torch_params_tracked():
+            self._untrack_torch_params()
+            self._track_torch_params()

--- a/keras/src/backend/torch/layer_test.py
+++ b/keras/src/backend/torch/layer_test.py
@@ -1,0 +1,222 @@
+import numpy as np
+import pytest
+
+from keras.src import backend
+from keras.src import layers
+from keras.src import testing
+from keras.src.backend.common import global_state
+
+if backend.backend() == "torch":
+    import torch
+
+
+@pytest.mark.skipif(backend.backend() != "torch", reason="Torch only test.")
+class LayerTest(testing.TestCase):
+
+    def get_torch_parameter_from_variable(self, layer, variable):
+        parameters = [
+            (pname, p)
+            for pname, p in layer.named_parameters()
+            if id(p) == id(variable.value)
+        ]
+        if len(parameters) > 1:
+            raise ValueError(
+                "Found more than one paramter match with variable."
+            )
+        if len(parameters) == 0:
+            return None
+        return parameters[0]
+
+    def test_torch_params_create_deterministic(self):
+        class MyLayer(layers.Layer):
+            def __init__(self):
+                super().__init__()
+                self.w1 = self.add_weight(initializer="zeros")
+                self.w3 = self.add_weight(dtype="bool", trainable=False)
+                self.w4 = self.add_weight(
+                    initializer="ones",
+                    dtype="int32",
+                    shape=(2, 2),
+                    trainable=False,
+                )
+                self.w5 = self.add_weight(initializer="ones", shape=(2, 2))
+
+        params = []
+        for _ in range(5):
+            global_state.clear_session()
+            layer = MyLayer()
+            layer.build(None)
+            layer_params = list(
+                (pname, np.copy(p.detach().numpy()))
+                for pname, p in layer.named_parameters()
+            )
+            self.assertEqual(len(layer_params), 4)
+            params.append(layer_params)
+
+        for idx in range(len(params) - 1):
+            param_a = params[idx]
+            param_b = params[idx + 1]
+            self.assertEqual(len(param_a), len(param_b))
+            for i in range(len(param_a)):
+                self.assertEqual(param_a[i][0], param_b[i][0])
+                np.testing.assert_array_equal(param_a[i][1], param_b[i][1])
+
+    def test_nested_modification_propagate(self):
+        class MyLayer(layers.Layer):
+            def __init__(self):
+                super().__init__()
+                self.child = ChildLayer()
+
+        class ChildLayer(layers.Layer):
+
+            def __init__(self):
+                super().__init__()
+                self.w1 = self.add_weight()
+                self.w2 = self.add_weight(dtype="int32", trainable=False)
+                self.grand_child = GrandChildLayer()
+
+        class GrandChildLayer(layers.Layer):
+
+            def __init__(self):
+                super().__init__()
+                self.w3 = self.add_weight(name="w3", trainable=False)
+                self.w4 = self.add_weight(shape=(2, 2), name="w4")
+                self.w5 = self.add_weight(
+                    initializer="ones", shape=(2, 2), name="w5"
+                )
+
+        layer = MyLayer()
+        layer.build(None)
+
+        self.assertEqual(len(list(layer.parameters())), 5)
+        w5 = self.get_torch_parameter_from_variable(
+            layer, layer.child.grand_child.w5
+        )
+        self.assertIsNotNone(w5)
+        # the order is trainable -> non_trainable -> seed, so in torch list it
+        # is w4->w5->w3.
+        self.assertEqual(w5[0], "child.grand_child.torch_params.1")
+        w5_value = w5[1]
+
+        np.testing.assert_array_equal(
+            w5_value.detach().numpy(), np.ones((2, 2))
+        )
+
+        layer.child.grand_child.w5.assign_sub(1)
+
+        np.testing.assert_array_equal(
+            w5_value.detach().numpy(), np.zeros((2, 2))
+        )
+
+    def test_trainable_modification_propagates(self):
+        class Layer(layers.Layer):
+
+            def __init__(self):
+                super().__init__()
+                self.w1 = self.add_weight(name="w1")
+                self.w2 = self.add_weight(name="w2")
+
+        layer = Layer()
+        layer.build(None)
+
+        torch_w1 = self.get_torch_parameter_from_variable(layer, layer.w1)
+        self.assertIsNotNone(torch_w1)
+        torch_w1_value = torch_w1[1]
+
+        self.assertTrue(layer.w1.trainable)
+        self.assertTrue(torch_w1_value.requires_grad)
+
+        layer.w1.trainable = False
+        self.assertFalse(layer.w1.trainable)
+        self.assertFalse(torch_w1_value.requires_grad)
+
+        # the order of parameter dict is w.r.t to the creation time trainable
+        # non-trainable assignment, flipping later doesn't affect parameter
+        # list order.
+
+        layer._untrack_torch_params()
+        layer._track_torch_params()
+
+        torch_w1 = self.get_torch_parameter_from_variable(layer, layer.w1)
+        self.assertIsNotNone(torch_w1)
+        torch_w1_value = torch_w1[1]
+        self.assertEqual(torch_w1[0], "torch_params.0")
+        np.testing.assert_array_equal(
+            torch_w1_value.detach().numpy(), layer.w1.numpy()
+        )
+
+        torch_w2 = self.get_torch_parameter_from_variable(layer, layer.w2)
+        self.assertIsNotNone(torch_w2)
+        torch_w1_value = torch_w2[1]
+        self.assertEqual(torch_w2[0], "torch_params.1")
+        np.testing.assert_array_equal(
+            torch_w1_value.detach().numpy(), layer.w2.numpy()
+        )
+
+    def test_load_dict_store_restore(self):
+
+        class Layer(layers.Layer):
+
+            def __init__(self):
+                super().__init__()
+                self.w = self.add_weight(shape=(2, 2))
+                self.seed_gen = backend.random.SeedGenerator(seed=1337)
+                self.child = ChildLayer()
+
+        class ChildLayer(layers.Layer):
+            def __init__(self):
+                super().__init__()
+                self.stat = self.add_weight(
+                    shape=(2, 2),
+                    dtype="int32",
+                    trainable=False,
+                    initializer="zero",
+                )
+                self.w = self.add_weight(shape=(2, 2))
+
+        layer1 = Layer()
+        layer1.build(None)
+        layer1.seed_gen.next()
+        layer1.child.stat.assign_add(1)
+
+        state_dict = layer1.state_dict()
+        global_state.clear_session()
+
+        layer2 = Layer()
+        layer2.build(None)
+
+        layer2_initial_state_dict = layer2.state_dict()
+
+        for key, v in state_dict.items():
+            self.assertTrue(key in layer2_initial_state_dict)
+            self.assertFalse(torch.equal(v, layer2_initial_state_dict[key]))
+
+        for layer1_var, layer2_var in zip(layer1.variables, layer2.variables):
+            self.assertTrue(layer1_var.path, layer2_var.path)
+            self.assertFalse(
+                np.array_equal(layer1_var.numpy(), layer2_var.numpy())
+            )
+
+        layer2.load_state_dict(state_dict)
+        for key, v in state_dict.items():
+            self.assertTrue(key in layer2_initial_state_dict)
+            self.assertTrue(torch.equal(v, layer2_initial_state_dict[key]))
+
+        for layer1_var, layer2_var in zip(layer1.variables, layer2.variables):
+            self.assertTrue(layer1_var.path, layer2_var.path)
+            np.testing.assert_array_equal(
+                layer1_var.numpy(), layer2_var.numpy()
+            )
+
+    def test_throw_error_when_build_not_called(self):
+        class Layer(layers.Layer):
+
+            def __init__(self):
+                super().__init__()
+                self.w = self.add_weight(name="w")
+
+        layer = Layer()
+        with self.assertRaisesRegex(
+            RuntimeError, "Did you forget to call build()?"
+        ):
+            layer.named_parameters()

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -10,7 +10,6 @@ from keras.src import metrics
 from keras.src import models
 from keras.src import ops
 from keras.src import testing
-from keras.src.backend.common import global_state
 
 
 class LayerTest(testing.TestCase):
@@ -1076,12 +1075,6 @@ class LayerTest(testing.TestCase):
         variable_paths = set(v.path for v in layer.variables)
         self.assertTrue("inner_layer/inner" in variable_paths)
         self.assertTrue("inner_inner_layer/inner" in variable_paths)
-        if backend.backend() == "torch":
-            parameter_names = set(
-                param_name.replace("torch_params.", "")
-                for param_name, _ in layer.named_parameters()
-            )
-            self.assertSetEqual(variable_paths, parameter_names)
 
     def test_custom_layer_add_weight_in_build_name(self):
         class TrainingLayer(layers.Layer):
@@ -1133,12 +1126,6 @@ class LayerTest(testing.TestCase):
             "training_layer/inner_layer/inner_inner_layer/inner"
             in variable_paths
         )
-        if backend.backend() == "torch":
-            parameter_names = set(
-                param_name.replace("torch_params.", "")
-                for param_name, _ in layer.named_parameters()
-            )
-            self.assertSetEqual(variable_paths, parameter_names)
 
     def test_layer_variable_tracking_correct(self):
         class TrainingLayer(layers.Layer):
@@ -1188,7 +1175,7 @@ class LayerTest(testing.TestCase):
             self.assertEqual(len(parameter_names), 1)
             self.assertEqual(
                 parameter_names[0],
-                "torch_params.training_layer/post_build_modify_layer/var",
+                "post_build_modify_layer.torch_params.0",
             )
 
         layer.post_build_modify_layer.post_build_add()
@@ -1202,30 +1189,35 @@ class LayerTest(testing.TestCase):
             "training_layer/post_build_modify_layer/var2",
         )
         if backend.backend() == "torch":
-            # TODO (haohuanw, fchollet): Needs further discussion on how to
-            # properly manage torch params. Post build modification cannot
-            # propagate to parent torch params.
-            parameter_names = [pname for pname, _ in layer.named_parameters()]
-            # Below check should have 2 parameters instead of 1.
-            self.assertEqual(len(parameter_names), 1)
-            self.assertEqual(
-                parameter_names[0],
-                "torch_params.training_layer/post_build_modify_layer/var",
-            )
+            self.assertEqual(len(list(layer.parameters())), 2)
+            for idx, (pname, var) in enumerate(layer.named_parameters()):
+                self.assertEqual(
+                    pname, f"post_build_modify_layer.torch_params.{idx}"
+                )
+                self.assertEqual(
+                    id(var),
+                    id(
+                        layer.post_build_modify_layer._trainable_variables[
+                            idx
+                        ].value
+                    ),
+                )
 
-            parameter_names = [
-                pname
-                for pname, _ in layer.post_build_modify_layer.named_parameters()
-            ]
-            self.assertEqual(len(parameter_names), 2)
             self.assertEqual(
-                parameter_names[0],
-                "torch_params.training_layer/post_build_modify_layer/var",
+                len(list(layer.post_build_modify_layer.parameters())), 2
             )
-            self.assertEqual(
-                parameter_names[1],
-                "torch_params.training_layer/post_build_modify_layer/var2",
-            )
+            for idx, (pname, var) in enumerate(
+                layer.post_build_modify_layer.named_parameters()
+            ):
+                self.assertEqual(pname, f"torch_params.{idx}")
+                self.assertEqual(
+                    id(var),
+                    id(
+                        layer.post_build_modify_layer._trainable_variables[
+                            idx
+                        ].value
+                    ),
+                )
 
         layer.post_build_modify_layer.post_build_remove()
         self.assertEqual(len(layer.variables), 1)
@@ -1234,51 +1226,32 @@ class LayerTest(testing.TestCase):
             "training_layer/post_build_modify_layer/var2",
         )
         if backend.backend() == "torch":
-            # TODO (haohuanw, fchollet): Needs further discussion on how to
-            # properly manage torch params. Post build modification cannot
-            # propagate to parent torch params.
-            parameter_names = [pname for pname, _ in layer.named_parameters()]
-            # Below check should have 1 parameters instead of 2, torch_params
-            # in parent layer is wrong.
-            self.assertEqual(len(parameter_names), 2)
-            self.assertEqual(
-                parameter_names[0],
-                "post_build_modify_layer.torch_params.training_layer/"
-                "post_build_modify_layer/var2",
-            )
-            self.assertEqual(
-                parameter_names[1],
-                "torch_params.training_layer/post_build_modify_layer/var",
-            )
-
-            parameter_names = [
-                pname
-                for pname, _ in layer.post_build_modify_layer.named_parameters()
-            ]
-            self.assertEqual(len(parameter_names), 1)
-            self.assertEqual(
-                parameter_names[0],
-                "torch_params.training_layer/post_build_modify_layer/var2",
-            )
-
-    @pytest.mark.skipif(backend.backend() != "torch", reason="Torch only test.")
-    def test_torch_params_create_deterministic(self):
-        class MyLayer(layers.Layer):
-            def __init__(self):
-                super().__init__()
-                self.w1 = self.add_weight()
-                self.w2 = self.add_weight(dtype="int32", trainable=False)
-                self.w3 = self.add_weight(dtype="bool", trainable=False)
-                self.w4 = self.add_weight(
-                    dtype="int32", shape=(2, 2), trainable=False
+            self.assertEqual(len(list(layer.parameters())), 1)
+            for idx, (pname, var) in enumerate(layer.named_parameters()):
+                self.assertEqual(
+                    pname, f"post_build_modify_layer.torch_params.{idx}"
                 )
-                self.w5 = self.add_weight(initializer="ones", shape=(2, 2))
+                self.assertEqual(
+                    id(var),
+                    id(
+                        layer.post_build_modify_layer.trainable_variables[
+                            idx
+                        ].value
+                    ),
+                )
 
-        layer1 = MyLayer()
-        layer1.build(None)
-        layer1_names = list(pname for pname, _ in layer1.named_parameters())
-        global_state.clear_session()
-        layer2 = MyLayer()
-        layer2.build(None)
-        layer2_names = list(pname for pname, _ in layer2.named_parameters())
-        self.assertListEqual(layer1_names, layer2_names)
+            self.assertEqual(
+                len(list(layer.post_build_modify_layer.parameters())), 1
+            )
+            for idx, (pname, var) in enumerate(
+                layer.post_build_modify_layer.named_parameters()
+            ):
+                self.assertEqual(pname, f"torch_params.{idx}")
+                self.assertEqual(
+                    id(var),
+                    id(
+                        layer.post_build_modify_layer.trainable_variables[
+                            idx
+                        ].value
+                    ),
+                )


### PR DESCRIPTION
this is a follow up from https://github.com/keras-team/keras/pull/19885 discussion where i am trying to make torch / keras well played together on tracking parameters.

the solution i ended up with:
1. since modules are properly tracked with torch module, every torch_params will only safe it's own variables. nested variable resolution will be done by torch with `recurse=True`
2. change back to use parameter list instead of dict. i did consider to keep using dict given the readability since now key in torch param could actually be `variable.name`, but current seed generator actually create duplicated variable names. if https://github.com/keras-team/keras/blob/master/keras/src/random/seed_generator.py#L80 can be changed to something like `f"{self.name}_generator_state"` it will work with ParameterDict
3. in `_post_track/untrack_variables`, refresh the entire torch params and it's sublayers. this could be changed to not re-create all sublayers if this function ever becomes too slow.

i also added few torch specific tests to reflect some of the assumptions and  usecases that torch user might have. eg. use `state_dict`.

