### PR TITLE
Add unravel_index op

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -254,6 +254,7 @@ from keras.src.ops.numpy import tril
 from keras.src.ops.numpy import triu
 from keras.src.ops.numpy import true_divide
 from keras.src.ops.numpy import trunc
+from keras.src.ops.numpy import unravel_index
 from keras.src.ops.numpy import var
 from keras.src.ops.numpy import vdot
 from keras.src.ops.numpy import vectorize

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -155,6 +155,7 @@ from keras.src.ops.numpy import tril
 from keras.src.ops.numpy import triu
 from keras.src.ops.numpy import true_divide
 from keras.src.ops.numpy import trunc
+from keras.src.ops.numpy import unravel_index
 from keras.src.ops.numpy import var
 from keras.src.ops.numpy import vdot
 from keras.src.ops.numpy import vectorize

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -254,6 +254,7 @@ from keras.src.ops.numpy import tril
 from keras.src.ops.numpy import triu
 from keras.src.ops.numpy import true_divide
 from keras.src.ops.numpy import trunc
+from keras.src.ops.numpy import unravel_index
 from keras.src.ops.numpy import var
 from keras.src.ops.numpy import vdot
 from keras.src.ops.numpy import vectorize

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -155,6 +155,7 @@ from keras.src.ops.numpy import tril
 from keras.src.ops.numpy import triu
 from keras.src.ops.numpy import true_divide
 from keras.src.ops.numpy import trunc
+from keras.src.ops.numpy import unravel_index
 from keras.src.ops.numpy import var
 from keras.src.ops.numpy import vdot
 from keras.src.ops.numpy import vectorize

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -904,6 +904,11 @@ def ravel(x):
     return jnp.ravel(x)
 
 
+def unravel_index(x, shape):
+    x = convert_to_tensor(x)
+    return jnp.unravel_index(x, shape)
+
+
 @sparse.elementwise_unary(linear=True)
 def real(x):
     x = convert_to_tensor(x)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -829,7 +829,10 @@ def ravel(x):
 
 
 def unravel_index(x, shape):
-    return np.unravel_index(x, shape)
+    dtype = dtypes.result_type(x.dtype)
+    return tuple(
+        indices.astype(dtype) for indices in np.unravel_index(x, shape)
+    )
 
 
 def real(x):

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -828,6 +828,10 @@ def ravel(x):
     return np.ravel(x)
 
 
+def unravel_index(x, shape):
+    return np.unravel_index(x, shape)
+
+
 def real(x):
     return np.real(x)
 

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1859,8 +1859,10 @@ def unravel_index(x, shape):
     x = tf.convert_to_tensor(x)
     input_dtype = x.dtype
 
-    if shape is None:
-        raise ValueError("Received `None` value for `shape`")
+    if None in shape:
+        raise ValueError(
+            "`shape` argument cannot contain `None`. Received: shape={shape}"
+        )
 
     if x.ndim == 1:
         coords = []

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1859,7 +1859,6 @@ def unravel_index(x, shape):
     x = tf.convert_to_tensor(x)
     input_dtype = x.dtype
 
-    # Handle case when x is 1D
     if x.ndim == 1:
         coords = []
         for dim in reversed(shape):
@@ -1867,7 +1866,6 @@ def unravel_index(x, shape):
             x = x // dim
         return tuple(reversed(coords))
 
-    # Handle multi-dimensional case
     x_shape = x.shape
     coords = []
     for dim in shape:

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1859,7 +1859,7 @@ def unravel_index(x, shape):
     x = tf.convert_to_tensor(x)
     input_dtype = x.dtype
 
-    if shape == None:
+    if shape is None:
         raise ValueError("Received `None` value for `shape`")
 
     if x.ndim == 1:

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1859,6 +1859,9 @@ def unravel_index(x, shape):
     x = tf.convert_to_tensor(x)
     input_dtype = x.dtype
 
+    if shape == None:
+        raise ValueError("Received `None` value for `shape`")
+
     if x.ndim == 1:
         coords = []
         for dim in reversed(shape):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1857,6 +1857,7 @@ def ravel(x):
 
 def unravel_index(x, shape):
     x = tf.convert_to_tensor(x)
