### PR TITLE
Replace Black with Ruff formatter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
                     "source.organizeImports": true
                 },
                 "[python]": {
-                    "editor.defaultFormatter": "ms-python.black-formatter"
+                    "editor.defaultFormatter": "charliermarsh.ruff"
                 },
                 "editor.rulers": [
                     80
@@ -18,8 +18,7 @@
             },
             "extensions": [
                 "charliermarsh.ruff",
-                "ms-python.python",
-                "ms-python.black-formatter"
+                "ms-python.python"
             ]
         }
     },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,7 @@ section of the README.
 
 ## Code style
 
-Keras uses [Black](https://black.readthedocs.io/en/stable/) and
-[Ruff](https://docs.astral.sh/ruff/) to format the code. Please refer to
+Keras uses [Ruff](https://docs.astral.sh/ruff/) to format the code. Please refer to
 [requirements-common.txt](https://github.com/keras-team/keras/blob/master/requirements-common.txt)
 for the required versions. Run the following command **at the root directory of
 the repo** to format your code.

--- a/examples/demo_custom_layer_backend_agnostic.py
+++ b/examples/demo_custom_layer_backend_agnostic.py
@@ -47,9 +47,7 @@ class MyDropout(layers.Layer):
 
     def call(self, inputs):
         # Use `keras.random` for random ops.
-        return keras.random.dropout(
-            inputs, self.rate, seed=self.seed_generator
-        )
+        return keras.random.dropout(inputs, self.rate, seed=self.seed_generator)
 
 
 class MyModel(Model):

--- a/examples/demo_jax_distributed.py
+++ b/examples/demo_jax_distributed.py
@@ -27,9 +27,9 @@ Classic MNIST, loaded using tf.data
 
 BATCH_SIZE = 192
 
-(x_train, train_labels), (
-    x_eval,
-    eval_labels,
+(
+    (x_train, train_labels),
+    (x_eval, eval_labels),
 ) = keras.datasets.mnist.load_data()
 x_train = np.expand_dims(x_train, axis=-1).astype(
     np.float32

--- a/guides/making_new_layers_and_models_via_subclassing.py
+++ b/guides/making_new_layers_and_models_via_subclassing.py
@@ -643,7 +643,7 @@ class VariationalAutoEncoder(keras.Model):
         intermediate_dim=64,
         latent_dim=32,
         name="autoencoder",
-        **kwargs
+        **kwargs,
     ):
         super().__init__(name=name, **kwargs)
         self.original_dim = original_dim

--- a/integration_tests/dataset_tests/boston_housing_test.py
+++ b/integration_tests/dataset_tests/boston_housing_test.py
@@ -3,7 +3,6 @@ from keras.src.datasets import boston_housing
 
 
 class BostonHousingTest(testing.TestCase):
-
     def test_load_data(self):
         (x_train, y_train), (x_test, y_test) = boston_housing.load_data()
         self.assertEqual(x_train.shape[1], 13)

--- a/integration_tests/dataset_tests/california_housing_test.py
+++ b/integration_tests/dataset_tests/california_housing_test.py
@@ -3,7 +3,6 @@ from keras.src.datasets import california_housing
 
 
 class CaliforniaHousingTest(testing.TestCase):
-
     def test_load_data_large(self):
         (x_train, y_train), (x_test, y_test) = california_housing.load_data(
             version="large"

--- a/integration_tests/model_visualization_test.py
+++ b/integration_tests/model_visualization_test.py
@@ -41,7 +41,6 @@ def get_edge_dict(dot):
 
 
 class ModelVisualizationTest(testing.TestCase):
-
     def test_plot_sequential_model(self):
         model = keras.Sequential(
             [

--- a/keras/src/backend/common/masking_test.py
+++ b/keras/src/backend/common/masking_test.py
@@ -6,7 +6,6 @@ from keras.src.backend.common.masking import set_keras_mask
 
 
 class MaskingTest(testing.TestCase):
-
     def test_mask_on_eager_tensor(self):
         x = ops.zeros((2, 3))
         self.assertIsNone(get_keras_mask(x))
@@ -25,7 +24,6 @@ class MaskingTest(testing.TestCase):
         self.assertIsNone(get_keras_mask(x))
 
     def test_mask_on_tracer_tensor(self):
-
         def fn(x):
             self.assertIsNone(get_keras_mask(x))
 

--- a/keras/src/backend/common/symbolic_scope_test.py
+++ b/keras/src/backend/common/symbolic_scope_test.py
@@ -8,7 +8,6 @@ from keras.src.backend.common.symbolic_scope import in_symbolic_scope
 
 class TestSymbolicScope(testing.TestCase):
     def test_basic_flow(self):
-
         # Define a function that behaves differently according to
         # `in_symbolic_scope`.
         def compute_loss(y, y_pred):

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -153,7 +153,6 @@ def compute_output_spec(fn, *args, **kwargs):
             return x
 
         def wrapped_fn(*args, **kwargs):
-
             # Turn inputs that are sparse to BCOO tensors
             def to_bcoo_if_sparse(x, maybe_symbolic_x):
                 if (

--- a/keras/src/backend/jax/optimizer.py
+++ b/keras/src/backend/jax/optimizer.py
@@ -13,7 +13,6 @@ from keras.src.optimizers import base_optimizer
 
 
 class JaxOptimizer(base_optimizer.BaseOptimizer):
-
     def _backend_apply_gradients(self, grads, trainable_variables):
         if self.gradient_accumulation_steps:
             is_update_step = (

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -354,10 +354,9 @@ class JAXTrainer(base_trainer.Trainer):
             # Create the validation data using the training data. Only supported
             # for TF/numpy/jax arrays.
             (
-                x,
-                y,
-                sample_weight,
-            ), validation_data = array_slicing.train_validation_split(
+                (x, y, sample_weight),
+                validation_data,
+            ) = array_slicing.train_validation_split(
                 (x, y, sample_weight), validation_split=validation_split
             )
 

--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -499,7 +499,6 @@ def associative_scan(f, elems, reverse=False, axis=0):
             )
 
         def _recursive_case():
-
             odd_elems = _scan(reduced_elems)
 
             def _even_length_case():

--- a/keras/src/backend/tensorflow/optimizer.py
+++ b/keras/src/backend/tensorflow/optimizer.py
@@ -18,7 +18,6 @@ from keras.src.optimizers import base_optimizer
 
 
 class TFOptimizer(KerasAutoTrackable, base_optimizer.BaseOptimizer):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._distribution_strategy = tf.distribute.get_strategy()

--- a/keras/src/backend/tensorflow/saved_model_test.py
+++ b/keras/src/backend/tensorflow/saved_model_test.py
@@ -150,22 +150,18 @@ class SavedModelTest(testing.TestCase):
         named_product(struct_type=["tuple", "array", "dict"])
     )
     def test_model_with_input_structure(self, struct_type):
-
         class TupleModel(models.Model):
-
             def call(self, inputs):
                 x, y = inputs
                 return x + ops.mean(y, axis=1)
 
         class ArrayModel(models.Model):
-
             def call(self, inputs):
                 x = inputs[0]
                 y = inputs[1]
                 return x + ops.mean(y, axis=1)
 
         class DictModel(models.Model):
-
             def call(self, inputs):
                 x = inputs["x"]
                 y = inputs["y"]

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -99,7 +99,6 @@ class TensorFlowTrainer(base_trainer.Trainer):
         return y_pred
 
     def _make_function(self, step_function):
-
         @tf.autograph.experimental.do_not_convert
         def one_step_on_data(data):
             """Runs a single training step on a batch of data."""
@@ -271,10 +270,9 @@ class TensorFlowTrainer(base_trainer.Trainer):
             # Create the validation data using the training data. Only supported
             # for TF/numpy/jax arrays.
             (
-                x,
-                y,
-                sample_weight,
-            ), validation_data = array_slicing.train_validation_split(
+                (x, y, sample_weight),
+                validation_data,
+            ) = array_slicing.train_validation_split(
                 (x, y, sample_weight), validation_split=validation_split
             )
 

--- a/keras/src/backend/torch/trainer.py
+++ b/keras/src/backend/torch/trainer.py
@@ -195,10 +195,9 @@ class TorchTrainer(base_trainer.Trainer):
             # for TF/numpy/jax arrays.
             # TODO: Support torch tensors for validation data.
             (
-                x,
-                y,
-                sample_weight,
-            ), validation_data = array_slicing.train_validation_split(
+                (x, y, sample_weight),
+                validation_data,
+            ) = array_slicing.train_validation_split(
                 (x, y, sample_weight), validation_split=validation_split
             )
 

--- a/keras/src/datasets/reuters.py
+++ b/keras/src/datasets/reuters.py
@@ -124,8 +124,9 @@ def load_data(
         xs = [[w for w in x if skip_top <= w < num_words] for x in xs]
 
     idx = int(len(xs) * (1 - test_split))
-    x_train, y_train = np.array(xs[:idx], dtype="object"), np.array(
-        labels[:idx]
+    x_train, y_train = (
+        np.array(xs[:idx], dtype="object"),
+        np.array(labels[:idx]),
     )
     x_test, y_test = np.array(xs[idx:], dtype="object"), np.array(labels[idx:])
 

--- a/keras/src/export/export_lib.py
+++ b/keras/src/export/export_lib.py
@@ -166,7 +166,6 @@ class ExportArchive:
             # Variables in the lists below are actually part of the trackables
             # that get saved, because the lists are created in __init__.
             if backend.backend() == "jax":
-
                 trainable_variables = tree.flatten(resource.trainable_variables)
                 non_trainable_variables = tree.flatten(
                     resource.non_trainable_variables
@@ -328,7 +327,6 @@ class ExportArchive:
                     fn, input_signature=input_signature, autograph=False
                 )
             else:  # JAX backend
-
                 # 1. Create a stateless wrapper for `fn`
                 # 2. jax2tf the stateless wrapper
                 # 3. Create a stateful function that binds the variables with

--- a/keras/src/export/export_lib_test.py
+++ b/keras/src/export/export_lib_test.py
@@ -74,7 +74,6 @@ class ExportArchiveTest(testing.TestCase):
         named_product(model_type=["sequential", "functional", "subclass"])
     )
     def test_model_with_rng_export(self, model_type):
-
         class RandomLayer(layers.Layer):
             def __init__(self):
                 super().__init__()
@@ -104,7 +103,6 @@ class ExportArchiveTest(testing.TestCase):
         named_product(model_type=["sequential", "functional", "subclass"])
     )
     def test_model_with_non_trainable_state_export(self, model_type):
-
         class StateLayer(layers.Layer):
             def __init__(self):
                 super().__init__()
@@ -151,22 +149,18 @@ class ExportArchiveTest(testing.TestCase):
         named_product(struct_type=["tuple", "array", "dict"])
     )
     def test_model_with_input_structure(self, struct_type):
-
         class TupleModel(models.Model):
-
             def call(self, inputs):
                 x, y = inputs
                 return ops.add(x, y)
 
         class ArrayModel(models.Model):
-
             def call(self, inputs):
                 x = inputs[0]
                 y = inputs[1]
                 return ops.add(x, y)
 
         class DictModel(models.Model):
-
             def call(self, inputs):
                 x = inputs["x"]
                 y = inputs["y"]
@@ -214,7 +208,6 @@ class ExportArchiveTest(testing.TestCase):
         export_lib.export_model(revived_model, self.get_temp_dir())
 
     def test_model_with_multiple_inputs(self):
-
         class TwoInputsModel(models.Model):
             def call(self, x, y):
                 return x + y
@@ -302,7 +295,6 @@ class ExportArchiveTest(testing.TestCase):
         named_product(model_type=["sequential", "functional", "subclass"])
     )
     def test_low_level_model_export_with_dynamic_dims(self, model_type):
-
         class ReductionLayer(layers.Layer):
             def call(self, inputs):
                 return ops.max(inputs, axis=1)
@@ -382,7 +374,6 @@ class ExportArchiveTest(testing.TestCase):
         reason="This test is only for the JAX backend.",
     )
     def test_low_level_model_export_with_jax2tf_polymorphic_shapes(self):
-
         class SquareLayer(layers.Layer):
             def call(self, inputs):
                 return ops.matmul(inputs, inputs)

--- a/keras/src/layers/activations/prelu.py
+++ b/keras/src/layers/activations/prelu.py
@@ -37,7 +37,7 @@ class PReLU(Layer):
         alpha_regularizer=None,
         alpha_constraint=None,
         shared_axes=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.supports_masking = True

--- a/keras/src/layers/convolutional/conv1d.py
+++ b/keras/src/layers/convolutional/conv1d.py
@@ -110,7 +110,7 @@ class Conv1D(BaseConv):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             rank=1,
@@ -130,7 +130,7 @@ class Conv1D(BaseConv):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )
 
     def _compute_causal_padding(self):

--- a/keras/src/layers/convolutional/conv1d_transpose.py
+++ b/keras/src/layers/convolutional/conv1d_transpose.py
@@ -108,7 +108,7 @@ class Conv1DTranspose(BaseConvTranspose):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             rank=1,
@@ -127,5 +127,5 @@ class Conv1DTranspose(BaseConvTranspose):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )

--- a/keras/src/layers/convolutional/conv2d.py
+++ b/keras/src/layers/convolutional/conv2d.py
@@ -104,7 +104,7 @@ class Conv2D(BaseConv):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             rank=2,
@@ -124,5 +124,5 @@ class Conv2D(BaseConv):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )

--- a/keras/src/layers/convolutional/conv2d_transpose.py
+++ b/keras/src/layers/convolutional/conv2d_transpose.py
@@ -110,7 +110,7 @@ class Conv2DTranspose(BaseConvTranspose):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             rank=2,
@@ -129,5 +129,5 @@ class Conv2DTranspose(BaseConvTranspose):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )

--- a/keras/src/layers/convolutional/conv3d.py
+++ b/keras/src/layers/convolutional/conv3d.py
@@ -110,7 +110,7 @@ class Conv3D(BaseConv):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             rank=3,
@@ -130,5 +130,5 @@ class Conv3D(BaseConv):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )

