### PR TITLE
Fix numeric instability in `LayerNormalization`

### DIFF
--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -4,7 +4,6 @@ from keras.src import initializers
 from keras.src import ops
 from keras.src import regularizers
 from keras.src.api_export import keras_export
-from keras.src.backend import standardize_dtype
 from keras.src.layers.input_spec import InputSpec
 from keras.src.layers.layer import Layer
 
@@ -244,11 +243,10 @@ class BatchNormalization(Layer):
                     f"mask.shape={mask.shape}, inputs.shape={inputs.shape}"
                 )
 
-        input_dtype = standardize_dtype(inputs.dtype)
-        if input_dtype in ("float16", "bfloat16"):
-            # BN is prone to overflowing for float16/bfloat16 inputs, so we opt
-            # out BN for mixed precision.
-            inputs = ops.cast(inputs, "float32")
+        compute_dtype = backend.result_type(inputs.dtype, "float32")
+        # BN is prone to overflow with float16/bfloat16 inputs, so we upcast to
+        # float32 for the subsequent computations.
+        inputs = ops.cast(inputs, compute_dtype)
 
         moving_mean = ops.cast(self.moving_mean, inputs.dtype)
         moving_variance = ops.cast(self.moving_variance, inputs.dtype)
@@ -286,9 +284,7 @@ class BatchNormalization(Layer):
             scale=gamma,
             epsilon=self.epsilon,
         )
-        if input_dtype in ("float16", "bfloat16"):
-            outputs = ops.cast(outputs, input_dtype)
-        return outputs
+        return ops.cast(outputs, self.compute_dtype)
 
     def get_config(self):
         base_config = super().get_config()


### PR DESCRIPTION
When implementing SD3, I found that `LayerNormalization` is numeric unstable when dtype is set to `float16`.
This PR upcasts float16/bfloat16 to float32 for the computation.

I used `backend.result_type(..., "float32")` to handle higher precision dtypes, such as float64.