### PR TITLE
Cast random.categorical seed to int32 in TF backend

### DIFF
--- a/keras/src/backend/tensorflow/random.py
+++ b/keras/src/backend/tensorflow/random.py
@@ -29,6 +29,8 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
 
 def categorical(logits, num_samples, dtype="int64", seed=None):
     seed = draw_seed(seed)
+    # Only int32 seeds are supported in stateless_categorical.
+    seed = tf.cast(tf.math.floormod(seed, tf.int32.max - 1), dtype="int32")
     output = tf.random.stateless_categorical(logits, num_samples, seed=seed)
     return tf.cast(output, dtype)
 

--- a/keras/src/backend/tensorflow/random_test.py
+++ b/keras/src/backend/tensorflow/random_test.py
@@ -1,0 +1,26 @@
+import pytest
+import tensorflow as tf
+
+from keras.src import backend
+from keras.src.backend.tensorflow import random
+from keras.src.testing import TestCase
+
+
+@pytest.mark.skipif(
+    backend.backend() != "tensorflow",
+    reason="Only applies to TensorFlow random ops.",
+)
+class TFRandomTest(TestCase):
+
+    def test_categorical(self):
+        inputs = tf.ones([2, 3], dtype="float32")
+        outputs = random.categorical(inputs, 2, seed=42)
+        expected = tf.constant([[0, 2], [1, 0]])
+        self.assertAllClose(outputs, expected)
+
+    def test_categorical_seed_cast(self):
+        inputs = tf.ones([2, 3], dtype="float32")
+        seed = tf.int32.max + 1000
+        outputs_mod = random.categorical(inputs, 2, seed=seed)
+        outputs_nomod = random.categorical(inputs, 2, seed=1001)
+        self.assertAllClose(outputs_mod, outputs_nomod)


### PR DESCRIPTION
src/samplers/top_k_sampler_test.py to run into a compilation error:

```
(OpKernel was found, but attributes didn't match) Requested Attributes: T=DT_FLOAT, Tseed=DT_INT64, output_dtype=DT_INT64){{node while/stateless_categorical/StatelessMultinomial}}
```