### PR TITLE
docs: enhance clarity and consistency in README by correcting platform capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python pip_build.py --install
 The `requirements.txt` file will install a CPU-only version of TensorFlow, JAX, and PyTorch. For GPU support, we also
 provide a separate `requirements-{backend}-cuda.txt` for TensorFlow, JAX, and PyTorch. These install all CUDA
 dependencies via `pip` and expect a NVIDIA driver to be pre-installed. We recommend a clean Python environment for each
-backend to avoid CUDA version mismatches. As an example, here is how to create a Jax GPU environment with `conda`:
+backend to avoid CUDA version mismatches. As an example, here is how to create a JAX GPU environment with `conda`:
 
 ```shell
 conda create -y -n keras-jax python=3.10

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ as well as `tf.data` pipelines.
 
 #### Minimal installation
 
-Keras 3 is compatible with Linux and MacOS systems. For Windows users, we recommend using WSL2 to run Keras.
+Keras 3 is compatible with Linux and macOS systems. For Windows users, we recommend using WSL2 to run Keras.
 To install a local development version:
 
 1. Install dependencies:
@@ -60,7 +60,7 @@ python pip_build.py --install
 
 The `requirements.txt` file will install a CPU-only version of TensorFlow, JAX, and PyTorch. For GPU support, we also
 provide a separate `requirements-{backend}-cuda.txt` for TensorFlow, JAX, and PyTorch. These install all CUDA
-dependencies via `pip` and expect a NVIDIA driver to be pre-installed. We recommend a clean python environment for each
+dependencies via `pip` and expect a NVIDIA driver to be pre-installed. We recommend a clean Python environment for each
 backend to avoid CUDA version mismatches. As an example, here is how to create a Jax GPU environment with `conda`:
 
 ```shell


### PR DESCRIPTION
This PR enhances the clarity and polish of the Keras README by correcting minor but important inconsistencies in platform naming:

- Updated “python” to “Python” to reflect the proper name of the language.
- Corrected “MacOS” to “macOS” to match Apple’s official styling.

While subtle, these adjustments contribute to a more professional, accurate, and trustworthy documentation experience for new developers evaluating or onboarding with Keras 3. Maintaining consistent terminology strengthens the credibility and quality of open source documentation.
