### PR TITLE
Fix typos

### DIFF
--- a/guides/transfer_learning.py
+++ b/guides/transfer_learning.py
@@ -22,7 +22,7 @@ import matplotlib.pyplot as plt
 
 **Transfer learning** consists of taking features learned on one problem, and
 leveraging them on a new, similar problem. For instance, features from a model that has
-learned to identify racoons may be useful to kick-start a model meant to identify
+learned to identify raccoons may be useful to kick-start a model meant to identify
  tanukis.
 
 Transfer learning is usually done for tasks where your dataset has too little data to

--- a/keras/src/applications/convnext.py
+++ b/keras/src/applications/convnext.py
@@ -357,7 +357,7 @@ def ConvNeXt(
             won't be used.
         default_size: Default input image size.
         name: An optional name for the model.
-        include_preprocessing: boolean denoting whther to
+        include_preprocessing: boolean denoting whether to
             include preprocessing in the model.
             When `weights="imagenet"` this should always be `True`.
             But for other models (e.g., randomly initialized) you should set it

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -614,7 +614,7 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
     batch_size, max_label_length = target.shape
     log_epsilon = -1e5
 
-    # Ensure that the dtype promotion behavior matchs that of `tf.nn.ctc_loss`
+    # Ensure that the dtype promotion behavior matches that of `tf.nn.ctc_loss`
     dtype = backend.result_type(output.dtype, "float32")
     output = cast(output, dtype)
 

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -647,7 +647,7 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
     batch_size, max_label_length = target.shape
     log_epsilon = -1e5
 
-    # Ensure that the dtype promotion behavior matchs that of `tf.nn.ctc_loss`
+    # Ensure that the dtype promotion behavior matches that of `tf.nn.ctc_loss`
     dtype = backend.result_type(output.dtype, "float32")
     output = output.astype(dtype)
 

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -296,7 +296,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
         dtype = dtypes.result_type(x.dtype, float)
     x = cast(x, dtype)
 
-    # Fast path to utilze `tf.linalg.norm`
+    # Fast path to utilize `tf.linalg.norm`
     if (num_axes == 1 and ord in ("euclidean", 1, 2, float("inf"))) or (
         num_axes == 2 and ord in ("euclidean", "fro", 1, 2, float("inf"))
     ):

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -323,7 +323,7 @@ def istft(
             )
 
     if sequence_length == fft_length and center is True and win is not None:
-        # can be falled back to torch.istft
+        # can be fallen back to torch.istft
         need_unpack = False
         *batch_shape, num_sequences, fft_unique_bins = complex_input.shape
         if len(complex_input.shape) > 3:

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -758,7 +758,7 @@ def ctc_loss(
     target_length = convert_to_tensor(target_length)
     output_length = convert_to_tensor(output_length)
 
-    # Ensure that the dtype promotion behavior matchs that of `tf.nn.ctc_loss`
+    # Ensure that the dtype promotion behavior matches that of `tf.nn.ctc_loss`
     dtype = backend.result_type(output.dtype, "float32")
     output = cast(output, dtype)
 

--- a/keras/src/callbacks/model_checkpoint_test.py
+++ b/keras/src/callbacks/model_checkpoint_test.py
@@ -401,7 +401,8 @@ class ModelCheckpointTest(testing.TestCase):
         self.assertTrue(os.path.exists(filepath))
         os.remove(filepath)
 
-        # Case 13: ModelCheckpoint doesn't save model if loss was minimum earlier
+        # Case 13: ModelCheckpoint doesn't save model if loss was minimum
+        # earlier
         mode = "min"
         monitor = "val_loss"
         initial_value_threshold = 0

--- a/keras/src/callbacks/model_checkpoint_test.py
+++ b/keras/src/callbacks/model_checkpoint_test.py
@@ -401,7 +401,7 @@ class ModelCheckpointTest(testing.TestCase):
         self.assertTrue(os.path.exists(filepath))
         os.remove(filepath)
 
-        # Case 13: ModelCheckpoint doesnt save model if loss was minimum earlier
+        # Case 13: ModelCheckpoint doesn't save model if loss was minimum earlier
         mode = "min"
         monitor = "val_loss"
         initial_value_threshold = 0
@@ -426,7 +426,7 @@ class ModelCheckpointTest(testing.TestCase):
         )
         self.assertFalse(os.path.exists(filepath))
 
-        # Case 14: ModelCheckpoint doesnt save model if loss was min earlier in
+        # Case 14: ModelCheckpoint doesn't save model if loss was min earlier in
         # auto mode
         mode = "auto"
         monitor = "val_loss"

--- a/keras/src/initializers/constant_initializers.py
+++ b/keras/src/initializers/constant_initializers.py
@@ -167,7 +167,7 @@ class STFTInitializer(Initializer):
     `hamming` windowing functions. This layer supports periodic windows and
     scaling-based normalization.
 
-    This is primarly intended for use in the `STFTSpectrogram` layer.
+    This is primarily intended for use in the `STFTSpectrogram` layer.
 
     Examples:
 

--- a/keras/src/layers/attention/attention.py
+++ b/keras/src/layers/attention/attention.py
@@ -27,7 +27,7 @@ class Attention(Layer):
             attention scores.
         dropout: Float between 0 and 1. Fraction of the units to drop for the
             attention scores. Defaults to `0.0`.
-        seed: A Python integer to use as random seed incase of `dropout`.
+        seed: A Python integer to use as random seed in case of `dropout`.
         score_mode: Function to use to compute attention scores, one of
             `{"dot", "concat"}`. `"dot"` refers to the dot product between the
             query and key vectors. `"concat"` refers to the hyperbolic tangent

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -642,7 +642,7 @@ class MultiHeadAttention(Layer):
 
 
 def _index_to_einsum_variable(i):
-    """Coverts an index to a einsum variable name.
+    """Converts an index to a einsum variable name.
 
     We simply map indices to lowercase characters, e.g. 0 -> 'a', 1 -> 'b'.
     """

--- a/keras/src/layers/preprocessing/stft_spectrogram.py
+++ b/keras/src/layers/preprocessing/stft_spectrogram.py
@@ -115,7 +115,7 @@ class STFTSpectrogram(layers.Layer):
         `(batch_size, input_channels, time_length)` if
         `data_format=="channels_first"`, where `time_length` is the length of
         the input signal, and `input_channels` is the number of input channels.
-        The same kernels are applied to each channel independetly.
+        The same kernels are applied to each channel independently.
 
     Output shape:
         If `data_format=="channels_first" and not expand_dims`, a 3D tensor:
@@ -150,14 +150,14 @@ class STFTSpectrogram(layers.Layer):
         ):
             raise ValueError(
                 "`frame_step` should be a positive integer not greater than "
-                f"`frame_length`. Recieved frame_step={frame_step}, "
+                f"`frame_length`. Received frame_step={frame_step}, "
                 f"frame_length={frame_length}"
             )
 
         if fft_length is not None and fft_length < frame_length:
             raise ValueError(
                 "`fft_length` should be not less than `frame_length`. "
-                f"Recieved fft_length={fft_length}, frame_length={frame_length}"
+                f"Received fft_length={fft_length}, frame_length={frame_length}"
             )
 
         if fft_length is not None and (fft_length & -fft_length) != fft_length:

--- a/keras/src/legacy/saving/legacy_h5_format_test.py
+++ b/keras/src/legacy/saving/legacy_h5_format_test.py
@@ -16,7 +16,7 @@ from keras.src.saving import serialization_lib
 # on exact weight ordering for each layer, so we need
 # to test across all types of layers.
 
-# TODO: reenable tests after tf_keras is available.
+# TODO: re-enable tests after tf_keras is available.
 tf_keras = None
 
 

--- a/keras/src/ops/linalg.py
+++ b/keras/src/ops/linalg.py
@@ -466,7 +466,7 @@ def solve(a, b):
 
     Args:
         a: A tensor of shape `(..., M, M)` representing the coefficients matrix.
-        b: A tensor of shape `(..., M)` or `(..., M, N)` represeting the
+        b: A tensor of shape `(..., M)` or `(..., M, N)` representing the
         right-hand side or "dependent variable" matrix.
 
     Returns:
@@ -514,7 +514,7 @@ def solve_triangular(a, b, lower=False):
 
     Args:
         a: A tensor of shape `(..., M, M)` representing the coefficients matrix.
-        b: A tensor of shape `(..., M)` or `(..., M, N)` represeting the
+        b: A tensor of shape `(..., M)` or `(..., M, N)` representing the
         right-hand side or "dependent variable" matrix.
 
     Returns:

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -4533,9 +4533,9 @@ def quantile(x, q, axis=None, method="linear", keepdims=False):
 
     Returns:
         The quantile(s). If `q` is a single probability and `axis=None`, then
-        the result is a scalar. If multiple probabilities levels are given, first
-        axis of the result corresponds to the quantiles. The other axes are the
-        axes that remain after the reduction of `x`.
+        the result is a scalar. If multiple probabilities levels are given,
+        first axis of the result corresponds to the quantiles. The other axes
+        are the axes that remain after the reduction of `x`.
     """
     if any_symbolic_tensors((x, q)):
         return Quantile(

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -890,7 +890,7 @@ class Argmin(Operation):
 
 @keras_export(["keras.ops.argmin", "keras.ops.numpy.argmin"])
 def argmin(x, axis=None, keepdims=False):
-    """Returns the indices of the minium values along an axis.
+    """Returns the indices of the minimum values along an axis.
 
     Args:
         x: Input tensor.
@@ -1057,7 +1057,7 @@ def average(x, axis=None, weights=None):
         axis: Integer along which to average `x`. The default, `axis=None`,
             will average over all of the elements of the input tensor. If axis
             is negative it counts from the last to the first axis.
-        weights: Tensor of wieghts associated with the values in `x`. Each
+        weights: Tensor of weights associated with the values in `x`. Each
             value in `x` contributes to the average according to its
             associated weight. The weights array can either be 1-D (in which
             case its length must be the size of a along the given axis) or of
@@ -2870,12 +2870,12 @@ class GetItem(Operation):
             remaining_key = key.copy()
         else:
             raise ValueError(
-                f"Unsupported key type for array slice. Recieved: `{key}`"
+                f"Unsupported key type for array slice. Received: `{key}`"
             )
         num_ellipses = remaining_key.count(Ellipsis)
         if num_ellipses > 1:
             raise ValueError(
-                f"Slice should only have one ellipsis. Recieved: `{key}`"
+                f"Slice should only have one ellipsis. Received: `{key}`"
             )
         elif num_ellipses == 0:
             # Add an implicit final ellipsis.
@@ -4214,7 +4214,7 @@ def not_equal(x1, x2):
         x2: Second input tensor.
 
     Returns:
-        Output tensor, element-wise comparsion of `x1` and `x2`.
+        Output tensor, element-wise comparison of `x1` and `x2`.
     """
     if any_symbolic_tensors((x1, x2)):
         return NotEqual().symbolic_call(x1, x2)
@@ -4533,7 +4533,7 @@ def quantile(x, q, axis=None, method="linear", keepdims=False):
 
     Returns:
         The quantile(s). If `q` is a single probability and `axis=None`, then
-        the result is a scalar. If multiple probabilies levels are given, first
+        the result is a scalar. If multiple probabilities levels are given, first
         axis of the result corresponds to the quantiles. The other axes are the
         axes that remain after the reduction of `x`.
     """

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -3992,8 +3992,8 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         # 5D (pad arbitrary dimensions)
         if backend.backend() == "torch" and mode != "constant":
             self.skipTest(
-                "reflect and symmetric padding for arbitrary dimensions are not "
-                "supported by torch"
+                "reflect and symmetric padding for arbitrary dimensions "
+                "are not supported by torch"
             )
         x = np.ones([2, 3, 4, 5, 6], dtype=dtype)
         pad_width = ((1, 1), (2, 1), (3, 2), (4, 3), (5, 4))

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -3295,7 +3295,7 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertTrue(backend.is_tensor(knp.array(x)))
         self.assertTrue(backend.is_tensor(knp.Array()(x)))
 
-        # Check dtype convertion.
+        # Check dtype conversion.
         x = [[1, 0, 1], [1, 1, 0]]
         output = knp.array(x, dtype="int32")
         self.assertEqual(standardize_dtype(output.dtype), "int32")
@@ -3746,7 +3746,7 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.isfinite(x), np.isfinite(x))
         self.assertAllClose(knp.Isfinite()(x), np.isfinite(x))
 
-    # TODO: fix and reenable
+    # TODO: fix and re-enable
     def DISABLED_test_isinf(self):
         x = np.array([[1, 2, np.inf], [np.nan, np.nan, np.nan]])
         self.assertAllClose(knp.isinf(x), np.isinf(x))
@@ -3992,7 +3992,7 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         # 5D (pad arbitrary dimensions)
         if backend.backend() == "torch" and mode != "constant":
             self.skipTest(
-                "reflect and symmetric padding for arbitary dimensions are not "
+                "reflect and symmetric padding for arbitrary dimensions are not "
                 "supported by torch"
             )
         x = np.ones([2, 3, 4, 5, 6], dtype=dtype)

--- a/keras/src/optimizers/adamw.py
+++ b/keras/src/optimizers/adamw.py
@@ -15,7 +15,7 @@ class AdamW(adam.Adam):
 
     According to
     [Kingma et al., 2014](http://arxiv.org/abs/1412.6980),
-    the underying Adam method is "*computationally
+    the underlying Adam method is "*computationally
     efficient, has little memory requirement, invariant to diagonal rescaling of
     gradients, and is well suited for problems that are large in terms of
     data/parameters*".

--- a/keras/src/optimizers/base_optimizer.py
+++ b/keras/src/optimizers/base_optimizer.py
@@ -468,7 +468,7 @@ class BaseOptimizer(KerasSaveable):
             grads = self._clip_gradients(grads)
             self._apply_weight_decay(trainable_variables)
 
-            # Run udpate step.
+            # Run update step.
             self._backend_update_step(
                 grads, trainable_variables, self.learning_rate
             )
@@ -766,7 +766,7 @@ class BaseOptimizer(KerasSaveable):
         """
         if hasattr(self, "_built") and self._built:
             raise ValueError(
-                "`exclude_from_weight_decay()` can only be configued before "
+                "`exclude_from_weight_decay()` can only be configured before "
                 "the optimizer is built."
             )
 

--- a/keras/src/random/random.py
+++ b/keras/src/random/random.py
@@ -273,7 +273,7 @@ def binomial(shape, counts, probabilities, dtype=None, seed=None):
 def beta(shape, alpha, beta, dtype=None, seed=None):
     """Draw samples from a Beta distribution.
 
-    The values are drawm from a Beta distribution parametrized
+    The values are drawn from a Beta distribution parametrized
     by alpha and beta.
 
     Args:

--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -279,13 +279,13 @@ class KerasFileEditor:
                     count += 1
                 return count
 
-            occurences = count_occurences(self.weights_dict, source_name)
-            if occurences > 1:
+            occurrences = count_occurences(self.weights_dict, source_name)
+            if occurrences > 1:
                 raise ValueError(
                     f"Name '{source_name}' occurs more than once in the model; "
                     "try passing a complete path"
                 )
-            if occurences == 0:
+            if occurrences == 0:
                 raise ValueError(
                     f"Source name '{source_name}' does not appear in the "
                     "model. Use `editor.weights_summary()` "

--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -586,7 +586,7 @@ class CompileLoss(losses_module.Loss):
                     raise ValueError(
                         f"`loss_weights` must match the number of losses, "
                         f"got {len(tree.flatten(loss))} losses "
-                        f"and {len(loss_weights)} weigths."
+                        f"and {len(loss_weights)} weights."
                     )
                 loss_weights = tree.pack_sequence_as(loss, flat_loss_weights)
             loss = tree.map_structure(

--- a/keras/src/utils/jax_layer.py
+++ b/keras/src/utils/jax_layer.py
@@ -192,7 +192,7 @@ class JaxLayer(Layer):
         call_fn: The function to call the model. See description above for the
             list of arguments it takes and the outputs it returns.
         init_fn: the function to call to initialize the model. See description
-            above for the list of arguments it takes and the ouputs it returns.
+            above for the list of arguments it takes and the outputs it returns.
             If `None`, then `params` and/or `state` must be provided.
       params: A `PyTree` containing all the model trainable parameters. This
             allows passing trained parameters or controlling the initialization.


### PR DESCRIPTION
This fixes a few typos, identified and fixed using interactive [codespell](https://github.com/codespell-project/codespell).

Most are comments, but there are some corrections to user-visible messages and docstrings.