### PR TITLE
Return explicitly layout if already set on variable.

### DIFF
--- a/keras/src/distribution/distribution_lib.py
+++ b/keras/src/distribution/distribution_lib.py
@@ -457,6 +457,10 @@ class DataParallel(Distribution):
         return TensorLayout(data_shard_spec, self.device_mesh)
 
     def get_variable_layout(self, variable):
+        # First check if the variable already has a layout assigned.
+        if getattr(variable, "_layout", None) is not None:
+            return variable._layout
+        # Otherwise, replicate variable.
         variable_shard_spec = [None] * len(variable.shape)
         return TensorLayout(variable_shard_spec, self.device_mesh)
 
@@ -610,6 +614,10 @@ class ModelParallel(Distribution):
         return TensorLayout(data_shard_spec, self.device_mesh)
 
     def get_variable_layout(self, variable):
+        # First check if the variable already has a layout assigned.
+        if getattr(variable, "_layout", None) is not None:
+            return variable._layout
+        # Check the layout map.
         variable_layout = self._layout_map[variable.path]
         if variable_layout is not None:
             return variable_layout


### PR DESCRIPTION
If explicitly overwriting a variable._layout, we want to keep this layout in any future calls.  This allows auxiliary variables (e.g. gradients, optimizer momentums) to use the same explicit layout.