### PR TITLE
Fix gradient accumulation

### DIFF
--- a/keras/src/backend/jax/optimizer.py
+++ b/keras/src/backend/jax/optimizer.py
@@ -16,7 +16,7 @@ class JaxOptimizer(base_optimizer.BaseOptimizer):
     def _backend_apply_gradients(self, grads, trainable_variables):
         if self.gradient_accumulation_steps:
             is_update_step = (
-                self.iterations + 1
+                self._iterations + 1
             ) % self.gradient_accumulation_steps == 0
             steps = self.gradient_accumulation_steps
 
@@ -109,4 +109,4 @@ class JaxOptimizer(base_optimizer.BaseOptimizer):
                         + var.value * should_not_overwrite_model_vars_int
                     )
 
-        self.iterations.assign_add(1)
+        self._iterations.assign_add(1)

--- a/keras/src/backend/jax/optimizer.py
+++ b/keras/src/backend/jax/optimizer.py
@@ -47,6 +47,10 @@ class JaxOptimizer(base_optimizer.BaseOptimizer):
                 lambda: list(grads),
             )
 
+            # Apply clipping and weight decay.
+            grads = self._clip_gradients(grads)
+            self._apply_weight_decay(trainable_variables)
+
             self._backend_update_step(
                 grads, trainable_variables, self.learning_rate
             )
@@ -71,6 +75,10 @@ class JaxOptimizer(base_optimizer.BaseOptimizer):
                 g_acc.assign(n_g_acc)
 
         else:
+            # Apply clipping and weight decay.
+            grads = self._clip_gradients(grads)
+            self._apply_weight_decay(trainable_variables)
+
             self._backend_update_step(
                 grads, trainable_variables, self.learning_rate
             )

--- a/keras/src/backend/tensorflow/optimizer_distribute_test.py
+++ b/keras/src/backend/tensorflow/optimizer_distribute_test.py
@@ -194,16 +194,19 @@ class OptimizerDistributeTest(testing.TestCase, parameterized.TestCase):
             self.assertAllClose(
                 optimizer._accumulated_gradients[0], [[1.0, 1.0], [2.0, 2.0]]
             )
-            self.assertAllClose(optimizer.iterations, 1)
+            self.assertAllClose(optimizer._iterations, 1)
+            self.assertAllClose(optimizer.iterations, 0)
             self.strategy.run(lambda: optimizer.apply_gradients([(grads, v)]))
             self.assertAllClose(v, [[1.0, 2.0], [3.0, 4.0]])
             self.assertAllClose(
                 optimizer._accumulated_gradients[0], [[2.0, 2.0], [4.0, 4.0]]
             )
-            self.assertAllClose(optimizer.iterations, 2)
+            self.assertAllClose(optimizer._iterations, 2)
+            self.assertAllClose(optimizer.iterations, 0)
             self.strategy.run(lambda: optimizer.apply_gradients([(grads, v)]))
             self.assertAllClose(v, [[-1.0, 0.0], [-1.0, 0.0]])
             self.assertAllClose(
                 optimizer._accumulated_gradients[0], [[0.0, 0.0], [0.0, 0.0]]
             )
-            self.assertAllClose(optimizer.iterations, 3)
+            self.assertAllClose(optimizer._iterations, 3)
+            self.assertAllClose(optimizer.iterations, 1)

--- a/keras/src/optimizers/base_optimizer.py
+++ b/keras/src/optimizers/base_optimizer.py
@@ -142,10 +142,11 @@ class BaseOptimizer(KerasSaveable):
     @property
     def iterations(self):
         if self.gradient_accumulation_steps:
-            return ops.floor_divide(self._iterations, self.gradient_accumulation_steps)
+            return ops.floor_divide(
+                self._iterations, self.gradient_accumulation_steps
+            )
 
         return self._iterations
-
 
     def _track_variable(self, variable):
         self._tracker.add_to_store("variables", variable)

