### PR TITLE
Preliminary parts needed for ragged support, including densification.

### DIFF
--- a/keras/src/backend/common/keras_tensor.py
+++ b/keras/src/backend/common/keras_tensor.py
@@ -32,6 +32,7 @@ class KerasTensor:
         shape,
         dtype="float32",
         sparse=False,
+        ragged=False,
         record_history=True,
         name=None,
     ):
@@ -40,6 +41,12 @@ class KerasTensor:
         self._shape = backend.standardize_shape(shape)
         self._dtype = backend.standardize_dtype(dtype)
         self._sparse = bool(sparse)
+        self._ragged = bool(ragged)
+        if self._sparse and self._ragged:
+            raise ValueError(
+                "KerasTensor cannot have `sparse=True` and `ragged=True` at "
+                "the same time."
+            )
         self.name = name or auto_name(self.__class__.__name__)
         self.record_history = record_history
 
@@ -50,7 +57,7 @@ class KerasTensor:
     @shape.setter
     def shape(self, value):
         raise AttributeError(
-            f"The shape of {self.__class__.__name__} is immutable. One should "
+            "The `shape` attribute of KerasTensor is immutable. One should "
             "create a new instance of KerasTensor for this."
         )
 
@@ -61,7 +68,7 @@ class KerasTensor:
     @dtype.setter
     def dtype(self, value):
         raise AttributeError(
-            f"The dtype of {self.__class__.__name__} is immutable. One should "
+            "The `dtype` attribute of KerasTensor is immutable. One should "
             "create a new instance of KerasTensor for this."
         )
 
@@ -72,7 +79,18 @@ class KerasTensor:
     @sparse.setter
     def sparse(self, value):
         raise AttributeError(
-            f"The sparse of {self.__class__.__name__} is immutable. One should "
+            "The `sparse` attribute of KerasTensor is immutable. One should "
+            "create a new instance of KerasTensor for this."
+        )
+
+    @property
+    def ragged(self):
+        return self._ragged
+
+    @ragged.setter
+    def ragged(self, value):
+        raise AttributeError(
+            "The `ragged` attribute of KerasTensor is immutable. One should "
             "create a new instance of KerasTensor for this."
         )
 
@@ -160,7 +178,7 @@ class KerasTensor:
     def __repr__(self):
         return (
             f"<KerasTensor shape={self.shape}, dtype={self.dtype}, "
-            f"sparse={self.sparse}, name={self.name}>"
+            f"sparse={self.sparse}, ragged={self.ragged}, name={self.name}>"
         )
 
     def __iter__(self):

--- a/keras/src/backend/common/keras_tensor_test.py
+++ b/keras/src/backend/common/keras_tensor_test.py
@@ -19,17 +19,41 @@ class KerasTensorTest(testing.TestCase):
 
         # Raise error if trying to set attributes
         with self.assertRaisesRegex(
-            AttributeError, "The shape of KerasTensor is immutable."
+            AttributeError, "The `shape` attribute of KerasTensor is immutable."
         ):
             x.shape = [3, 2]
         with self.assertRaisesRegex(
-            AttributeError, "The dtype of KerasTensor is immutable."
+            AttributeError, "The `dtype` attribute of KerasTensor is immutable."
         ):
             x.dtype = "int32"
+
+    def test_attributes_sparse(self):
+        x = keras_tensor.KerasTensor(shape=(3,), dtype="float32", sparse=True)
+        self.assertEqual(x.sparse, True)
+
+        # Raise error if trying to set attributes
         with self.assertRaisesRegex(
-            AttributeError, "The sparse of KerasTensor is immutable."
+            AttributeError,
+            "The `sparse` attribute of KerasTensor is immutable.",
         ):
             x.sparse = False
+
+    def test_attributes_ragged(self):
+        x = keras_tensor.KerasTensor(shape=(3,), dtype="float32", ragged=True)
+        self.assertEqual(x.ragged, True)
+
+        # Raise error if trying to set attributes
+        with self.assertRaisesRegex(
+            AttributeError,
+            "The `ragged` attribute of KerasTensor is immutable.",
+        ):
+            x.ragged = False
+
+    def test_init_sparse_ragged_raises(self):
+        with self.assertRaisesRegex(
+            ValueError, "cannot have `sparse=True` and `ragged=True`"
+        ):
+            keras_tensor.KerasTensor(shape=(3,), sparse=True, ragged=True)
 
     def test_numpy_methods(self):
         x = keras_tensor.KerasTensor(shape=(3, 2), dtype="float32")

--- a/keras/src/backend/jax/__init__.py
+++ b/keras/src/backend/jax/__init__.py
@@ -8,6 +8,7 @@ from keras.src.backend.jax import numpy
 from keras.src.backend.jax import random
 from keras.src.backend.jax import tensorboard
 from keras.src.backend.jax.core import IS_THREAD_SAFE
+from keras.src.backend.jax.core import SUPPORTS_RAGGED_TENSORS
 from keras.src.backend.jax.core import SUPPORTS_SPARSE_TENSORS
 from keras.src.backend.jax.core import Variable
 from keras.src.backend.jax.core import cast

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -15,6 +15,7 @@ from keras.src.backend.common.symbolic_scope import SymbolicScope
 from keras.src.backend.jax import distribution_lib
 
 SUPPORTS_SPARSE_TENSORS = True
