### PR TITLE
Allow some TF kernels fusion: tf.nn.bias_add as special case of tf.add

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -35,6 +35,25 @@ def add(x1, x2):
     )
     x1 = convert_to_tensor(x1, dtype)
     x2 = convert_to_tensor(x2, dtype)
+
+    # Special case of `tf.add`: `tf.nn.bias_add`
+    # `BiasAdd` can be fused with `MatMul` and `Conv*` kernels
+    # Expecting `x1` to be `inputs` and `x2` to be `bias` (no swapping)
+    x2_squeeze_shape = [d for d in x2.shape if d is None or d > 1]
+    if (
+        1 == len(x2_squeeze_shape)
+        and len(x1.shape) > 1
+        and x2_squeeze_shape[0] is not None
+        and x2_squeeze_shape[0] in {x1.shape[1], x1.shape[-1]}
+    ):
+        if x1.shape[-1] == x2_squeeze_shape[0]:
+            data_format = "NHWC"
+        else:
+            data_format = "NCHW"
+        if len(x2.shape) > 1:
+            x2 = tf.squeeze(x2)
+        return tf.nn.bias_add(x1, x2, data_format=data_format)
+
     return tf.add(x1, x2)
 
 

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -41,9 +41,13 @@ def add(x1, x2):
     # Expecting `x1` to be `inputs` and `x2` to be `bias` (no swapping)
     x2_squeeze_shape = [d for d in x2.shape if d is None or d > 1]
     if (
+        # `x2` looks like bias (can be squeezed to vector)
         1 == len(x2_squeeze_shape)
+        # `x1` looks like input tensor (rank >= 2)
         and len(x1.shape) > 1
+        # `x2` non-squeezable dimension defined
         and x2_squeeze_shape[0] is not None
+        # `x2` non-squeezable dimension match `x1` channel dimension
         and x2_squeeze_shape[0] in {x1.shape[1], x1.shape[-1]}
     ):
         if x1.shape[-1] == x2_squeeze_shape[0]:

--- a/keras/src/layers/convolutional/base_conv.py
+++ b/keras/src/layers/convolutional/base_conv.py
@@ -250,7 +250,7 @@ class BaseConv(Layer):
             else:
                 bias_shape = (1, self.filters) + (1,) * self.rank
             bias = ops.reshape(self.bias, bias_shape)
-            outputs += bias
+            outputs = ops.add(outputs, bias)
 
         if self.activation is not None:
             return self.activation(outputs)

--- a/keras/src/layers/convolutional/base_conv_transpose.py
+++ b/keras/src/layers/convolutional/base_conv_transpose.py
@@ -205,7 +205,7 @@ class BaseConvTranspose(Layer):
             else:
                 bias_shape = (1, self.filters) + (1,) * self.rank
             bias = ops.reshape(self.bias, bias_shape)
-            outputs += bias
+            outputs = ops.add(outputs, bias)
 
         if self.activation is not None:
             return self.activation(outputs)

--- a/keras/src/layers/convolutional/base_depthwise_conv.py
+++ b/keras/src/layers/convolutional/base_depthwise_conv.py
@@ -220,7 +220,7 @@ class BaseDepthwiseConv(Layer):
                     1,
                 ) * self.rank
             bias = ops.reshape(self.bias, bias_shape)
-            outputs += bias
+            outputs = ops.add(outputs, bias)
 
         if self.activation is not None:
             return self.activation(outputs)

--- a/keras/src/layers/convolutional/base_separable_conv.py
+++ b/keras/src/layers/convolutional/base_separable_conv.py
@@ -232,7 +232,7 @@ class BaseSeparableConv(Layer):
             else:
                 bias_shape = (1, self.filters) + (1,) * self.rank
             bias = ops.reshape(self.bias, bias_shape)
-            outputs += bias
+            outputs = ops.add(outputs, bias)
 
         if self.activation is not None:
             return self.activation(outputs)

--- a/keras/src/layers/convolutional/conv1d.py
+++ b/keras/src/layers/convolutional/conv1d.py
@@ -163,7 +163,7 @@ class Conv1D(BaseConv):
             else:
                 bias_shape = (1, self.filters) + (1,) * self.rank
             bias = ops.reshape(self.bias, bias_shape)
-            outputs += bias
+            outputs = ops.add(outputs, bias)
 
         if self.activation is not None:
             return self.activation(outputs)


### PR DESCRIPTION
Here is a demo how TF fuses BiasAdd kernel with MatMu/Conv* https://colab.research.google.com/drive/15TNcyvNcOCtvEFX8m-mA--W0MYK5bA6P?usp=sharing
The is no fusion if tf.add used instead.

To preserve behavior from Keras 2 (Dense and Conv* layers used tf.nn.bias_add), bias_add will be restored at backend level.
