### PR TITLE
Add Grain integration.

### DIFF
--- a/keras/src/backend/common/keras_tensor.py
+++ b/keras/src/backend/common/keras_tensor.py
@@ -35,8 +35,16 @@ class KerasTensor:
         ragged=False,
         record_history=True,
         name=None,
+        **kwargs,
     ):
         from keras.src import backend
+
+        ragged_rank = kwargs.pop("ragged_rank", None)
+        row_splits_dtype = kwargs.pop("row_splits_dtype", None)
+        if kwargs:
+            raise TypeError(
+                f"Unexpected keyword arguments: {', '.join(kwargs.keys())}"
+            )
 
         self._shape = backend.standardize_shape(shape)
         self._dtype = backend.standardize_dtype(dtype)
@@ -47,6 +55,14 @@ class KerasTensor:
                 "KerasTensor cannot have `sparse=True` and `ragged=True` at "
                 "the same time."
             )
+        self._ragged_rank = (
+            int(ragged_rank) if ragged_rank is not None else None
+        )
+        self._row_splits_dtype = (
+            backend.standardize_dtype(row_splits_dtype)
+            if row_splits_dtype is not None
+            else None
+        )
         self.name = name or auto_name(self.__class__.__name__)
         self.record_history = record_history
 
@@ -81,6 +97,28 @@ class KerasTensor:
         raise AttributeError(
             "The `sparse` attribute of KerasTensor is immutable. One should "
             "create a new instance of KerasTensor for this."
+        )
+
+    @property
+    def ragged_rank(self):
+        return self._ragged_rank
+
+    @ragged_rank.setter
+    def ragged_rank(self, value):
+        raise AttributeError(
+            "The `ragged_rank` attribute of KerasTensor is immutable. One "
+            "should create a new instance of KerasTensor for this."
+        )
+
+    @property
+    def row_splits_dtype(self):
+        return self._row_splits_dtype
+
+    @row_splits_dtype.setter
+    def row_splits_dtype(self, value):
+        raise AttributeError(
+            "The `row_splits_dtype` attribute of KerasTensor is immutable. One "
+            "should create a new instance of KerasTensor for this."
         )
 
     @property

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -1026,10 +1026,12 @@ class JAXEpochIterator(EpochIterator):
         distribution = distribution_lib.distribution()
         if distribution is not None:
             return self._get_distributed_iterator(distribution)
-
-        return self._prefetch_numpy_iterator(
-            self.data_adapter.get_jax_iterator()
-        )
+        if self.data_adapter.builtin_prefetch:
+            return self.data_adapter.get_jax_iterator()
+        else:
+            return self._prefetch_numpy_iterator(
+                self.data_adapter.get_jax_iterator()
+            )
 
     def _get_distributed_iterator(self, distribution):
         """Lazily compute layouts to reduce host to device transfer latency."""

--- a/keras/src/trainers/data_adapters/__init__.py
+++ b/keras/src/trainers/data_adapters/__init__.py
@@ -8,6 +8,9 @@ from keras.src.trainers.data_adapters.array_data_adapter import ArrayDataAdapter
 from keras.src.trainers.data_adapters.generator_data_adapter import (
     GeneratorDataAdapter,
 )
