### PR TITLE
Aligns Softmax masking behavior with JAX for fully masked axis

### DIFF
--- a/keras/src/layers/activations/softmax.py
+++ b/keras/src/layers/activations/softmax.py
@@ -72,7 +72,9 @@ class Softmax(Layer):
         if mask is not None:
             # Apply the mask to the softmax output to ensure that masked
             # values are set to 0 in case the entire axis is masked.
-            outputs = outputs * backend.cast(mask, outputs.dtype)
+            outputs = backend.numpy.multiply(
+                outputs, backend.cast(mask, outputs.dtype)
+            )
 
         return outputs
 

--- a/keras/src/layers/activations/softmax.py
+++ b/keras/src/layers/activations/softmax.py
@@ -70,9 +70,8 @@ class Softmax(Layer):
             outputs = activations.softmax(inputs, axis=self.axis)
 
         if mask is not None:
-            # Apply the mask to the softmax output
-            # to ensure that masked values are set to 0
-            # in case the entire axis is masked.
+            # Apply the mask to the softmax output to ensure that masked
+            # values are set to 0 in case the entire axis is masked.
             outputs = outputs * backend.cast(mask, outputs.dtype)
 
         return outputs

--- a/keras/src/layers/activations/softmax.py
+++ b/keras/src/layers/activations/softmax.py
@@ -58,15 +58,24 @@ class Softmax(Layer):
             inputs += adder
         if isinstance(self.axis, (tuple, list)):
             if len(self.axis) > 1:
-                return backend.numpy.exp(
+                outputs = backend.numpy.exp(
                     inputs
                     - backend.math.logsumexp(
                         inputs, axis=self.axis, keepdims=True
                     )
                 )
             else:
-                return activations.softmax(inputs, axis=self.axis[0])
-        return activations.softmax(inputs, axis=self.axis)
+                outputs = activations.softmax(inputs, axis=self.axis[0])
+        else:
+            outputs = activations.softmax(inputs, axis=self.axis)
+
+        if mask is not None:
+            # Apply the mask to the softmax output
+            # to ensure that masked values are set to 0
+            # in case the entire axis is masked.
+            outputs = outputs * backend.cast(mask, outputs.dtype)
+
+        return outputs
 
     def get_config(self):
         config = super().get_config()

--- a/keras/src/layers/activations/softmax_test.py
+++ b/keras/src/layers/activations/softmax_test.py
@@ -49,3 +49,40 @@ class SoftmaxTest(testing.TestCase):
         )
         result = softmax_layer(input)
         self.assertAllClose(result, expected_output)
+
+    def test_softmax_masked_values_are_zero_including_fully_masked(self):
+        """
+        Tests softmax with mask on default axis (-1).
+        Ensures output is 0 where mask is False.
+        Includes a row where all elements are masked.
+        """
+        softmax_layer = softmax.Softmax()  # Default axis = -1
+
+        input = np.array(
+            [
+                [1.0, 2.0, 5.0, 1.0],
+                [1.0, 1.0, 1.0, 1.0],
+                [3.0, 1.0, 2.0, 4.0],
+            ],
+            dtype=np.float32,
+        )
+        mask = np.array(
+            [
+                [True, True, False, False],  # Partially masked
+                [False, False, False, False],  # Fully masked
+                [True, True, True, True],  # Not masked
+            ],
+            dtype=bool,
+        )
+
+        expected_output = np.array(
+            [
+                [0.268941, 0.731059, 0.0, 0.0],  # last two masked
+                [0.0, 0.0, 0.0, 0.0],  # Fully masked row should be all zeros
+                [0.236883, 0.032059, 0.087144, 0.643914],
+            ]
+        )
+
+        result = softmax_layer(input, mask=mask)
+
+        self.assertAllClose(result, expected_output)


### PR DESCRIPTION
Fixes #21123

This change modifies the `keras.layers.activations.Softmax` layer to ensure consistent behavior when masking is applied, particularly for the edge case where all elements along the softmax axis are masked.

## Issue

1. The masking mechanism worked by adding a large negative number to the logits corresponding to masked positions before applying the softmax activation.
2. While this effectively minimized the contribution of masked elements when some elements were unmasked, it led to a non-zero, uniform distribution (e.g., `[0.25, 0.25, 0.25, 0.25]`) when all elements along the softmax axis were masked. This behavior differs from the semantics of `jax.nn.softmax(where=mask)`, which outputs zeros for all elements in a fully masked slice.

## Fix

The softmax output tensor is multiplied element-wise by the original boolean mask, ensuring any masked softmax output position is zero'd out.

```python
if mask is not None:
    # Apply the mask to the softmax output to ensure that masked
    # values are set to 0 in case the entire axis is masked.
    outputs = outputs * backend.cast(mask, outputs.dtype)
```