### PR TITLE
[JAX] Fix breakage due to default dtype handling in ctc_loss.

### DIFF
--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -708,7 +708,9 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
     logprobs_phi = logprobs[:, :, mask_index : mask_index + 1]  # [B, T, 1]
     logprobs_phi = jnp.transpose(logprobs_phi, (1, 0, 2))  # [T, B, 1]
 
-    _one_hot = jax.nn.one_hot(target, num_classes=num_classes)  # [B, N, K]
+    _one_hot = jax.nn.one_hot(
+        target, num_classes=num_classes, dtype=logprobs.dtype
+    )  # [B, N, K]
     logprobs_emit = jnp.einsum("btk,bnk->btn", logprobs, _one_hot)
     logprobs_emit = jnp.transpose(logprobs_emit, (1, 0, 2))  # [T, B, N]
 
@@ -765,7 +767,11 @@ def ctc_loss(target, output, target_length, output_length, mask_index=0):
 
     # extract per_seq_loss
     # [B, N+1]
-    _one_hot = jax.nn.one_hot(label_lengths, num_classes=max_label_length + 1)
+    _one_hot = jax.nn.one_hot(
+        label_lengths,
+        num_classes=max_label_length + 1,
+        dtype=logalpha_phi_last.dtype,
+    )
     per_seq_loss = -jnp.einsum("bn,bn->b", logalpha_phi_last, _one_hot)
     return per_seq_loss
 


### PR DESCRIPTION
from cl/794615827
"_Keras is the only user of a deprecated JAX api (jax_default_dtype_bits) for electing float32 default dtypes. This API will be removed in an upcoming JAX release.

A recent JAX change to default dtype handling if that flag is set broke a Keras test ([cl/794553125](http://cl/794553125)). Since the behavior that Keras is relying on is deprecated it is probably best to update Keras not to depend on that default dtype handling in the first place in the test that broke (ctc_loss)._"