### PR TITLE
Correct test case for ImdbLoadDataTest

### DIFF
--- a/integration_tests/dataset_tests/imdb_test.py
+++ b/integration_tests/dataset_tests/imdb_test.py
@@ -7,9 +7,9 @@ from keras.src.datasets import imdb
 class ImdbLoadDataTest(testing.TestCase):
     def test_load_data_default(self):
         (x_train, y_train), (x_test, y_test) = imdb.load_data()
-        self.assertIsInstance(x_train, list)
+        self.assertIsInstance(x_train, np.ndarray)
         self.assertIsInstance(y_train, np.ndarray)
-        self.assertIsInstance(x_test, list)
+        self.assertIsInstance(x_test, np.ndarray)
         self.assertIsInstance(y_test, np.ndarray)
 
         # Check lengths


### PR DESCRIPTION
Correct failed test case on ImdbLoadDataTest

Since, x_train,x_test are implicitly declared as np.array in source code below,
I think the x_train, x_test type should be changed from list to np.ndarray in test code.


- keras/src/datasets/imdb.py

```
def load_data(
    path="imdb.npz",
    num_words=None,
    skip_top=0,
    maxlen=None,
    seed=113,
    start_char=1,
    oov_char=2,
    index_from=3,
    **kwargs,
):        
....
x_train, y_train = np.array(xs[:idx], dtype="object"), labels[:idx] 
x_test, y_test = np.array(xs[idx:], dtype="object"), labels[idx:]
```

