### PR TITLE
Fix torch gpu CI

### DIFF
--- a/.kokoro/github/ubuntu/gpu/build.sh
+++ b/.kokoro/github/ubuntu/gpu/build.sh
@@ -74,7 +74,6 @@ then
 
    # TODO: keras/src/export/export_lib_test.py update LD_LIBRARY_PATH 
    pytest keras --ignore keras/src/applications \
-               --ignore keras/src/export/export_lib_test.py \
                --cov=keras \
                --cov-config=pyproject.toml
 

--- a/keras/src/export/export_lib_test.py
+++ b/keras/src/export/export_lib_test.py
@@ -57,6 +57,9 @@ def get_model(type="sequential", input_shape=(10,), layer_list=None):
     ),
 )
 @pytest.mark.skipif(testing.jax_uses_gpu(), reason="Leads to core dumps on CI")
+@pytest.mark.skipif(
+    testing.torch_uses_gpu(), reason="Leads to core dumps on CI"
+)
 class ExportSavedModelTest(testing.TestCase):
     @parameterized.named_parameters(
         named_product(model_type=["sequential", "functional", "subclass"])
@@ -344,6 +347,9 @@ class ExportSavedModelTest(testing.TestCase):
     reason="Export only currently supports the TF and JAX backends.",
 )
 @pytest.mark.skipif(testing.jax_uses_gpu(), reason="Leads to core dumps on CI")
+@pytest.mark.skipif(
+    testing.torch_uses_gpu(), reason="Leads to core dumps on CI"
+)
 class ExportArchiveTest(testing.TestCase):
     @parameterized.named_parameters(
         named_product(model_type=["sequential", "functional", "subclass"])

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -1229,6 +1229,9 @@ class ModelTest(testing.TestCase):
     @pytest.mark.skipif(
         testing.jax_uses_gpu(), reason="Leads to core dumps on CI"
     )
+    @pytest.mark.skipif(
+        testing.torch_uses_gpu(), reason="Leads to core dumps on CI"
+    )
     def test_export(self):
         import tensorflow as tf
 


### PR DESCRIPTION
Following #20685 

We should skip `torch_xla` related tests on Torch GPU CI.