### PR TITLE
fix(applications): Improve validation and error handling for ConvNeXt weights and fix broadcasting in EfficientNetV2

### DIFF
--- a/keras/src/applications/convnext.py
+++ b/keras/src/applications/convnext.py
@@ -522,6 +522,30 @@ def ConvNeXt(
 
     model = Functional(inputs=inputs, outputs=x, name=name)
 
+    # Validate weights before requesting them from the API
+    if weights == "imagenet":
+        expected_config = MODEL_CONFIGS[weights_name.split("convnext_")[-1]]
+        if (
+            depths != expected_config["depths"]
+            or projection_dims != expected_config["projection_dims"]
+        ):
+            raise ValueError(
+                f"Architecture configuration does not match {weights_name} "
+                f"variant. When using pre-trained weights, the model "
+                f"architecture must match the pre-trained configuration "
+                f"exactly. Expected depths: {expected_config['depths']}, "
+                f"got: {depths}. Expected projection_dims: "
+                f"{expected_config['projection_dims']}, got: {projection_dims}."
+            )
+
+        if weights_name not in name:
+            raise ValueError(
+                f'Model name "{name}" does not match weights variant '
+                f'"{weights_name}". When using imagenet weights, model name '
+                f'must contain the weights variant (e.g., "convnext_'
+                f'{weights_name.split("convnext_")[-1]}").'
+            )
+
     # Load weights.
     if weights == "imagenet":
         if include_top:

--- a/keras/src/applications/efficientnet_v2.py
+++ b/keras/src/applications/efficientnet_v2.py
@@ -935,9 +935,17 @@ def EfficientNetV2(
         num_channels = input_shape[bn_axis - 1]
         if name.split("-")[-1].startswith("b") and num_channels == 3:
             x = layers.Rescaling(scale=1.0 / 255)(x)
+            if backend.image_data_format() == "channels_first":
+                mean = [[[[0.485]], [[0.456]], [[0.406]]]]  # shape [1,3,1,1]
+                variance = [
+                    [[[0.229**2]], [[0.224**2]], [[0.225**2]]]
+                ]  # shape [1,3,1,1]
+            else:
+                mean = [0.485, 0.456, 0.406]
+                variance = [0.229**2, 0.224**2, 0.225**2]
             x = layers.Normalization(
-                mean=[0.485, 0.456, 0.406],
-                variance=[0.229**2, 0.224**2, 0.225**2],
+                mean=mean,
+                variance=variance,
                 axis=bn_axis,
             )(x)
         else:


### PR DESCRIPTION
- Validate architecture and weights compatibility before API request
- Enhance error messages for mismatched model name and weights
- Fixes #20271

**Original Error Message (Unnecessary Model Weights Download):**

```
Downloading data from https://storage.googleapis.com/tensorflow/keras-applications/convnext/convnext_large_notop.h5
785596384/785596384 ...
ValueError: Incomplete or corrupted file detected. The auto file hash does not match the provided value of 6fc8009faa2f00c1c1dfce59feea9b0745eb260a7dd11bee65c8e20843da6eab.
```

**New Error Message (Prevents Unnecessary Download and Prompts Early):**

```
ValueError: Model name "convnext_large" does not match weights variant "convnext_small". When using imagenet weights, the model name must contain the weights variant (e.g., "convnext_small").
```

**Unintended Fix For EfficientNetV2:**

Fixed a latent bug in EfficientNetV2's preprocessing for `channels_first` data format where mean and variance tensors were incorrectly shaped as `[1,3]` instead of `[1,3,1,1]`. This caused broadcasting errors when normalizing inputs in `channels_first` mode.

The issue was previously undetected because most users use `channels_last` format by default. The fix reshapes the normalization parameters to `[1,3,1,1]` for proper broadcasting across spatial dimensions when using `channels_first`, while maintaining the original behavior for `channels_last` format.

**Bug revealed by:** `test_application_*_channels_first` test failures
**Impact:** Affects all `EfficientNetV2` models when used with `channels_first` data format 