### PR TITLE
Disable XLA with TensorFlow determinisim

### DIFF
--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -1122,10 +1122,14 @@ def model_supports_jit(model):
                 return False
     # XLA not supported by some layers
     if all(x.supports_jit for x in model._flatten_layers()):
-        from tensorflow.python.framework.config import is_op_determinism_enabled
-        if is_op_determinism_enabled():
-            # disable XLA with determinism enabled since not all ops are
-            # supported by XLA with determinism enabled.
-            return False
+        if backend.backend() == "tensorflow":
+            from tensorflow.python.framework.config import (
+                is_op_determinism_enabled,
+            )
+
+            if is_op_determinism_enabled():
+                # disable XLA with determinism enabled since not all ops are
+                # supported by XLA with determinism enabled.
+                return False
         return True
     return False

--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -224,6 +224,7 @@ class Trainer:
 
         if backend.backend() == "tensorflow":
             import tensorflow as tf
+            from tensorflow.python.framework.config import is_op_determinism_enabled
 
             devices = tf.config.list_physical_devices()
             if not list(filter(lambda x: x.device_type != "CPU", devices)):
@@ -232,6 +233,11 @@ class Trainer:
 
             if self._distribute_strategy:
                 # Disable XLA with tf.distribute
+                return False
+
+            if is_op_determinism_enabled():
+                # disable XLA with determinism enabled since not all ops are
+                # supported by XLA with determinism enabled.
                 return False
 
         if model_supports_jit(self):

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -1724,7 +1724,8 @@ class TestTrainer(testing.TestCase):
     )
 
     def test_jit_compile_with_tf_determinism(self):
-        from tensorflow.config.experimental import enable_op_determinism
+        from tensorflow.python.framework.config import disable_op_determinism
+        from tensorflow.python.framework.config import enable_op_determinism
 
         enable_op_determinism()
 
@@ -1734,7 +1735,9 @@ class TestTrainer(testing.TestCase):
             loss=losses.MeanSquaredError(),
             metrics=[metrics.MeanSquaredError()],
         )
+
         self.assertFalse(model.jit_compile)
+        disable_op_determinism()
 
 
 class TrainerDistributeTest(testing.TestCase):

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -1722,7 +1722,7 @@ class TestTrainer(testing.TestCase):
         backend.backend() != "tensorflow",
         reason="This test is only applicable to TensorFlow.",
     )
-
+    @pytest.mark.requires_trainable_backend
     def test_jit_compile_with_tf_determinism(self):
         from tensorflow.python.framework.config import disable_op_determinism
         from tensorflow.python.framework.config import enable_op_determinism

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -1718,11 +1718,10 @@ class TestTrainer(testing.TestCase):
         for v in model._compile_loss.variables:
             self.assertAllClose(v, 0.0)
 
-    pytest.mark.skipif(
+    @pytest.mark.skipif(
         backend.backend() != "tensorflow",
         reason="This test is only applicable to TensorFlow.",
     )
-
     @pytest.mark.requires_trainable_backend
     def test_jit_compile_with_tf_determinism(self):
         from tensorflow.python.framework.config import disable_op_determinism

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -1722,6 +1722,7 @@ class TestTrainer(testing.TestCase):
         backend.backend() != "tensorflow",
         reason="This test is only applicable to TensorFlow.",
     )
+
     @pytest.mark.requires_trainable_backend
     def test_jit_compile_with_tf_determinism(self):
         from tensorflow.python.framework.config import disable_op_determinism

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -1722,8 +1722,10 @@ class TestTrainer(testing.TestCase):
         backend.backend() != "tensorflow",
         reason="This test is only applicable to TensorFlow.",
     )
+
     def test_jit_compile_with_tf_determinism(self):
         from tensorflow.config.experimental import enable_op_determinism
+
         enable_op_determinism()
 
         model = ExampleModel(units=3)

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -283,13 +283,12 @@ class TestTrainer(testing.TestCase):
 
     @parameterized.named_parameters(
         [
-            ("determinism_enabled", False, False, False, True),
-            ("eager", True, False, False, False),
-            ("graph_fn", False, False, False, False),
-            ("jit", False, True, False, True),
-            ("steps_per_epoch_eager", True, False, True, True),
-            ("steps_per_epoch_graph_fn", False, False, True, True),
-            ("steps_per_epoch_jit", False, True, True, True),
+            ("eager", True, False, False),
+            ("graph_fn", False, False, False),
+            ("jit", False, True, False),
+            ("steps_per_epoch_eager", True, False, True),
+            ("steps_per_epoch_graph_fn", False, False, True),
+            ("steps_per_epoch_jit", False, True, True),
         ]
     )
     @pytest.mark.requires_trainable_backend


### PR DESCRIPTION
Currently if someone runs https://keras.io/examples/keras_recipes/reproducibility_recipes/, gets an error:

(PR for fixing recipe https://github.com/keras-team/keras-io/pull/1941)

```python
UnimplementedError: Graph execution error:

Detected at node gradient_tape/sequential_1/max_pooling2d_1_2/MaxPool2d/MaxPoolGrad defined at (most recent call last):
<stack traces unavailable>
GPU MaxPool gradient ops do not yet have a deterministic XLA implementation.
	 [[{{node gradient_tape/sequential_1/max_pooling2d_1_2/MaxPool2d/MaxPoolGrad}}]]
	tf2xla conversion failed while converting __inference_one_step_on_data_2978[]. Run with TF_DUMP_GRAPH_PREFIX=/path/to/dump/dir and --vmodule=xla_compiler=2 to obtain a dump of the compiled functions.
	 [[StatefulPartitionedCall]] [Op:__inference_one_step_on_iterator_3061]
```

Considering Keras 2, which had `jit_compile = None` (not enabled by default) it's better not to use XLA when TF determinism is enabled?

(I can check the failed tests if the team is willing to merge this PR)