### PR TITLE
`mlx` - trainer update for compilation and data adapters

### DIFF
--- a/keras/src/backend/common/dtypes_test.py
+++ b/keras/src/backend/common/dtypes_test.py
@@ -47,10 +47,15 @@ class DtypesTest(test_case.TestCase):
 
         self.jax_enable_x64 = enable_x64()
         self.jax_enable_x64.__enter__()
+        if backend.backend() == "mlx":
+            self.mlx_cpu_context = backend.core.enable_float64()
+            self.mlx_cpu_context.__enter__()
         return super().setUp()
 
     def tearDown(self):
         self.jax_enable_x64.__exit__(None, None, None)
+        if backend.backend() == "mlx":
+            self.mlx_cpu_context.__exit__(None, None, None)
         return super().tearDown()
 
     @parameterized.named_parameters(

--- a/keras/src/backend/mlx/__init__.py
+++ b/keras/src/backend/mlx/__init__.py
@@ -17,6 +17,7 @@ from keras.src.backend.mlx.core import compute_output_spec
 from keras.src.backend.mlx.core import cond
 from keras.src.backend.mlx.core import convert_to_numpy
 from keras.src.backend.mlx.core import convert_to_tensor
+from keras.src.backend.mlx.core import device_scope
 from keras.src.backend.mlx.core import is_tensor
 from keras.src.backend.mlx.core import random_seed_dtype
 from keras.src.backend.mlx.core import scatter

--- a/keras/src/backend/mlx/numpy.py
+++ b/keras/src/backend/mlx/numpy.py
@@ -291,10 +291,16 @@ def right_shift(x, y):
 
 
 def _bincount_1d(x, weights=None, minlength=0):
-    length = builtins.max(builtins.max(x) + 1, minlength or 0)
+    x_max = mx.max(x)
+    length = mx.maximum(x_max + 1, minlength)
+
     counts = mx.zeros(length)
-    w = weights if weights is not None else mx.ones_like(x)
-    return counts.at[x].add(w)
+    if weights is None:
+        counts = counts.at[x].add(1)
+    else:
+        counts = counts.at[x].add(weights)
+
+    return counts
 
 
 def bincount(x, weights=None, minlength=0, sparse=False):

--- a/keras/src/backend/mlx/random.py
+++ b/keras/src/backend/mlx/random.py
@@ -226,7 +226,7 @@ def beta(shape, alpha, beta, dtype=None, seed=None):
 def binomial(shape, counts, probabilities, dtype=None, seed=None):
     # Binomial(n, p) distribution by summing n Bernoulli(p) samples
     dtype = to_mlx_dtype(dtype)
-    key = mx.random.key(seed)
+    key = mlx_draw_seed(seed)
 
     if isinstance(shape, int):
         shape = (shape,)

--- a/keras/src/backend/mlx/trainer.py
+++ b/keras/src/backend/mlx/trainer.py
@@ -353,7 +353,7 @@ class MLXTrainer(base_trainer.Trainer):
                             next_output,
                         )
                     return output
-                
+
                 if not self.run_eagerly and self.jit_compile:
                     concatenate = mx.compile(concatenate)
 
@@ -416,7 +416,7 @@ class MLXTrainer(base_trainer.Trainer):
     def make_predict_function(self, force=False):
         if self.predict_function is not None and not force:
             return
-        
+
         if not self.run_eagerly and self.jit_compile:
             predict_step = mx.compile(self.predict_step)
         else:

--- a/keras/src/backend/mlx/trainer.py
+++ b/keras/src/backend/mlx/trainer.py
@@ -1,3 +1,6 @@
+import collections
+import itertools
+
 import mlx.core as mx
 import numpy as np
 
@@ -33,7 +36,7 @@ class MLXTrainer(base_trainer.Trainer):
         return tree.map_structure(_transform, data)
 
     def mlx_state_sync(self):
-        if not getattr(self, "_mlx_state", None):
+        if not getattr(self, "_mlx_state", None) or self._mlx_state_synced:
             return
 
         trainable_variables = self._mlx_state.get("trainable_variables", None)
@@ -177,6 +180,7 @@ class MLXTrainer(base_trainer.Trainer):
             y=y,
             y_pred=y_pred,
             sample_weight=sample_weight,
+            training=training,
         )
         if losses:
             self._losses_override.clear()
@@ -198,14 +202,36 @@ class MLXTrainer(base_trainer.Trainer):
             metrics_variables,
         )
 
+    def _update_metrics_variables(
+        self, metrics_variables, unscaled_loss, x, y, y_pred, sample_weight
+    ):
+        with backend.StatelessScope(
+            state_mapping=[
+                (ref_v, v)
+                for ref_v, v in zip(self.metrics_variables, metrics_variables)
+            ]
+        ) as scope:
+            self._loss_tracker.update_state(
+                unscaled_loss, sample_weight=tree.flatten(x)[0].shape[0]
+            )
+            logs = self.compute_metrics(x, y, y_pred, sample_weight)
+
+        new_metrics_variables = []
+        for ref_v in self.metrics_variables:
+            new_v = scope.get_current_value(ref_v)
+            if new_v is None:
+                new_v = ref_v.value
+            new_metrics_variables.append(new_v)
+        return logs, new_metrics_variables
+
     def train_step(self, state, data):
-        data = self._data_to_mlx(data)
         (
             trainable_variables,
             non_trainable_variables,
             optimizer_variables,
             metrics_variables,
         ) = state
+        data = self._data_to_mlx(data)
         x, y, sample_weight = data_adapter_utils.unpack_x_y_sample_weight(data)
         grad_fn = mx.value_and_grad(self.compute_loss_and_updates)
 
@@ -254,24 +280,9 @@ class MLXTrainer(base_trainer.Trainer):
                 optimizer_variables=optimizer_variables,
             )
 
