### PR TITLE
Added openvino backend support for argmin and argmax (Issue #29011)

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -4,8 +4,6 @@ NumpyDtypeTest
 HistogramTest
 NumpyOneInputOpsCorrectnessTest::test_all
 NumpyOneInputOpsCorrectnessTest::test_any
-NumpyOneInputOpsCorrectnessTest::test_argmax
-NumpyOneInputOpsCorrectnessTest::test_argmin
 NumpyOneInputOpsCorrectnessTest::test_argpartition
 NumpyOneInputOpsCorrectnessTest::test_argsort
 NumpyOneInputOpsCorrectnessTest::test_array

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -274,10 +274,12 @@ def argmax(x, axis=None, keepdims=False):
     axis = ov_opset.constant(axis, Type.i32).output(0)
 
     if x_type == Type.boolean:
-        return OpenVINOKerasTensor(ov_opset.reduce_logical_or(x, axis, keepdims).output(0))
+        return OpenVINOKerasTensor(
+            ov_opset.reduce_logical_or(x, axis, keepdims).output(0)
+            )
 
-    sorted_values, sorted_indices = ov_opset.sort(x, axis, False)
-    max_index = sorted_indices[0]
+    topk_values, topk_indices = ov_opset.topk(x, 1, axis, "max", "index")
+    max_index = topk_indices.output(0)
     
     return OpenVINOKerasTensor(max_index)
 
@@ -294,15 +296,17 @@ def argmin(x, axis=None, keepdims=False):
         x = ov_opset.reshape(x, flatten_shape, False).output(0)
         axis = 0
     
-    if isinstance(axis, tuple):
+    if isinstance(axis, tuple): 
         axis = list(axis)
     axis = ov_opset.constant(axis, Type.i32).output(0)
 
     if x_type == Type.boolean:
-        return OpenVINOKerasTensor(ov_opset.reduce_logical_or(x, axis, keepdims).output(0))
+        return OpenVINOKerasTensor(
+            ov_opset.reduce_logical_or(x, axis, keepdims).output(0)
+            )
 
-    sorted_values, sorted_indices = ov_opset.sort(x, axis, True)
-    min_index = sorted_indices[0]
+    topk_values, topk_indices = ov_opset.topk(x, 1, axis, "min", "index")
+    min_index = topk_indices.output(0)
     
     return OpenVINOKerasTensor(min_index)
 

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -258,11 +258,53 @@ def arctanh(x):
 
 
 def argmax(x, axis=None, keepdims=False):
-    raise NotImplementedError("`argmax` is not supported with openvino backend")
+    if axis == () or axis == []:
+        return x
+
+    x = get_ov_output(x)
+    x_type = x.get_element_type()
+
+    if axis is None:
+        flatten_shape = ov_opset.constant([-1], Type.i32).output(0)
+        x = ov_opset.reshape(x, flatten_shape, False).output(0)
+        axis = 0
+    
+    if isinstance(axis, tuple):
+        axis = list(axis)
+    axis = ov_opset.constant(axis, Type.i32).output(0)
+
+    if x_type == Type.boolean:
+        return OpenVINOKerasTensor(ov_opset.reduce_logical_or(x, axis, keepdims).output(0))
+
+    sorted_values, sorted_indices = ov_opset.sort(x, axis, False)
+    max_index = sorted_indices[0]
+    
+    return OpenVINOKerasTensor(max_index)
 
 
 def argmin(x, axis=None, keepdims=False):
-    raise NotImplementedError("`argmin` is not supported with openvino backend")
+    if axis == () or axis == []:
+        return x
+
+    x = get_ov_output(x)
+    x_type = x.get_element_type()
+
+    if axis is None:
+        flatten_shape = ov_opset.constant([-1], Type.i32).output(0)
+        x = ov_opset.reshape(x, flatten_shape, False).output(0)
+        axis = 0
+    
+    if isinstance(axis, tuple):
+        axis = list(axis)
+    axis = ov_opset.constant(axis, Type.i32).output(0)
+
+    if x_type == Type.boolean:
+        return OpenVINOKerasTensor(ov_opset.reduce_logical_or(x, axis, keepdims).output(0))
+
+    sorted_values, sorted_indices = ov_opset.sort(x, axis, True)
+    min_index = sorted_indices[0]
+    
+    return OpenVINOKerasTensor(min_index)
 
 
 def argsort(x, axis=-1):


### PR DESCRIPTION
I added the OpenVINO backend support for the NumPy operation argmin and argmax which should close issue #29011.