### PR TITLE
SaturateCast op

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -18,6 +18,7 @@ from keras.src.ops.core import dtype
 from keras.src.ops.core import fori_loop
 from keras.src.ops.core import is_tensor
 from keras.src.ops.core import map
+from keras.src.ops.core import saturate_cast
 from keras.src.ops.core import scan
 from keras.src.ops.core import scatter
 from keras.src.ops.core import scatter_update

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -18,6 +18,7 @@ from keras.src.ops.core import dtype
 from keras.src.ops.core import fori_loop
 from keras.src.ops.core import is_tensor
 from keras.src.ops.core import map
+from keras.src.ops.core import saturate_cast
 from keras.src.ops.core import scan
 from keras.src.ops.core import scatter
 from keras.src.ops.core import scatter_update

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -818,6 +818,12 @@ class SaturateCast(Operation):
 def saturate_cast(x, dtype):
     """Performs a safe saturating cast to the desired dtype.
 
+    Saturating cast prevents data type overflow when casting to `dtype` with
+    smaller values range. E.g.
+    `ops.cast(ops.cast([-1, 256], "float32"), "uint8")` returns `[255, 0]`,
+    but `ops.saturate_cast(ops.cast([-1, 256], "float32"), "uint8")` returns
+    `[0, 255]`.
+
     Args:
         x: A tensor or variable.
         dtype: The target type.
@@ -827,8 +833,33 @@ def saturate_cast(x, dtype):
 
     Example:
 
-    >>> x = keras.ops.arange(-258, 259)
-    >>> x = keras.ops.saturate_cast(x, dtype="uint8")
+    Image resizing with bicubic interpolation may produce values outside
+    original range.
+    >>> image2x2 = np.array([0, 1, 254, 255], dtype="uint8").reshape(1, 2, 2, 1)
+    >>> image4x4 = tf.image.resize(image2x2, (4, 4), method="bicubic")
+    >>> print(image4x4.numpy().squeeze())
+    >>> # [[-22.500004 -22.204624 -21.618908 -21.32353 ]
+    >>> #  [ 52.526054  52.82143   53.407146  53.70253 ]
+    >>> #  [201.29752  201.59288  202.17859  202.47395 ]
+    >>> #  [276.32355  276.61893  277.20465  277.50006 ]]
+
+    Casting this resized image back to `uint8` will cause overflow.
+    >>> image4x4_casted = ops.cast(image4x4, "uint8")
+    >>> print(image4x4_casted.numpy().squeeze())
+    >>> # [[234 234 235 235]
+    >>> #  [ 52  52  53  53]
+    >>> #  [201 201 202 202]
+    >>> #  [ 20  20  21  21]]
+
+    Saturate casting to `uint8` will clip values to `uint8` range before
+    casting and will not cause overflow.
+    >>> image4x4_saturate_casted = ops.saturate_cast(image4x4, "uint8")
+    >>> print(image4x4_saturate_casted.numpy().squeeze())
+    >>> # [[  0   0   0   0]
+    >>> #  [ 52  52  53  53]
+    >>> #  [201 201 202 202]
+    >>> #  [255 255 255 255]]
+
     """
     dtype = backend.standardize_dtype(dtype)
 

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -769,6 +769,17 @@ class CoreOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(x.shape, y.shape)
         self.assertTrue(hasattr(x, "_keras_history"))
 
+    def test_saturate_cast(self):
+        x = ops.ones((2,), dtype="float32")
+        y = ops.saturate_cast(x, "float16")
+        self.assertIn("float16", str(y.dtype))
+
+        x = ops.KerasTensor((2,), dtype="float32")
+        y = ops.saturate_cast(x, "float16")
+        self.assertEqual("float16", y.dtype)
+        self.assertEqual(x.shape, y.shape)
+        self.assertTrue(hasattr(y, "_keras_history"))
+
     def test_vectorized_map(self):
         def fn(x):
             return x + 1
@@ -1138,6 +1149,19 @@ class CoreOpsCallsTests(testing.TestCase):
         self.assertEqual(result.dtype, target_dtype)
         # Check that the values are the same
         expected_values = x.astype(target_dtype)
+        self.assertTrue(np.array_equal(result, expected_values))
+
+    def test_saturate_cast_basic_functionality(self):
+        x = np.array([-256, 1.0, 257.0], dtype=np.float32)
+        target_dtype = np.uint8
+        cast = core.SaturateCast(target_dtype)
+        result = cast.call(x)
+        result = core.convert_to_numpy(result)
+        self.assertEqual(result.dtype, target_dtype)
+        # Check that the values are the same
+        expected_values = np.clip(x, 0, 255).astype(target_dtype)
+        print(result)
+        print(expected_values)
         self.assertTrue(np.array_equal(result, expected_values))
 
     def test_cond_check_output_spec_list_tuple(self):


### PR DESCRIPTION
Code and comments are adopted from TF https://github.com/tensorflow/tensorflow/blob/v2.17.0/tensorflow/python/ops/math_ops.py#L1086

But i don't know if copyright should be marked somehow.