### PR TITLE
Add tanh_shrink activation

### DIFF
--- a/keras/api/_tf_keras/keras/activations/__init__.py
+++ b/keras/api/_tf_keras/keras/activations/__init__.py
@@ -32,3 +32,4 @@ from keras.src.activations.activations import softmax
 from keras.src.activations.activations import softplus
 from keras.src.activations.activations import softsign
 from keras.src.activations.activations import tanh
+from keras.src.activations.activations import tanh_shrink

--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -98,6 +98,7 @@ from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign
 from keras.src.ops.nn import sparse_categorical_crossentropy
+from keras.src.ops.nn import tanh_shrink
 from keras.src.ops.numpy import abs
 from keras.src.ops.numpy import absolute
 from keras.src.ops.numpy import add

--- a/keras/api/_tf_keras/keras/ops/nn/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/nn/__init__.py
@@ -43,3 +43,4 @@ from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign
 from keras.src.ops.nn import sparse_categorical_crossentropy
+from keras.src.ops.nn import tanh_shrink

--- a/keras/api/activations/__init__.py
+++ b/keras/api/activations/__init__.py
@@ -32,3 +32,4 @@ from keras.src.activations.activations import softmax
 from keras.src.activations.activations import softplus
 from keras.src.activations.activations import softsign
 from keras.src.activations.activations import tanh
+from keras.src.activations.activations import tanh_shrink

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -98,6 +98,7 @@ from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign
 from keras.src.ops.nn import sparse_categorical_crossentropy
+from keras.src.ops.nn import tanh_shrink
 from keras.src.ops.numpy import abs
 from keras.src.ops.numpy import absolute
 from keras.src.ops.numpy import add

--- a/keras/api/ops/nn/__init__.py
+++ b/keras/api/ops/nn/__init__.py
@@ -43,3 +43,4 @@ from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign
 from keras.src.ops.nn import sparse_categorical_crossentropy
+from keras.src.ops.nn import tanh_shrink

--- a/keras/src/activations/__init__.py
+++ b/keras/src/activations/__init__.py
@@ -23,6 +23,7 @@ from keras.src.activations.activations import softmax
 from keras.src.activations.activations import softplus
 from keras.src.activations.activations import softsign
 from keras.src.activations.activations import tanh
+from keras.src.activations.activations import tanh_shrink
 from keras.src.api_export import keras_export
 from keras.src.saving import object_registration
 from keras.src.saving import serialization_lib