--- a/keras/src/layers/convolutional/conv3d_transpose.py
+++ b/keras/src/layers/convolutional/conv3d_transpose.py
@@ -115,7 +115,7 @@ class Conv3DTranspose(BaseConvTranspose):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             rank=3,
@@ -134,5 +134,5 @@ class Conv3DTranspose(BaseConvTranspose):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )

--- a/keras/src/layers/convolutional/conv_test.py
+++ b/keras/src/layers/convolutional/conv_test.py
@@ -717,7 +717,6 @@ class ConvBasicTest(testing.TestCase):
 
     @pytest.mark.requires_trainable_backend
     def test_lora_weight_name(self):
-
         class MyModel(models.Model):
             def __init__(self):
                 super().__init__(name="mymodel")

--- a/keras/src/layers/convolutional/depthwise_conv1d.py
+++ b/keras/src/layers/convolutional/depthwise_conv1d.py
@@ -114,7 +114,7 @@ class DepthwiseConv1D(BaseDepthwiseConv):
         activity_regularizer=None,
         depthwise_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             rank=1,
@@ -133,5 +133,5 @@ class DepthwiseConv1D(BaseDepthwiseConv):
             activity_regularizer=activity_regularizer,
             depthwise_constraint=depthwise_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )

--- a/keras/src/layers/convolutional/depthwise_conv2d.py
+++ b/keras/src/layers/convolutional/depthwise_conv2d.py
@@ -115,7 +115,7 @@ class DepthwiseConv2D(BaseDepthwiseConv):
         activity_regularizer=None,
         depthwise_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             rank=2,
