### PR TITLE
Add `ops.image.scale_and_translate`.

### DIFF
--- a/keras/api/_tf_keras/keras/ops/image/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/image/__init__.py
@@ -16,3 +16,4 @@ from keras.src.ops.image import perspective_transform as perspective_transform
 from keras.src.ops.image import resize as resize
 from keras.src.ops.image import rgb_to_grayscale as rgb_to_grayscale
 from keras.src.ops.image import rgb_to_hsv as rgb_to_hsv
+from keras.src.ops.image import scale_and_translate as scale_and_translate

--- a/keras/api/ops/image/__init__.py
+++ b/keras/api/ops/image/__init__.py
@@ -16,3 +16,4 @@ from keras.src.ops.image import perspective_transform as perspective_transform
 from keras.src.ops.image import resize as resize
 from keras.src.ops.image import rgb_to_grayscale as rgb_to_grayscale
 from keras.src.ops.image import rgb_to_hsv as rgb_to_hsv
+from keras.src.ops.image import scale_and_translate as scale_and_translate

--- a/keras/src/backend/jax/image.py
+++ b/keras/src/backend/jax/image.py
@@ -14,6 +14,34 @@ RESIZE_INTERPOLATIONS = (
     "lanczos5",
     "bicubic",
 )
+AFFINE_TRANSFORM_INTERPOLATIONS = {  # map to order
+    "nearest": 0,
+    "bilinear": 1,
+}
+AFFINE_TRANSFORM_FILL_MODES = {
+    "constant",
+    "nearest",
+    "wrap",
+    "mirror",
+    "reflect",
+}
+MAP_COORDINATES_FILL_MODES = {
+    "constant",
+    "nearest",
+    "wrap",
+    "mirror",
+    "reflect",
+}
+SCALE_AND_TRANSLATE_METHODS = {
+    "linear",
+    "bilinear",
+    "trilinear",
+    "cubic",
+    "bicubic",
+    "tricubic",
+    "lanczos3",
+    "lanczos5",
+}
 
 
 def rgb_to_grayscale(images, data_format=None):
@@ -372,19 +400,6 @@ def resize(
     )
 
 
