### PR TITLE
Add squareplus activation

### DIFF
--- a/keras/api/_tf_keras/keras/activations/__init__.py
+++ b/keras/api/_tf_keras/keras/activations/__init__.py
@@ -32,5 +32,6 @@ from keras.src.activations.activations import soft_shrink
 from keras.src.activations.activations import softmax
 from keras.src.activations.activations import softplus
 from keras.src.activations.activations import softsign
+from keras.src.activations.activations import squareplus
 from keras.src.activations.activations import tanh
 from keras.src.activations.activations import tanh_shrink

--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -99,6 +99,7 @@ from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign
 from keras.src.ops.nn import sparse_categorical_crossentropy
+from keras.src.ops.nn import squareplus
 from keras.src.ops.nn import tanh_shrink
 from keras.src.ops.numpy import abs
 from keras.src.ops.numpy import absolute

--- a/keras/api/_tf_keras/keras/ops/nn/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/nn/__init__.py
@@ -44,4 +44,5 @@ from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign
 from keras.src.ops.nn import sparse_categorical_crossentropy
+from keras.src.ops.nn import squareplus
 from keras.src.ops.nn import tanh_shrink

--- a/keras/api/activations/__init__.py
+++ b/keras/api/activations/__init__.py
@@ -32,5 +32,6 @@ from keras.src.activations.activations import soft_shrink
 from keras.src.activations.activations import softmax
 from keras.src.activations.activations import softplus
 from keras.src.activations.activations import softsign
+from keras.src.activations.activations import squareplus
 from keras.src.activations.activations import tanh
 from keras.src.activations.activations import tanh_shrink

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -99,6 +99,7 @@ from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign
 from keras.src.ops.nn import sparse_categorical_crossentropy
+from keras.src.ops.nn import squareplus
 from keras.src.ops.nn import tanh_shrink
 from keras.src.ops.numpy import abs
 from keras.src.ops.numpy import absolute

--- a/keras/api/ops/nn/__init__.py
+++ b/keras/api/ops/nn/__init__.py
@@ -44,4 +44,5 @@ from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign
 from keras.src.ops.nn import sparse_categorical_crossentropy
+from keras.src.ops.nn import squareplus
 from keras.src.ops.nn import tanh_shrink

--- a/keras/src/activations/__init__.py
+++ b/keras/src/activations/__init__.py
@@ -23,6 +23,7 @@ from keras.src.activations.activations import soft_shrink
 from keras.src.activations.activations import softmax
 from keras.src.activations.activations import softplus
 from keras.src.activations.activations import softsign
+from keras.src.activations.activations import squareplus
 from keras.src.activations.activations import tanh
 from keras.src.activations.activations import tanh_shrink
 from keras.src.api_export import keras_export
