### PR TITLE
Ensures consistent serialization for Functional model

### DIFF
--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -452,11 +452,11 @@ class Functional(Function, Model):
             new_node_index = node_reindexing_map[node_key]
             return [operation.name, new_node_index, tensor_index]
 
-        def create_io_structure(tensors):
+        def map_tensors(tensors):
             return tree.map_structure(get_tensor_config, tensors)
 
-        config["input_layers"] = create_io_structure(self._inputs_struct)
-        config["output_layers"] = create_io_structure(self._outputs_struct)
+        config["input_layers"] = map_tensors(self._inputs_struct)
+        config["output_layers"] = map_tensors(self._outputs_struct)
         return copy.deepcopy(config)
 
 

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -452,13 +452,11 @@ class Functional(Function, Model):
             new_node_index = node_reindexing_map[node_key]
             return [operation.name, new_node_index, tensor_index]
 
-        def map_tensors(tensors):
-            if isinstance(tensors, backend.KerasTensor):
-                return [get_tensor_config(tensors)]
+        def create_io_structure(tensors):
             return tree.map_structure(get_tensor_config, tensors)
 
-        config["input_layers"] = map_tensors(self._inputs_struct)
-        config["output_layers"] = map_tensors(self._outputs_struct)
+        config["input_layers"] = create_io_structure(self._inputs_struct)
+        config["output_layers"] = create_io_structure(self._outputs_struct)
         return copy.deepcopy(config)
 
 
@@ -621,10 +619,6 @@ def functional_from_config(cls, config, custom_objects=None):
 
     input_tensors = map_tensors(functional_config["input_layers"])
     output_tensors = map_tensors(functional_config["output_layers"])
-    if isinstance(input_tensors, list) and len(input_tensors) == 1:
-        input_tensors = input_tensors[0]
-    if isinstance(output_tensors, list) and len(output_tensors) == 1:
-        output_tensors = output_tensors[0]
 
     return cls(
         inputs=input_tensors,

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -11,6 +11,7 @@ from keras.src import layers
 from keras.src import ops
 from keras.src import saving
 from keras.src import testing
+from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.dtype_policies import dtype_policy
 from keras.src.layers.core.input_layer import Input
 from keras.src.layers.input_spec import InputSpec
@@ -286,6 +287,14 @@ class FunctionalTest(testing.TestCase):
 
         # Check that the serialized model is the same as the original
         self.assertEqual(json_config, restored_json_config)
+
+    def test_functional_input_shape_and_type(self):
+        input = layers.Input((1024, 4))
+        conv = layers.Conv1D(32, 3)(input)
+        model = Functional(input, conv)
+
+        self.assertIsInstance(model.input, KerasTensor)
+        self.assertEqual(model.input_shape, (None, 1024, 4))
 
     @pytest.mark.requires_trainable_backend
     def test_layer_getters(self):

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -17,6 +17,7 @@ from keras.src.layers.input_spec import InputSpec
 from keras.src.models import Functional
 from keras.src.models import Model
 from keras.src.models import Sequential
+from keras.src.models.model import model_from_json
 
 
 class FunctionalTest(testing.TestCase):
@@ -272,6 +273,19 @@ class FunctionalTest(testing.TestCase):
         # Symbolic call
         out_val = model_restored(Input(shape=(3,), batch_size=2))
         self.assertIsInstance(out_val, out_type)
+
+    def test_restored_nested_input(self):
+        input_a = Input(shape=(3,), batch_size=2, name="input_a")
+        x = layers.Dense(5)(input_a)
+        outputs = layers.Dense(4)(x)
+        model = Functional([[input_a]], outputs)
+
+        # Serialize and deserialize the model
+        json_config = model.to_json()
+        restored_json_config = model_from_json(json_config).to_json()
+
+        # Check that the serialized model is the same as the original
+        self.assertEqual(json_config, restored_json_config)
 
     @pytest.mark.requires_trainable_backend
     def test_layer_getters(self):


### PR DESCRIPTION
Related issues: #21328
Previous fix: #20993

## Original Bug
- Models created with nested list inputs (e.g., `inputs=[[input_a]]`) would have their structure flattened after a serialization round-trip.
- A previous fix for this issue removed an un-nesting step during deserialization. While it fixed the nested-input case, it introduced a regression where a standard single-input model (`inputs=input_a`) would have its `model.input` type change from `KerasTensor` to list upon loading.

The root cause was that the serialization format was ambiguous. It represented both a single tensor and a list containing one tensor identically.

## Fix
This change makes the serialization format unambiguous. The logic in `get_config` is updated to:
1. Serialize a single `KerasTensor` input/output as a direct pointer.
2. Serialize a list, tuple, or dict input/output as a corresponding structure containing pointers.
3. The deserializer can now perfectly reconstruct the original I/O structure without naive un-nesting logic, as the format is no longer lossy.