### PR TITLE
Fix stacked RNN with mask in JAX & Numpy backends

### DIFF
--- a/keras/src/backend/numpy/rnn.py
+++ b/keras/src/backend/numpy/rnn.py
@@ -160,12 +160,16 @@ def rnn(
                 else:
                     # Assume the first state is the previous output.
                     output_tm1 = states[0]
+                    if tree.is_nested(output_tm1):
+                        # Stacked RNN case: assume first state of last cell.
+                        output_tm1 = states[-1][0]
                     masked_outs = np.where(is_masked, output_tm1, output_t)
 
-                new_states = [
-                    np.where(is_masked, s, ns)
-                    for s, ns in zip(states, new_states)
-                ]
+                new_states = tree.map_structure(
+                    lambda s, ns: np.where(is_masked, s, ns),
+                    states,
+                    new_states,
+                )
                 return (new_states, masked_outs)
 
             scan_xs = (inputs, mask)

--- a/keras/src/layers/rnn/rnn_test.py
+++ b/keras/src/layers/rnn/rnn_test.py
@@ -381,4 +381,15 @@ class RNNTest(testing.TestCase):
         layer = layers.RNN(OneStateRNNCell(2), return_sequences=False)
         self.run_class_serialization_test(layer)
 
+    def test_stacked_rnn_mask(self):
+        sequence = np.ones((2, 3, 4))
+        mask = np.array([[True, True, True], [True, True, False]])
+        cell_kwargs = dict(
+            units=1, kernel_initializer="ones", recurrent_initializer="ones"
+        )
+        rnn_cells = [layers.LSTMCell(**cell_kwargs) for _ in range(2)]
+        stacked_rnn = layers.RNN(rnn_cells)
+        output = stacked_rnn(sequence, mask=mask)
+        self.assertAllClose(np.array([[0.7793], [0.5998]]), output, atol=1e-4)
+
     # TODO: test masking

--- a/keras/src/layers/rnn/rnn_test.py
+++ b/keras/src/layers/rnn/rnn_test.py
@@ -381,15 +381,4 @@ class RNNTest(testing.TestCase):
         layer = layers.RNN(OneStateRNNCell(2), return_sequences=False)
         self.run_class_serialization_test(layer)
 
-    def test_stacked_rnn_mask(self):
-        sequence = np.ones((2, 3, 4))
-        mask = np.array([[True, True, True], [True, True, False]])
-        cell_kwargs = dict(
-            units=1, kernel_initializer="ones", recurrent_initializer="ones"
-        )
-        rnn_cells = [layers.LSTMCell(**cell_kwargs) for _ in range(2)]
-        stacked_rnn = layers.RNN(rnn_cells)
-        output = stacked_rnn(sequence, mask=mask)
-        self.assertAllClose(np.array([[0.7793], [0.5998]]), output, atol=1e-4)
-
     # TODO: test masking

--- a/keras/src/layers/rnn/stacked_rnn_cells_test.py
+++ b/keras/src/layers/rnn/stacked_rnn_cells_test.py
@@ -275,3 +275,14 @@ class StackedRNNTest(testing.TestCase):
         self.assertEqual(shape[1][1], (2, 10))
         self.assertEqual(shape[2][0], (2, 10))
         self.assertEqual(shape[2][1], (2, 10))
+
+    def test_stacked_lstm_cell_mask(self):
+        sequence = np.ones((2, 3, 4))
+        mask = np.array([[True, True, True], [True, True, False]])
+        cell_kwargs = dict(
+            units=1, kernel_initializer="ones", recurrent_initializer="ones"
+        )
+        rnn_cells = [layers.LSTMCell(**cell_kwargs) for _ in range(2)]
+        stacked_rnn = layers.RNN(rnn_cells)
+        output = stacked_rnn(sequence, mask=mask)
+        self.assertAllClose(np.array([[0.7793], [0.5998]]), output, atol=1e-4)


### PR DESCRIPTION
There is currently a bug specific to JAX backend when using a stacked RNN with a mask (due to the fact that stacked RNN states are **nested** lists):

```python
import numpy as np
from keras import layers

sequence = np.ones((2, 3, 4))
mask = np.array([[True, True, True], [True, True, False]])  # shape (2, 3)

cell_kwargs = dict(
    units=5,
    kernel_initializer="ones",  # just to check consistency between backends
    recurrent_initializer="ones"  # just to check consistency between backends
)
rnn_cells = [layers.LSTMCell(**cell_kwargs) for _ in range(4)]  # 4 cells
lstm_layer = layers.RNN(rnn_cells)  # stacked RNN

output = lstm_layer(sequence, mask=mask)  # <--- raises error on JAX when mask used!
```

This PR fixes this bug (I also double-checked that the output is consistent across JAX/TF/Torch backends, even when changing the values for `unroll` and `zero_output_for_mask` RNN arguments).

**Note:** I didn't add a specific test case related to the code above since [rnn_test](https://github.com/keras-team/keras/blob/master/keras/src/layers/rnn/rnn_test.py) is fairly complex and I wasn't sure where/how to add it without polluting the original file - but feel free to do it if you think it is necessary.