### PR TITLE
Random seed doc

### DIFF
--- a/keras/src/random/random.py
+++ b/keras/src/random/random.py
@@ -15,14 +15,15 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`).
-        seed: A Python integer or instance of
-            `keras.random.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras.random.SeedGenerator`.
+        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
+            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
+            Note that passing an integer as the `seed` value will produce the same random values for each call.  
+            To generate different random values for repeated calls, an instance of  
+            `keras.random.SeedGenerator` must be provided as the `seed` value.  
+            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
+            when tracing functions with the JAX backend. In case the random number generator 
+            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
     """
     return backend.random.normal(
         shape, mean=mean, stddev=stddev, dtype=dtype, seed=seed
@@ -51,14 +52,15 @@ def categorical(logits, num_samples, dtype="int32", seed=None):
             row of the input. This will be the second dimension of the output
             tensor's shape.
         dtype: Optional dtype of the output tensor.
-        seed: A Python integer or instance of
-            `keras.random.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras.random.SeedGenerator`.
+        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
+            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
+            Note that passing an integer as the `seed` value will produce the same random values for each call.  
+            To generate different random values for repeated calls, an instance of  
+            `keras.random.SeedGenerator` must be provided as the `seed` value.  
+            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
+            when tracing functions with the JAX backend. In case the random number generator 
+            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
 
     Returns:
         A 2-D tensor with (batch_size, num_samples).
@@ -94,14 +96,16 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`)
-        seed: A Python integer or instance of
-            `keras.random.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras.random.SeedGenerator`.
+        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
+            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
+            Note that passing an integer as the `seed` value will produce the same random values for each call.  
+            To generate different random values for repeated calls, an instance of  
+            `keras.random.SeedGenerator` must be provided as the `seed` value.  
+            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
+            when tracing functions with the JAX backend. In case the random number generator 
+            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
+
     """
     if dtype and not backend.is_float_dtype(dtype):
         raise ValueError(
@@ -133,14 +137,15 @@ def randint(shape, minval, maxval, dtype="int32", seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`)
-        seed: A Python integer or instance of
-            `keras.random.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras.random.SeedGenerator`.
+        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
+            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
+            Note that passing an integer as the `seed` value will produce the same random values for each call.  
+            To generate different random values for repeated calls, an instance of  
+            `keras.random.SeedGenerator` must be provided as the `seed` value.  
+            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
+            when tracing functions with the JAX backend. In case the random number generator 
+            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
     """
     if dtype and not backend.is_int_dtype(dtype):
         raise ValueError(
@@ -169,14 +174,15 @@ def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`)
-        seed: A Python integer or instance of
-            `keras.random.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras.random.SeedGenerator`.
+        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
+            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
+            Note that passing an integer as the `seed` value will produce the same random values for each call.  
+            To generate different random values for repeated calls, an instance of  
+            `keras.random.SeedGenerator` must be provided as the `seed` value.  
+            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
+            when tracing functions with the JAX backend. In case the random number generator 
+            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
     """
     return backend.random.truncated_normal(
         shape, mean=mean, stddev=stddev, dtype=dtype, seed=seed
@@ -198,14 +204,15 @@ def shuffle(x, axis=0, seed=None):
         x: The tensor to be shuffled.
         axis: An integer specifying the axis along which to shuffle. Defaults to
             `0`.
-        seed: A Python integer or instance of
-            `keras.random.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras.random.SeedGenerator`.
+        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
+            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
+            Note that passing an integer as the `seed` value will produce the same random values for each call.  
+            To generate different random values for repeated calls, an instance of  
+            `keras.random.SeedGenerator` must be provided as the `seed` value.  
+            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
+            when tracing functions with the JAX backend. In case the random number generator 
+            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
     """
     return backend.random.shuffle(x, axis=axis, seed=seed)
 
@@ -221,14 +228,15 @@ def gamma(shape, alpha, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`).
-        seed: A Python integer or instance of
-            `keras.random.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras.random.SeedGenerator`.
+        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
+            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
+            Note that passing an integer as the `seed` value will produce the same random values for each call.  
+            To generate different random values for repeated calls, an instance of  
+            `keras.random.SeedGenerator` must be provided as the `seed` value.  
+            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
+            when tracing functions with the JAX backend. In case the random number generator 
+            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
     """
     return backend.random.gamma(shape, alpha=alpha, dtype=dtype, seed=seed)
 
@@ -251,14 +259,15 @@ def binomial(shape, counts, probabilities, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`).
-        seed: A Python integer or instance of
-            `keras.random.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras.random.SeedGenerator`.
+        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
+            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
+            Note that passing an integer as the `seed` value will produce the same random values for each call.  
+            To generate different random values for repeated calls, an instance of  
+            `keras.random.SeedGenerator` must be provided as the `seed` value.  
+            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
+            when tracing functions with the JAX backend. In case the random number generator 
+            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
     """
     return backend.random.binomial(
         shape,
@@ -286,14 +295,15 @@ def beta(shape, alpha, beta, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`).
-        seed: A Python integer or instance of
-            `keras.random.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras.random.SeedGenerator`.
+        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
+            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
+            Note that passing an integer as the `seed` value will produce the same random values for each call.  
+            To generate different random values for repeated calls, an instance of  
+            `keras.random.SeedGenerator` must be provided as the `seed` value.  
+            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
+            when tracing functions with the JAX backend. In case the random number generator 
+            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
     """
     return backend.random.beta(
         shape=shape, alpha=alpha, beta=beta, dtype=dtype, seed=seed

--- a/keras/src/random/random.py
+++ b/keras/src/random/random.py
@@ -79,7 +79,9 @@ def categorical(logits, num_samples, dtype="int32", seed=None):
             "`logits` should be a 2-D tensor with shape "
             f"[batch_size, num_classes]. Received: logits={logits}"
         )
-    return backend.random.categorical(logits, num_samples, dtype=dtype, seed=seed)
+    return backend.random.categorical(
+        logits, num_samples, dtype=dtype, seed=seed
+    )
 
 
 @keras_export("keras.random.uniform")

--- a/keras/src/random/random.py
+++ b/keras/src/random/random.py
@@ -15,18 +15,18 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`).
-        seed: Optional Python integer or instance of 
+        seed: Optional Python integer or instance of
            `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global 
-            `keras.random.SeedGenerator` is used. The `seed` argument can be 
-            used to ensure deterministic (repeatable) random number generation. 
-            Note that passing an integer as the `seed` value will produce the 
-            same random values for each call. To generate different random 
-            values for repeated calls, an instance of 
-            `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the 
-            JAX backend the global `keras.random.SeedGenerator` is not 
-            supported. Therefore, during tracing the default value seed=None 
+            By default, the `seed` argument is `None`, and an internal global
+            `keras.random.SeedGenerator` is used. The `seed` argument can be
+            used to ensure deterministic (repeatable) random number generation.
+            Note that passing an integer as the `seed` value will produce the
+            same random values for each call. To generate different random
+            values for repeated calls, an instance of
+            `keras.random.SeedGenerator` must be provided as the `seed` value.
+            Remark concerning the JAX backend: When tracing functions with the
+            JAX backend the global `keras.random.SeedGenerator` is not
+            supported. Therefore, during tracing the default value seed=None
             will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.normal(
@@ -56,18 +56,18 @@ def categorical(logits, num_samples, dtype="int32", seed=None):
             row of the input. This will be the second dimension of the output
             tensor's shape.
         dtype: Optional dtype of the output tensor.
-        seed: Optional Python integer or instance of 
+        seed: Optional Python integer or instance of
            `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global 
-            `keras.random.SeedGenerator` is used. The `seed` argument can be 
-            used to ensure deterministic (repeatable) random number generation. 
-            Note that passing an integer as the `seed` value will produce the 
-            same random values for each call. To generate different random 
-            values for repeated calls, an instance of 
-            `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the 
-            JAX backend the global `keras.random.SeedGenerator` is not 
-            supported. Therefore, during tracing the default value seed=None 
+            By default, the `seed` argument is `None`, and an internal global
+            `keras.random.SeedGenerator` is used. The `seed` argument can be
+            used to ensure deterministic (repeatable) random number generation.
+            Note that passing an integer as the `seed` value will produce the
+            same random values for each call. To generate different random
+            values for repeated calls, an instance of
+            `keras.random.SeedGenerator` must be provided as the `seed` value.
+            Remark concerning the JAX backend: When tracing functions with the
+            JAX backend the global `keras.random.SeedGenerator` is not
+            supported. Therefore, during tracing the default value seed=None
             will produce an error, and a `seed` argument must be provided.
 
     Returns:
@@ -79,9 +79,7 @@ def categorical(logits, num_samples, dtype="int32", seed=None):
             "`logits` should be a 2-D tensor with shape "
             f"[batch_size, num_classes]. Received: logits={logits}"
         )
-    return backend.random.categorical(
-        logits, num_samples, dtype=dtype, seed=seed
-    )
+    return backend.random.categorical(logits, num_samples, dtype=dtype, seed=seed)
 
 
 @keras_export("keras.random.uniform")
@@ -104,18 +102,18 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`)
-        seed: Optional Python integer or instance of 
+        seed: Optional Python integer or instance of
            `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global 
-            `keras.random.SeedGenerator` is used. The `seed` argument can be 
-            used to ensure deterministic (repeatable) random number generation. 
-            Note that passing an integer as the `seed` value will produce the 
-            same random values for each call. To generate different random 
-            values for repeated calls, an instance of 
-            `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the 
-            JAX backend the global `keras.random.SeedGenerator` is not 
-            supported. Therefore, during tracing the default value seed=None 
+            By default, the `seed` argument is `None`, and an internal global
+            `keras.random.SeedGenerator` is used. The `seed` argument can be
+            used to ensure deterministic (repeatable) random number generation.
+            Note that passing an integer as the `seed` value will produce the
+            same random values for each call. To generate different random
+            values for repeated calls, an instance of
+            `keras.random.SeedGenerator` must be provided as the `seed` value.
+            Remark concerning the JAX backend: When tracing functions with the
+            JAX backend the global `keras.random.SeedGenerator` is not
+            supported. Therefore, during tracing the default value seed=None
             will produce an error, and a `seed` argument must be provided.
     """
     if dtype and not backend.is_float_dtype(dtype):
@@ -148,18 +146,18 @@ def randint(shape, minval, maxval, dtype="int32", seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`)
-        seed: Optional Python integer or instance of 
+        seed: Optional Python integer or instance of
            `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global 
-            `keras.random.SeedGenerator` is used. The `seed` argument can be 
-            used to ensure deterministic (repeatable) random number generation. 
-            Note that passing an integer as the `seed` value will produce the 
-            same random values for each call. To generate different random 
-            values for repeated calls, an instance of 
-            `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the 
-            JAX backend the global `keras.random.SeedGenerator` is not 
-            supported. Therefore, during tracing the default value seed=None 
+            By default, the `seed` argument is `None`, and an internal global
+            `keras.random.SeedGenerator` is used. The `seed` argument can be
+            used to ensure deterministic (repeatable) random number generation.
+            Note that passing an integer as the `seed` value will produce the
+            same random values for each call. To generate different random
+            values for repeated calls, an instance of
+            `keras.random.SeedGenerator` must be provided as the `seed` value.
+            Remark concerning the JAX backend: When tracing functions with the
+            JAX backend the global `keras.random.SeedGenerator` is not
+            supported. Therefore, during tracing the default value seed=None
             will produce an error, and a `seed` argument must be provided.
     """
     if dtype and not backend.is_int_dtype(dtype):
@@ -189,18 +187,18 @@ def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`)
-        seed: Optional Python integer or instance of 
+        seed: Optional Python integer or instance of
            `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global 
-            `keras.random.SeedGenerator` is used. The `seed` argument can be 
-            used to ensure deterministic (repeatable) random number generation. 
-            Note that passing an integer as the `seed` value will produce the 
-            same random values for each call. To generate different random 
-            values for repeated calls, an instance of 
-            `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the 
-            JAX backend the global `keras.random.SeedGenerator` is not 
-            supported. Therefore, during tracing the default value seed=None 
+            By default, the `seed` argument is `None`, and an internal global
+            `keras.random.SeedGenerator` is used. The `seed` argument can be
+            used to ensure deterministic (repeatable) random number generation.
+            Note that passing an integer as the `seed` value will produce the
+            same random values for each call. To generate different random
+            values for repeated calls, an instance of
+            `keras.random.SeedGenerator` must be provided as the `seed` value.
+            Remark concerning the JAX backend: When tracing functions with the
+            JAX backend the global `keras.random.SeedGenerator` is not
+            supported. Therefore, during tracing the default value seed=None
             will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.truncated_normal(
@@ -210,9 +208,7 @@ def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
 
 @keras_export("keras.random.dropout")
 def dropout(inputs, rate, noise_shape=None, seed=None):
-    return backend.random.dropout(
-        inputs, rate, noise_shape=noise_shape, seed=seed
-    )
+    return backend.random.dropout(inputs, rate, noise_shape=noise_shape, seed=seed)
 
 
 @keras_export("keras.random.shuffle")
@@ -223,18 +219,18 @@ def shuffle(x, axis=0, seed=None):
         x: The tensor to be shuffled.
         axis: An integer specifying the axis along which to shuffle. Defaults to
             `0`.
-        seed: Optional Python integer or instance of 
+        seed: Optional Python integer or instance of
            `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global 
-            `keras.random.SeedGenerator` is used. The `seed` argument can be 
-            used to ensure deterministic (repeatable) random number generation. 
-            Note that passing an integer as the `seed` value will produce the 
-            same random values for each call. To generate different random 
-            values for repeated calls, an instance of 
-            `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the 
-            JAX backend the global `keras.random.SeedGenerator` is not 
-            supported. Therefore, during tracing the default value seed=None 
+            By default, the `seed` argument is `None`, and an internal global
+            `keras.random.SeedGenerator` is used. The `seed` argument can be
+            used to ensure deterministic (repeatable) random number generation.
+            Note that passing an integer as the `seed` value will produce the
+            same random values for each call. To generate different random
+            values for repeated calls, an instance of
+            `keras.random.SeedGenerator` must be provided as the `seed` value.
+            Remark concerning the JAX backend: When tracing functions with the
+            JAX backend the global `keras.random.SeedGenerator` is not
+            supported. Therefore, during tracing the default value seed=None
             will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.shuffle(x, axis=axis, seed=seed)
@@ -251,18 +247,18 @@ def gamma(shape, alpha, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`).
-        seed: Optional Python integer or instance of 
+        seed: Optional Python integer or instance of
            `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global 
-            `keras.random.SeedGenerator` is used. The `seed` argument can be 
-            used to ensure deterministic (repeatable) random number generation. 
-            Note that passing an integer as the `seed` value will produce the 
-            same random values for each call. To generate different random 
-            values for repeated calls, an instance of 
-            `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the 
-            JAX backend the global `keras.random.SeedGenerator` is not 
-            supported. Therefore, during tracing the default value seed=None 
+            By default, the `seed` argument is `None`, and an internal global
+            `keras.random.SeedGenerator` is used. The `seed` argument can be
+            used to ensure deterministic (repeatable) random number generation.
+            Note that passing an integer as the `seed` value will produce the
+            same random values for each call. To generate different random
+            values for repeated calls, an instance of
+            `keras.random.SeedGenerator` must be provided as the `seed` value.
+            Remark concerning the JAX backend: When tracing functions with the
+            JAX backend the global `keras.random.SeedGenerator` is not
+            supported. Therefore, during tracing the default value seed=None
             will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.gamma(shape, alpha=alpha, dtype=dtype, seed=seed)
@@ -286,18 +282,18 @@ def binomial(shape, counts, probabilities, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`).
-        seed: Optional Python integer or instance of 
+        seed: Optional Python integer or instance of
            `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global 
-            `keras.random.SeedGenerator` is used. The `seed` argument can be 
-            used to ensure deterministic (repeatable) random number generation. 
-            Note that passing an integer as the `seed` value will produce the 
-            same random values for each call. To generate different random 
-            values for repeated calls, an instance of 
-            `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the 
-            JAX backend the global `keras.random.SeedGenerator` is not 
-            supported. Therefore, during tracing the default value seed=None 
+            By default, the `seed` argument is `None`, and an internal global
+            `keras.random.SeedGenerator` is used. The `seed` argument can be
+            used to ensure deterministic (repeatable) random number generation.
+            Note that passing an integer as the `seed` value will produce the
+            same random values for each call. To generate different random
+            values for repeated calls, an instance of
+            `keras.random.SeedGenerator` must be provided as the `seed` value.
+            Remark concerning the JAX backend: When tracing functions with the
+            JAX backend the global `keras.random.SeedGenerator` is not
+            supported. Therefore, during tracing the default value seed=None
             will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.binomial(
@@ -326,18 +322,18 @@ def beta(shape, alpha, beta, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`).
-        seed: Optional Python integer or instance of 
+        seed: Optional Python integer or instance of
            `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global 
-            `keras.random.SeedGenerator` is used. The `seed` argument can be 
-            used to ensure deterministic (repeatable) random number generation. 
-            Note that passing an integer as the `seed` value will produce the 
-            same random values for each call. To generate different random 
-            values for repeated calls, an instance of 
-            `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the 
-            JAX backend the global `keras.random.SeedGenerator` is not 
-            supported. Therefore, during tracing the default value seed=None 
+            By default, the `seed` argument is `None`, and an internal global
+            `keras.random.SeedGenerator` is used. The `seed` argument can be
+            used to ensure deterministic (repeatable) random number generation.
+            Note that passing an integer as the `seed` value will produce the
+            same random values for each call. To generate different random
+            values for repeated calls, an instance of
+            `keras.random.SeedGenerator` must be provided as the `seed` value.
+            Remark concerning the JAX backend: When tracing functions with the
+            JAX backend the global `keras.random.SeedGenerator` is not
+            supported. Therefore, during tracing the default value seed=None
             will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.beta(

--- a/keras/src/random/random.py
+++ b/keras/src/random/random.py
@@ -210,7 +210,9 @@ def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
 
 @keras_export("keras.random.dropout")
 def dropout(inputs, rate, noise_shape=None, seed=None):
-    return backend.random.dropout(inputs, rate, noise_shape=noise_shape, seed=seed)
+    return backend.random.dropout(
+        inputs, rate, noise_shape=noise_shape, seed=seed
+    )
 
 
 @keras_export("keras.random.shuffle")

--- a/keras/src/random/random.py
+++ b/keras/src/random/random.py
@@ -15,14 +15,18 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`).
-        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
-            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
-            Note that passing an integer as the `seed` value will produce the same random values for each call.  
-            To generate different random values for repeated calls, an instance of  
+        seed: Optional Python integer or instance of 
+           `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global 
+            `keras.random.SeedGenerator` is used. The `seed` argument can be 
+            used to ensure deterministic (repeatable) random number generation. 
+            Note that passing an integer as the `seed` value will produce the 
+            same random values for each call. To generate different random 
+            values for repeated calls, an instance of 
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
-            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            Remark concerning the JAX backend: When tracing functions with the 
+            JAX backend the global `keras.random.SeedGenerator` is not 
+            supported. Therefore, during tracing the default value seed=None 
             will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.normal(
@@ -52,14 +56,18 @@ def categorical(logits, num_samples, dtype="int32", seed=None):
             row of the input. This will be the second dimension of the output
             tensor's shape.
         dtype: Optional dtype of the output tensor.
-        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
-            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
-            Note that passing an integer as the `seed` value will produce the same random values for each call.  
-            To generate different random values for repeated calls, an instance of  
+        seed: Optional Python integer or instance of 
+           `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global 
+            `keras.random.SeedGenerator` is used. The `seed` argument can be 
+            used to ensure deterministic (repeatable) random number generation. 
+            Note that passing an integer as the `seed` value will produce the 
+            same random values for each call. To generate different random 
+            values for repeated calls, an instance of 
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
-            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            Remark concerning the JAX backend: When tracing functions with the 
+            JAX backend the global `keras.random.SeedGenerator` is not 
+            supported. Therefore, during tracing the default value seed=None 
             will produce an error, and a `seed` argument must be provided.
 
     Returns:
@@ -96,14 +104,18 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`)
-        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
-            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
-            Note that passing an integer as the `seed` value will produce the same random values for each call.  
-            To generate different random values for repeated calls, an instance of  
+        seed: Optional Python integer or instance of 
+           `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global 
+            `keras.random.SeedGenerator` is used. The `seed` argument can be 
+            used to ensure deterministic (repeatable) random number generation. 
+            Note that passing an integer as the `seed` value will produce the 
+            same random values for each call. To generate different random 
+            values for repeated calls, an instance of 
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
-            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            Remark concerning the JAX backend: When tracing functions with the 
+            JAX backend the global `keras.random.SeedGenerator` is not 
+            supported. Therefore, during tracing the default value seed=None 
             will produce an error, and a `seed` argument must be provided.
     """
     if dtype and not backend.is_float_dtype(dtype):
