### PR TITLE
WIP: fix RandAugment behavior in tf graph mode

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/rand_augment.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/rand_augment.py
@@ -1,11 +1,10 @@
 import keras.src.layers as layers
-import keras.src.ops as ops
 from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
 )
-from keras.src.random import SeedGenerator, shuffle
+from keras.src.random import SeedGenerator
 from keras.src.utils import backend_utils
 
 

--- a/keras/src/layers/preprocessing/image_preprocessing/rand_augment_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/rand_augment_test.py
@@ -112,3 +112,21 @@ class RandAugmentTest(testing.TestCase):
             bounding_box_format="xyxy",
         )
         ds.map(layer)
+    
+    def test_rand_augment_tf_graph_mode(self):
+        data_format = backend.config.image_data_format()
+        if data_format == "channels_last":
+            input_data = np.random.random((4, 8, 8, 3))
+        else:
+            input_data = np.random.random((4, 3, 8, 8))
+        layer = layers.RandAugment(data_format=data_format, seed=42, num_ops=1)
+
+        # using tf.data.Dataset.map applies the function in graph mode
+        # lambda gets shuffled transform index
+        ds = tf_data.Dataset.from_tensor_slices(input_data).batch(2).map(
+            lambda x: layer.get_random_transformation(x)[0]
+        )
+        results = []
+        for output in ds:
+            results.append(output.numpy())
+        self.assertFalse(np.all(results[0] == results[1]))

--- a/keras/src/layers/preprocessing/image_preprocessing/rand_augment_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/rand_augment_test.py
@@ -150,3 +150,26 @@ class RandAugmentTest(testing.TestCase):
                 results.add(layer.augmentations[i].name)
         print(results)
         self.assertTrue(len(results) > 1)
+
+    def test_rand_augment_model(self):
+        from keras.src.models import Sequential
+
+        data_format = backend.config.image_data_format()
+        N = 32
+        if data_format == "channels_last":
+            input_data = np.random.random((N, 8, 8, 3))
+        else:
+            input_data = np.random.random((N, 3, 8, 8))
+        y_true = np.random.random((N, 1))
+        
+        model = Sequential([
+            layers.Input(input_data.shape[1:], dtype="float32"),
+            layers.RandAugment(data_format=data_format, seed=42, num_ops=2),
+            layers.Flatten(),
+            layers.Dense(10, activation="relu"),
+            layers.Dense(1),
+        ])
+        model.compile(loss="mse")
+        model.summary()
+
+        model.fit(input_data, y_true, batch_size=2, epochs=40)


### PR DESCRIPTION
fix for #21169

`RandAugment` changes:
* samples random execution order
* samples transform params for all sub layers
* uses `fori` and `switch` to execute the sub layers according to the sampled order

this is passing the tests in all three backends. However for the `test_rand_augment_model` test, jax runs very slowly, way slower than the other backends, by a factor of 10 - 50. I have no experience with jax, can you suggest anything that might help?

thanks