### PR TITLE
Add sparse_plus activation

### DIFF
--- a/keras/api/_tf_keras/keras/activations/__init__.py
+++ b/keras/api/_tf_keras/keras/activations/__init__.py
@@ -32,6 +32,7 @@ from keras.src.activations.activations import soft_shrink
 from keras.src.activations.activations import softmax
 from keras.src.activations.activations import softplus
 from keras.src.activations.activations import softsign
+from keras.src.activations.activations import sparse_plus
 from keras.src.activations.activations import squareplus
 from keras.src.activations.activations import tanh
 from keras.src.activations.activations import tanh_shrink

--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -99,6 +99,7 @@ from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign
 from keras.src.ops.nn import sparse_categorical_crossentropy
+from keras.src.ops.nn import sparse_plus
 from keras.src.ops.nn import squareplus
 from keras.src.ops.nn import tanh_shrink
 from keras.src.ops.numpy import abs

--- a/keras/api/_tf_keras/keras/ops/nn/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/nn/__init__.py
@@ -44,5 +44,6 @@ from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign
 from keras.src.ops.nn import sparse_categorical_crossentropy
+from keras.src.ops.nn import sparse_plus
 from keras.src.ops.nn import squareplus
 from keras.src.ops.nn import tanh_shrink

--- a/keras/api/activations/__init__.py
+++ b/keras/api/activations/__init__.py
@@ -32,6 +32,7 @@ from keras.src.activations.activations import soft_shrink
 from keras.src.activations.activations import softmax
 from keras.src.activations.activations import softplus
 from keras.src.activations.activations import softsign
+from keras.src.activations.activations import sparse_plus
 from keras.src.activations.activations import squareplus
 from keras.src.activations.activations import tanh
 from keras.src.activations.activations import tanh_shrink

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -99,6 +99,7 @@ from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign
 from keras.src.ops.nn import sparse_categorical_crossentropy
+from keras.src.ops.nn import sparse_plus
 from keras.src.ops.nn import squareplus
 from keras.src.ops.nn import tanh_shrink
 from keras.src.ops.numpy import abs

--- a/keras/api/ops/nn/__init__.py
+++ b/keras/api/ops/nn/__init__.py
@@ -44,5 +44,6 @@ from keras.src.ops.nn import softmax
 from keras.src.ops.nn import softplus
 from keras.src.ops.nn import softsign
 from keras.src.ops.nn import sparse_categorical_crossentropy
+from keras.src.ops.nn import sparse_plus
 from keras.src.ops.nn import squareplus
 from keras.src.ops.nn import tanh_shrink

--- a/keras/src/activations/__init__.py
+++ b/keras/src/activations/__init__.py
@@ -23,6 +23,7 @@ from keras.src.activations.activations import soft_shrink
 from keras.src.activations.activations import softmax
 from keras.src.activations.activations import softplus
 from keras.src.activations.activations import softsign
+from keras.src.activations.activations import sparse_plus
 from keras.src.activations.activations import squareplus
 from keras.src.activations.activations import tanh
 from keras.src.activations.activations import tanh_shrink
