### PR TITLE
Add threshold activation

### DIFF
--- a/keras/api/_tf_keras/keras/activations/__init__.py
+++ b/keras/api/_tf_keras/keras/activations/__init__.py
@@ -36,3 +36,4 @@ from keras.src.activations.activations import sparse_plus
 from keras.src.activations.activations import squareplus
 from keras.src.activations.activations import tanh
 from keras.src.activations.activations import tanh_shrink
+from keras.src.activations.activations import threshold

--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -102,6 +102,7 @@ from keras.src.ops.nn import sparse_categorical_crossentropy
 from keras.src.ops.nn import sparse_plus
 from keras.src.ops.nn import squareplus
 from keras.src.ops.nn import tanh_shrink
+from keras.src.ops.nn import threshold
 from keras.src.ops.numpy import abs
 from keras.src.ops.numpy import absolute
 from keras.src.ops.numpy import add

--- a/keras/api/_tf_keras/keras/ops/nn/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/nn/__init__.py
@@ -47,3 +47,4 @@ from keras.src.ops.nn import sparse_categorical_crossentropy
 from keras.src.ops.nn import sparse_plus
 from keras.src.ops.nn import squareplus
 from keras.src.ops.nn import tanh_shrink
+from keras.src.ops.nn import threshold

--- a/keras/api/activations/__init__.py
+++ b/keras/api/activations/__init__.py
@@ -36,3 +36,4 @@ from keras.src.activations.activations import sparse_plus
 from keras.src.activations.activations import squareplus
 from keras.src.activations.activations import tanh
 from keras.src.activations.activations import tanh_shrink
+from keras.src.activations.activations import threshold

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -102,6 +102,7 @@ from keras.src.ops.nn import sparse_categorical_crossentropy
 from keras.src.ops.nn import sparse_plus
 from keras.src.ops.nn import squareplus
 from keras.src.ops.nn import tanh_shrink
+from keras.src.ops.nn import threshold
 from keras.src.ops.numpy import abs
 from keras.src.ops.numpy import absolute
 from keras.src.ops.numpy import add

--- a/keras/api/ops/nn/__init__.py
+++ b/keras/api/ops/nn/__init__.py
@@ -47,3 +47,4 @@ from keras.src.ops.nn import sparse_categorical_crossentropy
 from keras.src.ops.nn import sparse_plus
 from keras.src.ops.nn import squareplus
 from keras.src.ops.nn import tanh_shrink
+from keras.src.ops.nn import threshold

--- a/keras/src/activations/__init__.py
+++ b/keras/src/activations/__init__.py
@@ -27,6 +27,7 @@ from keras.src.activations.activations import sparse_plus
 from keras.src.activations.activations import squareplus
 from keras.src.activations.activations import tanh
 from keras.src.activations.activations import tanh_shrink
+from keras.src.activations.activations import threshold
 from keras.src.api_export import keras_export
 from keras.src.saving import object_registration
 from keras.src.saving import serialization_lib
