### PR TITLE
Prevent information leakage and improve the ONNX export for the torch backend

### DIFF
--- a/keras/src/export/saved_model.py
+++ b/keras/src/export/saved_model.py
@@ -500,17 +500,18 @@ class ExportArchive(BackendExportArchive):
         )
 
         # Print out available endpoints
-        endpoints = "\n\n".join(
-            _print_signature(
-                getattr(self._tf_trackable, name), name, verbose=verbose
+        if verbose:
+            endpoints = "\n\n".join(
+                _print_signature(
+                    getattr(self._tf_trackable, name), name, verbose=verbose
+                )
+                for name in self._endpoint_names
             )
-            for name in self._endpoint_names
-        )
-        io_utils.print_msg(
-            f"Saved artifact at '{filepath}'. "
-            "The following endpoints are available:\n\n"
-            f"{endpoints}"
-        )
+            io_utils.print_msg(
+                f"Saved artifact at '{filepath}'. "
+                "The following endpoints are available:\n\n"
+                f"{endpoints}"
+            )
 
     def _convert_to_tf_variable(self, backend_variable):
         if not isinstance(backend_variable, backend.Variable):
@@ -561,7 +562,7 @@ class ExportArchive(BackendExportArchive):
 
 
 def export_saved_model(
-    model, filepath, verbose=True, input_signature=None, **kwargs
+    model, filepath, verbose=None, input_signature=None, **kwargs
 ):
     """Export the model as a TensorFlow SavedModel artifact for inference.
 
@@ -577,7 +578,8 @@ def export_saved_model(
     Args:
         filepath: `str` or `pathlib.Path` object. The path to save the artifact.
         verbose: `bool`. Whether to print a message during export. Defaults to
-            True`.
+            `None`, which uses the default value set by different backends and
+            formats.
         input_signature: Optional. Specifies the shape and dtype of the model
             inputs. Can be a structure of `keras.InputSpec`, `tf.TensorSpec`,
             `backend.KerasTensor`, or backend tensor. If not provided, it will
@@ -616,6 +618,8 @@ def export_saved_model(
     use the lower-level `keras.export.ExportArchive` class. The
     `export()` method relies on `ExportArchive` internally.
     """
+    if verbose is None:
+        verbose = True  # Defaults to `True` for all backends.
     export_archive = ExportArchive()
     if input_signature is None:
         input_signature = get_input_signature(model)

--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -464,7 +464,7 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         self,
         filepath,
         format="tf_saved_model",
-        verbose=True,
+        verbose=None,
         input_signature=None,
         **kwargs,
     ):
@@ -477,7 +477,8 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                 `"tf_saved_model"` and `"onnx"`.  Defaults to
                 `"tf_saved_model"`.
             verbose: `bool`. Whether to print a message during export. Defaults
-                to `True`.
+                to `None`, which uses the default value set by different
+                backends and formats.
             input_signature: Optional. Specifies the shape and dtype of the
                 model inputs. Can be a structure of `keras.InputSpec`,
                 `tf.TensorSpec`, `backend.KerasTensor`, or backend tensor. If
@@ -497,6 +498,10 @@ class Model(Trainer, base_trainer.Trainer, Layer):
 
         **Note:** This feature is currently supported only with TensorFlow, JAX
         and Torch backends.
+
+        **Note:** Be aware that the exported artifact may contain information
+        from the local file system when using `format="onnx"`, `verbose=True`
+        and Torch backend.
 
         Examples:
 

--- a/keras/src/utils/torch_utils.py
+++ b/keras/src/utils/torch_utils.py
@@ -153,7 +153,7 @@ class TorchModuleWrapper(Layer):
 
         if "module" in config:
             buffer = io.BytesIO(config["module"])
-            config["module"] = torch.load(buffer)
+            config["module"] = torch.load(buffer, weights_only=False)
         return cls(**config)
 
 

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -3,12 +3,9 @@ tensorflow-cpu~=2.18.0
 tf2onnx
 
 # Torch cpu-only version (needed for testing).
-# - torch is pinned to a version that is compatible with torch-xla
-# - torch-xla is pinned to a version that supports GPU (2.6 doesn't)
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.5.1+cpu
-torchvision==0.20.1+cpu
-torch-xla==2.5.1;sys_platform != 'darwin'
+torch==2.6.0+cpu
+torchvision==0.21.0+cpu
 
 # Jax with cuda support.
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -3,12 +3,9 @@ tensorflow[and-cuda]~=2.18.0
 tf2onnx
 
 # Torch cpu-only version (needed for testing).
-# - torch is pinned to a version that is compatible with torch-xla
-# - torch-xla is pinned to a version that supports GPU (2.6 doesn't)
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.5.1+cpu
-torchvision==0.20.1+cpu
-torch-xla==2.5.1;sys_platform != 'darwin'
+torch==2.6.0+cpu
+torchvision==0.21.0+cpu
 
 # Jax cpu-only version (needed for testing).
 jax[cpu]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,10 @@ tf_keras
 tf2onnx
 
 # Torch.
-# - torch is pinned to a version that is compatible with torch-xla
-# - torch-xla is pinned to a version that supports GPU (2.6 doesn't)
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.5.1
-torchvision==0.20.1
-torch-xla==2.5.1;sys_platform != 'darwin'
+torch==2.6.0+cpu
+torchvision==0.21.0+cpu
+torch-xla==2.6.0;sys_platform != 'darwin'
 
 # Jax.
 jax[cpu]


### PR DESCRIPTION
Fix #20826

This PR uses `None` for `verbose` during export, allowing low-level functions and backends to determine the actual value of `verbose`

Additionally, use the TorchDynamo-based ONNX exporter first and fall back to the TorchScript-based one if encountering any issues, making it more future-proof.

Note: We can remove `torch-xla` in the requirements if the testing backend is not torch.