### PR TITLE
Fix support for optional inputs in model.fit

### DIFF
--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -52,6 +52,11 @@ class TensorFlowTrainer(base_trainer.Trainer):
     def train_step(self, data):
         x, y, sample_weight = data_adapter_utils.unpack_x_y_sample_weight(data)
 
+        # Convert TF Optional implementations to None
+        x = tree.map_structure(
+            lambda i: None if isinstance(i, tf.experimental.Optional) else i, x
+        )
+
         # Forward pass
         with tf.GradientTape() as tape:
             if self._call_has_training_arg:

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -1245,7 +1245,7 @@ class ModelTest(testing.TestCase):
         x2 = None if is_optional_none else np.ones((2, 2))
         y_true = np.ones((2, 2))
 
-        model.compile(loss=losses.MeanSquaredError)
+        model.compile(loss="mse", optimizer="adam")
         model.fit(x={"x1": x1, "x2": x2}, y=y_true)
         model.evaluate(x={"x1": x1, "x2": x2}, y=y_true)
         model.predict(x={"x1": x1, "x2": x2})
@@ -1263,7 +1263,7 @@ class ModelTest(testing.TestCase):
             for _ in range(4):
                 yield ({"x1": x1, "x2": x2},) + ((y_true,) if with_y else ())
 
-        model.compile(loss=losses.MeanSquaredError)
+        model.compile(loss="mse", optimizer="adam")
         model.fit(data_generator())
         model.evaluate(data_generator())
         model.predict(data_generator(with_y=False))

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -157,6 +157,23 @@ def _get_model_with_duplicate_variable_path():
     return model
 
 
+def _get_model_optional_inputs():
+    class OptionalInputLayer(layers.Layer):
+        def __init__(self):
+            super().__init__()
+            self.dense = layers.Dense(2)
+
+        def call(self, a, b=None):
+            x = a if b is None else a + b
+            return self.dense(x)
+
+    x1 = Input((2,), name="x1")
+    x2 = Input((2,), name="x2", optional=True)
+    y = OptionalInputLayer()(x1, x2)
+    model = Model({"x1": x1, "x2": x2}, y)
+    return model
+
+
 def _get_variable_value_by_path(variables, path):
     for v in variables:
         if v.path == path:
@@ -1218,6 +1235,38 @@ class ModelTest(testing.TestCase):
             ]
         )
         self.assertListEqual(hist_keys, ref_keys)
