### PR TITLE
Fix test_softmax_correctness_with_axis_tuple test case failed on torch gpu ci.

### DIFF
--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1255,7 +1255,9 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         combination = combinations(range(3), 2)
         for axis in list(combination):
             result = keras.ops.nn.softmax(input, axis=axis)
-            normalized_sum_by_axis = np.sum(np.asarray(result), axis=axis)
+            normalized_sum_by_axis = np.sum(
+                ops.convert_to_numpy(result), axis=axis
+            )
             self.assertAllClose(normalized_sum_by_axis, 1.0)
 
     def test_log_softmax(self):


### PR DESCRIPTION
Fixing [test case failed on torch gpu ci](https://github.com/keras-team/keras/pull/20022#issuecomment-2241951918) reported by @james77777778 .