-        with backend.StatelessScope(
-            state_mapping=[
-                (ref_v, v)
-                for ref_v, v in zip(self.metrics_variables, metrics_variables)
-            ]
-        ) as scope:
-            self._loss_tracker.update_state(
-                unscaled_loss, sample_weight=tree.flatten(x)[0].shape[0]
-            )
-            logs = self.compute_metrics(x, y, y_pred, sample_weight)
-
-        new_metrics_variables = []
-        for ref_v in self.metrics_variables:
-            new_v = scope.get_current_value(ref_v)
-            if new_v is None:
-                new_v = ref_v.value
-            new_metrics_variables.append(new_v)
-        metrics_variables = new_metrics_variables
+        logs, metrics_variables = self._update_metrics_variables(
+            metrics_variables, unscaled_loss, x, y, y_pred, sample_weight
+        )
 
         state = (
             trainable_variables,
@@ -282,12 +293,12 @@ class MLXTrainer(base_trainer.Trainer):
         return logs, state
 
     def test_step(self, state, data):
-        data = self._data_to_mlx(data)
         (
             trainable_variables,
             non_trainable_variables,
             metrics_variables,
         ) = state
+        data = self._data_to_mlx(data)
         x, y, sample_weight = data_adapter_utils.unpack_x_y_sample_weight(data)
         (
             loss,
@@ -305,22 +316,9 @@ class MLXTrainer(base_trainer.Trainer):
             training=False,
         )
 
-        with backend.StatelessScope(
-            state_mapping=[
-                (ref_v, v)
-                for ref_v, v in zip(self.metrics_variables, metrics_variables)
-            ]
-        ) as scope:
-            self._loss_tracker.update_state(unscaled_loss)
-            logs = self.compute_metrics(x, y, y_pred, sample_weight)
-
-        new_metrics_variables = []
-        for ref_v in self.metrics_variables:
-            new_v = scope.get_current_value(ref_v)
-            if new_v is None:
-                new_v = ref_v.value
-            new_metrics_variables.append(new_v)
-        metrics_variables = new_metrics_variables
+        logs, metrics_variables = self._update_metrics_variables(
+            metrics_variables, unscaled_loss, x, y, y_pred, sample_weight
+        )
 
         state = (
             trainable_variables,
@@ -342,84 +340,118 @@ class MLXTrainer(base_trainer.Trainer):
         )
         return outputs, (trainable_variables, non_trainable_variables)
 
+    def _make_function(self, step_function, concatenate_outputs=False):
+        if self.steps_per_execution > 1:
+            if concatenate_outputs:
+
+                def concatenate(outputs):
+                    output = outputs[0]
+                    for next_output in outputs[1:]:
+                        output = tree.map_structure(
+                            lambda t1, t2: mx.concatenate([t1, t2]),
+                            output,
+                            next_output,
+                        )
+                    return output
+                
+                if not self.run_eagerly and self.jit_compile:
+                    concatenate = mx.compile(concatenate)
+
+                def iterator_step(state, iterator):
+                    data = next(iterator)
+                    outputs, state = step_function(state, data)
+                    outputs = [outputs]
+                    try:
+                        for _ in range(self.steps_per_execution - 1):
+                            data = next(iterator)
+                            _outputs, state = step_function(state, data)
+                            outputs.append(_outputs)
+                    except StopIteration:
+                        pass
+                    outputs = concatenate(outputs)
+                    return outputs, state
+
+            else:
+
+                def iterator_step(state, iterator):
+                    data = next(iterator)
+                    outputs, state = step_function(state, data)
+                    try:
+                        for _ in range(self.steps_per_execution - 1):
+                            data = next(iterator)
+                            outputs, state = step_function(state, data)
+                    except StopIteration:
+                        pass
+                    return outputs, state
+
+        else:
+
+            def iterator_step(state, iterator):
+                return step_function(state, next(iterator))
+
+        return iterator_step
+
     def make_train_function(self, force=False):
         if self.train_function is not None and not force:
-            return self.train_function
-
-        def one_train_step(state, data):
-            data = data[0]
-            return self.train_step(state, data)
-
-        def multi_train_steps(state, data):
-            for single_step_data in data:
-                logs, state = one_train_step(state, [single_step_data])
-            return logs, state
-
-        if self.steps_per_execution > 1:
-            train_step = multi_train_steps
+            return
+        if not self.run_eagerly and self.jit_compile:
+            train_step = mx.compile(self.train_step)
         else:
-            train_step = one_train_step
+            train_step = self.train_step
 
-        self.train_function = train_step
+        step_function = self._make_function(train_step)
+        self.train_function = step_function
 
     def make_test_function(self, force=False):
         if self.test_function is not None and not force:
-            return self.test_function
-
-        def one_test_step(state, data):
-            data = data[0]
-            return self.test_step(state, data)
-
-        def multi_test_steps(state, data):
-            for single_step_data in data:
-                logs, state = one_test_step(state, [single_step_data])
-            return logs, state
-
-        if self.steps_per_execution > 1:
-            test_step = multi_test_steps
+            return
+        if not self.run_eagerly and self.jit_compile:
+            test_step = mx.compile(self.test_step)
         else:
-            test_step = one_test_step
+            test_step = self.test_step
 
-        self.test_function = test_step
+        step_function = self._make_function(test_step)
+        self.test_function = step_function
 
     def make_predict_function(self, force=False):
         if self.predict_function is not None and not force:
-            return self.predict_function
-
-        def one_predict_step(state, data):
-            data = data[0]
-            return self.predict_step(state, data)
-
-        def multi_predict_steps(state, data):
-            outputs, state = one_predict_step(state, data[:1])
-
-            for single_step_data in data[1:]:
-                step_outputs, state = one_predict_step(
-                    state,
-                    [single_step_data],
-                )
-                outputs = tree.map_structure(
-                    lambda t1, t2: mx.concatenate([t1, t2]),
-                    outputs,
-                    step_outputs,
-                )
-            return outputs, state
-
-        if self.steps_per_execution > 1:
-            predict_step = multi_predict_steps
+            return
+        
+        if not self.run_eagerly and self.jit_compile:
+            predict_step = mx.compile(self.predict_step)
         else:
-            predict_step = one_predict_step
+            predict_step = self.predict_step
 
-        self.predict_function = predict_step
+        # def predict_step(state, data):
+        #     return self.predict_step(state, data)
 
-    def _symbolic_build(self, data_batch):
+        # if not self.run_eagerly and self.jit_compile:
+        #     predict_step = mx.compile(predict_step)
+
+        step_function = self._make_function(
+            predict_step, concatenate_outputs=True
+        )
+
+        self.predict_function = step_function
+
+    def _symbolic_build(self, iterator=None, data_batch=None):
         model_unbuilt = not all(layer.built for layer in self._flatten_layers())
         compile_metrics_unbuilt = (
             hasattr(self, "_compile_metrics")
             and self._compile_metrics is not None
             and not self._compile_metrics.built
         )
-        if model_unbuilt or compile_metrics_unbuilt:
+        compile_loss_unbuilt = (
+            hasattr(self, "_compile_loss")
+            and self._compile_loss is not None
+            and not self._compile_loss.built
+        )
+        optimizer_unbuilt = (
+            hasattr(self, "optimizer")
+            and self.optimizer is not None
+            and not self.optimizer.built
+        )
+        if model_unbuilt or compile_metrics_unbuilt or compile_loss_unbuilt:
             # Create symbolic tensors matching an input batch.
 
             def to_symbolic_input(v):
@@ -427,6 +459,13 @@ class MLXTrainer(base_trainer.Trainer):
                     return KerasTensor(v.shape, standardize_dtype(v.dtype))
                 return v
 
+            if data_batch is None:
+                for _, data_or_iterator in iterator:
+                    if isinstance(data_or_iterator, (list, tuple)):
+                        data_batch = data_or_iterator[0]
+                    else:
+                        data_batch = next(data_or_iterator)
+                    break
             data_batch = tree.map_structure(to_symbolic_input, data_batch)
             (
                 x,
@@ -435,7 +474,7 @@ class MLXTrainer(base_trainer.Trainer):
             ) = data_adapter_utils.unpack_x_y_sample_weight(data_batch)
             # Build all model state with `backend.compute_output_spec`.
             try:
-                y_pred = backend.compute_output_spec(self, x)
+                y_pred = backend.compute_output_spec(self, x, training=False)
             except Exception as e:
                 raise RuntimeError(
                     "Unable to automatically build the model. "
@@ -448,7 +487,7 @@ class MLXTrainer(base_trainer.Trainer):
                     "Exception encountered:\n"
                     f"'{e}'"
                 )
-            if compile_metrics_unbuilt and y is not None:
+            if compile_metrics_unbuilt:  # and y is not None:
                 # Build all metric state with `backend.compute_output_spec`.
                 backend.compute_output_spec(
                     self.compute_metrics,
@@ -457,11 +496,17 @@ class MLXTrainer(base_trainer.Trainer):
                     y_pred,
                     sample_weight=sample_weight,
                 )
-        if (
-            hasattr(self, "optimizer")
-            and self.optimizer is not None
-            and not self.optimizer.built
-        ):
+            if compile_loss_unbuilt:
+                # Build `CompileLoss` state with `backend.compute_output_spec`.
+                backend.compute_output_spec(
+                    self._compute_loss,
+                    x,
+                    y,
+                    y_pred,
+                    sample_weight=sample_weight,
+                    training=False,
+                )
+        if optimizer_unbuilt:
             # Build optimizer
             self.optimizer.build(self.trainable_variables)
         self._post_build()
@@ -486,10 +531,7 @@ class MLXTrainer(base_trainer.Trainer):
         validation_batch_size=None,
         validation_freq=1,
     ):
