### PR TITLE
Add `mean_with_sample_weight` reduction to `Loss`

### DIFF
--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -1056,7 +1056,9 @@ def divide_no_nan(x1, x2):
     )
     x1 = convert_to_tensor(x1, dtype)
     x2 = convert_to_tensor(x2, dtype)
-    return np.where(x2 == 0, 0, np.divide(x1, x2))
+    # No need for the double-where trick since we don't calculate gradients in
+    # numpy backend.
+    return np.where(x2 == 0, np.array(0, dtype=dtype), np.divide(x1, x2))
 
 
 def true_divide(x1, x2):

--- a/keras/src/losses/loss.py
+++ b/keras/src/losses/loss.py
@@ -43,12 +43,7 @@ class Loss(KerasSaveable):
     ```
     """
 
-    def __init__(
-        self,
-        name=None,
-        reduction="sum_over_batch_size",
-        dtype=None,
-    ):
+    def __init__(self, name=None, reduction="sum_over_batch_size", dtype=None):
         self.name = name or auto_name(self.__class__.__name__)
         self.reduction = standardize_reduction(reduction)
         self._dtype_policy = dtype_policies.get(dtype or backend.floatx())
@@ -93,10 +88,7 @@ class Loss(KerasSaveable):
         raise NotImplementedError
 
     def get_config(self):
-        return {
-            "name": self.name,
-            "reduction": self.reduction,
-        }
+        return {"name": self.name, "reduction": self.reduction}
 
     @classmethod
     def from_config(cls, config):

--- a/keras/src/losses/loss_test.py
+++ b/keras/src/losses/loss_test.py
@@ -271,7 +271,7 @@ class LossTest(testing.TestCase):
 
         # `dtype` setter should raise AttributeError
         with self.assertRaises(AttributeError):
-            loss.dtype = "bfloat16"
+            loss_fn.dtype = "bfloat16"
 
     def test_default_dtype(self):
         y_true = np.array([1.0, 0.0, 1.0, 0.0], dtype="float32")

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -32,7 +32,7 @@ class LossFunctionWrapper(Loss):
         return self.fn(y_true, y_pred, **self._fn_kwargs)
 
     def get_config(self):
-        config = Loss.get_config(self)
+        config = super().get_config()
         config.update({"fn": serialization_lib.serialize_keras_object(self.fn)})
         config.update(serialization_lib.serialize_keras_object(self._fn_kwargs))
         return config

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -17,9 +17,15 @@ class LossFunctionWrapper(Loss):
         reduction="sum_over_batch_size",
         name=None,
         dtype=None,
+        normalize_by_sample_weight=False,
         **kwargs,
     ):
-        super().__init__(name=name, reduction=reduction, dtype=dtype)
+        super().__init__(
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
+        )
         self.fn = fn
         self._fn_kwargs = kwargs
 
@@ -32,7 +38,7 @@ class LossFunctionWrapper(Loss):
         return self.fn(y_true, y_pred, **self._fn_kwargs)
 
     def get_config(self):
-        config = super().get_config()
+        config = Loss.get_config(self)
         config.update({"fn": serialization_lib.serialize_keras_object(self.fn)})
         config.update(serialization_lib.serialize_keras_object(self._fn_kwargs))
         return config
@@ -64,6 +70,12 @@ class MeanSquaredError(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
@@ -71,9 +83,14 @@ class MeanSquaredError(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="mean_squared_error",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
-            mean_squared_error, name=name, reduction=reduction, dtype=dtype
+            mean_squared_error,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
         )
 
     def get_config(self):
@@ -100,6 +117,12 @@ class MeanAbsoluteError(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
@@ -107,9 +130,14 @@ class MeanAbsoluteError(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="mean_absolute_error",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
-            mean_absolute_error, name=name, reduction=reduction, dtype=dtype
+            mean_absolute_error,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
         )
 
     def get_config(self):
@@ -136,6 +164,12 @@ class MeanAbsolutePercentageError(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
@@ -143,12 +177,14 @@ class MeanAbsolutePercentageError(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="mean_absolute_percentage_error",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
             mean_absolute_percentage_error,
             name=name,
             reduction=reduction,
             dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
         )
 
     def get_config(self):
@@ -175,6 +211,12 @@ class MeanSquaredLogarithmicError(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
@@ -182,12 +224,14 @@ class MeanSquaredLogarithmicError(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="mean_squared_logarithmic_error",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
             mean_squared_logarithmic_error,
             name=name,
             reduction=reduction,
             dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
         )
 
     def get_config(self):
@@ -223,6 +267,12 @@ class CosineSimilarity(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
@@ -231,12 +281,14 @@ class CosineSimilarity(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="cosine_similarity",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
             cosine_similarity,
             name=name,
             reduction=reduction,
             dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
             axis=axis,
         )
 
@@ -273,6 +325,12 @@ class Huber(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
@@ -281,9 +339,15 @@ class Huber(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="huber_loss",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
-            huber, name=name, reduction=reduction, dtype=dtype, delta=delta
+            huber,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
+            delta=delta,
         )
 
     def get_config(self):
@@ -312,12 +376,28 @@ class LogCosh(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
-        self, reduction="sum_over_batch_size", name="log_cosh", dtype=None
+        self,
+        reduction="sum_over_batch_size",
+        name="log_cosh",
+        dtype=None,
+        normalize_by_sample_weight=False,
     ):
-        super().__init__(log_cosh, name=name, reduction=reduction, dtype=dtype)
+        super().__init__(
+            log_cosh,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -346,12 +426,28 @@ class Hinge(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
-        self, reduction="sum_over_batch_size", name="hinge", dtype=None
+        self,
+        reduction="sum_over_batch_size",
+        name="hinge",
+        dtype=None,
+        normalize_by_sample_weight=False,
     ):
-        super().__init__(hinge, name=name, reduction=reduction, dtype=dtype)
+        super().__init__(
+            hinge,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -380,13 +476,27 @@ class SquaredHinge(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
-        self, reduction="sum_over_batch_size", name="squared_hinge", dtype=None
+        self,
+        reduction="sum_over_batch_size",
+        name="squared_hinge",
+        dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
-            squared_hinge, name=name, reduction=reduction, dtype=dtype
+            squared_hinge,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
         )
 
     def get_config(self):
@@ -415,6 +525,12 @@ class CategoricalHinge(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
@@ -422,9 +538,14 @@ class CategoricalHinge(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="categorical_hinge",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
-            categorical_hinge, name=name, reduction=reduction, dtype=dtype
+            categorical_hinge,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
         )
 
     def get_config(self):
@@ -455,13 +576,27 @@ class KLDivergence(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
-        self, reduction="sum_over_batch_size", name="kl_divergence", dtype=None
+        self,
+        reduction="sum_over_batch_size",
+        name="kl_divergence",
+        dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
-            kl_divergence, name=name, reduction=reduction, dtype=dtype
+            kl_divergence,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
         )
 
     def get_config(self):
@@ -488,12 +623,28 @@ class Poisson(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
-        self, reduction="sum_over_batch_size", name="poisson", dtype=None
+        self,
+        reduction="sum_over_batch_size",
+        name="poisson",
+        dtype=None,
+        normalize_by_sample_weight=False,
     ):
-        super().__init__(poisson, name=name, reduction=reduction, dtype=dtype)
+        super().__init__(
+            poisson,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
+        )
 
     def get_config(self):
         return Loss.get_config(self)
@@ -533,6 +684,12 @@ class BinaryCrossentropy(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
 
     Examples:
 
@@ -594,12 +751,14 @@ class BinaryCrossentropy(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="binary_crossentropy",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
             binary_crossentropy,
             name=name,
             reduction=reduction,
             dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
             from_logits=from_logits,
             label_smoothing=label_smoothing,
             axis=axis,
@@ -609,13 +768,15 @@ class BinaryCrossentropy(LossFunctionWrapper):
         self.axis = axis
 
     def get_config(self):
-        return {
-            "name": self.name,
-            "reduction": self.reduction,
-            "from_logits": self.from_logits,
-            "label_smoothing": self.label_smoothing,
-            "axis": self.axis,
-        }
+        config = Loss.get_config(self)
+        config.update(
+            {
+                "from_logits": self.from_logits,
+                "label_smoothing": self.label_smoothing,
+                "axis": self.axis,
+            }
+        )
+        return config
 
 
 @keras_export("keras.losses.BinaryFocalCrossentropy")
@@ -670,6 +831,12 @@ class BinaryFocalCrossentropy(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
 
     Examples:
 
@@ -766,12 +933,14 @@ class BinaryFocalCrossentropy(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="binary_focal_crossentropy",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
             binary_focal_crossentropy,
             name=name,
             reduction=reduction,
             dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
             apply_class_balancing=apply_class_balancing,
             alpha=alpha,
             gamma=gamma,
@@ -787,16 +956,18 @@ class BinaryFocalCrossentropy(LossFunctionWrapper):
         self.gamma = gamma
 
     def get_config(self):
-        return {
-            "name": self.name,
-            "reduction": self.reduction,
-            "from_logits": self.from_logits,
-            "label_smoothing": self.label_smoothing,
-            "axis": self.axis,
-            "apply_class_balancing": self.apply_class_balancing,
-            "alpha": self.alpha,
-            "gamma": self.gamma,
-        }
+        config = Loss.get_config(self)
+        config.update(
+            {
+                "from_logits": self.from_logits,
+                "label_smoothing": self.label_smoothing,
+                "axis": self.axis,
+                "apply_class_balancing": self.apply_class_balancing,
+                "alpha": self.alpha,
+                "gamma": self.gamma,
+            }
+        )
+        return config
 
 
 @keras_export("keras.losses.CategoricalCrossentropy")
@@ -828,6 +999,12 @@ class CategoricalCrossentropy(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
 
     Examples:
 
@@ -872,12 +1049,14 @@ class CategoricalCrossentropy(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="categorical_crossentropy",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
             categorical_crossentropy,
             name=name,
             reduction=reduction,
             dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
             from_logits=from_logits,
             label_smoothing=label_smoothing,
             axis=axis,
@@ -887,13 +1066,15 @@ class CategoricalCrossentropy(LossFunctionWrapper):
         self.axis = axis
 
     def get_config(self):
-        return {
-            "name": self.name,
-            "reduction": self.reduction,
-            "from_logits": self.from_logits,
-            "label_smoothing": self.label_smoothing,
-            "axis": self.axis,
-        }
+        config = Loss.get_config(self)
+        config.update(
+            {
+                "from_logits": self.from_logits,
+                "label_smoothing": self.label_smoothing,
+                "axis": self.axis,
+            }
+        )
+        return config
 
 
 @keras_export("keras.losses.CategoricalFocalCrossentropy")
@@ -966,6 +1147,12 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
 
     Examples:
 
@@ -1012,6 +1199,7 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="categorical_focal_crossentropy",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         """Initializes `CategoricalFocalCrossentropy` instance."""
         super().__init__(
@@ -1019,6 +1207,7 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
             name=name,
             reduction=reduction,
             dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
             alpha=alpha,
             gamma=gamma,
             from_logits=from_logits,
@@ -1032,15 +1221,17 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
         self.gamma = gamma
 
     def get_config(self):
-        return {
-            "name": self.name,
-            "reduction": self.reduction,
-            "from_logits": self.from_logits,
-            "label_smoothing": self.label_smoothing,
-            "axis": self.axis,
-            "alpha": self.alpha,
-            "gamma": self.gamma,
-        }
+        config = Loss.get_config(self)
+        config.update(
+            {
+                "from_logits": self.from_logits,
+                "label_smoothing": self.label_smoothing,
+                "axis": self.axis,
+                "alpha": self.alpha,
+                "gamma": self.gamma,
+            }
+        )
+        return config
 
 
 @keras_export("keras.losses.SparseCategoricalCrossentropy")
@@ -1071,6 +1262,12 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
 
     Examples:
 
@@ -1112,12 +1309,14 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="sparse_categorical_crossentropy",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
             sparse_categorical_crossentropy,
             name=name,
             reduction=reduction,
             dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
             from_logits=from_logits,
             ignore_class=ignore_class,
         )
@@ -1125,12 +1324,14 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
         self.ignore_class = ignore_class
 
     def get_config(self):
-        return {
-            "name": self.name,
-            "reduction": self.reduction,
-            "from_logits": self.from_logits,
-            "ignore_class": self.ignore_class,
-        }
+        config = Loss.get_config(self)
+        config.update(
+            {
+                "from_logits": self.from_logits,
+                "ignore_class": self.ignore_class,
+            }
+        )
+        return config
 
 
 def convert_binary_labels_to_hinge(y_true):
@@ -2040,6 +2241,12 @@ class CTC(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
     """
 
     def __init__(
@@ -2047,14 +2254,18 @@ class CTC(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="ctc",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
-        super().__init__(ctc, name=name, reduction=reduction, dtype=dtype)
+        super().__init__(
+            ctc,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
+        )
 
     def get_config(self):
-        return {
-            "name": self.name,
-            "reduction": self.reduction,
-        }
+        return Loss.get_config(self)
 
 
 @keras_export("keras.losses.ctc")
@@ -2116,6 +2327,12 @@ class Dice(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
 
     Returns:
         Dice loss value.
@@ -2152,22 +2369,22 @@ class Dice(LossFunctionWrapper):
         name="dice",
         axis=None,
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
             dice,
             name=name,
             reduction=reduction,
             dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
             axis=axis,
         )
         self.axis = axis
 
     def get_config(self):
-        return {
-            "name": self.name,
-            "reduction": self.reduction,
-            "axis": self.axis,
-        }
+        config = Loss.get_config(self)
+        config.update({"axis": self.axis})
+        return config
 
 
 @keras_export("keras.losses.dice")
@@ -2228,6 +2445,12 @@ class Tversky(LossFunctionWrapper):
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
+        normalize_by_sample_weight: Whether to normalize the loss value by the
+            provided `sample_weight`. If set to `True` and `reduction` is
+            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
+            divided by `ops.sum(sample_weight)` instead of the sample size. This
+            approach may help stabilize the range of the loss value. Defaults to
+            `False`.
 
     Returns:
         Tversky loss value.
@@ -2244,12 +2467,14 @@ class Tversky(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="tversky",
         dtype=None,
+        normalize_by_sample_weight=False,
     ):
         super().__init__(
             tversky,
             name=name,
             reduction=reduction,
             dtype=dtype,
+            normalize_by_sample_weight=normalize_by_sample_weight,
             alpha=alpha,
             beta=beta,
         )
@@ -2257,12 +2482,9 @@ class Tversky(LossFunctionWrapper):
         self.beta = beta
 
     def get_config(self):
-        return {
-            "name": self.name,
-            "alpha": self.alpha,
-            "beta": self.beta,
-            "reduction": self.reduction,
-        }
+        config = Loss.get_config(self)
+        config.update({"alpha": self.alpha, "beta": self.beta})
+        return config
 
 
 @keras_export("keras.losses.tversky")

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -17,15 +17,9 @@ class LossFunctionWrapper(Loss):
         reduction="sum_over_batch_size",
         name=None,
         dtype=None,
-        normalize_by_sample_weight=False,
         **kwargs,
     ):
-        super().__init__(
-            name=name,
-            reduction=reduction,
-            dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
-        )
+        super().__init__(name=name, reduction=reduction, dtype=dtype)
         self.fn = fn
         self._fn_kwargs = kwargs
 
@@ -62,20 +56,19 @@ class MeanSquaredError(LossFunctionWrapper):
 
     Args:
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
     """
 
     def __init__(
@@ -83,14 +76,9 @@ class MeanSquaredError(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="mean_squared_error",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
         super().__init__(
-            mean_squared_error,
-            name=name,
-            reduction=reduction,
-            dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
+            mean_squared_error, name=name, reduction=reduction, dtype=dtype
         )
 
     def get_config(self):
@@ -109,20 +97,19 @@ class MeanAbsoluteError(LossFunctionWrapper):
 
     Args:
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
     """
 
     def __init__(
@@ -130,14 +117,9 @@ class MeanAbsoluteError(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="mean_absolute_error",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
         super().__init__(
-            mean_absolute_error,
-            name=name,
-            reduction=reduction,
-            dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
+            mean_absolute_error, name=name, reduction=reduction, dtype=dtype
         )
 
     def get_config(self):
@@ -156,20 +138,19 @@ class MeanAbsolutePercentageError(LossFunctionWrapper):
 
     Args:
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
     """
 
     def __init__(
@@ -177,14 +158,12 @@ class MeanAbsolutePercentageError(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="mean_absolute_percentage_error",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
         super().__init__(
             mean_absolute_percentage_error,
             name=name,
             reduction=reduction,
             dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
         )
 
     def get_config(self):
@@ -203,20 +182,19 @@ class MeanSquaredLogarithmicError(LossFunctionWrapper):
 
     Args:
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
     """
 
     def __init__(
@@ -224,14 +202,12 @@ class MeanSquaredLogarithmicError(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="mean_squared_logarithmic_error",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
         super().__init__(
             mean_squared_logarithmic_error,
             name=name,
             reduction=reduction,
             dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
         )
 
     def get_config(self):
@@ -259,20 +235,19 @@ class CosineSimilarity(LossFunctionWrapper):
         axis: The axis along which the cosine similarity is computed
             (the features axis). Defaults to `-1`.
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
     """
 
     def __init__(
@@ -281,14 +256,12 @@ class CosineSimilarity(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="cosine_similarity",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
         super().__init__(
             cosine_similarity,
             name=name,
             reduction=reduction,
             dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
             axis=axis,
         )
 
@@ -316,21 +289,20 @@ class Huber(LossFunctionWrapper):
     Args:
         delta: A float, the point where the Huber loss function changes from a
             quadratic to linear.
-        reduction: Type of reduction to apply to loss. Options are `"sum"`,
-            `"sum_over_batch_size"` or `None`. Defaults to
-            `"sum_over_batch_size"`.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
     """
 
     def __init__(
@@ -339,14 +311,12 @@ class Huber(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="huber_loss",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
         super().__init__(
             huber,
             name=name,
             reduction=reduction,
             dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
             delta=delta,
         )
 
@@ -367,21 +337,20 @@ class LogCosh(LossFunctionWrapper):
     where x is the error `y_pred - y_true`.
 
     Args:
-        reduction: Type of reduction to apply to loss. Options are `"sum"`,
-            `"sum_over_batch_size"` or `None`. Defaults to
-            `"sum_over_batch_size"`.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
     """
 
     def __init__(
@@ -389,15 +358,8 @@ class LogCosh(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="log_cosh",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
-        super().__init__(
-            log_cosh,
-            name=name,
-            reduction=reduction,
-            dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
-        )
+        super().__init__(log_cosh, name=name, reduction=reduction, dtype=dtype)
 
     def get_config(self):
         return Loss.get_config(self)
@@ -418,20 +380,19 @@ class Hinge(LossFunctionWrapper):
 
     Args:
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
     """
 
     def __init__(
@@ -439,15 +400,8 @@ class Hinge(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="hinge",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
-        super().__init__(
-            hinge,
-            name=name,
-            reduction=reduction,
-            dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
-        )
+        super().__init__(hinge, name=name, reduction=reduction, dtype=dtype)
 
     def get_config(self):
         return Loss.get_config(self)
@@ -468,35 +422,26 @@ class SquaredHinge(LossFunctionWrapper):
 
     Args:
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
     """
 
     def __init__(
-        self,
-        reduction="sum_over_batch_size",
-        name="squared_hinge",
-        dtype=None,
-        normalize_by_sample_weight=False,
+        self, reduction="sum_over_batch_size", name="squared_hinge", dtype=None
     ):
         super().__init__(
-            squared_hinge,
-            name=name,
-            reduction=reduction,
-            dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
+            squared_hinge, name=name, reduction=reduction, dtype=dtype
         )
 
     def get_config(self):
@@ -517,20 +462,19 @@ class CategoricalHinge(LossFunctionWrapper):
 
     Args:
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
     """
 
     def __init__(
@@ -538,14 +482,9 @@ class CategoricalHinge(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="categorical_hinge",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
         super().__init__(
-            categorical_hinge,
-            name=name,
-            reduction=reduction,
-            dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
+            categorical_hinge, name=name, reduction=reduction, dtype=dtype
         )
 
     def get_config(self):
@@ -568,35 +507,26 @@ class KLDivergence(LossFunctionWrapper):
 
     Args:
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
     """
 
     def __init__(
-        self,
-        reduction="sum_over_batch_size",
-        name="kl_divergence",
-        dtype=None,
-        normalize_by_sample_weight=False,
+        self, reduction="sum_over_batch_size", name="kl_divergence", dtype=None
     ):
         super().__init__(
-            kl_divergence,
-            name=name,
-            reduction=reduction,
-            dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
+            kl_divergence, name=name, reduction=reduction, dtype=dtype
         )
 
     def get_config(self):
@@ -615,36 +545,25 @@ class Poisson(LossFunctionWrapper):
 
     Args:
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
     """
 
     def __init__(
-        self,
-        reduction="sum_over_batch_size",
-        name="poisson",
-        dtype=None,
-        normalize_by_sample_weight=False,
+        self, reduction="sum_over_batch_size", name="poisson", dtype=None
     ):
-        super().__init__(
-            poisson,
-            name=name,
-            reduction=reduction,
-            dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
-        )
+        super().__init__(poisson, name=name, reduction=reduction, dtype=dtype)
 
     def get_config(self):
         return Loss.get_config(self)
@@ -676,20 +595,19 @@ class BinaryCrossentropy(LossFunctionWrapper):
         axis: The axis along which to compute crossentropy (the features axis).
             Defaults to `-1`.
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
 
     Examples:
 
@@ -751,14 +669,12 @@ class BinaryCrossentropy(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="binary_crossentropy",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
         super().__init__(
             binary_crossentropy,
             name=name,
             reduction=reduction,
             dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
             from_logits=from_logits,
             label_smoothing=label_smoothing,
             axis=axis,
@@ -823,20 +739,19 @@ class BinaryFocalCrossentropy(LossFunctionWrapper):
         axis: The axis along which to compute crossentropy (the features axis).
             Defaults to `-1`.
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
 
     Examples:
 
@@ -933,14 +848,12 @@ class BinaryFocalCrossentropy(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="binary_focal_crossentropy",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
         super().__init__(
             binary_focal_crossentropy,
             name=name,
             reduction=reduction,
             dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
             apply_class_balancing=apply_class_balancing,
             alpha=alpha,
             gamma=gamma,
@@ -991,20 +904,19 @@ class CategoricalCrossentropy(LossFunctionWrapper):
         axis: The axis along which to compute crossentropy (the features
             axis). Defaults to `-1`.
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
 
     Examples:
 
@@ -1049,14 +961,12 @@ class CategoricalCrossentropy(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="categorical_crossentropy",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
         super().__init__(
             categorical_crossentropy,
             name=name,
             reduction=reduction,
             dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
             from_logits=from_logits,
             label_smoothing=label_smoothing,
             axis=axis,
@@ -1139,20 +1049,19 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
         axis: The axis along which to compute crossentropy (the features
             axis). Defaults to `-1`.
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
 
     Examples:
 
@@ -1199,7 +1108,6 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="categorical_focal_crossentropy",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
         """Initializes `CategoricalFocalCrossentropy` instance."""
         super().__init__(
@@ -1207,7 +1115,6 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
             name=name,
             reduction=reduction,
             dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
             alpha=alpha,
             gamma=gamma,
             from_logits=from_logits,
@@ -1254,20 +1161,19 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
         from_logits: Whether `y_pred` is expected to be a logits tensor. By
             default, we assume that `y_pred` encodes a probability distribution.
         reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
         name: Optional name for the loss instance.
         dtype: The dtype of the loss's computations. Defaults to `None`, which
             means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
             `"float32"` unless set to different value
             (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
             provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
 
     Examples:
 
@@ -1309,14 +1215,12 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
         reduction="sum_over_batch_size",
         name="sparse_categorical_crossentropy",
         dtype=None,
-        normalize_by_sample_weight=False,
     ):
         super().__init__(
             sparse_categorical_crossentropy,
             name=name,
             reduction=reduction,
             dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
             from_logits=from_logits,
             ignore_class=ignore_class,
         )
@@ -1331,6 +1235,171 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
                 "ignore_class": self.ignore_class,
             }
         )
+        return config
+
+
+@keras_export("keras.losses.CTC")
+class CTC(LossFunctionWrapper):
+    """CTC (Connectionist Temporal Classification) loss.
+
+    Args:
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
+        name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
+            provided, then the `compute_dtype` will be utilized.
+    """
+
+    def __init__(self, reduction="sum_over_batch_size", name="ctc", dtype=None):
+        super().__init__(ctc, name=name, reduction=reduction, dtype=dtype)
+
+    def get_config(self):
+        return Loss.get_config(self)
+
+
+@keras_export("keras.losses.Dice")
+class Dice(LossFunctionWrapper):
+    """Computes the Dice loss value between `y_true` and `y_pred`.
+
+    Formula:
+    ```python
+    loss = 1 - (2 * sum(y_true * y_pred)) / (sum(y_true) + sum(y_pred))
+    ```
+
+    Args:
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
+        name: Optional name for the loss instance.
+        axis: Tuple for which dimensions the loss is calculated. Defaults to
+            `None`.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
+            provided, then the `compute_dtype` will be utilized.
+
+    Returns:
+        Dice loss value.
+
+    Example:
+
+    >>> y_true = [[[[1.0], [1.0]], [[0.0], [0.0]]],
+    ...           [[[1.0], [1.0]], [[0.0], [0.0]]]]
+    >>> y_pred = [[[[0.0], [1.0]], [[0.0], [1.0]]],
+    ...           [[[0.4], [0.0]], [[0.0], [0.9]]]]
+    >>> axis = (1, 2, 3)
+    >>> loss = keras.losses.dice(y_true, y_pred, axis=axis)
+    >>> assert loss.shape == (2,)
+    >>> loss
+    array([0.5, 0.75757575], shape=(2,), dtype=float32)
+
+    >>> loss = keras.losses.dice(y_true, y_pred)
+    >>> assert loss.shape == ()
+    >>> loss
+    array(0.6164384, shape=(), dtype=float32)
+
+    >>> y_true = np.array(y_true)
+    >>> y_pred = np.array(y_pred)
+    >>> loss = keras.losses.Dice(axis=axis, reduction=None)(y_true, y_pred)
+    >>> assert loss.shape == (2,)
+    >>> loss
+    array([0.5, 0.75757575], shape=(2,), dtype=float32)
+
+    """
+
+    def __init__(
+        self,
+        reduction="sum_over_batch_size",
+        name="dice",
+        axis=None,
+        dtype=None,
+    ):
+        super().__init__(
+            dice, name=name, reduction=reduction, dtype=dtype, axis=axis
+        )
+        self.axis = axis
+
+    def get_config(self):
+        config = Loss.get_config(self)
+        config.update({"axis": self.axis})
+        return config
+
+
+@keras_export("keras.losses.Tversky")
+class Tversky(LossFunctionWrapper):
+    """Computes the Tversky loss value between `y_true` and `y_pred`.
+
+    This loss function is weighted by the alpha and beta coefficients
+    that penalize false positives and false negatives.
+
+    With `alpha=0.5` and `beta=0.5`, the loss value becomes equivalent to
+    Dice Loss.
+
+    Args:
+        alpha: The coefficient controlling incidence of false positives.
+            Defaults to `0.5`.
+        beta: The coefficient controlling incidence of false negatives.
+            Defaults to `0.5`.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
+        name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
+            provided, then the `compute_dtype` will be utilized.
+
+    Returns:
+        Tversky loss value.
+
+    Reference:
+
+    - [Salehi et al., 2017](https://arxiv.org/abs/1706.05721)
+    """
+
+    def __init__(
+        self,
+        alpha=0.5,
+        beta=0.5,
+        reduction="sum_over_batch_size",
+        name="tversky",
+        dtype=None,
+    ):
+        super().__init__(
+            tversky,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            alpha=alpha,
+            beta=beta,
+        )
+        self.alpha = alpha
+        self.beta = beta
+
+    def get_config(self):
+        config = Loss.get_config(self)
+        config.update({"alpha": self.alpha, "beta": self.beta})
         return config
 
 
@@ -2227,47 +2296,6 @@ def binary_focal_crossentropy(
     return ops.mean(focal_bce, axis=axis)
 
 
-@keras_export("keras.losses.CTC")
-class CTC(LossFunctionWrapper):
-    """CTC (Connectionist Temporal Classification) loss.
-
-    Args:
-        reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
-        name: Optional name for the loss instance.
-        dtype: The dtype of the loss's computations. Defaults to `None`, which
-            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
-            `"float32"` unless set to different value
-            (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
-            provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
-    """
-
-    def __init__(
-        self,
-        reduction="sum_over_batch_size",
-        name="ctc",
-        dtype=None,
-        normalize_by_sample_weight=False,
-    ):
-        super().__init__(
-            ctc,
-            name=name,
-            reduction=reduction,
-            dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
-        )
-
-    def get_config(self):
-        return Loss.get_config(self)
-
-
 @keras_export("keras.losses.ctc")
 def ctc(y_true, y_pred):
     """CTC (Connectionist Temporal Classification) loss.
@@ -2306,87 +2334,6 @@ def ctc(y_true, y_pred):
     )
 
 
-@keras_export("keras.losses.Dice")
-class Dice(LossFunctionWrapper):
-    """Computes the Dice loss value between `y_true` and `y_pred`.
-
-    Formula:
-    ```python
-    loss = 1 - (2 * sum(y_true * y_pred)) / (sum(y_true) + sum(y_pred))
-    ```
-
-    Args:
-        reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
-        name: Optional name for the loss instance.
-        axis: Tuple for which dimensions the loss is calculated. Defaults to
-            `None`.
-        dtype: The dtype of the loss's computations. Defaults to `None`, which
-            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
-            `"float32"` unless set to different value
-            (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
-            provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
-
-    Returns:
-        Dice loss value.
-
-    Example:
-
-    >>> y_true = [[[[1.0], [1.0]], [[0.0], [0.0]]],
-    ...           [[[1.0], [1.0]], [[0.0], [0.0]]]]
-    >>> y_pred = [[[[0.0], [1.0]], [[0.0], [1.0]]],
-    ...           [[[0.4], [0.0]], [[0.0], [0.9]]]]
-    >>> axis = (1, 2, 3)
-    >>> loss = keras.losses.dice(y_true, y_pred, axis=axis)
-    >>> assert loss.shape == (2,)
-    >>> loss
-    array([0.5, 0.75757575], shape=(2,), dtype=float32)
-
-    >>> loss = keras.losses.dice(y_true, y_pred)
-    >>> assert loss.shape == ()
-    >>> loss
-    array(0.6164384, shape=(), dtype=float32)
-
-    >>> y_true = np.array(y_true)
-    >>> y_pred = np.array(y_pred)
-    >>> loss = keras.losses.Dice(axis=axis, reduction=None)(y_true, y_pred)
-    >>> assert loss.shape == (2,)
-    >>> loss
-    array([0.5, 0.75757575], shape=(2,), dtype=float32)
-
-    """
-
-    def __init__(
-        self,
-        reduction="sum_over_batch_size",
-        name="dice",
-        axis=None,
-        dtype=None,
-        normalize_by_sample_weight=False,
-    ):
-        super().__init__(
-            dice,
-            name=name,
-            reduction=reduction,
-            dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
-            axis=axis,
-        )
-        self.axis = axis
-
-    def get_config(self):
-        config = Loss.get_config(self)
-        config.update({"axis": self.axis})
-        return config
-
-
 @keras_export("keras.losses.dice")
 def dice(y_true, y_pred, axis=None):
     """Computes the Dice loss value between `y_true` and `y_pred`.
@@ -2419,72 +2366,6 @@ def dice(y_true, y_pred, axis=None):
     )
 
     return 1 - dice
-
-
-@keras_export("keras.losses.Tversky")
-class Tversky(LossFunctionWrapper):
-    """Computes the Tversky loss value between `y_true` and `y_pred`.
-
-    This loss function is weighted by the alpha and beta coefficients
-    that penalize false positives and false negatives.
-
-    With `alpha=0.5` and `beta=0.5`, the loss value becomes equivalent to
-    Dice Loss.
-
-    Args:
-        alpha: The coefficient controlling incidence of false positives.
-            Defaults to `0.5`.
-        beta: The coefficient controlling incidence of false negatives.
-            Defaults to `0.5`.
-        reduction: Type of reduction to apply to the loss. In almost all cases
-            this should be `"sum_over_batch_size"`.
-            Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
-        name: Optional name for the loss instance.
-        dtype: The dtype of the loss's computations. Defaults to `None`, which
-            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
-            `"float32"` unless set to different value
-            (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
-            provided, then the `compute_dtype` will be utilized.
-        normalize_by_sample_weight: Whether to normalize the loss value by the
-            provided `sample_weight`. If set to `True` and `reduction` is
-            `"sum_over_batch_size"` or `"mean"`, the final loss value will be
-            divided by `ops.sum(sample_weight)` instead of the sample size. This
-            approach may help stabilize the range of the loss value. Defaults to
-            `False`.
-
-    Returns:
-        Tversky loss value.
-
-    Reference:
-
-    - [Salehi et al., 2017](https://arxiv.org/abs/1706.05721)
-    """
-
-    def __init__(
-        self,
-        alpha=0.5,
-        beta=0.5,
-        reduction="sum_over_batch_size",
-        name="tversky",
-        dtype=None,
-        normalize_by_sample_weight=False,
-    ):
-        super().__init__(
-            tversky,
-            name=name,
-            reduction=reduction,
-            dtype=dtype,
-            normalize_by_sample_weight=normalize_by_sample_weight,
-            alpha=alpha,
-            beta=beta,
-        )
-        self.alpha = alpha
-        self.beta = beta
-
-    def get_config(self):
-        config = Loss.get_config(self)
-        config.update({"alpha": self.alpha, "beta": self.beta})
-        return config
 
 
 @keras_export("keras.losses.tversky")

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -85,6 +85,16 @@ class MeanSquaredErrorTest(testing.TestCase):
         loss = mse_obj(y_true, y_pred)
         self.assertDType(loss, "bfloat16")
 
+    def test_normalize_by_sample_weight(self):
+        mse_obj = losses.MeanSquaredError(normalize_by_sample_weight=True)
+        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
+        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
+        sample_weight = np.array([[1.2], [3.4]])
+        loss = mse_obj(y_true, y_pred, sample_weight=sample_weight)
+        self.assertAlmostEqual(
+            loss, (110 / 3 * 1.2 + 187 / 3 * 3.4) / (1.2 + 3.4)
+        )
+
 
 class MeanAbsoluteErrorTest(testing.TestCase):
     def test_config(self):
@@ -160,6 +170,16 @@ class MeanAbsoluteErrorTest(testing.TestCase):
         loss = mae_obj(y_true, y_pred)
         self.assertDType(loss, "bfloat16")
 
+    def test_normalize_by_sample_weight(self):
+        mae_obj = losses.MeanAbsoluteError(normalize_by_sample_weight=True)
+        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
+        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
+        sample_weight = np.array([[1.2], [3.4]])
+        loss = mae_obj(y_true, y_pred, sample_weight=sample_weight)
+        self.assertAlmostEqual(
+            loss, (14 / 3 * 1.2 + 19 / 3 * 3.4) / (1.2 + 3.4)
+        )
+
 
 class MeanAbsolutePercentageErrorTest(testing.TestCase):
     def test_config(self):
@@ -228,6 +248,16 @@ class MeanAbsolutePercentageErrorTest(testing.TestCase):
         loss = mape_obj(y_true, y_pred)
         self.assertDType(loss, "bfloat16")
 
+    def test_normalize_by_sample_weight(self):
+        mape_obj = losses.MeanAbsolutePercentageError(
+            normalize_by_sample_weight=True
+        )
+        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
+        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
+        sample_weight = np.array([[1.2], [3.4]])
+        loss = mape_obj(y_true, y_pred, sample_weight=sample_weight)
+        self.assertAlmostEqual(loss, 183.865)
+
 
 class MeanSquaredLogarithmicErrorTest(testing.TestCase):
     def test_config(self):
@@ -282,6 +312,16 @@ class MeanSquaredLogarithmicErrorTest(testing.TestCase):
         y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
         loss = msle_obj(y_true, y_pred, sample_weight=2.3)
         self.assertDType(loss, "bfloat16")
+
+    def test_normalize_by_sample_weight(self):
+        msle_obj = losses.MeanSquaredLogarithmicError(
+            normalize_by_sample_weight=True
+        )
+        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
+        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
+        sample_weight = np.array([[1.2], [3.4]])
+        loss = msle_obj(y_true, y_pred, sample_weight=sample_weight)
+        self.assertAlmostEqual(loss, 1.646)
 
 
 class HingeTest(testing.TestCase):
@@ -492,7 +532,14 @@ class CosineSimilarityTest(testing.TestCase):
         self.assertEqual(cosine_obj.name, "cosine_loss")
         self.assertEqual(cosine_obj.reduction, "sum")
         config = cosine_obj.get_config()
-        self.assertEqual(config, {"name": "cosine_loss", "reduction": "sum"})
+        self.assertEqual(
+            config,
+            {
+                "name": "cosine_loss",
+                "reduction": "sum",
+                "normalize_by_sample_weight": False,
+            },
+        )
 
     def test_unweighted(self):
         self.setup()
@@ -584,7 +631,14 @@ class HuberLossTest(testing.TestCase):
         self.assertEqual(h_obj.name, "huber")
         self.assertEqual(h_obj.reduction, "sum")
         config = h_obj.get_config()
-        self.assertEqual(config, {"name": "huber", "reduction": "sum"})
+        self.assertEqual(
+            config,
+            {
+                "name": "huber",
+                "reduction": "sum",
+                "normalize_by_sample_weight": False,
+            },
+        )
 
     def test_all_correct(self):
         self.setup()
@@ -684,7 +738,14 @@ class LogCoshTest(testing.TestCase):
         self.assertEqual(logcosh_obj.name, "logcosh_loss")
         self.assertEqual(logcosh_obj.reduction, "sum")
         config = logcosh_obj.get_config()
-        self.assertEqual(config, {"name": "logcosh_loss", "reduction": "sum"})
+        self.assertEqual(
+            config,
+            {
+                "name": "logcosh_loss",
+                "reduction": "sum",
+                "normalize_by_sample_weight": False,
+            },
+        )
 
     def test_unweighted(self):
         self.setup()

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -78,15 +78,8 @@ class MeanSquaredErrorTest(testing.TestCase):
         loss = mse_obj(y_true, y_pred, sample_weight=2.3)
         self.assertAlmostEqual(loss, 227.69998)
 
-    def test_dtype_arg(self):
-        mse_obj = losses.MeanSquaredError(dtype="bfloat16")
-        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
-        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
-        loss = mse_obj(y_true, y_pred)
-        self.assertDType(loss, "bfloat16")
-
-    def test_normalize_by_sample_weight(self):
-        mse_obj = losses.MeanSquaredError(normalize_by_sample_weight=True)
+    def test_mean_with_sample_weight_reduction(self):
+        mse_obj = losses.MeanSquaredError(reduction="mean_with_sample_weight")
         y_true = np.array([[1, 9, 2], [-5, -2, 6]])
         y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
         sample_weight = np.array([[1.2], [3.4]])
@@ -94,6 +87,13 @@ class MeanSquaredErrorTest(testing.TestCase):
         self.assertAlmostEqual(
             loss, (110 / 3 * 1.2 + 187 / 3 * 3.4) / (1.2 + 3.4)
         )
+
+    def test_dtype_arg(self):
+        mse_obj = losses.MeanSquaredError(dtype="bfloat16")
+        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
+        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
+        loss = mse_obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
 
 
 class MeanAbsoluteErrorTest(testing.TestCase):
@@ -163,15 +163,8 @@ class MeanAbsoluteErrorTest(testing.TestCase):
         loss = mae_obj(y_true, y_pred, sample_weight=2.3)
         self.assertAlmostEqual(loss, 25.29999)
 
-    def test_dtype_arg(self):
-        mae_obj = losses.MeanAbsoluteError(dtype="bfloat16")
-        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
-        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
-        loss = mae_obj(y_true, y_pred)
-        self.assertDType(loss, "bfloat16")
-
-    def test_normalize_by_sample_weight(self):
-        mae_obj = losses.MeanAbsoluteError(normalize_by_sample_weight=True)
+    def test_mean_with_sample_weight_reduction(self):
+        mae_obj = losses.MeanAbsoluteError(reduction="mean_with_sample_weight")
         y_true = np.array([[1, 9, 2], [-5, -2, 6]])
         y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
         sample_weight = np.array([[1.2], [3.4]])
@@ -179,6 +172,13 @@ class MeanAbsoluteErrorTest(testing.TestCase):
         self.assertAlmostEqual(
             loss, (14 / 3 * 1.2 + 19 / 3 * 3.4) / (1.2 + 3.4)
         )
+
+    def test_dtype_arg(self):
+        mae_obj = losses.MeanAbsoluteError(dtype="bfloat16")
+        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
+        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
+        loss = mae_obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
 
 
 class MeanAbsolutePercentageErrorTest(testing.TestCase):
@@ -241,22 +241,22 @@ class MeanAbsolutePercentageErrorTest(testing.TestCase):
         loss = mape_obj(y_true, y_pred, sample_weight=2.3)
         self.assertAlmostEqual(loss, [621.8518, 352.6666])
 
-    def test_dtype_arg(self):
-        mape_obj = losses.MeanAbsolutePercentageError(dtype="bfloat16")
-        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
-        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
-        loss = mape_obj(y_true, y_pred)
-        self.assertDType(loss, "bfloat16")
-
-    def test_normalize_by_sample_weight(self):
+    def test_mean_with_sample_weight_reduction(self):
         mape_obj = losses.MeanAbsolutePercentageError(
-            normalize_by_sample_weight=True
+            reduction="mean_with_sample_weight"
         )
         y_true = np.array([[1, 9, 2], [-5, -2, 6]])
         y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
         sample_weight = np.array([[1.2], [3.4]])
         loss = mape_obj(y_true, y_pred, sample_weight=sample_weight)
         self.assertAlmostEqual(loss, 183.865)
+
+    def test_dtype_arg(self):
+        mape_obj = losses.MeanAbsolutePercentageError(dtype="bfloat16")
+        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
+        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
+        loss = mape_obj(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
 
 
 class MeanSquaredLogarithmicErrorTest(testing.TestCase):
@@ -306,22 +306,22 @@ class MeanSquaredLogarithmicErrorTest(testing.TestCase):
         loss = msle_obj(y_true, y_pred, sample_weight=0)
         self.assertAlmostEqual(loss, 0.0, 3)
 
-    def test_dtype_arg(self):
-        msle_obj = losses.MeanSquaredLogarithmicError(dtype="bfloat16")
-        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
-        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
-        loss = msle_obj(y_true, y_pred, sample_weight=2.3)
-        self.assertDType(loss, "bfloat16")
-
-    def test_normalize_by_sample_weight(self):
+    def test_mean_with_sample_weight_reduction(self):
         msle_obj = losses.MeanSquaredLogarithmicError(
-            normalize_by_sample_weight=True
+            reduction="mean_with_sample_weight"
         )
         y_true = np.array([[1, 9, 2], [-5, -2, 6]])
         y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
         sample_weight = np.array([[1.2], [3.4]])
         loss = msle_obj(y_true, y_pred, sample_weight=sample_weight)
         self.assertAlmostEqual(loss, 1.646)
+
+    def test_dtype_arg(self):
+        msle_obj = losses.MeanSquaredLogarithmicError(dtype="bfloat16")
+        y_true = np.array([[1, 9, 2], [-5, -2, 6]])
+        y_pred = np.array([[4, 8, 12], [8, 1, 3]], dtype="float32")
+        loss = msle_obj(y_true, y_pred, sample_weight=2.3)
+        self.assertDType(loss, "bfloat16")
 
 
 class HingeTest(testing.TestCase):
@@ -532,14 +532,7 @@ class CosineSimilarityTest(testing.TestCase):
         self.assertEqual(cosine_obj.name, "cosine_loss")
         self.assertEqual(cosine_obj.reduction, "sum")
         config = cosine_obj.get_config()
-        self.assertEqual(
-            config,
-            {
-                "name": "cosine_loss",
-                "reduction": "sum",
-                "normalize_by_sample_weight": False,
-            },
-        )
+        self.assertEqual(config, {"name": "cosine_loss", "reduction": "sum"})
 
     def test_unweighted(self):
         self.setup()
@@ -631,14 +624,7 @@ class HuberLossTest(testing.TestCase):
         self.assertEqual(h_obj.name, "huber")
         self.assertEqual(h_obj.reduction, "sum")
         config = h_obj.get_config()
-        self.assertEqual(
-            config,
-            {
-                "name": "huber",
-                "reduction": "sum",
-                "normalize_by_sample_weight": False,
-            },
-        )
+        self.assertEqual(config, {"name": "huber", "reduction": "sum"})
 
     def test_all_correct(self):
         self.setup()
@@ -738,14 +724,7 @@ class LogCoshTest(testing.TestCase):
         self.assertEqual(logcosh_obj.name, "logcosh_loss")
         self.assertEqual(logcosh_obj.reduction, "sum")
         config = logcosh_obj.get_config()
-        self.assertEqual(
-            config,
-            {
-                "name": "logcosh_loss",
-                "reduction": "sum",
-                "normalize_by_sample_weight": False,
-            },
-        )
+        self.assertEqual(config, {"name": "logcosh_loss", "reduction": "sum"})
 
     def test_unweighted(self):
         self.setup()


### PR DESCRIPTION
Fix #19740

In some cases, normalizing loss values based on the sum of `sample_weight` can help stabilize the loss range. To maintain backward compatibility (including with `tf_keras`), a new reduction, `mean_with_sample_weight`, has been added to `Loss` to toggle this feature.

This change should also not impact existing config files.

Let me know if this sounds good. If so, I will add remaining tests for all losses.