### PR TITLE
Openvino ravel op

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -42,7 +42,6 @@ NumpyDtypeTest::test_outer_
 NumpyDtypeTest::test_power
 NumpyDtypeTest::test_prod
 NumpyDtypeTest::test_quantile
-NumpyDtypeTest::test_ravel
 NumpyDtypeTest::test_repeat
 NumpyDtypeTest::test_roll
 NumpyDtypeTest::test_round
@@ -102,7 +101,6 @@ NumpyOneInputOpsCorrectnessTest::test_pad_int8_constant_2
 NumpyOneInputOpsCorrectnessTest::test_pad_uint8_constant_2
 NumpyOneInputOpsCorrectnessTest::test_pad_int32_constant_2
 NumpyOneInputOpsCorrectnessTest::test_prod
-NumpyOneInputOpsCorrectnessTest::test_ravel
 NumpyOneInputOpsCorrectnessTest::test_real
 NumpyOneInputOpsCorrectnessTest::test_reciprocal
 NumpyOneInputOpsCorrectnessTest::test_repeat

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -101,7 +101,6 @@ NumpyOneInputOpsCorrectnessTest::test_pad_int8_constant_2
 NumpyOneInputOpsCorrectnessTest::test_pad_uint8_constant_2
 NumpyOneInputOpsCorrectnessTest::test_pad_int32_constant_2
 NumpyOneInputOpsCorrectnessTest::test_prod
-NumpyOneInputOpsCorrectnessTest::test_ravel
 NumpyOneInputOpsCorrectnessTest::test_real
 NumpyOneInputOpsCorrectnessTest::test_reciprocal
 NumpyOneInputOpsCorrectnessTest::test_repeat

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -101,6 +101,7 @@ NumpyOneInputOpsCorrectnessTest::test_pad_int8_constant_2
 NumpyOneInputOpsCorrectnessTest::test_pad_uint8_constant_2
 NumpyOneInputOpsCorrectnessTest::test_pad_int32_constant_2
 NumpyOneInputOpsCorrectnessTest::test_prod
+NumpyOneInputOpsCorrectnessTest::test_ravel
 NumpyOneInputOpsCorrectnessTest::test_real
 NumpyOneInputOpsCorrectnessTest::test_reciprocal
 NumpyOneInputOpsCorrectnessTest::test_repeat

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1206,7 +1206,9 @@ def quantile(x, q, axis=None, method="linear", keepdims=False):
 
 
 def ravel(x):
-    raise NotImplementedError("`ravel` is not supported with openvino backend")
+    x = get_ov_output(x)
+    target_shape = ov_opset.constant([-1], dtype=Type.i32).output(0)
+    return OpenVINOKerasTensor(ov_opset.reshape(x, target_shape, special_zero=False).output(0))
 
 
 def real(x):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1208,7 +1208,9 @@ def quantile(x, q, axis=None, method="linear", keepdims=False):
 def ravel(x):
     x = get_ov_output(x)
     target_shape = ov_opset.constant([-1], dtype=Type.i32).output(0)
-    return OpenVINOKerasTensor(ov_opset.reshape(x, target_shape, special_zero=False).output(0))
+    return OpenVINOKerasTensor(
+        ov_opset.reshape(x, target_shape, special_zero=False).output(0)
+    )
 
 
 def real(x):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-env =
-    KERAS_BACKEND=openvino

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+env =
+    KERAS_BACKEND=openvino


### PR DESCRIPTION
Implemented support for numpy.ravel operation in the Keras OpenVINO backend.

This PR adds a decomposition for numpy.ravel using the OpenVINO reshape op with a shape of [-1], which flattens the input tensor to 1D—equivalent to NumPy’s ravel() behavior.

✅ Changes made:
Implemented ravel using ov_opset.reshape with [-1] as the target shape.

Ensured special_zero=False to avoid OpenVINO preserving dimensions unintentionally.

Wrapped the result using OpenVINOKerasTensor.

Removed test_ravel from excluded_concrete_tests.txt to enable testing.

Added a local pytest.ini to run tests with KERAS_BACKEND=openvino.

🔬 Testing:
All tests pass locally using:

bash
Copy
Edit
pytest -c ./pytest.ini ./keras/src/ops/numpy_test.py
Please let me know if any changes are needed.

@rkazants Kindly review this PR. Thanks!