### PR TITLE
Refactor `dot_product_attention` to use flash attention when available

### DIFF
--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -975,11 +975,18 @@ def psnr(x1, x2, max_val):
 def _can_use_flash_attention(query, key, value, bias, raise_error=False):
     # Ref: https://github.com/jax-ml/jax/blob/main/jax/_src/cudnn/fused_attention_stablehlo.py
     from jax._src.cudnn.fused_attention_stablehlo import _normalize_layout
-    from jax._src.cudnn.fused_attention_stablehlo import (
-        check_compute_capability,
-    )
     from jax._src.cudnn.fused_attention_stablehlo import check_cudnn_version
     from jax._src.cudnn.fused_attention_stablehlo import check_layout
+
+    try:
+        # The older version of jax doesn't have `check_compute_capability`
+        from jax._src.cudnn.fused_attention_stablehlo import (
+            check_compute_capability,
+        )
+    except ImportError:
+        if raise_error:
+            raise
+        return False
 
     try:
         # `dot_product_attention` is only available in jax>=0.4.31

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -984,7 +984,11 @@ def _can_use_flash_attention(query, key, value, bias, raise_error=False):
     try:
         # `dot_product_attention` is only available in jax>=0.4.31
         if not hasattr(jax.nn, "dot_product_attention"):
-            raise NotImplementedError
+            raise ValueError(
+                "Flash attention is not supported in your "
+                "current JAX version. Please update it "
+                "using `pip install -U jax jaxlib`."
+            )
         # Check if cuDNN is installed and raise RuntimeError if cuDNN is not
         # detected
         check_cudnn_version()

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -1080,10 +1080,13 @@ def dot_product_attention(
     mask=None,
     scale=None,
     is_causal=False,
-    flash_attention=False,
+    flash_attention=None,
 ):
+    if flash_attention is None:
+        flash_attention = False
     if flash_attention:
-        raise ValueError("Flash attention is not implemented in NumPy.")
+        raise ValueError("Flash attention is not supported in numpy backend.")
+
     # Ref: jax.nn.dot_product_attention
     # https://github.com/jax-ml/jax/blob/jax-v0.4.32/jax/_src/nn/functions.py#L828
     # Not support `query_seq_lengths` and `key_value_seq_lengths` args

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -999,11 +999,13 @@ def dot_product_attention(
     mask=None,
     scale=None,
     is_causal=False,
-    flash_attention=False,
+    flash_attention=None,
 ):