@@ -134,5 +134,5 @@ class DepthwiseConv2D(BaseDepthwiseConv):
             activity_regularizer=activity_regularizer,
             depthwise_constraint=depthwise_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -273,7 +273,6 @@ class DenseTest(testing.TestCase):
 
     @pytest.mark.requires_trainable_backend
     def test_lora_weight_name(self):
-
         class MyModel(models.Model):
             def __init__(self):
                 super().__init__(name="mymodel")

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -877,7 +877,6 @@ def _analyze_split_string(
 
 
 def _analyze_quantization_info(equation, input_shape):
-
     def get_specs(equation, input_shape):
         possible_labels = string.ascii_letters
         dot_replaced_string = re.sub(r"\.\.\.", "0", equation)

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -15,7 +15,6 @@ from keras.src.backend.common import global_state
 
 
 class LayerTest(testing.TestCase):
-
     def test_compute_output_spec(self):
         # Test that implementing compute_output_shape
         # is enough to make compute_output_spec work.
@@ -1196,7 +1195,6 @@ class LayerTest(testing.TestCase):
                 return self.post_build_modify_layer(input)
 
         class PostBuildModifyLayer(layers.Layer):
-
             def call(self, input):
                 return self.var + input
 
@@ -1330,7 +1328,6 @@ class LayerTest(testing.TestCase):
         self.assertListEqual(layer1_names, layer2_names)
 
     def test_complex_dtype_support(self):
-
         class MyDenseLayer(layers.Layer):
             def __init__(self, num_outputs):
                 super(MyDenseLayer, self).__init__()

--- a/keras/src/layers/pooling/average_pooling1d.py
+++ b/keras/src/layers/pooling/average_pooling1d.py
@@ -78,7 +78,7 @@ class AveragePooling1D(BasePooling):
         padding="valid",
         data_format=None,
         name=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             pool_size,

--- a/keras/src/layers/pooling/average_pooling2d.py
+++ b/keras/src/layers/pooling/average_pooling2d.py
@@ -95,7 +95,7 @@ class AveragePooling2D(BasePooling):
         padding="valid",
         data_format=None,
         name=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             pool_size,

--- a/keras/src/layers/pooling/average_pooling3d.py
+++ b/keras/src/layers/pooling/average_pooling3d.py
@@ -71,7 +71,7 @@ class AveragePooling3D(BasePooling):
         padding="valid",
         data_format=None,
         name=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             pool_size,

--- a/keras/src/layers/pooling/max_pooling1d.py
+++ b/keras/src/layers/pooling/max_pooling1d.py
@@ -79,7 +79,7 @@ class MaxPooling1D(BasePooling):
         padding="valid",
         data_format=None,
         name=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             pool_size,

--- a/keras/src/layers/pooling/max_pooling2d.py
+++ b/keras/src/layers/pooling/max_pooling2d.py
@@ -95,7 +95,7 @@ class MaxPooling2D(BasePooling):
         padding="valid",
         data_format=None,
         name=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             pool_size,

--- a/keras/src/layers/pooling/max_pooling3d.py
+++ b/keras/src/layers/pooling/max_pooling3d.py
@@ -71,7 +71,7 @@ class MaxPooling3D(BasePooling):
         padding="valid",
         data_format=None,
         name=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             pool_size,

--- a/keras/src/layers/preprocessing/image_preprocessing/base_image_preprocessing_layer.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/base_image_preprocessing_layer.py
@@ -6,7 +6,6 @@ from keras.src.layers.preprocessing.tf_data_layer import TFDataLayer
 
 
 class BaseImagePreprocessingLayer(TFDataLayer):
-
     _USE_BASE_FACTOR = True
     _FACTOR_BOUNDS = (-1, 1)
 

--- a/keras/src/layers/preprocessing/image_preprocessing/random_flip.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_flip.py
@@ -48,7 +48,7 @@ class RandomFlip(BaseImagePreprocessingLayer):
         mode=HORIZONTAL_AND_VERTICAL,
         seed=None,
         data_format=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(data_format=data_format, **kwargs)
         self.seed = seed

--- a/keras/src/layers/preprocessing/image_preprocessing/resizing.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/resizing.py
@@ -125,7 +125,6 @@ class Resizing(BaseImagePreprocessingLayer):
         return labels
 
     def get_random_transformation(self, data, training=True, seed=None):
-
         if isinstance(data, dict):
             input_shape = self.backend.shape(data["images"])
         else:

--- a/keras/src/layers/preprocessing/stft_spectrogram_test.py
+++ b/keras/src/layers/preprocessing/stft_spectrogram_test.py
@@ -11,7 +11,6 @@ from keras.src import testing
 
 
 class TestSpectrogram(testing.TestCase):
-
     DTYPE = "float32" if backend.backend() == "torch" else "float64"
 
     @staticmethod
@@ -106,7 +105,6 @@ class TestSpectrogram(testing.TestCase):
     )
     @pytest.mark.requires_trainable_backend
     def test_spectrogram_channels_first(self):
