### PR TITLE
[Keras 3 OpenVINO Backend]: Support numpy.log1p operation

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -33,7 +33,6 @@ NumpyDtypeTest::test_isfinite
 NumpyDtypeTest::test_isinf
 NumpyDtypeTest::test_isnan
 NumpyDtypeTest::test_linspace
-NumpyDtypeTest::test_log1p
 NumpyDtypeTest::test_logaddexp
 NumpyDtypeTest::test_logspace
 NumpyDtypeTest::test_matmul_

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -853,8 +853,17 @@ def log10(x):
 
 
 def log1p(x):
-    raise NotImplementedError("`log1p` is not supported with openvino backend")
+    x = get_ov_output(x)
+    x_type = x.get_element_type()
 
+    if x_type.is_integral():
+        x_type = OPENVINO_DTYPES[config.floatx()]
+        x = ov_opset.convert(x, x_type)
+
+    one_const = ov_opset.constant(1, x_type).output(0)
+    added = ov_opset.add(x, one_const).output(0)
+    result = ov_opset.log(added).output(0)
+    return OpenVINOKerasTensor(result)
 
 def log2(x):
     x = get_ov_output(x)


### PR DESCRIPTION
 @rkazants 
 Details: Added support numpy.log1p operation and a successful test run. [Code](https://github.com/victorgearhead/keras/blob/a7a1f794b0c0915a53fe7cd3836044dc104d5cae/keras/src/backend/numpy/numpy.py#L670)

can you review please ?


-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 5884 passed, 12 skipped, 200 warnings in 140.08s (0:02:20) ================= 