### PR TITLE
Fix loss scaling with `tf.distribute.MirroredStrategy` and `keras.regularizers`

### DIFF
--- a/keras/src/backend/tensorflow/distribute_test.py
+++ b/keras/src/backend/tensorflow/distribute_test.py
@@ -5,6 +5,7 @@ import pytest
 import tensorflow as tf
 from tensorflow.python.eager import context
 
+import keras
 from keras.src import backend
 from keras.src import layers
 from keras.src import models
@@ -135,3 +136,37 @@ class DistributeTest(testing.TestCase):
             v2 = backend.Variable(x, dtype="float32", aggregation="sum")
             self.assertEqual(v2.aggregation, "sum")
             self.assertEqual(v2.value.aggregation, tf.VariableAggregation.SUM)
+
+    def test_loss_scaling_with_num_replicas_in_sync(self):
+        strategy = tf.distribute.MirroredStrategy(["CPU:0", "CPU:1"])
+
+        batch_size = 12
+        x = keras.ops.ones((batch_size, 1))
+        y = keras.ops.zeros((batch_size, 1))
+
+        # Runs without a strategy.
+        inputs = layers.Input(shape=(1,))
+        layer = layers.Dense(
+            1, use_bias=False, kernel_initializer=keras.initializers.Constant(1)
+        )
+        model = models.Model(inputs, layer(inputs))
+        model.compile(loss="mse", optimizer="sgd")
+        model.fit(x, y, batch_size=batch_size, epochs=1)
+        expected_weights = keras.ops.convert_to_numpy(layer.kernel)
+
+        # Runs with a mirrored strategy.
+        with strategy.scope():
+            inputs = layers.Input(shape=(1,))
+            layer = layers.Dense(
+                1,
+                use_bias=False,
+                kernel_initializer=keras.initializers.Constant(1),
+            )
+            model = models.Model(inputs, layer(inputs))
+            model.compile(loss="mse", optimizer="sgd")
+            model.fit(x, y, batch_size=batch_size, epochs=1)
+            weights = strategy.run(lambda: layer.kernel.value).values
+            for w in weights:
+                self.assertAllClose(
+                    keras.ops.convert_to_numpy(w), expected_weights
+                )

--- a/keras/src/backend/tensorflow/distribute_test.py
+++ b/keras/src/backend/tensorflow/distribute_test.py
@@ -137,21 +137,25 @@ class DistributeTest(testing.TestCase):
             self.assertEqual(v2.aggregation, "sum")
             self.assertEqual(v2.value.aggregation, tf.VariableAggregation.SUM)
 
-    def test_loss_scaling_with_num_replicas_in_sync(self):
+    def test_correctness_with_fit_and_regularizer(self):
         strategy = tf.distribute.MirroredStrategy(["CPU:0", "CPU:1"])
 
         batch_size = 12
         x = keras.ops.ones((batch_size, 1))
         y = keras.ops.zeros((batch_size, 1))
 
-        # Runs without a strategy.
+        # Runs without a strategy to get expected weights.
         inputs = layers.Input(shape=(1,))
         layer = layers.Dense(
-            1, use_bias=False, kernel_initializer=keras.initializers.Constant(1)
+            1,
+            use_bias=False,
+            kernel_initializer=keras.initializers.Constant(1),
+            kernel_regularizer=keras.regularizers.L1L2(l1=0.01, l2=0.01),
         )
         model = models.Model(inputs, layer(inputs))
         model.compile(loss="mse", optimizer="sgd")
         model.fit(x, y, batch_size=batch_size, epochs=1)
+
         expected_weights = keras.ops.convert_to_numpy(layer.kernel)
 
         # Runs with a mirrored strategy.
@@ -161,6 +165,7 @@ class DistributeTest(testing.TestCase):
                 1,
                 use_bias=False,
                 kernel_initializer=keras.initializers.Constant(1),
+                kernel_regularizer=keras.regularizers.L1L2(l1=0.01, l2=0.01),
             )
             model = models.Model(inputs, layer(inputs))
             model.compile(loss="mse", optimizer="sgd")

--- a/keras/src/backend/tensorflow/layer.py
+++ b/keras/src/backend/tensorflow/layer.py
@@ -112,10 +112,3 @@ class TFLayer(KerasAutoTrackable):
             return self(inputs)
 
         return serving_default
-
-    def _scale_loss_for_distribution(self, loss):
-        """Scales the given value by the number of replicas in the strategy."""
-        num_replicas = tf.distribute.get_strategy().num_replicas_in_sync
-        if num_replicas > 1:
-            loss = tf.multiply(loss, tf.cast(num_replicas, loss.dtype))
-        return loss

--- a/keras/src/backend/tensorflow/layer.py
+++ b/keras/src/backend/tensorflow/layer.py
@@ -112,3 +112,10 @@ class TFLayer(KerasAutoTrackable):
             return self(inputs)
 
         return serving_default
+
+    def _scale_loss_for_distribution(self, loss):
+        """Scales the given value by the number of replicas in the strategy."""
+        num_replicas = tf.distribute.get_strategy().num_replicas_in_sync
+        if num_replicas > 1:
+            loss = tf.multiply(loss, tf.cast(num_replicas, loss.dtype))
+        return loss

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -5,8 +5,10 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.python.eager import context as tf_context
 
+from keras.src import backend as backend_module
 from keras.src import callbacks as callbacks_module
 from keras.src import metrics as metrics_module
+from keras.src import ops as ops_module
 from keras.src import optimizers as optimizers_module
 from keras.src import tree
 from keras.src.trainers import trainer as base_trainer
@@ -706,6 +708,19 @@ class TensorFlowTrainer(base_trainer.Trainer):
                 break
         with self.distribute_strategy.scope():
             self._symbolic_build(data_batch=data_batch)
+
+    def _aggregate_additional_loss(self, loss):
+        if not backend_module.is_float_dtype(loss.dtype):
+            loss = ops_module.cast(loss, dtype=backend_module.floatx())
+        loss = ops_module.sum(loss)
+
+        # Scales the loss by the number of replicas in the strategy.
+        num_replicas = tf.distribute.get_strategy().num_replicas_in_sync
+        if num_replicas > 1:
+            loss = ops_module.multiply(
+                loss, ops_module.cast(1.0 / num_replicas, loss.dtype)
+            )
+        return loss
 
 
 class TFEpochIterator(EpochIterator):


### PR DESCRIPTION
Fix #19891 

Identified the root cause: the loss should be scaled when using a `MirroredStrategy`.
References:
- https://github.com/keras-team/tf-keras/blob/06e37bfe00c400dd0b993f12596b5f766d4a172d/tf_keras/engine/compile_utils.py#L228
- https://github.com/keras-team/tf-keras/blob/master/tf_keras/utils/losses_utils.py#L360

A correctness test has been added.

cc @SamanehSaadat @drasmuss