### PR TITLE
Don't create unused optimizer variables.

### DIFF
--- a/keras/src/backend/torch/optimizers/torch_parallel_optimizer.py
+++ b/keras/src/backend/torch/optimizers/torch_parallel_optimizer.py
@@ -15,7 +15,9 @@ class TorchParallelOptimizer(BaseOptimizer):
 
     @torch_utils.no_grad
     def _backend_reset_gradient_accumulators(self):
-        acc_list = [v.value for v in self._accumulated_gradients]
+        acc_list = [
+            v.value for v in self._accumulated_gradients if v is not None
+        ]
         torch._foreach_mul_(acc_list, 0.0)
 
     @torch_utils.no_grad

--- a/keras/src/optimizers/adadelta.py
+++ b/keras/src/optimizers/adadelta.py
@@ -75,15 +75,12 @@ class Adadelta(optimizer.Optimizer):
         if self.built:
             return
         super().build(var_list)
-        self._accumulated_grads = []
-        self._accumulated_delta_vars = []
-        for var in var_list:
-            self._accumulated_grads.append(
-                self.add_variable_from_reference(var, "accumulated_grad")
-            )
-            self._accumulated_delta_vars.append(
-                self.add_variable_from_reference(var, "accumulated_delta_var")
-            )
+        self._accumulated_grads = self.add_optimizer_variables(
+            var_list, "accumulated_grad"
+        )
+        self._accumulated_delta_vars = self.add_optimizer_variables(
+            var_list, "accumulated_delta_var"
+        )
 
     def update_step(self, grad, variable, learning_rate):
         """Update step given gradient and the associated model variable."""

--- a/keras/src/optimizers/adafactor.py
+++ b/keras/src/optimizers/adafactor.py
@@ -1,4 +1,3 @@
-from keras.src import backend
 from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.optimizers import optimizer
@@ -97,16 +96,13 @@ class Adafactor(optimizer.Optimizer):
         self._c = []
         self._v = []
         for var in var_list:
-            if len(var.shape) < 2:
-                # Don't factor if variable is of dimension < 2, but we still
-                # need to create dummy variables as placeholder.
-                with backend.name_scope(self.name, caller=self):
-                    self._r.append(
-                        backend.Variable(0, name=var.name, trainable=False)
-                    )
-                    self._c.append(
-                        backend.Variable(0, name=var.name, trainable=False)
-                    )
+            if (
+                self._overwrite_variable_with_gradient(var)
+                or len(var.shape) < 2
+            ):
+                # Don't factor if variable is of dimension < 2.
+                self._r.append(None)
+                self._c.append(None)
             else:
                 # Always factor the last 2 dimensions.
                 r_shape = var.shape[:-1]
@@ -125,11 +121,15 @@ class Adafactor(optimizer.Optimizer):
                         name=var.name,
                     )
                 )
