### PR TITLE
Clear static loss-scale for inner optimizer in LossScaleOptimizer.

### DIFF
--- a/keras/src/optimizers/loss_scale_optimizer.py
+++ b/keras/src/optimizers/loss_scale_optimizer.py
@@ -60,6 +60,9 @@ class LossScaleOptimizer(optimizer.Optimizer):
         self.inner_optimizer = inner_optimizer
         self.initial_scale = initial_scale
         self.dynamic_growth_steps = dynamic_growth_steps
+        # Disable the inner optimizer's loss scaling, otherwise
+        # gradients will be scaled twice.
+        self.inner_optimizer.loss_scale_factor = None
 
     @tracking.no_automatic_dependency_tracking
     def build(self, var_list):


### PR DESCRIPTION
The outer `LossScaleOptimizer` ignores the inner's loss-scale factor when scaling the loss.  When computing unscaled gradients, we therefore need to eliminate the inner's loss scale factor, otherwise the gradients get incorrectly scaled.