### PR TITLE
Improve `keras.Variable` by exposing docstrings and ensuring consistency in the codebase

### DIFF
--- a/keras/src/backend/__init__.py
+++ b/keras/src/backend/__init__.py
@@ -19,6 +19,7 @@ from keras.src.backend.common.stateless_scope import in_stateless_scope
 from keras.src.backend.common.symbolic_scope import SymbolicScope
 from keras.src.backend.common.symbolic_scope import in_symbolic_scope
 from keras.src.backend.common.variables import AutocastScope
+from keras.src.backend.common.variables import Variable
 from keras.src.backend.common.variables import get_autocast_scope
 from keras.src.backend.common.variables import is_float_dtype
 from keras.src.backend.common.variables import is_int_dtype
@@ -35,25 +36,26 @@ from keras.src.backend.config import standardize_data_format
 # Import backend functions.
 if backend() == "tensorflow":
     from keras.src.backend.tensorflow import *  # noqa: F403
+    from keras.src.backend.tensorflow.core import Variable as BackendVariable
 elif backend() == "jax":
     from keras.src.backend.jax import *  # noqa: F403
+    from keras.src.backend.jax.core import Variable as BackendVariable
 elif backend() == "torch":
     from keras.src.backend.torch import *  # noqa: F403
+    from keras.src.backend.torch.core import Variable as BackendVariable
 
     distribution_lib = None
 elif backend() == "numpy":
     from keras.src.backend.numpy import *  # noqa: F403
+    from keras.src.backend.numpy.core import Variable as BackendVariable
 
     distribution_lib = None
 else:
     raise ValueError(f"Unable to import backend : {backend()}")
 
 
-BackendVariable = Variable  # noqa: F405
-
-
 @keras_export("keras.Variable")
-class Variable(BackendVariable):
+class Variable(BackendVariable, Variable):
     pass
 
 

--- a/keras/src/backend/common/__init__.py
+++ b/keras/src/backend/common/__init__.py
@@ -1,7 +1,7 @@
 from keras.src.backend.common import backend_utils
 from keras.src.backend.common.dtypes import result_type
 from keras.src.backend.common.variables import AutocastScope
-from keras.src.backend.common.variables import KerasVariable
+from keras.src.backend.common.variables import Variable as KerasVariable
 from keras.src.backend.common.variables import get_autocast_scope
 from keras.src.backend.common.variables import is_float_dtype
 from keras.src.backend.common.variables import is_int_dtype

--- a/keras/src/backend/common/stateless_scope.py
+++ b/keras/src/backend/common/stateless_scope.py
@@ -8,7 +8,7 @@ class StatelessScope:
 
     The values of variables to be used inside the scope
     should be passed via the `state_mapping` argument, a
-    list of tuples `(k, v)` where `k` is a `KerasVariable`
+    list of tuples `(k, v)` where `k` is a `Variable`
     and `v` is the intended value for this variable
     (a backend tensor).
 
@@ -39,7 +39,7 @@ class StatelessScope:
         initialize_variables=True,
     ):
         from keras.src import backend
-        from keras.src.backend.common.variables import KerasVariable
+        from keras.src.backend.common.variables import Variable
 
         self.collect_losses = collect_losses
         self.initialize_variables = initialize_variables
@@ -47,13 +47,13 @@ class StatelessScope:
         self.state_mapping = {}
         state_mapping = state_mapping or {}
         for k, v in state_mapping:
-            if not isinstance(k, KerasVariable):
+            if not isinstance(k, Variable):
                 raise ValueError(
                     "Invalid reference variable in StatelessScope: "
-                    "all keys in argument `mapping` must be KerasVariable "
+                    "all keys in argument `mapping` must be Variable "
                     f"instances. Received instead: {k}"
                 )
-            if isinstance(v, KerasVariable):
+            if isinstance(v, Variable):
                 v = backend.cast(v.value, dtype=k.dtype)
             else:
                 v = backend.convert_to_tensor(v, dtype=k.dtype)

