### PR TITLE
`mlx` - new image ops implemented

### DIFF
--- a/keras/src/backend/mlx/random.py
+++ b/keras/src/backend/mlx/random.py
@@ -3,9 +3,7 @@ import mlx.core as mx
 from keras.src.backend.config import floatx
 from keras.src.backend.mlx.core import convert_to_tensor
 from keras.src.backend.mlx.core import to_mlx_dtype
-from keras.src.random.seed_generator import SeedGenerator
 from keras.src.random.seed_generator import draw_seed
-from keras.src.random.seed_generator import make_default_seed
 
 
 def mlx_draw_seed(seed):
@@ -19,8 +17,9 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
     dtype = dtype or floatx()
     dtype = to_mlx_dtype(dtype)
     seed = mlx_draw_seed(seed)
-    sample = mx.random.normal(shape=shape, dtype=dtype, key=seed)
-    return sample * stddev + mean
+    return mx.random.normal(
+        shape=shape, loc=mean, scale=stddev, dtype=dtype, key=seed
+    )
 
 
 def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):

--- a/keras/src/backend/mlx/random.py
+++ b/keras/src/backend/mlx/random.py
@@ -3,7 +3,9 @@ import mlx.core as mx
 from keras.src.backend.config import floatx
 from keras.src.backend.mlx.core import convert_to_tensor
 from keras.src.backend.mlx.core import to_mlx_dtype
+from keras.src.random.seed_generator import SeedGenerator
 from keras.src.random.seed_generator import draw_seed
+from keras.src.random.seed_generator import make_default_seed
 
 
 def mlx_draw_seed(seed):


### PR DESCRIPTION
This continues work on #19571

This PR includes the following:
- implemented `image` ops: `compute_homography_matrix`, `perspective_transform`, `gaussian_blur`, and `elastic_transform` (very similar to jax implementations)
- adjust `random.normal` to use `loc` and `mean` directly in `mlx` method