### PR TITLE
Fix: Update SparseCategoricalCrossentropy example

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -1183,8 +1183,8 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
 
     Examples:
 
-    >>> y_true = [1, 2]
-    >>> y_pred = [[0.05, 0.95, 0], [0.1, 0.8, 0.1]]
+    >>> y_true = np.array([1, 2])
+    >>> y_pred = np.array([[0.05, 0.95, 0], [0.1, 0.8, 0.1]])
     >>> # Using 'auto'/'sum_over_batch_size' reduction type.
     >>> scce = keras.losses.SparseCategoricalCrossentropy()
     >>> scce(y_true, y_pred)


### PR DESCRIPTION
Update `SparseCategoricalCrossentropy` example to resolve `ValueError: Structures don't have the same nested structure.` [Gist](https://colab.sandbox.google.com/gist/sonali-kumari1/75522492c4d8b558bdd0cac557f8adff/-21426.ipynb)

Fixes : [#21426 ](https://github.com/keras-team/keras/issues/21426)