### PR TITLE
Fix JAX's `bitwise_*_shift` and `bitwise_invert`

### DIFF
--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -377,7 +377,7 @@ def bitwise_and(x, y):
 
 def bitwise_invert(x):
     x = convert_to_tensor(x)
-    return jnp.bitwise_invert(x)
+    return jnp.invert(x)
 
 
 def bitwise_not(x):
@@ -399,7 +399,7 @@ def bitwise_xor(x, y):
 def bitwise_left_shift(x, y):
     x = convert_to_tensor(x)
     y = convert_to_tensor(y)
-    return jnp.bitwise_left_shift(x, y)
+    return jnp.left_shift(x, y)
 
 
 def left_shift(x, y):
@@ -409,7 +409,7 @@ def left_shift(x, y):
 def bitwise_right_shift(x, y):
     x = convert_to_tensor(x)
     y = convert_to_tensor(y)
-    return jnp.bitwise_right_shift(x, y)
+    return jnp.right_shift(x, y)
 
 
 def right_shift(x, y):


### PR DESCRIPTION
Apparently, `jax<0.4.24` doesn't support `bitwise_*_shift` and `bitwise_invert`, which caused the CI to fail:
https://github.com/google/jax/commit/4e55086dfb73976002e3ede8d16bd92458324ae0

Actually, there are just aliases of `*_shift` and `invert`.
