### PR TITLE
[Keras Ops] Add einops-style `rearrange()` to `keras.ops`

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -30,6 +30,7 @@ from keras.src.ops.core import switch
 from keras.src.ops.core import unstack
 from keras.src.ops.core import vectorized_map
 from keras.src.ops.core import while_loop
+from keras.src.ops.einops import rearrange
 from keras.src.ops.linalg import cholesky
 from keras.src.ops.linalg import det
 from keras.src.ops.linalg import eig

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -30,6 +30,7 @@ from keras.src.ops.core import switch
 from keras.src.ops.core import unstack
 from keras.src.ops.core import vectorized_map
 from keras.src.ops.core import while_loop
+from keras.src.ops.einops import rearrange
 from keras.src.ops.linalg import cholesky
 from keras.src.ops.linalg import det
 from keras.src.ops.linalg import eig

--- a/keras/src/ops/einops.py
+++ b/keras/src/ops/einops.py
@@ -105,8 +105,8 @@ class Rearrange(Operation):
 
 @keras_export("keras.ops.rearrange")
 def rearrange(tensor, pattern, **axes_lengths):
-    """
-    Rearranges the axes of a Keras tensor according to a specified pattern.
+    """Rearranges the axes of a Keras tensor according to a specified pattern,
+    einops-style.
 
     Args:
         tensor: Input Keras tensor.
@@ -119,11 +119,43 @@ def rearrange(tensor, pattern, **axes_lengths):
 
     Follows the logic of:
 
-    1. If decomposition is needed:
-        - Reshape to match decomposed dimensions.
+    1. If decomposition is needed, reshape to match decomposed dimensions.
     2. Permute known and inferred axes to match the form of the output.
     3. Reshape to match the desired output shape.
-    """
+
+
+    Example Usage:
+
+    ```
+    >>> import numpy as np
+    >>> from keras.ops import rearrange
+    >>> images = np.random.rand(32, 30, 40, 3) # BHWC format
+
+    # Reordering to BCHW
+    >>> rearrange(images, 'b h w c -> b c h w').shape
+    TensorShape([32, 3, 30, 40])
+
+    # "Merge" along first axis - concat images from a batch
+    >>> rearrange(images, 'b h w c -> (b h) w c').shape
+    TensorShape([960, 40, 3])
+
+    # "Merge" along second axis - concat images horizontally
+    >>> rearrange(images, 'b h w c -> h (b w) c').shape
+    TensorShape([30, 1280, 3])
+
+    # Flatten images into a CHW vector
+    >>> rearrange(images, 'b h w c -> b (c h w)').shape
+    TensorShape([32, 3600])
+
+    # Decompose H and W axes into 4 smaller patches
+    >>> rearrange(images, 'b (h1 h) (w1 w) c -> (b h1 w1) h w c', h1=2, w1=2).shape
+    TensorShape([128, 15, 20, 3])
+
+    # Space-to-depth decomposition of input axes
+    >>> rearrange(images, 'b (h h1) (w w1) c -> b h w (c h1 w1)', h1=2, w1=2).shape
+    TensorShape([32, 15, 20, 12])
+    ```
+    """  # noqa: E501
 
     if any_symbolic_tensors((tensor,)):
         return Rearrange().symbolic_call(tensor, pattern, **axes_lengths)

--- a/keras/src/ops/einops.py
+++ b/keras/src/ops/einops.py
@@ -131,7 +131,7 @@ def rearrange(tensor, pattern, **axes_lengths):
     """
 
     if any_symbolic_tensors((tensor,)):
-        return Rearrange().symbolic_call(tensor)
+        return Rearrange().symbolic_call(tensor, pattern, **axes_lengths)
 
     # Split the input and output patterns
     input_pattern, output_pattern = re.split(r"\s*->\s*", pattern)

--- a/keras/src/ops/einops.py
+++ b/keras/src/ops/einops.py
@@ -87,21 +87,16 @@ def _compute_decomposed_shape(input_axes, axes_lengths, axes_map):
 
 
 class Rearrange(Operation):
-    def __init__(self, pattern, **axes_lengths):
-        super().__init__()
-        self.pattern = pattern
-        self.axes_lengths = axes_lengths
+    def call(self, tensor, pattern, **axes_lengths):
+        return rearrange(tensor, pattern, **axes_lengths)
 
-    def call(self, tensor, pattern, axes_lengths):
-        return rearrange(tensor, pattern, axes_lengths)
-
-    def compute_output_spec(self, tensor):
-        input_pattern, output_pattern = re.split(r"\s*->\s*", self.pattern)
+    def compute_output_spec(self, tensor, pattern, **axes_lengths):
+        input_pattern, output_pattern = re.split(r"\s*->\s*", pattern)
         input_axes = re.findall(r"\w+|\(.*?\)", input_pattern)
         output_axes = re.findall(r"\w+|\(.*?\)", output_pattern)
         input_shape = shape(tensor)
 
-        axes_map = _create_axes_map(input_axes, input_shape, self.axes_lengths)
+        axes_map = _create_axes_map(input_axes, input_shape, axes_lengths)
         grouped_output_axes = _create_grouped_axes(output_axes)
         output_shape = _compute_output_shape(axes_map, grouped_output_axes)
 

--- a/keras/src/ops/einops.py
+++ b/keras/src/ops/einops.py
@@ -2,6 +2,7 @@ import re
 
 from keras.src.api_export import keras_export
 from keras.src.backend import KerasTensor
+from keras.src.backend import any_symbolic_tensors
 from keras.src.ops.core import shape
 from keras.src.ops.numpy import prod
 from keras.src.ops.numpy import reshape
@@ -128,6 +129,9 @@ def rearrange(tensor, pattern, **axes_lengths):
     2. Permute known and inferred axes to match the form of the output.
     3. Reshape to match the desired output shape.
     """
