### PR TITLE
Fix `reset_state` for some metrics

### DIFF
--- a/guides/training_with_built_in_methods.py
+++ b/guides/training_with_built_in_methods.py
@@ -338,7 +338,7 @@ class CategoricalTruePositives(keras.metrics.Metric):
 
     def reset_state(self):
         # The state of the metric will be reset at the start of each epoch.
-        self.true_positives.assign(0.0)
+        self.true_positives.assign(0)
 
 
 model = get_uncompiled_model()

--- a/keras/src/metrics/metric_test.py
+++ b/keras/src/metrics/metric_test.py
@@ -39,7 +39,7 @@ class ExampleMetric(Metric):
         return _sum / (_total + _epsilon)
 
     def reset_state(self):
-        self.sum.assign(0.0)
+        self.sum.assign(0)
         self.total.assign(0)
 
 

--- a/keras/src/metrics/reduction_metrics.py
+++ b/keras/src/metrics/reduction_metrics.py
@@ -87,7 +87,7 @@ class Sum(Metric):
         self.total.assign_add(ops.sum(values))
 
     def reset_state(self):
-        self.total.assign(0.0)
+        self.total.assign(0)
 
     def result(self):
         return ops.cast(self.total, self.dtype)
@@ -150,7 +150,7 @@ class Mean(Metric):
         self.count.assign_add(ops.cast(num_samples, dtype=self.dtype))
 
     def reset_state(self):
-        self.total.assign(0.0)
+        self.total.assign(0)
         self.count.assign(0)
 
     def result(self):


### PR DESCRIPTION
Fixes #20012 
Only tensorflow backend has this problem.
source: https://github.com/tensorflow/tensorflow/blob/7f950f32717fa53b4265e92a181e7e9e3d1eb6a6/tensorflow/python/eager/pywrap_tensor.cc#L316-L339