### PR TITLE
Allow passing custom dataset adapters.

### DIFF
--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -146,7 +146,7 @@ class Embedding(Layer):
         return ops.not_equal(inputs, 0)
 
     def compute_output_shape(self, input_shape):
-        return input_shape + (self.output_dim,)
+        return (*input_shape, self.output_dim)
 
     def enable_lora(
         self, rank, a_initializer="he_uniform", b_initializer="zeros"

--- a/keras/src/trainers/data_adapters/__init__.py
+++ b/keras/src/trainers/data_adapters/__init__.py
@@ -2,6 +2,7 @@ import types
 
 from keras.src.distribution import distribution_lib
 from keras.src.trainers.data_adapters import array_data_adapter
+from keras.src.trainers.data_adapters import data_adapter
 from keras.src.trainers.data_adapters import py_dataset_adapter
 from keras.src.trainers.data_adapters.array_data_adapter import ArrayDataAdapter
 from keras.src.trainers.data_adapters.generator_data_adapter import (
@@ -23,6 +24,10 @@ def get_data_adapter(
     shuffle=False,
     class_weight=None,
 ):
+    # Allow passing a custom data adapter.
+    if isinstance(x, data_adapter.DataAdapter):
+        return x
+
     # Check for multi-process/worker distribution. Since only tf.dataset
     # is supported at the moment, we will raise error if the inputs fail
     # the type check


### PR DESCRIPTION
- Allow passing a custom dataset adapter - this is to enable enqueuing ID tensors to `TPUEmbedding` before converting them to Jax arrays and putting them on tensorcores.
- Small fix in `compute_output_shape` in embedding layer.
