### PR TITLE
Add daily Python 3.13 CPU-only tests to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@ name: Nightly
 on:
   workflow_dispatch: # To Generate wheels on demand outside of schedule.
   schedule:
-    - cron: '0 3 * * *' # run at 3 AM UTC / 8 PM PDT
+    - cron: "0 3 * * *" # run at 3 AM UTC / 8 PM PDT
 
 permissions:
   contents: read
@@ -13,9 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10']
+        python-version: ["3.10"]
         backend: [tensorflow, jax, torch, numpy]
-    name: Run tests
+    name: Run tests (Python 3.10)
     runs-on: ubuntu-latest
     env:
       PYTHON: ${{ matrix.python-version }}
@@ -57,6 +57,54 @@ jobs:
         run: |
           pytest keras --ignore keras/src/applications --cov=keras --cov-config=pyproject.toml
 
+  build-python-latest:
+    strategy:
+      fail-fast: false
+      matrix:
+      python-version: ["3.13"]
+      backend: [tensorflow, jax, torch, numpy]
+    name: Run tests (Python 3.13)
+    runs-on: ubuntu-latest
+    env:
+      PYTHON: ${{ matrix.python-version }}
+      KERAS_BACKEND: ${{ matrix.backend }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          python -m pip install --upgrade pip setuptools
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: pip cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-latest-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt --progress-bar off --upgrade
+          pip uninstall -y keras keras-nightly
+          pip install -e "." --progress-bar off --upgrade
+      - name: Test integrations
+        if: ${{ matrix.backend != 'numpy'}}
+        run: |
+          python integration_tests/import_test.py
+      - name: Test TF-specific integrations
+        if: ${{ matrix.backend == 'tensorflow'}}
+        run: |
+          python integration_tests/tf_distribute_training_test.py
+      - name: Test Torch-specific integrations
+        if: ${{ matrix.backend == 'torch'}}
+        run: |
+          pytest integration_tests/torch_workflow_test.py
+      - name: Test with pytest
+        run: |
+          pytest keras --ignore keras/src/applications --cov=keras --cov-config=pyproject.toml
+
   format:
     name: Check the code format
     runs-on: ubuntu-latest
@@ -65,7 +113,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -84,17 +132,16 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files --hook-stage manual
 
-
   nightly:
     name: Build Wheel file and upload
-    needs: [build, format]
+    needs: [build, build-python-latest, format]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         backend: [tensorflow, jax, torch, numpy]
-    name: Run tests (Python 3.10)
+    name: Run tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     env:
       PYTHON: ${{ matrix.python-version }}
@@ -61,16 +61,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-      python-version: ["3.13"]
-      backend: [tensorflow, jax, torch, numpy]
-    name: Run tests (Python 3.13)
+        python-version: ["3.13"]
+        backend: [tensorflow, jax, torch, numpy]
+    name: Run tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     env:
       PYTHON: ${{ matrix.python-version }}
       KERAS_BACKEND: ${{ matrix.backend }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.13
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/keras/src/applications/mobilenet_v3.py
+++ b/keras/src/applications/mobilenet_v3.py
@@ -91,6 +91,8 @@ Args:
     alpha: controls the width of the network. This is known as the
         depth multiplier in the MobileNetV3 paper, but the name is kept for
         consistency with MobileNetV1 in Keras.
+        When `weights` is `imagenet`, `alpha` can be one of `0.75` or `1.0`
+        for non-minimalistic models, and `1.0` for minimalistic models.
         - If `alpha < 1.0`, proportionally decreases the number
             of filters in each layer.
         - If `alpha > 1.0`, proportionally increases the number


### PR DESCRIPTION
fixes #21508 

Adds `build-python-latest` job in Nightly pipeline