### PR TITLE
Introduce flash attention to GQA and move the flash attention configs to `backend.config`

### DIFF
--- a/keras/api/_tf_keras/keras/config/__init__.py
+++ b/keras/api/_tf_keras/keras/config/__init__.py
@@ -5,17 +5,17 @@ since your modifications would be overwritten.
 """
 
 from keras.src.backend.config import backend
+from keras.src.backend.config import disable_flash_attention
+from keras.src.backend.config import enable_flash_attention
 from keras.src.backend.config import epsilon
 from keras.src.backend.config import floatx
 from keras.src.backend.config import image_data_format
+from keras.src.backend.config import is_flash_attention_enabled
 from keras.src.backend.config import set_epsilon
 from keras.src.backend.config import set_floatx
 from keras.src.backend.config import set_image_data_format
 from keras.src.dtype_policies.dtype_policy import dtype_policy
 from keras.src.dtype_policies.dtype_policy import set_dtype_policy
-from keras.src.layers.attention.attention import disable_flash_attention
-from keras.src.layers.attention.attention import enable_flash_attention
-from keras.src.layers.attention.attention import is_flash_attention_enabled
 from keras.src.saving.serialization_lib import enable_unsafe_deserialization
 from keras.src.utils.backend_utils import set_backend
 from keras.src.utils.io_utils import disable_interactive_logging

--- a/keras/api/config/__init__.py
+++ b/keras/api/config/__init__.py
@@ -5,17 +5,17 @@ since your modifications would be overwritten.
 """
 
 from keras.src.backend.config import backend
+from keras.src.backend.config import disable_flash_attention
+from keras.src.backend.config import enable_flash_attention
 from keras.src.backend.config import epsilon
 from keras.src.backend.config import floatx
 from keras.src.backend.config import image_data_format
+from keras.src.backend.config import is_flash_attention_enabled
 from keras.src.backend.config import set_epsilon
 from keras.src.backend.config import set_floatx
 from keras.src.backend.config import set_image_data_format
 from keras.src.dtype_policies.dtype_policy import dtype_policy
 from keras.src.dtype_policies.dtype_policy import set_dtype_policy
-from keras.src.layers.attention.attention import disable_flash_attention
-from keras.src.layers.attention.attention import enable_flash_attention
-from keras.src.layers.attention.attention import is_flash_attention_enabled
 from keras.src.saving.serialization_lib import enable_unsafe_deserialization
 from keras.src.utils.backend_utils import set_backend
 from keras.src.utils.io_utils import disable_interactive_logging

--- a/keras/src/backend/config.py
+++ b/keras/src/backend/config.py
@@ -167,6 +167,65 @@ def set_image_data_format(data_format):
     _IMAGE_DATA_FORMAT = data_format
 
 
+@keras_export("keras.config.enable_flash_attention")
+def enable_flash_attention():
+    """Enable flash attention.
+
+    Flash attention offers performance optimization for attention layers,
+    making it especially useful for large language models (LLMs) that
+    benefit from faster and more memory-efficient attention computations.
+
+    Once enabled, supported layers like `MultiHeadAttention` will **attempt** to
+    use flash attention for faster computations. By default, this feature is
+    enabled.
+
+    Note that enabling flash attention does not guarantee it will always be
+    used. Typically, the inputs must be in `float16` or `bfloat16` dtype, and
+    input layout requirements may vary depending on the backend.
+    """
+    from keras.src.backend.common import global_state
+
+    global_state.set_global_attribute("flash_attention", None)
+
+
+@keras_export("keras.config.disable_flash_attention")
+def disable_flash_attention():
+    """Disable flash attention.
+
+    Flash attention offers performance optimization for attention layers,
+    making it especially useful for large language models (LLMs) that
+    benefit from faster and more memory-efficient attention computations.
+
+    Once disabled, supported layers like `MultiHeadAttention` will not
+    use flash attention for faster computations.
+    """
+    from keras.src.backend.common import global_state
+
+    global_state.set_global_attribute("flash_attention", False)
+
+
+@keras_export("keras.config.is_flash_attention_enabled")
+def is_flash_attention_enabled():
+    """Checks whether flash attention is globally enabled in Keras.
+
+    Flash attention is a performance-optimized method for computing attention
+    in large models, such as transformers, allowing for faster and more
+    memory-efficient operations. This function checks the global Keras
+    configuration to determine if flash attention is enabled for compatible
+    layers (e.g., `MultiHeadAttention`).
+
+    Note that enabling flash attention does not guarantee it will always be
+    used. Typically, the inputs must be in `float16` or `bfloat16` dtype, and
+    input layout requirements may vary depending on the backend.
+
+    Returns:
+        `False` if disabled; otherwise, it indicates that it is enabled.
+    """
+    from keras.src.backend.common import global_state
+
+    return global_state.get_global_attribute("flash_attention", default=None)
+
+
 def standardize_data_format(data_format):
     if data_format is None:
         return image_data_format()

