### PR TITLE
Do not adapt TextVectorization preprocessor if provided with vocabulary  in FeatureSpace. 

### DIFF
--- a/keras/src/layers/preprocessing/feature_space.py
+++ b/keras/src/layers/preprocessing/feature_space.py
@@ -490,6 +490,10 @@ class FeatureSpace(Layer):
             if isinstance(preprocessor, layers.Normalization):
                 if preprocessor.input_mean is not None:
                     continue
+            # Special case: a TextVectorization layer with provided vocabulary.
+            elif isinstance(preprocessor, layers.TextVectorization):
+                if preprocessor._has_input_vocabulary:
+                    continue
             if hasattr(preprocessor, "adapt"):
                 adaptable_preprocessors.append(name)
         return adaptable_preprocessors

--- a/keras/src/layers/preprocessing/feature_space_test.py
+++ b/keras/src/layers/preprocessing/feature_space_test.py
@@ -454,42 +454,76 @@ class FeatureSpaceTest(testing.TestCase):
     def test_no_adapt(self):
         data = {
             "int_1": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            "text_1": ["This is", "not just", "an example", "of random words.",
-                       "these are", "some words", "in", "a random", "example.", "Bye!"],
-            "float_1": [-1.2, 0., 2.4, 1.2, 15., -100., 23.1, 3.12, 0.1, -0.01]
+            "text_1": [
+                "This is",
+                "not just",
+                "an example",
+                "of random words.",
+                "these are",
+                "some words",
+                "in",
+                "a random",
+                "example.",
+                "Bye!",
+            ],
+            "float_1": [
+                -1.2,
+                0.0,
+                2.4,
+                1.2,
+                15.0,
+                -100.0,
+                23.1,
+                3.12,
+                0.1,
+                -0.01,
+            ],
         }
         cls = feature_space.FeatureSpace
         # Pre-defined vocabulary. No need to adapt.
-        tv_vocab = ["this", "is", "just", "an", "example", "with", "some", "words"]
+        tv_vocab = [
+            "this",
+            "is",
+            "just",
+            "an",
+            "example",
+            "with",
+            "some",
+            "words",
+        ]
         tv_with_vocab = layers.TextVectorization(
-            vocabulary=tv_vocab,
-            output_mode="int",
-            output_sequence_length=3
+            vocabulary=tv_vocab, output_mode="int", output_sequence_length=3
         )
 
         # Pre-defined mean and variance. No need to adapt.
-        mean, variance = 12., 5.
-        norm_with_mean_var = layers.Normalization(mean=mean, variance=variance)
+        mean, variance = 12.0, 5.0
+        normalization = layers.Normalization(mean=mean, variance=variance)
+
         fs = feature_space.FeatureSpace(
             {
                 "int_1": "integer_hashed",
                 "text_1": cls.feature(
-                    preprocessor=tv_with_vocab, dtype="string", output_mode="int"
+                    dtype="string",
+                    preprocessor=tv_with_vocab,
+                    output_mode="int",
                 ),
                 "float_1": cls.feature(
-                    dtype="float32", preprocessor=norm_with_mean_var,  output_mode="float"
+                    dtype="float32",
+                    preprocessor=normalization,
+                    output_mode="float",
                 ),
             },
             output_mode="dict",
         )
 
         out = fs(data)
-        float_out = ops.expand_dims(
-            (ops.convert_to_tensor(data["float_1"]) - mean) / ops.sqrt(variance), axis=-1)
+        float_out = ops.divide(
+            ops.convert_to_tensor(data["float_1"]) - mean, ops.sqrt(variance)
+        )
+        float_out = ops.reshape(float_out, (10, -1))
 
         self.assertEqual(tuple(out["int_1"].shape), (10, 32))
         self.assertEqual(tuple(out["text_1"].shape), (10, 3))
-        self.assertEqual(tuple(out["float_1"].shape), (10, 1))
         self.assertAllEqual(out["float_1"], float_out)
 
     @pytest.mark.skipif(

--- a/keras/src/layers/preprocessing/text_vectorization.py
+++ b/keras/src/layers/preprocessing/text_vectorization.py
@@ -330,7 +330,7 @@ class TextVectorization(Layer):
         self._encoding = encoding
 
         # We save this hidden option to persist the fact
-        # that we have have a non-adaptable layer with a
+        # that we have a non-adaptable layer with a
         # manually set vocab.
         self._has_input_vocabulary = kwargs.pop(
             "has_input_vocabulary", (vocabulary is not None)


### PR DESCRIPTION
Since we can provide custom preprocessors to features of FeatureSpace, trying to adapt to data  a TextVectorization preprocessing layer, with vocabulary provided, raises `ValueError`:
For example the code bellow:
```
vocabulary = ['a', 'b', 'c', 'd']
preprocessor = TextVectorization(vocabulary=vocabulary, output_mode='int', output_sequence_length=5)
feature_space = FeatureSpace(
    features={'example': FeatureSpace.feature(dtype='string', output_mode='int', preprocessor=preprocessor)},
    output_mode='dict')

ds = tf.data.Dataset.from_tensor_slices({'example': tf.constant(['a b', 'b', 'c', 'd', 'bfr cdvew xas'])})

feature_space.adapt(ds)

for sample in ds:
    print(feature_space(sample))
```
raises:
```
  File ".../lib/python3.11/site-packages/keras/src/layers/preprocessing/index_lookup.py", line 586, in update_state
    raise ValueError(
ValueError: Cannot adapt layer 'string_lookup' after setting a static vocabulary via `vocabulary` argument or `set_vocabulary()` method.
```

With this fix we can avoid this error and get the processed features as intended.
```
{'example': <tf.Tensor: shape=(5,), dtype=int64, numpy=array([2, 3, 0, 0, 0])>}
{'example': <tf.Tensor: shape=(5,), dtype=int64, numpy=array([3, 0, 0, 0, 0])>}
{'example': <tf.Tensor: shape=(5,), dtype=int64, numpy=array([4, 0, 0, 0, 0])>}
{'example': <tf.Tensor: shape=(5,), dtype=int64, numpy=array([5, 0, 0, 0, 0])>}
{'example': <tf.Tensor: shape=(5,), dtype=int64, numpy=array([1, 1, 1, 0, 0])>}
```


