### PR TITLE
Make `vectorized_map` op serializable.

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -186,6 +186,7 @@ CoreOpsCorrectnessTest::test_scatter
 CoreOpsCorrectnessTest::test_switch 
 CoreOpsCorrectnessTest::test_unstack
 CoreOpsCorrectnessTest::test_vectorized_map
+CoreOpsBehaviorTests::test_vectorized_map_serialization
 ExtractSequencesOpTest::test_extract_sequences_call
 InTopKTest::test_in_top_k_call
 MathOpsCorrectnessTest::test_erfinv_operation_basic

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -8,6 +8,7 @@ from keras.src.backend import KerasTensor
 from keras.src.backend import any_symbolic_tensors
 from keras.src.backend.common.backend_utils import slice_along_axis
 from keras.src.ops.operation import Operation
+from keras.src.saving import serialization_lib
 from keras.src.utils import traceback_utils
 
 
@@ -1104,6 +1105,19 @@ class VectorizedMap(Operation):
 
         y = tree.map_structure(append_batch_axis, y)
         return y
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"function": self.function})
+        return config
+
+    @classmethod
+    def from_config(cls, config):
+        config = config.copy()
+        config["function"] = serialization_lib.deserialize_keras_object(
+            config["function"]
+        )
+        return cls(**config)
 
 
 @keras_export("keras.ops.vectorized_map")


### PR DESCRIPTION
All ops that take tensors as inputs are in scope for serialization. They get serialized if they appear as part of a functional model.

The `VectorizedMap` op class needs a custom `get_config()` and `from_config()` to handle the `function` parameter, which is not a simple type. The fallback `get_config` logic only handles simple types.

Note that some other ops will need a similar change, which will come in a separate PR because it requires a another change.