### PR TITLE
Ensures mask kwarg is used for output mask propagation

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -906,9 +906,14 @@ class Layer(BackendLayer, Operation):
 
         # We need to cache the `previous_mask` before `__call__` because the
         # mask might be removed during the call, such as `MultiHeadAttention`.
-        previous_mask = tree.map_structure(
-            backend.get_keras_mask, call_spec.first_arg
-        )
+        if "mask" in kwargs and kwargs["mask"] is not None:
+            # Case 1: Mask was explicitly passed or auto-populated in step 6.
+            previous_mask = kwargs["mask"]
+        else:
+            # Case 2: Fallback to the mask attached to the first input tensor.
+            previous_mask = tree.map_structure(
+                backend.get_keras_mask, call_spec.first_arg
+            )
 
         ####################
         # 7. Call the layer.


### PR DESCRIPTION
This fix addresses a bug in the Layer class where an explicitly passed `mask` keyword argument was ignored during the computation of the output mask for subsequent layers.

## The Problem

Currently, when a layer is called with an explicit mask (e.g., `layer(inputs, mask=my_mask)`), the framework correctly uses this mask for the layer's internal `call()` computation. However, when preparing to propagate a mask to the next layer, the framework incorrectly ignores this explicit mask. Instead, it only checks for a `_keras_mask` attribute attached directly to the input tensor.

If the input tensor has no such attribute, the output mask is computed as `None`, effectively breaking the mask propagation chain.

## Solution

The fix modifies how the `previous_mask` variable is determined within the `Layer.__call__` method. The logic has been updated to prioritize the explicitly passed mask keyword argument.

The new order of operations is:

1. Check if a mask was provided in `kwargs`. If yes, use it as `previous_mask`.
2. If no explicit mask is found, fall back to checking for a `_keras_mask` attribute on the first input tensor.

This ensures that the mask actually used by the layer is the same one used to compute the mask for its output, restoring correct and consistent mask propagation behavior.