### PR TITLE
stop_gradient in SpectralNormalization wrapper

### DIFF
--- a/keras/src/layers/normalization/spectral_normalization.py
+++ b/keras/src/layers/normalization/spectral_normalization.py
@@ -105,8 +105,8 @@ class SpectralNormalization(Wrapper):
                 ops.matmul(vector_u, ops.transpose(weights)), axis=None
             )
             vector_u = normalize(ops.matmul(vector_v, weights), axis=None)
-        # vector_u = tf.stop_gradient(vector_u)
-        # vector_v = tf.stop_gradient(vector_v)
+        vector_u = ops.stop_gradient(vector_u)
+        vector_v = ops.stop_gradient(vector_v)
         sigma = ops.matmul(
             ops.matmul(vector_v, weights), ops.transpose(vector_u)
         )


### PR DESCRIPTION
Address comment here: https://github.com/keras-team/keras/issues/20309

According to @hertschuh, the `stop_gradient` call was removed since it wasn't available in the `keras.ops` package. This resulted in unstable behavior for the entire Spectral Normalization wrapper. `stop_gradient` is now present, and the fix (tested on a much larger problem) appears to have stabilized the behavior.