### PR TITLE
Remove upperbound for torch version

### DIFF
--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -15,6 +15,8 @@ from keras.src.backend.common.backend_utils import slice_along_axis
 from keras.src.backend.common.dtypes import result_type
 from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.backend.common.stateless_scope import StatelessScope
+from keras.src.backend.common.stateless_scope import get_stateless_scope
+from keras.src.backend.common.stateless_scope import in_stateless_scope
 from keras.src.backend.config import floatx
 
 SUPPORTS_SPARSE_TENSORS = False
@@ -129,15 +131,38 @@ class Variable(KerasVariable):
 
     @property
     def value(self):
-        value = super().value
-        # Create and use a symbolic tensor stub in symbolic calls.
-        if str(get_device()) == "meta" and str(value.device) != "meta":
-            return torch.empty(
-                size=value.shape,
-                dtype=value.dtype,
-                device="meta",
+        # We cannot chain super() here because it will fail TorchDynamo. The
+        # reason why is unclear.
+        def maybe_use_symbolic_tensor(value):
+            # Create and use a symbolic tensor stub in symbolic calls.
+            if str(get_device()) == "meta" and str(value.device) != "meta":
+                return torch.nn.Parameter(
+                    torch.empty(
+                        size=self._shape,
+                        dtype=to_torch_dtype(self._dtype),
+                        device="meta",
+                    ),
+                    requires_grad=self.trainable,
+                )
+            return value
+
+        if in_stateless_scope():
+            scope = get_stateless_scope()
+            value = scope.get_current_value(self)
+            if value is not None:
+                value = self._maybe_autocast(value)
+                return maybe_use_symbolic_tensor(value)
+        if self._value is None:
+            # Uninitialized variable. Return a placeholder.
+            # This is fine because it's only ever used
+            # in during shape inference / graph tracing
+            # (anything else would be a bug, to be fixed.)
+            value = self._maybe_autocast(
+                self._initializer(self._shape, dtype=self._dtype)
             )
-        return value
+        else:
+            value = self._maybe_autocast(self._value)
+        return maybe_use_symbolic_tensor(value)
 
     @property
     def trainable(self):

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -3,7 +3,7 @@ tensorflow-cpu~=2.16.1  # Pin to TF 2.16
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0, <2.3.0
+torch>=2.1.0
 torchvision>=0.16.0
 
 # Jax with cuda support.

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -3,7 +3,7 @@ tensorflow[and-cuda]~=2.16.1  # Pin to TF 2.16
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0, <2.3.0
+torch>=2.1.0
 torchvision>=0.16.0
 
 # Jax cpu-only version (needed for testing).

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -3,8 +3,8 @@ tensorflow-cpu~=2.16.1  # Pin to TF 2.16
 
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu121
-torch==2.2.1+cu121
-torchvision==0.17.1+cu121
+torch==2.3.1+cu121
+torchvision==0.18.1+cu121
 
 # Jax cpu-only version (needed for testing).
 jax[cpu]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ tensorflow~=2.16.1;sys_platform == 'darwin'
 # Torch.
 # TODO: Pin to < 2.3.0 (GitHub issue #19602)
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0, <2.3.0
+torch>=2.1.0
 torchvision>=0.16.0
 
 # Jax.


### PR DESCRIPTION
Fix #19602
Fix #19765 

I just figured out the solution for the previously failed tests. Let's see if we can pass all the tests now.

cc @haifeng-jin 

EDITED:
All tests have passed!

Some thoughts:
- `torch.compile` easily fails to resolve `@property` and `isinstance`
- The speedup of `jit_compile=True` is still not significant in the torch backend.