### PR TITLE
Fix for https://github.com/keras-team/keras/issues/20425

### DIFF
--- a/keras/src/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter.py
@@ -193,6 +193,7 @@ class PyDatasetAdapter(DataAdapter):
         self.enqueuer = None
         self.shuffle = shuffle
         self._output_signature = None
+        self._within_epoch = False
 
         workers = self.py_dataset.workers
         use_multiprocessing = self.py_dataset.use_multiprocessing
@@ -314,6 +315,12 @@ class PyDatasetAdapter(DataAdapter):
         return data_adapter_utils.get_torch_dataloader(self._get_iterator())
 
     def on_epoch_begin(self):
+        if self._within_epoch:
+            raise ValueError(
+                "`on_epoch_begin` was called twice without `on_epoch_end` "
+                "having been called."
+            )
+        self._within_epoch = True
         if self.enqueuer:
             self.enqueuer.start()
         self.py_dataset.on_epoch_begin()
@@ -322,6 +329,7 @@ class PyDatasetAdapter(DataAdapter):
         if self.enqueuer:
             self.enqueuer.stop()
         self.py_dataset.on_epoch_end()
+        self._within_epoch = False
 
     @property
     def num_batches(self):
@@ -460,7 +468,7 @@ class PyDatasetEnqueuer:
                 return
             self.running = True
             self.run_thread = threading.Thread(target=self._run)
-            self.run_thread.name = f"Worker_{self.uid}"  # TODO remove
+            self.run_thread.name = f"Worker_{self.uid}"
             self.run_thread.daemon = True
             self.run_thread.start()
 
@@ -644,11 +652,7 @@ class OrderedEnqueuer(PyDatasetEnqueuer):
                 if inputs is not None:
                     yield inputs
             except queue.Empty:
-                warnings.warn(
-                    "Generator ran out of batches before reaching `num_batches`"
-                )
-                self.stop()
-                return
+                pass
             except Exception as e:
                 self.stop(drain_queue_and_join=True)
                 raise e

--- a/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
@@ -143,18 +143,23 @@ class PyDatasetAdapterTest(testing.TestCase):
     ):
         if use_multiprocessing and shuffle:
             pytest.skip("Starting processes is slow, test fewer variants")
-        if testing.tensorflow_uses_gpu():
-            pytest.skip("This test is flaky with TF on GPU")
 
         set_random_seed(1337)
         x = np.random.random((64, 4)).astype("float32")
         y = np.array([[i, i] for i in range(64)], dtype="float32")
-        if dataset_type == "tf":
-            x, y = tf.constant(x), tf.constant(y)
-        elif dataset_type == "jax":
-            x, y = jax.numpy.array(x), jax.numpy.array(y)
-        elif dataset_type == "torch":
-            x, y = torch.as_tensor(x), torch.as_tensor(y)
+        CPU_DEVICES = {
+            "tensorflow": "CPU:0",
+            "jax": "cpu:0",
+            "torch": "cpu",
+            "numpy": "cpu",
+        }
+        with backend.device(CPU_DEVICES[backend.backend()]):
+            if dataset_type == "tf":
+                x, y = tf.constant(x), tf.constant(y)
+            elif dataset_type == "jax":
+                x, y = jax.numpy.array(x), jax.numpy.array(y)
+            elif dataset_type == "torch":
+                x, y = torch.as_tensor(x), torch.as_tensor(y)
         py_dataset = ExamplePyDataset(
             x,
             y,

--- a/keras/src/trainers/epoch_iterator.py
+++ b/keras/src/trainers/epoch_iterator.py
@@ -91,6 +91,7 @@ class EpochIterator:
         self._num_batches = self.data_adapter.num_batches
         self._steps_seen = 0
         self._epoch_iterator = None
+        self.data_adapter.on_epoch_end()
 
     def _enumerate_iterator(self):
         self.data_adapter.on_epoch_begin()


### PR DESCRIPTION
The issue was caused by the fact that the iterator was not fully consumed and `on_epoch_end` was not called.

Added an exception to catch this situation in the future.

Added a unit test to test `model.fit()` with all the combinations of data adapters.