### PR TITLE
Improve error message for class_weight with PyTorch DataLoaders

### DIFF
--- a/keras/src/trainers/data_adapters/__init__.py
+++ b/keras/src/trainers/data_adapters/__init__.py
@@ -93,7 +93,12 @@ def get_data_adapter(
         if class_weight is not None:
             raise ValueError(
                 "Argument `class_weight` is not supported for torch "
-                f"DataLoader inputs. Received: class_weight={class_weight}"
+                f"DataLoader inputs. You can modify your `__getitem__ ` method"
+                " to return input tensor, label and class_weight. "
+                "Alternatively, use a custom training loop. See the User Guide "
+                "https://keras.io/guides/custom_train_step_in_torch/"
+                "#supporting-sampleweight-amp-classweight for more details "
+                f"Received: class_weight={class_weight}"
             )
         return TorchDataLoaderAdapter(x)
         # TODO: should we warn or not?

--- a/keras/src/trainers/data_adapters/__init__.py
+++ b/keras/src/trainers/data_adapters/__init__.py
@@ -97,7 +97,7 @@ def get_data_adapter(
                 " to return input tensor, label and class_weight. "
                 "Alternatively, use a custom training loop. See the User Guide "
                 "https://keras.io/guides/custom_train_step_in_torch/"
-                "#supporting-sampleweight-amp-classweight for more details "
+                "#supporting-sampleweight-amp-classweight for more details. "
                 f"Received: class_weight={class_weight}"
             )
         return TorchDataLoaderAdapter(x)


### PR DESCRIPTION
Updated the error message for `class_weight` with PyTorch DataLoaders to suggest two solutions: modifying the `__getitem__` method or using a custom training loop. Included a link to the user guide for the custom training loop.

Fixes [#21355 ](https://github.com/keras-team/keras/issues/21355)