### PR TITLE
Add soft_shrink activation

### DIFF
--- a/keras/api/_tf_keras/keras/activations/__init__.py
+++ b/keras/api/_tf_keras/keras/activations/__init__.py
@@ -28,6 +28,7 @@ from keras.src.activations.activations import selu
 from keras.src.activations.activations import sigmoid
 from keras.src.activations.activations import silu
 from keras.src.activations.activations import silu as swish
+from keras.src.activations.activations import soft_shrink
 from keras.src.activations.activations import softmax
 from keras.src.activations.activations import softplus
 from keras.src.activations.activations import softsign

--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -94,6 +94,7 @@ from keras.src.ops.nn import separable_conv
 from keras.src.ops.nn import sigmoid
 from keras.src.ops.nn import silu
 from keras.src.ops.nn import silu as swish
+from keras.src.ops.nn import soft_shrink
 from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign

--- a/keras/api/_tf_keras/keras/ops/nn/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/nn/__init__.py
@@ -39,6 +39,7 @@ from keras.src.ops.nn import separable_conv
 from keras.src.ops.nn import sigmoid
 from keras.src.ops.nn import silu
 from keras.src.ops.nn import silu as swish
+from keras.src.ops.nn import soft_shrink
 from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign

--- a/keras/api/activations/__init__.py
+++ b/keras/api/activations/__init__.py
@@ -28,6 +28,7 @@ from keras.src.activations.activations import selu
 from keras.src.activations.activations import sigmoid
 from keras.src.activations.activations import silu
 from keras.src.activations.activations import silu as swish
+from keras.src.activations.activations import soft_shrink
 from keras.src.activations.activations import softmax
 from keras.src.activations.activations import softplus
 from keras.src.activations.activations import softsign

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -94,6 +94,7 @@ from keras.src.ops.nn import separable_conv
 from keras.src.ops.nn import sigmoid
 from keras.src.ops.nn import silu
 from keras.src.ops.nn import silu as swish
+from keras.src.ops.nn import soft_shrink
 from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign

--- a/keras/api/ops/nn/__init__.py
+++ b/keras/api/ops/nn/__init__.py
@@ -39,6 +39,7 @@ from keras.src.ops.nn import separable_conv
 from keras.src.ops.nn import sigmoid
 from keras.src.ops.nn import silu
 from keras.src.ops.nn import silu as swish
+from keras.src.ops.nn import soft_shrink
 from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign

--- a/keras/src/activations/__init__.py
+++ b/keras/src/activations/__init__.py
@@ -19,6 +19,7 @@ from keras.src.activations.activations import relu6
 from keras.src.activations.activations import selu
 from keras.src.activations.activations import sigmoid
 from keras.src.activations.activations import silu
+from keras.src.activations.activations import soft_shrink
 from keras.src.activations.activations import softmax
 from keras.src.activations.activations import softplus
 from keras.src.activations.activations import softsign