@@ -39,6 +40,7 @@ ALL_OBJECTS = {
     selu,
     softplus,
     softsign,
+    squareplus,
     soft_shrink,
     silu,
     gelu,

--- a/keras/src/activations/activations.py
+++ b/keras/src/activations/activations.py
@@ -299,7 +299,7 @@ def silu(x):
 
 @keras_export("keras.activations.squareplus")
 def squareplus(x, b=4):
-    """SquarePlus activation function.
+    """Squareplus activation function.
 
     The SquarePlus activation function is defined as:
 

--- a/keras/src/activations/activations.py
+++ b/keras/src/activations/activations.py
@@ -297,6 +297,27 @@ def silu(x):
     return ops.silu(x)
 
 
+@keras_export("keras.activations.squareplus")
+def squareplus(x, b=4):
+    """SquarePlus activation function.
+
+    The SquarePlus activation function is defined as:
+
+    `f(x) = (x + sqrt(x^2 + b)) / 2`
+
+    Where `b` is a smoothness parameter.
+
+    Args:
+        x: Input tensor.
+        b: Smoothness parameter. Defaults to 4.
+
+    Reference:
+
+    - [Ramachandran et al., 2021](https://arxiv.org/abs/2112.11687)
+    """
+    return ops.squareplus(x, b=b)
+
+
 @keras_export("keras.activations.gelu")
 def gelu(x, approximate=False):
     """Gaussian error linear unit (GELU) activation function.

--- a/keras/src/activations/activations_test.py
+++ b/keras/src/activations/activations_test.py
@@ -683,6 +683,16 @@ class ActivationsTest(testing.TestCase):
         expected = hard_shrink(x)
         self.assertAllClose(result, expected, rtol=1e-05)
 
+    def test_squareplus(self):
+        def squareplus(x, b=4):
+            y = x + np.sqrt(x**2 + b)
+            return y / 2
+
+        x = np.random.random((2, 5))
+        result = activations.squareplus(x[np.newaxis, :])[0]
+        expected = squareplus(x)
+        self.assertAllClose(result, expected, rtol=1e-05)
+
     def test_soft_shrink(self):
         def soft_shrink(x, threshold=0.5):
             return np.where(

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -67,6 +67,11 @@ def silu(x):
     return jnn.silu(x)
 
 
+def squareplus(x, b=4):
+    x = convert_to_tensor(x)
+    return jnn.squareplus(x, b=b)
+
+
 def log_sigmoid(x):
     x = convert_to_tensor(x)
     return jnn.log_sigmoid(x)

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -67,6 +67,13 @@ def silu(x):
     return x * sigmoid(x)
 
 
+def squareplus(x, b=4):
+    x = convert_to_tensor(x)
+    b = convert_to_tensor(b, dtype=x.dtype)
+    y = x + np.sqrt(x**2 + b)
+    return y / 2
+
+
 def log_sigmoid(x):
     x = convert_to_tensor(x)
     return -softplus(-x)

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -54,6 +54,13 @@ def silu(x):
     return tf.nn.silu(x)
 
 
+def squareplus(x, b=4):
+    x = convert_to_tensor(x)
+    b = convert_to_tensor(b, dtype=x.dtype)
+    y = x + tf.sqrt(tf.square(x) + b)
+    return y / 2
+
+
 def log_sigmoid(x):
     return tf.math.log_sigmoid(x)
 

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -60,6 +60,13 @@ def silu(x):
     return tnn.silu(x)
 
 
+def squareplus(x, b=4):
+    x = convert_to_tensor(x)
+    b = convert_to_tensor(b)
+    y = x + torch.sqrt(x**2 + b)
+    return y / 2
+
+
 def log_sigmoid(x):
     x = convert_to_tensor(x)
     return tnn.logsigmoid(x)

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -258,6 +258,46 @@ def silu(x):
     return backend.nn.silu(x)
 
 
+class Squareplus(Operation):
+    def __init__(self, b=4):
+        super().__init__()
+        self.b = b
+
+    def call(self, x):
+        return backend.nn.squareplus(x, self.b)
+
+    def compute_output_spec(self, x):
+        return KerasTensor(x.shape, dtype=x.dtype)
+
+
+@keras_export(["keras.ops.squareplus", "keras.ops.nn.squareplus"])
+def squareplus(x, b=4):
+    """SquarePlus activation function.
+
+    The SquarePlus activation function is defined as:
+
+    `f(x) = (x + sqrt(x^2 + b)) / 2`
+
+    Args:
+        x: Input tensor.
+        b: Smoothness parameter. Defaults to 4.
+
+    Returns:
+        A tensor with the same shape as `x`.
+
+    Example:
+
+    >>> x = np.array([-1.0, 0.0, 1.0])
+    >>> x_squareplus = keras.ops.squareplus(x)
+    >>> print(x_squareplus)
+    array([0.6180, 1.0000, 1.6180], dtype=float32)
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Squareplus(b).symbolic_call(x)
+    return backend.nn.squareplus(x, b)
+
+
 class LogSigmoid(Operation):
     def call(self, x):
         return backend.nn.log_sigmoid(x)

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -160,6 +160,10 @@ class NNOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.hard_shrink(x).shape, (None, 2, 3))
 
+    def test_squareplus(self):
+        x = KerasTensor([None, 2, 3])
+        self.assertEqual(knn.squareplus(x).shape, (None, 2, 3))
+
     def test_soft_shrink(self):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.soft_shrink(x).shape, (None, 2, 3))
@@ -829,6 +833,10 @@ class NNOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.hard_shrink(x).shape, (1, 2, 3))
 
+    def test_squareplus(self):
+        x = KerasTensor([1, 2, 3])
+        self.assertEqual(knn.squareplus(x).shape, (1, 2, 3))
+
     def test_soft_shrink(self):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.soft_shrink(x).shape, (1, 2, 3))
@@ -1372,6 +1380,13 @@ class NNOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(
             knn.hard_shrink(x),
             [0.0, 0.0, 1.0, 2.0, 3.0],
+        )
+
+    def test_squareplus(self):
+        x = np.array([-0.5, 0, 1, 2, 3], dtype=np.float32)
+        self.assertAllClose(
+            knn.squareplus(x),
+            [0.780776, 1.0, 1.618034, 2.414214, 3.302776],
         )
 
     def test_soft_shrink(self):
@@ -2575,6 +2590,27 @@ class NNOpsDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knn.Glu().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_squareplus(self, dtype):
+        import jax.nn as jnn
+        import jax.numpy as jnp
+
+        if dtype == "bfloat16":
+            self.skipTest("Weirdness with numpy")
+
+        x = knp.ones((2), dtype=dtype)
+        x_jax = jnp.ones((2), dtype=dtype)
+        expected_dtype = standardize_dtype(jnn.squareplus(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knn.squareplus(x).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(knn.Squareplus().symbolic_call(x).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
Since Keras lacks built-in support for the squareplus activation function, I implemented it across TensorFlow, PyTorch, and NumPy, aiming to maintain consistency with existing implementations available in Jax.