### PR TITLE
Fix TorchModuleWrapper serialization issue

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -149,10 +149,12 @@ def serialize_keras_object(obj):
 
     # Special cases:
     if isinstance(obj, bytes):
-        return {
-            "class_name": "__bytes__",
-            "config": {"value": obj.decode("utf-8")},
-        }
+        try:
+            value = obj.decode("utf-8")
+        # For `torch` backend `latin-1` works
+        except UnicodeDecodeError:
+            value = obj.decode("latin-1")
+        return {"class_name": "__bytes__", "config": {"value": value}}
     if isinstance(obj, slice):
         return {
             "class_name": "__slice__",

--- a/keras/src/utils/torch_utils.py
+++ b/keras/src/utils/torch_utils.py
@@ -158,7 +158,9 @@ class TorchModuleWrapper(Layer):
             buffer = io.BytesIO(
                 config["module"]["config"]["value"].encode("latin-1")
             )
-            config["module"]["config"]["value"] = torch.load(buffer)
+            config["module"]["config"]["value"] = torch.load(
+                buffer, weights_only=False
+            )
         return cls(**config)
 
 

--- a/keras/src/utils/torch_utils_test.py
+++ b/keras/src/utils/torch_utils_test.py
@@ -10,9 +10,9 @@ from keras.src import layers
 from keras.src import models
 from keras.src import saving
 from keras.src import testing
-from keras.src.utils.torch_utils import TorchModuleWrapper
 from keras.src.models import Model
 from keras.src.saving import load_model
+from keras.src.utils.torch_utils import TorchModuleWrapper
 
 
 class Classifier(models.Model):


### PR DESCRIPTION
Currently model with `TorchModuleWrapper` fails to save with the following error.

`UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 64: invalid start byte
`

I have tried with different encoding as experimental and found '`latin-1`' works fine for saving and reloading along with some code changes to `TorchModuleWrapper` class. Atleast this change worked for the minimal code snippet as mentioned in #20860 

May fixes #20860 



