### PR TITLE
Update BackupAndRestore class example

### DIFF
--- a/keras/src/callbacks/backup_and_restore.py
+++ b/keras/src/callbacks/backup_and_restore.py
@@ -37,7 +37,7 @@ class BackupAndRestore(Callback):
     >>> callback = keras.callbacks.BackupAndRestore(backup_dir="/tmp/backup")
     >>> model = keras.models.Sequential([keras.layers.Dense(10)])
     >>> model.compile(keras.optimizers.SGD(), loss='mse')
-    >>> model.build(input_shape=(None,20))
+    >>> model.build(input_shape=(None, 20))
     >>> try:
     ...   model.fit(np.arange(100).reshape(5, 20), np.zeros(5), epochs=10,
     ...             batch_size=1, callbacks=[callback, InterruptingCallback()],

--- a/keras/src/callbacks/backup_and_restore.py
+++ b/keras/src/callbacks/backup_and_restore.py
@@ -37,6 +37,7 @@ class BackupAndRestore(Callback):
     >>> callback = keras.callbacks.BackupAndRestore(backup_dir="/tmp/backup")
     >>> model = keras.models.Sequential([keras.layers.Dense(10)])
     >>> model.compile(keras.optimizers.SGD(), loss='mse')
+    >>> model.build(input_shape=(None,20))
     >>> try:
     ...   model.fit(np.arange(100).reshape(5, 20), np.zeros(5), epochs=10,
     ...             batch_size=1, callbacks=[callback, InterruptingCallback()],


### PR DESCRIPTION
Updated example for BackupAndRestore class example  as it raises error as model is not build.
Fixed [#20712](https://github.com/keras-team/keras/issues/20712)