### PR TITLE
Fix masking propagation when `_keras_mask` is unset during `call`

### DIFF
--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -673,6 +673,23 @@ class LayerTest(testing.TestCase):
         layer((x1_1, x1_2), x2)
         layer(x1=(x1_1, x1_2), x2=x2)
 
+        class MaskUnsetDuringCallLayer(layers.Layer):
+            def __init__(self):
+                super().__init__()
+                self.supports_masking = True
+
+            def call(self, x, mask=None):
+                assert mask is not None
+                backend.set_keras_mask(x, None)  # Unset mask
+                return x
+
+        layer = MaskUnsetDuringCallLayer()
+        x = backend.numpy.ones((4, 4))
+        mask = backend.numpy.ones((4,))
+        backend.set_keras_mask(x, mask)
+        y = layer(x)
+        self.assertAllClose(y._keras_mask, mask)
+
     def test_stateless_call(self):
         class TestLayer(layers.Layer):
             def __init__(self):


### PR DESCRIPTION
#20562 causes issues in some downstream projects related to mask propagation.

The root cause is that `previous_mask` is retrieved after `__call__` but the mask might be removed during `__call__` to suppress warnings (ex: `MultiHeadAttention`). To fix it, we can cache the `previous_mask` before `__call__` and set it to the outputs.

cc @SamanehSaadat 