### PR TITLE
Pin onnxscript version to `0.3.1`.

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -20,8 +20,10 @@ pytest-cov
 packaging
 # for tree_test.py
 dm_tree
-coverage!=7.6.5  # 7.6.5 breaks CI
+coverage
 # for onnx_test.py
 onnxruntime
-onnxscript  # Needed by TorchDynamo-based ONNX exporter
+# TODO(https://github.com/keras-team/keras/issues/21390)
+# > 0.3.1 breaks LSTM model export in torch backend.
+onnxscript<=0.3.1
 openvino


### PR DESCRIPTION
Reported in https://github.com/keras-team/keras/issues/21390#issuecomment-3068295932

The root cause is that the test fails with `onnxscript==0.3.2` which is the latest version.

I don't have the capacity to investigate the root cause in `onnxscript`. As a workaround, we can pin the version to 0.3.1.

cc @pctablet505