### PR TITLE
Adjust value_range for random_contrast and random_hue

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/random_contrast.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_contrast.py
@@ -45,9 +45,10 @@ class RandomContrast(BaseImagePreprocessingLayer):
 
     _FACTOR_BOUNDS = (0, 1)
 
-    def __init__(self, factor, seed=None, **kwargs):
+    def __init__(self, factor, value_range=(0, 255), seed=None, **kwargs):
         super().__init__(**kwargs)
         self._set_factor(factor)
+        self.value_range = value_range
         self.seed = seed
         self.generator = SeedGenerator(seed)
 
@@ -89,7 +90,9 @@ class RandomContrast(BaseImagePreprocessingLayer):
         if training:
             constrast_factor = transformation["contrast_factor"]
             outputs = self._adjust_constrast(images, constrast_factor)
-            outputs = self.backend.numpy.clip(outputs, 0, 255)
+            outputs = self.backend.numpy.clip(
+                outputs, self.value_range[0], self.value_range[1]
+            )
             self.backend.numpy.reshape(outputs, self.backend.shape(images))
             return outputs
         return images
@@ -135,6 +138,7 @@ class RandomContrast(BaseImagePreprocessingLayer):
     def get_config(self):
         config = {
             "factor": self.factor,
+            "value_range": self.value_range,
             "seed": self.seed,
         }
         base_config = super().get_config()

--- a/keras/src/layers/preprocessing/image_preprocessing/random_contrast.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_contrast.py
@@ -40,6 +40,10 @@ class RandomContrast(BaseImagePreprocessingLayer):
             `[1.0 - lower, 1.0 + upper]`. For any pixel x in the channel,
             the output will be `(x - mean) * factor + mean`
             where `mean` is the mean value of the channel.
+        value_range: the range of values the incoming images will have.
+            Represented as a two-number tuple written `[low, high]`. This is
+            typically either `[0, 1]` or `[0, 255]` depending on how your
+            preprocessing pipeline is set up.
         seed: Integer. Used to create a random seed.
     """
 

--- a/keras/src/layers/preprocessing/image_preprocessing/random_contrast_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_contrast_test.py
@@ -37,8 +37,18 @@ class RandomContrastTest(testing.TestCase):
     def test_random_contrast_with_value_range_0_to_255(self):
         seed = 9809
         np.random.seed(seed)
-        inputs = np.random.random((12, 8, 16, 3))
-        inputs = backend.convert_to_tensor(inputs)
+
+        data_format = backend.config.image_data_format()
+        if data_format == "channels_last":
+            inputs = np.random.random((12, 8, 16, 3))
+            height_axis = -3
+            width_axis = -2
+        else:
+            inputs = np.random.random((12, 3, 8, 16))
+            height_axis = -2
+            width_axis = -1
+
+        inputs = backend.convert_to_tensor(inputs, dtype="float32")
         layer = layers.RandomContrast(
             factor=0.5, value_range=(0, 255), seed=seed
         )
@@ -49,8 +59,8 @@ class RandomContrastTest(testing.TestCase):
         np.random.seed(seed)
         factor = backend.convert_to_numpy(transformation["contrast_factor"])
         inputs = backend.convert_to_numpy(inputs)
-        inp_mean = np.mean(inputs, axis=-3, keepdims=True)
-        inp_mean = np.mean(inp_mean, axis=-2, keepdims=True)
+        inp_mean = np.mean(inputs, axis=height_axis, keepdims=True)
+        inp_mean = np.mean(inp_mean, axis=width_axis, keepdims=True)
         actual_outputs = (inputs - inp_mean) * factor + inp_mean
         outputs = backend.convert_to_numpy(outputs)
         actual_outputs = np.clip(actual_outputs, 0, 255)
@@ -60,8 +70,18 @@ class RandomContrastTest(testing.TestCase):
     def test_random_contrast_with_value_range_0_to_1(self):
         seed = 9809
         np.random.seed(seed)
-        inputs = np.random.random((12, 8, 16, 3))
-        inputs = backend.convert_to_tensor(inputs)
+
+        data_format = backend.config.image_data_format()
+        if data_format == "channels_last":
+            inputs = np.random.random((12, 8, 16, 3))
+            height_axis = -3
+            width_axis = -2
+        else:
+            inputs = np.random.random((12, 3, 8, 16))
+            height_axis = -2
+            width_axis = -1
+
+        inputs = backend.convert_to_tensor(inputs, dtype="float32")
         layer = layers.RandomContrast(factor=0.5, value_range=(0, 1), seed=seed)
         transformation = layer.get_random_transformation(inputs, training=True)
         outputs = layer.transform_images(inputs, transformation, training=True)
@@ -70,8 +90,8 @@ class RandomContrastTest(testing.TestCase):
         np.random.seed(seed)
         factor = backend.convert_to_numpy(transformation["contrast_factor"])
         inputs = backend.convert_to_numpy(inputs)
-        inp_mean = np.mean(inputs, axis=-3, keepdims=True)
-        inp_mean = np.mean(inp_mean, axis=-2, keepdims=True)
+        inp_mean = np.mean(inputs, axis=height_axis, keepdims=True)
+        inp_mean = np.mean(inp_mean, axis=width_axis, keepdims=True)
         actual_outputs = (inputs - inp_mean) * factor + inp_mean
         outputs = backend.convert_to_numpy(outputs)
         actual_outputs = np.clip(actual_outputs, 0, 1)

--- a/keras/src/layers/preprocessing/image_preprocessing/random_hue.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_hue.py
@@ -44,7 +44,12 @@ class RandomHue(BaseImagePreprocessingLayer):
     _FACTOR_BOUNDS = (0, 1)
 
     def __init__(
-        self, factor, value_range, data_format=None, seed=None, **kwargs
+        self,
+        factor,
+        value_range=(0, 255),
+        data_format=None,
+        seed=None,
+        **kwargs,
     ):
         super().__init__(data_format=data_format, **kwargs)
         self._set_factor(factor)

--- a/keras/src/layers/preprocessing/image_preprocessing/random_hue_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_hue_test.py
@@ -31,14 +31,23 @@ class RandomHueTest(testing.TestCase):
         output = layer(inputs, training=False)
         self.assertAllClose(inputs, output)
 
-    def test_random_hue_value_range(self):
+    def test_random_hue_value_range_0_to_1(self):
         image = keras.random.uniform(shape=(3, 3, 3), minval=0, maxval=1)
+
+        layer = layers.RandomHue(0.2, (0, 1))
+        adjusted_image = layer(image)
+
+        self.assertTrue(keras.ops.numpy.all(adjusted_image >= 0))
+        self.assertTrue(keras.ops.numpy.all(adjusted_image <= 1))
+
+    def test_random_hue_value_range_0_to_255(self):
+        image = keras.random.uniform(shape=(3, 3, 3), minval=0, maxval=255)
 
         layer = layers.RandomHue(0.2, (0, 255))
         adjusted_image = layer(image)
 
         self.assertTrue(keras.ops.numpy.all(adjusted_image >= 0))
-        self.assertTrue(keras.ops.numpy.all(adjusted_image <= 1))
+        self.assertTrue(keras.ops.numpy.all(adjusted_image <= 255))
 
     def test_random_hue_no_change_with_zero_factor(self):
         data_format = backend.config.image_data_format()


### PR DESCRIPTION
I’ve updated the processing logic for the value_range argument in the following components:

1. random_contrast
- Added the value_range argument.
- Corrected the existing test cases and added new test cases to validate the value_range functionality.

2. random_hue
- Set a default value for the value_range argument.
- Introduced new test cases to cover the value_range functionality.