### PR TITLE
[OpenVINO backend] fix ops.array

### DIFF
--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -12,6 +12,7 @@ from keras.src.backend.openvino.core import OpenVINOKerasTensor
 from keras.src.backend.openvino.core import (
     align_operand_types as _align_operand_types,
 )
+from keras.src.backend.openvino.core import convert_to_numpy
 from keras.src.backend.openvino.core import convert_to_tensor
 from keras.src.backend.openvino.core import get_ov_output
 from keras.src.backend.openvino.core import ov_to_keras_type
@@ -432,6 +433,12 @@ def argsort(x, axis=-1):
 
 
 def array(x, dtype=None):
+    if isinstance(x, OpenVINOKerasTensor):
+        if dtype is not None:
+            dtype = standardize_dtype(dtype)
+            dtype = OPENVINO_DTYPES[dtype]
+            x = ov_opset.convert(x.output, dtype)
+        return convert_to_numpy(OpenVINOKerasTensor(x.output))
     if dtype is not None:
         return np.array(x, dtype=dtype)
     return np.array(x)


### PR DESCRIPTION
@rkazants
@fchollet 
In https://github.com/keras-team/keras-hub/blob/master/keras_hub/src/samplers/random_sampler_test.py#L60-L74
This test fails due to `ops.array(logits)`,  where logits is an `OpenVINOKerasTensor`
```python
def test_temperature(self):
        def next(prompt, cache, index):
            # Dummy hidden states.
            hidden_states = ops.ones([self.batch_size, 5])
            logits = ops.arange(self.vocab_size, 0, -1, dtype="float32")
            logits = ops.reshape(logits[None, :], (self.batch_size, -1))
            return ops.array(logits), hidden_states, cache

        prompt = ops.full((self.batch_size, self.length), self.char_lookup["z"])

        output = RandomSampler(temperature=1e-5)(
            next=next,
            prompt=prompt,
        )
        self.assertAllEqual(output, ops.zeros_like(output))
```

