### PR TITLE
Improve the consistency of the names of initializers

### DIFF
--- a/keras/api/_tf_keras/keras/initializers/__init__.py
+++ b/keras/api/_tf_keras/keras/initializers/__init__.py
@@ -40,13 +40,11 @@ from keras.src.initializers.random_initializers import LecunUniform
 from keras.src.initializers.random_initializers import (
     LecunUniform as lecun_uniform,
 )
-from keras.src.initializers.random_initializers import OrthogonalInitializer
+from keras.src.initializers.random_initializers import Orthogonal
 from keras.src.initializers.random_initializers import (
-    OrthogonalInitializer as Orthogonal,
+    Orthogonal as OrthogonalInitializer,
 )
-from keras.src.initializers.random_initializers import (
-    OrthogonalInitializer as orthogonal,
-)
+from keras.src.initializers.random_initializers import Orthogonal as orthogonal
 from keras.src.initializers.random_initializers import RandomNormal
 from keras.src.initializers.random_initializers import (
     RandomNormal as random_normal,

--- a/keras/api/_tf_keras/keras/initializers/__init__.py
+++ b/keras/api/_tf_keras/keras/initializers/__init__.py
@@ -7,6 +7,9 @@ since your modifications would be overwritten.
 from keras.src.initializers import deserialize
 from keras.src.initializers import get
 from keras.src.initializers import serialize
+from keras.src.initializers.constant_initializers import STFT
+from keras.src.initializers.constant_initializers import STFT as STFTInitializer
+from keras.src.initializers.constant_initializers import STFT as stft
 from keras.src.initializers.constant_initializers import Constant
 from keras.src.initializers.constant_initializers import Constant as constant
 from keras.src.initializers.constant_initializers import Identity
@@ -16,7 +19,6 @@ from keras.src.initializers.constant_initializers import (
 from keras.src.initializers.constant_initializers import Identity as identity
 from keras.src.initializers.constant_initializers import Ones
 from keras.src.initializers.constant_initializers import Ones as ones
-from keras.src.initializers.constant_initializers import STFTInitializer
 from keras.src.initializers.constant_initializers import Zeros
 from keras.src.initializers.constant_initializers import Zeros as zeros
 from keras.src.initializers.initializer import Initializer

--- a/keras/api/initializers/__init__.py
+++ b/keras/api/initializers/__init__.py
@@ -40,13 +40,11 @@ from keras.src.initializers.random_initializers import LecunUniform
 from keras.src.initializers.random_initializers import (
     LecunUniform as lecun_uniform,
 )
-from keras.src.initializers.random_initializers import OrthogonalInitializer
+from keras.src.initializers.random_initializers import Orthogonal
 from keras.src.initializers.random_initializers import (
-    OrthogonalInitializer as Orthogonal,
+    Orthogonal as OrthogonalInitializer,
 )
-from keras.src.initializers.random_initializers import (
-    OrthogonalInitializer as orthogonal,
-)
+from keras.src.initializers.random_initializers import Orthogonal as orthogonal
 from keras.src.initializers.random_initializers import RandomNormal
 from keras.src.initializers.random_initializers import (
     RandomNormal as random_normal,

--- a/keras/api/initializers/__init__.py
+++ b/keras/api/initializers/__init__.py
@@ -7,6 +7,9 @@ since your modifications would be overwritten.
 from keras.src.initializers import deserialize
 from keras.src.initializers import get
 from keras.src.initializers import serialize
+from keras.src.initializers.constant_initializers import STFT
+from keras.src.initializers.constant_initializers import STFT as STFTInitializer
+from keras.src.initializers.constant_initializers import STFT as stft
 from keras.src.initializers.constant_initializers import Constant
 from keras.src.initializers.constant_initializers import Constant as constant
 from keras.src.initializers.constant_initializers import Identity
@@ -16,7 +19,6 @@ from keras.src.initializers.constant_initializers import (
 from keras.src.initializers.constant_initializers import Identity as identity
 from keras.src.initializers.constant_initializers import Ones
 from keras.src.initializers.constant_initializers import Ones as ones
-from keras.src.initializers.constant_initializers import STFTInitializer
 from keras.src.initializers.constant_initializers import Zeros
 from keras.src.initializers.constant_initializers import Zeros as zeros
 from keras.src.initializers.initializer import Initializer

--- a/keras/src/initializers/__init__.py
+++ b/keras/src/initializers/__init__.py
@@ -17,7 +17,7 @@ from keras.src.initializers.random_initializers import HeNormal
 from keras.src.initializers.random_initializers import HeUniform
 from keras.src.initializers.random_initializers import LecunNormal
 from keras.src.initializers.random_initializers import LecunUniform
-from keras.src.initializers.random_initializers import OrthogonalInitializer
+from keras.src.initializers.random_initializers import Orthogonal
 from keras.src.initializers.random_initializers import RandomNormal
 from keras.src.initializers.random_initializers import RandomUniform
 from keras.src.initializers.random_initializers import TruncatedNormal
@@ -38,11 +38,11 @@ ALL_OBJECTS = {
     HeUniform,
     LecunNormal,
     LecunUniform,
+    Orthogonal,
     RandomNormal,
-    TruncatedNormal,
     RandomUniform,
+    TruncatedNormal,
     VarianceScaling,
-    OrthogonalInitializer,
 }
 
 ALL_OBJECTS_DICT = {cls.__name__: cls for cls in ALL_OBJECTS}
@@ -52,11 +52,11 @@ ALL_OBJECTS_DICT.update(
 # Aliases
 ALL_OBJECTS_DICT.update(
     {
-        "uniform": RandomUniform,
+        "IdentityInitializer": Identity,  # For compatibility
         "normal": RandomNormal,
-        "orthogonal": OrthogonalInitializer,
-        "Orthogonal": OrthogonalInitializer,  # Legacy
         "one": Ones,
+        "OrthogonalInitializer": Orthogonal,  # For compatibility
+        "uniform": RandomUniform,
         "zero": Zeros,
     }
 )

--- a/keras/src/initializers/__init__.py
+++ b/keras/src/initializers/__init__.py
@@ -5,10 +5,10 @@ import numpy as np
 from keras.src import backend
 from keras.src import ops
 from keras.src.api_export import keras_export
+from keras.src.initializers.constant_initializers import STFT
 from keras.src.initializers.constant_initializers import Constant
 from keras.src.initializers.constant_initializers import Identity
 from keras.src.initializers.constant_initializers import Ones
-from keras.src.initializers.constant_initializers import STFTInitializer
 from keras.src.initializers.constant_initializers import Zeros
 from keras.src.initializers.initializer import Initializer
 from keras.src.initializers.random_initializers import GlorotNormal
@@ -30,7 +30,7 @@ ALL_OBJECTS = {
     Constant,
     Identity,
     Ones,
-    STFTInitializer,
+    STFT,
     Zeros,
     GlorotNormal,
     GlorotUniform,
@@ -55,6 +55,7 @@ ALL_OBJECTS_DICT.update(
         "IdentityInitializer": Identity,  # For compatibility
         "normal": RandomNormal,
         "one": Ones,
+        "STFTInitializer": STFT,  # For compatibility
         "OrthogonalInitializer": Orthogonal,  # For compatibility
         "uniform": RandomUniform,
         "zero": Zeros,

--- a/keras/src/initializers/constant_initializers.py
+++ b/keras/src/initializers/constant_initializers.py
@@ -154,8 +154,14 @@ class Identity(Initializer):
         return self.gain * ops.eye(*shape, dtype=dtype)
 
 
-@keras_export(["keras.initializers.STFTInitializer"])
-class STFTInitializer(Initializer):
+@keras_export(
+    [
+        "keras.initializers.STFT",
+        "keras.initializers.stft",
+        "keras.initializers.STFTInitializer",
+    ]
+)
+class STFT(Initializer):
     """Initializer of Conv kernels for Short-term Fourier Transformation (STFT).
 
     Since the formula involves complex numbers, this class compute either the
@@ -177,7 +183,8 @@ class STFTInitializer(Initializer):
 
     Args:
         side: String, `"real"` or `"imag"` deciding if the kernel will compute
-            the real side or the imaginary side of the output.
+            the real side or the imaginary side of the output. Defaults to
+            `"real"`.
         window: String for the name of the windowing function in the
             `scipy.signal.windows` module, or array_like for the window values,
             or `None` for no windowing.
@@ -188,7 +195,9 @@ class STFTInitializer(Initializer):
             periodic. Defaults to `False`.
     """
 
-    def __init__(self, side, window="hann", scaling="density", periodic=False):
+    def __init__(
+        self, side="real", window="hann", scaling="density", periodic=False
+    ):
         if side not in ["real", "imag"]:
             raise ValueError(f"side should be 'real' or 'imag', not {side}")
         if isinstance(window, str):

--- a/keras/src/initializers/constant_initializers.py
+++ b/keras/src/initializers/constant_initializers.py
@@ -108,9 +108,9 @@ class Ones(Initializer):
 
 @keras_export(
     [
-        "keras.initializers.IdentityInitializer",
         "keras.initializers.Identity",
         "keras.initializers.identity",
+        "keras.initializers.IdentityInitializer",
     ]
 )
 class Identity(Initializer):

--- a/keras/src/initializers/constant_initializers_test.py
+++ b/keras/src/initializers/constant_initializers_test.py
@@ -69,6 +69,10 @@ class ConstantInitializersTest(testing.TestCase):
 
         self.run_class_serialization_test(initializer)
 
+        # Test compatible class_name
+        initializer = initializers.get("IdentityInitializer")
+        self.assertIsInstance(initializer, initializers.Identity)
+
     def test_stft_initializer(self):
         shape = (256, 1, 513)
         time_range = np.arange(256).reshape((-1, 1, 1))

--- a/keras/src/initializers/constant_initializers_test.py
+++ b/keras/src/initializers/constant_initializers_test.py
@@ -86,12 +86,12 @@ class ConstantInitializersTest(testing.TestCase):
             # of non-small error in jax and torch
             tol_kwargs = {"atol": 1e-4, "rtol": 1e-6}
 
-        initializer = initializers.STFTInitializer("real", None)
+        initializer = initializers.STFT("real", None)
         values = backend.convert_to_numpy(initializer(shape))
         self.assertAllClose(np.cos(args), values, atol=1e-4)
         self.run_class_serialization_test(initializer)
 
-        initializer = initializers.STFTInitializer(
+        initializer = initializers.STFT(
             "real",
             "hamming",
             None,
@@ -103,7 +103,7 @@ class ConstantInitializersTest(testing.TestCase):
         self.assertAllClose(np.cos(args) * window, values, **tol_kwargs)
         self.run_class_serialization_test(initializer)
 
-        initializer = initializers.STFTInitializer(
+        initializer = initializers.STFT(
             "imag",
             "tukey",
             "density",
@@ -116,7 +116,7 @@ class ConstantInitializersTest(testing.TestCase):
         self.assertAllClose(np.sin(args) * window, values, **tol_kwargs)
         self.run_class_serialization_test(initializer)
 
-        initializer = initializers.STFTInitializer(
+        initializer = initializers.STFT(
             "imag",
             list(range(1, 257)),
             "spectrum",
@@ -129,8 +129,12 @@ class ConstantInitializersTest(testing.TestCase):
         self.run_class_serialization_test(initializer)
 
         with self.assertRaises(ValueError):
-            initializers.STFTInitializer("imaginary")
+            initializers.STFT("imaginary")
         with self.assertRaises(ValueError):
-            initializers.STFTInitializer("real", scaling="l2")
+            initializers.STFT("real", scaling="l2")
         with self.assertRaises(ValueError):
-            initializers.STFTInitializer("real", window="unknown")
+            initializers.STFT("real", window="unknown")
+
+        # Test compatible class_name
+        initializer = initializers.get("STFTInitializer")
+        self.assertIsInstance(initializer, initializers.STFT)

--- a/keras/src/initializers/random_initializers.py
+++ b/keras/src/initializers/random_initializers.py
@@ -639,12 +639,12 @@ def compute_fans(shape):
 
 @keras_export(
     [
-        "keras.initializers.OrthogonalInitializer",
         "keras.initializers.Orthogonal",
         "keras.initializers.orthogonal",
+        "keras.initializers.OrthogonalInitializer",
     ]
 )
-class OrthogonalInitializer(RandomInitializer):
+class Orthogonal(RandomInitializer):
     """Initializer that generates an orthogonal matrix.
 
     If the shape of the tensor to initialize is two-dimensional, it is

--- a/keras/src/initializers/random_initializers_test.py
+++ b/keras/src/initializers/random_initializers_test.py
@@ -7,7 +7,7 @@ from keras.src import testing
 from keras.src import utils
 
 
-class InitializersTest(testing.TestCase):
+class RandomInitializersTest(testing.TestCase):
     def test_random_normal(self):
         utils.set_random_seed(1337)
         shape = (25, 20)
@@ -124,11 +124,11 @@ class InitializersTest(testing.TestCase):
         )
         self.run_class_serialization_test(initializer)
 
-    def test_orthogonal_initializer(self):
+    def test_orthogonal(self):
         shape = (5, 5)
         gain = 2.0
         seed = 1234
-        initializer = initializers.OrthogonalInitializer(gain=gain, seed=seed)
+        initializer = initializers.Orthogonal(gain=gain, seed=seed)
         values = initializer(shape=shape)
         self.assertEqual(initializer.seed, seed)
         self.assertEqual(initializer.gain, gain)
@@ -148,9 +148,9 @@ class InitializersTest(testing.TestCase):
 
         self.run_class_serialization_test(initializer)
 
-        # Test legacy class_name
-        initializer = initializers.get("Orthogonal")
-        self.assertIsInstance(initializer, initializers.OrthogonalInitializer)
+        # Test compatible class_name
+        initializer = initializers.get("OrthogonalInitializer")
+        self.assertIsInstance(initializer, initializers.Orthogonal)
 
     def test_get_method(self):
         obj = initializers.get("glorot_normal")
@@ -214,7 +214,7 @@ class InitializersTest(testing.TestCase):
 
     def test_serialization_with_seed_generator(self):
         seed = random.SeedGenerator()
-        initializer = initializers.OrthogonalInitializer(seed=seed)
+        initializer = initializers.Orthogonal(seed=seed)
         self.run_class_serialization_test(initializer)
 
         seed = random.SeedGenerator()

--- a/keras/src/layers/preprocessing/stft_spectrogram.py
+++ b/keras/src/layers/preprocessing/stft_spectrogram.py
@@ -217,7 +217,7 @@ class STFTSpectrogram(layers.Layer):
             self.real_kernel = self.add_weight(
                 name="real_kernel",
                 shape=shape,
-                initializer=initializers.STFTInitializer(
+                initializer=initializers.STFT(
                     "real", self.window, self.scaling, self.periodic
                 ),
             )
@@ -225,7 +225,7 @@ class STFTSpectrogram(layers.Layer):
             self.imag_kernel = self.add_weight(
                 name="imag_kernel",
                 shape=shape,
-                initializer=initializers.STFTInitializer(
+                initializer=initializers.STFT(
                     "imag", self.window, self.scaling, self.periodic
                 ),
             )


### PR DESCRIPTION
Fix #20483 

This PR renames `OrthogonalInitializer` to `Orthogonal` and `STFTInitializer` to `STFT` for name consistency and adds serialization tests to prevent future breakages.

This PR also adds a default value `side="real"` to support calls to `initializers.get("STFT")`