### PR TITLE
Fix GPU CI and improve `save_model` and `load_model`

### DIFF
--- a/keras/src/random/random_test.py
+++ b/keras/src/random/random_test.py
@@ -396,21 +396,24 @@ class RandomBehaviorTest(testing.TestCase, parameterized.TestCase):
         import tensorflow as tf
 
         from keras.src.layers.preprocessing.tf_data_layer import TFDataLayer
+        from keras.src.random.seed_generator import SeedGenerator
 
         class BetaLayer(TFDataLayer):
-            def __init__(self, **kwargs):
+            def __init__(self, seed=None, **kwargs):
                 super().__init__(**kwargs)
-                self.generator = keras.random.SeedGenerator()
+                self.seed = seed
+                self.generator = SeedGenerator(seed)
 
             def compute_output_shape(self, input_shape):
                 return input_shape
 
             def call(self, inputs):
+                seed_generator = self._get_seed_generator(self.backend._backend)
                 noise = self.backend.random.beta(
                     self.backend.shape(inputs),
                     alpha=0.5,
                     beta=0.5,
-                    seed=self._get_seed_generator(),
+                    seed=seed_generator,
                 )
                 inputs = inputs + noise
                 return inputs

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 
 import keras
+from keras.src import backend
 from keras.src import ops
 from keras.src import testing
 from keras.src.saving import saving_lib
@@ -239,7 +240,11 @@ def _get_subclassed_functional_model(compile=True):
     return functional_model
 
 
-@pytest.mark.requires_trainable_backend
+# We need a global function for `Pool.apply_async`
+def _load_model_fn(filepath):
+    saving_lib.load_model(filepath)
+
+
 class SavingTest(testing.TestCase):
     def _test_inference_after_instantiation(self, model):
         x_ref = np.random.random((2, 4))
@@ -309,26 +314,32 @@ class SavingTest(testing.TestCase):
         for ref_m, m in zip(ref_metrics, new_metrics):
             self.assertAllClose(ref_m, m)
 
+    @pytest.mark.requires_trainable_backend
     def test_compile_preserved_subclassed(self):
         model = _get_subclassed_model(compile=True)
         self._test_compile_preserved(model)
 
+    @pytest.mark.requires_trainable_backend
     def test_compile_preserved_basic_sequential(self):
         model = _get_basic_sequential_model(compile=True)
         self._test_compile_preserved(model)
 
+    @pytest.mark.requires_trainable_backend
     def test_compile_preserved_custom_sequential(self):
         model = _get_custom_sequential_model(compile=True)
         self._test_compile_preserved(model)
 
+    @pytest.mark.requires_trainable_backend
     def test_compile_preserved_basic_functional(self):
         model = _get_basic_functional_model(compile=True)
         self._test_compile_preserved(model)
 
+    @pytest.mark.requires_trainable_backend
     def test_compile_preserved_custom_functional(self):
         model = _get_custom_functional_model(compile=True)
         self._test_compile_preserved(model)
 
+    @pytest.mark.requires_trainable_backend
     def test_compile_preserved_subclassed_functional(self):
         model = _get_subclassed_functional_model(compile=True)
         self._test_compile_preserved(model)
@@ -342,6 +353,7 @@ class SavingTest(testing.TestCase):
         self.assertFalse(subclassed_model.built)
         self.assertFalse(loaded_model.built)
 
+    @pytest.mark.requires_trainable_backend
     def test_saved_module_paths_and_class_names(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "my_model.keras")
         subclassed_model = _get_subclassed_model()
@@ -368,6 +380,7 @@ class SavingTest(testing.TestCase):
             "my_mean_squared_error",
         )
 
+    @pytest.mark.requires_trainable_backend
     def test_saving_custom_assets_and_variables(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "my_model.keras")
         model = ModelWithCustomSaving()
@@ -501,6 +514,7 @@ class SavingTest(testing.TestCase):
         saving_lib.load_weights_only(model, temp_filepath)
         self.assertAllClose(model.predict(ref_input), ref_output, atol=1e-6)
 
+    @pytest.mark.requires_trainable_backend
     def test_compile_arg(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "mymodel.keras")
         model = _get_basic_functional_model()
@@ -589,6 +603,7 @@ class SavingTest(testing.TestCase):
             np.array(new_model.layers[2].kernel), new_layer_kernel_value
         )
 
+    @pytest.mark.requires_trainable_backend
     def test_save_to_fileobj(self) -> None:
         model = keras.Sequential(
             [keras.layers.Dense(1, input_shape=(1,)), keras.layers.Dense(1)]
@@ -677,6 +692,30 @@ class SavingTest(testing.TestCase):
         # Ensure we don't have any temporary files left.
         self.assertLen(os.listdir(Path(filepath).parent), 1)
         self.assertIn("model.keras", os.listdir(Path(filepath).parent))
+
+    @pytest.mark.skipif(
+        backend.backend() == "jax",
+        reason="JAX backend doesn't support Python's multiprocessing",
+    )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu() or testing.torch_uses_gpu(),
+        reason="This test doesn't support GPU",
+    )
+    def test_load_model_concurrently(self):
+        import multiprocessing as mp
+
+        model = keras.Sequential([keras.Input([1]), keras.layers.Dense(2)])
+        filepath = f"{self.get_temp_dir()}/model.keras"
+        saving_lib.save_model(model, filepath)
+
+        # Load the model concurrently.
+        results = []
+        with mp.Pool(4) as pool:
+            for i in range(4):
+                results.append(pool.apply_async(_load_model_fn, (filepath,)))
+            pool.close()
+            pool.join()
+        [r.get() for r in results]  # No error occurs here
 
 
 @pytest.mark.requires_trainable_backend

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -586,7 +586,11 @@ def jax_uses_gpu():
 
 
 def torch_uses_gpu():
-    return backend.backend() == "torch" and uses_gpu()
+    if backend.backend() != "torch":
+        return False
+    from keras.src.backend.torch.core import get_device
+
+    return get_device() == "cuda"
 
 
 def uses_gpu():


### PR DESCRIPTION
This PR fixes the GPU CI of torch backend.

Additionally, this PR utilizes `tempfile` in `_save_model_to_fileobj` and `_load_model_from_fileobj` for better file handling, preventing race conditions when multiple processes try to save and load the model.

A test for OSError (read-only system) has also been included.

EDITED:
I have added a test to verify concurrent loading as mentioned in #19924 by @WeichenXu123