### PR TITLE
Adds Support For Custom Call-Context Arguments

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1703,8 +1703,6 @@ class CallSpec:
         # a layer, if user specifies them in their call without adding to spec,
         # we remove them to be able to bind variables. User is not using
         # `training` anyway so we can ignore.
-        # TODO: If necessary use workaround for `mask`
-        # TODO: We shouldn't need to hard-code this here, ideally should be picked up from builtin args.
         if "training" in kwargs and "training" not in signature.parameters:
             kwargs.pop("training")
             bound_args = signature.bind(*args, **kwargs)

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1717,7 +1717,7 @@ class CallSpec:
 
         bound_args = signature.bind(*args, **kwargs)
 
-        # 3. Combine the two dicts.
+        # Combine the two dicts.
         self.user_arguments_dict = {**call_args, **bound_args.arguments}
 
         bound_args.apply_defaults()

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -994,7 +994,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
             value = call_context.get_value(arg_name)
         # 3) else: default from the call() signature
         else:
-            value = call_spec.arguments_dict.get(arg_name)
+            value = call_spec.arguments_dict.get(arg_name, None)
 
         # stash it for downstream layers
         call_context.set_value(arg_name, value)

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1598,7 +1598,7 @@ class LayerTest(testing.TestCase):
         out_true = seq(sample_input, foo_mode=True)
         self.assertAllClose(out_true, sample_input + 1.0)
 
-        # foo_mode omitted -> foo_mode defaults to False in the signature -> no change
+        # foo_mode omitted -> foo_mode defaults to False -> no change
         out_false = seq(sample_input)
         self.assertAllClose(out_false, sample_input)
 
@@ -1611,6 +1611,6 @@ class LayerTest(testing.TestCase):
         y1 = model(sample_input, foo_mode=True)
         self.assertAllClose(y1, sample_input + 1.0)
 
-        # foo_mode omitted -> foo_mode defaults to False in the signature -> no change
+        # foo_mode omitted -> foo_mode defaults to False -> no change
         y2 = model(sample_input)
         self.assertAllClose(y2, sample_input)

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1547,13 +1547,13 @@ class LayerTest(testing.TestCase):
 
     def test_call_context_args_with_custom_layers(self):
         class Inner(layers.Layer):
-            call_context_flags = ("foo_mode",)
+            call_context_args = ("foo_mode",)
 
             def call(self, x, foo_mode=None):
                 return x + (1 if foo_mode else 0)
 
         class Outer(layers.Layer):
-            call_context_flags = ("foo_mode",)
+            call_context_args = ("foo_mode",)
 
             def __init__(self):
                 super().__init__()
@@ -1570,13 +1570,13 @@ class LayerTest(testing.TestCase):
 
     def test_context_args_with_triple_nesting_and_priority(self):
         class Inner(layers.Layer):
-            call_context_flags = ("foo_mode",)
+            call_context_args = ("foo_mode",)
 
             def call(self, x, foo_mode=None):
                 return x + (1 if foo_mode else 0)
 
         class Middle(layers.Layer):
-            call_context_flags = ("foo_mode",)
+            call_context_args = ("foo_mode",)
 
             def __init__(self):
                 super().__init__()
@@ -1587,7 +1587,7 @@ class LayerTest(testing.TestCase):
                 return self.inner(x)
 
         class Outer(layers.Layer):
-            call_context_flags = ("foo_mode",)
+            call_context_args = ("foo_mode",)
 
             def __init__(self):
                 super().__init__()
@@ -1608,7 +1608,7 @@ class LayerTest(testing.TestCase):
 
     def test_call_context_args_with_func_seq_models_as_layers(self):
         class Inner(layers.Layer):
-            call_context_flags = ("foo_mode",)
+            call_context_args = ("foo_mode",)
 
             def call(self, x, foo_mode=False):
                 # If foo_mode=True add 1, otherwise add 0
@@ -1616,7 +1616,7 @@ class LayerTest(testing.TestCase):
                 return x + add_val
 
         class Outer(layers.Layer):
-            call_context_flags = ("foo_mode",)
+            call_context_args = ("foo_mode",)
 
             def __init__(self):
                 super().__init__()

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1576,14 +1576,11 @@ class LayerTest(testing.TestCase):
                 return x + (1 if foo_mode else 0)
 
         class Middle(layers.Layer):
-            call_context_args = ("foo_mode",)
-
             def __init__(self):
                 super().__init__()
                 self.inner = Inner()
 
-            # The default value of foo_mode is False
-            def call(self, x, foo_mode=False):
+            def call(self, x):
                 return self.inner(x)
 
         class Outer(layers.Layer):
@@ -1602,7 +1599,6 @@ class LayerTest(testing.TestCase):
 
         # The value of foo_mode is set to True in the call to Outer,
         # so it should automatically propagate to Inner through Middle.
-        # Middle's default value of foo_mode=False should be ignored.
         self.assertEqual(int(layer(np.array(0), foo_mode=True)), 1)
         self.assertEqual(int(layer(np.array(0))), 0)
 

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -633,7 +633,8 @@ def operation_fn(operation, training=None, **flags):
     def call(*args, **kwargs):
         # 1) Propagate training
         if (
-            getattr(operation, "_call_has_flag_arg", {}).get("training", False)
+            hasattr(operation, "_call_has_training_arg")
+            and operation._call_has_training_arg
             and training is not None
         ):
             kwargs["training"] = training
