### PR TITLE
Fix torch LSTM onnx export issue.

### DIFF
--- a/keras/src/backend/torch/rnn.py
+++ b/keras/src/backend/torch/rnn.py
@@ -228,6 +228,8 @@ def rnn(
         elif isinstance(input_length, torch.Tensor):
             if go_backwards:
                 max_len = torch.max(input_length, dim=0)
+                if isinstance(max_len, torch.return_types.max):
+                    max_len = max_len[0]
                 rev_input_length = torch.subtract(max_len - 1, input_length)
 
                 def masking_fn(time):

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -23,4 +23,5 @@ dm_tree
 coverage!=7.6.5  # 7.6.5 breaks CI
 # for onnx_test.py
 onnxruntime
+onnxscript  # Needed by TorchDynamo-based ONNX exporter
 openvino


### PR DESCRIPTION
Fix #21390

The root cause is not related to ONNX export itself, but rather a type issue in torch's `rnn`.
`torch.max(..., dim=...)` returns a `torch.return_type.max`, not a tensor. Ref: https://docs.pytorch.org/docs/stable/generated/torch.max.html
After extracting the tensor via `max_len = max_len[0]`, the export works correctly.

I'm not a RNN expert and unsure how to test this at the ops level, so I have added a test based on the reported issue.

`onnxscript` dep was added to support the TorchDynamo-based ONNX exporter.

cc @mattdangerw @DLumi
