### PR TITLE
Fix `Trainer._symbolic_build`

### DIFF
--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -1001,12 +1001,6 @@ class Trainer:
         optimizer_unbuilt = (
             self.optimizer is not None and not self.optimizer.built
         )
-        if model_unbuilt or compile_metrics_unbuilt or optimizer_unbuilt:
-            if data_batch is None:
-                for _, data in iterator.enumerate_epoch():
-                    data_batch = data[0]
-                    break
-
         if model_unbuilt or compile_metrics_unbuilt:
             # Create symbolic tensors matching an input batch.
 
@@ -1017,6 +1011,10 @@ class Trainer:
                     v.shape, backend.standardize_dtype(v.dtype)
                 )
 
+            if data_batch is None:
+                for _, data in iterator.enumerate_epoch():
+                    data_batch = data[0]
+                    break
             data_batch = tree.map_structure(to_symbolic_input, data_batch)
             (
                 x,


### PR DESCRIPTION
https://github.com/keras-team/keras/blob/24ffc7cadb0e54a56d77527a0b9e47053dfebc97/keras/src/trainers/trainer.py#L1004-L1010

In `Trainer.fit()`, there's a call to `self._symbolic_build()` before training.
It consumes one extra piece of data which may be unexpected behavior if the amount of data is calculated.
Only the JAX and Torch backends are affected.

Closes #19929