### PR TITLE
Raghav/29359

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -93,7 +93,7 @@ NumpyOneInputOpsCorrectnessTest::test_diag
 NumpyOneInputOpsCorrectnessTest::test_diagonal
 NumpyOneInputOpsCorrectnessTest::test_exp2
 NumpyOneInputOpsCorrectnessTest::test_expm1
-NumpyOneInputOpsCorrectnessTest::test_flip
+
 NumpyOneInputOpsCorrectnessTest::test_floor_divide
 NumpyOneInputOpsCorrectnessTest::test_hstack
 NumpyOneInputOpsCorrectnessTest::test_imag

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -34,7 +34,7 @@ NumpyDtypeTest::test_isinf
 NumpyDtypeTest::test_isnan
 NumpyDtypeTest::test_linspace
 NumpyDtypeTest::test_log10
-NumpyDtypeTest::test_log1p
+
 NumpyDtypeTest::test_log
 NumpyDtypeTest::test_logspace
 NumpyDtypeTest::test_matmul_

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -840,7 +840,10 @@ def log10(x):
 
 
 def log1p(x):
-    raise NotImplementedError("`log1p` is not supported with openvino backend")
+    x=get_ov_output(x)
+    one=ov_opset.constant(1.0,dtype=x.dtype)
+    return OpenVINOKerasTensor(ov_opset.log(ov_opset.add(x,one)).output(0))
+
 
 
 def log2(x):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -707,7 +707,16 @@ def expm1(x):
 
 
 def flip(x, axis=None):
-    raise NotImplementedError("`flip` is not supported with openvino backend")
+    rank=len(x.shape)
+
+    if axis is None:
+        axis=list(range(rank))
+
+
+    axis_tensor=np.array(axis,dtype=np.int32)
+    reversed_tensor=ov_opset.Reverse(x,axis_tensor)
+
+    return reversed_tensor
 
 
 def floor(x):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+env =
+    KERAS_BACKEND=openvino

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ tf2onnx
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.6.0+cpu
-torch-xla==2.6.0;sys_platform != 'darwin'
+#torch-xla==2.6.0;sys_platform != 'darwin'
 
 # Jax.
 # Pinned to 0.5.0 on CPU. JAX 0.5.1 requires Tensorflow 2.19 for saved_model_test.


### PR DESCRIPTION
Implemented all the necessary mentioned in the issue:
1. Provide decomposition in Python for [numpy.flip](https://github.com/keras-team/keras/blob/master/keras/src/backend/openvino/numpy.py) using [OpenVINO opset](https://docs.openvino.ai/2025/documentation/openvino-ir-format/operation-sets/operation-specs.html)
2. Include tests by removing line corresponding to the implemented operation in [excluded_concrete_tests.txt file](https://github.com/keras-team/keras/blob/master/keras/src/backend/openvino/excluded_concrete_tests.txt).
3. create pytest.ini file and place it in the root directory of the clone repository. This file should contain the following content:
[pytest]
env =
    KERAS_BACKEND=openvino
    
    
    @rkazants please review this PR :)