### PR TITLE
fix argument description for on_train_batch callbacks in LambdaCallback

### DIFF
--- a/keras/src/callbacks/lambda_callback.py
+++ b/keras/src/callbacks/lambda_callback.py
@@ -14,8 +14,8 @@ class LambdaCallback(Callback):
       `epoch`, `logs`
     - `on_train_begin` and `on_train_end` expect one positional argument:
       `logs`
-    - `on_train_batch_begin` and `on_train_batch_end` expect two positional
-      arguments: `batch`, `logs`
+    - `on_train_batch_begin` and `on_train_batch_end` expect a positional
+      argument `batch` and a keyword argument `logs`
     - See `Callback` class definition for the full list of functions and their
       expected arguments.
 


### PR DESCRIPTION
The [LambdaCallback](https://keras.io/api/callbacks/lambda_callback/) docstring previously stated that callback methods receive their arguments as positional arguments, including `on_train_batch_begin` and `on_train_batch_end`.

However, `batch` is passed as a positional argument, but `logs` is passed as a keyword argument for `on_train_batch_begin` and `on_train_batch_end` methods. This PR updates the docstring to specify that `on_train_batch_begin` and `on_train_batch_end` expect a positional argument `batch` and a keyword argument `logs`.

Fixes : [#21459 ](https://github.com/keras-team/keras/issues/21459)
