### PR TITLE
Fix Trainer.get_compile_config base case (empty dict)

### DIFF
--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -945,6 +945,7 @@ class Trainer:
         """
         if self.compiled and hasattr(self, "_compile_config"):
             return self._compile_config.serialize()
+        return {}
 
     def compile_from_config(self, config):
         """Compiles the model with the information given in config.


### PR DESCRIPTION
It is unexpected for `Trainer.get_compile_config` to return `None` when calling it from subclasses. This change breaks backward-compatibility, but should not significantly impact any real use-cases.