### PR TITLE
Support torch `convert_to_numpy` for all devices

### DIFF
--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -240,7 +240,7 @@ def convert_to_numpy(x):
             if x.requires_grad:
                 x = x.detach()
             # Tensor has to be moved to CPU before converting to numpy.
-            if x.device != torch.device('cpu'):
+            if x.device != torch.device("cpu"):
                 x = x.cpu()
             if x.dtype == torch.bfloat16:
                 # Attempting to call .numpy() on a bfloat16 torch tensor leads

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -240,7 +240,7 @@ def convert_to_numpy(x):
             if x.requires_grad:
                 x = x.detach()
             # Tensor has to be moved to CPU before converting to numpy.
-            if x.is_cuda or x.is_mps:
+            if x.device != torch.device('cpu'):
                 x = x.cpu()
             if x.dtype == torch.bfloat16:
                 # Attempting to call .numpy() on a bfloat16 torch tensor leads


### PR DESCRIPTION
Issue: `convert_to_numpy` fails for XLA tensors in the torch backend.
Solution: Call `.cpu()` on any tensor that's not already a CPU tensor. 