### PR TITLE
Fix load_model from hf:// preset

### DIFF
--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -164,12 +164,14 @@ def load_model(filepath, custom_objects=None, compile=True, safe_mode=True):
     is_keras_dir = file_utils.isdir(filepath) and file_utils.exists(
         file_utils.join(filepath, "config.json")
     )
+    is_hf = str(filepath).startswith("hf://")
 
     # Support for remote zip files
     if (
         file_utils.is_remote_path(filepath)
         and not file_utils.isdir(filepath)
         and not is_keras_zip
+        and not is_hf
     ):
         local_path = file_utils.join(
             saving_lib.get_temp_dir(), os.path.basename(filepath)
@@ -183,7 +185,7 @@ def load_model(filepath, custom_objects=None, compile=True, safe_mode=True):
             filepath = local_path
             is_keras_zip = True
 
-    if is_keras_zip or is_keras_dir:
+    if is_keras_zip or is_keras_dir or is_hf:
         return saving_lib.load_model(
             filepath,
             custom_objects=custom_objects,


### PR DESCRIPTION
Follow-up PR after https://github.com/keras-team/keras/pull/19854 fixing `load_model` when trying to load a model from the Hugging Face Hub.

At the moment (`keras==3.5.0`), running the following snippet

```py
# Available backend options are: "jax", "tensorflow", "torch".
import os

os.environ["KERAS_BACKEND"] = "torch"

import keras

model = keras.saving.load_model("hf://Wauplin/densenet_121_example")
```

fails with 

```
Traceback (most recent call last):
  File "/home/wauplin/projects/huggingface_hub/az.py", line 10, in <module>
    model = keras.saving.load_model("hf://Wauplin/densenet_121_example")
  File "/home/wauplin/projects/huggingface_hub/.venv310/lib/python3.10/site-packages/keras/src/saving/saving_api.py", line 179, in load_model
    file_utils.copy(filepath, local_path)
  File "/home/wauplin/projects/huggingface_hub/.venv310/lib/python3.10/site-packages/keras/src/utils/file_utils.py", line 478, in copy
    return gfile.copy(src, dst, overwrite=True)
  File "/home/wauplin/projects/huggingface_hub/.venv310/lib/python3.10/site-packages/tensorflow/python/lib/io/file_io.py", line 581, in copy_v2
    _pywrap_file_io.CopyFile(
tensorflow.python.framework.errors_impl.UnimplementedError: File system scheme 'hf' not implemented (file: 'hf://Wauplin/densenet_121_example')
```

To load a model with the current version, one need to use `keras.src.saving.saving_lib.load_model` which is not the intended way:
```py
import keras

# works !
model = keras.src.saving.saving_lib.load_model("hf://Wauplin/densenet_121_example")
```

The error comes from the fact that in `keras.saving.load_model` we don't check if the filepath is a `hf://` preset. This PR fixes this. 

---

### How to test

Run the first snippet above and it should load properly.