### PR TITLE
Faster host to device transfer on Jax backend

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -968,7 +968,7 @@ class JAXTrainer(base_trainer.Trainer):
         return tuple(state)
 
 
-def _distribute_data(data, layouts):
+def _distribute_data(data, layouts=None):
     if layouts is not None:
 
         def distribute_single_value(d, layout):

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -970,16 +970,16 @@ class JAXTrainer(base_trainer.Trainer):
 def _distribute_data(data, layouts=None):
     distribution = distribution_lib.distribution()
     if distribution is not None:
+        if layouts is None:
+            layouts = tree.map_structure(
+                lambda d: distribution.get_data_layout(d.shape),
+                data,
+            )
+        return tree.map_structure(
+            jax_distribution_lib.distribute_data_input, data, layouts
+        )
 
-        def distribute_single_value(d, layouts=None):
-            if layouts is None:
-                layout = distribution.get_data_layout(d.shape)
-            return jax_distribution_lib.distribute_data_input(d, layout)
-
-        return tree.map_structure(distribute_single_value, data, layouts)
-
-    else:
-        return tree.map_structure(jax.device_put, data)
+    return tree.map_structure(jax.device_put, data)
 
 
 class JAXEpochIterator(EpochIterator):

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -14,6 +14,7 @@ from keras.src.distribution import distribution_lib
 from keras.src.trainers import trainer as base_trainer
 from keras.src.trainers.data_adapters import array_slicing
 from keras.src.trainers.data_adapters import data_adapter_utils
+from keras.src.trainers.data_adapters.tf_dataset_adapter import TFDatasetAdapter
 from keras.src.trainers.epoch_iterator import EpochIterator
 from keras.src.utils import traceback_utils
 
@@ -967,21 +968,35 @@ class JAXTrainer(base_trainer.Trainer):
         return tuple(state)
 
 
-def _distribute_data(data):
-    distribution = distribution_lib.distribution()
-    if distribution is not None:
+def _distribute_data(data, layouts):
+    if layouts is not None:
 
-        def distribute_single_value(d):
-            layout = distribution.get_data_layout(d.shape)
+        def distribute_single_value(d, layout):
             return jax_distribution_lib.distribute_data_input(d, layout)
 
-        return tree.map_structure(distribute_single_value, data)
+        return tree.map_structure(distribute_single_value, data, layouts)
     else:
         return tree.map_structure(jax.device_put, data)
 
 
 class JAXEpochIterator(EpochIterator):
     def _get_iterator(self):
+        layouts = None
+        distribution = distribution_lib.distribution()
+        if isinstance(self.data_adapter, TFDatasetAdapter):
+            # Lazily computes input layouts and re-uses them to reduce the host
+            # to device transfer latency. The prefetching logic is disabled
+            # since TF Data handles eager prefetching.
+            for data in self.data_adapter.get_jax_iterator():
+                if layouts is None and distribution is not None:
+                    layouts = tree.map_structure(
+                        lambda d: jax_distribution_lib._to_jax_layout(
+                            distribution.get_data_layout(d.shape)
+                        ),
+                        data,
+                    )
+                yield _distribute_data(data, layouts)
+
         return self._prefetch_numpy_iterator(
             self.data_adapter.get_jax_iterator()
         )


### PR DESCRIPTION
- Lazily compute the layout using the first batch and re-use it. This speeds up host to device transfers which were slowed down by creating a new mesh and sharding each time. `jax.device_put` is still pretty slow so longer term it might be worth looking into packing features with a similar layout so there's fewer device puts.
- Allow turning sharding across processes off in the distribution API. This allows doing `dataset.shard(index)` followed by `dataset.batch(per_process_batch_size)` which enables scaling up to larger batch sizes.

Before:

![image](https://github.com/user-attachments/assets/3977d8f9-c77d-44f3-9bd5-08811c9cbe70)

After:

![image](https://github.com/user-attachments/assets/28c557d7-426c-4c1c-8b25-f31a01ccefe5)