@@ -38,6 +39,7 @@ ALL_OBJECTS = {
     selu,
     softplus,
     softsign,
+    soft_shrink,
     silu,
     gelu,
     glu,

--- a/keras/src/activations/activations.py
+++ b/keras/src/activations/activations.py
@@ -259,6 +259,24 @@ def softsign(x):
     return ops.softsign(x)
 
 
+@keras_export("keras.activations.soft_shrink")
+def soft_shrink(x, threshold=0.5):
+    """Soft Shrink activation function.
+
+    It is defined as:
+
+    `soft_shrink(x) = x - threshold` if `x > threshold`,
+    `soft_shrink(x) = x + threshold` if `x < -threshold`,
+    `soft_shrink(x) = 0` otherwise.
+
+    Args:
+        x: Input tensor.
+        threshold: Threshold value. Defaults to 0.5.
+
+    """
+    return ops.soft_shrink(x, threshold=threshold)
+
+
 @keras_export(["keras.activations.silu", "keras.activations.swish"])
 def silu(x):
     """Swish (or Silu) activation function.

--- a/keras/src/activations/activations_test.py
+++ b/keras/src/activations/activations_test.py
@@ -683,6 +683,19 @@ class ActivationsTest(testing.TestCase):
         expected = hard_shrink(x)
         self.assertAllClose(result, expected, rtol=1e-05)
 
+    def test_soft_shrink(self):
+        def soft_shrink(x, threshold=0.5):
+            return np.where(
+                x > threshold,
+                x - threshold,
+                np.where(x < -threshold, x + threshold, 0.0),
+            )
+
+        x = np.random.random((2, 5))
+        result = activations.soft_shrink(x[np.newaxis, :])[0]
+        expected = soft_shrink(x)
+        self.assertAllClose(result, expected, rtol=1e-05)
+
     def test_elu(self):
         x = np.random.random((2, 5))
         result = activations.elu(x[np.newaxis, :])[0]

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -53,6 +53,15 @@ def softsign(x):
     return jnn.soft_sign(x)
 
 
+def soft_shrink(x, threshold=0.5):
+    x = convert_to_tensor(x)
+    return jnp.where(
+        x > threshold,
+        x - threshold,
+        jnp.where(x < -threshold, x + threshold, 0.0),
+    )
+
+
 def silu(x):
     x = convert_to_tensor(x)
     return jnn.silu(x)

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -50,6 +50,18 @@ def softsign(x):
     return x / (np.array(1.0, x.dtype) + np.abs(x))
 
 
+def soft_shrink(x, threshold=0.5):
+    return np.where(
+        x > threshold,
+        np.array(x - threshold, dtype=x.dtype),
+        np.where(
+            x < -threshold,
+            np.array(x + threshold, dtype=x.dtype),
+            np.array(0.0, dtype=x.dtype),
+        ),
+    )
+
+
 def silu(x):
     x = convert_to_tensor(x)
     return x * sigmoid(x)

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -42,6 +42,14 @@ def softsign(x):
     return tf.nn.softsign(x)
 
 
+def soft_shrink(x, threshold=0.5):
+    return tf.where(
+        x > threshold,
+        x - threshold,
+        tf.where(x < -threshold, x + threshold, tf.zeros_like(x)),
+    )
+
+
 def silu(x):
     return tf.nn.silu(x)
 

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -50,6 +50,11 @@ def softsign(x):
     return tnn.softsign(x)
 
 
+def soft_shrink(x, threshold=0.5):
+    x = convert_to_tensor(x)
+    return tnn.softshrink(x, lambd=threshold)
+
+
 def silu(x):
     x = convert_to_tensor(x)
     return tnn.silu(x)

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -174,6 +174,48 @@ def softsign(x):
     return backend.nn.softsign(x)
 
 
+class SoftShrink(Operation):
+    def __init__(self, threshold=0.5):
+        super().__init__()
+        self.threshold = threshold
+
+    def call(self, x):
+        return backend.nn.soft_shrink(x, self.threshold)
+
+    def compute_output_spec(self, x):
+        return KerasTensor(x.shape, dtype=x.dtype)
+
+
+@keras_export(["keras.ops.soft_shrink", "keras.ops.nn.soft_shrink"])
+def soft_shrink(x, threshold=0.5):
+    """Soft Shrink activation function.
+
+    It is defined as
+
+    `f(x) = x - threshold` if `x > threshold`,
+    `f(x) = x + threshold` if `x < -threshold`,
+    `f(x) = 0` otherwise.
+
+    Args:
+        x: Input tensor.
+        threshold: Threshold value. Defaults to 0.5.
+
+    Returns:
+        A tensor with the same shape as `x`.
+
+    Example:
+
+    >>> x = np.array([-1.0, 0.0, 1.0])
+    >>> x_soft_shrink = keras.ops.soft_shrink(x)
+    >>> print(x_soft_shrink)
+    array([-0.5  0.   0.5], shape=(3,), dtype=float64)
+
+    """
+    if any_symbolic_tensors((x,)):
+        return SoftShrink(threshold).symbolic_call(x)
+    return backend.nn.soft_shrink(x, threshold)
+
+
 class Silu(Operation):
     def call(self, x):
         return backend.nn.silu(x)

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -160,6 +160,10 @@ class NNOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.hard_shrink(x).shape, (None, 2, 3))
 
+    def test_soft_shrink(self):
+        x = KerasTensor([None, 2, 3])
+        self.assertEqual(knn.soft_shrink(x).shape, (None, 2, 3))
+
     def test_softmax(self):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.softmax(x).shape, (None, 2, 3))
@@ -825,6 +829,10 @@ class NNOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.hard_shrink(x).shape, (1, 2, 3))
 
+    def test_soft_shrink(self):
+        x = KerasTensor([1, 2, 3])
+        self.assertEqual(knn.soft_shrink(x).shape, (1, 2, 3))
+
     def test_softmax(self):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.softmax(x).shape, (1, 2, 3))
@@ -1364,6 +1372,13 @@ class NNOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(
             knn.hard_shrink(x),
             [0.0, 0.0, 1.0, 2.0, 3.0],
+        )
+
+    def test_soft_shrink(self):
+        x = np.array([-0.5, 0, 1, 2, 3], dtype=np.float32)
+        self.assertAllClose(
+            knn.soft_shrink(x),
+            [0.0, 0.0, 0.5, 1.5, 2.5],
         )
 
     def test_softmax(self):
@@ -2521,6 +2536,24 @@ class NNOpsDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knn.HardShrink().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_soft_shrink(self, dtype):
+        import torch
+        import torch.nn.functional as tnn
+
+        x = knp.ones((1), dtype=dtype)
+        x_torch = torch.ones(1, dtype=getattr(torch, dtype))
+        expected_dtype = standardize_dtype(tnn.softshrink(x_torch).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knn.soft_shrink(x).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(knn.SoftShrink().symbolic_call(x).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
Since Keras lacks built-in support for the soft_shrink activation function, I implemented it across TensorFlow, JAX, and NumPy, aiming to maintain consistency with existing implementations available in PyTorch.