### PR TITLE
Allow lower precision in `einsum` in `dot_product_attention`

### DIFF
--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -1015,12 +1015,8 @@ def _apply_masks(logits, mask, is_causal):
 
 def _dot_product_attention_xla(query, key, value, bias, mask, is_causal, scale):
     logits_dtype = backend.result_type(query.dtype, "float32")
-    logits = tf.einsum(
-        "BTNH,BSNH->BNTS",
-        tf.cast(query, dtype=logits_dtype),
-        tf.cast(key, dtype=logits_dtype),
-        optimize="optimal",
-    )
+    logits = tf.einsum("BTNH,BSNH->BNTS", query, key, optimize="optimal")
+    logits = tf.cast(logits, logits_dtype)
     logits = tf.multiply(logits, tf.cast(scale, logits.dtype))
 
     if bias is not None:


### PR DESCRIPTION
This PR updates the dtype used in `einsum` in `dot_product_attention` for tensorflow and numpy.

Initially, I followed jax's implementation which casts `key` and `query` to higher precision early to mimic the behavior of `preferred_element_type="float32"`. However, performing `einsum` in float32 is much slower than float16 or bfloat16. Additionally, the original MHA implementation doesn't cast them to float32.
Therefore, it seems reasonable to use the dtype of `key` and `query` directly for `einsum`.

Related to https://github.com/keras-team/keras-hub/pull/2014