### PR TITLE
use native dumpy conversion when available

### DIFF
--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -168,7 +168,8 @@ def convert_to_numpy(x):
         x = tf.convert_to_tensor(x)
     elif isinstance(x, tf.RaggedTensor):
         x = x.to_tensor()
-    return np.array(x)
+    return x.numpy() if hasattr(x, "numpy") else np.array(x)
+
 
 
 def is_tensor(x):


### PR DESCRIPTION
I was getting the following error when I was trying to save a model I made using a PennyLane qnn layer.
`DeprecationWarning: __array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments.` I just made this small change which uses and objects native bumpy conversion if it exists. 