+    input_dtype = x.dtype
     if x.ndim == 2:
         coords = []
         for dim in shape:
@@ -1865,7 +1866,7 @@ def unravel_index(x, shape):
             x = x // dim
 
         coords = [
-            tf.reshape(tf.cast(coord, tf.int64), x.shape) for coord in coords
+            tf.reshape(tf.cast(coord, input_dtype), x.shape) for coord in coords
         ]
 
         return tuple(np.array(coord) for coord in reversed(coords))

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1855,6 +1855,25 @@ def ravel(x):
     return tf.reshape(x, [-1])
 
 
+def unravel_index(x, shape):
+    x = tf.convert_to_tensor(x)
+    if x.ndim == 2:
+        coords = []
+        for dim in shape:
+            coord = x % dim
+            coords.append(coord)
+            x = x // dim
+
+        coords = [
+            tf.reshape(tf.cast(coord, tf.int64), x.shape) for coord in coords
+        ]
+
+        return tuple(np.array(coord) for coord in reversed(coords))
+
+    else:
+        return tf.unravel_index(x, shape)
+
+
 @sparse.elementwise_unary
 def real(x):
     x = convert_to_tensor(x)

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1858,20 +1858,23 @@ def ravel(x):
 def unravel_index(x, shape):
     x = tf.convert_to_tensor(x)
     input_dtype = x.dtype
+
+    # Handle case when x is 1D
     if x.ndim == 1:
-        return tf.unravel_index(x, shape)
-    else:
         coords = []
-        for dim in shape:
-            coord = x % dim
-            coords.append(coord)
+        for dim in reversed(shape):
+            coords.append(tf.cast(x % dim, input_dtype))
             x = x // dim
+        return tuple(reversed(coords))
 
-        coords = [
-            tf.reshape(tf.cast(coord, input_dtype), x.shape) for coord in coords
-        ]
+    # Handle multi-dimensional case
+    x_shape = x.shape
+    coords = []
+    for dim in shape:
+        coords.append(tf.reshape(tf.cast(x % dim, input_dtype), x_shape))
+        x = x // dim
 
-        return tuple(np.array(coord) for coord in reversed(coords))
+    return tuple(reversed(coords))
 
 
 @sparse.elementwise_unary

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1858,7 +1858,9 @@ def ravel(x):
 def unravel_index(x, shape):
     x = tf.convert_to_tensor(x)
     input_dtype = x.dtype
-    if x.ndim == 2:
+    if x.ndim == 1:
+        return tf.unravel_index(x, shape)
+    else:
         coords = []
         for dim in shape:
             coord = x % dim
@@ -1870,9 +1872,6 @@ def unravel_index(x, shape):
         ]
 
         return tuple(np.array(coord) for coord in reversed(coords))
-
-    else:
-        return tf.unravel_index(x, shape)
 
 
 @sparse.elementwise_unary

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1216,7 +1216,7 @@ def ravel(x):
 
 def unravel_index(x, shape):
     x = convert_to_tensor(x)
-    return torch.unravel(x, shape)
+    return torch.unravel_index(x, shape)
 
 
 def real(x):

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1216,7 +1216,8 @@ def ravel(x):
 
 def unravel_index(x, shape):
     x = convert_to_tensor(x)
-    return torch.unravel_index(x, shape)
+    dtype = dtypes.result_type(x.dtype)
+    return tuple(cast(idx, dtype) for idx in torch.unravel_index(x, shape))
 
 
 def real(x):

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1214,6 +1214,11 @@ def ravel(x):
     return torch.ravel(x)
 
 
+def unravel_index(x, shape):
+    x = convert_to_tensor(x)
+    return torch.unravel(x, shape)
+
+
 def real(x):
     if not isinstance(x, torch.Tensor):
         x = torch.from_numpy(x)  # needed for complex type conversion

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -4689,16 +4689,20 @@ class UnravelIndex(Operation):
 
 @keras_export(["keras.ops.unravel_index", "keras.ops.numpy.unravel_index"])
 def unravel_index(indices, shape):