+
+    @parameterized.named_parameters(
+        ("optional_none", True), ("optional_tensor", False)
+    )
+    def test_functional_optional_inputs(self, is_optional_none):
+        model = _get_model_optional_inputs()
+        x1 = np.ones((2, 2))
+        x2 = None if is_optional_none else np.ones((2, 2))
+        y_true = np.ones((2, 2))
+
+        model.compile(loss=losses.MeanSquaredError)
+        model.fit(x={"x1": x1, "x2": x2}, y=y_true)
+        model.evaluate(x={"x1": x1, "x2": x2}, y=y_true)
+        model.predict(x={"x1": x1, "x2": x2})
+
+    @parameterized.named_parameters(
+        ("optional_none", True), ("optional_tensor", False)
+    )
+    def test_functional_optional_inputs_generator(self, is_optional_none):
+        model = _get_model_optional_inputs()
+        x1 = np.ones((2, 2))
+        x2 = None if is_optional_none else np.ones((2, 2))
+        y_true = np.ones((2, 2))
+
+        def data_generator(with_y=True):
+            for _ in range(4):
+                yield ({"x1": x1, "x2": x2},) + ((y_true,) if with_y else ())
+
+        model.compile(loss=losses.MeanSquaredError)
+        model.fit(data_generator())
+        model.evaluate(data_generator())
+        model.predict(data_generator(with_y=False))
 
     def test_export_error(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")

--- a/keras/src/trainers/data_adapters/array_data_adapter.py
+++ b/keras/src/trainers/data_adapters/array_data_adapter.py
@@ -76,7 +76,9 @@ class ArrayDataAdapter(DataAdapter):
         inputs = data_adapter_utils.pack_x_y_sample_weight(x, y, sample_weight)
 
         data_adapter_utils.check_data_cardinality(inputs)
-        num_samples = set(i.shape[0] for i in tree.flatten(inputs)).pop()
+        num_samples = set(
+            i.shape[0] for i in tree.flatten(inputs) if i is not None
+        ).pop()
         self._num_samples = num_samples
         self._inputs = inputs
 
@@ -269,7 +271,9 @@ class ArrayDataAdapter(DataAdapter):
                     x = convert_to_tensor(x)
                     return x
 
-                return tree.map_structure(slice_and_convert, self.array)
+                return tree.map_structure(
+                    slice_and_convert, self.array, none_is_leaf=False
+                )
 
             def __len__(self):
                 return len(self.array[0])
@@ -337,7 +341,9 @@ class ArrayDataAdapter(DataAdapter):
             slice_indices_and_convert_fn = functools.partial(
                 slice_and_convert_fn, indices=indices
             )
-            yield tree.map_structure(slice_indices_and_convert_fn, inputs)
+            yield tree.map_structure(
+                slice_indices_and_convert_fn, inputs, none_is_leaf=False
+            )
 
     @property
     def num_batches(self):

--- a/keras/src/trainers/data_adapters/generator_data_adapter.py
+++ b/keras/src/trainers/data_adapters/generator_data_adapter.py
@@ -32,8 +32,8 @@ class GeneratorDataAdapter(DataAdapter):
         from keras.src.utils.module_utils import tensorflow as tf
 
         def convert_to_tf(x, spec):
-            if isinstance(spec, tf.OptionalSpec):
-                return x
+            if x is None:
+                return tf.experimental.Optional.empty(None)
             if data_adapter_utils.is_scipy_sparse(x):
                 x = data_adapter_utils.scipy_sparse_to_tf_sparse(x)
             elif data_adapter_utils.is_jax_sparse(x):
@@ -52,14 +52,6 @@ class GeneratorDataAdapter(DataAdapter):
 
         def get_tf_iterator():
             for batch in self.generator():
-                batch = tree.map_structure(
-                    (
-                        lambda i: tf.experimental.Optional.empty(None)
-                        if i is None
-                        else i
-                    ),
-                    batch,
-                )
                 batch = tree.map_structure(
                     convert_to_tf, batch, self._output_signature
                 )

--- a/keras/src/trainers/data_adapters/grain_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/grain_dataset_adapter.py
@@ -80,7 +80,9 @@ class GrainDatasetAdapter(DataAdapter):
 
         class ConvertToNumpy(grain.transforms.Map):
             def map(self, x):
-                return tree.map_structure(convert_to_numpy, x)
+                return tree.map_structure(
+                    convert_to_numpy, x, none_is_leaf=False
+                )
 
         if isinstance(self._dataset, (grain.MapDataset, grain.IterDataset)):
             dataset = self._dataset.map(ConvertToNumpy())
@@ -109,7 +111,9 @@ class GrainDatasetAdapter(DataAdapter):
 
         class ConvertToJaxCompatible(grain.transforms.Map):
             def map(self, x):
-                return tree.map_structure(convert_to_jax_compatible, x)
+                return tree.map_structure(
+                    convert_to_jax_compatible, x, none_is_leaf=False
+                )
 
         if isinstance(self._dataset, (grain.MapDataset, grain.IterDataset)):
             dataset = self._dataset.map(ConvertToJaxCompatible())
@@ -139,7 +143,7 @@ class GrainDatasetAdapter(DataAdapter):
 
         class ConvertToTF(grain.transforms.Map):
             def map(self, x):
-                return tree.map_structure(convert_to_tf, x)
+                return tree.map_structure(convert_to_tf, x, none_is_leaf=False)
 
         # `tf.data.Dataset.from_generator` does not support lists as output.
         # We convert lists to tuples.

--- a/keras/src/trainers/data_adapters/grain_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/grain_dataset_adapter.py
@@ -135,6 +135,8 @@ class GrainDatasetAdapter(DataAdapter):
 
     def get_tf_dataset(self):
         def convert_to_tf(x):
+            if x is None:
+                return tf.experimental.Optional.empty(None)
             if data_adapter_utils.is_scipy_sparse(x):
                 x = data_adapter_utils.scipy_sparse_to_tf_sparse(x)
             elif data_adapter_utils.is_jax_sparse(x):
@@ -143,7 +145,7 @@ class GrainDatasetAdapter(DataAdapter):
 
         class ConvertToTF(grain.transforms.Map):
             def map(self, x):
-                return tree.map_structure(convert_to_tf, x, none_is_leaf=False)
+                return tree.map_structure(convert_to_tf, x)
 
         # `tf.data.Dataset.from_generator` does not support lists as output.
         # We convert lists to tuples.

--- a/keras/src/trainers/data_adapters/tf_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/tf_dataset_adapter.py
@@ -38,7 +38,9 @@ class TFDatasetAdapter(DataAdapter):
         from keras.src.backend.tensorflow.core import convert_to_numpy
 
         for batch in self._dataset:
-            yield tree.map_structure(convert_to_numpy, batch)
+            yield tree.map_structure(
+                convert_to_numpy, batch, none_is_leaf=False
+            )
 
     def get_jax_iterator(self):
         from keras.src.backend.tensorflow.core import convert_to_numpy
@@ -52,7 +54,7 @@ class TFDatasetAdapter(DataAdapter):
                 return convert_to_numpy(x)
 
         for batch in self._dataset:
-            yield tree.map_structure(convert_to_jax, batch)
+            yield tree.map_structure(convert_to_jax, batch, none_is_leaf=False)
 
     def get_tf_dataset(self):
         return self._dataset

--- a/keras/src/trainers/data_adapters/torch_data_loader_adapter.py
+++ b/keras/src/trainers/data_adapters/torch_data_loader_adapter.py
@@ -35,7 +35,9 @@ class TorchDataLoaderAdapter(DataAdapter):
         for batch in self._dataloader:
             # shared memory using `np.asarray`
             yield tuple(
-                tree.map_structure(lambda x: np.asarray(x.cpu()), batch)
+                tree.map_structure(
+                    lambda x: np.asarray(x.cpu()), batch, none_is_leaf=False
+                )
             )
 
     def get_jax_iterator(self):

--- a/keras/src/tree/dmtree_impl.py
+++ b/keras/src/tree/dmtree_impl.py
@@ -206,7 +206,10 @@ def map_structure(func, *structures, none_is_leaf=True):
             # Check if the reference entry (first one) is None
             if args[0] is None:
                 if not all(s is None for s in args):
-                    raise ValueError("Structure mismatch: some arguments are None, others are not.")
+                    raise ValueError(
+                        "Structure mismatch: some arguments are None, others "
+                        "are not."
+                    )
                 return None
             return func(*args)
         

--- a/keras/src/tree/dmtree_impl.py
+++ b/keras/src/tree/dmtree_impl.py
@@ -202,6 +202,7 @@ def map_structure(func, *structures, none_is_leaf=True):
 
     map_func = func
     if not none_is_leaf:
+
         def func_skipping_none(*args):
             # Check if the reference entry (first one) is None
             if args[0] is None:
@@ -212,7 +213,7 @@ def map_structure(func, *structures, none_is_leaf=True):
                     )
                 return None
             return func(*args)
