### PR TITLE
Add coverage on legacy code, remove coverage on applications.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,13 +99,12 @@ exclude_lines = [
 ]
 omit = [
     "*/*_test.py",
-    "keras/src/legacy/*",
+    "keras/src/applications/*",
 ]
 
 [tool.coverage.run]
 branch = true
 omit = [
     "*/*_test.py",
-    "keras/src/legacy/*",
+    "keras/src/applications/*",
 ]
-


### PR DESCRIPTION
- Code on the `legacy` folder is covered as part of normal unit tests and the coverage information is useful.
- Tests in the `applications` folder are not run for coverage, so the coverage information is not useful and is incorrectly pulling the coverage numbers down.