### PR TITLE
Loading using legacy h5 api now calls load_own_variables

### DIFF
--- a/keras/src/legacy/saving/legacy_h5_format.py
+++ b/keras/src/legacy/saving/legacy_h5_format.py
@@ -397,7 +397,7 @@ def load_weights_from_hdf5_group(f, model):
             )
         if hasattr(model, "load_own_variables"):
             variable_names = map(str, list(range(len(weight_values))))
-            layer.load_own_variables(dict(zip(variable_names, weight_values)))
+            model.load_own_variables(dict(zip(variable_names, weight_values)))
         else:
             for ref_v, val in zip(symbolic_weights, weight_values):
                 ref_v.assign(val)

--- a/keras/src/legacy/saving/legacy_h5_format.py
+++ b/keras/src/legacy/saving/legacy_h5_format.py
@@ -364,42 +364,41 @@ def load_weights_from_hdf5_group(f, model):
         layer = filtered_layers[k]
         symbolic_weights = _legacy_weights(layer)
         weight_values = load_subset_weights_from_hdf5_group(g)
+        if len(weight_values) != len(symbolic_weights):
+            raise ValueError(
+                f"Weight count mismatch for layer #{k} (named {layer.name} in "
+                f"the current model, {name} in the save file). "
+                f"Layer expects {len(symbolic_weights)} weight(s). Received "
+                f"{len(weight_values)} saved weight(s)"
+            )
         if hasattr(layer, "load_own_variables"):
             variable_names = map(str, list(range(len(weight_values))))
             layer.load_own_variables(dict(zip(variable_names, weight_values)))
         else:
-            if len(weight_values) != len(symbolic_weights):
-                raise ValueError(
-                    f"Weight count mismatch for layer #{k} (named {layer.name} in "
-                    f"the current model, {name} in the save file). "
-                    f"Layer expects {len(symbolic_weights)} weight(s). Received "
-                    f"{len(weight_values)} saved weight(s)"
-                )
             for ref_v, val in zip(symbolic_weights, weight_values):
                 ref_v.assign(val)
 
     if "top_level_model_weights" in f:
+        symbolic_weights = list(
+            # model.weights
+            v
+            for v in model._trainable_variables + model._non_trainable_variables
+            if v in model.weights
+        )
         weight_values = load_subset_weights_from_hdf5_group(
             f["top_level_model_weights"]
         )
-
+        if len(weight_values) != len(symbolic_weights):
+            raise ValueError(
+                "Weight count mismatch for top-level weights when loading "
+                "weights from file. "
+                f"Model expects {len(symbolic_weights)} top-level weight(s). "
+                f"Received {len(weight_values)} saved top-level weight(s)"
+            )
         if hasattr(model, "load_own_variables"):
             variable_names = map(str, list(range(len(weight_values))))
             layer.load_own_variables(dict(zip(variable_names, weight_values)))
         else:
-            symbolic_weights = list(
-                # model.weights
-                v
-                for v in model._trainable_variables + model._non_trainable_variables
-                if v in model.weights
-            )
-            if len(weight_values) != len(symbolic_weights):
-                raise ValueError(
-                    "Weight count mismatch for top-level weights when loading "
-                    "weights from file. "
-                    f"Model expects {len(symbolic_weights)} top-level weight(s). "
-                    f"Received {len(weight_values)} saved top-level weight(s)"
-                )
             for ref_v, val in zip(symbolic_weights, weight_values):
                 ref_v.assign(val)
 

--- a/keras/src/legacy/saving/legacy_h5_format.py
+++ b/keras/src/legacy/saving/legacy_h5_format.py
@@ -19,7 +19,6 @@ try:
 except ImportError:
     h5py = None
 
-
 HDF5_OBJECT_HEADER_LIMIT = 64512
 
 
@@ -364,45 +363,45 @@ def load_weights_from_hdf5_group(f, model):
         g = f[name]
         layer = filtered_layers[k]
         symbolic_weights = _legacy_weights(layer)
