### PR TITLE
Remove non-used param & add initial value for callback.py

### DIFF
--- a/keras/src/callbacks/callback.py
+++ b/keras/src/callbacks/callback.py
@@ -64,7 +64,7 @@ class Callback:
     """
 
     def __init__(self):
-        self.validation_data = None
+        self.params = None
         self._model = None
 
     def set_params(self, params):


### PR DESCRIPTION
I couldn't find self.validation_data param's usage on callback class, and found that self.params has no initial value unlike self._model.
So, I removed self.validation_data, and add initial value as None for self.params