### PR TITLE
Adds `_register_call_context_args` to declare and use call-context arguments.

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -315,12 +315,12 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         # 1. collect names that should be auto‑propagated
         builtin_context_args = {"training"}
         custom_context_args = set(getattr(self, "call_context_args", ()))
-        self._call_context_args = builtin_context_args | custom_context_args
+        self._call_ctx_args = builtin_context_args | custom_context_args
 
         # 2. remember which of them exist in *this* call signature
         self._call_has_context_arg = {
             arg: (arg in call_signature_parameters)
-            for arg in self._call_context_args
+            for arg in self._call_ctx_args
         }
 
         self._supports_masking = not utils.is_default(self.compute_mask)
@@ -847,7 +847,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
 
         # Caches info about `call()` signature, args, kwargs.
         call_spec = CallSpec(
-            self._call_signature, self._call_context_args, args, kwargs
+            self._call_signature, self._call_ctx_args, args, kwargs
         )
 
         ############################################
@@ -872,7 +872,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         # across nested calls.
         call_context = self._get_call_context()
 
-        for context_arg in self._call_context_args:
+        for context_arg in self._call_ctx_args:
             self._resolve_and_populate_arg(
                 context_arg, call_spec, call_context, kwargs
             )
@@ -1126,7 +1126,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         else:
             # Use compute_output_shape() to return the right output spec
             call_spec = CallSpec(
-                self._call_signature, self._call_context_args, args, kwargs
+                self._call_signature, self._call_ctx_args, args, kwargs
             )
             shapes_dict = get_shapes_dict(call_spec)
             shapes_dict = update_shapes_dict_for_target_fn(
@@ -1742,12 +1742,12 @@ class Layer(BackendLayer, Operation, KerasSaveable):
             raise RuntimeError(
                 "Cannot add call-context args after the layer has been called."
             )
-        self._call_context_args = self._call_context_args | set(names)
+        self._call_ctx_args = self._call_ctx_args | set(names)
 
     @property
-    def call_context_args(self):
+    def _call_context_args(self):
         """Tuple of all context-args registered with this layer."""
-        return tuple(self._call_context_args)
+        return tuple(self._call_ctx_args)
 
 
 def is_backend_tensor_or_symbolic(x, allow_none=False):

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1697,7 +1697,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
                 return rematerialized_activation_call_wrapper
         return layer_call
 
-    def register_call_context_args(self, *names: str) -> None:
+    def register_call_context_args(self, *names):
         """Register call-context args to be propagated by this layer.
 
         This is useful in registering custom context-args with predefined

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1697,7 +1697,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
                 return rematerialized_activation_call_wrapper
         return layer_call
 
-    def register_call_context_args(self, *names):
+    def _register_call_context_args(self, *names):
         """Register call-context args to be propagated by this layer.
 
         This is useful in registering custom context-args with predefined

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1747,7 +1747,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
     @property
     def call_context_args(self):
         """Tuple of user-supplied context-arg names."""
-        return tuple(self._custom_context_args)
+        return tuple(self._call_context_args)
 
 
 def is_backend_tensor_or_symbolic(x, allow_none=False):

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1746,7 +1746,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
 
     @property
     def call_context_args(self):
-        """Tuple of user-supplied context-arg names."""
+        """Tuple of all context-args registered with this layer."""
         return tuple(self._call_context_args)
 
 

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1568,6 +1568,30 @@ class LayerTest(testing.TestCase):
         self.assertEqual(int(layer(np.array(0), foo_mode=True)), 1)
         self.assertEqual(int(layer(np.array(0))), 0)
 
+    def test_register_call_context_arguments(self):
+        class MyLayer(layers.Layer):
+            def call(self, x):
+                return x
+
+        layer = MyLayer()
+
+        layer.register_call_context_args("foo_mode")
+
+        self.assertCountEqual(layer.call_context_args, ("foo_mode", "training"))
+
+    def test_register_call_context_arguments_after_call(self):
+        class MyLayer(layers.Layer):
+            def call(self, x):
+                return x
+
+        layer = MyLayer()
+        layer(np.array(0))
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Cannot add call-context args after the layer has been called.",
+        ):
+            layer.register_call_context_args("foo_mode")
+
     def test_context_args_with_triple_nesting_and_priority(self):
         class Inner(layers.Layer):
             call_context_args = ("foo_mode",)

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1577,9 +1577,11 @@ class LayerTest(testing.TestCase):
 
         layer = MyLayer()
 
