### PR TITLE
Correct failed test case for model_visualization_test.py

### DIFF
--- a/keras/src/utils/model_visualization.py
+++ b/keras/src/utils/model_visualization.py
@@ -190,6 +190,14 @@ def make_node(layer, **kwargs):
     return node
 
 
+def remove_unused_edges(dot):
+    nodes = [v.get_name() for v in dot.get_nodes()]
+    for edge in dot.get_edges():
+        if edge.get_destination() not in nodes:
+            dot.del_edge(edge.get_source(), edge.get_destination())
+    return dot
+
+
 @keras_export("keras.utils.model_to_dot")
 def model_to_dot(
     model,
@@ -460,6 +468,7 @@ def plot_model(
     to_file = str(to_file)
     if dot is None:
         return
+    dot = remove_unused_edges(dot)
     _, extension = os.path.splitext(to_file)
     if not extension:
         extension = "png"


### PR DESCRIPTION
When running model_visualization_test, I found that there's failed test case,and it shows error as below.

- keras/integration_tests/model_visualization_test.py"
```
plot_model(model, "nested-functional.png", expand_nested=True)

"dot" with args ['-Tpng', '/tmp/tmpv2ec_hvt'] returned code: -6

stdout, stderr:
 b''
b"failed at node 380[1]\ndot: maze.c:313: chkSgraph: Assertion `np->cells[1]' failed.\n"

AssertionError: "dot" with args ['-Tpng', '/tmp/tmpv2ec_hvt'] returned code: -6
```

An error occurred because some edges represent destinations that do not exist on the dot.
So, I added the logic to remove this kind of edge from dot.