### PR TITLE
Fix symbolic call of `logsumexp` with int axis.

### DIFF
--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -179,8 +179,10 @@ class MathOpsDynamicShapeTest(testing.TestCase):
 
     def test_logsumexp(self):
         x = KerasTensor((None, 2, 3), dtype="float32")
-        result = kmath.logsumexp(x)
-        self.assertEqual(result.shape, ())
+        self.assertEqual(kmath.logsumexp(x).shape, ())
+        self.assertEqual(kmath.logsumexp(x, axis=1).shape, (None, 3))
+        self.assertEqual(kmath.logsumexp(x, axis=(1, 2)).shape, (None,))
+        self.assertEqual(kmath.logsumexp(x, keepdims=True).shape, (1, 1, 1))
 
     def test_extract_sequences(self):
         # Defined dimension

--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -375,6 +375,8 @@ def reduce_shape(shape, axis=None, keepdims=False):
             return tuple([1 for _ in shape])
         else:
             return tuple([])
+    elif isinstance(axis, int):
+        axis = (axis,)
 
     if keepdims:
         for ax in axis:


### PR DESCRIPTION
Using `keras.ops.math.logsumexp` with an int for `axis` in a functional model would throw an error.