### PR TITLE
Multiple Example Title has removed in OneHotMeanIoU funtion

### DIFF
--- a/keras/src/metrics/iou_metrics.py
+++ b/keras/src/metrics/iou_metrics.py
@@ -702,7 +702,6 @@ class OneHotMeanIoU(MeanIoU):
             associated label.
         axis: (Optional) The dimension containing the logits. Defaults to `-1`.
 
-    Example:
 
     Example:
 


### PR DESCRIPTION
Multiple Example Title has removed in OneHotMeanIoU funtion.