### PR TITLE
Fix: UpSampling2D bilinear set_image_data_format(channels_first) bug

### DIFF
--- a/keras/src/layers/reshaping/up_sampling2d.py
+++ b/keras/src/layers/reshaping/up_sampling2d.py
@@ -163,7 +163,7 @@ class UpSampling2D(Layer):
                 shape[1] * height_factor,
                 shape[2] * width_factor,
             )
-            x = ops.image.resize(x, new_shape, interpolation=interpolation)
+            x = ops.image.resize(x, new_shape, data_format="channels_last", interpolation=interpolation)
         if data_format == "channels_first":
             x = ops.transpose(x, [0, 3, 1, 2])
 

--- a/keras/src/layers/reshaping/up_sampling2d.py
+++ b/keras/src/layers/reshaping/up_sampling2d.py
@@ -163,7 +163,12 @@ class UpSampling2D(Layer):
                 shape[1] * height_factor,
                 shape[2] * width_factor,
             )
-            x = ops.image.resize(x, new_shape, data_format="channels_last", interpolation=interpolation)
+            x = ops.image.resize(
+                x,
+                new_shape,
+                data_format="channels_last",
+                interpolation=interpolation,
+            )
         if data_format == "channels_first":
             x = ops.transpose(x, [0, 3, 1, 2])
 

--- a/keras/src/layers/reshaping/up_sampling2d_test.py
+++ b/keras/src/layers/reshaping/up_sampling2d_test.py
@@ -68,7 +68,9 @@ class UpSampling2dTest(testing.TestCase):
         length_col=[2, 3],
     )
     @pytest.mark.requires_trainable_backend
-    def test_upsampling_2d_bilinear(self, data_format, use_set_image_data_format, length_row, length_col):
+    def test_upsampling_2d_bilinear(
+        self, data_format, use_set_image_data_format, length_row, length_col
+    ):
         num_samples = 2
         stack_size = 2
         input_num_row = 11

--- a/keras/src/layers/reshaping/up_sampling2d_test.py
+++ b/keras/src/layers/reshaping/up_sampling2d_test.py
@@ -10,6 +10,14 @@ from keras.backend import set_image_data_format
 
 
 class UpSampling2dTest(testing.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.original_image_data_format = backend.image_data_format()
+
+    @classmethod
+    def tearDownClass(cls):
+        backend.set_image_data_format(cls.original_image_data_format)
+
     @parameterized.product(
         data_format=["channels_first", "channels_last"],
         length_row=[2],

--- a/keras/src/layers/reshaping/up_sampling2d_test.py
+++ b/keras/src/layers/reshaping/up_sampling2d_test.py
@@ -6,6 +6,7 @@ from absl.testing import parameterized
 from keras.src import backend
 from keras.src import layers
 from keras.src import testing
+from keras.backend import set_image_data_format
 
 
 class UpSampling2dTest(testing.TestCase):
@@ -62,15 +63,20 @@ class UpSampling2dTest(testing.TestCase):
 
     @parameterized.product(
         data_format=["channels_first", "channels_last"],
+        use_set_image_data_format=[True, False],
         length_row=[2],
         length_col=[2, 3],
     )
     @pytest.mark.requires_trainable_backend
-    def test_upsampling_2d_bilinear(self, data_format, length_row, length_col):
+    def test_upsampling_2d_bilinear(self, data_format, use_set_image_data_format, length_row, length_col):
         num_samples = 2
         stack_size = 2
         input_num_row = 11
         input_num_col = 12
+
+        if use_set_image_data_format:
+            set_image_data_format(data_format)
+
         if data_format == "channels_first":
             inputs = np.random.rand(
                 num_samples, stack_size, input_num_row, input_num_col
@@ -93,6 +99,7 @@ class UpSampling2dTest(testing.TestCase):
         layer = layers.UpSampling2D(
             size=(length_row, length_col),
             data_format=data_format,
+            interpolation="bilinear",
         )
         layer.build(inputs.shape)
         np_output = layer(inputs=backend.Variable(inputs))


### PR DESCRIPTION
The current approach transforms the tensor to channels_last, before passing it in ops.image.resize, which has been defined as channels_first if keras.backend.set_image_data_format has been called on channelsfirst in the user's code. This creates a bug, a passed in tensor [16, 3, 224, 224] will return as shape [16, 448, 224, 448] instead of [16, 3, 448, 448]. Setting the data_format as the expected channels_last fixes that issue.

I changed the unit tests to integrate keras.backend.set_image_data_format, also I noticed 
layer = layers.UpSampling2D(
    size=(length_row, length_col),
    data_format=data_format,
)
Inside test_upsampling_2d_bilinear, wasn't using interpolation="bilinear", so I corrected that too

Closes #21401.


