### PR TITLE
Solving issue #20221

### DIFF
--- a/keras/src/layers/normalization/unit_normalization.py
+++ b/keras/src/layers/normalization/unit_normalization.py
@@ -43,37 +43,6 @@ class UnitNormalization(Layer):
         return ops.normalize(inputs, axis=self.axis, order=2, epsilon=1e-12)
 
     def compute_output_shape(self, input_shape):
-        """
-        Compute the output shape of the layer.
-
-        Parameters
-        ----------
-        input_shape
-            Shape tuple (tuple of integers) or list of shape tuples
-            (one per output tensor of the layer). Shape tuples can
-            include None for free dimensions, instead of an integer.
-
-        Returns
-        -------
-        output_shape
-            Shape of the output of Unit Normalization Layer for
-            an input of given shape.
-
-        Raises
-        ------
-        ValueError
-            If an axis is out of bounds for the input shape.
-        TypeError
-            If the input shape is not a tuple or a list of tuples.
-        """
-        if isinstance(input_shape, (tuple, list)):
-            input_shape = input_shape
-        else:
-            raise TypeError(
-                "Invalid input shape type: expected tuple or list. "
-                f"Received: {type(input_shape)}"
-            )
-
         # Ensure axis is always treated as a list
         if isinstance(self.axis, int):
             axes = [self.axis]
@@ -83,12 +52,9 @@ class UnitNormalization(Layer):
         for axis in axes:
             if axis >= len(input_shape) or axis < -len(input_shape):
                 raise ValueError(
-                    f"Axis {axis} is out of bounds for "
-                    f"input shape {input_shape}. "
-                    "Ensure axis is within the range of input"
-                    " dimensions."
+                    f"Axis {self.axis} is out of bounds for "
+                    f"input shape {input_shape}."
                 )
-
         return input_shape
 
     def get_config(self):

--- a/keras/src/layers/normalization/unit_normalization.py
+++ b/keras/src/layers/normalization/unit_normalization.py
@@ -49,9 +49,9 @@ class UnitNormalization(Layer):
         Parameters
         ----------
         input_shape
-            Shape tuple (tuple of integers) or list of shape tuples (one per
-            output tensor of the layer). Shape tuples can include None for free
-            dimensions, instead of an integer.
+            Shape tuple (tuple of integers) or list of shape tuples
+            (one per output tensor of the layer). Shape tuples can
+            include None for free dimensions, instead of an integer.
 
         Returns
         -------
@@ -74,12 +74,19 @@ class UnitNormalization(Layer):
                 f"Received: {type(input_shape)}"
             )
 
-        for axis in self.axis:
+        # Ensure axis is always treated as a list
+        if isinstance(self.axis, int):
+            axes = [self.axis]
+        else:
+            axes = self.axis
+
+        for axis in axes:
             if axis >= len(input_shape) or axis < -len(input_shape):
                 raise ValueError(
                     f"Axis {axis} is out of bounds for "
-                    "input shape {input_shape}. "
-                    "Ensure axis is within the range of input dimensions."
+                    f"input shape {input_shape}. "
+                    "Ensure axis is within the range of input"
+                    " dimensions."
                 )
 
         return input_shape

--- a/keras/src/layers/normalization/unit_normalization.py
+++ b/keras/src/layers/normalization/unit_normalization.py
@@ -43,6 +43,45 @@ class UnitNormalization(Layer):
         return ops.normalize(inputs, axis=self.axis, order=2, epsilon=1e-12)
 
     def compute_output_shape(self, input_shape):
+        """
+        Compute the output shape of the layer.
+
+        Parameters
+        ----------
+        input_shape
+            Shape tuple (tuple of integers) or list of shape tuples (one per
+            output tensor of the layer). Shape tuples can include None for free
+            dimensions, instead of an integer.
+
+        Returns
+        -------
+        output_shape
+            Shape of the output of Unit Normalization Layer for
+            an input of given shape.
+
+        Raises
+        ------
+        ValueError
+            If an axis is out of bounds for the input shape.
+        TypeError
+            If the input shape is not a tuple or a list of tuples.
+        """
+        if isinstance(input_shape, (tuple, list)):
+            input_shape = input_shape
+        else:
+            raise TypeError(
+                "Invalid input shape type: expected tuple or list. "
+                f"Received: {type(input_shape)}"
+            )
+
+        for axis in self.axis:
+            if axis >= len(input_shape) or axis < -len(input_shape):
+                raise ValueError(
+                    f"Axis {axis} is out of bounds for "
+                    "input shape {input_shape}. "
+                    "Ensure axis is within the range of input dimensions."
+                )
+
         return input_shape
 
     def get_config(self):


### PR DESCRIPTION
Enhanced the compute_output_shape method by adding validation for input shape types and axis bounds. The method now ensures that input_shape is either a list or tuple, and that all axis values are within the valid range of input dimensions. This provides clearer error handling and prevents potential issues during shape computation.

Reason for the Change: Previously, the compute_output_shape method did not validate the input shape type or check if the specified axes were within bounds. This could lead to ambiguous or delayed errors during dynamic execution when invalid input shapes or out-of-bound axes were used, leading to confusion for the user. 
The updated validation improves robustness by catching these issues earlier in the process, providing more informative error messages to the user. 

Hence solving the issue #20221 