### PR TITLE
Make ops consistent and test ops consistency.

### DIFF
--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -133,6 +133,7 @@ from keras.src.ops.numpy import right_shift as right_shift
 from keras.src.ops.numpy import roll as roll
 from keras.src.ops.numpy import rot90 as rot90
 from keras.src.ops.numpy import round as round
+from keras.src.ops.numpy import searchsorted as searchsorted
 from keras.src.ops.numpy import select as select
 from keras.src.ops.numpy import sign as sign
 from keras.src.ops.numpy import signbit as signbit

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -133,6 +133,7 @@ from keras.src.ops.numpy import right_shift as right_shift
 from keras.src.ops.numpy import roll as roll
 from keras.src.ops.numpy import rot90 as rot90
 from keras.src.ops.numpy import round as round
+from keras.src.ops.numpy import searchsorted as searchsorted
 from keras.src.ops.numpy import select as select
 from keras.src.ops.numpy import sign as sign
 from keras.src.ops.numpy import signbit as signbit

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -155,9 +155,9 @@ def log_softmax(x, axis=-1):
     return jnn.log_softmax(x, axis=axis)
 
 
-def sparsemax(logits, axis=-1):
+def sparsemax(x, axis=-1):
     # Sort logits along the specified axis in descending order
-    logits = convert_to_tensor(logits)
+    logits = convert_to_tensor(x)
     logits_sorted = -1.0 * jnp.sort(logits * -1.0, axis=axis)
     logits_cumsum = jnp.cumsum(logits_sorted, axis=axis)  # find cumulative sum
     r = jnp.arange(1, logits.shape[axis] + 1)  # Determine the sparsity
@@ -250,8 +250,8 @@ def max_pool(
 def average_pool(
     inputs,
     pool_size,
-    strides,
-    padding,
+    strides=None,
+    padding="valid",
     data_format=None,
 ):
     data_format = backend.standardize_data_format(data_format)
@@ -485,7 +485,7 @@ def conv_transpose(
     )
 
 
-def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+def one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     x = convert_to_tensor(x)
     if sparse:
         if axis < 0:
@@ -513,7 +513,7 @@ def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
     return jnn.one_hot(x, num_classes, axis=axis, dtype=dtype)
 
 
-def multi_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+def multi_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     x = convert_to_tensor(x)
     reduction_axis = 1 if len(x.shape) > 1 else 0
     if sparse:

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -630,10 +630,10 @@ def digitize(x, bins):
     return jnp.digitize(x, bins)
 
 
-def dot(x, y):
-    x = convert_to_tensor(x)
-    y = convert_to_tensor(y)
-    return jnp.dot(x, y)
+def dot(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return jnp.dot(x1, x2)
 
 
 def empty(shape, dtype=None):
@@ -982,9 +982,9 @@ def ravel(x):
     return jnp.ravel(x)
 
 
-def unravel_index(x, shape):
-    x = convert_to_tensor(x)
-    return jnp.unravel_index(x, shape)
+def unravel_index(indices, shape):
+    indices = convert_to_tensor(indices)
+    return jnp.unravel_index(indices, shape)
 
 
 @sparse.elementwise_unary(linear=True)
@@ -1212,7 +1212,7 @@ def vectorize(pyfunc, *, excluded=None, signature=None):
     return jnp.vectorize(pyfunc, excluded=excluded, signature=signature)
 
 
-def where(condition, x1, x2):
+def where(condition, x1=None, x2=None):
     return jnp.where(condition, x1, x2)
 
 
@@ -1357,5 +1357,5 @@ def argpartition(x, kth, axis=-1):
     return jnp.argpartition(x, kth, axis)
 
 
-def histogram(x, bins, range):
+def histogram(x, bins=10, range=None):
     return jnp.histogram(x, bins=bins, range=range)

--- a/keras/src/backend/numpy/core.py
+++ b/keras/src/backend/numpy/core.py
@@ -343,14 +343,14 @@ def scatter_update(inputs, indices, updates):
     return inputs
 
 
-def slice(inputs, start_indices, lengths):
+def slice(inputs, start_indices, shape):
     # Validate inputs
-    assert len(start_indices) == len(lengths)
+    assert len(start_indices) == len(shape)
 
     # Generate list of indices arrays for each dimension
     indices = [
         np.arange(start, start + length)
-        for start, length in zip(start_indices, lengths)
+        for start, length in zip(start_indices, shape)
     ]
 
     # Use np.ix_ to create a multidimensional index array
@@ -407,8 +407,8 @@ def fori_loop(lower, upper, body_fun, init_val):
     return val
 
 
-def stop_gradient(x):
-    return x
+def stop_gradient(variable):
+    return variable
 
 
 def unstack(x, num=None, axis=0):

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -52,7 +52,7 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
     )
 
 
-def top_k(x, k, sorted=False):
+def top_k(x, k, sorted=True):
     if sorted:
         # Take the k largest values.
         sorted_indices = np.argsort(x, axis=-1)[..., ::-1]

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -125,11 +125,9 @@ def elu(x, alpha=1.0):
     )
 
 
