### PR TITLE
Update saving_lib.py to properly convert from h5py to numpy array.

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1148,6 +1148,16 @@ class H5IOStore:
             and value.attrs["dtype"] == "bfloat16"
         ):
             value = np.array(value, dtype=ml_dtypes.bfloat16)
+
+        elif (
+            hasattr(value, "shape")
+            and hasattr(value, "dtype")
+            and not isinstance(value, np.ndarray)
+        ):
+            # Convert h5py datasets to numpy arrays
+            # to avoid tensor conversion issues.
+            value = np.array(value)
+
         return value
 
     def __setitem__(self, key, value):


### PR DESCRIPTION
## What does this PR do?

Fixes an incompatibility when loading model weights in environments where TensorFlow's NumPy behavior is enabled (`tf.experimental.numpy.experimental_enable_numpy_behavior`). Previously, some variables loaded as h5py datasets were not converted to numpy arrays, causing downstream errors during model construction and weight assignment, especially for layers like `ReversibleEmbedding` and `EinsumDense`.

This update ensures that all h5py datasets are converted to numpy arrays before further processing in `saving_lib.py`.

## Why is this needed?

When using TensorFlow's NumPy behavior, type promotion and array handling can differ, leading to incompatibilities if weights remain as h5py objects. This change guarantees consistent array types regardless of backend or NumPy mode.

## Related Issues/PRs

- Fixes part of [keras-hub#2136](https://github.com/keras-team/keras-hub/issues/2136)
- See also: [keras-hub PR #2295](https://github.com/keras-team/keras-hub/pull/2295)

