### PR TITLE
Raise error if inputs are not connected with output in functional model

### DIFF
--- a/keras/src/backend/tensorflow/saved_model_test.py
+++ b/keras/src/backend/tensorflow/saved_model_test.py
@@ -191,24 +191,37 @@ class SavedModelTest(testing.TestCase):
     def test_multi_input_model(self):
         input_1 = layers.Input(shape=(3,))
         input_2 = layers.Input(shape=(5,))
-        model = models.Model([input_1, input_2], [input_1, input_2])
-        path = os.path.join(self.get_temp_dir(), "my_keras_model")
 
-        tf.saved_model.save(model, path)
-        restored_model = tf.saved_model.load(path)
+        y1 = layers.Dense(1)(input_1)
+        y2 = layers.Dense(1)(input_2)
+        layer_2 = layers.Dense(1, activation="relu")
+        output_1 = layer_2(y1)
+        output_2 = layer_2(y2)
+        model = models.Model([input_1, input_2], [output_1, output_2])
+
         input_arr_1 = np.random.random((1, 3)).astype("float32")
         input_arr_2 = np.random.random((1, 5)).astype("float32")
 
-        outputs = restored_model.signatures["serving_default"](
+        model = models.Model([input_1, input_2], [output_1, output_2])
+        path = os.path.join(self.get_temp_dir(), "my_keras_model")
+        outputs_1 = model(
+            inputs=[
+                tf.convert_to_tensor(input_arr_1, dtype=tf.float32),
+                tf.convert_to_tensor(input_arr_2, dtype=tf.float32),
+            ],
+        )
+        tf.saved_model.save(model, path)
+        restored_model = tf.saved_model.load(path)
+
+        outputs_2 = restored_model.signatures["serving_default"](
             inputs=tf.convert_to_tensor(input_arr_1, dtype=tf.float32),
             inputs_1=tf.convert_to_tensor(input_arr_2, dtype=tf.float32),
         )
-
         self.assertAllClose(
-            input_arr_1, outputs["output_0"], rtol=1e-4, atol=1e-4
+            outputs_1[0], outputs_2["output_0"], rtol=1e-4, atol=1e-4
         )
         self.assertAllClose(
-            input_arr_2, outputs["output_1"], rtol=1e-4, atol=1e-4
+            outputs_1[1], outputs_2["output_1"], rtol=1e-4, atol=1e-4
         )
 
     def test_multi_input_custom_model_and_layer(self):

--- a/keras/src/ops/function.py
+++ b/keras/src/ops/function.py
@@ -81,6 +81,12 @@ class Function(Operation):
         self._nodes_by_depth = nodes_by_depth
         self._operations = operations
         self._operations_by_depth = operations_by_depth
+        for input in self._inputs:
+            if (
+                input._keras_history.operation
+                and not input._keras_history.operation._outbound_nodes
+            ):
+                raise ValueError("`inputs` not connected to `outputs`")
 
     @property
     def operations(self):

--- a/keras/src/ops/function_test.py
+++ b/keras/src/ops/function_test.py
@@ -6,7 +6,8 @@ from keras.src import testing
 from keras.src.backend.common import keras_tensor
 from keras.src.layers import Dense
 from keras.src.layers import Input
-from keras.src.models import Model, Sequential
+from keras.src.models import Model
+from keras.src.models import Sequential
 from keras.src.ops import function
 from keras.src.ops import numpy as knp
 

--- a/keras/src/ops/function_test.py
+++ b/keras/src/ops/function_test.py
@@ -6,7 +6,7 @@ from keras.src import testing
 from keras.src.backend.common import keras_tensor
 from keras.src.layers import Dense
 from keras.src.layers import Input
-from keras.src.models import Model
+from keras.src.models import Model, Sequential
 from keras.src.ops import function
 from keras.src.ops import numpy as knp
 
@@ -142,3 +142,26 @@ class FunctionTest(testing.TestCase):
             ValueError, "`inputs` argument cannot be empty"
         ):
             _ = function.Function(inputs=[], outputs=x)
+
+    def test_function_with_unconnected_inputs(self):
+        model_1 = Sequential(
+            [
+                Input(shape=(6,)),
+                Dense(3, activation="sigmoid"),
+            ]
+        )
+        model_2 = Sequential(
+            [
+                Input(shape=(3,)),
+                Dense(2, activation="sigmoid"),
+            ],
+        )
+        with self.assertRaisesRegex(
+            ValueError, "`inputs` not connected to `outputs`"
+        ):
+            _ = Model(Input(shape=(6,)), model_2(model_1(Input(shape=(6,)))))
+
+        with self.assertRaisesRegex(
+            ValueError, "`inputs` not connected to `outputs`"
+        ):
+            _ = Model(model_1(Input(shape=(6,))), model_2(Input(shape=(3,))))


### PR DESCRIPTION
Raise error if inputs are not connected with output in functional model.

The below code fails with `tensor_dict` related error which is not useful to users.

```
model_1 = Sequential([
    Input(shape=(6,)),
    layers.Dense(3, activation="sigmoid"),
])

model_2 = Sequential([
    Input(shape=(3,)),
    layers.Dense(1, activation="sigmoid"),
], )

combined = Model(Input(shape=(6,)), model_2(model_1(Input(shape=(6,)))), name='nested_model')
combined.compile(loss='binary_crossentropy', optimizer='adam')
output = combined.train_on_batch(np.random.normal(0, 1, (8, 6)), np.random.normal(0, 1, (8, 1)))
```

