### PR TITLE
Add support for jax named scope.

### DIFF
--- a/keras/src/backend/jax/__init__.py
+++ b/keras/src/backend/jax/__init__.py
@@ -1,4 +1,3 @@
-from keras.src.backend.common.name_scope import name_scope
 from keras.src.backend.jax import core
 from keras.src.backend.jax import distribution_lib
 from keras.src.backend.jax import image
@@ -18,6 +17,7 @@ from keras.src.backend.jax.core import convert_to_numpy
 from keras.src.backend.jax.core import convert_to_tensor
 from keras.src.backend.jax.core import device_scope
 from keras.src.backend.jax.core import is_tensor
+from keras.src.backend.jax.core import name_scope
 from keras.src.backend.jax.core import random_seed_dtype
 from keras.src.backend.jax.core import scatter
 from keras.src.backend.jax.core import shape

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -9,6 +9,7 @@ from keras.src.backend.common import KerasVariable
 from keras.src.backend.common import global_state
 from keras.src.backend.common import standardize_dtype
 from keras.src.backend.common.keras_tensor import KerasTensor
+from keras.src.backend.common.name_scope import name_scope as base_name_scope
 from keras.src.backend.common.stateless_scope import StatelessScope
 from keras.src.backend.common.symbolic_scope import SymbolicScope
 from keras.src.backend.jax import distribution_lib
@@ -360,6 +361,35 @@ def random_seed_dtype():
 
 def custom_gradient(fun):
     return jax.custom_gradient(fun=fun)
+
+
+class name_scope(base_name_scope):
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
+        self._jax_name_scope = jax.named_scope(name)
+
+    def __enter__(self):
+        name_scope_stack = global_state.get_global_attribute(
+            "name_scope_stack", default=[], set_to_default=True
+        )
+        if self.deduplicate and name_scope_stack:
+            parent_caller = name_scope_stack[-1].caller
+            parent_name = name_scope_stack[-1].name
+            if (
+                self.caller is not None
+                and self.caller is parent_caller
+                and self.name == parent_name
+            ):
+                return self
+        name_scope_stack.append(self)
+        self._pop_on_exit = True
+        self._jax_name_scope.__enter__()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        super().__exit__(*args, **kwargs)
+        if self._pop_on_exit:
+            self._jax_name_scope.__exit__(*args, **kwargs)
 
 
 def device_scope(device_name):


### PR DESCRIPTION
Makes the default `name_scope` in Jax backend use `jax.named_scope`. The layer name now shows up in profiles.

![image](https://github.com/user-attachments/assets/7b601529-5d7a-490c-ae95-821e99056cac)
