### PR TITLE
fix(ops): Fix inconsistent padding calculation in PyTorch backend ops

### DIFF
--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -214,7 +214,7 @@ def _compute_padding_length(
 
 
 def _apply_same_padding(
-    inputs, kernel_size, strides, operation_type, dilation_rate=1
+    inputs, kernel_size, strides, data_format, operation_type, dilation_rate=1
 ):
     """Apply same padding to the input tensor.
 
@@ -247,7 +247,10 @@ def _apply_same_padding(
                 spatial_shape[i], kernel_size[i], strides[i], dilation_rate[i]
             )
             mode = "constant"
-        padding = padding + (padding_size,)
+        if data_format == "channels_last":
+            padding = (padding_size,) + padding
+        else:
+            padding = padding + (padding_size,)
 
     if all([left == right for left, right in padding]):
         return inputs, [left for left, _ in padding]
@@ -325,7 +328,7 @@ def max_pool(
         # Torch does not natively support `"same"` padding, we need to manually
         # apply the right amount of padding to `inputs`.
         inputs, padding = _apply_same_padding(
-            inputs, pool_size, strides, operation_type="pooling"
+            inputs, pool_size, strides, data_format, operation_type="pooling"
         )
     else:
         padding = 0
@@ -385,7 +388,7 @@ def average_pool(
         # Torch does not natively support `"same"` padding, we need to manually
         # apply the right amount of padding to `inputs`.
         inputs, padding = _apply_same_padding(
-            inputs, pool_size, strides, operation_type="pooling"
+            inputs, pool_size, strides, data_format, operation_type="pooling"
         )
     else:
         padding = 0
@@ -450,6 +453,7 @@ def conv(
             inputs,
             kernel.shape[2:],
             strides,
+            data_format,
             operation_type="conv",
             dilation_rate=dilation_rate,
         )

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -247,7 +247,7 @@ def _apply_same_padding(
                 spatial_shape[i], kernel_size[i], strides[i], dilation_rate[i]
             )
             mode = "constant"
-        padding = (padding_size,) + padding
+        padding = padding + (padding_size,)
 
     if all([left == right for left, right in padding]):
         return inputs, [left for left, _ in padding]

--- a/keras/src/layers/pooling/average_pooling_test.py
+++ b/keras/src/layers/pooling/average_pooling_test.py
@@ -174,6 +174,7 @@ class AveragePoolingBasicTest(testing.TestCase):
         (2, 1, "same", "channels_first", (3, 5, 5, 4), (3, 5, 5, 4)),
         ((2, 3), (2, 2), "valid", "channels_last", (3, 5, 5, 4), (3, 2, 2, 4)),
         ((2, 3), (2, 2), "same", "channels_last", (3, 5, 5, 4), (3, 3, 3, 4)),
+        ((2, 3), (3, 3), "same", "channels_first", (3, 5, 5, 4), (3, 5, 2, 2)),
     )
     def test_average_pooling2d(
         self,

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1605,7 +1605,9 @@ class NNOpsCorrectnessTest(testing.TestCase):
         x = np.arange(540, dtype=float).reshape(input_shape)
         self.assertAllClose(
             knn.average_pool(x, [2, 3], (3, 3), padding="same"),
-            np_avgpool2d(x, [2, 3], (3, 3), padding="same", data_format=data_format),
+            np_avgpool2d(
+                x, [2, 3], (3, 3), padding="same", data_format=data_format
+            ),
         )
 
     @parameterized.product(

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1604,9 +1604,9 @@ class NNOpsCorrectnessTest(testing.TestCase):
             input_shape = (2, 3, 10, 9)
         x = np.arange(540, dtype=float).reshape(input_shape)
         self.assertAllClose(
-            knn.average_pool(x, [2, 3], (3, 3), padding="same"),
+            knn.average_pool(x, (2, 3), (3, 3), padding="same"),
             np_avgpool2d(
-                x, [2, 3], (3, 3), padding="same", data_format=data_format
+                x, (2, 3), (3, 3), padding="same", data_format=data_format
             ),
         )
 

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1597,6 +1597,16 @@ class NNOpsCorrectnessTest(testing.TestCase):
             knn.average_pool(x, 2, (2, 1), padding="same"),
             np_avgpool2d(x, 2, (2, 1), padding="same", data_format=data_format),
         )
+        # Test 2D average pooling with different pool size.
+        if data_format == "channels_last":
+            input_shape = (2, 10, 9, 3)
+        else:
+            input_shape = (2, 3, 10, 9)
+        x = np.arange(540, dtype=float).reshape(input_shape)
+        self.assertAllClose(
+            knn.average_pool(x, [2, 3], (3, 3), padding="same"),
+            np_avgpool2d(x, [2, 3], (3, 3), padding="same", data_format=data_format),
+        )
 
     @parameterized.product(
         strides=(1, 2, 3),


### PR DESCRIPTION
Was able to still reproduce the error, the PyTorch backend had inconsistent behavior between static shape inference and dynamic execution for pooling operations, particularly with 'same' padding and non-unit strides, figured that the root cause was by incorrect padding calculation logic that didn't properly handle asymmetric padding cases.

Key changes:
- Rewrote `_compute_padding_length()` to handle stride-based padding
- Fixed padding calculation to properly support asymmetric padding cases
- Standardize `channels_first`/`channels_last` conversion in pooling ops
- Cleaned up padding application in `_apply_same_padding()`
- Added proper handling of `data_format` throughout pooling pipeline

This fixes the issue where MaxPooling2D with 'same' padding would produce different shapes between compute_output_shape() and actual execution (e.g. (1,5,2,2) vs (1,5,2,1)) #20235.

Rebased on top of @sachinprasadhs's September 2024 PR to incorporate latest `keras:master` changes #20270.