### PR TITLE
Add openvino to the basic requirements file

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -47,12 +47,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
       - name: Install dependencies
         run: |
-          if [ "${{ matrix.backend }}" == "openvino" ]; then
-            REQUIREMENTS_FILE="requirements-openvino.txt"
-          else
-            REQUIREMENTS_FILE="requirements.txt"
-          fi
-          pip install -r $REQUIREMENTS_FILE --progress-bar off --upgrade
+          pip install -r requirements.txt --progress-bar off --upgrade
           pip uninstall -y keras keras-nightly
           pip install -e "." --progress-bar off --upgrade
       - name: Test applications with pytest
@@ -129,7 +124,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt --progress-bar off --upgrade
-          pip install -r requirements-openvino.txt --progress-bar off --upgrade
           pip uninstall -y keras keras-nightly
           pip install -e "." --progress-bar off --upgrade
       - name: Install pre-commit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,7 +79,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt --progress-bar off --upgrade
-          pip install -r requirements-openvino.txt --progress-bar off --upgrade
           pip uninstall -y keras keras-nightly
           pip install -e "." --progress-bar off --upgrade
       - name: Lint

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ the package has been imported.
 
 **Note:** The OpenVINO backend is an inference-only backend, meaning it is designed only for running model
 predictions using `model.predict()` method.
-To use `openvino` backend, install the required dependencies from the `requirements-openvino.txt` file.
 
 ## Backwards compatibility
 

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -22,3 +22,4 @@ dm_tree
 coverage!=7.6.5  # 7.6.5 breaks CI
 # for onnx_test.py
 onnxruntime
+openvino

--- a/requirements-openvino.txt
+++ b/requirements-openvino.txt
@@ -1,5 +1,0 @@
-# OpenVINO
-openvino
-
-# All testing deps.
--r requirements.txt


### PR DESCRIPTION
Unlike jax/torch/tensorflow which all vie for a certain cuda, I don't think openvino has trouble co-installing.

And without this the basic requirements.txt will not give a working dev environment. You can't run our pre-commit without openvino installed due to import errors.