### PR TITLE
Fix image resize conversion to original dtype

### DIFF
--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -297,7 +297,7 @@ def resize(
             resized = tf.transpose(resized, (0, 3, 1, 2))
         elif len(images.shape) == 3:
             resized = tf.transpose(resized, (2, 0, 1))
-    return tf.cast(resized, images.dtype)
+    return resized
 
 
 AFFINE_TRANSFORM_INTERPOLATIONS = (

--- a/keras/src/layers/preprocessing/resizing.py
+++ b/keras/src/layers/preprocessing/resizing.py
@@ -95,7 +95,7 @@ class Resizing(TFDataLayer):
         )
         if resized.dtype == inputs.dtype:
             return resized
-        if inputs.dtype.is_integer:
+        if backend.is_int_dtype(inputs.dtype):
             resized = self.backend.numpy.round(resized)
         resized = self.backend.numpy.clip(
             resized, inputs.dtype.min, inputs.dtype.max

--- a/keras/src/layers/preprocessing/resizing.py
+++ b/keras/src/layers/preprocessing/resizing.py
@@ -95,7 +95,7 @@ class Resizing(TFDataLayer):
         )
         if resized.dtype == inputs.dtype:
             return resized
-        if backend.is_int_dtype(inputs.dtype):
+        if inputs.dtype.is_integer:
             resized = self.backend.numpy.round(resized)
         resized = self.backend.numpy.clip(
             resized, inputs.dtype.min, inputs.dtype.max

--- a/keras/src/layers/preprocessing/resizing.py
+++ b/keras/src/layers/preprocessing/resizing.py
@@ -1,6 +1,7 @@
 from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.tf_data_layer import TFDataLayer
+from keras.src.ops.core import _saturate_cast
 
 
 @keras_export("keras.layers.Resizing")
@@ -97,10 +98,7 @@ class Resizing(TFDataLayer):
             return resized
         if backend.is_int_dtype(inputs.dtype):
             resized = self.backend.numpy.round(resized)
-        resized = self.backend.numpy.clip(
-            resized, inputs.dtype.min, inputs.dtype.max
-        )
-        return self.backend.cast(resized, inputs.dtype)
+        return _saturate_cast(resized, inputs.dtype, self.backend)
 
     def compute_output_shape(self, input_shape):
         input_shape = list(input_shape)

--- a/keras/src/layers/preprocessing/resizing.py
+++ b/keras/src/layers/preprocessing/resizing.py
@@ -83,7 +83,7 @@ class Resizing(TFDataLayer):
 
     def call(self, inputs):
         size = (self.height, self.width)
-        return self.backend.image.resize(
+        resized = self.backend.image.resize(
             inputs,
             size=size,
             interpolation=self.interpolation,
@@ -93,6 +93,14 @@ class Resizing(TFDataLayer):
             fill_mode=self.fill_mode,
             fill_value=self.fill_value,
         )
+        if resized.dtype == inputs.dtype:
+            return resized
+        if backend.is_int_dtype(inputs.dtype):
+            resized = self.backend.numpy.round(resized)
+        resized = self.backend.numpy.clip(
+            resized, inputs.dtype.min, inputs.dtype.max
+        )
+        return self.backend.cast(resized, inputs.dtype)
 
     def compute_output_shape(self, input_shape):
         input_shape = list(input_shape)

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -868,7 +868,8 @@ def saturate_cast(x, dtype):
     return _saturate_cast(x, dtype)
 
 
-def _saturate_cast(x, dtype):
+def _saturate_cast(x, dtype, backend_module=None):
+    backend_module = backend_module or backend
     dtype = backend.standardize_dtype(dtype)
     in_dtype = backend.standardize_dtype(x.dtype)
     in_info = np.iinfo(in_dtype) if "int" in in_dtype else np.finfo(in_dtype)
@@ -889,9 +890,9 @@ def _saturate_cast(x, dtype):
         max_limit = np.nextafter(max_limit, 0, dtype=in_dtype)
 
     # Unconditionally apply `clip` to fix `inf` behavior.
-    x = backend.numpy.clip(x, min_limit, max_limit)
+    x = backend_module.numpy.clip(x, min_limit, max_limit)
 
-    return cast(x, dtype)
+    return backend_module.cast(x, dtype)
 
 
 @keras_export("keras.ops.convert_to_tensor")

--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -240,7 +240,7 @@ class Resize(Operation):
         self.data_format = backend.standardize_data_format(data_format)
 
     def call(self, images):
-        return backend.image.resize(
+        return _resize(
             images,
             self.size,
             interpolation=self.interpolation,
@@ -362,7 +362,7 @@ def resize(
             fill_mode=fill_mode,
             fill_value=fill_value,
         ).symbolic_call(images)
-    return backend.image.resize(
+    return _resize(
         images,
         size,
         interpolation=interpolation,
@@ -373,6 +373,37 @@ def resize(
         fill_mode=fill_mode,
         fill_value=fill_value,
     )
+
+
+def _resize(
+    images,
+    size,
+    interpolation="bilinear",
+    antialias=False,
+    crop_to_aspect_ratio=False,
+    pad_to_aspect_ratio=False,
+    fill_mode="constant",
+    fill_value=0.0,
+    data_format=None,
+):
+    resized = backend.image.resize(
+        images,
+        size,
+        interpolation=interpolation,
+        antialias=antialias,
+        crop_to_aspect_ratio=crop_to_aspect_ratio,
+        data_format=data_format,
+        pad_to_aspect_ratio=pad_to_aspect_ratio,
+        fill_mode=fill_mode,
+        fill_value=fill_value,
+    )
+    if resized.dtype == images.dtype:
+        # Only `torch` backend will cast result to original dtype with
+        # correct rounding and without dtype overflow
+        return resized
+    if backend.is_int_dtype(images.dtype):
+        resized = ops.round(resized)
+    return ops.saturate_cast(resized, images.dtype)
 
 
 class AffineTransform(Operation):

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -642,7 +642,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             antialias=False,
         )
         self.assertEqual(tuple(out.shape), tuple(expected.shape))
-        self.assertEqual(out.dtype, expected.dtype)
+        self.assertEqual(backend.standardize_dtype(out.dtype), "uint8")
         self.assertAllClose(out, expected, atol=1e-4)
 
     def test_resize_uint8_round_saturate(self):
@@ -685,7 +685,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             antialias=False,
         )
         self.assertEqual(tuple(out.shape), tuple(expected.shape))
-        self.assertEqual(out.dtype, expected.dtype)
+        self.assertEqual(backend.standardize_dtype(out.dtype), "uint8")
         self.assertAllClose(out, expected, atol=1e-4)
 
     def test_resize_with_crop(self):


### PR DESCRIPTION
1. Drop resized image casting in TF backend: Jax/Numpy have no such casting

2. Fix convertion to original dtype for TF/Jax/Numpy backends:
- TF and Jax return resized image in `float32`
- If original dtype is integer, we should round it before cast
- If interpolation done with high-degree polynom, values can overcome source dtype range (e.g. [0; 255] for `uint8`), so we should make saturating cast
