### PR TITLE
mlx - patch for pytest to run

### DIFF
--- a/keras/src/backend/__init__.py
+++ b/keras/src/backend/__init__.py
@@ -57,7 +57,8 @@ elif backend() == "openvino":
     distribution_lib = None
 elif backend() == "mlx":
     from keras.src.backend.mlx import *  # noqa: F403
-
+    from keras.src.backend.mlx.core import Variable as BackendVariable
+    
     distribution_lib = None
 else:
     raise ValueError(f"Unable to import backend : {backend()}")

--- a/keras/src/backend/__init__.py
+++ b/keras/src/backend/__init__.py
@@ -58,7 +58,7 @@ elif backend() == "openvino":
 elif backend() == "mlx":
     from keras.src.backend.mlx import *  # noqa: F403
     from keras.src.backend.mlx.core import Variable as BackendVariable
-    
+
     distribution_lib = None
 else:
     raise ValueError(f"Unable to import backend : {backend()}")

--- a/keras/src/backend/mlx/__init__.py
+++ b/keras/src/backend/mlx/__init__.py
@@ -1,5 +1,6 @@
 """MLX backend APIs."""
 
+from keras.src.backend.common.name_scope import name_scope
 from keras.src.backend.mlx import core
 from keras.src.backend.mlx import image
 from keras.src.backend.mlx import linalg

--- a/keras/src/backend/mlx/export.py
+++ b/keras/src/backend/mlx/export.py
@@ -1,0 +1,10 @@
+class MlxExportArchive:
+    def track(self, resource):
+        raise NotImplementedError(
+            "`track` is not implemented in the mlx backend."
+        )
+
+    def add_endpoint(self, name, fn, input_signature=None, **kwargs):
+        raise NotImplementedError(
+            "`add_endpoint` is not implemented in the mlx backend."
+        )

--- a/keras/src/backend/mlx/nn.py
+++ b/keras/src/backend/mlx/nn.py
@@ -115,6 +115,11 @@ def gelu(x, approximate=True):
     return f(x)
 
 
+def celu(x, alpha=1.0):
+    x = convert_to_tensor(x)
+    return nn.celu(x, alpha=alpha)
+
+
 def softmax(x, axis=-1):
     x = convert_to_tensor(x)
     return mx.softmax(x, axis=axis)

--- a/keras/src/export/saved_model.py
+++ b/keras/src/export/saved_model.py
@@ -29,6 +29,10 @@ elif backend.backend() == "openvino":
     from keras.src.backend.openvino.export import (
         OpenvinoExportArchive as BackendExportArchive,
     )
+elif backend.backend() == "mlx":
+    from keras.src.backend.mlx.export import (
+        MlxExportArchive as BackendExportArchive,
+    )
 else:
     raise RuntimeError(
         f"Backend '{backend.backend()}' must implement a layer mixin class."


### PR DESCRIPTION
This is a small patch for `pytest` to run with `mlx` (after the merge with master)

Addresses #19571