-AFFINE_TRANSFORM_INTERPOLATIONS = {  # map to order
-    "nearest": 0,
-    "bilinear": 1,
-}
-AFFINE_TRANSFORM_FILL_MODES = {
-    "constant",
-    "nearest",
-    "wrap",
-    "mirror",
-    "reflect",
-}
-
-
 def affine_transform(
     images,
     transform,
@@ -483,15 +498,6 @@ def affine_transform(
     return affined
 
 
-MAP_COORDINATES_FILL_MODES = {
-    "constant",
-    "nearest",
-    "wrap",
-    "mirror",
-    "reflect",
-}
-
-
 def perspective_transform(
     images,
     start_points,
@@ -545,8 +551,8 @@ def perspective_transform(
     if data_format == "channels_first":
         images = jnp.transpose(images, (0, 2, 3, 1))
 
-    batch_size, height, width, channels = images.shape
-    transforms = compute_homography_matrix(
+    _, height, width, _ = images.shape
+    transforms = _compute_homography_matrix(
         jnp.asarray(start_points, dtype="float32"),
         jnp.asarray(end_points, dtype="float32"),
     )
@@ -593,7 +599,7 @@ def perspective_transform(
     return output
 
 
-def compute_homography_matrix(start_points, end_points):
+def _compute_homography_matrix(start_points, end_points):
     start_x, start_y = start_points[..., 0], start_points[..., 1]
     end_x, end_y = end_points[..., 0], end_points[..., 1]
 
@@ -859,3 +865,19 @@ def elastic_transform(
     transformed_images = transformed_images.astype(input_dtype)
 
     return transformed_images
+
+
+def scale_and_translate(
+    images, shape, spatial_dims, scale, translation, method, antialias=True
+):
+    if method not in SCALE_AND_TRANSLATE_METHODS:
+        raise ValueError(
+            "Invalid value for argument `method`. Expected of one "
+            f"{SCALE_AND_TRANSLATE_METHODS}. Received: method={method}"
+        )
+    images = convert_to_tensor(images)
+    scale = convert_to_tensor(scale)
+    translation = convert_to_tensor(translation)
+    return jax.image.scale_and_translate(
+        images, shape, spatial_dims, scale, translation, method, antialias
+    )

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -13,6 +13,34 @@ RESIZE_INTERPOLATIONS = (
     "lanczos5",
     "bicubic",
 )
+AFFINE_TRANSFORM_INTERPOLATIONS = {  # map to order
+    "nearest": 0,
+    "bilinear": 1,
+}
+AFFINE_TRANSFORM_FILL_MODES = {
+    "constant",
+    "nearest",
+    "wrap",
+    "mirror",
+    "reflect",
+}
+MAP_COORDINATES_FILL_MODES = {
+    "constant",
+    "nearest",
+    "wrap",
+    "mirror",
+    "reflect",
+}
+SCALE_AND_TRANSLATE_METHODS = {
+    "linear",
+    "bilinear",
+    "trilinear",
+    "cubic",
+    "bicubic",
+    "tricubic",
+    "lanczos3",
+    "lanczos5",
+}
 
 
 def rgb_to_grayscale(images, data_format=None):
@@ -367,7 +395,7 @@ def resize(
     return _resize(images, size, method=interpolation, antialias=antialias)
 
 
-def compute_weight_mat(
+def _compute_weight_mat(
     input_size, output_size, scale, translation, kernel, antialias
 ):
     dtype = np.result_type(scale, translation)
@@ -410,32 +438,11 @@ def compute_weight_mat(
 
 
 def _resize(image, shape, method, antialias):
-    def _fill_triangle_kernel(x):
-        return np.maximum(0, 1 - np.abs(x))
-
-    def _fill_keys_cubic_kernel(x):
-        out = ((1.5 * x - 2.5) * x) * x + 1.0
-        out = np.where(x >= 1.0, ((-0.5 * x + 2.5) * x - 4.0) * x + 2.0, out)
-        return np.where(x >= 2.0, 0.0, out)
-
-    def _fill_lanczos_kernel(radius, x):
-        y = radius * np.sin(np.pi * x) * np.sin(np.pi * x / radius)
-        out = np.where(
-            x > 1e-3, np.divide(y, np.where(x != 0, np.pi**2 * x**2, 1)), 1
-        )
-        return np.where(x > radius, 0.0, out)
-
     if method == "nearest":
         return _resize_nearest(image, shape)
-    elif method == "bilinear":
-        kernel = _fill_triangle_kernel
-    elif method == "lanczos3":
-        kernel = lambda x: _fill_lanczos_kernel(3.0, x)
-    elif method == "lanczos5":
-        kernel = lambda x: _fill_lanczos_kernel(5.0, x)
-    elif method == "bicubic":
-        kernel = _fill_keys_cubic_kernel
     else:
+        kernel = _kernels.get(method, None)
+    if kernel is None:
         raise ValueError("Unknown resize method")
 
     spatial_dims = tuple(
@@ -473,6 +480,32 @@ def _resize_nearest(x, output_shape):
     return x
 
 
+def _fill_triangle_kernel(x):
+    return np.maximum(0, 1 - np.abs(x))
+
+
+def _fill_keys_cubic_kernel(x):
+    out = ((1.5 * x - 2.5) * x) * x + 1.0
+    out = np.where(x >= 1.0, ((-0.5 * x + 2.5) * x - 4.0) * x + 2.0, out)
+    return np.where(x >= 2.0, 0.0, out)
+
+
+def _fill_lanczos_kernel(radius, x):
+    y = radius * np.sin(np.pi * x) * np.sin(np.pi * x / radius)
+    out = np.where(
+        x > 1e-3, np.divide(y, np.where(x != 0, np.pi**2 * x**2, 1)), 1
+    )
+    return np.where(x > radius, 0.0, out)
+
+
+_kernels = {
+    "linear": _fill_triangle_kernel,
+    "cubic": _fill_keys_cubic_kernel,
+    "lanczos3": lambda x: _fill_lanczos_kernel(3.0, x),
+    "lanczos5": lambda x: _fill_lanczos_kernel(5.0, x),
+}
+
+
 def _scale_and_translate(
     x, output_shape, spatial_dims, scale, translation, kernel, antialias
 ):
@@ -492,9 +525,9 @@ def _scale_and_translate(
         d = d % x.ndim
         m, n = input_shape[d], output_shape[d]
 
-        w = compute_weight_mat(
+        w = _compute_weight_mat(
             m, n, scale[i], translation[i], kernel, antialias
-        ).astype(np.float32)
+        ).astype(output.dtype)
         output = np.tensordot(output, w, axes=(d, 0))
         output = np.moveaxis(output, -1, d)
 
@@ -502,19 +535,6 @@ def _scale_and_translate(
         output = np.clip(np.round(output), x.min(), x.max())
         output = output.astype(x.dtype)
     return output
-
-
-AFFINE_TRANSFORM_INTERPOLATIONS = {  # map to order
-    "nearest": 0,
-    "bilinear": 1,
-}
-AFFINE_TRANSFORM_FILL_MODES = {
-    "constant",
-    "nearest",
-    "wrap",
-    "mirror",
-    "reflect",
-}
 
 
 def affine_transform(
@@ -688,7 +708,7 @@ def perspective_transform(
 
     batch_size, height, width, channels = images.shape
 
-    transforms = compute_homography_matrix(start_points, end_points)
+    transforms = _compute_homography_matrix(start_points, end_points)
 
     if len(transforms.shape) == 1:
         transforms = np.expand_dims(transforms, axis=0)
@@ -735,7 +755,7 @@ def perspective_transform(
     return output
 
 
-def compute_homography_matrix(start_points, end_points):
+def _compute_homography_matrix(start_points, end_points):
     start_x1, start_y1 = start_points[:, 0, 0], start_points[:, 0, 1]
     start_x2, start_y2 = start_points[:, 1, 0], start_points[:, 1, 1]
     start_x3, start_y3 = start_points[:, 2, 0], start_points[:, 2, 1]
@@ -875,15 +895,6 @@ def compute_homography_matrix(start_points, end_points):
     homography_matrix = np.reshape(homography_matrix, [-1, 8])
 
     return homography_matrix
-
-
-MAP_COORDINATES_FILL_MODES = {
-    "constant",
-    "nearest",
-    "wrap",
-    "mirror",
-    "reflect",
-}
 
 
 def map_coordinates(
@@ -1135,3 +1146,28 @@ def elastic_transform(
     transformed_images = transformed_images.astype(input_dtype)
 
     return transformed_images
+
+
+def scale_and_translate(
+    images, shape, spatial_dims, scale, translation, method, antialias=True
+):
+    if method not in SCALE_AND_TRANSLATE_METHODS:
+        raise ValueError(
+            "Invalid value for argument `method`. Expected of one "
+            f"{SCALE_AND_TRANSLATE_METHODS}. Received: method={method}"
+        )
+    if method in ("linear", "bilinear", "trilinear", "triangle"):
+        method = "linear"
+    elif method in ("cubic", "bicubic", "tricubic"):
+        method = "cubic"
+
+    images = convert_to_tensor(images)
+    scale = convert_to_tensor(scale)
+    translation = convert_to_tensor(translation)
+    kernel = _kernels[method]
+    dtype = backend.result_type(scale.dtype, translation.dtype)
+    scale = scale.astype(dtype)
+    translation = translation.astype(dtype)
+    return _scale_and_translate(
+        images, shape, spatial_dims, scale, translation, kernel, antialias
+    )

--- a/keras/src/backend/openvino/image.py
+++ b/keras/src/backend/openvino/image.py
@@ -37,3 +37,11 @@ def map_coordinates(
     raise NotImplementedError(
         "`map_coordinates` is not supported with openvino backend"
     )
+
+
+def scale_and_translate(
+    images, shape, spatial_dims, scale, translation, method, antialias=True
+):
+    raise NotImplementedError(
+        "`scale_and_translate` is not supported with openvino backend"
+    )

--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -2,10 +2,12 @@ import functools
 import itertools
 import operator
 
+import numpy as np
 import tensorflow as tf
 
 from keras.src import backend
 from keras.src.backend.tensorflow.core import convert_to_tensor
+from keras.src.backend.tensorflow.numpy import moveaxis
 from keras.src.random.seed_generator import draw_seed
 
 RESIZE_INTERPOLATIONS = (
@@ -16,6 +18,34 @@ RESIZE_INTERPOLATIONS = (
     "bicubic",
     "area",
 )
+AFFINE_TRANSFORM_INTERPOLATIONS = (
+    "nearest",
+    "bilinear",
+)
+AFFINE_TRANSFORM_FILL_MODES = (
+    "constant",
+    "nearest",
+    "wrap",
+    # "mirror", not supported by TF
+    "reflect",
+)
+MAP_COORDINATES_FILL_MODES = {
+    "constant",
+    "nearest",
+    "wrap",
+    "mirror",
+    "reflect",
+}
+SCALE_AND_TRANSLATE_METHODS = {
+    "linear",
+    "bilinear",
+    "trilinear",
+    "cubic",
+    "bicubic",
+    "tricubic",
+    "lanczos3",
+    "lanczos5",
+}
 
 
 def rgb_to_grayscale(images, data_format=None):
@@ -300,19 +330,6 @@ def resize(
         elif len(images.shape) == 3:
             resized = tf.transpose(resized, (2, 0, 1))
     return resized
-
-
-AFFINE_TRANSFORM_INTERPOLATIONS = (
-    "nearest",
-    "bilinear",
-)
-AFFINE_TRANSFORM_FILL_MODES = (
-    "constant",
-    "nearest",
-    "wrap",
-    # "mirror", not supported by TF
-    "reflect",
-)
 
 
 def affine_transform(
@@ -607,15 +624,6 @@ def _reflect_index_fixer(index, size):
     )
 
 
-_INDEX_FIXERS = {
-    "constant": lambda index, size: index,
-    "nearest": lambda index, size: tf.clip_by_value(index, 0, size - 1),
-    "wrap": lambda index, size: index % size,
-    "mirror": _mirror_index_fixer,
-    "reflect": _reflect_index_fixer,
-}
-
-
 def _nearest_indices_and_weights(coordinate):
     coordinate = (
         coordinate if coordinate.dtype.is_integer else tf.round(coordinate)
@@ -650,6 +658,12 @@ def map_coordinates(
         raise ValueError(
             "Invalid coordinates rank: expected at least rank 2."
             f" Received input with shape: {coordinate_arrs.shape}"
+        )
+    if fill_mode not in MAP_COORDINATES_FILL_MODES:
+        raise ValueError(
+            "Invalid value for argument `fill_mode`. Expected one of "
+            f"{set(MAP_COORDINATES_FILL_MODES.keys())}. Received: "
+            f"fill_mode={fill_mode}"
         )
 
     fill_value = convert_to_tensor(fill_value, dtype=input_arr.dtype)
@@ -928,3 +942,123 @@ def elastic_transform(
     transformed_images = tf.cast(transformed_images, input_dtype)
 
     return transformed_images
+
+
+def _fill_triangle_kernel(x):
+    return tf.maximum(tf.constant(0, dtype=x.dtype), 1 - tf.abs(x))
+
+
+def _fill_keys_cubic_kernel(x):
+    out = ((1.5 * x - 2.5) * x) * x + 1.0
+    out = tf.where(x >= 1.0, ((-0.5 * x + 2.5) * x - 4.0) * x + 2.0, out)
+    return tf.where(x >= 2.0, 0.0, out)
+
+
+def _fill_lanczos_kernel(radius, x):
+    y = radius * tf.sin(np.pi * x) * tf.sin(np.pi * x / radius)
+    out = tf.where(
+        x > 1e-3, tf.divide(y, tf.where(x != 0, np.pi**2 * x**2, 1)), 1
+    )
+    return tf.where(x > radius, 0.0, out)
+
+
+_kernels = {
+    "linear": _fill_triangle_kernel,
+    "cubic": _fill_keys_cubic_kernel,
+    "lanczos3": lambda x: _fill_lanczos_kernel(3.0, x),
+    "lanczos5": lambda x: _fill_lanczos_kernel(5.0, x),
+}
+
+
+def _compute_weight_mat(
+    input_size, output_size, scale, translation, kernel, antialias
+):
+    dtype = backend.result_type(scale.dtype, translation.dtype)
+    inv_scale = 1.0 / scale
+    kernel_scale = tf.maximum(inv_scale, 1.0) if antialias else 1.0
+    sample_f = (
+        (tf.range(output_size, dtype=dtype) + 0.5) * inv_scale
+        - translation * inv_scale
+        - 0.5
+    )
+    x = (
+        tf.abs(
+            sample_f[tf.newaxis, :]
+            - tf.range(input_size, dtype=dtype)[:, tf.newaxis]
+        )
+        / kernel_scale
+    )
+    weights = kernel(x)
+    total_weight_sum = tf.reduce_sum(weights, axis=0, keepdims=True)
+    weights = tf.where(
+        tf.abs(total_weight_sum) > 1000.0 * float(np.finfo(np.float32).eps),
+        tf.divide(
+            weights, tf.where(total_weight_sum != 0, total_weight_sum, 1)
+        ),
+        0,
+    )
+    input_size_minus_0_5 = tf.cast(input_size, dtype=dtype) - 0.5
+    return tf.where(
+        tf.logical_and(sample_f >= -0.5, sample_f <= input_size_minus_0_5)[
+            tf.newaxis, :
+        ],
+        weights,
+        0,
+    )
+
+
+def _scale_and_translate(
+    x, output_shape, spatial_dims, scale, translation, kernel, antialias
+):
+    x = convert_to_tensor(x)
+    input_shape = tf.shape(x)
+    if len(spatial_dims) == 0:
+        return x
+    if backend.is_int_dtype(x.dtype):
+        output = tf.cast(x, tf.float32)
+        use_rounding = True
+    else:
+        output = tf.identity(x)
+        use_rounding = False
+    for i, d in enumerate(spatial_dims):
+        d = d % x.ndim
+        m, n = input_shape[d], output_shape[d]
+        w = tf.cast(
+            _compute_weight_mat(
+                m, n, scale[i], translation[i], kernel, antialias
+            ),
+            output.dtype,
+        )
+        output = tf.tensordot(output, w, axes=(d, 0))
+        output = moveaxis(output, -1, d)
+    if use_rounding:
+        output = tf.clip_by_value(
+            tf.round(output), tf.reduce_min(x), tf.reduce_max(x)
+        )
+        output = tf.cast(output, x.dtype)
+    return output
+
+
+def scale_and_translate(
+    images, shape, spatial_dims, scale, translation, method, antialias=True
+):
+    if method not in SCALE_AND_TRANSLATE_METHODS:
+        raise ValueError(
+            "Invalid value for argument `method`. Expected of one "
+            f"{SCALE_AND_TRANSLATE_METHODS}. Received: method={method}"
+        )
+    if method in ("linear", "bilinear", "trilinear", "triangle"):
+        method = "linear"
+    elif method in ("cubic", "bicubic", "tricubic"):
+        method = "cubic"
+
+    images = convert_to_tensor(images)
+    scale = convert_to_tensor(scale)
+    translation = convert_to_tensor(translation)
+    kernel = _kernels[method]
+    dtype = backend.result_type(scale.dtype, translation.dtype)
+    scale = tf.cast(scale, dtype)
+    translation = tf.cast(translation, dtype)
+    return _scale_and_translate(
+        images, shape, spatial_dims, scale, translation, kernel, antialias
+    )

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -2,13 +2,16 @@ import functools
 import itertools
 import operator
 
+import numpy as np
 import torch
 import torch._dynamo as dynamo
 import torch.nn.functional as F
 
 from keras.src import backend
+from keras.src.backend.torch.core import cast
 from keras.src.backend.torch.core import convert_to_tensor
 from keras.src.backend.torch.core import get_device
+from keras.src.backend.torch.core import to_torch_dtype
 from keras.src.random.seed_generator import draw_seed
 
 RESIZE_INTERPOLATIONS = {
@@ -16,11 +19,31 @@ RESIZE_INTERPOLATIONS = {
     "nearest": "nearest-exact",
     "bicubic": "bicubic",
 }
-
 UNSUPPORTED_INTERPOLATIONS = (
     "lanczos3",
     "lanczos5",
 )
+AFFINE_TRANSFORM_INTERPOLATIONS = {
+    "nearest": 0,
+    "bilinear": 1,
+}
+AFFINE_TRANSFORM_FILL_MODES = {
+    "constant",
+    "nearest",
+    "wrap",
+    "mirror",
+    "reflect",
+}
+SCALE_AND_TRANSLATE_METHODS = {
+    "linear",
+    "bilinear",
+    "trilinear",
+    "cubic",
+    "bicubic",
+    "tricubic",
+    "lanczos3",
+    "lanczos5",
+}
 
 
 def rgb_to_grayscale(images, data_format=None):
@@ -324,19 +347,6 @@ def resize(
         out_dtype=out_dtype,
     )
     return resized
-
-
-AFFINE_TRANSFORM_INTERPOLATIONS = {
-    "nearest": 0,
-    "bilinear": 1,
-}
-AFFINE_TRANSFORM_FILL_MODES = {
-    "constant",
-    "nearest",
-    "wrap",
-    "mirror",
-    "reflect",
-}
 
 
 def affine_transform(
@@ -888,7 +898,7 @@ def gaussian_blur(
 
 
 @dynamo.disable()
-def torch_seed_generator(seed):
+def _torch_seed_generator(seed):
     first_seed, second_seed = draw_seed(seed)
     device = get_device()
     if device == "meta":
@@ -945,7 +955,7 @@ def elastic_transform(
         batch_size, channels, height, width = images.shape
         channel_axis = 1
 
-    generator = torch_seed_generator(seed) if get_device() == "meta" else None
+    generator = _torch_seed_generator(seed) if get_device() == "meta" else None
     dx = (
         torch.normal(
             0.0,
@@ -1030,3 +1040,131 @@ def elastic_transform(
     transformed_images = transformed_images.to(input_dtype)
 
     return transformed_images
+
+
+def _fill_triangle_kernel(x):
+    return torch.maximum(torch.tensor(0, dtype=x.dtype), 1 - torch.abs(x))
+
+
+def _fill_keys_cubic_kernel(x):
+    out = ((1.5 * x - 2.5) * x) * x + 1.0
+    out = torch.where(x >= 1.0, ((-0.5 * x + 2.5) * x - 4.0) * x + 2.0, out)
+    return torch.where(x >= 2.0, 0.0, out)
+
+
+def _fill_lanczos_kernel(radius, x):
+    y = radius * torch.sin(np.pi * x) * torch.sin(np.pi * x / radius)
+    out = torch.where(
+        x > 1e-3, torch.divide(y, torch.where(x != 0, np.pi**2 * x**2, 1)), 1
+    )
+    return torch.where(x > radius, 0.0, out)
+
+
+_kernels = {
+    "linear": _fill_triangle_kernel,
+    "cubic": _fill_keys_cubic_kernel,
+    "lanczos3": lambda x: _fill_lanczos_kernel(3.0, x),
+    "lanczos5": lambda x: _fill_lanczos_kernel(5.0, x),
+}
+
+
+def _compute_weight_mat(
+    input_size, output_size, scale, translation, kernel, antialias
+):
+    dtype = to_torch_dtype(backend.result_type(scale.dtype, translation.dtype))
+    inv_scale = 1.0 / scale
+    kernel_scale = (
+        torch.maximum(
+            inv_scale,
+            torch.tensor(1.0, dtype=inv_scale.dtype, device=inv_scale.device),
+        )
+        if antialias
+        else 1.0
+    )
+    sample_f = (
+        (torch.arange(output_size, dtype=dtype, device=inv_scale.device) + 0.5)
+        * inv_scale
+        - translation * inv_scale
+        - 0.5
+    )
+    x = (
+        torch.abs(
+            sample_f[torch.newaxis, :]
+            - torch.arange(input_size, dtype=dtype, device=sample_f.device)[
+                :, torch.newaxis
+            ]
+        )
+        / kernel_scale
+    )
+    weights = kernel(x)
+    total_weight_sum = torch.sum(weights, dim=0, keepdims=True)
+    weights = torch.where(
+        torch.abs(total_weight_sum) > 1000.0 * float(np.finfo(np.float32).eps),
+        torch.divide(
+            weights, torch.where(total_weight_sum != 0, total_weight_sum, 1)
+        ),
+        0,
+    )
+    input_size_minus_0_5 = input_size - 0.5
+    return torch.where(
+        torch.logical_and(sample_f >= -0.5, sample_f <= input_size_minus_0_5)[
+            torch.newaxis, :
+        ],
+        weights,
+        0,
+    )
+
+
+def _scale_and_translate(
+    x, output_shape, spatial_dims, scale, translation, kernel, antialias
+):
+    x = convert_to_tensor(x)
+    input_shape = x.shape
+    if len(spatial_dims) == 0:
+        return x
+    if backend.is_int_dtype(x.dtype):
+        output = cast(x, "float32")
+        use_rounding = True
+    else:
+        output = torch.clone(x)
+        use_rounding = False
+    for i, d in enumerate(spatial_dims):
+        d = d % x.ndim
+        m, n = input_shape[d], output_shape[d]
+        w = cast(
+            _compute_weight_mat(
+                m, n, scale[i], translation[i], kernel, antialias
+            ),
+            output.dtype,
+        )
+        output = torch.tensordot(output, w, dims=((d,), (0,)))
+        output = torch.moveaxis(output, -1, d)
+    if use_rounding:
+        output = torch.clip(torch.round(output), torch.min(x), torch.max(x))
+        output = cast(output, x.dtype)
+    return output
+
+
+def scale_and_translate(
+    images, shape, spatial_dims, scale, translation, method, antialias=True
+):
+    if method not in SCALE_AND_TRANSLATE_METHODS:
+        raise ValueError(
+            "Invalid value for argument `method`. Expected of one "
+            f"{SCALE_AND_TRANSLATE_METHODS}. Received: method={method}"
+        )
+    if method in ("linear", "bilinear", "trilinear", "triangle"):
+        method = "linear"
+    elif method in ("cubic", "bicubic", "tricubic"):
+        method = "cubic"
+
+    images = convert_to_tensor(images)
+    scale = convert_to_tensor(scale)
+    translation = convert_to_tensor(translation)
+    kernel = _kernels[method]
+    dtype = backend.result_type(scale.dtype, translation.dtype)
+    scale = cast(scale, dtype)
+    translation = cast(translation, dtype)
+    return _scale_and_translate(
+        images, shape, spatial_dims, scale, translation, kernel, antialias
+    )

--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -1603,3 +1603,100 @@ def elastic_transform(
         seed=seed,
         data_format=data_format,
     )
+
+
+class ScaleAndTranslate(Operation):
+    def __init__(self, spatial_dims, method, antialias=True, *, name=None):
+        super().__init__(name=name)
+        self.spatial_dims = spatial_dims
+        self.method = method
+        self.antialias = antialias
+
+    def call(self, images, shape, scale, translation):
+        return backend.image.scale_and_translate(
+            images,
+            shape=shape,
+            spatial_dims=self.spatial_dims,
+            scale=scale,
+            translation=translation,
+            method=self.method,
+            antialias=self.antialias,
+        )
+
+    def compute_output_spec(self, images, shape, scale, translation):
+        return KerasTensor(shape, dtype=images.dtype)
+
+
+@keras_export("keras.ops.image.scale_and_translate")
+def scale_and_translate(
+    images, shape, spatial_dims, scale, translation, method, antialias=True
+):
+    """Apply a scale and translation to the images.
+
+    Generates a new image of shape `shape` by resampling from the input image
+    using the sampling method corresponding to method. For 2D images, this
+    operation transforms a location in the input images, (x, y), to a location
+    in the output image according to:
+
+    `(x * scale[1] + translation[1], y * scale[0] + translation[0])`.
+
+    (Note the inverse warp is used to generate the sample locations.) Assumes
+    half-centered pixels, i.e the pixel at integer location row, col has
+    coordinates y, x = row + 0.5, col + 0.5, and similarly for other input image
+    dimensions.
+
+    If an output location(pixel) maps to an input sample location that is
+    outside the input boundaries then the value for the output location will be
+    set to zero.
+
+    The `method` argument expects one of the following resize methods:
+
+    - `"linear"`, `"bilinear"`, `"trilinear"`, `"triangle"`: Linear
+        interpolation. If `antialias` is True, uses a triangular filter when
+        downsampling.
+    - `"cubic"`, `"bicubic"`, `"tricubic"`: Cubic interpolation, using the Keys
+        cubic kernel.
+    - `"lanczos3"`: Lanczos resampling, using a kernel of radius 3.
+    - `"lanczos5"`: Lanczos resampling, using a kernel of radius 5.
+
+    Args:
+        images: The input array.
+        shape: The output shape, as a sequence of integers with length equal to
+            the number of dimensions of image.
+        spatial_dims: A length K tuple specifying the spatial dimensions that
+            the passed `scale` and `translation` should be applied to.
+        scale: A [K] array with the same number of dimensions as `images`,
+            containing the scale to apply in each dimension.
+        translation: A [K] array with the same number of dimensions as `images`,
+            containing the translation to apply in each dimension.
+        method: A string specifying the resizing method to use. Available
+            methods are `"linear"`, `"bilinear"`, `"trilinear"`, `"triangle"`,
+            `"cubic"`, `"bicubic"`, `"tricubic"`, `"lanczos3"` and `"lanczos5"`.
+        antialias: Whether an antialiasing filter should be applied when
+            downsampling. Has no effect when upsampling. Defaults to `True`.
+
+    Returns:
+        The scale and translated images.
+
+    Example:
+
+    >>> images = np.arange(9, dtype="float32").reshape((3, 3))
+    >>> scale = np.array([2.0, 2.0]).astype("float32")
+    >>> translation = -(scale / 2.0 - 0.5)
+    >>> resized_images = keras.image.scale_and_translate(
+    ...     images, (5, 5), (0, 1), scale, translation, "linear"
+    ... )
+    >>> resized_images
+    array([[0.0 0.5 1.0 1.5 2.0]
+           [1.5 2.0 2.5 3.0 3.5]
+           [3.0 3.5 4.0 4.5 5.0]
+           [4.5 5.0 5.5 6.0 6.5]
+           [6.0 6.5 7.0 7.5 8.0]], dtype=float32)
+    """
+    if any_symbolic_tensors((images, scale, translation)):
+        return ScaleAndTranslate(spatial_dims, method, antialias).symbolic_call(
+            images, shape, scale, translation
+        )
+    return backend.image.scale_and_translate(
+        images, shape, spatial_dims, scale, translation, method, antialias
+    )

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -1,5 +1,6 @@
 import math
 
+import jax
 import numpy as np
 import pytest
 import scipy.ndimage
@@ -202,6 +203,21 @@ class ImageOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor([None, 3, 20, 20])
         out = kimage.elastic_transform(x)
         self.assertEqual(out.shape, (None, 3, 20, 20))
+
+    def test_scale_and_translate(self):
+        images = KerasTensor([None, 20, 20, 3])
+        shape = (None, 25, 25, 3)
+        scale = KerasTensor([2])
+        translation = KerasTensor([2])
+        out = kimage.scale_and_translate(
+            images,
+            shape=shape,
+            spatial_dims=(1, 2),
+            scale=scale,
+            translation=translation,
+            method="linear",
+        )
+        self.assertEqual(out.shape, shape)
 
 
 class ImageOpsStaticShapeTest(testing.TestCase):
@@ -461,6 +477,21 @@ class ImageOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor([3, 20, 20])
         out = kimage.elastic_transform(x)
         self.assertEqual(out.shape, (3, 20, 20))
+
+    def test_scale_and_translate(self):
+        images = KerasTensor([20, 20, 3])
+        shape = (25, 25, 3)
+        scale = KerasTensor([2])
+        translation = KerasTensor([2])
+        out = kimage.scale_and_translate(
+            images,
+            shape=shape,
+            spatial_dims=(0, 1),
+            scale=scale,
+            translation=translation,
+            method="linear",
+        )
+        self.assertEqual(out.shape, shape)
 
 
 AFFINE_TRANSFORM_INTERPOLATIONS = {  # map to order
@@ -1888,6 +1919,37 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         self.assertTrue(np.all(out[:, :1] == 0))
         self.assertTrue(np.all(out[:, -1:] == 0))
         self.assertTrue(np.all(out[1:3, 1:3] == 1))
+
+    @parameterized.named_parameters(
+        named_product(
+            method=["linear", "cubic", "lanczos3", "lanczos5"],
+            antialias=[True, False],
+        )
+    )
+    def test_scale_and_translate(self, method, antialias):
+        images = np.random.random((30, 30, 3)).astype("float32") * 255
+        scale = np.array([2.0, 2.0]).astype("float32")
+        translation = -(scale / 2.0 - 0.5)
+        out = kimage.scale_and_translate(
+            images,
+            shape=(15, 15, 3),
+            spatial_dims=(0, 1),
+            scale=scale,
+            translation=translation,
+            method=method,
+            antialias=antialias,
+        )
+        ref_out = jax.image.scale_and_translate(
+            images,
+            shape=(15, 15, 3),
+            spatial_dims=(0, 1),
+            scale=scale,
+            translation=translation,
+            method=method,
+            antialias=antialias,
+        )
+        self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
+        self.assertAllClose(ref_out, out, atol=1e-4)
 
 
 class ImageOpsBehaviorTests(testing.TestCase):


### PR DESCRIPTION
This op is useful if we want to perform the same functionality as `torch.nn.functional.interpolate` with `align_corners=True`.

Some depth estimation models require this functionality.

Here is an example:

```python
import numpy as np
import torch

from keras.src import ops

torch_y = torch.nn.functional.interpolate(
    torch.from_numpy(x).unsqueeze(0).unsqueeze(0),
    size=(5, 5),
    mode="bilinear",
    align_corners=True,
)
torch_y = torch_y.detach().cpu().numpy()[0, 0]


def keras_interpolate(images, size, interpolation, antialias=False):
    shape = tuple([1] + list(size) + [1])
    spatial_dims = (1, 2)
    scale = ops.convert_to_tensor(
        [(shape[i] - 1.0) / (images.shape[i] - 1.0) for i in spatial_dims]
    )
    translation = -(scale / 2.0 - 0.5)
    return ops.image.scale_and_translate(
        images,
        shape,
        spatial_dims,
        scale,
        translation,
        interpolation,
        antialias,
    )


keras_y = keras_interpolate(
    ops.expand_dims(ops.convert_to_tensor(x, dtype="float32"), (0, -1)),
    size=(5, 5),
    interpolation="bilinear",
    antialias=False,
)
keras_y = ops.convert_to_numpy(keras_y)[0, ..., 0]
np.testing.assert_allclose(torch_y, keras_y, rtol=1e-5, atol=1e-5)
```

The benchmark:
- `(1, 256, 256, 64)` to `(1, 128, 128, 64)`
- Jitted / Compiled

|Backend|Time|
|-|-|
|jax|0.0114s|
|tensorflow|0.0668s|
|torch|0.0274s|

<details>

<summary> benchmark.py </summary>

```python
import time

import numpy as np

from keras.src import backend
from keras.src import ops

images = np.random.uniform(size=(2, 256, 256, 64)).astype("float32")
shape = (2, 128, 128, 64)
spatial_dims = (1, 2)
scale = np.array(
    [(shape[i] - 1.0) / (images.shape[i] - 1.0) for i in spatial_dims],
    dtype="float32",
)
translation = -(scale / 2.0 - 0.5)
method = "linear"

if backend.backend() == "jax":
    import jax

    jit_scale_and_translate = jax.jit(
        ops.image.scale_and_translate, static_argnums=(1, 2, 5)
    )

elif backend.backend() == "tensorflow":
    import tensorflow as tf

    @tf.function(jit_compile=True)
    def jit_scale_and_translate(*args, **kwargs):
        return ops.image.scale_and_translate(*args, **kwargs)

elif backend.backend() == "torch":
    import torch

    @torch.compile
    def jit_scale_and_translate(*args, **kwargs):
        return ops.image.scale_and_translate(*args, **kwargs)
else:

    def jit_scale_and_translate(*args, **kwargs):
        return ops.image.scale_and_translate(*args, **kwargs)


# Warmup
for _ in range(3):
    jit_scale_and_translate(
        images, shape, spatial_dims, scale, translation, method
    )
print("Warmup done.")

st = time.time()
for i in range(5):
    resized_images = jit_scale_and_translate(
        images, shape, spatial_dims, scale, translation, method
    )
ed = time.time()

print(resized_images.shape)
print(f"Time taken: {ed - st:.4f} seconds")

```

</details>