### PR TITLE
fix lamb bug

### DIFF
--- a/keras/src/optimizers/lamb.py
+++ b/keras/src/optimizers/lamb.py
@@ -94,8 +94,13 @@ class Lamb(optimizer.Optimizer):
         beta_1_power = ops.power(
             ops.cast(self.beta_1, variable.dtype), local_step
         )
+        if variable.dtype == "bfloat16":
+            # 0.996 is the largest number less than 1 in BF16
+            beta_2_power = ops.minimum(self.beta_2, 0.996)
+        else:
+            beta_2_power = self.beta_2
         beta_2_power = ops.power(
-            ops.cast(self.beta_2, variable.dtype), local_step
+            ops.cast(beta_2_power, variable.dtype), local_step
         )
 
         m = self._momentums[self._get_variable_index(variable)]


### PR DESCRIPTION
This PR is for the case of using BF16 in backward propagation.
The default parameter beta_2_power =0.999, which will be rounded to 1 in bf16.
```python
In [1]: ops.cast(0.999,"bfloat16")
Out[1]: <tf.Tensor: shape=(), dtype=bfloat16, numpy=1>
```
Therefore, in this PR, we will set beta_2 to a maximum of 0.996 under BF16, to avoid causing NAN due to rounding to 1.