-        
+
         map_func = func_skipping_none
 
     def func_traverse_wrapper(s):

--- a/keras/src/tree/dmtree_impl.py
+++ b/keras/src/tree/dmtree_impl.py
@@ -209,7 +209,7 @@ def map_structure(func, *structures, none_is_leaf=True):
                 if not all(s is None for s in args):
                     raise ValueError(
                         "Structure mismatch: some arguments are None, others "
-                        "are not."
+                        f"are not. Received arguments: {args}."
                     )
                 return None
             return func(*args)

--- a/keras/src/tree/optree_impl.py
+++ b/keras/src/tree/optree_impl.py
@@ -93,14 +93,14 @@ def flatten_with_path(structure):
     return list(zip(paths, leaves))
 
 
-def map_structure(func, *structures):
+def map_structure(func, *structures, none_is_leaf=True):
     if not structures:
         raise ValueError("Must provide at least one structure")
 
     # Add check for same structures, otherwise optree just maps to shallowest.
     def func_with_check(*args):
         if not all(
-            optree.tree_is_leaf(s, none_is_leaf=True, namespace="keras")
+            optree.tree_is_leaf(s, none_is_leaf=none_is_leaf, namespace="keras")
             for s in args
         ):
             raise ValueError("Structures don't have the same nested structure.")
