### PR TITLE
`mlx` - updates post compilation

### DIFF
--- a/keras/src/backend/mlx/core.py
+++ b/keras/src/backend/mlx/core.py
@@ -114,6 +114,11 @@ def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
         # load h5py._hl.dataset.Dataset object with numpy
         x = np.array(x)
 
+    if x is None:
+        # this is needed for tracking
+        # mlx.array returns a TypeError when called with None
+        raise ValueError("mlx cannot convert `None` to array")
+
     return mx.array(x, dtype=mlx_dtype)
 
 

--- a/keras/src/backend/mlx/export.py
+++ b/keras/src/backend/mlx/export.py
@@ -1,8 +1,45 @@
+from keras.src import layers
+from keras.src import tree
+
+
 class MlxExportArchive:
+    def __init__(self):
+        self._backend_variables = []
+        self._backend_trainable_variables = []
+        self._backend_non_trainable_variables = []
+
     def track(self, resource):
-        raise NotImplementedError(
-            "`track` is not implemented in the mlx backend."
-        )
+        if not isinstance(resource, layers.Layer):
+            raise ValueError(
+                "Invalid resource type. Expected an instance of a "
+                "MLX-based Keras `Layer` or `Model`. "
+                f"Received instead an object of type '{type(resource)}'. "
+                f"Object received: {resource}"
+            )
+
+        if isinstance(resource, layers.Layer):
+            # Variables in the lists below are actually part of the trackables
+            # that get saved, because the lists are created in __init__.
+            trainable_variables = resource.trainable_variables
+            non_trainable_variables = resource.non_trainable_variables
+
+            self._tf_trackable.trainable_variables += tree.map_structure(
+                self._convert_to_tf_variable, trainable_variables
+            )
+            self._tf_trackable.non_trainable_variables += tree.map_structure(
+                self._convert_to_tf_variable, non_trainable_variables
+            )
+            self._tf_trackable.variables = (
+                self._tf_trackable.trainable_variables
+                + self._tf_trackable.non_trainable_variables
+            )
+
+            self._backend_trainable_variables += trainable_variables
+            self._backend_non_trainable_variables += non_trainable_variables
+            self._backend_variables = (
+                self._backend_trainable_variables
+                + self._backend_non_trainable_variables
+            )
 
     def add_endpoint(self, name, fn, input_signature=None, **kwargs):
         raise NotImplementedError(

--- a/keras/src/backend/mlx/nn.py
+++ b/keras/src/backend/mlx/nn.py
@@ -1295,9 +1295,6 @@ def dot_product_attention(
     key = convert_to_tensor(key)
     value = convert_to_tensor(value)
 
-    query = convert_to_tensor(query)
-    key = convert_to_tensor(key)
-    value = convert_to_tensor(value)
     if len(query.shape) != 4:
         raise ValueError(
             "`dot_product_attention` only supports 4D inputs. "

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -382,6 +382,10 @@ class EinsumDenseTest(testing.TestCase):
 
     # Test quantization-related (int8 and float8) methods
 
+    @pytest.mark.skipif(
+        backend.backend() == "mlx",
+        reason="mlx backend doesn't int8 matmul.",
+    )
     def test_quantize_int8(self):
         layer = layers.EinsumDense(
             equation="ab,bcd->acd",
@@ -469,6 +473,10 @@ class EinsumDenseTest(testing.TestCase):
         ("btnh,nhd->btd", "btnh,nhd->btd", (None, 8), (1, 2, 2, 4)),
         ("btd,ndh->btnh", "btd,ndh->btnh", (None, 2, 8), (1, 2, 4)),
         ("btd,df->btf", "btd,df->btf", (None, 4), (1, 2, 4)),
+    )
+    @pytest.mark.skipif(
+        backend.backend() == "mlx",
+        reason="mlx backend doesn't int8 matmul.",
     )
     def test_quantize_int8_with_specific_equations(
         self, equation, output_shape, input_shape
@@ -608,6 +616,11 @@ class EinsumDenseTest(testing.TestCase):
     def test_quantize_dtype_argument(
         self, dtype, num_trainable_weights, num_non_trainable_weights
     ):
+        if backend.backend() == "mlx":
+            if "int8" in dtype:
+                self.skipTest("mlx backend doesn't support int8 matmul")
+            if "float8" in dtype:
+                self.skipTest("mlx backend doesn't support float8")
         self.run_layer_test(
             layers.EinsumDense,
             init_kwargs={
@@ -630,6 +643,10 @@ class EinsumDenseTest(testing.TestCase):
         ("btd,ndh->btnh", "btd,ndh->btnh", (1, 4, 32), (1, 4, 8, 16)),
     )
     @pytest.mark.requires_trainable_backend
+    @pytest.mark.skipif(
+        backend.backend() == "mlx",
+        reason="mlx backend doesn't int8 matmul.",
+    )
     def test_quantize_int8_when_lora_enabled(
         self, equation, input_shape, output_shape
     ):

--- a/keras/src/layers/reshaping/up_sampling2d_test.py
+++ b/keras/src/layers/reshaping/up_sampling2d_test.py
@@ -128,6 +128,9 @@ class UpSampling2dTest(testing.TestCase):
     def test_upsampling_2d_various_interpolation_methods(self):
         input_shape = (2, 2, 1, 3)
         x = np.arange(np.prod(input_shape)).reshape(input_shape)
+        if backend.backend() == "mlx":
+            # mlx does not support integer matmul
+            x = x.astype("float32")
         for interpolation in ["nearest", "bilinear", "bicubic"]:
             layers.UpSampling2D(size=(1, 2), interpolation=interpolation)(x)
 

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -1518,6 +1518,12 @@ def convert_binary_labels_to_hinge(y_true):
         # Returns the labels unchanged if they are non-binary
         return y_true
 
+    if backend.backend() == "mlx":
+        # ops.cond is non-compilable with mlx backend
+        return ops.where(
+            is_binary, _convert_binary_labels(), _return_labels_unconverted()
+        )
+
     updated_y_true = ops.cond(
         is_binary, _convert_binary_labels, _return_labels_unconverted
     )

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -779,6 +779,12 @@ class ModelTest(testing.TestCase):
         ("float8", "float8"),
     )
     def test_quantize(self, mode):
+        if backend.backend() == "mlx":
+            self.skipTest(
+                "mlx backend does not support float8."
+                if mode == "float8"
+                else "mlx backend does not support integer matmul"
+            )
         model = _get_model()
         x1 = np.random.rand(2, 3)
         x2 = np.random.rand(2, 3)
@@ -1232,8 +1238,8 @@ class ModelTest(testing.TestCase):
             with self.assertRaisesRegex(
                 NotImplementedError,
                 (
-                    r"`export_saved_model` only currently supports the "
-                    r"tensorflow, jax and torch backends."
+                    r"`ExportArchive` is only compatible with "
+                    r"TensorFlow, JAX and Torch backends."
                 ),
             ):
                 model.export(temp_filepath, format="tf_saved_model")


### PR DESCRIPTION
This addresses #19571

This includes the following:
- `segment_sum` and `segment_max` functions are vectorized and avoid explicit array evaluation, without numpy dependency (allows for compilation and `vmap`)
- replaces calls to `cond` with mlx backend specific logic when required for compilation
    - (would appreciate any feedback here)
- all tests in `optimizers`, `losses`, `metrics`, `models`, `callbacks`, `utils`, and `layers` now passing (or skipped)