### PR TITLE
Enable cuDNN RNNs when dropout is set and `training=True`

### DIFF
--- a/keras/src/layers/rnn/gru.py
+++ b/keras/src/layers/rnn/gru.py
@@ -354,7 +354,7 @@ class GRU(RNN):
 
     1. `activation` == `tanh`
     2. `recurrent_activation` == `sigmoid`
-    3. `dropout` == 0 and `recurrent_dropout` == 0
+    3. `recurrent_dropout` == 0
     4. `unroll` is `False`
     5. `use_bias` is `True`
     6. `reset_after` is `True`
@@ -553,7 +553,7 @@ class GRU(RNN):
         if self.use_cudnn in ("auto", True):
             if not self.recurrent_dropout:
                 try:
-                    if self.dropout:
+                    if training and self.dropout:
                         dp_mask = self.cell.get_dropout_mask(sequences[:, 0, :])
                         dp_mask = ops.expand_dims(dp_mask, axis=1)
                         dp_mask = ops.broadcast_to(

--- a/keras/src/layers/rnn/lstm.py
+++ b/keras/src/layers/rnn/lstm.py
@@ -343,7 +343,7 @@ class LSTM(RNN):
 
     1. `activation` == `tanh`
     2. `recurrent_activation` == `sigmoid`
-    3. `dropout` == 0 and `recurrent_dropout` == 0
+    3. `recurrent_dropout` == 0
     4. `unroll` is `False`
     5. `use_bias` is `True`
     6. Inputs, if use masking, are strictly right-padded.
@@ -534,7 +534,7 @@ class LSTM(RNN):
         if self.use_cudnn in ("auto", True):
             if not self.recurrent_dropout:
                 try:
-                    if self.dropout:
+                    if training and self.dropout:
                         dp_mask = self.cell.get_dropout_mask(sequences[:, 0, :])
                         dp_mask = ops.expand_dims(dp_mask, axis=1)
                         dp_mask = ops.broadcast_to(


### PR DESCRIPTION
After [this PR](https://github.com/keras-team/keras/pull/19645) we can dropout input in cuDNN-based RNN. This PR fixes docstring to reflect the new implementation. Furthermore we don't want to apply dropout during inference like happens when `self.use_cudnn` is `False`: https://github.com/keras-team/keras/blob/c356cae26e36ecd726dc1d5d41282dccdadf5f65/keras/src/layers/rnn/lstm.py#L274-L276