### PR TITLE
Mark layers with no state as built.

### DIFF
--- a/keras/src/layers/activations/activation.py
+++ b/keras/src/layers/activations/activation.py
@@ -26,6 +26,7 @@ class Activation(Layer):
         super().__init__(**kwargs)
         self.supports_masking = True
         self.activation = activations.get(activation)
+        self.built = True
 
     def call(self, inputs):
         return self.activation(inputs)

--- a/keras/src/layers/activations/activation_test.py
+++ b/keras/src/layers/activations/activation_test.py
@@ -20,6 +20,7 @@ class ActivationTest(testing.TestCase):
             expected_num_seed_generators=0,
             expected_num_losses=0,
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
         self.run_layer_test(
             layers.Activation,
@@ -33,4 +34,5 @@ class ActivationTest(testing.TestCase):
             expected_num_seed_generators=0,
             expected_num_losses=0,
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )

--- a/keras/src/layers/activations/elu.py
+++ b/keras/src/layers/activations/elu.py
@@ -23,6 +23,7 @@ class ELU(Layer):
         super().__init__(**kwargs)
         self.alpha = alpha
         self.supports_masking = True
+        self.built = True
 
     def call(self, inputs):
         return activations.elu(inputs, alpha=self.alpha)

--- a/keras/src/layers/activations/elu_test.py
+++ b/keras/src/layers/activations/elu_test.py
@@ -17,6 +17,7 @@ class ELUTest(testing.TestCase):
             init_kwargs={},
             input_shape=(2, 3, 4),
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
 
     def test_correctness(self):

--- a/keras/src/layers/activations/leaky_relu.py
+++ b/keras/src/layers/activations/leaky_relu.py
@@ -49,8 +49,9 @@ class LeakyReLU(Layer):
                 "cannot be None or negative value. Expected a float."
                 f" Received: negative_slope={negative_slope}"
             )
-        self.supports_masking = True
         self.negative_slope = negative_slope
+        self.supports_masking = True
+        self.built = True
 
     def call(self, inputs):
         return activations.leaky_relu(

--- a/keras/src/layers/activations/leaky_relu_test.py
+++ b/keras/src/layers/activations/leaky_relu_test.py
@@ -15,6 +15,7 @@ class LeakyReLUTest(testing.TestCase):
             },
             input_shape=(2, 3, 4),
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
 
     def test_leaky_relu_correctness(self):

--- a/keras/src/layers/activations/relu.py
+++ b/keras/src/layers/activations/relu.py
@@ -57,10 +57,11 @@ class ReLU(Layer):
                 f"value. Received: threshold={threshold}"
             )
 
-        self.supports_masking = True
         self.max_value = max_value
         self.negative_slope = negative_slope
         self.threshold = threshold
+        self.supports_masking = True
+        self.built = True
 
     def call(self, inputs):
         return activations.relu(

--- a/keras/src/layers/activations/relu_test.py
+++ b/keras/src/layers/activations/relu_test.py
@@ -17,6 +17,7 @@ class ReLUTest(testing.TestCase):
             },
             input_shape=(2, 3, 4),
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
 
     def test_normal_relu_correctness(self):

--- a/keras/src/layers/activations/softmax.py
+++ b/keras/src/layers/activations/softmax.py
@@ -44,8 +44,9 @@ class Softmax(Layer):
 
     def __init__(self, axis=-1, **kwargs):
         super().__init__(**kwargs)
-        self.supports_masking = True
         self.axis = axis
+        self.supports_masking = True
+        self.built = True
 
     def call(self, inputs, mask=None):
         if mask is not None:

--- a/keras/src/layers/activations/softmax_test.py
+++ b/keras/src/layers/activations/softmax_test.py
@@ -13,6 +13,7 @@ class SoftmaxTest(testing.TestCase):
             init_kwargs={},
             input_shape=(2, 3, 4),
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
 
     def test_softmax_correctness(self):

--- a/keras/src/layers/core/identity.py
+++ b/keras/src/layers/core/identity.py
@@ -15,6 +15,7 @@ class Identity(Layer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.supports_masking = True
+        self.built = True
 
     def call(self, inputs):
         return inputs

--- a/keras/src/layers/core/identity_test.py
+++ b/keras/src/layers/core/identity_test.py
@@ -30,4 +30,5 @@ class IdentityTest(testing.TestCase, parameterized.TestCase):
             expected_num_losses=0,
             run_training_check=not sparse,
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )

