### PR TITLE
Fixing example code for binarycrossentropy in losses.py file

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -549,7 +549,7 @@ class BinaryCrossentropy(LossFunctionWrapper):
     >>> y_pred = np.array([-18.6, 0.51, 2.94, -12.8])
     >>> bce = keras.losses.BinaryCrossentropy(from_logits=True)
     >>> bce(y_true, y_pred)
-    <tf.Tensor: shape=(), dtype=float32, numpy=0.8654580116271973>
+    0.8654
 
     >>> # Example 2: (batch_size = 2, number of samples = 4)
     >>> y_true = np.array([[0, 1], [0, 0]])
@@ -557,7 +557,7 @@ class BinaryCrossentropy(LossFunctionWrapper):
     >>> # Using default 'auto'/'sum_over_batch_size' reduction type.
     >>> bce = keras.losses.BinaryCrossentropy(from_logits=True)
     >>> bce(y_true, y_pred)
-    <tf.Tensor: shape=(), dtype=float32, numpy=0.8654580116271973>
+    0.8654
     >>> # Using 'sample_weight' attribute
     >>> bce(y_true, y_pred, sample_weight=[0.8, 0.2])
     0.243

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -545,15 +545,15 @@ class BinaryCrossentropy(LossFunctionWrapper):
     As a standalone function:
 
     >>> # Example 1: (batch_size = 1, number of samples = 4)
-    >>> y_true = [0, 1, 0, 0]
-    >>> y_pred = [-18.6, 0.51, 2.94, -12.8]
+    >>> y_true = np.array([0, 1, 0, 0])
+    >>> y_pred = np.array([-18.6, 0.51, 2.94, -12.8])
     >>> bce = keras.losses.BinaryCrossentropy(from_logits=True)
     >>> bce(y_true, y_pred)
     0.865
 
     >>> # Example 2: (batch_size = 2, number of samples = 4)
-    >>> y_true = [[0, 1], [0, 0]]
-    >>> y_pred = [[-18.6, 0.51], [2.94, -12.8]]
+    >>> y_true = np.array([[0, 1], [0, 0]])
+    >>> y_pred = np.array([[-18.6, 0.51], [2.94, -12.8]])
     >>> # Using default 'auto'/'sum_over_batch_size' reduction type.
     >>> bce = keras.losses.BinaryCrossentropy(from_logits=True)
     >>> bce(y_true, y_pred)

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -549,7 +549,7 @@ class BinaryCrossentropy(LossFunctionWrapper):
     >>> y_pred = np.array([-18.6, 0.51, 2.94, -12.8])
     >>> bce = keras.losses.BinaryCrossentropy(from_logits=True)
     >>> bce(y_true, y_pred)
-    0.865
+    <tf.Tensor: shape=(), dtype=float32, numpy=0.8654580116271973>
 
     >>> # Example 2: (batch_size = 2, number of samples = 4)
     >>> y_true = np.array([[0, 1], [0, 0]])
@@ -557,7 +557,7 @@ class BinaryCrossentropy(LossFunctionWrapper):
     >>> # Using default 'auto'/'sum_over_batch_size' reduction type.
     >>> bce = keras.losses.BinaryCrossentropy(from_logits=True)
     >>> bce(y_true, y_pred)
-    0.865
+    <tf.Tensor: shape=(), dtype=float32, numpy=0.8654580116271973>
     >>> # Using 'sample_weight' attribute
     >>> bce(y_true, y_pred, sample_weight=[0.8, 0.2])
     0.243


### PR DESCRIPTION
The example mentioned for the Keras API binarycrossentropy was failing with the error **AttributeError: 'list' object has no attribute 'shape'**.

```python
>>> y_true = [0, 1, 0, 0]
>>> y_pred = [-18.6, 0.51, 2.94, -12.8]
>>> bce = keras.losses.BinaryCrossentropy(from_logits=True)
>>> bce(y_true, y_pred)
AttributeError: 'list' object has no attribute 'shape'
```




It works if we change the input from list to arrays.

```python
>>> y_true = np.array([0, 1, 0, 0])
>>> y_pred = np.array([-18.6, 0.51, 2.94, -12.8])
>>> bce = keras.losses.BinaryCrossentropy(from_logits=True)
>>> bce(y_true, y_pred)
<tf.Tensor: shape=(), dtype=float32, numpy=0.8654580116271973>
```
 
