### PR TITLE
Implement hamming function in keras.ops

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -185,6 +185,7 @@ from keras.src.ops.numpy import full_like as full_like
 from keras.src.ops.numpy import get_item as get_item
 from keras.src.ops.numpy import greater as greater
 from keras.src.ops.numpy import greater_equal as greater_equal
+from keras.src.ops.numpy import hamming as hamming
 from keras.src.ops.numpy import histogram as histogram
 from keras.src.ops.numpy import hstack as hstack
 from keras.src.ops.numpy import identity as identity

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -75,6 +75,7 @@ from keras.src.ops.numpy import full_like as full_like
 from keras.src.ops.numpy import get_item as get_item
 from keras.src.ops.numpy import greater as greater
 from keras.src.ops.numpy import greater_equal as greater_equal
+from keras.src.ops.numpy import hamming as hamming
 from keras.src.ops.numpy import histogram as histogram
 from keras.src.ops.numpy import hstack as hstack
 from keras.src.ops.numpy import identity as identity

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -185,6 +185,7 @@ from keras.src.ops.numpy import full_like as full_like
 from keras.src.ops.numpy import get_item as get_item
 from keras.src.ops.numpy import greater as greater
 from keras.src.ops.numpy import greater_equal as greater_equal
+from keras.src.ops.numpy import hamming as hamming
 from keras.src.ops.numpy import histogram as histogram
 from keras.src.ops.numpy import hstack as hstack
 from keras.src.ops.numpy import identity as identity

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -75,6 +75,7 @@ from keras.src.ops.numpy import full_like as full_like
 from keras.src.ops.numpy import get_item as get_item
 from keras.src.ops.numpy import greater as greater
 from keras.src.ops.numpy import greater_equal as greater_equal
+from keras.src.ops.numpy import hamming as hamming
 from keras.src.ops.numpy import histogram as histogram
 from keras.src.ops.numpy import hstack as hstack
 from keras.src.ops.numpy import identity as identity

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -42,6 +42,11 @@ def bartlett(x):
     return jnp.bartlett(x)
 
 
+def hamming(x):
+    x = convert_to_tensor(x)
+    return jnp.hamming(x)
+
+
 def bincount(x, weights=None, minlength=0, sparse=False):
     # Note: bincount is never tracable / jittable because the output shape
     # depends on the values in x.

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -310,6 +310,11 @@ def bartlett(x):
     return np.bartlett(x).astype(config.floatx())
 
 
+def hamming(x):
+    x = convert_to_tensor(x)
+    return np.hamming(x).astype(config.floatx())
+
+
 def bincount(x, weights=None, minlength=0, sparse=False):
     if sparse:
         raise ValueError("Unsupported value `sparse=True` with numpy backend")

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -10,6 +10,7 @@ NumpyDtypeTest::test_argpartition
 NumpyDtypeTest::test_array
 NumpyDtypeTest::test_bartlett
 NumpyDtypeTest::test_blackman
+NumpyDtypeTest::test_hamming
 NumpyDtypeTest::test_bitwise
 NumpyDtypeTest::test_ceil
 NumpyDtypeTest::test_concatenate
@@ -77,6 +78,7 @@ NumpyOneInputOpsCorrectnessTest::test_argpartition
 NumpyOneInputOpsCorrectnessTest::test_array
 NumpyOneInputOpsCorrectnessTest::test_bartlett
 NumpyOneInputOpsCorrectnessTest::test_blackman
+NumpyOneInputOpsCorrectnessTest::test_hamming
 NumpyOneInputOpsCorrectnessTest::test_bitwise_invert
 NumpyOneInputOpsCorrectnessTest::test_conj
 NumpyOneInputOpsCorrectnessTest::test_correlate
@@ -153,4 +155,5 @@ NumpyTwoInputOpsCorrectnessTest::test_where
 NumpyOneInputOpsDynamicShapeTest::test_angle
 NumpyOneInputOpsDynamicShapeTest::test_bartlett
 NumpyOneInputOpsDynamicShapeTest::test_blackman
+NumpyOneInputOpsDynamicShapeTest::test_hamming
 NumpyOneInputOpsStaticShapeTest::test_angle

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -475,6 +475,12 @@ def bartlett(x):
     )
 
 
