### PR TITLE
WIP: Add PyTorch backend support for LSTM with CuDNN optimization

### DIFF
--- a/keras/src/backend/torch/rnn.py
+++ b/keras/src/backend/torch/rnn.py
@@ -1,7 +1,9 @@
 import torch
 
 from keras.src import tree
-from keras.src.backend.torch.core import convert_to_tensor
+from keras.src.backend.torch.core import convert_to_tensor,get_device
+import torch.nn.utils.rnn as rnn_utils
+import numpy as np
 
 
 def rnn(
@@ -370,13 +372,324 @@ def rnn(
 
     return last_output, outputs, new_states
 
+def _is_sequence_right_padded(mask):
+    """Check the mask tensor and see if it right padded.
 
-def cudnn_ok(*args, **kwargs):
-    return False
+    cuDNN uses the sequence length param to skip the tailing
+    timestep. If the data is left padded, or not a strict right padding (has
+    masked value in the middle of the sequence), then cuDNN won't work
+    properly in those cases.
+
+    Left padded data: [[False, False, True, True, True]].
+    Right padded data: [[True, True, True, False, False]].
+    Mixture of mask/unmasked data: [[True, False, True, False, False]].
+
+    Note that for the mixed data example above, the actually data RNN should see
+    are those 2 Trues (index 0 and 2), the index 1 False should be ignored and
+    not pollute the internal states.
+
+    Args:
+        mask: the Boolean tensor with shape [batch, timestep]
+
+    Returns:
+        boolean scalar tensor, whether the mask is strictly right padded.
+    """
+    #Get max sequence length
+    max_seq_length = mask.shape[1]
+    #Count True values in each sequence
+    count_of_true = torch.sum(mask, dim=1)
+    #Create right padded mask
+    batch_size = mask.shape[0]
+    indices = torch.arange(max_seq_length,device = mask.device).repeat(batch_size, 1)
+    right_padded_mask = indices < count_of_true.unsqueeze(1)
+    return torch.all(mask == right_padded_mask)
+
+def _has_fully_masked_sequence(mask):
+    # Cudnn kernel will error out if the input sequence contains any
+    # fully masked data. We walk around this issue by rerouting the computation
+    # to standard kernel, until the issue on cudnn side has been fixed.  For a
+    # fully masked sequence, it will contain all Falses. To make it easy to
+    # check, we inverse the boolean, check if any of the sequence has all True.
+    return torch.any(
+    torch.all(~mask, dim=1))
+
+def _assert_valid_mask(mask):
+    # Check if mask is valid for cuDNN
+    no_fully_masked = ~_has_fully_masked_sequence(mask)
+    is_right_padded = _is_sequence_right_padded(mask)
+    valid = no_fully_masked & is_right_padded
+
+    if not valid.item():
+        error_message = (
+            "You are passing a RNN mask that does not correspond to "
+            "right-padded sequences, while using cuDNN, which is not "
+            "supported. With cuDNN, RNN masks can only be used for "
+            "right-padding, e.g. `[[True, True, False, False]]` would "
+            "be a valid mask, but any mask that isn't just contiguous "
+            "`True`'s on the left and contiguous `False`'s on the right "
+            "would be invalid. You can pass `use_cudnn=False` to your "
+            "RNN layer to stop using cuDNN (this may be slower)."
+        )
+        raise ValueError(error_message)
 
 
-def lstm(*args, **kwargs):
-    raise NotImplementedError
+def _compute_sequence_length_from_mask(mask, batch_first):
+    """Calculate the sequence length tensor (1-D) based on the masking tensor.
+
+    The masking tensor is a 2D boolean tensor with shape [batch, timestep]. For
+    any timestep that should be masked, the corresponding field will be False.
+    Consider the following example:
+      a = [[True, True, False, False]
+           [True, True, True, False]]
+    It is a (2, 4) tensor, and the corresponding sequence length result should
+    be 1D tensor with value [2, 3]. Note that the masking tensor must be right
+    padded that could be checked by, e.g., `is_sequence_right_padded()`.
+
+    Args:
+        mask: Boolean tensor with shape [batch, timestep] or [timestep, batch]
+            if time_major=True.
+        time_major: Boolean, which indicates whether the mask is time major or
+            batch major.
+
+    Returns:
+        sequence_length: 1D int32 tensor.
+    """
+    timestep_index = 0 if not batch_first else 1
+    return torch.sum(mask.int(), dim=timestep_index)
+
+def prepare_lstm_weights(lstm,kernel,recurrent_kernel,bias,device):
+    """Copies kernel and recurrent kernel weights in the Pytorch format
+    We split the kernel and recurrent kernel weights, create associated
+    torch tensors adapted to be in line with the Cudnn optimization.
+    After we have copied the weights, we ensure the paramters are on 
+    the same device and memory layout is optimized for Cudnn.
+    
+    """
+
+    lstm = lstm.to(device)
+
+    input_size = lstm.input_size
+    hidden_size = lstm.hidden_size
+
+    # Convert gates from Keras [i,f,c,o] to PyTorch [i,f,g,o]
+    i_k, f_k, c_k, o_k = np.split(kernel, 4, axis=1)
+    weight_ih_data = np.concatenate([i_k, f_k, c_k, o_k], axis=1).T
+
+    i_r, f_r, c_r, o_r = np.split(recurrent_kernel, 4, axis=1)
+    weight_hh_data = np.concatenate([i_r, f_r, c_r, o_r], axis=1).T
+
+    if bias is not None:
+        # Split Keras combined bias into input and hidden biases
+        bias_ih_data = convert_to_tensor(bias,  dtype="float32")
+        bias_hh_data = torch.zeros_like(bias_ih_data)
+
+    else:
+        bias_ih_data = torch.zeros(4 * hidden_size, device=device)
+        bias_hh_data = torch.zeros(4 * hidden_size, device=device)
+
+    # Create PyTorch tensors for weights
+    weight_ih = convert_to_tensor(weight_ih_data,  dtype="float32").contiguous()
+    weight_hh = convert_to_tensor(weight_hh_data,  dtype="float32").contiguous()
+    bias_ih = convert_to_tensor(bias_ih_data, dtype="float32").contiguous()
+    bias_hh = convert_to_tensor(bias_hh_data, dtype="float32").contiguous()
+
+    # Ensure the weights are all on the same device
+    weight_ih = weight_ih.to(device)
+    weight_hh = weight_hh.to(device)
+    bias_ih = bias_ih.to(device)
+    bias_hh = bias_hh.to(device)
+
+    # Copy Keras weights into Torch's flat weights
+    with torch.no_grad():
+        lstm.weight_ih_l0.copy_(weight_ih)
+        lstm.weight_hh_l0.copy_(weight_hh)
+        lstm.bias_ih_l0.copy_(bias_ih)
+        lstm.bias_hh_l0.copy_(bias_hh)
+
+    # Optimize the layout
+    lstm.flatten_parameters()
+
+    # After prepare_lstm_weights:
+    # Force all LSTM parameters to be on the correct device
+    for param in lstm.parameters():
+        if param.device != device:
+            param.data = param.data.to(device)
+
+def _is_cuda_cudnn_available():
+    # We check if the cuda device is available and cudnn drivers are installed for it
+    return torch.cuda.is_available() and torch.backends.cudnn.is_available()
+
+def cudnn_ok(
+    activation,
+    recurrent_activation,
+    unroll,
+    go_backwards,
+    use_bias=True,
+):
+    from keras.src import activations
+    from keras.src import ops
+
+    return (
+        activation in (activations.tanh, torch.tanh, ops.tanh)
+        and recurrent_activation
+        in (activations.sigmoid, torch.sigmoid, ops.sigmoid)
+        and not unroll
+        and use_bias
+        and not go_backwards
+        and _is_cuda_cudnn_available()
+    )
+
+def lstm(
+    inputs,
+    initial_state_h,
+    initial_state_c,
+    mask,
+    kernel,
+    recurrent_kernel,
+    bias,
+    activation,
+    recurrent_activation,
+    return_sequences=False,
+    go_backwards=False,
+    unroll=False,
+    batch_first=True,
+):
+
+    cudnn_supported = cudnn_ok(
+        activation, recurrent_activation,unroll,
+        go_backwards, use_bias=bias is not None
+    )
+
+    if not cudnn_supported:
+        raise NotImplementedError
+
+    # Get device from inputs
+    device = get_device()
+
+    from keras.src.backend.torch import Variable
+
+    if isinstance(kernel, Variable):
+        kernel = kernel.value
+    if isinstance(recurrent_kernel, Variable):
+        recurrent_kernel = recurrent_kernel.value
+    if isinstance(bias, Variable):
+        bias = bias.value
+
+    #Convert to torch tensors
+    inputs = convert_to_tensor(inputs,dtype="float32")
+    initial_state_h = convert_to_tensor(initial_state_h,dtype="float32")
+    initial_state_c = convert_to_tensor(initial_state_c,dtype="float32")
+    mask = convert_to_tensor(mask, dtype="bool")
+    # Move all tensors to the same device
+    inputs = inputs.to(device)
+    initial_state_h = initial_state_h.to(device)
+    initial_state_c = initial_state_c.to(device)
+    mask = mask.to(device)
+
+    try:
+        return _cudnn_lstm(
+            inputs,
+            initial_state_h,
+            initial_state_c,
+            kernel,
+            recurrent_kernel,
+            bias,
+            mask,
+            batch_first,
+            go_backwards,
+            return_sequences,
+            device
+        )
+    except Exception:
+        raise NotImplementedError
+
+def _cudnn_lstm(
+    inputs,
+    initial_state_h,
+    initial_state_c,
+    kernel,
+    recurrent_kernel,
+    bias,
+    mask,
+    batch_first,
+    go_backwards,
+    return_sequences,
+    device
+):  
+    if mask is not None:
+      _assert_valid_mask(mask)
+      sequence_lengths = _compute_sequence_length_from_mask(mask, batch_first)
+
+    # Ensure inputs are in batch_first format for consistency
+    if not batch_first:
+        inputs = inputs.permute(1, 0, 2)
+    
+    seq_axis, batch_axis = (0, 1) if not batch_first else (1, 0)
+
+    # If shape is [batch, hidden]; Make [1, batch, hidden]
+    if initial_state_h.dim() == 2:
+        initial_state_h = initial_state_h.unsqueeze(0)
+        initial_state_c = initial_state_c.unsqueeze(0)
+    # If shape is [batch, 1, hidden]
+    elif initial_state_h.dim() == 3 and initial_state_h.shape[1] == 1:
+        initial_state_h = initial_state_h.permute(1, 0, 2)
+        initial_state_c = initial_state_c.permute(1, 0, 2)
+    
+    input_size = kernel.shape[0]
+    hidden_size = recurrent_kernel.shape[0]
+
+    # Configure LSTM with the provided parameters
+    lstm = torch.nn.LSTM(
+        input_size=input_size,
+        hidden_size=hidden_size,
+        num_layers=1,
+        batch_first=True,
+        bidirectional=False
+    )
+
+    prepare_lstm_weights(lstm,kernel, recurrent_kernel, bias,device)
+
+    if mask is not None:  
+      # Sort and pack
+      sorted_lengths, sorted_indices = torch.sort(sequence_lengths, descending=True)
+      sorted_inputs = inputs[sorted_indices]
+      sorted_initial_h = initial_state_h[:, sorted_indices]
+      sorted_initial_c = initial_state_c[:, sorted_indices]
+      
+      # Create the packed sequence
+      packed_inputs = torch.nn.utils.rnn.pack_padded_sequence(
+          sorted_inputs, sorted_lengths.cpu(), batch_first
+      )
+      
+      # Process with LSTM (which handles the packed sequence correctly)
+      packed_outputs, (h_n, c_n) = lstm(packed_inputs, (sorted_initial_h, sorted_initial_c))
+      
+      # Unpack back to padded tensor
+      outputs, _ = torch.nn.utils.rnn.pad_packed_sequence(packed_outputs, batch_first)
+      
+    else:
+
+      # Run LSTM without packing for fixed-length sequences
+      outputs, (h_n, c_n) = lstm(inputs, (initial_state_h, initial_state_c))
+    
+    outputs = outputs.detach().cpu()
+    h_n = h_n.detach().cpu()
+    c_n = c_n.detach().cpu()
+    # Reshape hidden states for return
+    h_n = h_n.squeeze(0)  # Remove num_layers=1 dimension
+    c_n = c_n.squeeze(0)  # Remove num_layers=1 dimension
+
+    # Return appropriate outputs based on return_sequences flag
+
+    if mask is not None:
+        last_output = h_n
+    else:
+        last_output = outputs[:,-1] if batch_first else outputs[-1]
+
+    if not return_sequences:
+        outputs = last_output.unsqueeze(1) if batch_first else last_output.unsqueeze(0)
+    
+    return (last_output,outputs,(h_n,c_n))
 
 
 def gru(*args, **kwargs):

--- a/keras/src/backend/torch/rnn.py
+++ b/keras/src/backend/torch/rnn.py
@@ -673,8 +673,8 @@ def _cudnn_lstm(
     h_n = h_n.detach().clone().cpu()
     c_n = c_n.detach().clone().cpu()
     # Reshape hidden states for return
-    h_n = h_n.squeeze(batch_axis)  # Remove num_layers=1 dimension
-    c_n = c_n.squeeze(batch_axis)  # Remove num_layers=1 dimension
+    h_n = h_n.squeeze(batch_axis)
+    c_n = c_n.squeeze(batch_axis)
 
     # Return appropriate outputs based on return_sequences flag
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ include = ["keras", "keras.*"]
 
 [tool.ruff]
 line-length = 80
+exclude = ["keras/src/namex"]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
This is a work-in-progress implementation of LSTM for the PyTorch backend with CuDNN optimization.
This is a followup from the GitHub pull request #20875 and #20916

The working example can be found under the following collab:
https://colab.research.google.com/drive/1Vciv4nulEAHpY8_wstNfNzx4GMjpxGyB

Current features:
- [x] Support for variable length sequences with padding masks
- [x] Proper weight conversion between Keras/TF format and PyTorch format
- [x] CuDNN acceleration when available

Still to be addressed:
- [x] Additional testing for edge cases
- [x] More comprehensive error handling
- [x] Performance optimization and benchmarking
- [ ] Support for additional configuration options (bidirectional, etc.)

Feedback welcome on:
1. The weight conversion approach between Keras and PyTorch
2. Handling of masks and variable-length sequences
3. Error handling and fallback options when CuDNN is not available

Note: I've added an exclusion for the keras/src/namex directory in the Ruff configuration to prevent linting errors in this third-party code. My actual implementation code passes all linting checks.