### PR TITLE
Update example and logic for mix_up

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/mix_up.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/mix_up.py
@@ -24,11 +24,9 @@ class MixUp(BaseImagePreprocessingLayer):
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     images, labels = images[:8], labels[:8]
-    labels = keras.ops.cast(keras.ops.one_hot(labels.flatten(), 10), tf.float32)
+    labels = keras.ops.cast(keras.ops.one_hot(labels.flatten(), 10), "float32")
     mix_up = keras.layers.MixUp(alpha=0.2)
-    output = mix_up(
-        {'images': images, 'labels': labels}
-    )
+    output = mix_up({"images": images, "labels": labels})
     ```
     """
 


### PR DESCRIPTION
I have updated the code with the following changes:

1. Modified the example to ensure it works seamlessly on the Keras platform.
2. Adjusted the mix_weight implementation to apply different weights to each sample in the batch, enabling more diverse augmentations.
3. Fixed a typo by correcting "mixup" to "mix_up" for consistency.