### PR TITLE
configure random seed dtype based on backend

### DIFF
--- a/keras/src/backend/jax/__init__.py
+++ b/keras/src/backend/jax/__init__.py
@@ -15,6 +15,7 @@ from keras.src.backend.jax.core import convert_to_numpy
 from keras.src.backend.jax.core import convert_to_tensor
 from keras.src.backend.jax.core import device_scope
 from keras.src.backend.jax.core import is_tensor
+from keras.src.backend.jax.core import random_seed_dtype
 from keras.src.backend.jax.core import scatter
 from keras.src.backend.jax.core import shape
 from keras.src.backend.jax.core import stop_gradient

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -348,7 +348,7 @@ def unstack(x, num=None, axis=0):
 
 def random_seed_dtype():
     # jax random seed uses uint32.
-    return standardize_dtype("uint32")
+    return "uint32"
 
 
 def custom_gradient(fun):

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -346,6 +346,11 @@ def unstack(x, num=None, axis=0):
     ]
 
 
+def random_seed_dtype():
+    # jax random seed uses uint32.
+    return standardize_dtype("uint32")
+
+
 def custom_gradient(fun):
     return jax.custom_gradient(fun=fun)
 

--- a/keras/src/backend/numpy/__init__.py
+++ b/keras/src/backend/numpy/__init__.py
@@ -13,6 +13,7 @@ from keras.src.backend.numpy.core import cond
 from keras.src.backend.numpy.core import convert_to_numpy
 from keras.src.backend.numpy.core import convert_to_tensor
 from keras.src.backend.numpy.core import is_tensor
+from keras.src.backend.numpy.core import random_seed_dtype
 from keras.src.backend.numpy.core import shape
 from keras.src.backend.numpy.core import vectorized_map
 from keras.src.backend.numpy.rnn import cudnn_ok

--- a/keras/src/backend/numpy/core.py
+++ b/keras/src/backend/numpy/core.py
@@ -298,6 +298,10 @@ def unstack(x, num=None, axis=0):
     return [x[i] for i in range(x.shape[0])]
 
 