@@ -49,6 +50,7 @@ ALL_OBJECTS = {
     glu,
     tanh,
     tanh_shrink,
+    threshold,
     sigmoid,
     exponential,
     hard_sigmoid,

--- a/keras/src/activations/activations.py
+++ b/keras/src/activations/activations.py
@@ -460,6 +460,24 @@ def hard_shrink(x, threshold=0.5):
     return ops.hard_shrink(x, threshold=threshold)
 
 
+@keras_export("keras.activations.threshold")
+def threshold(x, threshold_value, value):
+    """Threshold activation function.
+
+    It is defined as:
+
+    `threshold(x) = x` if `x > threshold_value`,
+    `threshold(x) = value` otherwise.
+
+    Args:
+        x: Input tensor.
+        threshold_value: The value that decides when to retain or replace x.
+        value: Value to assign when `x <= threshold_value`.
+
+    """
+    return ops.threshold(x, threshold_value, value)
+
+
 @keras_export("keras.activations.sigmoid")
 def sigmoid(x):
     """Sigmoid activation function.

--- a/keras/src/activations/activations.py
+++ b/keras/src/activations/activations.py
@@ -461,21 +461,21 @@ def hard_shrink(x, threshold=0.5):
 
 
 @keras_export("keras.activations.threshold")
-def threshold(x, threshold_value, value):
+def threshold(x, threshold, default_value):
     """Threshold activation function.
 
     It is defined as:
 
-    `threshold(x) = x` if `x > threshold_value`,
-    `threshold(x) = value` otherwise.
+    `threshold(x) = x` if `x > threshold`,
+    `threshold(x) = default_value` otherwise.
 
     Args:
         x: Input tensor.
-        threshold_value: The value that decides when to retain or replace x.
-        value: Value to assign when `x <= threshold_value`.
+        threshold: The value that decides when to retain or replace x.
+        default_value: Value to assign when `x <= threshold`.
 
     """
-    return ops.threshold(x, threshold_value, value)
+    return ops.threshold(x, threshold, default_value)
 
 
 @keras_export("keras.activations.sigmoid")

--- a/keras/src/activations/activations_test.py
+++ b/keras/src/activations/activations_test.py
@@ -683,6 +683,17 @@ class ActivationsTest(testing.TestCase):
         expected = hard_shrink(x)
         self.assertAllClose(result, expected, rtol=1e-05)
 
+    def test_threshold(self):
+        def threshold(x, threshold_value, value):
+            return np.where(
+                x > threshold_value, x, np.array(value, dtype=x.dtype)
+            )
+
+        x = np.random.random((2, 5))
+        result = activations.threshold(x[np.newaxis, :], 0, 0)[0]
+        expected = threshold(x, 0, 0)
+        self.assertAllClose(result, expected, rtol=1e-05)
+
     def test_squareplus(self):
         def squareplus(x, b=4):
             y = x + np.sqrt(x**2 + b)

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -132,9 +132,9 @@ def hard_shrink(x, threshold=0.5):
     return jnp.where(jnp.abs(x) > threshold, x, 0.0)
 
 
-def threshold(x, threshold_value, value):
+def threshold(x, threshold, default_value):
     x = convert_to_tensor(x)
-    return jnp.where(x > threshold_value, x, value)
+    return jnp.where(x > threshold, x, default_value)
 
 
 def softmax(x, axis=-1):

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -132,6 +132,11 @@ def hard_shrink(x, threshold=0.5):
     return jnp.where(jnp.abs(x) > threshold, x, 0.0)
 
 
+def threshold(x, threshold_value, value):
+    x = convert_to_tensor(x)
+    return jnp.where(x > threshold_value, x, value)
+
+
 def softmax(x, axis=-1):
     x = convert_to_tensor(x)
     return jnn.softmax(x, axis=axis)

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -182,7 +182,7 @@ def hard_shrink(x, threshold=0.5):
 
 def threshold(x, threshold_value, value):
     x = convert_to_tensor(x)
-    return np.where(x > threshold_value, x, value)
+    return np.where(x > threshold_value, x, np.array(value, dtype=x.dtype))
 
 
 def softmax(x, axis=None):

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -180,6 +180,11 @@ def hard_shrink(x, threshold=0.5):
     )
 
 
+def threshold(x, threshold_value, value):
+    x = convert_to_tensor(x)
+    return np.where(x > threshold_value, x, value)
+
+
 def softmax(x, axis=None):
     exp_x = np.exp(x - np.max(x, axis=axis, keepdims=True))
     return exp_x / np.sum(exp_x, axis=axis, keepdims=True)

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -180,9 +180,9 @@ def hard_shrink(x, threshold=0.5):
     )
 
 
-def threshold(x, threshold_value, value):
+def threshold(x, threshold, default_value):
     x = convert_to_tensor(x)
-    return np.where(x > threshold_value, x, np.array(value, dtype=x.dtype))
+    return np.where(x > threshold, x, np.array(default_value, dtype=x.dtype))
 
 
 def softmax(x, axis=None):

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -127,8 +127,8 @@ def hard_shrink(x, threshold=0.5):
     return tf.where(tf.abs(x) > threshold, x, tf.zeros_like(x))
 
 
-def threshold(x, threshold_value, value):
-    return tf.where(x > threshold_value, x, value)
+def threshold(x, threshold, default_value):
+    return tf.where(x > threshold, x, default_value)
 
 
 def softmax(x, axis=-1):

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -127,6 +127,10 @@ def hard_shrink(x, threshold=0.5):
     return tf.where(tf.abs(x) > threshold, x, tf.zeros_like(x))
 
 
+def threshold(x, threshold_value, value):
+    return tf.where(x > threshold_value, x, value)
+
+
 def softmax(x, axis=-1):
     logits = x
     if axis is None:

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -134,9 +134,9 @@ def hard_shrink(x, threshold=0.5):
     return tnn.hardshrink(x, lambd=threshold)
 
 
-def threshold(x, threshold_value, value):
+def threshold(x, threshold, default_value):
     x = convert_to_tensor(x)
-    return tnn.threshold(x, threshold=threshold_value, value=value)
+    return tnn.threshold(x, threshold=threshold, value=default_value)
 
 
 def softmax(x, axis=-1):

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -134,6 +134,11 @@ def hard_shrink(x, threshold=0.5):
     return tnn.hardshrink(x, lambd=threshold)
 
 
+def threshold(x, threshold_value, value):
+    x = convert_to_tensor(x)
+    return tnn.threshold(x, threshold=threshold_value, value=value)
+
+
 def softmax(x, axis=-1):
     x = convert_to_tensor(x)
     dtype = backend.standardize_dtype(x.dtype)

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -818,6 +818,48 @@ def hard_shrink(x, threshold=0.5):
     return backend.nn.hard_shrink(x, threshold)
 
 
+class Threshold(Operation):
+    def __init__(self, threshold_value, value):
+        super().__init__()
+        self.threshold_value = threshold_value
+        self.value = value
+
+    def call(self, x):
+        return backend.nn.threshold(x, self.threshold_value, self.value)
+
+    def compute_output_spec(self, x):
+        return KerasTensor(x.shape, dtype=x.dtype)
+
+
+@keras_export(["keras.ops.threshold", "keras.ops.nn.threshold"])
+def threshold(x, threshold_value, value):
+    """Threshold activation function.
+
+    The function thresholds the input `x` as follows:
+    `f(x) = x` if `x > threshold_value`,
+    `f(x) = value` otherwise.
+
+    Args:
+        x: Input tensor.
+        threshold_value: The value that decides when to retain or replace x.
+        value: Value to assign when `x <= threshold_value`.
+
+    Returns:
+        A tensor with the same shape as `x`.
+
+    Example:
+
+    >>> x = np.array([-1.0, 0.0, 1.0, 2.0])
+    >>> x_threshold = keras.ops.threshold(x, 1, 0)
+    >>> print(x_threshold)
+    array([0., 0., 0., 2.], shape=(4,), dtype=float64)
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Threshold(threshold_value, value).symbolic_call(x)
+    return backend.nn.threshold(x, threshold_value, value)
+
+
 class Softmax(Operation):
     def __init__(self, axis=-1):
         super().__init__()

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -832,17 +832,17 @@ class Threshold(Operation):
 
 
 @keras_export(["keras.ops.threshold", "keras.ops.nn.threshold"])
-def threshold(x, threshold_value, value):
+def threshold(x, threshold, default_value):
     """Threshold activation function.
 
     The function thresholds the input `x` as follows:
-    `f(x) = x` if `x > threshold_value`,
-    `f(x) = value` otherwise.
+    `f(x) = x` if `x > threshold`,
+    `f(x) = default_value` otherwise.
 
     Args:
         x: Input tensor.
-        threshold_value: The value that decides when to retain or replace x.
-        value: Value to assign when `x <= threshold_value`.
+        threshold: The value that decides when to retain or replace x.
+        default_value: Value to assign when `x <= threshold`.
 
     Returns:
         A tensor with the same shape as `x`.
@@ -856,8 +856,8 @@ def threshold(x, threshold_value, value):
 
     """
     if any_symbolic_tensors((x,)):
-        return Threshold(threshold_value, value).symbolic_call(x)
-    return backend.nn.threshold(x, threshold_value, value)
+        return Threshold(threshold, default_value).symbolic_call(x)
+    return backend.nn.threshold(x, threshold, default_value)
 
 
 class Softmax(Operation):

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -160,6 +160,10 @@ class NNOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.hard_shrink(x).shape, (None, 2, 3))
 
