### PR TITLE
Internally, replace `FloatDTypePolicy` with `DTypePolicy`

### DIFF
--- a/keras/src/dtype_policies/__init__.py
+++ b/keras/src/dtype_policies/__init__.py
@@ -63,17 +63,17 @@ def get(identifier):
 
     >>> policy = dtype_policies.get("mixed_bfloat16")
     >>> type(policy)
-    <class '...FloatDTypePolicy'>
+    <class '...DTypePolicy'>
 
     You can also specify `config` of the dtype policy to this function by
     passing dict containing `class_name` and `config` as an identifier. Also
     note that the `class_name` must map to a `DTypePolicy` class
 
-    >>> identifier = {"class_name": "FloatDTypePolicy",
+    >>> identifier = {"class_name": "DTypePolicy",
     ...               "config": {"name": "float32"}}
     >>> policy = dtype_policies.get(identifier)
     >>> type(policy)
-    <class '...FloatDTypePolicy'>
+    <class '...DTypePolicy'>
 
     Args:
         identifier: A dtype policy identifier. One of `None` or string name of a
@@ -97,9 +97,9 @@ def get(identifier):
         if identifier.startswith(QUANTIZATION_MODES):
             return _get_quantized_dtype_policy_by_str(identifier)
         else:
-            return FloatDTypePolicy(identifier)
+            return DTypePolicy(identifier)
     try:
-        return FloatDTypePolicy(backend.standardize_dtype(identifier))
+        return DTypePolicy(backend.standardize_dtype(identifier))
     except:
         raise ValueError(
             "Cannot interpret `dtype` argument. Expected a string "

--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -88,7 +88,7 @@ class DTypePolicy:
         except ValueError:
             raise ValueError(
                 f"Cannot convert '{name}' to a mixed precision "
-                "FloatDTypePolicy. Valid policies include 'mixed_float16', "
+                "DTypePolicy. Valid policies include 'mixed_float16', "
                 "'mixed_bfloat16', and the name of any float dtype such as "
                 "'float32'."
             )
@@ -182,8 +182,8 @@ class DTypePolicy:
 
     def __repr__(self):
         class_name = self.__class__.__name__
-        if class_name == "DTypePolicy":
-            class_name = "FloatDTypePolicy"
+        if class_name == "FloatDTypePolicy":
+            class_name = "DTypePolicy"
         return f'<{class_name} "{self._name}">'
 
     def __eq__(self, other):
@@ -306,7 +306,7 @@ def set_dtype_policy(policy):
             if policy.startswith(QUANTIZATION_MODES):
                 policy = _get_quantized_dtype_policy_by_str(policy)
             else:
-                policy = FloatDTypePolicy(policy)
+                policy = DTypePolicy(policy)
         else:
             raise ValueError(
                 "Invalid `policy` argument. "
@@ -329,7 +329,7 @@ def dtype_policy():
     """Returns the current default dtype policy object."""
     policy = global_state.get_global_attribute("dtype_policy", None)
     if policy is None:
-        policy = FloatDTypePolicy(backend.floatx())
+        policy = DTypePolicy(backend.floatx())
         set_dtype_policy(policy)
     return policy
 

--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -41,13 +41,13 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
 
     ```python
     dtype_policy_map = DTypePolicyMap()
-    dtype_policy_map["layer/dense_0"] = FloatDTypePolicy("bfloat16")
+    dtype_policy_map["layer/dense_0"] = DTypePolicy("bfloat16")
     dtype_policy_map["layer/dense_1"] = QuantizedDTypePolicy("int8", "bfloat16")
 
     policy_0 = dtype_policy_map["layer/dense_0"]
     policy_1 = dtype_policy_map["layer/dense_1"]
     policy_2 = dtype_policy_map["layer/dense_2"]  # No hit
-    assert policy_0 == FloatDTypePolicy("bfloat16")
+    assert policy_0 == DTypePolicy("bfloat16")
     assert policy_1 == QuantizedDTypePolicy("int8", "bfloat16")
     assert policy_2 == keras.config.dtype_policy()
     ```
@@ -167,7 +167,7 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
             # `default_policy=None` enables us to defer to
             # `keras.config.dtype_policy()` during loading.
             # To support this feature, we can set `_name` and `_source_name` to
-            # `None` in `FloatDTypePolicy` and `QuantizedDTypePolicy`,
+            # `None` in `DTypePolicy` and `QuantizedDTypePolicy`,
             # respectively.
             for policy in policy_map.values():
                 if isinstance(policy, dtype_policies.QuantizedDTypePolicy):

--- a/keras/src/dtype_policies/dtype_policy_map_test.py
+++ b/keras/src/dtype_policies/dtype_policy_map_test.py
@@ -66,11 +66,11 @@ class DTypePolicyMapTest(testing.TestCase):
                 )
             elif isinstance(layer, layers.BatchNormalization):
                 self.assertEqual(
-                    layer.dtype_policy, dtype_policies.FloatDTypePolicy()
+                    layer.dtype_policy, dtype_policies.DTypePolicy()
                 )
             elif isinstance(layer, layers.ReLU):
                 self.assertEqual(
-                    layer.dtype_policy, dtype_policies.FloatDTypePolicy()
+                    layer.dtype_policy, dtype_policies.DTypePolicy()
                 )
 
         # Verify the output after saving and loading
@@ -84,7 +84,7 @@ class DTypePolicyMapTest(testing.TestCase):
 
     def test_add(self):
         dtype_policy_map = DTypePolicyMap()
-        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+        dtype_policy_map["layer/dense_0"] = dtype_policies.DTypePolicy(
             "bfloat16"
         )
         dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
@@ -97,7 +97,7 @@ class DTypePolicyMapTest(testing.TestCase):
         self.assertLen(dtype_policy_map, 3)
 
         policy = dtype_policy_map["layer/dense_0"]
-        self.assertIsInstance(policy, dtype_policies.FloatDTypePolicy)
+        self.assertIsInstance(policy, dtype_policies.DTypePolicy)
         self.assertEqual(policy.name, "bfloat16")
 
         policy = dtype_policy_map["layer/dense_1"]
@@ -113,7 +113,7 @@ class DTypePolicyMapTest(testing.TestCase):
         with self.assertRaisesRegex(
             ValueError, "layer/dense_0 already exist in the DTypePolicyMap"
         ):
-            dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+            dtype_policy_map["layer/dense_0"] = dtype_policies.DTypePolicy(
                 "float32"
             )
 
@@ -124,7 +124,7 @@ class DTypePolicyMapTest(testing.TestCase):
 
     def test_get(self):
         dtype_policy_map = DTypePolicyMap()
-        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+        dtype_policy_map["layer/dense_0"] = dtype_policies.DTypePolicy(
             "bfloat16"
         )
         dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
@@ -136,7 +136,7 @@ class DTypePolicyMapTest(testing.TestCase):
 
         self.assertEqual(
             dtype_policy_map["layer/dense_0"],
-            dtype_policies.FloatDTypePolicy("bfloat16"),
+            dtype_policies.DTypePolicy("bfloat16"),
         )
         self.assertEqual(
             dtype_policy_map["layer/dense_1"],
@@ -161,8 +161,8 @@ class DTypePolicyMapTest(testing.TestCase):
         )
 
         # It will cause a ValueError in the case of one-to-many.
-        dtype_policy_map["dense"] = dtype_policies.FloatDTypePolicy("float32")
-        dtype_policy_map["dense_1"] = dtype_policies.FloatDTypePolicy("float32")
+        dtype_policy_map["dense"] = dtype_policies.DTypePolicy("float32")
+        dtype_policy_map["dense_1"] = dtype_policies.DTypePolicy("float32")
         with self.assertRaisesRegex(
             ValueError, "Path 'dense_10' matches multiple dtype policy"
         ):
@@ -170,7 +170,7 @@ class DTypePolicyMapTest(testing.TestCase):
 
     def test_delete(self):
         dtype_policy_map = DTypePolicyMap()
-        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+        dtype_policy_map["layer/dense_0"] = dtype_policies.DTypePolicy(
             "bfloat16"
         )
         dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
@@ -179,7 +179,7 @@ class DTypePolicyMapTest(testing.TestCase):
 
         self.assertEqual(
             dtype_policy_map.pop("layer/dense_0"),
-            dtype_policies.FloatDTypePolicy("bfloat16"),
+            dtype_policies.DTypePolicy("bfloat16"),
         )
         with self.assertRaises(KeyError):
             dtype_policy_map.pop("layer/dense_0")
@@ -196,7 +196,7 @@ class DTypePolicyMapTest(testing.TestCase):
         dtype_policy_map = DTypePolicyMap()
         self.assertLen(dtype_policy_map, 0)
 
-        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+        dtype_policy_map["layer/dense_0"] = dtype_policies.DTypePolicy(
             "bfloat16"
         )
         dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
@@ -206,7 +206,7 @@ class DTypePolicyMapTest(testing.TestCase):
 
     def test_iter(self):
         dtype_policy_map = DTypePolicyMap()
-        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+        dtype_policy_map["layer/dense_0"] = dtype_policies.DTypePolicy(
             "bfloat16"
         )
         dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
@@ -226,14 +226,14 @@ class DTypePolicyMapTest(testing.TestCase):
         self.assertEqual(
             values,
             [
-                dtype_policies.FloatDTypePolicy("bfloat16"),
+                dtype_policies.DTypePolicy("bfloat16"),
                 dtype_policies.QuantizedDTypePolicy("int8", "mixed_bfloat16"),
             ],
         )
 
     def test_in(self):
         dtype_policy_map = DTypePolicyMap()
-        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+        dtype_policy_map["layer/dense_0"] = dtype_policies.DTypePolicy(
             "bfloat16"
         )
         dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
@@ -247,7 +247,7 @@ class DTypePolicyMapTest(testing.TestCase):
     def test_default_policy(self):
         # Test default_policy is set to `"float32"`
         dtype_policy_map = DTypePolicyMap(default_policy="mixed_bfloat16")
-        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+        dtype_policy_map["layer/dense_0"] = dtype_policies.DTypePolicy(
             "mixed_bfloat16"
         )
         dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
@@ -257,7 +257,7 @@ class DTypePolicyMapTest(testing.TestCase):
         dtype_policy_map = DTypePolicyMap.from_config(config)
         self.assertEqual(
             dtype_policy_map["layer/dense_0"],
-            dtype_policies.FloatDTypePolicy("mixed_bfloat16"),
+            dtype_policies.DTypePolicy("mixed_bfloat16"),
         )
         self.assertEqual(
             dtype_policy_map["layer/dense_1"],
@@ -272,7 +272,7 @@ class DTypePolicyMapTest(testing.TestCase):
         # during loading
         set_dtype_policy("bfloat16")
         dtype_policy_map = DTypePolicyMap()
-        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+        dtype_policy_map["layer/dense_0"] = dtype_policies.DTypePolicy(
             "mixed_bfloat16"
         )
         dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
@@ -282,7 +282,7 @@ class DTypePolicyMapTest(testing.TestCase):
         dtype_policy_map = DTypePolicyMap.from_config(config)
         self.assertEqual(
             dtype_policy_map["layer/dense_0"],
-            dtype_policies.FloatDTypePolicy("bfloat16"),
+            dtype_policies.DTypePolicy("bfloat16"),
         )
         self.assertEqual(
             dtype_policy_map["layer/dense_1"],
@@ -299,7 +299,7 @@ class DTypePolicyMapTest(testing.TestCase):
 
     def test_serialization(self):
         dtype_policy_map = DTypePolicyMap(default_policy="mixed_bfloat16")
-        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+        dtype_policy_map["layer/dense_0"] = dtype_policies.DTypePolicy(
             "mixed_bfloat16"
         )
         dtype_policy_map["layer/dense_1"] = dtype_policies.QuantizedDTypePolicy(
@@ -323,7 +323,7 @@ class DTypePolicyMapTest(testing.TestCase):
 
     def test_repr(self):
         dtype_policy_map = DTypePolicyMap()
-        dtype_policy_map["layer/dense_0"] = dtype_policies.FloatDTypePolicy(
+        dtype_policy_map["layer/dense_0"] = dtype_policies.DTypePolicy(
             "mixed_bfloat16"
         )
         repr_str = repr(dtype_policy_map)
@@ -343,5 +343,5 @@ class DTypePolicyMapTest(testing.TestCase):
             TypeError, "If specified, `policy_map` must be a dict."
         ):
             DTypePolicyMap(
-                policy_map=dtype_policies.FloatDTypePolicy("mixed_bfloat16")
+                policy_map=dtype_policies.DTypePolicy("mixed_bfloat16")
             )

--- a/keras/src/dtype_policies/dtype_policy_test.py
+++ b/keras/src/dtype_policies/dtype_policy_test.py
@@ -12,8 +12,8 @@ from keras.src.dtype_policies.dtype_policy import set_dtype_policy
 from keras.src.testing import test_case
 
 
-class FloatDTypePolicyTest(test_case.TestCase, parameterized.TestCase):
-    """Test `FloatDTypePolicy`.
+class DTypePolicyTest(test_case.TestCase, parameterized.TestCase):
+    """Test `DTypePolicy`.
 
     In the tests, we also test `DTypePolicy` for historical reasons.
     """
@@ -136,10 +136,10 @@ class FloatDTypePolicyTest(test_case.TestCase, parameterized.TestCase):
     def test_repr(self):
         """Test __repr__ method."""
         policy = DTypePolicy("mixed_float16")
-        self.assertEqual(repr(policy), '<FloatDTypePolicy "mixed_float16">')
+        self.assertEqual(repr(policy), '<DTypePolicy "mixed_float16">')
 
         policy = FloatDTypePolicy("mixed_float16")
-        self.assertEqual(repr(policy), '<FloatDTypePolicy "mixed_float16">')
+        self.assertEqual(repr(policy), '<DTypePolicy "mixed_float16">')
 
     def test_get_config_from_config(self):
         """Test get_config and from_config methods."""
@@ -184,46 +184,34 @@ class FloatDTypePolicyTest(test_case.TestCase, parameterized.TestCase):
 
         # copy.deepcopy
         copied_policy = copy.deepcopy(policy)
-        self.assertEqual(
-            repr(copied_policy), '<FloatDTypePolicy "mixed_float16">'
-        )
+        self.assertEqual(repr(copied_policy), '<DTypePolicy "mixed_float16">')
         # copy.copy
         copied_policy = copy.copy(policy)
-        self.assertEqual(
-            repr(copied_policy), '<FloatDTypePolicy "mixed_float16">'
-        )
+        self.assertEqual(repr(copied_policy), '<DTypePolicy "mixed_float16">')
         # pickle
         temp_dir = self.get_temp_dir()
         with open(f"{temp_dir}/policy.pickle", "wb") as f:
             pickle.dump(policy, f)
         with open(f"{temp_dir}/policy.pickle", "rb") as f:
             copied_policy = pickle.load(f)
-        self.assertEqual(
-            repr(copied_policy), '<FloatDTypePolicy "mixed_float16">'
-        )
+        self.assertEqual(repr(copied_policy), '<DTypePolicy "mixed_float16">')
 
         # Test FloatDTypePolicy
         policy = FloatDTypePolicy("mixed_float16")
 
         # copy.deepcopy
         copied_policy = copy.deepcopy(policy)
-        self.assertEqual(
-            repr(copied_policy), '<FloatDTypePolicy "mixed_float16">'
-        )
+        self.assertEqual(repr(copied_policy), '<DTypePolicy "mixed_float16">')
         # copy.copy
         copied_policy = copy.copy(policy)
-        self.assertEqual(
-            repr(copied_policy), '<FloatDTypePolicy "mixed_float16">'
-        )
+        self.assertEqual(repr(copied_policy), '<DTypePolicy "mixed_float16">')
         # pickle
         temp_dir = self.get_temp_dir()
         with open(f"{temp_dir}/policy.pickle", "wb") as f:
             pickle.dump(policy, f)
         with open(f"{temp_dir}/policy.pickle", "rb") as f:
             copied_policy = pickle.load(f)
-        self.assertEqual(
-            repr(copied_policy), '<FloatDTypePolicy "mixed_float16">'
-        )
+        self.assertEqual(repr(copied_policy), '<DTypePolicy "mixed_float16">')
 
     def test_eq(self):
         policy = DTypePolicy("mixed_bfloat16")
@@ -564,14 +552,14 @@ class DTypePolicyGlobalFunctionsTest(test_case.TestCase):
         self.assertEqual(policy.name, "int8_from_mixed_bfloat16")
 
     def test_set_dtype_policy_valid_policy(self):
-        """Test set_dtype_policy with a valid FloatDTypePolicy object."""
-        policy_obj = FloatDTypePolicy("mixed_float16")
+        """Test set_dtype_policy with a valid DTypePolicy object."""
+        policy_obj = DTypePolicy("mixed_float16")
         set_dtype_policy(policy_obj)
         policy = dtype_policy()
         self.assertEqual(policy.name, "mixed_float16")
 
     def test_set_dtype_policy_valid_policy_quantized(self):
-        """Test set_dtype_policy with a valid FloatDTypePolicy object."""
+        """Test set_dtype_policy with a valid QuantizedDTypePolicy object."""
         policy_obj = QuantizedDTypePolicy(
             mode="int8", source_name="mixed_bfloat16"
         )
@@ -634,26 +622,26 @@ class DTypePolicyGlobalFunctionsTest(test_case.TestCase):
             get("int8_abc_")
 
 
-class FloatDTypePolicyEdgeCasesTest(test_case.TestCase):
+class DTypePolicyEdgeCasesTest(test_case.TestCase):
     def test_empty_name(self):
         """Test initialization with an empty name."""
         with self.assertRaisesRegex(ValueError, "Cannot convert"):
-            FloatDTypePolicy("")
+            DTypePolicy("")
 
     def test_special_character_name(self):
         """Test initialization with special characters in the name."""
         with self.assertRaisesRegex(ValueError, "Cannot convert"):
-            FloatDTypePolicy("@mixed_float16!")
+            DTypePolicy("@mixed_float16!")
 
     def test_very_long_name(self):
         """Test initialization with a very long name."""
         with self.assertRaisesRegex(ValueError, "Cannot convert"):
-            FloatDTypePolicy("mixed_float16" * 100)
+            DTypePolicy("mixed_float16" * 100)
 
     def test_almost_valid_name(self):
         """Test initialization with a name close to a valid one."""
         with self.assertRaisesRegex(ValueError, "Cannot convert"):
-            FloatDTypePolicy("mixed_float15")
+            DTypePolicy("mixed_float15")
 
 
 class QuantizedDTypePolicyEdgeCasesTest(test_case.TestCase):

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -971,8 +971,8 @@ class LayerTest(testing.TestCase):
         self.assertEqual(layer.dtype_policy.name, "mixed_bfloat16")
         self.assertEqual(layer.dtype_policy.compute_dtype, "bfloat16")
         self.assertEqual(layer.dtype_policy.variable_dtype, "float32")
-        # Set by FloatDTypePolicy
-        layer.dtype_policy = dtype_policies.FloatDTypePolicy("mixed_float16")
+        # Set by DTypePolicy
+        layer.dtype_policy = dtype_policies.DTypePolicy("mixed_float16")
         self.assertEqual(layer.dtype_policy.name, "mixed_float16")
         self.assertEqual(layer.dtype_policy.compute_dtype, "float16")
         self.assertEqual(layer.dtype_policy.variable_dtype, "float32")
@@ -986,7 +986,7 @@ class LayerTest(testing.TestCase):
         )
         self.assertEqual(
             layer._dtype_policy[layer.path],
-            dtype_policies.FloatDTypePolicy("mixed_bfloat16"),
+            dtype_policies.DTypePolicy("mixed_bfloat16"),
         )
 
     def test_pickle_layer(self):
@@ -1003,7 +1003,7 @@ class LayerTest(testing.TestCase):
                 dtype = kwargs["dtype"]
                 if isinstance(dtype, str):
                     # `dtype` is a plain string, it should be the `name` from a
-                    # `FloatDTypePolicy`
+                    # `DTypePolicy`
                     dtype = dtype_policies.get(dtype)
                     assertIsNone(dtype.quantization_mode)
                 else:
@@ -1018,9 +1018,7 @@ class LayerTest(testing.TestCase):
         self.assertIn("dtype", config)
         self.assertEqual(
             config["dtype"],
-            dtype_policies.serialize(
-                dtype_policies.FloatDTypePolicy("bfloat16")
-            ),
+            dtype_policies.serialize(dtype_policies.DTypePolicy("bfloat16")),
         )
         AssertionDense.from_config(config)  # Assertion inside
 

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -106,7 +106,7 @@ class Operation:
         dtype = kwargs.get("dtype", None)
         if dtype is not None and isinstance(dtype, dtype_policies.DTypePolicy):
             # For backward compatibility, we use a str (`name`) for
-            # `FloatDTypePolicy`
+            # `DTypePolicy`
             if dtype.quantization_mode is None:
                 kwargs["dtype"] = dtype.name
             # Otherwise, use `dtype_policies.serialize`
@@ -227,7 +227,7 @@ class Operation:
                 and policy.quantization_mode is None
             ):
                 # For backward compatibility, we use a str (`name`) for
-                # `FloatDTypePolicy`
+                # `DTypePolicy`
                 policy = policy.name
             config["dtype"] = policy
         try:


### PR DESCRIPTION
This PR silently deprecates the usage of `FloatDTypePolicy`. In the future, we could completely remove `FloatDTypePolicy`.

The reason is that we allow integer types for `DTypePolicy` (most commonly in preprocessing layers). This makes `FloatDTypePolicy` feel out of place:

```python
from keras import dtype_policies

policy = dtype_policies.DTypePolicy("int32")
print(policy)  # <FloatDTypePolicy "int32">

```

`FloatDTypePolicy` was initially introduced to distinguish between non-quantized and quantized policies.
However, we now have `quantization_mode` to indicate the status.