### PR TITLE
Restore variables on `fit()` interrupt with Jax backend

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -391,6 +391,7 @@ class JAXTrainer(base_trainer.Trainer):
         self.make_train_function()
         self.stop_training = False
         training_logs = {}
+        training_finished = False
         callbacks.on_train_begin()
         initial_epoch = self._initial_epoch or initial_epoch
         try:
@@ -486,6 +487,7 @@ class JAXTrainer(base_trainer.Trainer):
                 training_logs = epoch_logs
                 if self.stop_training:
                     break
+            training_finished = True
 
         finally:
             self.jax_state_sync()
@@ -498,7 +500,8 @@ class JAXTrainer(base_trainer.Trainer):
             # If _eval_epoch_iterator exists, delete it after all epochs are done.
             if getattr(self, "_eval_epoch_iterator", None) is not None:
                 del self._eval_epoch_iterator
-            callbacks.on_train_end(logs=training_logs)
+            if training_finished:
+                callbacks.on_train_end(logs=training_logs)
             self._jax_state = None
             self._clear_jax_state_sharding()
         return self.history

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -425,8 +425,8 @@ class JAXTrainer(base_trainer.Trainer):
                             metrics_variables,
                         ) = state
 
-                        # Setting _jax_state enables callbacks to force a state sync
-                        # if they need to.
+                        # Setting _jax_state enables callbacks to force a state
+                        # sync if they need to.
                         self._jax_state = {
                             "trainable_variables": trainable_variables,
                             "non_trainable_variables": non_trainable_variables,
@@ -441,12 +441,14 @@ class JAXTrainer(base_trainer.Trainer):
                             # this flag in on_(train_)batch_end.
                             break
 
-                # Reattach state to the model (if not already done by a callback).
+                # Reattach state to the model
+                # (if not already done by a callback).
                 # NOTE: doing this after each step would be a big performance
                 # bottleneck.
                 self.jax_state_sync()
 
-                # Override with model metrics instead of last step logs if needed.
+                # Override with model metrics instead of last step logs if
+                # needed.
                 # The jax spmd_mode is need for multi-process context, since the
                 # metrics values are replicated, and we don't want to do a all
                 # gather, and only need the local copy of the value.
@@ -497,7 +499,8 @@ class JAXTrainer(base_trainer.Trainer):
             ):
                 self.optimizer.finalize_variable_values(self.trainable_weights)
 
-            # If _eval_epoch_iterator exists, delete it after all epochs are done.
+            # If _eval_epoch_iterator exists, delete it after all epochs
+            # are done.
             if getattr(self, "_eval_epoch_iterator", None) is not None:
                 del self._eval_epoch_iterator
             if training_finished:
@@ -528,7 +531,8 @@ class JAXTrainer(base_trainer.Trainer):
         if use_cached_eval_dataset:
             epoch_iterator = self._eval_epoch_iterator
         else:
