### PR TITLE
Remove unused dependency

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -11,7 +11,6 @@ requests
 h5py
 ml-dtypes
 protobuf
-google
 tensorboard-plugin-profile
 rich
 build


### PR DESCRIPTION
`google` isn't used anywhere in Keras. It was added by mistake in a previous commit.

GitHub Page: https://github.com/MarioVilas/googlesearch/
PyPi Page: https://pypi.org/project/google/
