### PR TITLE
Add access to native mesh and layout distribution objects.

### DIFF
--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -27,9 +27,7 @@ class Variable(KerasVariable):
         # due to circular dependency.
         distribution = global_state.get_global_attribute("distribution")
         if distribution is not None:
-            self._layout = distribution_lib._to_jax_layout(
-                distribution.get_variable_layout(self)
-            )
+            self._layout = distribution.get_variable_layout(self).backend_layout
         else:
             self._layout = None
         self._direct_assign(value)
@@ -410,7 +408,7 @@ def device_scope(device_name):
     if isinstance(device_name, str):
         # We support string value like "cpu:0", "gpu:1", etc.
         device_name = device_name.lower()
-        jax_device = distribution_lib._to_jax_device(device_name)
+        jax_device = distribution_lib._to_backend_device(device_name)
     elif not isinstance(device_name, jax.Device):
         raise ValueError(
             "Invalid value for argument `device_name`. "

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -1026,9 +1026,9 @@ class JAXEpochIterator(EpochIterator):
         for data in self.data_adapter.get_jax_iterator():
             if layouts is None:
                 layouts = tree.map_structure(
-                    lambda d: jax_distribution_lib._to_jax_layout(
-                        distribution.get_data_layout(d.shape)
-                    ),
+                    lambda d: distribution.get_data_layout(
+                        d.shape
+                    ).backend_layout,
                     data,
                 )
             yield _distribute_data(data, layouts)

--- a/keras/src/backend/tensorflow/distribution_lib.py
+++ b/keras/src/backend/tensorflow/distribution_lib.py
@@ -50,7 +50,7 @@ def distribute_value(value, tensor_layout):
     pass
 
 
-def _to_dtensor_mesh(device_mesh):
+def _to_backend_mesh(device_mesh):
     """Convert the DeviceMesh to Tensorflow backend specific Mesh.
 
     Args:
@@ -65,7 +65,7 @@ def _to_dtensor_mesh(device_mesh):
     )
 
 
-def _to_dtensor_layout(tensor_layout):
+def _to_backend_layout(tensor_layout):
     """Convert the TensorLayout to Tensorflow backend specific Sharding.
 
     Args:
@@ -83,5 +83,5 @@ def _to_dtensor_layout(tensor_layout):
     sharding_specs = [
         axis if axis else dtensor.UNSHARDED for axis in tensor_layout.axes
     ]
-    dtensor_mesh = _to_dtensor_mesh(tensor_layout.device_mesh)
+    dtensor_mesh = tensor_layout.device_mesh.backend_mesh
     return dtensor.Layout(sharding_specs=sharding_specs, mesh=dtensor_mesh)

--- a/keras/src/distribution/distribution_lib.py
+++ b/keras/src/distribution/distribution_lib.py
@@ -197,6 +197,12 @@ class DeviceMesh:
     def devices(self):
         return self._devices
 
+    @property
+    def backend_mesh(self):
+        if not hasattr(self, "_backend_mesh"):
+            self._backend_mesh = distribution_lib._to_backend_mesh(self)
+        return self._backend_mesh
+
     def __repr__(self):
         return (
             f"<{self.__class__.__name__} "
@@ -250,6 +256,12 @@ class TensorLayout:
             )
         self._device_mesh = device_mesh
         self._validate_axes()
+
+    @property
+    def backend_layout(self):
+        if not hasattr(self, "_backend_layout"):
+            self._backend_layout = distribution_lib._to_backend_layout(self)
+        return self._backend_layout
 
     def _validate_axes(self):
         if self._device_mesh:


### PR DESCRIPTION
- Added `backend_mesh` property to `keras.distribution.DeviceMesh` to access the native mesh object.
- Added `backend_layout` property to `keras.distribution.TensorLayout` to access the native layout or sharding object.

The values are cached. Changed the code to access these directly instead of calling the convertion functions every time.

Made the following renames so that these functions can be used in backend agnostic code:
- `_to_jax_device` to `_to_backend_device`
- `_to_jax_mesh` and `_to_dtensor_mesh` to `_to_backend_mesh`
- `_to_jax_layout` and `_to_dtensor_layout` to `_to_backend_layout`