### PR TITLE
[OpenVINO backend] Support numpy.log10

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -98,6 +98,9 @@ NumpyOneInputOpsCorrectnessTest::test_hstack
 NumpyOneInputOpsCorrectnessTest::test_imag
 NumpyOneInputOpsCorrectnessTest::test_isfinite
 NumpyOneInputOpsCorrectnessTest::test_isinf
+NumpyOneInputOpsCorrectnessTest::test_log1p
+NumpyOneInputOpsCorrectnessTest::test_log2
+NumpyOneInputOpsCorrectnessTest::test_logaddexp
 NumpyOneInputOpsCorrectnessTest::test_max
 NumpyOneInputOpsCorrectnessTest::test_mean
 NumpyOneInputOpsCorrectnessTest::test_median

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -33,7 +33,6 @@ NumpyDtypeTest::test_isfinite
 NumpyDtypeTest::test_isinf
 NumpyDtypeTest::test_isnan
 NumpyDtypeTest::test_linspace
-NumpyDtypeTest::test_log10
 NumpyDtypeTest::test_log1p
 NumpyDtypeTest::test_log
 NumpyDtypeTest::test_logspace
@@ -99,7 +98,6 @@ NumpyOneInputOpsCorrectnessTest::test_hstack
 NumpyOneInputOpsCorrectnessTest::test_imag
 NumpyOneInputOpsCorrectnessTest::test_isfinite
 NumpyOneInputOpsCorrectnessTest::test_isinf
-NumpyOneInputOpsCorrectnessTest::test_log
 NumpyOneInputOpsCorrectnessTest::test_max
 NumpyOneInputOpsCorrectnessTest::test_mean
 NumpyOneInputOpsCorrectnessTest::test_median

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -836,7 +836,15 @@ def log(x):
 
 
 def log10(x):
-    raise NotImplementedError("`log10` is not supported with openvino backend")
+    x = get_ov_output(x)
+    x_type = x.get_element_type()
+    if x_type.is_integral():
+        ov_type = OPENVINO_DTYPES[config.floatx()]
+        x = ov_opset.convert(x, ov_type)
+    log_x = ov_opset.log(x).output(0)
+    log_10 = ov_opset.constant(np.log(10), log_x.get_element_type()).output(0)
+    result = ov_opset.divide(log_x, log_10).output(0)
+    return OpenVINOKerasTensor(result)
 
 
 def log1p(x):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -839,10 +839,11 @@ def log10(x):
     x = get_ov_output(x)
     x_type = x.get_element_type()
     if x_type.is_integral():
-        ov_type = OPENVINO_DTYPES[config.floatx()]
-        x = ov_opset.convert(x, ov_type)
+        x_type = OPENVINO_DTYPES[config.floatx()]
+        x = ov_opset.convert(x, x_type)
     log_x = ov_opset.log(x).output(0)
-    log_10 = ov_opset.constant(np.log(10), log_x.get_element_type()).output(0)
+    const_10 = ov_opset.constant(10, x_type).output(0)
+    log_10 = ov_opset.log(const_10).output(0)
     result = ov_opset.divide(log_x, log_10).output(0)
     return OpenVINOKerasTensor(result)
 

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -832,6 +832,10 @@ def linspace(
 
 def log(x):
     x = get_ov_output(x)
+    x_type = x.get_element_type()
+    if x_type.is_integral():
+        x_type = OPENVINO_DTYPES[config.floatx()]
+        x = ov_opset.convert(x, x_type)
     return OpenVINOKerasTensor(ov_opset.log(x).output(0))
 
 


### PR DESCRIPTION
I have added support for numpy.log10 in OpenVINO backend by:
1. Implementing log10(x) as log(x)/log(10) using available operations from OpenVINO
2. Remove numpy.log10 from excluded_concrete_tests.txt file

About implementation:
- I followed same pattern like other math functions in backend
- Added handling for proper type conversion with integral types
- Tests pass successfully on CPU environment

Related to: https://github.com/openvinotoolkit/openvino/issues/29486

cc @rkazants  could you please review?