### PR TITLE
fixed torch version issue for macOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ tf2onnx
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0+cpu
+torch==2.6.0+cpu;sys_platform != 'darwin'
+torch==2.6.0;sys_platform == 'darwin'
 torch-xla==2.6.0;sys_platform != 'darwin'
 
 # Jax.


### PR DESCRIPTION
This PR address a platform specific installation found on macOS when runnign `pip install -r requirements.txt` .The error caused from the use +cpu suffix in pytorch version,which is not supported in macOS.

Issue reference:
Fixes #21121

Tested on:
- MacOS(15.4)
- Python 3.12.6