+    def test_threshld(self):
+        x = KerasTensor([None, 2, 3])
+        self.assertEqual(knn.threshold(x, 0, 0).shape, (None, 2, 3))
+
     def test_squareplus(self):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.squareplus(x).shape, (None, 2, 3))
@@ -837,6 +841,10 @@ class NNOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.hard_shrink(x).shape, (1, 2, 3))
 
+    def test_threshold(self):
+        x = KerasTensor([1, 2, 3])
+        self.assertEqual(knn.threshold(x, 0, 0).shape, (1, 2, 3))
+
     def test_squareplus(self):
         x = KerasTensor([1, 2, 3])
         self.assertEqual(knn.squareplus(x).shape, (1, 2, 3))
@@ -1387,6 +1395,13 @@ class NNOpsCorrectnessTest(testing.TestCase):
         x = np.array([-0.5, 0, 1, 2, 3], dtype=np.float32)
         self.assertAllClose(
             knn.hard_shrink(x),
+            [0.0, 0.0, 1.0, 2.0, 3.0],
+        )
+
+    def test_threshold(self):
+        x = np.array([-0.5, 0, 1, 2, 3], dtype=np.float32)
+        self.assertAllClose(
+            knn.threshold(x, 0, 0),
             [0.0, 0.0, 1.0, 2.0, 3.0],
         )
 
@@ -2566,6 +2581,24 @@ class NNOpsDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knn.HardShrink().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_threshold(self, dtype):
+        import torch
+        import torch.nn.functional as tnn
+
+        x = knp.ones((1), dtype=dtype)
+        x_torch = torch.ones(1, dtype=getattr(torch, dtype))
+        expected_dtype = standardize_dtype(tnn.threshold(x_torch, 0, 0).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knn.threshold(x, 0, 0).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(knn.Threshold(0, 0).symbolic_call(x).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
Since Keras does not include built-in support for the threshold activation function, I implemented it using TensorFlow, JAX, and NumPy to ensure consistency with the implementation available in PyTorch. 
If adding this activation to Keras is acceptable, I am prepared to contribute further by modifying ops.py, activations.py, and adding corresponding test cases.