### PR TITLE
Fix `ops.Nonzero.compute_output_spec()`.

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -3886,7 +3886,9 @@ class Nonzero(Operation):
         return backend.numpy.nonzero(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor([None] * len(x.shape), dtype="int32")
+        return tuple(
+            [KerasTensor((None,), dtype="int32") for _ in range(len(x.shape))]
+        )
 
 
 @keras_export(["keras.ops.nonzero", "keras.ops.numpy.nonzero"])

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1317,7 +1317,11 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
 
     def test_nonzero(self):
         x = KerasTensor((None, 5, 6))
-        self.assertEqual(knp.nonzero(x).shape, (None, None, None))
+        result = knp.nonzero(x)
+        self.assertLen(result, 3)
+        self.assertEqual(result[0].shape, (None,))
+        self.assertEqual(result[1].shape, (None,))
+        self.assertEqual(result[2].shape, (None,))
 
     def test_ones_like(self):
         x = KerasTensor((None, 3))
@@ -3790,7 +3794,7 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(knp.Ndim()(x), np.ndim(x))
 
     def test_nonzero(self):
-        x = np.array([[1, 2, 3], [3, 2, 1]])
+        x = np.array([[0, 0, 3], [3, 0, 0]])
         self.assertAllClose(knp.nonzero(x), np.nonzero(x))
         self.assertAllClose(knp.Nonzero()(x), np.nonzero(x))
 
@@ -7119,8 +7123,8 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
     def test_nonzero(self, dtype):
         import jax.numpy as jnp
 
-        x = knp.ones((1,), dtype=dtype)
-        x_jax = jnp.ones((1,), dtype=dtype)
+        x = knp.zeros((1,), dtype=dtype)
+        x_jax = jnp.zeros((1,), dtype=dtype)
         expected_dtype = standardize_dtype(jnp.nonzero(x_jax)[0].dtype)
 
         self.assertEqual(


### PR DESCRIPTION
`nonzero` returns a tuple of N 1D integer tensors, one per dimension in the input.

Also changed `nonzero` unit tests to be more interesting by actually exercising the case where there are zeros.