### PR TITLE
Fixing issue #19754: len is not well defined for a symbolic Tensor

### DIFF
--- a/keras/src/backend/tensorflow/rnn.py
+++ b/keras/src/backend/tensorflow/rnn.py
@@ -775,6 +775,9 @@ def _cudnn_gru(
     if not return_sequences:
         outputs = tf.expand_dims(last_output, axis=0 if time_major else 1)
 
+    # Match keras RNN return format
+    state = [state]
+
     return (
         last_output,
         outputs,


### PR DESCRIPTION
Fixing issue [#19754](https://github.com/keras-team/keras/issues/19754)

I found when GRU layer is running on graph mode, it returns symbolic tensor and it occured the error related in that it can't be iterable. So, I added this tensor to list, so that can be matched with RNN states format as list.