### PR TITLE
Fix `Embedding.compute_output_spec` with a non-`KerasTensor` input.

### DIFF
--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -159,8 +159,9 @@ class Embedding(Layer):
 
     def compute_output_spec(self, inputs):
         output_shape = (*inputs.shape, self.output_dim)
+        ragged = getattr(inputs, "ragged", False)
         return KerasTensor(
-            output_shape, dtype=self.compute_dtype, ragged=inputs.ragged
+            output_shape, dtype=self.compute_dtype, ragged=ragged
         )
 
     def enable_lora(

--- a/keras/src/trainers/data_adapters/generator_data_adapter_test.py
+++ b/keras/src/trainers/data_adapters/generator_data_adapter_test.py
@@ -100,8 +100,8 @@ class GeneratorDataAdapterTest(testing.TestCase):
                 self.assertEqual(by.shape, (2, 2))
             if use_sample_weight:
                 self.assertIsInstance(bsw, expected_class)
-            for i in range(by.shape[0]):
-                sample_order.append(by[i, 0])
+            for j in range(by.shape[0]):
+                sample_order.append(by[j, 0])
         self.assertAllClose(sample_order, list(range(34)))
 
     def test_with_different_shapes(self):


### PR DESCRIPTION
The `ragged` attribute exists only with `KerasTensor`s.

Minor fix of a unit tests that was using the same local variable for two nested loops.