### PR TITLE
`CompileLoss`: fix for partially defined loss with different `y_pred` and `y_true` structures

### DIFF
--- a/keras/src/trainers/compile_utils_test.py
+++ b/keras/src/trainers/compile_utils_test.py
@@ -520,3 +520,15 @@ class TestCompileLoss(testing.TestCase):
         ):
             wrong_struc_y_true = [np.array([[1]])]
             compile_loss(wrong_struc_y_true, y_pred)
+
+    def test_y_true_partial_y_pred_span(self):
+        y_pred = [np.random.random((320, 3))] * 3
+        y_true = np.random.random((320, 3))
+
+        compile_loss = CompileLoss(
+            loss=["mse", None, None], output_names=["a", "b", "c"]
+        )
+        # build call
+        compile_loss(y_true, y_pred)
+        # built call
+        compile_loss(y_true, y_pred)

--- a/keras/src/trainers/compile_utils_test.py
+++ b/keras/src/trainers/compile_utils_test.py
@@ -522,8 +522,10 @@ class TestCompileLoss(testing.TestCase):
             compile_loss(wrong_struc_y_true, y_pred)
 
     def test_y_true_partial_y_pred_span(self):
-        y_pred = [np.random.random((320, 3))] * 3
-        y_true = np.random.random((320, 3))
+        ones = np.ones((320, 3))
+        zeros = np.zeros((320, 3))
+        y_pred = [ones, zeros, zeros]
+        y_true = ones
 
         compile_loss = CompileLoss(
             loss=["mse", None, None], output_names=["a", "b", "c"]
@@ -531,4 +533,5 @@ class TestCompileLoss(testing.TestCase):
         # build call
         compile_loss(y_true, y_pred)
         # built call
-        compile_loss(y_true, y_pred)
+        loss = compile_loss(y_true, y_pred)
+        self.assertEqual(loss, 0.0)


### PR DESCRIPTION
Fix for cases where the loss is partially defined over `y_pred`.

Example:
```python

inputs = keras.Input((2,))
x = keras.layers.Dense(3)(inputs)
model = keras.Model(inputs, [x, x, x])
model.compile(loss=["mse", None, None])

model.fit(x=np.random.random((320, 2)), y=np.random.random((320, 3)))
```