### PR TITLE
`mlx` - `stft`, `istft`, and dtype handling in `numpy.py`

### DIFF
--- a/keras/src/backend/mlx/__init__.py
+++ b/keras/src/backend/mlx/__init__.py
@@ -1,7 +1,7 @@
 """MLX backend APIs."""
 
 from keras.src.backend.common.name_scope import name_scope
-from keras.src.backend.jax.core import random_seed_dtype
+from keras.src.backend.mlx.core import random_seed_dtype
 from keras.src.backend.mlx import core
 from keras.src.backend.mlx import image
 from keras.src.backend.mlx import linalg

--- a/keras/src/backend/mlx/__init__.py
+++ b/keras/src/backend/mlx/__init__.py
@@ -1,7 +1,6 @@
 """MLX backend APIs."""
 
 from keras.src.backend.common.name_scope import name_scope
-from keras.src.backend.mlx.core import random_seed_dtype
 from keras.src.backend.mlx import core
 from keras.src.backend.mlx import image
 from keras.src.backend.mlx import linalg
@@ -19,6 +18,7 @@ from keras.src.backend.mlx.core import cond
 from keras.src.backend.mlx.core import convert_to_numpy
 from keras.src.backend.mlx.core import convert_to_tensor
 from keras.src.backend.mlx.core import is_tensor
+from keras.src.backend.mlx.core import random_seed_dtype
 from keras.src.backend.mlx.core import scatter
 from keras.src.backend.mlx.core import shape
 from keras.src.backend.mlx.core import stop_gradient

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -123,7 +123,7 @@ def _istft(
 
     x = _overlap_sequences(x, sequence_stride)
 
-    if backend.backend() in {"numpy", "jax"}:
+    if backend.backend() in {"numpy", "jax", "mlx"}:
         x = np.nan_to_num(x)
 
     start = 0 if center is False else fft_length // 2
@@ -855,7 +855,7 @@ class MathOpsCorrectnessTest(testing.TestCase):
             window=window,
             center=center,
         )
-        if backend.backend() in ("numpy", "jax", "torch"):
+        if backend.backend() in ("numpy", "jax", "torch", "mlx"):
             # these backends have different implementation for the boundary of
             # the output, so we need to truncate 5% befroe assertAllClose
             truncated_len = int(output.shape[-1] * 0.05)
@@ -884,7 +884,7 @@ class MathOpsCorrectnessTest(testing.TestCase):
             window=window,
             center=center,
         )
-        if backend.backend() in ("numpy", "jax", "torch"):
+        if backend.backend() in ("numpy", "jax", "torch", "mlx"):
             # these backends have different implementation for the boundary of
             # the output, so we need to truncate 5% befroe assertAllClose
             truncated_len = int(output.shape[-1] * 0.05)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -4410,7 +4410,8 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(y, ref_y)
 
     @pytest.mark.skipif(
-        backend.backend() == "jax", reason="JAX does not support float64."
+        backend.backend() in ["jax", "mlx"],
+        reason=f"{backend.backend().capitalize()} does not support float64.",
     )
     def test_sqrt_float64(self):
         x = np.array([[1, 4, 9], [16, 25, 36]], dtype="float64")


### PR DESCRIPTION
This addresses #19571
- implements `stft` and `istft`
- aligns dtype handling in `mlx/numpy.py` with other backends (matmul, tensordot, etc. still in progress)
- swaps jax dependency to numpy (for ease of testing)