-            self._v.append(
-                self.add_variable_from_reference(
-                    reference_variable=var, name="velocity"
+
+            if self._overwrite_variable_with_gradient(var):
+                self._v.append(None)
+            else:
+                self._v.append(
+                    self.add_variable_from_reference(
+                        reference_variable=var, name="velocity"
+                    )
                 )
-            )
 
     def _rms(self, x):
         return ops.sqrt(ops.mean(ops.square(x)))

--- a/keras/src/optimizers/adagrad.py
+++ b/keras/src/optimizers/adagrad.py
@@ -70,17 +70,10 @@ class Adagrad(optimizer.Optimizer):
         if self.built:
             return
         super().build(var_list)
-        self._accumulators = []
         initializer = initializers.Constant(self.initial_accumulator_value)
-        for var in var_list:
-            self._accumulators.append(
-                self.add_variable(
-                    shape=var.shape,
-                    initializer=initializer,
-                    dtype=var.dtype,
-                    name="accumulator",
-                )
-            )
+        self._accumulators = self.add_optimizer_variables(
+            var_list, "accumulator", initializer=initializer
+        )
 
     def update_step(self, gradient, variable, learning_rate):
         """Update step given gradient and the associated model variable."""

--- a/keras/src/optimizers/adam.py
+++ b/keras/src/optimizers/adam.py
@@ -90,27 +90,13 @@ class Adam(optimizer.Optimizer):
         if self.built:
             return
         super().build(var_list)
-        self._momentums = []
-        self._velocities = []
-        for var in var_list:
-            self._momentums.append(
-                self.add_variable_from_reference(
-                    reference_variable=var, name="momentum"
-                )
-            )
-            self._velocities.append(
-                self.add_variable_from_reference(
-                    reference_variable=var, name="velocity"
-                )
-            )
+        self._momentums = self.add_optimizer_variables(var_list, "momentum")
+        self._velocities = self.add_optimizer_variables(var_list, "velocity")
+
         if self.amsgrad:
-            self._velocity_hats = []
-            for var in var_list:
-                self._velocity_hats.append(
-                    self.add_variable_from_reference(
-                        reference_variable=var, name="velocity_hat"
-                    )
-                )
+            self._velocity_hats = self.add_optimizer_variables(
+                var_list, "velocity_hat"
+            )
 
     def update_step(self, gradient, variable, learning_rate):
         """Update step given gradient and the associated model variable."""

--- a/keras/src/optimizers/adamax.py
+++ b/keras/src/optimizers/adamax.py
@@ -98,19 +98,8 @@ class Adamax(optimizer.Optimizer):
         if self.built:
             return
         super().build(var_list)
-        self._m = []
-        self._u = []
-        for var in var_list:
-            self._m.append(
-                self.add_variable_from_reference(
-                    reference_variable=var, name="momentum"
-                )
-            )
-            self._u.append(
-                self.add_variable_from_reference(
-                    reference_variable=var, name="norm"
-                )
-            )
+        self._m = self.add_optimizer_variables(var_list, "momentum")
+        self._u = self.add_optimizer_variables(var_list, "norm")
 
     def update_step(self, gradient, variable, learning_rate):
         """Update step given gradient and the associated model variable."""

--- a/keras/src/optimizers/ftrl.py
+++ b/keras/src/optimizers/ftrl.py
@@ -159,24 +159,13 @@ class Ftrl(optimizer.Optimizer):
         if self.built:
             return
         super().build(var_list)
-        self._accumulators = []
-        self._linears = []
-        for var in var_list:
-            self._accumulators.append(
-                self.add_variable(
-                    shape=var.shape,
-                    dtype=var.dtype,
-                    name="accumulator",
-                    initializer=initializers.Constant(
-                        self.initial_accumulator_value,
-                    ),
-                )
-            )
-            self._linears.append(
-                self.add_variable_from_reference(
-                    reference_variable=var, name="linear"
-                )
-            )
+        accumulator_initializer = initializers.Constant(
+            self.initial_accumulator_value,
+        )
+        self._accumulators = self.add_optimizer_variables(
+            var_list, "accumulator", initializer=accumulator_initializer
+        )
+        self._linears = self.add_optimizer_variables(var_list, "linear")
 
     def update_step(self, gradient, variable, learning_rate):
         """Update step given gradient and the associated model variable."""

--- a/keras/src/optimizers/lamb.py
+++ b/keras/src/optimizers/lamb.py
@@ -82,19 +82,8 @@ class Lamb(optimizer.Optimizer):
         if self.built:
             return
         super().build(var_list)
-        self._momentums = []
-        self._velocities = []
-        for var in var_list:
-            self._momentums.append(
-                self.add_variable_from_reference(
-                    reference_variable=var, name="momentum"
-                )
-            )
-            self._velocities.append(
-                self.add_variable_from_reference(
-                    reference_variable=var, name="velocity"
-                )
-            )
+        self._momentums = self.add_optimizer_variables(var_list, "momentum")
+        self._velocities = self.add_optimizer_variables(var_list, "velocity")
 
     def update_step(self, gradient, variable, learning_rate):
         """Update step given gradient and the associated model variable."""

--- a/keras/src/optimizers/lion.py
+++ b/keras/src/optimizers/lion.py
@@ -91,13 +91,7 @@ class Lion(optimizer.Optimizer):
         if self.built:
             return
         super().build(var_list)
-        self._momentums = []
-        for var in var_list:
-            self._momentums.append(
-                self.add_variable_from_reference(
-                    reference_variable=var, name="momentum"
-                )
-            )
+        self._momentums = self.add_optimizer_variables(var_list, "momentum")
 
     def update_step(self, gradient, variable, learning_rate):
         """Update step given gradient and the associated model variable."""

--- a/keras/src/optimizers/loss_scale_optimizer.py
+++ b/keras/src/optimizers/loss_scale_optimizer.py
@@ -102,12 +102,6 @@ class LossScaleOptimizer(optimizer.Optimizer):
             ),
         )
 