-def selu(
-    x,
-    alpha=1.6732632423543772848170429916717,
-    scale=1.0507009873554804934193349852946,
-):
+def selu(x):
+    alpha = 1.6732632423543772848170429916717
+    scale = 1.0507009873554804934193349852946
     x = convert_to_tensor(x)
     return np.array(scale, x.dtype) * elu(x, alpha)
 
@@ -196,20 +194,20 @@ def threshold(x, threshold, default_value):
     return np.where(x > threshold, x, np.array(default_value, dtype=x.dtype))
 
 
-def softmax(x, axis=None):
+def softmax(x, axis=-1):
     exp_x = np.exp(x - np.max(x, axis=axis, keepdims=True))
     return exp_x / np.sum(exp_x, axis=axis, keepdims=True)
 
 
-def log_softmax(x, axis=None):
+def log_softmax(x, axis=-1):
     max_x = np.max(x, axis=axis, keepdims=True)
     logsumexp = np.log(np.exp(x - max_x).sum(axis=axis, keepdims=True))
     return x - max_x - logsumexp
 
 
-def sparsemax(logits, axis=-1):
+def sparsemax(x, axis=-1):
     # Sort logits along the specified axis in descending order
-    logits = convert_to_tensor(logits)
+    logits = convert_to_tensor(x)
     logits_sorted = -1.0 * np.sort(-1.0 * logits, axis=axis)
     logits_cumsum = np.cumsum(logits_sorted, axis=axis)
     r = np.arange(1, logits.shape[axis] + 1)
