### PR TITLE
Fix dtype detection for JAX types.

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -564,12 +564,12 @@ def standardize_dtype(dtype):
     dtype = dtypes.PYTHON_DTYPES_MAP.get(dtype, dtype)
     if hasattr(dtype, "name"):
         dtype = dtype.name
+    elif hasattr(dtype, "__name__"):
+        dtype = dtype.__name__
     elif hasattr(dtype, "__str__") and (
         "torch" in str(dtype) or "jax.numpy" in str(dtype)
     ):
         dtype = str(dtype).split(".")[-1]
-    elif hasattr(dtype, "__name__"):
-        dtype = dtype.__name__
 
     if dtype not in dtypes.ALLOWED_DTYPES:
         raise ValueError(f"Invalid dtype: {dtype}")


### PR DESCRIPTION
The jax types like `jax.float32` have a string representation of
```
<class 'jax.numpy.float32'>
```
so with the previous code, would be "standardized" as `float32'>` (trailing quote and angle bracket), which is an invalid type.  But, the JAX dtypes _do_ have a `__name__` property, so should be properly detected if we switch the order around.

Kept the old `jax.numpy` string version in place in case that worked with older versions of JAX.