### PR TITLE
Update CompileLoss to report unweighted metric values (breaking change)

### DIFF
--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -581,7 +581,7 @@ class CompileLoss(losses_module.Loss):
                     raise ValueError(
                         f"`loss_weights` must match the number of losses, "
                         f"got {len(tree.flatten(loss))} losses "
-                        f"and {len(loss_weights)} weigths."
+                        f"and {len(loss_weights)} weights."
                     )
                 loss_weights = tree.pack_sequence_as(loss, flat_loss_weights)
             loss = tree.map_structure(
@@ -717,14 +717,14 @@ class CompileLoss(losses_module.Loss):
             value = ops.cast(
                 loss_fn(y_t, y_p, _sample_weight), dtype=self.dtype
             )
-            if loss_weight is not None:
-                value = ops.multiply(value, loss_weight)
-            loss_values.append(value)
-            # Record individual losses.
+            # Record *unweighted* individual losses.
             if metric:
                 metric.update_state(
                     value, sample_weight=tree.flatten(y_p)[0].shape[0]
                 )
+            if loss_weight is not None:
+                value = ops.multiply(value, loss_weight)
+            loss_values.append(value)
 
         if loss_values:
             total_loss = sum(loss_values)

--- a/keras/src/trainers/compile_utils_test.py
+++ b/keras/src/trainers/compile_utils_test.py
@@ -378,6 +378,33 @@ class TestCompileLoss(testing.TestCase):
         value = compile_loss(y_true, y_pred)
         self.assertAllClose(value, 1.07666, atol=1e-5)
 
+    def test_struct_loss_valid_weights(self):
+        y_true = {
+            "a": np.array([1, 2]),
+            "b": np.array([1, 2]),
+        }
+        y_pred = {
+            "a": np.array([3, 4]),
+            "b": np.array([3, 4]),
+        }
+        loss = {"a": "mse", "b": "mse"}
+        compile_loss = CompileLoss(
+            loss=loss,
+            output_names=["a", "b"],
+            loss_weights={
+                "a": np.ones((2,)),
+                "b": np.zeros((2,)),
+            },
+        )
+        compile_loss.build(y_true, y_pred)
+        value = compile_loss(y_true, y_pred)
+        self.assertAllClose(value, 4)
+
+        # Metrics still report unweighted loss.
+        a_loss_mean, b_loss_mean = compile_loss.metrics
+        self.assertEqual(a_loss_mean.result(), 4)
+        self.assertEqual(b_loss_mean.result(), 4)
+
     def test_struct_loss_invalid_weights(self):
         y_true = {
             "a": {


### PR DESCRIPTION
Fixes #20343. Thanks to rivershah@ for pointing this out.

This changes CompileLoss metrics to report the values before weights are applied, which brings it in line with Keras 2 behavior.