### PR TITLE
Fix cloning with compiled sequential model

### DIFF
--- a/keras/src/models/cloning.py
+++ b/keras/src/models/cloning.py
@@ -323,6 +323,14 @@ def _clone_sequential_model(model, clone_function, input_tensors=None):
                 name=input_name,
             )
             new_layers = [inputs] + new_layers
+    # If model compiled already then set same to cloned model
+    if model.compiled:
+        compiled_config = model.get_compile_config()
+        cloned_model = Sequential(
+            new_layers, name=model.name, trainable=model.trainable
+        )
+        cloned_model.compile_from_config(compiled_config)
+        return cloned_model
     return Sequential(new_layers, name=model.name, trainable=model.trainable)
 
 

--- a/keras/src/models/cloning.py
+++ b/keras/src/models/cloning.py
@@ -413,5 +413,7 @@ def _clone_functional_model(
         # class than the original. However various existing models rely
         # on this behavior, so we keep it.
         new_model = Functional(input_tensors, output_tensors, name=model.name)
-
+    if model.compiled:
+        compiled_config = model.get_compile_config()
+        new_model.compile_from_config(compiled_config)
     return new_model

--- a/keras/src/models/cloning.py
+++ b/keras/src/models/cloning.py
@@ -323,15 +323,16 @@ def _clone_sequential_model(model, clone_function, input_tensors=None):
                 name=input_name,
             )
             new_layers = [inputs] + new_layers
+    cloned_model = Sequential(
+        new_layers, name=model.name, trainable=model.trainable
+    )
+
     # If model compiled already then set same to cloned model
     if model.compiled:
         compiled_config = model.get_compile_config()
-        cloned_model = Sequential(
-            new_layers, name=model.name, trainable=model.trainable
-        )
         cloned_model.compile_from_config(compiled_config)
         return cloned_model
-    return Sequential(new_layers, name=model.name, trainable=model.trainable)
+    return cloned_model
 
 
 def _clone_functional_model(

--- a/keras/src/models/cloning.py
+++ b/keras/src/models/cloning.py
@@ -331,7 +331,6 @@ def _clone_sequential_model(model, clone_function, input_tensors=None):
     if model.compiled:
         compiled_config = model.get_compile_config()
         cloned_model.compile_from_config(compiled_config)
-        return cloned_model
     return cloned_model
 
 

--- a/keras/src/models/cloning_test.py
+++ b/keras/src/models/cloning_test.py
@@ -242,3 +242,12 @@ class CloneModelTest(testing.TestCase):
             if isinstance(l2, layers.Dense):
                 self.assertFalse(hasattr(l1, "flag"))
                 self.assertTrue(hasattr(l2, "flag"))
+
+    def test_compiled_model_cloning(self):
+        model = models.Sequential()
+        model.add(layers.Input((3,)))
+        model.add(layers.Dense(5, activation="relu"))
+        model.add(layers.Dense(1, activation="sigmoid"))
+        model.compile(optimizer="adam", loss="binary_crossentropy")
+        cloned_model = clone_model(model)
+        self.assertEqual(model.compiled, cloned_model.compiled)


### PR DESCRIPTION
Currently cloning of model is not considering compiled config.

As reported in #20884, the minimal code snippet is as follows.

```
from keras.layers import Dense, Input
from keras.models import Sequential, clone_model
clf = Sequential()
clf.add(Input((7,)))
clf.add(Dense(8, activation="relu"))
clf.add(Dense(1, activation="sigmoid"))
clf.compile(optimizer="adam", loss="binary_crossentropy", metrics=["accuracy"])
print("Original compiled?", clf.compiled)
cloned = clone_model(clf)
print("Cloned compiled?", cloned.compiled)
```

Added a fix for Sequential model and Functional model also.

Fixes #20884 .

Similar issue #20876

