### PR TITLE
fix(layers): Fix incorrect masked mean/variance in BatchNormalization layer

### DIFF
--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -214,7 +214,7 @@ class BatchNormalization(Layer):
 
         reduction_axes = list(range(len(input_shape)))
         del reduction_axes[self.axis]
-        self._reduction_axes = list(reduction_axes)
+        self._reduction_axes = reduction_axes
         self.built = True
 
     def compute_output_shape(self, input_shape):

--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -318,15 +318,12 @@ class BatchNormalization(Layer):
                 synchronized=self.synchronized,
             )
 
-        mask_weights = ops.cast(
-            mask,
-            inputs.dtype,
+        mask_weights = ops.cast(mask, inputs.dtype)
+        mask_weights_broadcasted = ops.expand_dims(mask_weights, axis=-1)
+        broadcasted_mask = ops.broadcast_to(
+            mask_weights_broadcasted, ops.shape(inputs)
         )
-        mask_weights_broadcasted = ops.expand_dims(
-            mask_weights,
-            axis=-1,
-        )
-        weighted_inputs = mask_weights_broadcasted * inputs
+        weighted_inputs = broadcasted_mask * inputs
 
         weighted_input_sum = ops.sum(
             weighted_inputs,
@@ -334,7 +331,7 @@ class BatchNormalization(Layer):
             keepdims=True,
         )
         sum_of_weights = ops.sum(
-            mask_weights_broadcasted,
+            broadcasted_mask,
             self._reduction_axes,
             keepdims=True,
         )
@@ -343,7 +340,7 @@ class BatchNormalization(Layer):
         difference = weighted_inputs - mean
         squared_difference = ops.square(difference)
         weighted_distsq = ops.sum(
-            mask_weights_broadcasted * squared_difference,
+            broadcasted_mask * squared_difference,
             self._reduction_axes,
             keepdims=True,
         )

--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -335,7 +335,7 @@ class BatchNormalization(Layer):
             self._reduction_axes,
             keepdims=True,
         )
-        mean = weighted_input_sum / (sum_of_weights + backend.config.epsilon())
+        mean = weighted_input_sum / (sum_of_weights + backend.epsilon())
 
         difference = weighted_inputs - mean
         squared_difference = ops.square(difference)
@@ -344,6 +344,6 @@ class BatchNormalization(Layer):
             self._reduction_axes,
             keepdims=True,
         )
-        variance = weighted_distsq / (sum_of_weights + backend.config.epsilon())
+        variance = weighted_distsq / (sum_of_weights + backend.epsilon())
 
         return ops.squeeze(mean), ops.squeeze(variance)

--- a/keras/src/layers/normalization/batch_normalization_test.py
+++ b/keras/src/layers/normalization/batch_normalization_test.py
@@ -221,3 +221,20 @@ class BatchNormalizationTest(testing.TestCase):
         with backend.AutocastScope("float16"):
             layer.moving_variance.assign(large_value)
             self.assertAllClose(layer.moving_variance.value, large_value)
+
+    def test_masked_broadcast_normalization(self):
+        input_shape = (1, 2, 3, 4)
+        mask_shape = (1, 2, 1)
+        x = ops.ones(input_shape)
+        mask = ops.ones(mask_shape)
+
+        layer = layers.BatchNormalization(axis=-1, momentum=0.0, epsilon=1e-3)
+
+        y = layer(x, training=True, mask=mask)
+
+        mean_y = ops.mean(y, axis=(0, 1, 2))
+        self.assertAllClose(mean_y, ops.zeros((4,)), atol=1e-6)
+        self.assertAllClose(y, ops.zeros_like(y), atol=1e-6)
+
+        self.assertAllClose(layer.moving_mean, ops.ones((4,)), atol=1e-6)
+        self.assertAllClose(layer.moving_variance, ops.zeros((4,)), atol=1e-6)

--- a/keras/src/layers/normalization/batch_normalization_test.py
+++ b/keras/src/layers/normalization/batch_normalization_test.py
@@ -222,6 +222,13 @@ class BatchNormalizationTest(testing.TestCase):
             layer.moving_variance.assign(large_value)
             self.assertAllClose(layer.moving_variance.value, large_value)
 
+    @pytest.mark.skipif(
+        backend.backend() == "openvino",
+        reason="""
+        ops.mean() - TypeError: The necessary overload 
+        for constant was not found
+        """,
+    )
     def test_masked_broadcast_normalization(self):
         input_shape = (1, 2, 3, 4)
         mask_shape = (1, 2, 1)

--- a/keras/src/layers/normalization/batch_normalization_test.py
+++ b/keras/src/layers/normalization/batch_normalization_test.py
@@ -222,13 +222,6 @@ class BatchNormalizationTest(testing.TestCase):
             layer.moving_variance.assign(large_value)
             self.assertAllClose(layer.moving_variance.value, large_value)
 
-    @pytest.mark.skipif(
-        backend.backend() == "openvino",
-        reason="""
-        ops.mean() - TypeError: The necessary overload 
-        for constant was not found
-        """,
-    )
     def test_masked_broadcast_normalization(self):
         input_shape = (1, 2, 3, 4)
         mask_shape = (1, 2, 1)
@@ -239,7 +232,8 @@ class BatchNormalizationTest(testing.TestCase):
 
         y = layer(x, training=True, mask=mask)
 
-        mean_y = ops.mean(y, axis=(0, 1, 2))
+        mean_y = ops.mean(y, axis=[0, 1, 2])
+
         self.assertAllClose(mean_y, ops.zeros((4,)), atol=1e-6)
         self.assertAllClose(y, ops.zeros_like(y), atol=1e-6)
 


### PR DESCRIPTION
- Update masked moments calculation to properly account for broadcast dimensions when summing mask weights.
- Added test to verify broadcast mask handling produces zero-centered outputs.
- Fixes #19848.