### PR TITLE
Allow EarlyStopping to be reused between multiple `fit`s.

### DIFF
--- a/keras/src/callbacks/early_stopping.py
+++ b/keras/src/callbacks/early_stopping.py
@@ -136,14 +136,12 @@ class EarlyStopping(Callback):
             )
         if self.monitor_op == ops.less:
             self.min_delta *= -1
-        self.best = (
-            float("inf") if self.monitor_op == ops.less else -float("inf")
-        )
 
     def on_train_begin(self, logs=None):
         # Allow instances to be re-used
         self.wait = 0
         self.stopped_epoch = 0
+        self.best = None
         self.best_weights = None
         self.best_epoch = 0
 
@@ -210,4 +208,6 @@ class EarlyStopping(Callback):
         return monitor_value
 
     def _is_improvement(self, monitor_value, reference_value):
+        if reference_value is None:
+            return True
         return self.monitor_op(monitor_value - self.min_delta, reference_value)

--- a/keras/src/callbacks/early_stopping_test.py
+++ b/keras/src/callbacks/early_stopping_test.py
@@ -114,16 +114,17 @@ class EarlyStoppingTest(testing.TestCase):
             loss="mae",
             metrics=["mse"],
         )
-        weights = model.get_weights()
-
-        # This should allow training to go for at least `patience` epochs
-        model.set_weights(weights)
-
         stopper = callbacks.EarlyStopping(monitor="mse", patience=patience)
-        hist = model.fit(
+
+        history1 = model.fit(
             data, labels, callbacks=[stopper], verbose=0, epochs=20
         )
-        assert len(hist.epoch) >= patience
+        self.assertGreaterEqual(len(history1.epoch), patience)
+
+        history2 = model.fit(
+            data, labels, callbacks=[stopper], verbose=0, epochs=20
+        )
+        self.assertGreaterEqual(len(history2.epoch), patience)
 
     @pytest.mark.requires_trainable_backend
     def test_early_stopping_with_baseline(self):


### PR DESCRIPTION
All values were already reset properly in `on_train_begin` except `best`.

Fixes https://github.com/keras-team/keras/issues/20521
