### PR TITLE
`TensorFlowTrainer`: Add low-level API `unrolled_steps_per_execution` parameter

### DIFF
--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -842,7 +842,7 @@ class TestTrainer(testing.TestCase):
             steps_per_execution=steps_per_execution,
             jit_compile=True,
         )
-        model_2.unrolled_steps_per_execution = unrolled_steps_per_execution
+        model_2.unrolled_steps_per_execution = 1
         history_2 = model_2.fit(
             x=x, y=y, batch_size=batch_size, epochs=epochs, verbose=0
         )


### PR DESCRIPTION
Add low-level API parameter `unrolled_steps_per_execution` for `TensorFlowTrainer`.

This parameter specifies how many steps of the `step_per_execution` loop to unroll. Increasing this value can reduce kernel launch overhead, but will increase memory usage and compilation time.

Usage:
```python
model.unrolled_steps_per_execution = 4
model.fit(...)
```

The following example shows how this parameter can reduce GPU idling by reducing kernel launch delay when a model is trained using `step_per_execution = 4`, resulting in a 2x speedup.

With `unrolled_steps_per_execution = 1` (default value):

![image](https://github.com/user-attachments/assets/8700b127-3908-4d3e-bad4-993481b74675)

With `unrolled_steps_per_execution = 4`:

![image](https://github.com/user-attachments/assets/66df71f5-77ee-4d28-9b78-f796a872972a)


```python

import os

os.environ["KERAS_BACKEND"] = "tensorflow"

import tensorflow as tf  # For tf.data
import tensorflow_datasets as tfds

from keras.applications import MobileNet as app_model
from keras.src import callbacks

IMG_SIZE = 224
BATCH_SIZE = 1  # small patch size to reduce the data pipeline overhead
steps_per_execution = 4
dataset_size = BATCH_SIZE * max(steps_per_execution, 32)

dataset_name = "stanford_dogs"
(ds_train, ds_test), ds_info = tfds.load(
    dataset_name, split=["train", "test"], with_info=True, as_supervised=True
)
NUM_CLASSES = ds_info.features["label"].num_classes

size = (IMG_SIZE, IMG_SIZE)
ds_train = ds_train.take(dataset_size * (len(ds_train) // dataset_size)).map(
    lambda image, label: (tf.image.resize(image, size), label)
)
ds_test = ds_test.take(dataset_size * (len(ds_test) // dataset_size)).map(
    lambda image, label: (tf.image.resize(image, size), label)
)


# One-hot / categorical encoding
def input_preprocess(image, label):
    label = tf.one_hot(label, NUM_CLASSES)
    return image, label


ds_train = ds_train.map(input_preprocess, num_parallel_calls=tf.data.AUTOTUNE)
ds_train = ds_train.batch(batch_size=BATCH_SIZE, drop_remainder=True)
ds_train = (
    ds_train.take(4 * steps_per_execution).cache().prefetch(tf.data.AUTOTUNE)
)

ds_test = ds_test.map(input_preprocess, num_parallel_calls=tf.data.AUTOTUNE)
ds_test = (
    ds_test.batch(batch_size=BATCH_SIZE, drop_remainder=True)
    .take(4 * steps_per_execution)
    .cache()
    .prefetch(tf.data.AUTOTUNE)
)

model = app_model(
    include_top=True,
    weights=None,
    classes=NUM_CLASSES,
    input_shape=(IMG_SIZE, IMG_SIZE, 3),
)

model.compile(
    optimizer="adam",
    loss="categorical_crossentropy",
    metrics=["accuracy"],
    steps_per_execution=steps_per_execution,
    jit_compile=True,
)

# model.summary()
logdir = "logs/"
tb_cbk = callbacks.TensorBoard(
    logdir, histogram_freq=1, profile_batch="3,4", write_graph=False
)
model.unrolled_steps_per_execution = 4
epochs = 2
hist = model.fit(
    ds_train,
    epochs=epochs,
    validation_data=ds_test,
    callbacks=[tb_cbk],
)

```
