### PR TITLE
Fix evaluate() printed values being incorrect by default

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -513,7 +513,7 @@ class JAXTrainer(base_trainer.Trainer):
         x=None,
         y=None,
         batch_size=None,
-        verbose="auto",
+        verbose=2,
         sample_weight=None,
         steps=None,
         callbacks=None,

--- a/keras/src/backend/numpy/trainer.py
+++ b/keras/src/backend/numpy/trainer.py
@@ -227,7 +227,7 @@ class NumpyTrainer(base_trainer.Trainer):
         x=None,
         y=None,
         batch_size=None,
-        verbose="auto",
+        verbose=2,
         sample_weight=None,
         steps=None,
         callbacks=None,

--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -229,7 +229,7 @@ class OpenVINOTrainer(base_trainer.Trainer):
         x=None,
         y=None,
         batch_size=None,
-        verbose="auto",
+        verbose=2,
         sample_weight=None,
         steps=None,
         callbacks=None,

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -430,7 +430,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
         x=None,
         y=None,
         batch_size=None,
-        verbose="auto",
+        verbose=2,
         sample_weight=None,
         steps=None,
         callbacks=None,

--- a/keras/src/backend/torch/trainer.py
+++ b/keras/src/backend/torch/trainer.py
@@ -320,7 +320,7 @@ class TorchTrainer(base_trainer.Trainer):
         x=None,
         y=None,
         batch_size=None,
-        verbose="auto",
+        verbose=2,
         sample_weight=None,
         steps=None,
         callbacks=None,

--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -716,7 +716,7 @@ class Trainer:
         x=None,
         y=None,
         batch_size=None,
-        verbose="auto",
+        verbose=2,
         sample_weight=None,
         steps=None,
         callbacks=None,


### PR DESCRIPTION
Temporary fix for most users to [this issue](https://github.com/keras-team/keras/issues/20788) which was not present in previous versions of Keras.

This changes to 2 the default verbosity level of the model evaluate() method, as to not print incorrect values for e.g. the loss and accuracy (mismatching correct values printed during training or values computed "by hand").

This does not fix the problem as to why ``` verbose=1 ``` makes evaluate() print incorrect values while still returning correct ones when passing ``` return_dict=True ```.