### PR TITLE
Restrict the inputs of `ops.pad()`

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -4348,6 +4348,13 @@ class Pad(Operation):
         return pad_width
 
     def call(self, x, constant_values=None):
+        if len(self.pad_width) > 1 and len(self.pad_width) != len(x.shape):
+            raise ValueError(
+                "`pad_width` must have the same length as `x.shape`. "
+                f"Received: pad_width={self.pad_width} "
+                f"(of length {len(self.pad_width)}) and x.shape={x.shape} "
+                f"(of length {len(x.shape)})"
+            )
         return backend.numpy.pad(
             x,
             pad_width=self.pad_width,


### PR DESCRIPTION
If the dimensions of `pad_width` and `input` are not the same, other backends will throw a corresponding exception, but PyTorch can still work, which may result in an unrelated exception being raised.

Users may assume that the `pad_width = ((0, 0), (1, 2), (0, 0))` can be shortened to `pad_width = ((0, 0), (1, 2))`.
However, due to torch's use of reverse order, the latter will be processed to `((1, 2),)` (reversed and with higher dimensions removed).

https://github.com/keras-team/keras/blob/8e7843c9f8a3b3298730ab993fd6e6d7bf5c2b1c/keras/src/backend/torch/numpy.py#L1089

https://github.com/keras-team/keras/blob/8e7843c9f8a3b3298730ab993fd6e6d7bf5c2b1c/keras/src/backend/torch/numpy.py#L1096-L1097
