### PR TITLE
MLX small changes

### DIFF
--- a/keras/src/backend/mlx/linalg.py
+++ b/keras/src/backend/mlx/linalg.py
@@ -35,8 +35,9 @@ def det(a):
 
 
 def eig(a):
-    # Using numpy for now, as mlx does not support eig yet.
-    return np.linalg.eig(a)
+    with mx.stream(mx.cpu):
+        # This op is not yet supported on the GPU.
+        return mx.linalg.eig(a)
 
 
 def eigh(a):

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -629,7 +629,10 @@ class TestTrainer(testing.TestCase):
             dataset_kwargs.get("use_multiprocessing", False)
             and backend.backend() in ["jax", "mlx"]  # mlx fails on Linux only
         ):
-            pytest.skip("Multiprocessing not supported with JAX backend")
+            pytest.skip(
+                "Multiprocessing not supported with JAX backend "
+                "nor on MLX backend on Linux."
+            )
 
         model = ExampleModel(units=3)
         optimizer = optimizers.Adagrad()

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -627,7 +627,7 @@ class TestTrainer(testing.TestCase):
     ):
         if (
             dataset_kwargs.get("use_multiprocessing", False)
-            and backend.backend() == "jax"
+            and backend.backend() in ["jax", "mlx"]  # mlx fails on Linux only
         ):
             pytest.skip("Multiprocessing not supported with JAX backend")
 


### PR DESCRIPTION
This is a PR for 2 small changes:

- Use `mlx.core.linalg.eig` instead of numpy's now that it is supported in MLX
- skip `test_fit_with_data_adapter` for multiprocessing in case of MLX. This works fine on a Mac however it does not work on Linux. I skipped the test regardless of the OS. If it's better to skip it only for MLX on Linux, I can do that.

This is part of supporting MLX backend #19571 