### PR TITLE
Fix `save_model` and `load_model`

### DIFF
--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -634,6 +634,7 @@ class SavingTest(testing.TestCase):
         with zipfile.ZipFile(filepath) as zf:
             all_filenames = zf.namelist()
             self.assertNotIn("model.weights.h5", all_filenames)
+        self.assertFalse(Path(filepath).with_name("model.weights.h5").exists())
 
     def test_load_model_exception_raised(self):
         # Assume we have an error in `load_own_variables`.


### PR DESCRIPTION
Should fix #19921

The root cause is that #19852 will incorrectly duplicate `*.weights.h5` in `save_model`.
And we should consider falling back to the original behavior if the system is read-only in `load_model`.

Sorry for the inconvenience!