### PR TITLE
Remove MultiHeadAttention assertion that last dims of Q and V need to be equal

### DIFF
--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -211,13 +211,6 @@ class MultiHeadAttention(Layer):
         """
         key_shape = value_shape if key_shape is None else key_shape
 
-        if query_shape[-1] != value_shape[-1]:
-            raise ValueError(
-                "The last dimension of `query_shape` and `value_shape` "
-                f"must be equal, but are {query_shape[-1]}, {value_shape[-1]}. "
-                "Received: query_shape={query_shape}, value_shape={value_shape}"
-            )
-
         if value_shape[1:-1] != key_shape[1:-1]:
             raise ValueError(
                 "All dimensions of `value` and `key`, except the last one, "
@@ -603,13 +596,6 @@ class MultiHeadAttention(Layer):
     ):
         if key_shape is None:
             key_shape = value_shape
-
-        if query_shape[-1] != value_shape[-1]:
-            raise ValueError(
-                "The last dimension of `query_shape` and `value_shape` "
-                f"must be equal, but are {query_shape[-1]}, {value_shape[-1]}. "
-                "Received: query_shape={query_shape}, value_shape={value_shape}"
-            )
 
         if value_shape[1:-1] != key_shape[1:-1]:
             raise ValueError(

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -104,6 +104,13 @@ class MultiHeadAttentionTest(testing.TestCase):
             (1, 1, 5, 2),
             (3, 2),
         ),
+        (
+            "different_qv_last_dims",
+            (4, 2, 3, 8),
+            (4, 2, 3, 7),
+            (4, 2, 3, 8),
+            None,
+        ),
     )
     def test_compute_output_shape(
         self, query_dims, value_dims, key_dims, output_shape
@@ -130,7 +137,7 @@ class MultiHeadAttentionTest(testing.TestCase):
         self.assertEqual(output.shape, comp_output_shape)
 
     @parameterized.named_parameters(
-        ("query_value_dim_mismatch", (2, 4, 8), (2, 2, 7), 2),
+        ("query_value_dim_mismatch", (2, 4, 8), (2, 2, 7), (2,)),
         ("key_value_dim_mismatch", (2, 4, 8), (2, 2, 8), (2, 1, 7)),
         (
             "key_value_dim_mismatch_high_dim",


### PR DESCRIPTION
Via #20324.

This assertion was added in #19973, however re: #20324 it seems overly restrictive. It was not covered by an existing test case. 