### PR TITLE
Change dtypes for test_dtypes test case.

### DIFF
--- a/integration_tests/dataset_tests/cifar100_test.py
+++ b/integration_tests/dataset_tests/cifar100_test.py
@@ -26,9 +26,9 @@ class Cifar100LoadDataTest(testing.TestCase):
     def test_dtypes(self):
         (x_train, y_train), (x_test, y_test) = cifar100.load_data()
         self.assertEqual(x_train.dtype, np.uint8)
-        self.assertEqual(y_train.dtype, np.uint8)
+        self.assertEqual(y_train.dtype, np.int64)
         self.assertEqual(x_test.dtype, np.uint8)
-        self.assertEqual(y_test.dtype, np.uint8)
+        self.assertEqual(y_test.dtype, np.int64)
 
     def test_invalid_label_mode(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
I found that test case failed on "cifar100_test.py".
Because of type mismatching on y_train and y_test, it failed. and I changed the dtype to match with current y data.
I tested it on windows wsl, and if this problem is just related in my local configuration, plz let me know.