### PR TITLE
[Documentation] Added Dice Loss Function Example to Docstring

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -1307,12 +1307,12 @@ class Dice(LossFunctionWrapper):
     >>> y_pred = [[[[0.0], [1.0]], [[0.0], [1.0]]],
     ...           [[[0.4], [0.0]], [[0.0], [0.9]]]]
     >>> axis = (1, 2, 3)
-    >>> loss = keras.losses.dice(y_true, y_pred, axis=axis)
+    >>> loss = keras.losses.Dice(axis=axis, reduction=None)(y_true, y_pred)
     >>> assert loss.shape == (2,)
     >>> loss
     array([0.5, 0.75757575], shape=(2,), dtype=float32)
 
-    >>> loss = keras.losses.dice(y_true, y_pred)
+    >>> loss = keras.losses.Dice()(y_true, y_pred)
     >>> assert loss.shape == ()
     >>> loss
     array(0.6164384, shape=(), dtype=float32)
@@ -2543,6 +2543,24 @@ def dice(y_true, y_pred, axis=None):
 
     Returns:
         Dice loss value.
+
+    Example:
+
+    >>> y_true = [[[[1.0], [1.0]], [[0.0], [0.0]]],
+    ...           [[[1.0], [1.0]], [[0.0], [0.0]]]]
+    >>> y_pred = [[[[0.0], [1.0]], [[0.0], [1.0]]],
+    ...           [[[0.4], [0.0]], [[0.0], [0.9]]]]
+    >>> axis = (1, 2, 3)
+    >>> loss = keras.losses.dice(y_true, y_pred, axis=axis)
+    >>> assert loss.shape == (2,)
+    >>> loss
+    array([0.5, 0.75757575], shape=(2,), dtype=float32)
+
+    >>> loss = keras.losses.dice(y_true, y_pred)
+    >>> assert loss.shape == ()
+    >>> loss
+    array(0.6164384, shape=(), dtype=float32)
+    
     """
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)


### PR DESCRIPTION
### What's the update?
- Added example in docstring for Dice Loss **function**
- Updated example in docstring for Dice **class** to use the class instance, rather than the dice loss **function**

### Why was the update required?
- An example is missing for Dice Loss **function**