### PR TITLE
Fix convnext to work with any custom input tensors

### DIFF
--- a/keras/src/applications/applications_test.py
+++ b/keras/src/applications/applications_test.py
@@ -259,8 +259,10 @@ class ApplicationsTest(testing.TestCase):
             input_shape = (123, 123, 4)
             last_dim_axis = -1
 
-        inputs_custom = Input(shape=input_shape, name='custom_input')
-        inputs_custom = Conv2D(3, (2, 2), padding='valid', strides=(2,2))(inputs_custom)
+        inputs_custom = Input(shape=input_shape, name="custom_input")
+        inputs_custom = Conv2D(3, (2, 2), padding="valid", strides=(2, 2))(
+            inputs_custom
+        )
         model = app(weights=None, include_top=False, input_tensor=inputs_custom)
         output_shape = list(model.outputs[0].shape)
         self.assertEqual(output_shape[last_dim_axis], last_dim)

--- a/keras/src/applications/applications_test.py
+++ b/keras/src/applications/applications_test.py
@@ -21,7 +21,8 @@ from keras.src.applications import resnet_v2
 from keras.src.applications import vgg16
 from keras.src.applications import vgg19
 from keras.src.applications import xception
-from keras.src.layers import Input, Conv2D
+from keras.src.layers import Conv2D
+from keras.src.layers import Input
 from keras.src.saving import serialization_lib
 from keras.src.utils import file_utils
 from keras.src.utils import image_utils

--- a/keras/src/applications/applications_test.py
+++ b/keras/src/applications/applications_test.py
@@ -21,10 +21,10 @@ from keras.src.applications import resnet_v2
 from keras.src.applications import vgg16
 from keras.src.applications import vgg19
 from keras.src.applications import xception
+from keras.src.layers import Input, Conv2D
 from keras.src.saving import serialization_lib
 from keras.src.utils import file_utils
 from keras.src.utils import image_utils
-from keras.src.layers import Input, Conv2D
 
 try:
     import PIL

--- a/keras/src/applications/convnext.py
+++ b/keras/src/applications/convnext.py
@@ -432,10 +432,11 @@ def ConvNeXt(
 
     if input_tensor is not None:
         inputs = operation_utils.get_source_inputs(input_tensor)[0]
+        x = input_tensor
     else:
         inputs = img_input
+        x = inputs
 
-    x = inputs
     if include_preprocessing:
         channel_axis = (
             3 if backend.image_data_format() == "channels_last" else 1


### PR DESCRIPTION
Convnext fails with custom inputs that are more than 1 layer, it looks like a bug. I added a test that highlights the problem and fails for all Convnext and then fixed the issue.