-        weight_values = load_subset_weights_from_hdf5_group(g)       
+        weight_values = load_subset_weights_from_hdf5_group(g)
         if hasattr(layer, "load_own_variables"):
             variable_names = map(str, list(range(len(weight_values))))
             layer.load_own_variables(dict(zip(variable_names, weight_values)))
         else:
             if len(weight_values) != len(symbolic_weights):
                 raise ValueError(
-                  f"Weight count mismatch for layer #{k} (named {layer.name} in "
-                  f"the current model, {name} in the save file). "
-                  f"Layer expects {len(symbolic_weights)} weight(s). Received "
-                  f"{len(weight_values)} saved weight(s)"
+                    f"Weight count mismatch for layer #{k} (named {layer.name} in "
+                    f"the current model, {name} in the save file). "
+                    f"Layer expects {len(symbolic_weights)} weight(s). Received "
+                    f"{len(weight_values)} saved weight(s)"
                 )
             for ref_v, val in zip(symbolic_weights, weight_values):
-                  ref_v.assign(val)
+                ref_v.assign(val)
 
     if "top_level_model_weights" in f:
         weight_values = load_subset_weights_from_hdf5_group(
             f["top_level_model_weights"]
         )
-              
+
         if hasattr(model, "load_own_variables"):
             variable_names = map(str, list(range(len(weight_values))))
             layer.load_own_variables(dict(zip(variable_names, weight_values)))
         else:
             symbolic_weights = list(
-              # model.weights
-              v
-              for v in model._trainable_variables + model._non_trainable_variables
-              if v in model.weights
+                # model.weights
+                v
+                for v in model._trainable_variables + model._non_trainable_variables
+                if v in model.weights
             )
             if len(weight_values) != len(symbolic_weights):
-              raise ValueError(
-                  "Weight count mismatch for top-level weights when loading "
-                  "weights from file. "
-                  f"Model expects {len(symbolic_weights)} top-level weight(s). "
-                  f"Received {len(weight_values)} saved top-level weight(s)"
-              )
+                raise ValueError(
+                    "Weight count mismatch for top-level weights when loading "
+                    "weights from file. "
+                    f"Model expects {len(symbolic_weights)} top-level weight(s). "
+                    f"Received {len(weight_values)} saved top-level weight(s)"
+                )
             for ref_v, val in zip(symbolic_weights, weight_values):
-              ref_v.assign(val)
+                ref_v.assign(val)
 
 
 def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):

--- a/keras/src/legacy/saving/legacy_h5_format.py
+++ b/keras/src/legacy/saving/legacy_h5_format.py
@@ -371,10 +371,12 @@ def load_weights_from_hdf5_group(f, model):
                 f"Layer expects {len(symbolic_weights)} weight(s). Received "
                 f"{len(weight_values)} saved weight(s)"
             )
-        _set_weights(layer,
-                     symbolic_weights,
-                     weight_values,
-                     name=f"layer #{k} (named {layer.name})")
+        _set_weights(
+            layer,
+            symbolic_weights,
+            weight_values,
+            name=f"layer #{k} (named {layer.name})",
+        )
 
     if "top_level_model_weights" in f:
         symbolic_weights = list(
@@ -393,24 +395,28 @@ def load_weights_from_hdf5_group(f, model):
                 f"Model expects {len(symbolic_weights)} top-level weight(s). "
                 f"Received {len(weight_values)} saved top-level weight(s)"
             )
-        _set_weights(model,
-                     symbolic_weights,
-                     weight_values,
-                     name="top-level model")
+        _set_weights(
+            model, symbolic_weights, weight_values, name="top-level model"
+        )
 
 
-def _set_weights(group, symbolic_weights, weight_values, name, skip_mismatch=False):
-    """Safely set weights into a model or a layer, calling load_own_variables if implemented.
+def _set_weights(
+    group, symbolic_weights, weight_values, name, skip_mismatch=False
+):
+    """Safely set weights into a model or a layer,
+       calling load_own_variables if implemented.
 
     Args:
         group: Model or layer instance,
