### PR TITLE
Enable Structured Losses

### DIFF
--- a/keras/src/callbacks/tensorboard_test.py
+++ b/keras/src/callbacks/tensorboard_test.py
@@ -421,7 +421,7 @@ class TestTensorBoardV2(testing.TestCase):
         model.compile(
             optimizer="adam", loss=losses.BinaryCrossentropy(from_logits=True)
         )
-        x, y = np.ones((10, 10)), np.ones((10, 10, 1))
+        x, y = np.ones((10, 10)), np.ones((10, 10))
         logdir, _, _ = self._get_log_dirs()
         tb_cbk = callbacks.TensorBoard(
             logdir,

--- a/keras/src/callbacks/tensorboard_test.py
+++ b/keras/src/callbacks/tensorboard_test.py
@@ -421,7 +421,7 @@ class TestTensorBoardV2(testing.TestCase):
         model.compile(
             optimizer="adam", loss=losses.BinaryCrossentropy(from_logits=True)
         )
-        x, y = np.ones((10, 10)), np.ones((10, 10))
+        x, y = np.ones((10, 10)), np.ones((10, 10, 1))
         logdir, _, _ = self._get_log_dirs()
         tb_cbk = callbacks.TensorBoard(
             logdir,

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -6,6 +6,7 @@ from keras.src.api_export import keras_export
 from keras.src.losses.loss import Loss
 from keras.src.losses.loss import squeeze_or_expand_to_same_rank
 from keras.src.saving import serialization_lib
+from keras.src.utils.module_utils import optree
 from keras.src.utils.numerical_utils import normalize
 
 
@@ -23,7 +24,9 @@ class LossFunctionWrapper(Loss):
         self._fn_kwargs = kwargs
 
     def call(self, y_true, y_pred):
-        y_true, y_pred = squeeze_or_expand_to_same_rank(y_true, y_pred)
+        y_true, y_pred = optree.tree_transpose_map(
+            squeeze_or_expand_to_same_rank, y_true, y_pred
+        )
         return self.fn(y_true, y_pred, **self._fn_kwargs)
 
     def get_config(self):

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -6,7 +6,6 @@ from keras.src.api_export import keras_export
 from keras.src.losses.loss import Loss
 from keras.src.losses.loss import squeeze_or_expand_to_same_rank
 from keras.src.saving import serialization_lib
-from keras.src.utils.module_utils import optree
 from keras.src.utils.numerical_utils import normalize
 
 
@@ -24,9 +23,6 @@ class LossFunctionWrapper(Loss):
         self._fn_kwargs = kwargs
 
     def call(self, y_true, y_pred):
-        y_true, y_pred = optree.tree_transpose_map(
-            squeeze_or_expand_to_same_rank, y_true, y_pred
-        )
         return self.fn(y_true, y_pred, **self._fn_kwargs)
 
     def get_config(self):

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2,6 +2,7 @@ import warnings
 
 from keras.src import backend
 from keras.src import ops
+from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.losses.loss import Loss
 from keras.src.losses.loss import squeeze_or_expand_to_same_rank
@@ -23,6 +24,11 @@ class LossFunctionWrapper(Loss):
         self._fn_kwargs = kwargs
 
     def call(self, y_true, y_pred):
+        y_true_y_pred = tree.map_structure(
+            squeeze_or_expand_to_same_rank, y_true, y_pred
+        )
+        y_true = tree.map_structure_up_to(y_true, lambda x: x[0], y_true_y_pred)
+        y_pred = tree.map_structure_up_to(y_pred, lambda x: x[1], y_true_y_pred)
         return self.fn(y_true, y_pred, **self._fn_kwargs)
 
     def get_config(self):

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -7,7 +7,6 @@ from absl.testing import parameterized
 from keras.src import backend
 from keras.src import layers
 from keras.src import losses
-from keras.src import ops
 from keras.src import testing
 from keras.src import tree
 from keras.src.layers.core.input_layer import Input

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -71,19 +71,19 @@ def _get_model_multi_outputs_dict():
     return model
 
 
-def _get_model_multi_outputs_struct_list_like(type):
+def _get_model_multi_outputs_struct_list_like(_type):
     x = Input(shape=(3,), name="x")
     y1 = layers.Dense(1, name="y1", activation="sigmoid")(x)
     y2 = layers.Dense(1, name="y2", activation="sigmoid")(x)
-    model = Model(x, type([y1, y2]))
+    model = Model(x, _type([y1, y2]))
     return model
 
 
-def _get_model_multi_outputs_struct_long_list_like(type):
+def _get_model_multi_outputs_struct_long_list_like(_type):
     x = Input(shape=(3,), name="x")
     y1 = layers.Dense(1, name="y1", activation="sigmoid")(x)
     y2 = layers.Dense(1, name="y2", activation="sigmoid")(x)
-    model = Model(x, type([y1, y2, y1, y2, y1]))
+    model = Model(x, _type([y1, y2, y1, y2, y1]))
     return model
 
 
@@ -1018,21 +1018,21 @@ class ModelTest(testing.TestCase):
         return loss_fn
 
     @parameterized.product(
-        type=[tuple, list], anti_type=[list, tuple], weighted=[False, True]
+        _type=[tuple, list], anti_type=[list, tuple], weighted=[False, True]
     )
     def test_functional_struct_outputs_struct_losses(
-        self, type, anti_type, weighted
+        self, _type, anti_type, weighted
     ):
-        model = _get_model_multi_outputs_struct_list_like(type)
+        model = _get_model_multi_outputs_struct_list_like(_type)
         self.assertIsInstance(model, Functional)
         x = np.random.rand(8, 3)
         y1 = np.random.rand(8, 1)
         y2 = np.random.rand(8, 1)
-        y = type([y1, y2])
+        y = _type([y1, y2])
         loss = anti_type(
             [
                 self.get_struct_loss(model.output),
-                type(
+                _type(
                     [
                         self.get_struct_loss(model.output[0]),
                         self.get_struct_loss(model.output[1]),
@@ -1051,7 +1051,7 @@ class ModelTest(testing.TestCase):
             loss_weights=loss_weights,
         )
 
-        if type is anti_type:
+        if _type is anti_type:
             with self.assertRaisesRegex(
                 ValueError, "don't have the same structure"
             ):
@@ -1059,7 +1059,7 @@ class ModelTest(testing.TestCase):
         else:
             # Check dict outputs.
             outputs = model.predict(x)
-            self.assertIsInstance(outputs, type)
+            self.assertIsInstance(outputs, _type)
             # Fit the model to make sure compile_metrics are built
             hist = model.fit(
                 x,
@@ -1129,23 +1129,23 @@ class ModelTest(testing.TestCase):
         self.assertListEqual(hist_keys, ref_keys)
 
     @parameterized.product(
-        type=[tuple, list], anti_type=[list, tuple], weighted=[False, True]
+        _type=[tuple, list], anti_type=[list, tuple], weighted=[False, True]
     )
     def test_functional_struct_outputs_long_struct_losses(
-        self, type, anti_type, weighted
+        self, _type, anti_type, weighted
     ):
-        model = _get_model_multi_outputs_struct_long_list_like(type)
+        model = _get_model_multi_outputs_struct_long_list_like(_type)
         self.assertIsInstance(model, Functional)
         x = np.random.rand(8, 3)
         y1 = np.random.rand(8, 1)
         y2 = np.random.rand(8, 1)
 
-        y = type([y1, y2, y1, y2, y1])
+        y = _type([y1, y2, y1, y2, y1])
 
         loss = anti_type(
             [
                 self.get_struct_loss(model.output),
-                type(
+                _type(
                     [
                         self.get_struct_loss(model.output[0]),
                         self.get_struct_loss(model.output[1]),
@@ -1168,8 +1168,8 @@ class ModelTest(testing.TestCase):
         )
         # Check dict outputs.
         outputs = model.predict(x)
-        self.assertIsInstance(outputs, type)
-        if type is anti_type:
+        self.assertIsInstance(outputs, _type)
+        if _type is anti_type:
             with self.assertRaisesRegex(
                 ValueError, "don't have the same structure"
             ):

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -983,7 +983,7 @@ class ModelTest(testing.TestCase):
             flat_y_pred, flat_y_true = tree.flatten(y_pred), tree.flatten(
                 y_true
             )
-            diff = ops.convert_to_tensor(0, dtype=flat_y_pred[0].dtype)
+            diff = 0
             for y_p, y_t in zip(flat_y_pred, flat_y_true):
                 diff += losses.mean_absolute_error(y_t, y_p)
             return diff

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -6,7 +6,10 @@ from absl.testing import parameterized
 
 from keras.src import backend
 from keras.src import layers
+from keras.src import losses
+from keras.src import ops
 from keras.src import testing
+from keras.src import tree
 from keras.src.layers.core.input_layer import Input
 from keras.src.models.functional import Functional
 from keras.src.models.model import Model
@@ -68,6 +71,23 @@ def _get_model_multi_outputs_dict():
     return model
 
 
+def _get_model_multi_outputs_struct():
+    x = Input(shape=(3,), name="x")
+    y1 = layers.Dense(1, name="y1", activation="sigmoid")(x)
+    y2 = layers.Dense(1, name="y2", activation="sigmoid")(x)
+    y3 = layers.Dense(1, name="y3", activation="sigmoid")(x)
+    model = Model(
+        x,
+        {
+            "a": (y1, y2),
+            "b": {"b/1": y1, "b/2": y2},
+            "c": {"c/1": (y1, y2), "c/2": y2},
+            "d": y3,
+        },
+    )
+    return model
+
+
 def _get_model_multi_outputs_dict_with_single_tensor():
     x = Input(shape=(3,), name="input_a")
     output = layers.Dense(1, name="output_a")(x)
@@ -121,6 +141,7 @@ def _get_variable_value_by_path(variables, path):
 
 @pytest.mark.requires_trainable_backend
 class ModelTest(testing.TestCase):
+
     def test_functional_rerouting(self):
         model = _get_model()
         self.assertIsInstance(model, Functional)
@@ -944,3 +965,77 @@ class ModelTest(testing.TestCase):
             AttributeError, "`Model.layers` attribute is reserved"
         ):
             model.layers = [layers.Dense(4)]
+
+    def get_struct_loss(self, structure):
+        def loss_fn(y_true, y_pred):
+            tree.assert_same_structure(structure, y_true, check_types=False)
+            tree.assert_same_structure(structure, y_pred, check_types=False)
+            tree.map_structure(
+                lambda spec, tensor: self.assertEqual(spec.ndim, tensor.ndim),
+                structure,
+                y_true,
+            )
+            tree.map_structure(
+                lambda spec, tensor: self.assertEqual(spec.ndim, tensor.ndim),
+                structure,
+                y_pred,
+            )
+            flat_y_pred, flat_y_true = tree.flatten(y_pred), tree.flatten(
+                y_true
+            )
+            diff = ops.convert_to_tensor(0, dtype=flat_y_pred[0].dtype)
+            for y_p, y_t in zip(flat_y_pred, flat_y_true):
+                diff += losses.mean_absolute_error(y_t, y_p)
+            return diff
+
+        return loss_fn
+
+    def test_functional_struct_outputs_struct_losses(self):
+        model = _get_model_multi_outputs_struct()
+        self.assertIsInstance(model, Functional)
+        x = np.random.rand(8, 3)
+        y1 = np.random.rand(8, 1)
+        y2 = np.random.rand(8, 1)
+        y3 = np.random.rand(8, 1)
+        y = {
+            "a": (y1, y2),
+            "b": {"b/1": y1, "b/2": y2},
+            "c": {"c/1": (y1, y2), "c/2": y2},
+            "d": y3,
+        }
+        model.compile(
+            optimizer="sgd",
+            loss={
+                "a": self.get_struct_loss(model.output["a"]),
+                "a/1": self.get_struct_loss(model.output["a"][1]),
+                "b": self.get_struct_loss(model.output["b"]),
+                "b/b/1": self.get_struct_loss(model.output["b"]["b/1"]),
+                "c": self.get_struct_loss(model.output["c"]),
+                "d": self.get_struct_loss(model.output["d"]),
+            },
+        )
+        # Check dict outputs.
+        outputs = model.predict(x)
+        self.assertIsInstance(outputs, dict)
+
+        # Fit the model to make sure compile_metrics are built
+        hist = model.fit(
+            x,
+            y,
+            batch_size=2,
+            epochs=1,
+            verbose=0,
+        )
+        hist_keys = sorted(hist.history.keys())
+        ref_keys = sorted(
+            [
+                "a/1_loss",
+                "a_loss",
+                "b/b/1_loss",
+                "b_loss",
+                "c_loss",
+                "d_loss",
+                "loss",
+            ]
+        )
+        self.assertListEqual(hist_keys, ref_keys)

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -1018,10 +1018,10 @@ class ModelTest(testing.TestCase):
         return loss_fn
 
     @parameterized.product(
-        _type=[tuple, list], anti_type=[list, tuple], weighted=[False, True]
+        _type=[tuple, list], other_type=[list, tuple], weighted=[False, True]
     )
     def test_functional_struct_outputs_struct_losses(
-        self, _type, anti_type, weighted
+        self, _type, other_type, weighted
     ):
         model = _get_model_multi_outputs_struct_list_like(_type)
         self.assertIsInstance(model, Functional)
@@ -1029,7 +1029,7 @@ class ModelTest(testing.TestCase):
         y1 = np.random.rand(8, 1)
         y2 = np.random.rand(8, 1)
         y = _type([y1, y2])
-        loss = anti_type(
+        loss = other_type(
             [
                 self.get_struct_loss(model.output),
                 _type(
@@ -1051,7 +1051,7 @@ class ModelTest(testing.TestCase):
             loss_weights=loss_weights,
         )
 
-        if _type is anti_type:
+        if _type is other_type:
             with self.assertRaisesRegex(
                 ValueError, "don't have the same structure"
             ):
@@ -1129,10 +1129,10 @@ class ModelTest(testing.TestCase):
         self.assertListEqual(hist_keys, ref_keys)
 
     @parameterized.product(
-        _type=[tuple, list], anti_type=[list, tuple], weighted=[False, True]
+        _type=[tuple, list], other_type=[list, tuple], weighted=[False, True]
     )
     def test_functional_struct_outputs_long_struct_losses(
-        self, _type, anti_type, weighted
+        self, _type, other_type, weighted
     ):
         model = _get_model_multi_outputs_struct_long_list_like(_type)
         self.assertIsInstance(model, Functional)
@@ -1142,7 +1142,7 @@ class ModelTest(testing.TestCase):
 
         y = _type([y1, y2, y1, y2, y1])
 
-        loss = anti_type(
+        loss = other_type(
             [
                 self.get_struct_loss(model.output),
                 _type(
@@ -1169,7 +1169,7 @@ class ModelTest(testing.TestCase):
         # Check dict outputs.
         outputs = model.predict(x)
         self.assertIsInstance(outputs, _type)
-        if _type is anti_type:
+        if _type is other_type:
             with self.assertRaisesRegex(
                 ValueError, "don't have the same structure"
             ):

--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -483,10 +483,7 @@ class CompileLoss(losses_module.Loss):
                     flat_output_names = list(output_names.keys())
                 else:
                     flat_output_names = tree.flatten(output_names)
-
-                name = "_".join(flat_output_names[:4])
-                if len(flat_output_names) > 4:  # prevent too long naming string
-                    name += "..."
+                name = "_".join(flat_output_names)
             self._flat_losses.append(
                 CompileLoss.Loss(current_path, resolved_loss, loss_weight, name)
             )

--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -1,8 +1,10 @@
+from collections import namedtuple
+
 from keras.src import losses as losses_module
 from keras.src import metrics as metrics_module
 from keras.src import ops
 from keras.src import tree
-from keras.src.utils.module_utils import optree
+from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.utils.naming import get_object_name
 from keras.src.utils.tracking import Tracker
 
@@ -407,13 +409,14 @@ class CompileMetrics(metrics_module.Metric):
 
 
 class CompileLoss(losses_module.Loss):
+    Loss = namedtuple("Loss", ["path", "loss", "loss_weights", "name"])
+
     def __init__(
         self,
         loss,
         loss_weights=None,
         reduction="sum_over_batch_size",
         output_names=None,
-        path_separator="/",
     ):
         if loss_weights and not isinstance(
             loss_weights, (list, tuple, dict, float)
@@ -425,14 +428,12 @@ class CompileLoss(losses_module.Loss):
                 f"Received instead: loss_weights={loss_weights} "
                 f"of type {type(loss_weights)}"
             )
+
         self._user_loss = loss
         self._user_loss_weights = loss_weights
         self.built = False
         self.output_names = output_names
         super().__init__(name="compile_loss", reduction=reduction)
-
-        # Inferred by `y_pred` and `output_names`
-        self.inferred_output_names = None
 
         # Use `Tracker` to track metrics for individual losses.
         self._metrics = []
@@ -444,8 +445,8 @@ class CompileLoss(losses_module.Loss):
                 )
             }
         )
-        self._y_pred_compile_structure = None
-        self._path_separator = path_separator
+        self._flat_losses = None
+        self._y_pred_build_structure = None
 
     @property
     def metrics(self):
@@ -458,208 +459,214 @@ class CompileLoss(losses_module.Loss):
             vars.extend(m.variables)
         return vars
 
+    def _build_nested(self, y_true, y_pred, loss, output_names, current_path):
+        flat_y_pred = tree.flatten(y_pred)
+        if not tree.is_nested(loss):
+            _loss = loss.loss
+            if _loss is None:
+                return
+            loss_weight = loss.weight
+            resolved_loss = get_loss(_loss, y_true, y_pred)
+            name_path = current_path
+            if not tree.is_nested(output_names):
+                if output_names is not None:
+                    output_name = output_names
+                else:
+                    output_name = resolved_loss.name
+                if len(name_path) == 0:
+                    name_path = (output_name,)
+                elif isinstance(name_path[-1], int):
+                    name_path = name_path[:-1] + (output_name,)
+            name = "/".join([str(path) for path in name_path])
+            if name == "":
+                if isinstance(output_names, dict):
+                    flat_output_names = list(output_names.keys())
+                else:
+                    flat_output_names = tree.flatten(output_names)
+
+                name = "_".join(flat_output_names[:4])
+                if len(flat_output_names) > 4:  # prevent too long naming string
+                    name += "..."
+            self._flat_losses.append(
+                CompileLoss.Loss(current_path, resolved_loss, loss_weight, name)
+            )
+            return
+        elif (
+            issubclass(type(loss), (list, tuple))
+            and all([not tree.is_nested(_loss) for _loss in loss])
+            and len(loss) == len(flat_y_pred)
+        ):
+            loss = tree.pack_sequence_as(y_pred, loss)
+        elif issubclass(type(loss), (list, tuple)) and not isinstance(
+            y_pred, type(loss)
+        ):
+            for _loss in loss:
+                self._build_nested(
+                    y_true,
+                    y_pred,
+                    _loss,
+                    output_names,
+                    current_path,
+                )
+            return
+
+        if not tree.is_nested(loss):
+            return self._build_nested(
+                y_true, y_pred, loss, output_names, current_path
+            )
+
+        # At this point loss should match the structure of y_pred and y_true
+        # We assume y_pred and y_true have the same structure and this
+        # have been already asserted.
+
+        if not isinstance(loss, type(y_pred)):
+            raise KeyError(
+                f"The path: {current_path} in "
+                "the `loss` argument, can't be found in "
+                "the model's output (`y_pred`)."
+            )
+
+        # shallow traverse the loss config
+        if isinstance(loss, dict):
+            iterator = loss.items()
+
+            def key_check_fn(key, objs):
+                return all([key in obj for obj in objs])
+
+        elif issubclass(type(loss), (list, tuple)):
+            iterator = enumerate(loss)
+
+            def key_check_fn(key, objs):
+                return all([key < len(obj) for obj in objs])
+
+        else:
+            raise TypeError(
+                f"Unsupported type {type(loss)} "
+                f"in the `loss` configuration."
+            )
+
+        for key, _loss in iterator:
+            if not key_check_fn(key, (y_true, y_pred)):
+                raise KeyError(
+                    f"The path: {current_path + (key,)} in "
+                    "the `loss` argument, can't be found in "
+                    "the model's output (`y_pred`)."
+                )
+
+            self._build_nested(
+                y_true[key],
+                y_pred[key],
+                _loss,
+                output_names[key],
+                current_path + (key,),
+            )
+
     def build(self, y_true, y_pred):
         loss = self._user_loss
         loss_weights = self._user_loss_weights
-        output_names = self._get_y_pred_output_names(y_pred)
-        inferred_output_names = output_names or self.output_names
+        flat_output_names = self.output_names
 
-        if isinstance(loss, dict) and (
-            not tree.is_nested(y_pred) or isinstance(y_pred, (list, tuple))
-        ):
-            # loss maps output_names
-            loss_keys = set(loss.keys())
-            if inferred_output_names is not None:
-                y_pred_keys = set(inferred_output_names)
-                if len(loss_keys - y_pred_keys) > 0:
-                    raise KeyError(
-                        f"There are keys: {list(loss_keys - y_pred_keys)} in "
-                        "the `loss` argument, but they can't be found in "
-                        "the model's output (`y_pred`)."
+        # Pytree leaf container
+        class WeightedLoss:
+            def __init__(self, loss, weight):
+                self.loss = loss
+                self.weight = weight
+
+        # pack the losses and the weights together
+        if loss_weights is not None:
+            try:
+                tree.assert_same_structure(
+                    loss, loss_weights, check_types=False
+                )
+            except ValueError:
+                flat_loss_weights = tree.flatten(loss_weights)
+                if len(tree.flatten(loss)) != len(flat_loss_weights):
+                    raise ValueError(
+                        f"`loss_weights` must match the number of losses, "
+                        f"got {len(tree.flatten(loss))} losses "
+                        f"and {len(loss_weights)} weigths."
                     )
+                loss_weights = tree.pack_sequence_as(loss, flat_loss_weights)
+            loss = tree.map_structure(
+                lambda _loss, _weight: WeightedLoss(_loss, _weight),
+                loss,
+                loss_weights,
+            )
+        else:
+            loss = tree.map_structure(
+                lambda _loss: WeightedLoss(_loss, None), loss
+            )
 
-            loss = tree.flatten(loss)
+        self._flat_losses = []
+
+        if (
+            isinstance(loss, dict)
+            and issubclass(type(y_pred), (list, tuple))
+            and set(loss.keys()) == set(flat_output_names)
+            and len(y_pred) == len(flat_output_names)
+        ):
+            y_pred = {name: y_p for name, y_p in zip(flat_output_names, y_pred)}
+            y_true = {name: y_t for name, y_t in zip(flat_output_names, y_true)}
+        if (
+            isinstance(loss, dict)
+            and not tree.is_nested(y_pred)
+            and set(loss.keys()) == set(flat_output_names)
+            and len(flat_output_names) == 1
+        ):
+            y_pred = {
+                name: y_p for name, y_p in zip(flat_output_names, [y_pred])
+            }
+            y_true = {
+                name: y_t for name, y_t in zip(flat_output_names, [y_true])
+            }
+
+        try:
+            output_names = tree.pack_sequence_as(y_pred, flat_output_names)
+        except:
+            inferred_flat_output_names = self._get_y_pred_output_names(y_pred)
+            output_names = tree.pack_sequence_as(
+                y_pred, inferred_flat_output_names
+            )
 
         if not tree.is_nested(loss):
             loss = tree.map_structure(lambda x: loss, y_pred)
 
-        if isinstance(loss, dict):
-            is_loss_mapping = True
-            loss_keys = set(loss.keys())
-            accessors = optree.tree_accessors(y_pred, namespace="keras")
-            paths_list = []
-
-            def path_fn(a):
-                path = self._path_separator.join([str(e.entry) for e in a])
-                path_field = self._path_separator.join(
-                    [
-                        e.field if hasattr(e, "field") else str(e.entry)
-                        for e in a
-                    ]
-                )
-                accessor_paths = {path, path_field}
-                paths_list.extend(accessor_paths)
-                return a, tuple(accessor_paths)
-
-            accessors_paths = [path_fn(a) for a in accessors]
-            sorted_paths = sorted(paths_list)
-            # check whether paths don't overlap with each other,
-            # may happen if the structure's fields contain
-            # the path separator.
-            for i in range(len(sorted_paths) - 1):
-                if sorted_paths[i + 1].startswith(sorted_paths[i]):
-                    raise KeyError(
-                        f"The model's output structure contains "
-                        f"the following ambiguous path: {sorted_paths[i]}."
-                    )
-            flat_losses = []
-            remaining_loss_paths = loss_keys.copy()
-
-            def fn(a, paths):
-                for key in remaining_loss_paths:
-                    for path in paths:
-                        if path.startswith(key):
-                            loss_accessor = optree.PyTreeAccessor(
-                                a[: len(key.split(self._path_separator))]
-                            )
-                            losses = tree.flatten(loss[key])
-                            flat_losses.extend(
-                                [(loss_accessor, _loss) for _loss in losses]
-                            )
-                            remaining_loss_paths.remove(key)
-                            break
-                    if key not in remaining_loss_paths:
-                        break
-
-            remaining_count = len(remaining_loss_paths)
-            while remaining_loss_paths:
-                [fn(a, paths) for a, paths in accessors_paths]
-                if remaining_count == len(remaining_loss_paths):
-                    raise KeyError(
-                        f"There are keys: {list(remaining_loss_paths)} in "
-                        "the `loss` argument, but they can't be found in "
-                        "the model's output (`y_pred`)."
-                    )
-                remaining_count = len(remaining_loss_paths)
-        else:
-            is_loss_mapping = False
-            loss = tree.flatten(loss)
-            accessors, _, _ = optree.tree_flatten_with_accessor(loss)
-            flat_losses = [(a, a(loss)) for a in accessors]
-            y_pred = tree.flatten(y_pred)
-            y_true = tree.flatten(y_true)
-            if len(y_true) != len(flat_losses):
-                raise ValueError(
-                    "For a model with multiple outputs, "
-                    "when providing the `loss` argument as a list, "
-                    "it should have as many entries as the model has outputs. "
-                    f"Received:\nloss={loss}\nof length {len(flat_losses)} "
-                    f"whereas the model has {len(y_pred)} outputs."
-                )
-
-        # Get the real loss instances.
-        flat_losses = [
-            (accessor, get_loss(identifier, accessor(y_true), accessor(y_pred)))
-            for accessor, identifier in flat_losses
-        ]
+        self._build_nested(y_true, y_pred, loss, output_names, ())
 
         # Add `Mean` metric to the tracker for each loss.
-        if len(flat_losses) > 1:
-            for accessor, _loss in flat_losses:
-                if _loss is not None:
-                    if is_loss_mapping:
-                        name = self._path_separator.join(
-                            [str(e) for e in accessor.path]
-                        )
-                    elif inferred_output_names is not None and len(
-                        inferred_output_names
-                    ) == len(flat_losses):
-                        name = accessor(inferred_output_names)
-                    else:
-                        name = _loss.name
-                    name += "_loss"
-                    self._tracker.add_to_store(
-                        "metrics", metrics_module.Mean(name=name)
-                    )
-
-        if loss_weights is None:
-            flat_loss_weights = [None] * len(flat_losses)
-        else:
-            flat_loss_weights = tree.flatten(loss_weights)
-            for loss_weight in flat_loss_weights:
-                if not isinstance(loss_weight, (int, float, type(None))):
-                    raise TypeError(
-                        "When providing the `loss_weights` argument, each "
-                        "element should be a Python int, float (the weighting "
-                        "coefficient corresponding to the loss for that "
-                        "output) or `None`."
-                        f"Received: loss_weights={loss_weights}"
-                    )
-            if len(flat_loss_weights) != len(flat_losses):
-                raise ValueError(
-                    "When providing the `loss_weights` argument, it should "
-                    "have equal length of `loss` argument. "
-                    f"Received: loss_weights length={len(flat_loss_weights)}, "
-                    f"loss length={len(flat_losses)}"
+        if len(self._flat_losses) > 1:
+            for _loss in self._flat_losses:
+                name = _loss.name + "_loss"
+                self._tracker.add_to_store(
+                    "metrics", metrics_module.Mean(name=name)
                 )
 
-        self.flat_losses = flat_losses
-        self.flat_loss_weights = flat_loss_weights
-        self.inferred_output_names = inferred_output_names
-        self._y_pred_build_structure = optree.tree_structure(
-            y_pred, namespace="keras"
+        self._y_pred_build_structure = tree.map_structure(
+            lambda x: None, y_pred
         )
         self.built = True
 
     def _get_y_pred_output_names(self, y_pred):
-        if isinstance(y_pred, dict):
-            output_names = sorted(y_pred.keys())
+        flat_y_pred = tree.flatten(y_pred)
+        if all((isinstance(x, KerasTensor) for x in flat_y_pred)):
+            output_names = []
+            for tensor in flat_y_pred:
+                if hasattr(tensor, "_keras_history"):
+                    output_names.append(tensor._keras_history.operation.name)
+                else:
+                    output_names.append(tensor.name)
         else:
-            y_pred = tree.flatten(y_pred)
-            if all(hasattr(x, "_keras_history") for x in y_pred):
-                output_names = [x._keras_history.operation.name for x in y_pred]
-            else:
-                output_names = None
+            output_names = [None] * len(flat_y_pred)
         return output_names
-
-    def _filter_unused_inputs(
-        self,
-        y_true,
-        y_pred,
-        filtered_y_true_keys,
-        filtered_y_pred_keys,
-        output_names,
-    ):
-        if len(filtered_y_true_keys) > 0 and isinstance(y_true, dict):
-            # Modifying data in-place can cause errors in TF's graph.
-            filtered_y_true = {}
-            for k, v in y_true.items():
-                if k not in filtered_y_true_keys:
-                    filtered_y_true[k] = v
-            y_true = filtered_y_true
-        if len(filtered_y_pred_keys) > 0:
-            if isinstance(y_pred, dict):
-                # Modifying data in-place can cause errors in TF's graph.
-                filtered_y_pred = {}
-                for k, v in y_pred.items():
-                    if k not in filtered_y_pred_keys:
-                        filtered_y_pred[k] = v
-                y_pred = filtered_y_pred
-            elif output_names is not None:
-                y_pred = []
-                for x, output_name in zip(tree.flatten(y_pred), output_names):
-                    if output_name not in filtered_y_pred_keys:
-                        y_pred.append(x)
-        return y_true, y_pred
 
     def __call__(self, y_true, y_pred, sample_weight=None):
         with ops.name_scope(self.name):
             return self.call(y_true, y_pred, sample_weight)
 
     def call(self, y_true, y_pred, sample_weight=None):
-        y_pred_struct = optree.tree_structure(y_pred, namespace="keras")
-        y_true_struct = optree.tree_structure(y_true, namespace="keras")
-        if y_true_struct != y_pred_struct:
+        try:
+            tree.assert_same_structure(y_pred, y_true, check_types=False)
+        except ValueError:
             # y_true is either flat or leaf
             if not tree.is_nested(y_true):
                 y_true = [y_true]
@@ -668,15 +675,17 @@ class CompileLoss(losses_module.Loss):
         if not self.built:
             self.build(y_true, y_pred)
 
-        if self._y_pred_build_structure != y_pred_struct:
-            # the build have been made with flattened structure
-            y_pred = tree.flatten(y_pred)
-            y_true = tree.flatten(y_true)
-
-        if sample_weight is not None:
-            sample_weight = tree.flatten(sample_weight)
-        else:
-            sample_weight = [None for _ in self.flat_losses]
+        try:
+            tree.assert_same_structure(
+                self._y_pred_build_structure, y_pred, check_types=False
+            )
+        except ValueError:
+            y_pred = tree.pack_sequence_as(
+                self._y_pred_build_structure, tree.flatten(y_pred)
+            )
+            y_true = tree.pack_sequence_as(
+                self._y_pred_build_structure, tree.flatten(y_true)
+            )
 
         # We need to add a dummy `None` if the model has only a single output.
         metrics = [None] if len(self.metrics) == 0 else self.metrics
@@ -684,23 +693,30 @@ class CompileLoss(losses_module.Loss):
         # Iterate all losses in flat form.
         loss_values = []
 
-        for (accessor, loss_fn), loss_weight, sample_weight, metric in zip(
-            self.flat_losses, self.flat_loss_weights, sample_weight, metrics
-        ):
-            y_t, y_p = accessor(y_true), accessor(y_pred)
+        def resolve_path(path, object):
+            for _path in path:
+                object = object[_path]
+            return object
 
-            if loss_fn:
-                value = ops.cast(
-                    loss_fn(y_t, y_p, sample_weight), dtype=self.dtype
+        for (path, loss_fn, loss_weight, name), metric in zip(
+            self._flat_losses, metrics
+        ):
+            y_t, y_p = resolve_path(path, y_true), resolve_path(path, y_pred)
+            if sample_weight is not None and tree.is_nested(sample_weight):
+                _sample_weight = resolve_path(path, sample_weight)
+            else:
+                _sample_weight = sample_weight
+            value = ops.cast(
+                loss_fn(y_t, y_p, _sample_weight), dtype=self.dtype
+            )
+            if loss_weight is not None:
+                value = ops.multiply(value, loss_weight)
+            loss_values.append(value)
+            # Record individual losses.
+            if metric:
+                metric.update_state(
+                    value, sample_weight=tree.flatten(y_p)[0].shape[0]
                 )
-                if loss_weight is not None:
-                    value = ops.multiply(value, loss_weight)
-                loss_values.append(value)
-                # Record individual losses.
-                if metric:
-                    metric.update_state(
-                        value, sample_weight=tree.flatten(y_p)[0].shape[0]
-                    )
 
         if loss_values:
             total_loss = sum(loss_values)

--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -607,7 +607,7 @@ class CompileLoss(losses_module.Loss):
         ):
             y_pred = {name: y_p for name, y_p in zip(flat_output_names, y_pred)}
             y_true = {name: y_t for name, y_t in zip(flat_output_names, y_true)}
-        if (
+        elif (
             isinstance(loss, dict)
             and not tree.is_nested(y_pred)
             and set(loss.keys()) == set(flat_output_names)

--- a/keras/src/trainers/compile_utils_test.py
+++ b/keras/src/trainers/compile_utils_test.py
@@ -1,4 +1,7 @@
+from collections import namedtuple
+
 import numpy as np
+import tree
 from absl.testing import parameterized
 
 from keras.src import backend
@@ -347,3 +350,204 @@ class TestCompileLoss(testing.TestCase):
         }
         value = compile_loss(y_true, y_pred)
         self.assertAllClose(value, 1.07666, atol=1e-5)
+
+    def test_struct_loss(self):
+        y_true = {
+            "a": {
+                "c": np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]),
+                "d": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+            },
+            "b": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+        }
+        y_pred = {
+            "a": {
+                "c": np.array([[1.2, 1.1], [1.0, 0.9], [0.8, 0.7]]),
+                "d": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+            },
+            "b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+        }
+        loss = {"a/c": "mse", "a/d": "mae"}
+        compile_loss = CompileLoss(loss=loss, output_names=["c", "d", "b"])
+        y_true_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_true
+        )
+        y_pred_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_pred
+        )
+        compile_loss.build(y_true_symb, y_pred_symb)
+        value = compile_loss(y_true, y_pred)
+        self.assertAllClose(value, 1.07666, atol=1e-5)
+
+    def test_struct_loss_indice_path(self):
+        y_true = {
+            "a": (
+                np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]),
+                np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+            ),
+            "b": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+        }
+        y_pred = {
+            "a": (
+                np.array([[1.2, 1.1], [1.0, 0.9], [0.8, 0.7]]),
+                np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+            ),
+            "b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+        }
+        loss = {"a/0": "mse", "a/1": "mae"}
+        compile_loss = CompileLoss(loss=loss, output_names=["c", "d", "b"])
+        y_true_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_true
+        )
+        y_pred_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_pred
+        )
+        compile_loss.build(y_true_symb, y_pred_symb)
+        value = compile_loss(y_true, y_pred)
+        self.assertAllClose(value, 1.07666, atol=1e-5)
+
+    def test_struct_loss_namedtuple_field(self):
+        Point = namedtuple("Point", ["x", "y"])
+        y_true = {
+            "a": Point(
+                np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]),
+                np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+            ),
+            "b": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+        }
+        y_pred = {
+            "a": Point(
+                np.array([[1.2, 1.1], [1.0, 0.9], [0.8, 0.7]]),
+                np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+            ),
+            "b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+        }
+        loss = {"a/x": "mse", "a/y": "mae"}
+        compile_loss = CompileLoss(loss=loss, output_names=["c", "d", "b"])
+        y_true_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_true
+        )
+        y_pred_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_pred
+        )
+        compile_loss.build(y_true_symb, y_pred_symb)
+        value = compile_loss(y_true, y_pred)
+        self.assertAllClose(value, 1.07666, atol=1e-5)
+
+    def test_struct_loss_namedtuple_index(self):
+        Point = namedtuple("Point", ["x", "y"])
+        y_true = {
+            "a": Point(
+                np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]),
+                np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+            ),
+            "b": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+        }
+        y_pred = {
+            "a": Point(
+                np.array([[1.2, 1.1], [1.0, 0.9], [0.8, 0.7]]),
+                np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+            ),
+            "b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+        }
+        loss = {"a/0": "mse", "a/1": "mae"}
+        compile_loss = CompileLoss(loss=loss, output_names=["c", "d", "b"])
+        y_true_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_true
+        )
+        y_pred_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_pred
+        )
+        compile_loss.build(y_true_symb, y_pred_symb)
+        value = compile_loss(y_true, y_pred)
+        self.assertAllClose(value, 1.07666, atol=1e-5)
+
+    def test_struct_loss_invalid_path(self):
+        y_true = {
+            "a": {
+                "c": np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]),
+                "d": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+            },
+            "b": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+        }
+        y_pred = {
+            "a": {
+                "c": np.array([[1.2, 1.1], [1.0, 0.9], [0.8, 0.7]]),
+                "d": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+            },
+            "b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+        }
+        loss = {"a/c": "mse", "b/d": "mae"}
+        compile_loss = CompileLoss(loss=loss, output_names=["c", "d", "b"])
+        y_true_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_true
+        )
+        y_pred_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_pred
+        )
+        with self.assertRaisesRegex(
+            KeyError, "they can't be found in the model's output"
+        ):
+            compile_loss.build(y_true_symb, y_pred_symb)
+
+    def test_struct_loss_ambiguous(self):
+        y_true = {
+            "a": {"b": np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])},
+            "a/b": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+        }
+        y_pred = {
+            "a": {"b": np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])},
+            "a/b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+        }
+        loss = {"a/b": "mse"}
+        compile_loss = CompileLoss(loss=loss, output_names=["b", "a/b"])
+        y_true_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_true
+        )
+        y_pred_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_pred
+        )
+        with self.assertRaisesRegex(
+            KeyError,
+            "The model's output structure contains the "
+            "following ambiguous path",
+        ):
+            compile_loss.build(y_true_symb, y_pred_symb)
+
+    def get_loss_func(self, shape):
+        def loss_shape_check(y_t, y_p):
+            self.assertEqual(y_t.shape, shape)
+            self.assertEqual(y_p.shape, shape)
+            return ops.sum(ops.abs(y_t - y_p))
+
+        return loss_shape_check
+
+    def test_struct_loss_ambiguous2(self):
+        y_true = {
+            "a": (
+                (np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]),),
+                (np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),),
+            ),
+            "a/0": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+        }
+        y_pred = {
+            "a": (
+                (np.array([[1.2, 1.1], [1.0, 0.9], [0.8, 0.7]]),),
+                (np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),),
+            ),
+            "a/0": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+        }
+
+        loss = {"a/0": "mse"}
+        compile_loss = CompileLoss(loss=loss, output_names=["a", "a/0"])
+        y_true_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_true
+        )
+        y_pred_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_pred
+        )
+        with self.assertRaisesRegex(
+            KeyError,
+            "The model's output structure contains the "
+            "following ambiguous path",
+        ):
+            compile_loss.build(y_true_symb, y_pred_symb)

