### PR TITLE
Better handling of variable creation with tensor as initializer.

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -115,7 +115,6 @@ class Variable:
             self._path = current_path() + "/" + name
         else:
             self._path = name
-        self._dtype = standardize_dtype(dtype)
         self._shape = None
         self._initializer = None
         self._regularizer = None
@@ -139,6 +138,12 @@ class Variable:
                     f"Received: initializer={initializer} "
                     f"and shape={shape}"
                 )
+        else:
+            initializer = self._convert_to_tensor(initializer, dtype=dtype)
+            # If dtype is None and `initializer` is an array, use its dtype.
+            if dtype is None:
+                dtype = initializer.dtype
+        self._dtype = standardize_dtype(dtype)
 
         if in_stateless_scope():
             if callable(initializer):

--- a/keras/src/backend/common/variables_test.py
+++ b/keras/src/backend/common/variables_test.py
@@ -6,6 +6,7 @@ from absl.testing import parameterized
 
 from keras.src import backend
 from keras.src import initializers
+from keras.src import ops
 from keras.src.backend.common import dtypes
 from keras.src.backend.common.variables import AutocastScope
 from keras.src.backend.common.variables import shape_equal
@@ -33,10 +34,32 @@ class VariableInitializationTest(test_case.TestCase):
             with backend.StatelessScope():
                 v = backend.Variable(initializer=0)
 
-    def test_variable_initialization_with_non_callable(self):
-        """Test variable init with non-callable initializer."""
-        v = backend.Variable(initializer=np.ones((2, 2)))
+    def test_variable_initialization_with_numpy_array(self):
+        """Test variable init with numpy array initializer."""
+        v = backend.Variable(
+            initializer=np.ones((2, 2), dtype=np.int32), trainable=False
+        )
         self.assertAllClose(v.value, np.ones((2, 2)))
+        self.assertEqual(v.dtype, "int32")
+
+    def test_variable_initialization_with_native_array(self):
+        """Test variable init with native array initializer."""
+        v = backend.Variable(
+            initializer=ops.ones((2, 2), dtype="int32"), trainable=False
+        )
+        self.assertAllClose(v.value, np.ones((2, 2)))
+        self.assertEqual(v.dtype, "int32")
+
+    def test_variable_initialization_with_python_array(self):
+        """Test variable init with python array initializer."""
+        v = backend.Variable(initializer=[[1, 1], [1, 1]], trainable=False)
+        self.assertAllClose(v.value, np.ones((2, 2)))
+        self.assertEqual(v.dtype, "int32")
+        v = backend.Variable(
+            initializer=[[1.0, 1.0], [1.0, 1.0]], trainable=False
+        )
+        self.assertAllClose(v.value, np.ones((2, 2)))
+        self.assertEqual(v.dtype, "float32")
 
     def test_variable_initialization_with_strings(self):
         """Test variable init with non-callable initializer."""
@@ -66,8 +89,8 @@ class VariableInitializationTest(test_case.TestCase):
 
     def test_variable_initialize(self):
         """Test initializing a variable."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-        init_value = np.array([4, 5, 6])
+        v = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        init_value = np.array([4.0, 5.0, 6.0])
         v._initialize(value=init_value)
         self.assertAllClose(v.value, init_value)
 
@@ -276,9 +299,9 @@ class VariableNumpyValueAndAssignmentTest(test_case.TestCase):
 
     def test_variable_numpy(self):
         """Test retrieving the value of a variable as a numpy array."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
         self.assertIsInstance(v.numpy(), np.ndarray)
