### PR TITLE
Allow more dtypes in layer test

### DIFF
--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -647,7 +647,19 @@ def create_eager_tensors(input_shape, dtype, sparse):
     from keras.src.backend import random
 
     if set(tree.flatten(dtype)).difference(
-        ["float16", "float32", "float64", "int16", "int32", "int64"]
+        [
+            "float16",
+            "float32",
+            "float64",
+            "int8",
+            "uint8",
+            "int16",
+            "uint16",
+            "int32",
+            "uint32",
+            "uint64",
+            "int64",
+        ]
     ):
         raise ValueError(
             "dtype must be a standard float or int dtype. "

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -657,8 +657,8 @@ def create_eager_tensors(input_shape, dtype, sparse):
             "uint16",
             "int32",
             "uint32",
-            "uint64",
             "int64",
+            "uint64",
         ]
     ):
         raise ValueError(


### PR DESCRIPTION
Some layers may require (and ) missed dtypes like uint8 for images. E.g.:
```python
class MyCustomImageLayer(layers.Layer):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.input_spec = InputSpec(ndim=4, axes={-1: 3}, dtype="uint8")
```