### PR TITLE
[OpenVINO Backend] Get back tests for exp and expand_dims to precommit

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -91,8 +91,6 @@ NumpyOneInputOpsCorrectnessTest::test_correlate
 NumpyOneInputOpsCorrectnessTest::test_cumprod
 NumpyOneInputOpsCorrectnessTest::test_diag
 NumpyOneInputOpsCorrectnessTest::test_diagonal
-NumpyOneInputOpsCorrectnessTest::test_exp
-NumpyOneInputOpsCorrectnessTest::test_expand_dims
 NumpyOneInputOpsCorrectnessTest::test_exp2
 NumpyOneInputOpsCorrectnessTest::test_expm1
 NumpyOneInputOpsCorrectnessTest::test_flip


### PR DESCRIPTION
**Details:** tests for exp and expand_dims missed in https://github.com/keras-team/keras/pull/20982.
