### PR TITLE
Always allow `ExportArchive.track` to track TensorFlow resources.

### DIFF
--- a/keras/src/backend/jax/export.py
+++ b/keras/src/backend/jax/export.py
@@ -4,7 +4,6 @@ import itertools
 import string
 import warnings
 
-from keras.src import layers
 from keras.src import tree
 from keras.src.backend.common.stateless_scope import StatelessScope
 from keras.src.utils.module_utils import tensorflow as tf
@@ -16,38 +15,29 @@ class JaxExportArchive:
         self._backend_trainable_variables = []
         self._backend_non_trainable_variables = []
 
-    def track(self, resource):
-        if not isinstance(resource, layers.Layer):
-            raise ValueError(
-                "Invalid resource type. Expected an instance of a "
-                "JAX-based Keras `Layer` or `Model`. "
-                f"Received instead an object of type '{type(resource)}'. "
-                f"Object received: {resource}"
-            )
+    def _track_layer(self, layer):
+        # Variables in the lists below are actually part of the trackables
+        # that get saved, because the lists are created in __init__.
+        trainable_variables = layer.trainable_variables
+        non_trainable_variables = layer.non_trainable_variables
 
-        if isinstance(resource, layers.Layer):
-            # Variables in the lists below are actually part of the trackables
-            # that get saved, because the lists are created in __init__.
-            trainable_variables = resource.trainable_variables
-            non_trainable_variables = resource.non_trainable_variables
+        self._tf_trackable.trainable_variables += tree.map_structure(
+            self._convert_to_tf_variable, trainable_variables
+        )
+        self._tf_trackable.non_trainable_variables += tree.map_structure(
+            self._convert_to_tf_variable, non_trainable_variables
+        )
+        self._tf_trackable.variables = (
+            self._tf_trackable.trainable_variables
+            + self._tf_trackable.non_trainable_variables
+        )
 
-            self._tf_trackable.trainable_variables += tree.map_structure(
-                self._convert_to_tf_variable, trainable_variables
-            )
-            self._tf_trackable.non_trainable_variables += tree.map_structure(
-                self._convert_to_tf_variable, non_trainable_variables
-            )
-            self._tf_trackable.variables = (
-                self._tf_trackable.trainable_variables
-                + self._tf_trackable.non_trainable_variables
-            )
-
-            self._backend_trainable_variables += trainable_variables
-            self._backend_non_trainable_variables += non_trainable_variables
-            self._backend_variables = (
-                self._backend_trainable_variables
-                + self._backend_non_trainable_variables
-            )
+        self._backend_trainable_variables += trainable_variables
+        self._backend_non_trainable_variables += non_trainable_variables
+        self._backend_variables = (
+            self._backend_trainable_variables
+            + self._backend_non_trainable_variables
+        )
 
     def add_endpoint(self, name, fn, input_signature=None, **kwargs):
         jax2tf_kwargs = kwargs.pop("jax2tf_kwargs", None)

--- a/keras/src/backend/tensorflow/export.py
+++ b/keras/src/backend/tensorflow/export.py
@@ -1,29 +1,16 @@
 import tensorflow as tf
 
-from keras.src import layers
-
 
 class TFExportArchive:
