### PR TITLE
Fix stateful RNN to raise ValueError on batch size mismatch

### DIFF
--- a/keras/src/layers/rnn/rnn.py
+++ b/keras/src/layers/rnn/rnn.py
@@ -382,6 +382,20 @@ class RNN(Layer):
                 initial_state = self.get_initial_state(
                     batch_size=ops.shape(sequences)[0]
                 )
+
+        # Check for batch size mismatch when stateful
+        if self.stateful:
+            actual_batch_size = ops.shape(sequences)[0]
+            expected_batch_size = (self.states[0].shape[0] 
+                                  if self.states else None)
+            if (expected_batch_size is not None and 
+                not ops.equal(actual_batch_size, expected_batch_size)):
+                raise ValueError(
+                    f"Stateful RNN expected batch size {expected_batch_size}, "
+                    f"but got {actual_batch_size}."
+                )
+
+
         # RNN expect the states in a list, even if single state.
         if not tree.is_nested(initial_state):
             initial_state = [initial_state]


### PR DESCRIPTION
This PR fixes a silent failure when calling stateful RNN layers (SimpleRNN, GRU, LSTM) with an input that doesn't match the fixed batch size.

Previously:
- `SimpleRNN` would silently broadcast the input across all internal states.
- `GRU` and `LSTM` would crash in CuDNN but still mutate internal state before failing.

Now:
- A `ValueError` is raised early in `RNN.call()` if the batch size of the input doesn't match the expected value from the internal state.
- This avoids state corruption and aligns the behavior across all RNN variants.

Fixes #21183

Manually tested by calling a stateful model with incorrect batch sizes
and verifying that the new `ValueError` is raised as expected.
