### PR TITLE
Directly export `keras.backend.Variable` as `keras.Variable`

### DIFF
--- a/keras/api/__init__.py
+++ b/keras/api/__init__.py
@@ -31,10 +31,10 @@ from keras.api import regularizers
 from keras.api import saving
 from keras.api import tree
 from keras.api import utils
+from keras.src.backend import Variable
 from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.backend.common.stateless_scope import StatelessScope
 from keras.src.backend.common.symbolic_scope import SymbolicScope
-from keras.src.backend.exports import Variable
 from keras.src.backend.exports import device
 from keras.src.backend.exports import name_scope
 from keras.src.dtype_policies.dtype_policy import DTypePolicy

--- a/keras/api/_tf_keras/keras/__init__.py
+++ b/keras/api/_tf_keras/keras/__init__.py
@@ -29,10 +29,10 @@ from keras.api._tf_keras.keras import layers
 from keras.api._tf_keras.keras import losses
 from keras.api._tf_keras.keras import metrics
 from keras.api._tf_keras.keras import preprocessing
+from keras.src.backend import Variable
 from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.backend.common.stateless_scope import StatelessScope
 from keras.src.backend.common.symbolic_scope import SymbolicScope
-from keras.src.backend.exports import Variable
 from keras.src.backend.exports import device
 from keras.src.backend.exports import name_scope
 from keras.src.dtype_policies.dtype_policy import DTypePolicy

--- a/keras/src/api_export.py
+++ b/keras/src/api_export.py
@@ -31,8 +31,10 @@ def get_name_from_symbol(symbol):
 if namex:
 
     class keras_export(namex.export):
-        def __init__(self, path):
-            super().__init__(package="keras", path=path)
+        def __init__(self, path, import_path=None):
+            super().__init__(
+                package="keras", path=path, import_path=import_path
+            )
 
         def __call__(self, symbol):
             register_internal_serializable(self.path, symbol)
@@ -41,9 +43,11 @@ if namex:
 else:
 
     class keras_export:
-        def __init__(self, path):
+        def __init__(self, path, import_path=None):
             self.path = path
+            self.import_path = import_path
 
         def __call__(self, symbol):
+            # TODO resolve import_path instead?
             register_internal_serializable(self.path, symbol)
             return symbol

--- a/keras/src/backend/exports.py
+++ b/keras/src/backend/exports.py
@@ -1,28 +1,16 @@
 from keras.src import backend
 from keras.src.api_export import keras_export
-from keras.src.backend.common import KerasVariable
 
 if backend.backend() == "tensorflow":
-    BackendVariable = backend.tensorflow.core.Variable
     backend_name_scope = backend.tensorflow.core.name_scope
 elif backend.backend() == "jax":
-    BackendVariable = backend.jax.core.Variable
     backend_name_scope = backend.common.name_scope.name_scope
 elif backend.backend() == "torch":
-    BackendVariable = backend.torch.core.Variable
     backend_name_scope = backend.common.name_scope.name_scope
 elif backend.backend() == "numpy":
-    from keras.src.backend.numpy.core import Variable as NumpyVariable
-
-    BackendVariable = NumpyVariable
     backend_name_scope = backend.common.name_scope.name_scope
 else:
     raise RuntimeError(f"Invalid backend: {backend.backend()}")
-
-
-@keras_export("keras.Variable")
-class Variable(BackendVariable, KerasVariable):
-    pass
 
 
 @keras_export("keras.name_scope")

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -5,6 +5,7 @@ import ml_dtypes
 import numpy as np
 
 from keras.src import tree
+from keras.src.api_export import keras_export
 from keras.src.backend.common import KerasVariable
 from keras.src.backend.common import global_state
 from keras.src.backend.common import standardize_dtype
@@ -16,6 +17,7 @@ from keras.src.backend.jax import distribution_lib
 SUPPORTS_SPARSE_TENSORS = True
 
 
+@keras_export("keras.Variable", import_path="keras.src.backend.Variable")
 class Variable(KerasVariable):
     def _initialize(self, value):
         value = jnp.array(value, dtype=self._dtype)

--- a/keras/src/backend/numpy/core.py
+++ b/keras/src/backend/numpy/core.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 
 from keras.src import tree
+from keras.src.api_export import keras_export
 from keras.src.backend.common import KerasVariable
 from keras.src.backend.common import standardize_dtype
 from keras.src.backend.common.backend_utils import slice_along_axis
@@ -16,6 +17,7 @@ from keras.src.backend.common.symbolic_scope import SymbolicScope
 SUPPORTS_SPARSE_TENSORS = False
 
 
+@keras_export("keras.Variable", import_path="keras.src.backend.Variable")
 class Variable(KerasVariable):
     def _initialize(self, value):
         self._value = np.array(value, dtype=self._dtype)

--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 from tensorflow.compiler.tf2xla.python.xla import dynamic_update_slice
 
 from keras.src import tree
+from keras.src.api_export import keras_export
 from keras.src.backend.common import KerasVariable
 from keras.src.backend.common import global_state
 from keras.src.backend.common import standardize_dtype
@@ -20,6 +21,7 @@ from keras.src.utils.naming import auto_name
 SUPPORTS_SPARSE_TENSORS = True
 
 
+@keras_export("keras.Variable", import_path="keras.src.backend.Variable")
 class Variable(
     KerasVariable,
     tf.__internal__.types.Tensor,

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 
 from keras.src import tree
+from keras.src.api_export import keras_export
 from keras.src.backend.common import KerasVariable
 from keras.src.backend.common import global_state
 from keras.src.backend.common import standardize_dtype
@@ -94,6 +95,7 @@ def to_torch_dtype(dtype):
     return standardized_dtype
 
 
+@keras_export("keras.Variable", import_path="keras.src.backend.Variable")
 class Variable(KerasVariable):
     def _initialize(self, value):
         if isinstance(value, torch.nn.Parameter):


### PR DESCRIPTION
The exported `keras.Variable` class is a subclass of the backend specific implementation. However, that public class was not used internally to create variables, for instance via `add_weight()`.

There was no convenient way to detect that a tensor really is a variable. This code would print `False`:
```python
v = self.add_weight(x)
print(isinstance(v, keras.Variable)
```
This change makes `keras.Variable` the actual class used internally.