### PR TITLE
Simplify the logic of `quantize` and float8 build.

### DIFF
--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -160,11 +160,9 @@ class EinsumDense(Layer):
         )
         kernel_shape, bias_shape, full_output_shape = shape_data
         self.full_output_shape = tuple(full_output_shape)
-        # `self._int8_build` needs `self.input_spec`
         self.input_spec = InputSpec(ndim=len(input_shape))
-        # We use `self._dtype_policy` to check to avoid issues in torch dynamo
         if self.quantization_mode is not None:
-            self.quantized_build(input_shape, mode=self.quantization_mode)
+            self.quantized_build(kernel_shape, mode=self.quantization_mode)
         if self.quantization_mode != "int8":
             # If the layer is quantized to int8, `self._kernel` will be added
             # in `self._int8_build`. Therefore, we skip it here.
@@ -372,27 +370,16 @@ class EinsumDense(Layer):
 
     # Quantization-related (int8 and float8) methods
 
-    def quantized_build(self, input_shape, mode):
+    def quantized_build(self, kernel_shape, mode):
         if mode == "int8":
-            shape_data = _analyze_einsum_string(
-                self.equation,
-                self.bias_axes,
-                input_shape,
-                self.partial_output_shape,
-            )
-            kernel_shape, _, _ = shape_data
             self._int8_build(kernel_shape)
         elif mode == "float8":
             self._float8_build()
         else:
             raise self._quantization_mode_error(mode)
+        self._is_quantized = True
 
-    def _int8_build(
-        self,
-        kernel_shape,
-        kernel_initializer="zeros",
-        kernel_scale_initializer="ones",
-    ):
+    def _int8_build(self, kernel_shape):
         (
             self._input_reduced_axes,
             self._kernel_reduced_axes,
@@ -411,7 +398,7 @@ class EinsumDense(Layer):
         self._kernel = self.add_weight(
             name="kernel",
             shape=kernel_shape,
-            initializer=kernel_initializer,
+            initializer="zeros",
             dtype="int8",
             trainable=False,
         )
@@ -426,10 +413,9 @@ class EinsumDense(Layer):
         self.kernel_scale = self.add_weight(
             name="kernel_scale",
             shape=kernel_scale_shape,
-            initializer=kernel_scale_initializer,
+            initializer="ones",
             trainable=False,
         )
-        self._is_quantized = True
 
     def _float8_build(self):
         from keras.src.dtype_policies import QuantizedFloat8DTypePolicy
@@ -449,6 +435,7 @@ class EinsumDense(Layer):
             "dtype": "float32",  # Always be float32
             "trainable": True,
             "autocast": False,
+            "overwrite_with_gradient": True,
         }
         amax_history_kwargs = {
             "shape": (amax_history_length,),
@@ -456,6 +443,7 @@ class EinsumDense(Layer):
             "dtype": "float32",  # Always be float32
             "trainable": True,
             "autocast": False,
+            "overwrite_with_gradient": True,
         }
         self.inputs_scale = self.add_weight(name="inputs_scale", **scale_kwargs)
         self.inputs_amax_history = self.add_weight(
@@ -471,16 +459,6 @@ class EinsumDense(Layer):
         self.outputs_grad_amax_history = self.add_weight(
             name="outputs_grad_amax_history", **amax_history_kwargs
         )
-        # We need to set `overwrite_with_gradient=True` to instruct the
-        # optimizer to directly overwrite these variables with their computed
-        # gradients during training
-        self.inputs_scale.overwrite_with_gradient = True
-        self.inputs_amax_history.overwrite_with_gradient = True
-        self.kernel_scale.overwrite_with_gradient = True
-        self.kernel_amax_history.overwrite_with_gradient = True
-        self.outputs_grad_scale.overwrite_with_gradient = True
-        self.outputs_grad_amax_history.overwrite_with_gradient = True
-        self._is_quantized = True
 
     def _int8_call(self, inputs, training=None):
         @ops.custom_gradient
@@ -642,6 +620,7 @@ class EinsumDense(Layer):
         if type_check and (type(self) is not EinsumDense):
             raise self._not_implemented_error(self.quantize)
 
+        kernel_shape = self._kernel.shape
         if mode == "int8":
             (
                 self._input_reduced_axes,
@@ -670,15 +649,11 @@ class EinsumDense(Layer):
                 kernel_scale = ops.squeeze(
                     kernel_scale, axis=self._kernel_squeeze_axes
                 )
-            kernel_shape = tuple(self._kernel.shape)
             del self._kernel
-            # Utilize a lambda expression as an initializer to prevent adding a
-            # large constant to the computation graph.
-            self._int8_build(kernel_shape, kernel_value, kernel_scale)
-        elif mode == "float8":
-            self._float8_build()
-        else:
-            raise self._quantization_mode_error(mode)
+        self.quantized_build(kernel_shape, mode)
+        if mode == "int8":
+            self._kernel.assign(kernel_value)
+            self.kernel_scale.assign(kernel_scale)
 
         # Set new dtype policy
         if self.dtype_policy.quantization_mode is None:

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -521,6 +521,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         regularizer=None,
         constraint=None,
         aggregation="none",
+        overwrite_with_gradient=False,
         name=None,
     ):
         """Add a weight variable to the layer.
@@ -552,6 +553,9 @@ class Layer(BackendLayer, Operation, KerasSaveable):
                 the type of multi-replica aggregation to be used for this
                 variable when writing custom data parallel training loops.
                 Defaults to `"none"`.
+            overwrite_with_gradient: Boolean, whether to overwrite the variable
+                with the computed gradient. This is useful for float8 training.
+                Defaults to `False`.
             name: String name of the variable. Useful for debugging purposes.
         """
         self._check_super_called()
@@ -580,6 +584,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
         # Will be added to layer.losses
         variable.regularizer = regularizers.get(regularizer)
         variable.constraint = constraints.get(constraint)
+        variable.overwrite_with_gradient = overwrite_with_gradient
         self._track_variable(variable)
         return variable
 


### PR DESCRIPTION
I'm working on bringing QAT in Keras and want to clean up the current quantization impl.

This PR simplifies the logic of `quantize` in `Dense`, `Einsum`, and `Embedding` by utilizing `quantized_build`.
It also adds `overwrite_with_gradient` to `Layer.add_weight` to avoid manually assigning the property to variables.
