### PR TITLE
Adds scikit-learn dependency to setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "optree",
     "ml-dtypes",
     "packaging",
+    "scikit-learn",
 ]
 # Run also: pip install -r requirements.txt
 


### PR DESCRIPTION
#20599 added dependency to sklearn, but was not included in `pyproject.toml`. This caused the nightly wheel to not include it and fails TensorFlow nightly build.  This PR adds scikit-learn as a Keras Deps.