### PR TITLE
Fix `typing.cast` when using subclassing

### DIFF
--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -96,7 +96,7 @@ class Functional(Function, Model):
     """
 
     def __new__(cls, *args, **kwargs):
-        return typing.cast(Functional, super().__new__(cls))
+        return typing.cast(cls, super().__new__(cls))
 
     @tracking.no_automatic_dependency_tracking
     def __init__(self, inputs, outputs, name=None, **kwargs):

--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -141,7 +141,7 @@ class Model(Trainer, base_trainer.Trainer, Layer):
             from keras.src.models.functional import Functional
 
             return Functional.__new__(Functional, *args, **kwargs)
-        return typing.cast(Model, super().__new__(cls))
+        return typing.cast(cls, super().__new__(cls))
 
     def __init__(self, *args, **kwargs):
         Trainer.__init__(self)

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -63,7 +63,7 @@ class Sequential(Model):
     """
 
     def __new__(cls, *args, **kwargs):
-        return typing.cast(Sequential, super().__new__(cls))
+        return typing.cast(cls, super().__new__(cls))
 
     def __init__(self, layers=None, trainable=True, name=None):
         super().__init__(trainable=trainable, name=name)


### PR DESCRIPTION
When using subclassing of `Model` (`Functional` and `Sequential` are affected, but we generally don't subclass them), the return object type is forced to be `Model`, which might be incorrect.

```python
from keras import layers
from keras import models
from keras.src.models import Functional
from keras.src.models import Sequential


class MyModel(models.Model):
    def __init__(self, **kwargs):
        inputs = layers.Input((4,))
        outputs = layers.Dense(8)(inputs)
        super().__init__(inputs, outputs, **kwargs)


class MyFunctional(Functional):
    pass


class MySequential(Sequential):
    pass


model = MyModel()
model = MyFunctional()
model = MySequential()
```

||Before|After|
|-|-|-|
|`MyModel`|![image](https://github.com/user-attachments/assets/68fe4f21-d251-4e32-a746-2702e2d8b74e)|![image](https://github.com/user-attachments/assets/077c4f66-57e7-4c23-97ff-b1044a1ec28d)|
|`MyFunctional`|![image](https://github.com/user-attachments/assets/d76971ba-cfbf-4d64-988f-3404d73b04f9)|![image](https://github.com/user-attachments/assets/6eceb4bf-0c30-43d4-aabe-71678a4a76b7)|
|`MySequential`|![image](https://github.com/user-attachments/assets/25afaef3-e7f7-485b-bc30-e0edc17646e2)|![image](https://github.com/user-attachments/assets/bede5350-6122-4dce-a731-b1fc2091cc51)|

This PR will provide better auto-completion when using subclassing.