### PR TITLE
Fix rendering issue

### DIFF
--- a/keras/src/layers/attention/additive_attention.py
+++ b/keras/src/layers/attention/additive_attention.py
@@ -28,7 +28,7 @@ class AdditiveAttention(Attention):
         dropout: Float between 0 and 1. Fraction of the units to drop for the
             attention scores. Defaults to `0.0`.
 
-    Call Args:
+    Call arguments:
         inputs: List of the following tensors:
             - `query`: Query tensor of shape `(batch_size, Tq, dim)`.
             - `value`: Value tensor of shape `(batch_size, Tv, dim)`.

--- a/keras/src/layers/attention/attention.py
+++ b/keras/src/layers/attention/attention.py
@@ -33,7 +33,7 @@ class Attention(Layer):
             query and key vectors. `"concat"` refers to the hyperbolic tangent
             of the concatenation of the `query` and `key` vectors.
 
-    Call Args:
+    Call arguments:
         inputs: List of the following tensors:
             - `query`: Query tensor of shape `(batch_size, Tq, dim)`.
             - `value`: Value tensor of shape `(batch_size, Tv, dim)`.


### PR DESCRIPTION
Fix rendering issue in keras.io by making change from "Call Args:" to "Call arguments:" which is allowed docstring to render.
Fixes: https://github.com/keras-team/keras/issues/20297