### PR TITLE
Recognize placer as a remote location

### DIFF
--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -414,7 +414,8 @@ def is_remote_path(filepath):
     Determines if a given filepath indicates a remote location.
 
     This function checks if the filepath represents a known remote pattern
-    such as GCS (`/gcs`), CNS (`/cns`), CFS (`/cfs`), HDFS (`/hdfs`)
+    such as GCS (`/gcs`), CNS (`/cns`), CFS (`/cfs`), HDFS (`/hdfs`), Placer
+    (`/placer`), or a URL (`.*://`).
 
     Args:
         filepath (str): The path to be checked.
@@ -422,7 +423,10 @@ def is_remote_path(filepath):
     Returns:
         bool: True if the filepath is a recognized remote path, otherwise False
     """
-    if re.match(r"^(/cns|/cfs|/gcs|/hdfs|/readahead|.*://).*$", str(filepath)):
+    if re.match(
+        r"^(/cns|/cfs|/gcs|/hdfs|/readahead|/placer|.*://).*$",
+        str(filepath)
+    ):
         return True
     return False
 

--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -424,8 +424,7 @@ def is_remote_path(filepath):
         bool: True if the filepath is a recognized remote path, otherwise False
     """
     if re.match(
-        r"^(/cns|/cfs|/gcs|/hdfs|/readahead|/placer|.*://).*$",
-        str(filepath)
+        r"^(/cns|/cfs|/gcs|/hdfs|/readahead|/placer|.*://).*$", str(filepath)
     ):
         return True
     return False

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -715,6 +715,17 @@ class IsRemotePathTest(test_case.TestCase):
     def test_cns_remote_path(self):
         self.assertTrue(file_utils.is_remote_path("/cns/some/path"))
 
+    def test_placer_remote_path(self):
+        self.assertTrue(
+            file_utils.is_remote_path("/placer/prod/home/some/path")
+        )
+        self.assertTrue(
+            file_utils.is_remote_path("/placer/test/home/some/path")
+        )
+        self.assertTrue(
+            file_utils.is_remote_path("/placer/prod/scratch/home/some/path")
+        )
+
     def test_cfs_remote_path(self):
         self.assertTrue(file_utils.is_remote_path("/cfs/some/path"))
 


### PR DESCRIPTION
Recognize `/placer` paths as remote locations,
allowing users to save Keras models directly to
Placer paths.