### PR TITLE
Fix: UpSampling2D bilinear channels_first bug

### DIFF
--- a/keras/src/layers/reshaping/up_sampling2d.py
+++ b/keras/src/layers/reshaping/up_sampling2d.py
@@ -163,7 +163,7 @@ class UpSampling2D(Layer):
                 shape[1] * height_factor,
                 shape[2] * width_factor,
             )
-            x = ops.image.resize(x, new_shape, interpolation=interpolation)
+            x = ops.image.resize(x, new_shape, data_format="channels_last", interpolation=interpolation)
         if data_format == "channels_first":
             x = ops.transpose(x, [0, 3, 1, 2])
 


### PR DESCRIPTION
The current approach transforms the tensor to channels_last, before passing it in ops.image.resize, which has been defined as channels_first. This creates a bug, a passed in tensor [16, 3, 224, 224] will return as shape [16, 448, 224, 448] instead of [16, 3, 448, 448]. Setting the data_format as the expected channels_last fixes that issue.
Closes #21401