@@ -641,7 +642,7 @@ def operation_fn(operation, training=None, **flags):
         # 2) Propagate any other registered flags
         for name, value in flags.items():
             if (
-                getattr(operation, "_call_has_flag_arg", {}).get(name, False)
+                name in getattr(operation, "_call_context_flags", {})
                 and value is not None
             ):
                 kwargs[name] = value

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -642,7 +642,7 @@ def operation_fn(operation, training=None, **flags):
         # 2) Propagate any other registered flags
         for name, value in flags.items():
             if (
-                name in getattr(operation, "_call_context_flags", {})
+                name in getattr(operation, "_call_context_args", {})
                 and value is not None
             ):
                 kwargs[name] = value

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -628,7 +628,7 @@ def functional_from_config(cls, config, custom_objects=None):
 
 
 def operation_fn(operation, **call_context_args):
-    """Wraps each op to inject `training` and any other execution flags."""
+    """Wraps each op to inject the call-context args."""
 
     def call(*args, **kwargs):
         # Propagate all registered call-context args

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -627,20 +627,12 @@ def functional_from_config(cls, config, custom_objects=None):
     )
 
 
-def operation_fn(operation, training=None, **flags):
+def operation_fn(operation, **call_context_args):
     """Wraps each op to inject `training` and any other execution flags."""
 
     def call(*args, **kwargs):
-        # 1) Propagate training
-        if (
-            hasattr(operation, "_call_has_training_arg")
-            and operation._call_has_training_arg
-            and training is not None
-        ):
-            kwargs["training"] = training
-
-        # 2) Propagate any other registered flags
-        for name, value in flags.items():
+        # Propagate all registered call-context args
+        for name, value in call_context_args.items():
             if (
                 name in getattr(operation, "_call_context_args", {})
                 and value is not None

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -267,10 +267,10 @@ class Sequential(Model):
             )
         # Direct application
         for layer in self.layers:
-            # TODO: Should we pass kwargs to compute_output_spec?
             outputs = layer.compute_output_spec(
                 inputs,
                 training=training,
+                **kwargs,
             )  # Ignore mask
             inputs = outputs
         return outputs

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -228,15 +228,16 @@ class Sequential(Model):
             # `outputs` are the outputs of `layer` applied to `inputs`. At the
             # end of each iteration `inputs` is set to `outputs` to prepare for
             # the next layer.
-            layer_kwargs = {}
+            layer_kwargs = {
+                k: kwargs[k]
+                # only inject if this layer’s signature actually has that arg
+                for k in getattr(layer, "_call_has_context_arg", {})
+                if k in kwargs
+            }
             if layer._call_has_mask_arg:
                 layer_kwargs["mask"] = mask
             if layer._call_has_training_arg and training is not None:
                 layer_kwargs["training"] = training
-            for flag, value in kwargs.items():
-                # only inject if this layer’s signature actually has that arg
-                if getattr(layer, "_call_has_flag_arg", {}).get(flag, False):
-                    layer_kwargs[flag] = value
             outputs = layer(inputs, **layer_kwargs)
             inputs = outputs
 


### PR DESCRIPTION
This PR introduces a framework for supporting custom call-context arguments in Keras layers, allowing for more flexible context-aware logic within custom layers.

Currently, Keras layers have special handling for the `training` argument in `Layer.__call__`, which allows its value to be propagated through nested layers. This PR generalizes this mechanism.

## API
1. `Layer.call_context_args`: Custom layers can now define a class attribute `call_context_args` (a set of strings) to declare argument names they expect to be propagated across the model. The `training` argument is implicitly included and does not need to be added to this collection.
2. The call methods in `Functional` and `Sequential` models are updated to accept `**kwargs`.
3. `CallContext`: The `CallContext` object is updated to generically store and retrieve values for any registered call-context arguments using `get_value(arg_name)` and `set_value(arg_name, value)`
4. `CallSpec`: The `CallSpec` class is modified to be aware of `call_context_args` to correctly bind arguments, especially when args are passed that are not part of the immediate layer's call signature but are intended for nested layers.

## Example
```py
import keras
from keras import layers
import numpy as np

# 1. Define a custom layer that uses a new call-context arg `foo_mode`
class MyCustomLayer(layers.Layer):
    # Declare 'foo_mode' as a call-context argument
    call_context_args = ("foo_mode",)

    def call(self, inputs, foo_mode=None): # Default to None or a specific value
        if foo_mode:
            return inputs * 2
        return inputs

# 2. Create an outer layer that contains an instance of MyCustomLayer
class OuterLayer(layers.Layer):
    # The outer layer also declares 'foo_mode' to enable propagation
    call_context_args = ("foo_mode",)

    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.inner_layer = MyCustomLayer()

    def call(self, inputs): # not mandatory to include `foo_mode` here.
        # 'foo_mode' will be automatically propagated to self.inner_layer
        # if passed to OuterLayer or set in its context.
        return self.inner_layer(inputs)


layer = OuterLayer()
data = np.array([1, 2, 3])

# Call without `foo_mode` (it will be None or its default in `MyCustomLayer.call`)
output_default = layer(data)
print(f"Output (default foo_mode): {output_default}") # [1, 2, 3]

# Call with `foo_mode=True` at the `OuterLayer` level
# This value will be propagated to `MyCustomLayer`
output_foo_true = layer(data, foo_mode=True)
print(f"Output (foo_mode=True): {output_foo_true}") # [2, 4, 6]
```