### PR TITLE
[Keras Ops] Add `keras.ops.polar` operation 

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -87,6 +87,7 @@ from keras.src.ops.nn import moments
 from keras.src.ops.nn import multi_hot
 from keras.src.ops.nn import normalize
 from keras.src.ops.nn import one_hot
+from keras.src.ops.nn import polar
 from keras.src.ops.nn import psnr
 from keras.src.ops.nn import relu
 from keras.src.ops.nn import relu6

--- a/keras/api/_tf_keras/keras/ops/nn/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/nn/__init__.py
@@ -31,6 +31,7 @@ from keras.src.ops.nn import moments
 from keras.src.ops.nn import multi_hot
 from keras.src.ops.nn import normalize
 from keras.src.ops.nn import one_hot
+from keras.src.ops.nn import polar
 from keras.src.ops.nn import psnr
 from keras.src.ops.nn import relu
 from keras.src.ops.nn import relu6

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -87,6 +87,7 @@ from keras.src.ops.nn import moments
 from keras.src.ops.nn import multi_hot
 from keras.src.ops.nn import normalize
 from keras.src.ops.nn import one_hot
+from keras.src.ops.nn import polar
 from keras.src.ops.nn import psnr
 from keras.src.ops.nn import relu
 from keras.src.ops.nn import relu6

--- a/keras/api/ops/nn/__init__.py
+++ b/keras/api/ops/nn/__init__.py
@@ -31,6 +31,7 @@ from keras.src.ops.nn import moments
 from keras.src.ops.nn import multi_hot
 from keras.src.ops.nn import normalize
 from keras.src.ops.nn import one_hot
+from keras.src.ops.nn import polar
 from keras.src.ops.nn import psnr
 from keras.src.ops.nn import relu
 from keras.src.ops.nn import relu6

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1517,8 +1517,8 @@ class NNOpsCorrectnessTest(testing.TestCase):
             self.assertAllClose(normalized_sum_by_axis, 1.0)
 
     def test_polar_corectness(self):
-        abs_ = np.array([1, 2])
-        angle = np.array([2, 3])
+        abs_ = np.array([1, 2], dtype="float32")
+        angle = np.array([2, 3], dtype="float32")
         out = knn.polar(abs_, angle)
         self.assertAllClose(
             out, [-0.41614684 + 0.9092974j, -1.979985 + 0.28224j], atol=1e-3
@@ -2952,6 +2952,24 @@ class NNOpsDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knn.Softsign().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_polar(self, dtype):
+        import jax.nn as jnn
+        import jax.numpy as jnp
+
+        x = knp.ones((), dtype=dtype)
+        x_jax = jnp.ones((), dtype=dtype)
+        expected_dtype = standardize_dtype(jnn.hard_tanh(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knn.hard_tanh(x).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(knn.HardTanh().symbolic_call(x).dtype),
             expected_dtype,
         )
 

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1284,6 +1284,12 @@ class NNOpsStaticShapeTest(testing.TestCase):
         out = knn.dot_product_attention(query, key, value)
         self.assertEqual(out.shape, query.shape)
 
+    def test_polar(self):
+        abs_ = KerasTensor([1, 2])
+        angle = KerasTensor([3, 4])
+        out = knn.polar(abs_, angle)
+        self.assertEqual(out.shape, abs_.shape)
+
 
 class NNOpsCorrectnessTest(testing.TestCase):
     def test_relu(self):
@@ -1509,6 +1515,14 @@ class NNOpsCorrectnessTest(testing.TestCase):
                 np.exp(ops.convert_to_numpy(result)), axis=axis
             )
             self.assertAllClose(normalized_sum_by_axis, 1.0)
+
+    def test_polar_corectness(self):
+        abs_ = np.array([1, 2])
+        angle = np.array([2, 3])
+        out = knn.polar(abs_, angle)
+        self.assertAllClose(
+            out, [-0.9900 + 0.1411j, -1.3073 - 1.5136j], atol=1e-3
+        )
 
     def test_sparsemax(self):
         x = np.array([-0.5, 0, 1, 2, 3], dtype=np.float32)

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1521,7 +1521,7 @@ class NNOpsCorrectnessTest(testing.TestCase):
         angle = np.array([2, 3])
         out = knn.polar(abs_, angle)
         self.assertAllClose(
-            out, [-0.9900 + 0.1411j, -1.3073 - 1.5136j], atol=1e-3
+            out, [-0.41614684 + 0.9092974j, -1.979985 + 0.28224j], atol=1e-3
         )
 
     def test_sparsemax(self):


### PR DESCRIPTION
### Why?

Specifically to make it simpler to have multi-backend `polar()` for DeepSeek in KerasHub (https://github.com/keras-team/keras-hub/issues/2077), but is otherwise applicable as a Keras operation.

Equivalent to `torch.polar()`. Note that this is _not_ equivalent to SciPy's [polar()](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.polar.html), which performs decomposition.

### Basic Usage

```
>>> import keras
>>> import numpy as np
>>> import torch
>>> 
>>> abs = np.array([1, 2])
>>> angle = [np.pi / 2, 5 * np.pi / 4]
>>> keras.src.ops.polar(abs, angle)
Array([-4.3711388e-08+1.j       , -1.4142137e+00-1.4142134j], dtype=complex64)
>>> torch.polar(torch.tensor(abs).float(), torch.tensor(angle).float())
tensor([-4.3711e-08+1.0000j, -1.4142e+00-1.4142j])
```