### PR TITLE
add lamb optimizer

### DIFF
--- a/keras/api/_tf_keras/keras/optimizers/__init__.py
+++ b/keras/api/_tf_keras/keras/optimizers/__init__.py
@@ -16,6 +16,7 @@ from keras.src.optimizers.adam import Adam
 from keras.src.optimizers.adamax import Adamax
 from keras.src.optimizers.adamw import AdamW
 from keras.src.optimizers.ftrl import Ftrl
+from keras.src.optimizers.lamb import Lamb
 from keras.src.optimizers.lion import Lion
 from keras.src.optimizers.loss_scale_optimizer import LossScaleOptimizer
 from keras.src.optimizers.nadam import Nadam

--- a/keras/api/optimizers/__init__.py
+++ b/keras/api/optimizers/__init__.py
@@ -16,6 +16,7 @@ from keras.src.optimizers.adam import Adam
 from keras.src.optimizers.adamax import Adamax
 from keras.src.optimizers.adamw import AdamW
 from keras.src.optimizers.ftrl import Ftrl
+from keras.src.optimizers.lamb import Lamb
 from keras.src.optimizers.lion import Lion
 from keras.src.optimizers.loss_scale_optimizer import LossScaleOptimizer
 from keras.src.optimizers.nadam import Nadam

--- a/keras/src/optimizers/lamb.py
+++ b/keras/src/optimizers/lamb.py
@@ -1,0 +1,158 @@
+from keras.src import ops
+from keras.src.api_export import keras_export
+from keras.src.optimizers import optimizer
+
+
+@keras_export("keras.optimizers.Lamb")
+class Lamb(optimizer.Optimizer):
+    """Optimizer that implements the Lamb algorithm.
+
+    Lamb is a stochastic gradient descent method that
+    uses layer-wise adaptive moments to adjusts the
+    learning rate for each parameter based on the ratio of the
+    norm of the weight to the norm of the gradient
+    This helps to stabilize the training process and improves convergence
+    especially for large batch sizes.
+
+    Based on
+    [Yang et al.](https://arxiv.org/pdf/1904.00962)
+
+    Args:
+        learning_rate: A float, a
+            `keras.optimizers.schedules.LearningRateSchedule` instance, or
+            a callable that takes no arguments and returns the actual value to
+            use. The learning rate. Defaults to `0.001`.
+        beta_1: A float value or a constant float tensor, or a callable
+            that takes no arguments and returns the actual value to use. The
+            exponential decay rate for the 1st moment estimates. Defaults to
+            `0.9`.
+        beta_2: A float value or a constant float tensor, or a callable
+            that takes no arguments and returns the actual value to use. The
+            exponential decay rate for the 2nd moment estimates. Defaults to
+            `0.999`.
+        epsilon: A small constant for numerical stability.
+            Defaults to `1e-7`.
+        {{base_optimizer_keyword_args}}
+    """
+
+    def __init__(
+        self,
+        learning_rate=0.001,
+        beta_1=0.9,
+        beta_2=0.999,
+        epsilon=1e-7,
+        weight_decay=None,
+        clipnorm=None,
+        clipvalue=None,
+        global_clipnorm=None,
+        use_ema=False,
+        ema_momentum=0.99,
+        ema_overwrite_frequency=None,
+        loss_scale_factor=None,
+        gradient_accumulation_steps=None,
+        name="lamb",
+        **kwargs,
+    ):
+        super().__init__(
+            learning_rate=learning_rate,
+            name=name,
+            weight_decay=weight_decay,
+            clipnorm=clipnorm,
+            clipvalue=clipvalue,
+            global_clipnorm=global_clipnorm,
+            use_ema=use_ema,
+            ema_momentum=ema_momentum,
+            ema_overwrite_frequency=ema_overwrite_frequency,
+            loss_scale_factor=loss_scale_factor,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            **kwargs,
+        )
+        self.beta_1 = beta_1
+        self.beta_2 = beta_2
+        self.epsilon = epsilon
+
+    def build(self, var_list):
+        """Initialize optimizer variables.
+
+        Lamb optimizer has 2 types of variables: momentums and velocities
+
+        Args:
+            var_list: list of model variables to build Lamb variables on.
+        """
+        if self.built:
+            return
+        super().build(var_list)
+        self._momentums = []
+        self._velocities = []
+        for var in var_list:
+            self._momentums.append(
+                self.add_variable_from_reference(
+                    reference_variable=var, name="momentum"
+                )
+            )
+            self._velocities.append(
+                self.add_variable_from_reference(
+                    reference_variable=var, name="velocity"
+                )
+            )
+
+    def update_step(self, gradient, variable, learning_rate):
+        """Update step given gradient and the associated model variable."""
+        lr = ops.cast(learning_rate, variable.dtype)
+        gradient = ops.cast(gradient, variable.dtype)
+        local_step = ops.cast(self.iterations + 1, variable.dtype)
+
+        beta_1_power = ops.power(
+            ops.cast(self.beta_1, variable.dtype), local_step
+        )
+        beta_2_power = ops.power(
+            ops.cast(self.beta_2, variable.dtype), local_step
+        )
+
+        m = self._momentums[self._get_variable_index(variable)]
+        v = self._velocities[self._get_variable_index(variable)]
+
+        self.assign_add(
+            m, ops.multiply(ops.subtract(gradient, m), 1 - self.beta_1)
+        )
+
+        self.assign_add(
+            v,
+            ops.multiply(
+                ops.subtract(ops.square(gradient), v), 1 - self.beta_2
+            ),
+        )
+
+        m_t_hat = ops.divide(m, (1.0 - beta_1_power))
+        v_sqrt = ops.add(
+            ops.sqrt(ops.divide(v, (1.0 - beta_2_power))), self.epsilon
+        )
+
+        update = ops.divide(m_t_hat, v_sqrt)
+        w_norm = ops.sqrt(ops.sum(ops.power(variable, 2)))
+        g_norm = ops.sqrt(ops.sum(ops.power(update, 2)))
+
+        # ratio = w_norm / g_norm if w_norm > 0 and g_norm > 0 else 1
+        ratio = ops.where(
+            ops.greater(w_norm, 0),
+            ops.where(ops.greater(g_norm, 0), (w_norm / g_norm), 1.0),
+            1.0,
+        )
+
+        self.assign_sub(variable, ratio * lr * update)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "beta_1": self.beta_1,
+                "beta_2": self.beta_2,
+                "epsilon": self.epsilon,
+            }
+        )
+        return config
+
+
+Lamb.__doc__ = Lamb.__doc__.replace(
+    "{{base_optimizer_keyword_args}}", optimizer.base_optimizer_keyword_args
+)