+def random_seed_dtype():
+    return standardize_dtype("uint32")
+
+
 class custom_gradient:
     """Decorator for custom gradients.
 

--- a/keras/src/backend/numpy/core.py
+++ b/keras/src/backend/numpy/core.py
@@ -299,7 +299,7 @@ def unstack(x, num=None, axis=0):
 
 
 def random_seed_dtype():
-    return standardize_dtype("uint32")
+    return "uint32"
 
 
 class custom_gradient:

--- a/keras/src/backend/tensorflow/__init__.py
+++ b/keras/src/backend/tensorflow/__init__.py
@@ -17,6 +17,7 @@ from keras.src.backend.tensorflow.core import convert_to_tensor
 from keras.src.backend.tensorflow.core import device_scope
 from keras.src.backend.tensorflow.core import is_tensor
 from keras.src.backend.tensorflow.core import name_scope
+from keras.src.backend.tensorflow.core import random_seed_dtype
 from keras.src.backend.tensorflow.core import scatter
 from keras.src.backend.tensorflow.core import shape
 from keras.src.backend.tensorflow.core import stop_gradient

--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -417,6 +417,11 @@ def unstack(x, num=None, axis=0):
     return tf.unstack(x, num=num, axis=axis)
 
 
+def random_seed_dtype():
+    # tensorflow random operation only works on int32/int64, not uint32.
+    return standardize_dtype("int32")
+
+
 def custom_gradient(fun):
     return tf.custom_gradient(f=fun)
 

--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -419,7 +419,7 @@ def unstack(x, num=None, axis=0):
 
 def random_seed_dtype():
     # tensorflow random operation only works on int32/int64, not uint32.
-    return standardize_dtype("int32")
+    return "int32"
 
 
 def custom_gradient(fun):

--- a/keras/src/backend/tensorflow/random.py
+++ b/keras/src/backend/tensorflow/random.py
@@ -7,11 +7,6 @@ from keras.src.random.seed_generator import draw_seed
 from keras.src.random.seed_generator import make_default_seed
 
 
-def tf_draw_seed(seed):
-    # TF ops only accept int32/64 seeds but our base seed is uint32.
-    return tf.cast(draw_seed(seed), dtype="int32")
-
-
 def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
     dtype = dtype or floatx()
     seed = draw_seed(seed)

--- a/keras/src/backend/tensorflow/random.py
+++ b/keras/src/backend/tensorflow/random.py
@@ -14,7 +14,7 @@ def tf_draw_seed(seed):
 
 def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
     dtype = dtype or floatx()
-    seed = tf_draw_seed(seed)
+    seed = draw_seed(seed)
     return tf.random.stateless_normal(
         shape=shape, mean=mean, stddev=stddev, dtype=dtype, seed=seed
     )
@@ -22,7 +22,7 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
 
 def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
     dtype = dtype or floatx()
-    seed = tf_draw_seed(seed)
+    seed = draw_seed(seed)
     return tf.random.stateless_uniform(
         shape=shape,
         minval=tf.cast(minval, dtype),
@@ -33,7 +33,7 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
 
 
 def categorical(logits, num_samples, dtype="int64", seed=None):
-    seed = tf_draw_seed(seed)
+    seed = draw_seed(seed)
     output = tf.random.stateless_categorical(logits, num_samples, seed=seed)
     return tf.cast(output, dtype)
 
@@ -42,7 +42,7 @@ def randint(shape, minval, maxval, dtype="int32", seed=None):
     intemediate_dtype = dtype
     if standardize_dtype(dtype) not in ["int32", "int64"]:
         intemediate_dtype = "int64"
-    seed = tf_draw_seed(seed)
+    seed = draw_seed(seed)
     output = tf.random.stateless_uniform(
         shape=shape,
         minval=minval,
@@ -55,7 +55,7 @@ def randint(shape, minval, maxval, dtype="int32", seed=None):
 
 def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
     dtype = dtype or floatx()
-    seed = tf_draw_seed(seed)
+    seed = draw_seed(seed)
     return tf.random.stateless_truncated_normal(
         shape=shape, mean=mean, stddev=stddev, dtype=dtype, seed=seed
     )
@@ -75,7 +75,7 @@ def _get_concrete_noise_shape(inputs, noise_shape):
 
 
 def dropout(inputs, rate, noise_shape=None, seed=None):
-    seed = tf_draw_seed(seed)
+    seed = draw_seed(seed)
     noise_shape = _get_concrete_noise_shape(inputs, noise_shape)
     return tf.nn.experimental.stateless_dropout(
         inputs,
@@ -88,7 +88,7 @@ def dropout(inputs, rate, noise_shape=None, seed=None):
 def shuffle(x, axis=0, seed=None):
     from keras.src.backend.tensorflow.numpy import swapaxes
 
-    seed = tf_draw_seed(seed)
+    seed = draw_seed(seed)
     if axis == 0:
         return tf.random.experimental.stateless_shuffle(x, seed=seed)
     x = swapaxes(x, axis1=0, axis2=axis)
@@ -99,7 +99,7 @@ def shuffle(x, axis=0, seed=None):
 
 def gamma(shape, alpha, dtype=None, seed=None):
     dtype = dtype or floatx()
-    seed = tf_draw_seed(seed)
+    seed = draw_seed(seed)
     # TODO: `tf.random.stateless_gamma` doesn't support bfloat16
     intemediate_dtype = dtype
     if standardize_dtype(dtype) == "bfloat16":
@@ -117,7 +117,7 @@ def gamma(shape, alpha, dtype=None, seed=None):
 
 def binomial(shape, counts, probabilities, dtype=None, seed=None):
     dtype = dtype or floatx()
-    seed = tf_draw_seed(seed)
+    seed = draw_seed(seed)
     # TODO: `tf.random.stateless_binomial` doesn't support bfloat16
     intemediate_dtype = dtype
     if standardize_dtype(dtype) == "bfloat16":
@@ -146,7 +146,7 @@ def beta(shape, alpha, beta, dtype=None, seed=None):
     # gamma random variables to prevent any unintended
     # dependencies and correlations between the generated values
     # due to the usage of same seed.
-    seed_1 = tf_draw_seed(seed)
+    seed_1 = draw_seed(seed)
     # The choice of 12 is totally arbitrary, as we're
     # incrementing the first drawn seed by a CONSTANT to
     # ensure deterministic results.

--- a/keras/src/backend/torch/__init__.py
+++ b/keras/src/backend/torch/__init__.py
@@ -30,6 +30,7 @@ from keras.src.backend.torch.core import convert_to_numpy
 from keras.src.backend.torch.core import convert_to_tensor
 from keras.src.backend.torch.core import device_scope
 from keras.src.backend.torch.core import is_tensor
+from keras.src.backend.torch.core import random_seed_dtype
 from keras.src.backend.torch.core import scatter
 from keras.src.backend.torch.core import shape
 from keras.src.backend.torch.core import stop_gradient

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -503,7 +503,7 @@ def unstack(x, num=None, axis=0):
 
 def random_seed_dtype():
     # uint32 doesn't exist in torch, use int32 instead.
-    return standardize_dtype("int32")
+    return "int32"
 
 
 class custom_gradient:

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -501,6 +501,11 @@ def unstack(x, num=None, axis=0):
     return x.unbind(axis)
 
 
+def random_seed_dtype():
+    # uint32 doesn't exist in torch, use int32 instead.
+    return standardize_dtype("int32")
+
+
 class custom_gradient:
     """Decorator for custom gradients.
 

