### PR TITLE
Add hard_shrink activation function

### DIFF
--- a/keras/api/_tf_keras/keras/activations/__init__.py
+++ b/keras/api/_tf_keras/keras/activations/__init__.py
@@ -12,6 +12,7 @@ from keras.src.activations.activations import elu
 from keras.src.activations.activations import exponential
 from keras.src.activations.activations import gelu
 from keras.src.activations.activations import glu
+from keras.src.activations.activations import hard_shrink
 from keras.src.activations.activations import hard_sigmoid
 from keras.src.activations.activations import hard_silu
 from keras.src.activations.activations import hard_silu as hard_swish

--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -73,6 +73,7 @@ from keras.src.ops.nn import dot_product_attention
 from keras.src.ops.nn import elu
 from keras.src.ops.nn import gelu
 from keras.src.ops.nn import glu
+from keras.src.ops.nn import hard_shrink
 from keras.src.ops.nn import hard_sigmoid
 from keras.src.ops.nn import hard_silu
 from keras.src.ops.nn import hard_silu as hard_swish

--- a/keras/api/_tf_keras/keras/ops/nn/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/nn/__init__.py
@@ -18,6 +18,7 @@ from keras.src.ops.nn import dot_product_attention
 from keras.src.ops.nn import elu
 from keras.src.ops.nn import gelu
 from keras.src.ops.nn import glu
+from keras.src.ops.nn import hard_shrink
 from keras.src.ops.nn import hard_sigmoid
 from keras.src.ops.nn import hard_silu
 from keras.src.ops.nn import hard_silu as hard_swish

--- a/keras/api/activations/__init__.py
+++ b/keras/api/activations/__init__.py
@@ -12,6 +12,7 @@ from keras.src.activations.activations import elu
 from keras.src.activations.activations import exponential
 from keras.src.activations.activations import gelu
 from keras.src.activations.activations import glu
+from keras.src.activations.activations import hard_shrink
 from keras.src.activations.activations import hard_sigmoid
 from keras.src.activations.activations import hard_silu
 from keras.src.activations.activations import hard_silu as hard_swish

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -73,6 +73,7 @@ from keras.src.ops.nn import dot_product_attention
 from keras.src.ops.nn import elu
 from keras.src.ops.nn import gelu
 from keras.src.ops.nn import glu
+from keras.src.ops.nn import hard_shrink
 from keras.src.ops.nn import hard_sigmoid
 from keras.src.ops.nn import hard_silu
 from keras.src.ops.nn import hard_silu as hard_swish

--- a/keras/api/ops/nn/__init__.py
+++ b/keras/api/ops/nn/__init__.py
@@ -18,6 +18,7 @@ from keras.src.ops.nn import dot_product_attention
 from keras.src.ops.nn import elu
 from keras.src.ops.nn import gelu
 from keras.src.ops.nn import glu
+from keras.src.ops.nn import hard_shrink
 from keras.src.ops.nn import hard_sigmoid
 from keras.src.ops.nn import hard_silu
 from keras.src.ops.nn import hard_silu as hard_swish

--- a/keras/src/activations/__init__.py
+++ b/keras/src/activations/__init__.py
@@ -5,6 +5,7 @@ from keras.src.activations.activations import elu
 from keras.src.activations.activations import exponential
 from keras.src.activations.activations import gelu
 from keras.src.activations.activations import glu
+from keras.src.activations.activations import hard_shrink
 from keras.src.activations.activations import hard_sigmoid
 from keras.src.activations.activations import hard_silu
 from keras.src.activations.activations import hard_tanh
