### PR TITLE
Increment optimizer._iterations in apply(...).

### DIFF
--- a/keras/src/backend/jax/optimizer.py
+++ b/keras/src/backend/jax/optimizer.py
@@ -108,5 +108,3 @@ class JaxOptimizer(base_optimizer.BaseOptimizer):
                         average_var * should_overwrite_model_vars_int
                         + var.value * should_not_overwrite_model_vars_int
                     )
-
-        self._iterations.assign_add(1)

--- a/keras/src/optimizers/base_optimizer.py
+++ b/keras/src/optimizers/base_optimizer.py
@@ -513,20 +513,21 @@ class BaseOptimizer(KerasSaveable):
                 )
             )
 
-            if len(list(grads)) == 0:
-                return
+            if len(list(grads)) > 0:
+                # Unscale gradients.
+                scale = self.loss_scale_factor
+                if scale is not None:
+                    grads = [g if g is None else g / scale for g in grads]
 
-            # Unscale gradients.
-            scale = self.loss_scale_factor
-            if scale is not None:
-                grads = [g if g is None else g / scale for g in grads]
+                # Apply gradient updates.
+                self._backend_apply_gradients(grads, trainable_variables)
+                # Apply variable constraints after applying gradients.
+                for variable in trainable_variables:
+                    if variable.constraint is not None:
+                        variable.assign(variable.constraint(variable))
 
-            # Apply gradient updates.
-            self._backend_apply_gradients(grads, trainable_variables)
-            # Apply variable constraints after applying gradients.
-            for variable in trainable_variables:
-                if variable.constraint is not None:
-                    variable.assign(variable.constraint(variable))
+        # Update iteration counter.
+        self._iterations.assign_add(1)
 
     def _backend_apply_gradients(self, grads, trainable_variables):
         """Apply method that can be overridden by different backends.
@@ -606,8 +607,6 @@ class BaseOptimizer(KerasSaveable):
                     ),
                     lambda: None,
                 )
-        # Update iteration counter.
-        self._iterations.assign_add(1)
 
     def _backend_update_step(self, grads, trainable_variables, learning_rate):
         """Collective update_step that can be overridden by the backend.


### PR DESCRIPTION
Previously the iterations count was incremented in `backend_apply_gradients(...)`. However, this meant that if all variables had `overwrite_with_gradient`, or any other special handling within a custom optimizer, the iteration count would never be increased.  The iteration isn't updated via "applying gradients" anyways, so it seems to make more sense to increment it directly in `apply`.