### PR TITLE
Fix `CompileLoss` with undefined `loss` argument

### DIFF
--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -389,6 +389,49 @@ class ModelTest(testing.TestCase):
         )
         self.assertListEqual(hist_keys, ref_keys)
 
+    def test_functional_dict_outputs_dict_losses_with_undefined_loss(self):
+        model = _get_model_multi_outputs_dict()
+        self.assertIsInstance(model, Functional)
+        x = np.random.rand(8, 3)
+        y1 = np.random.rand(8, 1)
+        y2 = np.random.randint(0, 2, (8, 1))
+        model.compile(
+            optimizer="sgd",
+            loss={
+                "output_b": ["binary_crossentropy"],
+            },
+            metrics={
+                "output_b": ["mean_squared_error", "accuracy"],
+            },
+            weighted_metrics={
+                "output_b": ["mean_squared_error", "accuracy"],
+            },
+        )
+        # Check dict outputs.
+        outputs = model.predict(x)
+        self.assertIsInstance(outputs, dict)
+        self.assertEqual(outputs["output_a"].shape, (8, 1))
+        self.assertEqual(outputs["output_b"].shape, (8, 1))
+        # Fit the model to make sure compile_metrics are built
+        hist = model.fit(
+            x,
+            {"output_a": y1, "output_b": y2},
+            batch_size=2,
+            epochs=1,
+            verbose=0,
+        )
+        hist_keys = sorted(hist.history.keys())
+        ref_keys = sorted(
+            [
+                "loss",
+                "output_b_accuracy",
+                "output_b_mean_squared_error",
+                "output_b_weighted_accuracy",
+                "output_b_weighted_mean_squared_error",
+            ]
+        )
+        self.assertListEqual(hist_keys, ref_keys)
+
     def test_functional_list_outputs_dict_losses_metrics(self):
         model = _get_model_multi_outputs_list()
         self.assertIsInstance(model, Functional)

--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -591,14 +591,21 @@ class CompileLoss(losses_module.Loss):
         filtered_y_pred_keys,
         output_names,
     ):
-        if len(filtered_y_true_keys) > 0:
-            if isinstance(y_true, dict):
-                for k in filtered_y_true_keys:
-                    y_true.pop(k)
+        if len(filtered_y_true_keys) > 0 and isinstance(y_true, dict):
+            # Modifying data in-place can cause errors in TF's graph.
+            filtered_y_true = {}
+            for k, v in y_true.items():
+                if k not in filtered_y_true_keys:
+                    filtered_y_true[k] = v
+            y_true = filtered_y_true
         if len(filtered_y_pred_keys) > 0:
             if isinstance(y_pred, dict):
-                for k in filtered_y_pred_keys:
-                    y_pred.pop(k)
+                # Modifying data in-place can cause errors in TF's graph.
+                filtered_y_pred = {}
+                for k, v in y_pred.items():
+                    if k not in filtered_y_pred_keys:
+                        filtered_y_pred[k] = v
+                y_pred = filtered_y_pred
             elif output_names is not None:
                 y_pred = []
                 for x, output_name in zip(tree.flatten(y_pred), output_names):


### PR DESCRIPTION
Fix #20243 

Actually, #20243 works as expected in torch and jax backends without this PR. The underlying issue in TF backend has been resolved.

The root cause was that we used `pop` in `_filter_unused_inputs` within `CompileLoss`, which is not allowed in a jitted tf graph. The solution is to avoid modifying the incoming data.

A test has been added to verify the implementation.