### PR TITLE
fix(ops): Handle floating-point edge cases in ops.argmax()

### DIFF
--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -353,7 +353,12 @@ def arctanh(x):
 
 
 def argmax(x, axis=None, keepdims=False):
-    return jnp.argmax(x, axis=axis, keepdims=keepdims)
+    if x.ndim == 0:
+        return jnp.argmax(x, axis=axis, keepdims=keepdims)
+    x_float = x.astype(jnp.float32)
+    is_negative_zero = (x_float == 0.0) & jnp.signbit(x_float)
+    x_adjusted = jnp.where(is_negative_zero, -jnp.finfo(x_float.dtype).tiny, x_float)
+    return jnp.argmax(x_adjusted, axis=axis, keepdims=keepdims)
 
 
 def argmin(x, axis=None, keepdims=False):

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -357,7 +357,9 @@ def argmax(x, axis=None, keepdims=False):
         return jnp.argmax(x, axis=axis, keepdims=keepdims)
     x_float = x.astype(jnp.float32)
     is_negative_zero = (x_float == 0.0) & jnp.signbit(x_float)
-    x_adjusted = jnp.where(is_negative_zero, -jnp.finfo(x_float.dtype).tiny, x_float)
+    x_adjusted = jnp.where(
+        is_negative_zero, -jnp.finfo(x_float.dtype).tiny, x_float
+    )
     return jnp.argmax(x_adjusted, axis=axis, keepdims=keepdims)
 
 

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -249,7 +249,9 @@ def argmax(x, axis=None, keepdims=False):
         return np.argmax(x, axis=axis, keepdims=keepdims).astype("int32")
     x_float = x.astype(np.float32)
     is_negative_zero = (x_float == 0.0) & np.signbit(x_float)
-    x_adjusted = np.where(is_negative_zero, -np.finfo(x_float.dtype).tiny, x_float)
+    x_adjusted = np.where(
+        is_negative_zero, -np.finfo(x_float.dtype).tiny, x_float
+    )
     return np.argmax(x_adjusted, axis=axis, keepdims=keepdims).astype("int32")
 
 

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -245,8 +245,12 @@ def arctanh(x):
 
 
 def argmax(x, axis=None, keepdims=False):
-    axis = standardize_axis_for_numpy(axis)
-    return np.argmax(x, axis=axis, keepdims=keepdims).astype("int32")
+    if x.ndim == 0:
+        return np.argmax(x, axis=axis, keepdims=keepdims).astype("int32")
+    x_float = x.astype(np.float32)
+    is_negative_zero = (x_float == 0.0) & np.signbit(x_float)
+    x_adjusted = np.where(is_negative_zero, -np.finfo(x_float.dtype).tiny, x_float)
+    return np.argmax(x_adjusted, axis=axis, keepdims=keepdims).astype("int32")
 
 
 def argmin(x, axis=None, keepdims=False):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -841,17 +841,20 @@ def argmax(x, axis=None, keepdims=False):
         x = tf.reshape(x, [-1])
     x_float = tf.cast(x, tf.float32)
     is_negative_zero = tf.logical_and(
-        tf.equal(x_float, 0.0), 
-        tf.less(tf.bitwise.bitwise_and(
-            tf.bitcast(x_float, tf.int32), 
-            # tf.float32 sign bit
-            tf.constant(0x80000000, dtype=tf.int32)
-        ), 0)
+        tf.equal(x_float, 0.0),
+        tf.less(
+            tf.bitwise.bitwise_and(
+                tf.bitcast(x_float, tf.int32),
+                # tf.float32 sign bit
+                tf.constant(0x80000000, dtype=tf.int32),
+            ),
+            0,
+        ),
     )
     x_adjusted = tf.where(
-        is_negative_zero, 
-        -tf.reduce_min(tf.abs(x_float[tf.not_equal(x_float, 0.0)])), 
-        x_float
+        is_negative_zero,
+        -tf.reduce_min(tf.abs(x_float[tf.not_equal(x_float, 0.0)])),
+        x_float,
     )
     if axis is None:
         x_adjusted = tf.reshape(x_adjusted, [-1])

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1142,6 +1142,17 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.argmax(x, axis=1).shape, (None, 3))
         self.assertEqual(knp.argmax(x, keepdims=True).shape, (None, 3, 3))
 
+    @pytest.mark.skipif(
+        keras.config.backend() == "openvino",
+        reason="OpenVINO doesn't support this change",
+    )
+    def test_argmax_negative_zero(self):
+        input_data = np.array(
+            [-1.0, -0.0, 1.401298464324817e-45], dtype=np.float32
+        )
+        result = knp.argmax(input_data)
+        assert result == 2, f"Expected index 2, got {result}"
+
     def test_argmin(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.argmin(x).shape, ())

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1150,8 +1150,7 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         input_data = np.array(
             [-1.0, -0.0, 1.401298464324817e-45], dtype=np.float32
         )
-        result = knp.argmax(input_data)
-        assert result == 2, f"Expected index 2, got {result}"
+        self.assertEqual(knp.argmax(input_data), 2)
 
     def test_argmin(self):
         x = KerasTensor((None, 3))


### PR DESCRIPTION
- Adjust input for negative zero values in argmax.
- Modify implementation to use core ops with floating-point handling.
- Attempts to fix #20350.