### PR TITLE
Calling finalize_state() when loading legacy h5 weights

### DIFF
--- a/keras/src/legacy/saving/legacy_h5_format.py
+++ b/keras/src/legacy/saving/legacy_h5_format.py
@@ -445,10 +445,8 @@ def _set_weights(
             )
         symbolic_weights[i].assign(weight_value)
 
-    if hasattr(instance, "load_own_variables"):
-        vars = instance._trainable_variables + instance._non_trainable_variables
-        names = map(str, list(range(len(vars))))
-        instance.load_own_variables(dict(zip(names, vars)))
+    if hasattr(instance, "finalize_state") and symbolic_weights:
+        instance.finalize_state()
 
 
 def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):

--- a/keras/src/legacy/saving/legacy_h5_format.py
+++ b/keras/src/legacy/saving/legacy_h5_format.py
@@ -372,8 +372,12 @@ def load_weights_from_hdf5_group(f, model):
                 f"Layer expects {len(symbolic_weights)} weight(s). Received "
                 f"{len(weight_values)} saved weight(s)"
             )
-        for ref_v, val in zip(symbolic_weights, weight_values):
-            ref_v.assign(val)
+        _set_weights(
+            layer,
+            symbolic_weights,
+            weight_values,
+            name=f"layer #{k} (named {layer.name})",
+        )
 
     if "top_level_model_weights" in f:
         symbolic_weights = list(
@@ -392,8 +396,59 @@ def load_weights_from_hdf5_group(f, model):
                 f"Model expects {len(symbolic_weights)} top-level weight(s). "
                 f"Received {len(weight_values)} saved top-level weight(s)"
             )
-        for ref_v, val in zip(symbolic_weights, weight_values):
-            ref_v.assign(val)
+        _set_weights(
+            model,
+            symbolic_weights,
+            weight_values,
+            name="top-level model",
+        )
+
+
+def _set_weights(
+    instance, symbolic_weights, weight_values, name, skip_mismatch=False
+):
+    """Safely set weights into a model or a layer,
+       calling load_own_variables if implemented.
+    Args:
+        instance: Model or layer instance,
+        symbolic_weights: symbolic tensors representing
+                        the weights of the variables to load,
+        weight_values: values of the weights to load,
+        skip_mismatch: Boolean, whether to skip loading of weights
+            where there is a mismatch in the shape of the weights,
+        name: name used to identify the group.
+    Raises:
+        ValueError: in case of mismatch between provided
+            model/layer and weights.
+    """
+    for i, weight_value in enumerate(weight_values):
+        expected_shape = symbolic_weights[i].shape
+        received_shape = weight_value.shape
+        if expected_shape != received_shape:
+            if skip_mismatch:
+                warnings.warn(
+                    f"Skipping loading weights for {name}"
+                    f"due to mismatch in shape for "
+                    f"weight {symbolic_weights[i].path}. "
+                    f"Weight expects shape {expected_shape}. "
+                    "Received saved weight "
+                    f"with shape {received_shape}",
+                    stacklevel=2,
+                )
+                continue
+            raise ValueError(
+                f"Shape mismatch in {name}"
+                f"for weight {symbolic_weights[i].path}. "
+                f"Weight expects shape {expected_shape}. "
+                "Received saved weight "
+                f"with shape {received_shape}"
+            )
+        symbolic_weights[i].assign(weight_value)
+
+    if hasattr(instance, "load_own_variables"):
+        vars = instance._trainable_variables + instance._non_trainable_variables
+        names = map(str, list(range(len(vars))))
+        instance.load_own_variables(dict(zip(names, vars)))
 
 
 def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
@@ -456,30 +511,13 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
                     f"Received {len(weight_values)} saved weight(s)"
                 )
             # Set values.
