### PR TITLE
Fix Remat error when called with a model

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1051,6 +1051,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         ) as scope:
             if self.dtype_policy.quantization_mode is not None:
                 if self._remat_mode is not None:
+                    print("rematerializing", self._remat_mode)
                     outputs = self.rematerialized_call(
                         self.quantized_call, *args, **kwargs
                     )

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1642,7 +1642,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
                 @functools.wraps(layer_call)
                 def rematerialized_activation_call_wrapper(*args, **kwargs):
                     original_activation = self.activation
-                    self.activation = remat(original_activation)
+                    self.activation = remat.remat(original_activation)
                     try:
                         return layer_call(*args, **kwargs)
                     finally:

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1051,7 +1051,6 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         ) as scope:
             if self.dtype_policy.quantization_mode is not None:
                 if self._remat_mode is not None:
-                    print("rematerializing", self._remat_mode)
                     outputs = self.rematerialized_call(
                         self.quantized_call, *args, **kwargs
                     )

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -17,6 +17,7 @@ And some more magic:
 """
 
 import collections
+import functools
 import inspect
 import math
 import warnings
@@ -1594,30 +1595,6 @@ class Layer(BackendLayer, Operation, KerasSaveable):
             self._parent_path = current_path()
         return backend.name_scope(self.name, caller=self)
 
-    def rematerialized_activation_call_wrapper(self, layer_call):
-        """Wrapper to enable remat specifically for layers with activations.
-
-        This wrapper temporarily replaces the layer's activation function with a
-        rematerialized version before calling the original layer's `call` method
-        and restores it afterward.
-
-        Args:
-            layer_call: The original `call` method of a layer.
-            *args: Positional arguments passed to the layer's `call` method.
-            **kwargs: Keyword arguments passed to the layer's `call` method.
-
-        Returns:
-            The result of the layer's `call` method.
-        """
-
-        original_activation = self.activation
-        rematted_activation = remat.remat(original_activation)
-        self.activation = rematted_activation
-        try:
-            return layer_call
-        except:
-            self.activation = original_activation
-
     def rematerialized_call(self, layer_call, *args, **kwargs):
         """Enable rematerialization dynamically for layer's call method.
 
@@ -1661,7 +1638,17 @@ class Layer(BackendLayer, Operation, KerasSaveable):
                 hasattr(self, "activation") and self.activation is not None
             )
             if has_activation:
-                return self.rematerialized_activation_call_wrapper(layer_call)
+
+                @functools.wraps(layer_call)
+                def rematerialized_activation_call_wrapper(*args, **kwargs):
+                    original_activation = self.activation
+                    self.activation = remat(original_activation)
+                    try:
+                        return layer_call(*args, **kwargs)
+                    finally:
+                        self.activation = original_activation
+
+                return rematerialized_activation_call_wrapper
         return layer_call
 
 

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1615,7 +1615,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         self.activation = rematted_activation
         try:
             return layer_call
-        finally:
+        except:
             self.activation = original_activation
 
     def rematerialized_call(self, layer_call, *args, **kwargs):

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -17,6 +17,7 @@ from keras.src.backend.common import global_state
 from keras.src.backend.common import remat
 from keras.src.backend.common.remat import RematScope
 from keras.src.models import Model
+from keras.src.utils import traceback_utils
 
 
 class LayerTest(testing.TestCase):
@@ -219,6 +220,7 @@ class LayerTest(testing.TestCase):
             self.skipTest(
                 "remat is not supported in openvino and numpy backends."
             )
+        traceback_utils.enable_traceback_filtering()
         with patch(
             "keras.src.backend.common.remat.remat", wraps=remat.remat
         ) as mock_remat:

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -16,6 +16,7 @@ from keras.src import testing
 from keras.src.backend.common import global_state
 from keras.src.backend.common.remat import RematScope
 from keras.src.models import Model
+from keras.src.utils import traceback_utils
 
 
 class MockRemat:
@@ -237,7 +238,7 @@ class LayerTest(testing.TestCase):
             self.skipTest(
                 "remat is not supported in openvino and numpy backends."
             )
-        # traceback_utils.enable_traceback_filtering()
+        traceback_utils.enable_traceback_filtering()
         mock_remat = MockRemat()
         with mock.patch(
             "keras.src.backend.common.remat.remat", wraps=mock_remat

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -39,13 +39,12 @@ class Operation:
                     if getattr(self, "quantization_mode", None) is not None:
                         call_fn = self.rematerialized_call(
                             self.quantized_call,
-                            get_function_only=True,
                             *args,
                             **kwargs,
                         )
                     else:
                         call_fn = self.rematerialized_call(
-                            self.call, get_function_only=True, *args, **kwargs
+                            self.call, *args, **kwargs
                         )
                 else:
                     if getattr(self, "quantization_mode", None) is not None:
@@ -65,9 +64,11 @@ class Operation:
             if getattr(self, "quantization_mode", None) is not None:
                 return self.rematerialized_call(
                     self.quantized_call, *args, **kwargs
-                )
+                )(*args, **kwargs)
             else:
