### PR TITLE
Use tf.int32.min rather than relying on integer overflow

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2078,7 +2078,7 @@ def signbit(x):
             tf.bitwise.bitwise_and(
                 tf.bitcast(x, tf.int32),
                 # tf.float32 sign bit
-                tf.constant(0x80000000, dtype=tf.int32),
+                tf.constant(tf.int32.min, dtype=tf.int32),
             ),
             0,
         )


### PR DESCRIPTION
Fixes #21047

keras == 3.9.0 + tensorflow < 2.18.0 is throwing `OverflowError: Python int too large to convert to C long` errors.

This is due to the new function `keras.src.backend.tensorflow.numpy.signbit`, where the signbit is identified by comparing the tensor to `tf.constant(0x80000000, dtype=tf.int32)`. The construction of this constant tensor fails on tensorflow < 2.18.0.

The underlying cause is that this calls `np.array(0x80000000, dtype=np.int32)` which throws the overflow error.

The intention of this constant tensor is to create a constant with binary representation `10000...` so that the signbit can be tested. Rather than relying on overflow of `tf.int32.max + 1`, this can instead be instantiated more reliably from `tf.int32.min`.