### PR TITLE
Make sklearn dependency optional

### DIFF
--- a/keras/src/wrappers/sklearn_test.py
+++ b/keras/src/wrappers/sklearn_test.py
@@ -3,6 +3,9 @@
 from contextlib import contextmanager
 
 import pytest
+import sklearn
+from packaging.version import parse as parse_version
+from sklearn.utils.estimator_checks import parametrize_with_checks
 
 import keras
 from keras.src.backend import floatx
@@ -13,7 +16,45 @@ from keras.src.models import Model
 from keras.src.wrappers import SKLearnClassifier
 from keras.src.wrappers import SKLearnRegressor
 from keras.src.wrappers import SKLearnTransformer
-from keras.src.wrappers.fixes import parametrize_with_checks
+
+
+def wrapped_parametrize_with_checks(
+    estimators,
+    *,
+    legacy: bool = True,
+    expected_failed_checks=None,
+):
+    """Wrapped `parametrize_with_checks` handling backwards compat."""
+    sklearn_version = parse_version(
+        parse_version(sklearn.__version__).base_version
+    )
+
+    if sklearn_version >= parse_version("1.6"):
+        return parametrize_with_checks(
+            estimators,
+            legacy=legacy,
+            expected_failed_checks=expected_failed_checks,
+        )
+
+    def patched_more_tags(estimator, expected_failed_checks):
+        import copy
+
+        original_tags = copy.deepcopy(sklearn.utils._tags._safe_tags(estimator))
+
+        def patched_more_tags(self):
+            original_tags.update({"_xfail_checks": expected_failed_checks})
+            return original_tags
+
+        estimator.__class__._more_tags = patched_more_tags
+        return estimator
+
+    estimators = [
+        patched_more_tags(estimator, expected_failed_checks(estimator))
+        for estimator in estimators
+    ]
+
+    # legacy is not supported and ignored
+    return parametrize_with_checks(estimators)
 
 
 def dynamic_model(X, y, loss, layers=[10]):
@@ -80,7 +121,7 @@ EXPECTED_FAILED_CHECKS = {
 }
 
 
-@parametrize_with_checks(
+@wrapped_parametrize_with_checks(
     estimators=[
         SKLearnClassifier(
             model=dynamic_model,

--- a/keras/src/wrappers/utils.py
+++ b/keras/src/wrappers/utils.py
@@ -1,7 +1,23 @@
-from sklearn.base import BaseEstimator
-from sklearn.base import TransformerMixin
-from sklearn.base import check_is_fitted
-from sklearn.utils._array_api import get_namespace
+try:
+    import sklearn
+    from sklearn.base import BaseEstimator
+    from sklearn.base import TransformerMixin
+except ImportError:
+    sklearn = None
+
+    class BaseEstimator:
+        pass
+
+    class TransformerMixin:
+        pass
+
+
+def assert_sklearn_installed(symbol_name):
+    if sklearn is None:
+        raise ImportError(
+            f"{symbol_name} requires `scikit-learn` to be installed. "
+            "Run `pip install scikit-learn` to install it."
+        )
 
 
 def _check_model(model):
@@ -64,8 +80,8 @@ class TargetReshaper(TransformerMixin, BaseEstimator):
                 is passed, it will be squeezed back to 1D. Otherwise, it
                 will eb left untouched.
         """
-        check_is_fitted(self)
-        xp, _ = get_namespace(y)
+        sklearn.base.check_is_fitted(self)
+        xp, _ = sklearn.utils._array_api.get_namespace(y)
         if self.ndim_ == 1 and y.ndim == 2:
             return xp.squeeze(y, axis=1)
         return y

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "optree",
     "ml-dtypes",
     "packaging",
-    "scikit-learn",
 ]
 # Run also: pip install -r requirements.txt
 


### PR DESCRIPTION
Conditionally import sklearn. Only error on usage of keras sklearn symbol usage.

Kinda awkward that we need to declare empty classes for the classes we are missing from sklearn (if it isn't installed), but this seems like the simplest solution.