### PR TITLE
Fix PyTorch stateful RNN/LSTM gradient computation error resolves #20875

### DIFF
--- a/keras/src/layers/rnn/rnn.py
+++ b/keras/src/layers/rnn/rnn.py
@@ -331,6 +331,14 @@ class RNN(Layer):
             cell_kwargs["training"] = training
 
         def step(inputs, states):
+            """
+            Create new tensor copies when using PyTorch backend
+            with stateful=True. This prevents in-place modifications
+            that would otherwise break PyTorch's autograd functionality
+            by modifying tensors needed for gradient computation.
+            """
+            if backend.backend() == "torch" and self.stateful:
+                states = tree.map_structure(ops.copy, states)
             output, new_states = self.cell(inputs, states, **cell_kwargs)
             if not tree.is_nested(new_states):
                 new_states = [new_states]

--- a/keras/src/layers/rnn/rnn.py
+++ b/keras/src/layers/rnn/rnn.py
@@ -331,12 +331,10 @@ class RNN(Layer):
             cell_kwargs["training"] = training
 
         def step(inputs, states):
-            """
-            Create new tensor copies when using PyTorch backend
-            with stateful=True. This prevents in-place modifications
-            that would otherwise break PyTorch's autograd functionality
-            by modifying tensors needed for gradient computation.
-            """
+            # Create new tensor copies when using PyTorch backend
+            # with stateful=True. This prevents in-place modifications
+            # that would otherwise break PyTorch's autograd functionality
+            # by modifying tensors needed for gradient computation.
             if backend.backend() == "torch" and self.stateful:
                 states = tree.map_structure(ops.copy, states)
             output, new_states = self.cell(inputs, states, **cell_kwargs)

--- a/keras/src/layers/rnn/rnn_test.py
+++ b/keras/src/layers/rnn/rnn_test.py
@@ -383,19 +383,4 @@ class RNNTest(testing.TestCase):
         layer = layers.RNN(OneStateRNNCell(2), return_sequences=False)
         self.run_class_serialization_test(layer)
 
-    @pytest.mark.torch
-    def test_stateful_state_copying(self):
-        sequence = np.ones((1, 2, 3))
-        layer = layers.RNN(
-            TwoStatesRNNCell(2),
-            stateful=True,
-            return_state=True,
-        )
-        _, state1, state2 = layer(sequence)
-
-        self.assertIsNot(state1, layer.states[0])
-        self.assertIsNot(state2, layer.states[1])
-        self.assertAllClose(state1, layer.states[0])
-        self.assertAllClose(state2, layer.states[1])
-
     # TODO: test masking

--- a/keras/src/layers/rnn/rnn_test.py
+++ b/keras/src/layers/rnn/rnn_test.py
@@ -383,4 +383,19 @@ class RNNTest(testing.TestCase):
         layer = layers.RNN(OneStateRNNCell(2), return_sequences=False)
         self.run_class_serialization_test(layer)
 
+    @pytest.mark.torch
+    def test_stateful_state_copying(self):
+        sequence = np.ones((1, 2, 3))
+        layer = layers.RNN(
+            TwoStatesRNNCell(2),
+            stateful=True,
+            return_state=True,
+        )
+        _, state1, state2 = layer(sequence)
+
+        self.assertIsNot(state1, layer.states[0])
+        self.assertIsNot(state2, layer.states[1])
+        self.assertAllClose(state1, layer.states[0])
+        self.assertAllClose(state2, layer.states[1])
+
     # TODO: test masking


### PR DESCRIPTION
The error occurred because the PyTorch autograd engine detected that tensors required for gradient computation were modified in-place, invalidating the computational graph.

Fix: Added explicit state cloning in RNN.step() for PyTorch backend when stateful=True to create new tensor objects with separate memory allocation.