### PR TITLE
added validation checks in Group, Layer, Batch Normalization layers

### DIFF
--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -219,6 +219,49 @@ class BatchNormalization(Layer):
         self.built = True
 
     def compute_output_shape(self, input_shape):
+        """
+        Compute the output shape of the layer.
+        Parameters
+        ----------
+        input_shape
+            Shape tuple (tuple of integers) or list of shape tuples
+            (one per output tensor of the layer). Shape tuples can
+            include None for free dimensions, instead of an integer.
+        Returns
+        -------
+        output_shape
+            Shape of the output of Batch Normalization Layer for
+            an input of given shape.
+        Raises
+        ------
+        ValueError
+            If an axis is out of bounds for the input shape.
+        TypeError
+            If the input shape is not a tuple or a list of tuples.
+        """
+        if isinstance(input_shape, (tuple, list)):
+            input_shape = input_shape
+        else:
+            raise TypeError(
+                "Invalid input shape type: expected tuple or list. "
+                f"Received: {type(input_shape)}"
+            )
+
+        # Ensure axis is always treated as a list
+        if isinstance(self.axis, int):
+            axes = [self.axis]
+        else:
+            axes = self.axis
+
+        for axis in axes:
+            if axis >= len(input_shape) or axis < -len(input_shape):
+                raise ValueError(
+                    f"Axis {axis} is out of bounds for "
+                    f"input shape {input_shape}. "
+                    "Ensure axis is within the range of input"
+                    " dimensions."
+                )
+
         return input_shape
 
     def call(self, inputs, training=None, mask=None):

--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -219,35 +219,6 @@ class BatchNormalization(Layer):
         self.built = True
 
     def compute_output_shape(self, input_shape):
-        """
-        Compute the output shape of the layer.
-        Parameters
-        ----------
-        input_shape
-            Shape tuple (tuple of integers) or list of shape tuples
-            (one per output tensor of the layer). Shape tuples can
-            include None for free dimensions, instead of an integer.
-        Returns
-        -------
-        output_shape
-            Shape of the output of Batch Normalization Layer for
-            an input of given shape.
-        Raises
-        ------
-        ValueError
-            If an axis is out of bounds for the input shape.
-        TypeError
-            If the input shape is not a tuple or a list of tuples.
-        """
-        if isinstance(input_shape, (tuple, list)):
-            input_shape = input_shape
-        else:
-            raise TypeError(
-                "Invalid input shape type: expected tuple or list. "
-                f"Received: {type(input_shape)}"
-            )
-
-        # Ensure axis is always treated as a list
         if isinstance(self.axis, int):
             axes = [self.axis]
         else:
@@ -258,10 +229,8 @@ class BatchNormalization(Layer):
                 raise ValueError(
                     f"Axis {axis} is out of bounds for "
                     f"input shape {input_shape}. "
-                    "Ensure axis is within the range of input"
-                    " dimensions."
+                    f"Received: axis={self.axis}"
                 )
-
         return input_shape
 
     def call(self, inputs, training=None, mask=None):

--- a/keras/src/layers/normalization/group_normalization.py
+++ b/keras/src/layers/normalization/group_normalization.py
@@ -199,6 +199,49 @@ class GroupNormalization(Layer):
         return broadcast_shape
 
     def compute_output_shape(self, input_shape):
+        """
+        Compute the output shape of the layer.
+        Parameters
+        ----------
+        input_shape
+            Shape tuple (tuple of integers) or list of shape tuples
+            (one per output tensor of the layer). Shape tuples can
+            include None for free dimensions, instead of an integer.
+        Returns
+        -------
+        output_shape
+            Shape of the output of Group Normalization Layer for
+            an input of given shape.
+        Raises
+        ------
+        ValueError
+            If an axis is out of bounds for the input shape.
+        TypeError
+            If the input shape is not a tuple or a list of tuples.
+        """
+        if isinstance(input_shape, (tuple, list)):
+            input_shape = input_shape
+        else:
+            raise TypeError(
+                "Invalid input shape type: expected tuple or list. "
+                f"Received: {type(input_shape)}"
+            )
+
+        # Ensure axis is always treated as a list
+        if isinstance(self.axis, int):
+            axes = [self.axis]
+        else:
+            axes = self.axis
+
+        for axis in axes:
+            if axis >= len(input_shape) or axis < -len(input_shape):
+                raise ValueError(
+                    f"Axis {axis} is out of bounds for "
+                    f"input shape {input_shape}. "
+                    "Ensure axis is within the range of input"
+                    " dimensions."
+                )
+
         return input_shape
 
     def get_config(self):

--- a/keras/src/layers/normalization/group_normalization.py
+++ b/keras/src/layers/normalization/group_normalization.py
@@ -199,35 +199,6 @@ class GroupNormalization(Layer):
         return broadcast_shape
 
     def compute_output_shape(self, input_shape):