-    def track(self, resource):
-        if not isinstance(resource, tf.__internal__.tracking.Trackable):
-            raise ValueError(
-                "Invalid resource type. Expected an instance of a "
-                "TensorFlow `Trackable` (such as a Keras `Layer` or `Model`). "
-                f"Received instead an object of type '{type(resource)}'. "
-                f"Object received: {resource}"
-            )
-
-        if isinstance(resource, layers.Layer):
-            # Variables in the lists below are actually part of the trackables
-            # that get saved, because the lists are created in __init__.
-            variables = resource.variables
-            trainable_variables = resource.trainable_variables
-            non_trainable_variables = resource.non_trainable_variables
-            self._tf_trackable.variables += variables
-            self._tf_trackable.trainable_variables += trainable_variables
-            self._tf_trackable.non_trainable_variables += (
-                non_trainable_variables
-            )
+    def _track_layer(self, layer):
+        # Variables in the lists below are actually part of the trackables
+        # that get saved, because the lists are created in __init__.
+        variables = layer.variables
+        trainable_variables = layer.trainable_variables
+        non_trainable_variables = layer.non_trainable_variables
+        self._tf_trackable.variables += variables
+        self._tf_trackable.trainable_variables += trainable_variables
+        self._tf_trackable.non_trainable_variables += non_trainable_variables
 
     def add_endpoint(self, name, fn, input_signature=None, **kwargs):
         decorated_fn = tf.function(

--- a/keras/src/backend/torch/export.py
+++ b/keras/src/backend/torch/export.py
@@ -10,16 +10,16 @@ from keras.src.utils.module_utils import torch_xla
 
 
 class TorchExportArchive:
-    def track(self, resource):
+    def _track_layer(self, layer):
         raise NotImplementedError(
-            "`track` is not implemented in the torch backend. Use"
-            "`track_and_add_endpoint` instead."
+            "`track` is not supported for `Layer`s and `Model`s in the torch "
+            "backend. Use `track_and_add_endpoint` instead."
         )
 
     def add_endpoint(self, name, fn, input_signature, **kwargs):
         raise NotImplementedError(
-            "`add_endpoint` is not implemented in the torch backend. Use"
-            "`track_and_add_endpoint` instead."
+            "`add_endpoint` is not supported for `Layer`s and `Model`s in the "
+            "torch backend. Use `track_and_add_endpoint` instead."
         )
 
     def track_and_add_endpoint(self, name, resource, input_signature, **kwargs):

--- a/keras/src/export/saved_model.py
+++ b/keras/src/export/saved_model.py
@@ -31,7 +31,7 @@ elif backend.backend() == "openvino":
     )
 else:
     raise RuntimeError(
-        f"Backend '{backend.backend()}' must implement a layer mixin class."
+        f"Backend '{backend.backend()}' must implement ExportArchive."
     )
 
 
@@ -135,18 +135,17 @@ class ExportArchive(BackendExportArchive):
         return self._tf_trackable.non_trainable_variables
 
     def track(self, resource):
-        """Track the variables (and other assets) of a layer or model.
+        """Track the variables (of a layer or model) and other assets.
 
-        By default, all variables used by an endpoint function
-        are automatically tracked when you call `add_endpoint()`.
-        However, non-variables assets such as lookup tables
-        need to be tracked manually. Note that lookup tables
-        used by built-in Keras layers
-        (`TextVectorization`, `IntegerLookup`, `StringLookup`)
-        are automatically tracked in `add_endpoint()`.
+        By default, all variables used by an endpoint function are automatically
+        tracked when you call `add_endpoint()`. However, non-variables assets
+        such as lookup tables need to be tracked manually. Note that lookup
+        tables used by built-in Keras layers (`TextVectorization`,
+        `IntegerLookup`, `StringLookup`) are automatically tracked by
+        `add_endpoint()`.
 
         Args:
-            resource: A trackable Keras resource, such as a layer or model.
+            resource: A layer, model or a TensorFlow trackable resource.
         """
         if isinstance(resource, layers.Layer) and not resource.built:
             raise ValueError(
@@ -154,14 +153,22 @@ class ExportArchive(BackendExportArchive):
                 "It must be built before export."
             )
 
-        # Layers in `_tracked` are not part of the trackables that get saved,
-        # because we're creating the attribute in a
-        # no_automatic_dependency_tracking scope.
-        if not hasattr(self, "_tracked"):
-            self._tracked = []
-        self._tracked.append(resource)
+        # Note: with the TensorFlow backend, Layers and Models fall into both
+        # the Layer case and the Trackable case. The Trackable case is needed
+        # for preprocessing layers in order to track lookup tables.
+        if isinstance(resource, tf.__internal__.tracking.Trackable):
+            if not hasattr(self, "_tracked"):
+                self._tracked = []
+            self._tracked.append(resource)
 
-        BackendExportArchive.track(self, resource)
+        if isinstance(resource, layers.Layer):
+            self._track_layer(resource)
+        elif not isinstance(resource, tf.__internal__.tracking.Trackable):
+            raise ValueError(
+                "Invalid resource type. Expected a Keras `Layer` or `Model` "
+                "or a TensorFlow `Trackable` object. "
+                f"Received object {resource} of type '{type(resource)}'. "
+            )
 
     def add_endpoint(self, name, fn, input_signature=None, **kwargs):
         """Register a new serving endpoint.
