### PR TITLE
Fix docstring: typo for setting environment variables

### DIFF
--- a/keras/src/distribution/distribution_lib.py
+++ b/keras/src/distribution/distribution_lib.py
@@ -98,7 +98,7 @@ def initialize(job_addresses=None, num_processes=None, process_id=None):
         ```python
         os.environ[
             "KERAS_DISTRIBUTION_JOB_ADDRESSES"] = "10.0.0.1:1234,10.0.0.2:2345"
-        os.environ["KERAS_DISTRIBUTION_NUM_PROCESSES"] = "2
+        os.environ["KERAS_DISTRIBUTION_NUM_PROCESSES"] = "2"
         os.environ["KERAS_DISTRIBUTION_PROCESS_ID"] = "0"
         keras.distribute.initialize()
         ```
@@ -107,7 +107,7 @@ def initialize(job_addresses=None, num_processes=None, process_id=None):
         ```python
         os.environ[
             "KERAS_DISTRIBUTION_JOB_ADDRESSES"] = "10.0.0.1:1234,10.0.0.2:2345"
-        os.environ["KERAS_DISTRIBUTION_NUM_PROCESSES"] = "2
+        os.environ["KERAS_DISTRIBUTION_NUM_PROCESSES"] = "2"
         os.environ["KERAS_DISTRIBUTION_PROCESS_ID"] = "1"
         keras.distribute.initialize()
         ```


### PR DESCRIPTION
Just came across some minor typo in the code example that results in an error as the string is not closed. 