### PR TITLE
Add back shell/format.sh, but it just runs pre-commit

### DIFF
--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+if ! command -v pre-commit 2>&1 >/dev/null
+then
+    echo 'Please `pip install pre-commit` to run format.sh.'
+    exit 1
+fi
+
+base_dir=$(dirname $(dirname $0))
+
+echo "Formatting all files..."
+SKIP=api-gen pre-commit run --all-files


### PR DESCRIPTION
For folks who are used to the old format, this will print instructions. And for people like me, saves needing to remember
`SKIP=api-gen pre-commit run --all-files`
When I just want the formatter. api_gen.py is too slow to run every time.