### PR TITLE
Fix broken code block rendering in histogram documentation

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -7325,15 +7325,12 @@ def histogram(x, bins=10, range=None):
         - A tensor representing the bin edges.
 
     Example:
-
-    ```
     >>> input_tensor = np.random.rand(8)
     >>> keras.ops.histogram(input_tensor)
     (array([1, 1, 1, 0, 0, 1, 2, 1, 0, 1], dtype=int32),
     array([0.0189519 , 0.10294958, 0.18694726, 0.27094494, 0.35494262,
         0.43894029, 0.52293797, 0.60693565, 0.69093333, 0.77493101,
         0.85892869]))
-    ```
     """
     if not isinstance(bins, int):
         raise TypeError(


### PR DESCRIPTION
I removed the triple backticks (```) from the code block to fix the broken rendering issue.

- Before fix [(https://keras.io/api/ops/numpy/#histogram-function)](https://keras.io/api/ops/numpy/#histogram-function)
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/cb775956-2f77-46c4-a4bc-b8d43656cfd1" />


- After fix
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/b6fa84ff-63de-488b-9200-96c949ec190a" />
