### PR TITLE
Add support for jax.experimental.layout layouts.

### DIFF
--- a/keras/src/backend/jax/distribution_lib.py
+++ b/keras/src/backend/jax/distribution_lib.py
@@ -2,6 +2,7 @@
 
 import jax
 import numpy as np
+from jax.experimental import layout as jax_layout
 
 from keras.src.utils import jax_utils
 
@@ -36,32 +37,13 @@ def distribute_variable(value, layout):
     Args:
         value: the initial value of the variable.
         layout: `TensorLayout` for the created variable, or a
-            `jax.sharding.Sharding` instance.
+            JAX-supported layout instance
+            (e.g. `jax.experimental.layout.Layout`, `jax.sharding.Sharding`).
 
     Returns:
         jax.Array which is the distributed variable.
     """
-    if not isinstance(layout, jax.sharding.Sharding):
-        layout = layout.backend_layout
-    if isinstance(
-        value, (jax.Array, jax.numpy.ndarray)
-    ) and value.sharding.is_equivalent_to(layout, ndim=len(value.shape)):
-        # Skip the relayout if the value is already having the proper sharding
-        return value
-
-    if layout.is_fully_addressable:
-        return jax.device_put(value, layout)
-    else:
-        # Need to only distribute the value to local addressable devices, and
-        # repack them back into global format.
-        mapping = layout.addressable_devices_indices_map(value.shape)
-        local_values = jax.device_put(
-            [value[i] for i in mapping.values()], list(mapping.keys())
-        )
-        global_value = jax.make_array_from_single_device_arrays(
-            value.shape, layout, local_values
-        )
-        return global_value
+    return distribute_tensor(value, layout)
 
 
 def distribute_tensor(tensor, layout):
@@ -72,39 +54,43 @@ def distribute_tensor(tensor, layout):
 
     Args:
         tensor: `jax.Array` that need to be distributed.
-        layout: `TensorLayout` for the distribution information, or a
-            `jax.sharding.Sharding` instance.
+        layout: `TensorLayout` for the created variable, or a
+            JAX-supported layout instance
+            (e.g. `jax.experimental.layout.Layout`, `jax.sharding.Sharding`).
 
     Returns:
         Distributed value.
     """
-    if not isinstance(layout, jax.sharding.Sharding):
+    # Avoid circular imports.
+    from keras.src.distribution import TensorLayout
+
+    if isinstance(layout, TensorLayout):
         layout = layout.backend_layout
+
     # TODO(scottzhu): This might not be a cheap check, we should consider
     # have some proper JAX API for doing this check.
     if jax_utils.is_in_jax_tracing_scope():
         return jax.lax.with_sharding_constraint(tensor, layout)
 
-    if layout.is_fully_addressable:
-        return jax.device_put(tensor, layout)
-    else:
-        # Need to only distribute the value to local addressable devices, and
-        # repack them back into global format.
-        mapping = layout.addressable_devices_indices_map(tensor.shape)
-        local_values = jax.device_put(
-            [tensor[i] for i in mapping.values()], list(mapping.keys())
-        )
-        global_value = jax.make_array_from_single_device_arrays(
-            tensor.shape, layout, local_values
-        )
-        return global_value
+    # Skip relayout if unnecessary.
+    if isinstance(tensor, jax.Array):
+        if isinstance(
+            layout, jax.sharding.Sharding
+        ) and tensor.sharding.is_equivalent_to(layout, ndim=len(tensor.shape)):
+            return tensor
+        elif isinstance(layout, jax_layout.Layout):
+            current_layout = getattr(tensor, "layout", None)
+            if current_layout == layout:
+                return tensor
+
+    return jax.device_put(tensor, layout)
 
 
 def distribute_data_input(per_process_batch, layout, batch_dim_name):
     """Distribute the input data with the corresponding layout.
 
     Note that the inputs here is a local worker batch. Within the local worker,
-    the data need to be further partitioned to map to the each of the devices.
+    the data need to be further partitioned to map to each of the devices.
 
     Args:
         inputs: `jax.Array` that is already sharded to a local process size.
@@ -114,75 +100,13 @@ def distribute_data_input(per_process_batch, layout, batch_dim_name):
     Returns:
         A global batch distributed according to `layout`.
     """
-    if not isinstance(layout, jax.sharding.Sharding):
+    # Avoid circular imports.
+    from keras.src.distribution import TensorLayout
+
+    if isinstance(layout, TensorLayout):
         layout = layout.backend_layout
 
-    num_model_replicas_total = layout.mesh.shape[batch_dim_name]
-
-    mesh_model_dim_size = 1
-    for name, dim_size in layout.mesh.shape.items():
-        if not name == batch_dim_name:
-            mesh_model_dim_size *= dim_size
-
-    num_model_replicas_per_process = num_model_replicas_total / num_processes()
-    per_process_batch_size = per_process_batch.shape[0]
-
-    if num_model_replicas_per_process >= 1:
-        # If there is more than one model replica per process, we need to
-        # further shard the data to each of the model replicas.
-        if num_model_replicas_total % num_processes() != 0:
-            raise ValueError(
-                "If there is more than one replica per process, the batch "
-                "dimension of the mesh should be divisible "
-                "by the number of processes. Here, "
-                f"batch dimension = {num_model_replicas_total}, while "
-                f"number of processes = {num_processes()}"
-            )
-
-        per_replica_batch_size = int(
-            per_process_batch_size // num_model_replicas_per_process
-        )
-        if per_process_batch_size % per_replica_batch_size != 0:
-            raise ValueError(
-                "`per_process_batch_size` should be divisible by `"
-                "per_replica_batch_size`. "
-                f"per_process_batch_size={per_process_batch_size} and "
-                f"per_replica_batch_size = {per_replica_batch_size}"
-            )
-        per_replica_batches = np.split(
-            per_process_batch, num_model_replicas_per_process
-        )
-        # Replicate data along the model_dim.
-        per_device_batches = [
-            per_replica_batch
-            for per_replica_batch in per_replica_batches
-            for _ in range(mesh_model_dim_size)
-        ]
-        batches_on_devices = [
-            jax.device_put(batch, device)
-            for batch, device in zip(
-                per_device_batches, layout.addressable_devices
-            )
-        ]
-    else:
-        # If there are less than one model replicas per process, we need to
-        # replicate the data to each of the model replicas. No further data
-        # sharding is needed.
-        per_replica_batch_size = per_process_batch_size
-        batches_on_devices = [
-            jax.device_put(per_process_batch, device)
-            for device in layout.addressable_devices
-        ]
-
-    global_batch_size = per_replica_batch_size * num_model_replicas_total
-    global_batch_shape = (global_batch_size,) + per_process_batch.shape[1:]
-    global_batch_array = jax.make_array_from_single_device_arrays(
-        shape=global_batch_shape,
-        sharding=layout,
-        arrays=batches_on_devices,
-    )
-
-    return global_batch_array
+    return jax.make_array_from_process_local_data(layout, per_process_batch)
 
 
 def initialize(job_addresses, num_processes, process_id):


### PR DESCRIPTION
In some cases we need to explicitly specify the layout in JAX (e.g. for sparse-core tables).  The previous distribution lib was hard-coded to expect `jax.sharding.Sharding`.  Generalized to support explicit Layouts.

The previous `distribute_variable`/`distribute_tensor` code also used explicit device placement calls.  JAX should be able to handle all this automatically.  See [Making process-spanning arrays from external data](https://docs.jax.dev/en/latest/multi_process.html#making-process-spanning-arrays-from-external-data).