### PR TITLE
fix csv logger bug

### DIFF
--- a/keras/src/callbacks/csv_logger.py
+++ b/keras/src/callbacks/csv_logger.py
@@ -37,6 +37,7 @@ class CSVLogger(Callback):
         self.writer = None
         self.keys = None
         self.append_header = True
+        self.csv_file = None
 
     def on_train_begin(self, logs=None):
         if self.append:
@@ -46,7 +47,13 @@ class CSVLogger(Callback):
             mode = "a"
         else:
             mode = "w"
+        # ensure csv_file is None or closed before reassigning
+        if self.csv_file and not self.csv_file.closed:
+            self.csv_file.close()
         self.csv_file = file_utils.File(self.filename, mode)
+        # Reset writer and keys
+        self.writer = None
+        self.keys = None
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
@@ -65,22 +72,20 @@ class CSVLogger(Callback):
 
         if self.keys is None:
             self.keys = sorted(logs.keys())
-            # When validation_freq > 1, `val_` keys are not in first epoch logs
-            # Add the `val_` keys so that its part of the fieldnames of writer.
-            val_keys_found = False
-            for key in self.keys:
-                if key.startswith("val_"):
-                    val_keys_found = True
-                    break
-            if not val_keys_found:
-                self.keys.extend(["val_" + k for k in self.keys])
+
+            # Check if the model is expected to produce validation metrics.
+            if hasattr(self.model, "metrics_names"):
+                expected_metrics = self.model.metrics_names
+                for m_name in expected_metrics:
+                    if m_name.startswith("val_") and m_name not in self.keys:
+                        self.keys.append(m_name)
 
         if not self.writer:
 
             class CustomDialect(csv.excel):
                 delimiter = self.sep
 
-            fieldnames = ["epoch"] + self.keys
+            fieldnames = ["epoch"] + (self.keys or [])
 
             self.writer = csv.DictWriter(
                 self.csv_file, fieldnames=fieldnames, dialect=CustomDialect
@@ -96,5 +101,6 @@ class CSVLogger(Callback):
         self.csv_file.flush()
 
     def on_train_end(self, logs=None):
-        self.csv_file.close()
+        if self.csv_file and not self.csv_file.closed:
+            self.csv_file.close()
         self.writer = None


### PR DESCRIPTION
fixes the issue about `CSVLogger is setting val_* metrics to nan despite no validation data being provided`: https://github.com/keras-team/keras/issues/21173

Colab to verify : https://colab.sandbox.google.com/drive/1tZmeU2x_DpB6q5hBtsg2pGTR4KhqK2_7#scrollTo=RtemKVh36rI6

The values to be matched between progbar and cvs logger is fixed in https://github.com/keras-team/keras/pull/21331