### PR TITLE
`mlx` - remat and continued test updates

### DIFF
--- a/keras/src/backend/mlx/core.py
+++ b/keras/src/backend/mlx/core.py
@@ -21,7 +21,8 @@ except ImportError:
 
 SUPPORTS_SPARSE_TENSORS = False
 SUPPORTS_RAGGED_TENSORS = False
-IS_THREAD_SAFE = False  # True
+# TODO: follow updates and adjust to thread safe when possible
+IS_THREAD_SAFE = False  # False as of mlx 0.24.0
 
 MLX_DTYPES = {
     "float16": mx.float16,

--- a/keras/src/backend/mlx/core.py
+++ b/keras/src/backend/mlx/core.py
@@ -21,7 +21,7 @@ except ImportError:
 
 SUPPORTS_SPARSE_TENSORS = False
 SUPPORTS_RAGGED_TENSORS = False
-IS_THREAD_SAFE = True
+IS_THREAD_SAFE = False  # True
 
 MLX_DTYPES = {
     "float16": mx.float16,
@@ -594,6 +594,18 @@ class custom_gradient:
     def __call__(self, *args, **kwargs):
         outputs, _ = self.fun(*args, **kwargs)
         return outputs
+
+
+def remat(f):
+    """Implementation of rematerialization.
+
+    Args:
+        f: The function or operation to rematerialize.
+    Returns:
+        A function wrapping f that defines a custom gradient, which
+        recomputes f on the backwards pass of a gradient call.
+    """
+    return mx.checkpoint(f)
 
 
 def enable_float64():

--- a/keras/src/dtype_policies/dtype_policy_map_test.py
+++ b/keras/src/dtype_policies/dtype_policy_map_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from keras.src import backend
 from keras.src import dtype_policies
 from keras.src import layers
 from keras.src import models
@@ -23,6 +24,9 @@ class DTypePolicyMapTest(testing.TestCase):
 
     @pytest.mark.requires_trainable_backend
     def test_basic_usage(self):
+        if backend.backend() == "mlx":
+            self.skipTest("mlx backend does not yet support quantization")
+
         # Create a subclass that might contain mixing dtype policies for
         # sublayers.
         # It is important to ensure that `dtype` is passed to sublayers and

--- a/keras/src/initializers/constant_initializers_test.py
+++ b/keras/src/initializers/constant_initializers_test.py
@@ -77,6 +77,11 @@ class ConstantInitializersTest(testing.TestCase):
 
     @skip_if_backend("openvino", "openvino backend does not support `arange`")
     def test_stft_initializer(self):
+        if backend.backend() == "mlx":
+            # for mlx backend force on to cpu for float64
+            self.mlx_cpu_context = backend.core.enable_float64()
+            self.mlx_cpu_context.__enter__()
+
         shape = (256, 1, 513)
         time_range = np.arange(256).reshape((-1, 1, 1))
         freq_range = (np.arange(513) / 1024.0).reshape((1, 1, -1))
@@ -142,3 +147,6 @@ class ConstantInitializersTest(testing.TestCase):
         # Test compatible class_name
         initializer = initializers.get("STFTInitializer")
         self.assertIsInstance(initializer, initializers.STFT)
+
+        if backend.backend() == "mlx":
+            self.mlx_cpu_context.__exit__(None, None, None)

--- a/keras/src/layers/attention/grouped_query_attention_test.py
+++ b/keras/src/layers/attention/grouped_query_attention_test.py
@@ -287,8 +287,9 @@ class GroupedQueryAttentionTest(testing.TestCase):
             mask = mask & np.array(
                 [[[1, 0, 0], [1, 1, 0]] + [[1, 1, 1]] * 3]
             ).astype(bool)
-        del masked_query._keras_mask
-        del masked_value._keras_mask
+        if backend.backend() != "mlx":
+            del masked_query._keras_mask
+            del masked_value._keras_mask
         output_with_manual_mask = layer(
             query=masked_query, value=masked_value, attention_mask=mask
         )

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -356,8 +356,9 @@ class MultiHeadAttentionTest(testing.TestCase):
         )
         if use_causal_mask:
             mask = mask & np.array([[[1, 0, 0], [1, 1, 0]] + [[1, 1, 1]] * 3])
-        del masked_query._keras_mask
-        del masked_value._keras_mask
+        if backend.backend() != "mlx":
+            del masked_query._keras_mask
+            del masked_value._keras_mask
         output_with_manual_mask = layer(
             query=masked_query, value=masked_value, attention_mask=mask
         )

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -199,6 +199,8 @@ class LayerTest(testing.TestCase):
 
     def test_quantized_layer_with_remat(self):
         """Test rematerialization on a quantized layer."""
+        if backend.backend() == "mlx":
+            self.skipTest("float8 is not yet supported in mlx backend.")
         with patch(
             "keras.src.backend.common.remat.remat", wraps=remat.remat
         ) as mock_remat:

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -1238,8 +1238,8 @@ class ModelTest(testing.TestCase):
             with self.assertRaisesRegex(
                 NotImplementedError,
                 (
-                    r"`export_saved_model` only currently supports the "
-                    r"tensorflow, jax and torch backends."
+                    r"`ExportArchive` is only compatible with TensorFlow, "
+                    r"JAX and Torch backends."
                 ),
             ):
                 model.export(temp_filepath, format="tf_saved_model")

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -2497,17 +2497,19 @@ class NNOpsDtypeTest(testing.TestCase):
 
         self.jax_enable_x64 = enable_x64()
         self.jax_enable_x64.__enter__()
+        if backend.backend() == "mlx":
+            self.mlx_cpu_context = backend.core.enable_float64()
+            self.mlx_cpu_context.__enter__()
         return super().setUp()
 
     def tearDown(self):
         self.jax_enable_x64.__exit__(None, None, None)
+        if backend.backend() == "mlx":
+            self.mlx_cpu_context.__exit__(None, None, None)
         return super().tearDown()
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_elu(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2526,9 +2528,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_gelu(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2560,9 +2559,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_celu(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2581,9 +2577,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_tanh_shrink(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import torch
         import torch.nn.functional as tnn
 
@@ -2602,9 +2595,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_hard_tanh(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2623,9 +2613,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_hard_shrink(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import torch
         import torch.nn.functional as tnn
 
@@ -2644,9 +2631,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_threshold(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import torch
         import torch.nn.functional as tnn
 
@@ -2665,9 +2649,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_soft_shrink(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import torch
         import torch.nn.functional as tnn
 
@@ -2686,9 +2667,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_sparse_plus(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2707,9 +2685,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_glu(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2731,9 +2706,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_squareplus(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2755,9 +2727,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_hard_sigmoid(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2776,9 +2745,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_hard_silu(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2797,9 +2763,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_leaky_relu(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2818,9 +2781,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_log_sigmoid(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2839,9 +2799,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_log_softmax(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2860,9 +2817,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_relu(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2881,9 +2835,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_relu6(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2902,9 +2853,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_selu(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2923,9 +2871,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_sigmoid(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2944,9 +2889,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_silu(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2965,9 +2907,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_softplus(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -2986,9 +2925,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_softmax(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -3007,9 +2943,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_softsign(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         import jax.nn as jnn
         import jax.numpy as jnp
 
@@ -3046,9 +2979,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_ctc_loss(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         labels = knp.array([[1, 2, 1]], dtype="int32")
         outputs = knp.array(
             [[[0.4, 0.8, 0.4], [0.2, 0.8, 0.3], [0.9, 0.4, 0.5]]], dtype=dtype
@@ -3076,9 +3006,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_ctc_decode(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         inputs = knp.array(
             [[[0.4, 0.8, 0.4], [0.2, 0.8, 0.3], [0.9, 0.4, 0.5]]], dtype=dtype
         )
@@ -3114,9 +3041,6 @@ class NNOpsDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_dot_product_attention(self, dtype):
-        if backend.backend() == "mlx" and dtype == "float64":
-            pytest.skip("Backend does not support float64")
-
         # TODO: Get expected output from jax if `jax.nn.dot_product_attention`
         # is available.
         query = knp.ones((2, 3, 3, 8), dtype=dtype)

--- a/keras/src/quantizers/quantizers_test.py
+++ b/keras/src/quantizers/quantizers_test.py
@@ -10,6 +10,10 @@ from keras.src import random
 from keras.src import testing
 
 
+@pytest.mark.skipif(
+    backend.backend() == "mlx",
+    reason=("quantization for mlx backend not yet implemented"),
+)
 class QuantizersTest(testing.TestCase):
     def test_get_method(self):
         quantizer = quantizers.get("abs_max_quantizer", axis=-1)


### PR DESCRIPTION
This continues #19571

This includes the following:
- `remat`
- adjusted tests
- thread safety set to `False` following https://github.com/ml-explore/mlx/issues/2067 (in all tests this only caused an issue with the progress bar)

With this PR, all that remains are the final linalg ops to pass all tests on Apple silicon. Next steps are to do one more merge with master, continue to work on passing automated GitHub tests, and test Keras Hub.

Outstanding tracked issues are:
- thread safety (noted above) https://github.com/ml-explore/mlx/issues/2067
- conv issues on cpu https://github.com/ml-explore/mlx/issues/2038

Last local test results: `6 failed, 10830 passed, 1977 skipped, 3 xfailed, 7 xpassed in 167.21s (0:02:47)`