### PR TITLE
Fix issue with Masking layer with Tensor as `mask_value`

### DIFF
--- a/keras/src/layers/core/masking.py
+++ b/keras/src/layers/core/masking.py
@@ -45,6 +45,8 @@ class Masking(Layer):
 
     def __init__(self, mask_value=0.0, **kwargs):
         super().__init__(**kwargs)
+        if isinstance(mask_value, dict) and mask_value.get("config", None):
+            mask_value = mask_value["config"]["value"]
         self.mask_value = mask_value
         self.supports_masking = True
         self.built = True

--- a/keras/src/layers/core/masking.py
+++ b/keras/src/layers/core/masking.py
@@ -2,6 +2,7 @@ from keras.src import backend
 from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.layers.layer import Layer
+from keras.src.saving.serialization_lib import deserialize_keras_object
 
 
 @keras_export("keras.layers.Masking")
@@ -45,8 +46,9 @@ class Masking(Layer):
 
     def __init__(self, mask_value=0.0, **kwargs):
         super().__init__(**kwargs)
+        # `mask_value` can be a serialized tensor, hence verify it
         if isinstance(mask_value, dict) and mask_value.get("config", None):
-            mask_value = mask_value["config"]["value"]
+            mask_value = deserialize_keras_object(mask_value)
         self.mask_value = mask_value
         self.supports_masking = True
         self.built = True

--- a/keras/src/layers/core/masking_test.py
+++ b/keras/src/layers/core/masking_test.py
@@ -3,8 +3,8 @@ import pytest
 
 from keras.src import layers
 from keras.src import models
-from keras.src import testing
 from keras.src import ops
+from keras.src import testing
 from keras.src.saving import load_model
 
 

--- a/keras/src/layers/core/masking_test.py
+++ b/keras/src/layers/core/masking_test.py
@@ -4,6 +4,8 @@ import pytest
 from keras.src import layers
 from keras.src import models
 from keras.src import testing
+from keras.src import ops
+from keras.src.saving import load_model
 
 
 class MaskingTest(testing.TestCase):
@@ -57,3 +59,22 @@ class MaskingTest(testing.TestCase):
             ]
         )
         model(x)
+
+    @pytest.mark.requires_trainable_backend
+    def test_masking_with_tensor(self):
+        model = models.Sequential(
+            [
+                layers.Masking(mask_value=ops.convert_to_tensor([0.0])),
+                layers.LSTM(1),
+            ]
+        )
+        x = np.array(
+            [
+                [[0.0, 0.0], [1.0, 2.0], [0.0, 0.0]],
+                [[2.0, 2.0], [0.0, 0.0], [2.0, 1.0]],
+            ]
+        )
+        model(x)
+        model.save("model.keras")
+        reload_model = load_model("model.keras")
+        reload_model(x)


### PR DESCRIPTION
Currently , the Masking layer accepting Tensor also for argument `mask_value` . After saving and loading the model the `mask_value` no longer a tensor. Hence the issue. The issue with be an model which have Masking layer and uses a Tensor as `mask_value`.

Either the Masking layer should not allow Tensors for `mask_value` or while reloading the model we need to take care of this explicitly.

I am proposing to handle `mask_value` explicitly during reloading the model.

Might fix #20706 