### PR TITLE
Add `signbit` and fix `argmin` and `argmax`

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -231,6 +231,7 @@ from keras.src.ops.numpy import round
 from keras.src.ops.numpy import searchsorted
 from keras.src.ops.numpy import select
 from keras.src.ops.numpy import sign
+from keras.src.ops.numpy import signbit
 from keras.src.ops.numpy import sin
 from keras.src.ops.numpy import sinh
 from keras.src.ops.numpy import size

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -129,6 +129,7 @@ from keras.src.ops.numpy import rot90
 from keras.src.ops.numpy import round
 from keras.src.ops.numpy import select
 from keras.src.ops.numpy import sign
+from keras.src.ops.numpy import signbit
 from keras.src.ops.numpy import sin
 from keras.src.ops.numpy import sinh
 from keras.src.ops.numpy import size

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -231,6 +231,7 @@ from keras.src.ops.numpy import round
 from keras.src.ops.numpy import searchsorted
 from keras.src.ops.numpy import select
 from keras.src.ops.numpy import sign
+from keras.src.ops.numpy import signbit
 from keras.src.ops.numpy import sin
 from keras.src.ops.numpy import sinh
 from keras.src.ops.numpy import size

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -129,6 +129,7 @@ from keras.src.ops.numpy import rot90
 from keras.src.ops.numpy import round
 from keras.src.ops.numpy import select
 from keras.src.ops.numpy import sign
