### PR TITLE
Introduce weights sharding

### DIFF
--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -270,6 +270,16 @@ class Model(Trainer, base_trainer.Trainer, Layer):
     def save(self, filepath, overwrite=True, zipped=None, **kwargs):
         """Saves a model as a `.keras` file.
 
+        Note that `model.save()` is an alias for `keras.saving.save_model()`.
+
+        The saved `.keras` file contains:
+
+        - The model's configuration (architecture)
+        - The model's weights
+        - The model's optimizer's state (if any)
+
+        Thus models can be reinstantiated in the exact same state.
+
         Args:
             filepath: `str` or `pathlib.Path` object.
                 The path where to save the model. Must end in `.keras`
@@ -297,16 +307,6 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         x = keras.random.uniform((10, 3))
         assert np.allclose(model.predict(x), loaded_model.predict(x))
         ```
-
-        Note that `model.save()` is an alias for `keras.saving.save_model()`.
-
-        The saved `.keras` file contains:
-
-        - The model's configuration (architecture)
-        - The model's weights
-        - The model's optimizer's state (if any)
-
-        Thus models can be reinstantiated in the exact same state.
         """
         return saving_api.save_model(
             self, filepath, overwrite=overwrite, zipped=zipped, **kwargs
@@ -321,6 +321,13 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         will be saved in multiple files, each with a size at most
         `max_shard_size` (in GB). Additionally, a configuration file
         `.weights.json` will contain the metadata for the sharded files.
+
+        The saved sharded files contain:
+
+        - `*.weights.json`: The configuration file containing 'metadata' and
+            'weight_map'.
+        - `*_xxxxxx.weights.h5`: The sharded files containing only the
+            weights.
 
         Args:
             filepath: `str` or `pathlib.Path` object. Path where the weights
@@ -358,13 +365,6 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         x = keras.random.uniform((1, 480, 480, 3))
         assert np.allclose(model.predict(x), loaded_model.predict(x))
         ```
-
-        The saved sharded files contain:
-
-        - `*.weights.json`: The configuration file containing 'metadata' and
-            'weight_map'.
-        - `*_xxxxxx.weights.h5`: The sharded files containing only the
-            weights.
         """
         return saving_api.save_weights(
             self, filepath, overwrite=overwrite, max_shard_size=max_shard_size

--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -336,35 +336,26 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         Example:
 
         ```python
-        # Create a big model with about 272MB of weights.
-        model = keras.Sequential()
-        model.add(keras.Input(shape=(1024,)))
-        for _ in range(5):
-            model.add(keras.layers.Dense(4096))
+        # Instantiate a EfficientNetV2L model with about 454MB of weights.
+        model = keras.applications.EfficientNetV2L(weights=None)
 
         # Save the weights in a single file.
         model.save_weights("model.weights.h5")
 
-        # Save the weights in sharded files. Use `max_shard_size=0.1` means each
-        # sharded file will be at most ~100MB.
-        model.save_weights("model.weights.json", max_shard_size=0.1)
+        # Save the weights in sharded files. Use `max_shard_size=0.25` means
+        # each sharded file will be at most ~250MB.
+        model.save_weights("model.weights.json", max_shard_size=0.25)
 
         # Load the weights in a new model with the same architecture.
-        loaded_model = keras.Sequential()
-        loaded_model.add(keras.Input(shape=(1024,)))
-        for _ in range(5):
-            loaded_model.add(keras.layers.Dense(4096))
+        loaded_model = keras.applications.EfficientNetV2L(weights=None)
         loaded_model.load_weights("model.weights.h5")
-        x = keras.random.uniform((1, 1024))
+        x = keras.random.uniform((1, 480, 480, 3))
         assert np.allclose(model.predict(x), loaded_model.predict(x))
 
         # Load the sharded weights in a new model with the same architecture.
-        loaded_model = keras.Sequential()
-        loaded_model.add(keras.Input(shape=(1024,)))
-        for _ in range(5):
-            loaded_model.add(keras.layers.Dense(4096))
+        loaded_model = keras.applications.EfficientNetV2L(weights=None)
         loaded_model.load_weights("model.weights.json")
-        x = keras.random.uniform((1, 1024))
+        x = keras.random.uniform((1, 480, 480, 3))
         assert np.allclose(model.predict(x), loaded_model.predict(x))
         ```
 

--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -219,32 +219,45 @@ def load_model(filepath, custom_objects=None, compile=True, safe_mode=True):
 
 
 @keras_export("keras.saving.save_weights")
-def save_weights(model, filepath, overwrite=True, **kwargs):
-    if not str(filepath).endswith(".weights.h5"):
+def save_weights(
+    model, filepath, overwrite=True, max_shard_size=None, **kwargs
+):
+    filepath_str = str(filepath)
+    if max_shard_size is None and not filepath_str.endswith(".weights.h5"):
         raise ValueError(
             "The filename must end in `.weights.h5`. "
-            f"Received: filepath={filepath}"
+            f"Received: filepath={filepath_str}"
+        )
+    elif max_shard_size is not None and not filepath_str.endswith(
+        ("weights.h5", "weights.json")
+    ):
+        raise ValueError(
+            "The filename must end in `.weights.json` when `max_shard_size` is "
+            f"specified. Received: filepath={filepath_str}"
         )
     try:
         exists = os.path.exists(filepath)
     except TypeError:
         exists = False
     if exists and not overwrite:
-        proceed = io_utils.ask_to_proceed_with_overwrite(filepath)
+        proceed = io_utils.ask_to_proceed_with_overwrite(filepath_str)
         if not proceed:
             return
-    saving_lib.save_weights_only(model, filepath, **kwargs)
+    saving_lib.save_weights_only(model, filepath, max_shard_size, **kwargs)
 
 
 @keras_export("keras.saving.load_weights")
-def load_weights(model, filepath, skip_mismatch=False, **kwargs):
-    if str(filepath).endswith(".keras"):
+def load_weights(model, filepath, skip_mismatch=False, sharded=False, **kwargs):
+    filepath_str = str(filepath)
+    if filepath_str.endswith(".keras"):
         if kwargs:
             raise ValueError(f"Invalid keyword arguments: {kwargs}")
         saving_lib.load_weights_only(
-            model, filepath, skip_mismatch=skip_mismatch
+            model, filepath, skip_mismatch=skip_mismatch, sharded=sharded
         )
-    elif str(filepath).endswith(".weights.h5"):
+    elif filepath_str.endswith(".weights.h5") or filepath_str.endswith(
+        ".weights.json"
+    ):
         objects_to_skip = kwargs.pop("objects_to_skip", None)
         if kwargs:
             raise ValueError(f"Invalid keyword arguments: {kwargs}")
@@ -253,8 +266,9 @@ def load_weights(model, filepath, skip_mismatch=False, **kwargs):
             filepath,
             skip_mismatch=skip_mismatch,
             objects_to_skip=objects_to_skip,
+            sharded=sharded,
         )
-    elif str(filepath).endswith(".h5") or str(filepath).endswith(".hdf5"):
+    elif filepath_str.endswith(".h5") or filepath_str.endswith(".hdf5"):
         by_name = kwargs.pop("by_name", False)
         if kwargs:
             raise ValueError(f"Invalid keyword arguments: {kwargs}")

--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -247,13 +247,13 @@ def save_weights(
 
 
 @keras_export("keras.saving.load_weights")
-def load_weights(model, filepath, skip_mismatch=False, sharded=False, **kwargs):
+def load_weights(model, filepath, skip_mismatch=False, **kwargs):
     filepath_str = str(filepath)
     if filepath_str.endswith(".keras"):
         if kwargs:
             raise ValueError(f"Invalid keyword arguments: {kwargs}")
         saving_lib.load_weights_only(
-            model, filepath, skip_mismatch=skip_mismatch, sharded=sharded
+            model, filepath, skip_mismatch=skip_mismatch
         )
     elif filepath_str.endswith(".weights.h5") or filepath_str.endswith(
         ".weights.json"
@@ -266,7 +266,6 @@ def load_weights(model, filepath, skip_mismatch=False, sharded=False, **kwargs):
             filepath,
             skip_mismatch=skip_mismatch,
             objects_to_skip=objects_to_skip,
-            sharded=sharded,
         )
     elif filepath_str.endswith(".h5") or filepath_str.endswith(".hdf5"):
         by_name = kwargs.pop("by_name", False)

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import unittest.mock as mock
 
 import numpy as np
@@ -236,6 +237,20 @@ class LoadWeightsTests(test_case.TestCase):
         model = self.get_model()
         with self.assertRaisesRegex(ValueError, "File format not supported"):
             model.load_weights("invalid_extension.pkl")
+
+    def test_load_sharded_weights(self):
+        src_model = self.get_model()
+        temp_filepath = pathlib.Path(
+            os.path.join(self.get_temp_dir(), "test_weights.weights.json")
+        )
+        src_model.save_weights(temp_filepath, max_shard_size=1)
+        self.assertLen(os.listdir(temp_filepath.parent), 2)
+        src_weights = src_model.get_weights()
+        dest_model = self.get_model()
+        dest_model.load_weights(temp_filepath, sharded=True)
+        dest_weights = dest_model.get_weights()
+        for orig, loaded in zip(src_weights, dest_weights):
+            self.assertAllClose(orig, loaded)
 
 
 class SaveModelTestsWarning(test_case.TestCase):

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -247,7 +247,7 @@ class LoadWeightsTests(test_case.TestCase):
         self.assertLen(os.listdir(temp_filepath.parent), 2)
         src_weights = src_model.get_weights()
         dest_model = self.get_model()
-        dest_model.load_weights(temp_filepath, sharded=True)
+        dest_model.load_weights(temp_filepath)
         dest_weights = dest_model.get_weights()
         for orig, loaded in zip(src_weights, dest_weights):
             self.assertAllClose(orig, loaded)

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -998,8 +998,8 @@ class H5IOStore:
         archive: Optional `zipfile.ZipFile` object. If specified, the h5 file
             will be saved inside the archive and `path_or_io` will be used as
             the filename.
-        mode: `str`. One of {'r', 'w'}. The mode to open the h5 file. Defaults
-            to `"r"`.
+        mode: `str`. One of {`"r"`, `"w"`}. The mode to open the h5 file.
+            Defaults to `"r"`.
     """
 
     def __init__(self, path_or_io, archive=None, mode="r"):
@@ -1255,7 +1255,7 @@ class ShardedH5IOStore(H5IOStore):
 
     def _create_new_shard_file(self):
         new_shard_path = (
-            f"{self.base_name}_{self.current_shard_index:05}.weighs.h5"
+            f"{self.base_name}_{self.current_shard_index:05}.weights.h5"
         )
         self.current_shard_index += 1
         self.current_shard_path = self.path.with_name(new_shard_path)

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -830,9 +830,14 @@ class SavingTest(testing.TestCase):
             # 3 sharded file + 1 config file = 4.
             self.assertLen(os.listdir(temp_filepath.parent), 4)
 
+        with open(temp_filepath, "r") as f:
+            sharding_config = json.load(f)
+        self.assertIn("metadata", sharding_config)
+        self.assertIn("weight_map", sharding_config)
+
         # Instantiate new model and load the sharded files.
         model = model_fn(weights=None, input_shape=shape)
-        saving_lib.load_weights_only(model, temp_filepath, sharded=True)
+        saving_lib.load_weights_only(model, temp_filepath)
         self.assertAllClose(model.predict(ref_input), ref_output, atol=1e-6)
 
     def test_weights_sharding_exception_raised(self):


### PR DESCRIPTION
Continuing the work based on #19286

This PR introduces `max_shard_size` in `Model.save_weights`.

Behind the scenes, this PR refactors `H5IOStore` by combining it with `H5Entry`. This change allows for more fine-grained control when storing weights. Specifically, it enables the creation of a new shard file once the current shard file reaches its capacity due to incoming weights.

Compatibility has been verified, but please let me know if anything was overlooked.
The test for LoRA weights saving/loading in KerasHub has been included.

Ping @mattdangerw and @divyashreepathihalli for requesting this feature.

A simple demo script:

```python
import os

import numpy as np

from keras import applications

# EfficientNetB0 is about 20.3MB.
model = applications.EfficientNetB0(weights=None, input_shape=(224, 224, 3))
ref_input = np.random.random((1, 224, 224, 3)).astype("float32")
ref_output = model.predict(ref_input)

# `max_shard_size` is in GB. 0.015 means about 15MB per shard.
model.save_weights("model.weights.json", max_shard_size=0.015)
files = [x for x in os.listdir(".")]
assert "model.weights.json" in files
assert "model_00000.weighs.h5" in files
assert "model_00001.weighs.h5" in files
print("Sharded weights saved successfully!")

# Load the sharded weights with the new instance.
model = applications.EfficientNetB0(weights=None, input_shape=(224, 224, 3))
model.load_weights("model.weights.json", sharded=True)
np.testing.assert_allclose(model.predict(ref_input), ref_output, atol=1e-6)
print("Passed!")

```

The outputs:

```bash
1/1 ━━━━━━━━━━━━━━━━━━━━ 1s 1s/step
Sharded weights saved successfully!
1/1 ━━━━━━━━━━━━━━━━━━━━ 1s 996ms/step
Passed!
```

The format of `.weights.json` (similar to HF's format):

```json
{
    "metadata": {
        "total_size": 476111392.0
    },
    "weight_map": {
        "/vars": "model_00000.weighs.h5",
        "/layers/input_layer/vars": "model_00000.weights.h5",
        "/layers/rescaling/vars": "model_00000.weights.h5",
        "/layers/conv2d/vars": "model_00000.weights.h5",
        "/layers/batch_normalization/vars": "model_00000.weights.h5",
...
```