### PR TITLE
Fix LogSumExp Implementation for OpenVINO backend.

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -207,7 +207,6 @@ MathOpsCorrectnessTest::test_istft4
 MathOpsCorrectnessTest::test_istft5
 MathOpsCorrectnessTest::test_istft6
 MathOpsCorrectnessTest::test_logdet
-MathOpsCorrectnessTest::test_logsumexp
 MathOpsCorrectnessTest::test_rfft0
 MathOpsCorrectnessTest::test_rfft1
 MathOpsCorrectnessTest::test_rfft2


### PR DESCRIPTION
this PR updates the LogSumExp operation to work correctly with the OpenVINO backend and resolves related numerical issues. 

We use `keepdims=True` for `reduce_max` to ensure the output shape of the maximum matches the input shape for broadcasting during subtraction. If `keepdims=False`, the reduced axis is removed, so the shapes don't align and broadcasting fails or produces incorrect results. By always keeping the reduced dimension (`keepdims=True`), we guarantee that `x - max` works as intended, regardless of which axis is reduced. After all computations, we squeeze the result only if the user requested `keepdims=False`, so the final output shape matches expectations. This approach ensures both correct broadcasting and correct output shape.

fixes #21470 