--- a/keras/src/random/seed_generator.py
+++ b/keras/src/random/seed_generator.py
@@ -75,7 +75,7 @@ class SeedGenerator:
             self.state = self.backend.Variable(
                 seed_initializer,
                 shape=(2,),
-                dtype="uint32",
+                dtype=self.backend.random_seed_dtype(),
                 trainable=False,
                 name="seed_generator_state",
             )
@@ -86,7 +86,7 @@ class SeedGenerator:
         new_seed_value = seed_state.value * 1
         if ordered:
             increment = self.backend.convert_to_tensor(
-                np.array([0, 1]), dtype="uint32"
+                np.array([0, 1]), dtype=seed_state.dtype
             )
             self.state.assign(seed_state + increment)
         else:
@@ -133,11 +133,12 @@ def make_default_seed():
 
 def draw_seed(seed):
     from keras.src.backend import convert_to_tensor
+    from keras.src.backend import random_seed_dtype
 
     if isinstance(seed, SeedGenerator):
         return seed.next()
     elif isinstance(seed, int):
-        return convert_to_tensor([seed, 0], dtype="uint32")
+        return convert_to_tensor([seed, 0], dtype=random_seed_dtype())
     elif seed is None:
         return global_seed_generator().next(ordered=False)
     raise ValueError(

--- a/keras/src/random/seed_generator_test.py
+++ b/keras/src/random/seed_generator_test.py
@@ -37,6 +37,15 @@ class SeedGeneratorTest(testing.TestCase):
         seed2 = seed_generator.make_default_seed()
         self.assertNotEqual(seed1, seed2)
 
+    def test_seed_generator_dtype(self):
+        gen = seed_generator.SeedGenerator(seed=42)
+        self.assertEqual(gen.state.dtype, backend.random_seed_dtype())
+        seed = gen.next()
+        self.assertEqual(gen.state.dtype, backend.random_seed_dtype())
+        self.assertEqual(
+            backend.standardize_dtype(seed.dtype), backend.random_seed_dtype()
+        )
+
     def test_draw_seed_from_seed_generator(self):
         gen = seed_generator.SeedGenerator(seed=42)
         seed1 = seed_generator.draw_seed(gen)
@@ -45,6 +54,9 @@ class SeedGeneratorTest(testing.TestCase):
     def test_draw_seed_from_integer(self):
         seed2 = seed_generator.draw_seed(12345)
         self.assertTrue(backend.is_tensor(seed2))
+        self.assertEqual(
+            backend.standardize_dtype(seed2.dtype), backend.random_seed_dtype()
+        )
 
     def test_draw_seed_from_none(self):
         seed3 = seed_generator.draw_seed(None)


### PR DESCRIPTION
seeing below error on running tensorflow distributed training with multiple workers. the issue being seed state getting broadcasted is in a dtype that tensorflow doesn't support:

```
Exception encountered: ''Value for attr 'T' of uint32 is not in the list of allowed values: bool, float, half, double, int32, int64
	; NodeDef: {{node CollectiveBcastSend}}; Op<name=CollectiveBcastSend; signature=input:T -> data:T; attr=T:type,allowed=[DT_BOOL, DT_FLOAT, DT_HALF, DT_DOUBLE, DT_INT32, DT_INT64]; attr=group_size:int; attr=group_key:int; attr=instance_key:int; attr=shape:shape; attr=communication_hint:string,default="auto"; attr=timeout_seconds:float,default=0; is_stateful=true; is_distributed_communication=true> [Op:CollectiveBcastSend]''
```

this pr introduces a seed dtype function to customize for an ideal seed dtype for backends.