### PR TITLE
fix time_distributed layer with mask and partial_batch_size

### DIFF
--- a/keras/src/layers/rnn/time_distributed.py
+++ b/keras/src/layers/rnn/time_distributed.py
@@ -5,7 +5,10 @@ from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.layers.core.wrapper import Wrapper
 from keras.src.layers.layer import Layer
-import tensorflow as tf
+
+if backend.backend() == "tensorflow":
+    import tensorflow as tf
+
 
 @keras_export("keras.layers.TimeDistributed")
 class TimeDistributed(Wrapper):
@@ -85,7 +88,10 @@ class TimeDistributed(Wrapper):
                     f"received: mask.shape={mask_shape}"
                 )
         else:
-            if mask_shape is not None and mask_shape[:2] != (batch_size, timesteps):
+            if mask_shape is not None and mask_shape[:2] != (
+                batch_size,
+                timesteps,
+            ):
                 raise ValueError(
                     "`TimeDistributed` Layer should be passed a `mask` of shape "
                     f"({batch_size}, {timesteps}, ...), "

--- a/keras/src/layers/rnn/time_distributed.py
+++ b/keras/src/layers/rnn/time_distributed.py
@@ -83,8 +83,8 @@ class TimeDistributed(Wrapper):
         if backend.backend() == "tensorflow" and not tf.executing_eagerly():
             if mask_shape is not None and mask_shape[1:2] != (timesteps,):
                 raise ValueError(
-                    "`TimeDistributed` Layer should be passed a `mask` of shape "
-                    f"({batch_size}, {timesteps}, ...), "
+                    "`TimeDistributed` Layer should be passed a `mask` of "
+                    f"shape ({batch_size}, {timesteps}, ...), "
                     f"received: mask.shape={mask_shape}"
                 )
         else:
@@ -93,8 +93,8 @@ class TimeDistributed(Wrapper):
                 timesteps,
             ):
                 raise ValueError(
-                    "`TimeDistributed` Layer should be passed a `mask` of shape "
-                    f"({batch_size}, {timesteps}, ...), "
+                    "`TimeDistributed` Layer should be passed a `mask` of "
+                    f"shape ({batch_size}, {timesteps}, ...), "
                     f"received: mask.shape={mask_shape}"
                 )
 

--- a/keras/src/layers/rnn/time_distributed.py
+++ b/keras/src/layers/rnn/time_distributed.py
@@ -6,9 +6,6 @@ from keras.src.api_export import keras_export
 from keras.src.layers.core.wrapper import Wrapper
 from keras.src.layers.layer import Layer
 
-if backend.backend() == "tensorflow":
-    import tensorflow as tf
-
 
 @keras_export("keras.layers.TimeDistributed")
 class TimeDistributed(Wrapper):
@@ -80,23 +77,31 @@ class TimeDistributed(Wrapper):
         batch_size = input_shape[0]
         timesteps = input_shape[1]
 
-        if backend.backend() == "tensorflow" and not tf.executing_eagerly():
-            if mask_shape is not None and mask_shape[1:2] != (timesteps,):
-                raise ValueError(
-                    "`TimeDistributed` Layer should be passed a `mask` of "
-                    f"shape ({batch_size}, {timesteps}, ...), "
-                    f"received: mask.shape={mask_shape}"
-                )
-        else:
-            if mask_shape is not None and mask_shape[:2] != (
-                batch_size,
-                timesteps,
+        # For TF backend with graph mode and `partial_batch_size`, skip
+        # evaluation of `batch_size` as it can be a `strided_slice` and
+        # not a constant.
+        if backend.backend() == "tensorflow":
+            from keras.src.utils.module_utils import tensorflow as tf
+
+            if (
+                not tf.executing_eagerly
+                and mask_shape is not None
+                and mask_shape[1:2] != (timesteps,)
             ):
                 raise ValueError(
                     "`TimeDistributed` Layer should be passed a `mask` of "
                     f"shape ({batch_size}, {timesteps}, ...), "
                     f"received: mask.shape={mask_shape}"
                 )
+        elif mask_shape is not None and mask_shape[:2] != (
+            batch_size,
+            timesteps,
+        ):
+            raise ValueError(
+                "`TimeDistributed` Layer should be passed a `mask` of "
+                f"shape ({batch_size}, {timesteps}, ...), "
+                f"received: mask.shape={mask_shape}"
+            )
 
         def time_distributed_transpose(data):
             """Swaps the timestep and batch dimensions of a tensor."""

--- a/keras/src/layers/rnn/time_distributed.py
+++ b/keras/src/layers/rnn/time_distributed.py
@@ -5,7 +5,7 @@ from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.layers.core.wrapper import Wrapper
 from keras.src.layers.layer import Layer
-
+import tensorflow as tf
 
 @keras_export("keras.layers.TimeDistributed")
 class TimeDistributed(Wrapper):
@@ -77,12 +77,20 @@ class TimeDistributed(Wrapper):
         batch_size = input_shape[0]
         timesteps = input_shape[1]
 
-        if mask_shape is not None and mask_shape[:2] != (batch_size, timesteps):
-            raise ValueError(
-                "`TimeDistributed` Layer should be passed a `mask` of shape "
-                f"({batch_size}, {timesteps}, ...), "
-                f"received: mask.shape={mask_shape}"
-            )
+        if backend.backend() == "tensorflow" and not tf.executing_eagerly():
+            if mask_shape is not None and mask_shape[1:2] != (timesteps,):
+                raise ValueError(
+                    "`TimeDistributed` Layer should be passed a `mask` of shape "
+                    f"({batch_size}, {timesteps}, ...), "
+                    f"received: mask.shape={mask_shape}"
+                )
+        else:
+            if mask_shape is not None and mask_shape[:2] != (batch_size, timesteps):
+                raise ValueError(
+                    "`TimeDistributed` Layer should be passed a `mask` of shape "
+                    f"({batch_size}, {timesteps}, ...), "
+                    f"received: mask.shape={mask_shape}"
+                )
 
         def time_distributed_transpose(data):
             """Swaps the timestep and batch dimensions of a tensor."""

--- a/keras/src/layers/rnn/time_distributed_test.py
+++ b/keras/src/layers/rnn/time_distributed_test.py
@@ -78,7 +78,7 @@ class TimeDistributedTest(testing.TestCase):
             np.array([[[0], [0.22]], [[0.38], [0]], [[0.7], [0.86]]]),
             output,
         )
