### PR TITLE
Use `IndexError` instead of `ValueError` in `deserialize_node`

### DIFF
--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -699,7 +699,7 @@ def deserialize_node(node_data, created_layers):
             inbound_node_index = history[1]
             inbound_tensor_index = history[2]
             if len(layer._inbound_nodes) <= inbound_node_index:
-                raise ValueError(
+                raise IndexError(
                     "Layer node index out of bounds.\n"
                     f"inbound_layer = {layer}\n"
                     f"inbound_layer._inbound_nodes = {layer._inbound_nodes}\n"

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -723,6 +723,18 @@ class SavingTest(testing.TestCase):
             pool.join()
         [r.get() for r in results]  # No error occurs here
 
+    def test_load_model_containing_reused_layer(self):
+        # https://github.com/keras-team/keras/issues/20307
+        inputs = keras.Input((4,))
+        reused_layer = keras.layers.Dense(4)
+        x = reused_layer(inputs)
+        x = keras.layers.Dense(4)(x)
+        outputs = reused_layer(x)
+        model = keras.Model(inputs, outputs)
+
+        self.assertLen(model.layers, 3)  # Input + 2 Dense layers
+        self._test_inference_after_instantiation(model)
+
 
 @pytest.mark.requires_trainable_backend
 class SavingAPITest(testing.TestCase):


### PR DESCRIPTION
Fixes #20307 

Credit for the fix goes to @K1521. The corresponding test has been included.