-        layer.register_call_context_args("foo_mode")
+        layer._register_call_context_args("foo_mode")
 
-        self.assertCountEqual(layer.call_context_args, ("foo_mode", "training"))
+        self.assertCountEqual(
+            layer._call_context_args, ("foo_mode", "training")
+        )
 
     def test_register_call_context_arguments_after_call(self):
         """Validate that registering call-context args after the layer has
@@ -1595,7 +1597,7 @@ class LayerTest(testing.TestCase):
             RuntimeError,
             "Cannot add call-context args after the layer has been called.",
         ):
-            layer.register_call_context_args("foo_mode")
+            layer._register_call_context_args("foo_mode")
 
     def test_context_args_with_triple_nesting_and_priority(self):
         """Validate that call-context args are propagated correctly
@@ -1628,7 +1630,7 @@ class LayerTest(testing.TestCase):
                 return self.middle(x)
 
         layer = Outer()
-        layer.register_call_context_args("foo_mode")
+        layer._register_call_context_args("foo_mode")
 
         # The value of foo_mode is set to True in the call to Outer,
         # so it should automatically propagate to Inner through Middle.
@@ -1652,7 +1654,7 @@ class LayerTest(testing.TestCase):
                 return self.inner(x)
 
         layer = Wrapper()
-        layer.register_call_context_args("foo_mode")
+        layer._register_call_context_args("foo_mode")
 
         # The value of foo_mode is set to True in the call to Wrapper,
         # However, it is not declared as a call-context arg in Inner,
@@ -1689,7 +1691,7 @@ class LayerTest(testing.TestCase):
         seq = models.Sequential([layers.Identity(), Outer()])
         # Tell the Sequential model to propagate foo_mode down
         # the call-stack
-        seq.register_call_context_args("foo_mode")
+        seq._register_call_context_args("foo_mode")
 
         # foo_mode=True -> input + 1
         out_true = seq(sample_input, foo_mode=True)
@@ -1706,7 +1708,7 @@ class LayerTest(testing.TestCase):
         model = models.Model(inp, out)
         # Tell the Functional model to propagate foo_mode down
         # the call-stack
-        model.register_call_context_args("foo_mode")
+        model._register_call_context_args("foo_mode")
 
         # foo_mode=True -> input + 1
         y1 = model(sample_input, foo_mode=True)

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1547,16 +1547,17 @@ class LayerTest(testing.TestCase):
 
     def test_call_context_args_with_custom_layers(self):
         class Inner(layers.Layer):
-            call_context_args = ("foo_mode",)
+            def __init__(self):
+                super().__init__()
+                self._register_call_context_args("foo_mode")
 
             def call(self, x, foo_mode=None):
                 return x + (1 if foo_mode else 0)
 
         class Outer(layers.Layer):
-            call_context_args = ("foo_mode",)
-
             def __init__(self):
                 super().__init__()
+                self._register_call_context_args("foo_mode")
                 self.inner = Inner()
 
             def call(self, x):
@@ -1607,6 +1608,10 @@ class LayerTest(testing.TestCase):
 
         class Inner(layers.Layer):
             call_context_args = ("foo_mode",)
+
+            def __init__(self):
+                super().__init__()
+                self._register_call_context_args("foo_mode")
 
             def call(self, x, foo_mode=None):
                 return x + (1 if foo_mode else 0)
@@ -1668,7 +1673,9 @@ class LayerTest(testing.TestCase):
         """
 
         class Inner(layers.Layer):
-            call_context_args = ("foo_mode",)
+            def __init__(self):
+                super().__init__()
+                self._register_call_context_args("foo_mode")
 
             def call(self, x, foo_mode=False):
                 # If foo_mode=True add 1, otherwise add 0

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1584,8 +1584,6 @@ class LayerTest(testing.TestCase):
                 return self.inner(x)
 
         class Outer(layers.Layer):
-            call_context_args = ("foo_mode",)
-
             def __init__(self):
                 super().__init__()
                 self.middle = Middle()
@@ -1596,6 +1594,7 @@ class LayerTest(testing.TestCase):
                 return self.middle(x)
 
         layer = Outer()
+        layer.register_call_context_args("foo_mode")
 
         # The value of foo_mode is set to True in the call to Outer,
         # so it should automatically propagate to Inner through Middle.
@@ -1612,8 +1611,6 @@ class LayerTest(testing.TestCase):
                 return x + add_val
 
         class Outer(layers.Layer):
-            call_context_args = ("foo_mode",)
-
             def __init__(self):
                 super().__init__()
                 self.inner = Inner()
@@ -1627,6 +1624,9 @@ class LayerTest(testing.TestCase):
 
         # Sequential model
         seq = models.Sequential([Outer()])
+        # Tell the Sequential model to propagate foo_mode down
+        # the call-stack
+        seq.register_call_context_args("foo_mode")
 
         # foo_mode=True -> input + 1
         out_true = seq(sample_input, foo_mode=True)
@@ -1640,6 +1640,9 @@ class LayerTest(testing.TestCase):
         inp = Input(shape=(1,))
         out = Outer()(inp)
         model = models.Model(inp, out)
+        # Tell the Functional model to propagate foo_mode down
+        # the call-stack
+        model.register_call_context_args("foo_mode")
 
         # foo_mode=True -> input + 1
         y1 = model(sample_input, foo_mode=True)

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1607,8 +1607,6 @@ class LayerTest(testing.TestCase):
         """
 
         class Inner(layers.Layer):