@@ -41,6 +42,7 @@ ALL_OBJECTS = {
     gelu,
     glu,
     tanh,
+    tanh_shrink,
     sigmoid,
     exponential,
     hard_sigmoid,

--- a/keras/src/activations/activations.py
+++ b/keras/src/activations/activations.py
@@ -358,6 +358,20 @@ def tanh(x):
     return ops.tanh(x)
 
 
+@keras_export("keras.activations.tanh_shrink")
+def tanh_shrink(x):
+    """Tanh shrink activation function.
+
+    It is defined as:
+
+    `f(x) = x - tanh(x)`.
+
+    Args:
+        x: Input tensor.
+    """
+    return ops.tanh_shrink(x)
+
+
 @keras_export("keras.activations.hard_tanh")
 def hard_tanh(x):
     """HardTanh activation function.

--- a/keras/src/activations/activations_test.py
+++ b/keras/src/activations/activations_test.py
@@ -656,6 +656,15 @@ class ActivationsTest(testing.TestCase):
         expected = glu(x, axis=-2)
         self.assertAllClose(result, expected, rtol=1e-05)
 
+    def test_tanh_shrink(self):
+        def tanh_shrink(x):
+            return x - np.tanh(x)
+
+        x = np.random.random((2, 5))
+        result = activations.tanh_shrink(x[np.newaxis, :])[0]
+        expected = tanh_shrink(x)
+        self.assertAllClose(result, expected, rtol=1e-05)
+
     def test_hard_tanh(self):
         def hard_tanh(x):
             return np.clip(x, -1.0, 1.0)

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -38,6 +38,11 @@ def tanh(x):
     return jnn.tanh(x)
 
 
+def tanh_shrink(x):
+    x = convert_to_tensor(x)
+    return x - jnp.tanh(x)
+
+
 def softplus(x):
     x = convert_to_tensor(x)
     return jnn.softplus(x)

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -35,6 +35,11 @@ def tanh(x):
     return np.tanh(x)
 
 
+def tanh_shrink(x):
+    x = convert_to_tensor(x)
+    return x - np.tanh(x)
+
+
 def softplus(x):
     x = convert_to_tensor(x)
     return np.logaddexp(x, np.array(0.0, x.dtype))

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -30,6 +30,10 @@ def tanh(x):
     return tf.nn.tanh(x)
 
 
+def tanh_shrink(x):
+    return x - tf.math.tanh(x)
+
+
 def softplus(x):
     return tf.math.softplus(x)
 

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -35,6 +35,11 @@ def tanh(x):
     return tnn.tanh(x)
 
 
+def tanh_shrink(x):
+    x = convert_to_tensor(x)
+    return tnn.tanhshrink(x)
+
+
 def softplus(x):
     x = convert_to_tensor(x)
     return tnn.softplus(x)

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -579,6 +579,45 @@ def glu(x, axis=-1):
     return backend.nn.glu(x, axis=axis)
 
 
+class TanhShrink(Operation):
+    def __init__(self):
+        super().__init__()
+
+    def call(self, x):
+        return backend.nn.tanh_shrink(x)
+
+    def compute_output_spec(self, x):
+        return KerasTensor(x.shape, dtype=x.dtype)
+
+
+@keras_export(["keras.ops.tanh_shrink", "keras.ops.nn.tanh_shrink"])
+def tanh_shrink(x):
+    """Applies the tanh shrink function element-wise.
+
+    It is defined as:
+
+    `f(x) = x - tanh(x)`.
+
+    Args:
+        x: Input tensor.
+
+    Returns:
+        Output tensor of the same shape as `x`, where each element is
+        transformed according to the tanh shrink operation.
+
+    Example:
+
+    >>> x = np.array([ -1., 0., 1.])
+    >>> x_tanh_shrink = keras.ops.tanh_shrink(x)
+    >>> print(x_tanh_shrink)
+    array([-0.23840584  0.  0.23840584], shape=(3,), dtype=float64)
+
+    """
+    if any_symbolic_tensors((x,)):
+        return TanhShrink().symbolic_call(x)
+    return backend.nn.tanh_shrink(x)
+
+
 class HardTanh(Operation):
     def __init__(self):
         super().__init__()

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -149,6 +149,10 @@ class NNOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.glu(x).shape, (None, 2, 3))
 
+    def test_tanh_shrink(self):
+        x = KerasTensor([None, 2, 3])
+        self.assertEqual(knn.tanh_shrink(x).shape, (None, 2, 3))
+
     def test_hard_tanh(self):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.hard_tanh(x).shape, (None, 2, 3))
@@ -810,6 +814,10 @@ class NNOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.glu(x).shape, (1, 2, 3))
 
+    def test_tanh_shrink(self):
+        x = KerasTensor([1, 2, 3])
+        self.assertEqual(knn.tanh_shrink(x).shape, (1, 2, 3))
+
     def test_hard_tanh(self):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.hard_tanh(x).shape, (1, 2, 3))
@@ -1336,6 +1344,13 @@ class NNOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(
             knn.glu(x),
             [-0.8807971, 0.0, 0.98201376],
+        )
+
+    def test_tanh_shrink(self):
+        x = np.array([-1, 0, 1, 2, 3], dtype=np.float32)
+        self.assertAllClose(
+            knn.tanh_shrink(x),
+            [-0.238406, 0.0, 0.238406, 1.035972, 2.004945],
         )
 
     def test_hard_tanh(self):
@@ -2438,6 +2453,24 @@ class NNOpsDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knn.Celu().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_tanh_shrink(self, dtype):
+        import torch
+        import torch.nn.functional as tnn
+
+        x = knp.ones((1), dtype=dtype)
+        x_torch = torch.ones(1, dtype=getattr(torch, dtype))
+        expected_dtype = standardize_dtype(tnn.tanhshrink(x_torch).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knn.tanh_shrink(x).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(knn.TanhShrink().symbolic_call(x).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
Since Keras lacks built-in support for the tanh_shrink activation function, I implemented it across TensorFlow, JAX, and NumPy, aiming to maintain consistency with existing implementations available in PyTorch.