### PR TITLE
Add elastic_transform processing for image.py

### DIFF
--- a/keras/api/_tf_keras/keras/ops/image/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/image/__init__.py
@@ -6,6 +6,7 @@ since your modifications would be overwritten.
 
 from keras.src.ops.image import affine_transform
 from keras.src.ops.image import crop_images
+from keras.src.ops.image import elastic_transform
 from keras.src.ops.image import extract_patches
 from keras.src.ops.image import gaussian_blur
 from keras.src.ops.image import hsv_to_rgb

--- a/keras/api/ops/image/__init__.py
+++ b/keras/api/ops/image/__init__.py
@@ -6,6 +6,7 @@ since your modifications would be overwritten.
 
 from keras.src.ops.image import affine_transform
 from keras.src.ops.image import crop_images
+from keras.src.ops.image import elastic_transform
 from keras.src.ops.image import extract_patches
 from keras.src.ops.image import gaussian_blur
 from keras.src.ops.image import hsv_to_rgb

--- a/keras/src/backend/jax/image.py
+++ b/keras/src/backend/jax/image.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 
 from keras.src import backend
 from keras.src.backend.jax.core import convert_to_tensor
+from keras.src.random.seed_generator import draw_seed
 
 RESIZE_INTERPOLATIONS = (
     "bilinear",
@@ -731,7 +732,9 @@ def gaussian_blur(
     return blurred_images
 
 
-def elastic_transform(images, alpha=20.0, sigma=5.0, data_format=None):
+def elastic_transform(
+    images, alpha=20.0, sigma=5.0, seed=None, data_format=None
+):
     if len(images.shape) not in (3, 4):
         raise ValueError(
             "Invalid images rank: expected rank 3 (single image) "
@@ -757,12 +760,17 @@ def elastic_transform(images, alpha=20.0, sigma=5.0, data_format=None):
         batch_size, channels, height, width = images.shape
         channel_axis = 1
 
+    seed = draw_seed(seed)
     dx = (
-        jax.random.normal(jax.random.PRNGKey(0), (batch_size, height, width))
+        jax.random.normal(
+            seed, shape=(batch_size, height, width), dtype=input_dtype
+        )
         * sigma
     )
     dy = (
-        jax.random.normal(jax.random.PRNGKey(1), (batch_size, height, width))
+        jax.random.normal(
+            seed, shape=(batch_size, height, width), dtype=input_dtype
+        )
         * sigma
     )
 

--- a/keras/src/backend/jax/image.py
+++ b/keras/src/backend/jax/image.py
@@ -742,6 +742,18 @@ def elastic_transform(
     seed=None,
     data_format=None,
 ):
+    data_format = backend.standardize_data_format(data_format)
+    if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS.keys():
+        raise ValueError(
+            "Invalid value for argument `interpolation`. Expected of one "
+            f"{set(AFFINE_TRANSFORM_INTERPOLATIONS.keys())}. Received: "
+            f"interpolation={interpolation}"
+        )
+    if fill_mode not in AFFINE_TRANSFORM_FILL_MODES:
+        raise ValueError(
+            "Invalid value for argument `fill_mode`. Expected of one "
+            f"{AFFINE_TRANSFORM_FILL_MODES}. Received: fill_mode={fill_mode}"
+        )
     if len(images.shape) not in (3, 4):
         raise ValueError(
             "Invalid images rank: expected rank 3 (single image) "

--- a/keras/src/backend/jax/image.py
+++ b/keras/src/backend/jax/image.py
@@ -733,7 +733,12 @@ def gaussian_blur(
 
 
 def elastic_transform(
-    images, alpha=20.0, sigma=5.0, seed=None, data_format=None
+    images,
+    alpha=20.0,
+    sigma=5.0,
+    interpolation="bilinear",
+    seed=None,
+    data_format=None,
 ):
     if len(images.shape) not in (3, 4):
         raise ValueError(
@@ -806,7 +811,9 @@ def elastic_transform(
                         map_coordinates(
                             images[b, ..., i],
                             [distorted_y[b], distorted_x[b]],
-                            order=AFFINE_TRANSFORM_INTERPOLATIONS["bilinear"],
+                            order=AFFINE_TRANSFORM_INTERPOLATIONS[
+                                interpolation
+                            ],
                             fill_mode="reflect",
                         )
                         for b in range(batch_size)
@@ -821,7 +828,9 @@ def elastic_transform(
                         map_coordinates(
                             images[b, i, ...],
                             [distorted_y[b], distorted_x[b]],
-                            order=AFFINE_TRANSFORM_INTERPOLATIONS["bilinear"],
+                            order=AFFINE_TRANSFORM_INTERPOLATIONS[
+                                interpolation
+                            ],
                             fill_mode="reflect",
                         )
                         for b in range(batch_size)

--- a/keras/src/backend/jax/image.py
+++ b/keras/src/backend/jax/image.py
@@ -737,6 +737,8 @@ def elastic_transform(
     alpha=20.0,
     sigma=5.0,
     interpolation="bilinear",
+    fill_mode="reflect",
+    fill_value=0.0,
     seed=None,
     data_format=None,
 ):
@@ -814,7 +816,8 @@ def elastic_transform(
                             order=AFFINE_TRANSFORM_INTERPOLATIONS[
                                 interpolation
                             ],
-                            fill_mode="reflect",
+                            fill_mode=fill_mode,
+                            fill_value=fill_value,
                         )
                         for b in range(batch_size)
                     ]
@@ -831,7 +834,8 @@ def elastic_transform(
                             order=AFFINE_TRANSFORM_INTERPOLATIONS[
                                 interpolation
                             ],
-                            fill_mode="reflect",
+                            fill_mode=fill_mode,
+                            fill_value=fill_value,
                         )
                         for b in range(batch_size)
                     ]

--- a/keras/src/backend/jax/image.py
+++ b/keras/src/backend/jax/image.py
@@ -729,3 +729,100 @@ def gaussian_blur(
         blurred_images = blurred_images.squeeze(axis=0)
 
     return blurred_images
+
+
+def elastic_transform(images, alpha=20.0, sigma=5.0, data_format=None):
+    if len(images.shape) not in (3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 3 (single image) "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    images = convert_to_tensor(images)
+    alpha = convert_to_tensor(alpha)
+    sigma = convert_to_tensor(sigma)
+    input_dtype = images.dtype
+    kernel_size = (int(6 * sigma) | 1, int(6 * sigma) | 1)
+
+    need_squeeze = False
+    if len(images.shape) == 3:
+        images = jnp.expand_dims(images, axis=0)
+        need_squeeze = True
+
+    if data_format == "channels_last":
+        batch_size, height, width, channels = images.shape
+        channel_axis = -1
+    else:
+        batch_size, channels, height, width = images.shape
+        channel_axis = 1
+
+    dx = (
+        jax.random.normal(jax.random.PRNGKey(0), (batch_size, height, width))
+        * sigma
+    )
+    dy = (
+        jax.random.normal(jax.random.PRNGKey(1), (batch_size, height, width))
+        * sigma
+    )
+
+    dx = gaussian_blur(
+        jnp.expand_dims(dx, axis=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+    dy = gaussian_blur(
+        jnp.expand_dims(dy, axis=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+
+    dx = jnp.squeeze(dx)
+    dy = jnp.squeeze(dy)
+
+    x, y = jnp.meshgrid(jnp.arange(width), jnp.arange(height))
+    x, y = x[None, :, :], y[None, :, :]
+
+    distorted_x = x + alpha * dx
+    distorted_y = y + alpha * dy
+
+    transformed_images = jnp.zeros_like(images)
+
+    if data_format == "channels_last":
+        for i in range(channels):
+            transformed_images = transformed_images.at[..., i].set(
+                jnp.stack(
+                    [
+                        map_coordinates(
+                            images[b, ..., i],
+                            [distorted_y[b], distorted_x[b]],
+                            order=AFFINE_TRANSFORM_INTERPOLATIONS["bilinear"],
+                            fill_mode="reflect",
+                        )
+                        for b in range(batch_size)
+                    ]
+                )
+            )
+    else:
+        for i in range(channels):
+            transformed_images = transformed_images.at[:, i, :, :].set(
+                jnp.stack(
+                    [
+                        map_coordinates(
+                            images[b, i, ...],
+                            [distorted_y[b], distorted_x[b]],
+                            order=AFFINE_TRANSFORM_INTERPOLATIONS["bilinear"],
+                            fill_mode="reflect",
+                        )
+                        for b in range(batch_size)
+                    ]
+                )
+            )
+
+    if need_squeeze:
+        transformed_images = jnp.squeeze(transformed_images, axis=0)
+    transformed_images = transformed_images.astype(input_dtype)
+
+    return transformed_images

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -891,6 +891,18 @@ def elastic_transform(
     seed=None,
     data_format=None,
 ):
+    data_format = backend.standardize_data_format(data_format)
+    if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS.keys():
+        raise ValueError(
+            "Invalid value for argument `interpolation`. Expected of one "
+            f"{set(AFFINE_TRANSFORM_INTERPOLATIONS.keys())}. Received: "
+            f"interpolation={interpolation}"
+        )
+    if fill_mode not in AFFINE_TRANSFORM_FILL_MODES:
+        raise ValueError(
+            "Invalid value for argument `fill_mode`. Expected of one "
+            f"{AFFINE_TRANSFORM_FILL_MODES}. Received: fill_mode={fill_mode}"
+        )
     if len(images.shape) not in (3, 4):
         raise ValueError(
             "Invalid images rank: expected rank 3 (single image) "

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -906,8 +906,8 @@ def elastic_transform(images, alpha=20.0, sigma=5.0, data_format=None):
         batch_size, channels, height, width = images.shape
         channel_axis = 1
 
-    dx = np.random.randn(batch_size, height, width).astype(np.float32) * sigma
-    dy = np.random.randn(batch_size, height, width).astype(np.float32) * sigma
+    dx = np.random.randn(batch_size, height, width).astype(input_dtype) * sigma
+    dy = np.random.randn(batch_size, height, width).astype(input_dtype) * sigma
 
     dx = gaussian_blur(
         np.expand_dims(dx, axis=channel_axis),

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -882,7 +882,12 @@ def gaussian_blur(
 
 
 def elastic_transform(
-    images, alpha=20.0, sigma=5.0, seed=None, data_format=None
+    images,
+    alpha=20.0,
+    sigma=5.0,
+    interpolation="bilinear",
+    seed=None,
+    data_format=None,
 ):
     if len(images.shape) not in (3, 4):
         raise ValueError(
@@ -957,7 +962,7 @@ def elastic_transform(
                     map_coordinates(
                         images[b, ..., i],
                         [distorted_y[b], distorted_x[b]],
-                        order=AFFINE_TRANSFORM_INTERPOLATIONS["bilinear"],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
                         fill_mode="reflect",
                     )
                     for b in range(batch_size)

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -886,6 +886,8 @@ def elastic_transform(
     alpha=20.0,
     sigma=5.0,
     interpolation="bilinear",
+    fill_mode="reflect",
+    fill_value=0.0,
     seed=None,
     data_format=None,
 ):
@@ -963,7 +965,8 @@ def elastic_transform(
                         images[b, ..., i],
                         [distorted_y[b], distorted_x[b]],
                         order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
-                        fill_mode="reflect",
+                        fill_mode=fill_mode,
+                        fill_value=fill_value,
                     )
                     for b in range(batch_size)
                 ]
@@ -975,8 +978,9 @@ def elastic_transform(
                     map_coordinates(
                         images[b, i, ...],
                         [distorted_y[b], distorted_x[b]],
-                        order=AFFINE_TRANSFORM_INTERPOLATIONS["bilinear"],
-                        fill_mode="reflect",
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
+                        fill_mode=fill_mode,
+                        fill_value=fill_value,
                     )
                     for b in range(batch_size)
                 ]

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -878,3 +878,90 @@ def gaussian_blur(
         blurred_images = np.squeeze(blurred_images, axis=0)
 
     return blurred_images
+
+
+def elastic_transform(images, alpha=20.0, sigma=5.0, data_format=None):
+    if len(images.shape) not in (3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 3 (single image) "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    images = convert_to_tensor(images)
+    alpha = convert_to_tensor(alpha)
+    sigma = convert_to_tensor(sigma)
+    input_dtype = images.dtype
+    kernel_size = (int(6 * sigma) | 1, int(6 * sigma) | 1)
+
+    need_squeeze = False
+    if len(images.shape) == 3:
+        images = np.expand_dims(images, axis=0)
+        need_squeeze = True
+
+    if data_format == "channels_last":
+        batch_size, height, width, channels = images.shape
+        channel_axis = -1
+    else:
+        batch_size, channels, height, width = images.shape
+        channel_axis = 1
+
+    dx = np.random.randn(batch_size, height, width).astype(np.float32) * sigma
+    dy = np.random.randn(batch_size, height, width).astype(np.float32) * sigma
+
+    dx = gaussian_blur(
+        np.expand_dims(dx, axis=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+    dy = gaussian_blur(
+        np.expand_dims(dy, axis=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+
+    dx = np.squeeze(dx)
+    dy = np.squeeze(dy)
+
+    x, y = np.meshgrid(np.arange(width), np.arange(height))
+    x, y = x[None, :, :], y[None, :, :]
+
+    distorted_x = x + alpha * dx
+    distorted_y = y + alpha * dy
+
+    transformed_images = np.zeros_like(images)
+
+    if data_format == "channels_last":
+        for i in range(channels):
+            transformed_images[..., i] = np.stack(
+                [
+                    map_coordinates(
+                        images[b, ..., i],
+                        [distorted_y[b], distorted_x[b]],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS["bilinear"],
+                        fill_mode="reflect",
+                    )
+                    for b in range(batch_size)
+                ]
+            )
+    else:
+        for i in range(channels):
+            transformed_images[:, i, :, :] = np.stack(
+                [
+                    map_coordinates(
+                        images[b, i, ...],
+                        [distorted_y[b], distorted_x[b]],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS["bilinear"],
+                        fill_mode="reflect",
+                    )
+                    for b in range(batch_size)
+                ]
+            )
+
+    if need_squeeze:
+        transformed_images = np.squeeze(transformed_images, axis=0)
+    transformed_images = transformed_images.astype(input_dtype)
+
+    return transformed_images

--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -780,7 +780,12 @@ def gaussian_blur(
 
 
 def elastic_transform(
-    images, alpha=20.0, sigma=5.0, seed=None, data_format=None
+    images,
+    alpha=20.0,
+    sigma=5.0,
+    interpolation="bilinear",
+    seed=None,
+    data_format=None,
 ):
     if len(images.shape) not in (3, 4):
         raise ValueError(
@@ -859,7 +864,9 @@ def elastic_transform(
                     map_coordinates(
                         images[b, ..., i],
                         [distorted_y[b], distorted_x[b]],
-                        order=1,
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS.index(
+                            interpolation
+                        ),
                         fill_mode="reflect",
                     )
                     for b in range(batch_size)
@@ -875,7 +882,9 @@ def elastic_transform(
                     map_coordinates(
                         images[b, i, ...],
                         [distorted_y[b], distorted_x[b]],
-                        order=1,
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS.index(
+                            interpolation
+                        ),
                         fill_mode="reflect",
                     )
                     for b in range(batch_size)

--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -784,6 +784,8 @@ def elastic_transform(
     alpha=20.0,
     sigma=5.0,
     interpolation="bilinear",
+    fill_mode="reflect",
+    fill_value=0.0,
     seed=None,
     data_format=None,
 ):
@@ -867,7 +869,8 @@ def elastic_transform(
                         order=AFFINE_TRANSFORM_INTERPOLATIONS.index(
                             interpolation
                         ),
-                        fill_mode="reflect",
+                        fill_mode=fill_mode,
+                        fill_value=fill_value,
                     )
                     for b in range(batch_size)
                 ],
@@ -885,7 +888,8 @@ def elastic_transform(
                         order=AFFINE_TRANSFORM_INTERPOLATIONS.index(
                             interpolation
                         ),
-                        fill_mode="reflect",
+                        fill_mode=fill_mode,
+                        fill_value=fill_value,
                     )
                     for b in range(batch_size)
                 ],

--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -6,6 +6,7 @@ import tensorflow as tf
 
 from keras.src import backend
 from keras.src.backend.tensorflow.core import convert_to_tensor
+from keras.src.random.seed_generator import draw_seed
 
 RESIZE_INTERPOLATIONS = (
     "bilinear",
@@ -778,7 +779,9 @@ def gaussian_blur(
     return blurred_images
 
 
-def elastic_transform(images, alpha=20.0, sigma=5.0, data_format=None):
+def elastic_transform(
+    images, alpha=20.0, sigma=5.0, seed=None, data_format=None
+):
     if len(images.shape) not in (3, 4):
         raise ValueError(
             "Invalid images rank: expected rank 3 (single image) "
@@ -805,11 +808,20 @@ def elastic_transform(images, alpha=20.0, sigma=5.0, data_format=None):
         batch_size, channels, height, width = images.shape
         channel_axis = 1
 
-    dx = (
-        tf.random.normal([batch_size, height, width], dtype=input_dtype) * sigma
+    seed = draw_seed(seed)
+    dx = tf.random.stateless_normal(
+        shape=(batch_size, height, width),
+        mean=0.0,
+        stddev=1.0,
+        dtype=input_dtype,
+        seed=seed,
     )
-    dy = (
-        tf.random.normal([batch_size, height, width], dtype=input_dtype) * sigma
+    dy = tf.random.stateless_normal(
+        shape=(batch_size, height, width),
+        mean=0.0,
+        stddev=1.0,
+        dtype=input_dtype,
+        seed=seed,
     )
 
     dx = gaussian_blur(

--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -789,6 +789,18 @@ def elastic_transform(
     seed=None,
     data_format=None,
 ):
+    data_format = backend.standardize_data_format(data_format)
+    if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS:
+        raise ValueError(
+            "Invalid value for argument `interpolation`. Expected of one "
+            f"{AFFINE_TRANSFORM_INTERPOLATIONS}. Received: "
+            f"interpolation={interpolation}"
+        )
+    if fill_mode not in AFFINE_TRANSFORM_FILL_MODES:
+        raise ValueError(
+            "Invalid value for argument `fill_mode`. Expected of one "
+            f"{AFFINE_TRANSFORM_FILL_MODES}. Received: fill_mode={fill_mode}"
+        )
     if len(images.shape) not in (3, 4):
         raise ValueError(
             "Invalid images rank: expected rank 3 (single image) "

--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -776,3 +776,105 @@ def gaussian_blur(
         blurred_images = tf.squeeze(blurred_images, axis=0)
 
     return blurred_images
+
+
+def elastic_transform(images, alpha=20.0, sigma=5.0, data_format=None):
+    if len(images.shape) not in (3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 3 (single image) "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    images = convert_to_tensor(images)
+    input_dtype = images.dtype
+
+    alpha = convert_to_tensor(alpha, dtype=input_dtype)
+    sigma = convert_to_tensor(sigma, dtype=input_dtype)
+    kernel_size = (int(6 * sigma) | 1, int(6 * sigma) | 1)
+
+    need_squeeze = False
+    if len(images.shape) == 3:
+        images = tf.expand_dims(images, axis=0)
+        need_squeeze = True
+
+    if data_format == "channels_last":
+        batch_size, height, width, channels = images.shape
+        channel_axis = -1
+    else:
+        batch_size, channels, height, width = images.shape
+        channel_axis = 1
+
+    dx = (
+        tf.random.normal([batch_size, height, width], dtype=input_dtype) * sigma
+    )
+    dy = (
+        tf.random.normal([batch_size, height, width], dtype=input_dtype) * sigma
+    )
+
+    dx = gaussian_blur(
+        tf.expand_dims(dx, axis=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+    dy = gaussian_blur(
+        tf.expand_dims(dy, axis=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+
+    dx = tf.squeeze(dx, axis=channel_axis)
+    dy = tf.squeeze(dy, axis=channel_axis)
+
+    x, y = tf.meshgrid(
+        tf.range(width, dtype=input_dtype),
+        tf.range(height, dtype=input_dtype),
+        indexing="xy",
+    )
+    x = tf.expand_dims(x, axis=0)
+    y = tf.expand_dims(y, axis=0)
+
+    distorted_x = x + alpha * dx
+    distorted_y = y + alpha * dy
+
+    channel_outputs = []
+    if data_format == "channels_last":
+        for i in range(channels):
+            channel_transformed = tf.stack(
+                [
+                    map_coordinates(
+                        images[b, ..., i],
+                        [distorted_y[b], distorted_x[b]],
+                        order=1,
+                        fill_mode="reflect",
+                    )
+                    for b in range(batch_size)
+                ],
+                axis=0,
+            )
+            channel_outputs.append(channel_transformed)
+        transformed_images = tf.stack(channel_outputs, axis=-1)
+    else:
+        for i in range(channels):
+            channel_transformed = tf.stack(
+                [
+                    map_coordinates(
+                        images[b, i, ...],
+                        [distorted_y[b], distorted_x[b]],
+                        order=1,
+                        fill_mode="reflect",
+                    )
+                    for b in range(batch_size)
+                ],
+                axis=0,
+            )
+            channel_outputs.append(channel_transformed)
+        transformed_images = tf.stack(channel_outputs, axis=1)
+
+    if need_squeeze:
+        transformed_images = tf.squeeze(transformed_images, axis=0)
+    transformed_images = tf.cast(transformed_images, input_dtype)
+
+    return transformed_images

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -903,6 +903,8 @@ def elastic_transform(
     alpha=20.0,
     sigma=5.0,
     interpolation="bilinear",
+    fill_mode="reflect",
+    fill_value=0.0,
     seed=None,
     data_format=None,
 ):
@@ -990,7 +992,8 @@ def elastic_transform(
                         images[b, ..., i],
                         [distorted_y[b], distorted_x[b]],
                         order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
-                        fill_mode="reflect",
+                        fill_mode=fill_mode,
+                        fill_value=fill_value,
                     )
                     for b in range(batch_size)
                 ]
@@ -1003,7 +1006,8 @@ def elastic_transform(
                         images[b, i, ...],
                         [distorted_y[b], distorted_x[b]],
                         order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
-                        fill_mode="reflect",
+                        fill_mode=fill_mode,
+                        fill_value=fill_value,
                     )
                     for b in range(batch_size)
                 ]

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -899,7 +899,12 @@ def torch_seed_generator(seed):
 
 
 def elastic_transform(
-    images, alpha=20.0, sigma=5.0, seed=None, data_format=None
+    images,
+    alpha=20.0,
+    sigma=5.0,
+    interpolation="bilinear",
+    seed=None,
+    data_format=None,
 ):
     images = convert_to_tensor(images)
     alpha = convert_to_tensor(alpha)
@@ -984,7 +989,7 @@ def elastic_transform(
                     map_coordinates(
                         images[b, ..., i],
                         [distorted_y[b], distorted_x[b]],
-                        order=AFFINE_TRANSFORM_INTERPOLATIONS["bilinear"],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
                         fill_mode="reflect",
                     )
                     for b in range(batch_size)
@@ -997,7 +1002,7 @@ def elastic_transform(
                     map_coordinates(
                         images[b, i, ...],
                         [distorted_y[b], distorted_x[b]],
-                        order=AFFINE_TRANSFORM_INTERPOLATIONS["bilinear"],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS[interpolation],
                         fill_mode="reflect",
                     )
                     for b in range(batch_size)

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -833,7 +833,6 @@ def gaussian_blur(
             return kernel1d / torch.sum(kernel1d)
 
         def _get_gaussian_kernel2d(size, sigma):
-            size = torch.tensor(size, dtype=dtype)
             kernel1d_x = _get_gaussian_kernel1d(size[0], sigma[0])
             kernel1d_y = _get_gaussian_kernel1d(size[1], sigma[1])
             return torch.outer(kernel1d_y, kernel1d_x)
@@ -868,8 +867,6 @@ def gaussian_blur(
 
     kernel = kernel.expand(num_channels, 1, kernel_size[0], kernel_size[1])
 
-    print(kernel_size[0] // 2)
-
     blurred_images = torch.nn.functional.conv2d(
         images,
         kernel,
@@ -885,3 +882,92 @@ def gaussian_blur(
         blurred_images = blurred_images.squeeze(dim=0)
 
     return blurred_images
+
+
+def elastic_transform(images, alpha=20.0, sigma=5.0, data_format=None):
+    images = convert_to_tensor(images)
+    alpha = convert_to_tensor(alpha)
+    sigma = convert_to_tensor(sigma)
+    input_dtype = images.dtype
+    kernel_size = (int(6 * sigma) | 1, int(6 * sigma) | 1)
+
+    if len(images.shape) not in (3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 3 (single image) "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    need_squeeze = False
+    if images.ndim == 3:
+        images = images.unsqueeze(dim=0)
+        need_squeeze = True
+
+    if data_format == "channels_last":
+        batch_size, height, width, channels = images.shape
+        channel_axis = -1
+    else:
+        batch_size, channels, height, width = images.shape
+        channel_axis = 1
+
+    dx = torch.randn(batch_size, height, width, dtype=input_dtype) * sigma
+    dy = torch.randn(batch_size, height, width, dtype=input_dtype) * sigma
+
+    dx = gaussian_blur(
+        dx.unsqueeze(dim=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+    dy = gaussian_blur(
+        dy.unsqueeze(dim=channel_axis),
+        kernel_size=kernel_size,
+        sigma=(sigma, sigma),
+        data_format=data_format,
+    )
+
+    dx = dx.squeeze()
+    dy = dy.squeeze()
+
+    x, y = torch.meshgrid(
+        torch.arange(width), torch.arange(height), indexing="xy"
+    )
+    x, y = x.unsqueeze(0), y.unsqueeze(0)
+
+    distorted_x = x + alpha * dx
+    distorted_y = y + alpha * dy
+
+    transformed_images = torch.zeros_like(images)
+
+    if data_format == "channels_last":
+        for i in range(channels):
+            transformed_images[..., i] = torch.stack(
+                [
+                    map_coordinates(
+                        images[b, ..., i],
+                        [distorted_y[b], distorted_x[b]],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS["bilinear"],
+                        fill_mode="reflect",
+                    )
+                    for b in range(batch_size)
+                ]
+            )
+    else:
+        for i in range(channels):
+            transformed_images[:, i, :, :] = torch.stack(
+                [
+                    map_coordinates(
+                        images[b, i, ...],
+                        [distorted_y[b], distorted_x[b]],
+                        order=AFFINE_TRANSFORM_INTERPOLATIONS["bilinear"],
+                        fill_mode="reflect",
+                    )
+                    for b in range(batch_size)
+                ]
+            )
+
+    if need_squeeze:
+        transformed_images = transformed_images.squeeze(0)
+    transformed_images = transformed_images.to(input_dtype)
+
+    return transformed_images

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -908,18 +908,30 @@ def elastic_transform(
     seed=None,
     data_format=None,
 ):
-    images = convert_to_tensor(images)
-    alpha = convert_to_tensor(alpha)
-    sigma = convert_to_tensor(sigma)
-    input_dtype = images.dtype
-    kernel_size = (int(6 * sigma) | 1, int(6 * sigma) | 1)
-
+    data_format = backend.standardize_data_format(data_format)
+    if interpolation not in AFFINE_TRANSFORM_INTERPOLATIONS.keys():
+        raise ValueError(
+            "Invalid value for argument `interpolation`. Expected of one "
+            f"{set(AFFINE_TRANSFORM_INTERPOLATIONS.keys())}. Received: "
+            f"interpolation={interpolation}"
+        )
+    if fill_mode not in AFFINE_TRANSFORM_FILL_MODES:
+        raise ValueError(
+            "Invalid value for argument `fill_mode`. Expected of one "
+            f"{AFFINE_TRANSFORM_FILL_MODES}. Received: fill_mode={fill_mode}"
+        )
     if len(images.shape) not in (3, 4):
         raise ValueError(
             "Invalid images rank: expected rank 3 (single image) "
             "or rank 4 (batch of images). Received input with shape: "
             f"images.shape={images.shape}"
         )
+
+    images = convert_to_tensor(images)
+    alpha = convert_to_tensor(alpha)
+    sigma = convert_to_tensor(sigma)
+    input_dtype = images.dtype
+    kernel_size = (int(6 * sigma) | 1, int(6 * sigma) | 1)
 
     need_squeeze = False
     if images.ndim == 3:


### PR DESCRIPTION
I have added the elastic_transform method for NumPy, TensorFlow, Torch, and JAX. If this concept and implementation prove to be effective, I can proceed with adding the ops layer and corresponding test cases.

torchvision's [elastic_transform](https://pytorch.org/vision/main/generated/torchvision.transforms.ElasticTransform.html)
here is my [gist](https://colab.research.google.com/drive/1upYpl7yfeqsO4BXIS1fpeEZmqEBNsH_z?usp=sharing)