### PR TITLE
[Documentation] Updated Binary Focal Crossentropy Loss Docstring

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2363,7 +2363,7 @@ def binary_focal_crossentropy(
 
     >>> y_true = [[0, 1], [0, 0]]
     >>> y_pred = [[0.6, 0.4], [0.4, 0.6]]
-    >>> # In this instance, the second sample in the second batch is the
+    >>> # In this instance, the first sample in the second batch is the
     >>> # 'easier' example.
     >>> focal_loss = keras.losses.binary_focal_crossentropy(
     ...        y_true, y_pred, gamma=2)

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2363,7 +2363,8 @@ def binary_focal_crossentropy(
 
     >>> y_true = [[0, 1], [0, 0]]
     >>> y_pred = [[0.6, 0.4], [0.4, 0.6]]
-    >>> # In this instance, sample 1 in the first batch is the 'harder' example
+    >>> # In this instance, the second sample in the second batch is the
+    >>> # 'easier' example.
     >>> focal_loss = keras.losses.binary_focal_crossentropy(
     ...        y_true, y_pred, gamma=2)
     >>> assert loss.shape == (2,)

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2363,11 +2363,22 @@ def binary_focal_crossentropy(
 
     >>> y_true = [[0, 1], [0, 0]]
     >>> y_pred = [[0.6, 0.4], [0.4, 0.6]]
-    >>> loss = keras.losses.binary_focal_crossentropy(
+    >>> # In this instance, sample 1 in the first batch is the 'harder' example
+    >>> focal_loss = keras.losses.binary_focal_crossentropy(
     ...        y_true, y_pred, gamma=2)
     >>> assert loss.shape == (2,)
-    >>> loss
+    >>> focal_loss
     array([0.330, 0.206], dtype=float32)
+    >>> # Compare with binary_crossentropy
+    >>> bce_loss = keras.losses.binary_focal_crossentropy(
+    ...        y_true, y_pred)
+    >>> bce_loss
+    array([0.916, 0.714], dtype=float32)
+    >>> # Binary focal crossentropy loss attributes more importance to the
+    >>> # harder example which results in a higher loss for the first batch
+    >>> # when normalized by binary cross entropy loss
+    >>> focal_loss/bce_loss
+    array([0.360, 0.289]
     """
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)


### PR DESCRIPTION
### What's the update?

Updated example in docstring for Binary Focal Crossentropy Loss

### Why was the update required?

While reading the documentation for Binary Focal Crossentropy Loss, the example imo seems to lack clarity on how the resultant loss translates to an increased focus on _harder_ examples, compared to Binary Crossentropy Loss.