### PR TITLE
[OpenVINO backend] Support numpy.expm1

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -90,7 +90,6 @@ NumpyOneInputOpsCorrectnessTest::test_cumprod
 NumpyOneInputOpsCorrectnessTest::test_diag
 NumpyOneInputOpsCorrectnessTest::test_diagonal
 NumpyOneInputOpsCorrectnessTest::test_exp2
-NumpyOneInputOpsCorrectnessTest::test_expm1
 NumpyOneInputOpsCorrectnessTest::test_flip
 NumpyOneInputOpsCorrectnessTest::test_floor_divide
 NumpyOneInputOpsCorrectnessTest::test_hstack

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -21,7 +21,6 @@ NumpyDtypeTest::test_diag
 NumpyDtypeTest::test_digitize
 NumpyDtypeTest::test_einsum
 NumpyDtypeTest::test_exp2
-NumpyDtypeTest::test_expm1
 NumpyDtypeTest::test_eye
 NumpyDtypeTest::test_flip
 NumpyDtypeTest::test_floor

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -709,7 +709,7 @@ def expm1(x):
         ov_type = OPENVINO_DTYPES[config.floatx()]
         x = ov_opset.convert(x, ov_type)
     exp_x = ov_opset.exp(x).output(0)
-    const_one = ov_opset.constant(1, x_type)
+    const_one = ov_opset.constant(1, exp_x.get_element_type())
     result = ov_opset.subtract(exp_x, const_one).output(0)
     return OpenVINOKerasTensor(result)
 

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -703,7 +703,15 @@ def expand_dims(x, axis):
 
 
 def expm1(x):
-    raise NotImplementedError("`expm1` is not supported with openvino backend")
+    x = get_ov_output(x)
+    x_type = x.get_element_type()
+    if x_type.is_integral():
+        ov_type = OPENVINO_DTYPES[config.floatx()]
+        x = ov_opset.convert(x, ov_type)
+    exp_x = ov_opset.exp(x).output(0)
+    const_one = ov_opset.constant(1, exp_x.get_element_type())
+    result = ov_opset.subtract(exp_x, const_one).output(0)
+    return OpenVINOKerasTensor(result)
 
 
 def flip(x, axis=None):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -709,7 +709,7 @@ def expm1(x):
         ov_type = OPENVINO_DTYPES[config.floatx()]
         x = ov_opset.convert(x, ov_type)
     exp_x = ov_opset.exp(x).output(0)
-    const_one = ov_opset.constant(1, exp_x.get_element_type())
+    const_one = ov_opset.constant(1, x_type)
     result = ov_opset.subtract(exp_x, const_one).output(0)
     return OpenVINOKerasTensor(result)
 


### PR DESCRIPTION
### Details:
* Adds numpy.expm1 function to OpenVino backend.

### Tickets:
* Closes [[Good First Issue][Keras 3 OpenVINO Backend]: Support numpy.expm1 operation #29358](https://github.com/openvinotoolkit/openvino/issues/29358)

