### PR TITLE
Catch optree exception when changing backends

### DIFF
--- a/keras/src/tree/optree_impl.py
+++ b/keras/src/tree/optree_impl.py
@@ -40,7 +40,6 @@ if backend() == "tensorflow":
         pass
 
 
-
 def is_nested(structure):
     return not optree.tree_is_leaf(
         structure, none_is_leaf=True, namespace="keras"

--- a/keras/src/utils/tracking.py
+++ b/keras/src/utils/tracking.py
@@ -27,6 +27,7 @@ def no_automatic_dependency_tracking(fn):
 
     return wrapper
 
+
 def safe_register_tree_node_class(cls):
     try:
         return tree.register_tree_node_class(cls)
@@ -34,7 +35,6 @@ def safe_register_tree_node_class(cls):
         # optree raises a ValueError if the class is already registered.
         # Triggered if config.set_backend() is called multiple times.
         return cls
-
 
 
 class Tracker:


### PR DESCRIPTION
This PR fixes an exception raised when `keras.config.set_backend("tensorflow")` is called.

```
ValueError: PyTree type <class 'tensorflow.python.trackable.data_structures.ListWrapper'> is already registered in namespace 'keras'.
```

To reproduce:
```
import keras
keras.config.set_backend("jax")
keras.config.set_backend("tensorflow")
```

Example python session with all output:
```
$ /home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/bin/python3
Python 3.11.11 (main, Jan 14 2025, 22:49:08) [Clang 19.1.6 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import keras
2025-02-09 07:46:12.849103: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
>>> keras.config.set_backend("jax")
>>> keras.config.set_backend("tensorflow")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/utils/backend_utils.py", line 130, in set_backend
    import keras
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/__init__.py", line 2, in <module>
    from keras.api import DTypePolicy
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/api/__init__.py", line 8, in <module>
    from keras.api import activations
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/api/activations/__init__.py", line 7, in <module>
    from keras.src.activations import deserialize
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/__init__.py", line 1, in <module>
    from keras.src import activations
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/activations/__init__.py", line 3, in <module>
    from keras.src.activations.activations import celu
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/activations/activations.py", line 1, in <module>
    from keras.src import backend
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/backend/__init__.py", line 10, in <module>
    from keras.src.backend.common.dtypes import result_type
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/backend/common/__init__.py", line 2, in <module>
    from keras.src.backend.common.dtypes import result_type
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/backend/common/dtypes.py", line 5, in <module>
    from keras.src.backend.common.variables import standardize_dtype
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/backend/common/variables.py", line 11, in <module>
    from keras.src.utils.module_utils import tensorflow as tf
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/utils/__init__.py", line 1, in <module>
    from keras.src.utils.audio_dataset_utils import audio_dataset_from_directory
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/utils/audio_dataset_utils.py", line 4, in <module>
    from keras.src.utils import dataset_utils
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/utils/dataset_utils.py", line 9, in <module>
    from keras.src import tree
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/tree/__init__.py", line 1, in <module>
    from keras.src.tree.tree_api import assert_same_paths
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/tree/tree_api.py", line 8, in <module>
    from keras.src.tree import optree_impl as tree_impl
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/keras/src/tree/optree_impl.py", line 16, in <module>
    optree.register_pytree_node(
  File "/home/tomasz/.cache/r-reticulate/uv-cache/archive-v0/dToXXMV7F8HhQ1QmEA2SZ/lib/python3.11/site-packages/optree/registry.py", line 319, in register_pytree_node
    _C.register_node(
ValueError: PyTree type <class 'tensorflow.python.trackable.data_structures.ListWrapper'> is already registered in namespace 'keras'.
>>> keras.__version__
'3.8.0'
```