### PR TITLE
Add implementation of precision-recall gain AUC

### DIFF
--- a/keras/src/metrics/confusion_metrics.py
+++ b/keras/src/metrics/confusion_metrics.py
@@ -1481,13 +1481,53 @@ class AUC(Metric):
             )
             x = fp_rate
             y = recall
-        else:  # curve == 'PR'.
+        elif self.curve == metrics_utils.AUCCurve.PR:  # curve == 'PR'.
             precision = ops.divide_no_nan(
                 self.true_positives,
                 ops.add(self.true_positives, self.false_positives),
             )
             x = recall
             y = precision
+        else:  # curve == 'PRGAIN'.
+            # Due to the hyperbolic transform, this formula is less robust than
+            # ROC and PR values. In particular
+            # 1) Both measures diverge when there are no negative values;
+            # 2) Both measures diverge when there are no true positives;
+            # 3) Recall gain becomes negative when the recall is lower than the
+            #    label average (i.e. when more negative exampless are
+            #    classified positive than real positives).
+            #
+            # We ignore case 1 as it is easily understood that metrics would be
+            # badly defined then. For case 2 we set recall_gain to 0 and
+            # precision_gain to 1. For case 3 we set recall_gain to 0. These
+            # fixes will result in an overstimation of the AUCfor estimators
+            # that are anti-correlated with the label (at some threshold).
+
+            # The scaling factor $\frac{P}{N}$ that is used to for mboth gain
+            # values.
+            scaling_factor = ops.divide_no_nan(
+                ops.add(self.true_positives, self.false_negatives),
+                ops.add(self.true_negatives, self.false_positives),
+            )
+
+            recall_gain = 1.0 - scaling_factor * ops.divide_no_nan(
+                self.false_negatives, self.true_positives
+            )
+            precision_gain = 1.0 - scaling_factor * ops.divide_no_nan(
+                self.false_positives, self.true_positives
+            )
+            # Handle case 2.
+            recall_gain = ops.where(
+                ops.equal(self.true_positives, 0.0), 0.0, recall_gain
+            )
+            precision_gain = ops.where(
+                ops.equal(self.true_positives, 0.0), 1.0, precision_gain
+            )
+            # Handle case 3.
+            recall_gain = ops.maximum(recall_gain, 0.0)
+
+            x = recall_gain
+            y = precision_gain
 
         # Find the rectangle heights based on `summation_method`.
         if (

--- a/keras/src/metrics/confusion_metrics.py
+++ b/keras/src/metrics/confusion_metrics.py
@@ -1346,25 +1346,6 @@ class AUC(Metric):
         if not self._built:
             self._build(y_pred.shape)
 
-        if self.multi_label or (self.label_weights is not None):
-            # y_true should have shape (number of examples, number of labels).
-            shapes = [(y_true, ("N", "L"))]
-            if self.multi_label:
-                # TP, TN, FP, and FN should all have shape
-                # (number of thresholds, number of labels).
-                shapes.extend(
-                    [
-                        (self.true_positives, ("T", "L")),
-                        (self.true_negatives, ("T", "L")),
-                        (self.false_positives, ("T", "L")),
-                        (self.false_negatives, ("T", "L")),
-                    ]
-                )
-            if self.label_weights is not None:
-                # label_weights should be of length equal to the number of
-                # labels.
-                shapes.append((self.label_weights, ("L",)))
-
         # Only forward label_weights to update_confusion_matrix_variables when
         # multi_label is False. Otherwise the averaging of individual label AUCs
         # is handled in AUC.result

--- a/keras/src/metrics/metrics_utils.py
+++ b/keras/src/metrics/metrics_utils.py
@@ -43,6 +43,7 @@ class AUCCurve(Enum):
 
     ROC = "ROC"
     PR = "PR"
+    PRGAIN = "PRGAIN"
 
     @staticmethod
     def from_str(key):
@@ -50,10 +51,12 @@ class AUCCurve(Enum):
             return AUCCurve.PR
         elif key in ("roc", "ROC"):
             return AUCCurve.ROC
+        elif key in ("prgain", "PRGAIN"):
+            return AUCCurve.PRGAIN
         else:
             raise ValueError(
                 f'Invalid AUC curve value: "{key}". '
-                'Expected values are ["PR", "ROC"]'
+                'Expected values are ["PR", "ROC", "PRGAIN"]'
             )
 
 


### PR DESCRIPTION
We implement the AUC metric described in https://research-information.bris.ac.uk/files/72164009/5867_precision_recall_gain_curves_pr_analysis_done_right.pdf

This metric is intended to help classifiers when the true label fraction is far from balanced (0.5) and to be independent of the true label fraction, allowing to compare values between reweighted models, unlike the original PR curve.