### PR TITLE
Revert "Add sparse support to `ops.ones_like` and `ops.zeros_like`."

### DIFF
--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -920,12 +920,10 @@ def not_equal(x1, x2):
     return jnp.not_equal(x1, x2)
 
 
-@sparse.elementwise_unary(linear=False)
 def ones_like(x, dtype=None):
     return jnp.ones_like(x, dtype=dtype)
 
 
-@sparse.elementwise_unary(linear=True)
 def zeros_like(x, dtype=None):
     return jnp.zeros_like(x, dtype=dtype)
 

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1840,12 +1840,10 @@ def not_equal(x1, x2):
     return tf.not_equal(x1, x2)
 
 
-@sparse.elementwise_unary
 def ones_like(x, dtype=None):
     return tf.ones_like(x, dtype=dtype)
 
 
-@sparse.elementwise_unary
 def zeros_like(x, dtype=None):
     return tf.zeros_like(x, dtype=dtype)
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -4516,8 +4516,7 @@ class OnesLike(Operation):
     def compute_output_spec(self, x, dtype=None):
         if dtype is None:
             dtype = x.dtype
-        sparse = getattr(x, "sparse", False)
-        return KerasTensor(x.shape, dtype=dtype, sparse=sparse)
+        return KerasTensor(x.shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.ones_like", "keras.ops.numpy.ones_like"])
@@ -4543,8 +4542,7 @@ class ZerosLike(Operation):
     def compute_output_spec(self, x, dtype=None):
         if dtype is None:
             dtype = x.dtype
-        sparse = getattr(x, "sparse", False)
-        return KerasTensor(x.shape, dtype=dtype, sparse=sparse)
+        return KerasTensor(x.shape, dtype=dtype)
 
 
 @keras_export(

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -5141,7 +5141,6 @@ class SparseTest(testing.TestCase):
         "imag",
         "log1p",
         "negative",
-        "ones_like",
         "real",
         "round",
         "sign",
@@ -5151,7 +5150,6 @@ class SparseTest(testing.TestCase):
         "square",
         "tan",
         "tanh",
-        "zeros_like",
     ]
     ELEMENTWISE_UNARY_OPS_TESTS = [
         {
@@ -5333,11 +5331,10 @@ class SparseTest(testing.TestCase):
             x = np.array([[1, 0.5, -0.7], [0.9, 0.2, -1]])
         x = create_sparse_tensor(x)
         x_np = backend.convert_to_numpy(x)
-        expected = np_op(x_np) * backend.convert_to_numpy(knp.ones_like(x))
 
-        self.assertAllClose(op_function(x), expected)
+        self.assertAllClose(op_function(x), np_op(x_np))
         self.assertSameSparseness(op_function(x), x)
-        self.assertAllClose(op_class()(x), expected)
+        self.assertAllClose(op_class()(x), np_op(x_np))
         self.assertSameSparseness(op_class()(x), x)
 
     @parameterized.named_parameters(ELEMENTWISE_UNARY_OPS_TESTS)
@@ -5350,11 +5347,10 @@ class SparseTest(testing.TestCase):
             x = np.array([[1, 0.5, -0.7], [0.9, 0.2, -1]])
         x = create_indexed_slices(x)
         x_np = backend.convert_to_numpy(x)
-        expected = np_op(x_np) * backend.convert_to_numpy(knp.ones_like(x))
 
-        self.assertAllClose(op_function(x), expected)
+        self.assertAllClose(op_function(x), np_op(x_np))
         self.assertSameSparseness(op_function(x), x)
-        self.assertAllClose(op_class()(x), expected)
+        self.assertAllClose(op_class()(x), np_op(x_np))
         self.assertSameSparseness(op_class()(x), x)
 
     @parameterized.named_parameters(OTHER_UNARY_OPS_TESTS)


### PR DESCRIPTION
Arguably, the result of `ones_like` and `zeros_like` should not be sparse.