### PR TITLE
fix: upload cifar10 and cifar100 datasets

### DIFF
--- a/keras/src/datasets/cifar10.py
+++ b/keras/src/datasets/cifar10.py
@@ -75,9 +75,9 @@ def load_data():
 
     x_train = np.empty((num_train_samples, 3, 32, 32), dtype="uint8")
     y_train = np.empty((num_train_samples,), dtype="uint8")
-    
+
     # batches are within an inner folder
-    path=os.path.join(path, "cifar-10-batches-py") 
+    path = os.path.join(path, "cifar-10-batches-py")
     for i in range(1, 6):
         fpath = os.path.join(path, "data_batch_" + str(i))
         (

--- a/keras/src/datasets/cifar10.py
+++ b/keras/src/datasets/cifar10.py
@@ -60,12 +60,12 @@ def load_data():
     assert y_test.shape == (10000, 1)
     ```
     """
-    dirname = "cifar-10-batches-py"
+    dirname = "cifar-10-batches-py-target"
     origin = "https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
     path = get_file(
         fname=dirname,
         origin=origin,
-        untar=True,
+        extract=True,
         file_hash=(  # noqa: E501
             "6d958be074577803d12ecdefd02955f39262c83c16fe9348329d7fe0b5c001ce"
         ),
@@ -75,7 +75,9 @@ def load_data():
 
     x_train = np.empty((num_train_samples, 3, 32, 32), dtype="uint8")
     y_train = np.empty((num_train_samples,), dtype="uint8")
-
+    
+    # batches are within an inner folder
+    path=os.path.join(path, "cifar-10-batches-py") 
     for i in range(1, 6):
         fpath = os.path.join(path, "data_batch_" + str(i))
         (

--- a/keras/src/datasets/cifar100.py
+++ b/keras/src/datasets/cifar100.py
@@ -58,17 +58,18 @@ def load_data(label_mode="fine"):
             f"Received: label_mode={label_mode}."
         )
 
-    dirname = "cifar-100-python"
+    dirname = "cifar-100-python-target"
     origin = "https://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz"
     path = get_file(
         fname=dirname,
         origin=origin,
-        untar=True,
+        extract=True,
         file_hash=(  # noqa: E501
             "85cd44d02ba6437773c5bbd22e183051d648de2e7d6b014e1ef29b855ba677a7"
         ),
     )
-
+    
+    path = os.path.join(path, 'cifar-100-python')
     fpath = os.path.join(path, "train")
     x_train, y_train = load_batch(fpath, label_key=label_mode + "_labels")
 

--- a/keras/src/datasets/cifar100.py
+++ b/keras/src/datasets/cifar100.py
@@ -68,8 +68,8 @@ def load_data(label_mode="fine"):
             "85cd44d02ba6437773c5bbd22e183051d648de2e7d6b014e1ef29b855ba677a7"
         ),
     )
-    
-    path = os.path.join(path, 'cifar-100-python')
+
+    path = os.path.join(path, "cifar-100-python")
     fpath = os.path.join(path, "train")
     x_train, y_train = load_batch(fpath, label_key=label_mode + "_labels")
 


### PR DESCRIPTION
The modifications to `get_file`, and removing the deprecated `untar` need an extra directory name to be accessed.
Other possible solutions were provided by myself an others in the linked Issue.

I did a demo here: [Colab](https://colab.research.google.com/gist/ghsanti/284e8b5012dba741ba6929c1aaf8e30c/print.ipynb), also tested on Windows.

The commit that produced the issue [seems to be this one](https://github.com/keras-team/keras/commit/dcefb139863505d166dd1325066f329b3033d45a).

Maybe @ashep29 or @mehtamansi29 have an opinion.

Note that it's just one commit, somehow VSCode managed to duplicate it.

Closes #20180 