### PR TITLE
Fix `BinaryAccuracy` to handle boolean inputs.

### DIFF
--- a/keras/src/metrics/accuracy_metrics.py
+++ b/keras/src/metrics/accuracy_metrics.py
@@ -62,10 +62,10 @@ class Accuracy(reduction_metrics.MeanMetricWrapper):
 @keras_export("keras.metrics.binary_accuracy")
 def binary_accuracy(y_true, y_pred, threshold=0.5):
     y_pred = ops.convert_to_tensor(y_pred)
-    y_true = ops.convert_to_tensor(y_true, dtype=y_pred.dtype)
+    y_true = ops.convert_to_tensor(y_true)
+    threshold = ops.convert_to_tensor(threshold)
     y_true, y_pred = squeeze_or_expand_to_same_rank(y_true, y_pred)
-    threshold = ops.cast(threshold, y_pred.dtype)
-    y_pred = ops.cast(y_pred > threshold, y_true.dtype)
+    y_pred = ops.cast(ops.greater(y_pred, threshold), y_true.dtype)
     return ops.cast(ops.equal(y_true, y_pred), dtype=backend.floatx())
 
 

--- a/keras/src/metrics/reduction_metrics.py
+++ b/keras/src/metrics/reduction_metrics.py
@@ -2,7 +2,6 @@ from keras.src import backend
 from keras.src import initializers
 from keras.src import losses
 from keras.src import ops
-from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.metrics.metric import Metric
 from keras.src.saving import serialization_lib
@@ -200,9 +199,6 @@ class MeanMetricWrapper(Mean):
             self._direction = "down"
 
     def update_state(self, y_true, y_pred, sample_weight=None):
-        y_true = tree.map_structure(lambda x: ops.cast(x, self.dtype), y_true)
-        y_pred = tree.map_structure(lambda x: ops.cast(x, self.dtype), y_pred)
-
         mask = backend.get_keras_mask(y_pred)
         values = self._fn(y_true, y_pred, **self._fn_kwargs)
         if sample_weight is not None and mask is not None:


### PR DESCRIPTION
This is a follow up to https://github.com/keras-team/keras/pull/20782 and a replacement for https://github.com/keras-team/keras/pull/20782

We cannot cast `y_pred` and `y_true` to the expected output dtype in `MeanMetricWrapper`. Some metrics expect integers (indices or IDs for instance) and fail if `y_pred` and `y_true` are provided as floats.

It is the responsibility of the metric function to cast as needed. In this case, the correct approach in `BinaryAccuracy` is to use the regular type promotion rules to ensure that the comparison between `y_pred` and `threshold` is done without losing precision. `ops.greater` already does the type promotion correctly. Previously, `threshold` was incorrectly cast to the `y_pred` dtype, which in this case would lower its precision.