--- a/keras/src/optimizers/lamb_test.py
+++ b/keras/src/optimizers/lamb_test.py
@@ -1,0 +1,76 @@
+import numpy as np
+
+from keras.src import backend
+from keras.src import ops
+from keras.src import testing
+from keras.src.optimizers.lamb import Lamb
+
+
+class LambTest(testing.TestCase):
+    def test_config(self):
+        optimizer = Lamb(
+            learning_rate=0.5,
+            beta_1=0.5,
+            beta_2=0.67,
+            epsilon=1e-5,
+        )
+        self.run_class_serialization_test(optimizer)
+
+    def test_single_step(self):
+        optimizer = Lamb(learning_rate=0.5)
+        grads = ops.array([1.0, 6.0, 7.0, 2.0])
+        vars = backend.Variable([1.0, 2.0, 3.0, 4.0])
+        optimizer.apply_gradients(zip([grads], [vars]))
+        self.assertAllClose(
+            vars, [-0.3693, 0.6306, 1.6306, 2.6306], rtol=1e-4, atol=1e-4
+        )
+
+    def test_weight_decay(self):
+        grads, var1, var2, var3 = (
+            ops.zeros(()),
+            backend.Variable(2.0),
+            backend.Variable(2.0, name="exclude"),
+            backend.Variable(2.0),
+        )
+        optimizer_1 = Lamb(learning_rate=1.0, weight_decay=0.004)
+        optimizer_1.apply_gradients(zip([grads], [var1]))
+
+        optimizer_2 = Lamb(learning_rate=1.0, weight_decay=0.004)
+        optimizer_2.exclude_from_weight_decay(var_names=["exclude"])
+        optimizer_2.apply_gradients(zip([grads, grads], [var1, var2]))
+
+        optimizer_3 = Lamb(learning_rate=1.0, weight_decay=0.004)
+        optimizer_3.exclude_from_weight_decay(var_list=[var3])
+        optimizer_3.apply_gradients(zip([grads, grads], [var1, var3]))
+
+        self.assertAlmostEqual(var1.numpy(), 1.9760959, decimal=6)
+        self.assertAlmostEqual(var2.numpy(), 2.0, decimal=6)
+        self.assertAlmostEqual(var3.numpy(), 2.0, decimal=6)
+
+    def test_correctness_with_golden(self):
+        optimizer = Lamb()
+
+        x = backend.Variable(np.ones([10]))
+        grads = ops.arange(0.1, 1.1, 0.1)
+        first_grads = ops.full((10,), 0.01)
+
+        golden = np.tile(
+            [[0.999], [0.9982], [0.9974], [0.9965], [0.9955]], (1, 10)
+        )
+
+        optimizer.apply_gradients(zip([first_grads], [x]))
+        for i in range(5):
+            self.assertAllClose(x, golden[i], rtol=5e-4, atol=5e-4)
+            optimizer.apply_gradients(zip([grads], [x]))
+
+    def test_clip_norm(self):
+        optimizer = Lamb(clipnorm=1)
+        grad = [np.array([100.0, 100.0])]
+        clipped_grad = optimizer._clip_gradients(grad)
+        self.assertAllClose(clipped_grad[0], [2**0.5 / 2, 2**0.5 / 2])
+
+    def test_clip_value(self):
+        optimizer = Lamb(clipvalue=1)
+        grad = [np.array([100.0, 100.0])]
+        clipped_grad = optimizer._clip_gradients(grad)
+        self.assertAllClose(clipped_grad[0], [1.0, 1.0])