--- a/keras/src/layers/attention/attention.py
+++ b/keras/src/layers/attention/attention.py
@@ -1,7 +1,6 @@
 from keras.src import backend
 from keras.src import ops
 from keras.src.api_export import keras_export
-from keras.src.backend.common import global_state
 from keras.src.layers.layer import Layer
 
 
@@ -283,56 +282,3 @@ class Attention(Layer):
             "dropout": self.dropout,
         }
         return {**base_config, **config}
-
-
-@keras_export("keras.config.enable_flash_attention")
-def enable_flash_attention():
-    """Enable flash attention.
-
-    Flash attention offers performance optimization for attention layers,
-    making it especially useful for large language models (LLMs) that
-    benefit from faster and more memory-efficient attention computations.
-
-    Once enabled, supported layers like `MultiHeadAttention` will **attempt** to
-    use flash attention for faster computations. By default, this feature is
-    enabled.
-
-    Note that enabling flash attention does not guarantee it will always be
-    used. Typically, the inputs must be in `float16` or `bfloat16` dtype, and
-    input layout requirements may vary depending on the backend.
-    """
-    global_state.set_global_attribute("flash_attention", None)
-
-
-@keras_export("keras.config.disable_flash_attention")
-def disable_flash_attention():
-    """Disable flash attention.
-
-    Flash attention offers performance optimization for attention layers,
-    making it especially useful for large language models (LLMs) that
-    benefit from faster and more memory-efficient attention computations.
-
-    Once disabled, supported layers like `MultiHeadAttention` will not
-    use flash attention for faster computations.
-    """
-    global_state.set_global_attribute("flash_attention", False)
-
-
-@keras_export("keras.config.is_flash_attention_enabled")
-def is_flash_attention_enabled():
-    """Checks whether flash attention is globally enabled in Keras.
-
-    Flash attention is a performance-optimized method for computing attention
-    in large models, such as transformers, allowing for faster and more
-    memory-efficient operations. This function checks the global Keras
-    configuration to determine if flash attention is enabled for compatible
-    layers (e.g., `MultiHeadAttention`).
-
-    Note that enabling flash attention does not guarantee it will always be
-    used. Typically, the inputs must be in `float16` or `bfloat16` dtype, and
-    input layout requirements may vary depending on the backend.
-
-    Returns:
-        `False` if disabled; otherwise, it indicates that it is enabled.
-    """
-    return global_state.get_global_attribute("flash_attention", default=None)

--- a/keras/src/layers/attention/grouped_query_attention_test.py
+++ b/keras/src/layers/attention/grouped_query_attention_test.py
@@ -6,10 +6,24 @@ from keras.src import backend
 from keras.src import initializers
 from keras.src import layers
 from keras.src import testing
+from keras.src.backend.config import disable_flash_attention
+from keras.src.backend.config import enable_flash_attention
+from keras.src.backend.config import is_flash_attention_enabled
 
 
 class GroupedQueryAttentionTest(testing.TestCase):
+    def setUp(self):
+        super().setUp()
+        # Flash attention is a newly introduced feature. We need to disable it
+        # for testing purposes.
+        disable_flash_attention()
+
+    def tearDown(self):
+        enable_flash_attention()
+        return super().tearDown()
+
     def test_basics(self):
