### PR TITLE
Add random_perspective layer

### DIFF
--- a/keras/api/_tf_keras/keras/layers/__init__.py
+++ b/keras/api/_tf_keras/keras/layers/__init__.py
@@ -190,6 +190,9 @@ from keras.src.layers.preprocessing.image_preprocessing.random_hue import (
 from keras.src.layers.preprocessing.image_preprocessing.random_invert import (
     RandomInvert,
 )
+from keras.src.layers.preprocessing.image_preprocessing.random_perspective import (
+    RandomPerspective,
+)
 from keras.src.layers.preprocessing.image_preprocessing.random_posterization import (
     RandomPosterization,
 )

--- a/keras/api/layers/__init__.py
+++ b/keras/api/layers/__init__.py
@@ -190,6 +190,9 @@ from keras.src.layers.preprocessing.image_preprocessing.random_hue import (
 from keras.src.layers.preprocessing.image_preprocessing.random_invert import (
     RandomInvert,
 )
+from keras.src.layers.preprocessing.image_preprocessing.random_perspective import (
+    RandomPerspective,
+)
 from keras.src.layers.preprocessing.image_preprocessing.random_posterization import (
     RandomPosterization,
 )

--- a/keras/src/layers/__init__.py
+++ b/keras/src/layers/__init__.py
@@ -134,6 +134,9 @@ from keras.src.layers.preprocessing.image_preprocessing.random_hue import (
 from keras.src.layers.preprocessing.image_preprocessing.random_invert import (
     RandomInvert,
 )
+from keras.src.layers.preprocessing.image_preprocessing.random_perspective import (
+    RandomPerspective,
+)
 from keras.src.layers.preprocessing.image_preprocessing.random_posterization import (
     RandomPosterization,
 )

--- a/keras/src/layers/preprocessing/image_preprocessing/random_perspective.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_perspective.py
@@ -58,6 +58,14 @@ class RandomPerspective(BaseImagePreprocessingLayer):
         self.generator = SeedGenerator(seed)
         self.supports_jit = False
 
+        if scale < 0.0 or scale > 1.0:
+            raise ValueError(
+                "The `scale` argument should be a number "
+                "in the range "
+                f"[0,1]. "
+                f"Received: scale={scale}"
+            )
+
         if interpolation not in self._SUPPORTED_INTERPOLATION:
             raise NotImplementedError(
                 f"Unknown `interpolation` {interpolation}. Expected of one "

--- a/keras/src/layers/preprocessing/image_preprocessing/random_perspective.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_perspective.py
@@ -1,0 +1,215 @@
+from keras.src.api_export import keras_export
+from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
+    BaseImagePreprocessingLayer,
+)
+from keras.src.random.seed_generator import SeedGenerator
+
+
+@keras_export("keras.layers.RandomPerspective")
+class RandomPerspective(BaseImagePreprocessingLayer):
+    """A preprocessing layer that applies random perspective transformations.
+
+    This layer distorts the perspective of input images by shifting their
+    corner points, simulating a 3D-like transformation. The amount of distortion
+    is controlled by the `factor` and `scale` parameters.
+
+    Args:
+        factor: A float or a tuple of two floats.
+            Represents the probability of applying the perspective
+            transformation to each image in the batch.
+            - `factor=0.0` ensures no transformation is applied.
+            - `factor=1.0` means the transformation is always applied.
+            - If a tuple `(min, max)` is provided, a probability is randomly
+              sampled between `min` and `max` for each image.
+            - If a single float is given, the probability is sampled between
+              `0.0` and the provided float.
+            Default is 1.0.
+        scale: A float defining the relative amount of perspective shift.
+            Determines how much the image corners are displaced, affecting
+            the intensity of the perspective effect.
+        interpolation: Interpolation mode. Supported values: `nearest`,
+            `bilinear`.
+        fill_value: a float represents the value to be filled outside the
+            boundaries when `fill_mode="constant"`.
+        seed: Integer. Used to create a random seed.
+
+    """
+
+    _USE_BASE_FACTOR = False
+    _FACTOR_BOUNDS = (0, 1)
+    _SUPPORTED_INTERPOLATION = ("nearest", "bilinear")
+
+    def __init__(
+        self,
+        factor=1.0,
+        scale=0.3,
+        interpolation="bilinear",
+        fill_value=0.0,
+        seed=None,
+        data_format=None,
+        **kwargs,
+    ):
+        super().__init__(data_format=data_format, **kwargs)
+        self._set_factor(factor)
+        self.scale = scale
+        self.fill_value = fill_value
+        self.interpolation = interpolation
+        self.seed = seed
+        self.generator = SeedGenerator(seed)
+        self.supports_jit = False
+
+        if interpolation not in self._SUPPORTED_INTERPOLATION:
+            raise NotImplementedError(
+                f"Unknown `interpolation` {interpolation}. Expected of one "
+                f"{self._SUPPORTED_INTERPOLATION}."
+            )
+
+    def get_random_transformation(self, data, training=True, seed=None):
+        if not training:
+            return None
+
+        if isinstance(data, dict):
+            images = data["images"]
+        else:
+            images = data
+
+        images_shape = self.backend.shape(images)
+        unbatched = len(images_shape) == 3
+        if unbatched:
+            batch_size = 1
+        else:
+            batch_size = images_shape[0]
+
+        seed = seed or self._get_seed_generator(self.backend._backend)
+
+        transformation_probability = self.backend.random.uniform(
+            shape=(batch_size,),
+            minval=self.factor[0],
+            maxval=self.factor[1],
+            seed=seed,
+        )
+
+        random_threshold = self.backend.random.uniform(
+            shape=(batch_size,),
+            minval=0.0,
+            maxval=1.0,
+            seed=seed,
+        )
+        apply_perspective = random_threshold < transformation_probability
+
+        horizontal_shift = self.backend.random.uniform(
+            minval=-self.scale,
+            maxval=self.scale,
+            shape=[batch_size, 1],
+            seed=seed,
+            dtype=self.compute_dtype,
+        )
+        vertical_shift = self.backend.random.uniform(
+            minval=-self.scale,
+            maxval=self.scale,
+            shape=[batch_size, 1],
+            seed=seed,
+            dtype=self.compute_dtype,
+        )
+
+        perspective_factor = self.backend.cast(
+            self.backend.numpy.concatenate(
+                [horizontal_shift, vertical_shift], axis=1
+            ),
+            dtype=self.compute_dtype,
+        )
+        return {
+            "apply_perspective": apply_perspective,
+            "perspective_factor": perspective_factor,
+        }
+
+    def transform_images(self, images, transformation, training=True):
+        images = self.backend.cast(images, self.compute_dtype)
+        if training and transformation is not None:
+            apply_perspective = transformation["apply_perspective"]
+            perspective_images = self._perspective_inputs(
+                images, transformation
+            )
+
+            images = self.backend.numpy.where(
+                apply_perspective[:, None, None, None],
+                perspective_images,
+                images,
+            )
+        return images
+
+    def _perspective_inputs(self, inputs, transformation):
+        if transformation is None:
+            return inputs
+
+        inputs_shape = self.backend.shape(inputs)
+        unbatched = len(inputs_shape) == 3
+        if unbatched:
+            inputs = self.backend.numpy.expand_dims(inputs, axis=0)
+
+        perspective_factor = transformation["perspective_factor"]
+        outputs = self.backend.image.affine_transform(
+            inputs,
+            transform=self._get_perspective_matrix(perspective_factor),
+            interpolation=self.interpolation,
+            fill_mode="constant",
+            fill_value=self.fill_value,
+            data_format=self.data_format,
+        )
+
+        if unbatched:
+            outputs = self.backend.numpy.squeeze(outputs, axis=0)
+        return outputs
+
+    def _get_perspective_matrix(self, perspectives):
+        num_perspectives = self.backend.shape(perspectives)[0]
+        return self.backend.numpy.concatenate(
+            [
+                self.backend.numpy.ones(
+                    (num_perspectives, 1), dtype=self.compute_dtype
+                )
+                + perspectives[:, :1],
+                perspectives[:, :1],
+                self.backend.numpy.zeros((num_perspectives, 1)),
+                perspectives[:, 1:],
+                self.backend.numpy.ones(
+                    (num_perspectives, 1), dtype=self.compute_dtype
+                )
+                + perspectives[:, 1:],
+                self.backend.numpy.zeros((num_perspectives, 1)),
+                self.backend.numpy.zeros((num_perspectives, 2)),
+            ],
+            axis=1,
+        )
+
+    def transform_labels(self, labels, transformation, training=True):
+        return labels
+
+    def transform_bounding_boxes(
+        self,
+        bounding_boxes,
+        transformation,
+        training=True,
+    ):
+        raise NotImplementedError()
+
+    def transform_segmentation_masks(
+        self, segmentation_masks, transformation, training=True
+    ):
+        return self.transform_images(
+            segmentation_masks, transformation, training=training
+        )
+
+    def compute_output_shape(self, input_shape):
+        return input_shape
+
+    def get_config(self):
+        base_config = super().get_config()
+        config = {
+            "factor": self.factor,
+            "scale": self.scale,
+            "interpolation": self.interpolation,
+            "fill_value": self.fill_value,
+            "seed": self.seed,
+        }
+        return {**base_config, **config}

--- a/keras/src/layers/preprocessing/image_preprocessing/random_perspective.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_perspective.py
@@ -27,8 +27,8 @@ class RandomPerspective(BaseImagePreprocessingLayer):
         scale: A float defining the relative amount of perspective shift.
             Determines how much the image corners are displaced, affecting
             the intensity of the perspective effect.
-        interpolation: Interpolation mode. Supported values: `nearest`,
-            `bilinear`.
+        interpolation: Interpolation mode. Supported values: `"nearest"`,
+            `"bilinear"`.
         fill_value: a float represents the value to be filled outside the
             boundaries when `fill_mode="constant"`.
         seed: Integer. Used to create a random seed.

--- a/keras/src/layers/preprocessing/image_preprocessing/random_perspective_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_perspective_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from absl.testing import parameterized
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -54,28 +55,27 @@ class RandomPerspectiveTest(testing.TestCase):
         if data_format == "channels_last":
             inputs = np.ones((2, 2, 1))
             expected_output = np.array(
-                [[[[1.0], [0.9473801]], [[0.920486], [0.75246817]]]]
+                [[[[1.0], [0.89476013]], [[0.84097195], [0.6412543]]]]
             )
 
         else:
             inputs = np.ones((1, 2, 2))
-
-            expected_output = np.array(
-                [[[[1.0, 0.9473801], [0.920486, 0.75246817]]]]
-            )
+            expected_output = np.array([[[[1.0000, 0.8948], [0.8410, 0.6413]]]])
 
         layer = layers.RandomPerspective(data_format=data_format)
 
         transformation = {
             "apply_perspective": np.asarray([True]),
-            "perspective_factor": np.asarray([[0.05261999, 0.07951406]]),
+            "perspective_factor": np.asarray(
+                [[0.05261999, 0.07951406, 0.05261999, 0.07951406]]
+            ),
         }
 
         output = layer.transform_images(inputs, transformation)
 
         print(output)
 
-        self.assertAllClose(expected_output, output)
+        self.assertAllClose(expected_output, output, atol=1e-4, rtol=1e-4)
 
     def test_tf_data_compatibility(self):
         data_format = backend.config.image_data_format()
@@ -88,3 +88,131 @@ class RandomPerspectiveTest(testing.TestCase):
         ds = tf_data.Dataset.from_tensor_slices(input_data).batch(2).map(layer)
         for output in ds.take(1):
             output.numpy()
+
+    @parameterized.named_parameters(
+        (
+            "with_negative_shift",
+            [[-0.5, -0.1, -0.3, -0.2]],
+            [
+                [
+                    [6.6750007, 2.0750003, 8.0, 5.0750003],
+                    [8.0, 6.8250003, 8.0, 9.825],
+                ]
+            ],
+        ),
+        (
+            "with_positive_shift",
+            [[0.5, 0.1, 0.3, 0.2]],
+            [
+                [
+                    [0.29375008, 0.51874995, 2.2937498, 2.5187497],
+                    [2.1062498, 3.0812497, 4.10625, 5.08125],
+                ]
+            ],
+        ),
+    )
+    def test_random_perspective_bounding_boxes(self, factor, expected_boxes):
+        data_format = backend.config.image_data_format()
+        if data_format == "channels_last":
+            image_shape = (10, 8, 3)
+        else:
+            image_shape = (3, 10, 8)
+        input_image = np.random.random(image_shape)
+        bounding_boxes = {
+            "boxes": np.array(
+                [
+                    [2, 1, 4, 3],
+                    [6, 4, 8, 6],
+                ]
+            ),
+            "labels": np.array([[1, 2]]),
+        }
+        input_data = {"images": input_image, "bounding_boxes": bounding_boxes}
+        layer = layers.RandomPerspective(
+            data_format=data_format,
+            seed=42,
+            bounding_box_format="xyxy",
+        )
+
+        transformation = {
+            "apply_perspective": np.asarray([True]),
+            "perspective_factor": np.asarray(factor),
+            "input_shape": image_shape,
+        }
+        output = layer.transform_bounding_boxes(
+            input_data["bounding_boxes"],
+            transformation=transformation,
+            training=True,
+        )
+
+        print(output)
+
+        self.assertAllClose(output["boxes"], expected_boxes)
+
+    @parameterized.named_parameters(
+        (
+            "with_negative_shift",
+            [[-0.5, -0.1, -0.3, -0.2]],
+            [
+                [
+                    [6.6750007, 2.0750003, 8.0, 5.0750003],
+                    [8.0, 6.8250003, 8.0, 9.825],
+                ]
+            ],
+        ),
+        (
+            "with_positive_shift",
+            [[0.5, 0.1, 0.3, 0.2]],
+            [
+                [
+                    [0.29375008, 0.51874995, 2.2937498, 2.5187497],
+                    [2.1062498, 3.0812497, 4.10625, 5.08125],
+                ]
+            ],
+        ),
+    )
+    def test_random_flip_tf_data_bounding_boxes(self, factor, expected_boxes):
+        data_format = backend.config.image_data_format()
+        if backend.config.image_data_format() == "channels_last":
+            image_shape = (1, 10, 8, 3)
+        else:
+            image_shape = (1, 3, 10, 8)
+        input_image = np.random.random(image_shape)
+        bounding_boxes = {
+            "boxes": np.array(
+                [
+                    [
+                        [2, 1, 4, 3],
+                        [6, 4, 8, 6],
+                    ]
+                ]
+            ),
+            "labels": np.array([[1, 2]]),
+        }
+
+        input_data = {"images": input_image, "bounding_boxes": bounding_boxes}
+
+        ds = tf_data.Dataset.from_tensor_slices(input_data)
+        layer = layers.RandomPerspective(
+            data_format=data_format,
+            seed=42,
+            bounding_box_format="xyxy",
+        )
+
+        transformation = {
+            "apply_perspective": np.asarray([True]),
+            "perspective_factor": np.asarray(factor),
+            "input_shape": image_shape,
+        }
+
+        ds = ds.map(
+            lambda x: layer.transform_bounding_boxes(
+                x["bounding_boxes"],
+                transformation=transformation,
+                training=True,
+            )
+        )
+
+        output = next(iter(ds))
+        expected_boxes = np.array(expected_boxes)
+        self.assertAllClose(output["boxes"], expected_boxes)

--- a/keras/src/layers/preprocessing/image_preprocessing/random_perspective_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_perspective_test.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pytest
+from tensorflow import data as tf_data
+
+from keras.src import backend
+from keras.src import layers
+from keras.src import testing
+
+
+class RandomPerspectiveTest(testing.TestCase):
+    @pytest.mark.requires_trainable_backend
+    def test_layer(self):
+        self.run_layer_test(
+            layers.RandomPerspective,
+            init_kwargs={
+                "factor": 1.0,
+                "scale": 0.5,
+                "interpolation": "bilinear",
+                "fill_value": 0,
+                "seed": 1,
+            },
+            input_shape=(8, 3, 4, 3),
+            supports_masking=False,
+            expected_output_shape=(8, 3, 4, 3),
+        )
+
+    def test_random_perspective_inference(self):
+        seed = 3481
+        layer = layers.RandomPerspective()
+
+        np.random.seed(seed)
+        inputs = np.random.randint(0, 255, size=(224, 224, 3))
+        output = layer(inputs, training=False)
+        self.assertAllClose(inputs, output)
+
+    def test_random_perspective_no_op(self):
+        seed = 3481
+        layer = layers.RandomPerspective(factor=0)
+
+        np.random.seed(seed)
+        inputs = np.random.randint(0, 255, size=(224, 224, 3))
+        output = layer(inputs)
+        self.assertAllClose(inputs, output)
+
+        layer = layers.RandomPerspective(scale=0)
+
+        np.random.seed(seed)
+        inputs = np.random.randint(0, 255, size=(224, 224, 3))
+        output = layer(inputs)
+        self.assertAllClose(inputs, output)
+
+    def test_random_perspective_basic(self):
+        data_format = backend.config.image_data_format()
+        if data_format == "channels_last":
+            inputs = np.ones((2, 2, 1))
+            expected_output = np.array(
+                [[[[1.0], [0.9473801]], [[0.920486], [0.75246817]]]]
+            )
+
+        else:
+            inputs = np.ones((1, 2, 2))
+
+            expected_output = np.array(
+                [[[[1.0, 0.9473801], [0.920486, 0.75246817]]]]
+            )
+
+        layer = layers.RandomPerspective(data_format=data_format)
+
+        transformation = {
+            "apply_perspective": np.asarray([True]),
+            "perspective_factor": np.asarray([[0.05261999, 0.07951406]]),
+        }
+
+        output = layer.transform_images(inputs, transformation)
+
+        print(output)
+
+        self.assertAllClose(expected_output, output)
+
+    def test_tf_data_compatibility(self):
+        data_format = backend.config.image_data_format()
+        if data_format == "channels_last":
+            input_data = np.random.random((2, 8, 8, 3))
+        else:
+            input_data = np.random.random((2, 3, 8, 8))
+        layer = layers.RandomPerspective(data_format=data_format)
+
+        ds = tf_data.Dataset.from_tensor_slices(input_data).batch(2).map(layer)
+        for output in ds.take(1):
+            output.numpy()


### PR DESCRIPTION
I have implemented the transform_images method in the RandomPerspective image processing layer. If this pull request is accepted, I can proceed with implementing the transform_bounding_boxes method as well.

here is my [gist](https://colab.research.google.com/drive/1l5jLASctK0kUBmDRlrUlnLeehuo9yzy4?usp=sharing)