@@ -109,7 +109,7 @@ def map_structure(func, *structures):
     map_func = func_with_check if len(structures) > 1 else func
 
     return optree.tree_map(
-        map_func, *structures, none_is_leaf=True, namespace="keras"
+        map_func, *structures, none_is_leaf=none_is_leaf, namespace="keras"
     )
 
 

--- a/keras/src/tree/tree_api.py
+++ b/keras/src/tree/tree_api.py
@@ -179,7 +179,9 @@ def map_structure(func, *structures, none_is_leaf=True):
     Args:
         func: A callable that accepts as many arguments as there are structures.
         *structures: Arbitrarily nested structures of the same layout.
-        none_is_leaf: If True, None is treated as a leaf.
+        none_is_leaf: If True, `func` will be called on `None` leaves. If False,
+            `None` values are not passed to `func` and are returned in the
+            output directly.
 
     Returns:
         A new structure with the same layout as the given ones.

--- a/keras/src/tree/tree_api.py
+++ b/keras/src/tree/tree_api.py
@@ -160,7 +160,7 @@ def flatten_with_path(structure):
 
 
 @keras_export("keras.tree.map_structure")
-def map_structure(func, *structures):
+def map_structure(func, *structures, none_is_leaf=True):
     """Maps `func` through given structures.
 
     Examples:
@@ -179,6 +179,7 @@ def map_structure(func, *structures):
     Args:
         func: A callable that accepts as many arguments as there are structures.
         *structures: Arbitrarily nested structures of the same layout.
+        none_is_leaf: If True, None is treated as a leaf.
 
     Returns:
         A new structure with the same layout as the given ones.
@@ -189,7 +190,7 @@ def map_structure(func, *structures):
             the nested structures don't match according to the rules of
             `assert_same_structure`.
     """
-    return tree_impl.map_structure(func, *structures)
+    return tree_impl.map_structure(func, *structures, none_is_leaf=none_is_leaf)
 
 
 @keras_export("keras.tree.map_structure_up_to")


### PR DESCRIPTION
Here is an example of a model with 2 inputs, the second one being optional:

```python
class OptionalInputLayer(layers.Layer):
    def __init__(self):
        super().__init__()
        self.dense = layers.Dense(2)

    def call(self, x, y=None):
        z = x if y is None else x + y
        return self.dense(z)

    def compute_output_shape(self, x_shape):
        return x_shape

i1 = Input((2,), name="input1")
i2 = Input((2,), name="input2", optional=True)
outputs = OptionalInputLayer()(i1, i2)
model = Model({"input1": i1, "input2": i2}, outputs)
```

With this definition, the model can be called in Jax/TF/Torch without issue, even when input2 is None:

```python
model({"input1": np.ones((2, 2)), "input2": None})  # WORKS
model.predict_on_batch({"input1": np.ones((2, 2)), "input2": None})  # WORKS AS WELL
```

It is even possible to train **on a batch** when input2 is None:

```python
model.compile(loss=losses.MeanSquaredError)
model.train_on_batch(x={"input1": np.ones((2, 2)), "input2": None}, y=np.ones((2, 2)))  # WORKS
```

However, doing the same with model.fit API is currently failing on all backends:

```python
# Without generator
model.fit(x={"input1": np.ones((2, 2)), "input2": None}, y=np.ones((2, 2)))  # DOESN'T WORK

# With generator
data_generator = (({"input1": np.ones((2, 2)), "input2": None}, np.ones((2, 2))) for _ in range(3))
model.fit(x=data_generator)  # DOESN'T WORK EITHER
```

The purpose of this PR is to fix this issue (on Jax/TF/Torch), so that the last code block above becomes possible (btw. I could add 1 or 2 unit tests along those lines to demonstrate the fix but I am unsure where would be the best place for it... [model_test](https://github.com/keras-team/keras/blob/master/keras/src/models/model_test.py) maybe?).