-                return self.rematerialized_call(self.call, *args, **kwargs)
+                return self.rematerialized_call(self.call, *args, **kwargs)(
+                    *args, **kwargs
+                )
         else:
             if getattr(self, "quantization_mode", None) is not None:
                 return self.quantized_call(*args, **kwargs)

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -1,10 +1,13 @@
 import inspect
+import math
 import textwrap
 
 from keras.src import backend
 from keras.src import dtype_policies
 from keras.src import tree
 from keras.src.api_export import keras_export
+from keras.src.backend.common import remat
+from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.backend.common.keras_tensor import any_symbolic_tensors
 from keras.src.ops.node import Node
 from keras.src.utils import python_utils
@@ -28,6 +31,51 @@ class Operation:
         self._inbound_nodes = []
         self._outbound_nodes = []
 
+    def rematerialized_function(self, function, *args, **kwargs):
+        """Rematerialize a function based on remat mode."""
+
+        def compute_size(x):
+            return (
+                math.prod([d or 1 for d in x.shape])
+                if isinstance(x, KerasTensor)
+                else 0
+            )
+
+        # Full rematerialization
+        if self._remat_mode.mode == "full":
+            return remat.remat(function)
+
+        # Apply rematerialization to specific layers
+        elif self._remat_mode.mode == "list_of_layers" and (
+            self.name in self._remat_mode.layer_names
+        ):
+            return remat.remat(function)
+        # Apply rematerialization based on output size threshold
+        elif self._remat_mode.mode == "larger_than":
+            output_spec = self.compute_output_spec(*args, **kwargs)
+            output_size = sum(
+                tree.flatten(tree.map_structure(compute_size, output_spec))
+            )
+            if (
+                output_size
+                and output_size > self._remat_mode.output_size_threshold
+            ):
+                return remat.remat(function)
+
+        elif self._remat_mode.mode == "activations":
+            has_activation = (
+                hasattr(self, "activation") and self.activation is not None
+            )
+            if has_activation:
+                not_rematted_activation = self.activation
+                try:
+                    self.activation = remat.remat(not_rematted_activation)
+                    return function
+                finally:
+                    self.activation = not_rematted_activation
+
+        return function
+
     @traceback_utils.filter_traceback
     def __call__(self, *args, **kwargs):
         if traceback_utils.is_traceback_filtering_enabled():
@@ -37,9 +85,13 @@ class Operation:
             else:
                 if getattr(self, "_remat_mode", None) is not None:
                     if getattr(self, "quantization_mode", None) is not None:
-                        call_fn = self.rematerialized_call(self.quantized_call)
+                        call_fn = self.rematerialized_function(
+                            self.quantized_call, *args, **kwargs
+                        )
                     else:
-                        call_fn = self.rematerialized_call(self.call)
+                        call_fn = self.rematerialized_function(
+                            self.call, *args, **kwargs
+                        )
                 else:
                     if getattr(self, "quantization_mode", None) is not None:
                         call_fn = self.quantized_call


### PR DESCRIPTION
When RematScope was applied to a model the following error was encountered
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
[<ipython-input-2-38319c893c81>](https://localhost:8080/#) in <cell line: 0>()
     12     "padding_mask": np.array([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]]),
     13 }
---> 14 gemma_model_backbone(input_data)

1 frames
[/usr/local/lib/python3.11/dist-packages/keras/src/utils/traceback_utils.py](https://localhost:8080/#) in error_handler(*args, **kwargs)
    120             # To get the full stack trace, call:
    121             # `keras.config.disable_traceback_filtering()`
--> 122             raise e.with_traceback(filtered_tb) from None
    123         finally:
    124             del filtered_tb

[/usr/local/lib/python3.11/dist-packages/tensorflow/python/ops/custom_gradient.py](https://localhost:8080/#) in inner(*args, **kwargs)
    709     current_var_scope = variable_scope.get_variable_scope()
    710     with record.stop_recording():
--> 711       result = f(*args, **kwargs)
    712 
    713     def grad_wrapper(*wrapper_args, variables=None):

TypeError: Functional.call() missing 1 required positional argument: 'inputs'
```
This PR should fix the issue
The fix has been tested with training a Gemma backbone here 
 https://colab.sandbox.google.com/drive/16pUDE_OfUDGY9BuXwZ8lFm8dntaruraf#scrollTo=-Gg95NUB-nHw