### PR TITLE
Addressed variable names mismatch in example code in softmax.py

### DIFF
--- a/keras/src/layers/activations/softmax.py
+++ b/keras/src/layers/activations/softmax.py
@@ -22,9 +22,10 @@ class Softmax(Layer):
     ```
 
     Example:
-    >>>softmax_layer = keras.layers.activations.Softmax()
-    >>>input = np.array([1.0, 2.0, 1.0])
-    >>>result = softmax_layer(input)
+    >>> softmax_layer = keras.layers.activations.Softmax()
+    >>> input = np.array([1.0, 2.0, 1.0])
+    >>> result = softmax_layer(input)
+    >>> result
     [0.21194157, 0.5761169, 0.21194157]
 
 


### PR DESCRIPTION
This PR is raised to address the variable names mismatch in the example code.