### PR TITLE
Fix: Raise TypeError for invalid state_size in RNN constructor

### DIFF
--- a/keras/src/layers/rnn/rnn.py
+++ b/keras/src/layers/rnn/rnn.py
@@ -219,7 +219,7 @@ class RNN(Layer):
                 "state_size must be specified as property on the RNN cell."
             )
         if not isinstance(state_size, (list, tuple, int)):
-            raise ValueError(
+            raise TypeError(
                 "state_size must be an integer, or a list/tuple of integers "
                 "(one for each state tensor)."
             )


### PR DESCRIPTION
Previously, the code raised a ValueError when state_size was of the wrong type. This commit updates it to raise a TypeError instead, as it's a more appropriate exception for type mismatches.

Fixes keras-team/keras#21391