### PR TITLE
Refactoring for batch_normalization

### DIFF
--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -211,7 +211,6 @@ class BatchNormalization(Layer):
         self.input_spec = InputSpec(
             ndim=len(input_shape), axes={self.axis: input_shape[self.axis]}
         )
-
         reduction_axes = list(range(len(input_shape)))
         del reduction_axes[self.axis]
         self._reduction_axes = reduction_axes

--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -5,7 +5,6 @@ from keras.src import ops
 from keras.src import regularizers
 from keras.src.api_export import keras_export
 from keras.src.backend import standardize_dtype
-from keras.src.layers.input_spec import InputSpec
 from keras.src.layers.layer import Layer
 
 
@@ -166,6 +165,12 @@ class BatchNormalization(Layer):
         self.gamma_constraint = constraints.get(gamma_constraint)
         self.supports_masking = True
 
+        self.gamma = None
+        self.beta = None
+        self.moving_mean = None
+        self.moving_variance = None
+        self._reduction_axes = None
+
     def build(self, input_shape):
         shape = (input_shape[self.axis],)
         if self.scale:
@@ -202,9 +207,7 @@ class BatchNormalization(Layer):
             trainable=False,
             autocast=False,
         )
-        self.input_spec = InputSpec(
-            ndim=len(input_shape), axes={self.axis: input_shape[self.axis]}
-        )
+
         reduction_axes = list(range(len(input_shape)))
         del reduction_axes[self.axis]
         self._reduction_axes = reduction_axes
@@ -230,10 +233,12 @@ class BatchNormalization(Layer):
             # out BN for mixed precision.
             inputs = ops.cast(inputs, "float32")
 
+        moving_mean = ops.cast(self.moving_mean, inputs.dtype)
+        moving_variance = ops.cast(self.moving_variance, inputs.dtype)
+
         if training and self.trainable:
             mean, variance = self._moments(inputs, mask)
-            moving_mean = ops.cast(self.moving_mean, inputs.dtype)
-            moving_variance = ops.cast(self.moving_variance, inputs.dtype)
+
             self.moving_mean.assign(
                 moving_mean * self.momentum + mean * (1.0 - self.momentum)
             )
@@ -242,8 +247,6 @@ class BatchNormalization(Layer):
                 + variance * (1.0 - self.momentum)
             )
         else:
-            moving_mean = ops.cast(self.moving_mean, inputs.dtype)
-            moving_variance = ops.cast(self.moving_variance, inputs.dtype)
             mean = moving_mean
             variance = moving_variance
 

--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -5,6 +5,7 @@ from keras.src import ops
 from keras.src import regularizers
 from keras.src.api_export import keras_export
 from keras.src.backend import standardize_dtype
+from keras.src.layers.input_spec import InputSpec
 from keras.src.layers.layer import Layer
 
 
@@ -206,6 +207,9 @@ class BatchNormalization(Layer):
             initializer=self.moving_variance_initializer,
             trainable=False,
             autocast=False,
+        )
+        self.input_spec = InputSpec(
+            ndim=len(input_shape), axes={self.axis: input_shape[self.axis]}
         )
 
         reduction_axes = list(range(len(input_shape)))


### PR DESCRIPTION
I did several changes for batch_normalization.
Plz, feel free to comment your thought about my changes.

- Add initial values for params on build method.

```
        self.gamma = None
        self.beta = None
        self.moving_mean = None
        self.moving_variance = None
        self._reduction_axes = None
```

- Remove un-used parameter
```
        self.input_spec = InputSpec(
            ndim=len(input_shape), axes={self.axis: input_shape[self.axis]}
        )
```

- Take duplicate code out of if condition block
```
        moving_mean = ops.cast(self.moving_mean, inputs.dtype)
        moving_variance = ops.cast(self.moving_variance, inputs.dtype)
```