### PR TITLE
Add `type_check` for `quantize`

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -524,15 +524,12 @@ class Dense(Layer):
             x = self.activation(x)
         return x
 
-    def quantize(self, mode):
+    def quantize(self, mode, type_check=True):
         import gc
 
         # Prevent quantization of the subclasses
-        if type(self) is not Dense:
-            raise NotImplementedError(
-                f"Layer {self.__class__.__name__} does not have a `quantize()` "
-                "method implemented."
-            )
+        if type_check and (type(self) is not Dense):
+            raise self._quantize_not_implemented_error()
         self._check_quantize_args(mode, self.compute_dtype)
 
         self._tracker.unlock()

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -408,6 +408,8 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
         with self.assertRaises(NotImplementedError):
             layer.quantize(mode)
 
+        layer.quantize(mode, type_check=False)  # No error
+
     @parameterized.named_parameters(
         ("int8", "int8"),
         ("float8", "float8"),
@@ -422,12 +424,7 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
             ):
                 layer.quantize(m)
 
-    @parameterized.named_parameters(
-        ("int8", "int8_from_float32"),
-        ("float8", "float8_from_float32"),
-    )
-    def test_quantize_when_already_quantized_using_dtype_argument(self, mode):
-        layer = layers.Dense(units=2, dtype=mode)
+        layer = layers.Dense(units=2, dtype=f"{mode}_from_float32")
         layer.build((None, 2))
         for m in ["int8", "float8"]:
             with self.assertRaisesRegex(
@@ -479,18 +476,21 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
             layer.quantized_call(x)
         self.assertEqual(layer.dtype_policy, original_dtype_policy)
 
+    @parameterized.named_parameters(
+        ("int8", "int8_from_mixed_bfloat16", 1, 2),
+        ("float8", "float8_from_mixed_bfloat16", 8, 0),
+    )
     @pytest.mark.requires_trainable_backend
-    def test_quantize_int8_dtype_argument(self):
+    def test_quantize_dtype_argument(
+        self, dtype, num_trainable_weights, num_non_trainable_weights
+    ):
         self.run_layer_test(
             layers.Dense,
-            init_kwargs={
-                "units": 5,
-                "dtype": "int8_from_mixed_bfloat16",
-            },
+            init_kwargs={"units": 5, "dtype": dtype},
             input_shape=(2, 3, 4),
             expected_output_shape=(2, 3, 5),
-            expected_num_trainable_weights=1,
-            expected_num_non_trainable_weights=2,
+            expected_num_trainable_weights=num_trainable_weights,
+            expected_num_non_trainable_weights=num_non_trainable_weights,
             expected_num_seed_generators=0,
             expected_num_losses=0,
             supports_masking=True,
@@ -576,23 +576,6 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
                 reloaded_layer.non_trainable_weights,
                 len(model.non_trainable_weights),
             )
-
-    @pytest.mark.requires_trainable_backend
-    def test_quantize_float8_dtype_argument(self):
-        self.run_layer_test(
-            layers.Dense,
-            init_kwargs={
-                "units": 5,
-                "dtype": "float8_from_mixed_bfloat16",
-            },
-            input_shape=(2, 3, 4),
-            expected_output_shape=(2, 3, 5),
-            expected_num_trainable_weights=8,
-            expected_num_non_trainable_weights=0,
-            expected_num_seed_generators=0,
-            expected_num_losses=0,
-            supports_masking=True,
-        )
 
     @pytest.mark.requires_trainable_backend
     def test_quantize_float8(self):

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -640,15 +640,12 @@ class EinsumDense(Layer):
             x = self.activation(x)
         return x
 
-    def quantize(self, mode):
+    def quantize(self, mode, type_check=True):
         import gc
 
         # Prevent quantization of the subclasses
-        if type(self) is not EinsumDense:
-            raise NotImplementedError(
-                f"Layer {self.__class__.__name__} does not have a `quantize()` "
-                "method implemented."
-            )
+        if type_check and (type(self) is not EinsumDense):
+            raise self._quantize_not_implemented_error()
         self._check_quantize_args(mode, self.compute_dtype)
 
         self._tracker.unlock()

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -344,15 +344,12 @@ class Embedding(Layer):
             outputs = ops.add(outputs, lora_outputs)
         return outputs
 
-    def quantize(self, mode):
+    def quantize(self, mode, type_check=True):
         import gc
 
         # Prevent quantization of the subclasses
-        if type(self) is not Embedding:
-            raise NotImplementedError(
-                f"Layer {self.__class__.__name__} does not have a `quantize()` "
-                "method implemented."
-            )
+        if type_check and (type(self) is not Embedding):
+            raise self._quantize_not_implemented_error()
         self._check_quantize_args(mode, self.compute_dtype)
 
         self._tracker.unlock()

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -308,8 +308,11 @@ class EmbeddingTest(test_case.TestCase, parameterized.TestCase):
             pass
 
         layer = MyEmbedding(10, 16)
+        layer.build()
         with self.assertRaises(NotImplementedError):
             layer.quantize("int8")
+
+        layer.quantize("int8", type_check=False)  # No error
 
     def test_quantize_when_already_quantized(self):
         layer = layers.Embedding(10, 16)
@@ -320,7 +323,6 @@ class EmbeddingTest(test_case.TestCase, parameterized.TestCase):
         ):
             layer.quantize("int8")
 
-    def test_quantize_when_already_quantized_using_dtype_argument(self):
         layer = layers.Embedding(10, 16, dtype="int8_from_float32")
         layer.build()
         with self.assertRaisesRegex(

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1171,7 +1171,10 @@ class Layer(BackendLayer, Operation, KerasSaveable):
             layer._clear_losses()
 
     def quantize(self, mode):
-        raise NotImplementedError(
+        raise self._quantize_not_implemented_error()
+
+    def _quantize_not_implemented_error(self):
+        return NotImplementedError(
             f"Layer {self.__class__.__name__} does not have a `quantize()` "
             "method implemented."
         )


### PR DESCRIPTION
Related to https://github.com/keras-team/keras-nlp/pull/1670
The logic could be further simplified if we could call `super().quantize` in subclasses.

A minor simplification in the tests for quantization is also included.