### PR TITLE
Fix divide_no_nan jax op to be differentiable

### DIFF
--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -1062,7 +1062,8 @@ def divide(x1, x2):
 def divide_no_nan(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    return jnp.where(x2 == 0, 0, jnp.divide(x1, x2))
+    safe_x2 = jnp.where(x2 == 0, 1, x2)
+    return jnp.where(x2 == 0, 0, jnp.divide(x1, safe_x2))
 
 
 def true_divide(x1, x2):


### PR DESCRIPTION
The current implementation of `keras.ops.divide_no_nan` is non differentiable in Jax and returns `nan` gradients. This can be verified with the following code:
```
>>> x1 = jnp.array(1, dtype=jnp.float32)
>>> x2 = jnp.array(0, dtype=jnp.float32)
>>> jax.grad(keras.ops.divide_no_nan)(x1, x2)
Array(nan, dtype=float32)
```

The fix is to prevent `jnp.divide` from returning `inf` by using an additional `jnp.where` call. More details on how to prevent `nan` gradients when using `jnp.where` can be found  [here](https://jax.readthedocs.io/en/latest/faq.html#gradients-contain-nan-where-using-where) in the Jax documentation.