-        self.assertAllClose(v.numpy(), np.array([1, 2, 3]))
+        self.assertAllClose(v.numpy(), np.array([1.0, 2.0, 3.0]))
 
     @pytest.mark.skipif(
         backend.backend() != "tensorflow",
@@ -297,44 +320,44 @@ class VariableNumpyValueAndAssignmentTest(test_case.TestCase):
 
     def test_variable_value(self):
         """Test retrieving the value of a variable."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-        self.assertAllClose(v.value, np.array([1, 2, 3]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        self.assertAllClose(v.value, np.array([1.0, 2.0, 3.0]))
 
     def test_variable_assign(self):
         """Test assigning a new value to a variable."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-        v.assign(np.array([4, 5, 6]))
-        self.assertAllClose(v.value, np.array([4, 5, 6]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v.assign(np.array([4.0, 5.0, 6.0]))
+        self.assertAllClose(v.value, np.array([4.0, 5.0, 6.0]))
 
     def test_variable_assign_return(self):
         """Test assigning a new value and returning."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-        r = v.assign(np.array([4, 5, 6]))
-        self.assertAllClose(r, np.array([4, 5, 6]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        r = v.assign(np.array([4.0, 5.0, 6.0]))
+        self.assertAllClose(r, np.array([4.0, 5.0, 6.0]))
 
     def test_variable_assign_add(self):
         """Test the assign_add method on a variable."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-        v.assign_add(np.array([1, 1, 1]))
-        self.assertAllClose(v.value, np.array([2, 3, 4]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v.assign_add(np.array([1.0, 1.0, 1.0]))
+        self.assertAllClose(v.value, np.array([2.0, 3.0, 4.0]))
 
     def test_variable_assign_add_return(self):
         """Test assign_add a new value and returning."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-        r = v.assign_add(np.array([1, 1, 1]))
-        self.assertAllClose(r, np.array([2, 3, 4]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        r = v.assign_add(np.array([1.0, 1.0, 1.0]))
+        self.assertAllClose(r, np.array([2.0, 3.0, 4.0]))
 
     def test_variable_assign_sub(self):
         """Test the assign_sub method on a variable."""
-        v = backend.Variable(initializer=np.array([2, 3, 4]))
-        v.assign_sub(np.array([1, 1, 1]))
-        self.assertAllClose(v.value, np.array([1, 2, 3]))
+        v = backend.Variable(initializer=np.array([2.0, 3.0, 4.0]))
+        v.assign_sub(np.array([1.0, 1.0, 1.0]))
+        self.assertAllClose(v.value, np.array([1.0, 2.0, 3.0]))
 
     def test_variable_assign_sub_return(self):
         """Test assign_sub a new value and returning."""
-        v = backend.Variable(initializer=np.array([2, 3, 4]))
-        r = v.assign_sub(np.array([1, 1, 1]))
-        self.assertAllClose(r, np.array([1, 2, 3]))
+        v = backend.Variable(initializer=np.array([2.0, 3.0, 4.0]))
+        r = v.assign_sub(np.array([1.0, 1.0, 1.0]))
+        self.assertAllClose(r, np.array([1.0, 2.0, 3.0]))
 
     def test_deferred_initialize_within_stateless_scope(self):
         """Test deferred init within a stateless scope."""
@@ -355,22 +378,27 @@ class VariableDtypeShapeNdimRepr(test_case.TestCase):
 
     def test_variable_dtype(self):
         """Test retrieving the dtype of a variable."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
+        v = backend.Variable(
+            initializer=np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        )
         self.assertEqual(v.dtype, "float32")
 
     def test_variable_shape(self):
         """Test retrieving the shape of a variable."""
-        v = backend.Variable(initializer=np.array([[1, 2], [3, 4]]))
+        v = backend.Variable(initializer=np.array([[1.0, 2.0], [3.0, 4.0]]))
         self.assertEqual(v.shape, (2, 2))
 
     def test_variable_ndim(self):
         """Test retrieving the number of dimensions of a variable."""
-        v = backend.Variable(initializer=np.array([[1, 2], [3, 4]]))
+        v = backend.Variable(initializer=np.array([[1.0, 2.0], [3.0, 4.0]]))
         self.assertEqual(v.ndim, 2)
 
     def test_variable_repr(self):
         """Test the string representation of a variable."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]), name="test_var")
+        v = backend.Variable(
+            initializer=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            name="test_var",
+        )
         expected_repr = (
             "<Variable path=test_var, shape=(3,), dtype=float32, "
             "value=[1. 2. 3.]>"
@@ -389,32 +417,35 @@ class VariableDtypeShapeNdimRepr(test_case.TestCase):
 
     def test_variable_getitem(self):
         """Test getting an item from a variable."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
         self.assertEqual(v[0], 1)
 
     def test_variable_initialize(self):
         """Test initializing a variable."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-        init_value = np.array([4, 5, 6])
+        v = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        init_value = np.array([4.0, 5.0, 6.0])
         v._initialize(value=init_value)
         self.assertAllClose(v.value, init_value)
 
     def test_variable_convert_to_tensor(self):
         """Test converting a variable to a tensor."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-        self.assertAllClose(v._convert_to_tensor(v.value), np.array([1, 2, 3]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        self.assertAllClose(
+            v._convert_to_tensor(v.value), np.array([1.0, 2.0, 3.0])
+        )
 
     def test_variable_convert_to_tensor_with_dtype(self):
         """Test converting a variable to a tensor with a dtype."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
         self.assertAllClose(
-            v._convert_to_tensor(v.value, dtype="float32"), np.array([1, 2, 3])
+            v._convert_to_tensor(v.value, dtype="float32"),
+            np.array([1.0, 2.0, 3.0]),
         )
 
     def test_variable_array(self):
         """Test converting a variable to an array."""
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-        self.assertAllClose(v.__array__(), np.array([1, 2, 3]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        self.assertAllClose(v.__array__(), np.array([1.0, 2.0, 3.0]))
 
 
 class VariableOpsCorrectnessTest(test_case.TestCase):
@@ -430,13 +461,13 @@ class VariableOpsCorrectnessTest(test_case.TestCase):
 
     def test__neg__(self):
         """Test negating a variable."""
-        v = backend.Variable(initializer=np.array([-1, 2]), trainable=False)
-        self.assertAllClose(v.__neg__(), np.array([1, -2]))
+        v = backend.Variable(initializer=np.array([-1.0, 2.0]), trainable=False)
+        self.assertAllClose(v.__neg__(), np.array([1.0, -2.0]))
 
     def test__abs__(self):
         """Test absolute value on a variable."""
-        v = backend.Variable(initializer=np.array([-1, 2]), trainable=False)
-        self.assertAllClose(v.__abs__(), np.array([1, 2]))
+        v = backend.Variable(initializer=np.array([-1.0, 2.0]), trainable=False)
+        self.assertAllClose(v.__abs__(), np.array([1.0, 2.0]))
 
     def test__invert__(self):
         """Test bitwise not on a variable."""
@@ -447,135 +478,145 @@ class VariableOpsCorrectnessTest(test_case.TestCase):
 
     def test__eq__(self):
         """Test equality comparison on a variable."""
-        v = backend.Variable(initializer=np.array([1, 2]), trainable=False)
-        self.assertAllClose(v.__eq__(np.array([1, 2])), np.array([True, True]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0]), trainable=False)
+        self.assertAllClose(
+            v.__eq__(np.array([1.0, 2.0])), np.array([True, True])
+        )
 
     def test__ne__(self):
         """Test inequality comparison on a variable."""
-        v = backend.Variable(initializer=np.array([1, 2]), trainable=False)
+        v = backend.Variable(initializer=np.array([1.0, 2.0]), trainable=False)
         self.assertAllClose(
-            v.__ne__(np.array([1, 2])), np.array([False, False])
+            v.__ne__(np.array([1.0, 2.0])), np.array([False, False])
         )
 
     def test__lt__(self):
         """Test less than comparison on a variable."""
-        v = backend.Variable(initializer=np.array([1, 2]), trainable=False)
+        v = backend.Variable(initializer=np.array([1.0, 2.0]), trainable=False)
         self.assertAllClose(
-            v.__lt__(np.array([1, 2])), np.array([False, False])
+            v.__lt__(np.array([1.0, 2.0])), np.array([False, False])
         )
 
     def test__le__(self):
         """Test less than or equal to comparison on a variable."""
-        v = backend.Variable(initializer=np.array([1, 2]), trainable=False)
-        self.assertAllClose(v.__le__(np.array([1, 2])), np.array([True, True]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0]), trainable=False)
+        self.assertAllClose(
+            v.__le__(np.array([1.0, 2.0])), np.array([True, True])
+        )
 
     def test__gt__(self):
         """Test greater than comparison on a variable."""
-        v = backend.Variable(initializer=np.array([1, 2]), trainable=False)
+        v = backend.Variable(initializer=np.array([1.0, 2.0]), trainable=False)
         self.assertAllClose(
-            v.__gt__(np.array([1, 2])), np.array([False, False])
+            v.__gt__(np.array([1.0, 2.0])), np.array([False, False])
         )
 
     def test__ge__(self):
         """Test greater than or equal to comparison on a variable."""
-        v = backend.Variable(initializer=np.array([1, 2]), trainable=False)
-        self.assertAllClose(v.__ge__(np.array([1, 2])), np.array([True, True]))
+        v = backend.Variable(initializer=np.array([1.0, 2.0]), trainable=False)
+        self.assertAllClose(
+            v.__ge__(np.array([1.0, 2.0])), np.array([True, True])
+        )
 
     def test__add__(self):
         """Test addition operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([4, 5, 6]))
-        self.assertAllClose(v1.__add__(v2), np.array([5, 7, 9]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([4.0, 5.0, 6.0]))
+        self.assertAllClose(v1.__add__(v2), np.array([5.0, 7.0, 9.0]))
 
     def test__radd__(self):
         """Test reverse addition operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([4, 5, 6]))
-        self.assertAllClose(v1.__radd__(v2), np.array([5, 7, 9]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([4.0, 5.0, 6.0]))
+        self.assertAllClose(v1.__radd__(v2), np.array([5.0, 7.0, 9.0]))
 
     def test__sub__(self):
         """Test subtraction operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([4, 5, 6]))
-        self.assertAllClose(v1.__sub__(v2), np.array([-3, -3, -3]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([4.0, 5.0, 6.0]))
+        self.assertAllClose(v1.__sub__(v2), np.array([-3.0, -3.0, -3.0]))
 
     def test__rsub__(self):
         """Test reverse subtraction operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([4, 5, 6]))
-        v2 = backend.Variable(initializer=np.array([1, 2, 3]))
-        self.assertAllClose(v1.__rsub__(v2), np.array([-3, -3, -3]))
+        v1 = backend.Variable(initializer=np.array([4.0, 5.0, 6.0]))
+        v2 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        self.assertAllClose(v1.__rsub__(v2), np.array([-3.0, -3.0, -3.0]))
 
     def test__mul__(self):
         """Test multiplication operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([4, 5, 6]))
-        self.assertAllClose(v1.__mul__(v2), np.array([4, 10, 18]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([4.0, 5.0, 6.0]))
+        self.assertAllClose(v1.__mul__(v2), np.array([4.0, 10.0, 18.0]))
 
     def test__rmul__(self):
         """Test reverse multiplication operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([4, 5, 6]))
-        self.assertAllClose(v1.__rmul__(v2), np.array([4, 10, 18]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([4.0, 5.0, 6.0]))
+        self.assertAllClose(v1.__rmul__(v2), np.array([4.0, 10.0, 18.0]))
 
     def test__truediv__(self):
         """Test true division operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([4, 5, 6]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([4.0, 5.0, 6.0]))
         self.assertAllClose(v1.__truediv__(v2), np.array([0.25, 0.4, 0.5]))
 
     def test__rtruediv__(self):
         """Test reverse true division operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([4, 5, 6]))
-        v2 = backend.Variable(initializer=np.array([1, 2, 3]))
+        v1 = backend.Variable(initializer=np.array([4.0, 5.0, 6.0]))
+        v2 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
         self.assertAllClose(v1.__rtruediv__(v2), np.array([0.25, 0.4, 0.5]))
 
     def test__floordiv__(self):
         """Test floordiv operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([-4, 5, 6]))
-        self.assertAllClose(v1.__floordiv__(v2), np.array([-1, 0, 0]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([-4.0, 5.0, 6.0]))
+        self.assertAllClose(v1.__floordiv__(v2), np.array([-1.0, 0.0, 0.0]))
 
     def test__rfloordiv__(self):
         """Test reverse floordiv operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([-4, 5, 6]))
-        v2 = backend.Variable(initializer=np.array([1, 2, 3]))
-        self.assertAllClose(v1.__rfloordiv__(v2), np.array([-1, 0, 0]))
+        v1 = backend.Variable(initializer=np.array([-4.0, 5.0, 6.0]))
+        v2 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        self.assertAllClose(v1.__rfloordiv__(v2), np.array([-1.0, 0.0, 0.0]))
 
     def test__mod__(self):
         """Test mod operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([-4, 5, 6]))
-        self.assertAllClose(v1.__mod__(v2), np.array([-3, 2, 3]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([-4.0, 5.0, 6.0]))
+        self.assertAllClose(v1.__mod__(v2), np.array([-3.0, 2.0, 3.0]))
 
     def test__rmod__(self):
         """Test reverse mod operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([1, 2, 3]))
-        self.assertAllClose(v1.__rmod__(v2), np.array([0, 0, 0]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        self.assertAllClose(v1.__rmod__(v2), np.array([0.0, 0.0, 0.0]))
 
     def test__pow__(self):
         """Test pow operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([-4, 5, 6]))
-        self.assertAllClose(v1.__pow__(v2), np.array([1, 32, 729]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([-4.0, 5.0, 6.0]))
+        self.assertAllClose(v1.__pow__(v2), np.array([1.0, 32.0, 729.0]))
 
     def test__rpow__(self):
         """Test reverse power operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([1, 2, 3]))
-        self.assertAllClose(v1.__rpow__(v2), np.array([1, 4, 27]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        self.assertAllClose(v1.__rpow__(v2), np.array([1.0, 4.0, 27.0]))
 
     def test__matmul__(self):
         """Test matmul operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([[1, 2], [3, 4]]))
-        v2 = backend.Variable(initializer=np.array([[5, 6], [7, 8]]))
-        self.assertAllClose(v1.__matmul__(v2), np.array([[19, 22], [43, 50]]))
+        v1 = backend.Variable(initializer=np.array([[1.0, 2.0], [3.0, 4.0]]))
+        v2 = backend.Variable(initializer=np.array([[5.0, 6.0], [7.0, 8.0]]))
+        self.assertAllClose(
+            v1.__matmul__(v2), np.array([[19.0, 22.0], [43.0, 50.0]])
+        )
 
     def test__rmatmul__(self):
         """Test reverse matmul operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([[1, 2], [3, 4]]))
-        v2 = backend.Variable(initializer=np.array([[5, 6], [7, 8]]))
-        self.assertAllClose(v1.__rmatmul__(v2), np.array([[23, 34], [31, 46]]))
+        v1 = backend.Variable(initializer=np.array([[1.0, 2.0], [3.0, 4.0]]))
+        v2 = backend.Variable(initializer=np.array([[5.0, 6.0], [7.0, 8.0]]))
+        self.assertAllClose(
+            v1.__rmatmul__(v2), np.array([[23.0, 34.0], [31.0, 46.0]])
+        )
 
     def test__and__(self):
         """Test bitwise and operation on a variable."""
@@ -639,26 +680,26 @@ class VariableOpsCorrectnessTest(test_case.TestCase):
 
     def test__pos__(self):
         """Test unary plus on a variable."""
-        v = backend.Variable(initializer=np.array([-1, 2]), trainable=False)
-        self.assertAllClose(v.__pos__(), np.array([-1, 2]))
+        v = backend.Variable(initializer=np.array([-1.0, 2.0]), trainable=False)
+        self.assertAllClose(v.__pos__(), np.array([-1.0, 2.0]))
 
     def test_variable_pow(self):
         """Test pow operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([4, 5, 6]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([4.0, 5.0, 6.0]))
         result = v1**v2
-        self.assertAllClose(result, np.array([1, 32, 729]))
+        self.assertAllClose(result, np.array([1.0, 32.0, 729.0]))
 
     def test_variable_rpow(self):
         """Test reverse power operation on a variable."""
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([4, 5, 6]))
+        v1 = backend.Variable(initializer=np.array([1.0, 2.0, 3.0]))
+        v2 = backend.Variable(initializer=np.array([4.0, 5.0, 6.0]))
         result = v2**v1
-        self.assertAllClose(result, np.array([4, 25, 216]))
+        self.assertAllClose(result, np.array([4.0, 25.0, 216.0]))
 
     def test_round(self):
         v = backend.Variable(initializer=np.array([1.1, 2.2, 3.3]))
-        self.assertAllClose(round(v), np.array([1, 2, 3]))
+        self.assertAllClose(round(v), np.array([1.0, 2.0, 3.0]))
 
 
 class VariableOpsBehaviorTest(test_case.TestCase):
@@ -731,8 +772,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.equal(x1_jax, x2_jax).dtype)
@@ -746,8 +787,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.not_equal(x1_jax, x2_jax).dtype)
@@ -761,8 +802,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.less(x1_jax, x2_jax).dtype)
@@ -776,8 +817,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.less_equal(x1_jax, x2_jax).dtype)
@@ -791,8 +832,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.greater(x1_jax, x2_jax).dtype)
@@ -806,8 +847,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(
@@ -823,8 +864,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.add(x1_jax, x2_jax).dtype)
@@ -839,8 +880,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.add(x1_jax, x2_jax).dtype)
@@ -855,8 +896,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.add(x1_jax, x2_jax).dtype)
@@ -876,8 +917,12 @@ class VariableOpsDTypeTest(test_case.TestCase):
         # the expected dtype from 64 bit to 32 bit when using jax backend.
         with jax.experimental.disable_x64():
             dtype1, dtype2 = dtypes
