### PR TITLE
Update ModelCheckpoint support ".h5" support

### DIFF
--- a/keras/src/callbacks/model_checkpoint.py
+++ b/keras/src/callbacks/model_checkpoint.py
@@ -74,13 +74,14 @@ class ModelCheckpoint(Callback):
             which will be filled the value of `epoch` and keys in `logs`
             (passed in `on_epoch_end`).
             The `filepath` name needs to end with `".weights.h5"` when
-            `save_weights_only=True` or should end with `".keras"` when
-            checkpoint saving the whole model (default).
+            `save_weights_only=True` or should end with `".keras"` or `".h5"`
+            when checkpoint saving the whole model (default).
             For example:
-            if `filepath` is `"{epoch:02d}-{val_loss:.2f}.keras"`, then the
-            model checkpoints will be saved with the epoch number and the
-            validation loss in the filename. The directory of the filepath
-            should not be reused by any other callbacks to avoid conflicts.
+            if `filepath` is `"{epoch:02d}-{val_loss:.2f}.keras"` or
+            "{epoch:02d}-{val_loss:.2f}.h5"`, then the model checkpoints
+            will be saved with the epoch number and the validation loss in
+            the filename. The directory of the filepath should not be reused
+            by any other callbacks to avoid conflicts.
         monitor: The metric name to monitor. Typically the metrics are set by
             the `Model.compile` method. Note:
             * Prefix the name with `"val_"` to monitor validation metrics.
@@ -184,13 +185,6 @@ class ModelCheckpoint(Callback):
                     "When using `save_weights_only=True` in `ModelCheckpoint`"
                     ", the filepath provided must end in `.weights.h5` "
                     "(Keras weights format). Received: "
-                    f"filepath={self.filepath}"
-                )
-        else:
-            if not self.filepath.endswith(".keras"):
-                raise ValueError(
-                    "The filepath provided must end in `.keras` "
-                    "(Keras model format). Received: "
                     f"filepath={self.filepath}"
                 )
 

--- a/keras/src/callbacks/model_checkpoint.py
+++ b/keras/src/callbacks/model_checkpoint.py
@@ -187,6 +187,15 @@ class ModelCheckpoint(Callback):
                     "(Keras weights format). Received: "
                     f"filepath={self.filepath}"
                 )
+        else:
+            if not any(
+                self.filepath.endswith(ext) for ext in (".keras", ".h5")
+            ):
+                raise ValueError(
+                    "The filepath provided must end in `.keras` "
+                    "(Keras model format) or `.h5` (HDF5 format). Received: "
+                    f"filepath={self.filepath}"
+                )
 
     def on_train_batch_end(self, batch, logs=None):
         if self._should_save_on_batch(batch):

--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -78,6 +78,17 @@ def save_model(model, filepath, overwrite=True, zipped=None, **kwargs):
             f"{list(kwargs.keys())}"
         )
 
+    # Deprecation warnings
+    if str(filepath).endswith((".h5", ".hdf5")):
+        logging.warning(
+            "You are saving your model as an HDF5 file via "
+            "`model.save()` or `keras.saving.save_model(model)`. "
+            "This file format is considered legacy. "
+            "We recommend using instead the native Keras format, "
+            "e.g. `model.save('my_model.keras')` or "
+            "`keras.saving.save_model(model, 'my_model.keras')`. "
+        )
+
     is_hf = str(filepath).startswith("hf://")
     if zipped is None:
         zipped = not is_hf  # default behavior depends on destination

--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -78,17 +78,6 @@ def save_model(model, filepath, overwrite=True, zipped=None, **kwargs):
             f"{list(kwargs.keys())}"
         )
 
-    # Deprecation warnings
-    if str(filepath).endswith((".h5", ".hdf5")):
-        logging.warning(
-            "You are saving your model as an HDF5 file via "
-            "`model.save()` or `keras.saving.save_model(model)`. "
-            "This file format is considered legacy. "
-            "We recommend using instead the native Keras format, "
-            "e.g. `model.save('my_model.keras')` or "
-            "`keras.saving.save_model(model, 'my_model.keras')`. "
-        )
-
     is_hf = str(filepath).startswith("hf://")
     if zipped is None:
         zipped = not is_hf  # default behavior depends on destination


### PR DESCRIPTION
Update ModelCheckpoint support ".h5" and ".keras" both filetype support with with the save_weights_only=False
Fixes [#20490](https://github.com/keras-team/keras/issues/20490)