### PR TITLE
Remove all type annotations for consistency.

### DIFF
--- a/keras/src/backend/common/backend_utils.py
+++ b/keras/src/backend/common/backend_utils.py
@@ -356,7 +356,7 @@ def _vectorize_parse_input_dimensions(
             f"expected {len(input_core_dims)}, got {len(args)}"
         )
     shapes = []
-    dim_sizes: dict[str, int] = {}
+    dim_sizes = {}
     for arg, core_dims in zip(args, input_core_dims):
         _vectorize_update_dim_sizes(
             dim_sizes, arg.shape, core_dims, is_input=True

--- a/keras/src/backend/common/dtypes_test.py
+++ b/keras/src/backend/common/dtypes_test.py
@@ -43,7 +43,7 @@ class DtypesTest(test_case.TestCase):
         self.jax_enable_x64.__enter__()
         return super().setUp()
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         self.jax_enable_x64.__exit__(None, None, None)
         return super().tearDown()
 

--- a/keras/src/backend/common/variables_test.py
+++ b/keras/src/backend/common/variables_test.py
@@ -820,7 +820,7 @@ class VariableOpsDTypeTest(test_case.TestCase):
         self.jax_enable_x64.__enter__()
         return super().setUp()
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         self.jax_enable_x64.__exit__(None, None, None)
         return super().tearDown()
 

--- a/keras/src/backend/torch/layer.py
+++ b/keras/src/backend/torch/layer.py
@@ -1,6 +1,3 @@
-from typing import Iterator
-from typing import Tuple
-
 import torch
 
 from keras.src.backend.common.stateless_scope import in_stateless_scope
@@ -30,10 +27,10 @@ class TorchLayer(torch.nn.Module):
 
     def named_parameters(
         self,
-        prefix: str = "",
-        recurse: bool = True,
-        remove_duplicate: bool = True,
-    ) -> Iterator[Tuple[str, torch.nn.Parameter]]:
+        prefix="",
+        recurse=True,
+        remove_duplicate=True,
+    ):
         if not hasattr(self, "_torch_params"):
             self._track_variables()
         return torch.nn.Module.named_parameters(

--- a/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/bounding_box.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/bounding_box.py
@@ -22,8 +22,8 @@ class BoundingBox:
     def convert_format(
         self,
         boxes,
-        source: str,
-        target: str,
+        source,
+        target,
         height=None,
         width=None,
         dtype="float32",

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -936,7 +936,7 @@ class CoreOpsDtypeTest(testing.TestCase):
         self.jax_enable_x64.__enter__()
         return super().setUp()
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         self.jax_enable_x64.__exit__(None, None, None)
         return super().tearDown()
 

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -20,7 +20,7 @@ class ImageOpsDynamicShapeTest(testing.TestCase):
         backend.set_image_data_format("channels_last")
         return super().setUp()
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         backend.set_image_data_format(self.data_format)
         return super().tearDown()
 
@@ -171,7 +171,7 @@ class ImageOpsStaticShapeTest(testing.TestCase):
         backend.set_image_data_format("channels_last")
         return super().setUp()
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         backend.set_image_data_format(self.data_format)
         return super().tearDown()
 
@@ -396,7 +396,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         backend.set_image_data_format("channels_last")
         return super().setUp()
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         backend.set_image_data_format(self.data_format)
         return super().tearDown()
 
@@ -1144,7 +1144,7 @@ class ImageOpsBehaviorTests(testing.TestCase):
         backend.set_image_data_format("channels_last")
         return super().setUp()
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         backend.set_image_data_format(self.data_format)
         return super().tearDown()
 

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1003,7 +1003,7 @@ class MathDtypeTest(testing.TestCase):
         self.jax_enable_x64.__enter__()
         return super().setUp()
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         self.jax_enable_x64.__exit__(None, None, None)
         return super().tearDown()
 

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -2474,7 +2474,7 @@ class NNOpsDtypeTest(testing.TestCase):
         self.jax_enable_x64.__enter__()
         return super().setUp()
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         self.jax_enable_x64.__exit__(None, None, None)
         return super().tearDown()
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -5357,7 +5357,7 @@ class NumpyDtypeTest(testing.TestCase):
         self.jax_enable_x64.__enter__()
         return super().setUp()
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         self.jax_enable_x64.__exit__(None, None, None)
         return super().tearDown()
 

--- a/keras/src/random/random_test.py
+++ b/keras/src/random/random_test.py
@@ -456,7 +456,7 @@ class RandomDTypeTest(testing.TestCase):
             self.jax_enable_x64.__enter__()
         return super().setUp()
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         if backend.backend() == "jax":
             self.jax_enable_x64.__exit__(None, None, None)
         return super().tearDown()

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -253,7 +253,7 @@ class SavingTest(testing.TestCase):
         saving_lib._MEMORY_UPPER_BOUND = 0
         return super().setUp()
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         saving_lib._MEMORY_UPPER_BOUND = self.original_value
         return super().tearDown()
 
@@ -621,7 +621,7 @@ class SavingTest(testing.TestCase):
         )
 
     @pytest.mark.requires_trainable_backend
-    def test_save_to_fileobj(self) -> None:
+    def test_save_to_fileobj(self):
         model = keras.Sequential(
             [keras.layers.Dense(1, input_shape=(1,)), keras.layers.Dense(1)]
         )

--- a/keras/src/visualization/draw_segmentation_masks.py
+++ b/keras/src/visualization/draw_segmentation_masks.py
@@ -104,6 +104,6 @@ def draw_segmentation_masks(
     return outputs
 
 
-def _generate_color_palette(num_classes: int):
+def _generate_color_palette(num_classes):
     palette = np.array([2**25 - 1, 2**15 - 1, 2**21 - 1])
     return [((i * palette) % 255).tolist() for i in range(num_classes)]

--- a/keras/src/wrappers/sklearn_test.py
+++ b/keras/src/wrappers/sklearn_test.py
@@ -21,7 +21,7 @@ from keras.src.wrappers import SKLearnTransformer
 def wrapped_parametrize_with_checks(
     estimators,
     *,
-    legacy: bool = True,
+    legacy=True,
     expected_failed_checks=None,
 ):
     """Wrapped `parametrize_with_checks` handling backwards compat."""
@@ -77,7 +77,7 @@ def dynamic_model(X, y, loss, layers=[10]):
 
 
 @contextmanager
-def use_floatx(x: str):
+def use_floatx(x):
     """Context manager to temporarily
     set the keras backend precision.
     """

--- a/keras/src/wrappers/sklearn_wrapper.py
+++ b/keras/src/wrappers/sklearn_wrapper.py
@@ -107,7 +107,7 @@ class SKLBase(BaseEstimator):
         )
 
     @property
-    def epoch_(self) -> int:
+    def epoch_(self):
         """The current training epoch."""
         return getattr(self, "history_", {}).get("epoch", 0)
 


### PR DESCRIPTION
Some tools don't like the mix of code with and without type hints.