### PR TITLE
Bump up minimum version of python to 3.10.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ To set up your local dev environment, you will need the following tools.
 2.  [python](https://www.python.org/) to build and code in Keras.
 
 The following commands check the tools above are successfully installed. Note
-that Keras requires at least Python 3.9 to run.
+that Keras requires at least Python 3.10 to run.
 
 ```shell
 git --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,12 @@ authors = [
 ]
 description = "Multi-backend Keras"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "Apache License 2.0"}
 dynamic = ["version"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
The latest versions of JAX (0.6.0) and TensorFlow (2.20) no longer support Python 3.9.  They do support 3.12.