--- a/keras/src/trainers/compile_utils_test.py
+++ b/keras/src/trainers/compile_utils_test.py
@@ -366,7 +366,7 @@ class TestCompileLoss(testing.TestCase):
             },
             "b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
         }
-        loss = {"a/c": "mse", "a/d": "mae"}
+        loss = {"a": {"c": "mse", "d": "mae"}}
         compile_loss = CompileLoss(loss=loss, output_names=["c", "d", "b"])
         y_true_symb = tree.map_structure(
             lambda _: backend.KerasTensor((3, 4)), y_true
@@ -377,6 +377,36 @@ class TestCompileLoss(testing.TestCase):
         compile_loss.build(y_true_symb, y_pred_symb)
         value = compile_loss(y_true, y_pred)
         self.assertAllClose(value, 1.07666, atol=1e-5)
+
+    def test_struct_loss_invalid_weights(self):
+        y_true = {
+            "a": {
+                "c": np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]),
+                "d": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+            },
+            "b": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
+        }
+        y_pred = {
+            "a": {
+                "c": np.array([[1.2, 1.1], [1.0, 0.9], [0.8, 0.7]]),
+                "d": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+            },
+            "b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
+        }
+        loss = {"a": {"c": "mse", "d": "mae"}}
+        compile_loss = CompileLoss(
+            loss=loss, output_names=["c", "d", "b"], loss_weights=[1]
+        )
+        y_true_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_true
+        )
+        y_pred_symb = tree.map_structure(
+            lambda _: backend.KerasTensor((3, 4)), y_pred
+        )
+        with self.assertRaisesRegex(
+            ValueError, "must match the number of losses"
+        ):
+            compile_loss.build(y_true_symb, y_pred_symb)
 
     def test_struct_loss_indice_path(self):
         y_true = {
@@ -393,7 +423,7 @@ class TestCompileLoss(testing.TestCase):
             ),
             "b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
         }
