### PR TITLE
Fix log_softmax logic for tuple axis

### DIFF
--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1291,6 +1291,16 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             ],
         )
 
+    def test_log_softmax_correctness_with_axis_tuple(self):
+        input = np.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])
+        combination = combinations(range(3), 2)
+        for axis in list(combination):
+            result = keras.ops.nn.log_softmax(input, axis=axis)
+            normalized_sum_by_axis = np.sum(
+                np.exp(ops.convert_to_numpy(result)), axis=axis
+            )
+            self.assertAllClose(normalized_sum_by_axis, 1.0)
+
     def test_max_pool(self):
         data_format = backend.config.image_data_format()
         # Test 1D max pooling.


### PR DESCRIPTION
Similar with [#20021](https://github.com/keras-team/keras/issues/20021),
On log_softmax function, also has the same issue.
It couldn't pass the below test case that check the sum of all the exponential values should be 1.0.
So, I fixed the logic on log_softmax function also.

```
    def test_log_softmax_correctness_with_axis_tuple(self):
        input = np.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])
        combination = combinations(range(3), 2)
        for axis in list(combination):
            result = keras.ops.nn.log_softmax(input, axis=axis)
            normalized_sum_by_axis = np.sum(
                np.exp(ops.convert_to_numpy(result)), axis=axis
            )
            self.assertAllClose(normalized_sum_by_axis, 1.0)
```