### PR TITLE
Fix the compatibility of the quantization for MHA 

### DIFF
--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -541,13 +541,13 @@ class MultiHeadAttention(Layer):
         #   H = `size_per_head`
 
         # `query` = [B, T, N ,H]
-        query = self._query_dense.call(query)
+        query = self._query_dense(query)
 
         # `key` = [B, S, N, H]
-        key = self._key_dense.call(key)
+        key = self._key_dense(key)
 
         # `value` = [B, S, N, H]
-        value = self._value_dense.call(value)
+        value = self._value_dense(value)
         attention_output, attention_scores = self._compute_attention(
             query,
             key,
@@ -555,7 +555,7 @@ class MultiHeadAttention(Layer):
             attention_mask,
             training,
         )
-        attention_output = self._output_dense.call(attention_output)
+        attention_output = self._output_dense(attention_output)
 
         if return_attention_scores:
             return attention_output, attention_scores


### PR DESCRIPTION
We should use `__call__` for sublayers in MHA to ensure compatibility with quantization.

This PR should fix the CI for KerasHub:
https://github.com/keras-team/keras-hub/actions/runs/12061895640/job/33634697425

cc @mattdangerw 