### PR TITLE
Fix progbar bug

### DIFF
--- a/keras/src/utils/progbar.py
+++ b/keras/src/utils/progbar.py
@@ -79,6 +79,8 @@ class Progbar:
 
         values = values or []
         for k, v in values:
+            if finalize and k not in self.stateful_metrics:
+                self._values[k] = [v, 1]
             if k not in self._values_order:
                 self._values_order.append(k)
             if k not in self.stateful_metrics:


### PR DESCRIPTION
This PR will fix 
https://github.com/keras-team/keras/issues/21173
- The values logged by training and the csv logger was not matching
- ProgbarLogger is doing its own averaging during batch updates and then performs a final update step with the epoch averages.
- CSVLogger is not doing any averaging - it's logging the already-averaged epoch results
- with this update during logging the final line for an epoch will display the exact values from the logs dictionary 

tested in this colab - https://colab.research.google.com/drive/1qVFZ1C53O1Kq5RxOZYbbexA20D4DWoax?usp=sharing

Previously failing colab showing the issue is here - https://colab.sandbox.google.com/gist/dhantule/9c39fbd2eb21a7a9f501a97c6adaa5c6/untitled101.ipynb