-        loss = {"a/0": "mse", "a/1": "mae"}
+        loss = {"a": ["mse", "mae"]}
         compile_loss = CompileLoss(loss=loss, output_names=["c", "d", "b"])
         y_true_symb = tree.map_structure(
             lambda _: backend.KerasTensor((3, 4)), y_true
@@ -405,7 +435,7 @@ class TestCompileLoss(testing.TestCase):
         value = compile_loss(y_true, y_pred)
         self.assertAllClose(value, 1.07666, atol=1e-5)
 
-    def test_struct_loss_namedtuple_field(self):
+    def test_struct_loss_namedtuple(self):
         Point = namedtuple("Point", ["x", "y"])
         y_true = {
             "a": Point(
@@ -421,35 +451,7 @@ class TestCompileLoss(testing.TestCase):
             ),
             "b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
         }
-        loss = {"a/x": "mse", "a/y": "mae"}
-        compile_loss = CompileLoss(loss=loss, output_names=["c", "d", "b"])
-        y_true_symb = tree.map_structure(
-            lambda _: backend.KerasTensor((3, 4)), y_true
-        )
-        y_pred_symb = tree.map_structure(
-            lambda _: backend.KerasTensor((3, 4)), y_pred
-        )
-        compile_loss.build(y_true_symb, y_pred_symb)
-        value = compile_loss(y_true, y_pred)
-        self.assertAllClose(value, 1.07666, atol=1e-5)
-
-    def test_struct_loss_namedtuple_index(self):
-        Point = namedtuple("Point", ["x", "y"])
-        y_true = {
-            "a": Point(
-                np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]),
-                np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
-            ),
-            "b": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
-        }
-        y_pred = {
-            "a": Point(
-                np.array([[1.2, 1.1], [1.0, 0.9], [0.8, 0.7]]),
-                np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
-            ),
-            "b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
-        }
-        loss = {"a/0": "mse", "a/1": "mae"}
+        loss = {"a": Point("mse", "mae")}
         compile_loss = CompileLoss(loss=loss, output_names=["c", "d", "b"])
         y_true_symb = tree.map_structure(
             lambda _: backend.KerasTensor((3, 4)), y_true
@@ -476,7 +478,7 @@ class TestCompileLoss(testing.TestCase):
             },
             "b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
         }
