### PR TITLE
minor: Fix Functional API guide

### DIFF
--- a/guides/functional_api.py
+++ b/guides/functional_api.py
@@ -179,6 +179,7 @@ to save the entire model as a single file. You can later recreate the same model
 from this file, even if the code that built the model is no longer available.
 
 This saved file includes the:
+
 - model architecture
 - model weight values (that were learned during training)
 - model training config, if any (as passed to `compile()`)


### PR DESCRIPTION
Add an empty line so the list is rendered as a list, not as a single line of text

Currently:
<img width="742" alt="image" src="https://github.com/user-attachments/assets/81b3d3aa-bcef-443f-84fb-899a80011872" />
