### PR TITLE
implement remaining functions in `mlx.nn.py` excluding pooling

### DIFF
--- a/keras/src/backend/mlx/linalg.py
+++ b/keras/src/backend/mlx/linalg.py
@@ -52,7 +52,10 @@ def norm(x, ord=None, axis=None, keepdims=False):
     if "int" in dtype or dtype == "bool":
         dtype = dtypes.result_type(x.dtype, "float32")
     x = convert_to_tensor(x, dtype=dtype)
-    return mx.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+    # TODO: swap to mlx.linalg.norm when it support singular value norms
+    x = jnp.array(x)
+    output = jnp.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+    return mx.array(output)
 
 
 def inv(a):


### PR DESCRIPTION
This addresses #19571, to complete the rest of `mlx.nn.py` excluding the pooling functions

This implements:
- `psnr`
- `ctc_loss`
- `ctc_decode`
    - `_ctc_greedy_decode`
    - `_ctc_beam_search_decode`
        - it's not very efficient, mostly because mlx does not have a `unique` function (I probably spent too much time on this 😅)
        - we could disable it in the tests (I saw that for torch)

This patches the following:
- `one_hot`
- `categorical_crossentropy`
- `moments` 
- `batch_normalization`
    - this now depends on jax's `norm` function until mlx's `norm` supports singular value norms
    - (is numpy preferred here?)