### PR TITLE
Fix jax version

### DIFF
--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -11,7 +11,7 @@ torch-xla
 # Jax with cuda support.
 # TODO: Higher version breaks CI.
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[cuda12]==0.4.28
+jax[cuda12]==0.5.0
 flax
 
 -r requirements-common.txt

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -11,7 +11,7 @@ torch-xla
 # Jax with cuda support.
 # TODO: Higher version breaks CI.
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[cuda12]==0.5.0
+jax[cuda12]>=0.5.0
 flax
 
 -r requirements-common.txt


### PR DESCRIPTION
The jax version currently is causing jax.nn.dot_product_attention import error
repro - https://colab.sandbox.google.com/drive/1dRNCwDLRUYcVpOul8V94GTo9HfN0dRoE#scrollTo=jKIdMM2reib0
I am not sure why the tests in Keras are not failing but KerasHub is seeing the following error
```Flash attention is not supported in your current JAX version. Please update it by following the official guide: https://jax.readthedocs.io/en/latest/installation.html```
coming from https://github.com/keras-team/keras/blob/14d9256108a65470512fa0340ecaf9d8eb5b003a/keras/src/backend/jax/nn.py#L1017-L1037

The root of the error being `AttributeError: module 'jax.nn' has no attribute 'dot_product_attention'`
