### PR TITLE
Never pass enable_xla=False or native_serialization=False in tests

### DIFF
--- a/keras/src/export/export_lib_test.py
+++ b/keras/src/export/export_lib_test.py
@@ -275,7 +275,7 @@ class ExportSavedModelTest(testing.TestCase):
             is_static=(True, False),
             jax2tf_kwargs=(
                 None,
-                {"enable_xla": False, "native_serialization": False},
+                {"enable_xla": True, "native_serialization": True},
             ),
         )
     )


### PR DESCRIPTION
These are invalid options in the latest version of jax2tf, they will just immediately throw.