### PR TITLE
docs: Keras 3 evaluate() and compiled metrics clarification

### DIFF
--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -800,7 +800,7 @@ class Trainer:
         top-level names (e.g., 'loss', 'compile_metrics'), leading to a
         length mismatch. The order of the `evaluate()` output corresponds
         to the order of metrics specified during `model.compile()`. You can
-        use this order to map the evaluate() results to the intended
+        use this order to map the `evaluate()` results to the intended
         metric. `model.metrics_names` itself will still return only the
         top-level names.
         """

--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -795,14 +795,14 @@ class Trainer:
             or list of scalars (if the model has multiple outputs
             and/or metrics).
 
-            Note: When using compiled metrics, `evaluate()` may return multiple
-            submetric values, while `model.metrics_names` often lists only
-            top-level names (e.g., 'loss', 'compile_metrics'), leading to a
-            length mismatch. The order of the `evaluate()` output corresponds
-            to the order of metrics specified during `model.compile()`. You can
-            use this order to map the evaluate() results to the intended
-            metric. `model.metrics_names` itself will still return only the
-            top-level names.
+        Note: When using compiled metrics, `evaluate()` may return multiple
+        submetric values, while `model.metrics_names` often lists only
+        top-level names (e.g., 'loss', 'compile_metrics'), leading to a
+        length mismatch. The order of the `evaluate()` output corresponds
+        to the order of metrics specified during `model.compile()`. You can
+        use this order to map the evaluate() results to the intended
+        metric. `model.metrics_names` itself will still return only the
+        top-level names.
         """
         raise NotImplementedError
 

--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -793,8 +793,16 @@ class Trainer:
         Returns:
             Scalar test loss (if the model has a single output and no metrics)
             or list of scalars (if the model has multiple outputs
-            and/or metrics). The attribute `model.metrics_names` will give you
-            the display labels for the scalar outputs.
+            and/or metrics).
+
+            Note: When using compiled metrics, `evaluate()` may return multiple
+            submetric values, while `model.metrics_names` often lists only
+            top-level names (e.g., 'loss', 'compile_metrics'), leading to a
+            length mismatch. The order of the `evaluate()` output corresponds
+            to the order of metrics specified during `model.compile()`. You can
+            use this order to map the evaluate() results to the intended
+            metric. `model.metrics_names` itself will still return only the
+            top-level names.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
This commit improves the documentation for `evaluate()` when used with compiled metrics in Keras 3.  The existing documentation can be imprecise because `model.metrics_names` does not always provide a complete list of the values returned by `evaluate()`.
[colab gist ](https://colab.sandbox.google.com/gist/sonali-kumari1/9d8548135711679d9d7730d53f24b2f4/-21487.ipynb)

Fixes : [#21487](https://github.com/keras-team/keras/issues/21487)