+from keras.src.ops.numpy import signbit
 from keras.src.ops.numpy import sin
 from keras.src.ops.numpy import sinh
 from keras.src.ops.numpy import size

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -363,10 +363,11 @@ def arctanh(x):
 
 def argmax(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
-    if not jax_uses_cpu() or x.ndim == 0:
+    dtype = standardize_dtype(x.dtype)
+    if "float" not in dtype or not jax_uses_cpu() or x.ndim == 0:
         return jnp.argmax(x, axis=axis, keepdims=keepdims)
 
-    dtype = dtypes.result_type(x.dtype, "float32")
+    dtype = dtypes.result_type(dtype, "float32")
     x = cast(x, dtype)
     is_negative_zero = (x == 0.0) & jnp.signbit(x)
     x = jnp.where(is_negative_zero, -jnp.finfo(x.dtype).tiny, x)
@@ -375,10 +376,11 @@ def argmax(x, axis=None, keepdims=False):
 
 def argmin(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
-    if not jax_uses_cpu() or x.ndim == 0:
+    dtype = standardize_dtype(x.dtype)
+    if "float" not in dtype or not jax_uses_cpu() or x.ndim == 0:
         return jnp.argmin(x, axis=axis, keepdims=keepdims)
 
-    dtype = dtypes.result_type(x.dtype, "float32")
+    dtype = dtypes.result_type(dtype, "float32")
     x = cast(x, dtype)
     is_negative_zero = (x == 0.0) & jnp.signbit(x)
     x = jnp.where(is_negative_zero, -jnp.finfo(x.dtype).tiny, x)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -245,32 +245,29 @@ def arctanh(x):
 
 
 def argmax(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
+    axis = standardize_axis_for_numpy(axis)
     if x.ndim == 0:
         return np.argmax(x, axis=axis, keepdims=keepdims).astype("int32")
-    x_float = x.astype(np.float32)
-    is_negative_zero = (x_float == 0.0) & np.signbit(x_float)
-    x_adjusted = np.where(
-        is_negative_zero, -np.finfo(x_float.dtype).tiny, x_float
-    )
-    return np.argmax(x_adjusted, axis=axis, keepdims=keepdims).astype("int32")
+
+    dtype = dtypes.result_type(x.dtype, "float32")
+    x = x.astype(dtype)
+    is_negative_zero = (x == 0.0) & np.signbit(x)
+    x = np.where(is_negative_zero, -np.finfo(x.dtype).tiny, x)
+    return np.argmax(x, axis=axis, keepdims=keepdims).astype("int32")
 
 
 def argmin(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
     axis = standardize_axis_for_numpy(axis)
-    x_64 = np.asarray(x, dtype=np.float64)
-    if axis is not None:
-        min_mask = x_64 == np.min(x_64, axis=axis, keepdims=True)
-        indices = np.argmin(
-            np.where(min_mask, x_64, np.inf), axis=axis, keepdims=keepdims
-        ).astype("int32")
-    else:
-        min_mask = (x_64 < x_64.min()) | (
-            (x_64 == x_64.min()) & (np.signbit(x_64))
-        )
-        indices = np.argmin(
-            np.where(min_mask, x_64, np.inf), axis=axis, keepdims=keepdims
-        ).astype("int32")
-    return indices
+    if x.ndim == 0:
+        return np.argmin(x, axis=axis, keepdims=keepdims).astype("int32")
+
+    dtype = dtypes.result_type(x.dtype, "float32")
+    x = x.astype(dtype)
+    is_negative_zero = (x == 0.0) & np.signbit(x)
+    x = np.where(is_negative_zero, -np.finfo(x.dtype).tiny, x)
+    return np.argmin(x, axis=axis, keepdims=keepdims).astype("int32")
 
 
 def argsort(x, axis=-1):
@@ -905,6 +902,10 @@ def searchsorted(sorted_sequence, values, side="left"):
 
 def sign(x):
     return np.sign(x)
+
+
+def signbit(x):
+    return np.signbit(x)
 
 
 def sin(x):

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -247,10 +247,11 @@ def arctanh(x):
 def argmax(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
     axis = standardize_axis_for_numpy(axis)
-    if x.ndim == 0:
+    dtype = standardize_dtype(x.dtype)
+    if "float" not in dtype or x.ndim == 0:
         return np.argmax(x, axis=axis, keepdims=keepdims).astype("int32")
 
-    dtype = dtypes.result_type(x.dtype, "float32")
+    dtype = dtypes.result_type(dtype, "float32")
     x = x.astype(dtype)
     is_negative_zero = (x == 0.0) & np.signbit(x)
     x = np.where(is_negative_zero, -np.finfo(x.dtype).tiny, x)
@@ -260,10 +261,11 @@ def argmax(x, axis=None, keepdims=False):
 def argmin(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
     axis = standardize_axis_for_numpy(axis)
-    if x.ndim == 0:
+    dtype = standardize_dtype(x.dtype)
+    if "float" not in dtype or x.ndim == 0:
         return np.argmin(x, axis=axis, keepdims=keepdims).astype("int32")
 
-    dtype = dtypes.result_type(x.dtype, "float32")
+    dtype = dtypes.result_type(dtype, "float32")
     x = x.astype(dtype)
     is_negative_zero = (x == 0.0) & np.signbit(x)
     x = np.where(is_negative_zero, -np.finfo(x.dtype).tiny, x)

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -751,6 +751,12 @@ def sign(x):
     return OpenVINOKerasTensor(ov_opset.sign(x).output(0))
 
 
+def signbit(x):
+    raise NotImplementedError(
+        "`signbit` is not supported with openvino backend"
+    )
+
+
 def sin(x):
     x = get_ov_output(x)
     x_type = x.get_element_type()

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -857,7 +857,8 @@ def _keepdims(x, y, axis):
 
 def argmax(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
-    if not tf_uses_cpu() or x.ndim == 0:
+    dtype = standardize_dtype(x.dtype)
+    if "float" not in dtype or not tf_uses_cpu() or x.ndim == 0:
         _x = x
         if axis is None:
             x = tf.reshape(x, [-1])
@@ -866,7 +867,7 @@ def argmax(x, axis=None, keepdims=False):
             y = _keepdims(_x, y, axis)
         return y
 
-    dtype = dtypes.result_type(x.dtype, "float32")
+    dtype = dtypes.result_type(dtype, "float32")
     x = cast(x, dtype)
     is_negative_zero = tf.logical_and(tf.equal(x, 0.0), signbit(x))
     x = tf.where(
@@ -883,7 +884,8 @@ def argmax(x, axis=None, keepdims=False):
 
 def argmin(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
-    if not tf_uses_cpu() or x.ndim == 0:
+    dtype = standardize_dtype(x.dtype)
+    if "float" not in dtype or not tf_uses_cpu() or x.ndim == 0:
         _x = x
         if axis is None:
             x = tf.reshape(x, [-1])
@@ -892,7 +894,7 @@ def argmin(x, axis=None, keepdims=False):
             y = _keepdims(_x, y, axis)
         return y
 
-    dtype = dtypes.result_type(x.dtype, "float32")
+    dtype = dtypes.result_type(dtype, "float32")
     x = cast(x, dtype)
     is_negative_zero = tf.logical_and(tf.equal(x, 0.0), signbit(x))
     x = tf.where(

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2060,8 +2060,7 @@ def signbit(x):
     elif "int" in ori_dtype:
         return x < 0
     else:
-        compute_dtype = dtypes.result_type(ori_dtype, "float32")
-        x = cast(x, compute_dtype)
+        x = cast(x, "float32")
         return tf.less(
             tf.bitwise.bitwise_and(
                 tf.bitcast(x, tf.int32),

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1319,6 +1319,11 @@ def sign(x):
     return torch.sign(x)
 
 
+def signbit(x):
+    x = convert_to_tensor(x)
+    return torch.signbit(x)
+
+
 def sin(x):
     x = convert_to_tensor(x)
     return torch.sin(x)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -5067,6 +5067,33 @@ def sign(x):
     return backend.numpy.sign(x)
 
 
+class Signbit(Operation):
+    def call(self, x):
+        return backend.numpy.signbit(x)
+
+    def compute_output_spec(self, x):
+        sparse = getattr(x, "sparse", False)
+        return KerasTensor(x.shape, dtype="bool", sparse=sparse)
+
+
+@keras_export(["keras.ops.signbit", "keras.ops.numpy.signbit"])
+def signbit(x):
+    """Return the sign bit of the elements of `x`.
+
+    The output boolean tensor contains `True` where the sign of `x` is negative,
+    and `False` otherwise.
+
+    Args:
+        x: Input tensor.
+
+    Returns:
+        Output boolean tensor of same shape as `x`.
+    """
+    if any_symbolic_tensors((x,)):
+        return Signbit().symbolic_call(x)
+    return backend.numpy.signbit(x)
+
+
 class Sin(Operation):
     def call(self, x):
         return backend.numpy.sin(x)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -4333,8 +4333,8 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
 
     def test_signbit(self):
         x = np.array([[0.0, -0.0, -1.1e-45], [1.1e-38, 2, -1]])
-        self.assertAllClose(knp.sign(x), np.sign(x))
-        self.assertAllClose(knp.Sign()(x), np.sign(x))
+        self.assertAllClose(knp.signbit(x), np.signbit(x))
+        self.assertAllClose(knp.Signbit()(x), np.signbit(x))
 
     def test_sin(self):
         x = np.array([[1, -2, 3], [-3, 2, -1]])

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1597,6 +1597,10 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.sign(x).shape, (None, 3))
 
+    def test_signbit(self):
+        x = KerasTensor((None, 3))
+        self.assertEqual(knp.signbit(x).shape, (None, 3))
+
     def test_sin(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.sin(x).shape, (None, 3))
@@ -2160,6 +2164,10 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
     def test_sign(self):
         x = KerasTensor((2, 3))
         self.assertEqual(knp.sign(x).shape, (2, 3))
+
+    def test_signbit(self):
+        x = KerasTensor((2, 3))
+        self.assertEqual(knp.signbit(x).shape, (2, 3))
 
     def test_sin(self):
         x = KerasTensor((2, 3))
@@ -4320,6 +4328,11 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
 
     def test_sign(self):
         x = np.array([[1, -2, 3], [-3, 2, -1]])
+        self.assertAllClose(knp.sign(x), np.sign(x))
+        self.assertAllClose(knp.Sign()(x), np.sign(x))
+
+    def test_signbit(self):
+        x = np.array([[0.0, -0.0, -1.1e-45], [1.1e-38, 2, -1]])
         self.assertAllClose(knp.sign(x), np.sign(x))
         self.assertAllClose(knp.Sign()(x), np.sign(x))
 
@@ -8036,6 +8049,23 @@ class NumpyDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knp.Sign().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_signbit(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((), dtype=dtype)
+        x_jax = jnp.ones((), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.signbit(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.signbit(x).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Signbit().symbolic_call(x).dtype),
             expected_dtype,
         )
 

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -646,6 +646,13 @@ def uses_gpu():
     return False
 
 
+def uses_cpu():
+    devices = distribution.list_devices()
+    if any(d.startswith("cpu") for d in devices):
+        return True
+    return False
+
+
 def create_keras_tensors(input_shape, dtype, sparse):
     if isinstance(input_shape, dict):
         return {

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -3,11 +3,11 @@ tensorflow-cpu~=2.18.0
 tf2onnx
 
 # Torch cpu-only version (needed for testing).
+# TODO: torch-xla needs to support a higher version of Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0
-torchvision>=0.16.0
-torch-xla
-
+torch==2.5.1+cpu
+torchvision==0.20.1+cpu
+torch-xla==2.5.1;sys_platform != 'darwin'
 # Jax with cuda support.
 # TODO: Higher version breaks CI.
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -3,7 +3,7 @@ tensorflow-cpu~=2.18.0
 tf2onnx
 
 # Torch cpu-only version (needed for testing).
-# TODO: torch-xla needs to support a higher version of Torch.
+# TODO: Pinned to a version that is compatible with torch-xla
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.5.1+cpu
 torchvision==0.20.1+cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -3,7 +3,7 @@ tensorflow[and-cuda]~=2.18.0
 tf2onnx
 
 # Torch cpu-only version (needed for testing).
-# TODO: torch-xla needs to support a higher version of Torch.
+# TODO: Pinned to a version that is compatible with torch-xla
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.5.1+cpu
 torchvision==0.20.1+cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -3,10 +3,11 @@ tensorflow[and-cuda]~=2.18.0
 tf2onnx
 
 # Torch cpu-only version (needed for testing).
+# TODO: torch-xla needs to support a higher version of Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0
-torchvision>=0.16.0
-torch-xla
+torch==2.5.1+cpu
+torchvision==0.20.1+cpu
+torch-xla==2.5.1;sys_platform != 'darwin'
 
 # Jax cpu-only version (needed for testing).
 jax[cpu]

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -3,6 +3,7 @@ tensorflow-cpu~=2.18.0
 tf2onnx
 
 # Torch with cuda support.
+# TODO: Pinned to a version that is compatible with torch-xla
 --extra-index-url https://download.pytorch.org/whl/cu121
 torch==2.5.1+cu121
 torchvision==0.20.1+cu121

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -6,7 +6,7 @@ tf2onnx
 --extra-index-url https://download.pytorch.org/whl/cu121
 torch==2.5.1+cu121
 torchvision==0.20.1+cu121
-torch-xla
+torch-xla==2.5.1
 
 # Jax cpu-only version (needed for testing).
 jax[cpu]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,11 @@ tf_keras
 tf2onnx
 
 # Torch.
-# TODO: Pin to < 2.3.0 (GitHub issue #19602)
+# TODO: torch-xla needs to support a higher version of Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0
-torchvision>=0.16.0
-torch-xla;sys_platform != 'darwin'
+torch==2.5.1+cpu
+torchvision==0.20.1+cpu
+torch-xla==2.5.1;sys_platform != 'darwin'
 
 # Jax.
 jax[cpu]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,10 @@ tf_keras
 tf2onnx
 
 # Torch.
-# Pinned to a version that is compatible with torch-xla
+# TODO: Pinned to a version that is compatible with torch-xla
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.5.1
-torchvision>=0.20.1
+torchvision==0.20.1
 torch-xla;sys_platform != 'darwin'
 
 # Jax.


### PR DESCRIPTION
Based on this issue https://github.com/jax-ml/jax/issues/24280, we should patch `argmin` and `argmax` ops only when using the CPU due to the flush-to-zero (FTZ) issue.

Since we need `signbit` to patch these ops, adding it is straightforward.
