### PR TITLE
Fix dtype issue in `abs_max_quantize`

### DIFF
--- a/keras/src/quantizers/quantizers.py
+++ b/keras/src/quantizers/quantizers.py
@@ -84,10 +84,12 @@ def abs_max_quantize(
             scale, dtype=original_dtype
         )
 
+    inputs = ops.convert_to_tensor(inputs)
     scale = ops.divide(
         value_range[1],
         ops.add(ops.max(ops.abs(inputs), axis=axis, keepdims=True), epsilon),
     )
+    scale = ops.cast(scale, backend.standardize_dtype(inputs.dtype))
     outputs = ops.multiply(inputs, scale)
     outputs = ops.clip(ops.round(outputs), value_range[0], value_range[1])
     outputs = ops.cast(outputs, dtype)


### PR DESCRIPTION
I encountered an issue with dtype in `abs_max_quantize` when trying to quantize KerasNLP models using `bfloat16` setting.

The root cause is that the computed `scale` might be float32 instead of bfloat16 in some backends (at least, JAX) using a non-CUDA env.

cc @mattdangerw 
