### PR TITLE
Docs - Fixed Syntax Error in vectorized_map function example

### DIFF
--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -1074,18 +1074,18 @@ def vectorized_map(function, elements):
     in the case of a single tensor input `elements`:
 
     ```python
-    def vectorized_map(function, elements)
+    def vectorized_map(function, elements):
         outputs = []
         for e in elements:
             outputs.append(function(e))
-        return stack(outputs)
+        return np.stack(outputs)
     ```
 
     In the case of an iterable of tensors `elements`,
     it implements the following:
 
     ```python
-    def vectorized_map(function, elements)
+    def vectorized_map(function, elements):
         batch_size = elements[0].shape[0]
         outputs = []
         for index in range(batch_size):


### PR DESCRIPTION
I have fixed the [vectorized_map ](https://keras.io/api/ops/core/#vectorizedmap-function)function example in core.py, which had some syntax errors. 