### PR TITLE
Add `/readahead` to the list of recognized remote paths

### DIFF
--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -403,7 +403,7 @@ def is_remote_path(filepath):
     Returns:
         bool: True if the filepath is a recognized remote path, otherwise False
     """
-    if re.match(r"^(/cns|/cfs|/gcs|/hdfs|.*://).*$", str(filepath)):
+    if re.match(r"^(/cns|/cfs|/gcs|/hdfs|/readahead|.*://).*$", str(filepath)):
         return True
     return False
 

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -721,6 +721,9 @@ class IsRemotePathTest(test_case.TestCase):
     def test_cfs_remote_path(self):
         self.assertTrue(file_utils.is_remote_path("/cfs/some/path"))
 
+    def test_readahead_remote_path(self):
+        self.assertTrue(file_utils.is_remote_path("/readahead/some/path"))
+
     def test_non_remote_paths(self):
         self.assertFalse(file_utils.is_remote_path("/local/path/to/file.txt"))
         self.assertFalse(


### PR DESCRIPTION
This PR improves KerasNLP model loading time internally.