### PR TITLE
Multiple Example Title has been removed in metrics.MeanIoU method

### DIFF
--- a/keras/src/metrics/iou_metrics.py
+++ b/keras/src/metrics/iou_metrics.py
@@ -474,7 +474,6 @@ class MeanIoU(IoU):
             is used to determine each sample's most likely associated label.
         axis: (Optional) The dimension containing the logits. Defaults to `-1`.
 
-    Example:
 
     Example:
 


### PR DESCRIPTION
Multiple Example Title has removed in metrics.MeanIoU method.