### PR TITLE
Fixing example code for CategoricalCrossentropy in losses.py file

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -923,8 +923,8 @@ class CategoricalCrossentropy(LossFunctionWrapper):
 
     Standalone usage:
 
-    >>> y_true = [[0, 1, 0], [0, 0, 1]]
-    >>> y_pred = [[0.05, 0.95, 0], [0.1, 0.8, 0.1]]
+    >>> y_true = np.array([[0, 1, 0], [0, 0, 1]])
+    >>> y_pred = np.array([[0.05, 0.95, 0], [0.1, 0.8, 0.1]])
     >>> # Using 'auto'/'sum_over_batch_size' reduction type.
     >>> cce = keras.losses.CategoricalCrossentropy()
     >>> cce(y_true, y_pred)


### PR DESCRIPTION
The example mentioned for the Keras API CategoricalCrossentropy was failing with the error AttributeError: 'list' object has no attribute 'shape'.