### PR TITLE
[OpenVINO backend] Added support for numpy.isclose operation

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -28,7 +28,6 @@ NumpyDtypeTest::test_floor
 NumpyDtypeTest::test_hstack
 NumpyDtypeTest::test_identity
 NumpyDtypeTest::test_inner
-NumpyDtypeTest::test_isclose
 NumpyDtypeTest::test_isfinite
 NumpyDtypeTest::test_isinf
 NumpyDtypeTest::test_isnan

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -156,7 +156,6 @@ NumpyTwoInputOpsCorrectnessTest::test_digitize
 NumpyTwoInputOpsCorrectnessTest::test_divide_no_nan
 NumpyTwoInputOpsCorrectnessTest::test_einsum
 NumpyTwoInputOpsCorrectnessTest::test_inner
-NumpyTwoInputOpsCorrectnessTest::test_isclose
 NumpyTwoInputOpsCorrectnessTest::test_linspace
 NumpyTwoInputOpsCorrectnessTest::test_logspace
 NumpyTwoInputOpsCorrectnessTest::test_outer

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -778,21 +778,18 @@ def imag(x):
 
 
 def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
-
     abs_diff = ov_opset.abs(x1 - x2)
     abs_x2 = ov_opset.abs(x2)
-    rtol_tensor = ov_opset.constant(rtol, dtype=x1.dtype)
-    atol_tensor = ov_opset.constant(atol, dtype=x2.dtype)
+    rtol_tensor = ov_opset.constant(np.array(rtol, dtype=np.float32))
+    atol_tensor = ov_opset.constant(np.array(atol, dtype=np.float32))
     total_tolerance = atol_tensor + rtol_tensor * abs_x2
     is_close = ov_opset.less_equal(abs_diff, total_tolerance)
-
     if equal_nan:
         nan_a = ov_opset.isnan(x1)
         nan_b = ov_opset.isnan(x2)
         both_nan = ov_opset.logical_and(nan_a, nan_b)
         is_close = ov_opset.logical_or(is_close, both_nan)
-
-    return is_close
+    return OpenVINOKerasTensor(is_close.output(0))
 
 
 def isfinite(x):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -778,17 +778,21 @@ def imag(x):
 
 
 def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
+    dtype = OPENVINO_DTYPES[config.floatx()]
+
+    x1 = ov_opset.convert(get_ov_output(x1), dtype)
+    x2 = ov_opset.convert(get_ov_output(x2), dtype)
+    rtol = ov_opset.convert(get_ov_output(rtol), dtype)
+    atol = ov_opset.convert(get_ov_output(atol), dtype)
+
     abs_diff = ov_opset.abs(x1 - x2)
     abs_x2 = ov_opset.abs(x2)
-    rtol_tensor = ov_opset.constant(np.array(rtol, dtype=np.float32))
-    atol_tensor = ov_opset.constant(np.array(atol, dtype=np.float32))
-    total_tolerance = atol_tensor + rtol_tensor * abs_x2
+    total_tolerance = atol + rtol * abs_x2
     is_close = ov_opset.less_equal(abs_diff, total_tolerance)
     if equal_nan:
-        nan_a = ov_opset.isnan(x1)
-        nan_b = ov_opset.isnan(x2)
-        both_nan = ov_opset.logical_and(nan_a, nan_b)
+        both_nan = ov_opset.logical_and(ov_opset.isnan(x1), ov_opset.isnan(x2))
         is_close = ov_opset.logical_or(is_close, both_nan)
+
     return OpenVINOKerasTensor(is_close.output(0))
 
 


### PR DESCRIPTION
Added decomposition for `numpy.isclose` in the OpenVINO backend as specified in [#29484](https://github.com/openvinotoolkit/openvino/issues/29484).



@rkazants , Could you please review this pr.