-        if not self.compiled:
-            raise ValueError(
-                "You must call `compile()` before calling `fit()`."
-            )
+        self._assert_compile_called("fit")
 
         # TODO: respect compiled trainable state
         self._eval_epoch_iterator = None
@@ -515,7 +557,7 @@ class MLXTrainer(base_trainer.Trainer):
             ) = data_adapter_utils.unpack_x_y_sample_weight(validation_data)
 
         # Create an iterator that yields batches for one epoch.
-        epoch_iterator = EpochIterator(
+        epoch_iterator = MLXEpochIterator(
             x=x,
             y=y,
             sample_weight=sample_weight,
@@ -526,20 +568,8 @@ class MLXTrainer(base_trainer.Trainer):
             steps_per_execution=self.steps_per_execution,
         )
 
-        needs_building = (
-            not all(layer.built for layer in self._flatten_layers())
-            or not self.optimizer.built
-            or (
-                self._compile_metrics is not None
-                and not self._compile_metrics.built
-            )
-        )
-        if needs_building:
-            # Build the model on one batch of data.
-            for _, data in epoch_iterator.enumerate_epoch():
-                data_batch = data[0]
-                self._symbolic_build(data_batch)
-                break
+        self._symbolic_build(iterator=epoch_iterator)
+        epoch_iterator.reset()
 
         # Container that configures and calls callbacks.
         if not isinstance(callbacks, callbacks_module.CallbackList):
@@ -563,43 +593,46 @@ class MLXTrainer(base_trainer.Trainer):
             callbacks.on_epoch_begin(epoch)
 
             self._mlx_state_synced = True
-            for step, data in epoch_iterator.enumerate_epoch():
-                # Callbacks
-                callbacks.on_train_batch_begin(step)
-                # Train step
-                if self._mlx_state_synced:
-                    # The state may have been synced by a callback.
-                    state = self._get_mlx_state(
-                        trainable_variables=True,
-                        non_trainable_variables=True,
-                        optimizer_variables=True,
-                        metrics_variables=True,
-                        purge_model_variables=True,
+            with epoch_iterator.catch_stop_iteration():
+                for step, iterator in epoch_iterator:
+                    # Callbacks
+                    callbacks.on_train_batch_begin(step)
+                    # Train step
+                    if self._mlx_state_synced:
+                        # The state may have been synced by a callback.
+                        state = self._get_mlx_state(
+                            trainable_variables=True,
+                            non_trainable_variables=True,
+                            optimizer_variables=True,
+                            metrics_variables=True,
+                            purge_model_variables=True,
+                        )
+                        self._mlx_state_synced = False
+
+                    logs, state = self.train_function(state, iterator)
+                    mx.eval(logs, state)
+                    (
+                        trainable_variables,
+                        non_trainable_variables,
+                        optimizer_variables,
+                        metrics_variables,
+                    ) = state
+
+                    # Setting _mlx_state enables callbacks to force a state sync
+                    # if they need to.
+                    self._mlx_state = {
+                        "trainable_variables": trainable_variables,
+                        "non_trainable_variables": non_trainable_variables,
+                        "optimizer_variables": optimizer_variables,
+                        "metrics_variables": metrics_variables,
+                    }
+
+                    # Callbacks
+                    callbacks.on_train_batch_end(
+                        step, self._pythonify_logs(logs)
                     )
-                    self._mlx_state_synced = False
-
-                logs, state = self.train_function(state, data)
-                mx.eval(logs, state)
-                (
-                    trainable_variables,
-                    non_trainable_variables,
-                    optimizer_variables,
-                    metrics_variables,
-                ) = state
-
-                # Setting _mlx_state enables callbacks to force a state sync
-                # if they need to.
-                self._mlx_state = {
-                    "trainable_variables": trainable_variables,
-                    "non_trainable_variables": non_trainable_variables,
-                    "optimizer_variables": optimizer_variables,
-                    "metrics_variables": metrics_variables,
-                }
-
-                # Callbacks
-                callbacks.on_train_batch_end(step, self._pythonify_logs(logs))
-                if self.stop_training:
-                    break
+                    if self.stop_training:
+                        break
 
             # Reattach state to model variables.
             self.mlx_state_sync()
@@ -613,7 +646,7 @@ class MLXTrainer(base_trainer.Trainer):
             if validation_data and self._should_eval(epoch, validation_freq):
                 # Create EpochIterator for evaluation and cache it.
                 if getattr(self, "_eval_epoch_iterator", None) is None:
-                    self._eval_epoch_iterator = EpochIterator(
+                    self._eval_epoch_iterator = MLXEpochIterator(
                         x=val_x,
                         y=val_y,
                         sample_weight=val_sample_weight,
@@ -669,16 +702,16 @@ class MLXTrainer(base_trainer.Trainer):
         return_dict=False,
         **kwargs,
     ):
+        self._assert_compile_called("evaluate")
         # TODO: respect compiled trainable state
         use_cached_eval_dataset = kwargs.pop("_use_cached_eval_dataset", False)
         if kwargs:
             raise ValueError(f"Arguments not recognized: {kwargs}")
-
         if use_cached_eval_dataset:
             epoch_iterator = self._eval_epoch_iterator
         else:
             # Create an iterator that yields batches of input/target data.
-            epoch_iterator = EpochIterator(
+            epoch_iterator = MLXEpochIterator(
                 x=x,
                 y=y,
                 sample_weight=sample_weight,
@@ -688,12 +721,8 @@ class MLXTrainer(base_trainer.Trainer):
                 steps_per_execution=self.steps_per_execution,
             )
 
-        if not all(layer.built for layer in self._flatten_layers()):
-            # Build the model on one batch of data.
-            for _, data in epoch_iterator.enumerate_epoch():
-                data_batch = data[0]
-                self._symbolic_build(data_batch)
-                break
+        self._symbolic_build(iterator=epoch_iterator)
+        epoch_iterator.reset()
 
         # Container that configures and calls callbacks.
         if not isinstance(callbacks, callbacks_module.CallbackList):
@@ -713,39 +742,39 @@ class MLXTrainer(base_trainer.Trainer):
         logs = {}
         self.reset_metrics()
 
-        trainable_variables = [v.value for v in self.trainable_variables]
-        non_trainable_variables = [
-            v.value for v in self.non_trainable_variables
-        ]
-        metrics_variables = [v.value for v in self.metrics_variables]
+        self._mlx_state_synced = True
+        with epoch_iterator.catch_stop_iteration():
+            for step, iterator in epoch_iterator:
+                callbacks.on_test_batch_begin(step)
 
-        self._purge_model_variables(optimizer_variables=False)
-        for step, data in epoch_iterator.enumerate_epoch():
-            callbacks.on_test_batch_begin(step)
+                if self._mlx_state_synced:
+                    # The state may have been synced by a callback.
+                    state = self._get_mlx_state(
+                        trainable_variables=True,
+                        non_trainable_variables=True,
+                        metrics_variables=True,
+                        purge_model_variables=True,
+                    )
+                    self._mlx_state_synced = False
 
-            state = (
-                trainable_variables,
-                non_trainable_variables,
-                metrics_variables,
-            )
-            logs, state = self.test_function(state, data)
-            mx.eval(logs, state)
-            (
-                trainable_variables,
-                non_trainable_variables,
-                metrics_variables,
-            ) = state
+                logs, state = self.test_function(state, iterator)
+                mx.eval(logs, state)
+                (
+                    trainable_variables,
+                    non_trainable_variables,
+                    metrics_variables,
+                ) = state
 
-            self._mlx_state = {
-                # I wouldn't recommend modifying non-trainable model state
-                # during evaluate(), but it's allowed.
-                "trainable_variables": trainable_variables,
-                "non_trainable_variables": non_trainable_variables,
-                "metrics_variables": metrics_variables,
-            }
-            callbacks.on_test_batch_end(step, self._pythonify_logs(logs))
-            if self.stop_evaluating:
-                break
+                self._mlx_state = {
+                    # I wouldn't recommend modifying non-trainable model state
+                    # during evaluate(), but it's allowed.
+                    "trainable_variables": trainable_variables,
+                    "non_trainable_variables": non_trainable_variables,
+                    "metrics_variables": metrics_variables,
+                }
+                callbacks.on_test_batch_end(step, self._pythonify_logs(logs))
+                if self.stop_evaluating:
+                    break
 
         self.mlx_state_sync()
         logs = self._pythonify_logs(self._get_metrics_result_or_logs(logs))
@@ -761,7 +790,7 @@ class MLXTrainer(base_trainer.Trainer):
         self, x, batch_size=None, verbose="auto", steps=None, callbacks=None
     ):
         # Create an iterator that yields batches of input data.
-        epoch_iterator = EpochIterator(
+        epoch_iterator = MLXEpochIterator(
             x=x,
             batch_size=batch_size,
             steps_per_epoch=steps,
@@ -771,18 +800,21 @@ class MLXTrainer(base_trainer.Trainer):
 
         if not all(layer.built for layer in self._flatten_layers()):
             # Build the model on one batch of data.
-            for _, data in epoch_iterator.enumerate_epoch():
+            for _, iterator in epoch_iterator:
                 # Build model
-                x, _, _ = data_adapter_utils.unpack_x_y_sample_weight(data[0])
+                x, _, _ = data_adapter_utils.unpack_x_y_sample_weight(
+                    next(iterator)
+                )
                 with backend.StatelessScope():
                     self(x)
                 break
+            epoch_iterator.reset()
 
         # Container that configures and calls callbacks.
         if not isinstance(callbacks, callbacks_module.CallbackList):
             callbacks = callbacks_module.CallbackList(
                 callbacks,
-                add_history=True,
+                # add_history=True,
                 add_progbar=verbose != 0,
                 verbose=verbose,
                 epochs=1,
@@ -812,25 +844,27 @@ class MLXTrainer(base_trainer.Trainer):
         self._mlx_state_synced = True
         outputs = None
         non_trainable_variables = None
-        for step, data in epoch_iterator.enumerate_epoch():
-            callbacks.on_predict_batch_begin(step)
-            if self._mlx_state_synced:
-                # The state may have been synced by a callback.
-                state = self._get_mlx_state(
-                    trainable_variables=True,
-                    non_trainable_variables=True,
-                )
-                self._purge_model_variables(non_trainable_variables=True)
-                self._mlx_state_synced = False
-            else:
-                state = (state[0], non_trainable_variables)
-            batch_outputs, state = self.predict_function(state, data)
-            mx.eval(batch_outputs, state)
-            (trainable_variables, non_trainable_variables) = state
-            outputs = append_to_outputs(batch_outputs, outputs)
-            callbacks.on_predict_batch_end(step, {"outputs": batch_outputs})
-            if self.stop_predicting:
-                break
+        with epoch_iterator.catch_stop_iteration():
+            for step, iterator in epoch_iterator:
+                callbacks.on_predict_batch_begin(step)
+                if self._mlx_state_synced:
+                    # The state may have been synced by a callback.
+                    state = self._get_mlx_state(
+                        trainable_variables=True,
+                        non_trainable_variables=True,
+                    )
+                    self._purge_model_variables(non_trainable_variables=True)
+                    self._mlx_state_synced = False
+                else:
+                    state = (state[0], non_trainable_variables)
+                batch_outputs, state = self.predict_function(state, iterator)
+                mx.eval(batch_outputs, state)
+                (trainable_variables, non_trainable_variables) = state
+                outputs = append_to_outputs(batch_outputs, outputs)
+
+                callbacks.on_predict_batch_end(step, {"outputs": batch_outputs})
+                if self.stop_predicting:
+                    break
         self._mlx_state = {
             # I wouldn't recommend modifying non-trainable model state
             # during predict(), but it's allowed.
@@ -865,10 +899,14 @@ class MLXTrainer(base_trainer.Trainer):
                 y, class_weight
             )
 
-        data = (x, y, sample_weight)
+        def data():
+            packed_data = data_adapter_utils.pack_x_y_sample_weight(
+                x, y=y, sample_weight=sample_weight
+            )
+            yield self._data_to_mlx(packed_data)
 
         # Maybe build model
-        self._symbolic_build(data)
+        self._symbolic_build(data_batch=next(data()))
         self.make_train_function()
 
         state = self._get_mlx_state(
@@ -879,7 +917,7 @@ class MLXTrainer(base_trainer.Trainer):
             purge_model_variables=False,
         )
         self._mlx_state_synced = False
-        logs, state = self.train_function(state, [data])
+        logs, state = self.train_function(state, data())
         mx.eval(logs, state)
 
         # State sync
@@ -911,10 +949,14 @@ class MLXTrainer(base_trainer.Trainer):
     ):
         self._assert_compile_called("test_on_batch")
 
-        data = (x, y, sample_weight)
+        def data():
+            packed_data = data_adapter_utils.pack_x_y_sample_weight(
+                x, y=y, sample_weight=sample_weight
+            )
+            yield self._data_to_mlx(packed_data)
 
         # Maybe build model
-        self._symbolic_build(data)
+        self._symbolic_build(data_batch=next(data()))
         self.make_test_function()
 
         # Test step
@@ -925,7 +967,7 @@ class MLXTrainer(base_trainer.Trainer):
             purge_model_variables=False,
         )
         self._mlx_state_synced = False
-        logs, state = self.test_function(state, [data])
+        logs, state = self.test_function(state, data())
         mx.eval(logs, state)
 
         # State sync
@@ -947,7 +989,6 @@ class MLXTrainer(base_trainer.Trainer):
             # Build model
             with backend.StatelessScope():
                 self(x)
-        self._symbolic_build(x)
         self.make_predict_function()
         state = self._get_mlx_state(
             trainable_variables=True,
@@ -956,7 +997,13 @@ class MLXTrainer(base_trainer.Trainer):
             purge_model_variables=False,
         )
         self._mlx_state_synced = False
-        batch_outputs, state = self.predict_function(state, [(x,)])
+
+        x = self._data_to_mlx(x)
+
+        def data():
+            yield (x,)
+
+        batch_outputs, state = self.predict_function(state, data())
         mx.eval(batch_outputs, state)
         trainable_variables, non_trainable_variables = state
         self._mlx_state = {
@@ -968,3 +1015,37 @@ class MLXTrainer(base_trainer.Trainer):
             backend.convert_to_numpy, batch_outputs
         )
         return batch_outputs
+
+
+class MLXEpochIterator(EpochIterator):
+    def __next__(self):
+        return next(self._epoch_iterator)
+
+    def _get_iterator(self):
+        # prefetch similar to jax
+        return self._prefetch_iterator(self.data_adapter.get_mlx_iterator())
+
+    def _prefetch_iterator(self, iterator):
+        """Prefetch batches on device.
+
+        Most of the implementation has been borrowed from
+        `flax.jax_utils.prefetch_to_device`
+
+        This utility takes an iterator and returns a new iterator which fills an
+        on device prefetch buffer. Eager prefetching can improve the performance
+        of training loops significantly by overlapping compute and data
+        transfer.
+        """
+        queue = collections.deque()
+
+        # If you're training on GPUs, 2 is generally the best choice because
+        # this guarantees that you can overlap a training step on GPU with a
+        # data prefetch step on CPU.
+        def enqueue(n=2):
+            for data in itertools.islice(iterator, n):
+                queue.append(data)
+
+        enqueue(n=2)  # TODO: should we make `n` configurable?
+        while queue:
+            yield queue.popleft()
+            enqueue(1)

--- a/keras/src/callbacks/tensorboard_test.py
+++ b/keras/src/callbacks/tensorboard_test.py
@@ -468,6 +468,10 @@ class TestTensorBoardV2(testing.TestCase):
                     # TODO: Use device scope after the API is added.
                     if tensor.is_cuda:
                         tensor = tensor.cpu()
+                if backend.backend() == "mlx":
+                    # summary.write can't write mlx array directly
+                    # assuming scalar array, retrieve value first
+                    tensor = tensor.item()
                 summary.write(
                     tag=tag,
                     tensor=tensor,
@@ -630,7 +634,9 @@ class TestTensorBoardV2(testing.TestCase):
                 "NumPy conversion."
             )
 
-        tensor.numpy = mock_numpy
+        if backend.backend() != "mlx":
+            # mlx arrays do not have a __dict__ attribute
+            tensor.numpy = mock_numpy
 
         logs = {"metric": tensor}
 

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -713,6 +713,10 @@ class EinsumDenseTest(testing.TestCase):
             )
 
     @pytest.mark.requires_trainable_backend
+    @pytest.mark.skipif(
+        backend.backend() == "mlx",
+        reason=f"{backend.backend()} backend doesn't support float8.",
+    )
     def test_quantize_float8(self):
         import ml_dtypes
 
@@ -832,6 +836,10 @@ class EinsumDenseTest(testing.TestCase):
             self.assertAllClose(layer.outputs_grad_scale, scale_g)
 
     @pytest.mark.requires_trainable_backend
+    @pytest.mark.skipif(
+        backend.backend() == "mlx",
+        reason=f"{backend.backend()} backend doesn't support float8.",
+    )
     def test_quantize_float8_fitting(self):
         config = dict(
             equation="ab,bcd->acd",
@@ -889,6 +897,10 @@ class EinsumDenseTest(testing.TestCase):
                 len(model.non_trainable_weights),
             )
 
+    @pytest.mark.skipif(
+        backend.backend() == "mlx",
+        reason=f"{backend.backend()} backend doesn't support float8.",
+    )
     def test_quantize_float8_inference(self):
         config = dict(
             equation="ab,bcd->acd",

--- a/keras/src/layers/preprocessing/image_preprocessing/cut_mix.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/cut_mix.py
@@ -36,6 +36,9 @@ class CutMix(BaseImagePreprocessingLayer):
         self._set_factor(factor)
         self.seed = seed
         self.generator = SeedGenerator(seed)
+        if self.backend.name == "mlx":
+            # mlx.random.beta() is not currently jit compilable
+            self.supports_jit = False
 
         if self.data_format == "channels_first":
             self.height_axis = -2

--- a/keras/src/layers/preprocessing/image_preprocessing/equalization.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/equalization.py
@@ -70,6 +70,9 @@ class Equalization(BaseImagePreprocessingLayer):
         self.bins = bins
         self._set_value_range(value_range)
         self.data_format = backend.standardize_data_format(data_format)
+        if self.backend.name == "mlx":
+            # mlx.numpy.bincount() is not currently jit compilable
+            self.supports_jit = False
 
     def _set_value_range(self, value_range):
         if not isinstance(value_range, (tuple, list)):

--- a/keras/src/layers/preprocessing/image_preprocessing/mix_up.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/mix_up.py
@@ -37,6 +37,9 @@ class MixUp(BaseImagePreprocessingLayer):
         self.alpha = alpha
         self.seed = seed
         self.generator = SeedGenerator(seed)
+        if self.backend.name == "mlx":
+            # mlx.random.beta() is not currently jit compilable
+            self.supports_jit = False
 
     def get_random_transformation(self, data, training=True, seed=None):
         if isinstance(data, dict):

--- a/keras/src/layers/preprocessing/normalization.py
+++ b/keras/src/layers/preprocessing/normalization.py
@@ -112,6 +112,8 @@ class Normalization(TFDataLayer):
         self.supports_masking = True
         self._build_input_shape = None
         self.mean = None
+        # if self.backend.name == "mlx":
+        #     self.supports_jit = False
 
         # Set `mean` and `variance` if passed.
         if (mean is not None) != (variance is not None):

--- a/keras/src/losses/loss_test.py
+++ b/keras/src/losses/loss_test.py
@@ -8,6 +8,7 @@ from keras.src import dtype_policies
 from keras.src import losses as losses_module
 from keras.src import ops
 from keras.src import testing
+from keras.src.backend.common import masking
 from keras.src.losses.loss import Loss
 from keras.src.losses.loss import squeeze_or_expand_to_same_rank
 
@@ -94,7 +95,10 @@ class LossTest(testing.TestCase):
         mask = ops.convert_to_tensor(mask)
         y_true = ops.convert_to_tensor(y_true)
         y_pred = ops.convert_to_tensor(y_pred)
-        y_pred._keras_mask = mask
+        if backend.backend() == "mlx":
+            masking.set_keras_mask(y_pred, mask)
+        else:
+            y_pred._keras_mask = mask
 
         loss_fn = ExampleLoss()
         loss = loss_fn(y_true, y_pred)
@@ -105,7 +109,10 @@ class LossTest(testing.TestCase):
 
         # Test edge case where everything is masked.
         mask = np.array([False, False, False, False])
-        y_pred._keras_mask = mask
+        if backend.backend() == "mlx":
+            masking.set_keras_mask(y_pred, mask)
+        else:
+            y_pred._keras_mask = mask
         loss = loss_fn(y_true, y_pred)
         self.assertEqual(backend.standardize_dtype(loss.dtype), "float32")
         self.assertAllClose(loss, 0)  # No NaN.
@@ -145,7 +152,10 @@ class LossTest(testing.TestCase):
         mask = ops.convert_to_tensor(mask)
         y_true = ops.convert_to_tensor(y_true)
         y_pred = ops.convert_to_tensor(y_pred)
-        y_pred._keras_mask = mask
+        if backend.backend() == "mlx":
+            masking.set_keras_mask(y_pred, mask)
+        else:
+            y_pred._keras_mask = mask
 
         loss_fn = ExampleLoss()
         loss = loss_fn(y_true, y_pred, sample_weight=sample_weight)
@@ -170,7 +180,10 @@ class LossTest(testing.TestCase):
         mask = ops.convert_to_tensor(mask)
         y_true = ops.convert_to_tensor(y_true)
         y_pred = ops.convert_to_tensor(y_pred)
-        y_pred._keras_mask = mask
+        if backend.backend() == "mlx":
+            masking.set_keras_mask(y_pred, mask)
+        else:
+            y_pred._keras_mask = mask
 
         loss_fn = ExampleLoss()
         rank1_loss = loss_fn(y_true, y_pred, sample_weight=sample_weight)
@@ -180,7 +193,10 @@ class LossTest(testing.TestCase):
         y_true = ops.tile(ops.expand_dims(y_true, axis=0), (2, 1))
         y_pred = ops.tile(ops.expand_dims(y_pred, axis=0), (2, 1))
         sample_weight = ops.tile(ops.expand_dims(sample_weight, axis=0), (2, 1))
-        y_pred._keras_mask = mask
+        if backend.backend() == "mlx":
+            masking.set_keras_mask(y_pred, mask)
+        else:
+            y_pred._keras_mask = mask
         rank2_loss = loss_fn(y_true, y_pred, sample_weight=sample_weight)
         self.assertAllClose(rank1_loss, rank2_loss)
 
@@ -213,7 +229,10 @@ class LossTest(testing.TestCase):
             mask = ops.convert_to_tensor(mask)
             y_true = ops.convert_to_tensor(y_true)
             y_pred = ops.convert_to_tensor(y_pred)
-            y_pred._keras_mask = mask
+            if backend.backend() == "mlx":
+                masking.set_keras_mask(y_pred, mask)
+            else:
+                y_pred._keras_mask = mask
 
             loss_fn = ExampleLoss()
             loss = loss_fn(y_true, y_pred, sample_weight=sample_weight)

--- a/keras/src/trainers/data_adapters/array_data_adapter.py
+++ b/keras/src/trainers/data_adapters/array_data_adapter.py
@@ -253,6 +253,21 @@ class ArrayDataAdapter(DataAdapter):
 
         return self._get_iterator(slice_and_convert_to_jax, inputs)
 
+    def get_mlx_iterator(self):
+        from keras.src.backend.mlx.core import convert_to_tensor
+
+        inputs = array_slicing.convert_to_sliceable(
+            self._inputs, target_backend="mlx"
+        )
+
+        def slice_and_convert_to_mlx(sliceable, indices=None):
+            x = sliceable[indices]
+            x = sliceable.convert_to_mlx_compatible(x)
+            x = convert_to_tensor(x)
+            return x
+
+        return self._get_iterator(slice_and_convert_to_mlx, inputs)
+
     def get_torch_dataloader(self):
         import torch
 

--- a/keras/src/trainers/data_adapters/array_data_adapter_test.py
+++ b/keras/src/trainers/data_adapters/array_data_adapter_test.py
@@ -1,5 +1,6 @@
 import jax
 import jax.experimental.sparse as jax_sparse
+import mlx.core as mx
 import numpy as np
 import pandas
 import scipy
@@ -30,6 +31,8 @@ class TestArrayDataAdapter(testing.TestCase):
             return jax_sparse.BCOO.fromdense(x)
         elif array_type == "torch":
             return torch.as_tensor(x)
+        elif array_type == "mlx":
+            return mx.array(x)
         elif array_type == "pandas_data_frame":
             return pandas.DataFrame(x)
         elif array_type == "pandas_series":
@@ -47,6 +50,7 @@ class TestArrayDataAdapter(testing.TestCase):
                 "jax",
                 "jax_sparse",
                 "torch",
+                "mlx",
                 "pandas_data_frame",
                 "pandas_series",
                 "scipy_sparse",
@@ -96,6 +100,9 @@ class TestArrayDataAdapter(testing.TestCase):
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
+        elif backend.backend() == "mlx":
+            it = adapter.get_mlx_iterator()
+            expected_class = mx.array
 
         x_order = []
         y_order = []

--- a/keras/src/trainers/data_adapters/array_slicing.py
+++ b/keras/src/trainers/data_adapters/array_slicing.py
@@ -103,6 +103,20 @@ class Sliceable:
         return x
 
     @classmethod
+    def convert_to_mlx_compatible(cls, x):
+        """Convert a tensor to something that the MLX backend can consume.
+
+        This can be a `MLX` array or a NumPy array.
+        Only called after slicing using `__getitem__`.
+        Used to convert sparse tensors and densify ragged tensors.
+
+        Args:
+            x: the tensor to convert.
+        Returns: the converted tensor.
+        """
+        return x
+
+    @classmethod
     def convert_to_torch_compatible(cls, x):
         """Convert a tensor to something that the Torch backend can consume.
 
@@ -161,6 +175,10 @@ class TensorflowRaggedSliceable(TensorflowSliceable):
         return cls.convert_to_numpy(x)
 
     @classmethod
+    def convert_to_mlx_compatible(cls, x):
+        return cls.convert_to_numpy(x)
+
+    @classmethod
     def convert_to_torch_compatible(cls, x):
         return x.to_tensor()
 
@@ -190,6 +208,12 @@ class TensorflowSparseSliceable(TensorflowSliceable):
 
         return tf_sparse.sparse_to_dense(x)
 
+    @classmethod
+    def convert_to_mlx_compatible(cls, x):
+        from keras.src.backend.tensorflow import sparse as tf_sparse
+
+        return tf_sparse.sparse_to_dense(x)
+
 
 class JaxSparseSliceable(Sliceable):
     def __getitem__(self, indices):
@@ -209,6 +233,10 @@ class JaxSparseSliceable(Sliceable):
 
     @classmethod
     def convert_to_torch_compatible(cls, x):
+        return x.todense()
+
+    @classmethod
+    def convert_to_mlx_compatible(cls, x):
         return x.todense()
 
 
@@ -240,6 +268,10 @@ class PandasSliceable(Sliceable):
 
     @classmethod
     def convert_to_jax_compatible(cls, x):
+        return cls.convert_to_numpy(x)
+
+    @classmethod
+    def convert_to_mlx_compatible(cls, x):
         return cls.convert_to_numpy(x)
 
     @classmethod
@@ -279,6 +311,10 @@ class ScipySparseSliceable(Sliceable):
 
     @classmethod
     def convert_to_torch_compatible(cls, x):
+        return x.todense()
+
+    @classmethod
+    def convert_to_mlx_compatible(cls, x):
         return x.todense()
 
 

--- a/keras/src/trainers/data_adapters/data_adapter_utils.py
+++ b/keras/src/trainers/data_adapters/data_adapter_utils.py
@@ -199,6 +199,19 @@ def get_jax_iterator(iterable):
         yield tree.map_structure(convert_to_jax_compatible, batch)
 
 
+def get_mlx_iterator(iterable):
+    import mlx.core as mx
+
+    def convert_to_mlx(x):
+        if isinstance(x, mx.array):
+            return x
+        else:
+            return mx.array(x)
+
+    for batch in iterable:
+        yield tree.map_structure(convert_to_mlx, batch)
+
+
 def get_numpy_iterator(iterable):
     def convert_to_numpy(x):
         if not isinstance(x, np.ndarray):

--- a/keras/src/trainers/data_adapters/generator_data_adapter.py
+++ b/keras/src/trainers/data_adapters/generator_data_adapter.py
@@ -28,6 +28,9 @@ class GeneratorDataAdapter(DataAdapter):
     def get_jax_iterator(self):
         return data_adapter_utils.get_jax_iterator(self.generator())
 
+    def get_mlx_iterator(self):
+        return data_adapter_utils.get_mlx_iterator(self.generator())
+
     def get_tf_dataset(self):
         from keras.src.utils.module_utils import tensorflow as tf
 

--- a/keras/src/trainers/data_adapters/generator_data_adapter_test.py
+++ b/keras/src/trainers/data_adapters/generator_data_adapter_test.py
@@ -2,6 +2,7 @@ import math
 
 import jax
 import jax.experimental.sparse as jax_sparse
+import mlx.core as mx
 import numpy as np
 import pytest
 import scipy
@@ -38,7 +39,7 @@ class GeneratorDataAdapterTest(testing.TestCase):
                 {"testcase_name": "use_weight", "use_sample_weight": True},
                 {"testcase_name": "no_weight", "use_sample_weight": False},
             ],
-            generator_type=["np", "tf", "jax", "torch"],
+            generator_type=["np", "tf", "jax", "torch", "mlx"],
         )
     )
     def test_basic_flow(self, use_sample_weight, generator_type):
@@ -55,6 +56,8 @@ class GeneratorDataAdapterTest(testing.TestCase):
                 torch.as_tensor(y),
                 torch.as_tensor(sw),
             )
+        elif generator_type == "mlx":
+            x, y, sw = mx.array(x), mx.array(y), mx.array(sw)
         if not use_sample_weight:
             sw = None
         make_generator = example_generator(
@@ -79,6 +82,9 @@ class GeneratorDataAdapterTest(testing.TestCase):
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
+        elif backend.backend() == "mlx":
+            it = adapter.get_mlx_iterator()
+            expected_class = mx.array
 
         sample_order = []
         for i, batch in enumerate(it):
@@ -120,6 +126,8 @@ class GeneratorDataAdapterTest(testing.TestCase):
             it = adapter.get_jax_iterator()
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
+        elif backend.backend() == "mlx":
+            it = adapter.get_mlx_iterator()
 
         for i, batch in enumerate(it):
             self.assertEqual(len(batch), 2)

--- a/keras/src/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter.py
@@ -279,6 +279,9 @@ class PyDatasetAdapter(DataAdapter):
     def get_jax_iterator(self):
         return data_adapter_utils.get_jax_iterator(self._get_iterator())
 
+    def get_mlx_iterator(self):
+        return data_adapter_utils.get_mlx_iterator(self._get_iterator())
+
     def get_tf_dataset(self):
         from keras.src.utils.module_utils import tensorflow as tf
 

--- a/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
@@ -2,6 +2,7 @@ import math
 import time
 
 import jax
+import mlx.core as mx
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -128,6 +129,10 @@ class PyDatasetAdapterTest(testing.TestCase):
                     "testcase_name": "single_torch",
                     "dataset_type": "torch",
                 },
+                {
+                    "testcase_name": "single_mlx",
+                    "dataset_type": "mlx",
+                },
             ],
             infinite=[True, False],
             shuffle=[True, False],
@@ -153,6 +158,7 @@ class PyDatasetAdapterTest(testing.TestCase):
             "jax": "cpu:0",
             "torch": "cpu",
             "numpy": "cpu",
+            "mlx": "cpu",
         }
         with backend.device(CPU_DEVICES[backend.backend()]):
             if dataset_type == "tf":
@@ -161,6 +167,8 @@ class PyDatasetAdapterTest(testing.TestCase):
                 x, y = jax.numpy.array(x), jax.numpy.array(y)
             elif dataset_type == "torch":
                 x, y = torch.as_tensor(x), torch.as_tensor(y)
+            elif dataset_type == "mlx":
+                x, y = mx.array(x), mx.array(y)
         py_dataset = ExamplePyDataset(
             x,
             y,
@@ -186,6 +194,9 @@ class PyDatasetAdapterTest(testing.TestCase):
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
+        elif backend.backend() == "mlx":
+            it = adapter.get_mlx_iterator()
+            expected_class = mx.array
 
         sample_order = []
         adapter.on_epoch_begin()
@@ -236,6 +247,8 @@ class PyDatasetAdapterTest(testing.TestCase):
             gen = adapter.get_jax_iterator()
         elif backend.backend() == "torch":
             gen = adapter.get_torch_dataloader()
+        elif backend.backend() == "mlx":
+            gen = adapter.get_mlx_iterator()
 
         for index, batch in enumerate(gen):
             # Batch is a tuple of (x, y, class_weight)
@@ -351,6 +364,8 @@ class PyDatasetAdapterTest(testing.TestCase):
             it = adapter.get_jax_iterator()
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
+        elif backend.backend() == "mlx":
+            it = adapter.get_mlx_iterator()
 
         for i, batch in enumerate(it):
             self.assertEqual(len(batch), 2)
@@ -414,6 +429,8 @@ class PyDatasetAdapterTest(testing.TestCase):
             it = adapter.get_jax_iterator()
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
+        elif backend.backend() == "mlx":
+            it = adapter.get_mlx_iterator()
 
         it = iter(it)
         next(it)

--- a/keras/src/trainers/data_adapters/tf_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/tf_dataset_adapter.py
@@ -54,6 +54,21 @@ class TFDatasetAdapter(DataAdapter):
         for batch in self._dataset:
             yield tree.map_structure(convert_to_jax, batch)
 
+    def get_mlx_iterator(self):
+        from keras.src.backend.tensorflow.core import sparse_to_dense
+        from keras.src.utils.module_utils import mlx
+        from keras.src.utils.module_utils import tensorflow as tf
+
+        def convert_to_mlx(x):
+            if isinstance(x, tf.SparseTensor):
+                x = sparse_to_dense(x)
+            # tensorflow supports the buffer protocol
+            # but requires explicit memoryview with mlx
+            return mlx.core.array(memoryview(x))
+
+        for batch in self._dataset:
+            yield tree.map_structure(convert_to_mlx, batch)
+
     def get_tf_dataset(self):
         return self._dataset
 

--- a/keras/src/trainers/data_adapters/tf_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/tf_dataset_adapter_test.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import jax
+import mlx.core as mx
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -35,6 +36,9 @@ class TestTFDatasetAdapter(testing.TestCase):
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
+        elif backend.backend() == "mlx":
+            it = adapter.get_mlx_iterator()
+            expected_class = mx.array
 
         for i, batch in enumerate(it):
             self.assertEqual(len(batch), 2)

--- a/keras/src/trainers/data_adapters/torch_data_loader_adapter.py
+++ b/keras/src/trainers/data_adapters/torch_data_loader_adapter.py
@@ -42,6 +42,15 @@ class TorchDataLoaderAdapter(DataAdapter):
         # We use numpy as an intermediary because it is faster.
         return self.get_numpy_iterator()
 
+    def get_mlx_iterator(self):
+        from keras.src.utils.module_utils import mlx
+
+        # mlx requires converting to numpy first for torch tensors for now
+        for batch in self._dataloader:
+            yield tuple(
+                tree.map_structure(lambda x: mlx.core.array(x.numpy()), batch)
+            )
+
     def get_tf_dataset(self):
         from keras.src.utils.module_utils import tensorflow as tf
 

--- a/keras/src/trainers/data_adapters/torch_data_loader_adapter_test.py
+++ b/keras/src/trainers/data_adapters/torch_data_loader_adapter_test.py
@@ -1,5 +1,6 @@
 import math
 
+import mlx.core as mx
 import numpy as np
 import tensorflow as tf
 import torch
@@ -38,6 +39,9 @@ class TestTorchDataLoaderAdapter(testing.TestCase):
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
+        elif backend.backend() == "mlx":
+            it = adapter.get_mlx_iterator()
+            expected_class = mx.array
 
         for i, batch in enumerate(it):
             self.assertEqual(len(batch), 2)
@@ -106,6 +110,9 @@ class TestTorchDataLoaderAdapter(testing.TestCase):
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
+        elif backend.backend() == "mlx":
+            it = adapter.get_mlx_iterator()
+            expected_class = mx.array
 
         batch_count = 0
         for i, batch in enumerate(it):
@@ -156,6 +163,8 @@ class TestTorchDataLoaderAdapter(testing.TestCase):
             it = adapter.get_jax_iterator()
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
+        elif backend.backend() == "mlx":
+            it = adapter.get_mlx_iterator()
 
         for i, batch in enumerate(it):
             self.assertEqual(len(batch), 2)

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -160,6 +160,7 @@ class TestPyDataset(py_dataset_adapter.PyDataset):
             "tensorflow": "CPU:0",
             "jax": "cpu:0",
             "torch": "cpu",
+            "mlx": "cpu",
         }
         with backend.device(CPU_DEVICES[backend.backend()]):
             return ops.ones((5, 4)), ops.zeros((5, 3))

--- a/keras/src/utils/module_utils.py
+++ b/keras/src/utils/module_utils.py
@@ -44,6 +44,7 @@ gfile = LazyModule("tensorflow.io.gfile", pip_name="tensorflow")
 tensorflow_io = LazyModule("tensorflow_io")
 scipy = LazyModule("scipy")
 jax = LazyModule("jax")
+mlx = LazyModule("mlx")
 torchvision = LazyModule("torchvision")
 torch_xla = LazyModule(
     "torch_xla",


### PR DESCRIPTION
This addresses #19571

This update includes:
- `MLXTrainer` update for compilation (heavily mimics jax's trainer)
- all data adapters work with mlx
- faster `bincount`
- added `mlx.core.enable_float64()` similar to jax's `enable_x64()` to put in tests and let the user manage `float64` (must be on cpu)

Note:
- compilation in `MLXTrainer` works great except when `ops.cond` is involved, but can mostly be handled by evaluating both branches and doing a `where`. The most notable occurrence of this is in `loss_scale_optimizer`. I'm going to propose a `_mlx_stateless_apply()` in the next PR that avoids `where`