-            call_context_args = ("foo_mode",)
-
             def __init__(self):
                 super().__init__()
                 self._register_call_context_args("foo_mode")

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1647,7 +1647,7 @@ class LayerTest(testing.TestCase):
         sample_input = np.array([[1.0], [2.0]])
 
         # Sequential model
-        seq = models.Sequential([Outer()])
+        seq = models.Sequential([layers.Identity(), Outer()])
         # Tell the Sequential model to propagate foo_mode down
         # the call-stack
         seq.register_call_context_args("foo_mode")
@@ -1662,7 +1662,8 @@ class LayerTest(testing.TestCase):
 
         # Functional model
         inp = Input(shape=(1,))
-        out = Outer()(inp)
+        out = layers.Identity()(inp)
+        out = Outer()(out)
         model = models.Model(inp, out)
         # Tell the Functional model to propagate foo_mode down
         # the call-stack


### PR DESCRIPTION
# Summary
Previously model authors were required to define call-context args in the entry-point layer to tell keras that these arguments should be propagated down. This was slightly awkward.

This also means that in case the entry-point layer is a pre-defined layer (eg. `Dense`), we need to subclass it to tell it to propagate these arguments in its context. This is bad UX.

### Existing approach
```py
class Inner(layers.Layer):
    call_context_args = ("foo_mode",)

    def call(self, x, foo_mode=False):
        add_val = ops.where(foo_mode, 1.0, 0.0)
        return x + add_val

class Outer(layers.Layer):
    # This is an awkward requirement to have.
    call_context_args = ("foo_mode",)

    def __init__(self):
        super().__init__()
        self.inner = Inner()

    def call(self, x):
        return self.inner(x)

sample_input = np.array([[1.0], [2.0]])

# Functional model
inp = Input(shape=(1,))
out = Outer()(inp)
model = models.Model(inp, out)

# foo_mode=True -> input + 1
y1 = model(sample_input, foo_mode=True)
self.assertAllClose(y1, sample_input + 1.0)

# foo_mode omitted -> foo_mode defaults to False -> no change
y2 = model(sample_input)
self.assertAllClose(y2, sample_input)
```

However, with the new `register_call_context_args` API, we can simply register call context arguments at the top-level layers or models (before they're called) without having to define the call_context_args inside the class definition. In fact this can remove the need for the `call_context_args` attribute, and each layer can simply use the registration API instead.

This also means we no longer need to subclass existing layers to make them propagate these arguments down.

### New Approach
```py
class Inner(layers.Layer):
    def __init__(self):
        super().__init__()
        self._register_call_context_args("foo_mode")

    def call(self, x, foo_mode=False):
        add_val = ops.where(foo_mode, 1.0, 0.0)
        return x + add_val

class Outer(layers.Layer):
    def __init__(self):
        super().__init__()
        self.inner = Inner()

    def call(self, x):
        return self.inner(x)

sample_input = np.array([[1.0], [2.0]])

# Functional model
inp = Input(shape=(1,))
out = Outer()(inp)
model = models.Model(inp, out)
# Tell the model instance to propagate this argument down.
model._register_call_context_args("foo_mode")

# foo_mode=True -> input + 1
y1 = model(sample_input, foo_mode=True)
self.assertAllClose(y1, sample_input + 1.0)

# foo_mode omitted -> foo_mode defaults to False -> no change
y2 = model(sample_input)
self.assertAllClose(y2, sample_input)
```

# API
## `register_call_context_args(self, *names)`
* `*names`: string arguments, defining the names of the context-arguments to be passed down.