### PR TITLE
Fix deserialization issue with custom_loss function while reloading

### DIFF
--- a/keras/src/saving/object_registration.py
+++ b/keras/src/saving/object_registration.py
@@ -227,9 +227,9 @@ def get_registered_object(name, custom_objects=None, module_objects=None):
         return custom_objects[name]
     elif module_objects and name in module_objects:
         return module_objects[name]
-    # Check if there are objects without Package name appended to them.
-    # For Backward compatibility of custom_loss functions in versions <3.7
-    elif name is not None and any(
+    # # Check if there are objects without Package name appended to them.
+    # # For Backward compatibility of custom_loss functions in versions <3.7
+    elif name not in (None, "Functional") and any(
         lambda key: key.contains(name)
         for key in custom_objects_scope_dict.keys()
     ):

--- a/keras/src/saving/object_registration.py
+++ b/keras/src/saving/object_registration.py
@@ -227,4 +227,13 @@ def get_registered_object(name, custom_objects=None, module_objects=None):
         return custom_objects[name]
     elif module_objects and name in module_objects:
         return module_objects[name]
+    # Check if there are objects without Package name appended to them.
+    # For Backward compatibility of custom_loss functions in versions <3.7
+    elif name is not None and any(
+        lambda key: key.contains(name)
+        for key in custom_objects_scope_dict.keys()
+    ):
+        for key in custom_objects_scope_dict.keys():
+            if name in key:
+                return custom_objects_scope_dict[key]
     return None

--- a/keras/src/saving/object_registration.py
+++ b/keras/src/saving/object_registration.py
@@ -227,13 +227,4 @@ def get_registered_object(name, custom_objects=None, module_objects=None):
         return custom_objects[name]
     elif module_objects and name in module_objects:
         return module_objects[name]
-    # # Check if there are objects without Package name appended to them.
-    # # For Backward compatibility of custom_loss functions in versions <3.7
-    elif name not in (None, "Functional") and any(
-        lambda key: key.contains(name)
-        for key in custom_objects_scope_dict.keys()
-    ):
-        for key in custom_objects_scope_dict.keys():
-            if name in key:
-                return custom_objects_scope_dict[key]
     return None

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -780,7 +780,15 @@ def _retrieve_class_or_fn(
                 )
                 if obj is not None:
                     return obj
-
+            # Fall back code for reloading saved models of versions <=3.6
+            # into versions >=3.7
+            filtered_dict = {
+                k: v
+                for k, v in custom_objects.items()
+                if k.endswith(full_config["config"])
+            }
+            if filtered_dict:
+                return next(iter(filtered_dict.values()))
         # Otherwise, attempt to retrieve the class object given the `module`
         # and `class_name`. Import the module, find the class.
         package = module.split(".", maxsplit=1)[0]


### PR DESCRIPTION
Fix deserialization issue with `custom_loss` function while reloading saved models of <3.7v.

Suppose for a model with custom loss function and saved in 3.6V, to reload in newer version we are facing an issue due to changes in appending the package name to loss function from versions 3.7v onwards.

One Workaround is to pass these custom objects explicitly to `load_model`. The reason this works is mentioned below.

When we pass `custom_objects` explicitly to `load_model`, For example in this case, it will be duplicated and custom_objects will become double like below,with Package name and without function names:

`{'MyLayers': <class '__main__.CustomLayer'>, 'MyLayers>CustomLayer': <class '__main__.CustomLayer'>, 'custom_fn': <function custom_fn at 0x0000029D776D440>, 'custom_fn>custom_fn': <function custom_fn at 0x0000029D776D440>, 'custom_fn>my_loss_fn': <function my_loss_fn at 0x0000029DA6E2C00>, 'my_loss_fn': <function my_loss_fn at 0x0000029DA6E2C00>}`

This can be a workaround for loading saved model in 3.6V with custom_loss in Versions >3.7. If it is OK then documentation needs to be updated accordingly.

Alternatively this PR will resolve this issue until Keras 3.6 v become inactive for use.

Might Fix #20806