### PR DESCRIPTION
This PR adds the Lamb optimizer described in the paper "Large Batch Optimization for Deep Learning: Training BERT in 76 minutes" (https://arxiv.org/abs/1904.00962)

The optimizer was previously implemented by the authors of the paper in the tensorflow_addons repository (https://github.com/tensorflow/addons) which is deprecated.

I was interested in this optimizer and opened an issue before. It is available here: https://github.com/keras-team/keras/issues/19965

I compared its output against `tensorflow_addons.optimizers.LAMB` and behavior is identical **only if `weight_decay=0.0`**. This is because the implementation in tensorflow_addons couples weight decay to the optimization procedure (as did previous implementations of Adam, see https://arxiv.org/abs/1711.05101 for details)

When looking at other optimizer implementations in keras 3 it seems to me that the preferred way to handle weight decay is to leave it to the optimizer base class and therefore I did the same. Contrary to pytorch where `Adam` and `AdamW` treat weight decay differently, keras 3 only implements a single version of weight decay and `keras.optimizers.AdamW` is just a child class of `keras.optimizers.Adam` that enforces the usage of weight decay (see here: https://github.com/keras-team/keras/blob/master/keras/src/optimizers/adamw.py#L91)

This however means that this implementation differs from the implementation in `tensorflow_addons` which might lead to confusion. Please let me know if this is the preferred behaviour. I also created a colab to highlight this:

https://colab.research.google.com/drive/13oSX0daqRV199v0wCFtFAriRA_wlAj8w

Furthermore, it seems like there are different versions of Lamb floating around the internet. The paper "ResNet strikes back: An improved training procedure in timm" (https://arxiv.org/abs/2110.00476) uses the implementation that is available here: https://github.com/huggingface/pytorch-image-models/blob/main/timm/optim/lamb.py

This implementation adds a normalization over all gradients before applying the Lamb algorithm. More details are available on this blog post from Nvidia: https://developer.nvidia.com/blog/pretraining-bert-with-layer-wise-adaptive-learning-rates/

For now, I'd like some feedback on this PR to see if I understood the handling of weight decay correctly. Please also let me know if you would prefer the version with gradient norm instead of this. Otherwise I plan to add another PR later which implements it as a different optimizer (probably going to call it `keras.optimizers.NVLamb`).
