### PR TITLE
Enable distribution test

### DIFF
--- a/.kokoro/github/ubuntu/gpu/build.sh
+++ b/.kokoro/github/ubuntu/gpu/build.sh
@@ -55,7 +55,10 @@ then
                --ignore keras/src/layers/merging/merging_test.py \
                --ignore keras/src/trainers/data_adapters/py_dataset_adapter_test.py \
                --ignore keras/src/backend/jax/distribution_lib_test.py \
+               --ignore keras/src/distribution/distribution_lib_test.py \
                --cov=keras
+
+   pytest keras/src/distribution/distribution_lib_test.py --cov=keras
 fi
 
 if [ "$KERAS_BACKEND" == "torch" ]

--- a/.kokoro/github/ubuntu/gpu/build.sh
+++ b/.kokoro/github/ubuntu/gpu/build.sh
@@ -55,7 +55,6 @@ then
                --ignore keras/src/layers/merging/merging_test.py \
                --ignore keras/src/trainers/data_adapters/py_dataset_adapter_test.py \
                --ignore keras/src/backend/jax/distribution_lib_test.py \
-               --ignore keras/src/distribution/distribution_lib_test.py \
                --cov=keras
 fi
 


### PR DESCRIPTION
Enabling `distribution_lib_test` to ensure we continuously test our distribution logic. We need this more than before as with larger Gemma models, there is a higher interest in distributed training and inference.