### PR TITLE
Add an easy way to run a script for a few steps only

### DIFF
--- a/keras/api/_tf_keras/keras/config/__init__.py
+++ b/keras/api/_tf_keras/keras/config/__init__.py
@@ -17,10 +17,16 @@ from keras.src.backend.config import image_data_format as image_data_format
 from keras.src.backend.config import (
     is_flash_attention_enabled as is_flash_attention_enabled,
 )
+from keras.src.backend.config import max_epochs as max_epochs
+from keras.src.backend.config import max_steps_per_epoch as max_steps_per_epoch
 from keras.src.backend.config import set_epsilon as set_epsilon
 from keras.src.backend.config import set_floatx as set_floatx
 from keras.src.backend.config import (
     set_image_data_format as set_image_data_format,
+)
+from keras.src.backend.config import set_max_epochs as set_max_epochs
+from keras.src.backend.config import (
+    set_max_steps_per_epoch as set_max_steps_per_epoch,
 )
 from keras.src.dtype_policies.dtype_policy import dtype_policy as dtype_policy
 from keras.src.dtype_policies.dtype_policy import (

--- a/keras/api/config/__init__.py
+++ b/keras/api/config/__init__.py
@@ -17,10 +17,16 @@ from keras.src.backend.config import image_data_format as image_data_format
 from keras.src.backend.config import (
     is_flash_attention_enabled as is_flash_attention_enabled,
 )
+from keras.src.backend.config import max_epochs as max_epochs
+from keras.src.backend.config import max_steps_per_epoch as max_steps_per_epoch
 from keras.src.backend.config import set_epsilon as set_epsilon
 from keras.src.backend.config import set_floatx as set_floatx
 from keras.src.backend.config import (
     set_image_data_format as set_image_data_format,
+)
+from keras.src.backend.config import set_max_epochs as set_max_epochs
+from keras.src.backend.config import (
+    set_max_steps_per_epoch as set_max_steps_per_epoch,
 )
 from keras.src.dtype_policies.dtype_policy import dtype_policy as dtype_policy
 from keras.src.dtype_policies.dtype_policy import (

--- a/keras/src/backend/config.py
+++ b/keras/src/backend/config.py
@@ -15,6 +15,10 @@ _IMAGE_DATA_FORMAT = "channels_last"
 # Default backend: TensorFlow.
 _BACKEND = "tensorflow"
 
+# Cap run duration for debugging.
+_MAX_EPOCHS = None
+_MAX_STEPS_PER_EPOCH = None
+
 
 @keras_export(["keras.config.floatx", "keras.backend.floatx"])
 def floatx():
@@ -304,7 +308,10 @@ if "KERAS_BACKEND" in os.environ:
     _backend = os.environ["KERAS_BACKEND"]
     if _backend:
         _BACKEND = _backend
-
+if "KERAS_MAX_EPOCHS" in os.environ:
+    _MAX_EPOCHS = int(os.environ["KERAS_MAX_EPOCHS"])
+if "KERAS_MAX_STEPS_PER_EPOCH" in os.environ:
+    _MAX_STEPS_PER_EPOCH = int(os.environ["KERAS_MAX_STEPS_PER_EPOCH"])
 
 if _BACKEND != "tensorflow":
     # If we are not running on the tensorflow backend, we should stop tensorflow
@@ -333,3 +340,66 @@ def backend():
 
     """
     return _BACKEND
+
+
+@keras_export(["keras.config.set_max_epochs"])
+def set_max_epochs(max_epochs):
+    """Limit the maximum number of epochs for any call to fit.
+
+    This will cap the number of epochs for any training run using `model.fit()`.
+    This is purely for debugging, and can also be set via the `KERAS_MAX_EPOCHS`
+    environment variable to quickly run a script without modifying its source.
+
+    Args:
+        max_epochs: The integer limit on the number of epochs or `None`. If
+            `None`, no limit is applied.
+    """
+    global _MAX_EPOCHS
+    _MAX_EPOCHS = max_epochs
+
+
+@keras_export(["keras.config.set_max_steps_per_epoch"])
+def set_max_steps_per_epoch(max_steps_per_epoch):
+    """Limit the maximum number of steps for any call to fit/evaluate/predict.
+
+    This will cap the number of steps for single epoch of a call to `fit()`,
+    `evaluate()`, or `predict()`. This is purely for debugging, and can also be
+    set via the `KERAS_MAX_STEPS_PER_EPOCH` environment variable to quickly run
+    a scrip without modifying its source.
+
+    Args:
+        max_epochs: The integer limit on the number of epochs or `None`. If
+            `None`, no limit is applied.
+    """
+    global _MAX_STEPS_PER_EPOCH
+    _MAX_STEPS_PER_EPOCH = max_steps_per_epoch
+
+
+@keras_export(["keras.config.max_epochs"])
+def max_epochs():
+    """Get the maximum number of epochs for any call to fit.
+
+    Retrieves the limit on the number of epochs set by
+    `keras.config.set_max_epochs` or the `KERAS_MAX_EPOCHS` environment
+    variable.
+
+    Returns:
+        The integer limit on the number of epochs or `None`, if no limit has
+        been set.
+    """
+    return _MAX_EPOCHS
+
+
+@keras_export(["keras.config.max_steps_per_epoch"])
+def max_steps_per_epoch():
+    """Get the maximum number of steps for any call to fit/evaluate/predict.
+
+    Retrieves the limit on the number of epochs set by
+    `keras.config.set_max_steps_per_epoch` or the `KERAS_MAX_STEPS_PER_EPOCH`
+    environment variable.
+
+    Args:
+        max_epochs: The integer limit on the number of epochs or `None`. If
+            `None`, no limit is applied.
+    """
+    return _MAX_STEPS_PER_EPOCH

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -1,5 +1,6 @@
 import collections
 import itertools
+import warnings
 from functools import partial
 
 import jax
@@ -9,6 +10,7 @@ from keras.src import backend
 from keras.src import callbacks as callbacks_module
 from keras.src import optimizers as optimizers_module
 from keras.src import tree
+from keras.src.backend import config
 from keras.src.backend import distribution_lib as jax_distribution_lib
 from keras.src.distribution import distribution_lib
 from keras.src.trainers import trainer as base_trainer
@@ -341,6 +343,11 @@ class JAXTrainer(base_trainer.Trainer):
         validation_freq=1,
     ):
         self._assert_compile_called("fit")
+        # Possibly cap epochs for debugging runs.
+        max_epochs = config.max_epochs()
+        if max_epochs and max_epochs < epochs:
+            warnings.warn("Limiting epochs to %d" % max_epochs)
+            epochs = max_epochs
         # TODO: respect compiled trainable state
         self._eval_epoch_iterator = None
         if validation_split and validation_data is None:

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -9,6 +9,7 @@ from keras.src import callbacks as callbacks_module
 from keras.src import metrics as metrics_module
 from keras.src import optimizers as optimizers_module
 from keras.src import tree
+from keras.src.backend import config
 from keras.src.losses import loss as loss_module
 from keras.src.trainers import trainer as base_trainer
 from keras.src.trainers.data_adapters import array_slicing
@@ -309,6 +310,11 @@ class TensorFlowTrainer(base_trainer.Trainer):
         validation_freq=1,
     ):
         self._assert_compile_called("fit")
+        # Possibly cap epochs for debugging runs.
+        max_epochs = config.max_epochs()
+        if max_epochs and max_epochs < epochs:
+            warnings.warn("Limiting epochs to %d" % max_epochs)
+            epochs = max_epochs
         # TODO: respect compiled trainable state
         self._eval_epoch_iterator = None
         if validation_split and validation_data is None:

--- a/keras/src/backend/torch/trainer.py
+++ b/keras/src/backend/torch/trainer.py
@@ -8,6 +8,7 @@ from keras.src import backend
 from keras.src import callbacks as callbacks_module
 from keras.src import optimizers as optimizers_module
 from keras.src import tree
+from keras.src.backend import config
 from keras.src.trainers import trainer as base_trainer
 from keras.src.trainers.data_adapters import array_slicing
 from keras.src.trainers.data_adapters import data_adapter_utils
@@ -187,6 +188,11 @@ class TorchTrainer(base_trainer.Trainer):
             raise ValueError(
                 "You must call `compile()` before calling `fit()`."
             )
+        # Possibly cap epochs for debugging runs.
+        max_epochs = config.max_epochs()
+        if max_epochs and max_epochs < epochs:
+            warnings.warn("Limiting epochs to %d" % max_epochs)
+            epochs = max_epochs
 
         # TODO: respect compiled trainable state
         self._eval_epoch_iterator = None

--- a/keras/src/trainers/epoch_iterator.py
+++ b/keras/src/trainers/epoch_iterator.py
@@ -42,6 +42,7 @@ or until there is no data
 import contextlib
 import warnings
 
+from keras.src.backend import config
 from keras.src.trainers import data_adapters
 
 
@@ -57,6 +58,14 @@ class EpochIterator:
         class_weight=None,
         steps_per_execution=1,
     ):
+        # Possibly cap steps_per_epoch for debugging runs.
+        max_steps_per_epoch = config.max_steps_per_epoch()
+        if max_steps_per_epoch:
+            if not steps_per_epoch or max_steps_per_epoch < steps_per_epoch:
+                warnings.warn(
+                    "Limiting steps_per_epoch to %d" % max_steps_per_epoch
+                )
+                steps_per_epoch = max_steps_per_epoch
         self.steps_per_epoch = steps_per_epoch
         self.steps_per_execution = steps_per_execution
         self._current_iterator = None


### PR DESCRIPTION
I've wanted this tool for a while, figured I should just propose it. Often I need to test out a script or colab I did not write, and just want to run a few train steps without for every fit call without finding every call to fit in the script. This adds a debugging tool to do just that.

```
KERAS_MAX_EPOCHS=1 KERAS_MAX_STEPS_PER_EPOCH=5 python train.py
```