-    def _overwrite_variable_with_gradient(self, variable):
-        return (
-            hasattr(variable, "overwrite_with_gradient")
-            and variable.overwrite_with_gradient
-        )
-
     def _stateless_handle_finite_grads(
         self, optimizer_variables, grads, trainable_variables
     ):

--- a/keras/src/optimizers/nadam.py
+++ b/keras/src/optimizers/nadam.py
@@ -87,21 +87,9 @@ class Nadam(optimizer.Optimizer):
         else:
             dtype = backend.floatx()
         super().build(var_list)
-        self._momentums = []
-        self._velocities = []
+        self._momentums = self.add_optimizer_variables(var_list, "momentum")
+        self._velocities = self.add_optimizer_variables(var_list, "velocity")
         self._u_product = backend.Variable(1.0, dtype=dtype)
-
-        for var in var_list:
-            self._momentums.append(
-                self.add_variable_from_reference(
-                    reference_variable=var, name="momentum"
-                )
-            )
-            self._velocities.append(
-                self.add_variable_from_reference(
-                    reference_variable=var, name="velocity"
-                )
-            )
 
     def _backend_update_step(self, grads, trainable_variables, learning_rate):
         dtype = self._u_product.dtype

--- a/keras/src/optimizers/rmsprop.py
+++ b/keras/src/optimizers/rmsprop.py
@@ -94,25 +94,17 @@ class RMSprop(optimizer.Optimizer):
 
         super().build(var_list)
 
-        self._velocities = []
-        for var in var_list:
-            self._velocities.append(
-                self.add_variable_from_reference(var, "velocity")
-            )
+        self._velocities = self.add_optimizer_variables(var_list, "velocity")
 
         self._momentums = []
         if self.momentum > 0:
-            for var in var_list:
-                self._momentums.append(
-                    self.add_variable_from_reference(var, "momentum")
-                )
+            self._momentums = self.add_optimizer_variables(var_list, "momentum")
 
         self._average_gradients = []
         if self.centered:
-            for var in var_list:
-                self._average_gradients.append(
-                    self.add_variable_from_reference(var, "average_gradient")
-                )
+            self._average_gradients = self.add_optimizer_variables(
+                var_list, "average_gradient"
+            )
 
     def update_step(self, gradient, variable, learning_rate):
         """Update step given gradient and the associated model variable."""

--- a/keras/src/optimizers/sgd.py
+++ b/keras/src/optimizers/sgd.py
@@ -90,12 +90,7 @@ class SGD(optimizer.Optimizer):
         super().build(variables)
         self.momentums = []
         if self.momentum != 0:
-            for variable in variables:
-                self.momentums.append(
-                    self.add_variable_from_reference(
-                        reference_variable=variable, name="momentum"
-                    )
-                )
+            self.momentums = self.add_optimizer_variables(variables, "momentum")
 
     def update_step(self, gradient, variable, learning_rate):
         """Update step given gradient and the associated model variable."""


### PR DESCRIPTION
If `variable.overwrite_with_gradient == True`, then the only optimizer variable ever used for that variable is `base_optimizer._accumulated_gradients`. All other optimizer variables are unused.  This can be extremely wasteful if the training variables are large, for example in the case of large embedding tables that span multiple hosts/devices.

Added a convenience function in the base optimizer `add_optimizer_variables(...)` that loops through the variable list and automatically adds a variable only if appropriate.  If a variable would otherwise be unused, a `None` is inserted into the list.  This is needed to keep `optimizer._get_variable_index()` consistent. Updated all built-in optimizers to use this.

NOTE: if a custom optimizer that exists out in the wild still does create unused optimizer variables, the optimizer should still work - it will just be wasteful.  IOW this should not be a breaking change.