### PR TITLE
Proposed fix for issue #21519: Reshape layer does not handle -1 shape…

### DIFF
--- a/keras/src/layers/reshaping/reshape.py
+++ b/keras/src/layers/reshaping/reshape.py
@@ -11,9 +11,9 @@ class Reshape(Layer):
 
     Args:
         target_shape: Target shape. Tuple of integers, does not include the
-            samples dimension (batch size). One element of the `target_shape` can
-            be -1 in which case the missing value is inferred from the size
-            of the array and remaining dimensions.
+            samples dimension (batch size). One element of the `target_shape`
+            can be -1 in which case the missing value is inferred from the
+            size of the array and remaining dimensions.
 
     Input shape:
         Arbitrary, but required to be compatible with `target_shape`.

--- a/keras/src/layers/reshaping/reshape.py
+++ b/keras/src/layers/reshaping/reshape.py
@@ -1,9 +1,11 @@
+import math
+
 from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.layers.layer import Layer
 from keras.src.ops import operation_utils
-import math
+
 
 @keras_export("keras.layers.Reshape")
 class Reshape(Layer):
@@ -46,7 +48,9 @@ class Reshape(Layer):
             )
         self.target_shape = target_shape
         # precalculate all values that might be required
-        self.need_explicit_shape_for_batch_size_None = (target_shape.count(-1) == 1)
+        self.need_explicit_shape_for_batch_size_None = (
+            target_shape.count(-1) == 1
+        )
         self.new_size_no_minus_one = math.prod(
             d for d in target_shape if d != -1
         )
@@ -67,16 +71,20 @@ class Reshape(Layer):
 
     def call(self, inputs):
         target_shape = self.target_shape
-        if self.need_explicit_shape_for_batch_size_None and (inputs.shape[0] is None):
+        if self.need_explicit_shape_for_batch_size_None and (
+            inputs.shape[0] is None
+        ):
             input_nonbatch_shape = tuple(inputs.shape[1:])
             if input_nonbatch_shape.count(None) == 0:
                 inp_nonbatch_size = math.prod(inputs.shape[1:])
