### PR TITLE
Fix warning for random_saturation

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/random_saturation.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_saturation.py
@@ -95,7 +95,7 @@ class RandomSaturation(BaseImagePreprocessingLayer):
             maxval=self.factor[1],
             seed=seed,
         )
-        factor = factor / (1 - factor)
+        factor = factor / (1 - factor + 1e-6)
         return {"factor": factor}
 
     def transform_images(self, images, transformation=None, training=True):

--- a/keras/src/layers/preprocessing/image_preprocessing/random_saturation.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_saturation.py
@@ -1,4 +1,5 @@
 from keras.src.api_export import keras_export
+from keras.src.backend import epsilon
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
 )
@@ -95,7 +96,7 @@ class RandomSaturation(BaseImagePreprocessingLayer):
             maxval=self.factor[1],
             seed=seed,
         )
-        factor = factor / (1 - factor + 1e-6)
+        factor = factor / (1 - factor + epsilon())
         return {"factor": factor}
 
     def transform_images(self, images, transformation=None, training=True):

--- a/keras/src/layers/preprocessing/image_preprocessing/random_saturation.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_saturation.py
@@ -95,7 +95,7 @@ class RandomSaturation(BaseImagePreprocessingLayer):
             maxval=self.factor[1],
             seed=seed,
         )
-        factor = factor / (1 - factor + 1e-6)
+        factor = factor / (1 - factor + self.backend.epsilon())
         return {"factor": factor}
 
     def transform_images(self, images, transformation=None, training=True):

--- a/keras/src/layers/preprocessing/image_preprocessing/random_saturation.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_saturation.py
@@ -95,7 +95,7 @@ class RandomSaturation(BaseImagePreprocessingLayer):
             maxval=self.factor[1],
             seed=seed,
         )
-        factor = factor / (1 - factor + self.backend.epsilon())
+        factor = factor / (1 - factor + 1e-6)
         return {"factor": factor}
 
     def transform_images(self, images, transformation=None, training=True):

--- a/keras/src/optimizers/muon.py
+++ b/keras/src/optimizers/muon.py
@@ -177,9 +177,9 @@ class Muon(optimizer.Optimizer):
                 gradient, variable, learning_rate * self.adam_lr_ratio
             )
         else:
-            self._muon_update_step (gradient, variable, learning_rate)
+            self._muon_update_step(gradient, variable, learning_rate)
 
-    def _muon_update_step (self, gradient, variable, lr):
+    def _muon_update_step(self, gradient, variable, lr):
         m = self.adam_momentums[variable.path]
         self.assign_add(m, ops.add(gradient, m * (self.momentum - 1)))
         shape = variable.shape


### PR DESCRIPTION
I have resolved the runtime warning that occurred when the factor was set to 1.0.

```
layer = keras.layers.RandomSaturation(factor=(1, 1), value_range=(0, 1))

...
RuntimeWarning: divide by zero encountered in divide
  factor = factor / (1 - factor)
```

