### PR TITLE
Add weight visualization for file_editor

### DIFF
--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -4,7 +4,6 @@ import pprint
 import zipfile
 
 import h5py
-import IPython.display
 import numpy as np
 import rich.console
 
@@ -735,7 +734,7 @@ class KerasFileEditor:
 
         _initialize_id_counter()
         output += _generate_html_weights(self.weights_dict)
-        IPython.display.display(IPython.display.HTML(output))
+        ipython.display.display(ipython.display.HTML(output))
 
 
 def get_weight_spec_of_saveable(saveable, spec, visited_saveables=None):


### PR DESCRIPTION
I implemented weight visualization for the saved file format using HTML and CSS. By default, all weights are displayed along the last axis, as I intended to represent the features. However, when the feature size is large, processing can take considerable time. To address this, I added a threshold for the display size of each grid.

here is my [gist](https://colab.research.google.com/drive/1BKPakUsJdimeF5uZSpQCXqrL3tRuC_QW?usp=sharing#scrollTo=nLKUSHZ-Gb2J)