-
+    @pytest.mark.requires_trainable_backend
     def test_with_mask_zero(self):
         model = Sequential(
             [

--- a/keras/src/layers/rnn/time_distributed_test.py
+++ b/keras/src/layers/rnn/time_distributed_test.py
@@ -6,6 +6,7 @@ from keras.src import initializers
 from keras.src import layers
 from keras.src import ops
 from keras.src import testing
+from keras.src.models import Sequential
 
 
 class TimeDistributedTest(testing.TestCase):
@@ -77,3 +78,23 @@ class TimeDistributedTest(testing.TestCase):
             np.array([[[0], [0.22]], [[0.38], [0]], [[0.7], [0.86]]]),
             output,
         )
+
+    def test_with_mask_zero(self):
+        model = Sequential(
+            [
+                layers.Input(shape=(20,)),
+                layers.Embedding(input_dim=10, output_dim=5, mask_zero=True),
+                layers.TimeDistributed(
+                    layers.Dense(units=5, activation="softmax")
+                ),
+            ]
+        )
+        model.compile(
+            optimizer="adam",
+            loss="sparse_categorical_crossentropy",
+            metrics=["accuracy"],
+        )
+        X_train = np.random.uniform(1, 10, size=(22, 20))
+        Y_train = np.random.randint(1, 2, size=(22, 20))
+
+        model.fit(X_train, Y_train, epochs=1, batch_size=16)

--- a/keras/src/layers/rnn/time_distributed_test.py
+++ b/keras/src/layers/rnn/time_distributed_test.py
@@ -78,6 +78,7 @@ class TimeDistributedTest(testing.TestCase):
             np.array([[[0], [0.22]], [[0.38], [0]], [[0.7], [0.86]]]),
             output,
         )
+
     @pytest.mark.requires_trainable_backend
     def test_with_mask_zero(self):
         model = Sequential(


### PR DESCRIPTION
If the model includes an Embedding layer with `mask_zero = True` parameter and sub sequent model has time distributed layer it is observed that training fails in graph mode if there is `partial_batch_size` . This happens due to concatenation of partial batch dataset which makes `batch_size` to None and hence shape to (None,...).

Hence the model fails with graph execution error if we try to compare batch_size with the respective value from mask.

Hence I am proposing to omit the `batch_size` comparison for TF backend with graph mode. It would have been better if this check is for when there is actually a `partial_batch_size` but not sure how to propogate this to time distributed layer .

Fixes #20754 

Code to replicate the issue:

```
import keras
import numpy as np

model = keras.Sequential([
    keras.Input(shape = (20,)),
    keras.layers.Embedding( input_dim = 10,
                           output_dim = 5,
                            mask_zero = True
                            ),

    keras.layers.Bidirectional(keras.layers.LSTM(units = 10, return_sequences = True )),
    keras.layers.TimeDistributed(keras.layers.Dense(units = 5, activation = "softmax")  ),#not works with mask_zero
])
model.compile(
    optimizer="adam",
    loss="binary_crossentropy",
    metrics=["accuracy"],
)
X_train = np.random.uniform(1,10,size = (50,20))
Y_train = np.random.randint(1,2,size = (50,20,5))

model.fit(X_train, Y_train, epochs = 2, batch_size = 8)

```


