### PR TITLE
Move `_dtype_policy` from `Operation` to `Layer`.

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -271,7 +271,8 @@ class Layer(BackendLayer, Operation, KerasSaveable):
     ):
         BackendLayer.__init__(self)
         self._lock = False
-        Operation.__init__(self, dtype=dtype, name=name)
+        Operation.__init__(self, name=name)
+        self._dtype_policy = dtype_policies.get(dtype)
         self.activity_regularizer = regularizers.get(activity_regularizer)
         input_dim_arg = kwargs.pop("input_dim", None)
         if input_dim_arg is not None:

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -14,7 +14,7 @@ from keras.src.utils.naming import auto_name
 
 @keras_export("keras.Operation")
 class Operation:
-    def __init__(self, dtype=None, name=None):
+    def __init__(self, name=None):
         if name is None:
             name = auto_name(self.__class__.__name__)
         if not isinstance(name, str) or "/" in name:
@@ -23,7 +23,6 @@ class Operation:
                 "cannot contain character `/`. "
                 f"Received: name={name} (of type {type(name)})"
             )
-        self._dtype_policy = dtype_policies.get(dtype)
         self.name = name
         self._inbound_nodes = []
         self._outbound_nodes = []
@@ -123,17 +122,6 @@ class Operation:
         # Generate a config to be returned by default by `get_config()`.
         arg_names = inspect.getfullargspec(cls.__init__).args
         kwargs.update(dict(zip(arg_names[1 : len(args) + 1], args)))
-
-        # Explicitly serialize `dtype` to support auto_config
-        dtype = kwargs.get("dtype", None)
-        if dtype is not None and isinstance(dtype, dtype_policies.DTypePolicy):
-            # For backward compatibility, we use a str (`name`) for
-            # `DTypePolicy`
-            if dtype.quantization_mode is None:
-                kwargs["dtype"] = dtype.name
-            # Otherwise, use `dtype_policies.serialize`
-            else:
-                kwargs["dtype"] = dtype_policies.serialize(dtype)
 
         # For safety, we only rely on auto-configs for a small set of
         # serializable types.

--- a/keras/src/ops/operation_test.py
+++ b/keras/src/ops/operation_test.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from conftest import skip_if_backend
 from keras.src import backend
-from keras.src import dtype_policies
 from keras.src import testing
 from keras.src.backend.common import keras_tensor
 from keras.src.ops import numpy as knp
@@ -40,22 +39,6 @@ class OpWithCustomConstructor(operation.Operation):
         if self.mode == "foo":
             return x
         return self.alpha * x
-
-    def compute_output_spec(self, x):
-        return keras_tensor.KerasTensor(x.shape, x.dtype)
-
-
-class OpWithCustomDtype(operation.Operation):
-    def __init__(self, dtype):
-        if not isinstance(dtype, (str, dtype_policies.DTypePolicy)):
-            raise AssertionError(
-                "`dtype` must be a instance of `DTypePolicy` or str. "
-                f"Received: dtype={dtype} of type {type(dtype)}"
-            )
-        super().__init__(dtype=dtype)
-
-    def call(self, x):
-        return x
 
     def compute_output_spec(self, x):
         return keras_tensor.KerasTensor(x.shape, x.dtype)
@@ -181,34 +164,3 @@ class OperationTest(testing.TestCase):
             ValueError, "must be a string and cannot contain character `/`."
         ):
             OpWithMultipleOutputs(name="test/op")
-
-    def test_dtype(self):
-        # Test dtype argument
-        op = OpWithCustomDtype(dtype="bfloat16")
-        self.assertEqual(op._dtype_policy.name, "bfloat16")
-
-        policy = dtype_policies.DTypePolicy("mixed_bfloat16")
-        op = OpWithCustomDtype(dtype=policy)
-        self.assertEqual(op._dtype_policy.name, "mixed_bfloat16")
-
-        # Test dtype config to ensure it remains unchanged
-        config = op.get_config()
-        copied_config = config.copy()
-        OpWithCustomDtype.from_config(config)
-        self.assertEqual(config, copied_config)
-
-        # Test floating dtype serialization
-        op = OpWithCustomDtype(dtype="mixed_bfloat16")
-        config = op.get_config()
-        self.assertEqual(config["dtype"], "mixed_bfloat16")  # A plain string
-        revived_op = OpWithCustomDtype.from_config(config)
-        self.assertEqual(op._dtype_policy.name, revived_op._dtype_policy.name)
-
-        # Test quantized dtype serialization
-        policy = dtype_policies.QuantizedDTypePolicy("int8", "bfloat16")
-        op = OpWithCustomDtype(policy)
-        self.assertEqual(op._dtype_policy.name, "int8_from_bfloat16")
-        config = op.get_config()  # A serialized config
-        self.assertEqual(config["dtype"], dtype_policies.serialize(policy))
-        revived_op = OpWithCustomDtype.from_config(config)
-        self.assertEqual(op._dtype_policy.name, revived_op._dtype_policy.name)


### PR DESCRIPTION
- The `dtype` in `Operation.__init__` was used to populate `self._dtype_policy`, but was not used by `Operation` itself, nor by any of the subclasses besides `Layer`.
- `Operation`s never apply the dtype policy.
- The serialization of `self._dtype_policy` is already implemented in `Layer`, and in a different way than in `Operation`.
- Many ops (e.g. `cast`) have a `dtype` parameter in their `__init__` which has different semantics from `_dtype_policy` and which cannot be a `DTypePolicy`. While it doesn't appear to interfere, it just makes it very confusing.