### PR TITLE
feat(linalg): support eigh on mlx

### DIFF
--- a/keras/src/backend/mlx/linalg.py
+++ b/keras/src/backend/mlx/linalg.py
@@ -18,7 +18,8 @@ def eig(a):
 
 
 def eigh(a):
-    raise NotImplementedError("eigh not yet implemented in mlx.")
+    with mx.stream(mx.cpu):
+        return mx.linalg.eigh(a)
 
 
 def lu_factor(a):


### PR DESCRIPTION
Adds support for `linalg.eigh` on MLX backend.