### PR TITLE
Implement isneginf function in keras.ops

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -202,6 +202,7 @@ from keras.src.ops.numpy import isfinite as isfinite
 from keras.src.ops.numpy import isin as isin
 from keras.src.ops.numpy import isinf as isinf
 from keras.src.ops.numpy import isnan as isnan
+from keras.src.ops.numpy import isneginf as isneginf
 from keras.src.ops.numpy import kaiser as kaiser
 from keras.src.ops.numpy import left_shift as left_shift
 from keras.src.ops.numpy import less as less

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -91,6 +91,7 @@ from keras.src.ops.numpy import isfinite as isfinite
 from keras.src.ops.numpy import isin as isin
 from keras.src.ops.numpy import isinf as isinf
 from keras.src.ops.numpy import isnan as isnan
+from keras.src.ops.numpy import isneginf as isneginf
 from keras.src.ops.numpy import kaiser as kaiser
 from keras.src.ops.numpy import left_shift as left_shift
 from keras.src.ops.numpy import less as less

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -202,6 +202,7 @@ from keras.src.ops.numpy import isfinite as isfinite
 from keras.src.ops.numpy import isin as isin
 from keras.src.ops.numpy import isinf as isinf
 from keras.src.ops.numpy import isnan as isnan
+from keras.src.ops.numpy import isneginf as isneginf
 from keras.src.ops.numpy import kaiser as kaiser
 from keras.src.ops.numpy import left_shift as left_shift
 from keras.src.ops.numpy import less as less

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -91,6 +91,7 @@ from keras.src.ops.numpy import isfinite as isfinite
 from keras.src.ops.numpy import isin as isin
 from keras.src.ops.numpy import isinf as isinf
 from keras.src.ops.numpy import isnan as isnan
+from keras.src.ops.numpy import isneginf as isneginf
 from keras.src.ops.numpy import kaiser as kaiser
 from keras.src.ops.numpy import left_shift as left_shift
 from keras.src.ops.numpy import less as less

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -787,6 +787,11 @@ def isnan(x):
     return jnp.isnan(x)
 
 
