### PR TITLE
Migrate numpy namespace to numpy 2.0

### DIFF
--- a/keras/src/callbacks/model_checkpoint.py
+++ b/keras/src/callbacks/model_checkpoint.py
@@ -157,20 +157,20 @@ class ModelCheckpoint(Callback):
         if mode == "min":
             self.monitor_op = np.less
             if self.best is None:
-                self.best = np.Inf
+                self.best = np.inf
         elif mode == "max":
             self.monitor_op = np.greater
             if self.best is None:
-                self.best = -np.Inf
+                self.best = -np.inf
         else:
             if "acc" in self.monitor or self.monitor.startswith("fmeasure"):
                 self.monitor_op = np.greater
                 if self.best is None:
-                    self.best = -np.Inf
+                    self.best = -np.inf
             else:
                 self.monitor_op = np.less
                 if self.best is None:
-                    self.best = np.Inf
+                    self.best = np.inf
 
         if self.save_freq != "epoch" and not isinstance(self.save_freq, int):
             raise ValueError(

--- a/keras/src/callbacks/reduce_lr_on_plateau.py
+++ b/keras/src/callbacks/reduce_lr_on_plateau.py
@@ -92,10 +92,10 @@ class ReduceLROnPlateau(Callback):
             self.mode == "auto" and "acc" not in self.monitor
         ):
             self.monitor_op = lambda a, b: np.less(a, b - self.min_delta)
-            self.best = np.Inf
+            self.best = np.inf
         else:
             self.monitor_op = lambda a, b: np.greater(a, b + self.min_delta)
-            self.best = -np.Inf
+            self.best = -np.inf
         self.cooldown_counter = 0
         self.wait = 0
 

--- a/keras/src/utils/sequence_utils.py
+++ b/keras/src/utils/sequence_utils.py
@@ -101,7 +101,7 @@ def pad_sequences(
         maxlen = np.max(lengths)
 
     is_dtype_str = np.issubdtype(dtype, np.str_) or np.issubdtype(
-        dtype, np.unicode_
+        dtype, np.str_
     )
     if isinstance(value, str) and dtype != object and not is_dtype_str:
         raise ValueError(


### PR DESCRIPTION
Numpy 2.0 deprecates part of their namespace, see https://numpy.org/doc/stable/numpy_2_0_migration_guide.html for all details.
Keras is affected by `np.Inf` -> `np.inf` and `np.unicode_` -> `np.str_`.