### PR TITLE
Fix(OpenVINO): Ensure numpy.prod passes tests and handles boolean inp…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ examples/**/*.jpg
 .coverage
 *coverage.xml
 .ruff_cache
+my_clean_keras_env_py310/

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -43,7 +43,6 @@ NumpyDtypeTest::test_meshgrid
 NumpyDtypeTest::test_minimum_python_types
 NumpyDtypeTest::test_multiply
 NumpyDtypeTest::test_power
-NumpyDtypeTest::test_prod
 NumpyDtypeTest::test_quantile
 NumpyDtypeTest::test_repeat
 NumpyDtypeTest::test_roll
@@ -104,7 +103,6 @@ NumpyOneInputOpsCorrectnessTest::test_pad_int16_constant_2
 NumpyOneInputOpsCorrectnessTest::test_pad_int8_constant_2
 NumpyOneInputOpsCorrectnessTest::test_pad_uint8_constant_2
 NumpyOneInputOpsCorrectnessTest::test_pad_int32_constant_2
-NumpyOneInputOpsCorrectnessTest::test_prod
 NumpyOneInputOpsCorrectnessTest::test_real
 NumpyOneInputOpsCorrectnessTest::test_repeat
 NumpyOneInputOpsCorrectnessTest::test_reshape


### PR DESCRIPTION
This pull request implements keras.numpy.prod for the OpenVINO backend.

Features:
Handles reduction along specified axes, including single integers, tuples, and None.
Implements promotion for dtype when dtype is passed as None ,converting to a suitable OpenVINO type.
If dtype is specified, the output is converted to the specified dtype.
Properly manages the keepdims argument to retain or drop the reduced dimensions in the output shape.