### PR TITLE
Migrating numpy namespace to numpy 2.0 in writing_your_own_callbacks.py

### DIFF
--- a/guides/writing_your_own_callbacks.py
+++ b/guides/writing_your_own_callbacks.py
@@ -333,7 +333,7 @@ class EarlyStoppingAtMinLoss(keras.callbacks.Callback):
         # The epoch the training stops at.
         self.stopped_epoch = 0
         # Initialize the best as infinity.
-        self.best = np.Inf
+        self.best = np.inf
 
     def on_epoch_end(self, epoch, logs=None):
         current = logs.get("loss")


### PR DESCRIPTION
Numpy 2.0 deprecates part of their namespace, see https://numpy.org/doc/stable/numpy_2_0_migration_guide.html for all details.
Keras is affected by **np.Inf** -> **np.inf**