-        loss = {"a/c": "mse", "b/d": "mae"}
+        loss = {"a": {"c": "mse"}, "b": {"d": "mae"}}
         compile_loss = CompileLoss(loss=loss, output_names=["c", "d", "b"])
         y_true_symb = tree.map_structure(
             lambda _: backend.KerasTensor((3, 4)), y_true
@@ -485,69 +487,6 @@ class TestCompileLoss(testing.TestCase):
             lambda _: backend.KerasTensor((3, 4)), y_pred
         )
         with self.assertRaisesRegex(
-            KeyError, "they can't be found in the model's output"
-        ):
-            compile_loss.build(y_true_symb, y_pred_symb)
-
-    def test_struct_loss_ambiguous(self):
-        y_true = {
-            "a": {"b": np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])},
-            "a/b": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
-        }
-        y_pred = {
-            "a": {"b": np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])},
-            "a/b": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
-        }
-        loss = {"a/b": "mse"}
-        compile_loss = CompileLoss(loss=loss, output_names=["b", "a/b"])
-        y_true_symb = tree.map_structure(
-            lambda _: backend.KerasTensor((3, 4)), y_true
-        )
-        y_pred_symb = tree.map_structure(
-            lambda _: backend.KerasTensor((3, 4)), y_pred
-        )
-        with self.assertRaisesRegex(
-            KeyError,
-            "The model's output structure contains the "
-            "following ambiguous path",
-        ):
-            compile_loss.build(y_true_symb, y_pred_symb)
-
-    def get_loss_func(self, shape):
-        def loss_shape_check(y_t, y_p):
-            self.assertEqual(y_t.shape, shape)
-            self.assertEqual(y_p.shape, shape)
-            return ops.sum(ops.abs(y_t - y_p))
-
-        return loss_shape_check
-
-    def test_struct_loss_ambiguous2(self):
-        y_true = {
-            "a": (
-                (np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]),),
-                (np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),),
-            ),
-            "a/0": np.array([[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]]),
-        }
-        y_pred = {
-            "a": (
-                (np.array([[1.2, 1.1], [1.0, 0.9], [0.8, 0.7]]),),
-                (np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),),
-            ),
-            "a/0": np.array([[0.6, 0.5], [0.4, 0.3], [0.2, 0.1]]),
-        }
-
-        loss = {"a/0": "mse"}
-        compile_loss = CompileLoss(loss=loss, output_names=["a", "a/0"])
-        y_true_symb = tree.map_structure(
-            lambda _: backend.KerasTensor((3, 4)), y_true
-        )
-        y_pred_symb = tree.map_structure(
-            lambda _: backend.KerasTensor((3, 4)), y_pred
-        )
-        with self.assertRaisesRegex(
-            KeyError,
-            "The model's output structure contains the "
-            "following ambiguous path",
+            KeyError, "can't be found in the model's output"
         ):
             compile_loss.build(y_true_symb, y_pred_symb)

