### PR TITLE
Add iterations property to LossScaleOptimizer

### DIFF
--- a/keras/src/optimizers/loss_scale_optimizer.py
+++ b/keras/src/optimizers/loss_scale_optimizer.py
@@ -262,6 +262,10 @@ class LossScaleOptimizer(optimizer.Optimizer):
     def learning_rate(self, learning_rate):
         self.inner_optimizer.learning_rate = learning_rate
 
+    @property
+    def iterations(self):
+        return self.inner_optimizer.iterations
+
     def scale_loss(self, loss):
         scale = self.dynamic_scale if self.built else self.initial_scale
         return loss * scale


### PR DESCRIPTION
Fixes #20878. TensorBoard isn't able to report the correct step because this optimizer doesn't forward the `iterations` property.