-    """Convert a flat index or array of flat indices into a tuple of
-    coordinate arrays.
+    """Convert flat indices to coordinate arrays in a given array shape.
 
     Args:
         indices: An integer or array of integers representing flat indices.
         shape: The shape of the array to unravel into.
 
     Returns:
-        Tuple of arrays, one for each dimension, containing the unraveled
-        indices.
+        Tuple of arrays for each dimension with unraveled indices.
+
+    Example:
+        >>> indices = 5
+        >>> shape = (3, 3)
+        >>> unravel_index(indices, shape)
+        (1, 2)  # 5 is at row 1, column 2 in a 3x3 array
     """
     if any_symbolic_tensors((indices,)):
         return UnravelIndex(shape).symbolic_call(indices)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -4682,7 +4682,13 @@ class UnravelIndex(Operation):
                 except Exception:
                     output_shapes = [[None] for _ in self.shape]
 
-        input_dtype = getattr(indices, "dtype", np.int64)
+        if isinstance(indices, KerasTensor):
+            input_dtype = indices.dtype
+        else:
+            input_dtype = getattr(indices, "dtype", None)
+            if input_dtype is None:
+                input_dtype = np.int64
+
         return [
             KerasTensor(shape, dtype=input_dtype) for shape in output_shapes
         ]

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -4682,15 +4682,8 @@ class UnravelIndex(Operation):
                 except Exception:
                     output_shapes = [[None] for _ in self.shape]
 
-        if isinstance(indices, KerasTensor):
-            input_dtype = indices.dtype
-        else:
-            input_dtype = getattr(indices, "dtype", None)
-            if input_dtype is None:
-                input_dtype = np.int64
-
         return [
-            KerasTensor(shape, dtype=input_dtype) for shape in output_shapes
+            KerasTensor(shape, dtype=indices.dtype) for shape in output_shapes
         ]
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -7841,8 +7841,6 @@ class NumpyDtypeTest(testing.TestCase):
         import jax.numpy as jnp
 
         if backend.backend() == "tensorflow":
-            import tensorflow as tf
-
             if dtype in ("int8", "int16", "uint16", "uint32", "uint8"):
                 pytest.skip(
                     f"unravel index unsupported for {dtype}"

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1455,6 +1455,26 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.ravel(x).shape, (None,))
 
+    def test_unravel_index(self):
+        x = KerasTensor((None,))
+        indices = knp.unravel_index(x, (2, 3))
+        self.assertEqual(len(indices), 2)
+        self.assertEqual(indices[0].shape, (None,))
+        self.assertEqual(indices[1].shape, (None,))
+
+        x = KerasTensor((None, 4))
+        indices = knp.unravel_index(x, (3, 4))
+        self.assertEqual(len(indices), 2)
+        self.assertEqual(indices[0].shape, (None, 4))
+        self.assertEqual(indices[1].shape, (None, 4))
+
+        x = KerasTensor((None, 3, 2))
+        indices = knp.unravel_index(x, (5, 6, 4))
+        self.assertEqual(len(indices), 3)
+        self.assertEqual(indices[0].shape, (None, 3, 2))
+        self.assertEqual(indices[1].shape, (None, 3, 2))
+        self.assertEqual(indices[2].shape, (None, 3, 2))
+
     def test_real(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.real(x).shape, (None, 3))
@@ -1998,6 +2018,19 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
     def test_ravel(self):
         x = KerasTensor((2, 3))
         self.assertEqual(knp.ravel(x).shape, (6,))
+
+    def test_unravel_index(self):
+        x = KerasTensor((6,))
+        indices = knp.unravel_index(x, (2, 3))
+        self.assertEqual(len(indices), 2)
+        self.assertEqual(indices[0].shape, (6,))
+        self.assertEqual(indices[1].shape, (6,))
+
+        x = KerasTensor((2, 3))
+        indices = knp.unravel_index(x, (3, 4))
+        self.assertEqual(len(indices), 2)
+        self.assertEqual(indices[0].shape, (2, 3))
+        self.assertEqual(indices[1].shape, (2, 3))
 
     def test_real(self):
         x = KerasTensor((2, 3))
@@ -4114,6 +4147,19 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertAllClose(knp.ravel(x), np.ravel(x))
         self.assertAllClose(knp.Ravel()(x), np.ravel(x))
+
+    def test_unravel_index(self):
+        x = np.array([0, 1, 2, 3])
+        shape = (2, 2)
+        self.assertAllClose(
+            knp.unravel_index(x, shape), np.unravel_index(x, shape)
+        )
+
+        x = np.array([[0, 1], [2, 3]])
+        shape = (2, 2)
+        self.assertAllClose(
+            knp.unravel_index(x, shape), np.unravel_index(x, shape)
+        )
 
     def test_real(self):
         x = np.array([[1, 2, 3 - 3j], [3, 2, 1 + 5j]])
@@ -7789,6 +7835,41 @@ class NumpyDtypeTest(testing.TestCase):
             standardize_dtype(knp.Ravel().symbolic_call(x).dtype),
             expected_dtype,
         )
+
+    @parameterized.named_parameters(named_product(dtype=INT_DTYPES))
+    def test_unravel_index(self, dtype):
+        import jax.numpy as jnp
+
+        if backend.backend() == "tensorflow":
+            import tensorflow as tf
+
+            if dtype in ("int8", "int16", "uint16", "uint32", "uint8"):
+                pytest.skip(
+                    f"unravel index unsupported for {dtype}"
+                    " with TensorFlow backend"
+                )
+        x = knp.ones((3,), dtype=dtype)
+        x_jax = jnp.ones((3,), dtype=dtype)
+
+        indices = knp.array([2, 0], dtype=dtype)
+        indices_jax = jnp.array([2, 0], dtype=dtype)
+
+        unravel_result_knp = knp.unravel_index(indices, x.shape)
+        unravel_result_jax = jnp.unravel_index(indices_jax, x_jax.shape)
+
+        expected_dtype_knp = standardize_dtype(unravel_result_knp[0].dtype)
+        expected_dtype_jax = standardize_dtype(unravel_result_jax[0].dtype)
+
+        self.assertEqual(expected_dtype_knp, expected_dtype_jax)
+
+        unravel_result_knp_symbolic = knp.UnravelIndex(x.shape).symbolic_call(
+            indices
+        )
+        expected_dtype_symbolic = standardize_dtype(
+            unravel_result_knp_symbolic[0].dtype
+        )
+
+        self.assertEqual(expected_dtype_symbolic, expected_dtype_jax)
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_repeat(self, dtype):

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -7840,12 +7840,6 @@ class NumpyDtypeTest(testing.TestCase):
     def test_unravel_index(self, dtype):
         import jax.numpy as jnp
 
-        if backend.backend() == "tensorflow":
-            if dtype in ("int8", "int16", "uint16", "uint32", "uint8"):
-                pytest.skip(
-                    f"unravel index unsupported for {dtype}"
-                    " with TensorFlow backend"
-                )
         x = knp.ones((3,), dtype=dtype)
         x_jax = jnp.ones((3,), dtype=dtype)
 


### PR DESCRIPTION
I have also added support for n-d in the TensorFlow implementation, which was not included in the original version. Also only int64 and int32 are support in tensorflow implementation

we can include this implementation which is supported by all INT_DTYPES for tensorflow implementation, I have checked it passes all the tests WDYT?

```python
def unravel_index(x, shape):
    x = tf.convert_to_tensor(x)
    input_dtype = x.dtype

    # Handle case when x is 1D
    if x.ndim == 1:
        coords = []
        for dim in reversed(shape):
            coords.append(tf.cast(x % dim, input_dtype))
            x = x // dim
        return tuple(reversed(coords))

    # Handle multi-dimensional case
    x_shape = x.shape
    coords = []
    for dim in shape:
        coords.append(tf.reshape(tf.cast(x % dim, input_dtype), x_shape))
        x = x // dim

    return tuple(reversed(coords))

```

@fchollet 