### PR TITLE
Fix tensorflow `_dot_product_attention_xla` and update `enable_flash_attention`

### DIFF
--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -984,7 +984,7 @@ def _dot_product_attention_xla(query, key, value, bias, mask, is_causal, scale):
         tf.cast(key, dtype=logits_dtype),
         optimize="optimal",
     )
-    logits = tf.multiply(logits, tf.cast(logits, logits.dtype))
+    logits = tf.multiply(logits, tf.cast(scale, logits.dtype))
 
     if bias is not None:
         logits = tf.add(logits, tf.cast(bias, logits.dtype))

--- a/keras/src/layers/attention/attention.py
+++ b/keras/src/layers/attention/attention.py
@@ -293,10 +293,15 @@ def enable_flash_attention():
     making it especially useful for large language models (LLMs) that
     benefit from faster and more memory-efficient attention computations.
 
-    Once enabled, supported layers like `MultiHeadAttention` will
-    use flash attention for faster computations.
+    Once enabled, supported layers like `MultiHeadAttention` will **attempt** to
+    use flash attention for faster computations. By default, this feature is
+    enabled.
+
+    Note that enabling flash attention does not guarantee it will always be
+    used. Typically, the inputs must be in `float16` or `bfloat16` dtype, and
+    input layout requirements may vary depending on the backend.
     """
-    global_state.set_global_attribute("flash_attention", True)
+    global_state.set_global_attribute("flash_attention", None)
 
 
 @keras_export("keras.config.disable_flash_attention")
@@ -323,9 +328,11 @@ def is_flash_attention_enabled():
     configuration to determine if flash attention is enabled for compatible
     layers (e.g., `MultiHeadAttention`).
 
+    Note that enabling flash attention does not guarantee it will always be
+    used. Typically, the inputs must be in `float16` or `bfloat16` dtype, and
+    input layout requirements may vary depending on the backend.
+
     Returns:
-        bool or None: Returns `True` if flash attention is enabled,
-                      `False` if it is disabled, and `None` if the global
-                      setting has not been defined.
+        `False` if disabled; otherwise, it indicates that it is enabled.
     """
     return global_state.get_global_attribute("flash_attention", default=None)

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -16,7 +16,7 @@ from keras.src import saving
 from keras.src import testing
 from keras.src.layers.attention.attention import disable_flash_attention
 from keras.src.layers.attention.attention import enable_flash_attention
-from keras.src.layers.attention.multi_head_attention import MultiHeadAttention
+from keras.src.layers.attention.attention import is_flash_attention_enabled
 
 
 class MultiHeadAttentionTest(testing.TestCase):
@@ -613,55 +613,26 @@ class MultiHeadAttentionTest(testing.TestCase):
         ):
             layer(query=query, value=value, return_attention_scores=True)
 
-    def test_flash_attention_numerical_correctness(self):
-        if backend.backend() == "numpy" or backend.backend() == "tensorflow":
-            pytest.skip(
-                reason="Flash attention is not supported on Tensorflow "
-                "and numpy."
-            )
-        # Create sample input data
-        # Define sample input
-        query = np.random.random((2, 4, 8))
-        value = np.random.random((2, 4, 8))
+    def test_multi_head_attention_output_shape_as_int(self):
+        """Test MultiHeadAttention with output_shape as an int."""
+        mha = layers.MultiHeadAttention(num_heads=2, key_dim=16, output_shape=8)
+        query = random.uniform((2, 4, 16))
+        value = random.uniform((2, 4, 16))
+        output = mha(query=query, value=value)
 
-        # Initialize MultiHeadAttention layer
-        mha_layer = layers.MultiHeadAttention(
-            num_heads=2,
-            key_dim=2,
+        assert output.shape == (2, 4, 8), (
+            f"Expected shape (2, 4, 8)," f" got {output.shape}"
         )
 
-        # Run with flash attention enabled
-        enable_flash_attention()
-        output_with_flash = mha_layer(query=query, value=value, training=False)
-
-        disable_flash_attention()
-        # Run with flash attention disabled
-        output_without_flash = mha_layer(
-            query=query, value=value, training=False
+    def test_multi_head_attention_output_shape_as_tuple(self):
+        """Test MultiHeadAttention with output_shape as a tuple."""
+        mha = layers.MultiHeadAttention(
+            num_heads=2, key_dim=16, output_shape=(8, 8)
         )
+        query = random.uniform((2, 4, 16))
+        value = random.uniform((2, 4, 16))
+        output = mha(query=query, value=value)
 
-        self.assertAllClose(output_with_flash, output_without_flash)
-
-
-def test_multi_head_attention_output_shape_as_int():
-    """Test MultiHeadAttention with output_shape as an int."""
-    mha = MultiHeadAttention(num_heads=2, key_dim=16, output_shape=8)
-    query = random.uniform((2, 4, 16))
-    value = random.uniform((2, 4, 16))
-    output = mha(query=query, value=value)
-
-    assert output.shape == (2, 4, 8), (
-        f"Expected shape (2, 4, 8)," f" got {output.shape}"
-    )
-
-
-def test_multi_head_attention_output_shape_as_tuple():
-    """Test MultiHeadAttention with output_shape as a tuple."""
-    mha = MultiHeadAttention(num_heads=2, key_dim=16, output_shape=(8, 8))
-    query = random.uniform((2, 4, 16))
-    value = random.uniform((2, 4, 16))
-    output = mha(query=query, value=value)
-
-    assert output.shape == (2, 4, 8, 8), (
-        f"Expected shape (2, 4, 8, 8)," f" got {output.shape}"
-    )
+        assert output.shape == (2, 4, 8, 8), (
+            f"Expected shape (2, 4, 8, 8)," f" got {output.shape}"
+        )

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -2381,7 +2381,7 @@ class DotProductAttention(Operation):
         bias=None,
         mask=None,
         scale=None,
-        flash_attention=False,
+        flash_attention=None,
     ):
         return backend.nn.dot_product_attention(
             query,
@@ -2402,7 +2402,7 @@ class DotProductAttention(Operation):
         bias=None,
         mask=None,
         scale=None,
-        flash_attention=False,
+        flash_attention=None,
     ):
         return KerasTensor(query.shape, dtype=query.dtype)
 


### PR DESCRIPTION
This PR modifies `enable_flash_attention` to set the value to `None`. This makes it more user-friendly by allowing the backend to decide whether to use flash attention.

The MHA tests have been also updated.

Additionally, a minor but crucial bug in `dot_product_attention` in tensorflow backend has been fixed. (identified by the updated test)
