### PR TITLE
Implement deg2rad function in keras.ops

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -163,6 +163,7 @@ from keras.src.ops.numpy import count_nonzero as count_nonzero
 from keras.src.ops.numpy import cross as cross
 from keras.src.ops.numpy import cumprod as cumprod
 from keras.src.ops.numpy import cumsum as cumsum
+from keras.src.ops.numpy import deg2rad as deg2rad
 from keras.src.ops.numpy import diag as diag
 from keras.src.ops.numpy import diagflat as diagflat
 from keras.src.ops.numpy import diagonal as diagonal

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -52,6 +52,7 @@ from keras.src.ops.numpy import count_nonzero as count_nonzero
 from keras.src.ops.numpy import cross as cross
 from keras.src.ops.numpy import cumprod as cumprod
 from keras.src.ops.numpy import cumsum as cumsum
+from keras.src.ops.numpy import deg2rad as deg2rad
 from keras.src.ops.numpy import diag as diag
 from keras.src.ops.numpy import diagflat as diagflat
 from keras.src.ops.numpy import diagonal as diagonal

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -163,6 +163,7 @@ from keras.src.ops.numpy import count_nonzero as count_nonzero
 from keras.src.ops.numpy import cross as cross
 from keras.src.ops.numpy import cumprod as cumprod
 from keras.src.ops.numpy import cumsum as cumsum
+from keras.src.ops.numpy import deg2rad as deg2rad
 from keras.src.ops.numpy import diag as diag
 from keras.src.ops.numpy import diagflat as diagflat
 from keras.src.ops.numpy import diagonal as diagonal

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -52,6 +52,7 @@ from keras.src.ops.numpy import count_nonzero as count_nonzero
 from keras.src.ops.numpy import cross as cross
 from keras.src.ops.numpy import cumprod as cumprod
 from keras.src.ops.numpy import cumsum as cumsum
+from keras.src.ops.numpy import deg2rad as deg2rad
 from keras.src.ops.numpy import diag as diag
 from keras.src.ops.numpy import diagflat as diagflat
 from keras.src.ops.numpy import diagonal as diagonal

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -598,6 +598,10 @@ def cumsum(x, axis=None, dtype=None):
     return jnp.cumsum(x, axis=axis, dtype=dtype)
 
 
+def deg2rad(x):
+    return jnp.deg2rad(x)
+
+
 def diag(x, k=0):
     x = convert_to_tensor(x)
     return jnp.diag(x, k=k)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -515,6 +515,10 @@ def cumsum(x, axis=None, dtype=None):
     return np.cumsum(x, axis=axis, dtype=dtype)
 
 
+def deg2rad(x):
+    return np.deg2rad(x)
+
+
 def diag(x, k=0):
     return np.diag(x, k=k)
 

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -516,7 +516,16 @@ def cumsum(x, axis=None, dtype=None):
 
 
 def deg2rad(x):
-    return np.deg2rad(x)
+    if x.dtype in ["int64", "float64"]:
+        dtype = "float64"
+    elif x.dtype in ["bfloat16", "float16"]:
+        dtype = x.dtype
+    else:
+        dtype = config.floatx()
+
+    x = convert_to_tensor(x)
+
+    return np.deg2rad(x).astype(dtype)
 
 
 def diag(x, k=0):

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -21,6 +21,7 @@ NumpyDtypeTest::test_correlate
 NumpyDtypeTest::test_cross
 NumpyDtypeTest::test_cumprod
 NumpyDtypeTest::test_cumsum_bool
+NumpyDtypeTest::test_deg2rad
 NumpyDtypeTest::test_diag
 NumpyDtypeTest::test_digitize
 NumpyDtypeTest::test_einsum
@@ -84,6 +85,7 @@ NumpyOneInputOpsCorrectnessTest::test_conj
 NumpyOneInputOpsCorrectnessTest::test_corrcoef
 NumpyOneInputOpsCorrectnessTest::test_correlate
 NumpyOneInputOpsCorrectnessTest::test_cumprod
+NumpyOneInputOpsCorrectnessTest::test_deg2rad
 NumpyOneInputOpsCorrectnessTest::test_diag
 NumpyOneInputOpsCorrectnessTest::test_diagonal
 NumpyOneInputOpsCorrectnessTest::test_exp2
@@ -152,10 +154,12 @@ NumpyOneInputOpsDynamicShapeTest::test_angle
 NumpyOneInputOpsDynamicShapeTest::test_bartlett
 NumpyOneInputOpsDynamicShapeTest::test_blackman
 NumpyOneInputOpsDynamicShapeTest::test_corrcoef
