### PR TITLE
Let Tensorflow call the initializer of variables when callable.

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -159,12 +159,11 @@ class KerasVariable:
                 )
         else:
             if callable(initializer):
-                shape = self._validate_shape(shape)
-                value = initializer(shape, dtype=dtype)
+                self._shape = self._validate_shape(shape)
+                self._initialize_with_initializer(initializer)
             else:
-                value = initializer
-            self._initialize(value)
-            self._shape = tuple(self._value.shape)
+                self._initialize(initializer)
+                self._shape = tuple(self._value.shape)
         self._ndim = len(self._shape)
 
     def _deferred_initialize(self):
@@ -178,8 +177,8 @@ class KerasVariable:
                 "Make sure that all variables are initialized "
                 "before you start using your layer/model objects."
             )
-        value = self._initializer(self._shape, dtype=self._dtype)
-        self._initialize(value)
+        self._initialize_with_initializer(self._initializer)
+        self._initializer = None
 
     def _validate_shape(self, shape):
         shape = standardize_shape(shape)
@@ -334,6 +333,10 @@ class KerasVariable:
 
     def _initialize(self, value):
         raise NotImplementedError
+
+    def _initialize_with_initializer(self, initializer):
+        value = initializer(self._shape, dtype=self._dtype)
+        self._initialize(value)
 
     def _convert_to_tensor(self, value, dtype=None):
         raise NotImplementedError

--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -37,6 +37,14 @@ class Variable(
             value, dtype=self._dtype, trainable=self.trainable, name=self.name
         )
 
+    def _initialize_with_initializer(self, initializer):
+        self._value = tf.Variable(
+            lambda: initializer(self._shape, dtype=self._dtype),
+            dtype=self._dtype,
+            trainable=self.trainable,
+            name=self.name,
+        )
+
     def _deferred_initialize(self):
         if self._value is not None:
             raise ValueError(f"Variable {self.path} is already initialized.")
@@ -49,8 +57,8 @@ class Variable(
                 "before you start using your layer/model objects."
             )
         with tf.init_scope():
-            value = self._initializer(self._shape, dtype=self._dtype)
-            self._initialize(value)
+            self._initialize_with_initializer(self._initializer)
+            self._initializer = None
 
     def _direct_assign(self, value):
         self._value.assign(tf.cast(value, self._value.dtype))


### PR DESCRIPTION
`tf.Variable` allows passing a callable instead of an initial value. We now use a callable when the initializer passed to the Keras `Variable` is a callable. This defers the materialization of the full initial value, which is unnecessary when tracing for instance.