+def isneginf(x):
+    x = convert_to_tensor(x)
+    return jnp.isneginf(x)
+
+
 def less(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -696,6 +696,11 @@ def isnan(x):
     return np.isnan(x)
 
 
+def isneginf(x):
+    x = convert_to_tensor(x)
+    return np.isneginf(x)
+
+
 def less(x1, x2):
     return np.less(x1, x2)
 

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -35,6 +35,7 @@ NumpyDtypeTest::test_isfinite
 NumpyDtypeTest::test_isin
 NumpyDtypeTest::test_isinf
 NumpyDtypeTest::test_isnan
+NumpyDtypeTest::test_isneginf
 NumpyDtypeTest::test_linspace
 NumpyDtypeTest::test_logaddexp
 NumpyDtypeTest::test_logspace
@@ -95,6 +96,7 @@ NumpyOneInputOpsCorrectnessTest::test_floor_divide
 NumpyOneInputOpsCorrectnessTest::test_imag
 NumpyOneInputOpsCorrectnessTest::test_isfinite
 NumpyOneInputOpsCorrectnessTest::test_isinf
+NumpyOneInputOpsCorrectnessTest::test_isneginf
 NumpyOneInputOpsCorrectnessTest::test_logaddexp
 NumpyOneInputOpsCorrectnessTest::test_max
 NumpyOneInputOpsCorrectnessTest::test_mean
@@ -157,10 +159,12 @@ NumpyOneInputOpsDynamicShapeTest::test_corrcoef
 NumpyOneInputOpsDynamicShapeTest::test_deg2rad
 NumpyOneInputOpsDynamicShapeTest::test_hamming
 NumpyOneInputOpsDynamicShapeTest::test_hanning
+NumpyOneInputOpsDynamicShapeTest::test_isneginf
 NumpyOneInputOpsDynamicShapeTest::test_kaiser
 NumpyOneInputOpsStaticShapeTest::test_angle
 NumpyOneInputOpsStaticShapeTest::test_cbrt
 NumpyOneInputOpsStaticShapeTest::test_deg2rad
+NumpyOneInputOpsStaticShapeTest::test_isneginf
 NumpyTwoInputOpsDynamicShapeTest::test_heaviside
 NumpyTwoInputOpsDynamicShapeTest::test_isin
 NumpyTwoInputOpsStaticShapeTest::test_heaviside

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -943,6 +943,12 @@ def isnan(x):
     return OpenVINOKerasTensor(ov_opset.is_nan(x).output(0))
 
 
+def isneginf(x):
+    raise NotImplementedError(
+        "`isneginf` is not supported with openvino backend"
+    )
+
+
 def less(x1, x2):
     element_type = None
     if isinstance(x1, OpenVINOKerasTensor):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1632,6 +1632,9 @@ def isnan(x):
 
 def isneginf(x):
     x = convert_to_tensor(x)
+    dtype_as_dtype = tf.as_dtype(x.dtype)
+    if dtype_as_dtype.is_integer or not dtype_as_dtype.is_numeric:
+        return tf.zeros(x.shape, tf.bool)
     return tf.math.equal(x, -tf.constant(float("inf"), dtype=x.dtype))
 
 

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1630,6 +1630,11 @@ def isnan(x):
     return tf.math.is_nan(x)
 
 
+def isneginf(x):
+    x = convert_to_tensor(x)
+    return tf.math.equal(x, -tf.constant(float("inf"), dtype=x.dtype))
+
+
 def less(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -913,6 +913,11 @@ def isnan(x):
     return torch.isnan(x)
 
 
+def isneginf(x):
+    x = convert_to_tensor(x)
+    return torch.isneginf(x)
+
+
 def less(x1, x2):
     x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
     return torch.less(x1, x2)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -3700,6 +3700,29 @@ def isnan(x):
     return backend.numpy.isnan(x)
 
 
+class IsNegInf(Operation):
+    def call(self, x):
+        return backend.numpy.isneginf(x)
+
+    def compute_output_spec(self, x):
+        return KerasTensor(x.shape, dtype="bool")
+
+
+@keras_export(["keras.ops.isneginf", "keras.ops.numpy.isneginf"])
+def isneginf(x):
+    """Test element-wise for negative infinity.
+
+    Args:
+        x: Input tensor.
+
+    Returns:
+        Output boolean tensor.
+    """
+    if any_symbolic_tensors((x,)):
+        return IsNegInf().symbolic_call(x)
+    return backend.numpy.isneginf(x)
+
+
 class Less(Operation):
     def call(self, x1, x2):
         return backend.numpy.less(x1, x2)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -3700,7 +3700,7 @@ def isnan(x):
     return backend.numpy.isnan(x)
 
 
-class IsNegInf(Operation):
+class Isneginf(Operation):
     def call(self, x):
         return backend.numpy.isneginf(x)
 
@@ -3719,7 +3719,7 @@ def isneginf(x):
         Output boolean tensor.
     """
     if any_symbolic_tensors((x,)):
-        return IsNegInf().symbolic_call(x)
+        return Isneginf().symbolic_call(x)
     return backend.numpy.isneginf(x)
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -7519,6 +7519,22 @@ class NumpyDtypeTest(testing.TestCase):
             expected_dtype,
         )
 
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_isneginf(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((), dtype=dtype)
+        x_jax = jnp.ones((), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.isneginf(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.isneginf(x).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.IsNegInf().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
     @parameterized.named_parameters(
         named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
     )

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1512,6 +1512,10 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.isnan(x).shape, (None, 3))
 
+    def test_isneginf(self):
+        x = KerasTensor((None, 3))
+        self.assertEqual(knp.isneginf(x).shape, (None, 3))
+
     def test_log(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.log(x).shape, (None, 3))
@@ -2104,6 +2108,10 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
     def test_isnan(self):
         x = KerasTensor((2, 3))
         self.assertEqual(knp.isnan(x).shape, (2, 3))
+
+    def test_isneginf(self):
+        x = KerasTensor((2, 3))
+        self.assertEqual(knp.isneginf(x).shape, (2, 3))
 
     def test_log(self):
         x = KerasTensor((2, 3))
@@ -4189,6 +4197,13 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         x = np.array([[1, 2, np.inf], [np.nan, np.nan, np.nan]])
         self.assertAllClose(knp.isnan(x), np.isnan(x))
         self.assertAllClose(knp.Isnan()(x), np.isnan(x))
+
+    def test_isneginf(self):
+        x = np.array(
+            [[1, 2, np.inf, -np.inf], [np.nan, np.nan, np.nan, np.nan]]
+        )
+        self.assertAllClose(knp.isneginf(x), np.isneginf(x))
+        self.assertAllClose(knp.Isneginf()(x), np.isneginf(x))
 
     def test_log(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
@@ -7531,7 +7546,7 @@ class NumpyDtypeTest(testing.TestCase):
             standardize_dtype(knp.isneginf(x).dtype), expected_dtype
         )
         self.assertEqual(
-            standardize_dtype(knp.IsNegInf().symbolic_call(x).dtype),
+            standardize_dtype(knp.Isneginf().symbolic_call(x).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
Adds keras.ops.isneginf, which checks whether each element in the input tensor is negative infinity.
Supported across NumPy, TensorFlow, PyTorch, and JAX backends. Not supported on OpenVINO.