### PR TITLE
Fix absence of filtering in CompileLoss when not built

### DIFF
--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -620,15 +620,15 @@ class CompileLoss(losses_module.Loss):
     def call(self, y_true, y_pred, sample_weight=None):
         if not self.built:
             self.build(y_true, y_pred)
-        else:
-            # Filter unused inputs.
-            y_true, y_pred = self._filter_unused_inputs(
-                y_true,
-                y_pred,
-                self.filtered_y_true_keys,
-                self.filtered_y_pred_keys,
-                self.inferred_output_names,
-            )
+
+        # Filter unused inputs.
+        y_true, y_pred = self._filter_unused_inputs(
+            y_true,
+            y_pred,
+            self.filtered_y_true_keys,
+            self.filtered_y_pred_keys,
+            self.inferred_output_names,
+        )
 
         # Flatten the inputs.
         y_true = tree.flatten(y_true)


### PR DESCRIPTION
Last August, I suggested a simple workaround to avoid duplicated filtering in CompileLoss when not built (PR #20161), stressing in the description that the root cause was that [_filter_unused_inputs](https://github.com/keras-team/keras/blob/4bf1d80fb994ca8e6bebc679b05d124fb294764c/keras/src/trainers/compile_utils.py#L586) was modifying y_true/y_pred arguments in-place.

This PR suggests to undo the workaround, now that [_filter_unused_inputs](https://github.com/keras-team/keras/blob/acceb5a995b82a006bb174b396844afc9f1fd052/keras/src/trainers/compile_utils.py#L586) has been properly fixed [in this commit](https://github.com/keras-team/keras/pull/20296/commits/b9955ad204c0813d7a43392b76780c9ab39266d2) to not modify y_true/y_pred in-place anymore (PR #20296).

Without this PR (in Keras 3.6.0), the necessary filtering does not occur anymore in CompileLoss when not built (the bug typically becomes apparent whenever y_pred is a dict with more keys than y_true/loss).