### PR TITLE
Optionally aggregate metrics for custom step method models in `Trainer.evaluate()`

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -573,7 +573,7 @@ class JAXTrainer(base_trainer.Trainer):
             if not _logs:
                 return _step_logs
 
-            return keras.tree.map_structure(keras.ops.add, _logs, _step_logs)
+            return tree.map_structure(backend.numpy.add, _logs, _step_logs)
 
         def _reduce_fn(_logs, _total_steps):
             if _total_steps == 0:
@@ -582,7 +582,7 @@ class JAXTrainer(base_trainer.Trainer):
             def _div(val):
                 return val / _total_steps
 
-            return keras.tree.map_structure(_div, _logs)
+            return tree.map_structure(_div, _logs)
 
         self._jax_state_synced = True
         with epoch_iterator.catch_stop_iteration():

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -5,6 +5,7 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.python.eager import context as tf_context
 
+from keras.src import backend
 from keras.src import callbacks as callbacks_module
 from keras.src import metrics as metrics_module
 from keras.src import optimizers as optimizers_module
@@ -490,7 +491,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
             if not _logs:
                 return _step_logs
 
-            return keras.tree.map_structure(keras.ops.add, _logs, _step_logs)
+            return tree.map_structure(backend.numpy.add, _logs, _step_logs)
 
         def _reduce_fn(_logs, _total_steps):
             if _total_steps == 0:
@@ -499,7 +500,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
             def _div(val):
                 return val / _total_steps
 
-            return keras.tree.map_structure(_div, _logs)
+            return tree.map_structure(_div, _logs)
 
         with epoch_iterator.catch_stop_iteration():
             for step, iterator in epoch_iterator:

--- a/keras/src/backend/torch/trainer.py
+++ b/keras/src/backend/torch/trainer.py
@@ -381,7 +381,7 @@ class TorchTrainer(base_trainer.Trainer):
             if not _logs:
                 return _step_logs
 
-            return keras.tree.map_structure(keras.ops.add, _logs, _step_logs)
+            return tree.map_structure(backend.numpy.add, _logs, _step_logs)
 
         def _reduce_fn(_logs, _total_steps):
             if _total_steps == 0:
@@ -390,7 +390,7 @@ class TorchTrainer(base_trainer.Trainer):
             def _div(val):
                 return val / _total_steps
 
-            return keras.tree.map_structure(_div, _logs)
+            return tree.map_structure(_div, _logs)
 
         for step, data in epoch_iterator:
             callbacks.on_test_batch_begin(step)


### PR DESCRIPTION
Currently, models that use a custom `test_step` function do not support metric aggregation in `evaluate()`. Instead, the method simply returns metrics from the last step:

https://github.com/keras-team/keras/blob/785c9b0b59be9d7921f48562998d4b0257e24ee9/keras/src/trainers/trainer.py#L1013-L1015

This can lead to user confusion, e.g. in https://github.com/bayesflow-org/bayesflow/issues/481.

This PR introduces a very primitive way to aggregate metrics, which is controllable by a boolean flag in the `evaluate` method: `aggregate=False` is set to `False` by default to preserve backward-compatibility. The current idea is to simply sum all metrics and divide by the total number of steps taken, which works when all steps return any PyTree of numerical (tensor or primitive) metrics, which must be consistent across all steps taken.

I understand that this code might still be too simple, lack extensibility to multi-device synchronization, or be inconsistent with other parts of the library. I am open to modifying the PR, given feedback.