+NumpyOneInputOpsDynamicShapeTest::test_deg2rad
 NumpyOneInputOpsDynamicShapeTest::test_hamming
 NumpyOneInputOpsDynamicShapeTest::test_hanning
 NumpyOneInputOpsDynamicShapeTest::test_kaiser
 NumpyOneInputOpsStaticShapeTest::test_angle
+NumpyOneInputOpsStaticShapeTest::test_deg2rad
 CoreOpsBehaviorTests::test_associative_scan_invalid_arguments
 CoreOpsBehaviorTests::test_scan_invalid_arguments
 CoreOpsCallsTests::test_associative_scan_basic_call

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -642,6 +642,12 @@ def cumsum(x, axis=None, dtype=None):
     return OpenVINOKerasTensor(ov_opset.cumsum(x, axis).output(0))
 
 
+def deg2rad(x, k=0):
+    raise NotImplementedError(
+        "`deg2rad` is not supported with openvino backend"
+    )
+
+
 def diag(x, k=0):
     raise NotImplementedError("`diag` is not supported with openvino backend")
 

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1257,6 +1257,7 @@ def cumsum(x, axis=None, dtype=None):
 
 
 def deg2rad(x):
+    x = convert_to_tensor(x)
     return tf.experimental.numpy.deg2rad(x)
 
 

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1256,6 +1256,10 @@ def cumsum(x, axis=None, dtype=None):
     return tf.math.cumsum(x, axis=axis)
 
 
+def deg2rad(x):
+    return tf.experimental.numpy.deg2rad(x)
+
+
 def diag(x, k=0):
     x = convert_to_tensor(x)
     if len(x.shape) == 1:

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1257,8 +1257,24 @@ def cumsum(x, axis=None, dtype=None):
 
 
 def deg2rad(x):
+    dtype = x.dtype
+    if standardize_dtype(dtype) in [
+        "bool",
+        "int8",
+        "int16",
+        "int32",
+        "uint8",
+        "uint16",
+        "uint32",
+    ]:
+        dtype = config.floatx()
+    elif standardize_dtype(dtype) in ["int64"]:
+        dtype = "float64"
+    x = tf.cast(x, dtype)
+
     x = convert_to_tensor(x)
-    return tf.experimental.numpy.deg2rad(x)
+    pi = tf.constant(math.pi, dtype=dtype)
+    return x * (pi / tf.constant(180.0, dtype=dtype))
 
 
 def diag(x, k=0):

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -671,6 +671,8 @@ def cumsum(x, axis=None, dtype=None):
 
 
 def deg2rad(x):
+    if standardize_dtype(x.dtype) == "int64":
+        return cast(torch.deg2rad(x), "float64")
     x = convert_to_tensor(x)
     return torch.deg2rad(x)
 

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -670,6 +670,10 @@ def cumsum(x, axis=None, dtype=None):
     return torch.cumsum(x, dim=axis, dtype=to_torch_dtype(dtype))
 
 
+def deg2rad(x):
+    return torch.deg2rad(x)
+
+
 def diag(x, k=0):
     x = convert_to_tensor(x)
     return torch.diag(x, diagonal=k)

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -671,6 +671,7 @@ def cumsum(x, axis=None, dtype=None):
 
 
 def deg2rad(x):
+    x = convert_to_tensor(x)
     return torch.deg2rad(x)
 
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2295,6 +2295,29 @@ class Diag(Operation):
         return KerasTensor(output_shape, dtype=x.dtype)
 
 