--- a/keras/src/layers/core/masking.py
+++ b/keras/src/layers/core/masking.py
@@ -45,8 +45,9 @@ class Masking(Layer):
 
     def __init__(self, mask_value=0.0, **kwargs):
         super().__init__(**kwargs)
-        self.supports_masking = True
         self.mask_value = mask_value
+        self.supports_masking = True
+        self.built = True
 
     def compute_mask(self, inputs, mask=None):
         return ops.any(ops.not_equal(inputs, self.mask_value), axis=-1)

--- a/keras/src/layers/core/masking_test.py
+++ b/keras/src/layers/core/masking_test.py
@@ -19,6 +19,7 @@ class MaskingTest(testing.TestCase):
             expected_num_seed_generators=0,
             expected_num_losses=0,
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
 
     @pytest.mark.requires_trainable_backend

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1102,7 +1102,7 @@ class LayerTest(testing.TestCase, parameterized.TestCase):
         self.assertTrue("inner_inner_layer/inner" in variable_paths)
         if backend.backend() == "torch":
             parameter_names = set(
-                param_name.replace("torch_params.", "")
+                param_name.replace("_torch_params.", "")
                 for param_name, _ in layer.named_parameters()
             )
             self.assertSetEqual(variable_paths, parameter_names)
@@ -1159,7 +1159,7 @@ class LayerTest(testing.TestCase, parameterized.TestCase):
         )
         if backend.backend() == "torch":
             parameter_names = set(
-                param_name.replace("torch_params.", "")
+                param_name.replace("_torch_params.", "")
                 for param_name, _ in layer.named_parameters()
             )
             self.assertSetEqual(variable_paths, parameter_names)
@@ -1212,7 +1212,7 @@ class LayerTest(testing.TestCase, parameterized.TestCase):
             self.assertEqual(len(parameter_names), 1)
             self.assertEqual(
                 parameter_names[0],
-                "torch_params.training_layer/post_build_modify_layer/var",
+                "_torch_params.training_layer/post_build_modify_layer/var",
             )
 
         layer.post_build_modify_layer.post_build_add()
