### PR TITLE
_get_node_attribute_at_index() raising AttributeError instead of ValueError

### DIFF
--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -282,7 +282,7 @@ class Operation:
             The operation's attribute `attr` at the node of index `node_index`.
         """
         if not self._inbound_nodes:
-            raise ValueError(
+            raise AttributeError(
                 f"The layer {self.name} has never been called "
                 f"and thus has no defined {attr_name}."
             )


### PR DESCRIPTION
https://github.com/keras-team/keras/issues/20155

This PR allows using hasattr() on node attributes, without raising an error.