### PR TITLE
`mlx` - numpy.searchsorted and numpy.historgram implemented

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -78,6 +78,10 @@ jobs:
         if: ${{ matrix.backend == 'jax'}}
         run: |
           python integration_tests/jax_custom_fit_test.py
+      - name: Test MLX-specific integrations
+        if: ${{ matrix.backend == 'mlx'}}
+        run: |
+          python integration_tests/mlx_custom_fit_test.py
       - name: Test TF-specific integrations
         if: ${{ matrix.backend == 'tensorflow'}}
         run: |

--- a/integration_tests/mlx_custom_fit_test.py
+++ b/integration_tests/mlx_custom_fit_test.py
@@ -1,0 +1,102 @@
+import mlx.core as mx
+import numpy as np
+
+import keras
+
+
+def test_custom_fit():
+    class CustomModel(keras.Model):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.loss_tracker = keras.metrics.Mean(name="loss")
+            self.mae_metric = keras.metrics.MeanAbsoluteError(name="mae")
+            self.loss_fn = keras.losses.MeanSquaredError()
+
+        def compute_loss_and_updates(
+            self,
+            trainable_variables,
+            non_trainable_variables,
+            x,
+            y,
+            training=False,
+        ):
+            y_pred, non_trainable_variables = self.stateless_call(
+                trainable_variables,
+                non_trainable_variables,
+                x,
+                training=training,
+            )
+            loss = self.loss_fn(y, y_pred)
+            return loss, (y_pred, non_trainable_variables)
+
+        def train_step(self, state, data):
+            (
+                trainable_variables,
+                non_trainable_variables,
+                optimizer_variables,
+                metrics_variables,
+            ) = state
+            x, y = data
+            grad_fn = mx.value_and_grad(self.compute_loss_and_updates)
+            (loss, (y_pred, non_trainable_variables)), grads = grad_fn(
+                trainable_variables,
+                non_trainable_variables,
+                x,
+                y,
+                training=True,
+            )
+            (
+                trainable_variables,
+                optimizer_variables,
+            ) = self.optimizer.stateless_apply(
+                optimizer_variables, grads, trainable_variables
+            )
+            loss_tracker_vars = metrics_variables[
+                : len(self.loss_tracker.variables)
+            ]
+            mae_metric_vars = metrics_variables[
+                len(self.loss_tracker.variables) :
+            ]
+            loss_tracker_vars = self.loss_tracker.stateless_update_state(
+                loss_tracker_vars, loss
+            )
+            mae_metric_vars = self.mae_metric.stateless_update_state(
+                mae_metric_vars, y, y_pred
+            )
+            logs = {}
+            logs[self.loss_tracker.name] = self.loss_tracker.stateless_result(
+                loss_tracker_vars
+            )
+            logs[self.mae_metric.name] = self.mae_metric.stateless_result(
+                mae_metric_vars
+            )
+            new_metrics_vars = loss_tracker_vars + mae_metric_vars
+            state = (
+                trainable_variables,
+                non_trainable_variables,
+                optimizer_variables,
+                new_metrics_vars,
+            )
+            return logs, state
+
+        @property
+        def metrics(self):
+            return [self.loss_tracker, self.mae_metric]
+
+    inputs = keras.Input(shape=(32,))
+    outputs = keras.layers.Dense(1)(inputs)
+    model = CustomModel(inputs, outputs)
+    model.compile(optimizer="adam")
+    x = np.random.random((64, 32))
+    y = np.random.random((64, 1))
+    history = model.fit(x, y, epochs=1)
+
+    assert "loss" in history.history
+    assert "mae" in history.history
+
+    print("History:")
+    print(history.history)
+
+
+if __name__ == "__main__":
+    test_custom_fit()

--- a/keras/src/backend/common/dtypes_test.py
+++ b/keras/src/backend/common/dtypes_test.py
@@ -29,6 +29,12 @@ class DtypesTest(test_case.TestCase):
             for x in dtypes.ALLOWED_DTYPES
             if x not in ["string", "complex64", "complex128"]
         ] + [None]