--- a/keras/src/backend/common/stateless_scope_test.py
+++ b/keras/src/backend/common/stateless_scope_test.py
@@ -41,7 +41,7 @@ class TestStatelessScope(testing.TestCase):
         value1 = ops.ones(shape=(2,))
 
         with self.assertRaisesRegex(
-            ValueError, "all keys in argument `mapping` must be KerasVariable"
+            ValueError, "all keys in argument `mapping` must be Variable"
         ):
             StatelessScope(state_mapping=[(invalid_key, value1)])
 

--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -12,7 +12,7 @@ from keras.src.utils.module_utils import tensorflow as tf
 from keras.src.utils.naming import auto_name
 
 
-class KerasVariable:
+class Variable:
     """Represents a backend-agnostic variable in Keras.
 
     A `Variable` acts as a container for state. It holds a tensor value and can
@@ -30,17 +30,16 @@ class KerasVariable:
             dtype type (`"float32"` if never configured).
         trainable: Optional. Boolean indicating if variable is trainable.
             Defaults to `True`.
+        autocast: Optional. Boolean indicating whether the variable supports
+            autocasting. If `True`, the layer may first convert the variable
+            to the compute data type when accessed. Defaults to `True`.
+        aggregation: Optional. String specifying how a distributed variable will
+            be aggregated. This argument is specific to TensorFlow. For more
+            details, please refer to
+            https://www.tensorflow.org/api_docs/python/tf/VariableAggregation.
+            Defaults to `"mean"`.
         name: Optional. A unique name for the variable. Automatically generated
             if not set.
-
-    Attributes:
-        name: The name of the variable (string).
-        path: The path of the variable within the Keras model or layer (string).
-        dtype: The data type of the variable (string).
-        shape: The shape of the variable (tuple of integers).
-        ndim: The number of dimensions of the variable (integer).
-        trainable: Whether the variable is trainable (boolean).
-        value: The current value of the variable (NumPy array or tensor).
 
     Examples:
 
@@ -101,20 +100,19 @@ class KerasVariable:
                 "one of {'none', 'mean', 'sum', 'only_first_replica'}. "
                 f"Received: aggregation={aggregation}"
             )
-        self.name = name
+        self._name = name
         parent_path = current_path()
         if parent_path:
-            self.path = current_path() + "/" + self.name
+            self._path = current_path() + "/" + name
         else:
-            self.path = self.name
-        dtype = standardize_dtype(dtype)
-        self._dtype = dtype
+            self._path = name
+        self._dtype = standardize_dtype(dtype)
         self._shape = None
         self._initializer = None
         self._regularizer = None
         self._constraint = None
-        self._trainable = trainable
-        self._autocast = autocast
+        self._trainable = bool(trainable)
+        self._autocast = bool(autocast)
         self._aggregation = aggregation
         # `self._overwrite_with_gradient` is an internal property to determine
         # whether this variable should be overwritten by the computed gradient.
@@ -163,7 +161,7 @@ class KerasVariable:
                 self._initialize_with_initializer(initializer)
             else:
                 self._initialize(initializer)
-                self._shape = tuple(self._value.shape)
+                self._shape = self._validate_shape(self._value.shape)
         self._ndim = len(self._shape)
 
     def _deferred_initialize(self):
@@ -201,10 +199,12 @@ class KerasVariable:
 
     @property
     def aggregation(self):
+        """The strategy for aggregating this variable."""
         return self._aggregation
 
     @property
     def value(self):
+        """The current value of the variable (numpy array or backend tensor)."""
         if in_stateless_scope():
             scope = get_stateless_scope()
             value = scope.get_current_value(self)
@@ -246,30 +246,46 @@ class KerasVariable:
 
     @property
     def dtype(self):
+        """The data type of the variable."""
         autocast_scope = get_autocast_scope()
         if (
             self._autocast
             and autocast_scope is not None
             and is_float_dtype(self._dtype)
         ):
-            return autocast_scope.dtype
-        return self._dtype
+            dtype = autocast_scope.dtype
+        else:
+            dtype = self._dtype
+        return backend.standardize_dtype(dtype)
 
     @property
     def shape(self):
+        """The shape of the variable."""
         return self._shape
 
     @property
     def ndim(self):
+        """The number of dimensions of the variable."""
         return self._ndim
 
     @property
     def trainable(self):
+        """Whether the variable is trainable."""
         return self._trainable
 
     @trainable.setter
     def trainable(self, value):
-        self._trainable = value
+        self._trainable = bool(value)
+
+    @property
+    def name(self):
+        """The name of the variable."""
+        return self._name
+
+    @property
+    def path(self):
+        """The path of the variable within the Keras model or layer."""
+        return self._path
 
     @property
     def overwrite_with_gradient(self):
@@ -326,9 +342,13 @@ class KerasVariable:
         self._constraint = value
 
     def __repr__(self):
+        value = None
+        if hasattr(self, "_value") and self._value is not None:
+            value = backend.core.convert_to_numpy(self._value)
+        value_str = f", value={value}" if value is not None else ""
         return (
-            f"<KerasVariable shape={self.shape}, dtype={self.dtype}, "
-            f"path={self.path}>"
+            f"<Variable path={self.path}, shape={self.shape}, "
+            f"dtype={self.dtype}{value_str}>"
         )
 
     def _initialize(self, value):
@@ -573,7 +593,7 @@ def get_autocast_scope():
 class AutocastScope:
     """Context manager that enables the autocasting of float variables.
 