+def hamming(x):
+    raise NotImplementedError(
+        "`hamming` is not supported with openvino backend"
+    )
+
+
 def bincount(x, weights=None, minlength=0, sparse=False):
     if x is None:
         raise ValueError("input x is None")

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -148,7 +148,7 @@ def bartlett(x):
 
 def hamming(x):
     x = convert_to_tensor(x)
-    return tf.signal.hamming_window(x)
+    return tf.signal.hamming_window(x, periodic=False)
 
 
 def bincount(x, weights=None, minlength=0, sparse=False):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -146,6 +146,11 @@ def bartlett(x):
     return window
 
 
+def hamming(x):
+    x = convert_to_tensor(x)
+    return tf.signal.hamming_window(x)
+
+
 def bincount(x, weights=None, minlength=0, sparse=False):
     x = convert_to_tensor(x)
     dtypes_to_resolve = [x.dtype]

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -147,7 +147,7 @@ def bartlett(x):
 
 
 def hamming(x):
-    x = convert_to_tensor(x)
+    x = convert_to_tensor(x, dtype=tf.int32)
     return tf.signal.hamming_window(x, periodic=False)
 
 

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -435,6 +435,11 @@ def bartlett(x):
     return torch.signal.windows.bartlett(x)
 
 
+def hamming(x):
+    x = convert_to_tensor(x)
+    return torch.signal.windows.hamming(x)
+
+
 def bincount(x, weights=None, minlength=0, sparse=False):
     if sparse:
         raise ValueError("Unsupported value `sparse=True` with torch backend")

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1239,6 +1239,37 @@ def bartlett(x):
     return backend.numpy.bartlett(x)
 
 
+class Hamming(Operation):
+    def call(self, x):
+        return backend.numpy.hamming(x)
+
+    def compute_output_spec(self, x):
+        return KerasTensor(x.shape, dtype=backend.floatx())
+
+
+@keras_export(["keras.ops.hamming", "keras.ops.numpy.hamming"])
+def hamming(x):
+    """Hamming window function.
+
+    The Hamming window is defined as:
+    `w[n] = 0.54 - 0.46 * cos(2 * pi * n / (N - 1))` for `0 <= n <= N - 1`.
+
+    Args:
+        x: Scalar or 1D Tensor. The window length.
+
+    Returns:
+        A 1D tensor containing the Hamming window values.
+
+    Example:
+    >>> x = keras.ops.convert_to_tensor(5)
+    >>> keras.ops.hamming(x)
+    array([0.08, 0.54, 1.  , 0.54, 0.08], dtype=float32)
+    """
+    if any_symbolic_tensors((x,)):
+        return Hamming().symbolic_call(x)
+    return backend.numpy.hamming(x)
+
+
 class Bincount(Operation):
     def __init__(self, weights=None, minlength=0, sparse=False):
         super().__init__()

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1228,6 +1228,10 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         x = np.random.randint(1, 100 + 1)
         self.assertEqual(knp.blackman(x).shape[0], x)
 
+    def test_hamming(self):
+        x = np.random.randint(1, 100 + 1)
+        self.assertEqual(knp.hamming(x).shape[0], x)
+
     def test_bitwise_invert(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.bitwise_invert(x).shape, (None, 3))
@@ -3610,6 +3614,12 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
 
         self.assertAllClose(knp.Blackman()(x), np.blackman(x))
 
+    def test_hamming(self):
+        x = np.random.randint(1, 100 + 1)
+        self.assertAllClose(knp.hamming(x), np.hamming(x))
+
+        self.assertAllClose(knp.Hamming()(x), np.hamming(x))
+
     @parameterized.named_parameters(
         named_product(sparse_input=(False, True), sparse_arg=(False, True))
     )
@@ -5602,6 +5612,22 @@ class NumpyDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knp.Blackman().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_hamming(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((), dtype=dtype)
+        x_jax = jnp.ones((), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.hamming(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.hamming(x).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Hamming().symbolic_call(x).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
Adds keras.ops.hamming, which computes the Hamming window. Supported across NumPy, TensorFlow, PyTorch, and JAX backends, but not supported on OpenVINO.