-
         rnd = np.random.RandomState(41)
         audio = rnd.uniform(-1, 1, size=(3, 16000, 7))
 

--- a/keras/src/layers/reshaping/up_sampling2d_test.py
+++ b/keras/src/layers/reshaping/up_sampling2d_test.py
@@ -106,8 +106,8 @@ class UpSampling2dTest(testing.TestCase):
     def test_upsampling_2d_correctness(self):
         input_shape = (2, 2, 1, 3)
         x = np.arange(np.prod(input_shape)).reshape(input_shape)
+        # fmt: off
         expected_output = np.array(
-            # fmt: off
             [[[[ 0.,  1.,  2.],
                [ 0.,  1.,  2.]],
               [[ 3.,  4.,  5.],
@@ -116,8 +116,8 @@ class UpSampling2dTest(testing.TestCase):
                [ 6.,  7.,  8.]],
               [[ 9., 10., 11.],
                [ 9., 10., 11.]]]]
-            # fmt: on
         )
+        # fmt: on
         if backend.config.image_data_format() == "channels_first":
             expected_output = expected_output.transpose((0, 3, 1, 2))
             x = x.transpose((0, 3, 1, 2))

--- a/keras/src/layers/rnn/conv_lstm1d.py
+++ b/keras/src/layers/rnn/conv_lstm1d.py
@@ -149,7 +149,7 @@ class ConvLSTM1D(ConvLSTM):
         return_state=False,
         go_backwards=False,
         stateful=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             rank=1,
