### PR TITLE
Fix incorrect argument in JAX flash attention.

### DIFF
--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -1129,7 +1129,7 @@ def wrap_flash_attention(
         )
 
     if custom_mask is not None:
-        mask = splash_attention_mask.NumpyMask(mask=custom_mask)
+        mask = splash_attention_mask.NumpyMask(array=custom_mask)
 
     else:
         mask = splash_attention_mask.CausalMask(


### PR DESCRIPTION
The mask is named `array` in [`NumpyMask`](https://github.com/jax-ml/jax/blob/1aca76fc133a36903cf154a499b1cc319d340a48/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_mask.py#L423).