### PR TITLE
Clarification: new mean option is synonym with sum_over_batch_size in loss function base class

### DIFF
--- a/keras/src/losses/loss.py
+++ b/keras/src/losses/loss.py
@@ -14,7 +14,8 @@ class Loss(KerasSaveable):
     Args:
         reduction: Type of reduction to apply to the loss. In almost all cases
             this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            Supported options are `"sum"`, `"sum_over_batch_size"`, `mean`
+            or `None`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
@@ -92,7 +93,7 @@ class Loss(KerasSaveable):
 
 
 def standardize_reduction(reduction):
-    allowed = {"sum_over_batch_size", "sum", None, "none"}
+    allowed = {"sum_over_batch_size", "sum", None, "none", "mean"}
     if reduction not in allowed:
         raise ValueError(
             "Invalid value for argument `reduction`. "
@@ -132,7 +133,7 @@ def reduce_values(values, reduction="sum_over_batch_size"):
     ):
         return values
     loss = ops.sum(values)
-    if reduction == "sum_over_batch_size":
+    if (reduction == "sum_over_batch_size") or (reduction == "mean"):
         loss /= ops.cast(
             ops.prod(ops.convert_to_tensor(ops.shape(values), dtype="int32")),
             loss.dtype,

--- a/keras/src/losses/loss.py
+++ b/keras/src/losses/loss.py
@@ -178,7 +178,7 @@ def apply_mask(sample_weight, mask, dtype, reduction):
     """Applies any mask on predictions to sample weights."""
     if mask is not None:
         mask = ops.cast(mask, dtype=dtype)
-        if reduction == "sum_over_batch_size":
+        if (reduction == "sum_over_batch_size") or (reduction == "mean")
             # Valid entries have weight `total/valid`, while invalid ones
             # have 0. When summed over batch, they will be reduced to:
             #

--- a/keras/src/losses/loss.py
+++ b/keras/src/losses/loss.py
@@ -1,7 +1,4 @@
-from keras.src import backend
-from keras.src import dtype_policies
-from keras.src import ops
-from keras.src import tree
+from keras.src import backend, dtype_policies, ops, tree
 from keras.src.api_export import keras_export
 from keras.src.saving.keras_saveable import KerasSaveable
 from keras.src.utils.naming import auto_name
@@ -14,7 +11,7 @@ class Loss(KerasSaveable):
     Args:
         reduction: Type of reduction to apply to the loss. In almost all cases
             this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"`, `mean`
+            Supported options are `"sum"`, `"sum_over_batch_size"`, `"mean"`
             or `None`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
@@ -164,9 +161,7 @@ def reduce_weighted_values(
     if sample_weight is not None:
         sample_weight = ops.cast(sample_weight, values.dtype)
         # Update dimensions of `sample_weight` to match `losses`.
-        values, sample_weight = squeeze_or_expand_to_same_rank(
-            values, sample_weight
-        )
+        values, sample_weight = squeeze_or_expand_to_same_rank(values, sample_weight)
         values = values * sample_weight
 
     # Apply reduction function to the individual weighted losses.
@@ -178,7 +173,7 @@ def apply_mask(sample_weight, mask, dtype, reduction):
     """Applies any mask on predictions to sample weights."""
     if mask is not None:
         mask = ops.cast(mask, dtype=dtype)
-        if (reduction == "sum_over_batch_size") or (reduction == "mean")
+        if (reduction == "sum_over_batch_size") or (reduction == "mean"):
             # Valid entries have weight `total/valid`, while invalid ones
             # have 0. When summed over batch, they will be reduced to:
             #
@@ -195,9 +190,7 @@ def apply_mask(sample_weight, mask, dtype, reduction):
 
         if sample_weight is not None:
             sample_weight = ops.cast(sample_weight, dtype=dtype)
-            mask, sample_weight = squeeze_or_expand_to_same_rank(
-                mask, sample_weight
-            )
+            mask, sample_weight = squeeze_or_expand_to_same_rank(mask, sample_weight)
             sample_weight *= mask
         else:
             sample_weight = mask

--- a/keras/src/losses/loss.py
+++ b/keras/src/losses/loss.py
@@ -1,4 +1,7 @@
-from keras.src import backend, dtype_policies, ops, tree
+from keras.src import backend
+from keras.src import dtype_policies
+from keras.src import ops
+from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.saving.keras_saveable import KerasSaveable
 from keras.src.utils.naming import auto_name
@@ -161,7 +164,9 @@ def reduce_weighted_values(
     if sample_weight is not None:
         sample_weight = ops.cast(sample_weight, values.dtype)
         # Update dimensions of `sample_weight` to match `losses`.
-        values, sample_weight = squeeze_or_expand_to_same_rank(values, sample_weight)
+        values, sample_weight = squeeze_or_expand_to_same_rank(
+            values, sample_weight
+        )
         values = values * sample_weight
 
     # Apply reduction function to the individual weighted losses.
@@ -190,7 +195,9 @@ def apply_mask(sample_weight, mask, dtype, reduction):
 
         if sample_weight is not None:
             sample_weight = ops.cast(sample_weight, dtype=dtype)
-            mask, sample_weight = squeeze_or_expand_to_same_rank(mask, sample_weight)
+            mask, sample_weight = squeeze_or_expand_to_same_rank(
+                mask, sample_weight
+            )
             sample_weight *= mask
         else:
             sample_weight = mask

--- a/keras/src/losses/loss.py
+++ b/keras/src/losses/loss.py
@@ -133,7 +133,7 @@ def reduce_values(values, reduction="sum_over_batch_size"):
     ):
         return values
     loss = ops.sum(values)
-    if (reduction == "sum_over_batch_size") or (reduction == "mean"):
+    if reduction in ("mean", "sum_over_batch_size"):
         loss /= ops.cast(
             ops.prod(ops.convert_to_tensor(ops.shape(values), dtype="int32")),
             loss.dtype,
@@ -178,7 +178,7 @@ def apply_mask(sample_weight, mask, dtype, reduction):
     """Applies any mask on predictions to sample weights."""
     if mask is not None:
         mask = ops.cast(mask, dtype=dtype)
-        if (reduction == "sum_over_batch_size") or (reduction == "mean"):
+        if reduction in ("mean", "sum_over_batch_size"):
             # Valid entries have weight `total/valid`, while invalid ones
             # have 0. When summed over batch, they will be reduced to:
             #

--- a/keras/src/losses/loss_test.py
+++ b/keras/src/losses/loss_test.py
@@ -69,7 +69,7 @@ class LossTest(testing.TestCase):
         self.assertEqual(backend.standardize_dtype(loss.dtype), "float32")
         self.assertAllClose(np.sum((y_true - y_pred) ** 2), loss)
 
-        # sum_over_batch_size
+        # sum_over_batch_size or mean
         loss_fn = ExampleLoss(reduction="sum_over_batch_size")
         loss = loss_fn(y_true, y_pred)
         self.assertEqual(backend.standardize_dtype(loss.dtype), "float32")


### PR DESCRIPTION
Since `sum_over_batch_size` actually is `mean`, `mean` option was added as equivalent of `sum_over_batch_size` to explicitly and clearly state what `sum_over_batch_size` does, under the expected name `mean`, while keeping `sum_over_batch_size` for backwards compatibility. See also https://github.com/keras-team/keras/issues/18818, where the problem with the current name is noted.

Also, why is done like this:
```
loss = ops.sum(values)
loss /= ops.cast(
    ops.prod(ops.convert_to_tensor(ops.shape(values), dtype="int32")),
    loss.dtype,
)
```
if there's the clearer and shorter keras mean?
`loss = ops.mean(values, axis=None, keepdims=False)`

Please take it, `sum_over_batch_size` is confusing, I already implemented `mean` when I realized it was already done under a different name. 

Edit: already undid formating while keeping the typo fixes see last commit: https://github.com/keras-team/keras/pull/20352/commits/19933d94523d482ac7642913467d1a015e54b882