### PR TITLE
Add the logic to assert and remove files after running test

### DIFF
--- a/integration_tests/model_visualization_test.py
+++ b/integration_tests/model_visualization_test.py
@@ -308,7 +308,7 @@ def plot_nested_functional_model():
     )
     plot_model(
         model,
-        "nested-functional-show_layer_activations-show_trainable.png",  # noqa: E501
+        "nested-functional-show_layer_activations-show_trainable.png",
         show_layer_activations=True,
         show_trainable=True,
         expand_nested=True,

--- a/integration_tests/model_visualization_test.py
+++ b/integration_tests/model_visualization_test.py
@@ -51,7 +51,7 @@ def test_plot_sequential_model():
         show_layer_activations=True,
     )
     assert_file_exists(
-        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations.png"
+        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations.png"  # noqa: E501
     )
 
     plot_model(
@@ -64,7 +64,7 @@ def test_plot_sequential_model():
         show_trainable=True,
     )
     assert_file_exists(
-        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png"
+        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png"  # noqa: E501
     )
 
     plot_model(
@@ -78,7 +78,7 @@ def test_plot_sequential_model():
         rankdir="LR",
     )
     assert_file_exists(
-        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png"
+        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png"  # noqa: E501
     )
 
     plot_model(

--- a/integration_tests/model_visualization_test.py
+++ b/integration_tests/model_visualization_test.py
@@ -16,58 +16,60 @@ def test_plot_sequential_model():
             keras.layers.Dense(1, activation="sigmoid"),
         ]
     )
+    file_name = "sequential.png"
+    plot_model(model, file_name)
+    assert_file_exists(file_name)
 
-    plot_model(model, "sequential.png")
-    assert_file_exists("sequential.png")
+    file_name = "sequential-show_shapes.png"
+    plot_model(model, file_name, show_shapes=True)
+    assert_file_exists(file_name)
 
-    plot_model(model, "sequential-show_shapes.png", show_shapes=True)
-    assert_file_exists("sequential-show_shapes.png")
-
+    file_name = "sequential-show_shapes-show_dtype.png"
     plot_model(
         model,
-        "sequential-show_shapes-show_dtype.png",
+        file_name,
         show_shapes=True,
         show_dtype=True,
     )
-    assert_file_exists("sequential-show_shapes-show_dtype.png")
+    assert_file_exists(file_name)
 
+    file_name = "sequential-show_shapes-show_dtype-show_layer_names.png"
     plot_model(
         model,
-        "sequential-show_shapes-show_dtype-show_layer_names.png",
+        file_name,
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
     )
-    assert_file_exists("sequential-show_shapes-show_dtype-show_layer_names.png")
+    assert_file_exists(file_name)
 
+    file_name = "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations.png"  # noqa: E501
     plot_model(
         model,
-        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations.png",  # noqa: E501
+        file_name,
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
         show_layer_activations=True,
     )
-    assert_file_exists(
-        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations.png"  # noqa: E501
-    )
+    assert_file_exists(file_name)
 
+    file_name = "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png"  # noqa: E501
     plot_model(
         model,
-        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png",  # noqa: E501
+        file_name,
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
         show_layer_activations=True,
         show_trainable=True,
     )
-    assert_file_exists(
-        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png"  # noqa: E501
-    )
+    assert_file_exists(file_name)
 
+    file_name = "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png"  # noqa: E501
     plot_model(
         model,
-        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png",  # noqa: E501
+        file_name,
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -75,17 +77,16 @@ def test_plot_sequential_model():
         show_trainable=True,
         rankdir="LR",
     )
-    assert_file_exists(
-        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png"  # noqa: E501
-    )
+    assert_file_exists(file_name)
 
+    file_name = "sequential-show_layer_activations-show_trainable.png"
     plot_model(
         model,
-        "sequential-show_layer_activations-show_trainable.png",
+        file_name,
         show_layer_activations=True,
         show_trainable=True,
     )
-    assert_file_exists("sequential-show_layer_activations-show_trainable.png")
+    assert_file_exists(file_name)
 
 
 def plot_functional_model():
