### PR TITLE
fix: Torch MPS backend failing test

### DIFF
--- a/keras/src/utils/backend_utils_test.py
+++ b/keras/src/utils/backend_utils_test.py
@@ -15,7 +15,7 @@ class BackendUtilsTest(testing.TestCase):
     )
     def test_dynamic_backend(self, name):
         dynamic_backend = backend_utils.DynamicBackend()
-        x = np.random.uniform(size=[1, 2, 3])
+        x = np.random.uniform(size=[1, 2, 3]).astype("float32")
 
         if name == "numpy":
             dynamic_backend.set_backend(name)


### PR DESCRIPTION
closes #20708

On the same machine that produced the test failure, I tried the following 2 code bits in a shell:

```python
x = np.random.uniform(size=[1, 2, 3])
torch.as_tensor(x, device=torch.device("mps"))
```

as well as

```python
y = np.random.uniform(size=[1, 2, 3]).astype("float32")
torch.as_tensor(y, device=torch.device("mps"))
```

the first produced the same error from #20708 while the second didn't, so this should fix things.