+
+    if any_symbolic_tensors((tensor,)):
+        return Rearrange().symbolic_call(tensor)
 
     # Split the input and output patterns
     input_pattern, output_pattern = re.split(r"\s*->\s*", pattern)

--- a/keras/src/ops/einops.py
+++ b/keras/src/ops/einops.py
@@ -1,0 +1,133 @@
+import re
+
+from keras.src.api_export import keras_export
+from keras.src.ops.core import shape
+from keras.src.ops.numpy import prod
+from keras.src.ops.numpy import reshape
+from keras.src.ops.numpy import transpose
+
+
+def __create_axes_map(axes, input_shape, axes_lengths):
+    axes_map = {}
+
+    for axis, dim in zip(axes, input_shape):
+        # Check for grouped axes pattern, e.g., "(h1 h)"
+        grouped_axes = re.match(r"\(([\w\s]+)\)", axis)
+
+        if grouped_axes:
+            inner_axes = grouped_axes.group(1).split()
+            known_axes = [a for a in inner_axes if a in axes_lengths]
+            inferred_axes = [a for a in inner_axes if a not in axes_lengths]
+
+            if inferred_axes:
+                inferred_axis = inferred_axes[0]
+                known_product = prod([axes_lengths[a] for a in known_axes])
+                axes_lengths[inferred_axis] = dim // known_product
+
+            axes_map.update({a: axes_lengths[a] for a in inner_axes})
+        else:
+            axes_map[axis] = dim
+
+    return axes_map
+
+
+def __create_grouped_axes(axes):
+    grouped_output_axes = []
+    for axis in axes:
+        grouped_axes = re.match(r"\(([\w\s]+)\)", axis)
+
+        if grouped_axes:
+            inner_axes = grouped_axes.group(1).split()
+            grouped_output_axes.append(inner_axes)
+        else:
+            grouped_output_axes.append([axis])
+
+    return grouped_output_axes
+
+
+def __flatten_group(axes):
+    return [x for xs in axes for x in xs]
+
+
+def __get_transpose_order(from_shape, to_shape):
+    flattened_from_shape = __flatten_group(__create_grouped_axes(from_shape))
+
+    return [flattened_from_shape.index(dim) for dim in to_shape]
+
+
+def __compute_output_shape(axes_map, grouped_axes):
+    output_shape = []
+    for group in grouped_axes:
+        size = 1
+        for axis in group:
+            size *= axes_map[axis]
+        output_shape.append(size)
+
+    return tuple(output_shape)
+
+
+def __compute_decomposed_shape(input_axes, axes_lengths, axes_map):
+    reshaped_input_axes = []
+    reshaped_sizes = []
+
+    for axis in input_axes:
+        if "(" in axis:  # Decomposed axis
+            inner_axes = re.findall(r"\w+", axis)
+            sizes = [axes_lengths[a] for a in inner_axes]
+            reshaped_input_axes.extend(inner_axes)
+            reshaped_sizes.extend(sizes)
+        else:
+            reshaped_input_axes.append(axis)
+            reshaped_sizes.append(axes_map[axis])
+
+    return reshaped_sizes
+
+
+@keras_export("keras.ops.rearrange")
+def rearrange(tensor, pattern, **axes_lengths):
+    """
+    Rearranges the axes of a Keras tensor according to a specified pattern.
+
+    Args:
+        tensor (Tensor): Input Keras tensor.
+        pattern (str): String describing the rearrangement in einops notation.
+        **axes_lengths: Keyword arguments specifying lengths of axes
+            when axes decomposition is used.
+
+    Returns:
+        Tensor: A Keras tensor with rearranged axes.
+
+    Follows the logic:
+        1. If decomposition is needed:
+            - Reshape to match dimension decomposition.
+        2. Permute axes to match the form of the output.
+        3. Reshape to match the desired output shape.
+    """
+
+    # Split the input and output patterns
+    input_pattern, output_pattern = re.split(r"\s*->\s*", pattern)
+    input_axes = re.findall(r"\w+|\(.*?\)", input_pattern)
+    output_axes = re.findall(r"\w+|\(.*?\)", output_pattern)
+    input_shape = shape(tensor)
+
+    # Create axes map, and flattened output group
+    axes_map = __create_axes_map(input_axes, input_shape, axes_lengths)
+    grouped_output_axes = __create_grouped_axes(output_axes)
+    flattened_output_axes = __flatten_group(grouped_output_axes)
+
+    # 1. Axes decomposition
+    decomposed_shapes = __compute_decomposed_shape(
+        input_axes, axes_lengths, axes_map
+    )
+    if decomposed_shapes != tensor.shape:
+        tensor = reshape(tensor, decomposed_shapes)
+
+    # 2. Transpose to match target shape
+    permute_order = __get_transpose_order(input_axes, flattened_output_axes)
+    tensor = transpose(tensor, permute_order)
+
+    # 3. Reshape to final target shape
+    output_shape = __compute_output_shape(axes_map, grouped_output_axes)
+    tensor = reshape(tensor, output_shape)
+
+    return tensor

