### PR TITLE
Fix: Set torch to None when import fails in conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,7 @@ try:
     # import to happen first for all tests.
     import torch  # noqa: F401
 except ImportError:
-    pass
+    torch = None
 
 import pytest  # noqa: E402
 


### PR DESCRIPTION
In conftest.py, when importing torch, if an ImportError occurs, the previous code would simply pass. This change modifies the except block to set torch = None. Fixes #21004
