### PR TITLE
fixes activation layer serialization logic

### DIFF
--- a/keras/src/activations/__init__.py
+++ b/keras/src/activations/__init__.py
@@ -116,7 +116,7 @@ def get(identifier):
     if identifier is None:
         return linear
     if isinstance(identifier, dict):
-        obj = deserialize(identifier)
+        obj = serialization_lib.deserialize_keras_object(identifier)
     elif isinstance(identifier, str):
         obj = ALL_OBJECTS_DICT.get(identifier, None)
     else:

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -367,6 +367,44 @@ class SerializationLibTest(testing.TestCase):
         obj = serialization_lib.deserialize_keras_object(config)
         self.assertIs(obj, custom_registered_fn)
 
+    def test_layer_instance_as_activation(self):
+        """Tests serialization when activation is a Layer instance."""
+
+        # Dense layer with ReLU layer as activation
+        layer_dense_relu = keras.layers.Dense(
+            units=4, activation=keras.layers.ReLU(name="my_relu")
+        )
+        # Build the layer to ensure weights/state are initialized if needed
+        layer_dense_relu.build(input_shape=(None, 8))
+        _, restored_dense_relu, _ = self.roundtrip(layer_dense_relu)
+
+        # Verify the activation is correctly deserialized as a ReLU layer instance
+        self.assertIsInstance(restored_dense_relu.activation, keras.layers.ReLU)
+        # Verify properties are preserved
+        self.assertEqual(restored_dense_relu.activation.name, "my_relu")
+
+    def test_layer_instance_with_config_as_activation(self):
+        """Tests serialization when activation is a Layer instance with config."""
+
+        # Conv1D layer with LeakyReLU layer (with config) as activation
+        leaky_activation = keras.layers.LeakyReLU(
+            negative_slope=0.15, name="my_leaky"
+        )
+        layer_conv_leaky = keras.layers.Conv1D(
+            filters=2, kernel_size=3, activation=leaky_activation
+        )
+        # Build the layer
+        layer_conv_leaky.build(input_shape=(None, 10, 4))
+        _, restored_conv_leaky, _ = self.roundtrip(layer_conv_leaky)
+
+        # Verify the activation is correctly deserialized as LeakyReLU
+        self.assertIsInstance(
+            restored_conv_leaky.activation, keras.layers.LeakyReLU
+        )
+        # Verify configuration of the activation layer is preserved
+        self.assertEqual(restored_conv_leaky.activation.negative_slope, 0.15)
+        self.assertEqual(restored_conv_leaky.activation.name, "my_leaky")
+
 
 @keras.saving.register_keras_serializable()
 class MyDense(keras.layers.Layer):

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -405,6 +405,22 @@ class SerializationLibTest(testing.TestCase):
         self.assertEqual(restored_conv_leaky.activation.negative_slope, 0.15)
         self.assertEqual(restored_conv_leaky.activation.name, "my_leaky")
 
+    def test_layer_string_as_activation(self):
+        """Tests serialization when activation is a string."""
+
+        layer_dense_relu_string = keras.layers.Dense(units=4, activation="relu")
+        layer_dense_relu_string.build(input_shape=(None, 8))
+        _, restored_dense_relu_string, _ = self.roundtrip(
+            layer_dense_relu_string
+        )
+
+        # Verify the activation is correctly deserialized to the relu function
+        self.assertTrue(callable(restored_dense_relu_string.activation))
+        # Check if it resolves to the canonical keras activation function
+        self.assertEqual(
+            restored_dense_relu_string.activation, keras.activations.relu
+        )
+
 
 @keras.saving.register_keras_serializable()
 class MyDense(keras.layers.Layer):


### PR DESCRIPTION
This PR fixes a bug in `keras.activations.get` that prevented Keras layers from being correctly deserialized when their activation argument was configured using a Keras Layer instance (e.g., activation=layers.ReLU()) instead of a string identifier (e.g., activation="relu").

## Problem
Keras layers generally support specifying activation functions either via string identifiers ("relu") or by passing an actual activation Layer instance (layers.ReLU()).

While using a Layer instance works during model definition, serialization and subsequent deserialization fail.

The typical error encountered is:
```
ValueError: Could not interpret activation function identifier: {'module': 'keras.layers', 'class_name': 'ReLU', 'config': {...}, 'registered_name': None}
```

## Root Cause
1. When deserializing a layer, the `from_config` method typically retrieves the activation config (which is a dictionary in this case) and passes it to `keras.activations.get()`.
2. `keras.activations.get()` detects the dictionary input and calls `keras.activations.deserialize()`.
3. `keras.activations.deserialize()` is a wrapper around `keras.saving.deserialize_keras_object()`, passing the dictionary config along with `module_objects=ALL_OBJECTS_DICT` (where `ALL_OBJECTS_DICT` maps activation strings like "relu" to their callables).
4. Inside `keras.saving.deserialize_keras_object()`, there's a specific code path executed when `module_objects` is provided. This path checks if the input config (our dictionary) is a key within `module_objects`. Since the dictionary (config of the activation layer) is not a string key like "relu", this check fails.
5. Crucially, in this specific scenario (dictionary input + module_objects provided + key not found in module_objects), the function incorrectly returns the original dictionary config instead of proceeding to the logic that deserializes Keras objects from their dictionary representations using from_config.
6. Back in `keras.activations.get()`, the returned value is the original dictionary. The final if callable(obj): check fails because a dictionary is not callable, leading to the `ValueError`.