### PR TITLE
Add `ops.nn.dot_product_attention`

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -67,6 +67,7 @@ from keras.src.ops.nn import conv_transpose
 from keras.src.ops.nn import ctc_decode
 from keras.src.ops.nn import ctc_loss
 from keras.src.ops.nn import depthwise_conv
+from keras.src.ops.nn import dot_product_attention
 from keras.src.ops.nn import elu
 from keras.src.ops.nn import gelu
 from keras.src.ops.nn import hard_sigmoid

--- a/keras/api/_tf_keras/keras/ops/nn/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/nn/__init__.py
@@ -13,6 +13,7 @@ from keras.src.ops.nn import conv_transpose
 from keras.src.ops.nn import ctc_decode
 from keras.src.ops.nn import ctc_loss
 from keras.src.ops.nn import depthwise_conv
+from keras.src.ops.nn import dot_product_attention
 from keras.src.ops.nn import elu
 from keras.src.ops.nn import gelu
 from keras.src.ops.nn import hard_sigmoid

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -67,6 +67,7 @@ from keras.src.ops.nn import conv_transpose
 from keras.src.ops.nn import ctc_decode
 from keras.src.ops.nn import ctc_loss
 from keras.src.ops.nn import depthwise_conv
+from keras.src.ops.nn import dot_product_attention
 from keras.src.ops.nn import elu
 from keras.src.ops.nn import gelu
 from keras.src.ops.nn import hard_sigmoid

--- a/keras/api/ops/nn/__init__.py
+++ b/keras/api/ops/nn/__init__.py
@@ -13,6 +13,7 @@ from keras.src.ops.nn import conv_transpose
 from keras.src.ops.nn import ctc_decode
 from keras.src.ops.nn import ctc_loss
 from keras.src.ops.nn import depthwise_conv
+from keras.src.ops.nn import dot_product_attention
 from keras.src.ops.nn import elu
 from keras.src.ops.nn import gelu
 from keras.src.ops.nn import hard_sigmoid

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -942,3 +942,102 @@ def psnr(x1, x2, max_val):
     mse = jnp.mean(jnp.square(x1 - x2))
     psnr = 20 * jnp.log10(max_val) - 10 * jnp.log10(mse)
     return psnr
+
+
+def _apply_masks(logits, mask, is_causal):
+    if mask is None and not is_causal:
+        return logits
+
+    combined_mask = jnp.ones_like(logits, dtype="bool")
+    if mask is not None:
+        combined_mask = jnp.logical_and(combined_mask, mask)
+
+    if is_causal:
+        T, S = logits.shape[2], logits.shape[3]
+        mask = jnp.tril(jnp.ones((T, S), dtype="bool"))
+        mask = mask[None, None, :, :]
+        combined_mask = jnp.logical_and(combined_mask, mask)
+
+    large_negative_number = jnp.asarray(
+        -0.7 * jnp.finfo(logits.dtype).max, dtype=logits.dtype
+    )
+    padded_logits = jnp.where(combined_mask, logits, large_negative_number)
+    return padded_logits
+
+
+def _dot_product_attention_core(
+    query, key, value, bias, mask, is_causal, scale
+):
+    logits_dtype = jnp.promote_types(query.dtype, jnp.float32)
+    logits = jnp.einsum(
+        "BTNH,BSNH->BNTS", query, key, preferred_element_type=logits_dtype
+    )
+    logits *= jnp.array(scale, dtype=logits.dtype)
+
+    if bias is not None:
+        logits = (logits + bias).astype(logits.dtype)
+
+    padded_logits = _apply_masks(logits, mask, is_causal)
+
+    # Softmax and it is always carried out in fp32.
+    padded_logits = padded_logits.astype(jnp.float32)
+    probs = jax.nn.softmax(padded_logits, axis=-1).astype(key.dtype)
+    return jnp.einsum("BNTS,BSNH->BTNH", probs, value)
+
+
+def dot_product_attention(
+    query, key, value, bias=None, mask=None, scale=None, is_causal=False
+):
+    query = convert_to_tensor(query)
+    key = convert_to_tensor(key)
+    value = convert_to_tensor(value)
+    if len(query.shape) != 4:
+        raise ValueError(
+            "`dot_product_attention` only supports 4D inputs. "
+            f"Received: query.shape={query.shape}, key.shape={key.shape}, "
+            f"value.shape={value.shape}."
+        )
+
+    # `dot_product_attention` is only available in jax>=0.4.31
+    if hasattr(jax.nn, "dot_product_attention"):
+        return jax.nn.dot_product_attention(
+            query,
+            key,
+            value,
+            bias=bias,
+            mask=mask,
+            scale=scale,
+            is_causal=is_causal,
+        )
+
+    # Ref: jax.nn.dot_product_attention
+    # https://github.com/jax-ml/jax/blob/jax-v0.4.33/jax/_src/nn/functions.py#L886
+    # Not support `query_seq_lengths` and `key_value_seq_lengths` args
+    output_shape = query.shape
+    _, _, K, H = key.shape
+    scale = (1.0 / jnp.sqrt(H)) if scale is None else scale
+
+    # _dot_product_attention_xla
+    B, T, N, H = query.shape
+    G = N // K
+    query = jnp.reshape(query, (B, T, K, G, H))
+
+    def _reshape_to_grouped(t):
+        if t is not None:
+            tB, tN, tT, tS = t.shape
+            if tN == 1:
+                t = jnp.broadcast_to(t[:, :, None, :, :], (tB, tN, G, tT, tS))
+            else:
+                assert tN == N
+                t = jnp.reshape(t, (tB, K, G, tT, tS))
+        return t
+
+    bias = _reshape_to_grouped(bias)
+    mask = _reshape_to_grouped(mask)
+    vmapped_fn = jax.vmap(
+        _dot_product_attention_core,
+        in_axes=(3, None, None, 2, 2, None, None),
+        out_axes=3,
+    )
+    encoded = vmapped_fn(query, key, value, bias, mask, is_causal, scale)
+    return jnp.reshape(encoded, output_shape)

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -2124,3 +2124,96 @@ def psnr(
         x2,
         max_val,
     )