@@ -180,5 +180,5 @@ class ConvLSTM1D(ConvLSTM):
             dropout=dropout,
             recurrent_dropout=recurrent_dropout,
             seed=seed,
-            **kwargs
+            **kwargs,
         )

--- a/keras/src/layers/rnn/conv_lstm2d.py
+++ b/keras/src/layers/rnn/conv_lstm2d.py
@@ -149,7 +149,7 @@ class ConvLSTM2D(ConvLSTM):
         return_state=False,
         go_backwards=False,
         stateful=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             rank=2,
@@ -180,5 +180,5 @@ class ConvLSTM2D(ConvLSTM):
             dropout=dropout,
             recurrent_dropout=recurrent_dropout,
             seed=seed,
-            **kwargs
+            **kwargs,
         )

--- a/keras/src/layers/rnn/conv_lstm3d.py
+++ b/keras/src/layers/rnn/conv_lstm3d.py
@@ -148,7 +148,7 @@ class ConvLSTM3D(ConvLSTM):
         return_state=False,
         go_backwards=False,
         stateful=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             rank=3,
@@ -179,5 +179,5 @@ class ConvLSTM3D(ConvLSTM):
             dropout=dropout,
             recurrent_dropout=recurrent_dropout,
             seed=seed,
-            **kwargs
+            **kwargs,
         )

--- a/keras/src/legacy/preprocessing/text.py
+++ b/keras/src/legacy/preprocessing/text.py
@@ -91,7 +91,7 @@ class Tokenizer:
         char_level=False,
         oov_token=None,
         analyzer=None,
-        **kwargs
+        **kwargs,
     ):
         # Legacy support
         if "nb_words" in kwargs:

--- a/keras/src/models/cloning_test.py
+++ b/keras/src/models/cloning_test.py
@@ -76,7 +76,6 @@ def get_subclassed_model():
 
 @pytest.mark.requires_trainable_backend
 class CloneModelTest(testing.TestCase):
-
     def assert_models_equal(self, model1, model2, ref_input):
         result1 = model1(ref_input)
         result2 = model2(ref_input)

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -121,7 +121,6 @@ def _get_model_multi_outputs_dict_with_single_tensor():
 
 
 def _get_model_with_custom_compute_loss():
-
     class MyModel(Model):
         def __init__(self):
             inputs = Input(shape=(3,), name="inputs")
@@ -166,7 +165,6 @@ def _get_variable_value_by_path(variables, path):
 
 @pytest.mark.requires_trainable_backend
 class ModelTest(testing.TestCase):
-
     def test_functional_rerouting(self):
         model = _get_model()
         self.assertIsInstance(model, Functional)
@@ -1000,9 +998,8 @@ class ModelTest(testing.TestCase):
                 structure,
                 y_pred,
             )
-            flat_y_pred, flat_y_true = tree.flatten(y_pred), tree.flatten(
-                y_true
-            )
+            flat_y_pred = tree.flatten(y_pred)
+            flat_y_true = tree.flatten(y_true)
             diff = 0
             for y_p, y_t in zip(flat_y_pred, flat_y_true):
                 diff += losses.mean_absolute_error(y_t, y_p)

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -818,7 +818,6 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         reason=f"{backend.backend()} doesn't support `custom_gradient`.",
     )
     def test_custom_gradient(self):