@@ -283,6 +290,28 @@ class ExportArchive(BackendExportArchive):
         export_archive.track(model)
         export_archive.add_endpoint(name="serve", fn=serving_fn)
         ```
+
+        Combining a model with some TensorFlow preprocessing, which can use
+        TensorFlow resources:
+
+        ```python
+        lookup_table = tf.lookup.StaticHashTable(initializer, default_value=0.0)
+
+        export_archive = ExportArchive()
+        model_fn = export_archive.track_and_add_endpoint(
+            "model_fn",
+            model,
+            input_signature=[tf.TensorSpec(shape=(None, 5), dtype=tf.float32)],
+        )
+        export_archive.track(lookup_table)
+
+        @tf.function()
+        def serving_fn(x):
+            x = lookup_table.lookup(x)
+            return model_fn(x)
+
+        export_archive.add_endpoint(name="serve", fn=serving_fn)
+        ```
         """
         if name in self._endpoint_names:
             raise ValueError(f"Endpoint name '{name}' is already taken.")
@@ -332,9 +361,7 @@ class ExportArchive(BackendExportArchive):
         input_signature = tree.map_structure(
             make_tf_tensor_spec, input_signature
         )
-        decorated_fn = BackendExportArchive.add_endpoint(
-            self, name, fn, input_signature, **kwargs
-        )
+        decorated_fn = super().add_endpoint(name, fn, input_signature, **kwargs)
         self._endpoint_signatures[name] = input_signature
         setattr(self._tf_trackable, name, decorated_fn)
         self._endpoint_names.append(name)
@@ -400,8 +427,8 @@ class ExportArchive(BackendExportArchive):
             )
         else:
             # Special case for the torch backend.
-            decorated_fn = BackendExportArchive.track_and_add_endpoint(
-                self, name, resource, input_signature, **kwargs
+            decorated_fn = super().track_and_add_endpoint(
+                name, resource, input_signature, **kwargs
             )
             self._endpoint_signatures[name] = input_signature
             setattr(self._tf_trackable, name, decorated_fn)
@@ -480,8 +507,7 @@ class ExportArchive(BackendExportArchive):
             raise ValueError(
                 "No endpoints have been set yet. Call add_endpoint()."
             )
-        if backend.backend() == "tensorflow":
-            self._filter_and_track_resources()
+        self._filter_and_track_resources()
 
         signatures = {}
         for name in self._endpoint_names:

--- a/keras/src/export/saved_model_test.py
+++ b/keras/src/export/saved_model_test.py
@@ -1002,3 +1002,40 @@ class ExportArchiveTest(testing.TestCase):
         self.assertAllClose(ref_output, revived_model.serve(ref_input))
         # Test with a different batch size
         revived_model.serve(tf.random.normal((6, 10)))
+
+    def test_model_combined_with_tf_preprocessing(self):
+        temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
+
+        lookup_table = tf.lookup.StaticHashTable(
+            tf.lookup.KeyValueTensorInitializer(
+                tf.constant(["a", "b", "c"]), tf.constant([1.0, 2.0, 3.0])
+            ),
+            default_value=-1.0,
+        )
+        ref_input = tf.constant([["c", "b", "c", "a", "d"]])
+        ref_intermediate = lookup_table.lookup(ref_input)
+
+        model = models.Sequential([layers.Dense(1)])
+        ref_output = model(ref_intermediate)
+
+        export_archive = saved_model.ExportArchive()
+        model_fn = export_archive.track_and_add_endpoint(
+            "model",
+            model,
+            input_signature=[tf.TensorSpec(shape=(None, 5), dtype=tf.float32)],
+        )
+        export_archive.track(lookup_table)
+
+        @tf.function()
+        def combined_fn(x):
+            x = lookup_table.lookup(x)
+            x = model_fn(x)
+            return x
+
+        self.assertAllClose(combined_fn(ref_input), ref_output)
+
+        export_archive.add_endpoint("combined_fn", combined_fn)
+        export_archive.write_out(temp_filepath)
+
+        revived_model = tf.saved_model.load(temp_filepath)
+        self.assertAllClose(revived_model.combined_fn(ref_input), ref_output)


### PR DESCRIPTION
Previously, `track` would only work with `Layer`s or `Model`s unless the backend was TensorFlow. It would raise an error on JAX for instance.

It is now possible to export saved models with a mix of Keras models and TensorFlow native preprocessing involving resources even with the JAX backend.

- Added example on how to use `ExportArchive` to export a function combining a model with some TensorFlow native preprocessing with a resource.
- Added unit test testing the combining of a model with some TensorFlow native preprocessing with a resource.
- Renamed `track` to `_track_layer` in backend specific `ExportArchive` classes because that is the use case.
- Use `super()` instead of `BackendExportArchive` for consistency.