### PR TITLE
Suppress warnings for mismatched tuples and lists in functional models

### DIFF
--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -214,8 +214,12 @@ class Functional(Function, Model):
 
     def _maybe_warn_inputs_struct_mismatch(self, inputs):
         try:
+            # We first normalize to tuples before performing the check to
+            # suppress warnings when encountering mismatched tuples and lists.
             tree.assert_same_structure(
-                inputs, self._inputs_struct, check_types=False
+                tree.lists_to_tuples(inputs),
+                tree.lists_to_tuples(self._inputs_struct),
+                check_types=False,
             )
         except:
             model_inputs_struct = tree.map_structure(

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import numpy as np
 import pytest
@@ -503,12 +504,18 @@ class FunctionalTest(testing.TestCase):
         model = Model({"i1": i1, "i2": i2}, outputs)
 
         with pytest.warns() as record:
-            model([np.ones((2, 2)), np.zeros((2, 2))])
+            model.predict([np.ones((2, 2)), np.zeros((2, 2))], verbose=0)
         self.assertLen(record, 1)
         self.assertStartsWith(
             str(record[0].message),
             r"The structure of `inputs` doesn't match the expected structure:",
         )
+
+        # No warning for mismatched tuples and lists.
+        model = Model([i1, i2], outputs)
+        with warnings.catch_warnings(record=True) as warning_logs:
+            model.predict((np.ones((2, 2)), np.zeros((2, 2))), verbose=0)
+            self.assertLen(warning_logs, 0)
 
     def test_for_functional_in_sequential(self):
         # Test for a v3.4.1 regression.


### PR DESCRIPTION
Fix #20170

It should be acceptable to suppress warnings for mismatched tuples and lists in functional models, as the TF backend will automatically convert lists to tuples for input data.