### PR TITLE
[OpenVINO backend] fix numpy conversions

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -492,6 +492,21 @@ class OpenVINOKerasTensor:
         )
         return OpenVINOKerasTensor(ov_opset.mod(first, other).output(0))
 
+    def __array__(self, dtype=None):
+        try:
+            tensor = cast(self, dtype=dtype) if dtype is not None else self
+            return convert_to_numpy(tensor)
+        except Exception as e:
+            raise RuntimeError(
+                "A OpenVINOKerasTensor is symbolic: it's a placeholder "
+                "for a shape and a dtype.\n"
+                "It doesn't have any actual numerical value.\n"
+                "You cannot convert it to a NumPy array."
+            ) from e
+
+    def numpy(self):
+        return self.__array__()
+
 
 def ov_to_keras_type(ov_type):
     for _keras_type, _ov_type in OPENVINO_DTYPES.items():
@@ -670,8 +685,10 @@ def convert_to_numpy(x):
         ov_model = Model(results=[ov_result], parameters=[])
         ov_compiled_model = compile_model(ov_model, get_device())
         result = ov_compiled_model({})[0]
-    except:
-        raise "`convert_to_numpy` cannot convert to numpy"
+    except Exception as inner_exception:
+        raise RuntimeError(
+            "`convert_to_numpy` failed to convert the tensor."
+        ) from inner_exception
     return result
 
 
@@ -688,6 +705,7 @@ def shape(x):
 
 
 def cast(x, dtype):
+    dtype = standardize_dtype(dtype)
     ov_type = OPENVINO_DTYPES[dtype]
     x = get_ov_output(x)
     return OpenVINOKerasTensor(ov_opset.convert(x, ov_type).output(0))

--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -498,7 +498,7 @@ class OpenVINOKerasTensor:
             return convert_to_numpy(tensor)
         except Exception as e:
             raise RuntimeError(
-                "A OpenVINOKerasTensor is symbolic: it's a placeholder "
+                "An OpenVINOKerasTensor is symbolic: it's a placeholder "
                 "for a shape and a dtype.\n"
                 "It doesn't have any actual numerical value.\n"
                 "You cannot convert it to a NumPy array."


### PR DESCRIPTION
@rkazants  
@fchollet  

I've noticed that this test (and several similar ones) pass on all backends **except OpenVINO**:  
https://github.com/keras-team/keras-hub/blob/master/keras_hub/src/layers/preprocessing/masked_lm_mask_generator_test.py#L46-L59

After investigating, I found that the following minimal example works correctly on `TensorFlow`, `JAX`, and `Torch` backends, but fails with `OpenVINO`:

```python
import os
os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
os.environ["KERAS_BACKEND"] = "openvino"

from keras import ops
import numpy as np

tensor = np.array([[1, 2, 3], [4, 5, 6]], dtype="float32")
tensor = ops.convert_to_tensor(tensor)
print(np.array(tensor, dtype="int32"))  # Works on other backends, fails here for OpenVINO
```
```
(env) mohamed-ashraf@mohamed-ashraf-LOQ-15IRX9:~/Desktop/GSoC2025$ python test_array.py 
/home/mohamed-ashraf/Desktop/GSoC2025/env/lib/python3.12/site-packages/openvino/runtime/__init__.py:10: DeprecationWarning: The `openvino.runtime` module is deprecated and will be removed in the 2026.0 release. Please replace `openvino.runtime` with `openvino`.
  warnings.warn(
[[1 2 3]
 [4 5 6]]
```
To confirm the fix, I also created a reproducer that explicitly simulates the failure when an `OpenVINOKerasTensor` is used as a symbolic placeholder and `.numpy()` conversion is attempted:
```python 
import os
os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
os.environ["KERAS_BACKEND"] = "openvino"

import numpy as np
import openvino as ov
from openvino import opset14 as ov_opset
from keras.src.backend.openvino.core import OpenVINOKerasTensor

# Construct a symbolic tensor manually
x = OpenVINOKerasTensor(ov_opset.parameter(shape=(3,), dtype=ov.Type.f32).output(0))
y = x * 2

print(np.array(y))  # Expected to raise ValueError for symbolic tensors
```
```
(env) mohamed-ashraf@mohamed-ashraf-LOQ-15IRX9:~/Desktop/GSoC2025$ python test_array.py 
/home/mohamed-ashraf/Desktop/GSoC2025/env/lib/python3.12/site-packages/openvino/runtime/__init__.py:10: DeprecationWarning: The `openvino.runtime` module is deprecated and will be removed in the 2026.0 release. Please replace `openvino.runtime` with `openvino`.
  warnings.warn(
Traceback (most recent call last):
  File "/home/mohamed-ashraf/Desktop/GSoC2025/keras/keras/src/backend/openvino/core.py", line 685, in convert_to_numpy
    ov_model = Model(results=[ov_result], parameters=[])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mohamed-ashraf/Desktop/GSoC2025/env/lib/python3.12/site-packages/openvino/_ov_api.py", line 81, in __init__
    self.__model = ModelBase(**kwargs)
                   ^^^^^^^^^^^^^^^^^^^
RuntimeError: Check 'unregistered_parameters.str().empty()' failed at src/core/src/model.cpp:58:
Model references undeclared parameters: opset1::Parameter Parameter_1 () -> (f32[3])



The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/mohamed-ashraf/Desktop/GSoC2025/keras/keras/src/backend/openvino/core.py", line 498, in __array__
    return convert_to_numpy(tensor)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mohamed-ashraf/Desktop/GSoC2025/keras/keras/src/backend/openvino/core.py", line 689, in convert_to_numpy
    raise RuntimeError(
RuntimeError: `convert_to_numpy` failed to convert the tensor.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/mohamed-ashraf/Desktop/GSoC2025/test_array.py", line 26, in <module>
    print(np.array(y))
          ^^^^^^^^^^^
  File "/home/mohamed-ashraf/Desktop/GSoC2025/keras/keras/src/backend/openvino/core.py", line 500, in __array__
    raise RuntimeError(
RuntimeError: An OpenVINOKerasTensor is symbolic: it's a placeholder for a shape and a dtype.
It doesn't have any actual numerical value.
You cannot convert it to a NumPy array.
```