### PR TITLE
Add OpenVINO backend support for numpy.expm1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ examples/**/*.jpg
 .python-version
 .coverage
 *coverage.xml
-.ruff_cache
+.ruff_cachepytest.ini

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ examples/**/*.jpg
 .python-version
 .coverage
 *coverage.xml
-.ruff_cachepytest.ini
+.ruff_cache

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1379,3 +1379,13 @@ def argpartition(x, kth, axis=-1):
     raise NotImplementedError(
         "`argpartition` is not supported with openvino backend"
     )
+
+@numpy_support
+def expm1(x):
+    """Calculates exp(x) - 1 element-wise.
+
+    >>> x = np.array([0.0, 1.0])
+    >>> print(expm1(x))
+    [0.        1.7182817]
+    """
+    return ov.exp(x) - ov.constant(1, dtype=x.dtype)

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -703,10 +703,7 @@ def expand_dims(x, axis):
 
 
 def expm1(x):
-    element_type = None
-    if isinstance(x, OpenVINOKerasTensor):
-        element_type = x.output.get_element_type()
-    x = get_ov_output(x, element_type)
+    x = get_ov_output(x)
     one = ov_opset.constant(1.0, dtype=x.get_element_type())
     return OpenVINOKerasTensor(ov_opset.subtract(ov_opset.exp(x), one).output(0))
 
@@ -1378,7 +1375,6 @@ def slogdet(x):
     raise NotImplementedError(
         "`slogdet` is not supported with openvino backend"
     )
-
 
 def argpartition(x, kth, axis=-1):
     raise NotImplementedError(

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1376,6 +1376,7 @@ def slogdet(x):
         "`slogdet` is not supported with openvino backend"
     )
 
+
 def argpartition(x, kth, axis=-1):
     raise NotImplementedError(
         "`argpartition` is not supported with openvino backend"

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -703,7 +703,12 @@ def expand_dims(x, axis):
 
 
 def expm1(x):
-    raise NotImplementedError("`expm1` is not supported with openvino backend")
+    element_type = None
+    if isinstance(x, OpenVINOKerasTensor):
+        element_type = x.output.get_element_type()
+    x = get_ov_output(x, element_type)
+    one = ov_opset.constant(1.0, dtype=x.get_element_type())
+    return OpenVINOKerasTensor(ov_opset.subtract(ov_opset.exp(x), one).output(0))
 
 
 def flip(x, axis=None):
@@ -1379,12 +1384,3 @@ def argpartition(x, kth, axis=-1):
     raise NotImplementedError(
         "`argpartition` is not supported with openvino backend"
     )
-
-
-def expm1(x):
-    element_type = None
-    if isinstance(x, OpenVINOKerasTensor):
-        element_type = x.output.get_element_type()
-    x = get_ov_output(x, element_type)
-    one = ov_opset.constant(1.0, dtype=x.get_element_type())
-    return OpenVINOKerasTensor(ov_opset.subtract(ov_opset.exp(x), one).output(0))

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1380,12 +1380,11 @@ def argpartition(x, kth, axis=-1):
         "`argpartition` is not supported with openvino backend"
     )
 
-@numpy_support
-def expm1(x):
-    """Calculates exp(x) - 1 element-wise.
 
-    >>> x = np.array([0.0, 1.0])
-    >>> print(expm1(x))
-    [0.        1.7182817]
-    """
-    return ov.exp(x) - ov.constant(1, dtype=x.dtype)
+def expm1(x):
+    element_type = None
+    if isinstance(x, OpenVINOKerasTensor):
+        element_type = x.output.get_element_type()
+    x = get_ov_output(x, element_type)
+    one = ov_opset.constant(1.0, dtype=x.get_element_type())
+    return OpenVINOKerasTensor(ov_opset.subtract(ov_opset.exp(x), one).output(0))


### PR DESCRIPTION
This pull request adds OpenVINO backend support for numpy.expm1. The expm1 function is implemented using OpenVINO operations to perform element-wise exp(x) - 1.

Changes include:
- Added expm1 implementation in `numpy.py` for OpenVINO backend.
- Updated relevant files to ensure compatibility with the new operation.
- Verified correctness by running relevant tests.
