### PR TITLE
[OpenVINO backend] add supporting for lists and tuples in get_ov_output

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -110,6 +110,13 @@ def get_ov_output(x, ov_type=None):
             x = ov_opset.constant(x, OPENVINO_DTYPES["bfloat16"]).output(0)
         else:
             x = ov_opset.constant(x).output(0)
+    elif isinstance(x, (list, tuple)):
+        if isinstance(x, tuple):
+            x = list(x)
+        if ov_type is None:
+            x = ov_opset.constant(x).output(0)
+        else:
+            x = ov_opset.constant(x, ov_type).output(0)
     elif np.isscalar(x):
         x = ov_opset.constant(x).output(0)
     elif isinstance(x, KerasVariable):


### PR DESCRIPTION
@rkazants 

These tests fails due to passing lists and tuples:
https://github.com/keras-team/keras-hub/blob/master/keras_hub/src/layers/modeling/rotary_embedding_test.py#L88-L98

https://github.com/keras-team/keras-hub/blob/master/keras_hub/src/layers/modeling/rotary_embedding_test.py#L110-L157

https://github.com/keras-team/keras-hub/blob/master/keras_hub/src/utils/tensor_utils_test.py#L198-L205

here is a reproducer:
```python
from keras import ops
import numpy as np

data = ops.convert_to_tensor(np.random.rand(2, 3, 4), dtype="float32")
permuted_data = ops.transpose(data, (0, 2, 1))
print(ops.convert_to_numpy(permuted_data))
```