### PR TITLE
Pass config to constructor when reviving custom functional model

### DIFF
--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -132,7 +132,7 @@ class Functional(Function, Model):
         if not all(is_input_keras_tensor(t) for t in flat_inputs):
             inputs, outputs = clone_graph_nodes(inputs, outputs)
 
-        Function.__init__(self, inputs, outputs, name=name, **kwargs)
+        Function.__init__(self, inputs, outputs, name=name)
 
         if trainable is not None:
             self.trainable = trainable

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -169,6 +169,24 @@ class ModelTest(testing.TestCase):
         )
         self.assertIsInstance(new_model, Functional)
 
+    def test_reviving_functional_from_config_custom_model(self):
+        class CustomModel(Model):
+            def __init__(self, *args, param=1, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.param = param
+
+            def get_config(self):
+                base_config = super().get_config()
+                config = {"param": self.param}
+                return base_config | config
+
+        inputs = layers.Input((3,))
+        outputs = layers.Dense(5)(inputs)
+        model = CustomModel(inputs=inputs, outputs=outputs, param=3)
+
+        new_model = CustomModel.from_config(model.get_config())
+        self.assertEqual(new_model.param, 3)
+
     @parameterized.named_parameters(
         ("single_output_1", _get_model_single_output),
         ("single_output_2", _get_model_single_output),


### PR DESCRIPTION
Currently, when loading a model instantiated from a custom `Model` subclass its config is not passed to it's constructor. This leads to some parameters not being restored.

Here is a snippet showing the behavior mentioned:
```py
class CustomModel(Model):
    def __init__(self, *args, param=1, **kwargs):
        super().__init__(*args, **kwargs)
        self.param = param

    def get_config(self):
        base_config = super().get_config()
        config = {"param": self.param}
        return base_config | config

inputs = layers.Input((3,))
outputs = layers.Dense(5)(inputs)
model = CustomModel(inputs=inputs, outputs=outputs, param=3)

new_model = CustomModel.from_config(model.get_config())
print(new_model.param) # prints 1 currently i.e. default value of param
```

This PR proposes to fix this issue by passing config in `functional_from_config` to the model constructor.