### PR TITLE
[Openvino Backend] support numpy.arange, modify dtype check

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -1,11 +1,12 @@
 NumPyTestRot90
-NumpyArrayCreateOpsCorrectnessTest
+NumpyArrayCreateOpsCorrectnessTest::test_eye
+NumpyArrayCreateOpsCorrectnessTest::test_identity
+NumpyArrayCreateOpsCorrectnessTest::test_tri
 NumpyDtypeTest::test_absolute_bool
 NumpyDtypeTest::test_add_
 NumpyDtypeTest::test_all
 NumpyDtypeTest::test_any
 NumpyDtypeTest::test_append_
-NumpyDtypeTest::test_arange
 NumpyDtypeTest::test_arctan2_
 NumpyDtypeTest::test_argmax
 NumpyDtypeTest::test_argmin


### PR DESCRIPTION
Support numpy.arange operation for openvino backend and pass the tests. 
Besides, I add dtype checks and conversions to other operations to avoid situations where the dtype is a built-in Python type, such as **dtype=int**.