### PR TITLE
Fix CI breakage with torch-xla.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,10 @@ tf_keras
 tf2onnx
 
 # Torch.
-# TODO: Pin to < 2.3.0 (GitHub issue #19602)
+# Pinned to a version that is compatible with torch-xla
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0
-torchvision>=0.16.0
+torch==2.5.1
+torchvision>=0.20.1
 torch-xla;sys_platform != 'darwin'
 
 # Jax.


### PR DESCRIPTION
Error with torch 2.6:
```
ImportError: /opt/hostedtoolcache/Python/3.9.21/x64/lib/python3.9/site-packages/_XLAC.cpython-39-x86_64-linux-gnu.so: undefined symbol: _ZN5torch8autograd12VariableInfoC1ERKN2at6TensorE

/opt/hostedtoolcache/Python/3.9.21/x64/lib/python3.9/site-packages/torch_xla/__init__.py:20: Impo
```