### PR TITLE
`CompileLoss`: Better handling of partial loss configs

### DIFF
--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -715,12 +715,17 @@ class CompileLoss(losses_module.Loss):
                         flat_y_true = tree.flatten(y_true)
                         flat_loss = tree.flatten(self._user_loss)
                         flat_loss_non_nones = [
-                            loss for loss in flat_loss if loss is not None
+                            (i, loss)
+                            for i, loss in enumerate(flat_loss)
+                            if loss is not None
                         ]
                         assert len(flat_y_true) == len(flat_loss_non_nones)
-                        if not tree.is_nested(y_true):
-                            y_true = flat_y_true
-
+                        y_true = [None] * len(flat_loss)
+                        for y_t, (i, loss) in zip(
+                            flat_y_true, flat_loss_non_nones
+                        ):
+                            y_true[i] = y_t
+                        y_true = tree.pack_sequence_as(self._user_loss, y_true)
             except:
                 y_true_struct = tree.map_structure(lambda _: "*", y_true)
                 y_pred_struct = tree.map_structure(lambda _: "*", y_pred)

--- a/keras/src/trainers/compile_utils_test.py
+++ b/keras/src/trainers/compile_utils_test.py
@@ -548,15 +548,22 @@ class TestCompileLoss(testing.TestCase):
             wrong_struc_y_true = [np.array([[1]])]
             compile_loss(wrong_struc_y_true, y_pred)
 
-    def test_y_true_partial_y_pred_span(self):
+    @parameterized.parameters(
+        ["mse", None, None],
+        [None, "mse", None],
+        [None, None, "mse"],
+        [None, "mse", "mse"],
+        ["mse", None, "mse"],
+    )
+    def test_y_true_partial_y_pred_span(self, *loss_conf):
+        loss_conf = list(loss_conf)
         ones = np.ones((320, 3))
         zeros = np.zeros((320, 3))
-        y_pred = [ones, zeros, zeros]
-        y_true = ones
-
-        compile_loss = CompileLoss(
-            loss=["mse", None, None], output_names=["a", "b", "c"]
-        )
+        twos = np.ones((320, 3)) * 2
+        y_pred = [zeros, ones, twos]
+        y_true = [y for y, loss in zip(y_pred, loss_conf) if loss is not None]
+        y_true = y_true[0] if len(y_true) == 1 else y_true
+        compile_loss = CompileLoss(loss=loss_conf, output_names=["a", "b", "c"])
         # build call
         compile_loss(y_true, y_pred)
         # built call


### PR DESCRIPTION
Fix handling of partial loss configurations in PR [#20477](https://github.com/keras-team/keras/pull/20477). This PR improves robustness of the implementation.