### PR TITLE
add on_epoch_begin for dataset

### DIFF
--- a/guides/training_with_built_in_methods.py
+++ b/guides/training_with_built_in_methods.py
@@ -592,6 +592,7 @@ A `PyDataset` must implement two methods:
 
 The method `__getitem__` should return a complete batch.
 If you want to modify your dataset between epochs, you may implement `on_epoch_end`.
+You may also implement `on_epoch_begin` to at the start of each epoch.
 
 Here's a quick example:
 """

--- a/guides/training_with_built_in_methods.py
+++ b/guides/training_with_built_in_methods.py
@@ -592,7 +592,7 @@ A `PyDataset` must implement two methods:
 
 The method `__getitem__` should return a complete batch.
 If you want to modify your dataset between epochs, you may implement `on_epoch_end`.
-You may also implement `on_epoch_begin` to at the start of each epoch.
+You may also implement `on_epoch_begin` to be called at the start of each epoch.
 
 Here's a quick example:
 """

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -638,6 +638,7 @@ class TFEpochIterator(EpochIterator):
         return self.data_adapter.get_tf_dataset()
 
     def enumerate_epoch(self):
+        self.data_adapter.on_epoch_begin()
         if self.steps_per_epoch:
             if not self._current_iterator:
                 self._current_iterator = iter(self._distributed_dataset)

--- a/keras/src/trainers/data_adapters/data_adapter.py
+++ b/keras/src/trainers/data_adapters/data_adapter.py
@@ -87,6 +87,10 @@ class DataAdapter:
         """
         raise NotImplementedError
 
+    def on_epoch_begin(self):
+        """A hook called before each epoch."""
+        pass
+
     def on_epoch_end(self):
         """A hook called after each epoch."""
         pass

--- a/keras/src/trainers/epoch_iterator.py
+++ b/keras/src/trainers/epoch_iterator.py
@@ -77,6 +77,7 @@ class EpochIterator:
 
     def enumerate_epoch(self):
         buffer = []
+        self.data_adapter.on_epoch_begin()
         if self.steps_per_epoch:
             if self._current_iterator is None:
                 self._current_iterator = iter(self._get_iterator())

--- a/keras/src/trainers/epoch_iterator_test.py
+++ b/keras/src/trainers/epoch_iterator_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import tensorflow as tf
+from absl.testing import parameterized
 
 from keras.src import backend
 from keras.src import testing
@@ -8,7 +9,7 @@ from keras.src.trainers import data_adapters
 from keras.src.trainers import epoch_iterator
 
 
-class TestEpochIterator(testing.TestCase):
+class TestEpochIterator(testing.TestCase, parameterized.TestCase):
     def test_basic_flow(self):
         x = np.random.random((100, 16))
         y = np.random.random((100, 4))
@@ -171,3 +172,54 @@ class TestEpochIterator(testing.TestCase):
         x = "unsupported_data"
         with self.assertRaisesRegex(ValueError, "Unrecognized data type"):
             _ = epoch_iterator.EpochIterator(x=x)
+
+    @parameterized.named_parameters(
+        [
+            {"testcase_name": "infinite", "infinite": True},
+            {"testcase_name": "finite", "infinite": False},
+        ]
+    )
+    def test_epoch_callbacks(self, infinite):
+        class TestPyDataset(data_adapters.py_dataset_adapter.PyDataset):
+            def __init__(
+                self,
+                workers=1,
+                use_multiprocessing=False,
+                max_queue_size=10,
+                infinite=False,
+            ):
+                super().__init__(workers, use_multiprocessing, max_queue_size)
+                self.data = np.random.rand(64, 2)
+                self.batch_size = 16
+                self.infinite = infinite
+
+                # check that callbacks are called in the correct order
+                self.tracker = []
+
+            @property
+            def num_batches(self):
+                if self.infinite:
+                    return None
+                return len(self.data) // self.batch_size
+
+            def on_epoch_begin(self):
+                self.tracker.append(1)
+
+            def __getitem__(self, index):
+                idx = index % 2
+                return self.data[
+                    idx * self.batch_size : (idx + 1) * self.batch_size
+                ]
+
+            def on_epoch_end(self):
+                self.tracker.append(2)
+
+        ds = TestPyDataset(infinite=infinite)
+        epoch_iter = epoch_iterator.EpochIterator(x=ds, steps_per_epoch=10)
+
+        num_epochs = 5
+        for epoch in range(num_epochs):
+            for step, batch in epoch_iter.enumerate_epoch():
+                pass
+
+        self.assertAllEqual(ds.tracker, [1, 2] * num_epochs)


### PR DESCRIPTION
Addresses issue #19749 

I wanted to double-check a couple of things, though: 
  1. `on_epoch_end` and `on_epoch_begin` are for `PyDataset` and not for other backend-specific datasets.
  2. The user is responsible for making these callbacks thread-safe and free of side effects. I made a [notebook](https://colab.research.google.com/drive/1LPQRLw0ujJkPZF_VScZ0zxuAe2YUzB2t?usp=sharing) to demonstrate this.
   e.g. if the user were to shuffle the dataset at the end of each epoch, there is a chance that the dataset is shuffled twice, as demonstrated in the notebook. 

I implemented `on_epoch_begin()` based on the above understanding. But if that's a misunderstanding please let me know and would be happy to fix! Thanks!