### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,9 @@ torch==2.6.0+cpu
 torch-xla==2.6.0;sys_platform != 'darwin'
 
 # Jax.
-jax[cpu]
+# Pinned to 0.5.0 on CPU. JAX 0.5.1 requires Tensorflow 2.19 for saved_model_test.
+# Note that we test against the latest JAX on GPU.
+jax[cpu]==0.5.0
 flax
 
 # Common deps.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Tensorflow.
 tensorflow-cpu~=2.19.0;sys_platform != 'darwin'
 tensorflow~=2.19.0;sys_platform == 'darwin'
-tf_keras
+tf_keras~=2.19.0
 tf2onnx
 
 # Torch.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 # Tensorflow.
 tensorflow-cpu~=2.19.0;sys_platform != 'darwin'
-tensorflow~=2.19.0;sys_platform == 'darwin'
-tf_keras~=2.19.0
+tf_keras
 tf2onnx
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0+cpu
+torch==2.6.0+cpu;sys_platform != 'darwin'
+torch==2.6.0;sys_platform == 'darwin'
 torch-xla==2.6.0;sys_platform != 'darwin'
 
 # Jax.
@@ -14,6 +14,9 @@ torch-xla==2.6.0;sys_platform != 'darwin'
 # Note that we test against the latest JAX on GPU.
 jax[cpu]==0.5.0
 flax
+
+# pre-commit checks (formatting, linting, etc.)
+pre-commit
 
 # Common deps.
 -r requirements-common.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Tensorflow.
-tensorflow-cpu~=2.18.0;sys_platform != 'darwin'
-tensorflow~=2.18.0;sys_platform == 'darwin'
+tensorflow-cpu~=2.19.0;sys_platform != 'darwin'
+tensorflow~=2.19.0;sys_platform == 'darwin'
 tf_keras
 tf2onnx
 
@@ -10,9 +10,7 @@ torch==2.6.0+cpu
 torch-xla==2.6.0;sys_platform != 'darwin'
 
 # Jax.
-# Pinned to 0.5.0 on CPU. JAX 0.5.1 requires Tensorflow 2.19 for saved_model_test.
-# Note that we test against the latest JAX on GPU.
-jax[cpu]==0.5.0
+jax[cpu]
 flax
 
 # Common deps.


### PR DESCRIPTION
Since Tensorflow and Tensorfow-cpu 2.19.0 is released, updating the version, also removed the version pin of JAX which was depending on the Tensorflow 2.19 release.