### PR TITLE
fix(ops): Fix TensorFlow backend keras.ops.rot90 shape transformation and improve test coverage

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -25,12 +25,13 @@ from keras.src.backend.tensorflow.core import shape as shape_op
 
 def rot90(array, k=1, axes=(0, 1)):
     """Rotate an array by 90 degrees in the specified plane.
-    
+
     Args:
         array: Input tensor
         k: Number of 90-degree rotations (default=1)
-        axes: Tuple of two axes that define the plane of rotation (defaults to (0, 1))
-        
+        axes: Tuple of two axes that define the plane of rotation.
+        Defaults to (0, 1).
+
     Returns:
         Rotated tensor with correct shape transformation
     """
@@ -63,26 +64,26 @@ def rot90(array, k=1, axes=(0, 1)):
     shape = tf.shape(array)
     non_rot_shape = shape[:-2]
     h, w = shape[-2], shape[-1]
-    
+
     array = tf.reshape(array, tf.concat([[-1], [h, w]], axis=0))
-    
+
     array = tf.reverse(array, axis=[2])
     array = tf.transpose(array, [0, 2, 1])
-    
+
     if k % 2 == 1:
         final_h, final_w = w, h
     else:
         final_h, final_w = h, w
-    
+
     if k > 1:
         array = tf.reshape(array, tf.concat([[-1], [final_h, final_w]], axis=0))
         for _ in range(k - 1):
             array = tf.reverse(array, axis=[2])
             array = tf.transpose(array, [0, 2, 1])
-    
+
     final_shape = tf.concat([non_rot_shape, [final_h, final_w]], axis=0)
     array = tf.reshape(array, final_shape)
-    
+
     inv_perm = [0] * len(perm)
     for i, p in enumerate(perm):
         inv_perm[p] = i

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -24,7 +24,16 @@ from keras.src.backend.tensorflow.core import shape as shape_op
 
 
 def rot90(array, k=1, axes=(0, 1)):
-    """Rotate an array by 90 degrees in the specified plane."""
+    """Rotate an array by 90 degrees in the specified plane.
+    
+    Args:
+        array: Input tensor
+        k: Number of 90-degree rotations (default=1)
+        axes: Tuple of two axes that define the plane of rotation (defaults to (0, 1))
+        
+    Returns:
+        Rotated tensor with correct shape transformation
+    """
     array = convert_to_tensor(array)
 
     if array.shape.rank < 2:
@@ -53,15 +62,27 @@ def rot90(array, k=1, axes=(0, 1)):
 
     shape = tf.shape(array)
     non_rot_shape = shape[:-2]
-    rot_shape = shape[-2:]
-
-    array = tf.reshape(array, tf.concat([[-1], rot_shape], axis=0))
-
-    for _ in range(k):
-        array = tf.transpose(array, [0, 2, 1])
-        array = tf.reverse(array, axis=[1])
-    array = tf.reshape(array, tf.concat([non_rot_shape, rot_shape], axis=0))
-
+    h, w = shape[-2], shape[-1]
+    
+    array = tf.reshape(array, tf.concat([[-1], [h, w]], axis=0))
+    
+    array = tf.reverse(array, axis=[2])
+    array = tf.transpose(array, [0, 2, 1])
+    
+    if k % 2 == 1:
+        final_h, final_w = w, h
+    else:
+        final_h, final_w = h, w
+    
+    if k > 1:
+        array = tf.reshape(array, tf.concat([[-1], [final_h, final_w]], axis=0))
+        for _ in range(k - 1):
+            array = tf.reverse(array, axis=[2])
+            array = tf.transpose(array, [0, 2, 1])
+    
+    final_shape = tf.concat([non_rot_shape, [final_h, final_w]], axis=0)
+    array = tf.reshape(array, final_shape)
+    
     inv_perm = [0] * len(perm)
     for i, p in enumerate(perm):
         inv_perm[p] = i

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -31,8 +31,8 @@ class NumPyTestRot90(testing.TestCase):
         ("k_1", 1, [[2, 4], [1, 3]]),
         ("k_2", 2, [[4, 3], [2, 1]]),
         ("k_neg1", -1, [[3, 1], [4, 2]]),
-        ("k_5", 5, [[2, 4], [1, 3]]), # k=5 ≡ k=1 (mod 4)
-        ("k_6", 6, [[4, 3], [2, 1]])  # k=6 ≡ k=2 (mod 4)
+        ("k_5", 5, [[2, 4], [1, 3]]),  # k=5 ≡ k=1 (mod 4)
+        ("k_6", 6, [[4, 3], [2, 1]]),  # k=6 ≡ k=2 (mod 4)
     )
     def test_k_parameter_variations(self, k, expected):
         array = np.array([[1, 2], [3, 4]])
@@ -42,9 +42,7 @@ class NumPyTestRot90(testing.TestCase):
         print(k)
 
     @parameterized.named_parameters(
-        ("axes_0_1", (0, 1)),
-        ("axes_1_2", (1, 2)),
-        ("axes_0_2", (0, 2))
+        ("axes_0_1", (0, 1)), ("axes_1_2", (1, 2)), ("axes_0_2", (0, 2))
     )
     def test_3d_operations(self, axes):
         array_3d = np.arange(12).reshape(3, 2, 2)
@@ -54,7 +52,7 @@ class NumPyTestRot90(testing.TestCase):
 
     @parameterized.named_parameters(
         ("single_image", np.random.random((4, 4, 3))),
-        ("batch_images", np.random.random((2, 4, 4, 3)))
+        ("batch_images", np.random.random((2, 4, 4, 3))),
     )
     def test_image_processing(self, array):
         np.random.seed(0)
@@ -65,7 +63,7 @@ class NumPyTestRot90(testing.TestCase):
     @parameterized.named_parameters(
         ("single_row", [[1, 2, 3]]),
         ("single_column", [[1], [2], [3]]),
-        ("negative_values", [[-1, 0], [1, -2]])
+        ("negative_values", [[-1, 0], [1, -2]]),
     )
     def test_edge_conditions(self, array):
         numpy_array = np.array(array)
@@ -75,7 +73,7 @@ class NumPyTestRot90(testing.TestCase):
 
     @parameterized.named_parameters(
         ("1D_array", np.array([1, 2, 3]), None),
-        ("duplicate_axes", np.array([[1, 2], [3, 4]]), (0, 0))
+        ("duplicate_axes", np.array([[1, 2], [3, 4]]), (0, 0)),
     )
     def test_error_conditions(self, array, axes):
         if axes is None:


### PR DESCRIPTION
- Fix shape handling in `keras.ops.rot90` to correctly swap height/width dimensions based on k rotations.
- Refactor test suite to use parameterized test cases and cover edge conditions more thoroughly.