+    if flash_attention is None:
+        flash_attention = False
     if flash_attention:
         raise ValueError(
-            "Flash attention is not supported yet in TensorFlow backend."
+            "Flash attention is not supported in tensorflow backend."
         )
 
     # Ref: jax.nn.dot_product_attention

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -954,22 +954,22 @@ def dot_product_attention(
         flash_attention = _can_use_flash_attention(
             query=query, key=key, value=value, mask=mask, is_causal=is_causal
         )
-    elif flash_attention is True:
-        if (
-            _can_use_flash_attention(
-                query=query,
-                key=key,
-                value=value,
-                mask=mask,
-                is_causal=is_causal,
-                debug=True,
-            )
-            is False
-        ):
-            raise ValueError(
-                "Flash attention is not supported with the provided inputs. "
-                "Please check the warnings for more details."
-            )
+    elif (
+        flash_attention is True
+        and _can_use_flash_attention(
+            query=query,
+            key=key,
+            value=value,
+            mask=mask,
+            is_causal=is_causal,
+            debug=True,
+        )
+        is False
+    ):
+        raise ValueError(
+            "Flash attention is not supported with the provided inputs. "
+            "Please check the warnings for more details."
+        )
     if flash_attention:
         with torch.nn.attention.sdpa_kernel(
             backends=[torch.nn.attention.SDPBackend.FLASH_ATTENTION],

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -892,14 +892,26 @@ def _get_large_negative(dtype):
 def _can_use_flash_attention(
     query, key, value, mask=None, is_causal=False, debug=False
 ):
-    spda_params = torch.backends.cuda.SDPAParams(
-        query,
-        key,
-        value,
-        mask,
-        0.0,
-        is_causal,
-    )
+    try:
+        spda_params = torch.backends.cuda.SDPAParams(
+            query,
+            key,
+            value,
+            mask,
+            0.0,  # dropout_p
+            is_causal,
+        )
+    except TypeError:
+        # The signature changed in newer version of torch.
+        spda_params = torch.backends.cuda.SDPAParams(
+            query,
+            key,
+            value,
+            mask,
+            0.0,  # dropout_p
+            is_causal,
+            False,  # enable_gqa
+        )
     return torch.backends.cuda.can_use_flash_attention(spda_params, debug)
 
 

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -889,8 +889,10 @@ def _get_large_negative(dtype):
     return convert_to_tensor(val * -0.7, dtype=dtype)
 
 
-def is_flash_attention_enabled(query, key, value, mask=None, is_causal=False):
-    params = torch.backends.cuda.SDPAParams(
+def _can_use_flash_attention(
+    query, key, value, mask=None, is_causal=False, debug=False
+):
+    spda_params = torch.backends.cuda.SDPAParams(
         query,
         key,
         value,
@@ -898,8 +900,7 @@ def is_flash_attention_enabled(query, key, value, mask=None, is_causal=False):
         0.0,
         is_causal,
     )
-    is_enabled = torch.backends.cuda.can_use_flash_attention(params, False)
-    return is_enabled
+    return torch.backends.cuda.can_use_flash_attention(spda_params, debug)
 
 
 def dot_product_attention(
@@ -910,7 +911,7 @@ def dot_product_attention(
     mask=None,
     scale=None,
     is_causal=False,
-    flash_attention=False,
+    flash_attention=None,
 ):
     if bias is not None:
         raise ValueError(
@@ -919,9 +920,9 @@ def dot_product_attention(
     query = convert_to_tensor(query)
     key = convert_to_tensor(key)
     value = convert_to_tensor(value)
-    if len(query.shape) != 4:
+    if len(query.shape) != 4 or len(key.shape) != 4 or len(value.shape) != 4:
         raise ValueError(
-            "`dot_product_attention` only supports 3D and 4D inputs. "
+            "`dot_product_attention` only supports 4D inputs. "
             f"Received: query.shape={query.shape}, key.shape={key.shape}, "
             f"value.shape={value.shape}."
         )
@@ -937,21 +938,27 @@ def dot_product_attention(
     key = torch.transpose(key, axis0, axis1)
     value = torch.transpose(value, axis0, axis1)
 
-    if flash_attention:
-        is_enabled = is_flash_attention_enabled(
-            query=query,
-            key=key,
-            value=value,
-            mask=mask,
-            is_causal=is_causal,
+    if flash_attention is None:
+        flash_attention = _can_use_flash_attention(
+            query=query, key=key, value=value, mask=mask, is_causal=is_causal
         )
-        if not is_enabled:
-            raise ValueError(
-                "Flash attention is not enabled in `torch` backend. "
-                "The dtype of the inputs should be float16/bfloat16 "
-                "and your GPU should support flash attention implementation."
+    elif flash_attention is True:
+        if (
+            _can_use_flash_attention(
+                query=query,
+                key=key,
+                value=value,
+                mask=mask,
+                is_causal=is_causal,
+                debug=True,
             )
-
+            is False
+        ):
+            raise ValueError(
+                "Flash attention is not supported with the provided inputs. "
+                "Please check the warnings for more details."
+            )
+    if flash_attention:
         with torch.nn.attention.sdpa_kernel(
             backends=[torch.nn.attention.SDPBackend.FLASH_ATTENTION],
         ):

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -120,9 +120,9 @@ class MultiHeadAttentionTest(testing.TestCase):
                     ),
                 )
             except RuntimeError as e:
-                try:
+                if str(e.args[0]).startswith("cuDNN"):
                     self.assertStartsWith(e.args[0], "cuDNN is not detected.")
-                except:
+                elif str(e.args[0]).startswith("Require at least"):
                     self.assertStartsWith(
                         e.args[0], "Require at least Ampere arch to run"
                     )

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -54,17 +54,13 @@ class MultiHeadAttentionTest(testing.TestCase):
         )
 
     def test_basics_with_flash_attention(self):
-        if backend.backend() in [
-            "torch",
-            "tensorflow",
-            "numpy",
-        ]:
+        if backend.backend() in ("tensorflow", "numpy"):
             self.skipTest(
-                "Not supported in TF and NumPy and supported for "
-                "PyTorch with specific requirements."
+                "Flash attention is not supported in tensorflow and numpy "
+                "backends."
             )
 
-        if backend.backend() == "jax":
+        elif backend.backend() == "torch":
             try:
                 enable_flash_attention()
                 self.run_layer_test(
@@ -72,6 +68,7 @@ class MultiHeadAttentionTest(testing.TestCase):
                     init_kwargs={
                         "num_heads": 2,
                         "key_dim": 2,
+                        "dtype": "float16",
                     },
                     input_shape={
                         "query_shape": (2, 8, 16),
@@ -85,45 +82,49 @@ class MultiHeadAttentionTest(testing.TestCase):
                     supports_masking=True,
                     run_training_check=False,
                 )
-
+                disable_flash_attention()
+            except ValueError as e:
+                self.assertStartsWith(
+                    e.args[0],
+                    "Flash attention is not supported with the provided inputs",
+                )
+        elif backend.backend() == "jax":
+            try:
+                enable_flash_attention()
                 self.run_layer_test(
                     layers.MultiHeadAttention,
                     init_kwargs={
                         "num_heads": 2,
-                        "key_dim": 2,
-                        "value_dim": 4,
-                        "use_bias": False,
-                        "dropout": 0.5,
+                        "key_dim": 8,  # key_dim % 8 == 0
+                        "dtype": "float16",
                     },
                     input_shape={
                         "query_shape": (2, 8, 16),
                         "value_shape": (2, 4, 16),
                     },
                     expected_output_shape=(2, 8, 16),
-                    expected_num_trainable_weights=4,
+                    expected_num_trainable_weights=8,
                     expected_num_non_trainable_weights=0,
-                    expected_num_seed_generators=1,
+                    expected_num_seed_generators=0,
                     expected_num_losses=0,
                     supports_masking=True,
                     run_training_check=False,
                 )
                 disable_flash_attention()
             except ValueError as e:
-                if e.args[0].startswith(
-                    "Flash attention is not supported in your "
-                    "current JAX version"
-                ):
-                    self.skipTest(
-                        "JAX version does not have "
-                        "`dot_product_attention` function."
-                    )
+                self.assertStartsWith(
+                    e.args[0],
+                    (
+                        "Flash attention is not supported in your current JAX "
+                        "version."
+                    ),
+                )
             except RuntimeError as e:
-                if e.args[0] == "cuDNN is not detected.":
-                    self.skipTest("No CuDNN to run flash attention for JAX.")
-                elif e.args[0] == "Require at least Ampere arch to run":
-                    self.skipTest(
-                        "Requires at least Ampere arch to run flash attention "
-                        "for JAX."
+                try:
+                    self.assertStartsWith(e.args[0], "cuDNN is not detected.")
+                except:
+                    self.assertStartsWith(
+                        e.args[0], "Require at least Ampere arch to run"
                     )
 
     @parameterized.named_parameters(

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -2376,7 +2376,7 @@ def dot_product_attention(
     mask=None,
     scale=None,
     is_causal=False,
-    flash_attention=False,
+    flash_attention=None,
 ):
     """Scaled dot product attention function.
 
@@ -2411,6 +2411,10 @@ def dot_product_attention(
         scale: Optional scale for the logits. If `None`, the scale will be set
             to `1.0 / sqrt(H)`.
         is_causal: Whether to apply causal mask.
+        flash_attention: Whether to use flash attention. If `None`, it will
+            attempt to use flash attention if the required conditions are met.
+            Typically, the inputs must be in float16 and bfloat16 dtype and the
+            input layout requirements may vary depending on the backend.
 
     Returns:
         An array of the attention output with the same shape of `query`.

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -75,6 +75,7 @@ def _dot_product_attention(
         exp_x = np.exp(x - np.max(x, axis=axis, keepdims=True))
         return exp_x / np.sum(exp_x, axis=axis, keepdims=True)
 
+    dtype = query.dtype
     _, _, _, H = key.shape
     scale = (1.0 / np.sqrt(H)) if scale is None else scale
     logits = np.einsum("BTNH,BSNH->BNTS", query, key)
@@ -85,7 +86,7 @@ def _dot_product_attention(
     padded_logits = padded_logits.astype(np.float32)
     probs = softmax(padded_logits, axis=-1).astype(key.dtype)
     encoded = np.einsum("BNTS,BSNH->BTNH", probs, value)
-    return encoded
+    return encoded.astype(dtype)
 
 
 class NNOpsDynamicShapeTest(testing.TestCase):
@@ -2283,24 +2284,22 @@ class NNOpsCorrectnessTest(testing.TestCase):
             bias=(None, True),
             scale=(None, 1.0),
             mask_and_is_causal=((None, False), (True, False), (None, True)),
-            flash_attention=(True, False),
+            flash_attention=(None, True, False),
         )
     )
     def test_dot_product_attention(
         self, bias, scale, mask_and_is_causal, flash_attention
     ):
         mask, is_causal = mask_and_is_causal
-        query_shape = (2, 3, 4, 5)
-        key_shape = (2, 6, 4, 5)
-        mask_shape = (2, 4, 3, 6)
-        query = np.arange(math.prod(query_shape), dtype=float).reshape(
-            query_shape
-        )
-        key = np.arange(math.prod(key_shape), dtype=float).reshape(key_shape)
-        value = np.arange(math.prod(key_shape), dtype=float).reshape(key_shape)
+        query_shape = (2, 3, 4, 8)
+        key_shape = (2, 3, 4, 8)
+        mask_shape = (2, 4, 3, 3)
+        query = np.random.uniform(low=-1.0, high=1.0, size=query_shape)
+        key = np.random.uniform(low=-1.0, high=1.0, size=key_shape)
+        value = np.random.uniform(low=-1.0, high=1.0, size=key_shape)
         if mask is not None:
-            mask = np.arange(math.prod(mask_shape)).reshape(mask_shape)
-            mask = (mask > 10).astype("bool")
+            mask = np.random.uniform(low=-1.0, high=1.0, size=mask_shape)
+            mask = (mask > 0.0).astype("bool")
         if bias is not None:
             if backend.backend() == "torch":
                 self.skipTest(
@@ -2310,56 +2309,48 @@ class NNOpsCorrectnessTest(testing.TestCase):
                 mask_shape
             )
 
-        if flash_attention and backend.backend() in [
-            "torch",
-            "tensorflow",
-            "numpy",
-        ]:
+        if flash_attention and backend.backend() in ["tensorflow", "numpy"]:
             self.skipTest(
-                "Not supported in TF and NumPy and supported for "
-                "PyTorch with specific requirements."
+                "Flash attention is not supported in tensorflow and numpy "
+                "backends."
             )
+        if flash_attention and backend.backend() == "torch":
+            import torch
 
-        if flash_attention and backend.backend() == "jax":
-            try:
-                outputs = knn.dot_product_attention(
-                    query,
-                    key,
-                    value,
-                    bias=bias,
-                    mask=mask,
-                    scale=scale,
-                    is_causal=is_causal,
-                    flash_attention=flash_attention,
+            if mask is not None:
+                self.skipTest(
+                    "Flash attention doesn't support `mask=None` in torch "
+                    "backend."
                 )
-            except ValueError as e:
-                if e.args[0].startswith(
-                    "Flash attention is not supported in your "
-                    "current JAX version"
-                ):
-                    self.skipTest(
-                        "JAX version does not have "
-                        "`dot_product_attention` function."
-                    )
-            except RuntimeError as e:
-                if e.args[0] == "cuDNN is not detected.":
-                    self.skipTest("No CuDNN to run flash attention for JAX.")
-                elif e.args[0] == "Require at least Ampere arch to run":
-                    self.skipTest(
-                        "Requires at least Ampere arch to run flash attention "
-                        "for JAX."
-                    )
-        else:
-            outputs = knn.dot_product_attention(
-                query,
-                key,
-                value,
-                bias=bias,
-                mask=mask,
-                scale=scale,
-                is_causal=is_causal,
-                flash_attention=flash_attention,
-            )
+            if not torch.cuda.is_available():
+                self.skipTest(
+                    "Flash attention must be run on CUDA in torch backend."
+                )
+        if flash_attention and backend.backend() == "jax":
+            import jax
+
+            if jax.devices()[0].platform != "gpu":
+                self.skipTest(
+                    "Flash attention must be run on CUDA in jax backend."
+                )
+
+        if flash_attention:
+            # Flash attention only supports float16 and bfloat16. We multiply
+            # 0.005 to avoid overflow.
+            query = (query * 0.005).astype("float16")
+            key = (key * 0.005).astype("float16")
+            value = (value * 0.005).astype("float16")
+
+        outputs = knn.dot_product_attention(
+            query,
+            key,
+            value,
+            bias=bias,
+            mask=mask,
+            scale=scale,
+            is_causal=is_causal,
+            flash_attention=flash_attention,
+        )
 
         expected = _dot_product_attention(
             query,
@@ -2370,7 +2361,12 @@ class NNOpsCorrectnessTest(testing.TestCase):
             scale=scale,
             is_causal=is_causal,
         )
-        self.assertAllClose(outputs, expected)
+        if flash_attention:
+            outputs = ops.where(ops.isnan(outputs), 0.0, outputs)
+            expected = ops.where(ops.isnan(outputs), 0.0, expected)
+            self.assertAllClose(outputs, expected, atol=0.01)
+        else:
+            self.assertAllClose(outputs, expected)
 
 
 class NNOpsDtypeTest(testing.TestCase):
@@ -2831,9 +2827,9 @@ class NNOpsDtypeTest(testing.TestCase):
     def test_dot_product_attention(self, dtype):
         # TODO: Get expected output from jax if `jax.nn.dot_product_attention`
         # is available.
-        query = knp.ones((2, 3, 3, 4), dtype=dtype)
-        key = knp.ones((2, 3, 3, 4), dtype=dtype)
-        value = knp.ones((2, 3, 3, 4), dtype=dtype)
+        query = knp.ones((2, 3, 3, 8), dtype=dtype)
+        key = knp.ones((2, 3, 3, 8), dtype=dtype)
+        value = knp.ones((2, 3, 3, 8), dtype=dtype)
         expected_dtype = dtype
 
         self.assertDType(


### PR DESCRIPTION
I was experimenting with the new flash attention version of `dot_product_attention` and found it to be performant using jax backend.

For example, using SD3 medium to generate a 800x800 image on a RTX4070:
|flash attention|cost time|
|-|-|
|`False`|10.61s|
|`True`|5.45s|

However, the current implementation of `dot_product_attention` relies on users to decide whether to use flash attention, which can heavily depend on the backend.

This PR refactors the implementation by setting `flash_attention=None` to allow the backend to automatically detect availability. This change should be more user-friendly and improve maintainability IMO.

cc @divyashreepathihalli @hazemessamm