### PR TITLE
[OpenVINO Backend] support ops.split

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -450,8 +450,13 @@ def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
 def convert_to_numpy(x):
     if isinstance(x, np.ndarray):
         return x
-    elif isinstance(x, (int, float, list, tuple)):
+    elif isinstance(x, (int, float)):
         return np.array(x)
+    elif isinstance(x, (list, tuple)):
+        x_new = []
+        for elem in x:
+            x_new.append(convert_to_numpy(elem))
+        return np.array(x_new)
     elif np.isscalar(x):
         return x
     elif isinstance(x, ov.Tensor):

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -49,7 +49,6 @@ NumpyDtypeTest::test_round
 NumpyDtypeTest::test_searchsorted
 NumpyDtypeTest::test_signbit
 NumpyDtypeTest::test_sort
-NumpyDtypeTest::test_split
 NumpyDtypeTest::test_sqrt
 NumpyDtypeTest::test_stack_
 NumpyDtypeTest::test_std
@@ -114,7 +113,6 @@ NumpyOneInputOpsCorrectnessTest::test_signbit
 NumpyOneInputOpsCorrectnessTest::test_size
 NumpyOneInputOpsCorrectnessTest::test_slogdet
 NumpyOneInputOpsCorrectnessTest::test_sort
-NumpyOneInputOpsCorrectnessTest::test_split
 NumpyOneInputOpsCorrectnessTest::test_sqrt_int32
 NumpyOneInputOpsCorrectnessTest::test_squeeze
 NumpyOneInputOpsCorrectnessTest::test_std

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1326,7 +1326,49 @@ def sort(x, axis=-1):
 
 
 def split(x, indices_or_sections, axis=0):
-    raise NotImplementedError("`split` is not supported with openvino backend")
+    x = get_ov_output(x)
+    axis_tensor = ov_opset.constant(axis, dtype=Type.i32).output(0)
+
+    shape_tensor = ov_opset.shape_of(x)
+    axis_i32 = ov_opset.constant([axis], dtype=Type.i32)
+    dim_at_axis_tensor = ov_opset.gather(
+        shape_tensor, axis_i32, ov_opset.constant(0, dtype=Type.i32)
+    )
+
+    if isinstance(indices_or_sections, int):
+        num_splits = indices_or_sections
+        splits = ov_opset.split(x, axis_tensor, num_splits=num_splits)
+        result = []
+        for i in range(num_splits):
+            result.append(OpenVINOKerasTensor(splits.output(i)))
+        return result
+
+    if isinstance(indices_or_sections, (list, tuple, np.ndarray)):
+        indices = list(indices_or_sections)
+        split_lengths = []
+        split_lengths.append(indices[0])
+        for i in range(1, len(indices)):
+            split_lengths.append(indices[i] - indices[i - 1])
+
+        last_index_tensor = ov_opset.constant(indices[-1], dtype=Type.i64)
+        remaining_length_tensor = ov_opset.subtract(
+            dim_at_axis_tensor, last_index_tensor
+        )
+
+        length_parts = []
+        length_parts.append(ov_opset.constant(split_lengths, dtype=Type.i64))
+        length_parts.append(remaining_length_tensor)
+        length_tensor = ov_opset.concat(length_parts, axis=0)
+
+        splits = ov_opset.variadic_split(x, axis_tensor, length_tensor)
+        result = []
+        for i in range(len(split_lengths) + 1):
+            result.append(OpenVINOKerasTensor(splits.output(i)))
+        return result
+
+    raise TypeError(
+        f"unsupported type of indices_or_sections: {type(indices_or_sections)}"
+    )
 
 
 def stack(x, axis=0):


### PR DESCRIPTION
Hi @rkazants 

I've supported ```ops.split```, which I need for my GSoC project.
Could you please review it? Thanks!

While working on it, I found an issue with ```convert_to_numpy```, it doesn’t handle a list of ```OpenVINOKerasTensor```. I included a simple reproducer to demonstrate the problem.

![issue](https://github.com/user-attachments/assets/3a0ab9d5-fca9-46a6-82f4-f40bbf7f8545)
```python
from keras import ops
import numpy as np
from datetime import datetime

ov_tensor = ops.convert_to_tensor(np.array([1, 2, 3]))

tensor_list = [ov_tensor for _ in range(3)]

start_time = datetime.now()
print("Start:", start_time.strftime("%I:%M:%S %p"))

# This is where the problem is
# convert list of OpenVINOKerasTensor to a numpy array (this hangs)
_ = ops.convert_to_numpy(tensor_list)

# Print time after (won't reach this if it hangs)
end_time = datetime.now()
print("End:", end_time.strftime("%I:%M:%S %p"))
```
The issue is with ```np.array(x)``` in ```convert_to_numpy``` where x is a list of ```OpenVINOKerasTensor```, which is being returned by ```split``` op because ```split``` returns lists of ```OpenVINOKerasTensor```, that call hangs indefinitely or takes way too long.
So here's a minimal reproducer showing that ```convert_to_numpy()``` hangs and took about 3 mins when passed a list of ```OpenVINOKerasTensor``` objects. This justifies the need to fix convert_to_numpy().

I resolved the issue by first checking if any element in the list is an ```OpenVINOKerasTensor```. If so, I convert those elements to ```NumPy``` before converting the entire list.