@@ -307,7 +308,7 @@ def plot_nested_functional_model():
     )
     plot_model(
         model,
-        "nested-functional-show_layer_activations-show_trainable.png",
+        "nested-functional-show_layer_activations-show_trainable.png",  # noqa: E501
         show_layer_activations=True,
         show_trainable=True,
         expand_nested=True,

--- a/integration_tests/model_visualization_test.py
+++ b/integration_tests/model_visualization_test.py
@@ -358,6 +358,7 @@ def plot_functional_model_with_splits_and_merges():
 
 
 if __name__ == "__main__":
+    test_plot_sequential_model()
     plot_functional_model()
     plot_subclassed_model()
     plot_nested_functional_model()

--- a/integration_tests/model_visualization_test.py
+++ b/integration_tests/model_visualization_test.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import keras
@@ -7,7 +6,6 @@ from keras.src.utils import plot_model
 
 def assert_file_exists(path):
     assert Path(path).is_file(), "File does not exist"
-    os.remove(path)
 
 
 def test_plot_sequential_model():

--- a/integration_tests/model_visualization_test.py
+++ b/integration_tests/model_visualization_test.py
@@ -1,8 +1,16 @@
+import os
+from pathlib import Path
+
 import keras
 from keras.src.utils import plot_model
 
 
-def plot_sequential_model():
+def assert_file_exists(path):
+    assert Path(path).is_file(), "File does not exist"
+    os.remove(path)
+
+
+def test_plot_sequential_model():
     model = keras.Sequential(
         [
             keras.Input((3,)),
@@ -10,14 +18,21 @@ def plot_sequential_model():
             keras.layers.Dense(1, activation="sigmoid"),
         ]
     )
+
     plot_model(model, "sequential.png")
+    assert_file_exists("sequential.png")
+
     plot_model(model, "sequential-show_shapes.png", show_shapes=True)
+    assert_file_exists("sequential-show_shapes.png")
+
     plot_model(
         model,
         "sequential-show_shapes-show_dtype.png",
         show_shapes=True,
         show_dtype=True,
     )
+    assert_file_exists("sequential-show_shapes-show_dtype.png")
+
     plot_model(
         model,
         "sequential-show_shapes-show_dtype-show_layer_names.png",
@@ -25,6 +40,8 @@ def plot_sequential_model():
         show_dtype=True,
         show_layer_names=True,
     )
+    assert_file_exists("sequential-show_shapes-show_dtype-show_layer_names.png")
+
     plot_model(
         model,
         "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations.png",  # noqa: E501
@@ -33,6 +50,10 @@ def plot_sequential_model():
         show_layer_names=True,
         show_layer_activations=True,
     )
+    assert_file_exists(
+        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations.png"
+    )
+
     plot_model(
         model,
         "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png",  # noqa: E501
@@ -42,6 +63,10 @@ def plot_sequential_model():
         show_layer_activations=True,
         show_trainable=True,
     )
+    assert_file_exists(
+        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png"
+    )
+
     plot_model(
         model,
         "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png",  # noqa: E501
@@ -52,12 +77,17 @@ def plot_sequential_model():
         show_trainable=True,
         rankdir="LR",
     )
+    assert_file_exists(
+        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png"
+    )
+
     plot_model(
         model,
         "sequential-show_layer_activations-show_trainable.png",
         show_layer_activations=True,
         show_trainable=True,
     )
+    assert_file_exists("sequential-show_layer_activations-show_trainable.png")
 
 
 def plot_functional_model():
@@ -329,7 +359,6 @@ def plot_functional_model_with_splits_and_merges():
 
 
 if __name__ == "__main__":
-    plot_sequential_model()
     plot_functional_model()
     plot_subclassed_model()
     plot_nested_functional_model()


### PR DESCRIPTION
I've updated the model_visualization_test to be compatible with pytest. 
Additionally, I included assertion logic to verify that the file exists and implemented a cleanup process to remove PNG files after running pytest. If this approach is acceptable, I plan to extend these changes to all methods in model_visualization_test.