--- a/keras/src/ops/einops_test.py
+++ b/keras/src/ops/einops_test.py
@@ -1,3 +1,4 @@
+from conftest import skip_if_backend
 from keras.src import ops
 from keras.src import testing
 from keras.src.backend.common import keras_tensor
@@ -11,12 +12,14 @@ class RearrangeTest(testing.TestCase):
         self.assertIsInstance(y, keras_tensor.KerasTensor)
         self.assertEqual(y.shape, (2, 4, 3))
 
+    @skip_if_backend("openvino", "Test operation not supported by openvino")
     def test_basic_rearrangement(self):
         x = ops.random.uniform((2, 3, 4))
         y = rearrange(x, "b c h -> b h c")
         self.assertEqual(y.shape, (2, 4, 3))
         self.assertTrue(ops.all(ops.equal(y, ops.transpose(x, (0, 2, 1)))))
 
+    @skip_if_backend("openvino", "Test operation not supported by openvino")
     def test_output_composition(self):
         x = ops.random.uniform((2, 4, 4, 3))
         y = rearrange(x, "b h w c -> (b h) w c")
@@ -35,6 +38,7 @@ class RearrangeTest(testing.TestCase):
         y = rearrange(x, "(h w) c -> h w c", h=2, w=3)
         self.assertEqual(y.shape, (2, 3, 8))
 
+    @skip_if_backend("openvino", "Test operation not supported by openvino")
     def test_unchanged_shape(self):
         x = ops.ones([2, 3, 4])
         y = rearrange(x, "b h c -> b h c")

--- a/keras/src/ops/einops_test.py
+++ b/keras/src/ops/einops_test.py
@@ -6,19 +6,43 @@ from keras.src.ops.einops import rearrange
 
 
 class RearrangeTest(testing.TestCase):
-    def test_basic_rearrangement(self):
+    def test_basic_rearrangement_symbolic(self):
         x = keras_tensor.KerasTensor((2, 3, 4))
         y = rearrange(x, "b c h -> b h c")
         self.assertIsInstance(y, keras_tensor.KerasTensor)
         self.assertEqual(y.shape, (2, 4, 3))
 
-    def test_basic_decomposition_and_rearrangement(self):
+    def test_basic_rearrangement(self):
+        x = np.random.rand(2, 3, 4)
+        y = rearrange(x, "b c h -> b h c")
+        self.assertEqual(y.shape, (2, 4, 3))
+        np.testing.assert_array_equal(y, x.transpose(0, 2, 1))
+
+    def test_output_composition(self):
+        x = np.random.rand(2, 4, 4, 3)
+        y = rearrange(x, "b h w c -> (b h) w c")
+        target_shape = (8, 4, 3)
+        self.assertEqual(y.shape, target_shape)
+        np.testing.assert_array_equal(y, x.reshape(8, 4, 3))
+
+    def test_basic_decomposition_and_rearrangement_symbolic(self):
         x = keras_tensor.KerasTensor((6, 8))
         y = rearrange(x, "(h w) c -> h w c", h=2, w=3)
         self.assertIsInstance(y, keras_tensor.KerasTensor)
         self.assertEqual(y.shape, (2, 3, 8))
 
