### PR TITLE
Fix `Model.export` to Saved Model for models with dict inputs.

### DIFF
--- a/keras/src/export/export_utils.py
+++ b/keras/src/export/export_utils.py
@@ -17,10 +17,12 @@ def get_input_signature(model):
             "The model provided has not yet been built. It must be built "
             "before export."
         )
-    if isinstance(model, (models.Functional, models.Sequential)):
+    if isinstance(model, models.Functional):
+        input_signature = [
+            tree.map_structure(make_input_spec, model._inputs_struct)
+        ]
+    elif isinstance(model, models.Sequential):
         input_signature = tree.map_structure(make_input_spec, model.inputs)
-        if isinstance(input_signature, list) and len(input_signature) > 1:
-            input_signature = [input_signature]
     else:
         input_signature = _infer_input_signature_from_model(model)
         if not input_signature or not model._called:

--- a/keras/src/export/saved_model_test.py
+++ b/keras/src/export/saved_model_test.py
@@ -728,19 +728,7 @@ class ExportArchiveTest(testing.TestCase):
         ref_inputs = [tf.random.normal((3, 2)), tf.random.normal((3, 2))]
         ref_outputs = model(ref_inputs)
 
-        export_archive = saved_model.ExportArchive()
-        export_archive.track(model)
-        export_archive.add_endpoint(
-            "serve",
-            model.__call__,
-            input_signature=[
-                [
-                    tf.TensorSpec(shape=(None, 2), dtype=tf.float32),
-                    tf.TensorSpec(shape=(None, 2), dtype=tf.float32),
-                ]
-            ],
-        )
-        export_archive.write_out(temp_filepath)
+        model.export(temp_filepath)
         revived_model = tf.saved_model.load(temp_filepath)
         self.assertAllClose(ref_outputs[0], revived_model.serve(ref_inputs)[0])
         self.assertAllClose(ref_outputs[1], revived_model.serve(ref_inputs)[1])
@@ -758,19 +746,7 @@ class ExportArchiveTest(testing.TestCase):
         }
         ref_outputs = model(ref_inputs)
 
-        export_archive = saved_model.ExportArchive()
-        export_archive.track(model)
-        export_archive.add_endpoint(
-            "serve",
-            model.__call__,
-            input_signature=[
-                {
-                    "x1": tf.TensorSpec(shape=(None, 2), dtype=tf.float32),
-                    "x2": tf.TensorSpec(shape=(None, 2), dtype=tf.float32),
-                }
-            ],
-        )
-        export_archive.write_out(temp_filepath)
+        model.export(temp_filepath)
         revived_model = tf.saved_model.load(temp_filepath)
         self.assertAllClose(ref_outputs[0], revived_model.serve(ref_inputs)[0])
         self.assertAllClose(ref_outputs[1], revived_model.serve(ref_inputs)[1])


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras/issues/20835

Also changed multi-input tests to exercise `model.export()` and its signature inference logic.