--- a/keras/src/optimizers/base_optimizer.py
+++ b/keras/src/optimizers/base_optimizer.py
@@ -110,7 +110,7 @@ class BaseOptimizer(KerasSaveable):
                 aggregation="only_first_replica",
             )
         self._track_variable(iterations)
-        self.iterations = iterations
+        self._iterations = iterations
 
         # Create learning rate (schedule or variable)
         if isinstance(
@@ -138,6 +138,14 @@ class BaseOptimizer(KerasSaveable):
                 )
             self._track_variable(learning_rate)
             self._learning_rate = learning_rate
+
+    @property
+    def iterations(self):
+        if self.gradient_accumulation_steps:
+            return ops.floor_divide(self._iterations, self.gradient_accumulation_steps)
+
+        return self._iterations
+
 
     def _track_variable(self, variable):
         self._tracker.add_to_store("variables", variable)
@@ -281,7 +289,7 @@ class BaseOptimizer(KerasSaveable):
         grads, trainable_variables = zip(*grads_and_vars)
         self.apply(grads, trainable_variables)
         # Return iterations for compat with tf.keras.
-        return self.iterations
+        return self._iterations
 
     def apply(self, grads, trainable_variables=None):
         """Update traininable variables according to provided gradient values.
@@ -368,7 +376,7 @@ class BaseOptimizer(KerasSaveable):
         """
         if self.gradient_accumulation_steps:
             is_update_step = (
-                self.iterations + 1
+                self._iterations + 1
             ) % self.gradient_accumulation_steps == 0
             # `trainable_variables` might have been filtered in previous
             # processing steps, so we need to ensure the correct mapping between
@@ -429,7 +437,7 @@ class BaseOptimizer(KerasSaveable):
                     lambda: None,
                 )
         # Update iteration counter.
-        self.iterations.assign_add(1)
+        self._iterations.assign_add(1)
 
     def _backend_update_step(self, grads, trainable_variables, learning_rate):
         """Collective update_step that can be overridden by the backend.
@@ -591,7 +599,7 @@ class BaseOptimizer(KerasSaveable):
         if isinstance(
             self._learning_rate, learning_rate_schedule.LearningRateSchedule
         ):
-            return self._learning_rate(self.iterations)
+            return self._learning_rate(self._iterations)
         elif callable(self._learning_rate):
             return self._learning_rate()
         return self._learning_rate
@@ -624,7 +632,7 @@ class BaseOptimizer(KerasSaveable):
                 if self.gradient_accumulation_steps:
                     # Utilize a stateless manner for JAX compatibility
                     steps = self.gradient_accumulation_steps
-                    is_update_step = (self.iterations + 1) % steps == 0
+                    is_update_step = (self._iterations + 1) % steps == 0
                     acc_g = self._accumulated_gradients[
                         self._get_variable_index(v)
                     ]
@@ -969,7 +977,10 @@ base_optimizer_keyword_args = """name: String. The name to use
             value of the gradients since the last update. This is known as
             "gradient accumulation". This can be useful
             when your batch size is very small, in order to reduce gradient
