### PR TITLE
Improve deserialization error about `@register_keras_serializable`.

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -834,8 +834,9 @@ def _retrieve_class_or_fn(
                 )
 
     raise TypeError(
-        f"Could not locate {obj_type} '{name}'. "
-        "Make sure custom classes are decorated with "
-        "`@keras.saving.register_keras_serializable()`. "
-        f"Full object config: {full_config}"
+        f"Could not locate {obj_type} '{name}'. Make sure custom classes and "
+        "functions are decorated with "
+        "`@keras.saving.register_keras_serializable()`. If they are already "
+        "decorated, make sure they are all imported so that the decorator is "
+        f"run before trying to load them. Full object config: {full_config}"
     )


### PR DESCRIPTION
There is a confusing case when a user has decorated their class or function with `@keras.saving.register_keras_serializable()`, but gets the error message: "Make sure custom classes are decorated with `@keras.saving.register_keras_serializable()`". This happens if the decorated function or class has not been imported/loaded and the decorator has not been run.

This augments the error message to explain this case.