### PR TITLE
Fix SKLearnClassifier and SKLearnRegressor examples

### DIFF
--- a/keras/src/wrappers/sklearn_wrapper.py
+++ b/keras/src/wrappers/sklearn_wrapper.py
@@ -249,7 +249,7 @@ class SKLearnClassifier(ClassifierMixin, SKLBase):
             hidden = Dense(layer_size, activation="relu")(hidden)
 
         n_outputs = y.shape[1] if len(y.shape) > 1 else 1
-        out = [Dense(n_outputs, activation="softmax")(hidden)]
+        out = Dense(n_outputs, activation="softmax")(hidden)
         model = Model(inp, out)
         model.compile(loss=loss, optimizer="rmsprop")
 
@@ -361,7 +361,7 @@ class SKLearnRegressor(RegressorMixin, SKLBase):
             hidden = Dense(layer_size, activation="relu")(hidden)
 
         n_outputs = y.shape[1] if len(y.shape) > 1 else 1
-        out = [Dense(n_outputs, activation="sigmoid")(hidden)]
+        out = Dense(n_outputs, activation="sigmoid")(hidden)
         model = Model(inp, out)
         model.compile(loss=loss, optimizer="rmsprop")
 
@@ -454,7 +454,7 @@ class SKLearnTransformer(TransformerMixin, SKLBase):
     X, y = my_data()
 
     trs = SKLearnTransformer(model=my_model)
-    trs.fit(X, y)
+    trs.fit(X, y)  # Fit the transformer before freezing to avoid NotFittedError
 
     pipe = make_pipeline(FrozenEstimator(trs), HistGradientBoostingClassifier())
     pipe.fit(X, y)

--- a/keras/src/wrappers/sklearn_wrapper.py
+++ b/keras/src/wrappers/sklearn_wrapper.py
@@ -235,7 +235,8 @@ class SKLearnClassifier(ClassifierMixin, SKLBase):
     scikit-learn model.
 
     ``` python
-    from keras.src.layers import Dense, Input, Model
+    from keras.src.layers import Dense, Input
+    from keras.src.models import Model
 
     def dynamic_model(X, y, loss, layers=[10]):
         # Creates a basic MLP model dynamically choosing the input and
@@ -262,7 +263,7 @@ class SKLearnClassifier(ClassifierMixin, SKLBase):
     from sklearn.datasets import make_classification
     from keras.wrappers import SKLearnClassifier
 
-    X, y = make_classification(n_samples=1000, n_features=10, n_classes=3)
+    X, y = make_classification(n_samples=1000, n_features=10)
     est = SKLearnClassifier(
         model=dynamic_model,
         model_kwargs={
@@ -346,7 +347,8 @@ class SKLearnRegressor(RegressorMixin, SKLBase):
     scikit-learn model.
 
     ``` python
-    from keras.src.layers import Dense, Input, Model
+    from keras.src.layers import Dense, Input
+    from keras.src.models import Model
 
     def dynamic_model(X, y, loss, layers=[10]):
         # Creates a basic MLP model dynamically choosing the input and

--- a/keras/src/wrappers/sklearn_wrapper.py
+++ b/keras/src/wrappers/sklearn_wrapper.py
@@ -453,10 +453,8 @@ class SKLearnTransformer(TransformerMixin, SKLBase):
 
     X, y = my_data()
 
-    trs = SKLearnTransformer(model=my_model)
-    trs.fit(X, y)  # Fit the transformer before freezing to avoid NotFittedError
-
-    pipe = make_pipeline(FrozenEstimator(trs), HistGradientBoostingClassifier())
+    trs = FrozenEstimator(SKLearnTransformer(model=my_model))
+    pipe = make_pipeline(trs, HistGradientBoostingClassifier())
     pipe.fit(X, y)
     ```
 

--- a/keras/src/wrappers/sklearn_wrapper.py
+++ b/keras/src/wrappers/sklearn_wrapper.py
@@ -453,8 +453,10 @@ class SKLearnTransformer(TransformerMixin, SKLBase):
 
     X, y = my_data()
 
-    trs = FrozenEstimator(SKLearnTransformer(model=my_model))
-    pipe = make_pipeline(trs, HistGradientBoostingClassifier())
+    trs = SKLearnTransformer(model=my_model)
+    trs.fit(X, y)
+
+    pipe = make_pipeline(FrozenEstimator(trs), HistGradientBoostingClassifier())
     pipe.fit(X, y)
     ```
 

--- a/keras/src/wrappers/sklearn_wrapper.py
+++ b/keras/src/wrappers/sklearn_wrapper.py
@@ -235,8 +235,8 @@ class SKLearnClassifier(ClassifierMixin, SKLBase):
     scikit-learn model.
 
     ``` python
-    from keras.src.layers import Dense, Input
-    from keras.src.models import Model
+    from keras.layers import Dense, Input
+    from keras.models import Model
 
     def dynamic_model(X, y, loss, layers=[10]):
         # Creates a basic MLP model dynamically choosing the input and
@@ -347,8 +347,8 @@ class SKLearnRegressor(RegressorMixin, SKLBase):
     scikit-learn model.
 
     ``` python
-    from keras.src.layers import Dense, Input
-    from keras.src.models import Model
+    from keras.layers import Dense, Input
+    from keras.models import Model
 
     def dynamic_model(X, y, loss, layers=[10]):
         # Creates a basic MLP model dynamically choosing the input and
@@ -361,7 +361,7 @@ class SKLearnRegressor(RegressorMixin, SKLBase):
             hidden = Dense(layer_size, activation="relu")(hidden)
 
         n_outputs = y.shape[1] if len(y.shape) > 1 else 1
-        out = [Dense(n_outputs, activation="softmax")(hidden)]
+        out = [Dense(n_outputs, activation="sigmoid")(hidden)]
         model = Model(inp, out)
         model.compile(loss=loss, optimizer="rmsprop")
 

--- a/keras/src/wrappers/sklearn_wrapper.py
+++ b/keras/src/wrappers/sklearn_wrapper.py
@@ -361,7 +361,7 @@ class SKLearnRegressor(RegressorMixin, SKLBase):
             hidden = Dense(layer_size, activation="relu")(hidden)
 
         n_outputs = y.shape[1] if len(y.shape) > 1 else 1
-        out = Dense(n_outputs, activation="sigmoid")(hidden)
+        out = Dense(n_outputs)(hidden)
         model = Model(inp, out)
         model.compile(loss=loss, optimizer="rmsprop")
 


### PR DESCRIPTION
The examples in the docstrings for `SKLearnClassifier` and `SKLearnRegressor` are currently not working. This PR addresses the problems mentioned in, and closes #21384:

- General Fixes:
  - Import layers from `keras.layers`
  - Import `Model` from `keras.models`
  - Remove unnecessary `[]`
- `SKLearnClassifier` Fix:
  - Use a 2 class classification problem as an example (instead of the 3 class example)
- `SKLearnRegressor` Fix:
  - Use `linear` activation because it is a regression problem that does not fall between `[0, 1]`