### PR TITLE
[OpenVINO Backend] Support: Implemented numpy.diagonal for keras ov backend

### DIFF
--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1,5 +1,5 @@
 import numpy as np
-import openvino.runtime.opset14 as ov_opset
+import openvino.opset14 as ov_opset
 from openvino import Type
 
 from keras.src.backend import config
@@ -595,7 +595,9 @@ def diagonal(x, offset=0, axis1=-2, axis2=-1):
         keras_dtype = ov_to_keras_type(x.get_element_type())
         np_dtype = np.dtype(keras_dtype)
         empty_np = np.empty((0,), dtype=np_dtype)
-        empty_const = ov_opset.constant(empty_np, x.get_element_type()).output(0)
+        empty_const = ov_opset.constant(empty_np, x.get_element_type()).output(
+            0
+        )
         return OpenVINOKerasTensor(empty_const)
 
     indices = np.array(indices, dtype=np.int32)


### PR DESCRIPTION
- [x] 1. Implemented a diagonal function similar to diag, handling 2D+ tensors.
- [x] 2. Extracted diagonals based on the given axis1, axis2, and offset (k).
- [x] 3. Used OpenVINO ops like gather or gather_nd to fetch diagonal elements.



**Ticket Id:**

[#29116](https://github.com/openvinotoolkit/openvino/issues/29116)


 **Concerned Authority:**

CC: @rkazants