### PR TITLE
Fix issue with unsorted dict

### DIFF
--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -305,7 +305,13 @@ class Functional(Function, Model):
                     raise_exception = True
             else:
                 raise_exception = True
-
+        if (
+            isinstance(self._inputs_struct, dict)
+            and not isinstance(inputs, dict)
+            and list(self._inputs_struct.keys())
+            != sorted(self._inputs_struct.keys())
+        ):
+            raise_exception = True
         self._maybe_warn_inputs_struct_mismatch(
             inputs, raise_exception=raise_exception
         )

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -15,6 +15,7 @@ from keras.src.layers.input_spec import InputSpec
 from keras.src.models import Functional
 from keras.src.models import Model
 from keras.src.models import Sequential
+from keras.src import ops
 
 
 class FunctionalTest(testing.TestCase):
@@ -573,7 +574,6 @@ class FunctionalTest(testing.TestCase):
         with pytest.warns() as warning_logs:
             model.predict([np.ones((2, 2)), np.zeros((2, 2))], verbose=0)
             self.assertLen(list(filter(is_input_warning, warning_logs)), 1)
-
         # No warning for mismatched tuples and lists.
         model = Model([i1, i2], outputs)
         with warnings.catch_warnings(record=True) as warning_logs:
@@ -699,3 +699,17 @@ class FunctionalTest(testing.TestCase):
                 "tags": tags_data,
             }
         )
+
+    def test_list_input_with_dict_build(self):
+        x1 = Input((10,), name="IT")
+        x2 = Input((10,), name="IS")
+        y = layers.subtract([x1, x2])
+        model = Model(inputs={"IT": x1, "IS": x2}, outputs=y)
+        x1 = ops.ones((1, 10))
+        x2 = ops.zeros((1, 10))
+        r1 = model({"IT": x1, "IS": x2})
+        with self.assertRaisesRegex(
+            ValueError,
+            "The structure of `inputs` doesn't match the expected structure",
+        ):
+            r2 = model([x1, x2])


### PR DESCRIPTION
When a functional model built with `dict` and called with `list` as arguments, current implementation just raises warning. This is OK if the keys are ordered in the dict.

In my opinion when the keys are unordered it should raise a error. The below code should raise the Error instead of simple warning as All Users may not aware that Keras sorts the `dict` as per the keys. In below code while building the model keras makes the sorting of keys internally and hence it changes the order to [x2, x1] and hence there is the difference in result when called the model with arguments as `dict` vs `list` .

```
x1 = keras.Input((10,), name='IT')
x2 = keras.Input((10,), name='IS')
y = keras.layers.subtract([x1, x2])
model = keras.Model(inputs={"IT": x1, "IS": x2}, outputs=y)
x1 = keras.ops.ones((1, 10))
x2 = keras.ops.zeros((1, 10))

r1 = model([x1, x2])
r2 = model({'IT': x1, 'IS': x2})

assert r1.numpy().sum()==r2.numpy().sum()
```

May be related to #20070 