+SUPPORTS_RAGGED_TENSORS = False
 IS_THREAD_SAFE = True
 
 
@@ -46,7 +47,9 @@ class Variable(KerasVariable):
         return self.value
 
 
-def convert_to_tensor(x, dtype=None, sparse=True):
+def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
+    if ragged:
+        raise ValueError("`ragged=True` is not supported with jax backend")
     if dtype is not None:
         dtype = standardize_dtype(dtype)
     if isinstance(x, (jnp.ndarray, jax.Array)) and (

--- a/keras/src/backend/numpy/__init__.py
+++ b/keras/src/backend/numpy/__init__.py
@@ -7,6 +7,7 @@ from keras.src.backend.numpy import nn
 from keras.src.backend.numpy import numpy
 from keras.src.backend.numpy import random
 from keras.src.backend.numpy.core import IS_THREAD_SAFE
+from keras.src.backend.numpy.core import SUPPORTS_RAGGED_TENSORS
 from keras.src.backend.numpy.core import SUPPORTS_SPARSE_TENSORS
 from keras.src.backend.numpy.core import Variable
 from keras.src.backend.numpy.core import cast

--- a/keras/src/backend/numpy/core.py
+++ b/keras/src/backend/numpy/core.py
@@ -15,6 +15,7 @@ from keras.src.backend.common.stateless_scope import StatelessScope
 from keras.src.backend.common.symbolic_scope import SymbolicScope
 
 SUPPORTS_SPARSE_TENSORS = False
+SUPPORTS_RAGGED_TENSORS = False
 IS_THREAD_SAFE = True
 
 
@@ -33,9 +34,11 @@ class Variable(KerasVariable):
         return self.value
 
 
-def convert_to_tensor(x, dtype=None, sparse=None):
+def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
     if sparse:
         raise ValueError("`sparse=True` is not supported with numpy backend")
+    if ragged:
+        raise ValueError("`ragged=True` is not supported with numpy backend")
     if dtype is not None:
         dtype = standardize_dtype(dtype)
     if isinstance(x, Variable):

--- a/keras/src/backend/openvino/__init__.py
+++ b/keras/src/backend/openvino/__init__.py
@@ -7,6 +7,7 @@ from keras.src.backend.openvino import nn
 from keras.src.backend.openvino import numpy
 from keras.src.backend.openvino import random
 from keras.src.backend.openvino.core import IS_THREAD_SAFE
+from keras.src.backend.openvino.core import SUPPORTS_RAGGED_TENSORS
 from keras.src.backend.openvino.core import SUPPORTS_SPARSE_TENSORS
 from keras.src.backend.openvino.core import Variable
 from keras.src.backend.openvino.core import cast

--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -19,6 +19,7 @@ from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.backend.common.stateless_scope import StatelessScope
 
 SUPPORTS_SPARSE_TENSORS = False
+SUPPORTS_RAGGED_TENSORS = False
 IS_THREAD_SAFE = True
 
 OPENVINO_DTYPES = {
@@ -367,9 +368,11 @@ def _get_first_element(x):
     return None
 
 
-def convert_to_tensor(x, dtype=None, sparse=None):
+def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
     if sparse:
         raise ValueError("`sparse=True` is not supported with openvino backend")
+    if ragged:
+        raise ValueError("`ragged=True` is not supported with openvino backend")
     if isinstance(x, OpenVINOKerasTensor):
         return x
     elif isinstance(x, np.ndarray):

--- a/keras/src/backend/tensorflow/__init__.py
+++ b/keras/src/backend/tensorflow/__init__.py
@@ -8,6 +8,7 @@ from keras.src.backend.tensorflow import numpy
 from keras.src.backend.tensorflow import random
 from keras.src.backend.tensorflow import tensorboard
 from keras.src.backend.tensorflow.core import IS_THREAD_SAFE
+from keras.src.backend.tensorflow.core import SUPPORTS_RAGGED_TENSORS
 from keras.src.backend.tensorflow.core import SUPPORTS_SPARSE_TENSORS
 from keras.src.backend.tensorflow.core import Variable
 from keras.src.backend.tensorflow.core import cast

--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -19,6 +19,7 @@ from keras.src.backend.tensorflow.sparse import sparse_to_dense
 from keras.src.utils.naming import auto_name
 
 SUPPORTS_SPARSE_TENSORS = True
+SUPPORTS_RAGGED_TENSORS = True
 # https://github.com/tensorflow/tensorflow/issues/78338
 IS_THREAD_SAFE = False
 
@@ -122,9 +123,11 @@ class Variable(
         return mapping[aggregation]
 
 
-def convert_to_tensor(x, dtype=None, sparse=None):
+def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
     if isinstance(x, tf.SparseTensor) and sparse is not None and not sparse:
         x = sparse_to_dense(x)
+    if isinstance(x, tf.RaggedTensor) and ragged is not None and not ragged:
+        x = x.to_tensor()
     if dtype is not None:
         dtype = standardize_dtype(dtype)
     if not tf.is_tensor(x):

--- a/keras/src/backend/torch/__init__.py
+++ b/keras/src/backend/torch/__init__.py
@@ -23,6 +23,7 @@ from keras.src.backend.torch import nn
 from keras.src.backend.torch import numpy
 from keras.src.backend.torch import random
 from keras.src.backend.torch.core import IS_THREAD_SAFE
+from keras.src.backend.torch.core import SUPPORTS_RAGGED_TENSORS
 from keras.src.backend.torch.core import SUPPORTS_SPARSE_TENSORS
 from keras.src.backend.torch.core import Variable
 from keras.src.backend.torch.core import cast

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -20,6 +20,7 @@ from keras.src.backend.common.symbolic_scope import SymbolicScope
 from keras.src.backend.config import floatx
 
 SUPPORTS_SPARSE_TENSORS = False
+SUPPORTS_RAGGED_TENSORS = False
 IS_THREAD_SAFE = True
 
 # Some operators such as 'aten::_foreach_mul_.Scalar'
@@ -185,9 +186,11 @@ class Variable(KerasVariable):
             return False
 
 
-def convert_to_tensor(x, dtype=None, sparse=None):
+def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
     if sparse:
         raise ValueError("`sparse=True` is not supported with torch backend")
+    if ragged:
+        raise ValueError("`ragged=True` is not supported with torch backend")
     if isinstance(x, Variable):
         # TorchDynamo has bugs supporting nn.Parameter type check.
         # Return it directly instead of pass it to the rest of the logic in the

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -929,8 +929,11 @@ class ConvertToTensor(Operation):
 
 
 @keras_export("keras.ops.convert_to_tensor")
-def convert_to_tensor(x, dtype=None, sparse=None):
-    """Convert a NumPy array to a tensor.
+def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
+    """Convert a NumPy array or Python array to a tensor.
+
+    Native tensors for the current backend or left unchanged unless the `dtype`,
+    `sparse` or `ragged` arguments are set.
 
     Args:
         x: A NumPy array, Python array (can be nested) or a backend tensor.
@@ -938,6 +941,9 @@ def convert_to_tensor(x, dtype=None, sparse=None):
         sparse: Whether to keep sparse tensors. `False` will cause sparse
             tensors to be densified. The default value of `None` means that
             sparse tensors are kept only if the backend supports them.
+        ragged: Whether to keep ragged tensors. `False` will cause ragged
+            tensors to be densified. The default value of `None` means that
+            ragged tensors are kept only if the backend supports them.
 
     Returns:
         A backend tensor of the specified `dtype` and sparseness.
@@ -949,7 +955,9 @@ def convert_to_tensor(x, dtype=None, sparse=None):
     """
     if any_symbolic_tensors((x,)):
         return ConvertToTensor(dtype=dtype, sparse=sparse)(x)
-    return backend.core.convert_to_tensor(x, dtype=dtype, sparse=sparse)
+    return backend.core.convert_to_tensor(
+        x, dtype=dtype, sparse=sparse, ragged=ragged
+    )
 
 
 @keras_export("keras.ops.convert_to_numpy")

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -644,7 +644,7 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         self.assertAllEqual(core.shape(x), (2, 3))
 
     @pytest.mark.skipif(
-        backend.backend() != "tensorflow",
+        not backend.SUPPORTS_SPARSE_TENSORS,
         reason="Backend does not support ragged tensors.",
     )
     def test_shape_ragged(self):
@@ -698,6 +698,29 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(x, x_sparse)
         x_dense = ops.convert_to_tensor(x, sparse=False)
         self.assertSparse(x_dense, False)
+        self.assertAllClose(x, x_dense)
+
+        x_numpy = ops.convert_to_numpy(x)
+        self.assertIsInstance(x_numpy, np.ndarray)
+        self.assertAllClose(x_numpy, x_dense)
+
+    @pytest.mark.skipif(
+        not backend.SUPPORTS_RAGGED_TENSORS,
+        reason="Backend does not support ragged tensors.",
+    )
+    def test_convert_to_tensor_ragged(self):
+        import tensorflow as tf
+
+        x = tf.ragged.constant([[3, 1, 4, 1], [], [5, 9, 2], [6], []])
+
+        x_default = ops.convert_to_tensor(x)
+        self.assertIsInstance(x_default, tf.RaggedTensor)
+        self.assertAllClose(x, x_default)
+        x_ragged = ops.convert_to_tensor(x, ragged=True)
+        self.assertIsInstance(x_ragged, tf.RaggedTensor)
+        self.assertAllClose(x, x_ragged)
+        x_dense = ops.convert_to_tensor(x, ragged=False)
+        self.assertNotIsInstance(x_dense, tf.RaggedTensor)
         self.assertAllClose(x, x_dense)
 
         x_numpy = ops.convert_to_numpy(x)


### PR DESCRIPTION
Added `ragged` option to `KerasTensor`, `InputLayer` and `convert_to_tensor`. The logic is the same as for sparse tensors.

Fixes https://github.com/keras-team/keras/issues/20731