### PR TITLE
Disable `torch.load` in `TorchModuleWrapper` when in safe mode.

### DIFF
--- a/keras/src/utils/torch_utils.py
+++ b/keras/src/utils/torch_utils.py
@@ -8,6 +8,7 @@ from keras.src.api_export import keras_export
 from keras.src.layers import Layer
 from keras.src.ops import convert_to_numpy
 from keras.src.ops import convert_to_tensor
+from keras.src.saving.serialization_lib import in_safe_mode
 
 
 @keras_export("keras.layers.TorchModuleWrapper")
@@ -166,6 +167,17 @@ class TorchModuleWrapper(Layer):
         import torch
 
         if "module" in config:
+            if in_safe_mode():
+                raise ValueError(
+                    "Requested the deserialization of a `torch.nn.Module` "
+                    "object via `torch.load()`. This carries a potential risk "
+                    "of arbitrary code execution and thus it is disallowed by "
+                    "default. If you trust the source of the saved model, you "
+                    "can pass `safe_mode=False` to the loading function in "
+                    "order to allow `torch.nn.Module` loading, or call "
+                    "`keras.config.enable_unsafe_deserialization()`."
+                )
+
             # Decode the base64 string back to bytes
             buffer_bytes = base64.b64decode(config["module"].encode("ascii"))
             buffer = io.BytesIO(buffer_bytes)


### PR DESCRIPTION
Raise an exception and explain the user about the risks.