### PR TITLE
Remove `Empty` class, which is never used by the `empty` op.

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2924,15 +2924,6 @@ def einsum(subscripts, *operands, **kwargs):
     return backend.numpy.einsum(subscripts, *operands, **kwargs)
 
 
-class Empty(Operation):
-    def call(self, shape, dtype=None):
-        return backend.numpy.empty(shape, dtype=dtype)
-
-    def compute_output_spec(self, shape, dtype=None):
-        dtype = dtype or backend.floatx()
-        return KerasTensor(shape, dtype=dtype)
-
-
 @keras_export(["keras.ops.empty", "keras.ops.numpy.empty"])
 def empty(shape, dtype=None):
     """Return a tensor of given shape and type filled with uninitialized data.

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6982,12 +6982,6 @@ class NumpyDtypeTest(testing.TestCase):
             standardize_dtype(knp.empty([2, 3], dtype=dtype).dtype),
             expected_dtype,
         )
-        self.assertEqual(
-            standardize_dtype(
-                knp.Empty().symbolic_call([2, 3], dtype=dtype).dtype
-            ),
-            expected_dtype,
-        )
 
     @parameterized.named_parameters(
         named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))


### PR DESCRIPTION
Because `ops.numpy.empty` has no tensor inputs, only static parameters, it cannot be used as part of functional model.

`empty` never does the usual `if any_symbolic_tensor ... return Empty(...)(...)` so the `Empty` class is dead code.