### PR TITLE
Allow `Embedding` subclasses to only override `compute_output_shape`.

### DIFF
--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -158,7 +158,7 @@ class Embedding(Layer):
         return (*input_shape, self.output_dim)
 
     def compute_output_spec(self, inputs):
-        output_shape = (*inputs.shape, self.output_dim)
+        output_shape = self.compute_output_shape(inputs.shape)
         ragged = getattr(inputs, "ragged", False)
         return KerasTensor(
             output_shape, dtype=self.compute_dtype, ragged=ragged


### PR DESCRIPTION
Without the need to also override `compute_output_spec`.