+
+
+class DotProductAttention(Operation):
+    def __init__(self, is_causal=False):
+        super().__init__()
+        self.is_causal = is_causal
+
+    def call(self, query, key, value, bias=None, mask=None, scale=None):
+        return backend.nn.dot_product_attention(
+            query,
+            key,
+            value,
+            bias=bias,
+            mask=mask,
+            scale=scale,
+            is_causal=self.is_causal,
+        )
+
+    def compute_output_spec(
+        self, query, key, value, bias=None, mask=None, scale=None
+    ):
+        return KerasTensor(query.shape, dtype=query.dtype)
+
+
+@keras_export(
+    ["keras.ops.dot_product_attention", "keras.ops.nn.dot_product_attention"]
+)
+def dot_product_attention(
+    query, key, value, bias=None, mask=None, scale=None, is_causal=False
+):
+    """Scaled dot product attention function.
+
+    Computes the attention function on Q (`query`), K (`key`), and V(`value`):
+    `attention(Q, K, V) = softmax(Q * K / sqrt(d)) * V`. If we define `logits`
+    as the output of `Q * K` and the `probs` as the output of `softmax`.
+
+    Throughout this function, we utilize the following notation to represent the
+    shape of array:
+    - B: batch size
+    - S: length of the key/value
+    - T: length of the query
+    - N: number of attention heads
+    - H: dimensions of each attention head
+    - K: number of key/value heads
+    - G: number of groups, which equals to `N // K`
+
+    Args:
+        query: The query array with the shape of `(B, T, N, H)`.
+        key: The key array with the shape of `(B, S, K, H)`. When `K` equals
+            `N`, multi-headed attention (MHA) is performed. Otherwise, grouped
+            query attention (GQA) is performed if `N` is a multiple of `K`. and
+            multi-query attention (MQA) is performed if `K==1` (a special case
+            of GQA).
+        value: The value array with the same shape of `key`.
+        bias: Optional bias array to be added to logits. The shape must be
+            broadcastable to `(B, N, T, S)`.
+        mask: Optional mask array used to filter out logits. It is a boolean
+            mask where `True` indicates the element should take part in
+            attention. For an additive mask, users should pass it to bias. The
+            shape must be broadcastable to `(B, N, T, S)`.
+        scale: Optional scale for the logits. If `None`, the scale will be set
+            to `1.0 / sqrt(H)`.
+        is_causal: Whether to apply causal mask.
+
+    Returns:
+        An array of the attention output with the same shape of `query`.
+
+    Example:
+
+    >>> query = keras.random.normal((2, 4, 8, 16))
+    >>> key = keras.random.normal((2, 6, 8, 16))
+    >>> value = keras.random.normal((2, 6, 8, 16))
+    >>> keras.ops.nn.dot_product_attention(query, key, value).shape
+    (2, 4, 8, 16)
+    """
+    if any_symbolic_tensors((query, key, value)):
+        return DotProductAttention(is_causal=is_causal).symbolic_call(
+            query,
+            key,
+            value,
+            bias=bias,
+            mask=mask,
+            scale=scale,
+        )
+    return backend.nn.dot_product_attention(
+        query,
+        key,
+        value,
+        bias=bias,
+        mask=mask,
+        scale=scale,
+        is_causal=is_causal,
+    )


### PR DESCRIPTION
I haven't check the performance yet, but I believe adding this operation will be beneficial since both torch and jax have optimized it in their codebases.

From a performance perspective, we should be able to replace `_compute_attention` in `MultiHeadAttention` with this op if the input shapes are strictly 4D.

EDITED:
It seems that CI is using `jax<=0.4.30` due to python version limitation. I implemented a pure numpy version of `dot_product_attention` for the unit tests.

For backends:
- jax: Uses `jax.nn.dot_product_attention` if available. Otherwise, adapts the impl from `jax==0.4.33`.
- numpy: Adapts the impl from `jax==0.4.31` (no customizable `vmap`)
- tensorflow: Adapts the impl from `jax==0.4.31` (no customizable `vmap`)
- torch: Uses `torch.nn.functional.scaled_dot_product_attention`