### PR TITLE
Replace `ValueError` with `AttributeError` in `Sequential`'s property

### DIFF
--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -268,7 +268,7 @@ class Sequential(Model):
     def input_shape(self):
         if self._functional:
             return self._functional.input_shape
-        raise ValueError(
+        raise AttributeError(
             f"Sequential model '{self.name}' has no defined input shape yet."
         )
 
@@ -276,7 +276,7 @@ class Sequential(Model):
     def output_shape(self):
         if self._functional:
             return self._functional.output_shape
-        raise ValueError(
+        raise AttributeError(
             f"Sequential model '{self.name}' has no defined output shape yet."
         )
 
@@ -284,7 +284,7 @@ class Sequential(Model):
     def inputs(self):
         if self._functional:
             return self._functional.inputs
-        raise ValueError(
+        raise AttributeError(
             f"Sequential model '{self.name}' has no defined inputs yet."
         )
 
@@ -292,7 +292,7 @@ class Sequential(Model):
     def outputs(self):
         if self._functional:
             return self._functional.outputs
-        raise ValueError(
+        raise AttributeError(
             f"Sequential model '{self.name}' has no defined outputs yet."
         )
 

--- a/keras/src/models/sequential_test.py
+++ b/keras/src/models/sequential_test.py
@@ -227,6 +227,12 @@ class SequentialTest(testing.TestCase):
         self.assertEqual(type(y), list)
         model.summary()
 
+    def test_nested_sequential(self):
+        # https://github.com/keras-team/keras/issues/20203
+        model = Sequential()
+        model.add(Input(shape=(16,)))
+        Sequential([model])
+
     def test_errors(self):
         # Trying to pass 2 Inputs
         model = Sequential()

--- a/keras/src/models/sequential_test.py
+++ b/keras/src/models/sequential_test.py
@@ -359,3 +359,16 @@ class SequentialTest(testing.TestCase):
         layer = Sequential([layers.Dense(4), layers.Dense(8)])
         output_shape = layer.compute_output_shape((1, 2))
         self.assertEqual(output_shape, (1, 8))
+
+    def test_hasattr(self):
+        model = Sequential()
+        self.assertFalse(hasattr(model, "input_shape"))
+        self.assertFalse(hasattr(model, "output_shape"))
+        self.assertFalse(hasattr(model, "inputs"))
+        self.assertFalse(hasattr(model, "outputs"))
+
+        model = Sequential([layers.Input((4,)), layers.Dense(8)])
+        self.assertTrue(hasattr(model, "input_shape"))
+        self.assertTrue(hasattr(model, "output_shape"))
+        self.assertTrue(hasattr(model, "inputs"))
+        self.assertTrue(hasattr(model, "outputs"))


### PR DESCRIPTION
Fix #20203