@@ -136,14 +148,18 @@ def randint(shape, minval, maxval, dtype="int32", seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`)
-        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
-            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
-            Note that passing an integer as the `seed` value will produce the same random values for each call.  
-            To generate different random values for repeated calls, an instance of  
+        seed: Optional Python integer or instance of 
+           `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global 
+            `keras.random.SeedGenerator` is used. The `seed` argument can be 
+            used to ensure deterministic (repeatable) random number generation. 
+            Note that passing an integer as the `seed` value will produce the 
+            same random values for each call. To generate different random 
+            values for repeated calls, an instance of 
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
-            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            Remark concerning the JAX backend: When tracing functions with the 
+            JAX backend the global `keras.random.SeedGenerator` is not 
+            supported. Therefore, during tracing the default value seed=None 
             will produce an error, and a `seed` argument must be provided.
     """
     if dtype and not backend.is_int_dtype(dtype):
@@ -173,13 +189,18 @@ def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`)
-        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
-            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
-            Note that passing an integer as the `seed` value will produce the same random values for each call.  
-            To generate different random values for repeated calls, an instance of  
-            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
-            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+        seed: Optional Python integer or instance of 
+           `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global 
+            `keras.random.SeedGenerator` is used. The `seed` argument can be 
+            used to ensure deterministic (repeatable) random number generation. 
+            Note that passing an integer as the `seed` value will produce the 
+            same random values for each call. To generate different random 
+            values for repeated calls, an instance of 
+            `keras.random.SeedGenerator` must be provided as the `seed` value.  
+            Remark concerning the JAX backend: When tracing functions with the 
+            JAX backend the global `keras.random.SeedGenerator` is not 
+            supported. Therefore, during tracing the default value seed=None 
             will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.truncated_normal(
@@ -202,14 +223,18 @@ def shuffle(x, axis=0, seed=None):
         x: The tensor to be shuffled.
         axis: An integer specifying the axis along which to shuffle. Defaults to
             `0`.
-        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
-            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
-            Note that passing an integer as the `seed` value will produce the same random values for each call.  
-            To generate different random values for repeated calls, an instance of  
+        seed: Optional Python integer or instance of 
+           `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global 
+            `keras.random.SeedGenerator` is used. The `seed` argument can be 
+            used to ensure deterministic (repeatable) random number generation. 
+            Note that passing an integer as the `seed` value will produce the 
+            same random values for each call. To generate different random 
+            values for repeated calls, an instance of 
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
-            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            Remark concerning the JAX backend: When tracing functions with the 
+            JAX backend the global `keras.random.SeedGenerator` is not 
+            supported. Therefore, during tracing the default value seed=None 
             will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.shuffle(x, axis=axis, seed=seed)
@@ -226,14 +251,18 @@ def gamma(shape, alpha, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`).
-        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
-            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
-            Note that passing an integer as the `seed` value will produce the same random values for each call.  
-            To generate different random values for repeated calls, an instance of  
+        seed: Optional Python integer or instance of 
+           `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global 
+            `keras.random.SeedGenerator` is used. The `seed` argument can be 
+            used to ensure deterministic (repeatable) random number generation. 
+            Note that passing an integer as the `seed` value will produce the 
+            same random values for each call. To generate different random 
+            values for repeated calls, an instance of 
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
-            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            Remark concerning the JAX backend: When tracing functions with the 
+            JAX backend the global `keras.random.SeedGenerator` is not 
+            supported. Therefore, during tracing the default value seed=None 
             will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.gamma(shape, alpha=alpha, dtype=dtype, seed=seed)
@@ -257,14 +286,18 @@ def binomial(shape, counts, probabilities, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`).
-        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
-            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
-            Note that passing an integer as the `seed` value will produce the same random values for each call.  
-            To generate different random values for repeated calls, an instance of  
+        seed: Optional Python integer or instance of 
+           `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global 
+            `keras.random.SeedGenerator` is used. The `seed` argument can be 
+            used to ensure deterministic (repeatable) random number generation. 
+            Note that passing an integer as the `seed` value will produce the 
+            same random values for each call. To generate different random 
+            values for repeated calls, an instance of 
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
-            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            Remark concerning the JAX backend: When tracing functions with the 
+            JAX backend the global `keras.random.SeedGenerator` is not 
+            supported. Therefore, during tracing the default value seed=None 
             will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.binomial(
@@ -293,14 +326,18 @@ def beta(shape, alpha, beta, dtype=None, seed=None):
             supported. If not specified, `keras.config.floatx()` is used,
             which defaults to `float32` unless you configured it otherwise (via
             `keras.config.set_floatx(float_dtype)`).
-        seed: Optional Python integer or instance of `keras.random.SeedGenerator`.
-            By default, the `seed` argument is `None`, and an internal global `keras.random.SeedGenerator` is used.
-            The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
-            Note that passing an integer as the `seed` value will produce the same random values for each call.  
-            To generate different random values for repeated calls, an instance of  
+        seed: Optional Python integer or instance of 
+           `keras.random.SeedGenerator`.
+            By default, the `seed` argument is `None`, and an internal global 
+            `keras.random.SeedGenerator` is used. The `seed` argument can be 
+            used to ensure deterministic (repeatable) random number generation. 
+            Note that passing an integer as the `seed` value will produce the 
+            same random values for each call. To generate different random 
+            values for repeated calls, an instance of 
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
-            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            Remark concerning the JAX backend: When tracing functions with the 
+            JAX backend the global `keras.random.SeedGenerator` is not 
+            supported. Therefore, during tracing the default value seed=None 
             will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.beta(

--- a/keras/src/random/random.py
+++ b/keras/src/random/random.py
@@ -21,9 +21,9 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
             Note that passing an integer as the `seed` value will produce the same random values for each call.  
             To generate different random values for repeated calls, an instance of  
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
-            when tracing functions with the JAX backend. In case the random number generator 
-            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
+            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
+            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.normal(
         shape, mean=mean, stddev=stddev, dtype=dtype, seed=seed
@@ -58,9 +58,9 @@ def categorical(logits, num_samples, dtype="int32", seed=None):
             Note that passing an integer as the `seed` value will produce the same random values for each call.  
             To generate different random values for repeated calls, an instance of  
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
-            when tracing functions with the JAX backend. In case the random number generator 
-            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
+            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
+            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            will produce an error, and a `seed` argument must be provided.
 
     Returns:
         A 2-D tensor with (batch_size, num_samples).
@@ -102,10 +102,9 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
             Note that passing an integer as the `seed` value will produce the same random values for each call.  
             To generate different random values for repeated calls, an instance of  
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
-            when tracing functions with the JAX backend. In case the random number generator 
-            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
-
+            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
+            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            will produce an error, and a `seed` argument must be provided.
     """
     if dtype and not backend.is_float_dtype(dtype):
         raise ValueError(
@@ -143,9 +142,9 @@ def randint(shape, minval, maxval, dtype="int32", seed=None):
             Note that passing an integer as the `seed` value will produce the same random values for each call.  
             To generate different random values for repeated calls, an instance of  
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
-            when tracing functions with the JAX backend. In case the random number generator 
-            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
+            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
+            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            will produce an error, and a `seed` argument must be provided.
     """
     if dtype and not backend.is_int_dtype(dtype):
         raise ValueError(
@@ -179,10 +178,9 @@ def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
             The `seed` argument can be used to ensure deterministic (repeatable) random number generation.  
             Note that passing an integer as the `seed` value will produce the same random values for each call.  
             To generate different random values for repeated calls, an instance of  
-            `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
-            when tracing functions with the JAX backend. In case the random number generator 
-            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
+            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
+            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.truncated_normal(
         shape, mean=mean, stddev=stddev, dtype=dtype, seed=seed
@@ -210,9 +208,9 @@ def shuffle(x, axis=0, seed=None):
             Note that passing an integer as the `seed` value will produce the same random values for each call.  
             To generate different random values for repeated calls, an instance of  
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
-            when tracing functions with the JAX backend. In case the random number generator 
-            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
+            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
+            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.shuffle(x, axis=axis, seed=seed)
 
@@ -234,9 +232,9 @@ def gamma(shape, alpha, dtype=None, seed=None):
             Note that passing an integer as the `seed` value will produce the same random values for each call.  
             To generate different random values for repeated calls, an instance of  
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
-            when tracing functions with the JAX backend. In case the random number generator 
-            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
+            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
+            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.gamma(shape, alpha=alpha, dtype=dtype, seed=seed)
 
@@ -265,9 +263,9 @@ def binomial(shape, counts, probabilities, dtype=None, seed=None):
             Note that passing an integer as the `seed` value will produce the same random values for each call.  
             To generate different random values for repeated calls, an instance of  
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
-            when tracing functions with the JAX backend. In case the random number generator 
-            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
+            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
+            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.binomial(
         shape,
@@ -301,9 +299,9 @@ def beta(shape, alpha, beta, dtype=None, seed=None):
             Note that passing an integer as the `seed` value will produce the same random values for each call.  
             To generate different random values for repeated calls, an instance of  
             `keras.random.SeedGenerator` must be provided as the `seed` value.  
-            Remark concerning the JAX backend: The global `keras.random.SeedGenerator` is not supported  
-            when tracing functions with the JAX backend. In case the random number generator 
-            is used with JIT compilation and the JAX backend, a `seed` argument must be provided.
+            Remark concerning the JAX backend: When tracing functions with the JAX backend the global 
+            `keras.random.SeedGenerator` is not supported. Therefore, during tracing the default value seed=None 
+            will produce an error, and a `seed` argument must be provided.
     """
     return backend.random.beta(
         shape=shape, alpha=alpha, beta=beta, dtype=dtype, seed=seed

--- a/keras/src/random/seed_generator.py
+++ b/keras/src/random/seed_generator.py
@@ -11,14 +11,18 @@ from keras.src.utils.naming import auto_name
 
 @keras_export("keras.random.SeedGenerator")
 class SeedGenerator:
-    """Generates variable seeds upon each call to a RNG-using function.
+    """Generates variable seeds upon each call to a function generating random numbers.
 
-    In Keras, all RNG-using methods (such as `keras.random.normal()`)
+    In Keras, all random number generators (such as `keras.random.normal()`)
     are stateless, meaning that if you pass an integer seed to them
     (such as `seed=42`), they will return the same values at each call.
-    In order to get different values at each call, you must use a
-    `SeedGenerator` instead as the seed argument. The `SeedGenerator`
-    object is stateful.
+    In order to get different values at each call, a `SeedGenerator` providing 
+    the state of the random generator has to be used. The random number generators all have a 
+    default seed of None, which implies that an internal global SeedGenerator is used.
+    If you need to decouple the RNG from the global state you can provide a local 
+    `StateGenerator` with either a deterministic or random initial state.
+    Note that the use of a local `StateGenerator` as seed argument is required 
+    for JIT compilation with the JAX backend, where the use of global state is not supported.
 
     Example:
 

--- a/keras/src/random/seed_generator.py
+++ b/keras/src/random/seed_generator.py
@@ -11,23 +11,23 @@ from keras.src.utils.naming import auto_name
 
 @keras_export("keras.random.SeedGenerator")
 class SeedGenerator:
-    """Generates variable seeds upon each call to a function generating 
+    """Generates variable seeds upon each call to a function generating
     random numbers.
 
-    In Keras, all random number generators (such as 
-    `keras.random.normal()`) are stateless, meaning that if you pass an 
-    integer seed to them (such as `seed=42`), they will return the same 
-    values for repeated calls. To get different values for each 
-    call, a `SeedGenerator` providing the state of the random generator 
-    has to be used. 
+    In Keras, all random number generators (such as
+    `keras.random.normal()`) are stateless, meaning that if you pass an
+    integer seed to them (such as `seed=42`), they will return the same
+    values for repeated calls. To get different values for each
+    call, a `SeedGenerator` providing the state of the random generator
+    has to be used.
     Note that all the random number generators have a default seed of None,
     which implies that an internal global SeedGenerator is used.
-    If you need to decouple the RNG from the global state you can provide 
-    a local `StateGenerator` with either a deterministic or random initial 
+    If you need to decouple the RNG from the global state you can provide
+    a local `StateGenerator` with either a deterministic or random initial
     state.
-    Remark concerning the JAX backen: Note that the use of a local 
-    `StateGenerator` as seed argument is required for JIT compilation of 
-    RNG with the JAX backend, because the use of global state is not 
+    Remark concerning the JAX backen: Note that the use of a local
+    `StateGenerator` as seed argument is required for JIT compilation of
+    RNG with the JAX backend, because the use of global state is not
     supported.
 
     Example:

--- a/keras/src/random/seed_generator.py
+++ b/keras/src/random/seed_generator.py
@@ -11,19 +11,24 @@ from keras.src.utils.naming import auto_name
 
 @keras_export("keras.random.SeedGenerator")
 class SeedGenerator:
-    """Generates variable seeds upon each call to a function generating random numbers.
+    """Generates variable seeds upon each call to a function generating 
+    random numbers.
 
-    In Keras, all random number generators (such as `keras.random.normal()`)
-    are stateless, meaning that if you pass an integer seed to them
-    (such as `seed=42`), they will return the same values for each call.
-    In order to get different values for each call, a `SeedGenerator` providing 
-    the state of the random generator has to be used. The random number generators all have a 
-    default seed of None, which implies that an internal global SeedGenerator is used.
-    If you need to decouple the RNG from the global state you can provide a local 
-    `StateGenerator` with either a deterministic or random initial state.
-    Note that the use of a local `StateGenerator` as seed argument is required 
-    for JIT compilation of RNG with the JAX backend, because the use of global state 
-    is not supported.
+    In Keras, all random number generators (such as 
+    `keras.random.normal()`) are stateless, meaning that if you pass an 
+    integer seed to them (such as `seed=42`), they will return the same 
+    values for repeated calls. To get different values for each 
+    call, a `SeedGenerator` providing the state of the random generator 
+    has to be used. 
+    Note that all the random number generators have a default seed of None,
+    which implies that an internal global SeedGenerator is used.
+    If you need to decouple the RNG from the global state you can provide 
+    a local `StateGenerator` with either a deterministic or random initial 
+    state.
+    Remark concerning the JAX backen: Note that the use of a local 
+    `StateGenerator` as seed argument is required for JIT compilation of 
+    RNG with the JAX backend, because the use of global state is not 
+    supported.
 
     Example:
 

--- a/keras/src/random/seed_generator.py
+++ b/keras/src/random/seed_generator.py
@@ -15,14 +15,15 @@ class SeedGenerator:
 
     In Keras, all random number generators (such as `keras.random.normal()`)
     are stateless, meaning that if you pass an integer seed to them
-    (such as `seed=42`), they will return the same values at each call.
-    In order to get different values at each call, a `SeedGenerator` providing 
+    (such as `seed=42`), they will return the same values for each call.
+    In order to get different values for each call, a `SeedGenerator` providing 
     the state of the random generator has to be used. The random number generators all have a 
     default seed of None, which implies that an internal global SeedGenerator is used.
     If you need to decouple the RNG from the global state you can provide a local 
     `StateGenerator` with either a deterministic or random initial state.
     Note that the use of a local `StateGenerator` as seed argument is required 
-    for JIT compilation with the JAX backend, where the use of global state is not supported.
+    for JIT compilation of RNG with the JAX backend, because the use of global state 
+    is not supported.
 
     Example:
 


### PR DESCRIPTION
Following the discussion under #20569 this pull request contains a reformulation of the outdated doc concerning
the seed argument of all RNG functions. I also added a clarification to the SeedGenerator class documentation.

Resolves #20569 