### PR TITLE
Add alpha argument description to elu docstring

### DIFF
--- a/keras/src/activations/activations.py
+++ b/keras/src/activations/activations.py
@@ -187,6 +187,7 @@ def elu(x, alpha=1.0):
 
     Args:
         x: Input tensor.
+        alpha: A scalar, slope of positive section. Defaults to `1.0`.
 
     Reference:
 


### PR DESCRIPTION
I updated the docstring for the elu activation function to include a description of the alpha argument.