-            noise at each update step.
+            noise at each update step. EMA frequency will look at "accumulated"
+            iterations value (optimizer steps // gradient_accumulation_steps).
+            Learning rate schedules will look at "real" iterations value
+            (optimizer steps).
 """
 
 

--- a/keras/src/optimizers/base_optimizer.py
+++ b/keras/src/optimizers/base_optimizer.py
@@ -343,10 +343,6 @@ class BaseOptimizer(KerasSaveable):
             if scale is not None:
                 grads = [g if g is None else g / scale for g in grads]
 
-            # Apply clipping and weight decay.
-            grads = self._clip_gradients(grads)
-            self._apply_weight_decay(trainable_variables)
-
             # Apply gradient updates.
             self._backend_apply_gradients(grads, trainable_variables)
             # Apply variable constraints after applying gradients.
@@ -388,6 +384,11 @@ class BaseOptimizer(KerasSaveable):
                 grads = [
                     (g + acc_g) / steps for g, acc_g in zip(grads, acc_grads)
                 ]
+
+                # Apply clipping and weight decay.
+                grads = self._clip_gradients(grads)
+                self._apply_weight_decay(trainable_variables)
+
                 self._backend_update_step(
                     grads, trainable_variables, self.learning_rate
                 )
@@ -401,6 +402,10 @@ class BaseOptimizer(KerasSaveable):
                 ),
             )
         else:
+            # Apply clipping and weight decay.
+            grads = self._clip_gradients(grads)
+            self._apply_weight_decay(trainable_variables)
+
             # Run udpate step.
             self._backend_update_step(
                 grads, trainable_variables, self.learning_rate

--- a/keras/src/optimizers/optimizer_test.py
+++ b/keras/src/optimizers/optimizer_test.py
@@ -195,30 +195,42 @@ class OptimizerTest(testing.TestCase, parameterized.TestCase):
             learning_rate=1.0, gradient_accumulation_steps=3
         )
         self.assertEqual(optimizer.gradient_accumulation_steps, 3)
+
+        # Iteration 1
         optimizer.apply_gradients([(grads, v)])
         self.assertAllClose(v, [[1.0, 2.0], [3.0, 4.0]])
         self.assertAllClose(
             optimizer._accumulated_gradients[0], [[1.0, 1.0], [1.0, 1.0]]
         )
-        self.assertAllClose(optimizer.iterations, 1)
+        self.assertAllClose(optimizer._iterations, 1)
+        self.assertAllClose(optimizer.iterations, 0)
+
+        # Iteration 2
         optimizer.apply_gradients([(grads, v)])
         self.assertAllClose(v, [[1.0, 2.0], [3.0, 4.0]])
         self.assertAllClose(
             optimizer._accumulated_gradients[0], [[2.0, 2.0], [2.0, 2.0]]
         )
-        self.assertAllClose(optimizer.iterations, 2)
+        self.assertAllClose(optimizer._iterations, 2)
+        self.assertAllClose(optimizer.iterations, 0)
+
+        # Iteration 3
         optimizer.apply_gradients([(grads, v)])
         self.assertAllClose(v, [[0.0, 1.0], [2.0, 3.0]])
         self.assertAllClose(
             optimizer._accumulated_gradients[0], [[0.0, 0.0], [0.0, 0.0]]
         )
-        self.assertAllClose(optimizer.iterations, 3)
+        self.assertAllClose(optimizer._iterations, 3)
+        self.assertAllClose(optimizer.iterations, 1)
+
+        # Iteration 4
         optimizer.apply_gradients([(grads, v)])
         self.assertAllClose(v, [[0.0, 1.0], [2.0, 3.0]])
         self.assertAllClose(
             optimizer._accumulated_gradients[0], [[1.0, 1.0], [1.0, 1.0]]
         )
-        self.assertAllClose(optimizer.iterations, 4)
+        self.assertAllClose(optimizer._iterations, 4)
+        self.assertAllClose(optimizer.iterations, 1)
 
     @pytest.mark.skipif(backend.backend() != "tensorflow", reason="Requires TF")
     def test_tf_checkpointing(self):
@@ -281,7 +293,8 @@ class OptimizerTest(testing.TestCase, parameterized.TestCase):
 
         # Iteration 1
         optimizer.apply_gradients([(grad_ones, v), (grad_ones, v2)])
-        self.assertAllClose(optimizer.iterations, 1)
+        self.assertAllClose(optimizer._iterations, 1)
+        self.assertAllClose(optimizer.iterations, 0)
         self.assertAllClose(v, [[1.0, 2.0], [3.0, 4.0]])
         self.assertAllClose(v2, [[1.0, 2.0], [3.0, 4.0]])
         self.assertAllClose(
@@ -290,9 +303,11 @@ class OptimizerTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(
             optimizer._accumulated_gradients[1], [[1.0, 1.0], [1.0, 1.0]]
         )
+
         # Iteration 2
         optimizer.apply_gradients([(grad_twos, v), (grad_twos, v2)])
-        self.assertAllClose(optimizer.iterations, 2)
+        self.assertAllClose(optimizer._iterations, 2)
+        self.assertAllClose(optimizer.iterations, 1)
         self.assertAllClose(v, [[2.0, 2.0], [2.0, 2.0]])
         self.assertAllClose(v2, [[-0.5, 0.5], [1.5, 2.5]])
         self.assertAllClose(
@@ -301,9 +316,11 @@ class OptimizerTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(
             optimizer._accumulated_gradients[1], [[0.0, 0.0], [0.0, 0.0]]
         )
+
         # Iteration 3
         optimizer.apply_gradients([(grad_ones, v), (grad_ones, v2)])
-        self.assertAllClose(optimizer.iterations, 3)
+        self.assertAllClose(optimizer._iterations, 3)
+        self.assertAllClose(optimizer.iterations, 1)
         self.assertAllClose(v, [[2.0, 2.0], [2.0, 2.0]])
         self.assertAllClose(v2, [[-0.5, 0.5], [1.5, 2.5]])
         self.assertAllClose(
@@ -315,17 +332,17 @@ class OptimizerTest(testing.TestCase, parameterized.TestCase):
 
     @parameterized.parameters(
          [
-            # ("adam",),
+            ("adam",),
             ("sgd",),
-            # ("adamw",),
-            # ("adagrad",),
-            # ("rmsprop",),
-            # ("adadelta",),
-            # ("adamax",),
-            # ("lion",),
-            # ("nadam",),
-            # ("ftrl",),
-            # ("adafactor",),
+            ("adamw",),
+            ("adagrad",),
+            ("rmsprop",),
+            ("adadelta",),
+            ("adamax",),
+            ("lion",),
+            ("nadam",),
+            ("ftrl",),
+            ("adafactor",),
          ]
     )
     def test_gradient_accumulation_with_weigth_decay(self, optimizer):

--- a/keras/src/optimizers/optimizer_test.py
+++ b/keras/src/optimizers/optimizer_test.py
@@ -331,7 +331,7 @@ class OptimizerTest(testing.TestCase, parameterized.TestCase):
         )
 
     @parameterized.parameters(
-         [
+        [
             ("adam",),
             ("sgd",),
             ("adamw",),
@@ -343,16 +343,26 @@ class OptimizerTest(testing.TestCase, parameterized.TestCase):
             ("nadam",),
             ("ftrl",),
             ("adafactor",),
-         ]
+        ]
     )
     def test_gradient_accumulation_with_weigth_decay(self, optimizer):
-        optimizer1 = optimizers.get({'class_name': optimizer, 'config': {'weight_decay': 0.05}})
-        optimizer3 = optimizers.get({'class_name': optimizer, 'config': {'weight_decay': 0.05, 'gradient_accumulation_steps': 3}})
+        optimizer1 = optimizers.get(
+            {"class_name": optimizer, "config": {"weight_decay": 0.05}}
+        )
+        optimizer3 = optimizers.get(
+            {
+                "class_name": optimizer,
+                "config": {
+                    "weight_decay": 0.05,
+                    "gradient_accumulation_steps": 3,
+                },
+            }
+        )
         variable1 = backend.Variable([[0.9], [0.5]])
         variable3 = backend.Variable([[0.9], [0.5]])
 
         for epoch in range(8):
-            grads3 = np.random.random([3, 2, 1]).astype('float32')
+            grads3 = np.random.random([3, 2, 1]).astype("float32")
 
             grads1 = backend.convert_to_tensor(grads3.mean(axis=0))
             optimizer1.apply_gradients([(grads1, variable1)])


### PR DESCRIPTION
Fix https://github.com/keras-team/keras/issues/19990
Removes unnecessary (wrong) weight decay and gradient clipping during gradient accumulation. The will be applied only before actual variable update.

To make gradient accumulation work in the same way as "large batch" real number of iterations was hidden under property.
This is done because a lot of optimizers use it during gradient estimation in update_step.