-    Under this context manager, float `KerasVariables`s will be cast to `dtype`
+    Under this context manager, float `Variables`s will be cast to `dtype`
     (note that `dtype` must also be float).
     """
 

--- a/keras/src/backend/jax/__init__.py
+++ b/keras/src/backend/jax/__init__.py
@@ -10,7 +10,6 @@ from keras.src.backend.jax import random
 from keras.src.backend.jax import tensorboard
 from keras.src.backend.jax.core import IS_THREAD_SAFE
 from keras.src.backend.jax.core import SUPPORTS_SPARSE_TENSORS
-from keras.src.backend.jax.core import Variable
 from keras.src.backend.jax.core import cast
 from keras.src.backend.jax.core import compute_output_spec
 from keras.src.backend.jax.core import cond

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -940,7 +940,7 @@ class JAXTrainer(base_trainer.Trainer):
 
         During JAX training, since the training function are stateless, we have
         to pass in and get the model weights over and over, during which the
-        copy of the weights that attached to the KerasVariable are still and
+        copy of the weights that attached to the Variable are still and
         occupying extra memory. We remove those variable to save memory (for
         better memory utilization) at the beginning of the epoch, and reattach
         the value back to variables at the end of the epoch, via

--- a/keras/src/backend/numpy/__init__.py
+++ b/keras/src/backend/numpy/__init__.py
@@ -8,7 +8,6 @@ from keras.src.backend.numpy import numpy
 from keras.src.backend.numpy import random
 from keras.src.backend.numpy.core import IS_THREAD_SAFE
 from keras.src.backend.numpy.core import SUPPORTS_SPARSE_TENSORS
-from keras.src.backend.numpy.core import Variable
 from keras.src.backend.numpy.core import cast
 from keras.src.backend.numpy.core import compute_output_spec
 from keras.src.backend.numpy.core import cond

--- a/keras/src/backend/tensorflow/__init__.py
+++ b/keras/src/backend/tensorflow/__init__.py
@@ -9,7 +9,6 @@ from keras.src.backend.tensorflow import random
 from keras.src.backend.tensorflow import tensorboard
 from keras.src.backend.tensorflow.core import IS_THREAD_SAFE
 from keras.src.backend.tensorflow.core import SUPPORTS_SPARSE_TENSORS
-from keras.src.backend.tensorflow.core import Variable
 from keras.src.backend.tensorflow.core import cast
 from keras.src.backend.tensorflow.core import compute_output_spec
 from keras.src.backend.tensorflow.core import cond

--- a/keras/src/backend/tensorflow/optimizer.py
+++ b/keras/src/backend/tensorflow/optimizer.py
@@ -12,7 +12,6 @@ import warnings
 import tensorflow as tf
 
 from keras.src import backend
-from keras.src.backend.common import KerasVariable
 from keras.src.backend.tensorflow.trackable import KerasAutoTrackable
 from keras.src.optimizers import base_optimizer
 
@@ -46,7 +45,7 @@ class TFOptimizer(KerasAutoTrackable, base_optimizer.BaseOptimizer):
         )
 
     def assign(self, variable, value):
-        if isinstance(variable, KerasVariable):
+        if isinstance(variable, backend.Variable):
             variable = variable.value
         value = tf.cast(value, variable.dtype)
         if isinstance(value, tf.IndexedSlices):
@@ -55,7 +54,7 @@ class TFOptimizer(KerasAutoTrackable, base_optimizer.BaseOptimizer):
             variable.assign(value)
 
     def assign_add(self, variable, value):
-        if isinstance(variable, KerasVariable):
+        if isinstance(variable, backend.Variable):
             variable = variable.value
         value = tf.cast(value, variable.dtype)
         if isinstance(value, tf.IndexedSlices):
@@ -64,7 +63,7 @@ class TFOptimizer(KerasAutoTrackable, base_optimizer.BaseOptimizer):
             variable.assign_add(value)
 
     def assign_sub(self, variable, value):
-        if isinstance(variable, KerasVariable):
+        if isinstance(variable, backend.Variable):
             variable = variable.value
         value = tf.cast(value, variable.dtype)
         if isinstance(value, tf.IndexedSlices):

--- a/keras/src/backend/torch/__init__.py
+++ b/keras/src/backend/torch/__init__.py
@@ -24,7 +24,6 @@ from keras.src.backend.torch import numpy
 from keras.src.backend.torch import random
 from keras.src.backend.torch.core import IS_THREAD_SAFE
 from keras.src.backend.torch.core import SUPPORTS_SPARSE_TENSORS
-from keras.src.backend.torch.core import Variable
 from keras.src.backend.torch.core import cast
 from keras.src.backend.torch.core import compute_output_spec
 from keras.src.backend.torch.core import cond

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -118,13 +118,11 @@ class Variable(KerasVariable):
     # Overload native accessor.
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
-        args = [
-            arg.value if isinstance(arg, KerasVariable) else arg for arg in args
-        ]
+        args = [arg.value if isinstance(arg, Variable) else arg for arg in args]
         if kwargs is None:
             kwargs = {}
         kwargs = {
-            key: value.value if isinstance(value, KerasVariable) else value
+            key: value.value if isinstance(value, Variable) else value
             for key, value in kwargs.items()
         }
         return func(*args, **kwargs)
@@ -275,7 +273,7 @@ def shape(x):
 
 def cast(x, dtype):
     dtype = to_torch_dtype(dtype)
-    if isinstance(x, KerasVariable):
+    if isinstance(x, Variable):
         x = x.value
     if is_tensor(x):
         if x.dtype == dtype:
@@ -644,7 +642,7 @@ def fori_loop(lower, upper, body_fun, init_val):
 
 
 def stop_gradient(variable):
-    if isinstance(variable, KerasVariable):
+    if isinstance(variable, Variable):
         variable = variable.value
     # We can't use `.requires_grad_(False)` here since it only
     # works when the tensor is a leaf node in the graph.

--- a/keras/src/distribution/distribution_lib.py
+++ b/keras/src/distribution/distribution_lib.py
@@ -308,7 +308,7 @@ class Distribution:
         """Retrieve the `TensorLayout` for the variable.
 
         Args:
-            variable: A `KerasVariable` instance.
+            variable: A `Variable` instance.
 
         return:
             The `TensorLayout` for the variable, which can be used by


### PR DESCRIPTION
This PR fixes the missing docstrings for `keras.Variable` after #20330.  

Additionally, all `KerasVariable` in the codebase have been replaced with `Variable` for consistency, as users don't need to be aware of `KerasVariable`.  

The value of the variable is also exposed if available, to improve the debugging UX.

|Before|After|
|-|-|
|![2](https://github.com/user-attachments/assets/54291375-6828-47b7-8f56-6e9630efd4fc)|![1](https://github.com/user-attachments/assets/256bad2d-e894-47d1-87bb-d87cb05343d7)|
