### PR TITLE
convert_to_np_if_not_ragged needs a tf.SparceTensor check

### DIFF
--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -905,6 +905,8 @@ def _is_tpu_strategy_class(clz):
 def convert_to_np_if_not_ragged(x):
     if isinstance(x, tf.RaggedTensor):
         return x
+    elif isinstance(x, tf.SparseTensor):
+        return x
     return x.numpy()
 
 


### PR DESCRIPTION
The problem occurs when Model.predict() returns a sparse matrix.

Example code:

```python
import keras
import numpy as np
import tensorflow as tf


class SparseLayer(keras.layers.Layer):

    def __init__(self, **kwargs):
        super().__init__(**kwargs)

    def call(self, inputs):
        return inputs
        #return tf.sparse.to_dense(inputs)


n_batches = 4
input_shape = (3, 3)
indices = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]])
batch_input = tf.sparse.SparseTensor(dense_shape=(n_batches, *input_shape),
                                      indices=indices,
                                      values=tf.constant([1, 1, 1, 1], dtype=tf.dtypes.float32))

model_input = keras.Input(shape=input_shape, batch_size=1, sparse=True)
sparselayer = SparseLayer()(model_input)
model = keras.Model(inputs=model_input, outputs=sparselayer)

# works
output_call = model(batch_input)
print('output_call', output_call)

# Fails with AttributeError: 'SparseTensor' object has no attribute 'numpy'. Did you mean: '_numpy'?
output_predict = model.predict(batch_input, batch_size=1)
print('output_predict', output_predict)

``` 

Proposed solution:

check for sparce tensors in [keras/src/backend/tensorflow/trainer.py](https://github.com/keras-team/keras/blob/master/keras/src/backend/tensorflow/trainer.py),
```python
def convert_to_np_if_not_ragged(x):
    if isinstance(x, tf.RaggedTensor):
        return x
    elif isinstance(x, tf.SparseTensor):  # added
        return x
    return x.numpy()
```