### PR TITLE
Patch to fix TF1 shape comparison in add function

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -48,7 +48,8 @@ def add(x1, x2):
         # `x2` non-squeezable dimension defined
         and x2_squeeze_shape[0] is not None
         # `x2` non-squeezable dimension match `x1` channel dimension
-        and x2_squeeze_shape[0] in {x1.shape[1], x1.shape[-1]}
+        and x2_squeeze_shape[0]
+        in {x1.shape.as_list()[1], x1.shape.as_list()[-1]}
     ):
         if x1.shape[-1] == x2_squeeze_shape[0]:
             data_format = "NHWC"


### PR DESCRIPTION
eb5c5ae broke Dense layers in TF1, since `.shape` returns a list of Dimensions which are unhashable types. Adding `.as_list()` enables this check in both TF1 and TF2.

```
# Repro: confirmed this works in TF1 and TF2.
{tf.constant([1, 2]).shape.as_list()[0],}
```