### PR TITLE
Fix paths for pytest in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,11 +162,11 @@ We use [pytest](https://pytest.org/) to run the tests.
 
 ### Run a test file
 
-To run the tests in `keras/losses/losses_test.py`, use the following command
+To run the tests in `keras/src/losses/losses_test.py`, use the following command
 at the root directory of the repo.
 
 ```shell
-pytest keras/losses/losses_test.py
+pytest keras/src/losses/losses_test.py
 ```
 
 ### Run a single test case
@@ -174,13 +174,13 @@ pytest keras/losses/losses_test.py
 You can specify a single test class to run within a file.
 
 ```shell
-pytest keras/losses/losses_test.py::MeanSquaredErrorTest
+pytest keras/src/losses/losses_test.py::MeanSquaredErrorTest
 ```
 
 You can also specify a single test method to run within a class.
 
 ```shell
-pytest keras/losses/losses_test.py::MeanSquaredErrorTest::test_sample_weighted
+pytest keras/src/losses/losses_test.py::MeanSquaredErrorTest::test_sample_weighted
 ```
 
 ### Run all tests


### PR DESCRIPTION
It looks like that the internal structure of `keras/` changed to `keras/src` at a certain point. Hence, the paths are not valid anymore and `pytest` cannot find the proper files. For example:

```sh
$ pytest keras/losses/losses_test.py
ERROR: file or directory not found: keras/losses/losses_test.py
```

After fixing all these paths, the tests run successfully locally.