### PR TITLE
Add a gradient checkpoint feature

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -112,6 +112,16 @@ class Layer(BackendLayer, Operation, KerasSaveable):
             as part of `layer.trainable_weights`.
         input_spec: Optional (list of) `InputSpec` object(s) specifying the
             constraints on inputs that can be accepted by the layer.
+        enable_gradient_checkpoint: bool variable,
+        Whether to start the gradient_checkpoint.
+        In the Torch backend, your layer need to meet the following conditions:
+        Ensure that there are no dropout layers.
+        Ensure that there are no normalization layers (such as BN, LN).
+        Ensure consistent forward and backward behaviors in your function.
+        In the TensorFlow backend, you can only enable this setting at eager.
+        In the JAX backend, your inputs should meet the following conditions:
+        Ensure that there are no strings.
+        Ensure that there are no other non-differentiable JAX valid types.
 
     We recommend that descendants of `Layer` implement the following methods:
 
@@ -266,12 +276,6 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         enable_gradient_ckeckpoint:bool=False,
         **kwargs,
     ):
-        '''
-        enable_gradient_ckeckpoint:bool variable, Whether to start the gradient_checkpoint.
-        In the Torch backend, you should ensure that there are no dropout layers or normalization layers (such as BN, LN, GN, etc.) with inconsistent forward and backward behaviors in the layer of the function you're starting.
-        In the TensorFlow backend, you can only enable this setting in eager mode.
-        In the JAX backend, you should ensure that there are no strings or other non-differentiable JAX vaild types in the inputs of your function.
-        '''
         BackendLayer.__init__(self)
         self._lock = False
         Operation.__init__(self, dtype=dtype, name=name)

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -263,8 +263,15 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         dtype=None,
         autocast=True,
         name=None,
+        enable_gradient_ckeckpoint:bool=False,
         **kwargs,
     ):
+        '''
+        enable_gradient_ckeckpoint:bool variable, Whether to start the gradient_checkpoint.
+        In the Torch backend, you should ensure that there are no dropout layers or normalization layers (such as BN, LN, GN, etc.) with inconsistent forward and backward behaviors in the layer of the function you're starting.
+        In the TensorFlow backend, you can only enable this setting in eager mode.
+        In the JAX backend, you should ensure that there are no strings or other non-differentiable JAX vaild types in the inputs of your function.
+        '''
         BackendLayer.__init__(self)
         self._lock = False
         Operation.__init__(self, dtype=dtype, name=name)
@@ -318,6 +325,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         # Parent path
         self._parent_path = None
         self._initialize_tracker()
+        self.enable_gradient_ckeckpoint = enable_gradient_ckeckpoint
 
     @tracking.no_automatic_dependency_tracking
     def _initialize_tracker(self):

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -48,9 +48,8 @@ class Operation:
             if check_point_flag and self.enable_gradient_ckeckpoint and \
                 (not self._call_has_training_arg or kwargs.get('training')):
                 if backend.backend()=='torch':
-                    from torch.utils.checkpoint import checkpoint
-                    return checkpoint(call_fn,use_reentrant=False,\
-                                      *args, **kwargs)
+                    from torch.utils.checkpoint import checkpoint as cp
+                    return cp(call_fn,use_reentrant=False,*args, **kwargs)
                 elif backend.backend()=='tensorflow':
                     from tensorflow import recompute_grad
                     return recompute_grad(call_fn)(*args, **kwargs)

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -49,7 +49,8 @@ class Operation:
                 (not self._call_has_training_arg or kwargs.get('training')):
                 if backend.backend()=='torch':
                     from torch.utils.checkpoint import checkpoint
-                    return checkpoint(call_fn,use_reentrant=False,*args, **kwargs)
+                    return checkpoint(call_fn,use_reentrant=False,\
+                                      *args, **kwargs)
                 elif backend.backend()=='tensorflow':
                     from tensorflow import recompute_grad
                     return recompute_grad(call_fn)(*args, **kwargs)


### PR DESCRIPTION
[Gradient checkpoint](https://papers.cool/arxiv/1604.06174) is a widely used technique to reduce memory consumption. 
Now we are adapting it for Keras. To make minimal modifications to existing models, we add a parameter `enable_gradient_checkpoint` to the layer, which is set to `False` by default. By simply changing this parameter, we can enable gradient checkpointing. However, for specific implementations depending on different backends, the following points need to be considered:
      In the Torch backend, you should ensure that there are no dropout layers or normalization layers (such as BN, LN, GN, etc.) with inconsistent forward and backward behaviors in the layer of the function you're starting.
      In the TensorFlow backend, you can only enable this setting in eager mode.
      In the JAX backend, you should ensure that there are no strings or other non-differentiable JAX vaild types in the inputs of your function.Such as str