-            x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-            x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+            x1 = backend.Variable(
+                "ones", shape=(1,), dtype=dtype1, trainable=False
+            )
+            x2 = backend.Variable(
+                "ones", shape=(1,), dtype=dtype2, trainable=False
+            )
             x1_jax = jnp.ones((1,), dtype=dtype1)
             x2_jax = jnp.ones((1,), dtype=dtype2)
             expected_dtype = standardize_dtype(
@@ -898,8 +943,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(
@@ -916,8 +961,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.mod(x1_jax, x2_jax).dtype)
@@ -932,8 +977,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.power(x1_jax, x2_jax).dtype)
@@ -948,8 +993,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.matmul(x1_jax, x2_jax).dtype)
@@ -964,8 +1009,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(
@@ -982,8 +1027,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(jnp.logical_or(x1_jax, x2_jax).dtype)
@@ -998,8 +1043,8 @@ class VariableOpsDTypeTest(test_case.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
+        x1 = backend.Variable("ones", shape=(1,), dtype=dtype1, trainable=False)
+        x2 = backend.Variable("ones", shape=(1,), dtype=dtype2, trainable=False)
         x1_jax = jnp.ones((1,), dtype=dtype1)
         x2_jax = jnp.ones((1,), dtype=dtype2)
         expected_dtype = standardize_dtype(

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -19,7 +19,6 @@ IS_THREAD_SAFE = True
 
 class Variable(KerasVariable):
     def _initialize(self, value):
-        value = jnp.array(value, dtype=self._dtype)
         # Note that variable.shape is needed by distribution_lib
         self._shape = tuple(value.shape)
         # We can't import the keras/distribution/distribution_lib

--- a/keras/src/backend/numpy/core.py
+++ b/keras/src/backend/numpy/core.py
@@ -20,7 +20,7 @@ IS_THREAD_SAFE = True
 
 class Variable(KerasVariable):
     def _initialize(self, value):
-        self._value = np.array(value, dtype=self._dtype)
+        self._value = value
 
     def _direct_assign(self, value):
         self._value = np.array(value, dtype=self._dtype)

--- a/keras/src/regularizers/regularizers_test.py
+++ b/keras/src/regularizers/regularizers_test.py
@@ -21,19 +21,19 @@ class RegularizersTest(testing.TestCase):
         self.run_class_serialization_test(reg)
 
     def test_l1(self):
-        value = np.random.random((4, 4))
+        value = np.random.random((4, 4)).astype(np.float32)
         x = backend.Variable(value)
         y = regularizers.L1(0.1)(x)
         self.assertAllClose(y, 0.1 * np.sum(np.abs(value)))
 
     def test_l2(self):
-        value = np.random.random((4, 4))
+        value = np.random.random((4, 4)).astype(np.float32)
         x = backend.Variable(value)
         y = regularizers.L2(0.1)(x)
         self.assertAllClose(y, 0.1 * np.sum(np.square(value)))
 
     def test_l1_l2(self):
-        value = np.random.random((4, 4))
+        value = np.random.random((4, 4)).astype(np.float32)
         x = backend.Variable(value)
         y = regularizers.L1L2(l1=0.1, l2=0.2)(x)
         self.assertAllClose(
@@ -41,7 +41,7 @@ class RegularizersTest(testing.TestCase):
         )
 
     def test_orthogonal_regularizer(self):
-        value = np.random.random((4, 4))
+        value = np.random.random((4, 4)).astype(np.float32)
         x = backend.Variable(value)
         y = regularizers.OrthogonalRegularizer(factor=0.1, mode="rows")(x)
 
@@ -103,7 +103,7 @@ class RegularizersTest(testing.TestCase):
 
     def test_orthogonal_regularizer_input_rank_validation(self):
         with self.assertRaises(ValueError) as context:
-            value = np.random.random((4, 4, 4))
+            value = np.random.random((4, 4, 4)).astype(np.float32)
             x = backend.Variable(value)
             regularizers.OrthogonalRegularizer(factor=0.1)(x)
 

--- a/keras/src/utils/tracking_test.py
+++ b/keras/src/utils/tracking_test.py
@@ -16,8 +16,8 @@ class TrackingTest(testing.TestCase):
                 ),
             }
         )
