### PR TITLE
allow TorchModuleWrapper compute output shape

### DIFF
--- a/keras/src/utils/torch_utils.py
+++ b/keras/src/utils/torch_utils.py
@@ -25,7 +25,7 @@ class TorchModuleWrapper(Layer):
             instance, then its parameters must be initialized before
             passing the instance to `TorchModuleWrapper` (e.g. by calling
             it once).
-        out_shape :The shape of the output of this layer. It helps Keras
+        output_shape :The shape of the output of this layer. It helps Keras
             perform automatic shape inference.
         name: The name of the layer (string).
 
@@ -82,7 +82,7 @@ class TorchModuleWrapper(Layer):
     ```
     """
 
-    def __init__(self, module, name=None, out_shape=None, **kwargs):
+    def __init__(self, module, name=None, output_shape=None, **kwargs):
         super().__init__(name=name, **kwargs)
         import torch.nn as nn
 
@@ -100,7 +100,7 @@ class TorchModuleWrapper(Layer):
 
         self.module = module.to(get_device())
         self._track_module_parameters()
-        self.out_shape = out_shape
+        self.output_shape = output_shape
 
     def parameters(self, recurse=True):
         return self.module.parameters(recurse=recurse)
@@ -142,9 +142,9 @@ class TorchModuleWrapper(Layer):
         self.module.load_state_dict(state_dict)
 
     def compute_output_shape(self, input_shape):
-        if self.out_shape is None:
+        if self.output_shape is None:
             return super().compute_output_shape(input_shape)
-        return self.out_shape
+        return self.output_shape
 
     def get_config(self):
         base_config = super().get_config()
@@ -152,7 +152,10 @@ class TorchModuleWrapper(Layer):
 
         buffer = io.BytesIO()
         torch.save(self.module, buffer)
-        config = {"module": buffer.getvalue(), "out_shape": self.out_shape}
+        config = {
+            "module": buffer.getvalue(),
+            "output_shape": self.output_shape,
+        }
         return {**base_config, **config}
 
     @classmethod

--- a/keras/src/utils/torch_utils_test.py
+++ b/keras/src/utils/torch_utils_test.py
@@ -239,8 +239,10 @@ class TorchUtilsTest(testing.TestCase):
 
     def test_build_model(self):
         x = keras.Input([4])
-        z = TorchModuleWrapper(torch.nn.Linear(4, 8), out_shape=[None, 8])(x)
-        y = TorchModuleWrapper(torch.nn.Linear(8, 16), out_shape=[None, 16])(z)
+        z = TorchModuleWrapper(torch.nn.Linear(4, 8), output_shape=[None, 8])(x)
+        y = TorchModuleWrapper(torch.nn.Linear(8, 16), output_shape=[None, 16])(
+            z
+        )
         model = keras.Model(x, y)
-        out = model.predict(np.zeros([5, 4]))
-        self.assertEqual(out.shape, (5, 16))
+        self.assertEqual(model.predict(np.zeros([5, 4])).shape, (5, 16))
+        self.assertEqual(model(np.zeros([5, 4])).shape, (5, 16))

--- a/keras/src/utils/torch_utils_test.py
+++ b/keras/src/utils/torch_utils_test.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 from absl.testing import parameterized
 
+import keras
 from keras.src import backend
 from keras.src import layers
 from keras.src import models
@@ -235,3 +236,11 @@ class TorchUtilsTest(testing.TestCase):
         new_mw = TorchModuleWrapper.from_config(config)
         for ref_w, new_w in zip(mw.get_weights(), new_mw.get_weights()):
             self.assertAllClose(ref_w, new_w, atol=1e-5)
+
+    def test_build_model(self):
+        x = keras.Input([4])
+        z = TorchModuleWrapper(torch.nn.Linear(4, 8), out_shape=[None, 8])(x)
+        y = TorchModuleWrapper(torch.nn.Linear(8, 16), out_shape=[None, 16])(z)
+        model = keras.Model(x, y)
+        out = model.predict(np.zeros([5, 4]))
+        self.assertEqual(out.shape, (5, 16))


### PR DESCRIPTION
The TorchModuleWrapper layer does not allow automatic inference of the output. Therefore, the model that owns this layer cannot be used like other keras.Model. For example, you cannot use model.summary().

And now the vast majority of models are based on Torch. By adding this feature, we can let ordinary Torch models enjoy the workflow of Keras without making too many modifications.