### PR TITLE
TF cond with plain bool's

### DIFF
--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -223,7 +223,11 @@ def compute_output_spec(fn, *args, **kwargs):
 
 
 def cond(pred, true_fn, false_fn):
-    return tf.cond(pred, true_fn=true_fn, false_fn=false_fn)
+    if isinstance(pred, tf.Variable):
+        return tf.cond(pred, true_fn=true_fn, false_fn=false_fn)
+    return tf.__internal__.smart_cond.smart_cond(
+        pred, true_fn=true_fn, false_fn=false_fn
+    )
 
 
 def vectorized_map(function, elements):

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -703,6 +703,19 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
                 lambda: ops.zeros((4,)),
             )
 
+    def test_cond_raw_bool_compile(self):
+        class ExampleLayer(layers.Layer):
+            def call(self, x, training=False):
+                return ops.cond(training, lambda: x, lambda: x * 2.0)
+
+        model = models.Sequential([ExampleLayer()])
+        model.compile(
+            optimizer=optimizers.SGD(), loss=losses.MeanSquaredError()
+        )
+        x = np.ones((2, 4), dtype=np.float32)
+        y = np.zeros((2, 4), dtype=np.float32)
+        model.evaluate(x, y, batch_size=2)
+
     def test_unstack(self):
         rng = np.random.default_rng(0)
         x = rng.uniform(size=(2, 3, 4))


### PR DESCRIPTION
tf.cond allows raw bool value as `pred` only outside tf.functions (model.compile(jit_compile=True)).

To work with this issue there is a smart_cond op, which allows raw boolean values in any context and in case of raw booleans can build much simpler graph.

The code is ported from keras V2 https://github.com/keras-team/tf-keras/blob/master/tf_keras/utils/control_flow_util.py#L106

See failing (without this PR) example in test.