-    def test_static_shape(self):
+    def test_basic_decomposition_and_rearrangement(self):
+        x = np.random.rand(6, 8)
+        y = rearrange(x, "(h w) c -> h w c", h=2, w=3)
+        self.assertEqual(y.shape, (2, 3, 8))
+
+    def test_unchanged_shape(self):
         x = np.ones([2, 3, 4])
-        y = rearrange(x, "b c h -> b h c")
-        np.testing.assert_array_equal(y, np.transpose(x, (0, 2, 1)))
+        y = rearrange(x, "b h c -> b h c")
+        np.testing.assert_array_equal(y, x)
+        self.assertTrue(x.shape, y.shape)
+
+    def test_unchanged_shape_symbolic(self):
+        x = keras_tensor.KerasTensor((2, 3, 4))
+        y = rearrange(x, "b h c -> b h c")
+        self.assertTrue(x.shape, y.shape)

--- a/keras/src/ops/einops_test.py
+++ b/keras/src/ops/einops_test.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from keras.src import testing
+from keras.src.backend.common import keras_tensor
+from keras.src.ops.einops import rearrange
+
+
+class RearrangeTest(testing.TestCase):
+    def test_basic_rearrangement(self):
+        x = keras_tensor.KerasTensor((2, 3, 4))
+        y = rearrange(x, "b c h -> b h c")
+        self.assertIsInstance(y, keras_tensor.KerasTensor)
+        self.assertEqual(y.shape, (2, 4, 3))
+
+    def test_basic_decomposition_and_rearrangement(self):
+        x = keras_tensor.KerasTensor((6, 8))
+        y = rearrange(x, "(h w) c -> h w c", h=2, w=3)
+        self.assertIsInstance(y, keras_tensor.KerasTensor)
+        self.assertEqual(y.shape, (2, 3, 8))
+
+    def test_static_shape(self):
+        x = np.ones([2, 3, 4])
+        y = rearrange(x, "b c h -> b h c")
+        np.testing.assert_array_equal(y, np.transpose(x, (0, 2, 1)))

--- a/keras/src/ops/einops_test.py
+++ b/keras/src/ops/einops_test.py
@@ -1,10 +1,12 @@
 import numpy as np
 
+from conftest import skip_if_backend
 from keras.src import testing
 from keras.src.backend.common import keras_tensor
 from keras.src.ops.einops import rearrange
 
 
+@skip_if_backend("openvino", "NumPy ops not supported with openvino backend")
 class RearrangeTest(testing.TestCase):
     def test_basic_rearrangement_symbolic(self):
         x = keras_tensor.KerasTensor((2, 3, 4))

--- a/keras/src/ops/einops_test.py
+++ b/keras/src/ops/einops_test.py
@@ -1,12 +1,9 @@
-import numpy as np
-
-from conftest import skip_if_backend
+from keras.src import ops
 from keras.src import testing
 from keras.src.backend.common import keras_tensor
 from keras.src.ops.einops import rearrange
 
 
-@skip_if_backend("openvino", "NumPy ops not supported with openvino backend")
 class RearrangeTest(testing.TestCase):
     def test_basic_rearrangement_symbolic(self):
         x = keras_tensor.KerasTensor((2, 3, 4))
@@ -15,17 +12,17 @@ class RearrangeTest(testing.TestCase):
         self.assertEqual(y.shape, (2, 4, 3))
 
     def test_basic_rearrangement(self):
-        x = np.random.rand(2, 3, 4)
+        x = ops.random.uniform((2, 3, 4))
         y = rearrange(x, "b c h -> b h c")
         self.assertEqual(y.shape, (2, 4, 3))
-        np.testing.assert_array_equal(y, x.transpose(0, 2, 1))
+        self.assertTrue(ops.all(ops.equal(y, ops.transpose(x, (0, 2, 1)))))
 
     def test_output_composition(self):
-        x = np.random.rand(2, 4, 4, 3)
+        x = ops.random.uniform((2, 4, 4, 3))
         y = rearrange(x, "b h w c -> (b h) w c")
         target_shape = (8, 4, 3)
         self.assertEqual(y.shape, target_shape)
-        np.testing.assert_array_equal(y, x.reshape(8, 4, 3))
+        self.assertTrue(ops.all(ops.equal(y, ops.reshape(x, (8, 4, 3)))))
 
     def test_basic_decomposition_and_rearrangement_symbolic(self):
         x = keras_tensor.KerasTensor((6, 8))
