### PR TITLE
Add support for numpy.flip in OpenVINO backend

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -91,7 +91,6 @@ NumpyOneInputOpsCorrectnessTest::test_diag
 NumpyOneInputOpsCorrectnessTest::test_diagonal
 NumpyOneInputOpsCorrectnessTest::test_exp2
 NumpyOneInputOpsCorrectnessTest::test_expm1
-NumpyOneInputOpsCorrectnessTest::test_flip
 NumpyOneInputOpsCorrectnessTest::test_floor_divide
 NumpyOneInputOpsCorrectnessTest::test_hstack
 NumpyOneInputOpsCorrectnessTest::test_imag

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -23,7 +23,6 @@ NumpyDtypeTest::test_einsum
 NumpyDtypeTest::test_exp2
 NumpyDtypeTest::test_expm1
 NumpyDtypeTest::test_eye
-NumpyDtypeTest::test_flip
 NumpyDtypeTest::test_floor
 NumpyDtypeTest::test_hstack
 NumpyDtypeTest::test_identity

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -730,7 +730,7 @@ def flip(x, axis=None):
         stop  = ov_opset.constant(-1, Type.i64).output(0)
         step  = ov_opset.constant(-1, Type.i64).output(0)
 
-        reversed_indices = ov_opset.range(start, stop, step).output(0)
+        reversed_indices = ov_opset.range(start, stop, step,Type.i64).output(0)
         x = ov_opset.gather(
             x,
             reversed_indices,

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -718,7 +718,7 @@ def flip(x, axis=None):
         axis = list(axis)
     axis_const = ov_opset.constant(axis, Type.i32).output(0)
     flipped = ov_opset.reverse(x, axis_const, mode="index").output(0)
-    return OpenVINOKerasTensor(flipped)    
+    return OpenVINOKerasTensor(flipped)
 
 
 def floor(x):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -723,20 +723,21 @@ def flip(x, axis=None):
     for ax in sorted(axis):
         dim_node = ov_opset.gather(
             shape_of_x,
-            ov_opset.constant(ax, Type.i32).output(0),
-            ov_opset.constant(0, Type.i32).output(0),
+            ov_opset.constant(ax, Type.i64).output(0),
+            ov_opset.constant(0, Type.i64).output(0),
         ).output(0)
-        start = ov_opset.subtract(dim_node, ov_opset.constant(1, Type.i32).output(0)).output(0)
-        stop  = ov_opset.constant(-1, Type.i32).output(0)
-        step  = ov_opset.constant(-1, Type.i32).output(0)
+        start = ov_opset.subtract(dim_node, ov_opset.constant(1, Type.i64).output(0)).output(0)
+        stop  = ov_opset.constant(-1, Type.i64).output(0)
+        step  = ov_opset.constant(-1, Type.i64).output(0)
 
         reversed_indices = ov_opset.range(start, stop, step).output(0)
         x = ov_opset.gather(
             x,
             reversed_indices,
-            ov_opset.constant(ax, Type.i32).output(0)
+            ov_opset.constant(ax, Type.i64).output(0)
         ).output(0)
     return OpenVINOKerasTensor(x)
+
 
 
 def floor(x):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -712,15 +712,15 @@ def flip(x, axis=None):
     x = get_ov_output(x)
     rank = x.get_partial_shape().rank.get_length()
     if axis is None:
-        axes = list(range(rank))
+        axis = list(range(rank))
     else:
         if np.isscalar(axis):
             axis = [axis]
         else:
             axis = list(axis)
-        axes = [ax if ax >= 0 else ax + rank for ax in axes]
+        axis = [ax if ax >= 0 else ax + rank for ax in axis]
     shape_of_x = ov_opset.shape_of(x)
-    for ax in sorted(axes):
+    for ax in sorted(axis):
         dim_node = ov_opset.gather(
             shape_of_x,
             ov_opset.constant(ax, Type.i32).output(0),
@@ -729,7 +729,7 @@ def flip(x, axis=None):
         start = ov_opset.subtract(dim_node, ov_opset.constant(1, Type.i32).output(0)).output(0)
         stop  = ov_opset.constant(-1, Type.i32).output(0)
         step  = ov_opset.constant(-1, Type.i32).output(0)
-        
+
         reversed_indices = ov_opset.range(start, stop, step).output(0)
         x = ov_opset.gather(
             x,

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -707,7 +707,18 @@ def expm1(x):
 
 
 def flip(x, axis=None):
-    raise NotImplementedError("`flip` is not supported with openvino backend")
+    if axis == () or axis == []:
+        return x
+    x = get_ov_output(x)
+    if axis is None:
+        axis = list(range(len(x.get_shape())))
+    elif isinstance(axis, int):
+        axis = [axis]
+    else:
+        axis = list(axis)
+    axis_const = ov_opset.constant(axis, Type.i32).output(0)
+    flipped = ov_opset.reverse(x, axis_const, mode="index").output(0)
+    return OpenVINOKerasTensor(flipped)    
 
 
 def floor(x):


### PR DESCRIPTION
## Summary

This PR adds OpenVINO backend support for `numpy.flip` in Keras 3.

- Decomposed `numpy.flip` using OpenVINO’s `reverse` operator with `"index"` mode.
- Added handling for axis=None (flip all axes) and single/multiple axes.
- Confirmed that all tests in `keras/src/ops/numpy_test.py` pass with the OpenVINO backend.


### Testing

- Removed `flip openvino` from `excluded_concrete_tests.txt`
- Ran tests using `KERAS_BACKEND=openvino`
- Verified `flip_test.py` passes and is covered in full suite