-
         # function to test custom_gradient on
         @ops.custom_gradient
         def log1pexp(x):

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -657,7 +657,6 @@ class ImageOpsCorrectnessTest(testing.TestCase):
                     [255, 255, 255, 255],
                 ]
                 if "torch" == backend.backend()
-                else
                 # Resize without `round` and `saturate_cast` - differences in
                 # 16 points
                 # [
@@ -669,7 +668,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
                 #
                 # Resize with `round` and `saturate_cast` - differences in
                 # 8 points
-                [
+                else [
                     [0, 0, 0, 0],
                     [53, 53, 53, 54],
                     [201, 202, 202, 202],

--- a/keras/src/ops/linalg.py
+++ b/keras/src/ops/linalg.py
@@ -47,7 +47,6 @@ def _cholesky(x):
 
 
 class Det(Operation):
-
     def __init__(self):
         super().__init__()
 
@@ -84,7 +83,6 @@ def _det(x):
 
 
 class Eig(Operation):
-
     def __init__(self):
         super().__init__()
 
@@ -124,7 +122,6 @@ def _eig(x):
 
 
 class Eigh(Operation):
-
     def __init__(self):
         super().__init__()
 
@@ -165,7 +162,6 @@ def _eigh(x):
 
 
 class Inv(Operation):
-
     def __init__(self):
         super().__init__()
 
@@ -202,7 +198,6 @@ def _inv(x):
 
 
 class LuFactor(Operation):
-
     def __init__(self):
         super().__init__()
 
@@ -445,7 +440,6 @@ def qr(x, mode="reduced"):
 
 
 class Solve(Operation):
-
     def __init__(self):
         super().__init__()
 
@@ -490,7 +484,6 @@ def _solve(a, b):
 
 
 class SolveTriangular(Operation):
-
     def __init__(self, lower=False):
         super().__init__()
         self.lower = lower
@@ -538,7 +531,6 @@ def _solve_triangular(a, b, lower=False):
 
 
 class SVD(Operation):
-
     def __init__(self, full_matrices=True, compute_uv=True):
         super().__init__()
         self.full_matrices = full_matrices

--- a/keras/src/ops/linalg_test.py
+++ b/keras/src/ops/linalg_test.py
@@ -330,7 +330,6 @@ class LinalgOpsStaticShapeTest(testing.TestCase):
 
 
 class LinalgOpsCorrectnessTest(testing.TestCase):
-
     def test_cholesky(self):
         x = np.random.rand(4, 3, 3).astype("float32")
         with self.assertRaises(ValueError):

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -43,7 +43,6 @@ class SegmentReduction(Operation):
 
 
 class SegmentSum(SegmentReduction):
-
     def call(self, data, segment_ids):
         _segment_reduce_validation(data, segment_ids)
         return backend.math.segment_sum(
@@ -90,7 +89,6 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
 
 
 class SegmentMax(SegmentReduction):
-
     def call(self, data, segment_ids):
         _segment_reduce_validation(data, segment_ids)
         return backend.math.segment_max(

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -145,7 +145,6 @@ def _max_reduce(left, right):
 
 
 class MathOpsDynamicShapeTest(testing.TestCase):
-
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     def test_segment_reduce(self, segment_reduce_op):
         # 1D case
@@ -418,7 +417,6 @@ class MathOpsStaticShapeTest(testing.TestCase):
 
 
 class MathOpsCorrectnessTest(testing.TestCase):
-
     def run_segment_reduce_test(
         self,
         segment_reduce_op,
@@ -1345,7 +1343,6 @@ class ISTFTTest(testing.TestCase):
 
 
 class TestMathErrors(testing.TestCase):
-
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     @pytest.mark.skipif(
         backend.backend() != "jax", reason="Testing Jax errors only"

--- a/keras/src/optimizers/optimizer_sparse_test.py
+++ b/keras/src/optimizers/optimizer_sparse_test.py
@@ -206,21 +206,29 @@ class OptimizerSparseTest(testing.TestCase):
         # patch "_apply_weight_decay" to exclude this special case.
         # patch the optimizer "assign" methods to detect sparse updates.
         # patch the tf.Variable "assign" methods to detect direct assign calls.
-        with mock.patch.object(
-            optimizer_to_patch, "_apply_weight_decay", autospec=True
-        ), mock.patch.object(
-            optimizer_to_patch, "assign", autospec=True
-        ) as optimizer_assign, mock.patch.object(
-            optimizer_to_patch, "assign_add", autospec=True
-        ) as optimizer_assign_add, mock.patch.object(
-            optimizer_to_patch, "assign_sub", autospec=True
-        ) as optimizer_assign_sub, mock.patch.object(
-            variable_class, "assign", autospec=True
-        ) as variable_assign, mock.patch.object(
-            variable_class, "assign_add", autospec=True
-        ) as variable_assign_add, mock.patch.object(
-            variable_class, "assign_sub", autospec=True
-        ) as variable_assign_sub:
+        with (
+            mock.patch.object(
+                optimizer_to_patch, "_apply_weight_decay", autospec=True
+            ),
+            mock.patch.object(
+                optimizer_to_patch, "assign", autospec=True
+            ) as optimizer_assign,
+            mock.patch.object(
+                optimizer_to_patch, "assign_add", autospec=True
+            ) as optimizer_assign_add,
+            mock.patch.object(
+                optimizer_to_patch, "assign_sub", autospec=True
+            ) as optimizer_assign_sub,
+            mock.patch.object(
+                variable_class, "assign", autospec=True
+            ) as variable_assign,
+            mock.patch.object(
+                variable_class, "assign_add", autospec=True
+            ) as variable_assign_add,
+            mock.patch.object(
+                variable_class, "assign_sub", autospec=True
+            ) as variable_assign_sub,
+        ):
             optimizer_assign.side_effect = mock_optimizer_assign
             optimizer_assign_add.side_effect = mock_optimizer_assign
             optimizer_assign_sub.side_effect = mock_optimizer_assign

--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -552,7 +552,6 @@ class KerasFileEditor:
         self._print_weights_structure(self.weights_dict, prefix=" " * 2)
 
     def _weights_summary_interactive(self):
-
         def _generate_html_weights(dictionary, margin_left=0, font_size=1):
             html = ""
             for key, value in dictionary.items():

--- a/keras/src/saving/file_editor_test.py
+++ b/keras/src/saving/file_editor_test.py
@@ -26,7 +26,6 @@ def get_target_model():
 
 
 class SavingTest(testing.TestCase):
-
     def test_basics(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "my_model.keras")
 

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -352,7 +352,7 @@ class MyDense(keras.layers.Layer):
         *,
         kernel_regularizer=None,
         kernel_initializer=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self._units = units
@@ -364,7 +364,7 @@ class MyDense(keras.layers.Layer):
             units=self._units,
             kernel_initializer=self._kernel_initializer,
             kernel_regularizer=self._kernel_regularizer,
-            **super().get_config()
+            **super().get_config(),
         )
 
     def build(self, input_shape):

--- a/keras/src/trainers/compile_utils_test.py
+++ b/keras/src/trainers/compile_utils_test.py
@@ -20,9 +20,8 @@ class TestCompileMetrics(testing.TestCase):
             weighted_metrics=[metrics_module.MeanSquaredError()],
         )
         # Test symbolic build
-        y_true, y_pred = backend.KerasTensor((3, 4)), backend.KerasTensor(
-            (3, 4)
-        )
+        y_true = backend.KerasTensor((3, 4))
+        y_pred = backend.KerasTensor((3, 4))
         compile_metrics.build(y_true, y_pred)
         # Test eager build
         y_true = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])
@@ -243,9 +242,8 @@ class TestCompileLoss(testing.TestCase):
             loss=losses_module.MeanSquaredError(),
         )
         # Test symbolic build
-        y_true, y_pred = backend.KerasTensor((3, 4)), backend.KerasTensor(
-            (3, 4)
-        )
+        y_true = backend.KerasTensor((3, 4))
+        y_pred = backend.KerasTensor((3, 4))
         compile_loss.build(y_true, y_pred)
         # Test eager build
         y_true = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])
