### PR TITLE
Make code compatible with Numpy >= 2.1.

### DIFF
--- a/keras/src/backend/jax/image.py
+++ b/keras/src/backend/jax/image.py
@@ -465,7 +465,7 @@ def affine_transform(
     # transform the indices
     coordinates = jnp.einsum("Bhwij, Bjk -> Bhwik", indices, transform)
     coordinates = jnp.moveaxis(coordinates, source=-1, destination=1)
-    coordinates += jnp.reshape(a=offset, shape=(*offset.shape, 1, 1, 1))
+    coordinates += jnp.reshape(offset, shape=(*offset.shape, 1, 1, 1))
 
     # apply affine transformation
     _map_coordinates = functools.partial(

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -600,7 +600,7 @@ def affine_transform(
     # transform the indices
     coordinates = np.einsum("Bhwij, Bjk -> Bhwik", indices, transform)
     coordinates = np.moveaxis(coordinates, source=-1, destination=1)
-    coordinates += np.reshape(a=offset, newshape=(*offset.shape, 1, 1, 1))
+    coordinates += np.reshape(offset, newshape=(*offset.shape, 1, 1, 1))
 
     # apply affine transformation
     affined = np.stack(

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -424,7 +424,7 @@ def affine_transform(
     # transform the indices
     coordinates = torch.einsum("Bhwij, Bjk -> Bhwik", indices, transform)
     coordinates = torch.moveaxis(coordinates, source=-1, destination=1)
-    coordinates += torch.reshape(a=offset, shape=(*offset.shape, 1, 1, 1))
+    coordinates += torch.reshape(offset, shape=(*offset.shape, 1, 1, 1))
 
     # Note: torch.stack is faster than torch.vmap when the batch size is small.
     affined = torch.stack(


### PR DESCRIPTION
Starting with 2.1, the first argument of `np.reshape` is positional only.

Removed keyword `a` and for consistency did the same with other backends.