### PR TITLE
Support shape -1 for `slice` op in the jax backend

### DIFF
--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -300,7 +300,13 @@ def scatter_update(inputs, indices, updates):
 
 
 def slice(inputs, start_indices, shape):
-    return jax.lax.dynamic_slice(inputs, start_indices, shape)
+    # If shape[i] is -1, all remaining elements in dimension i are included in
+    #  the slice.
+    final_shape = tuple(
+        inputs.shape[i] - start_indices[i] if s == -1 else s
+        for i, s in enumerate(shape)
+    )
+    return jax.lax.dynamic_slice(inputs, start_indices, final_shape)
 
 
 def slice_update(inputs, start_indices, updates):

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -301,7 +301,7 @@ def scatter_update(inputs, indices, updates):
 
 def slice(inputs, start_indices, shape):
     # If shape[i] is -1, all remaining elements in dimension i are included in
-    #  the slice.
+    # the slice.
     final_shape = tuple(
         inputs.shape[i] - start_indices[i] if s == -1 else s
         for i, s in enumerate(shape)

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -397,6 +397,13 @@ class Slice(Operation):
         return backend.core.slice(inputs, start_indices, self.shape)
 
     def compute_output_spec(self, inputs, start_indices):
+        if any(s == -1 for s in self.shape) and isinstance(
+            start_indices, KerasTensor
+        ):
+            raise ValueError(
+                "When using -1 in `shape`, `start_indices` should not be a "
+                "KerasTensor. "
+            )
         # If self.shape[i] is -1, all remaining elements in dimension i are
         # included in the slice.
         final_shape = tuple(

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -397,7 +397,7 @@ class Slice(Operation):
         return backend.core.slice(inputs, start_indices, self.shape)
 
     def compute_output_spec(self, inputs, start_indices):
-        # If shape[i] is -1, all remaining elements in dimension i are
+        # If self.shape[i] is -1, all remaining elements in dimension i are
         # included in the slice.
         final_shape = tuple(
             inputs.shape[i] - start_indices[i] if s == -1 else s

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -397,7 +397,13 @@ class Slice(Operation):
         return backend.core.slice(inputs, start_indices, self.shape)
 
     def compute_output_spec(self, inputs, start_indices):
-        return KerasTensor(self.shape, dtype=inputs.dtype)
+        # If shape[i] is -1, all remaining elements in dimension i are
+        # included in the slice.
+        final_shape = tuple(
+            inputs.shape[i] - start_indices[i] if s == -1 else s
+            for i, s in enumerate(self.shape)
+        )
+        return KerasTensor(final_shape, dtype=inputs.dtype)
 
 
 @keras_export("keras.ops.slice")

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -265,6 +265,14 @@ class CoreOpsStaticShapeTest(testing.TestCase):
         shape = (2, 2)
         self.assertEqual(core.slice(inputs, start_indices, shape).shape, (2, 2))
 
+    def test_slice_dynamic_shape(self):
+        inputs = KerasTensor(shape=(3, 3), dtype="float32")
+        start_indices = (1, 1)
+        dynamic_shape = (-1, -1)
+        self.assertEqual(
+            core.slice(inputs, start_indices, dynamic_shape).shape, (2, 2)
+        )
+
     def test_slice_update(self):
         inputs = KerasTensor((4, 4))
         start_indices = KerasTensor((2,))

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -271,6 +271,13 @@ class CoreOpsStaticShapeTest(testing.TestCase):
         shape = (-1, -1)
         self.assertEqual(core.slice(inputs, start_indices, shape).shape, (2, 2))
 
+    def test_slice_negative_one_shape_raises(self):
+        inputs = KerasTensor(shape=(3, 3), dtype="float32")
+        start_indices = KerasTensor(shape=(2,), dtype="int32")
+        shape = (-1, -1)
+        with self.assertRaises(ValueError):
+            core.slice(inputs, start_indices, shape)
+
     def test_slice_update(self):
         inputs = KerasTensor((4, 4))
         start_indices = KerasTensor((2,))

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -265,13 +265,11 @@ class CoreOpsStaticShapeTest(testing.TestCase):
         shape = (2, 2)
         self.assertEqual(core.slice(inputs, start_indices, shape).shape, (2, 2))
 
-    def test_slice_dynamic_shape(self):
+    def test_slice_negative_one_shape(self):
         inputs = KerasTensor(shape=(3, 3), dtype="float32")
         start_indices = (1, 1)
-        dynamic_shape = (-1, -1)
-        self.assertEqual(
-            core.slice(inputs, start_indices, dynamic_shape).shape, (2, 2)
-        )
+        shape = (-1, -1)
+        self.assertEqual(core.slice(inputs, start_indices, shape).shape, (2, 2))
 
     def test_slice_update(self):
         inputs = KerasTensor((4, 4))


### PR DESCRIPTION
TF's slice op supports -1 for shape (https://www.tensorflow.org/api_docs/python/tf/slice), which means that all remaining elements in dimension i are included in the slice. Since all the shapes are static in JAX, it errors when -1 is passed. We have a feature request to support -1 shape for the JAX backend as well to have a better UX.