### PR TITLE
Special handling of Torch DDP in callback

### DIFF
--- a/keras/src/callbacks/callback.py
+++ b/keras/src/callbacks/callback.py
@@ -84,11 +84,11 @@ class Callback:
         ):
             # Keras Callbacks expect to work with Keras models. e.g.          |
             # ModelCheckpoint and EarlyStopping both attempt to call
-            # self.model.weights. Torch Modules do not# have this property,
-            # and when using DDP, self._model is a DistributedDataParallel
-            # instance, not a keras.Model instance. Therefore, when using
-            # DDP, we should "unwrap" the underlying model for use in
-            # the callbacks.
+            # keras-specific APIs on the value returned from this
+            # property. If this callback was created against a DDP
+            # wrapper instead of the underlying keras.Model, it is
+            # likely to fail. Return self._model.module for DDP
+            # instances instead.
             return self._model.module
         else:
             if backend.backend() == "jax" and hasattr(


### PR DESCRIPTION
Keras callbacks do not properly handle Torch DistributedDataParallel models. When using DDP, the keras.Model is wrapped in a DDP instance which is obviously not a keras.Model. The keras.Model must be retrieved from the DDP's `module` property, and the callbacks should execute against that instead.

Example of the Problem:
```
import os
os.environ["KERAS_BACKEND"]="torch"
os.environ["CUDA_VISIBLE_DEVICES"] = "0"  # For simplicity ...
os.environ["MASTER_ADDR"] = "127.0.0.1"
os.environ["MASTER_PORT"] = "29500"

import tempfile
import keras
import torch
from torch.nn.parallel import DistributedDataParallel

def test_callback(model):
    """
    Runs a callback through its lifecycle without actually doing any training...
    """
    logs = {"val_loss": 10}

    checkpoint_path = tempfile.NamedTemporaryFile('w', suffix=".keras", delete=True)
    callbacks = keras.callbacks.CallbackList(
        model=model,
        callbacks=[
            keras.callbacks.ModelCheckpoint(
                filepath=checkpoint_path.name,
                save_best_only=False)
        ]
    )

    callbacks.on_train_begin(logs=logs)
    callbacks.on_epoch_begin(0, logs=logs)
    callbacks.on_train_batch_begin(0, logs)
    callbacks.on_train_batch_end(0, logs)
    callbacks.on_epoch_end(0,logs={"val_loss":100})
    callbacks.on_train_end(logs=logs)


if __name__ == "__main__":
    # Create a super-simple model
    model = keras.Sequential([
        keras.layers.Dense(1, input_shape=(1,))
    ])

    # Test the callbacks against the keras.Model
    # this works fine...
    test_callback(model)

    # But if we want to use DDP, some callbacks will fail, since the model 
    # given to them is a DDP instance, not a keras.Model instance.
    torch.distributed.init_process_group(
        backend="gloo",
        init_method="env://",
        world_size=1,
        rank=0,
    )
    ddp_model = DistributedDataParallel(model, device_ids=[0], output_device=0)
    test_callback(ddp_model)
```

This raises an exception during `test_callback(ddp_model)`:
```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/timcsf/git/affectsai/arrc-ardt-training/src/test.py", line 101, in <module>
[rank0]:     test_callback(ddp_model)
[rank0]:   File "/home/timcsf/git/affectsai/arrc-ardt-training/src/test.py", line 82, in test_callback
[rank0]:     callback.on_epoch_end(0,logs={"val_loss":100})
[rank0]:   File "/home/timcsf/.local/lib/python3.12/site-packages/keras/src/callbacks/model_checkpoint.py", line 209, in on_epoch_end
[rank0]:     self._save_model(epoch=epoch, batch=None, logs=logs)
[rank0]:   File "/home/timcsf/.local/lib/python3.12/site-packages/keras/src/callbacks/model_checkpoint.py", line 292, in _save_model
[rank0]:     self.model.save(filepath, overwrite=True)
[rank0]:     ^^^^^^^^^^^^^^^
[rank0]:   File "/home/timcsf/miniconda3/envs/pytorch_cuda128/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1940, in __getattr__
[rank0]:     raise AttributeError(
[rank0]: AttributeError: 'DistributedDataParallel' object has no attribute 'save'
```

The callbacks must be executed on the keras.Model instance that is accessible via DistributedDataParallel.module instead. This PR patches keras.callback.Callback so that the `model` property checks to see if it is a DDP instance, and if so returns `self._model.module` instead of `self._model`

**Arguments AGAINST accepting this PR:**
1. Since users must define a custom training loop to use Keras3 with Torch DDP anyway, one could make the argument that this patch is not necessary, as you can simply do this in your custom training loop:

```
    callbacks = keras.callback.CallbackList(
        model=model.module if isinstance(model, DistributedDataParallel) else model,
        callbacks=[
            keras.callbacks.ModelCheckpoint(
                filepath=checkpoint_path.name,
                save_best_only=False)
        ]
    )
```
2. DistributedDataParallel _is _not__ a keras.Model and it is therefore reasonable to say that keras.callbacks will not work with it.

**Arguments FOR accepting this PR:**
I counter that keras callbacks work unmodified with Tensorflow's distributed training mechanism, and should be reasonably expected to behave the same when using PyTorch distributed training techniques instead. Obviously there is a major architectural difference -- TF doesn't wrap the keras.Model, so you're still passing it to the keras.callback.Callback with no additional thought required -- but requiring the additional thought when using Torch instead of TF violates the principal of progressive disclosure of complexity.

Further, since the model property in `keras.callbacks.Callback` already checks for the JAX backend to perform special handling, adding the additional check for Torch DDP does not seem to be unreasonable.

At a minimum, I would suggest that if this PR is rejected, that the documentation on distributed training with PyTorch backends be updated to demonstrate how to use keras callbacks with ddp in the custom train loop. It currently implies very heavily that "all you have to do wrap your model in `torch.nn.parallel.DistributedDataParallel` and off you go..." (clearly I am oversimplifying).