+        self.assertFalse(is_flash_attention_enabled())
         self.run_layer_test(
             layers.GroupedQueryAttention,
             init_kwargs={
@@ -45,6 +59,98 @@ class GroupedQueryAttentionTest(testing.TestCase):
             supports_masking=True,
             run_training_check=False,
         )
+
+    def test_basics_with_flash_attention(self):
+        enable_flash_attention()
+        init_kwargs = {
+            "num_query_heads": 2,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "dtype": "float16",
+        }
+        input_shape = {
+            "query_shape": (2, 8, 16),
+            "value_shape": (2, 4, 16),
+        }
+        expected_output_shape = (2, 8, 16)
+        if backend.backend() in ("tensorflow", "numpy"):
+            self.skipTest(
+                "Flash attention is not supported in tensorflow and numpy "
+                "backends."
+            )
+        elif backend.backend() == "torch":
+            try:
+                self.run_layer_test(
+                    layers.GroupedQueryAttention,
+                    init_kwargs=init_kwargs,
+                    input_shape=input_shape,
+                    expected_output_shape=expected_output_shape,
+                    expected_num_trainable_weights=8,
+                    expected_num_non_trainable_weights=0,
+                    expected_num_seed_generators=0,
+                    expected_num_losses=0,
+                    supports_masking=True,
+                    run_training_check=False,
+                )
+            except ImportError as e:
+                if "Flash attention is not supported" in str(e.args[0]):
+                    self.assertTrue(
+                        (
+                            "Flash attention is not supported in your current "
+                            "PyTorch version."
+                        )
+                        in str(e.args[0])
+                    )
+            except RuntimeError as e:
+                if (
+                    "Flash attention is not supported with the provided inputs"
+                    in str(e.args[0])
+                ):
+                    self.assertTrue(
+                        (
+                            "Flash attention is not supported with the "
+                            "provided inputs"
+                        )
+                        in str(e.args[0])
+                    )
+        elif backend.backend() == "jax":
+            try:
+                self.run_layer_test(
+                    layers.GroupedQueryAttention,
+                    init_kwargs=init_kwargs,
+                    input_shape=input_shape,
+                    expected_output_shape=expected_output_shape,
+                    expected_num_trainable_weights=8,
+                    expected_num_non_trainable_weights=0,
+                    expected_num_seed_generators=0,
+                    expected_num_losses=0,
+                    supports_masking=True,
+                    run_training_check=False,
+                )
+            except ImportError as e:
+                if "Flash attention is not supported" in str(e.args[0]):
+                    self.assertTrue(
+                        (
+                            "Flash attention is not supported in your current "
+                            "JAX version."
+                        )
+                        in str(e.args[0])
+                    )
+            except RuntimeError as e:
+                if "cuDNN" in str(e.args[0]):
+                    self.assertTrue("cuDNN is not detected." in str(e.args[0]))
+                elif "Require at least" in str(e.args[0]):
+                    self.assertTrue(
+                        "Require at least Ampere arch to run" in str(e.args[0])
+                    )
+                elif "Flash attention" in str(e.args[0]):
+                    self.assertTrue(
+                        (
+                            "Flash attention is not supported in your current "
+                            "JAX version."
+                        )
+                        in str(e.args[0])
+                    )
 
     @parameterized.named_parameters(
         ("without_key_proj_mha", (4, 8), (2, 8), None, 2, 2),
@@ -171,39 +277,74 @@ class GroupedQueryAttentionTest(testing.TestCase):
         )
         self.assertAllClose(output, output_with_manual_mask)
 
-    def test_correctness(self):
-        query = np.array([[[1.0, 0.0], [0.0, 1.0]]])
-        key = np.array([[[0.0, 1.0], [1.0, 0.0]]])
-        value = np.array([[[1.0, 2.0], [3.0, 4.0]]])
+    @parameterized.named_parameters(
+        ("disable_flash_attention", False),
+        ("enable_flash_attention", True),
+    )
+    def test_correctness(self, flash_attention):
+        if flash_attention:
+            # Let the backend decide whether to use flase attention
+            enable_flash_attention()
+        dtype = "float16"  # Flash attention only accepts float16/bfloat16
+        head_dim = 8  # key_dim % 8 == 0 to enable flash attention
+        num_query_heads = num_key_value_heads = 8
+
+        query = np.identity(head_dim)[np.newaxis, ...]
+        key = np.identity(head_dim)[np.newaxis, ...]
+        value = (
+            np.reshape(np.arange(head_dim * head_dim), (1, head_dim, head_dim))
+            / 100.0  # Prevent overflow/underflow
+        )
 
         # Setup layer.
-        num_heads = 2
-        key_dim = 2
-        layer = layers.MultiHeadAttention(
-            num_heads=num_heads,
-            key_dim=key_dim,
+        layer = layers.GroupedQueryAttention(
+            head_dim=head_dim,
+            num_query_heads=num_query_heads,
+            num_key_value_heads=num_key_value_heads,
+            dtype=dtype,
         )
         layer.build(query.shape, key.shape, value.shape)
 
         # Set layer weights.
-        kernel = np.identity(key_dim)
+        kernel = np.identity(head_dim)
         # To get an identity kernel we need to add a head dim and repeat on it.
-        kernel = np.repeat(kernel[:, np.newaxis, :], num_heads, axis=1)
+        kernel = np.repeat(kernel[:, np.newaxis, :], num_query_heads, axis=1)
         # Zeros for all biases.
-        bias = np.zeros((2, 2))
-        output_bias = np.zeros((2,))
+        bias = np.zeros((num_query_heads, head_dim))
+        output_bias = np.zeros((head_dim,))
         layer.set_weights([kernel, bias] * 3 + [kernel, output_bias])
 
         # Call layer and assert output.
-        output, scores = layer(
-            query=query,
-            value=value,
-            key=key,
-            return_attention_scores=True,
+        expected_output = np.array(
+            [2.406, 2.440, 2.473, 2.504, 2.535, 2.568, 2.602, 2.633]
         )
-        self.assertAllClose(output, [[[5.679, 5.679], [4.32, 4.32]]], atol=1e-3)
-        self.assertAllClose(
-            scores,
-            [[[[0.33, 0.67], [0.67, 0.33]], [[0.33, 0.67], [0.67, 0.33]]]],
-            atol=1e-3,
+        expected_output = np.tile(
+            expected_output[np.newaxis, :, np.newaxis], (1, 1, head_dim)
         )
+        expected_score = np.array(
+            [
+                [0.1187] * 0 + [0.1691] + [0.1187] * 7,
+                [0.1187] * 1 + [0.1691] + [0.1187] * 6,
+                [0.1187] * 2 + [0.1691] + [0.1187] * 5,
+                [0.1187] * 3 + [0.1691] + [0.1187] * 4,
+                [0.1187] * 4 + [0.1691] + [0.1187] * 3,
+                [0.1187] * 5 + [0.1691] + [0.1187] * 2,
+                [0.1187] * 6 + [0.1691] + [0.1187] * 1,
+                [0.1187] * 7 + [0.1691] + [0.1187] * 0,
+            ]
+        )
+        expected_score = np.tile(
+            expected_score[np.newaxis, np.newaxis, ...], (1, head_dim, 1, 1)
+        )
+        if flash_attention:
+            output = layer(query=query, value=value, key=key)
+            self.assertAllClose(output, expected_output, atol=1e-2)
+        else:
+            output, scores = layer(
+                query=query,
+                value=value,
+                key=key,
+                return_attention_scores=True,
+            )
+            self.assertAllClose(output, expected_output, atol=1e-2)
+            self.assertAllClose(scores, expected_score, atol=1e-2)

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -9,8 +9,8 @@ from keras.src import initializers
 from keras.src import ops
 from keras.src import regularizers
 from keras.src.api_export import keras_export
+from keras.src.backend.config import is_flash_attention_enabled
 from keras.src.layers.activations.softmax import Softmax
-from keras.src.layers.attention.attention import is_flash_attention_enabled
 from keras.src.layers.core.einsum_dense import EinsumDense
 from keras.src.layers.layer import Layer
 from keras.src.layers.regularization.dropout import Dropout

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -14,9 +14,9 @@ from keras.src import ops
 from keras.src import random
 from keras.src import saving
 from keras.src import testing
-from keras.src.layers.attention.attention import disable_flash_attention
-from keras.src.layers.attention.attention import enable_flash_attention
-from keras.src.layers.attention.attention import is_flash_attention_enabled
+from keras.src.backend.config import disable_flash_attention
+from keras.src.backend.config import enable_flash_attention
+from keras.src.backend.config import is_flash_attention_enabled
 
 
 class MultiHeadAttentionTest(testing.TestCase):


### PR DESCRIPTION
This PR introduces flash attention to GQA and moves the flash attention configs to `backend.config`.
The previous location of the flash attention configs was a bit weird IMO.