-            for i in range(len(weight_values)):
-                expected_shape = symbolic_weights[i].shape
-                received_shape = weight_values[i].shape
-                if expected_shape != received_shape:
-                    if skip_mismatch:
-                        warnings.warn(
-                            f"Skipping loading weights for layer #{k} (named "
-                            f"{layer.name}) due to mismatch in shape for "
-                            f"weight {symbolic_weights[i].path}. "
-                            f"Weight expects shape {expected_shape}. "
-                            "Received saved weight "
-                            f"with shape {received_shape}",
-                            stacklevel=2,
-                        )
-                        continue
-                    raise ValueError(
-                        f"Shape mismatch in layer #{k} (named {layer.name}) "
-                        f"for weight {symbolic_weights[i].path}. "
-                        f"Weight expects shape {expected_shape}. "
-                        "Received saved weight "
-                        f"with shape {received_shape}"
-                    )
-                else:
-                    symbolic_weights[i].assign(weight_values[i])
+            _set_weights(
+                layer,
+                symbolic_weights,
+                weight_values,
+                skip_mismatch=skip_mismatch,
+                name=f"layer #{k} (named {layer.name})",
+            )
 
     if "top_level_model_weights" in f:
         symbolic_weights = model.trainable_weights + model.non_trainable_weights
@@ -505,30 +543,13 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
                     f"Received {len(weight_values)} saved top-level weight(s)"
                 )
         else:
-            for i in range(len(weight_values)):
-                expected_shape = symbolic_weights[i].shape
-                received_shape = weight_values[i].shape
-                if expected_shape != received_shape:
-                    if skip_mismatch:
-                        warnings.warn(
-                            "Skipping loading top-level weight for model due "
-                            "to mismatch in shape for "
-                            f"weight {symbolic_weights[i].path}. "
-                            f"Weight expects shape {expected_shape}. "
-                            "Received saved weight "
-                            f"with shape {received_shape}",
-                            stacklevel=2,
-                        )
-                    else:
-                        raise ValueError(
-                            "Shape mismatch in model for top-level weight "
-                            f"{symbolic_weights[i].path}. "
-                            f"Weight expects shape {expected_shape}. "
-                            "Received saved weight "
-                            f"with shape {received_shape}"
-                        )
-                else:
-                    symbolic_weights[i].assign(weight_values[i])
+            _set_weights(
+                model,
+                symbolic_weights,
+                weight_values,
+                skip_mismatch=skip_mismatch,
+                name="top-level model",
+            )
 
 
 def load_subset_weights_from_hdf5_group(f):

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -959,6 +959,26 @@ class SavingBattleTest(testing.TestCase):
             model_a.dense.kernel.numpy(), model_b.dense.kernel.numpy()
         )
 
+    def test_normalization_legacy_h5_format(self):
+        temp_filepath = os.path.join(self.get_temp_dir(), "custom_model.h5")
+
+        inputs = keras.Input((32,))
+        normalization = keras.layers.Normalization()
+        x = normalization(inputs)
+        x = MyDense(2)(x)
+        outputs = CustomModelX()(x)
+
+        model = keras.Model(inputs, outputs)
+
+        x = np.random.random((1, 32))
+        normalization.adapt(x)
+        ref_out = model(x)
+
+        model.save(temp_filepath)
+        new_model = keras.saving.load_model(temp_filepath)
+        out = new_model(x)
+        self.assertAllClose(ref_out, out, atol=1e-6)
+
     def test_legacy_h5_format(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "custom_model.h5")
 

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -964,9 +964,7 @@ class SavingBattleTest(testing.TestCase):
 
         inputs = keras.Input((32,))
         normalization = keras.layers.Normalization()
-        x = normalization(inputs)
-        x = MyDense(2)(x)
-        outputs = CustomModelX()(x)
+        outputs = normalization(inputs)
 
         model = keras.Model(inputs, outputs)
 


### PR DESCRIPTION
Fixes: https://github.com/keras-team/keras/issues/20147

> So, I investigated it a bit and the problem is the keras.layers.Normalization layer, which is not finalized.
> This is because keras.layers.Normalization has two weights loaded from the file, adapted_mean and adapted_std, but these are not used directly when making a prediction.
> What is used directly are two variables, **which are not added as weights**, called mean and std, that are updated whenever finalize_state() is called.
> 
> And this is the problem. Theoretically, whenever loading weights from a file, finalize_state() should be called by load_own_variables().
> But load_own_variables() is called only with the new saving API, when the weights are saved in the format ".weights.h5", while the efficientnet weights have the legacy extension ".h5".
> 
> Therefore, weights are loaded, which means we have adapted_mean and adapted_std, but the actual mean and std are not loaded (since they're not weights) and instead, they're just initialized with the default values of build(), i.e. a vector of zeros and a vector of ones.