### PR TITLE
fix tracking issue with lazy filled attributes

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -226,14 +226,25 @@ class Layer(BackendLayer, Operation, KerasSaveable):
                 original_build_method(*args, **kwargs)
             # Check for any untracked attrs/vars
             if obj._tracker._has_untracked_attrs:
-                for attr in obj._tracked:
-                    if (
-                        id(getattr(obj, attr))
-                        in obj._tracker._untracked_attrs_ids
-                    ):
-                        untracked_attr = getattr(obj, attr)
-                        for var in untracked_attr:
-                            obj._tracker.track(var)
+                if backend.backend() == "tensorflow":
+                    for attr in obj._tracked:
+                        if (
+                            id(getattr(obj, attr))
+                            in obj._tracker._untracked_attrs_ids
+                        ):
+                            untracked_attr = getattr(obj, attr)
+                            for var in untracked_attr:
+                                obj._tracker.track(var)
+                else:
+                    for attr in obj.__dict__.keys():
+                        if (
+                            id(getattr(obj, attr))
+                            in obj._tracker._untracked_attrs_ids
+                        ):
+                            untracked_attr = getattr(obj, attr)
+                            for var in untracked_attr:
+                                obj._tracker.track(var)
+
             # Record build config.
             signature = inspect.signature(original_build_method)
             obj._build_shapes_dict = signature.bind(*args, **kwargs).arguments

--- a/keras/src/utils/tracking.py
+++ b/keras/src/utils/tracking.py
@@ -66,6 +66,9 @@ class Tracker:
         self.locked = False
         self._lock_violation_msg = None
         self.exclusions = exclusions or {}
+        # log untracked attrs if any
+        self._has_untracked_attrs = False
+        self._untracked_attrs_ids = []
 
     def track(self, attr):
         if not is_tracking_enabled():
@@ -144,6 +147,10 @@ class TrackedList(list):
     def append(self, value):
         if self.tracker:
             self.tracker.track(value)
+        if not self and not value:
+            if self.tracker:
+                self.tracker._has_untracked_attrs = True
+                self.tracker._untracked_attrs_ids.append(id(self))
         super().append(value)
 
     def insert(self, index, value):

--- a/keras/src/utils/tracking.py
+++ b/keras/src/utils/tracking.py
@@ -147,7 +147,7 @@ class TrackedList(list):
     def append(self, value):
         if self.tracker:
             self.tracker.track(value)
-        #Check if an empty attr assigned with empty list and list them
+        # Check if an empty attr assigned with empty list and list them
         if not self and isinstance(value, list) and not value:
             if self.tracker:
                 self.tracker._has_untracked_attrs = True

--- a/keras/src/utils/tracking.py
+++ b/keras/src/utils/tracking.py
@@ -147,7 +147,8 @@ class TrackedList(list):
     def append(self, value):
         if self.tracker:
             self.tracker.track(value)
-        if not self and not value:
+        #Check if an empty attr assigned with empty list and list them
+        if not self and isinstance(value, list) and not value:
             if self.tracker:
                 self.tracker._has_untracked_attrs = True
                 self.tracker._untracked_attrs_ids.append(id(self))


### PR DESCRIPTION
Currently there is an issue with Tracking when for custom layers the attributes initialized empty and assigned with empty values that filled at later stage. This PR addresses the same.

Fixes #20598 