@@ -1234,7 +1234,7 @@ class LayerTest(testing.TestCase, parameterized.TestCase):
             self.assertEqual(len(parameter_names), 1)
             self.assertEqual(
                 parameter_names[0],
-                "torch_params.training_layer/post_build_modify_layer/var",
+                "_torch_params.training_layer/post_build_modify_layer/var",
             )
 
             parameter_names = [
@@ -1244,11 +1244,11 @@ class LayerTest(testing.TestCase, parameterized.TestCase):
             self.assertEqual(len(parameter_names), 2)
             self.assertEqual(
                 parameter_names[0],
-                "torch_params.training_layer/post_build_modify_layer/var",
+                "_torch_params.training_layer/post_build_modify_layer/var",
             )
             self.assertEqual(
                 parameter_names[1],
-                "torch_params.training_layer/post_build_modify_layer/var2",
+                "_torch_params.training_layer/post_build_modify_layer/var2",
             )
 
         layer.post_build_modify_layer.post_build_remove()
@@ -1267,12 +1267,12 @@ class LayerTest(testing.TestCase, parameterized.TestCase):
             self.assertEqual(len(parameter_names), 2)
             self.assertEqual(
                 parameter_names[0],
-                "post_build_modify_layer.torch_params.training_layer/"
+                "post_build_modify_layer._torch_params.training_layer/"
                 "post_build_modify_layer/var2",
             )
             self.assertEqual(
                 parameter_names[1],
-                "torch_params.training_layer/post_build_modify_layer/var",
+                "_torch_params.training_layer/post_build_modify_layer/var",
             )
 
             parameter_names = [
@@ -1282,7 +1282,7 @@ class LayerTest(testing.TestCase, parameterized.TestCase):
             self.assertEqual(len(parameter_names), 1)
             self.assertEqual(
                 parameter_names[0],
-                "torch_params.training_layer/post_build_modify_layer/var2",
+                "_torch_params.training_layer/post_build_modify_layer/var2",
             )
 
     @pytest.mark.skipif(backend.backend() != "torch", reason="Torch only test.")

--- a/keras/src/layers/normalization/unit_normalization.py
+++ b/keras/src/layers/normalization/unit_normalization.py
@@ -37,8 +37,6 @@ class UnitNormalization(Layer):
                 f"Received: axis={axis}"
             )
         self.supports_masking = True
-
-    def build(self, input_shape):
         self.built = True
 
     def call(self, inputs):

--- a/keras/src/layers/normalization/unit_normalization_test.py
+++ b/keras/src/layers/normalization/unit_normalization_test.py
@@ -20,6 +20,7 @@ class UnitNormalizationTest(testing.TestCase):
             input_shape=(2, 3),
             expected_output_shape=(2, 3),
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
         self.run_layer_test(
             layers.UnitNormalization,
@@ -27,6 +28,7 @@ class UnitNormalizationTest(testing.TestCase):
             input_shape=(1, 3, 3),
             expected_output_shape=(1, 3, 3),
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
 
     def test_invalid_axis(self):

--- a/keras/src/layers/pooling/average_pooling_test.py
+++ b/keras/src/layers/pooling/average_pooling_test.py
@@ -164,6 +164,7 @@ class AveragePoolingBasicTest(testing.TestCase, parameterized.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            assert_built_after_instantiation=True,
         )
 
     @parameterized.parameters(
@@ -197,6 +198,7 @@ class AveragePoolingBasicTest(testing.TestCase, parameterized.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            assert_built_after_instantiation=True,
         )
 
     @parameterized.parameters(
@@ -236,6 +238,7 @@ class AveragePoolingBasicTest(testing.TestCase, parameterized.TestCase):
             supports_masking=False,
             # Incomplete op support on tensorflow.
             run_mixed_precision_check=False,
+            assert_built_after_instantiation=True,
         )
 
 

--- a/keras/src/layers/pooling/base_global_pooling.py
+++ b/keras/src/layers/pooling/base_global_pooling.py
@@ -14,6 +14,7 @@ class BaseGlobalPooling(Layer):
         self.data_format = backend.standardize_data_format(data_format)
         self.keepdims = keepdims
         self.input_spec = InputSpec(ndim=pool_dimensions + 2)
+        self.built = True
 
     def call(self, inputs):
         raise NotImplementedError

--- a/keras/src/layers/pooling/base_pooling.py
+++ b/keras/src/layers/pooling/base_pooling.py
@@ -34,6 +34,7 @@ class BasePooling(Layer):
         self.data_format = backend.standardize_data_format(data_format)
 
         self.input_spec = InputSpec(ndim=pool_dimensions + 2)
+        self.built = True
 
     def call(self, inputs):
         if self.pool_mode == "max":

--- a/keras/src/layers/pooling/global_average_pooling_test.py
+++ b/keras/src/layers/pooling/global_average_pooling_test.py
@@ -32,6 +32,7 @@ class GlobalAveragePoolingBasicTest(testing.TestCase, parameterized.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
 
     @parameterized.parameters(
@@ -58,6 +59,7 @@ class GlobalAveragePoolingBasicTest(testing.TestCase, parameterized.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            assert_built_after_instantiation=True,
         )
 
     @parameterized.parameters(
@@ -84,6 +86,7 @@ class GlobalAveragePoolingBasicTest(testing.TestCase, parameterized.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            assert_built_after_instantiation=True,
         )
 
 

--- a/keras/src/layers/pooling/global_max_pooling_test.py
+++ b/keras/src/layers/pooling/global_max_pooling_test.py
@@ -32,6 +32,7 @@ class GlobalMaxPoolingBasicTest(testing.TestCase, parameterized.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            assert_built_after_instantiation=True,
         )
 
     @parameterized.parameters(
@@ -58,6 +59,7 @@ class GlobalMaxPoolingBasicTest(testing.TestCase, parameterized.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            assert_built_after_instantiation=True,
         )
 
     @parameterized.parameters(
@@ -84,6 +86,7 @@ class GlobalMaxPoolingBasicTest(testing.TestCase, parameterized.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            assert_built_after_instantiation=True,
         )
 
 

--- a/keras/src/layers/pooling/max_pooling_test.py
+++ b/keras/src/layers/pooling/max_pooling_test.py
@@ -163,6 +163,7 @@ class MaxPoolingBasicTest(testing.TestCase, parameterized.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            assert_built_after_instantiation=True,
         )
 
     @parameterized.parameters(
@@ -193,6 +194,7 @@ class MaxPoolingBasicTest(testing.TestCase, parameterized.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            assert_built_after_instantiation=True,
         )
 
     @parameterized.parameters(
@@ -232,6 +234,7 @@ class MaxPoolingBasicTest(testing.TestCase, parameterized.TestCase):
             supports_masking=False,
             # Incomplete op support on tensorflow.
             run_mixed_precision_check=False,
+            assert_built_after_instantiation=True,
         )
 
 

--- a/keras/src/layers/regularization/activity_regularization.py
+++ b/keras/src/layers/regularization/activity_regularization.py
@@ -27,6 +27,7 @@ class ActivityRegularization(Layer):
         self.supports_masking = True
         self.l1 = l1
         self.l2 = l2
+        self.built = True
 
     def call(self, inputs):
         return inputs

--- a/keras/src/layers/regularization/activity_regularization_test.py
+++ b/keras/src/layers/regularization/activity_regularization_test.py
@@ -25,4 +25,5 @@ class ActivityRegularizationTest(test_case.TestCase):
             expected_num_seed_generators=0,
             expected_num_losses=1,
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )

--- a/keras/src/layers/regularization/alpha_dropout.py
+++ b/keras/src/layers/regularization/alpha_dropout.py
@@ -46,6 +46,7 @@ class AlphaDropout(Layer):
         if rate > 0:
             self.seed_generator = backend.random.SeedGenerator(seed)
         self.supports_masking = True
+        self.built = True
 
     def call(self, inputs, training=False):
         if training and self.rate > 0:

--- a/keras/src/layers/regularization/alpha_dropout_test.py
+++ b/keras/src/layers/regularization/alpha_dropout_test.py
@@ -22,6 +22,7 @@ class AlphaDropoutTest(testing.TestCase):
             expected_num_seed_generators=1,
             expected_num_losses=0,
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
 
     def test_alpha_dropout_correctness(self):

--- a/keras/src/layers/regularization/dropout.py
+++ b/keras/src/layers/regularization/dropout.py
@@ -52,6 +52,7 @@ class Dropout(Layer):
         if rate > 0:
             self.seed_generator = backend.random.SeedGenerator(seed)
         self.supports_masking = True
+        self.built = True
 
     def call(self, inputs, training=False):
         if training and self.rate > 0:

--- a/keras/src/layers/regularization/dropout_test.py
+++ b/keras/src/layers/regularization/dropout_test.py
@@ -22,6 +22,7 @@ class DropoutTest(testing.TestCase):
             expected_num_seed_generators=1,
             expected_num_losses=0,
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
 
     def test_dropout_rescaling(self):

--- a/keras/src/layers/regularization/gaussian_dropout.py
+++ b/keras/src/layers/regularization/gaussian_dropout.py
@@ -37,6 +37,7 @@ class GaussianDropout(layers.Layer):
         if rate > 0:
             self.seed_generator = backend.random.SeedGenerator(seed)
         self.supports_masking = True
+        self.built = True
 
     def call(self, inputs, training=False):
         if training and self.rate > 0:

--- a/keras/src/layers/regularization/gaussian_dropout_test.py
+++ b/keras/src/layers/regularization/gaussian_dropout_test.py
@@ -22,6 +22,7 @@ class GaussianDropoutTest(testing.TestCase):
             expected_num_seed_generators=1,
             expected_num_losses=0,
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
 
     def test_gaussian_dropout_correctness(self):

--- a/keras/src/layers/regularization/gaussian_noise.py
+++ b/keras/src/layers/regularization/gaussian_noise.py
@@ -38,6 +38,7 @@ class GaussianNoise(layers.Layer):
         if stddev > 0:
             self.seed_generator = backend.random.SeedGenerator(seed)
         self.supports_masking = True
+        self.built = True
 
     def call(self, inputs, training=False):
         if training and self.stddev > 0:

--- a/keras/src/layers/regularization/gaussian_noise_test.py
+++ b/keras/src/layers/regularization/gaussian_noise_test.py
@@ -22,6 +22,7 @@ class GaussianNoiseTest(testing.TestCase):
             expected_num_seed_generators=1,
             expected_num_losses=0,
             supports_masking=True,
+            assert_built_after_instantiation=True,
         )
 
     def test_gaussian_noise_correctness(self):

--- a/keras/src/layers/regularization/spatial_dropout_test.py
+++ b/keras/src/layers/regularization/spatial_dropout_test.py
@@ -14,6 +14,7 @@ class SpatialDropoutTest(test_case.TestCase):
             init_kwargs={"rate": 0.5},
             call_kwargs={"training": True},
             input_shape=(2, 3, 4),
+            assert_built_after_instantiation=True,
         )
 
         self.run_layer_test(
@@ -21,6 +22,7 @@ class SpatialDropoutTest(test_case.TestCase):
             init_kwargs={"rate": 0.5},
             call_kwargs={"training": False},
             input_shape=(2, 3, 4),
+            assert_built_after_instantiation=True,
         )
 
     @pytest.mark.requires_trainable_backend
@@ -30,6 +32,7 @@ class SpatialDropoutTest(test_case.TestCase):
             init_kwargs={"rate": 0.5},
             call_kwargs={"training": True},
             input_shape=(2, 3, 4, 5),
+            assert_built_after_instantiation=True,
         )
 
         self.run_layer_test(
@@ -37,6 +40,7 @@ class SpatialDropoutTest(test_case.TestCase):
             init_kwargs={"rate": 0.5, "data_format": "channels_first"},
             call_kwargs={"training": True},
             input_shape=(2, 3, 4, 5),
+            assert_built_after_instantiation=True,
         )
 
     @pytest.mark.requires_trainable_backend
@@ -46,6 +50,7 @@ class SpatialDropoutTest(test_case.TestCase):
             init_kwargs={"rate": 0.5},
             call_kwargs={"training": True},
             input_shape=(2, 3, 4, 4, 5),
+            assert_built_after_instantiation=True,
         )
 
         self.run_layer_test(
@@ -53,6 +58,7 @@ class SpatialDropoutTest(test_case.TestCase):
             init_kwargs={"rate": 0.5, "data_format": "channels_first"},
             call_kwargs={"training": True},
             input_shape=(2, 3, 4, 4, 5),
+            assert_built_after_instantiation=True,
         )
 
     def test_spatial_dropout_1D_dynamic(self):

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -174,6 +174,7 @@ class TestCase(unittest.TestCase):
         custom_objects=None,
         run_training_check=True,
         run_mixed_precision_check=True,
+        assert_built_after_instantiation=False,
     ):
         """Run basic checks on a layer.
 
@@ -216,6 +217,8 @@ class TestCase(unittest.TestCase):
                 (if an input shape or input data was provided).
             run_mixed_precision_check: Whether to test the layer with a mixed
                 precision dtype policy.
+            assert_built_after_instantiation: Whether to assert `built=True`
+                after the layer's instantiation.
         """
         if input_shape is not None and input_data is not None:
             raise ValueError(
@@ -550,6 +553,17 @@ class TestCase(unittest.TestCase):
             if expected_mask_shape is not None:
                 output_mask = layer.compute_mask(keras_tensor_inputs)
                 self.assertEqual(expected_mask_shape, output_mask.shape)
+
+            # The stateless layers should be built after instantiation.
+            if assert_built_after_instantiation:
+                layer = layer_cls(**init_kwargs)
+                self.assertTrue(
+                    layer.built,
+                    msg=(
+                        f"{type(layer)} is stateless, so it should be built "
+                        "after instantiation."
+                    ),
+                )
 
         # Eager call test and compiled training test.
         if input_data is not None or input_shape is not None:


### PR DESCRIPTION
There is an issue reported by Matt where the QLoRA tutorial failed due to unbuilt layers.

The root cause is that the line `self.built = True` was removed from `__init__` in some layers, particularly in `Dropout` and `Softmax`.
(This line was originally added in this commit: https://github.com/keras-team/keras/commit/7748a6aebba4bbc77a7866c44c1293c4bb9e0808)

This PR adds an `assert_built_after_instantiation` in the test case to prevent future breakages.

cc @mattdangerw 

Note: there are still many stateless layers not included in this PR, but I want to keep this PR manageable for review. These can be addressed in the future.