### PR TITLE
various numpy_test changes

### DIFF
--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1146,6 +1146,12 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         keras.config.backend() == "openvino",
         reason="OpenVINO doesn't support this change",
     )
+    @pytest.mark.skipif(
+        keras.config.backend() == "mlx",
+        reason="""
+        MLX flush denormal numbers to 0 on GPU resulting in wrong results.
+        """,
+    )
     def test_argmax_negative_zero(self):
         input_data = np.array(
             [-1.0, -0.0, 1.401298464324817e-45], dtype=np.float32
@@ -1159,6 +1165,12 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         OpenVINO and TensorFlow don't support this 
         change, TensorFlow behavior for this case is under
         evaluation and may change within this PR
+        """,
+    )
+    @pytest.mark.skipif(
+        keras.config.backend() == "mlx",
+        reason="""
+        MLX flush denormal numbers to 0 on GPU resulting in wrong results.
         """,
     )
     def test_argmin_negative_zero(self):
@@ -5391,10 +5403,16 @@ class NumpyDtypeTest(testing.TestCase):
 
         self.jax_enable_x64 = enable_x64()
         self.jax_enable_x64.__enter__()
+
+        if backend.backend() == "mlx":
+            self.mlx_cpu_context = backend.core.enable_float64()
+            self.mlx_cpu_context.__enter__()
         return super().setUp()
 
     def tearDown(self):
         self.jax_enable_x64.__exit__(None, None, None)
+        if backend.backend() == "mlx":
+            self.mlx_cpu_context.__exit__(None, None, None)
         return super().tearDown()
 
     @parameterized.named_parameters(
@@ -5598,6 +5616,13 @@ class NumpyDtypeTest(testing.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
+        if (
+            all(dtype not in self.FLOAT_DTYPES for dtype in dtypes)
+            and backend.backend() == "mlx"
+        ):
+            # This must be removed once mlx.core.matmul supports integer dtypes
+            self.skipTest("mlx doesn't support integer dot product")
+
         # The shape of the matrix needs to meet the requirements of
         # torch._int_mm to test hardware-accelerated matmul
         x1 = knp.ones((17, 16), dtype=dtype1)
@@ -6620,6 +6645,13 @@ class NumpyDtypeTest(testing.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
+        if (
+            all(dtype not in self.FLOAT_DTYPES for dtype in dtypes)
+            and backend.backend() == "mlx"
+        ):
+            # This must be removed once mlx.core.matmul supports integer dtypes
+            self.skipTest("mlx doesn't support integer dot product")
+
         x1 = knp.ones((2, 3, 4), dtype=dtype1)
         x2 = knp.ones((4, 3), dtype=dtype2)
         x1_jax = jnp.ones((2, 3, 4), dtype=dtype1)
@@ -6648,6 +6680,13 @@ class NumpyDtypeTest(testing.TestCase):
             return x1_shape, x2_shape
 
         dtype1, dtype2 = dtypes
+        if (
+            all(dtype not in self.FLOAT_DTYPES for dtype in dtypes)
+            and backend.backend() == "mlx"
+        ):
+            # This must be removed once mlx.core.matmul supports integer dtypes
+            self.skipTest("mlx doesn't support integer dot product")
+
         subscripts = "ijk,lkj->il"
         x1_shape, x2_shape = get_input_shapes(subscripts)
         x1 = knp.ones(x1_shape, dtype=dtype1)
@@ -8312,6 +8351,13 @@ class NumpyDtypeTest(testing.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
+        if (
+            all(dtype not in self.FLOAT_DTYPES for dtype in dtypes)
+            and backend.backend() == "mlx"
+        ):
+            # This must be removed once mlx.core.matmul supports integer dtypes
+            self.skipTest("mlx doesn't support integer dot product")
+
         x1 = knp.ones((1, 1), dtype=dtype1)
         x2 = knp.ones((1, 1), dtype=dtype2)
         x1_jax = jnp.ones((1, 1), dtype=dtype1)
@@ -8522,6 +8568,13 @@ class NumpyDtypeTest(testing.TestCase):
         import jax.numpy as jnp
 
         dtype1, dtype2 = dtypes
+        if (
+            all(dtype not in self.FLOAT_DTYPES for dtype in dtypes)
+            and backend.backend() == "mlx"
+        ):
+            # This must be removed once mlx.core.matmul supports integer dtypes
+            self.skipTest("mlx doesn't support integer dot product")
+
         x1 = knp.ones((1,), dtype=dtype1)
         x2 = knp.ones((1,), dtype=dtype2)
         x1_jax = jnp.ones((1,), dtype=dtype1)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1148,9 +1148,7 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
     )
     @pytest.mark.skipif(
         keras.config.backend() == "mlx",
-        reason="""
-        MLX flush denormal numbers to 0 on GPU resulting in wrong results.
-        """,
+        reason="Wrong results due to MLX flushing denormal numbers to 0 on GPU",
     )
     def test_argmax_negative_zero(self):
         input_data = np.array(
@@ -1169,9 +1167,7 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
     )
     @pytest.mark.skipif(
         keras.config.backend() == "mlx",
-        reason="""
-        MLX flush denormal numbers to 0 on GPU resulting in wrong results.
-        """,
+        reason="Wrong results due to MLX flushing denormal numbers to 0 on GPU",
     )
     def test_argmin_negative_zero(self):
         input_data = np.array(


### PR DESCRIPTION
This PR contains changes to numpy_test.py in order to:

1. Forcing the following tests  to run on CPU. 
    * NumpyDtypeTest::test_correlate_*
    * NumpyDtypeTest::test_eye_int64
    * NumpyDtypeTest::test_identity_int64
   All tests are now successful
2. Skipping the following tests because mlx.core.matmul does not support non-floating multiplication. This will eventually be supported by mlx (https://github.com/keras-team/keras/issues/19571#issuecomment-2649744226) but not a top priority.
    * NumpyDtypeTest::test_einsum_*
    * NumpyDtypeTest::test_inner_*
    * NumpyDtypeTest::test_matmul_*
    * NumpyDtypeTest::test_tensordot_*
    * NumpyDtypeTest::test_dot_*
3. Skipping the following tests that do not work on GPU (https://github.com/ml-explore/mlx/issues/1895):
    * NumpyOneInputOpsDynamicShapeTest::test_argmax_negative_zero
    * NumpyOneInputOpsDynamicShapeTest::test_argmin_negative_zero 