-        """
-        Compute the output shape of the layer.
-        Parameters
-        ----------
-        input_shape
-            Shape tuple (tuple of integers) or list of shape tuples
-            (one per output tensor of the layer). Shape tuples can
-            include None for free dimensions, instead of an integer.
-        Returns
-        -------
-        output_shape
-            Shape of the output of Group Normalization Layer for
-            an input of given shape.
-        Raises
-        ------
-        ValueError
-            If an axis is out of bounds for the input shape.
-        TypeError
-            If the input shape is not a tuple or a list of tuples.
-        """
-        if isinstance(input_shape, (tuple, list)):
-            input_shape = input_shape
-        else:
-            raise TypeError(
-                "Invalid input shape type: expected tuple or list. "
-                f"Received: {type(input_shape)}"
-            )
-
-        # Ensure axis is always treated as a list
         if isinstance(self.axis, int):
             axes = [self.axis]
         else:
@@ -238,10 +209,8 @@ class GroupNormalization(Layer):
                 raise ValueError(
                     f"Axis {axis} is out of bounds for "
                     f"input shape {input_shape}. "
-                    "Ensure axis is within the range of input"
-                    " dimensions."
+                    f"Received: axis={self.axis}"
                 )
-
         return input_shape
 
     def get_config(self):

--- a/keras/src/layers/normalization/layer_normalization.py
+++ b/keras/src/layers/normalization/layer_normalization.py
@@ -117,7 +117,7 @@ class LayerNormalization(Layer):
         gamma_regularizer=None,
         beta_constraint=None,
         gamma_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(**kwargs)
         if isinstance(axis, (list, tuple)):
@@ -235,6 +235,49 @@ class LayerNormalization(Layer):
         return ops.cast(outputs, input_dtype)
 
     def compute_output_shape(self, input_shape):
+        """
+        Compute the output shape of the layer.
+        Parameters
+        ----------
+        input_shape
+            Shape tuple (tuple of integers) or list of shape tuples
+            (one per output tensor of the layer). Shape tuples can
+            include None for free dimensions, instead of an integer.
+        Returns
+        -------
+        output_shape
+            Shape of the output of Layer Normalization Layer for
+            an input of given shape.
+        Raises
+        ------
+        ValueError
+            If an axis is out of bounds for the input shape.
+        TypeError
+            If the input shape is not a tuple or a list of tuples.
+        """
+        if isinstance(input_shape, (tuple, list)):
+            input_shape = input_shape
+        else:
+            raise TypeError(
+                "Invalid input shape type: expected tuple or list. "
+                f"Received: {type(input_shape)}"
+            )
+
+        # Ensure axis is always treated as a list
+        if isinstance(self.axis, int):
+            axes = [self.axis]
+        else:
+            axes = self.axis
+
+        for axis in axes:
+            if axis >= len(input_shape) or axis < -len(input_shape):
+                raise ValueError(
+                    f"Axis {axis} is out of bounds for "
+                    f"input shape {input_shape}. "
+                    "Ensure axis is within the range of input"
+                    " dimensions."
+                )
+
         return input_shape
 
     def get_config(self):

--- a/keras/src/layers/normalization/layer_normalization.py
+++ b/keras/src/layers/normalization/layer_normalization.py
@@ -235,35 +235,6 @@ class LayerNormalization(Layer):
         return ops.cast(outputs, input_dtype)
 
     def compute_output_shape(self, input_shape):
-        """
-        Compute the output shape of the layer.
-        Parameters
-        ----------
-        input_shape
-            Shape tuple (tuple of integers) or list of shape tuples
-            (one per output tensor of the layer). Shape tuples can
-            include None for free dimensions, instead of an integer.
-        Returns
-        -------
-        output_shape
-            Shape of the output of Layer Normalization Layer for
-            an input of given shape.
-        Raises
-        ------
-        ValueError
-            If an axis is out of bounds for the input shape.
-        TypeError
-            If the input shape is not a tuple or a list of tuples.
-        """
-        if isinstance(input_shape, (tuple, list)):
-            input_shape = input_shape
-        else:
-            raise TypeError(
-                "Invalid input shape type: expected tuple or list. "
-                f"Received: {type(input_shape)}"
-            )
-
-        # Ensure axis is always treated as a list
         if isinstance(self.axis, int):
             axes = [self.axis]
         else:
@@ -274,10 +245,8 @@ class LayerNormalization(Layer):
                 raise ValueError(
                     f"Axis {axis} is out of bounds for "
                     f"input shape {input_shape}. "
-                    "Ensure axis is within the range of input"
-                    " dimensions."
+                    f"Received: axis={self.axis}"
                 )
-
         return input_shape
 
     def get_config(self):


### PR DESCRIPTION
Added validation checks in Group, Layer, Batch Normalization layers for the compute_output_shape function to ensure that no issues like #20221 arises again.