### PR TITLE
[Documentation] Updated Categorical Focal Crossentropy Loss Docstring

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2143,10 +2143,22 @@ def categorical_focal_crossentropy(
 
     >>> y_true = [[0, 1, 0], [0, 0, 1]]
     >>> y_pred = [[0.05, 0.9, 0.05], [0.1, 0.85, 0.05]]
-    >>> loss = keras.losses.categorical_focal_crossentropy(y_true, y_pred)
-    >>> assert loss.shape == (2,)
-    >>> loss
+    >>> # In this instance, the second sample in the second batch is the
+    >>> # 'harder' example.
+    >>> focal_loss = keras.losses.categorical_focal_crossentropy(y_true, y_pred)
+    >>> assert focal_loss.shape == (2,)
+    >>> focal_loss
     array([2.63401289e-04, 6.75912094e-01], dtype=float32)
+    >>> # Compare with binary_crossentropy
+    >>> bce_loss = keras.losses.binary_crossentropy(
+    ...        y_true, y_pred)
+    >>> bce_loss
+    array([0.10536054, 2.9957323], dtype=float32)
+    >>> # Categorical focal crossentropy loss attributes more importance to the
+    >>> # harder example which results in a higher loss for the second batch
+    >>> # when normalized by categorical cross entropy loss
+    >>> focal_loss/bce_loss
+    array([0.0025  , 0.225625], dtype=float32)
     """
     if isinstance(axis, bool):
         raise ValueError(
@@ -2367,11 +2379,11 @@ def binary_focal_crossentropy(
     >>> # 'easier' example.
     >>> focal_loss = keras.losses.binary_focal_crossentropy(
     ...        y_true, y_pred, gamma=2)
-    >>> assert loss.shape == (2,)
+    >>> assert focal_loss.shape == (2,)
     >>> focal_loss
     array([0.330, 0.206], dtype=float32)
     >>> # Compare with binary_crossentropy
-    >>> bce_loss = keras.losses.binary_focal_crossentropy(
+    >>> bce_loss = keras.losses.binary_crossentropy(
     ...        y_true, y_pred)
     >>> bce_loss
     array([0.916, 0.714], dtype=float32)
@@ -2379,7 +2391,7 @@ def binary_focal_crossentropy(
     >>> # harder example which results in a higher loss for the first batch
     >>> # when normalized by binary cross entropy loss
     >>> focal_loss/bce_loss
-    array([0.360, 0.289]
+    array([0.360, 0.289], dtype=float32)
     """
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2143,19 +2143,18 @@ def categorical_focal_crossentropy(
 
     >>> y_true = [[0, 1, 0], [0, 0, 1]]
     >>> y_pred = [[0.05, 0.9, 0.05], [0.1, 0.85, 0.05]]
-    >>> # In this instance, the second sample in the second batch is the
-    >>> # 'harder' example.
+    >>> # In this instance, the second example is the 'harder' example.
     >>> focal_loss = keras.losses.categorical_focal_crossentropy(y_true, y_pred)
     >>> assert focal_loss.shape == (2,)
     >>> focal_loss
     array([2.63401289e-04, 6.75912094e-01], dtype=float32)
-    >>> # Compare with binary_crossentropy
-    >>> bce_loss = keras.losses.binary_crossentropy(
+    >>> # Compare with categorical_crossentropy
+    >>> bce_loss = keras.losses.categorical_crossentropy(
     ...        y_true, y_pred)
     >>> bce_loss
     array([0.10536054, 2.9957323], dtype=float32)
     >>> # Categorical focal crossentropy loss attributes more importance to the
-    >>> # harder example which results in a higher loss for the second batch
+    >>> # harder example which results in a higher loss for the second example
     >>> # when normalized by categorical cross entropy loss
     >>> focal_loss/bce_loss
     array([0.0025  , 0.225625], dtype=float32)

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2149,14 +2149,14 @@ def categorical_focal_crossentropy(
     >>> focal_loss
     array([2.63401289e-04, 6.75912094e-01], dtype=float32)
     >>> # Compare with categorical_crossentropy
-    >>> bce_loss = keras.losses.categorical_crossentropy(
+    >>> cce_loss = keras.losses.categorical_crossentropy(
     ...        y_true, y_pred)
-    >>> bce_loss
+    >>> cce_loss
     array([0.10536054, 2.9957323], dtype=float32)
     >>> # Categorical focal crossentropy loss attributes more importance to the
     >>> # harder example which results in a higher loss for the second example
     >>> # when normalized by categorical cross entropy loss
-    >>> focal_loss/bce_loss
+    >>> focal_loss/cce_loss
     array([0.0025  , 0.225625], dtype=float32)
     """
     if isinstance(axis, bool):


### PR DESCRIPTION
### What's the update?
- Updated example in docstring for Categorical Focal Crossentropy Loss
- Fixed typos in docstring for Binary Focal Crossentropy Loss

### Why was the update required?
- While reading the documentation for Categorical Focal Crossentropy Loss, the example imo seems to lack clarity on how the resultant loss translates to an increased focus on harder examples, compared to Categorical Crossentropy Loss.