### PR TITLE
Unscale loss value in metrics in tensorflow

### DIFF
--- a/keras/src/backend/tensorflow/distribute_test.py
+++ b/keras/src/backend/tensorflow/distribute_test.py
@@ -154,8 +154,8 @@ class DistributeTest(testing.TestCase):
         )
         model = models.Model(inputs, layer(inputs))
         model.compile(loss="mse", optimizer="sgd")
-        model.fit(x, y, batch_size=batch_size, epochs=1)
-
+        history = model.fit(x, y, batch_size=batch_size, epochs=1)
+        expected_loss = history.history["loss"]
         expected_weights = keras.ops.convert_to_numpy(layer.kernel)
 
         # Runs with a mirrored strategy.
@@ -169,8 +169,10 @@ class DistributeTest(testing.TestCase):
             )
             model = models.Model(inputs, layer(inputs))
             model.compile(loss="mse", optimizer="sgd")
-            model.fit(x, y, batch_size=batch_size, epochs=1)
+            history = model.fit(x, y, batch_size=batch_size, epochs=1)
             weights = strategy.run(lambda: layer.kernel.value).values
+
+            self.assertAllClose(history.history["loss"], expected_loss)
             for w in weights:
                 self.assertAllClose(
                     keras.ops.convert_to_numpy(w), expected_weights

--- a/keras/src/losses/loss.py
+++ b/keras/src/losses/loss.py
@@ -239,3 +239,18 @@ def scale_loss_for_distribution(value):
                 value, ops.cast(1.0 / num_replicas, value.dtype)
             )
     return value
+
+
+def unscale_loss_for_distribution(value):
+    """Unscales the given value by the number of replicas in the strategy.
+
+    Currently, this function is only effective when using the tensorflow backend
+    and `tf.distribute`.
+    """
+    if backend.backend() == "tensorflow":
+        import tensorflow as tf
+
+        num_replicas = tf.distribute.get_strategy().num_replicas_in_sync
+        if num_replicas > 1:
+            value = ops.multiply(value, ops.cast(num_replicas, value.dtype))
+    return value

--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -5,6 +5,7 @@ from keras.src import metrics as metrics_module
 from keras.src import ops
 from keras.src import tree
 from keras.src.backend.common.keras_tensor import KerasTensor
+from keras.src.losses import loss as loss_module
 from keras.src.utils.naming import get_object_name
 from keras.src.utils.tracking import Tracker
 
@@ -799,7 +800,8 @@ class CompileLoss(losses_module.Loss):
             # Record *unweighted* individual losses.
             if metric:
                 metric.update_state(
-                    value, sample_weight=tree.flatten(y_p)[0].shape[0]
+                    loss_module.unscale_loss_for_distribution(value),
+                    sample_weight=tree.flatten(y_p)[0].shape[0],
                 )
             if loss_weight is not None:
                 value = ops.multiply(value, loss_weight)


### PR DESCRIPTION
Follow-up to #20609

We need to unscale the loss value for metrics when using distributed strategies.
The test has been updated.