### PR TITLE
fix torch module wrapper serialization error

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -164,11 +164,9 @@ def serialize_keras_object(obj):
 
     # Special cases:
     if isinstance(obj, bytes):
-        import base64
-
         return {
             "class_name": "__bytes__",
-            "config": {"value": base64.b64encode(obj).decode("utf-8")},
+            "config": {"value": obj.decode("utf-8")},
         }
     if isinstance(obj, slice):
         return {
@@ -634,9 +632,7 @@ def deserialize_keras_object(
     if class_name == "__numpy__":
         return np.array(inner_config["value"], dtype=inner_config["dtype"])
     if config["class_name"] == "__bytes__":
-        import base64
-
-        return base64.b64decode(inner_config["value"].encode("utf-8"))
+        return inner_config["value"].encode("utf-8")
     if config["class_name"] == "__ellipsis__":
         return Ellipsis
     if config["class_name"] == "__slice__":

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -164,9 +164,11 @@ def serialize_keras_object(obj):
 
     # Special cases:
     if isinstance(obj, bytes):
+        import base64
+
         return {
             "class_name": "__bytes__",
-            "config": {"value": obj.decode("utf-8")},
+            "config": {"value": base64.b64encode(obj).decode("utf-8")},
         }
     if isinstance(obj, slice):
         return {
@@ -632,7 +634,9 @@ def deserialize_keras_object(
     if class_name == "__numpy__":
         return np.array(inner_config["value"], dtype=inner_config["dtype"])
     if config["class_name"] == "__bytes__":
-        return inner_config["value"].encode("utf-8")
+        import base64
+
+        return base64.b64decode(inner_config["value"].encode("utf-8"))
     if config["class_name"] == "__ellipsis__":
         return Ellipsis
     if config["class_name"] == "__slice__":

--- a/keras/src/utils/torch_utils.py
+++ b/keras/src/utils/torch_utils.py
@@ -1,3 +1,4 @@
+import base64
 import io
 
 from packaging.version import parse
@@ -149,12 +150,11 @@ class TorchModuleWrapper(Layer):
     def get_config(self):
         base_config = super().get_config()
         import torch
-        import base64
 
         buffer = io.BytesIO()
         torch.save(self.module, buffer)
         # Encode the buffer using base64 to ensure safe serialization
-        buffer_b64 = base64.b64encode(buffer.getvalue()).decode("utf-8")
+        buffer_b64 = base64.b64encode(buffer.getvalue()).decode("ascii")
         config = {
             "module": buffer_b64,
             "output_shape": self.output_shape,
@@ -164,11 +164,10 @@ class TorchModuleWrapper(Layer):
     @classmethod
     def from_config(cls, config):
         import torch
-        import base64
 
         if "module" in config:
             # Decode the base64 string back to bytes
-            buffer_bytes = base64.b64decode(config["module"].encode("utf-8"))
+            buffer_bytes = base64.b64decode(config["module"].encode("ascii"))
             buffer = io.BytesIO(buffer_bytes)
             config["module"] = torch.load(buffer, weights_only=False)
         return cls(**config)

--- a/keras/src/utils/torch_utils_test.py
+++ b/keras/src/utils/torch_utils_test.py
@@ -11,6 +11,7 @@ from keras.src import layers
 from keras.src import models
 from keras.src import saving
 from keras.src import testing
+from keras.src.backend.torch.core import get_device
 from keras.src.utils.torch_utils import TorchModuleWrapper
 
 
@@ -260,8 +261,10 @@ class TorchUtilsTest(testing.TestCase):
                 return self.sequence(x)
 
         m = M()
-        device = backend.get_device()  # Get the current device (e.g., "cuda" or "cpu")
-        x = torch.ones((10, 1, 28, 28), device=device)  # Place input on the correct device
+        device = get_device()  # Get the current device (e.g., "cuda" or "cpu")
+        x = torch.ones(
+            (10, 1, 28, 28), device=device
+        )  # Place input on the correct device
         m(x)
         temp_filepath = os.path.join(self.get_temp_dir(), "mymodel.keras")
         m.save(temp_filepath)

--- a/keras/src/utils/torch_utils_test.py
+++ b/keras/src/utils/torch_utils_test.py
@@ -260,7 +260,8 @@ class TorchUtilsTest(testing.TestCase):
                 return self.sequence(x)
 
         m = M()
-        x = torch.ones((10, 1, 28, 28))
+        device = backend.get_device()  # Get the current device (e.g., "cuda" or "cpu")
+        x = torch.ones((10, 1, 28, 28), device=device)  # Place input on the correct device
         m(x)
         temp_filepath = os.path.join(self.get_temp_dir(), "mymodel.keras")
         m.save(temp_filepath)


### PR DESCRIPTION
Fixes : https://github.com/keras-team/keras/issues/19226


The `get_config` method of `TorchModuleWrapper` was attempting to decode a byte array as a UTF-8 string, which was causing an error. 