### PR TITLE
the dynamic has a result, but the static inference shape reports an error

### DIFF
--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -799,14 +799,11 @@ def average_pool(
     data_format = standardize_data_format(data_format)
     padding = padding.lower()
     if any_symbolic_tensors((inputs,)):
-        return AveragePool(
-            pool_size,
-            strides,
-            padding,
-            data_format,
-        ).symbolic_call(inputs)
-    return operation_utils.compute_pooling_output_shape(
-        inputs.shape, pool_size, strides, padding, data_format
+        return operation_utils.compute_pooling_output_shape(
+            inputs.shape, pool_size, strides, padding, data_format
+        )
+    return backend.nn.average_pool(
+        inputs, pool_size, strides, padding, data_format
     )
 
 

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -805,8 +805,8 @@ def average_pool(
             padding,
             data_format,
         ).symbolic_call(inputs)
-    return backend.nn.average_pool(
-        inputs, pool_size, strides, padding, data_format
+    return operation_utils.compute_pooling_output_shape(
+        inputs.shape, pool_size, strides, padding, data_format
     )
 
 

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -167,11 +167,11 @@ class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):
             input_shape = (None, 3, 8)
         x = KerasTensor(input_shape)
         self.assertEqual(
-            knn.average_pool(x, 2, 1).shape,
+            knn.average_pool(x, 2, 1),
             (None, 7, 3) if data_format == "channels_last" else (None, 3, 7),
         )
         self.assertEqual(
-            knn.average_pool(x, 2, 2, padding="same").shape,
+            knn.average_pool(x, 2, 2, padding="same"),
             (None, 4, 3) if data_format == "channels_last" else (None, 3, 4),
         )
 
@@ -181,7 +181,7 @@ class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):
             input_shape = (None, 3, 8, None)
         x = KerasTensor(input_shape)
         self.assertEqual(
-            knn.average_pool(x, 2, 1).shape,
+            knn.average_pool(x, 2, 1),
             (
                 (None, 7, None, 3)
                 if data_format == "channels_last"
@@ -189,7 +189,7 @@ class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):
             ),
         )
         self.assertEqual(
-            knn.average_pool(x, 2, 2, padding="same").shape,
+            knn.average_pool(x, 2, 2, padding="same"),
             (
                 (None, 4, None, 3)
                 if data_format == "channels_last"
@@ -197,7 +197,7 @@ class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):
             ),
         )
         self.assertEqual(
-            knn.average_pool(x, (2, 2), (2, 2), padding="same").shape,
+            knn.average_pool(x, (2, 2), (2, 2), padding="same"),
             (
                 (None, 4, None, 3)
                 if data_format == "channels_last"
@@ -780,11 +780,11 @@ class NNOpsStaticShapeTest(testing.TestCase):
             input_shape = (1, 3, 8)
         x = KerasTensor(input_shape)
         self.assertEqual(
-            knn.average_pool(x, 2, 1).shape,
+            knn.average_pool(x, 2, 1),
             (1, 7, 3) if data_format == "channels_last" else (1, 3, 7),
         )
         self.assertEqual(
-            knn.average_pool(x, 2, 2, padding="same").shape,
+            knn.average_pool(x, 2, 2, padding="same"),
             (1, 4, 3) if data_format == "channels_last" else (1, 3, 4),
         )
 
@@ -794,15 +794,15 @@ class NNOpsStaticShapeTest(testing.TestCase):
             input_shape = (1, 3, 8, 8)
         x = KerasTensor(input_shape)
         self.assertEqual(
-            knn.average_pool(x, 2, 1).shape,
+            knn.average_pool(x, 2, 1),
             (1, 7, 7, 3) if data_format == "channels_last" else (1, 3, 7, 7),
         )
         self.assertEqual(
-            knn.average_pool(x, 2, 2, padding="same").shape,
+            knn.average_pool(x, 2, 2, padding="same"),
             (1, 4, 4, 3) if data_format == "channels_last" else (1, 3, 4, 4),
         )
         self.assertEqual(
-            knn.average_pool(x, (2, 2), (2, 2), padding="same").shape,
+            knn.average_pool(x, (2, 2), (2, 2), padding="same"),
             (1, 4, 4, 3) if data_format == "channels_last" else (1, 3, 4, 4),
         )
 


### PR DESCRIPTION
static and dynamic input to AveragePooling2D should show same result and error. Fixes [#20218 ](https://github.com/keras-team/keras/issues/20218)