### PR TITLE
Fix duplicated filtering in CompileLoss when not built

### DIFF
--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -613,15 +613,15 @@ class CompileLoss(losses_module.Loss):
     def call(self, y_true, y_pred, sample_weight=None):
         if not self.built:
             self.build(y_true, y_pred)
-
-        # Filter unused inputs.
-        y_true, y_pred = self._filter_unused_inputs(
-            y_true,
-            y_pred,
-            self.filtered_y_true_keys,
-            self.filtered_y_pred_keys,
-            self.inferred_output_names,
-        )
+        else:
+            # Filter unused inputs.
+            y_true, y_pred = self._filter_unused_inputs(
+                y_true,
+                y_pred,
+                self.filtered_y_true_keys,
+                self.filtered_y_pred_keys,
+                self.inferred_output_names,
+            )
 
         # Flatten the inputs.
         y_true = tree.flatten(y_true)


### PR DESCRIPTION
Currently, when CompileLoss is [called](https://github.com/keras-team/keras/blob/4bf1d80fb994ca8e6bebc679b05d124fb294764c/keras/src/trainers/compile_utils.py#L613) (e.g. by `model.fit(...)`) but not yet built, it will internally call its [_filter_unused_inputs](https://github.com/keras-team/keras/blob/4bf1d80fb994ca8e6bebc679b05d124fb294764c/keras/src/trainers/compile_utils.py#L586) method twice:

- a [first time](https://github.com/keras-team/keras/blob/4bf1d80fb994ca8e6bebc679b05d124fb294764c/keras/src/trainers/compile_utils.py#L502) inside `self.build(y_true, y_pred)`
- a [second time](https://github.com/keras-team/keras/blob/4bf1d80fb994ca8e6bebc679b05d124fb294764c/keras/src/trainers/compile_utils.py#L618) inside the `call` itself

This is not only redudant, but most importantly can raise a KeyError when trying to filter out the second time (since the filtering already happened). This is due to the fact that the `_filter_unused_inputs` method actually modifies its y_true & y_pred input parameters in-place [here](https://github.com/keras-team/keras/blob/4bf1d80fb994ca8e6bebc679b05d124fb294764c/keras/src/trainers/compile_utils.py#L597) and [there](https://github.com/keras-team/keras/blob/4bf1d80fb994ca8e6bebc679b05d124fb294764c/keras/src/trainers/compile_utils.py#L601) (when they are dictionaries).

This PR is a very simple fix to solve this issue (alternatively, this could also be fixed by not using `pop` in `_filter_unused_inputs` to avoid any in-place modification of input parameters).