### PR TITLE
Change dtypes for test_dtypes test case.

### DIFF
--- a/integration_tests/dataset_tests/cifar100_test.py
+++ b/integration_tests/dataset_tests/cifar100_test.py
@@ -26,9 +26,9 @@ class Cifar100LoadDataTest(testing.TestCase):
     def test_dtypes(self):
         (x_train, y_train), (x_test, y_test) = cifar100.load_data()
         self.assertEqual(x_train.dtype, np.uint8)
-        self.assertEqual(y_train.dtype, np.uint8)
+        self.assertEqual(y_train.dtype, np.int64)
         self.assertEqual(x_test.dtype, np.uint8)
-        self.assertEqual(y_test.dtype, np.uint8)
+        self.assertEqual(y_test.dtype, np.int64)
 
     def test_invalid_label_mode(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Test case for test_dtypes is fixed.
I found that there is a failed test case in "integration_tests/dataset_tests/cifar100_test.py",because of type difference.
I run this test case on windows wsl2, and if this problem is only for my local configuration issue, plz let me know.