### PR TITLE
Fix missing and fragile scikit-learn imports in Keras sklearn wrappers

### DIFF
--- a/keras/src/wrappers/fixes.py
+++ b/keras/src/wrappers/fixes.py
@@ -1,5 +1,6 @@
 try:
     import sklearn
+    from sklearn.utils.multiclass import type_of_target as sk_type_of_target
 except ImportError:
     sklearn = None
 
@@ -34,9 +35,7 @@ def type_of_target(y, input_name="", *, raise_unknown=False):
         else:
             return target_type
 
-    target_type = sklearn.utils.multiclass.type_of_target(
-        y, input_name=input_name
-    )
+    target_type = sk_type_of_target(y, input_name=input_name)
     return _raise_or_return(target_type)
 
 

--- a/keras/src/wrappers/fixes.py
+++ b/keras/src/wrappers/fixes.py
@@ -1,6 +1,5 @@
 try:
     import sklearn
-    from sklearn.utils.multiclass import type_of_target as sk_type_of_target
 except ImportError:
     sklearn = None
 
@@ -34,6 +33,8 @@ def type_of_target(y, input_name="", *, raise_unknown=False):
             raise ValueError(f"Unknown label type for {input}: {y!r}")
         else:
             return target_type
+
+    from sklearn.utils.multiclass import type_of_target as sk_type_of_target
 
     target_type = sk_type_of_target(y, input_name=input_name)
     return _raise_or_return(target_type)

--- a/keras/src/wrappers/sklearn_wrapper.py
+++ b/keras/src/wrappers/sklearn_wrapper.py
@@ -13,7 +13,6 @@ from keras.src.wrappers.utils import _check_model
 from keras.src.wrappers.utils import assert_sklearn_installed
 
 try:
-    import sklearn
     from sklearn.base import BaseEstimator
     from sklearn.base import ClassifierMixin
     from sklearn.base import RegressorMixin
@@ -23,7 +22,6 @@ try:
     from sklearn.utils.metadata_routing import MetadataRequest
     from sklearn.utils.validation import check_is_fitted
 except ImportError:
-    sklearn = None
 
     class BaseEstimator:
         pass

--- a/keras/src/wrappers/utils.py
+++ b/keras/src/wrappers/utils.py
@@ -2,6 +2,8 @@ try:
     import sklearn
     from sklearn.base import BaseEstimator
     from sklearn.base import TransformerMixin
+    from sklearn.utils._array_api import get_namespace
+    from sklearn.utils.validation import check_is_fitted
 except ImportError:
     sklearn = None
 
@@ -25,8 +27,8 @@ def _check_model(model):
     # compile model if user gave us an un-compiled model
     if not model.compiled or not model.loss or not model.optimizer:
         raise RuntimeError(
-            "Given model needs to be compiled, and have a loss and an "
-            "optimizer."
+            "Given model needs to be compiled, and have a loss "
+            "and an optimizer."
         )
 
 
@@ -80,8 +82,8 @@ class TargetReshaper(TransformerMixin, BaseEstimator):
                 is passed, it will be squeezed back to 1D. Otherwise, it
                 will eb left untouched.
         """
-        sklearn.base.check_is_fitted(self)
-        xp, _ = sklearn.utils._array_api.get_namespace(y)
+        check_is_fitted(self)
+        xp, _ = get_namespace(y)
         if self.ndim_ == 1 and y.ndim == 2:
             return xp.squeeze(y, axis=1)
         return y

--- a/keras/src/wrappers/utils.py
+++ b/keras/src/wrappers/utils.py
@@ -4,7 +4,6 @@ try:
     import sklearn
     from sklearn.base import BaseEstimator
     from sklearn.base import TransformerMixin
-    from sklearn.utils.validation import check_is_fitted
 except ImportError:
     sklearn = None
 
@@ -83,6 +82,8 @@ class TargetReshaper(TransformerMixin, BaseEstimator):
                 is passed, it will be squeezed back to 1D. Otherwise, it
                 will eb left untouched.
         """
+        from sklearn.utils.validation import check_is_fitted
+
         check_is_fitted(self)
         if self.ndim_ == 1 and y.ndim == 2:
             return np.squeeze(y, axis=1)

--- a/keras/src/wrappers/utils.py
+++ b/keras/src/wrappers/utils.py
@@ -1,8 +1,9 @@
+import numpy as np
+
 try:
     import sklearn
     from sklearn.base import BaseEstimator
     from sklearn.base import TransformerMixin
-    from sklearn.utils._array_api import get_namespace
     from sklearn.utils.validation import check_is_fitted
 except ImportError:
     sklearn = None
@@ -83,7 +84,6 @@ class TargetReshaper(TransformerMixin, BaseEstimator):
                 will eb left untouched.
         """
         check_is_fitted(self)
-        xp, _ = get_namespace(y)
         if self.ndim_ == 1 and y.ndim == 2:
-            return xp.squeeze(y, axis=1)
+            return np.squeeze(y, axis=1)
         return y


### PR DESCRIPTION
This PR addresses a bug where the `SKLearnClassifier` and `SKLearnRegressor` wrappers raise an `AttributeError` when used without other `scikit-learn` utilities (e.g. `make_classification`).

#### Fixes
- Explicitly imports `sklearn.utils.multiclass.type_of_target` instead of relying on indirect access via `sklearn.utils`
- Cleans up related imports in related files:
  - Replaces several indirect accesses with explicit imports (`make_pipeline, OneHotEncoder, MetadataRequest, check_is_fitted`)
  - Avoids the use of private API `sklearn.utils._array_api` by using `np.squeeze` directly, which is consistent with the docstring expectations

#### Related Issue
Fixes #21386