### PR TITLE
Allow variable layout to be set on construction.

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -51,6 +51,7 @@ class Variable:
         value: The current value of the variable (NumPy array or tensor).
         name: The name of the variable (string).
         path: The path of the variable within the Keras model or layer (string).
+        kwargs: Additional backend-specific keyword arguments.
 
     Examples:
 
@@ -98,7 +99,9 @@ class Variable:
         aggregation="none",
         synchronization="auto",
         name=None,
+        **kwargs,
     ):
+        del kwargs
         name = name or auto_name(self.__class__.__name__)
         if not isinstance(name, str) or "/" in name:
             raise ValueError(

--- a/keras/src/optimizers/base_optimizer.py
+++ b/keras/src/optimizers/base_optimizer.py
@@ -244,6 +244,7 @@ class BaseOptimizer(KerasSaveable):
         initializer="zeros",
         dtype=None,
         aggregation="none",
+        layout=None,
         name=None,
     ):
         """Add a variable to the optimizer.
@@ -261,6 +262,7 @@ class BaseOptimizer(KerasSaveable):
                 the type of multi-replica aggregation to be used for this
                 variable when writing custom data parallel training loops.
                 Defaults to `"none"`.
+            layout: Optional tensor layout.  Defaults to `None`.
             name: String name of the variable. Useful for debugging purposes.
 
         Returns:
@@ -275,6 +277,7 @@ class BaseOptimizer(KerasSaveable):
                 dtype=dtype,
                 trainable=False,
                 aggregation=aggregation,
+                layout=layout,
                 name=name,
             )
         self._track_variable(variable)
@@ -319,6 +322,7 @@ class BaseOptimizer(KerasSaveable):
             initializer=initializer,
             dtype=reference_variable.dtype,
             name=name,
+            layout=getattr(reference_variable, "_layout", None),
         )
 
     def add_optimizer_variables(


### PR DESCRIPTION
If a variable has a particular layout (e.g. is sharded across multiple devices/hosts), then any corresponding auxiliary variables, like optimizer gradient accumulators, need to have the same layout. This requires use to set the variable layout prior to initialization so that it is initialized correctly and efficiently across devices.

Added optional `kwargs` to the base `Variable` class so they can handle (and ignore) any backend-specific options.  Modified `JaxVariable` to allow setting the layout parameter on construction. Modified `add_variable_from_reference` to copy the layout from the reference variable.