+    elif backend.backend() == "mlx":
+        ALL_DTYPES = [
+            x
+            for x in dtypes.ALLOWED_DTYPES
+            if x not in ["string", "complex128"]
+        ] + [None]
     else:
         ALL_DTYPES = [x for x in dtypes.ALLOWED_DTYPES if x != "string"] + [
             None

--- a/keras/src/backend/mlx/core.py
+++ b/keras/src/backend/mlx/core.py
@@ -25,7 +25,7 @@ IS_THREAD_SAFE = True
 MLX_DTYPES = {
     "float16": mx.float16,
     "float32": mx.float32,
-    "float64": None,  # mlx does not support float64
+    "float64": None,  # mlx only supports float64 on cpu
     "uint8": mx.uint8,
     "uint16": mx.uint16,
     "uint32": mx.uint32,

--- a/keras/src/backend/mlx/trainer.py
+++ b/keras/src/backend/mlx/trainer.py
@@ -553,9 +553,8 @@ class MLXTrainer(base_trainer.Trainer):
                 model=self,
             )
 
-        # self.stop_training = False
-        self.make_train_function()
         self.stop_training = False
+        self.make_train_function()
         training_logs = {}
         callbacks.on_train_begin()
         initial_epoch = self._initial_epoch or initial_epoch

--- a/keras/src/backend/mlx/trainer.py
+++ b/keras/src/backend/mlx/trainer.py
@@ -260,7 +260,9 @@ class MLXTrainer(base_trainer.Trainer):
                 for ref_v, v in zip(self.metrics_variables, metrics_variables)
             ]
         ) as scope:
-            self._loss_tracker.update_state(unscaled_loss)
+            self._loss_tracker.update_state(
+                unscaled_loss, sample_weight=tree.flatten(x)[0].shape[0]
+            )
             logs = self.compute_metrics(x, y, y_pred, sample_weight)
 
         new_metrics_variables = []
@@ -551,8 +553,10 @@ class MLXTrainer(base_trainer.Trainer):
                 model=self,
             )
 
-        self.stop_training = False
+        # self.stop_training = False
         self.make_train_function()
+        self.stop_training = False
+        training_logs = {}
         callbacks.on_train_begin()
         initial_epoch = self._initial_epoch or initial_epoch
         for epoch in range(initial_epoch, epochs):
@@ -648,6 +652,7 @@ class MLXTrainer(base_trainer.Trainer):
         # If _eval_epoch_iterator exists, delete it after all epochs are done.
         if getattr(self, "_eval_epoch_iterator", None) is not None:
             del self._eval_epoch_iterator
+
         callbacks.on_train_end(logs=training_logs)
         self._mlx_state = None
         return self.history
@@ -706,7 +711,7 @@ class MLXTrainer(base_trainer.Trainer):
         self.make_test_function()
         self.stop_evaluating = False
         callbacks.on_test_begin()
-        logs = None
+        logs = {}
         self.reset_metrics()
 
         trainable_variables = [v.value for v in self.trainable_variables]


### PR DESCRIPTION
This addresses #19571

This implements:
- `numpy.searchsorted`
- `numpy.histogram`
- `integration_tests/mlx_custom_fit_test.py` (if this was okay to add)
    - very similar to jax

Question/comment:
- mlx added float64, but only on the cpu. I'm not sure the cleanest way to handle this, any thoughts? 
    - I was thinking about a custom wrapper that executed functions within a context manager to the cpu when a float64 is present
    - usually, it's (a) passed as the stream, (b) with a context manager, or (c) setting the default device
```python
import mlx.core as mx

x = mx.array([1, 2, 3], dtype=mx.float64)
y = mx.array([4, 5, 6], dtype=mx.float64)

z = mx.add(x, y, stream=mx.cpu) # (a)

with mx.stream(mx.cpu): # (b)
    z = mx.add(x, y)

mx.set_default_device(mx.cpu) # (c)
z = mx.add(x, y)
```