### PR TITLE
Use Python 3.10 for testing environment

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ['3.10']
         backend: [tensorflow, jax, torch, numpy, openvino]
     name: Run tests
     runs-on: ubuntu-latest
@@ -112,10 +112,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Get pip cache dir
         id: pip-cache
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ['3.10']
         backend: [tensorflow, jax, torch, numpy]
     name: Run tests
     runs-on: ubuntu-latest
@@ -62,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -104,7 +104,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools

--- a/.kokoro/github/ubuntu/gpu/build.sh
+++ b/.kokoro/github/ubuntu/gpu/build.sh
@@ -3,9 +3,9 @@ set -x
 
 cd "${KOKORO_ROOT}/"
 
-sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 
-PYTHON_BINARY="/usr/bin/python3.9"
+PYTHON_BINARY="/usr/bin/python3.10"
 
 "${PYTHON_BINARY}" -m venv venv
 source venv/bin/activate

--- a/keras/src/trainers/data_adapters/tf_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/tf_dataset_adapter_test.py
@@ -290,7 +290,7 @@ class TestTFDatasetAdapter(testing.TestCase):
             self.assertEqual(by.shape, (2, 2))
 
     def test_distributed_datasets_from_function_adapter_properties(self):
-        strategy = tf.distribute.MirroredStrategy()
+        strategy = tf.distribute.MirroredStrategy(["CPU:0"])
 
         def dataset_fn(input_context):
             batch_size = input_context.get_per_replica_batch_size(
@@ -334,7 +334,7 @@ class TestTFDatasetAdapter(testing.TestCase):
 
     @pytest.mark.requires_trainable_backend
     def test_distributed_datasets_from_function_model_integration(self):
-        strategy = tf.distribute.MirroredStrategy()
+        strategy = tf.distribute.MirroredStrategy(["CPU:0"])
 
         def dataset_fn(input_context):
             batch_size = input_context.get_per_replica_batch_size(
@@ -348,6 +348,5 @@ class TestTFDatasetAdapter(testing.TestCase):
 
         model = Sequential([layers.Dense(2, input_shape=(1,))])
         model.compile(optimizer="adam", loss="mse")
-        model.fit(dist_dataset, epochs=1)
         history = model.fit(dist_dataset, epochs=1)
         self.assertIn("loss", history.history)

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -11,7 +11,6 @@ torchvision==0.20.1+cpu
 torch-xla==2.5.1;sys_platform != 'darwin'
 
 # Jax with cuda support.
-# TODO: Higher version breaks CI.
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 jax[cuda12]>=0.5.0
 flax


### PR DESCRIPTION
Currently, the JAX GPU CI failed because `jax>=0.5.0` is incompatible with `python3.9`.
This PR upgrades the testing environment from py3.9 to py3.10.

Note: I cannot access the internal machine for GPU CI but I think these changes should be fine. Could someone test it by adding the label in this PR?