### PR TITLE
Fix `rms_normalization` and `layer_normalization` to ensure consistent precision in computations.

### DIFF
--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -775,6 +775,19 @@ class NNOpsDynamicShapeTest(testing.TestCase):
         out = knn.dot_product_attention(query, key, value)
         self.assertEqual(out.shape, query.shape)
 
+    def test_rms_normalization(self):
+        x = KerasTensor([None, 8, 16])
+        scale = KerasTensor([None, 8, 16])
+        out = knn.rms_normalization(x, scale)
+        self.assertEqual(out.shape, x.shape)
+
+    def test_layer_normalization(self):
+        x = KerasTensor([None, 8, 16])
+        gamma = KerasTensor([None, 16])
+        beta = KerasTensor([None, 16])
+        out = knn.layer_normalization(x, gamma, beta)
+        self.assertEqual(out.shape, x.shape)
+
 
 class NNOpsStaticShapeTest(testing.TestCase):
     def test_relu(self):
@@ -1291,6 +1304,17 @@ class NNOpsStaticShapeTest(testing.TestCase):
         value = KerasTensor([2, 4, 6, 16])
         out = knn.dot_product_attention(query, key, value)
         self.assertEqual(out.shape, query.shape)
+
+    def test_rms_normalization(self):
+        x = KerasTensor([2, 8, 16])
+        scale = KerasTensor([2, 8, 16])
+        self.assertEqual(knn.rms_normalization(x, scale).shape, x.shape)
+
+    def test_layer_normalization(self):
+        x = KerasTensor([2, 8, 16])
+        gamma = KerasTensor([2, 16])
+        beta = KerasTensor([2, 16])
+        self.assertEqual(knn.layer_normalization(x, gamma, beta).shape, x.shape)
 
     def test_polar(self):
         abs_ = KerasTensor([1, 2])
@@ -2499,6 +2523,31 @@ class NNOpsCorrectnessTest(testing.TestCase):
             outputs, expected, atol=1e-3 if flash_attention else 1e-6
         )
 
+    @parameterized.named_parameters(named_product(scale=(1.0, 10.0)))
+    def test_rms_normalization(self, scale):
+        x = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], dtype="float32")
+        scale = np.array([scale] * x.shape[-1], dtype="float32")
+        expected_output = (
+            np.array([[0.46291, 0.92582, 1.38873], [0.78954, 0.98693, 1.18431]])
+            * scale
+        )
+
+        self.assertAllClose(
+            knn.rms_normalization(x, scale), expected_output, atol=1e-3
+        )
+        self.assertAllClose(knn.RMSNorm()(x, scale), expected_output, atol=1e-3)
+
+    def test_layer_normalization(self):
+        x = np.arange(5, dtype="float32")
+        expected_output = np.array(
+            [-1.4142135, -0.70710677, 0.0, 0.7071067, 1.4142135]
+        )
+
+        self.assertAllClose(
+            knn.layer_normalization(x), expected_output, atol=1e-3
+        )
+        self.assertAllClose(knn.LayerNorm()(x), expected_output, atol=1e-3)
+
 
 class NNOpsDtypeTest(testing.TestCase):
     """Test the dtype to verify that the behavior matches JAX."""
@@ -3082,6 +3131,37 @@ class NNOpsDtypeTest(testing.TestCase):
             expected_dtype,
         )
 
+    @parameterized.named_parameters(
+        named_product(dtypes=combinations(FLOAT_DTYPES, 2))
+    )
+    def test_rms_normalization(self, dtypes):
+        input_dtype, weight_dtype = dtypes
+        inputs = knp.ones((2, 8), dtype=input_dtype)
+        scale = knp.ones((8,), dtype=weight_dtype)
+        expected_dtype = input_dtype
+
+        self.assertDType(knn.rms_normalization(inputs, scale), expected_dtype)
+        self.assertDType(
+            knn.RMSNorm().symbolic_call(inputs, scale), expected_dtype
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=combinations(FLOAT_DTYPES, 2))
+    )
+    def test_layer_normalization(self, dtypes):
+        input_dtype, weight_dtype = dtypes
+        inputs = knp.ones((2, 8), dtype=input_dtype)
+        gamma = knp.ones((8,), dtype=weight_dtype)
+        beta = knp.ones((8,), dtype=weight_dtype)
+        expected_dtype = input_dtype
+
+        self.assertDType(
+            knn.layer_normalization(inputs, gamma, beta), expected_dtype
+        )
+        self.assertDType(
+            knn.LayerNorm().symbolic_call(inputs, gamma, beta), expected_dtype
+        )
+
 
 class NNOpsBehaviorTest(testing.TestCase):
     def test_logit_recovery_binary_crossentropy(self):
@@ -3173,14 +3253,9 @@ class NNOpsBehaviorTest(testing.TestCase):
                 top_paths=top_paths,
             )
 
-    def test_rms_normalization(self):
-        x = KerasTensor([None, 2, 3])
-        self.assertEqual(
-            knn.rms_normalization(x, (None, 2, 3)).shape, (None, 2, 3)
-        )
-
-    def test_layer_normalization(self):
-        x = KerasTensor([None, 2, 3])
-        self.assertEqual(
-            knn.layer_normalization(x, (None, 2, 3)).shape, (None, 2, 3)
-        )
+    def test_layer_normalization_rms_scaling_warning(self):
+        x = np.arange(5, dtype="float32")
+        with self.assertWarnsRegex(
+            UserWarning, r"You passed `rms_scaling=True`, which is deprecated"
+        ):
+            knn.layer_normalization(x, rms_scaling=True)


### PR DESCRIPTION
- Added tests.
- Fixed numeric stability issues in half-precision training by using float32 for computations (which is also the default in Flax)
- Updated the fn signature of the `Operation`.

Ref: https://github.com/google/flax/blob/main/flax/linen/normalization.py