### PR TITLE
Fixes inconsistent serialization logic for inputs

### DIFF
--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -618,8 +618,6 @@ def functional_from_config(cls, config, custom_objects=None):
 
     input_tensors = map_tensors(functional_config["input_layers"])
     output_tensors = map_tensors(functional_config["output_layers"])
-    if isinstance(input_tensors, list) and len(input_tensors) == 1:
-        input_tensors = input_tensors[0]
     if isinstance(output_tensors, list) and len(output_tensors) == 1:
         output_tensors = output_tensors[0]
 

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 from absl.testing import parameterized
 
-import keras
 from keras.src import applications
 from keras.src import backend
 from keras.src import layers
@@ -17,6 +16,7 @@ from keras.src.layers.input_spec import InputSpec
 from keras.src.models import Functional
 from keras.src.models import Model
 from keras.src.models import Sequential
+from keras.src.models.model import model_from_json
 
 
 class FunctionalTest(testing.TestCase):
@@ -281,9 +281,7 @@ class FunctionalTest(testing.TestCase):
 
         # Serialize and deserialize the model
         json_config = model.to_json()
-        restored_json_config = keras.models.model_from_json(
-            json_config
-        ).to_json()
+        restored_json_config = model_from_json(json_config).to_json()
 
         # Check that the serialized model is the same as the original
         self.assertEqual(json_config, restored_json_config)

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from absl.testing import parameterized
 
+import keras
 from keras.src import applications
 from keras.src import backend
 from keras.src import layers
@@ -271,6 +272,21 @@ class FunctionalTest(testing.TestCase):
         # Symbolic call
         out_val = model_restored(Input(shape=(3,), batch_size=2))
         self.assertIsInstance(out_val, out_type)
+
+    def test_restored_nested_input(self):
+        input_a = Input(shape=(3,), batch_size=2, name="input_a")
+        x = layers.Dense(5)(input_a)
+        outputs = layers.Dense(4)(x)
+        model = Functional([[input_a]], outputs)
+
+        # Serialize and deserialize the model
+        json_config = model.to_json()
+        restored_json_config = keras.models.model_from_json(
+            json_config
+        ).to_json()
+
+        # Check that the serialized model is the same as the original
+        self.assertEqual(json_config, restored_json_config)
 
     @pytest.mark.requires_trainable_backend
     def test_layer_getters(self):


### PR DESCRIPTION
## Issue
Consider a model where its `input` property is represented as `[[[input_layer_1, 0, 0]]]`.
When serialized and deserialized, it turns into `[[input_layer_1, 0, 0]]`.

## Fix
This change removes the input_tensor un-nesting logic from `functional_from_config` method which adds special handling for the above case, now the code proceeds with the regular flow irrespective of triply nested input arrays and maintains consistent representations across serialization round-trips.