@@ -258,9 +256,8 @@ class TestCompileLoss(testing.TestCase):
         compile_loss = CompileLoss(loss="crossentropy")
 
         # Test symbolic build
-        y_true, y_pred = backend.KerasTensor((3, 4)), backend.KerasTensor(
-            (3, 4)
-        )
+        y_true = backend.KerasTensor((3, 4))
+        y_pred = backend.KerasTensor((3, 4))
         compile_loss.build(y_true, y_pred)
         # Test eager build
         y_true = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])

--- a/keras/src/trainers/data_adapters/array_data_adapter.py
+++ b/keras/src/trainers/data_adapters/array_data_adapter.py
@@ -198,7 +198,6 @@ class ArrayDataAdapter(DataAdapter):
             )
 
             def grab_batch(i, data):
-
                 def grab_one(x):
                     if isinstance(x, array_slicing.TensorflowSparseWrapper):
                         return array_slicing.slice_tensorflow_sparse_wrapper(

--- a/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
@@ -24,7 +24,7 @@ class ExamplePyDataset(py_dataset_adapter.PyDataset):
         batch_size=32,
         delay=0,
         infinite=False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.x, self.y = x_set, y_set
@@ -80,7 +80,6 @@ class DictPyDataset(py_dataset_adapter.PyDataset):
 
 
 class ExceptionPyDataset(py_dataset_adapter.PyDataset):
-
     @property
     def num_batches(self):
         return 4
@@ -285,7 +284,6 @@ class PyDatasetAdapterTest(testing.TestCase):
             self.assertEqual(tuple(by.shape), (4, 2))
 
     def test_with_different_shapes(self):
-
         class TestPyDataset(py_dataset_adapter.PyDataset):
             @property
             def num_batches(self):

--- a/keras/src/trainers/data_adapters/torch_data_loader_adapter_test.py
+++ b/keras/src/trainers/data_adapters/torch_data_loader_adapter_test.py
@@ -57,7 +57,6 @@ class TestTorchDataLoaderAdapter(testing.TestCase):
         named_product(batch_size=[None, 3], implements_len=[True, False])
     )
     def test_dataloader_iterable_dataset(self, batch_size, implements_len):
