### PR TITLE
Fix Data+Model Distribution Issues

### DIFF
--- a/keras/src/backend/jax/distribution_lib.py
+++ b/keras/src/backend/jax/distribution_lib.py
@@ -118,7 +118,7 @@ def distribute_data_input(per_process_batch, layout):
             `jax.sharding.Sharding` instance.
 
     Returns:
-        Distributed inputs that's been properly put to local devices.
+        A global batch distributed according to `layout`.
     """
     if not isinstance(layout, jax.sharding.Sharding):
         layout = _to_jax_layout(layout)

--- a/keras/src/backend/jax/distribution_lib_test.py
+++ b/keras/src/backend/jax/distribution_lib_test.py
@@ -323,6 +323,37 @@ class JaxDistributionLibTest(testing.TestCase):
             )
         )
 
+    def test_distribute_data_input(self):
+        per_process_batch = jax.numpy.arange(24).reshape(
+            6, 4
+        )  # Example input array
+        devices = jax.devices()[:4]  # Simulate 4 devices
+        batch_dim_size, model_dim_size = 2, 2
+        mesh = jax.sharding.Mesh(
+            np.array(devices).reshape(batch_dim_size, model_dim_size),
+            axis_names=["batch", "model"],
+        )
+        layout = jax.sharding.NamedSharding(
+            mesh, jax.sharding.PartitionSpec("batch", None)
+        )
+
+        result = backend_dlib.distribute_data_input(per_process_batch, layout)
+
+        # Check the shape of the global batch array
+        self.assertEqual(
+            result.shape, (6, 4)
+        )  # (per_replica_batch_size * num_model_replicas_total, 4)
+
+        # Check the sharding of the global batch array
+        self.assertEqual(len(result.addressable_shards), len(devices))
+        # Since batch_dim_size=2, there are 2 model replicas so there is one
+        # replication of data for model replica #1 and another replication of
+        # data for model replica #2. Within each model replica, the data is
+        # sharded to two shards. Therefore, each shard has 1/2 of
+        # per_process_batch.
+        for shard in result.addressable_shards:
+            self.assertEqual(shard.data.shape, (3, 4))
+
 
 class ShardingCaptureLayer(layers.Layer):
     def __init__(self, **kwargs):


### PR DESCRIPTION
This PR fixes these issues:
1. There was a bug that `distribute_data_input()` put the entire data on the first device when there was only one process.
2. `distribute_data_input()` and `distribute_dataset()` in `DataParallel` didn't work in the multi-process environment.