@@ -45,6 +46,7 @@ ALL_OBJECTS = {
     hard_sigmoid,
     hard_silu,
     hard_tanh,
+    hard_shrink,
     linear,
     mish,
     log_softmax,

--- a/keras/src/activations/activations.py
+++ b/keras/src/activations/activations.py
@@ -374,19 +374,19 @@ def hard_tanh(x):
 
 
 @keras_export("keras.activations.hard_shrink")
-def hard_shrink(x, lambd=0.5):
+def hard_shrink(x, threshold=0.5):
     """Hard Shrink activation function.
 
     It is defined as:
 
-    `hard_shrink(x) = x if |x| > lambd`, `hard_shrink(x) = 0 otherwise`.
+    `hard_shrink(x) = x if |x| > threshold`, `hard_shrink(x) = 0 otherwise`.
 
     Args:
         x: Input tensor.
-        lambd: Threshold value. Defaults to `0.5`.
+        threshold: Threshold value. Defaults to `0.5`.
 
     """
-    return ops.hard_shrink(x, lambd=lambd)
+    return ops.hard_shrink(x, threshold=threshold)
 
 
 @keras_export("keras.activations.sigmoid")

--- a/keras/src/activations/activations.py
+++ b/keras/src/activations/activations.py
@@ -373,6 +373,22 @@ def hard_tanh(x):
     return ops.hard_tanh(x)
 
 
+@keras_export("keras.activations.hard_shrink")
+def hard_shrink(x, lambd=0.5):
+    """Hard Shrink activation function.
+
+    It is defined as:
+
+    `hard_shrink(x) = x if |x| > lambd`, `hard_shrink(x) = 0 otherwise`.
+
+    Args:
+        x: Input tensor.
+        lambd: Threshold value. Defaults to `0.5`.
+
+    """
+    return ops.hard_shrink(x, lambd=lambd)
+
+
 @keras_export("keras.activations.sigmoid")
 def sigmoid(x):
     """Sigmoid activation function.

--- a/keras/src/activations/activations_test.py
+++ b/keras/src/activations/activations_test.py
@@ -665,6 +665,15 @@ class ActivationsTest(testing.TestCase):
         expected = hard_tanh(x)
         self.assertAllClose(result, expected, rtol=1e-05)
 
+    def test_hard_shrink(self):
+        def hard_shrink(x):
+            return np.where(np.abs(x) > 0.5, x, 0.0)
+
+        x = np.random.random((2, 5))
+        result = activations.hard_shrink(x[np.newaxis, :])[0]
+        expected = hard_shrink(x)
+        self.assertAllClose(result, expected, rtol=1e-05)
+
     def test_elu(self):
         x = np.random.random((2, 5))
         result = activations.elu(x[np.newaxis, :])[0]

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -103,9 +103,9 @@ def hard_tanh(x):
     return jnn.hard_tanh(x)
 
 
-def hard_shrink(x, lambd=0.5):
+def hard_shrink(x, threshold=0.5):
     x = convert_to_tensor(x)
-    return jnp.where(jnp.abs(x) > lambd, x, 0.0)
+    return jnp.where(jnp.abs(x) > threshold, x, 0.0)
 
 
 def softmax(x, axis=-1):

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -103,6 +103,11 @@ def hard_tanh(x):
     return jnn.hard_tanh(x)
 
 
+def hard_shrink(x, lambd=0.5):
+    x = convert_to_tensor(x)
+    return jnp.where(jnp.abs(x) > lambd, x, 0.0)
+
+
 def softmax(x, axis=-1):
     x = convert_to_tensor(x)
     return jnn.softmax(x, axis=axis)

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -142,7 +142,10 @@ def hard_tanh(x):
 def hard_shrink(x, lambd=0.5):
     x = convert_to_tensor(x)
     lambd = np.asarray(lambd, x.dtype)
-    return np.array(np.where(np.abs(x) > lambd, x, 0.0), dtype=x.dtype)
+    return np.array(
+        np.where(np.abs(x) > lambd, x, np.array(0.0, dtype=x.dtype)),
+        dtype=x.dtype,
+    )
 
 
 def softmax(x, axis=None):

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -139,11 +139,11 @@ def hard_tanh(x):
     return np.array(np.clip(x, min_val, max_val), dtype=x.dtype)
 
 
-def hard_shrink(x, lambd=0.5):
+def hard_shrink(x, threshold=0.5):
     x = convert_to_tensor(x)
-    lambd = np.asarray(lambd, x.dtype)
+    threshold = np.asarray(threshold, x.dtype)
     return np.array(
-        np.where(np.abs(x) > lambd, x, np.array(0.0, dtype=x.dtype)),
+        np.where(np.abs(x) > threshold, x, np.array(0.0, dtype=x.dtype)),
         dtype=x.dtype,
     )
 

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -139,6 +139,12 @@ def hard_tanh(x):
     return np.array(np.clip(x, min_val, max_val), dtype=x.dtype)
 
 
+def hard_shrink(x, lambd=0.5):
+    x = convert_to_tensor(x)
+    lambd = np.asarray(lambd, x.dtype)
+    return np.array(np.where(np.abs(x) > lambd, x, 0.0), dtype=x.dtype)
+
+
 def softmax(x, axis=None):
     exp_x = np.exp(x - np.max(x, axis=axis, keepdims=True))
     return exp_x / np.sum(exp_x, axis=axis, keepdims=True)

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -96,8 +96,8 @@ def hard_tanh(x):
     return tf.clip_by_value(x, clip_value_min=-1.0, clip_value_max=1.0)
 
 
-def hard_shrink(x, lambd=0.5):
-    return tf.where(tf.abs(x) > lambd, x, tf.zeros_like(x))
+def hard_shrink(x, threshold=0.5):
+    return tf.where(tf.abs(x) > threshold, x, tf.zeros_like(x))
 
 
 def softmax(x, axis=-1):

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -96,6 +96,10 @@ def hard_tanh(x):
     return tf.clip_by_value(x, clip_value_min=-1.0, clip_value_max=1.0)
 
 
+def hard_shrink(x, lambd=0.5):
+    return tf.where(tf.abs(x) > lambd, x, tf.zeros_like(x))
+
+
 def softmax(x, axis=-1):
     logits = x
     if axis is None:

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -103,6 +103,11 @@ def hard_tanh(x):
     return tnn.hardtanh(x, min_val=-1.0, max_val=1.0)
 
 
+def hard_shrink(x, lambd=0.5):
+    x = convert_to_tensor(x)
+    return tnn.hardshrink(x, lambd=lambd)
+
+
 def softmax(x, axis=-1):
     x = convert_to_tensor(x)
     dtype = backend.standardize_dtype(x.dtype)

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -103,9 +103,9 @@ def hard_tanh(x):
     return tnn.hardtanh(x, min_val=-1.0, max_val=1.0)
 
 
-def hard_shrink(x, lambd=0.5):
+def hard_shrink(x, threshold=0.5):
     x = convert_to_tensor(x)
-    return tnn.hardshrink(x, lambd=lambd)
+    return tnn.hardshrink(x, lambd=threshold)
 
 
 def softmax(x, axis=-1):

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -618,6 +618,46 @@ def hard_tanh(x):
     return backend.nn.hard_tanh(x)
 
 
+class HardShrink(Operation):
+    def __init__(self, lambd=0.5):
+        super().__init__()
+        self.lambd = lambd
+
+    def call(self, x):
+        return backend.nn.hard_shrink(x, self.lambd)
+
+    def compute_output_spec(self, x):
+        return KerasTensor(x.shape, dtype=x.dtype)
+
+
+@keras_export(["keras.ops.hard_shrink", "keras.ops.nn.hard_shrink"])
+def hard_shrink(x, lambd=0.5):
+    """Hard Shrink activation function.
+
+    The Hard Shrink function is a thresholding operation defined as:
+
+    `f(x) = x if |x| > lambd`, `f(x) = 0 otherwise`.
+
+    Args:
+        x: Input tensor.
+        lambd: Threshold value. Defaults to `0.5`.
+
+    Returns:
+        A tensor with the same shape as `x`.
+
+    Example:
+
+    >>> x = np.array([-0.5, 0., 1.])
+    >>> x_hard_shrink = keras.ops.hard_shrink(x)
+    >>> print(x_hard_shrink)
+    array([0. 0. 1.], shape=(3,), dtype=float64)
+
+    """
+    if any_symbolic_tensors((x,)):
+        return HardShrink(lambd).symbolic_call(x)
+    return backend.nn.hard_shrink(x, lambd)
+
+
 class Softmax(Operation):
     def __init__(self, axis=-1):
         super().__init__()

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -619,12 +619,12 @@ def hard_tanh(x):
 
 
 class HardShrink(Operation):
-    def __init__(self, lambd=0.5):
+    def __init__(self, threshold=0.5):
         super().__init__()
-        self.lambd = lambd
+        self.threshold = threshold
 
     def call(self, x):
-        return backend.nn.hard_shrink(x, self.lambd)
+        return backend.nn.hard_shrink(x, self.threshold)
 
     def compute_output_spec(self, x):
         return KerasTensor(x.shape, dtype=x.dtype)

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -631,16 +631,16 @@ class HardShrink(Operation):
 
 
 @keras_export(["keras.ops.hard_shrink", "keras.ops.nn.hard_shrink"])
-def hard_shrink(x, lambd=0.5):
+def hard_shrink(x, threshold=0.5):
     """Hard Shrink activation function.
 
     The Hard Shrink function is a thresholding operation defined as:
 
-    `f(x) = x if |x| > lambd`, `f(x) = 0 otherwise`.
+    `f(x) = x if |x| > threshold`, `f(x) = 0 otherwise`.
 
     Args:
         x: Input tensor.
-        lambd: Threshold value. Defaults to `0.5`.
+        threshold: Threshold value. Defaults to `0.5`.
 
     Returns:
         A tensor with the same shape as `x`.
@@ -654,8 +654,8 @@ def hard_shrink(x, lambd=0.5):
 
     """
     if any_symbolic_tensors((x,)):
-        return HardShrink(lambd).symbolic_call(x)
-    return backend.nn.hard_shrink(x, lambd)
+        return HardShrink(threshold).symbolic_call(x)
+    return backend.nn.hard_shrink(x, threshold)
 
 
 class Softmax(Operation):

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -153,6 +153,10 @@ class NNOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.hard_tanh(x).shape, (None, 2, 3))
 
+    def test_hard_shrink(self):
+        x = KerasTensor([None, 2, 3])
+        self.assertEqual(knn.hard_shrink(x).shape, (None, 2, 3))
+
     def test_softmax(self):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.softmax(x).shape, (None, 2, 3))
@@ -810,6 +814,10 @@ class NNOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.hard_tanh(x).shape, (1, 2, 3))
 
+    def test_hard_shrink(self):
+        x = KerasTensor([1, 2, 3])
+        self.assertEqual(knn.hard_shrink(x).shape, (1, 2, 3))
+
     def test_softmax(self):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.softmax(x).shape, (1, 2, 3))
@@ -1335,6 +1343,13 @@ class NNOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(
             knn.hard_tanh(x),
             [-1.0, 0.0, 1.0, 1.0, 1.0],
+        )
+
+    def test_hard_shrink(self):
+        x = np.array([-0.5, 0, 1, 2, 3], dtype=np.float32)
+        self.assertAllClose(
+            knn.hard_shrink(x),
+            [0.0, 0.0, 1.0, 2.0, 3.0],
         )
 
     def test_softmax(self):
@@ -2441,6 +2456,24 @@ class NNOpsDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knn.HardTanh().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_hard_shrink(self, dtype):
+        import torch
+        import torch.nn.functional as tnn
+
+        x = knp.ones((1), dtype=dtype)
+        x_torch = torch.ones(1, dtype=getattr(torch, dtype))
+        expected_dtype = standardize_dtype(tnn.hardshrink(x_torch).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knn.hard_shrink(x).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(knn.HardShrink().symbolic_call(x).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
Since Keras lacks built-in support for the hard_shrink activation function, I implemented it across TensorFlow, JAX, and NumPy, aiming to maintain consistency with existing implementations available in PyTorch.