-
         class TestIterableDataset(torch.utils.data.IterableDataset):
             def __init__(self):
                 self.x = torch.normal(2, 3, size=(16, 4))

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -1999,7 +1999,6 @@ class TestTrainer(testing.TestCase):
 
     @pytest.mark.requires_trainable_backend
     def test_callbacks_can_update_state_at_batch_boundary(self):
-
         class CounterModel(keras.Model):
             def __init__(self):
                 super().__init__()
@@ -2176,7 +2175,6 @@ class TestTrainer(testing.TestCase):
 
     @pytest.mark.requires_trainable_backend
     def test_compute_loss_no_training_backwards_compatibility(self):
-
         class MyModel(keras.Model):
             def __init__(self):
                 super().__init__()

--- a/keras/src/tree/optree_impl.py
+++ b/keras/src/tree/optree_impl.py
@@ -198,7 +198,6 @@ def pack_sequence_as(structure, flat_sequence, sequence_fn=None):
 
 
 def lists_to_tuples(structure):
-
     def sequence_fn(instance, args):
         if isinstance(instance, list):
             return tuple(args)
@@ -210,7 +209,6 @@ def lists_to_tuples(structure):
 
 
 def map_shape_structure(func, structure):
-
     def is_shape_tuple(x):
         return isinstance(x, (list, tuple)) and all(
             isinstance(e, (int, type(None))) for e in x

--- a/keras/src/tree/tree_test.py
+++ b/keras/src/tree/tree_test.py
@@ -38,7 +38,6 @@ if optree.available:
 
 @parameterized.named_parameters(TEST_CASES)
 class TreeTest(testing.TestCase):
-
     def test_is_nested(self, tree_impl, is_optree):
         self.assertFalse(tree_impl.is_nested("1234"))
         self.assertFalse(tree_impl.is_nested(b"1234"))

--- a/keras/src/utils/dataset_utils_test.py
+++ b/keras/src/utils/dataset_utils_test.py
@@ -11,7 +11,6 @@ from keras.src.utils.module_utils import tensorflow as tf
 
 
 class MyTorchDataset(TorchDataset):
-
     def __init__(self, x, y):
         self.x = x
         self.y = y

--- a/keras/src/utils/jax_layer_test.py
+++ b/keras/src/utils/jax_layer_test.py
@@ -207,7 +207,6 @@ class TestJaxLayer(testing.TestCase):
             return count
 
         def verify_weights_and_params(layer):
-
             self.assertEqual(trainable_weights, len(layer.trainable_weights))
             self.assertEqual(
                 trainable_params,
@@ -329,7 +328,6 @@ class TestJaxLayer(testing.TestCase):
 
         # test subclass model building without a build method
         class TestModel(models.Model):
-
             def __init__(self, layer):
                 super().__init__()
                 self._layer = layer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,19 +47,6 @@ version = {attr = "keras.src.version.__version__"}
 [tool.setuptools.packages.find]
 include = ["keras", "keras.*"]
 
-[tool.black]
-line-length = 80
-target-version = []
-
-# black needs this to be a regex
-# to add more exclude expressions
-# append `| <regex-expr>` (e.g. `| .*_test\\.py`) to this list
-extend-exclude = """
-(
-  examples/
-)
-"""
-
 [tool.ruff]
 line-length = 80
 

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,5 +1,4 @@
 namex>=0.0.8
-black>=22
 ruff
 pytest
 numpy

--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-set -Eeuo pipefail
+set -Euo pipefail
 
 base_dir=$(dirname $(dirname $0))
 
-ruff check --exit-zero --config "${base_dir}/pyproject.toml" --fix .
+ruff check --config "${base_dir}/pyproject.toml" --fix .
 
-black --config "${base_dir}/pyproject.toml" .
+ruff format --config "${base_dir}/pyproject.toml" .
 

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-set -Eeuo pipefail
+set -Euo pipefail
 
 base_dir=$(dirname $(dirname $0))
 
-ruff check --exit-zero --config "${base_dir}/pyproject.toml" .
+ruff check --config "${base_dir}/pyproject.toml" .
+exitcode=$?
 
-black --config "${base_dir}/pyproject.toml" --check .
+ruff format --check --config "${base_dir}/pyproject.toml" .
+exitcode=$(($exitcode + $?))
 
+exit $exitcode


### PR DESCRIPTION
This PR follows on from #20442 to replace Black with Ruff as the Python code formatter.

Some manual code changes were applied to minimize automated changes or hopefully better represent the logic.

With this transition, `examples` is not excluded, as there was only a minor change to files in this directory.

Some shell scripts (in `shell/`) are modified to remove the [`-e` flag](https://www.gnu.org/software/bash/manual/bash.html#Modifying-Shell-Behavior), and `shell/lint.sh` is modified to run and accumulate error codes while running the whole script (i.e. 0=good, 1=one failure, 2=two failures).