+@keras_export(["keras.ops.deg2rad", "keras.ops.numpy.deg2rad"])
+def deg2rad(x):
+    """Convert angles from degrees to radians.
+
+    The conversion is defined as:
+    `rad = deg * (π / 180)`
+
+    Args:
+        x: Input tensor of angles in degrees.
+
+    Returns:
+        A tensor containing angles converted to radians.
+
+    Examples:
+    >>> from keras.src import ops
+    >>> ops.deg2rad(180.0)
+    3.141592653589793
+    >>> ops.deg2rad([0.0, 90.0, 180.0])
+    array([0.        , 1.57079633, 3.14159265])
+    """
+    return backend.numpy.deg2rad(x)
+
+
 @keras_export(["keras.ops.diag", "keras.ops.numpy.diag"])
 def diag(x, k=0):
     """Extract a diagonal or construct a diagonal array.

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2258,6 +2258,34 @@ def cumsum(x, axis=None, dtype=None):
     return Cumsum(axis=axis, dtype=dtype)(x)
 
 
+class Deg2rad(Operation):
+    def call(self, x):
+        return backend.numpy.deg2rad(x)
+
+
+@keras_export(["keras.ops.deg2rad", "keras.ops.numpy.deg2rad"])
+def deg2rad(x):
+    """Convert angles from degrees to radians.
+
+    The conversion is defined as:
+    `rad = deg * (π / 180)`
+
+    Args:
+        x: Input tensor of angles in degrees.
+
+    Returns:
+        A tensor containing angles converted to radians.
+
+    Examples:
+    >>> from keras.src import ops
+    >>> ops.deg2rad(180.0)
+    3.141592653589793
+    >>> ops.deg2rad([0.0, 90.0, 180.0])
+    array([0.        , 1.57079633, 3.14159265])
+    """
+    return backend.numpy.deg2rad(x)
+
+
 class Diag(Operation):
     def __init__(self, k=0, *, name=None):
         super().__init__(name=name)
@@ -2293,29 +2321,6 @@ class Diag(Operation):
                 f"`x` must be 1-D or 2-D, but received shape {x.shape}."
             )
         return KerasTensor(output_shape, dtype=x.dtype)
-
-
-@keras_export(["keras.ops.deg2rad", "keras.ops.numpy.deg2rad"])
-def deg2rad(x):
-    """Convert angles from degrees to radians.
-
-    The conversion is defined as:
-    `rad = deg * (π / 180)`
-
-    Args:
-        x: Input tensor of angles in degrees.
-
-    Returns:
-        A tensor containing angles converted to radians.
-
-    Examples:
-    >>> from keras.src import ops
-    >>> ops.deg2rad(180.0)
-    3.141592653589793
-    >>> ops.deg2rad([0.0, 90.0, 180.0])
-    array([0.        , 1.57079633, 3.14159265])
-    """
-    return backend.numpy.deg2rad(x)
 
 
 @keras_export(["keras.ops.diag", "keras.ops.numpy.diag"])

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2283,6 +2283,8 @@ def deg2rad(x):
     >>> ops.deg2rad([0.0, 90.0, 180.0])
     array([0.        , 1.57079633, 3.14159265])
     """
+    if any_symbolic_tensors((x,)):
+        return Deg2rad().symbolic_call(x)
     return backend.numpy.deg2rad(x)
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1926,7 +1926,7 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
 
     def test_deg2rad(self):
         x = KerasTensor((2, 3))
-        self.assertEqual(knp.deg2rad(x).shape, (6,))
+        self.assertEqual(knp.deg2rad(x).shape, (2, 3))
 
     def test_diag(self):
         x = KerasTensor((3,))

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6688,6 +6688,7 @@ class NumpyDtypeTest(testing.TestCase):
         self.assertEqual(
             standardize_dtype(knp.deg2rad(x).dtype), expected_dtype
         )
+
         self.assertEqual(
             standardize_dtype(knp.Deg2rad().symbolic_call(x).dtype),
             expected_dtype,

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1346,6 +1346,10 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor((None, 3, 3))
         self.assertEqual(knp.cumsum(x, axis=1).shape, (None, 3, 3))
 
+    def test_deg2rad(self):
+        x = KerasTensor((None, 3))
+        self.assertEqual(knp.deg2rad(x).shape, (None, 3))
+
     def test_diag(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.diag(x).shape, (None,))
@@ -1919,6 +1923,10 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
     def test_cumsum(self):
         x = KerasTensor((2, 3))
         self.assertEqual(knp.cumsum(x).shape, (6,))
+
+    def test_deg2rad(self):
+        x = KerasTensor((2, 3))
+        self.assertEqual(knp.deg2rad(x).shape, (6,))
 
     def test_diag(self):
         x = KerasTensor((3,))
@@ -3910,6 +3918,11 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             knp.Cumsum(axis=axis, dtype=dtype)(x),
             np.cumsum(x, axis=axis, dtype=dtype or x.dtype),
         )
+
+    def test_deg2rad(self):
+        x = np.random.uniform(-360, 360, size=(3, 3))
+        self.assertAllClose(knp.deg2rad(x), np.deg2rad(x))
+        self.assertAllClose(knp.Deg2rad()(x), np.deg2rad(x))
 
     def test_diag(self):
         x = np.array([1, 2, 3])

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6678,6 +6678,22 @@ class NumpyDtypeTest(testing.TestCase):
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_deg2rad(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.deg2rad(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.deg2rad(x).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Deg2rad().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_diag(self, dtype):
         import jax.numpy as jnp
 


### PR DESCRIPTION
Adds keras.ops.deg2rad, which converts angles from degrees to radians.
Supported across NumPy, TensorFlow, PyTorch, and JAX backends. Not supported on OpenVINO.