### PR TITLE
Fix TypeError in keras.ops.searchsorted by using shape instead of len

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2134,7 +2134,9 @@ def searchsorted(sorted_sequence, values, side="left"):
             f"sorted_sequence.shape={sorted_sequence.shape}"
         )
     out_type = (
-        "int32" if len(sorted_sequence) <= np.iinfo(np.int32).max else "int64"
+        "int32" 
+        if (sorted_sequence).shape[0] <= np.iinfo(np.int32).max 
+        else "int64"
     )
     return tf.searchsorted(
         sorted_sequence, values, side=side, out_type=out_type

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2134,9 +2134,7 @@ def searchsorted(sorted_sequence, values, side="left"):
             f"sorted_sequence.shape={sorted_sequence.shape}"
         )
     out_type = (
-        "int32" 
-        if (sorted_sequence).shape[0] <= np.iinfo(np.int32).max 
-        else "int64"
+        "int32" if sorted_sequence.shape[0] <= np.iinfo(np.int32).max else "int64"
     )
     return tf.searchsorted(
         sorted_sequence, values, side=side, out_type=out_type


### PR DESCRIPTION
Replaces `len(sorted_sequence)` with `sorted_sequence.shape[0]` in the `searchsorted` function to prevent a TypeError when `sorted_sequence` is a symbolic Tensor, error reproduced in this [gist](https://colab.sandbox.google.com/gist/dhantule/8c559296147199673f716fa9097b1fe3/keras-ops-searchsorted-doesn-t-work-with-symbolic-tensors-21465-open.ipynb).

Fixes: #21465


