### PR TITLE
Updated error message where variable is integer or string

### DIFF
--- a/keras/src/optimizers/base_optimizer.py
+++ b/keras/src/optimizers/base_optimizer.py
@@ -673,7 +673,7 @@ class BaseOptimizer(KerasSaveable):
                 missing_grad_vars.append(v.name)
 
         if not filtered_grads:
-            raise ValueError("No gradients provided for any variable.")
+            raise ValueError("No gradients provided for integer and string variable.")
         if missing_grad_vars:
             warnings.warn(
                 "Gradients do not exist for variables "


### PR DESCRIPTION
Updated error message where variable is integer or string. As integer and string are not differentiable and there will be no gradients. Fixes [#20058 ](https://github.com/keras-team/keras/issues/20058)