### PR TITLE
fix torch backend resize with `pad_to_aspectio_ratio` is set to `True`

### DIFF
--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -231,25 +231,25 @@ def resize(
         pad_width = max(width, pad_width)
         img_box_hstart = int(float(pad_height - height) / 2)
         img_box_wstart = int(float(pad_width - width) / 2)
-        
+
         if len(images.shape) == 4:
             if img_box_hstart > 0:
                 padded_img = np.concatenate(
-                [
-                    np.ones(
-                        (batch_size, channels, img_box_hstart, width),
-                        dtype=images.dtype,
-                    )
-                    * fill_value,
-                    images,
-                    np.ones(
-                        (batch_size, channels, img_box_hstart, width),
-                        dtype=images.dtype,
-                    )
-                    * fill_value,
-                ],
-                axis=2,
-            )
+                    [
+                        np.ones(
+                            (batch_size, channels, img_box_hstart, width),
+                            dtype=images.dtype,
+                        )
+                        * fill_value,
+                        images,
+                        np.ones(
+                            (batch_size, channels, img_box_hstart, width),
+                            dtype=images.dtype,
+                        )
+                        * fill_value,
+                    ],
+                    axis=2,
+                )
             else:
                 padded_img = images
 
@@ -268,7 +268,7 @@ def resize(
                         * fill_value,
                     ],
                     axis=3,
