### PR TITLE
Change recurrent dropout implementation for LSTM.

### DIFF
--- a/keras/src/layers/rnn/gru.py
+++ b/keras/src/layers/rnn/gru.py
@@ -133,7 +133,8 @@ class GRUCell(Layer, DropoutRNNCell):
         self.recurrent_dropout = min(1.0, max(0.0, recurrent_dropout))
         if self.recurrent_dropout != 0.0:
             self.implementation = 1
-        self.dropout_mask_count = 3
+        if self.implementation == 1:
+            self.dropout_mask_count = 3
         self.seed = seed
         self.seed_generator = backend.random.SeedGenerator(seed=seed)
 
@@ -255,7 +256,7 @@ class GRUCell(Layer, DropoutRNNCell):
         else:
             if training and 0.0 < self.dropout < 1.0:
                 dp_mask = self.get_dropout_mask(inputs)
-                inputs = inputs * dp_mask[0]
+                inputs = inputs * dp_mask
 
             # inputs projected by all gate matrices at once
             matrix_x = ops.matmul(inputs, self.kernel)

--- a/keras/src/layers/rnn/gru_test.py
+++ b/keras/src/layers/rnn/gru_test.py
@@ -12,6 +12,16 @@ class GRUTest(testing.TestCase):
     def test_basics(self):
         self.run_layer_test(
             layers.GRU,
+            init_kwargs={"units": 3, "dropout": 0.5},
+            input_shape=(3, 2, 4),
+            call_kwargs={"training": True},
+            expected_output_shape=(3, 3),
+            expected_num_trainable_weights=3,
+            expected_num_non_trainable_weights=0,
+            supports_masking=True,
+        )
+        self.run_layer_test(
+            layers.GRU,
             init_kwargs={"units": 3, "dropout": 0.5, "recurrent_dropout": 0.5},
             input_shape=(3, 2, 4),
             call_kwargs={"training": True},

--- a/keras/src/layers/rnn/lstm_test.py
+++ b/keras/src/layers/rnn/lstm_test.py
@@ -12,6 +12,16 @@ class LSTMTest(testing.TestCase):
     def test_basics(self):
         self.run_layer_test(
             layers.LSTM,
+            init_kwargs={"units": 3, "dropout": 0.5},
+            input_shape=(3, 2, 4),
+            call_kwargs={"training": True},
+            expected_output_shape=(3, 3),
+            expected_num_trainable_weights=3,
+            expected_num_non_trainable_weights=0,
+            supports_masking=True,
+        )
+        self.run_layer_test(
+            layers.LSTM,
             init_kwargs={"units": 3, "dropout": 0.5, "recurrent_dropout": 0.5},
             input_shape=(3, 2, 4),
             call_kwargs={"training": True},


### PR DESCRIPTION
This change is to make the implementation of recurrent dropout consistent with GRU (changed as of https://github.com/keras-team/keras/pull/20656 ) and Keras 2.

Also fixed a bug where the GRU fix would break when using CUDNN with a dropout and no recurrent dropout. The solution is to create multiple masks only when needed (implementation == 1).

Added coverage for the case when dropout is set and recurrent dropout is not set.