### PR TITLE
[OpenVINO backend] Support numpy.argsort

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -73,7 +73,10 @@ def get_ov_output(x, ov_type=None):
             ov_type = Type.i32
         x = ov_opset.constant(x, ov_type).output(0)
     elif isinstance(x, np.ndarray):
-        x = ov_opset.constant(x).output(0)
+        if x.dtype == np.dtype("bfloat16"):
+            x = ov_opset.constant(x, OPENVINO_DTYPES["bfloat16"]).output(0)
+        else:
+            x = ov_opset.constant(x).output(0)
     elif np.isscalar(x):
         x = ov_opset.constant(x).output(0)
     elif isinstance(x, KerasVariable):

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -93,7 +93,6 @@ NumpyOneInputOpsCorrectnessTest::test_any
 NumpyOneInputOpsCorrectnessTest::test_argmax
 NumpyOneInputOpsCorrectnessTest::test_argmin
 NumpyOneInputOpsCorrectnessTest::test_argpartition
-NumpyOneInputOpsCorrectnessTest::test_argsort
 NumpyOneInputOpsCorrectnessTest::test_array
 NumpyOneInputOpsCorrectnessTest::test_average
 NumpyOneInputOpsCorrectnessTest::test_bincount

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -10,7 +10,6 @@ NumpyDtypeTest::test_arctan2_
 NumpyDtypeTest::test_argmax
 NumpyDtypeTest::test_argmin
 NumpyDtypeTest::test_argpartition
-NumpyDtypeTest::test_argsort
 NumpyDtypeTest::test_array
 NumpyDtypeTest::test_average_
 NumpyDtypeTest::test_bincount

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -312,20 +312,23 @@ def argsort(x, axis=-1):
     if axis is None:
         flatten_shape = ov_opset.constant([-1], Type.i32).output(0)
         x = ov_opset.reshape(x, flatten_shape, False).output(0)
-        x_shape = ov_opset.shape_of(x, Type.i32).output(0)
+        x_shape_tensor = ov_opset.shape_of(x, Type.i32).output(0)
         k = ov_opset.reduce_prod(
-            x_shape, ov_opset.constant([0], Type.i32), keep_dims=False
+            x_shape_tensor, ov_opset.constant([0], Type.i32), keep_dims=False
         )
-        axis_dim = x.shape[0]
-        axis_dim = k
         axis = 0
     else:
         if axis < 0:
             axis = rank + axis
-        axis_dim = x_shape[axis].get_length()
+        x_shape_tensor = ov_opset.shape_of(x, Type.i32).output(0)
+        k = ov_opset.gather(
+            x_shape_tensor,
+            ov_opset.constant(axis, Type.i32).output(0),
+            ov_opset.constant(0, Type.i32).output(0),
+        ).output(0)
     sorted_indices = ov_opset.topk(
         x,
-        k=axis_dim,
+        k=k,
         axis=axis,
         mode="min",
         sort="value",

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -304,7 +304,6 @@ def argmin(x, axis=None, keepdims=False):
 
 
 def argsort(x, axis=-1):
-    axis_dim = None
     x = get_ov_output(x)
     x_shape = x.get_partial_shape()
     rank = x_shape.rank.get_length()
@@ -313,9 +312,9 @@ def argsort(x, axis=-1):
     if axis is None:
         flatten_shape = ov_opset.constant([-1], Type.i32).output(0)
         x = ov_opset.reshape(x, flatten_shape, False).output(0)
-        print("shape_of: ", shape_1 := ov_opset.shape_of(x, Type.i32).output(0))
+        x_shape = ov_opset.shape_of(x, Type.i32).output(0)
         k = ov_opset.reduce_prod(
-            shape_1, ov_opset.constant([0], Type.i32), keep_dims=False
+            x_shape, ov_opset.constant([0], Type.i32), keep_dims=False
         )
         axis_dim = x.shape[0]
         axis_dim = k
@@ -324,7 +323,6 @@ def argsort(x, axis=-1):
         if axis < 0:
             axis = rank + axis
         axis_dim = x_shape[axis].get_length()
-    print("k: ", axis_dim)
     sorted_indices = ov_opset.topk(
         x,
         k=axis_dim,


### PR DESCRIPTION
Implements the numpy.argsort operation for the Keras 3 OpenVINO backend.
Fixes [#29012](https://github.com/openvinotoolkit/openvino/issues/29012)

@rkazants, could you please review?
