### PR TITLE
Fix `take_along_axis` with TensorFlow with non-int32 indices.

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2330,7 +2330,11 @@ def take_along_axis(x, indices, axis=None):
     indices = tf.broadcast_to(indices, indices_shape)
 
     # Correct the indices using "fill" mode which is the same as in jax
-    indices = tf.where(indices < 0, indices + x_shape[static_axis], indices)
+    indices = tf.where(
+        indices < 0,
+        indices + tf.cast(x_shape[static_axis], dtype=indices.dtype),
+        indices,
+    )
 
     x = swapaxes(x, static_axis, -1)
     indices = swapaxes(indices, static_axis, -1)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -8411,14 +8411,16 @@ class NumpyDtypeTest(testing.TestCase):
             expected_dtype,
         )
 
-    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
-    def test_take_along_axis(self, dtype):
+    @parameterized.named_parameters(
+        named_product(dtype=ALL_DTYPES, indices_dtype=INT_DTYPES)
+    )
+    def test_take_along_axis(self, dtype, indices_dtype):
         import jax.numpy as jnp
 
         x = knp.ones((1,), dtype=dtype)
-        indices = knp.zeros((1,), dtype="int32")
+        indices = knp.zeros((1,), dtype=indices_dtype)
         x_jax = jnp.ones((1,), dtype=dtype)
-        indices_jax = jnp.zeros((1,), dtype="int32")
+        indices_jax = jnp.zeros((1,), dtype=indices_dtype)
         expected_dtype = standardize_dtype(
             jnp.take_along_axis(x_jax, indices_jax, 0).dtype
         )


### PR DESCRIPTION
Change https://github.com/keras-team/keras/pull/21239 broke one use case when the axis dimension is dynamic, the type of the indices is not int32, and the op is run in graph mode.

Note that the additional unit tests don't actually cover this.