### PR TITLE
Minor changes to asserts in keras.src.layers.attention.MultiHeadAttention

### DIFF
--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -669,7 +669,10 @@ class MultiHeadAttention(Layer):
             )
 
         if self._output_shape:
-            return query_shape[:-1] + self._output_shape
+            if isinstance(self._output_shape, tuple):
+                return query_shape[:-1] + self._output_shape
+            else:
+                return query_shape[:-1] + (self._output_shape,)
 
         return query_shape
 


### PR DESCRIPTION
Removed another assert leading to same issue that #20340 fixed.
Made _output_shape more flexible; now it can be either a scalar integer or a tuple (as previously required).
Both are discussed in #19769 