### PR TITLE
Update conftest.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,8 +38,8 @@ def pytest_collection_modifyitems(config, items):
             ]
 
     requires_trainable_backend = pytest.mark.skipif(
-        backend() == "numpy" or backend() == "openvino",
-        reason="Trainer not implemented for NumPy and OpenVINO backend.",
+        backend() in ["numpy", "openvino"],
+        reason="Trainer not implemented for NumPy and OpenVINO backend.", 
     )
     for item in items:
         if "requires_trainable_backend" in item.keywords:

--- a/conftest.py
+++ b/conftest.py
@@ -39,7 +39,7 @@ def pytest_collection_modifyitems(config, items):
 
     requires_trainable_backend = pytest.mark.skipif(
         backend() in ["numpy", "openvino"],
-        reason="Trainer not implemented for NumPy and OpenVINO backend.", 
+        reason="Trainer not implemented for NumPy and OpenVINO backend.",
     )
     for item in items:
         if "requires_trainable_backend" in item.keywords:


### PR DESCRIPTION
updated the `requires_trainable_backend` to use `in` operator for checking backend values.
fixes [#21005](https://github.com/keras-team/keras/issues/21005)