### PR TITLE
fixes torch GPU test on mix_up

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/mix_up.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/mix_up.py
@@ -68,6 +68,7 @@ class MixUp(BaseImagePreprocessingLayer):
         }
 
     def transform_images(self, images, transformation=None, training=True):
+        images = self.backend.cast(images, self.compute_dtype)
         mix_weight = transformation["mix_weight"]
         permutation_order = transformation["permutation_order"]
 


### PR DESCRIPTION
Fixes Torch GPU Test on `mix_up`

```
FAILED keras/src/layers/preprocessing/image_preprocessing/mix_up_test.py::MixUpTest::test_mix_up_basic_functionality - TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
FAILED keras/src/layers/preprocessing/image_preprocessing/mix_up_test.py::MixUpTest::test_mix_up_basic_functionality_channel_first - TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
FAILED keras/src/layers/preprocessing/image_preprocessing/mix_up_test.py::MixUpTest::test_tf_data_compatibility - TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
===== 3 failed, 9336 passed, 1214 skipped, 1 xpassed in 962.68s (0:16:02) ======
```