### PR TITLE
Remove duplicated code from rnn.py

### DIFF
--- a/keras/src/layers/rnn/rnn.py
+++ b/keras/src/layers/rnn/rnn.py
@@ -428,9 +428,6 @@ class RNN(Layer):
             output = last_output
 
         if self.return_state:
-            if len(states) == 1:
-                state = states[0]
-                return output, state
             return output, *states
         return output
 


### PR DESCRIPTION
It seems that without handling the case that it has length as 1, it would be working as the same manner.
However, if there is another specific reason or special case that this code is needed, feel free to comment here and let me know. :)