### PR TITLE
Fix `set_tensor_attr` so that setting `None` clears the attribute.

### DIFF
--- a/keras/src/backend/common/masking_test.py
+++ b/keras/src/backend/common/masking_test.py
@@ -1,0 +1,45 @@
+from keras.src import backend
+from keras.src import ops
+from keras.src import testing
+from keras.src.backend.common.masking import get_keras_mask
+from keras.src.backend.common.masking import set_keras_mask
+
+
+class MaskingTest(testing.TestCase):
+
+    def test_mask_on_eager_tensor(self):
+        x = ops.zeros((2, 3))
+        self.assertIsNone(get_keras_mask(x))
+
+        set_keras_mask(x, None)
+        self.assertIsNone(get_keras_mask(x))
+
+        mask = ops.ones((2, 3))
+        set_keras_mask(x, mask)
+        self.assertIs(get_keras_mask(x), mask)
+
+        set_keras_mask(x, None)
+        self.assertIsNone(get_keras_mask(x))
+
+        set_keras_mask(x, None)
+        self.assertIsNone(get_keras_mask(x))
+
+    def test_mask_on_tracer_tensor(self):
+
+        def fn(x):
+            self.assertIsNone(get_keras_mask(x))
+
+            set_keras_mask(x, None)
+            self.assertIsNone(get_keras_mask(x))
+
+            mask = ops.ones((2, 3))
+            set_keras_mask(x, mask)
+            self.assertIs(get_keras_mask(x), mask)
+
+            set_keras_mask(x, None)
+            self.assertIsNone(get_keras_mask(x))
+
+            set_keras_mask(x, None)  # key is now deleted, should be a no-op
+            self.assertIsNone(get_keras_mask(x))
+
+        backend.compute_output_spec(fn, backend.KerasTensor((2, 3)))

--- a/keras/src/backend/common/tensor_attributes.py
+++ b/keras/src/backend/common/tensor_attributes.py
@@ -7,13 +7,16 @@ def set_tensor_attr(tensor, attr, value):
     try:
         setattr(tensor, attr, value)
     except AttributeError:
-        if value is None:
-            return
         attr_dict = global_state.get_global_attribute(f"{attr}_dict")
         if attr_dict is None:
+            if value is None:
+                return
             attr_dict = weakref.WeakValueDictionary()
             global_state.set_global_attribute(f"{attr}_dict", attr_dict)
-        attr_dict[id(tensor)] = value
+        if value is not None:
+            attr_dict[id(tensor)] = value
+        elif id(tensor) in attr_dict:
+            del attr_dict[id(tensor)]
 
 
 def get_tensor_attr(tensor, attr):
@@ -21,4 +24,6 @@ def get_tensor_attr(tensor, attr):
         attr_dict = global_state.get_global_attribute(f"{attr}_dict")
         if attr_dict is not None:
             return attr_dict.get(id(tensor), None)
+        else:
+            return None
     return getattr(tensor, attr, None)


### PR DESCRIPTION
There was a shortcut ignoring `None` values.

Also added unit tests to cover that masking cases.