### PR TITLE
Fix incorrect argument name and update description in RNN documentation

### DIFF
--- a/keras/src/layers/rnn/rnn.py
+++ b/keras/src/layers/rnn/rnn.py
@@ -63,7 +63,7 @@ class RNN(Layer):
             merging bidirectional RNNs.
 
     Call arguments:
-        inputs: Input tensor.
+        sequences: A 3-D tensor with shape `(batch_size, timesteps, features)`.
         initial_state: List of initial state tensors to be passed to the first
             call of the cell.
         mask: Binary tensor of shape `[batch_size, timesteps]`
@@ -75,9 +75,6 @@ class RNN(Layer):
             training mode or in inference mode. This argument is passed
             to the cell when calling it.
             This is for use with cells that use dropout.
-
-    Input shape:
-        3-D tensor with shape `(batch_size, timesteps, features)`.
 
     Output shape:
 


### PR DESCRIPTION
The documentation for the base class for recurrent layers (class `RNN` exported as `keras.layers.RNN`) incorrectly mentioned the call argument `sequences` as `inputs`. This PR corrects the argument's name in the documentation and updates the argument's description to align more closely with similar arguments in similar layers.