### PR TITLE
Fix typos in simple_rnn

### DIFF
--- a/keras/src/layers/rnn/simple_rnn.py
+++ b/keras/src/layers/rnn/simple_rnn.py
@@ -256,12 +256,12 @@ class SimpleRNN(RNN):
             If `True`, process the input sequence backwards and return the
             reversed sequence.
         stateful: Boolean (default: `False`). If `True`, the last state
-            for each sample at index i in a batch will be used as initial
-            state for the sample of index i in the following batch.
+            for each sample at index i in a batch will be used as the 
+            initial state for the sample of index i in the following batch.
         unroll: Boolean (default: `False`).
             If `True`, the network will be unrolled,
             else a symbolic loop will be used.
-            Unrolling can speed-up a RNN,
+            Unrolling can speed-up an RNN,
             although it tends to be more memory-intensive.
             Unrolling is only suitable for short sequences.
 


### PR DESCRIPTION
I observed a  few typos in simple_rnn