### PR TITLE
Fix profiling for Tensorflow and JAX

### DIFF
--- a/keras/src/backend/jax/__init__.py
+++ b/keras/src/backend/jax/__init__.py
@@ -7,6 +7,7 @@ from keras.src.backend.jax import math
 from keras.src.backend.jax import nn
 from keras.src.backend.jax import numpy
 from keras.src.backend.jax import random
+from keras.src.backend.jax import tensorboard
 from keras.src.backend.jax.core import IS_THREAD_SAFE
 from keras.src.backend.jax.core import SUPPORTS_SPARSE_TENSORS
 from keras.src.backend.jax.core import Variable

--- a/keras/src/backend/jax/tensorboard.py
+++ b/keras/src/backend/jax/tensorboard.py
@@ -1,17 +1,19 @@
-from keras.src.utils.module_utils import tensorflow as tf
+from keras.src.utils.module_utils import jax
 
 
 def start_trace(logdir):
-    tf.profiler.experimental.start(logdir=logdir)
+    if logdir:
+        jax.profiler.start_trace(logdir)
 
 
 def stop_trace(save):
-    tf.profiler.experimental.stop(save=save)
+    if save:
+        jax.profiler.stop_trace()
 
 
 def start_batch_trace(batch):
-    batch_trace_context = tf.profiler.experimental.Trace(
-        "Profiled batch", step_num=batch
+    batch_trace_context = jax.profiler.TraceAnnotation(
+        f"Profiled batch {batch}"
     )
     batch_trace_context.__enter__()
     return batch_trace_context

--- a/keras/src/callbacks/tensorboard.py
+++ b/keras/src/callbacks/tensorboard.py
@@ -176,14 +176,23 @@ class TensorBoard(Callback):
         self.update_freq = 1 if update_freq == "batch" else update_freq
         self.embeddings_freq = embeddings_freq
         self.embeddings_metadata = embeddings_metadata
-        if profile_batch and backend.backend() != "tensorflow":
-            # TODO: profiling not available in JAX/torch
-            raise ValueError(
-                "Profiling is not yet available with the "
-                f"{backend.backend()} backend. Please open a PR "
-                "if you'd like to add this feature. Received: "
-                f"profile_batch={profile_batch} (must be 0)"
-            )
+        if profile_batch:
+            if backend.backend() == "torch":
+                # TODO: profiling not available in torch
+                raise ValueError(
+                    "Profiling is not yet available with the "
+                    f"{backend.backend()} backend. Please open a PR "
+                    "if you'd like to add this feature. Received: "
+                    f"profile_batch={profile_batch} (must be 0)"
+                )
+            elif backend.backend() == "jax":
+                if sys.version_info[1] < 12:
+                    warnings.warn(
+                        "Profiling with the "
+                        f"{backend.backend()} backend requires python >= 3.12."
+                    )
+                    profile_batch = 0
+
         self._init_profile_batch(profile_batch)
         self._global_train_batch = 0
         self._previous_epoch_iterations = 0
@@ -384,6 +393,8 @@ class TensorBoard(Callback):
         # We track the status here to make sure callbacks do not interfere with
         # each other. The callback will only stop the profiler it started.
         self._profiler_started = False
+        self._batch_trace_context = None
+
         if self._start_batch > 0:
             # Warm up and improve the profiling accuracy.
             self._start_profiler(logdir="")
@@ -437,6 +448,10 @@ class TensorBoard(Callback):
 
         if self._global_train_batch == self._start_batch:
             self._start_trace()
+        if self._profiler_started:
+            self._batch_trace_context = backend.tensorboard.start_batch_trace(
+                batch
+            )
 
     def on_train_batch_end(self, batch, logs=None):
         if self._should_write_train_graph:
@@ -460,8 +475,12 @@ class TensorBoard(Callback):
         if not self._should_trace:
             return
 
-        if self._is_tracing and self._global_train_batch >= self._stop_batch:
-            self._stop_trace()
+        if self._is_tracing:
+            if self._profiler_started and self._batch_trace_context is not None:
+                backend.tensorboard.stop_batch_trace(self._batch_trace_context)
+                self._batch_trace_context = None
+            if self._global_train_batch >= self._stop_batch:
+                self._stop_trace()
 
     def on_epoch_begin(self, epoch, logs=None):
         # Keeps track of epoch for profiling.
@@ -483,7 +502,7 @@ class TensorBoard(Callback):
 
     def _start_trace(self):
         self.summary.trace_on(graph=True, profiler=False)
-        self._start_profiler(logdir=self.log_dir)
+        self._start_profiler(logdir=self._train_dir)
         self._is_tracing = True
 
     def _stop_trace(self, batch=None):

--- a/keras/src/callbacks/tensorboard_test.py
+++ b/keras/src/callbacks/tensorboard_test.py
@@ -1,6 +1,7 @@
 import collections
 import os
 import random
+import sys
 
 import numpy as np
 import pytest
@@ -736,14 +737,10 @@ class TestTensorBoardV2(testing.TestCase):
         pass
 
     @pytest.mark.skipif(
-        backend.backend() != "tensorflow",
-        reason="The profiling test can only run with TF backend.",
+        backend.backend() == "torch",
+        reason="The profiling test can only run with TF and JAX backends.",
     )
     def test_TensorBoard_auto_trace(self):
-        # TODO: Waiting for implementation for torch/jax for profiling ops
-        # if backend.backend() == "jax":
-        #       return
-        # TODO: Debug profiling for JAX
         logdir, train_dir, validation_dir = self._get_log_dirs()
         model = models.Sequential(
             [
@@ -753,6 +750,16 @@ class TestTensorBoardV2(testing.TestCase):
             ]
         )
         x, y = np.ones((10, 10, 10, 1)), np.ones((10, 1))
+        if backend.backend() == "jax" and sys.version_info[1] < 12:
+            with pytest.warns(match="backend requires python >= 3.12"):
+                callbacks.TensorBoard(
+                    logdir, histogram_freq=1, profile_batch=1, write_graph=False
+                )
+            self.skipTest(
+                "Profiling with JAX and python < 3.12 "
+                "raises segmentation fault."
+            )
+
         tb_cbk = callbacks.TensorBoard(
             logdir, histogram_freq=1, profile_batch=1, write_graph=False
         )
@@ -773,5 +780,5 @@ class TestTensorBoardV2(testing.TestCase):
                 _ObservedSummary(logdir=train_dir, tag="batch_1"),
             },
         )
