### PR TITLE
Fixed missing axis annotation in tf map_coordinates

### DIFF
--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -707,7 +707,7 @@ def map_coordinates(
         gathered = tf.transpose(tf.gather_nd(input_arr, indices))
 
         if fill_mode == "constant":
-            all_valid = tf.reduce_all(validities)
+            all_valid = tf.reduce_all(validities, axis=0)
             gathered = tf.where(all_valid, gathered, fill_value)
 
         contribution = gathered

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -1865,6 +1865,30 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )
         self.assertAllClose(np.var(ref_out), np.var(out), atol=1e-2, rtol=1e-2)
 
+    def test_map_coordinates_constant_padding(self):
+        input_img = tf.ones((2, 2), dtype=tf.uint8)
+        # one pixel outside of the input space around the edges
+        grid = tf.stack(
+            tf.meshgrid(
+                tf.range(-1, 3, dtype=tf.float32),
+                tf.range(-1, 3, dtype=tf.float32),
+                indexing="ij",
+            ),
+            axis=0,
+        )
+        out = backend.convert_to_numpy(
+            kimage.map_coordinates(
+                input_img, grid, order=0, fill_mode="constant", fill_value=0
+            )
+        )
+
+        # check for ones in the middle and zeros around the edges
+        self.assertTrue(np.all(out[:1] == 0))
+        self.assertTrue(np.all(out[-1:] == 0))
+        self.assertTrue(np.all(out[:, :1] == 0))
+        self.assertTrue(np.all(out[:, -1:] == 0))
+        self.assertTrue(np.all(out[1:3, 1:3] == 1))
+
 
 class ImageOpsBehaviorTests(testing.TestCase):
     def setUp(self):


### PR DESCRIPTION
When calling the tensorflow version of `keras.ops.image.map_coordinates` with `coordinates` containing an index outside of the input image dimensions and constant padding, the output image is filled with `fill_value` due to a missing axis annotation in the tensorflow backend code.

Script to reproduce with current master branch:
```python
import keras
import tensorflow as tf
import matplotlib.pyplot as plt


def main():
    img = tf.random.normal((128, 128))
    # identity map for comparison
    grid = tf.stack(
        tf.meshgrid(
            tf.range(0, img.shape[0], dtype=tf.float64),
            tf.range(0, img.shape[1], dtype=tf.float64),
        ),
        axis=0,
    )
    # first row and column are -1 and therefore considered out-of-bounds
    grid_with_oob = tf.stack(
        tf.meshgrid(
            tf.range(-1, img.shape[0] - 1, dtype=tf.float64),
            tf.range(-1, img.shape[1] - 1, dtype=tf.float64),
        ),
        axis=0,
    )

    identity_mapped = keras.ops.image.map_coordinates(img, grid, 1)
    mapped_with_oob = keras.ops.image.map_coordinates(img, grid_with_oob, 1)

    fig, ax = plt.subplots(1, 3)

    ax[0].imshow(img.numpy())
    ax[1].imshow(identity_mapped.numpy())
    ax[2].imshow(mapped_with_oob.numpy())

    plt.show()


if __name__ == "__main__":
    main()
```