### PR TITLE
Updated Elu definition in elu.py

### DIFF
--- a/keras/src/layers/activations/elu.py
+++ b/keras/src/layers/activations/elu.py
@@ -10,8 +10,8 @@ class ELU(Layer):
     Formula:
 
     ```
-    f(x) = alpha * (exp(x) - 1.) for x < 0
-    f(x) = x for x >= 0
+    f(x) = alpha * (exp(x) - 1.) for x <= 0
+    f(x) = x for x > 0
     ```
 
     Args:


### PR DESCRIPTION
As per the journal reference(Page-5, Equation- 15), **Elu** definition is updated.

https://arxiv.org/pdf/1511.07289

![image](https://github.com/user-attachments/assets/654d2455-9f5e-4f85-a64e-5f90f96a1e4f)


Note: The functionality might not be changed with the current update. Requesting to update the equation as per the standard definition. Thank you!