### PR TITLE
Improve `fake_quant_with_min_max_vars`

### DIFF
--- a/keras/api/_tf_keras/keras/quantizers/__init__.py
+++ b/keras/api/_tf_keras/keras/quantizers/__init__.py
@@ -12,7 +12,5 @@ from keras.src.quantizers.quantizers import Quantizer
 from keras.src.quantizers.quantizers import abs_max_quantize
 from keras.src.quantizers.quantizers import compute_float8_amax_history
 from keras.src.quantizers.quantizers import compute_float8_scale
-from keras.src.quantizers.quantizers import (
-    fake_quant_with_min_max_vars as fake_quant_with_min_max_vars_per_channel,
-)
+from keras.src.quantizers.quantizers import fake_quant_with_min_max_vars
 from keras.src.quantizers.quantizers import quantize_and_dequantize

--- a/keras/api/quantizers/__init__.py
+++ b/keras/api/quantizers/__init__.py
@@ -12,7 +12,5 @@ from keras.src.quantizers.quantizers import Quantizer
 from keras.src.quantizers.quantizers import abs_max_quantize
 from keras.src.quantizers.quantizers import compute_float8_amax_history
 from keras.src.quantizers.quantizers import compute_float8_scale
-from keras.src.quantizers.quantizers import (
-    fake_quant_with_min_max_vars as fake_quant_with_min_max_vars_per_channel,
-)
+from keras.src.quantizers.quantizers import fake_quant_with_min_max_vars
 from keras.src.quantizers.quantizers import quantize_and_dequantize


### PR DESCRIPTION
This PR includes:

- Fixes JAX GPU CI issues
- Enhances dtype inference in the computation of `fake_quant_with_min_max_vars`
- Replaces `ops.multiply` with `ops.where` to optimize computation
- Adds tests for bfloat16 and float16 output dtypes

cc @doncarlos999

~~EDITED:~~
~~I'm going to test this new op to check if `tf.lite.TFLiteConverter` can correctly recognize it.~~
~~(I suspect it won’t, and we may need to make some changes when using the TF backend)~~

EDITED2:

- Fixes the export of `keras.quantizers.fake_quant_with_min_max_vars`
- Adds `FakeQuantWithMinMaxVars` operation
- Uses `tf.quantization.fake_quant_*` as a shortcut to be recognizable for TFLite converter.

A POC:

```python
import tensorflow as tf

import keras


class QuantConv2D(keras.layers.Conv2D):
    def convolution_op(self, inputs, kernel):
        inputs = keras.quantizers.fake_quant_with_min_max_vars(
            inputs, -3.0, 3.0, narrow_range=True
        )
        kernel = keras.quantizers.fake_quant_with_min_max_vars(
            self.kernel,
            -3.0 * keras.ops.ones([self.filters]),
            3.0 * keras.ops.ones([self.filters]),
            narrow_range=True,
            axis=-1,
        )

        outputs = super().convolution_op(inputs, kernel)

        outputs = keras.quantizers.fake_quant_with_min_max_vars(
            outputs, -3.0, 3.0, narrow_range=True
        )
        return outputs


inp = keras.Input(shape=(16, 16, 3), batch_size=1)
x = QuantConv2D(8, 3, 1)(inp)
model = keras.Model(inp, x)

model.export("/tmp/fake_quant")
converter = tf.lite.TFLiteConverter.from_saved_model("/tmp/fake_quant")
converter.optimizations = [tf.lite.Optimize.DEFAULT]
converter.inference_input_type = tf.int8
converter.inference_output_type = tf.int8

tflite_model = converter.convert()
with open("model.tflite", "wb") as f:
    f.write(tflite_model)

```

The full INT8 TFLite artifact:
![image](https://github.com/user-attachments/assets/ce25b133-0afb-4734-8317-dfda1758ba2e)
