### PR TITLE
Added parameter 'verbose' when exporting TF SavedModel

### DIFF
--- a/keras/src/export/export_lib.py
+++ b/keras/src/export/export_lib.py
@@ -465,7 +465,7 @@ class ExportArchive:
             variables = tree.flatten(tree.map_structure(tf.Variable, variables))
         setattr(self._tf_trackable, name, list(variables))
 
-    def write_out(self, filepath, options=None):
+    def write_out(self, filepath, options=None, verbose=True):
         """Write the corresponding SavedModel to disk.
 
         Arguments:
@@ -473,6 +473,8 @@ class ExportArchive:
                 Path where to save the artifact.
             options: `tf.saved_model.SaveOptions` object that specifies
                 SavedModel saving options.
+            verbose: whether to print all the variables of an
+                exported SavedModel.
 
         **Note on TF-Serving**: all endpoints registered via `add_endpoint()`
         are made visible for TF-Serving in the SavedModel artifact. In addition,
@@ -506,7 +508,7 @@ class ExportArchive:
 
         # Print out available endpoints
         endpoints = "\n\n".join(
-            _print_signature(getattr(self._tf_trackable, name), name)
+            _print_signature(getattr(self._tf_trackable, name), name, verbose)
             for name in self._endpoint_names
         )
         io_utils.print_msg(
@@ -625,7 +627,7 @@ class ExportArchive:
             return True
 
 
-def export_model(model, filepath):
+def export_model(model, filepath, verbose=True):
     export_archive = ExportArchive()
     export_archive.track(model)
     if isinstance(model, (Functional, Sequential)):
@@ -641,7 +643,7 @@ def export_model(model, filepath):
                 "It must be called at least once before export."
             )
         export_archive.add_endpoint("serve", model.__call__, input_signature)
-    export_archive.write_out(filepath)
+    export_archive.write_out(filepath, verbose)
 
 
 def _get_input_signature(model):
@@ -813,9 +815,9 @@ def _make_tensor_spec(x):
     return tf.TensorSpec(shape, dtype=x.dtype, name=x.name)
 
 
-def _print_signature(fn, name):
+def _print_signature(fn, name, verbose=True):
     concrete_fn = fn._list_all_concrete_functions()[0]
-    pprinted_signature = concrete_fn.pretty_printed_signature(verbose=True)
+    pprinted_signature = concrete_fn.pretty_printed_signature(verbose=verbose)
     lines = pprinted_signature.split("\n")
     lines = [f"* Endpoint '{name}'"] + lines[1:]
     endpoint = "\n".join(lines)

--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -457,7 +457,7 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         model_config = serialization_lib.serialize_keras_object(self)
         return json.dumps(model_config, **kwargs)
 
-    def export(self, filepath, format="tf_saved_model"):
+    def export(self, filepath, format="tf_saved_model", verbose=True):
         """Create a TF SavedModel artifact for inference.
 
         **Note:** This can currently only be used with
@@ -475,6 +475,7 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         Args:
             filepath: `str` or `pathlib.Path` object. Path where to save
                 the artifact.
+            verbose: whether to print all the variables of the exported model.
 
         Example:
 
@@ -493,7 +494,7 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         """
         from keras.src.export import export_lib
 
-        export_lib.export_model(self, filepath)
+        export_lib.export_model(self, filepath, verbose)
 
     @classmethod
     def from_config(cls, config, custom_objects=None):


### PR DESCRIPTION
When exporting a Keras model into a TF SavedModel, the current output is like this:
```
The following endpoints are available:

* Endpoint 'serve'
  inputs (POSITIONAL_OR_KEYWORD): ...
  training (POSITIONAL_OR_KEYWORD): ...
  mask (POSITIONAL_OR_KEYWORD): ...
Output Type:
  ...
Captures:
  * Huge list of variables, usually in this form: TensorSpec(shape=(), dtype=tf.resource, name=None) *
```

This could be quite overwhelming whenever you have to export models many times.
This PR adds a parameter that allows choosing whether to print all the variables when exporting or not.