### PR TITLE
Fix bug in `layer.save_own_variables`

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1212,8 +1212,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         Args:
             store: Dict where the state of the model will be saved.
         """
-        all_vars = self._trainable_variables + self._non_trainable_variables
-        for i, v in enumerate(all_vars):
+        for i, v in enumerate(self.variables):
             store[f"{i}"] = v
 
     def load_own_variables(self, store):

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1212,7 +1212,8 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         Args:
             store: Dict where the state of the model will be saved.
         """
-        for i, v in enumerate(self.variables):
+        all_vars = self.trainable_variables + self.non_trainable_variables
+        for i, v in enumerate(all_vars):
             store[f"{i}"] = v
 
     def load_own_variables(self, store):


### PR DESCRIPTION
`layer.save_own_variables(store)` doesn't save sub-layer variables. Can change to `self.trainable_variables + self.non_trainable_variables` if we don't want to save seed generator state.

Repro:

```
model = keras.Sequential([
    keras.layers.Conv2D(32, kernel_size=(3, 3), activation="relu"),
    keras.layers.MaxPooling2D(pool_size=(2, 2)),
    keras.layers.Conv2D(64, kernel_size=(3, 3), activation="relu"),
    keras.layers.MaxPooling2D(pool_size=(2, 2)),
    keras.layers.Flatten(),
    keras.layers.Dense(256, activation="relu"),
    keras.layers.Dense(10),
])
model.compile(
    loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
    optimizer=keras.optimizers.SGD(0.1),
    metrics=[keras.metrics.SparseCategoricalAccuracy()],
)
model.build((None, 28, 28, 1))

>>> print(model.variables)
[<KerasVariable shape=(3, 3, 1, 32), dtype=float32, path=sequential/conv2d/kernel>,
 <KerasVariable shape=(32,), dtype=float32, path=sequential/conv2d/bias>,
 <KerasVariable shape=(3, 3, 32, 64), dtype=float32, path=sequential/conv2d_1/kernel>,
 <KerasVariable shape=(64,), dtype=float32, path=sequential/conv2d_1/bias>,
 <KerasVariable shape=(1600, 256), dtype=float32, path=sequential/dense/kernel>,
 <KerasVariable shape=(256,), dtype=float32, path=sequential/dense/bias>,
 <KerasVariable shape=(256, 10), dtype=float32, path=sequential/dense_1/kernel>,
 <KerasVariable shape=(10,), dtype=float32, path=sequential/dense_1/bias>]

store = {}
model.save_own_variables(store)

>>> print(store)
{}
```