### PR TITLE
fix ciou implementation bug in bounding_boxes/iou.py

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/iou.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/iou.py
@@ -267,9 +267,9 @@ def compute_ciou(boxes1, boxes2, bounding_box_format, image_shape=None):
     )
 
     v = ops.squeeze(
-        ops.power(
-            (4 / math.pi**2)
-            * (ops.arctan(width_2 / height_2) - ops.arctan(width_1 / height_1)),
+        (4 / math.pi**2)
+        * ops.power(
+            (ops.arctan(width_2 / height_2) - ops.arctan(width_1 / height_1)),
             2,
         ),
         axis=-1,


### PR DESCRIPTION
Fix `ciou` implementation bug in bounding_boxes/iou.py.

As per the CIOU paper there seems a bug in implementation of `v` in `compute_ciou` as reported by the user of #20780

As per original paper and other resource referred by the user changing the implementation.

Fixes #20780.