-        v1 = backend.Variable(1)
-        v2 = backend.Variable(2)
+        v1 = backend.Variable(1.0)
+        v2 = backend.Variable(2.0)
         lst = tracking.TrackedList([], tracker)
         lst.append(v1)
         lst.append(None)
@@ -67,8 +67,8 @@ class TrackingTest(testing.TestCase):
                 ),
             }
         )
-        v1 = backend.Variable(1)
-        v2 = backend.Variable(2)
+        v1 = backend.Variable(1.0)
+        v2 = backend.Variable(2.0)
         tup = (v1, v2)
         tup = tracker.track(tup)
         self.assertIsInstance(tup, tuple)
@@ -86,8 +86,8 @@ class TrackingTest(testing.TestCase):
                 ),
             }
         )
-        v1 = backend.Variable(1)
-        v2 = backend.Variable(2)
+        v1 = backend.Variable(1.0)
+        v2 = backend.Variable(2.0)
         nt = collections.namedtuple("NT", ["x", "y"])
         tup = nt(x=v1, y=v2)
         tup = tracker.track(tup)


### PR DESCRIPTION
- when the variable dtype is not specified, the dtype of the tensor/array passed as initializer is used instead of defaulting to `backend.floatx()`.
- with the JAX backend, don't needlessly create a copy of the initializer value, reuse it if possible