### PR TITLE
Fix default value of `logs` in Trainer

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -554,7 +554,7 @@ class JAXTrainer(base_trainer.Trainer):
         self.make_test_function()
         self.stop_evaluating = False
         callbacks.on_test_begin()
-        logs = None
+        logs = {}
         self.reset_metrics()
 
         self._jax_state_synced = True

--- a/keras/src/backend/numpy/trainer.py
+++ b/keras/src/backend/numpy/trainer.py
@@ -276,7 +276,7 @@ class NumpyTrainer(base_trainer.Trainer):
         self.make_test_function()
         self.stop_evaluating = False
         callbacks.on_test_begin()
-        logs = None
+        logs = {}
         self.reset_metrics()
         for step, data in epoch_iterator.enumerate_epoch():
             callbacks.on_test_batch_begin(step)

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -309,7 +309,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
         self.make_train_function()
         callbacks.on_train_begin()
         training_logs = None
-        logs = None
+        logs = {}
         initial_epoch = self._initial_epoch or initial_epoch
         for epoch in range(initial_epoch, epochs):
             self.reset_metrics()
@@ -425,7 +425,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
         self.make_test_function()
         self.stop_evaluating = False
         callbacks.on_test_begin()
-        logs = None
+        logs = {}
         self.reset_metrics()
         with epoch_iterator.catch_stop_iteration():
             for step, iterator in epoch_iterator.enumerate_epoch():

--- a/keras/src/backend/torch/trainer.py
+++ b/keras/src/backend/torch/trainer.py
@@ -366,7 +366,7 @@ class TorchTrainer(base_trainer.Trainer):
         self.make_test_function()
         self.stop_evaluating = False
         callbacks.on_test_begin()
-        logs = None
+        logs = {}
         self.reset_metrics()
         for step, data in epoch_iterator.enumerate_epoch():
             callbacks.on_test_batch_begin(step)


### PR DESCRIPTION
Fixes #20104 .

`_pythonify_logs()` treat `logs` as dict: https://github.com/keras-team/keras/blob/933579d3c4a585f236982d05d3a74921f9567415/keras/src/trainers/trainer.py#L931
`on_test_batch_end()` `on_test_end()` same: https://github.com/keras-team/keras/blob/933579d3c4a585f236982d05d3a74921f9567415/keras/src/callbacks/callback_list.py#L114
`_get_metrics_result_or_logs()` process `logs` if it's a dict, or return it as is.

and finally: https://github.com/keras-team/keras/blob/933579d3c4a585f236982d05d3a74921f9567415/keras/src/backend/tensorflow/trainer.py#L356