### PR TITLE
Fix tril/triu ops

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2382,9 +2382,14 @@ def tril(x, k=0):
         mask = i >= j - k
         return tf.where(tf.broadcast_to(mask, shape), x, tf.zeros_like(x))
 
-    if k >= 0:
-        return tf.linalg.band_part(x, -1, k)
-    return _negative_k_branch()
+    if isinstance(k, int):
+        if k >= 0:
+            return tf.linalg.band_part(x, -1, k)
+        return _negative_k_branch()
+
+    return tf.cond(
+        k >= 0, lambda: tf.linalg.band_part(x, -1, k), _negative_k_branch
+    )
 
 
 def triu(x, k=0):
@@ -2397,9 +2402,14 @@ def triu(x, k=0):
         mask = i <= j - k
         return tf.where(tf.broadcast_to(mask, shape), x, tf.zeros_like(x))
 
-    if k <= 0:
-        return tf.linalg.band_part(x, -k, -1)
-    return _positive_k_branch()
+    if isinstance(k, int):
+        if k <= 0:
+            return tf.linalg.band_part(x, -k, -1)
+        return _positive_k_branch()
+
+    return tf.cond(
+        k <= 0, lambda: tf.linalg.band_part(x, -k, -1), _positive_k_branch
+    )
 
 
 def trunc(x):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2389,7 +2389,9 @@ def tril(x, k=0):
 
     # when `k` is a tensor
     return tf.cond(
-        k >= 0, lambda: tf.linalg.band_part(x, -1, k), _negative_k_branch
+        tf.greater_equal(k, 0),
+        lambda: tf.linalg.band_part(x, -1, k),
+        _negative_k_branch,
     )
 
 
@@ -2410,7 +2412,9 @@ def triu(x, k=0):
 
     # when `k` is a tensor
     return tf.cond(
-        k <= 0, lambda: tf.linalg.band_part(x, -k, -1), _positive_k_branch
+        tf.less_equal(k, 0),
+        lambda: tf.linalg.band_part(x, -k, -1),
+        _positive_k_branch,
     )
 
 

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2384,7 +2384,7 @@ def tril(x, k=0):
 
     if k >= 0:
         return tf.linalg.band_part(x, -1, k)
-    return _negative_k_branch
+    return _negative_k_branch()
 
 
 def triu(x, k=0):
@@ -2399,7 +2399,7 @@ def triu(x, k=0):
 
     if k <= 0:
         return tf.linalg.band_part(x, -k, -1)
-    return _positive_k_branch
+    return _positive_k_branch()
 
 
 def trunc(x):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2383,7 +2383,7 @@ def tril(x, k=0):
         return tf.where(tf.broadcast_to(mask, shape), x, tf.zeros_like(x))
 
     if k >= 0:
-        return tf.linalg.band_part(x, -k, -1)
+        return tf.linalg.band_part(x, -1, k)
     return _negative_k_branch
 
 

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2382,9 +2382,9 @@ def tril(x, k=0):
         mask = i >= j - k
         return tf.where(tf.broadcast_to(mask, shape), x, tf.zeros_like(x))
 
-    return tf.cond(
-        k >= 0, lambda: tf.linalg.band_part(x, -1, k), _negative_k_branch
-    )
+    if k >= 0:
+        return tf.linalg.band_part(x, -k, -1)
+    return _negative_k_branch
 
 
 def triu(x, k=0):
@@ -2397,9 +2397,9 @@ def triu(x, k=0):
         mask = i <= j - k
         return tf.where(tf.broadcast_to(mask, shape), x, tf.zeros_like(x))
 
-    return tf.cond(
-        k <= 0, lambda: tf.linalg.band_part(x, -k, -1), _positive_k_branch
-    )
+    if k <= 0:
+        return tf.linalg.band_part(x, -k, -1)
+    return _positive_k_branch
 
 
 def trunc(x):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2387,6 +2387,7 @@ def tril(x, k=0):
             return tf.linalg.band_part(x, -1, k)
         return _negative_k_branch()
 
+    # when `k` is a tensor
     return tf.cond(
         k >= 0, lambda: tf.linalg.band_part(x, -1, k), _negative_k_branch
     )
@@ -2407,6 +2408,7 @@ def triu(x, k=0):
             return tf.linalg.band_part(x, -k, -1)
         return _positive_k_branch()
 
+    # when `k` is a tensor
     return tf.cond(
         k <= 0, lambda: tf.linalg.band_part(x, -k, -1), _positive_k_branch
     )


### PR DESCRIPTION
Tril/triu ops fail (post compilation) because `tf.cond` expects `k` to be a tensor:

```
>>> inputs = keras.Input((5,))
>>> outputs = keras.ops.tril(inputs)
>>> model = keras.Model(inputs, outputs)
>>> model.predict(keras.ops.ones((2, 5)))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/abheesht/Work/repos/keras/keras/src/utils/traceback_utils.py", line 122, in error_handler
    raise e.with_traceback(filtered_tb) from None
  File "/Users/abheesht/Work/repos/keras/keras/src/utils/traceback_utils.py", line 122, in error_handler
    raise e.with_traceback(filtered_tb) from None
TypeError: Exception encountered when calling Tril.call().

pred must not be a Python bool

Arguments received by Tril.call():
  • x=tf.Tensor(shape=(2, 5), dtype=float32)
```

Post this PR, this gets fixed:

```
>>> model.predict(keras.ops.ones((2, 5)))
1/1 ━━━━━━━━━━━━━━━━━━━━ 0s 24ms/step
array([[1., 0., 0., 0., 0.],
       [1., 1., 0., 0., 0.]], dtype=float32)
```
