### PR TITLE
Update output_padding argument in convolution transpose layer

### DIFF
--- a/keras/src/layers/convolutional/base_conv_transpose.py
+++ b/keras/src/layers/convolutional/base_conv_transpose.py
@@ -112,6 +112,7 @@ class BaseConvTranspose(Layer):
                 output_padding,
                 rank,
                 "output_padding",
+                allow_zero=True,
             )
         self.data_format = standardize_data_format(data_format)
         self.activation = activations.get(activation)

--- a/keras/src/layers/convolutional/conv1d_transpose.py
+++ b/keras/src/layers/convolutional/conv1d_transpose.py
@@ -29,6 +29,10 @@ class Conv1DTranspose(BaseConvTranspose):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input such that output has the same
             height/width dimension as the input.
+        output_padding: An integer tuple/list of 1 integer specifying the
+            amount of padding along the time dimension of the output tensor.
+            The amount of output padding must be lower than the stride.
+            If set to `None` (default), the output shape is inferred.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape `(batch, steps, features)`
@@ -36,8 +40,11 @@ class Conv1DTranspose(BaseConvTranspose):
             `(batch, features, steps)`. It defaults to the `image_data_format`
             value found in your Keras config file at `~/.keras/keras.json`.
             If you never set it, then it will be `"channels_last"`.
-        dilation_rate: int or tuple/list of 1 integers, specifying the dilation
-            rate to use for dilated transposed convolution.
+        dilation_rate: An integer tuple/list of 1 integer, specifying
+            the dilation rate to use for dilated convolution.
+            Currently, specifying a `dilation_rate` value != 1 is
+            incompatible with specifying a stride value != 1.
+            Also dilation rate larger than 1 is not currently supported.
         activation: Activation function. If `None`, no activation is applied.
         use_bias: bool, if `True`, bias will be added to the output.
         kernel_initializer: Initializer for the convolution kernel. If `None`,
@@ -97,6 +104,7 @@ class Conv1DTranspose(BaseConvTranspose):
         kernel_size,
         strides=1,
         padding="valid",
+        output_padding=None,
         data_format=None,
         dilation_rate=1,
         activation=None,
@@ -116,6 +124,7 @@ class Conv1DTranspose(BaseConvTranspose):
             kernel_size=kernel_size,
             strides=strides,
             padding=padding,
+            output_padding=output_padding,
             data_format=data_format,
             dilation_rate=dilation_rate,
             activation=activation,

--- a/keras/src/layers/convolutional/conv2d_transpose.py
+++ b/keras/src/layers/convolutional/conv2d_transpose.py
@@ -29,6 +29,14 @@ class Conv2DTranspose(BaseConvTranspose):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input. When `padding="same"` and
             `strides=1`, the output has the same size as the input.
+        output_padding: An integer or tuple/list of 2 integers,
+            specifying the amount of padding along the height and width
+            of the output tensor.
+            Can be a single integer to specify the same value for all
+            spatial dimensions.
+            The amount of output padding along a given dimension must be
+            lower than the stride along that same dimension.
+            If set to `None` (default), the output shape is inferred.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape
@@ -38,8 +46,13 @@ class Conv2DTranspose(BaseConvTranspose):
             `image_data_format` value found in your Keras config file at
             `~/.keras/keras.json`. If you never set it, then it will be
             `"channels_last"`.
-        dilation_rate: int or tuple/list of 1 integers, specifying the dilation
-            rate to use for dilated transposed convolution.
+         dilation_rate: An integer or tuple/list of 2 integers,
+            specifying the dilation rate for
+            all spatial dimensions for dilated convolution.
+            Specifying different dilation rates
+            for different dimensions is not supported.
+            Currently, specifying any `dilation_rate` value != 1 is
+            incompatible with specifying any stride value != 1.
         activation: Activation function. If `None`, no activation is applied.
         use_bias: bool, if `True`, bias will be added to the output.
         kernel_initializer: Initializer for the convolution kernel. If `None`,
@@ -99,6 +112,7 @@ class Conv2DTranspose(BaseConvTranspose):
         kernel_size,
         strides=(1, 1),
         padding="valid",
+        output_padding=None,
         data_format=None,
         dilation_rate=(1, 1),
         activation=None,
@@ -118,6 +132,7 @@ class Conv2DTranspose(BaseConvTranspose):
             kernel_size=kernel_size,
             strides=strides,
             padding=padding,
+            output_padding=output_padding,
             data_format=data_format,
             dilation_rate=dilation_rate,
             activation=activation,

--- a/keras/src/layers/convolutional/conv3d_transpose.py
+++ b/keras/src/layers/convolutional/conv3d_transpose.py
@@ -29,6 +29,14 @@ class Conv3DTranspose(BaseConvTranspose):
             `"valid"` means no padding. `"same"` results in padding evenly to
             the left/right or up/down of the input. When `padding="same"` and
             `strides=1`, the output has the same size as the input.
+         output_padding: An integer or tuple/list of 3 integers,
+            specifying the amount of padding along the depth, height, and
+            width.
+            Can be a single integer to specify the same value for all
+            spatial dimensions.
+            The amount of output padding along a given dimension must be
+            lower than the stride along that same dimension.
+            If set to `None` (default), the output shape is inferred.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
             corresponds to inputs with shape
@@ -38,8 +46,12 @@ class Conv3DTranspose(BaseConvTranspose):
             It defaults to the `image_data_format` value found in your Keras
             config file at `~/.keras/keras.json`. If you never set it, then it
             will be `"channels_last"`.
-        dilation_rate: int or tuple/list of 1 integers, specifying the dilation
-            rate to use for dilated transposed convolution.
+        dilation_rate: an integer or tuple/list of 3 integers, specifying
+            the dilation rate to use for dilated convolution.
+            Can be a single integer to specify the same value for
+            all spatial dimensions.
+            Currently, specifying any `dilation_rate` value != 1 is
+            incompatible with specifying any stride value != 1.
         activation: Activation function. If `None`, no activation is applied.
         use_bias: bool, if `True`, bias will be added to the output.
         kernel_initializer: Initializer for the convolution kernel. If `None`,
@@ -105,6 +117,7 @@ class Conv3DTranspose(BaseConvTranspose):
         strides=(1, 1, 1),
         padding="valid",
         data_format=None,
+        output_padding=None,
         dilation_rate=(1, 1, 1),
         activation=None,
         use_bias=True,
@@ -123,6 +136,7 @@ class Conv3DTranspose(BaseConvTranspose):
             kernel_size=kernel_size,
             strides=strides,
             padding=padding,
+            output_padding=output_padding,
             data_format=data_format,
             dilation_rate=dilation_rate,
             activation=activation,


### PR DESCRIPTION
- Added `output_padding` Argument in `Conv1DTranspose`, `Conv2DTranspose`, and `Conv3DTranspose` layers, which was previously missing in the constructors of these layers.

- Improved  description of `dilation_rate` argument.

- Added `allow_zero=True` as an extra argument to `standardize_tuple()` in `BaseConvTranspose`
- The documentation for `Conv1DTranspose`, `Conv2DTranspose`, and `Conv3DTranspose` layers has been updated to include the `output_padding` argument.

Fixes https://github.com/keras-team/keras/issues/19870 and https://github.com/keras-team/keras/issues/20408