### PR TITLE
`MultiHeadAttention._compute_attention_mask()` always returns a bool …

### DIFF
--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -550,12 +550,15 @@ class MultiHeadAttention(Layer):
             # the shape of the causal mask is [1, T, S]
             mask = self._compute_causal_mask(query, value)
             auto_mask = mask if auto_mask is None else auto_mask & mask
+
+        if attention_mask is not None:
+            attention_mask = ops.cast(attention_mask, "bool")
         if auto_mask is not None:
             # merge attention_mask & automatic mask, to shape [B, T, S]
             attention_mask = (
                 auto_mask
                 if attention_mask is None
-                else ops.cast(attention_mask, bool) & auto_mask
+                else attention_mask & auto_mask
             )
         return attention_mask
 

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -218,11 +218,9 @@ class MultiHeadAttentionTest(testing.TestCase):
             [[[1, 1, 0]] * 3 + [[0, 0, 0]] * 2]
             + [[[1, 0, 0]] * 5]
             + [[[1, 1, 1]] + [[0, 0, 0]] * 4]
-        ).astype(bool)
+        )
         if use_causal_mask:
-            mask = mask & np.array(
-                [[[1, 0, 0], [1, 1, 0]] + [[1, 1, 1]] * 3]
-            ).astype(bool)
+            mask = mask & np.array([[[1, 0, 0], [1, 1, 0]] + [[1, 1, 1]] * 3])
         del masked_query._keras_mask
         del masked_value._keras_mask
         output_with_manual_mask = layer(


### PR DESCRIPTION
…tensor.

Previously, if an non-bool `attention_mask` was passed and no other mask was passed, the original `attention_mask` was returned unchanged.

Now, it is always cast to bool.