@@ -34,14 +31,14 @@ class RearrangeTest(testing.TestCase):
         self.assertEqual(y.shape, (2, 3, 8))
 
     def test_basic_decomposition_and_rearrangement(self):
-        x = np.random.rand(6, 8)
+        x = ops.random.uniform((6, 8))
         y = rearrange(x, "(h w) c -> h w c", h=2, w=3)
         self.assertEqual(y.shape, (2, 3, 8))
 
     def test_unchanged_shape(self):
-        x = np.ones([2, 3, 4])
+        x = ops.ones([2, 3, 4])
         y = rearrange(x, "b h c -> b h c")
-        np.testing.assert_array_equal(y, x)
+        self.assertTrue(ops.all(ops.equal(y, x)))
         self.assertTrue(x.shape, y.shape)
 
     def test_unchanged_shape_symbolic(self):


### PR DESCRIPTION
### Context

Closes #20332.

Add an `einops` style `rearrange()` operation to the `keras.src.ops.einops`.
Making a new module for this makes sense if we plan to add other similar operations and want to re-use some of the private-marked utility methods here or generalize the logic further.

It makes use of solely `reshape()` and `transpose()`, so these natively run on all backends. Furthermore, only these two operations are applied so it should be fine with symbolic tensors (sometimes, `einops` doesn't work correctly with symbolic tensors in a computation graph).

### Comparison with `einops`

Direct comparison with `einops`, using the examples from the official documentation:

```
import numpy as np
import keras
import einops

tensor = np.random.randn(2, 10, 10, 3)

examples = [
    (tensor, 'b h w c -> b h w c', {}),
    (tensor, 'b h w c -> b c h w', {}),
    (tensor, 'b h w c -> (b h) w c', {}),
    (tensor, 'b h w c -> h (b w) c', {}),
    (tensor, 'b h w c -> b (c h w)', {}),
    (tensor, 'b (h h1) (w w1) c -> b (h w1) (w h1) c', {'h1': 2, 'w1': 2}),
    (tensor, 'b (h h1) (w w1) c -> b c (h w1) (w h1)', {'h1': 2, 'w1': 2}),
    (tensor, 'b (h1 h) (w1 w) c -> (b h1 w1) h w c', {'h1': 2, 'w1': 2}),
    (tensor, 'b (h h1) (w w1) c -> b h w (c h1 w1)', {'h1': 2, 'w1': 2})
]

results = []

for data, pattern, axes_lengths in examples:
    keras_result = keras.ops.rearrange(data, pattern, **axes_lengths)
    einops_result = einops.rearrange(data, pattern, **axes_lengths)
    
    are_equal = np.allclose(keras_result, einops_result)
    
    result_entry = {
        "pattern": pattern,
        "from": data.shape,
        "to": keras_result.shape,
        "equal": are_equal
    }
    
    results.append(result_entry)
```

Results in:

```
{'pattern': 'b h w c -> b h w c', 'from': (2, 10, 10, 3), 'to': TensorShape([2, 10, 10, 3]), 'equal': True}
{'pattern': 'b h w c -> b c h w', 'from': (2, 10, 10, 3), 'to': TensorShape([2, 3, 10, 10]), 'equal': True}
{'pattern': 'b h w c -> (b h) w c', 'from': (2, 10, 10, 3), 'to': TensorShape([20, 10, 3]), 'equal': True}
{'pattern': 'b h w c -> h (b w) c', 'from': (2, 10, 10, 3), 'to': TensorShape([10, 20, 3]), 'equal': True}
{'pattern': 'b h w c -> b (c h w)', 'from': (2, 10, 10, 3), 'to': TensorShape([2, 300]), 'equal': True}
{'pattern': 'b (h h1) (w w1) c -> b (h w1) (w h1) c', 'from': (2, 10, 10, 3), 'to': TensorShape([2, 10, 10, 3]), 'equal': True}
{'pattern': 'b (h h1) (w w1) c -> b c (h w1) (w h1)', 'from': (2, 10, 10, 3), 'to': TensorShape([2, 3, 10, 10]), 'equal': True}
{'pattern': 'b (h1 h) (w1 w) c -> (b h1 w1) h w c', 'from': (2, 10, 10, 3), 'to': TensorShape([8, 5, 5, 3]), 'equal': True}
{'pattern': 'b (h h1) (w w1) c -> b h w (c h1 w1)', 'from': (2, 10, 10, 3), 'to': TensorShape([2, 5, 5, 12]), 'equal': True}
```

### Other

TODO:
- Write tests
- Performance benchmark 