### PR TITLE
Fix unbound local error in torch backend when a call to `train_step` generates no training logs

### DIFF
--- a/keras/src/backend/torch/trainer.py
+++ b/keras/src/backend/torch/trainer.py
@@ -247,6 +247,8 @@ class TorchTrainer(base_trainer.Trainer):
             # do training behavior in case the user did not use `self.training`
             # when implementing a custom layer with torch layers.
             self.train()
+
+            logs = {}
             for step, data in epoch_iterator.enumerate_epoch():
                 # Callbacks
                 callbacks.on_train_batch_begin(step)


### PR DESCRIPTION
I ran into this issue, so I fixed it. My linter is showing many more possibly undefined references in the trainer objects for all backends, so maybe these are due for a general cleanup.