-            # Create an iterator that yields batches of input/target data.
+            # Create an iterator that yields batches of
+            # input/target data.
             epoch_iterator = JAXEpochIterator(
                 x=x,
                 y=y,

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -393,111 +393,114 @@ class JAXTrainer(base_trainer.Trainer):
         training_logs = {}
         callbacks.on_train_begin()
         initial_epoch = self._initial_epoch or initial_epoch
-        for epoch in range(initial_epoch, epochs):
-            self.reset_metrics()
-            callbacks.on_epoch_begin(epoch)
+        try:
+            for epoch in range(initial_epoch, epochs):
+                self.reset_metrics()
+                callbacks.on_epoch_begin(epoch)
 
-            self._jax_state_synced = True
-            with epoch_iterator.catch_stop_iteration():
-                for step, iterator in epoch_iterator:
-                    # Callbacks
-                    callbacks.on_train_batch_begin(step)
+                self._jax_state_synced = True
+                with epoch_iterator.catch_stop_iteration():
+                    for step, iterator in epoch_iterator:
+                        # Callbacks
+                        callbacks.on_train_batch_begin(step)
 
-                    # Train step
-                    if self._jax_state_synced:
-                        # The state may have been synced by a callback.
-                        state = self._get_jax_state(
-                            trainable_variables=True,
-                            non_trainable_variables=True,
-                            optimizer_variables=True,
-                            metrics_variables=True,
-                            purge_model_variables=True,
+                        # Train step
+                        if self._jax_state_synced:
+                            # The state may have been synced by a callback.
+                            state = self._get_jax_state(
+                                trainable_variables=True,
+                                non_trainable_variables=True,
+                                optimizer_variables=True,
+                                metrics_variables=True,
+                                purge_model_variables=True,
+                            )
+                            self._jax_state_synced = False
+
+                        logs, state = self.train_function(state, iterator)
+                        (
+                            trainable_variables,
+                            non_trainable_variables,
+                            optimizer_variables,
+                            metrics_variables,
+                        ) = state
+
+                        # Setting _jax_state enables callbacks to force a state sync
+                        # if they need to.
+                        self._jax_state = {
+                            "trainable_variables": trainable_variables,
+                            "non_trainable_variables": non_trainable_variables,
+                            "optimizer_variables": optimizer_variables,
+                            "metrics_variables": metrics_variables,
+                        }
+                        # Dispatch callbacks. This takes care of async dispatch.
+                        callbacks.on_train_batch_end(step, logs)
+
+                        if self.stop_training:
+                            # Stop training if a callback has set
+                            # this flag in on_(train_)batch_end.
+                            break
+
+                # Reattach state to the model (if not already done by a callback).
+                # NOTE: doing this after each step would be a big performance
+                # bottleneck.
+                self.jax_state_sync()
+
+                # Override with model metrics instead of last step logs if needed.
+                # The jax spmd_mode is need for multi-process context, since the
+                # metrics values are replicated, and we don't want to do a all
+                # gather, and only need the local copy of the value.
+                with jax.spmd_mode("allow_all"):
+                    epoch_logs = dict(self._get_metrics_result_or_logs(logs))
+
+                # Run validation.
+                if validation_data is not None and self._should_eval(
+                    epoch, validation_freq
+                ):
+                    # Create JAXEpochIterator for evaluation and cache it.
+                    if getattr(self, "_eval_epoch_iterator", None) is None:
+                        self._eval_epoch_iterator = JAXEpochIterator(
+                            x=val_x,
+                            y=val_y,
+                            sample_weight=val_sample_weight,
+                            batch_size=validation_batch_size or batch_size,
+                            steps_per_execution=self.steps_per_execution,
+                            steps_per_epoch=validation_steps,
+                            shuffle=False,
                         )
-                        self._jax_state_synced = False
-
-                    logs, state = self.train_function(state, iterator)
-                    (
-                        trainable_variables,
-                        non_trainable_variables,
-                        optimizer_variables,
-                        metrics_variables,
-                    ) = state
-
-                    # Setting _jax_state enables callbacks to force a state sync
-                    # if they need to.
-                    self._jax_state = {
-                        "trainable_variables": trainable_variables,
-                        "non_trainable_variables": non_trainable_variables,
-                        "optimizer_variables": optimizer_variables,
-                        "metrics_variables": metrics_variables,
-                    }
-                    # Dispatch callbacks. This takes care of async dispatch.
-                    callbacks.on_train_batch_end(step, logs)
-
-                    if self.stop_training:
-                        # Stop training if a callback has set
-                        # this flag in on_(train_)batch_end.
-                        break
-
-            # Reattach state to the model (if not already done by a callback).
-            # NOTE: doing this after each step would be a big performance
-            # bottleneck.
-            self.jax_state_sync()
-
-            # Override with model metrics instead of last step logs if needed.
-            # The jax spmd_mode is need for multi-process context, since the
-            # metrics values are replicated, and we don't want to do a all
-            # gather, and only need the local copy of the value.
-            with jax.spmd_mode("allow_all"):
-                epoch_logs = dict(self._get_metrics_result_or_logs(logs))
-
-            # Run validation.
-            if validation_data is not None and self._should_eval(
-                epoch, validation_freq
-            ):
-                # Create JAXEpochIterator for evaluation and cache it.
-                if getattr(self, "_eval_epoch_iterator", None) is None:
-                    self._eval_epoch_iterator = JAXEpochIterator(
+                    val_logs = self.evaluate(
                         x=val_x,
                         y=val_y,
                         sample_weight=val_sample_weight,
                         batch_size=validation_batch_size or batch_size,
-                        steps_per_execution=self.steps_per_execution,
-                        steps_per_epoch=validation_steps,
-                        shuffle=False,
+                        steps=validation_steps,
+                        callbacks=callbacks,
+                        return_dict=True,
+                        _use_cached_eval_dataset=True,
                     )
-                val_logs = self.evaluate(
-                    x=val_x,
-                    y=val_y,
-                    sample_weight=val_sample_weight,
-                    batch_size=validation_batch_size or batch_size,
-                    steps=validation_steps,
-                    callbacks=callbacks,
-                    return_dict=True,
-                    _use_cached_eval_dataset=True,
-                )
-                val_logs = {
-                    "val_" + name: val for name, val in val_logs.items()
-                }
-                epoch_logs.update(val_logs)
+                    val_logs = {
+                        "val_" + name: val for name, val in val_logs.items()
+                    }
+                    epoch_logs.update(val_logs)
 
-            callbacks.on_epoch_end(epoch, epoch_logs)
-            training_logs = epoch_logs
-            if self.stop_training:
-                break
+                callbacks.on_epoch_end(epoch, epoch_logs)
+                training_logs = epoch_logs
+                if self.stop_training:
+                    break
 
-        if (
-            isinstance(self.optimizer, optimizers_module.Optimizer)
-            and epochs > 0
-        ):
-            self.optimizer.finalize_variable_values(self.trainable_weights)
+        finally:
+            self.jax_state_sync()
+            if (
+                isinstance(self.optimizer, optimizers_module.Optimizer)
+                and epochs > 0
+            ):
+                self.optimizer.finalize_variable_values(self.trainable_weights)
 
-        # If _eval_epoch_iterator exists, delete it after all epochs are done.
-        if getattr(self, "_eval_epoch_iterator", None) is not None:
-            del self._eval_epoch_iterator
-        callbacks.on_train_end(logs=training_logs)
-        self._jax_state = None
-        self._clear_jax_state_sharding()
+            # If _eval_epoch_iterator exists, delete it after all epochs are done.
+            if getattr(self, "_eval_epoch_iterator", None) is not None:
+                del self._eval_epoch_iterator
+            callbacks.on_train_end(logs=training_logs)
+            self._jax_state = None
+            self._clear_jax_state_sharding()
         return self.history
 
     @traceback_utils.filter_traceback


### PR DESCRIPTION
This PR fixes an issue with the Jax backend, where, if `fit()` is interrupted, it cannot be restarted because variable values are not restored. 

It's a little tricky to reprex with a too-small example, since it seem a different code path is taken when provided a trivially small dataset.

Starting from the `cats_vs_dogs_small` dataset however, this is easy to reproduce. 

Script `interrupt-train.py`
```python

import os
os.environ["KERAS_BACKEND"] = "jax"

import keras
keras.config.disable_traceback_filtering()
from keras.utils import image_dataset_from_directory
from pathlib import Path

new_base_dir = Path("cats_vs_dogs_small")

inputs = keras.Input(shape=(180, 180, 3))
x = keras.layers.Rescaling(1 / 255)(inputs)
x = keras.layers.Conv2D(32, 3, activation="relu")(x)
x = keras.layers.MaxPooling2D(2)(x)
x = keras.layers.Conv2D(64, 3, activation="relu")(x)
x = keras.layers.MaxPooling2D(2)(x)
x = keras.layers.Conv2D(128, 3, activation="relu")(x)
x = keras.layers.MaxPooling2D(2)(x)
x = keras.layers.Conv2D(256, 3, activation="relu")(x)
x = keras.layers.MaxPooling2D(2)(x)
x = keras.layers.Conv2D(256, 3, activation="relu")(x)
x = keras.layers.Flatten()(x)
outputs = keras.layers.Dense(1, activation="sigmoid")(x)

model = keras.Model(inputs, outputs)

model.compile(loss="binary_crossentropy", optimizer="rmsprop", metrics=["accuracy"])

image_size = (180, 180)
batch_size = 32

train_dataset = image_dataset_from_directory(
    new_base_dir / "train", image_size=image_size, batch_size=batch_size
)
validation_dataset = image_dataset_from_directory(
    new_base_dir / "validation", image_size=image_size, batch_size=batch_size
)
test_dataset = image_dataset_from_directory(
    new_base_dir / "test", image_size=image_size, batch_size=batch_size
)

data_batch, labels_batch = next(iter(train_dataset))
print(data_batch.shape)
print(labels_batch.shape)


import os
pid = os.getpid()
print("pid: ", pid)


self = model

history = model.fit(train_dataset, epochs=300, validation_data=validation_dataset, callbacks=callbacks)
```

This command will start training and then drop into an interactive Python session afterwards: 
```
uv run --with keras --with tensorflow-cpu --with jax[cuda12] --python 3.11 python -i ../interrupt-train2.py 
```
If you send an interrupt `^C` once training starts, a subsequent call to `fit()` raises an Exception:

```python
>>> history = model.fit(train_dataset, epochs=30, validation_data=validation_dataset, callbacks=callbacks)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tomasz/.cache/uv/archive-v0/zs2ngTf-6CAPcviJmdovf/lib/python3.11/site-packages/keras/src/utils/traceback_utils.py", line 113, in error_handler
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/tomasz/.cache/uv/archive-v0/zs2ngTf-6CAPcviJmdovf/lib/python3.11/site-packages/keras/src/backend/jax/trainer.py", line 389, in fit
    self._record_training_state_sharding_spec()
  File "/home/tomasz/.cache/uv/archive-v0/zs2ngTf-6CAPcviJmdovf/lib/python3.11/site-packages/keras/src/backend/jax/trainer.py", line 865, in _record_training_state_sharding_spec
    self._trainable_variable_shardings = [
                                         ^
  File "/home/tomasz/.cache/uv/archive-v0/zs2ngTf-6CAPcviJmdovf/lib/python3.11/site-packages/keras/src/backend/jax/trainer.py", line 866, in <listcomp>
    v.value.sharding for v in self.trainable_variables
    ^^^^^^^
  File "/home/tomasz/.cache/uv/archive-v0/zs2ngTf-6CAPcviJmdovf/lib/python3.11/site-packages/keras/src/backend/common/variables.py", line 244, in value
    self._initializer(self._shape, dtype=self._dtype)
TypeError: 'NoneType' object is not callable
```


