### PR TITLE
Fix `export_lib.make_tensor_spec`

### DIFF
--- a/keras/src/export/export_lib.py
+++ b/keras/src/export/export_lib.py
@@ -654,13 +654,18 @@ def _get_input_signature(model):
         # into plain Python structures because they don't work with jax2tf/JAX.
         if isinstance(structure, dict):
             return {k: make_tensor_spec(v) for k, v in structure.items()}
-        if isinstance(structure, (list, tuple)):
+        elif isinstance(structure, tuple):
             if all(isinstance(d, (int, type(None))) for d in structure):
                 return tf.TensorSpec(
                     shape=(None,) + structure[1:], dtype=model.input_dtype
                 )
-            result = [make_tensor_spec(v) for v in structure]
-            return tuple(result) if isinstance(structure, tuple) else result
+            return tuple(make_tensor_spec(v) for v in structure)
+        elif isinstance(structure, list):
+            if all(isinstance(d, (int, type(None))) for d in structure):
+                return tf.TensorSpec(
+                    shape=[None] + structure[1:], dtype=model.input_dtype
+                )
+            return [make_tensor_spec(v) for v in structure]
         else:
             raise ValueError(
                 f"Unsupported type {type(structure)} for {structure}"

--- a/keras/src/export/export_lib_test.py
+++ b/keras/src/export/export_lib_test.py
@@ -197,7 +197,9 @@ class ExportArchiveTest(testing.TestCase, parameterized.TestCase):
         revived_model.serve(bigger_input)
 
         # Test with keras.saving_lib
-        temp_filepath = os.path.join(self.get_temp_dir(), "exported_model.keras")
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "exported_model.keras"
+        )
         saving_lib.save_model(model, temp_filepath)
         revived_model = saving_lib.load_model(
             temp_filepath,

--- a/keras/src/export/export_lib_test.py
+++ b/keras/src/export/export_lib_test.py
@@ -196,6 +196,20 @@ class ExportArchiveTest(testing.TestCase, parameterized.TestCase):
         )
         revived_model.serve(bigger_input)
 
+        # Test with keras.saving_lib
+        temp_filepath = os.path.join(self.get_temp_dir(), "exported_model.keras")
+        saving_lib.save_model(model, temp_filepath)
+        revived_model = saving_lib.load_model(
+            temp_filepath,
+            {
+                "TupleModel": TupleModel,
+                "ArrayModel": ArrayModel,
+                "DictModel": DictModel,
+            },
+        )
+        self.assertAllClose(ref_output, revived_model(ref_input))
+        export_lib.export_model(revived_model, self.get_temp_dir())
+
     def test_model_with_multiple_inputs(self):
 
         class TwoInputsModel(models.Model):


### PR DESCRIPTION
Fixes #19913 

a simple repro from the original issue with minor changes:

```
import keras
import numpy as np

class SomeModel(keras.Model):
    def __init__(self, output_channels: int):
        super().__init__()
        self.output_channels = output_channels
        self.fc1 = keras.layers.Dense(256, activation="relu")
        self.fc2 = keras.layers.Dense(
            self.output_channels * 2,
            bias_initializer="ones",
            kernel_initializer="zeros",
        )

    def build(self, input_shape):
        super().build(input_shape)
        self.fc1.build(input_shape)
        fc1_out = self.fc1.compute_output_shape(input_shape)
        self.fc2.build(fc1_out)

    def call(self, inputs):
        features = self.fc1(inputs)
        return self.fc2(features)


class SomeParentModel(keras.Model):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.fx = SomeModel(20)

    def call(self, im_batch):
        features = self.fx(im_batch)
        ...
        return features

parent_inst = SomeParentModel()
random_data = np.random.random((1, 512)).astype('float32')

parent_inst(random_data)
parent_inst.save('test_model.keras')

reloaded = keras.models.load_model('test_model.keras', custom_objects={'SomeParentModel': SomeParentModel})
reloaded(random_data)
reloaded.export('test')
```


