### PR TITLE
Updated keras.layers.activations.ReLU API with keras.layers.ReLU in E…

### DIFF
--- a/keras/src/layers/activations/relu.py
+++ b/keras/src/layers/activations/relu.py
@@ -17,7 +17,7 @@ class ReLU(Layer):
 
     Example:
     ``` python
-    relu_layer = keras.layers.activations.ReLU(
+    relu_layer = keras.layers.ReLU(
         max_value=10,
         negative_slope=0.5,
         threshold=0,


### PR DESCRIPTION
…xample from relu.py file

`keras.layers.activations.ReLU API` throwing `AttributeError: module 'keras.api.layers' has no attribute 'activations'`.  Modified      it with`keras.layers.ReLU API.