--- a/keras/src/tree/optree_impl.py
+++ b/keras/src/tree/optree_impl.py
@@ -23,6 +23,17 @@ if backend() == "tensorflow":
         namespace="keras",
     )
 
+    from tensorflow.python.trackable.data_structures import _DictWrapper
+
+    optree.register_pytree_node(
+        _DictWrapper,
+        lambda x: (list(x.values()), list(x.keys())),
+        lambda metadata, children: _DictWrapper(
+            {key: child for key, child in zip(metadata, children)}
+        ),
+        namespace="keras",
+    )
+
 
 def is_nested(structure):
     return not optree.tree_is_leaf(


### PR DESCRIPTION
### Description

This pull request enhances loss configuration flexibility by allowing the use of a nested structure that mirrors the output structure to map outputs to loss functions. This enables training with structured losses that can be applied to any level of the output hierarchy such as individual tensors or nested structures of tensors.

Key features:

1. Flexibility to apply losses to both individual tensors (leaf nodes) and nested structures of tensors (intermediate nodes) in the output.
2. The entire subtree at a given node is passed to the corresponding loss function, allowing for custom loss calculations on structured data.

### Usage Example

```python
import keras
import numpy as np
from keras.src import tree

# Generate some dummy data
np.random.seed(0)
data_shape = (10, 2)
X = np.random.rand(*data_shape)
y1 = np.random.rand(*data_shape)
y2 = np.random.rand(*data_shape)
y3 = np.random.rand(*data_shape)
Y = {'a': y1, 'b': {'c': (y1, y2), 'd': y3}}


# Loss function working on arbitrary pytrees
def loss_fn(y_true, y_pred):
  flat_y_pred, flat_y_true = tree.flatten(y_pred), tree.flatten(y_true)
  diff = 0
  for y_p, y_t in zip(flat_y_pred, flat_y_true):
    diff += keras.losses.mean_absolute_error(y_t, y_p)
  return diff


# Define the model
inputs = keras.Input(shape=data_shape[1:])
x = keras.layers.Dense(64, activation='relu')(inputs)
x = keras.layers.Dense(32, activation='relu')(x)
y1 = keras.layers.Dense(data_shape[-1], name='y1')(x)
y2 = keras.layers.Dense(data_shape[-1], name='y2')(x)
y3 = keras.layers.Dense(data_shape[-1], name='y3')(x)

model = keras.Model(inputs=inputs,
                    outputs={'a': y1, 'b': {'c': (y1, y2), 'd': y3}})

# The following losses configuration applies the loss to the paths:
# 'a', 'b', 'b/c', 'b/c/0', 'b/d'
loss = {
         'a': loss_fn,
         'b': [loss_fn, 
                {
                  'c': [loss_fn, (loss_fn, None)],
                  'd': loss_fn
                 }
              ], 
        }

model.compile(optimizer='adam', loss=loss)

model.fit(X, Y, epochs=4, batch_size=2, verbose=1)

```

Example output:
```
Epoch 1/4
5/5 ━━━━━━━━━━━━━━━━━━━━ 0s 7ms/step - a_loss: 0.5786 - b/c/y1_loss: 0.5786 - b/c_loss: 0.9755 - b/d_loss: 0.5344 - b_loss: 1.5099 - loss: 4.1770  
Epoch 2/4
5/5 ━━━━━━━━━━━━━━━━━━━━ 0s 7ms/step - a_loss: 0.5413 - b/c/y1_loss: 0.5413 - b/c_loss: 0.9610 - b/d_loss: 0.3915 - b_loss: 1.3525 - loss: 3.7876
Epoch 3/4
5/5 ━━━━━━━━━━━━━━━━━━━━ 0s 7ms/step - a_loss: 0.5184 - b/c/y1_loss: 0.5184 - b/c_loss: 0.8692 - b/d_loss: 0.2813 - b_loss: 1.1505 - loss: 3.3379
Epoch 4/4
5/5 ━━━━━━━━━━━━━━━━━━━━ 0s 7ms/step - a_loss: 0.4610 - b/c/y1_loss: 0.4610 - b/c_loss: 0.7571 - b/d_loss: 0.2707 - b_loss: 1.0279 - loss: 2.9779
```
