### PR TITLE
Remove threshold limits in BinaryAccuracy()

### DIFF
--- a/keras/src/metrics/accuracy_metrics.py
+++ b/keras/src/metrics/accuracy_metrics.py
@@ -110,12 +110,6 @@ class BinaryAccuracy(reduction_metrics.MeanMetricWrapper):
     """
 
     def __init__(self, name="binary_accuracy", dtype=None, threshold=0.5):
-        if threshold is not None and (threshold <= 0 or threshold >= 1):
-            raise ValueError(
-                "Invalid value for argument `threshold`. "
-                "Expected a value in interval (0, 1). "
-                f"Received: threshold={threshold}"
-            )
         super().__init__(
             fn=binary_accuracy, name=name, dtype=dtype, threshold=threshold
         )

--- a/keras/src/metrics/accuracy_metrics_test.py
+++ b/keras/src/metrics/accuracy_metrics_test.py
@@ -1,5 +1,3 @@
-import re
-
 import numpy as np
 
 from keras.src import testing
@@ -173,18 +171,6 @@ class BinaryAccuracyTest(testing.TestCase):
         # Higher threshold must result in lower measured accuracy.
         self.assertAllClose(result_1, 1.0)
         self.assertAllClose(result_2, 0.75)
-
-    def test_invalid_threshold(self):
-        self.assertRaisesRegex(
-            ValueError,
-            re.compile(r"Invalid value for argument `threshold`"),
-            lambda: accuracy_metrics.BinaryAccuracy(threshold=-0.5),
-        )
-        self.assertRaisesRegex(
-            ValueError,
-            re.compile(r"Invalid value for argument `threshold`"),
-            lambda: accuracy_metrics.BinaryAccuracy(threshold=1.5),
-        )
 
 
 class CategoricalAccuracyTest(testing.TestCase):


### PR DESCRIPTION
`BinaryAccuracy` metric asserts that threshold is in [0, 1]. But this is not the legacy BinaryAccuracy behaviour in TensorFlow 2.15 (and below) and in torcheval metrics, where threshold is not limited to [0, 1]. This behaviour is useful when `y_pred` are logits and not probabilities.

This PR proposes to remove the assertion on threshold value.

Edit: This change could be extended to `FBetaScore` metric that has the same assertion on the threshold.