-        symbolic_weights: symbolic tensors representing the weights of the variables to load,
+        symbolic_weights: symbolic tensors representing
+                        the weights of the variables to load,
         weight_values: values of the weights to load,
         skip_mismatch: Boolean, whether to skip loading of weights
             where there is a mismatch in the shape of the weights,
         name: name used to identify the group.
     Raises:
-        ValueError: in case of mismatch between provided model/layer and weights.
+        ValueError: in case of mismatch between provided
+            model/layer and weights.
     """
     if hasattr(group, "load_own_variables"):
         variable_names = map(str, list(range(len(weight_values))))
@@ -421,12 +427,15 @@ def _set_weights(group, symbolic_weights, weight_values, name, skip_mismatch=Fal
             received_shape = weight_value.shape
             if expected_shape != received_shape:
                 if skip_mismatch:
-                    warnings.warn(f"Skipping loading weights for {name}"
-                                  f"due to mismatch in shape for "
-                                  f"weight {symbolic_weights[i].path}. "
-                                  f"Weight expects shape {expected_shape}. "
-                                  "Received saved weight "
-                                  f"with shape {received_shape}", stacklevel=2)
+                    warnings.warn(
+                        f"Skipping loading weights for {name}"
+                        f"due to mismatch in shape for "
+                        f"weight {symbolic_weights[i].path}. "
+                        f"Weight expects shape {expected_shape}. "
+                        "Received saved weight "
+                        f"with shape {received_shape}",
+                        stacklevel=2,
+                    )
                     continue
                 raise ValueError(
                     f"Shape mismatch in {name}"
@@ -497,11 +506,13 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
                     f"Layer expects {len(symbolic_weights)} weight(s). "
                     f"Received {len(weight_values)} saved weight(s)"
                 )
-            _set_weights(layer,
-                         symbolic_weights,
-                         weight_values,
-                         skip_mismatch=True,
-                         name=f"layer #{k} (named {layer.name})")
+            _set_weights(
+                layer,
+                symbolic_weights,
+                weight_values,
+                skip_mismatch=True,
+                name=f"layer #{k} (named {layer.name})",
+            )
     if "top_level_model_weights" in f:
         symbolic_weights = model.trainable_weights + model.non_trainable_weights
         weight_values = load_subset_weights_from_hdf5_group(
@@ -525,11 +536,13 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
                     "top-level weight(s). "
                     f"Received {len(weight_values)} saved top-level weight(s)"
                 )
-        _set_weights(layer,
-                     symbolic_weights,
-                     weight_values,
-                     skip_mismatch=True,
-                     name="top-level model")
+        _set_weights(
+            layer,
+            symbolic_weights,
+            weight_values,
+            skip_mismatch=True,
+            name="top-level model",
+        )
 
 
 def load_subset_weights_from_hdf5_group(f):


### PR DESCRIPTION
https://github.com/keras-team/keras/issues/20147

```
So, I investigated it a bit and the problem is the keras.layers.Normalization layer, which is not finalized.
This is because keras.layers.Normalization has two weights loaded from the file, adapted_mean and adapted_std, but these are not used directly when making a prediction.
What is used directly are two variables, which are not added as weights, called mean and std, that are updated whenever finalize_state() is called.

And this is the problem. Theoretically, whenever loading weights from a file, finalize_state() should be called by load_own_variables().
But load_own_variables() is called only with the new saving API, when the weights are saved in the format ".weights.h5", while the efficientnet weights have the legacy extension ".h5".

Therefore, weights are loading, we have adapted_mean and adapted_std, but the actual mean and std are initialized with build(), i.e. a vector of zeros and a vector of ones.
```