### PR TITLE
`keras.utils.split_dataset` now supports nested structures in dataset.

### DIFF
--- a/keras/src/utils/dataset_utils_test.py
+++ b/keras/src/utils/dataset_utils_test.py
@@ -1,17 +1,49 @@
+import itertools
+
 import numpy as np
+from absl.testing import parameterized
+from torch.utils.data import Dataset as TorchDataset
 
 from keras.src.testing import test_case
+from keras.src.testing.test_utils import named_product
 from keras.src.utils.dataset_utils import split_dataset
 from keras.src.utils.module_utils import tensorflow as tf
 
 
-class DatasetUtilsTest(test_case.TestCase):
-    def test_split_dataset_list(self):
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = [
-            np.random.sample((n_sample, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        ]
+class MyTorchDataset(TorchDataset):
+
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+    def __len__(self):
+        return len(self.x)
+
+    def __getitem__(self, index):
+        return self.x[index], self.y[index]
+
+
+class DatasetUtilsTest(test_case.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(
+        named_product(
+            dataset_type=["list", "tuple", "tensorflow", "torch"],
+            features_shape=[(2,), (100, 2), (10, 10, 2)],
+        )
+    )
+    def test_split_dataset(self, dataset_type, features_shape):
+        n_sample, left_size, right_size = 100, 0.2, 0.8
+        features = np.random.sample((n_sample,) + features_shape)
+        labels = np.random.sample((n_sample, 1))
+
+        if dataset_type == "list":
+            dataset = [features, labels]
+        elif dataset_type == "tuple":
+            dataset = (features, labels)
+        elif dataset_type == "tensorflow":
+            dataset = tf.data.Dataset.from_tensor_slices((features, labels))
+        elif dataset_type == "torch":
+            dataset = MyTorchDataset(features, labels)
+
         dataset_left, dataset_right = split_dataset(
             dataset, left_size=left_size, right_size=right_size
         )
@@ -21,15 +53,28 @@ class DatasetUtilsTest(test_case.TestCase):
         self.assertEqual(
             int(dataset_right.cardinality()), int(n_sample * right_size)
         )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape, (n_cols)
-        )
+        for sample in itertools.chain(dataset_left, dataset_right):
+            self.assertEqual(sample[0].shape, features_shape)
+            self.assertEqual(sample[1].shape, (1,))
 
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = [
-            np.random.sample((n_sample, 100, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        ]
+    @parameterized.named_parameters(
+        named_product(structure_type=["dict", "tuple"])
+    )
+    def test_split_dataset_nested_structures(self, structure_type):
+        n_sample, left_size, right_size = 100, 0.2, 0.8
+        features1 = np.random.sample((n_sample, 2))
+        features2 = np.random.sample((n_sample, 10, 2))
+        labels = np.random.sample((n_sample, 1))
+
+        if structure_type == "dict":
+            dataset = tf.data.Dataset.from_tensor_slices(
+                {"x1": features1, "x2": features2, "labels": labels}
+            )
+        elif structure_type == "tuple":
+            dataset = tf.data.Dataset.from_tensor_slices(
+                ((features1, features2), labels)
+            )
+
         dataset_left, dataset_right = split_dataset(
             dataset, left_size=left_size, right_size=right_size
         )
@@ -39,296 +84,11 @@ class DatasetUtilsTest(test_case.TestCase):
         self.assertEqual(
             int(dataset_right.cardinality()), int(n_sample * right_size)
         )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape, (100, n_cols)
-        )
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = [
-            np.random.sample((n_sample, 10, 10, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        ]
-        dataset_left, dataset_right = split_dataset(
-            dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            int(dataset_left.cardinality()), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            int(dataset_right.cardinality()), int(n_sample * right_size)
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape, (10, 10, n_cols)
-        )
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = [
-            np.random.sample((n_sample, 100, 10, 30, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        ]
-        dataset_left, dataset_right = split_dataset(
-            dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            int(dataset_left.cardinality()), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            int(dataset_right.cardinality()), int(n_sample * right_size)
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape,
-            (100, 10, 30, n_cols),
-        )
-
-    def test_split_dataset_tuple(self):
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = (
-            np.random.sample((n_sample, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        )
-        dataset_left, dataset_right = split_dataset(
-            dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            int(dataset_left.cardinality()), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            int(dataset_right.cardinality()), int(n_sample * right_size)
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape, (n_cols)
-        )
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = (
-            np.random.sample((n_sample, 100, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        )
-        dataset_left, dataset_right = split_dataset(
-            dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            int(dataset_left.cardinality()), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            int(dataset_right.cardinality()), int(n_sample * right_size)
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape, (100, n_cols)
-        )
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = (
-            np.random.sample((n_sample, 10, 10, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        )
-        dataset_left, dataset_right = split_dataset(
-            dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            int(dataset_left.cardinality()), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            int(dataset_right.cardinality()), int(n_sample * right_size)
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape, (10, 10, n_cols)
-        )
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = (
-            np.random.sample((n_sample, 100, 10, 30, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        )
-        dataset_left, dataset_right = split_dataset(
-            dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            int(dataset_left.cardinality()), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            int(dataset_right.cardinality()), int(n_sample * right_size)
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape,
-            (100, 10, 30, n_cols),
-        )
-
-    def test_split_dataset_tensorflow(self):
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (
-            np.random.sample((n_sample, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        )
-        tf_dataset = tf.data.Dataset.from_tensor_slices((features, labels))
-        dataset_left, dataset_right = split_dataset(
-            tf_dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            int(dataset_left.cardinality()), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            int(dataset_right.cardinality()), int(n_sample * right_size)
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape, (n_cols)
-        )
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (
-            np.random.sample((n_sample, 100, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        )
-        tf_dataset = tf.data.Dataset.from_tensor_slices((features, labels))
-        dataset_left, dataset_right = split_dataset(
-            tf_dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            int(dataset_left.cardinality()), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            int(dataset_right.cardinality()), int(n_sample * right_size)
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape, (100, n_cols)
-        )
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (
-            np.random.sample((n_sample, 10, 10, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        )
-        tf_dataset = tf.data.Dataset.from_tensor_slices((features, labels))
-        dataset_left, dataset_right = split_dataset(
-            tf_dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            int(dataset_left.cardinality()), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            int(dataset_right.cardinality()), int(n_sample * right_size)
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape, (10, 10, n_cols)
-        )
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (
-            np.random.sample((n_sample, 100, 10, 30, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        )
-        tf_dataset = tf.data.Dataset.from_tensor_slices((features, labels))
-        dataset_left, dataset_right = split_dataset(
-            tf_dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            int(dataset_left.cardinality()), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            int(dataset_right.cardinality()), int(n_sample * right_size)
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape,
-            (100, 10, 30, n_cols),
-        )
-
-    def test_split_dataset_torch(self):
-        # sample torch dataset class
-        from torch.utils.data import Dataset as torchDataset
-
-        class Dataset(torchDataset):
-            "Characterizes a dataset for PyTorch"
-
-            def __init__(self, x, y):
-                "Initialization"
-                self.x = x
-                self.y = y
-
-            def __len__(self):
-                "Denotes the total number of samples"
-                return len(self.x)
-
-            def __getitem__(self, index):
-                "Generates one sample of data"
-                return self.x[index], self.y[index]
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (
-            np.random.sample((n_sample, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        )
-        torch_dataset = Dataset(features, labels)
-        dataset_left, dataset_right = split_dataset(
-            torch_dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            len([sample for sample in dataset_left]), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            len([sample for sample in dataset_right]),
-            int(n_sample * right_size),
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape, (n_cols,)
-        )
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (
-            np.random.sample((n_sample, 100, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        )
-        torch_dataset = Dataset(features, labels)
-        dataset_left, dataset_right = split_dataset(
-            torch_dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            len([sample for sample in dataset_left]), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            len([sample for sample in dataset_right]),
-            int(n_sample * right_size),
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape, (100, n_cols)
-        )
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (
-            np.random.sample((n_sample, 10, 10, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        )
-        torch_dataset = Dataset(features, labels)
-        dataset_left, dataset_right = split_dataset(
-            torch_dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            len([sample for sample in dataset_left]), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            len([sample for sample in dataset_right]),
-            int(n_sample * right_size),
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape, (10, 10, n_cols)
-        )
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (
-            np.random.sample((n_sample, 100, 10, 30, n_cols)),
-            np.random.sample((n_sample, n_pred)),
-        )
-        torch_dataset = Dataset(features, labels)
-        dataset_left, dataset_right = split_dataset(
-            torch_dataset, left_size=left_size, right_size=right_size
-        )
-        self.assertEqual(
-            len([sample for sample in dataset_left]), int(n_sample * left_size)
-        )
-        self.assertEqual(
-            len([sample for sample in dataset_right]),
-            int(n_sample * right_size),
-        )
-        self.assertEqual(
-            [sample for sample in dataset_right][0][0].shape,
-            (100, 10, 30, n_cols),
-        )
+        for sample in itertools.chain(dataset_left, dataset_right):
+            if structure_type == "dict":
+                x1, x2, labels = sample["x1"], sample["x2"], sample["labels"]
+            elif structure_type == "tuple":
+                (x1, x2), labels = sample
+            self.assertEqual(x1.shape, (2,))
+            self.assertEqual(x2.shape, (10, 2))
+            self.assertEqual(labels.shape, (1,))


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras/issues/19797

Also:
- remove conversion to `np.array` since ealier check verifies inputs are `np.array`.
- improved verification in the `np.array` case to check the type of all the elements, not just the first one.
- removed code related to `dict`s, which are not supported as top-level structure.
- refactored tests as parameterized tests.