### PR TITLE
[OpenVINO backend] update get_ov_output to support lists and tuples

### DIFF
--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1138,7 +1138,7 @@ def moveaxis(x, source, destination):
         axes.remove(src)
         axes.insert(dst, src)
 
-    axes_const = ov_opset.constant(axes, Type.i32).output(0)
+    axes_const = get_ov_output(axes)
     return OpenVINOKerasTensor(ov_opset.transpose(x, axes_const).output(0))
 
 
@@ -1628,7 +1628,7 @@ def transpose(x, axes=None):
             rank_minus_one, const_minus_one, const_minus_one, "i64"
         ).output(0)
     else:
-        axes = ov_opset.constant(axes, Type.i32).output(0)
+        axes = get_ov_output(axes)
     return OpenVINOKerasTensor(ov_opset.transpose(x, axes).output(0))
 
 


### PR DESCRIPTION
@rkazants 
@fchollet 

This PR addresses the issue of retrieving `ov.output` when the input is a `list` or `tuple`, and ensures correct handling of cases where the elements are instances of `OpenVINOKerasTensor`.