### PR TITLE
fix(metrics): Fix BinaryAccuracy metric to handle boolean inputs

### DIFF
--- a/keras/src/metrics/reduction_metrics.py
+++ b/keras/src/metrics/reduction_metrics.py
@@ -201,7 +201,7 @@ class MeanMetricWrapper(Mean):
     def update_state(self, y_true, y_pred, sample_weight=None):
         y_true = backend.cast(y_true, backend.floatx())
         y_pred = backend.cast(y_pred, backend.floatx())
-    
+
         mask = backend.get_keras_mask(y_pred)
         values = self._fn(y_true, y_pred, **self._fn_kwargs)
         if sample_weight is not None and mask is not None:

--- a/keras/src/metrics/reduction_metrics.py
+++ b/keras/src/metrics/reduction_metrics.py
@@ -199,6 +199,9 @@ class MeanMetricWrapper(Mean):
             self._direction = "down"
 
     def update_state(self, y_true, y_pred, sample_weight=None):
+        y_true = backend.cast(y_true, backend.floatx())
+        y_pred = backend.cast(y_pred, backend.floatx())
+    
         mask = backend.get_keras_mask(y_pred)
         values = self._fn(y_true, y_pred, **self._fn_kwargs)
         if sample_weight is not None and mask is not None:

--- a/keras/src/metrics/reduction_metrics.py
+++ b/keras/src/metrics/reduction_metrics.py
@@ -199,8 +199,8 @@ class MeanMetricWrapper(Mean):
             self._direction = "down"
 
     def update_state(self, y_true, y_pred, sample_weight=None):
-        y_true = backend.cast(y_true, backend.floatx())
-        y_pred = backend.cast(y_pred, backend.floatx())
+        y_true = backend.cast(y_true, self.dtype)
+        y_pred = backend.cast(y_pred, self.dtype)
 
         mask = backend.get_keras_mask(y_pred)
         values = self._fn(y_true, y_pred, **self._fn_kwargs)

--- a/keras/src/metrics/reduction_metrics_test.py
+++ b/keras/src/metrics/reduction_metrics_test.py
@@ -1,11 +1,13 @@
 import numpy as np
 
 from keras.src import backend
+from keras.src import layers
+from keras.src import metrics
+from keras.src import models
 from keras.src import testing
 from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.metrics import reduction_metrics
 from keras.src.saving import register_keras_serializable
-from keras.src import metrics, layers, models
 
 
 class SumTest(testing.TestCase):

--- a/keras/src/metrics/reduction_metrics_test.py
+++ b/keras/src/metrics/reduction_metrics_test.py
@@ -5,6 +5,7 @@ from keras.src import testing
 from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.metrics import reduction_metrics
 from keras.src.saving import register_keras_serializable
+from keras.src import metrics, layers, models
 
 
 class SumTest(testing.TestCase):
@@ -174,3 +175,17 @@ class MetricWrapperTest(testing.TestCase):
             KerasTensor((None, 5)),
         )
         self.assertAllEqual(result.shape, ())
+
+    def test_binary_accuracy_with_boolean_inputs(self):
+        inp = layers.Input(shape=(1,))
+        out = inp > 0.5
+        model = models.Model(inputs=inp, outputs=out)
+
+        x = np.random.rand(32, 1)
+        y = x > 0.5
+
+        res = model.predict(x)
+        metric = metrics.BinaryAccuracy()
+        metric.update_state(y, res)
+        result = metric.result()
+        assert result == 1.0


### PR DESCRIPTION
Previously, `BinaryAccuracy` would return incorrect results when given boolean inputs in JAX backend, and would raise errors in TensorFlow backend. This was because the metric expects numerical values (floats/integers) but wasn't properly handling boolean array inputs.
Fix by casting `y_true` and `y_pred` to `floatx()` in `MeanMetricWrapper.update_state()`. This ensures consistent behavior across backends and proper handling of boolean inputs.
Fixes #20178 raised in August 2024 but still persists in this version.