@@ -304,8 +302,8 @@ def max_pool(
 def average_pool(
     inputs,
     pool_size,
-    strides,
-    padding,
+    strides=None,
+    padding="valid",
     data_format=None,
 ):
     data_format = backend.standardize_data_format(data_format)
@@ -543,9 +541,11 @@ def conv_transpose(
     )
 
 
-def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+def one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     if sparse:
         raise ValueError("Unsupported value `sparse=True` with numpy backend")
+    if dtype is None:
+        dtype = "float32"
     x = convert_to_tensor(x)
     input_shape = x.shape
 
@@ -569,7 +569,7 @@ def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
     return categorical
 
 
-def multi_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+def multi_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     if sparse:
         raise ValueError("Unsupported value `sparse=True` with numpy backend")
     x = convert_to_tensor(x)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -173,7 +173,7 @@ def append(x1, x2, axis=None):
     return np.append(x1, x2, axis=axis)
 
 
-def arange(start, stop=None, step=None, dtype=None):
+def arange(start, stop=None, step=1, dtype=None):
     if dtype is None:
         dtypes_to_resolve = [
             getattr(start, "dtype", type(start)),
@@ -537,13 +537,13 @@ def digitize(x, bins):
     return np.digitize(x, bins).astype(np.int32)
 
 
-def dot(x, y):
-    x = convert_to_tensor(x)
-    y = convert_to_tensor(y)
-    dtype = dtypes.result_type(x.dtype, y.dtype)
-    x = x.astype(dtype)
-    y = y.astype(dtype)
-    return np.dot(x, y)
+def dot(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    x1 = x1.astype(dtype)
+    x2 = x2.astype(dtype)
+    return np.dot(x1, x2)
 
 
 def empty(shape, dtype=None):
@@ -898,10 +898,10 @@ def ravel(x):
     return np.ravel(x)
 
 
-def unravel_index(x, shape):
-    dtype = dtypes.result_type(x.dtype)
+def unravel_index(indices, shape):
+    dtype = dtypes.result_type(indices.dtype)
     return tuple(
-        indices.astype(dtype) for indices in np.unravel_index(x, shape)
+        indices.astype(dtype) for indices in np.unravel_index(indices, shape)
     )
 
 
@@ -1114,7 +1114,7 @@ def vectorize(pyfunc, *, excluded=None, signature=None):
     return np.vectorize(pyfunc, excluded=excluded, signature=signature)
 
 
-def where(condition, x1, x2):
+def where(condition, x1=None, x2=None):
     if x1 is not None and x2 is not None:
         if not isinstance(x1, (int, float)):
             x1 = convert_to_tensor(x1)
@@ -1283,5 +1283,5 @@ def argpartition(x, kth, axis=-1):
     return np.argpartition(x, kth, axis).astype("int32")
 
 
-def histogram(x, bins, range):
+def histogram(x, bins=10, range=None):
     return np.histogram(x, bins=bins, range=range)

--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -565,21 +565,21 @@ def scatter_update(inputs, indices, updates):
     )
 
 
-def slice(inputs, start_indices, lengths):
+def slice(inputs, start_indices, shape):
     inputs = get_ov_output(inputs)
     assert isinstance(start_indices, tuple), (
         "`slice` is not supported by openvino backend"
-        " for `start_indices` of type {}".format(type(lengths))
+        " for `start_indices` of type {}".format(type(shape))
     )
-    assert isinstance(lengths, tuple), (
+    assert isinstance(shape, tuple), (
         "`slice` is not supported by openvino backend"
-        " for `lengths` of type {}".format(type(lengths))
+        " for `lengths` of type {}".format(type(shape))
     )
 
     axes = []
     start = []
     stop = []
-    for idx, length in enumerate(lengths):
+    for idx, length in enumerate(shape):
         if length is not None and length >= 0:
             axes.append(idx)
             start.append(start_indices[idx])
@@ -621,8 +621,8 @@ def fori_loop(lower, upper, body_fun, init_val):
     )
 
 
-def stop_gradient(x):
-    return x
+def stop_gradient(variable):
+    return variable
 
 
 def unstack(x, num=None, axis=0):

--- a/keras/src/backend/openvino/image.py
+++ b/keras/src/backend/openvino/image.py
@@ -1,4 +1,4 @@
-def rgb_to_grayscale(image, data_format="channels_last"):
+def rgb_to_grayscale(images, data_format=None):
     raise NotImplementedError(
         "`rgb_to_grayscale` is not supported with openvino backend"
     )
@@ -19,12 +19,12 @@ def resize(
 
 
 def affine_transform(
-    image,
+    images,
     transform,
     interpolation="bilinear",
     fill_mode="constant",
     fill_value=0,
-    data_format="channels_last",
+    data_format=None,
 ):
     raise NotImplementedError(
         "`affine_transform` is not supported with openvino backend"
@@ -32,7 +32,7 @@ def affine_transform(
 
 
 def map_coordinates(
-    input, coordinates, order, fill_mode="constant", fill_value=0.0
+    inputs, coordinates, order, fill_mode="constant", fill_value=0
 ):
     raise NotImplementedError(
         "`map_coordinates` is not supported with openvino backend"

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -17,7 +17,7 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
     )
 
 
-def top_k(x, k, sorted=False):
+def top_k(x, k, sorted=True):
     raise NotImplementedError("`top_k` is not supported with openvino backend")
 
 

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -78,11 +78,9 @@ def elu(x, alpha=1.0):
     return OpenVINOKerasTensor(ov_opset.elu(x, alpha).output(0))
 
 
-def selu(
-    x,
-    alpha=1.6732632423543772848170429916717,
-    scale=1.0507009873554804934193349852946,
-):
+def selu(x):
+    alpha = 1.6732632423543772848170429916717
+    scale = 1.0507009873554804934193349852946
     x = get_ov_output(x)
     alpha = get_ov_output(alpha, x.get_element_type())
     scale = get_ov_output(scale, x.get_element_type())
@@ -97,7 +95,7 @@ def gelu(x, approximate=True):
     return OpenVINOKerasTensor(ov_opset.gelu(x, approximate_mode).output(0))
 
 
-def softmax(x, axis=None):
+def softmax(x, axis=-1):
     x = get_ov_output(x)
     if axis is None:
         x_shape = ov_opset.shape_of(x)
@@ -110,7 +108,7 @@ def softmax(x, axis=None):
     return OpenVINOKerasTensor(ov_opset.softmax(x, axis).output(0))
 
 
-def log_softmax(x, axis=None):
+def log_softmax(x, axis=-1):
     x = get_ov_output(x)
     if axis is None:
         x_shape = ov_opset.shape_of(x)
@@ -138,8 +136,8 @@ def max_pool(
 def average_pool(
     inputs,
     pool_size,
-    strides,
-    padding,
+    strides=None,
+    padding="valid",
     data_format=None,
 ):
     raise NotImplementedError(
@@ -375,13 +373,13 @@ def conv_transpose(
     )
 
 
-def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+def one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     raise NotImplementedError(
         "`one_hot` is not supported with openvino backend"
     )
 
 
-def multi_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+def multi_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     raise NotImplementedError(
         "`multi_hot` is not supported with openvino backend"
     )

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -208,7 +208,7 @@ def append(x1, x2, axis=None):
     return OpenVINOKerasTensor(ov_opset.concat([x1, x2], axis).output(0))
 
 
-def arange(start, stop=None, step=None, dtype=None):
+def arange(start, stop=None, step=1, dtype=None):
     if stop is None:
         start, stop = get_ov_output(0), get_ov_output(start)
     else:
@@ -731,18 +731,18 @@ def digitize(x, bins):
     )
 
 
-def dot(x, y):
+def dot(x1, x2):
     element_type = None
-    if isinstance(x, OpenVINOKerasTensor):
-        element_type = x.output.get_element_type()
-    if isinstance(y, OpenVINOKerasTensor):
-        element_type = y.output.get_element_type()
-    x = get_ov_output(x, element_type)
-    y = get_ov_output(y, element_type)
-    x, y = _align_operand_types(x, y, "dot()")
-    if x.get_partial_shape().rank == 0 or y.get_partial_shape().rank == 0:
-        return OpenVINOKerasTensor(ov_opset.multiply(x, y).output(0))
-    return OpenVINOKerasTensor(ov_opset.matmul(x, y, False, False).output(0))
+    if isinstance(x1, OpenVINOKerasTensor):
+        element_type = x1.output.get_element_type()
+    if isinstance(x2, OpenVINOKerasTensor):
+        element_type = x2.output.get_element_type()
+    x1 = get_ov_output(x1, element_type)
+    x2 = get_ov_output(x2, element_type)
+    x1, x2 = _align_operand_types(x1, x2, "dot()")
+    if x1.get_partial_shape().rank == 0 or x2.get_partial_shape().rank == 0:
+        return OpenVINOKerasTensor(ov_opset.multiply(x1, x2).output(0))
+    return OpenVINOKerasTensor(ov_opset.matmul(x1, x2, False, False).output(0))
 
 
 def empty(shape, dtype=None):
@@ -1509,7 +1509,7 @@ def vectorize(pyfunc, *, excluded=None, signature=None):
     )
 
 
-def where(condition, x1, x2):
+def where(condition, x1=None, x2=None):
     raise NotImplementedError("`where` is not supported with openvino backend")
 
 

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -164,9 +164,9 @@ def log_softmax(x, axis=-1):
     return tf.nn.log_softmax(x, axis=axis)
 
 
-def sparsemax(logits, axis=-1):
+def sparsemax(x, axis=-1):
     # Sort logits along the specified axis in descending order
-    logits = convert_to_tensor(logits)
+    logits = convert_to_tensor(x)
     logits_sorted = tf.sort(logits, direction="DESCENDING", axis=axis)
     logits_cumsum = tf.cumsum(logits_sorted, axis=axis)
     r = tf.range(1, tf.shape(logits)[axis] + 1, dtype=logits.dtype)
@@ -505,7 +505,7 @@ def conv_transpose(
     )
 
 
-def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+def one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     x = convert_to_tensor(x, dtype="int64")
     if dtype is None:
         dtype = "float32"
@@ -541,7 +541,7 @@ def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
     )
 
 
-def multi_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+def multi_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     reduction_axis = 1 if len(x.shape) > 1 else 0
     if backend.standardize_dtype(dtype) == "bool":
         if sparse:
@@ -886,13 +886,7 @@ def batch_normalization(
     )
 
 
-def ctc_loss(
-    target,
-    output,
-    target_length,
-    output_length,
-    mask_index=0,
-):
+def ctc_loss(target, output, target_length, output_length, mask_index=0):
     target = convert_to_tensor(target)
     output = convert_to_tensor(output)
     target = tf.cast(target, dtype="int32")

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1364,23 +1364,23 @@ def digitize(x, bins):
     return tf.raw_ops.Bucketize(input=x, boundaries=bins)
 
 
-def dot(x, y):
-    x = convert_to_tensor(x)
-    y = convert_to_tensor(y)
-    result_dtype = dtypes.result_type(x.dtype, y.dtype)
+def dot(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    result_dtype = dtypes.result_type(x1.dtype, x2.dtype)
     # GPU only supports float types
     compute_dtype = dtypes.result_type(result_dtype, float)
-    x = tf.cast(x, compute_dtype)
-    y = tf.cast(y, compute_dtype)
+    x1 = tf.cast(x1, compute_dtype)
+    x2 = tf.cast(x2, compute_dtype)
 
-    x_shape = x.shape
-    y_shape = y.shape
+    x_shape = x1.shape
+    y_shape = x2.shape
     if x_shape.rank == 0 or y_shape.rank == 0:
-        output = x * y
+        output = x1 * x2
     elif y_shape.rank == 1:
-        output = tf.tensordot(x, y, axes=[[-1], [-1]])
+        output = tf.tensordot(x1, x2, axes=[[-1], [-1]])
     else:
-        output = tf.tensordot(x, y, axes=[[-1], [-2]])
+        output = tf.tensordot(x1, x2, axes=[[-1], [-2]])
     return tf.cast(output, result_dtype)
 
 
@@ -2018,27 +2018,29 @@ def ravel(x):
     return tf.reshape(x, [-1])
 
 
-def unravel_index(x, shape):
-    x = tf.convert_to_tensor(x)
-    input_dtype = x.dtype
+def unravel_index(indices, shape):
+    indices = tf.convert_to_tensor(indices)
+    input_dtype = indices.dtype
 
     if None in shape:
         raise ValueError(
             f"`shape` argument cannot contain `None`. Received: shape={shape}"
         )
 
-    if x.ndim == 1:
+    if indices.ndim == 1:
         coords = []
         for dim in reversed(shape):
-            coords.append(tf.cast(x % dim, input_dtype))
-            x = x // dim
+            coords.append(tf.cast(indices % dim, input_dtype))
+            indices = indices // dim
         return tuple(reversed(coords))
 
-    x_shape = x.shape
+    indices_shape = indices.shape
     coords = []
     for dim in shape:
-        coords.append(tf.reshape(tf.cast(x % dim, input_dtype), x_shape))
-        x = x // dim
+        coords.append(
+            tf.reshape(tf.cast(indices % dim, input_dtype), indices_shape)
+        )
+        indices = indices // dim
 
     return tuple(reversed(coords))
 
@@ -2587,7 +2589,7 @@ def vectorize(pyfunc, *, excluded=None, signature=None):
     )
 
 
-def where(condition, x1, x2):
+def where(condition, x1=None, x2=None):
     condition = tf.cast(condition, "bool")
     if x1 is not None and x2 is not None:
         if not isinstance(x1, (int, float)):
@@ -2856,7 +2858,7 @@ def argpartition(x, kth, axis=-1):
     return swapaxes(out, -1, axis)
 
 
-def histogram(x, bins, range):
+def histogram(x, bins=10, range=None):
     """Computes a histogram of the data tensor `x`.
 
     Note: the `tf.histogram_fixed_width()` and

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -52,13 +52,13 @@ def _segment_reduction_fn(data, segment_ids, reduction_method, num_segments):
     return result.type(data.dtype)
 
 
-def segment_sum(data, segment_ids, num_segments=None, **kwargs):
+def segment_sum(data, segment_ids, num_segments=None, sorted=False):
     data = convert_to_tensor(data)
     segment_ids = convert_to_tensor(segment_ids)
     return _segment_reduction_fn(data, segment_ids, "sum", num_segments)
 
 
-def segment_max(data, segment_ids, num_segments=None, **kwargs):
+def segment_max(data, segment_ids, num_segments=None, sorted=False):
     data = convert_to_tensor(data)
     segment_ids = convert_to_tensor(segment_ids)
     return _segment_reduction_fn(data, segment_ids, "amax", num_segments)

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -191,9 +191,9 @@ def log_softmax(x, axis=-1):
     return cast(output, dtype)
 
 
-def sparsemax(logits, axis=-1):
+def sparsemax(x, axis=-1):
     # Sort logits along the specified axis in descending order
-    logits = convert_to_tensor(logits)
+    logits = convert_to_tensor(x)
     logits_sorted, _ = torch.sort(logits, dim=axis, descending=True)
     logits_cumsum = torch.cumsum(logits_sorted, dim=axis)
     r = torch.arange(
@@ -656,7 +656,7 @@ def conv_transpose(
     return outputs
 
 
-def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+def one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     if sparse:
         raise ValueError("Unsupported value `sparse=True` with torch backend")
     # Axis is the output axis. By default, PyTorch, outputs to last axis.
@@ -682,7 +682,7 @@ def one_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
     return output
 
 
-def multi_hot(x, num_classes, axis=-1, dtype="float32", sparse=False):
+def multi_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     if sparse:
         raise ValueError("Unsupported value `sparse=True` with torch backend")
     x = convert_to_tensor(x)
@@ -848,13 +848,7 @@ def batch_normalization(
     )
 
 
-def ctc_loss(
-    target,
-    output,
-    target_length,
-    output_length,
-    mask_index=0,
-):
+def ctc_loss(target, output, target_length, output_length, mask_index=0):
     target = convert_to_tensor(target)
     output = convert_to_tensor(output)
     target_length = convert_to_tensor(target_length)

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -614,7 +614,7 @@ def count_nonzero(x, axis=None):
     return cast(torch.count_nonzero(x, dim=axis).T, "int32")
 
 
-def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=-1):
+def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
     if axisa != -1 or axisb != -1 or axisc != -1:
         raise ValueError(
             "Torch backend does not support `axisa`, `axisb`, or `axisc`. "
@@ -703,10 +703,10 @@ def digitize(x, bins):
     return cast(torch.bucketize(x, bins, right=True), "int32")
 
 
-def dot(x, y):
-    x = convert_to_tensor(x)
-    y = convert_to_tensor(y)
-    result_dtype = dtypes.result_type(x.dtype, y.dtype)
+def dot(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    result_dtype = dtypes.result_type(x1.dtype, x2.dtype)
     # GPU only supports float types
     compute_dtype = dtypes.result_type(result_dtype, float)
 
@@ -714,11 +714,11 @@ def dot(x, y):
     if get_device() == "cpu" and compute_dtype == "float16":
         compute_dtype = "float32"
 
-    x = cast(x, compute_dtype)
-    y = cast(y, compute_dtype)
-    if x.ndim == 0 or y.ndim == 0:
-        return cast(torch.multiply(x, y), result_dtype)
-    return cast(torch.matmul(x, y), result_dtype)
+    x1 = cast(x1, compute_dtype)
+    x2 = cast(x2, compute_dtype)
+    if x1.ndim == 0 or x2.ndim == 0:
+        return cast(torch.multiply(x1, x2), result_dtype)
+    return cast(torch.matmul(x1, x2), result_dtype)
 
 
 def empty(shape, dtype=None):
@@ -1291,10 +1291,12 @@ def ravel(x):
     return torch.ravel(x)
 
 
-def unravel_index(x, shape):
-    x = convert_to_tensor(x)
-    dtype = dtypes.result_type(x.dtype)
-    return tuple(cast(idx, dtype) for idx in torch.unravel_index(x, shape))
+def unravel_index(indices, shape):
+    indices = convert_to_tensor(indices)
+    dtype = dtypes.result_type(indices.dtype)
+    return tuple(
+        cast(idx, dtype) for idx in torch.unravel_index(indices, shape)
+    )
 
 
 def real(x):
@@ -1528,7 +1530,7 @@ def tile(x, repeats):
     return torch.tile(x, dims=repeats)
 
 
-def trace(x, offset=None, axis1=None, axis2=None):
+def trace(x, offset=0, axis1=0, axis2=1):
     x = convert_to_tensor(x)
     dtype = standardize_dtype(x.dtype)
     if dtype != "int64":
@@ -1605,7 +1607,7 @@ def vectorize(pyfunc, *, excluded=None, signature=None):
     )
 
 
-def where(condition, x1, x2):
+def where(condition, x1=None, x2=None):
     condition = convert_to_tensor(condition, dtype=bool)
     if x1 is not None and x2 is not None:
         x1 = convert_to_tensor(x1)
@@ -1704,7 +1706,7 @@ def sum(x, axis=None, keepdims=False):
     return cast(torch.sum(x), dtype)
 
 
-def eye(N, M=None, k=None, dtype=None):
+def eye(N, M=None, k=0, dtype=None):
     dtype = to_torch_dtype(dtype or config.floatx())
     M = N if M is None else M
     k = 0 if k is None else k
@@ -1818,6 +1820,6 @@ def argpartition(x, kth, axis=-1):
     return cast(torch.transpose(out, -1, axis), "int32")
 
 
-def histogram(x, bins, range):
+def histogram(x, bins=10, range=None):
     hist_result = torch.histogram(x, bins=bins, range=range)
     return hist_result.hist, hist_result.bin_edges

--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -1007,12 +1007,12 @@ def _pad_images(
 class CropImages(Operation):
     def __init__(
         self,
-        top_cropping,
-        left_cropping,
-        bottom_cropping,
-        right_cropping,
-        target_height,
-        target_width,
+        top_cropping=None,
+        left_cropping=None,
+        bottom_cropping=None,
+        right_cropping=None,
+        target_height=None,
+        target_width=None,
         data_format=None,
     ):
         super().__init__()

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -134,7 +134,7 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
 
 
 class TopK(Operation):
-    def __init__(self, k, sorted=False):
+    def __init__(self, k, sorted=True):
         super().__init__()
         self.k = k
         self.sorted = sorted
@@ -328,10 +328,6 @@ def extract_sequences(x, sequence_length, sequence_stride):
 
 
 class FFT(Operation):
-    def __init__(self, axis=-1):
-        super().__init__()
-        self.axis = axis
-
     def compute_output_spec(self, x):
         if not isinstance(x, (tuple, list)) or len(x) != 2:
             raise ValueError(
@@ -360,7 +356,7 @@ class FFT(Operation):
         m = real.shape[-1]
         if m is None:
             raise ValueError(
-                f"Input should have its {self.axis}th axis fully-defined. "
+                f"Input should have its last dimension fully-defined. "
                 f"Received: input.shape = {real.shape}"
             )
 

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1160,13 +1160,9 @@ class FFTTest(testing.TestCase):
         real = KerasTensor(shape=(None,), dtype="float32")
         imag = KerasTensor(shape=(None,), dtype="float32")
         with self.assertRaisesRegex(
-            ValueError, "Input should have its -1th axis fully-defined"
+            ValueError, "Input should have its last dimension fully-defined"
         ):
             fft_op.compute_output_spec((real, imag))
-
-    def test_fft_init_default_axis(self):
-        fft_op = kmath.FFT()
-        self.assertEqual(fft_op.axis, -1, "Default axis should be -1")
 
 
 class FFT2Test(testing.TestCase):

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1207,7 +1207,7 @@ def average(x, axis=None, weights=None):
     """
     if any_symbolic_tensors((x,)):
         return Average(axis=axis).symbolic_call(x, weights=weights)
-    return backend.numpy.average(x, weights=weights, axis=axis)
+    return backend.numpy.average(x, axis=axis, weights=weights)
 
 
 class Bartlett(Operation):
@@ -2661,8 +2661,8 @@ class Einsum(Operation):
         super().__init__()
         self.subscripts = subscripts
 
-    def call(self, *operands):
-        return backend.numpy.einsum(self.subscripts, *operands)
+    def call(self, *operands, **kwargs):
+        return backend.numpy.einsum(self.subscripts, *operands, **kwargs)
 
     def compute_output_spec(self, *operands):
         """Compute the output shape of `einsum`.
@@ -2836,7 +2836,7 @@ class Einsum(Operation):
 
 
 @keras_export(["keras.ops.einsum", "keras.ops.numpy.einsum"])
-def einsum(subscripts, *operands):
+def einsum(subscripts, *operands, **kwargs):
     """Evaluates the Einstein summation convention on the operands.
 
     Args:
@@ -2920,8 +2920,8 @@ def einsum(subscripts, *operands):
     array([ 30,  80, 130, 180, 230])
     """
     if any_symbolic_tensors(operands):
-        return Einsum(subscripts).symbolic_call(*operands)
-    return backend.numpy.einsum(subscripts, *operands)
+        return Einsum(subscripts).symbolic_call(*operands, **kwargs)
+    return backend.numpy.einsum(subscripts, *operands, **kwargs)
 
 
 class Empty(Operation):
@@ -3611,7 +3611,7 @@ def less_equal(x1, x2):
 
 class Linspace(Operation):
     def __init__(
-        self, num=50, endpoint=True, retstep=False, dtype=float, axis=0
+        self, num=50, endpoint=True, retstep=False, dtype=None, axis=0
     ):
         super().__init__()
         self.num = num
@@ -3957,7 +3957,7 @@ def logical_or(x1, x2):
 
 
 class Logspace(Operation):
-    def __init__(self, num=50, endpoint=True, base=10, dtype=float, axis=0):
+    def __init__(self, num=50, endpoint=True, base=10, dtype=None, axis=0):
         super().__init__()
         self.num = num
         self.endpoint = endpoint
@@ -5226,7 +5226,7 @@ class SearchSorted(Operation):
         return KerasTensor(values.shape, dtype=out_type)
 
 
-@keras_export(["keras.ops.searchsorted"])
+@keras_export(["keras.ops.searchsorted", "keras.ops.numpy.searchsorted"])
 def searchsorted(sorted_sequence, values, side="left"):
     """Perform a binary search, returning indices for insertion of `values`
     into `sorted_sequence` that maintain the sorting order.
@@ -5484,22 +5484,22 @@ class Stack(Operation):
         super().__init__()
         self.axis = axis
 
-    def call(self, xs):
-        return backend.numpy.stack(xs, axis=self.axis)
+    def call(self, x):
+        return backend.numpy.stack(x, axis=self.axis)
 
-    def compute_output_spec(self, xs):
-        first_shape = xs[0].shape
+    def compute_output_spec(self, x):
+        first_shape = x[0].shape
         dtypes_to_resolve = []
-        for x in xs:
-            if not shape_equal(x.shape, first_shape, axis=[], allow_none=True):
+        for a in x:
+            if not shape_equal(a.shape, first_shape, axis=[], allow_none=True):
                 raise ValueError(
-                    "Every value in `xs` must have the same shape. But found "
-                    f"element of shape {x.shape},  which is different from the "
+                    "Every value in `x` must have the same shape. But found "
+                    f"element of shape {a.shape},  which is different from the "
                     f"first element's shape {first_shape}."
                 )
-            dtypes_to_resolve.append(getattr(x, "dtype", type(x)))
+            dtypes_to_resolve.append(getattr(a, "dtype", type(a)))
 
-        size_on_axis = len(xs)
+        size_on_axis = len(x)
         output_shape = list(first_shape)
         if self.axis == -1:
             output_shape = output_shape + [size_on_axis]

--- a/keras/src/ops/ops_test.py
+++ b/keras/src/ops/ops_test.py
@@ -1,0 +1,205 @@
+import inspect
+
+from absl.testing import parameterized
+
+from keras.api import ops as api_ops_root
+from keras.src import backend
+from keras.src import ops
+from keras.src import testing
+from keras.src.ops.operation import Operation
+from keras.src.testing.test_utils import named_product
+from keras.src.utils.naming import to_snake_case
+
+OPS_MODULES = ("core", "image", "linalg", "math", "nn", "numpy")
+
+
+def op_functions_and_classes(ops_module):
+    """Enumerate pairs of op function and op classes in a module.
+
+    Will return for instance `(ExpandDims, expand_dims)`, `(Sum, sum)`, ...
+
+    Args:
+        ops_module: the module to explore.
+
+    Returns:
+        iterable returning tuples with function and class pairs.
+    """
+    # Go through all symbols.
+    for op_class_name in dir(ops_module):
+        op_class = getattr(ops_module, op_class_name)
+        # Find the ones that are classes that extend `Operation`.
+        if isinstance(op_class, type) and Operation in op_class.__mro__:
+            # Infer what the corresponding op function name should be.
+            op_function_name = to_snake_case(op_class_name)
+            # With some exceptions.
+            op_function_name = {
+                "batch_norm": "batch_normalization",
+                "rms_norm": "rms_normalization",
+                "search_sorted": "searchsorted",
+            }.get(op_function_name, op_function_name)
+            # Check if that function exist. Some classes are abstract super
+            # classes for multiple operations and should be ignored.
+            op_function = getattr(ops_module, op_function_name, None)
+            if op_function is not None:
+                # We have a pair, return it.
+                yield op_function, op_class
+
+
+class OperationTest(testing.TestCase):
+    @parameterized.named_parameters(named_product(module_name=OPS_MODULES))
+    def test_class_function_consistency(self, module_name):
+        ops_module = getattr(ops, module_name)
+        if module_name in ("core", "math"):
+            # `core` and `math` are not exported as their own module.
+            api_ops_module = None
+        else:
+            api_ops_module = getattr(api_ops_root, module_name)
+
+        for op_function, op_class in op_functions_and_classes(ops_module):
+            name = op_function.__name__
+
+            # ==== Check exports ====
+            # - op should be exported as e.g. `keras.ops.numpy.sum`
+            # - op should also be exported as e.g. `keras.ops.sum`
+
+            if module_name != "image":
+                # `image` ops are not exported at the top-level.
+                self.assertIsNotNone(
+                    getattr(api_ops_root, name, None),
+                    f"Not exported as `keras.ops.{name}`",
+                )
+            if api_ops_module is not None:
+                # `core` and `math` are not exported as their own module.
+                self.assertIsNotNone(
+                    getattr(api_ops_module, name, None),
+                    f"Not exported as `keras.ops.{module_name}.{name}`",
+                )
+
+            # ==== Check static parameters ====
+            # Static parameters are declared in the class' `__init__`.
+            # Dynamic parameters are declared in the class' `call` method.
+            # - they should all appear in the op signature with the same name
+            # - they should have the same default value
+            # - they should appear in the same order and usually with the
+            #   dynamic parameters first, and the static parameters last.
+
+            dynamic_parameters = list(
+                inspect.signature(op_class.call).parameters.values()
+            )[1:]  # Remove self
+
+            if op_class.__init__ is Operation.__init__:
+                # This op class has no static parameters. Do not use the `name`
+                # and `dtype` parameters from the `__init__` of `Operation`.
+                static_parameters = []
+            else:
+                class_init_signature = inspect.signature(op_class.__init__)
+                static_parameters = list(
+                    class_init_signature.parameters.values()
+                )[1:]  # Remove self
+
+            op_signature = inspect.signature(op_function)
+
+            for p in dynamic_parameters + static_parameters:
+                # Check the same name appeas in the op signature
+                self.assertIn(
+                    p.name,
+                    op_signature.parameters,
+                    f"Op function `{name}` is missing a parameter that is in "
+                    f"op class `{op_class.__name__}`",
+                )
+                # Check default values are the same
+                self.assertEqual(
+                    p.default,
+                    op_signature.parameters[p.name].default,
+                    f"Default mismatch for parameter `{p.name}` between op "
+                    f"function `{name}` and op class `{op_class.__name__}`",
+                )
+
+            # Check order of parameters.
+            dynamic_parameter_names = [p.name for p in dynamic_parameters]
+            static_parameter_names = [p.name for p in static_parameters]
+
+            if name in (
+                "fori_loop",
+                "while_loop",
+                "batch_normalization",
+                "dot_product_attention",
+                "average",
+                "einsum",
+                "pad",
+            ):
+                # Loose case:
+                # order of of parameters is preserved but they are interspersed.
+                op_dynamic_parameter_names = [
+                    name
+                    for name in op_signature.parameters.keys()
+                    if name in dynamic_parameter_names
+                ]
+                self.assertEqual(
+                    op_dynamic_parameter_names,
+                    dynamic_parameter_names,
+                    "Inconsistent dynamic parameter order for op "
+                    f"function `{name}` and op class `{op_class.__name__}`",
+                )
+                op_static_parameter_names = [
+                    name
+                    for name in op_signature.parameters.keys()
+                    if name in static_parameter_names
+                ]
+                self.assertEqual(
+                    op_static_parameter_names,
+                    static_parameter_names,
+                    "Inconsistent static parameter order for op "
+                    f"function `{name}` and op class `{op_class.__name__}`",
+                )
+            else:
+                # Strict case:
+                # dynamic parameters first and static parameters at the end.
+                self.assertEqual(
+                    list(op_signature.parameters.keys()),
+                    dynamic_parameter_names + static_parameter_names,
+                    "Inconsistent static parameter position for op "
+                    f"function `{name}` and op class `{op_class.__name__}`",
+                )
+
+    @parameterized.named_parameters(named_product(module_name=OPS_MODULES))
+    def test_backend_consistency(self, module_name):
+        ops_module = getattr(ops, module_name)
+        backend_ops_module = getattr(backend, module_name)
+
+        for op_function, _ in op_functions_and_classes(ops_module):
+            name = op_function.__name__
+
+            if hasattr(ops_module, "_" + name):
+                # For an op function `foo`, if there is a function named `_foo`,
+                # that means we have a backend independent implementation.
+                continue
+            if name in ("view_as_complex", "view_as_real", "get_item"):
+                # These ops have an inlined backend independent implementation.
+                continue
+
+            # ==== Check backend implementation ====
+            # - op should have an implementation in every backend
+            # - op implementation should have the same signature (same
+            #   parameters, same order, same defaults)
+
+            backend_op_function = getattr(backend_ops_module, name, None)
+
+            if backend.backend() == "openvino" and backend_op_function is None:
+                # Openvino is still missing a number of ops.
+                continue
+
+            self.assertIsNotNone(backend_op_function, f"Missing op `{name}`")
+
+            if name == "multi_hot":
+                # multi_hot has code to massage the input parameters before
+                # calling the backend implementation, so the signature is
+                # different on purpose.
+                continue
+
+            # Signature should match in every way.
+            self.assertEqual(
+                inspect.signature(backend_op_function),
+                inspect.signature(op_function),
+                f"Signature mismatch for `{name}`",
+            )


### PR DESCRIPTION
Added tests to verify that:
- All the parameters in the op class `call` (dynamic / tensor parameters) and `__init__` (static / non-tensor parameters) match the parameters in the op function
  - the names should match
  - default values should match
  - the order should be consistent, usually with the static parameters all at the end
- Ops are exported in `keras.ops`
- Ops are exported in their module, e.g. `keras.ops.numpy`
- Ops are implemented in every backend
- The backend implementation has the same signature as the op wrapper (same parameters in the same order with the same default values)

Note about default values: only the default values declared in the common op function are used by users, which is why those values were not changed and were applied to the class and backend implementations.
- The default values for the class `__init__` are not used because the op function passes all parameters when constructing the class.
- The default values for the backend implementation are not used, because the common op function passes all parameters when calling the backend implementation. The exception to this is when an op implementation calls another op directly.

Therefore:
- The defaults on the backend implementations are just a reminder for the implementer
- The defaults on the class `__init__` are mostly a reminder, but can also serve as a forward compatibility mechanism when deserializing a model after a parameter is added.

Fixed all inconsistencies, mostly inconsistent default values.
