### PR TITLE
Fix `_to_jax_device()`

### DIFF
--- a/keras/src/backend/jax/distribution_lib.py
+++ b/keras/src/backend/jax/distribution_lib.py
@@ -221,13 +221,6 @@ def process_id():
     return jax.process_index()
 
 
-def get_device_by_id(device_id, devices):
-    for device in devices:
-        if device.id == device_id:
-            return device
-    return None
-
-
 def _to_jax_device(device_name):
     if isinstance(device_name, jax.Device):
         return device_name

--- a/keras/src/backend/jax/distribution_lib.py
+++ b/keras/src/backend/jax/distribution_lib.py
@@ -221,15 +221,24 @@ def process_id():
     return jax.process_index()
 
 
-def _to_jax_device(device_id):
-    if isinstance(device_id, jax.Device):
-        return device_id
-    device_type, index = device_id.split(":")
-    index = int(index)
+def get_device_by_id(device_id, devices):
+    for device in devices:
+        if device.id == device_id:
+            return device
+    return None
+
+
+def _to_jax_device(device_name):
+    if isinstance(device_name, jax.Device):
+        return device_name
+    device_type, device_id = device_name.split(":")
+    device_id = int(device_id)
+
     devices = jax.devices(backend=device_type)
-    if index >= len(devices):
-        raise ValueError(f"Unknown device: {device_id}")
-    return devices[index]
+    for device in devices:
+        if device.platform == device_type and device.id == device_id:
+            return device
+    raise ValueError(f"Device not found: {device_name}")
 
 
 def _to_jax_mesh(device_mesh):

--- a/keras/src/backend/jax/distribution_lib.py
+++ b/keras/src/backend/jax/distribution_lib.py
@@ -225,11 +225,10 @@ def _to_jax_device(device_name):
     if isinstance(device_name, jax.Device):
         return device_name
     device_type, device_id = device_name.split(":")
-    device_id = int(device_id)
 
     devices = jax.devices(backend=device_type)
     for device in devices:
-        if device.platform == device_type and device.id == device_id:
+        if device.platform == device_type and device.id == int(device_id):
             return device
     raise ValueError(f"Device not found: {device_name}")
 


### PR DESCRIPTION
The current `_to_jax_device()` implementation assumes that in `jax.devices` devices are sorted by id but specific order is not guaranteed.

Example output with 2 processes with 4 devices each:
```
  [
      TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0),
      TpuDevice(id=1, process_index=0, coords=(0,0,0), core_on_chip=1),
      TpuDevice(id=4, process_index=0, coords=(0,1,0), core_on_chip=0),
      TpuDevice(id=5, process_index=0, coords=(0,1,0), core_on_chip=1),
      TpuDevice(id=2, process_index=1, coords=(1,0,0), core_on_chip=0),
      TpuDevice(id=3, process_index=1, coords=(1,0,0), core_on_chip=1),
      TpuDevice(id=6, process_index=1, coords=(1,1,0), core_on_chip=0),
      TpuDevice(id=7, process_index=1, coords=(1,1,0), core_on_chip=1),
  ]
```