-            )
+                )
 
         else:
             channels = images.shape[0]

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -254,7 +254,7 @@ def resize(
                 padded_img = images
 
             if img_box_wstart > 0:
-                padded_img = np.cat(
+                padded_img = np.concatenate(
                     [
                         np.ones(
                             (batch_size, channels, height, img_box_wstart),

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -231,72 +231,83 @@ def resize(
         pad_width = max(width, pad_width)
         img_box_hstart = int(float(pad_height - height) / 2)
         img_box_wstart = int(float(pad_width - width) / 2)
-        if data_format == "channels_last":
-            if len(images.shape) == 4:
-                padded_img = (
+        
+        if len(images.shape) == 4:
+            if img_box_hstart > 0:
+                padded_img = np.concatenate(
+                [
                     np.ones(
-                        (
-                            batch_size,
-                            pad_height + height,
-                            pad_width + width,
-                            channels,
-                        ),
+                        (batch_size, channels, img_box_hstart, width),
                         dtype=images.dtype,
                     )
-                    * fill_value
-                )
-                padded_img[
-                    :,
-                    img_box_hstart : img_box_hstart + height,
-                    img_box_wstart : img_box_wstart + width,
-                    :,
-                ] = images
+                    * fill_value,
+                    images,
+                    np.ones(
+                        (batch_size, channels, img_box_hstart, width),
+                        dtype=images.dtype,
+                    )
+                    * fill_value,
+                ],
+                axis=2,
+            )
             else:
-                padded_img = (
-                    np.ones(
-                        (pad_height + height, pad_width + width, channels),
-                        dtype=images.dtype,
-                    )
-                    * fill_value
-                )
-                padded_img[
-                    img_box_hstart : img_box_hstart + height,
-                    img_box_wstart : img_box_wstart + width,
-                    :,
-                ] = images
+                padded_img = images
+
+            if img_box_wstart > 0:
+                padded_img = np.cat(
+                    [
+                        np.ones(
+                            (batch_size, channels, height, img_box_wstart),
+                            dtype=images.dtype,
+                        ),
+                        padded_img,
+                        np.ones(
+                            (batch_size, channels, height, img_box_wstart),
+                            dtype=images.dtype,
+                        )
+                        * fill_value,
+                    ],
+                    axis=3,
+            )
+
         else:
-            if len(images.shape) == 4:
-                padded_img = (
-                    np.ones(
-                        (
-                            batch_size,
-                            channels,
-                            pad_height + height,
-                            pad_width + width,
-                        ),
-                        dtype=images.dtype,
-                    )
-                    * fill_value
+            channels = images.shape[0]
+            if img_box_wstart > 0:
+                padded_img = np.concatenate(
+                    [
+                        np.ones(
+                            (channels, img_box_hstart, width),
+                            dtype=images.dtype,
+                        )
+                        * fill_value,
+                        images,
+                        np.ones(
+                            (channels, img_box_hstart, width),
+                            dtype=images.dtype,
+                        )
+                        * fill_value,
+                    ],
+                    axis=1,
                 )
-                padded_img[
-                    :,
-                    :,
-                    img_box_hstart : img_box_hstart + height,
-                    img_box_wstart : img_box_wstart + width,
-                ] = images
             else:
-                padded_img = (
-                    np.ones(
-                        (channels, pad_height + height, pad_width + width),
-                        dtype=images.dtype,
-                    )
-                    * fill_value
+                padded_img = images
+            if img_box_wstart > 0:
+                np.concatenate(
+                    [
+                        np.ones(
+                            (channels, height, img_box_wstart),
+                            dtype=images.dtype,
+                        )
+                        * fill_value,
+                        padded_img,
+                        np.ones(
+                            (channels, height, img_box_wstart),
+                            dtype=images.dtype,
+                        )
+                        * fill_value,
+                    ],
+                    axis=2,
                 )
-                padded_img[
-                    :,
-                    img_box_hstart : img_box_hstart + height,
-                    img_box_wstart : img_box_wstart + width,
-                ] = images
         images = padded_img
 
     return np.array(

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -232,82 +232,136 @@ def resize(
         img_box_hstart = int(float(pad_height - height) / 2)
         img_box_wstart = int(float(pad_width - width) / 2)
 
-        if len(images.shape) == 4:
+        if data_format == "channels_last":
             if img_box_hstart > 0:
-                padded_img = np.concatenate(
-                    [
-                        np.ones(
-                            (batch_size, channels, img_box_hstart, width),
-                            dtype=images.dtype,
-                        )
-                        * fill_value,
-                        images,
-                        np.ones(
-                            (batch_size, channels, img_box_hstart, width),
-                            dtype=images.dtype,
-                        )
-                        * fill_value,
-                    ],
-                    axis=2,
-                )
+                if len(images.shape) == 4:
+                    padded_img = np.concatenate(
+                        [
+                            np.ones(
+                                (batch_size, img_box_hstart, width, channels),
+                                dtype=images.dtype,
+                            )
+                            * fill_value,
+                            images,
+                            np.ones(
+                                (batch_size, img_box_hstart, width, channels),
+                                dtype=images.dtype,
+                            )
+                            * fill_value,
+                        ],
+                        axis=1,
+                    )
+                else:
+                    padded_img = np.concatenate(
+                        [
+                            np.ones(
+                                (img_box_hstart, width, channels),
+                                dtype=images.dtype,
+                            )
+                            * fill_value,
+                            images,
+                            np.ones(
+                                (img_box_hstart, width, channels),
+                                dtype=images.dtype,
+                            )
+                            * fill_value,
+                        ],
+                        axis=0,
+                    )
+            elif img_box_wstart > 0:
+                if len(images.shape) == 4:
+                    padded_img = np.concatenate(
+                        [
+                            np.ones(
+                                (batch_size, height, img_box_wstart, channels),
+                                dtype=images.dtype,
+                            )
+                            * fill_value,
+                            images,
+                            np.ones(
+                                (batch_size, height, img_box_wstart, channels),
+                                dtype=images.dtype,
+                            )
+                            * fill_value,
+                        ],
+                        axis=2,
+                    )
+                else:
+                    padded_img = np.concatenate(
+                        [
+                            np.ones(
+                                (height, img_box_wstart, channels),
+                                dtype=images.dtype,
+                            )
+                            * fill_value,
+                            images,
+                            np.ones(
+                                (height, img_box_wstart, channels),
+                                dtype=images.dtype,
+                            )
+                            * fill_value,
+                        ],
+                        axis=1,
+                    )
             else:
                 padded_img = images
-
-            if img_box_wstart > 0:
-                padded_img = np.concatenate(
-                    [
-                        np.ones(
-                            (batch_size, channels, height, img_box_wstart),
-                            dtype=images.dtype,
-                        ),
-                        padded_img,
-                        np.ones(
-                            (batch_size, channels, height, img_box_wstart),
-                            dtype=images.dtype,
-                        )
-                        * fill_value,
-                    ],
-                    axis=3,
-                )
-
         else:
-            channels = images.shape[0]
-            if img_box_wstart > 0:
-                padded_img = np.concatenate(
-                    [
-                        np.ones(
-                            (channels, img_box_hstart, width),
-                            dtype=images.dtype,
-                        )
-                        * fill_value,
-                        images,
-                        np.ones(
-                            (channels, img_box_hstart, width),
-                            dtype=images.dtype,
-                        )
-                        * fill_value,
-                    ],
-                    axis=1,
-                )
+            if img_box_hstart > 0:
+                if len(images.shape) == 4:
+                    padded_img = np.concatenate(
+                        [
+                            np.ones(
+                                (batch_size, channels, img_box_hstart, width)
+                            )
+                            * fill_value,
+                            images,
+                            np.ones(
+                                (batch_size, channels, img_box_hstart, width)
+                            )
+                            * fill_value,
+                        ],
+                        axis=2,
+                    )
+                else:
+                    padded_img = np.concatenate(
+                        [
+                            np.ones((channels, img_box_hstart, width))
+                            * fill_value,
+                            images,
+                            np.ones((channels, img_box_hstart, width))
+                            * fill_value,
+                        ],
+                        axis=1,
+                    )
+            elif img_box_wstart > 0:
+                if len(images.shape) == 4:
+                    padded_img = np.concatenate(
+                        [
+                            np.ones(
+                                (batch_size, channels, height, img_box_wstart)
+                            )
+                            * fill_value,
+                            images,
+                            np.ones(
+                                (batch_size, channels, height, img_box_wstart)
+                            )
+                            * fill_value,
+                        ],
+                        axis=3,
+                    )
+                else:
+                    padded_img = np.concatenate(
+                        [
+                            np.ones((channels, height, img_box_wstart))
+                            * fill_value,
+                            images,
+                            np.ones((channels, height, img_box_wstart))
+                            * fill_value,
+                        ],
+                        axis=2,
+                    )
             else:
                 padded_img = images
-            if img_box_wstart > 0:
-                np.concatenate(
-                    [
-                        np.ones(
-                            (channels, height, img_box_wstart),
-                            dtype=images.dtype,
-                        )
-                        * fill_value,
-                        padded_img,
-                        np.ones(
-                            (channels, height, img_box_wstart),
-                            dtype=images.dtype,
-                        )
-                        * fill_value,
-                    ],
-                    axis=2,
-                )
         images = padded_img
 
     return np.array(

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -276,7 +276,7 @@ def resize(
                         )
                         * fill_value,
                     ],
-                    axis=0,
+                    axis=1,
                 )
             else:
                 padded_img = images
@@ -295,7 +295,7 @@ def resize(
                         )
                         * fill_value,
                     ],
-                    axis=1,
+                    axis=2,
                 )
         images = padded_img
 

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -230,11 +230,14 @@ def resize(
                         torch.ones(
                             (batch_size, channels, img_box_hstart, width),
                             dtype=images.dtype,
+                            device=images.device,
                         )
                         * fill_value,
                         images,
                         torch.ones(
-                            (batch_size, channels, img_box_hstart, width)
+                            (batch_size, channels, img_box_hstart, width),
+                            dtype=images.dtype,
+                            device=images.device,
                         )
                         * fill_value,
                     ],
@@ -249,10 +252,13 @@ def resize(
                         torch.ones(
                             (batch_size, channels, height, img_box_wstart),
                             dtype=images.dtype,
+                            device=images.device,
                         ),
                         padded_img,
                         torch.ones(
-                            (batch_size, channels, height, img_box_wstart)
+                            (batch_size, channels, height, img_box_wstart),
+                            dtype=images.dtype,
+                            device=images.device,
                         )
                         * fill_value,
                     ],

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -267,12 +267,14 @@ def resize(
                         torch.ones(
                             (channels, img_box_hstart, width),
                             dtype=images.dtype,
+                            device=images.device,
                         )
                         * fill_value,
                         images,
                         torch.ones(
                             (channels, img_box_hstart, width),
                             dtype=images.dtype,
+                            device=images.device,
                         )
                         * fill_value,
                     ],
@@ -286,12 +288,14 @@ def resize(
                         torch.ones(
                             (channels, height, img_box_wstart),
                             dtype=images.dtype,
+                            device=images.device,
                         )
                         * fill_value,
                         padded_img,
                         torch.ones(
                             (channels, height, img_box_wstart),
                             dtype=images.dtype,
+                            device=images.device,
                         )
                         * fill_value,
                     ],

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -224,38 +224,79 @@ def resize(
         if len(images.shape) == 4:
             batch_size = images.shape[0]
             channels = images.shape[1]
-            padded_img = (
-                torch.ones(
-                    (
-                        batch_size,
-                        channels,
-                        pad_height + height,
-                        pad_width + width,
-                    ),
-                    dtype=images.dtype,
+            if img_box_hstart > 0:
+                padded_img = torch.cat(
+                    [
+                        torch.ones(
+                            (batch_size, channels, img_box_hstart, width),
+                            dtype=images.dtype,
+                        )
+                        * fill_value,
+                        images,
+                        torch.ones(
+                            (batch_size, channels, img_box_hstart, width)
+                        )
+                        * fill_value,
+                    ],
+                    axis=2,
                 )
-                * fill_value
-            )
-            padded_img[
-                :,
-                :,
-                img_box_hstart : img_box_hstart + height,
-                img_box_wstart : img_box_wstart + width,
-            ] = images
+            else:
+                padded_img = images
+
+            if img_box_wstart > 0:
+                padded_img = torch.cat(
+                    [
+                        torch.ones(
+                            (batch_size, channels, height, img_box_wstart),
+                            dtype=images.dtype,
+                        ),
+                        padded_img,
+                        torch.ones(
+                            (batch_size, channels, height, img_box_wstart)
+                        )
+                        * fill_value,
+                    ],
+                    axis=3,
+                )
+
         else:
             channels = images.shape[0]
-            padded_img = (
-                torch.ones(
-                    (channels, pad_height + height, pad_width + width),
-                    dtype=images.dtype,
+            if img_box_wstart > 0:
+                padded_img = torch.cat(
+                    [
+                        torch.ones(
+                            (channels, img_box_hstart, width),
+                            dtype=images.dtype,
+                        )
+                        * fill_value,
+                        images,
+                        torch.ones(
+                            (channels, img_box_hstart, width),
+                            dtype=images.dtype,
+                        )
+                        * fill_value,
+                    ],
+                    axis=0,
                 )
-                * fill_value
-            )
-            padded_img[
-                :,
-                img_box_hstart : img_box_hstart + height,
-                img_box_wstart : img_box_wstart + width,
-            ] = images
+            else:
+                padded_img = images
+            if img_box_wstart > 0:
+                torch.cat(
+                    [
+                        torch.ones(
+                            (channels, height, img_box_wstart),
+                            dtype=images.dtype,
+                        )
+                        * fill_value,
+                        padded_img,
+                        torch.ones(
+                            (channels, height, img_box_wstart),
+                            dtype=images.dtype,
+                        )
+                        * fill_value,
+                    ],
+                    axis=1,
+                )
         images = padded_img
 
     resized = torchvision.transforms.functional.resize(

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -791,6 +791,31 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )
         self.assertEqual(out.shape, (2, 3, 25, 25))
 
+        x = np.ones((2, 3, 10, 10)) * 128
+        out = kimage.resize(
+            x, size=(4, 4), pad_to_aspect_ratio=True, fill_value=fill_value
+        )
+        self.assertEqual(out.shape, (2, 3, 4, 4))
+        self.assertAllClose(out[:, 0, :, :], np.ones((2, 4, 4)) * 128)
+
+        x = np.ones((2, 3, 10, 8)) * 128
+        out = kimage.resize(
+            x, size=(4, 4), pad_to_aspect_ratio=True, fill_value=fill_value
+        )
+        self.assertEqual(out.shape, (2, 3, 4, 4))
+        self.assertAllClose(
+            out,
+            np.concatenate(
+                [
+                    np.ones((2, 3, 4, 1)) * 96.25,
+                    np.ones((2, 3, 4, 2)) * 128.0,
+                    np.ones((2, 3, 4, 1)) * 96.25,
+                ],
+                axis=3,
+            ),
+            atol=1.0,
+        )
+
     @parameterized.named_parameters(
         named_product(
             interpolation=["bilinear", "nearest"],


### PR DESCRIPTION
The resize doesn't work as expected while setting flag `pad_to_aspectio_ratio=True`.

1. [Resize with JAX](https://colab.sandbox.google.com/gist/sineeli/2fecee7658464ab0c02867e2883864dc/resize-with-tensorflow-backend-correct.ipynb) works as expected.
2. [Resize with Torch](https://colab.sandbox.google.com/gist/sineeli/1187a1426655a28fe4b39c69da9566db/resize-with-torch-backend-bug.ipynb) needs fix.
3. [Resize with Torch Fixed Code](https://colab.sandbox.google.com/gist/sineeli/9da8ee127669a58ee6e3bc263d25816e/resize-with-torch-backend-fixed.ipynb)