### PR TITLE
Add build method to supress warning

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/random_color_jitter.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_color_jitter.py
@@ -112,6 +112,19 @@ class RandomColorJitter(BaseImagePreprocessingLayer):
                 seed=self.seed,
             )
 
+    def build(self, input_shape):
+        if self.brightness_factor is not None:
+            self.random_brightness.build(input_shape)
+
+        if self.contrast_factor is not None:
+            self.random_contrast.build(input_shape)
+
+        if self.saturation_factor is not None:
+            self.random_saturation.build(input_shape)
+
+        if self.hue_factor is not None:
+            self.random_hue.build(input_shape)
+
     def transform_images(self, images, transformation, training=True):
         if training:
             if backend_utils.in_tf_graph():


### PR DESCRIPTION
To suppress the warning mentioned below, I declared the build method.

`UserWarning: `build()` was called on layer 'random_color_jitter', however the layer does not have a `build()` method implemented and it looks like it has unbuilt state. This will cause the layer to be marked as built, despite not being actually built, which may cause failures down the line. Make sure to implement a proper `build()` method.
  warnings.warn(`