-                target_shape = tuple(d if d != -1 else (inp_nonbatch_size // self.new_size_no_minus_one) for d in self.target_shape)
+                target_shape = tuple(
+                    d
+                    if d != -1
+                    else (inp_nonbatch_size // self.new_size_no_minus_one)
+                    for d in self.target_shape
+                )
 
-        return ops.reshape(
-            inputs, (ops.shape(inputs)[0],) + target_shape
-        )
-
+        return ops.reshape(inputs, (ops.shape(inputs)[0],) + target_shape)
 
     def get_config(self):
         config = {"target_shape": self.target_shape}

--- a/keras/src/layers/reshaping/reshape.py
+++ b/keras/src/layers/reshaping/reshape.py
@@ -70,11 +70,7 @@ class Reshape(Layer):
         if self.need_explicit_shape_for_batch_size_None and (inputs.shape[0] is None):
             input_nonbatch_shape = tuple(inputs.shape[1:])
             if input_nonbatch_shape.count(None) == 0:
-                # If the input shape is fully defined, we can compute the desired target_shape
-                if True:
-                    inp_nonbatch_size = math.prod(inputs.shape[1:])
-                else:
-                    inp_nonbatch_size = ops.prod(ops.shape(inputs)[1:])
+                inp_nonbatch_size = math.prod(inputs.shape[1:])
                 target_shape = tuple(d if d != -1 else (inp_nonbatch_size // self.new_size_no_minus_one) for d in self.target_shape)
 
         return ops.reshape(

--- a/keras/src/layers/reshaping/reshape.py
+++ b/keras/src/layers/reshaping/reshape.py
@@ -11,15 +11,12 @@ class Reshape(Layer):
 
     Args:
         target_shape: Target shape. Tuple of integers, does not include the
-            samples dimension (batch size). One element of the target_shape can
-            be -1 in which case the missing value is inferred from the length
+            samples dimension (batch size). One element of the `target_shape` can
+            be -1 in which case the missing value is inferred from the size
             of the array and remaining dimensions.
 
     Input shape:
-        Arbitrary, but required to be compatible with target shape.
-        Use the keyword argument `input_shape` (tuple of integers,
-        does not include the samples/batch size axis) when using this layer as
-        the first layer in a model.
+        Arbitrary, but required to be compatible with `target_shape`.
 
     Output shape:
         `(batch_size, *target_shape)`

--- a/keras/src/layers/reshaping/reshape.py
+++ b/keras/src/layers/reshaping/reshape.py
@@ -11,9 +11,9 @@ class Reshape(Layer):
 
     Args:
         target_shape: Target shape. Tuple of integers, does not include the
-            samples dimension (batch size). One element of the target_shape can be -1
-            in which case the missing value is inferred from the length of the array
-            and remaining dimensions.
+            samples dimension (batch size). One element of the target_shape can
+            be -1 in which case the missing value is inferred from the length
+            of the array and remaining dimensions.
 
     Input shape:
         Arbitrary, but required to be compatible with target shape.

--- a/keras/src/layers/reshaping/reshape_test.py
+++ b/keras/src/layers/reshaping/reshape_test.py
@@ -1,6 +1,7 @@
 import pytest
 from absl.testing import parameterized
 
+from keras.src import ops
 from keras.src import backend
 from keras.src import layers
 from keras.src import testing
@@ -99,6 +100,16 @@ class ReshapeTest(testing.TestCase):
         layer.build(input.shape)
         reshaped = backend.compute_output_spec(layer.__call__, input)
         self.assertEqual(reshaped.shape, (None, 3, 8))
+
+    def test_reshape_with_varying_static_batch_size_and_minus_one(self):
+        input = KerasTensor((None, 6, 4))
+        layer = layers.Reshape((-1, 8))
+        layer.build(input.shape)
+        layer(ops.ones((1, 6, 4), dtype="float32"))
+        layer(ops.ones((1, 10, 4), dtype="float32"))
+        reshaped = backend.compute_output_spec(layer.__call__, input)
+        self.assertEqual(reshaped.shape, (None, 3, 8))
+
 
     def test_reshape_with_dynamic_dim_and_minus_one(self):
         input = KerasTensor((4, 6, None, 3))

--- a/keras/src/layers/reshaping/reshape_test.py
+++ b/keras/src/layers/reshaping/reshape_test.py
@@ -102,7 +102,6 @@ class ReshapeTest(testing.TestCase):
         self.assertEqual(reshaped.shape, (None, 3, 8))
 
     def test_reshape_layer_with_varying_input_size_and_minus_one(self):
-        input = KerasTensor((None, 6, 4))
         layer = layers.Reshape((-1, 8))
         res = layer(ops.ones((1, 6, 4), dtype="float32"))
         self.assertEqual(res.shape, (1, 3, 8))

--- a/keras/src/layers/reshaping/reshape_test.py
+++ b/keras/src/layers/reshaping/reshape_test.py
@@ -105,11 +105,10 @@ class ReshapeTest(testing.TestCase):
         input = KerasTensor((None, 6, 4))
         layer = layers.Reshape((-1, 8))
         layer.build(input.shape)
-        layer(ops.ones((1, 6, 4), dtype="float32"))
-        layer(ops.ones((1, 10, 4), dtype="float32"))
-        reshaped = backend.compute_output_spec(layer.__call__, input)
-        self.assertEqual(reshaped.shape, (None, 3, 8))
-
+        res = layer(ops.ones((1, 6, 4), dtype="float32"))
+        self.assertEqual(res.shape, (1, 3, 8))
+        res = layer(ops.ones((1, 10, 4), dtype="float32"))
+        self.assertEqual(res.shape, (1, 5, 8))
 
     def test_reshape_with_dynamic_dim_and_minus_one(self):
         input = KerasTensor((4, 6, None, 3))

--- a/keras/src/layers/reshaping/reshape_test.py
+++ b/keras/src/layers/reshaping/reshape_test.py
@@ -120,6 +120,7 @@ class ReshapeTest(testing.TestCase):
         # Also make sure the batch dim is not lost after reshape.
         self.assertEqual(reshaped.shape, (2, 3, 5))
 
+    @pytest.mark.requires_trainable_backend
     def test_reshape_model_fit_with_varying_input_size_and_minus_one(self):
         def generator():
             yield (

--- a/keras/src/layers/reshaping/reshape_test.py
+++ b/keras/src/layers/reshaping/reshape_test.py
@@ -1,10 +1,9 @@
 import pytest
 from absl.testing import parameterized
 
-from keras.src import Model
-from keras.src import ops
 from keras.src import backend
 from keras.src import layers
+from keras.src import ops
 from keras.src import testing
 from keras.src.backend.common.keras_tensor import KerasTensor
 

--- a/keras/src/layers/reshaping/reshape_test.py
+++ b/keras/src/layers/reshaping/reshape_test.py
@@ -1,7 +1,7 @@
 import pytest
 from absl.testing import parameterized
 
-from keras.src import Model
+from keras.src import Sequential
 from keras.src import backend
 from keras.src import layers
 from keras.src import ops
@@ -98,40 +98,20 @@ class ReshapeTest(testing.TestCase):
     def test_reshape_with_dynamic_batch_size_and_minus_one(self):
         input = KerasTensor((None, 6, 4))
         layer = layers.Reshape((-1, 8))
-        layer.build(input.shape)
         reshaped = backend.compute_output_spec(layer.__call__, input)
         self.assertEqual(reshaped.shape, (None, 3, 8))
 
     def test_reshape_layer_with_varying_input_size_and_minus_one(self):
         input = KerasTensor((None, 6, 4))
         layer = layers.Reshape((-1, 8))
-        layer.build(input.shape)
         res = layer(ops.ones((1, 6, 4), dtype="float32"))
         self.assertEqual(res.shape, (1, 3, 8))
         res = layer(ops.ones((1, 10, 4), dtype="float32"))
         self.assertEqual(res.shape, (1, 5, 8))
 
-    def test_custom_reshape_model_with_varying_input_size_and_minus_one(self):
-        class MM(Model):
-            def __init__(self):
-                super().__init__()
-                self.conv = layers.Conv1D(4, 3, padding="same")
-                self.reshape = layers.Reshape((-1, 8))
-
-            def call(self, inputs):
-                x = self.conv(inputs)
-                return self.reshape(x)
-
-        m = MM()
-        res = m(ops.ones((1, 6, 2), dtype="float32"))
-        self.assertEqual(res.shape, (1, 3, 8))
-        res = m(ops.ones((1, 10, 2), dtype="float32"))
-        self.assertEqual(res.shape, (1, 5, 8))
-
     def test_reshape_with_dynamic_dim_and_minus_one(self):
         input = KerasTensor((4, 6, None, 3))
         layer = layers.Reshape((-1, 3))
-        layer.build(input.shape)
         reshaped = backend.compute_output_spec(layer.__call__, input)
         self.assertEqual(reshaped.shape, (4, None, 3))
 
@@ -140,3 +120,19 @@ class ReshapeTest(testing.TestCase):
         reshaped = layers.Reshape((3, 5))(input_layer)
         # Also make sure the batch dim is not lost after reshape.
         self.assertEqual(reshaped.shape, (2, 3, 5))
+
+    def test_reshape_model_fit_with_varying_input_size_and_minus_one(self):
+        def generator():
+            yield (
+                ops.ones((1, 12, 2), dtype="float32"),
+                ops.zeros((1, 3, 8), dtype="float32"),
+            )
+            yield (
+                ops.ones((1, 20, 2), dtype="float32"),
+                ops.zeros((1, 5, 8), dtype="float32"),
+            )
+
+        layer = layers.Reshape((-1, 8))
+        model = Sequential([layer])
+        model.compile(loss="mean_squared_error")
+        model.fit(generator(), steps_per_epoch=2, epochs=1)

--- a/keras/src/layers/reshaping/reshape_test.py
+++ b/keras/src/layers/reshaping/reshape_test.py
@@ -1,6 +1,7 @@
 import pytest
 from absl.testing import parameterized
 
+from keras.src import Model
 from keras.src import backend
 from keras.src import layers
 from keras.src import ops
@@ -111,7 +112,7 @@ class ReshapeTest(testing.TestCase):
         self.assertEqual(res.shape, (1, 5, 8))
 
     def test_custom_reshape_model_with_varying_input_size_and_minus_one(self):
-        class MM(layers.Layer):
+        class MM(Model):
             def __init__(self):
                 super().__init__()
                 self.conv = layers.Conv1D(4, 3, padding="same")


### PR DESCRIPTION
I have implemented a fix that avoids precalculating a statically resolved reshape target in the build method and instead properly calculates the proper shape information for the problematic case when the shape information is not complete in the call method. The method appears to pass the reshape tests for all backends.