### PR TITLE
Fix flaky `JaxLayer` test.

### DIFF
--- a/keras/src/utils/jax_layer_test.py
+++ b/keras/src/utils/jax_layer_test.py
@@ -324,11 +324,13 @@ class TestJaxLayer(testing.TestCase):
         model2.export(path, format="tf_saved_model")
         model4 = tf.saved_model.load(path)
         output4 = model4.serve(x_test)
+        # The output difference is greater when using the GPU or bfloat16
+        lower_precision = testing.jax_uses_gpu() or "dtype" in layer_init_kwargs
         self.assertAllClose(
             output1,
             output4,
-            # The output difference might be significant when using the GPU
-            atol=1e-2 if testing.jax_uses_gpu() else 1e-6,
+            atol=1e-2 if lower_precision else 1e-6,
+            rtol=1e-3 if lower_precision else 1e-6,
         )
 
         # test subclass model building without a build method


### PR DESCRIPTION
The `DTypePolicy` test produces lower precision results.