### PR TITLE
`api_gen` now excludes backend code.

### DIFF
--- a/api_gen.py
+++ b/api_gen.py
@@ -152,7 +152,16 @@ def build():
     try:
         os.chdir(build_dir)
         open(build_api_init_fname, "w").close()
-        namex.generate_api_files("keras", code_directory="src")
+        namex.generate_api_files(
+            "keras",
+            code_directory="src",
+            exclude_directories=[
+                os.path.join("src", "backend", "jax"),
+                os.path.join("src", "backend", "openvino"),
+                os.path.join("src", "backend", "tensorflow"),
+                os.path.join("src", "backend", "torch"),
+            ],
+        )
         # Add __version__ to `api/`.
         export_version_string(build_api_init_fname)
         # Creates `_tf_keras` with full keras API


### PR DESCRIPTION
This:
- Allows development (`api_gen` / git presubmit hooks) without all backends installed and working. For instance, OpenVino currently doesn't import on MacOS Sequoia, this allows running `api_gen` regardless.
- Makes sure we don't accidentally create and honor exports that are backend specific.