+from keras.src.trainers.data_adapters.grain_dataset_adapter import (
+    GrainDatasetAdapter,
+)
 from keras.src.trainers.data_adapters.py_dataset_adapter import PyDatasetAdapter
 from keras.src.trainers.data_adapters.tf_dataset_adapter import TFDatasetAdapter
 from keras.src.trainers.data_adapters.torch_data_loader_adapter import (
@@ -111,6 +114,32 @@ def get_data_adapter(
         #     "data `x` was provided as a torch DataLoader. The DataLoader "
         #     "is expected to already be shuffled."
         # )
+    elif is_grain_dataset(x):
+        if y is not None:
+            raise_unsupported_arg(
+                "y", "the targets", "grain.Dataset and grain.DataLoader"
+            )
+        if sample_weight is not None:
+            raise_unsupported_arg(
+                "sample_weights",
+                "the sample weights",
+                "grain.Dataset and grain.DataLoader",
+            )
+        if class_weight is not None:
+            raise ValueError(
+                "Argument `class_weight` is not supported for grain.Dataset "
+                f"and grain.DataLoader inputs. You can modify your "
+                "`__getitem__ ` method to return input tensor, label and "
+                "class_weight. "
+                f"Received: class_weight={class_weight}"
+            )
+        return GrainDatasetAdapter(x)
+        # TODO: should we warn or not?
+        # warnings.warn(
+        #     "`shuffle=True` was passed, but will be ignored since the "
+        #     "data `x` was provided as a grain dataset. The grain dataset "
+        #     "is expected to already be shuffled."
+        # )
     elif isinstance(x, types.GeneratorType):
         if y is not None:
             raise_unsupported_arg("y", "the targets", "PyDataset")
@@ -160,5 +189,17 @@ def is_torch_dataloader(x):
             if parent.__name__ == "DataLoader" and "torch.utils.data" in str(
                 parent.__module__
             ):
+                return True
+    return False
+
+
+def is_grain_dataset(x):
+    if hasattr(x, "__class__"):
+        for parent in x.__class__.__mro__:
+            if parent.__name__ in (
+                "MapDataset",
+                "IterDataset",
+                "DataLoader",
+            ) and "grain" in str(parent.__module__):
                 return True
     return False

--- a/keras/src/trainers/data_adapters/data_adapter.py
+++ b/keras/src/trainers/data_adapters/data_adapter.py
@@ -47,6 +47,21 @@ class DataAdapter:
         raise NotImplementedError
 
     @property
+    def builtin_prefetch(self):
+        """Whether the DataAdapter has built-in prefetching capabilities.
+
+        Prefetching is an optimization technique where data is loaded and
+        prepared in advance while the model is processing the current batch,
+        reducing training time by overlapping data loading with computation.
+
+        Returns:
+            bool: True if the DataAdapter implements its own prefetching
+            mechanism and handles data loading asynchronously. False if the
+            caller should implement prefetching externally.
+        """
+        return False
+
+    @property
     def num_batches(self):
         """Return the size (number of batches) for the dataset created.
 

--- a/keras/src/trainers/data_adapters/grain_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/grain_dataset_adapter.py
@@ -1,0 +1,255 @@
+import itertools
+import math
+import sys
+
+import numpy as np
+
+from keras.src import tree
+from keras.src.trainers.data_adapters import data_adapter_utils
+from keras.src.trainers.data_adapters.data_adapter import DataAdapter
+
+
+class GrainDatasetAdapter(DataAdapter):
+    """Adapter that Grain dataset."""
+
+    def __init__(self, dataset):
+        import grain
+
+        if not isinstance(
+            dataset, (grain.MapDataset, grain.IterDataset, grain.DataLoader)
+        ):
+            raise ValueError(
+                "Expected argument `dataset` to be a grain.MapDataset, "
+                "grain.IterDataset or grain.DataLoader. "
+                f"Received: {dataset} of type {type(dataset)}"
+            )
+
+        self._dataset = dataset
+
+        # Retrieve the information.
+        num_batches = None
+        batch_size = None
+        if isinstance(self._dataset, (grain.MapDataset, grain.IterDataset)):
+            from grain._src.python.dataset.transformations import batch
+
+            current_dataset = self._dataset
+            while True:
+                if isinstance(current_dataset, batch.BatchMapDataset):
+                    num_batches = len(current_dataset)
+                    batch_size = current_dataset._batch_size
+                    break
+                elif isinstance(current_dataset, batch.BatchIterDataset):
+                    batch_size = current_dataset._batch_size
+                    break
+                else:
+                    try:
+                        # We may receive a non-batched dataset.
+                        num_batches = len(current_dataset)
+                        break
+                    except TypeError:
+                        pass
+                if not hasattr(current_dataset, "_parent"):
+                    break
+                try:
+                    current_dataset = current_dataset._parent
+                except AssertionError:
+                    break
+        else:
+            drop_remainder = False
+            operations = self._dataset._operations
+            # Retrieve the `batch_size`.
+            for op in reversed(operations):
+                if isinstance(op, grain.transforms.Batch):
+                    batch_size = op.batch_size
+                    drop_remainder = op.drop_remainder
+                    break
+            if batch_size is not None:
+                data_source = self._dataset._data_source
+                if drop_remainder:
+                    num_batches = len(data_source) // batch_size
+                else:
+                    num_batches = math.ceil(len(data_source) / batch_size)
+        self._num_batches = num_batches
+        self._batch_size = batch_size
+        self._output_signature = None
+
+    def get_numpy_iterator(self):
+        import grain
+        from grain._src.python.dataset.transformations import map
+        from grain._src.python.shared_memory_array import (
+            SharedMemoryArrayMetadata,
+        )
+
+        def convert_to_numpy(x):
+            if isinstance(x, (np.ndarray, SharedMemoryArrayMetadata)):
+                return x
+            else:
+                # Using `__array__` should handle `tf.Tensor`, `jax.np.ndarray`,
+                # `torch.Tensor`, as well as any other tensor-like object that
+                # has added numpy support.
+                if hasattr(x, "__array__"):
+                    if data_adapter_utils.is_torch_tensor(x):
+                        x = x.cpu()
+                    x = np.asarray(x)
+                return x
+
+        class ConvertToNumpy(grain.transforms.Map):
+            def map(self, x):
+                return tree.map_structure(convert_to_numpy, x)
+
+        if isinstance(self._dataset, grain.MapDataset):
+            dataset = map.MapMapDataset(self._dataset, ConvertToNumpy())
+        elif isinstance(self._dataset, grain.IterDataset):
+            dataset = map.MapIterDataset(self._dataset, ConvertToNumpy())
+        else:
+
+            class ConvertToNumpy(grain.transforms.Map):
+                def map(self, x):
+                    return tree.map_structure(convert_to_numpy, x)
+
+            # Instantiate a new `DataLoader`.
+            dataset = grain.DataLoader(
+                data_source=self._dataset._data_source,
+                sampler=self._dataset._sampler,
+                # Append `ConvertToNumpy`.
+                operations=list(self._dataset._operations) + [ConvertToNumpy()],
+                worker_count=self._dataset._multiprocessing_options.num_workers,
+                worker_buffer_size=self._dataset._multiprocessing_options.per_worker_buffer_size,
+                shard_options=self._dataset._shard_options,
+                read_options=self._dataset._read_options,
+                enable_profiling=self._dataset._multiprocessing_options.enable_profiling,
+            )
+        return dataset
+
+    def get_jax_iterator(self):
+        import grain
+        from grain._src.python.dataset.transformations import map
+
+        def convert_to_jax_compatible(x):
+            if data_adapter_utils.is_scipy_sparse(x):
+                x = data_adapter_utils.scipy_sparse_to_jax_sparse(x)
+            elif data_adapter_utils.is_tensorflow_sparse(x):
+                x = data_adapter_utils.tf_sparse_to_jax_sparse(x)
+            return x
+
+        class ConvertToJaxCompatible(grain.transforms.Map):
+            def map(self, x):
+                return tree.map_structure(convert_to_jax_compatible, x)
+
+        if isinstance(self._dataset, grain.MapDataset):
+            dataset = map.MapMapDataset(self._dataset, ConvertToJaxCompatible())
+        elif isinstance(self._dataset, grain.IterDataset):
+            dataset = map.MapIterDataset(
+                self._dataset, ConvertToJaxCompatible()
+            )
+        else:
+            # Instantiate a new `DataLoader`.
+            dataset = grain.DataLoader(
+                data_source=self._dataset._data_source,
+                sampler=self._dataset._sampler,
+                # Append `ConvertToJaxCompatible`.
+                operations=list(self._dataset._operations)
+                + [ConvertToJaxCompatible()],
+                worker_count=self._dataset._multiprocessing_options.num_workers,
+                worker_buffer_size=self._dataset._multiprocessing_options.per_worker_buffer_size,
+                shard_options=self._dataset._shard_options,
+                read_options=self._dataset._read_options,
+                enable_profiling=self._dataset._multiprocessing_options.enable_profiling,
+            )
+        return dataset
+
+    def get_tf_dataset(self):
+        import grain
+        import tensorflow as tf
+        from grain._src.python.dataset.transformations import map
+
+        def convert_to_tf(x):
+            if data_adapter_utils.is_scipy_sparse(x):
+                x = data_adapter_utils.scipy_sparse_to_tf_sparse(x)
+            elif data_adapter_utils.is_jax_sparse(x):
+                x = data_adapter_utils.jax_sparse_to_tf_sparse(x)
+            return x
+
+        class ConvertToTF(grain.transforms.Map):
+            def map(self, x):
+                return tree.map_structure(convert_to_tf, x)
+
+        # `tf.data.Dataset.from_generator` does not support lists as output.
+        # We convert lists to tuples.
+        class ListToTuple(grain.transforms.Map):
+            def map(self, x):
+                return tree.lists_to_tuples(x)
+
+        if isinstance(self._dataset, grain.MapDataset):
+            dataset = map.MapMapDataset(self._dataset, ConvertToTF())
+            dataset = map.MapMapDataset(dataset, ListToTuple())
+        elif isinstance(self._dataset, grain.IterDataset):
+            dataset = map.MapIterDataset(self._dataset, ConvertToTF())
+            dataset = map.MapIterDataset(dataset, ListToTuple())
+        else:
+            # Instantiate a new `DataLoader`.
+            dataset = grain.DataLoader(
+                data_source=self._dataset._data_source,
+                sampler=self._dataset._sampler,
+                # Append `ConvertToTF` and `ListToTuple`.
+                operations=list(self._dataset._operations)
+                + [ConvertToTF(), ListToTuple()],
+                worker_count=self._dataset._multiprocessing_options.num_workers,
+                worker_buffer_size=self._dataset._multiprocessing_options.per_worker_buffer_size,
+                shard_options=self._dataset._shard_options,
+                read_options=self._dataset._read_options,
+                enable_profiling=self._dataset._multiprocessing_options.enable_profiling,
+            )
+
+        if self._output_signature is None:
+            batches = list(
+                itertools.islice(
+                    self._dataset,
+                    data_adapter_utils.NUM_BATCHES_FOR_TENSOR_SPEC,
+                )
+            )
+            self._output_signature = data_adapter_utils.get_tensor_spec(batches)
+
+        return tf.data.Dataset.from_generator(
+            lambda: dataset, output_signature=self._output_signature
+        )
+
+    def get_torch_dataloader(self):
+        import torch.utils.data as torch_data
+
+        class ConverterIterableDataset(torch_data.IterableDataset):
+            def __init__(self, iterable):
+                super().__init__()
+                self.iterable = iterable
+
+            def __iter__(self):
+                return iter(self.iterable)
+
+        # `batch_size=None` indicates that we should not re-batch
+        return torch_data.DataLoader(
+            ConverterIterableDataset(self._dataset), batch_size=None
+        )
+
+    @property
+    def builtin_prefetch(self):
+        return True
+
+    @property
+    def num_batches(self):
+        # After calling `repeat()`, the number of batches becomes `sys.maxsize`
+        # which means infinite.
+        if self._num_batches == sys.maxsize:
+            return None
+        return self._num_batches
+
+    @property
+    def batch_size(self):
+        return self._batch_size
+
+    @property
+    def has_partial_batch(self):
+        return None
+
+    @property
+    def partial_batch_size(self):
+        return None

--- a/keras/src/trainers/data_adapters/grain_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/grain_dataset_adapter.py
@@ -102,11 +102,6 @@ class GrainDatasetAdapter(DataAdapter):
         elif isinstance(self._dataset, grain.IterDataset):
             dataset = map.MapIterDataset(self._dataset, ConvertToNumpy())
         else:
-
-            class ConvertToNumpy(grain.transforms.Map):
-                def map(self, x):
-                    return tree.map_structure(convert_to_numpy, x)
-
             # Instantiate a new `DataLoader`.
             dataset = grain.DataLoader(
                 data_source=self._dataset._data_source,

--- a/keras/src/trainers/data_adapters/grain_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/grain_dataset_adapter_test.py
@@ -52,7 +52,7 @@ class GrainDatasetAdapterTest(testing.TestCase):
 
     @parameterized.named_parameters(
         named_product(
-            dataset_type=["map_datast", "iter_dataset", "data_loader"]
+            dataset_type=["map_dataset", "iter_dataset", "data_loader"]
         )
     )
     def test_basic_flow(self, dataset_type):
@@ -161,32 +161,6 @@ class GrainDatasetAdapterTest(testing.TestCase):
             self.assertEqual(bx.dtype, by.dtype)
             self.assertEqual(bx.shape, (4, 4))
             self.assertEqual(by.shape, (4, 2))
-
-    def test_worker_count(self):
-        dataset = self._get_dataset(
-            "data_loader", worker_count=2, num_threads=2
-        )
-        adapter = grain_dataset_adapter.GrainDatasetAdapter(dataset)
-        if backend.backend() == "tensorflow":
-            it = adapter.get_tf_dataset()
-        elif backend.backend() == "jax":
-            it = adapter.get_jax_iterator()
-        elif backend.backend() == "torch":
-            it = adapter.get_torch_dataloader()
-        else:
-            it = adapter.get_numpy_iterator()
-
-        for i, batch in enumerate(it):
-            bx, by = batch
-            self.assertDType(bx, "float32")
-            self.assertDType(by, "float32")
-            if i < 2:
-                self.assertEqual(bx.shape, (16, 4))
-                self.assertEqual(by.shape, (16, 2))
-            else:
-                # TODO: Not sure why the last batch is missing 1 data.
-                self.assertIn(bx.shape, [(2, 4), (1, 4)])
-                self.assertIn(by.shape, [(2, 2), (1, 2)])
 
     def test_num_batches(self):
         dataset = grain.MapDataset.range(42)

--- a/keras/src/trainers/data_adapters/grain_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/grain_dataset_adapter_test.py
@@ -1,0 +1,217 @@
+import grain
+import numpy as np
+import tensorflow as tf
+import torch
+from absl.testing import parameterized
+
+from keras.src import backend
+from keras.src import testing
+from keras.src.testing.test_utils import named_product
+from keras.src.trainers.data_adapters import grain_dataset_adapter
+
+
+class GrainDatasetAdapterTest(testing.TestCase):
+    def _get_dataset(self, dataset_type, worker_count=0, num_threads=0):
+        x = np.random.normal(size=(34, 4)).astype("float32")
+        y = np.random.normal(size=(34, 2)).astype("float32")
+
+        class MySource(grain.sources.RandomAccessDataSource):
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+            def __getitem__(self, idx):
+                return self.x[idx], self.y[idx]
+
+            def __len__(self):
+                return len(self.x)
+
+        if dataset_type == "map_dataset":
+            dataset = grain.MapDataset.source(MySource(x, y)).batch(
+                batch_size=16
+            )
+        elif dataset_type == "iter_dataset":
+            dataset = (
+                grain.MapDataset.source(MySource(x, y))
+                .to_iter_dataset()
+                .batch(batch_size=16)
+            )
+        else:
+            source = MySource(x, y)
+            dataset = grain.DataLoader(
+                data_source=source,
+                operations=[grain.transforms.Batch(batch_size=16)],
+                shard_options=grain.sharding.NoSharding(),
+                sampler=grain.samplers.IndexSampler(
+                    num_records=len(source), num_epochs=1
+                ),
+                worker_count=worker_count,
+                read_options=grain.ReadOptions(num_threads=num_threads),
+            )
+        return dataset
+
+    @parameterized.named_parameters(
+        named_product(
+            dataset_type=["map_datast", "iter_dataset", "data_loader"]
+        )
+    )
+    def test_basic_flow(self, dataset_type):
+        dataset = self._get_dataset(dataset_type)
+        adapter = grain_dataset_adapter.GrainDatasetAdapter(dataset)
+
+        if dataset_type == "iter_dataset":
+            self.assertEqual(adapter.num_batches, None)
+        else:
+            self.assertEqual(adapter.num_batches, 3)
+        self.assertEqual(adapter.batch_size, 16)
+        self.assertEqual(adapter.has_partial_batch, None)
+        self.assertEqual(adapter.partial_batch_size, None)
+
+        if backend.backend() == "tensorflow":
+            it = adapter.get_tf_dataset()
+            expected_class = tf.Tensor
+        elif backend.backend() == "jax":
+            it = adapter.get_jax_iterator()
+            expected_class = np.ndarray
+        elif backend.backend() == "torch":
+            it = adapter.get_torch_dataloader()
+            expected_class = torch.Tensor
+        else:
+            it = adapter.get_numpy_iterator()
+            expected_class = np.ndarray
+
+        for i, batch in enumerate(it):
+            self.assertEqual(len(batch), 2)
+            bx, by = batch
+            self.assertIsInstance(bx, expected_class)
+            self.assertIsInstance(by, expected_class)
+            self.assertEqual(bx.dtype, by.dtype)
+            self.assertContainsExactSubsequence(str(bx.dtype), "float32")
+            if i < 2:
+                self.assertEqual(bx.shape, (16, 4))
+                self.assertEqual(by.shape, (16, 2))
+            else:
+                self.assertEqual(bx.shape, (2, 4))
+                self.assertEqual(by.shape, (2, 2))
+
+    @parameterized.named_parameters(
+        named_product(data_type=["list", "dict", "nested_list", "nested_dict"])
+    )
+    def test_nested_data(self, data_type):
+        if data_type not in ("list", "dict", "nested_list", "nested_dict"):
+            raise ValueError(
+                "data_type must be one of 'list', 'dict', 'nested_list' or "
+                f"'nested_dict'. Received: {data_type}"
+            )
+
+        class NestedSource(grain.sources.RandomAccessDataSource):
+            def __init__(self, data_type):
+                self.x = np.random.random((40, 4)).astype("float32")
+                self.y = np.random.random((40, 2)).astype("float32")
+                self.data_type = data_type
+
+            def __len__(self):
+                return len(self.x)
+
+            def __getitem__(self, idx):
+                x = self.x[idx]
+                y = self.y[idx]
+                if self.data_type == "list":
+                    return x, y
+                elif self.data_type == "dict":
+                    return {"x": x, "y": y}
+                elif self.data_type == "nested_list":
+                    return x, (x, y)
+                elif self.data_type == "nested_dict":
+                    return {"data": {"x": x, "y": y}}
+
+        dataset = grain.MapDataset.source(NestedSource(data_type)).batch(
+            batch_size=4
+        )
+        adapter = grain_dataset_adapter.GrainDatasetAdapter(dataset)
+
+        if backend.backend() == "tensorflow":
+            it = adapter.get_tf_dataset()
+            expected_class = tf.Tensor
+        elif backend.backend() == "jax":
+            it = adapter.get_jax_iterator()
+            expected_class = np.ndarray
+        elif backend.backend() == "torch":
+            it = adapter.get_torch_dataloader()
+            expected_class = torch.Tensor
+        else:
+            it = adapter.get_numpy_iterator()
+            expected_class = np.ndarray
+
+        for batch in it:
+            if data_type == "list":
+                self.assertEqual(len(batch), 2)
+                bx, by = batch
+            elif data_type == "dict":
+                self.assertEqual(len(batch), 2)
+                bx, by = batch["x"], batch["y"]
+            elif data_type == "nested_list":
+                self.assertEqual(len(batch), 2)
+                bx, (_, by) = batch
+            elif data_type == "nested_dict":
+                self.assertEqual(len(batch["data"]), 2)
+                bx, by = batch["data"]["x"], batch["data"]["y"]
+            self.assertIsInstance(bx, expected_class)
+            self.assertIsInstance(by, expected_class)
+            self.assertEqual(bx.dtype, by.dtype)
+            self.assertEqual(bx.shape, (4, 4))
+            self.assertEqual(by.shape, (4, 2))
+
+    def test_worker_count(self):
+        dataset = self._get_dataset(
+            "data_loader", worker_count=2, num_threads=2
+        )
+        adapter = grain_dataset_adapter.GrainDatasetAdapter(dataset)
+        if backend.backend() == "tensorflow":
+            it = adapter.get_tf_dataset()
+        elif backend.backend() == "jax":
+            it = adapter.get_jax_iterator()
+        elif backend.backend() == "torch":
+            it = adapter.get_torch_dataloader()
+        else:
+            it = adapter.get_numpy_iterator()
+
+        for i, batch in enumerate(it):
+            bx, by = batch
+            self.assertDType(bx, "float32")
+            self.assertDType(by, "float32")
+            if i < 2:
+                self.assertEqual(bx.shape, (16, 4))
+                self.assertEqual(by.shape, (16, 2))
+            else:
+                # TODO: Not sure why the last batch is missing 1 data.
+                self.assertIn(bx.shape, [(2, 4), (1, 4)])
+                self.assertIn(by.shape, [(2, 2), (1, 2)])
+
+    def test_num_batches(self):
+        dataset = grain.MapDataset.range(42)
+        adapter = grain_dataset_adapter.GrainDatasetAdapter(dataset)
+        self.assertEqual(adapter.num_batches, 42)
+
+        # Test for Infinite Cardinality
+        dataset = grain.MapDataset.range(42)
+        dataset = dataset.repeat()
+        adapter = grain_dataset_adapter.GrainDatasetAdapter(dataset)
+        self.assertIsNone(adapter.num_batches)
+
+        # Test for Unknown Cardinality
+        dataset = dataset.filter(lambda x: True)
+        adapter = grain_dataset_adapter.GrainDatasetAdapter(dataset)
+        self.assertIsNone(adapter.num_batches)
+
+    def test_invalid_dataset_type(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            (
+                r"Expected argument `dataset` to be a grain.MapDataset, "
+                r"grain.IterDataset or grain.DataLoader. "
+            ),
+        ):
+            grain_dataset_adapter.GrainDatasetAdapter(
+                "This is not a grain.Dataset"
+            )

--- a/keras/src/trainers/data_adapters/grain_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/grain_dataset_adapter_test.py
@@ -171,6 +171,20 @@ class GrainDatasetAdapterTest(testing.TestCase):
             self.assertEqual(bx.shape, (4, 4))
             self.assertEqual(by.shape, (4, 2))
 
+    def test_multiple_calling_on_iterators(self):
+        dataset = self._get_dataset("iter_dataset")
+        adapter = grain_dataset_adapter.GrainDatasetAdapter(dataset)
+
+        numpy_it = adapter.get_numpy_iterator()
+        jax_it = adapter.get_jax_iterator()
+        tf_it = adapter.get_tf_dataset()
+        torch_it = adapter.get_torch_dataloader()
+        for it in (numpy_it, jax_it, tf_it, torch_it):
+            for batch in it:
+                self.assertEqual(len(batch), 2)
+                bx, by = batch
+                self.assertEqual(bx.dtype, by.dtype)
+
     def test_builtin_prefetch(self):
         dataset = grain.MapDataset.source(Range2DSource(0, 42))
         adapter = grain_dataset_adapter.GrainDatasetAdapter(dataset)

--- a/keras/src/trainers/data_adapters/tf_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/tf_dataset_adapter.py
@@ -61,6 +61,10 @@ class TFDatasetAdapter(DataAdapter):
         return data_adapter_utils.get_torch_dataloader(self._dataset)
 
     @property
+    def builtin_prefetch(self):
+        return True
+
+    @property
     def num_batches(self):
         cardinality = self._dataset.cardinality
         if callable(cardinality):

--- a/keras/src/trainers/data_adapters/tf_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/tf_dataset_adapter_test.py
@@ -84,6 +84,11 @@ class TestTFDatasetAdapter(testing.TestCase):
     def test_class_weights_categorical_targets(self):
         self._test_class_weights(target_encoding="categorical")
 
+    def test_builtin_prefetch(self):
+        dataset = tf.data.Dataset.range(42)
+        adapter = tf_dataset_adapter.TFDatasetAdapter(dataset)
+        self.assertTrue(adapter.builtin_prefetch)
+
     def test_num_batches(self):
         dataset = tf.data.Dataset.range(42)
         cardinality = int(dataset.cardinality())

--- a/keras/src/trainers/data_adapters/torch_data_loader_adapter.py
+++ b/keras/src/trainers/data_adapters/torch_data_loader_adapter.py
@@ -64,6 +64,14 @@ class TorchDataLoaderAdapter(DataAdapter):
         return self._dataloader
 
     @property
+    def builtin_prefetch(self):
+        prefetch_factor = self._dataloader.prefetch_factor
+        if prefetch_factor is not None and prefetch_factor > 0:
+            return True
+        else:
+            return False
+
+    @property
     def num_batches(self):
         return self._num_batches
 

--- a/keras/src/trainers/data_adapters/torch_data_loader_adapter_test.py
+++ b/keras/src/trainers/data_adapters/torch_data_loader_adapter_test.py
@@ -171,3 +171,17 @@ class TestTorchDataLoaderAdapter(testing.TestCase):
             else:
                 self.assertEqual(bx.shape, (2, 6))
                 self.assertEqual(by.shape, (2, 2))
+
+    @parameterized.named_parameters(named_product(num_workers=[0, 2]))
+    def test_builtin_prefetch(self, num_workers):
+        x = torch.normal(2, 3, size=(34, 4))
+        y = torch.normal(1, 3, size=(34, 2))
+        ds = torch.utils.data.TensorDataset(x, y)
+        dataloader = torch.utils.data.DataLoader(
+            ds, batch_size=16, num_workers=num_workers
+        )
+        adapter = TorchDataLoaderAdapter(dataloader)
+        if num_workers > 0:
+            self.assertTrue(adapter.builtin_prefetch)
+        else:
+            self.assertFalse(adapter.builtin_prefetch)

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -217,6 +217,35 @@ def create_dataset(dataset_type, dataset_kwargs):
             return generate_infinite(), None
         else:
             return generate_finite(), None
+    elif dataset_type == "grain_datast":
+        import grain
+
+        class TestIterableDataset(grain.sources.RandomAccessDataSource):
+            def __init__(self):
+                super().__init__()
+                self.x = np.ones((100, 4)).astype("float32")
+                self.y = np.zeros((100, 3)).astype("float32")
+
+            def __len__(self):
+                return len(self.x)
+
+            def __getitem__(self, idx):
+                return self.x[idx], self.y[idx]
+
+        if dataset_kwargs.get("use_dataloader", False):
+            source = TestIterableDataset()
+            dataloader = grain.DataLoader(
+                data_source=source,
+                sampler=grain.samplers.IndexSampler(len(source), num_epochs=1),
+                operations=[grain.transforms.Batch(batch_size=5)],
+            )
+            return dataloader, None
+        else:
+            dataset = grain.MapDataset.source(TestIterableDataset())
+            if dataset_kwargs.get("has_len", False):
+                dataset = dataset.to_iter_dataset()
+            dataset = dataset.batch(5)
+            return dataset, None
     else:
         raise ValueError(f"Invalid dataset type {dataset_type}")
 
@@ -615,17 +644,36 @@ class TestTrainer(testing.TestCase):
                 "dataset_kwargs": {"infinite": True},
                 "fit_kwargs": {"steps_per_epoch": 20},
             },
+            {
+                "testcase_name": "grain_datast",
+                "dataset_type": "grain_datast",
+                "dataset_kwargs": {"has_len": False},
+            },
+            {
+                "testcase_name": "grain_datast_with_len",
+                "dataset_type": "grain_datast",
+                "dataset_kwargs": {"has_len": True},
+            },
+            {
+                "testcase_name": "grain_dataloader",
+                "dataset_type": "grain_datast",
+                "dataset_kwargs": {"use_dataloader": True},
+            },
         ]
     )
     @pytest.mark.requires_trainable_backend
     def test_fit_with_data_adapter(
         self, dataset_type, dataset_kwargs={}, fit_kwargs={}
     ):
+        jit_compile = True
         if (
             dataset_kwargs.get("use_multiprocessing", False)
             and backend.backend() == "jax"
         ):
             pytest.skip("Multiprocessing not supported with JAX backend")
+        if dataset_type == "grain_datast" and backend.backend() == "torch":
+            # Grain datasets are not supported with torch + jit_compile.
+            jit_compile = False
 
         model = ExampleModel(units=3)
         optimizer = optimizers.Adagrad()
@@ -633,7 +681,7 @@ class TestTrainer(testing.TestCase):
             optimizer=optimizer,
             loss=losses.MeanSquaredError(),
             metrics=[metrics.MeanSquaredError()],
-            jit_compile=True,
+            jit_compile=jit_compile,
         )
         x, y = create_dataset(dataset_type, dataset_kwargs)
         model.fit(x, y, epochs=3, **fit_kwargs)

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -27,3 +27,5 @@ onnxruntime
 # > 0.3.1 breaks LSTM model export in torch backend.
 onnxscript<=0.3.1
 openvino
+# for grain_dataset_adapter_test.py
+grain


### PR DESCRIPTION
This PR adds a new `GrainDatasetAdapter`.

With this PR, we can now pass a `grain.MapDataset`, `grain.IterDataset`, or `grain.DataLoader` (with `worker_count >= 0`) into `Model.fit`, `Model.predict`, and `Model.evaluate`.

Thanks to @mattdangerw for the detailed doc on this proposal!

## Overview

We propose gradually switching Keras default mode of preprocessing from [tf.data](https://www.tensorflow.org/guide/data) to [PyGrain](https://github.com/google/grain). We want the following:
1. A uniform preprocessing experience across backends. Write preprocessing once, switch backends seamlessly. Have the option, but not the requirement, to use backend specific solutions (e.g. torch data loaders).
2. Minimal dependencies. We should not depend on the TensorFlow binary (which is huge) or TensorflowText (which is largely unmaintained) on other backends. Similarly we should not need Jax when running Torch or Torch when running Jax.
3. Multi-processed execution for arbitrary python code. We should be able to run regular python preprocessing code without needing to worry about compiled graph compatibility or XLA constraints. Users should be able to mix in arbitrary python code and python packages and get reasonably fast execution by simply running across all available CPU cores.

tf.data is a good solution for 1) but not 2) and 3). This has been a long running source of user pain since the release of Keras 3 (e.g. [bug](https://github.com/keras-team/keras/issues/20071), [bug](https://github.com/keras-team/keras/issues/19895), [bug](https://github.com/keras-team/keras-hub/issues/2101)).
We are not dogmatically attached to PyGrain, but believe it is the best available option – it solves all three points above and is becoming the default preprocessing solution for JAX.

## Benchmark

|Dataloader|Backend|`fit()` cost time (step time)|`evaluate` cost time|
|-|-|-|-|
|`grain.IterDataset`|JAX|2.81s (2ms)|0.11s|
|`grain.DataLoader`|JAX|4.64s (3ms)|0.11s|
|`PyDataset`|JAX|0.73s (503us)|0.03s|
|`tf.data`|JAX|0.84s (523us)|0.04s|
|`torch.utils.data.DataLoader`|JAX|1.31s (894us)|0.06s|

Note that I didn’t enable multiprocessing or prefetching in any of the dataloaders to simplify the test, so the performance here isn’t optimized.
Also, the dataset is in memory with no heavy augmentation which might differ from real-world scenarios.

Here is the script that benchmarks various dataloaders on the MNIST dataset:

`python3 benchmark.py --type [grain_dataloader|grain_dataset|pydataset|tf_data|torch_dataloader]`

<details>

<summary>benchmark.py</summary>

```python
import argparse
import math
import time

import grain
import numpy as np
from torch.utils.data import DataLoader
from torch.utils.data import Dataset

import keras
from keras.src import datasets
from keras.src import layers
from keras.src import utils
from keras.src.trainers.data_adapters.py_dataset_adapter import PyDataset


class MNISTSource(grain.sources.RandomAccessDataSource):
    def __init__(self, x, y):
        super().__init__()
        self.x = x
        self.y = y

    def __len__(self):
        return len(self.x)

    def __getitem__(self, index):
        return self.x[index], self.y[index]


class MNISTPyDataset(PyDataset):
    def __init__(self, x, y, batch_size=128):
        super().__init__()
        self.x = x
        self.y = y
        self.batch_size = batch_size

    def __len__(self):
        return math.ceil(len(self.x) / self.batch_size)

    def __getitem__(self, idx):
        low = idx * self.batch_size
        high = min(low + self.batch_size, len(self.x))
        batch_x = self.x[low:high]
        batch_y = self.y[low:high]
        return batch_x, batch_y


class MNISTTorchDataset(Dataset):
    def __init__(self, x, y):
        self.x = x
        self.y = y

    def __len__(self):
        return len(self.x)

    def __getitem__(self, index):
        return self.x[index], self.y[index]


if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument(
        "--type",
        choices=[
            "grain_dataloader",
            "grain_dataset",
            "pydataset",
            "tf_data",
            "torch_dataloader",
        ],
        default="grain_dataloader",
    )
    args = parser.parse_args()

    # Set the parameters.
    num_classes = 10
    batch_size = 128
    epochs = 3
    input_shape = (28, 28, 1)

    # Build the MNIST train & test dataloader.
    (x_train, y_train), (x_test, y_test) = datasets.mnist.load_data()
    x_train = np.expand_dims(x_train.astype("float32") / 255, -1)
    x_test = np.expand_dims(x_test.astype("float32") / 255, -1)
    y_train = utils.to_categorical(y_train, num_classes).astype("float32")
    y_test = utils.to_categorical(y_test, num_classes).astype("float32")

    if args.type == "grain_dataloader":
        train_source = MNISTSource(x_train, y_train)
        test_source = MNISTSource(x_test, y_test)
        train_dataloader = grain.DataLoader(
            data_source=train_source,
            sampler=grain.samplers.IndexSampler(
                len(train_source), shuffle=True, num_epochs=1, seed=42
            ),
            operations=[grain.transforms.Batch(batch_size=batch_size)],
        )
        test_dataloader = grain.DataLoader(
            data_source=test_source,
            sampler=grain.samplers.IndexSampler(
                len(test_source), shuffle=False, num_epochs=1
            ),
            operations=[grain.transforms.Batch(batch_size=batch_size)],
        )
    elif args.type == "grain_dataset":
        train_source = MNISTSource(x_train, y_train)
        test_source = MNISTSource(x_test, y_test)
        train_dataloader = (
            grain.MapDataset.source(train_source)
            .shuffle(seed=42)
            .to_iter_dataset()
            .batch(batch_size)
        )
        test_dataloader = (
            grain.MapDataset.source(test_source)
            .to_iter_dataset()
            .batch(batch_size)
        )
    elif args.type == "pydataset":
        train_dataloader = MNISTPyDataset(
            x_train, y_train, batch_size=batch_size
        )
        test_dataloader = MNISTPyDataset(x_test, y_test, batch_size=batch_size)
    elif args.type == "tf_data":
        import tensorflow as tf

        train_dataloader = tf.data.Dataset.from_tensor_slices(
            (x_train, y_train)
        )
        train_dataloader = (
            train_dataloader.shuffle(60000).batch(batch_size).prefetch(1)
        )
        test_dataloader = tf.data.Dataset.from_tensor_slices((x_test, y_test))
        test_dataloader = test_dataloader.batch(batch_size)
    elif args.type == "torch_dataloader":
        train_dataloader = DataLoader(
            MNISTTorchDataset(x_train, y_train),
            batch_size=batch_size,
            shuffle=True,
        )
        test_dataloader = DataLoader(
            MNISTTorchDataset(x_test, y_test),
            batch_size=batch_size,
            shuffle=False,
        )
    else:
        raise ValueError(f"Unknown type: {args.type}")

    # Build a simple ConvNet.
    model = keras.Sequential(
        [
            keras.Input(shape=input_shape),
            layers.Conv2D(32, kernel_size=(3, 3), activation="relu"),
            layers.MaxPooling2D(pool_size=(2, 2)),
            layers.Conv2D(64, kernel_size=(3, 3), activation="relu"),
            layers.MaxPooling2D(pool_size=(2, 2)),
            layers.Flatten(),
            layers.Dropout(0.5),
            layers.Dense(num_classes, activation="softmax"),
        ]
    )
    model.compile(
        loss="categorical_crossentropy", optimizer="adam", metrics=["accuracy"]
    )

    # Warmup.
    print("Warmup...")
    model.fit(train_dataloader, batch_size=batch_size, epochs=3, verbose=0)
    model.evaluate(test_dataloader, verbose=0)

    # Benchmark.
    print("Benchmark...")
    time_start_fit = time.time()
    model.fit(train_dataloader, batch_size=batch_size, epochs=epochs)
    time_end_fit = time.time()
    score = model.evaluate(test_dataloader, verbose=0)
    time_end_evaluate = time.time()
    print("Test loss:", score[0])
    print("Test accuracy:", score[1])
    print(f"Fit cost time: {time_end_fit - time_start_fit:.2f} s")
    print(f"Evaluate cost time: {time_end_evaluate - time_end_fit:.2f} s")
```

</details>

## Reference

- https://google-grain.readthedocs.io/en/latest/
- https://github.com/google/grain/tree/main
- https://github.com/rcrowe-google/Learning-JAX (Thanks to @rcrowe-google for sharing the materials!)

## Additional Notes

cc @mattdangerw @divyashreepathihalli 