### PR TITLE
Provide a setter for `layers` in `Sequential` and `Functional`.

### DIFF
--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -162,6 +162,13 @@ class Functional(Function, Model):
                 layers.append(operation)
         return layers
 
+    @layers.setter
+    def layers(self, _):
+        raise AttributeError(
+            "`Model.layers` attribute is reserved and should not be used. "
+            "Please use another name."
+        )
+
     def call(self, inputs, training=None, mask=None):
         # Add support for training, masking
         inputs = self._standardize_inputs(inputs)

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -530,3 +530,12 @@ class FunctionalTest(testing.TestCase):
     def test_add_loss(self):
         # TODO
         pass
+
+    def test_layers_setter(self):
+        inputs = Input(shape=(3,), batch_size=2, name="input")
+        outputs = layers.Dense(5)(inputs)
+        model = Functional(inputs, outputs)
+        with self.assertRaisesRegex(
+            AttributeError, "`Model.layers` attribute is reserved"
+        ):
+            model.layers = [layers.Dense(4)]

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -876,3 +876,10 @@ class ModelTest(testing.TestCase):
             "The following variable path is found twice in the model",
         ):
             model.get_state_tree()
+
+    def test_layers_setter(self):
+        model = Model()
+        with self.assertRaisesRegex(
+            AttributeError, "`Model.layers` attribute is reserved"
+        ):
+            model.layers = [layers.Dense(4)]

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -240,6 +240,13 @@ class Sequential(Model):
             return layers[1:]
         return layers[:]
 
+    @layers.setter
+    def layers(self, _):
+        raise AttributeError(
+            "`Sequential.layers` attribute is reserved and should not be used. "
+            "Use `add()` and `pop()` to change the layers in this model."
+        )
+
     def compute_output_spec(self, inputs, training=None, mask=None):
         if self._functional:
             return self._functional.compute_output_spec(

--- a/keras/src/models/sequential_test.py
+++ b/keras/src/models/sequential_test.py
@@ -378,3 +378,10 @@ class SequentialTest(testing.TestCase):
         self.assertTrue(hasattr(model, "output_shape"))
         self.assertTrue(hasattr(model, "inputs"))
         self.assertTrue(hasattr(model, "outputs"))
+
+    def test_layers_setter(self):
+        model = Sequential()
+        with self.assertRaisesRegex(
+            AttributeError, "Use `add\(\)` and `pop\(\)`"
+        ):
+            model.layers = [layers.Dense(4)]


### PR DESCRIPTION
The `Model` class has a setter for `layers` to provide a more descriptive message on why this property cannot be changed. But it only applies to sub-class models as classes that override `layers` don't inherit it.

This adds a similar message for functional and sequential models.