### PR TITLE
Force computation and data placement on the CPU when using a Grain data pipeline.

### DIFF
--- a/keras/src/backend/jax/distribution_lib.py
+++ b/keras/src/backend/jax/distribution_lib.py
@@ -201,7 +201,11 @@ def process_id():
 def _to_backend_device(device_name):
     if isinstance(device_name, jax.Device):
         return device_name
-    device_type, device_id = device_name.split(":")
+    device_name = str(device_name)
+    if ":" not in device_name:
+        device_type, device_id = device_name, 0
+    else:
+        device_type, device_id = device_name.split(":")
 
     devices = jax.devices(backend=device_type)
     for device in devices:

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -62,7 +62,7 @@ def device_scope(device_name):
     current_device = _parse_device_input(device_name)
     global_state.set_global_attribute("torch_device", current_device)
     try:
-        yield
+        yield torch.device(current_device)
     finally:
         global_state.set_global_attribute("torch_device", previous_device)
 

--- a/keras/src/layers/preprocessing/rescaling_test.py
+++ b/keras/src/layers/preprocessing/rescaling_test.py
@@ -1,3 +1,4 @@
+import grain
 import numpy as np
 import pytest
 from tensorflow import data as tf_data
@@ -73,6 +74,21 @@ class RescalingTest(testing.TestCase):
         x = np.random.random((3, 10, 10, 3)) * 255
         ds = tf_data.Dataset.from_tensor_slices(x).batch(3).map(layer)
         next(iter(ds)).numpy()
+
+    def test_grain_compatibility(self):
+        layer = layers.Rescaling(scale=1.0 / 255, offset=0.5)
+        x = np.random.random((3, 10, 10, 3)) * 255
+        ds = grain.MapDataset.source(x).to_iter_dataset().batch(3).map(layer)
+        output = next(iter(ds))
+
+        self.assertTrue(backend.is_tensor(output))
+        # Ensure the device of the data is on CPU.
+        if backend.backend() == "tensorflow":
+            self.assertIn("CPU", str(output.device))
+        elif backend.backend() == "jax":
+            self.assertIn("CPU", str(output.device))
+        elif backend.backend() == "torch":
+            self.assertEqual("cpu", str(output.device))
 
     def test_rescaling_with_channels_first_and_vector_scale(self):
         config = backend.image_data_format()


### PR DESCRIPTION
This PR enhances `TFDataLayer` to detect whether it is part of a Grain data pipeline. If so, `TFDataLayer` will force computation and data placement on the CPU.

`test_grain_compatibility` has been added in `Rescaling` and `Resizing` to verify that the output device is CPU in GPU tests.

A demo colab:
https://colab.research.google.com/drive/13RNE_KTbc13Shp5c1uIKzCbo-Ztfe5Ik?usp=sharing

Results:

|`worker_count`|Best Step Speed|
|-|-|
|0 (single worker)|49 ms/step|
|2|17 ms/step|

cc @divyashreepathihalli @mattdangerw 