-        self.assertEqual(1, self._count_xplane_file(logdir=logdir))
+        self.assertEqual(1, self._count_xplane_file(logdir=train_dir))
         pass


### PR DESCRIPTION
Fix profiling for TensorFlow and JAX.
Profiling with JAX backend on Python version < 3.12 raises segmentation faults on my local setup. The profiling is deactivated for JAX when this requirement is not met.
Example of profiling traces using the following code snippet:

Tensorflow:
![tf_profile](https://github.com/user-attachments/assets/5c7053da-f057-48a8-9878-5aa8b5916d86)

JAX:
![jax_profile](https://github.com/user-attachments/assets/81951379-34ab-406b-86a0-807af9158b00)


```python

import os

os.environ["KERAS_BACKEND"] = "tensorflow"

import tensorflow as tf  # For tf.data
import tensorflow_datasets as tfds

from keras import layers
from keras.applications import ResNet50 as app_model
from keras.src import callbacks

IMG_SIZE = 224
BATCH_SIZE = 64
steps_per_execution = 1
dataset_size = BATCH_SIZE * max(steps_per_execution, 32)

dataset_name = "stanford_dogs"
(ds_train, ds_test), ds_info = tfds.load(
    dataset_name, split=["train", "test"], with_info=True, as_supervised=True
)
NUM_CLASSES = ds_info.features["label"].num_classes

size = (IMG_SIZE, IMG_SIZE)
ds_train = ds_train.take(dataset_size * (len(ds_train) // dataset_size)).map(
    lambda image, label: (tf.image.resize(image, size), label)
)
ds_test = ds_test.take(dataset_size * (len(ds_test) // dataset_size)).map(
    lambda image, label: (tf.image.resize(image, size), label)
)

# One-hot / categorical encoding
def input_preprocess(image, label):
    label = tf.one_hot(label, NUM_CLASSES)
    return image, label

ds_train = ds_train.map(
    input_preprocess, num_parallel_calls=tf.data.AUTOTUNE
)
ds_train = ds_train.batch(batch_size=BATCH_SIZE, drop_remainder=True)
ds_train = ds_train.prefetch(tf.data.AUTOTUNE)

ds_test = ds_test.map(
    input_preprocess, num_parallel_calls=tf.data.AUTOTUNE
)
ds_test = ds_test.batch(batch_size=BATCH_SIZE, drop_remainder=True).prefetch(
    tf.data.AUTOTUNE
)

model = app_model(
    include_top=True,
    weights=None,
    classes=NUM_CLASSES,
    input_shape=(IMG_SIZE, IMG_SIZE, 3),
)

model.compile(
    optimizer="adam",
    loss="categorical_crossentropy",
    metrics=["accuracy"],
    steps_per_execution=steps_per_execution,
    jit_compile=True,
)

# model.summary()
logdir = "logs/"
tb_cbk = callbacks.TensorBoard(
    logdir, histogram_freq=1, profile_batch="3,4", write_graph=False
)

epochs = 2
hist = model.fit(
    ds_train,
    epochs=epochs,
    validation_data=ds_test,
    callbacks=[tb_cbk],
)

```