### PR TITLE
Remove `output_shape` property in MHA

### DIFF
--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -247,6 +247,14 @@ class MultiHeadAttentionTest(testing.TestCase):
         )
         self.assertEqual(output.shape, comp_output_shape)
 
+        # Test shapes as lists.
+        comp_output_shape = layer.compute_output_shape(
+            list(query_shape),
+            list(value_shape),
+            list(key_shape) if key_shape is not None else None,
+        )
+        self.assertEqual(output.shape, comp_output_shape)
+
     @parameterized.named_parameters(
         ("query_value_dim_mismatch", (2, 4, 8), (2, 2, 7), (2,)),
         ("key_value_dim_mismatch", (2, 4, 8), (2, 2, 8), (2, 1, 7)),

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -642,3 +642,7 @@ class MultiHeadAttentionTest(testing.TestCase):
         assert output.shape == (2, 4, 8, 8), (
             f"Expected shape (2, 4, 8, 8)," f" got {output.shape}"
         )
+
+    def test_multi_head_attention_output_shape_error(self):
+        with self.assertRaisesRegex(ValueError, r"Invalid `output_shape`"):
+            layers.MultiHeadAttention(num_heads=2, key_dim=16, output_shape=8.0)

--- a/keras/src/utils/summary_utils.py
+++ b/keras/src/utils/summary_utils.py
@@ -103,7 +103,7 @@ def format_layer_shape(layer):
     else:
         try:
             if hasattr(layer, "output_shape"):
-                output_shapes = layer.output_shape
+                output_shapes = format_shape(layer.output_shape)
             else:
                 outputs = layer.compute_output_shape(**layer._build_shapes_dict)
                 output_shapes = tree.map_shape_structure(

--- a/keras/src/utils/summary_utils_test.py
+++ b/keras/src/utils/summary_utils_test.py
@@ -107,14 +107,11 @@ class SummaryUtilsTest(testing.TestCase):
                 super().__init__()
                 self.mha = layers.MultiHeadAttention(2, 2, output_shape=(4,))
 
-            def build(self, input_shape):
-                self.mha.build(input_shape, input_shape, input_shape)
-
             def call(self, inputs):
                 return self.mha(inputs, inputs, inputs)
 
         model = MyModel()
-        model.build((None, 2, 2))
+        model(np.ones((1, 2, 2)))
 
         summary_content = []
 
@@ -123,7 +120,7 @@ class SummaryUtilsTest(testing.TestCase):
 
         summary_utils.print_summary(model, print_fn=print_to_variable)
         summary_content = "\n".join(summary_content)
-        self.assertIn("(None, 2, 4)", summary_content)  # mha
+        self.assertIn("(1, 2, 4)", summary_content)  # mha
         self.assertIn("Total params: 56", summary_content)
         self.assertIn("Trainable params: 56", summary_content)
         self.assertIn("Non-trainable params: 0", summary_content)

--- a/keras/src/utils/summary_utils_test.py
+++ b/keras/src/utils/summary_utils_test.py
@@ -98,3 +98,29 @@ class SummaryUtilsTest(testing.TestCase):
         self.assertIn("Total params: 12", summary_content)
         self.assertIn("Trainable params: 12", summary_content)
         self.assertIn("Non-trainable params: 0", summary_content)
+
+    def test_print_model_summary_with_mha(self):
+        # In Keras <= 3.6, MHA exposes `output_shape` property which breaks this
+        # test.
+        class MyModel(models.Model):
+            def __init__(self):
+                super().__init__()
+                self.mha = layers.MultiHeadAttention(2, 2, output_shape=(4,))
+
+            def call(self, inputs):
+                return self.mha(inputs, inputs, inputs)
+
+        model = MyModel()
+        model(layers.Input((2, 2)))
+
+        summary_content = []
+
+        def print_to_variable(text, line_break=False):
+            summary_content.append(text)
+
+        summary_utils.print_summary(model, print_fn=print_to_variable)
+        summary_content = "\n".join(summary_content)
+        self.assertIn("(None, 2, 4)", summary_content)  # mha
+        self.assertIn("Total params: 56", summary_content)
+        self.assertIn("Trainable params: 56", summary_content)
+        self.assertIn("Non-trainable params: 0", summary_content)

--- a/keras/src/utils/summary_utils_test.py
+++ b/keras/src/utils/summary_utils_test.py
@@ -107,11 +107,14 @@ class SummaryUtilsTest(testing.TestCase):
                 super().__init__()
                 self.mha = layers.MultiHeadAttention(2, 2, output_shape=(4,))
 
+            def build(self, input_shape):
+                self.mha.build(input_shape, input_shape, input_shape)
+
             def call(self, inputs):
                 return self.mha(inputs, inputs, inputs)
 
         model = MyModel()
-        model(layers.Input((2, 2)))
+        model.build((None, 2, 2))
 
         summary_content = []
 


### PR DESCRIPTION
Fix the issue here:
https://github.com/keras-team/keras/pull/20002#discussion_r1855446457

We should avoid expose `output_shape` in MHA; otherwise, the `summary()` breaks in subclassed models.
Also, the logic of parsing `self._output_shape` has been simplified.

cc @nglehuy