@@ -42,6 +43,7 @@ ALL_OBJECTS = {
     softsign,
     squareplus,
     soft_shrink,
+    sparse_plus,
     silu,
     gelu,
     glu,

--- a/keras/src/activations/activations.py
+++ b/keras/src/activations/activations.py
@@ -277,6 +277,23 @@ def soft_shrink(x, threshold=0.5):
     return ops.soft_shrink(x, threshold=threshold)
 
 
+@keras_export("keras.activations.sparse_plus")
+def sparse_plus(x):
+    """SparsePlus activation function.
+
+    SparsePlus is defined as:
+
+    `sparse_plus(x) = 0` for `x <= -1`.
+    `sparse_plus(x) = (1/4) * (x + 1)^2` for `-1 < x < 1`.
+    `sparse_plus(x) = x` for `x >= 1`.
+
+    Args:
+        x: Input tensor.
+
+    """
+    return ops.sparse_plus(x)
+
+
 @keras_export(["keras.activations.silu", "keras.activations.swish"])
 def silu(x):
     """Swish (or Silu) activation function.

--- a/keras/src/activations/activations_test.py
+++ b/keras/src/activations/activations_test.py
@@ -706,6 +706,19 @@ class ActivationsTest(testing.TestCase):
         expected = soft_shrink(x)
         self.assertAllClose(result, expected, rtol=1e-05)
 
+    def test_sparse_plus(self):
+        def sparse_plus(x):
+            return np.where(
+                x <= -1,
+                np.zeros_like(x),
+                np.where(x < 1, (1 / 4) * (x + 1) ** 2, x),
+            )
+
+        x = np.random.random((2, 5))
+        result = activations.sparse_plus(x[np.newaxis, :])[0]
+        expected = sparse_plus(x)
+        self.assertAllClose(result, expected, rtol=1e-05)
+
     def test_elu(self):
         x = np.random.random((2, 5))
         result = activations.elu(x[np.newaxis, :])[0]

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -62,6 +62,11 @@ def soft_shrink(x, threshold=0.5):
     )
 
 
+def sparse_plus(x):
+    x = convert_to_tensor(x)
+    return jnn.sparse_plus(x)
+
+
 def silu(x):
     x = convert_to_tensor(x)
     return jnn.silu(x)

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -62,6 +62,12 @@ def soft_shrink(x, threshold=0.5):
     )
 
 
+def sparse_plus(x):
+    return np.where(
+        x <= -1, np.zeros_like(x), np.where(x < 1, (1 / 4) * (x + 1) ** 2, x)
+    )
+
+
 def silu(x):
     x = convert_to_tensor(x)
     return x * sigmoid(x)

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -50,6 +50,14 @@ def soft_shrink(x, threshold=0.5):
     )
 
 
+def sparse_plus(x):
+    return tf.where(
+        x <= -1,
+        tf.zeros_like(x),
+        tf.where(x < 1, (1 / 4) * tf.pow(x + 1, 2), x),
+    )
+
+
 def silu(x):
     return tf.nn.silu(x)
 

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -55,6 +55,14 @@ def soft_shrink(x, threshold=0.5):
     return tnn.softshrink(x, lambd=threshold)
 
 
+def sparse_plus(x):
+    return torch.where(
+        x <= -1,
+        torch.zeros_like(x),
+        torch.where(x < 1, (1 / 4) * (x + 1) ** 2, x),
+    )
+
+
 def silu(x):
     x = convert_to_tensor(x)
     return tnn.silu(x)

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -216,6 +216,44 @@ def soft_shrink(x, threshold=0.5):
     return backend.nn.soft_shrink(x, threshold)
 
 
+class SparsePlus(Operation):
+    def call(self, x):
+        return backend.nn.sparse_plus(x)
+
+    def compute_output_spec(self, x):
+        return KerasTensor(x.shape, dtype=x.dtype)
+
+
+@keras_export(["keras.ops.sparse_plus", "keras.ops.nn.sparse_plus"])
+def sparse_plus(x):
+    """SparsePlus activation function.
+
+    It is defined as
+
+    `f(x) = 0` for `x <= -1`.
+    `f(x) = (1/4) * (x + 1)^2` for `-1 < x < 1`.
+    `f(x) = x` for `x >= 1`.
+
+
+    Args:
+        x: Input tensor.
+
+    Returns:
+        A tensor with the same shape as `x`.
+
+    Example:
+
+    >>> x = np.array([-1.0, 0.0, 1.0])
+    >>> x_sparse_plus = keras.ops.sparse_plus(x)
+    >>> print(x_sparse_plus)
+    Array([0.   0.25 1.  ], shape=(3,), dtype=float32)
+
+    """
+    if any_symbolic_tensors((x,)):
+        return SparsePlus().symbolic_call(x)
+    return backend.nn.sparse_plus(x)
+
+
 class Silu(Operation):
     def call(self, x):
         return backend.nn.silu(x)

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -168,6 +168,10 @@ class NNOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.soft_shrink(x).shape, (None, 2, 3))
 
+    def test_sparse_plus(self):
+        x = KerasTensor([None, 2, 3])
+        self.assertEqual(knn.sparse_plus(x).shape, (None, 2, 3))
+
     def test_softmax(self):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.softmax(x).shape, (None, 2, 3))
@@ -841,6 +845,10 @@ class NNOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.soft_shrink(x).shape, (1, 2, 3))
 
+    def test_sparse_plus(self):
+        x = KerasTensor([1, 2, 3])
+        self.assertEqual(knn.sparse_plus(x).shape, (1, 2, 3))
+
     def test_softmax(self):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.softmax(x).shape, (1, 2, 3))
@@ -1394,6 +1402,13 @@ class NNOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(
             knn.soft_shrink(x),
             [0.0, 0.0, 0.5, 1.5, 2.5],
+        )
+
+    def test_sparse_plus(self):
+        x = np.array([-0.5, 0, 1, 2, 3], dtype=np.float32)
+        self.assertAllClose(
+            knn.sparse_plus(x),
+            [0.0625, 0.25, 1.0, 2.0, 3.0],
         )
 
     def test_softmax(self):
@@ -2569,6 +2584,24 @@ class NNOpsDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knn.SoftShrink().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_sparse_plus(self, dtype):
+        import jax.nn as jnn
+        import jax.numpy as jnp
+
+        x = knp.ones((), dtype=dtype)
+        x_jax = jnp.ones((), dtype=dtype)
+        expected_dtype = standardize_dtype(jnn.sparse_plus(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knn.sparse_plus(x).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(knn.SparsePlus().symbolic_call(x).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
Since Keras lacks built-in support for the sparse_plus activation function, I implemented it across TensorFlow, PyTorch, and NumPy, aiming to maintain consistency with existing implementations available in Jax.