### PR TITLE
Revert to the original default behavior of `dtype` in `Loss` and `Metric`

### DIFF
--- a/keras/src/losses/loss.py
+++ b/keras/src/losses/loss.py
@@ -39,7 +39,7 @@ class Loss(KerasSaveable):
     def __init__(self, name=None, reduction="sum_over_batch_size", dtype=None):
         self.name = name or auto_name(self.__class__.__name__)
         self.reduction = standardize_reduction(reduction)
-        self._dtype_policy = dtype_policies.get(dtype)
+        self._dtype_policy = dtype_policies.get(dtype or backend.floatx())
         self._dtype = self._dtype_policy.compute_dtype
 
     @property

--- a/keras/src/losses/loss_test.py
+++ b/keras/src/losses/loss_test.py
@@ -18,6 +18,16 @@ class ExampleLoss(Loss):
 
 
 class LossTest(testing.TestCase):
+    def setUp(self):
+        self._global_dtype_policy = dtype_policies.dtype_policy.dtype_policy()
+        self._floatx = backend.floatx()
+        return super().setUp()
+
+    def tearDown(self):
+        dtype_policies.dtype_policy.set_dtype_policy(self._global_dtype_policy)
+        backend.set_floatx(self._floatx)
+        return super().tearDown()
+
     def test_squeeze_or_expand(self):
         x1 = ops.ones((3,))
         x2 = ops.ones((3, 1))
@@ -262,3 +272,18 @@ class LossTest(testing.TestCase):
         # `dtype` setter should raise AttributeError
         with self.assertRaises(AttributeError):
             loss.dtype = "bfloat16"
+
+    def test_default_dtype(self):
+        y_true = np.array([1.0, 0.0, 1.0, 0.0], dtype="float32")
+        y_pred = np.array([0.1, 0.2, 0.3, 0.4], dtype="float32")
+
+        # Defaults to `keras.config.floatx()` not global `dtype_policy`
+        dtype_policies.dtype_policy.set_dtype_policy("mixed_float16")
+        loss_fn = ExampleLoss()
+        loss = loss_fn(y_true, y_pred)
+        self.assertDType(loss, "float32")
+
+        backend.set_floatx("float16")
+        loss_fn = ExampleLoss()
+        loss = loss_fn(y_true, y_pred)
+        self.assertDType(loss, backend.floatx())

--- a/keras/src/metrics/metric.py
+++ b/keras/src/metrics/metric.py
@@ -91,7 +91,7 @@ class Metric(KerasSaveable):
 
     def __init__(self, dtype=None, name=None):
         self.name = name or auto_name(self.__class__.__name__)
-        self._dtype_policy = dtype_policies.get(dtype)
+        self._dtype_policy = dtype_policies.get(dtype or backend.floatx())
         self._dtype = self._dtype_policy.compute_dtype
         self._metrics = []
         self._variables = []


### PR DESCRIPTION
There is a regression after #19937 where, when users set a global dtype policy such as "mixed_float16" or "mixed_bfloat16", the `dtype` is wrongly set in `Loss` and `Metric`.
It should follow `keras.config.floatx()` as stated in the docstrings.