### PR TITLE
Allow `keras.Variable` for loss weights

### DIFF
--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -1,3 +1,4 @@
+from keras.src import backend
 from keras.src import losses as losses_module
 from keras.src import metrics as metrics_module
 from keras.src import ops
@@ -413,8 +414,8 @@ class CompileLoss(losses_module.Loss):
         reduction="sum_over_batch_size",
         output_names=None,
     ):
-        if loss_weights and not isinstance(
-            loss_weights, (list, tuple, dict, float)
+        if loss_weights is not None and not isinstance(
+            loss_weights, (list, tuple, dict, float, backend.Variable)
         ):
             raise ValueError(
                 "Expected `loss_weights` argument to be a float "
@@ -517,12 +518,14 @@ class CompileLoss(losses_module.Loss):
         else:
             flat_loss_weights = tree.flatten(loss_weights)
             for loss_weight in flat_loss_weights:
-                if not isinstance(loss_weight, (int, float, type(None))):
+                if not isinstance(
+                    loss_weight, (int, float, type(None), backend.Variable)
+                ):
                     raise TypeError(
                         "When providing the `loss_weights` argument, each "
                         "element should be a Python int, float (the weighting "
                         "coefficient corresponding to the loss for that "
-                        "output) or `None`."
+                        "output), `None` or `Variable`."
                         f"Received: loss_weights={loss_weights}"
                     )
             if len(flat_loss_weights) != len(flat_losses):

--- a/keras/src/trainers/compile_utils_test.py
+++ b/keras/src/trainers/compile_utils_test.py
@@ -347,3 +347,20 @@ class TestCompileLoss(testing.TestCase):
         }
         value = compile_loss(y_true, y_pred)
         self.assertAllClose(value, 1.07666, atol=1e-5)
+
+    def test_variable_as_loss_weights(self):
+        loss_weights = backend.Variable(initializer="zeros", shape=())
+        compile_loss = CompileLoss(loss="mse", loss_weights=loss_weights)
+        y_true = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])
+        y_pred = np.array([[0.4, 0.1], [0.2, 0.6], [0.6, 0.1]])
+        compile_loss.build(y_true, y_pred)
+        # `loss_weights` is set to `0.0`.
+        value = compile_loss(y_true, y_pred)
+        self.assertAllClose(value, 0.0, atol=1e-5)
+        # Test changing the `loss_weights` value
+        loss_weights.assign(1.0)
+        value = compile_loss(y_true, y_pred)
+        self.assertAllClose(value, 0.068333, atol=1e-5)
+        loss_weights.assign(1.5)
+        value = compile_loss(y_true, y_pred)
+        self.assertAllClose(value, 0.068333 * 1.5, atol=1e-5)


### PR DESCRIPTION
Fix #20294 

With this PR, we can use `keras.Variable` for loss weights:

```python
import numpy as np

import keras
from keras import layers
from keras import models

x = np.random.rand(8, 3)
y1 = np.random.rand(8, 1)
y2 = np.random.randint(0, 2, (8, 1))

inputs = layers.Input(shape=(3,), name="input_a")
output_a = layers.Dense(1, name="output_a")(inputs)
output_b = layers.Dense(1, name="output_b", activation="sigmoid")(inputs)
model = models.Model(inputs, [output_a, output_b])

loss_weights = [
    keras.Variable(initializer="ones", shape=()),
    keras.Variable(initializer="ones", shape=()),
]
model.compile(
    optimizer="sgd",
    loss=["mean_squared_error", "binary_crossentropy"],
    loss_weights=loss_weights,
)

loss_weights[0].assign(0.00001)
loss_weights[1].assign(1.0)
model.fit(x, (y1, y2), batch_size=2, epochs=1)

# Change the values
loss_weights[0].assign(1.0)
loss_weights[1].assign(0.00001)
model.fit(x, (y1, y2), batch_size=2, epochs=1)


```

```bash
4/4 ━━━━━━━━━━━━━━━━━━━━ 0s 2ms/step - loss: 0.7180 - output_a_loss: 6.9707e-06 - output_b_loss: 0.7180  
4/4 ━━━━━━━━━━━━━━━━━━━━ 0s 1ms/step - loss: 0.6000 - output_a_loss: 0.5999 - output_b_loss: 6.9904e-06
```
We can see that the individual losses correspond to the loss weights.