### PR TITLE
Fix Layer normalization issue with scalar mean & variance

### DIFF
--- a/keras/src/layers/preprocessing/normalization.py
+++ b/keras/src/layers/preprocessing/normalization.py
@@ -190,8 +190,8 @@ class Normalization(TFDataLayer):
             # with proper broadcast shape for use during call.
             mean = ops.convert_to_tensor(self.input_mean)
             variance = ops.convert_to_tensor(self.input_variance)
-            mean = ops.reshape(mean, self._broadcast_shape)
-            variance = ops.reshape(variance, self._broadcast_shape)
+            mean = ops.broadcast_to(mean, self._broadcast_shape)
+            variance = ops.broadcast_to(variance, self._broadcast_shape)
             self.mean = ops.cast(mean, dtype=self.compute_dtype)
             self.variance = ops.cast(variance, dtype=self.compute_dtype)
             self.built = True

--- a/keras/src/layers/preprocessing/normalization_test.py
+++ b/keras/src/layers/preprocessing/normalization_test.py
@@ -164,3 +164,8 @@ class NormalizationTest(testing.TestCase):
         )
         for output in ds.map(layer).take(1):
             output.numpy()
+
+    def test_normalization_with_scalar_mean_var(self):
+        input_data = np.array([[1,2,3]], dtype='float32')
+        layer = layers.Normalization(mean=3., variance=2.)
+        layer(input_data)


### PR DESCRIPTION
Fix Layer normalization issue with scalar mean & variance.

With scalar mean instead of broadcasting reshaping applied currently. Changed the same.

Fixes #20624.