### PR TITLE
Propagate `safe_mode` flag to legacy h5 loading code.

### DIFF
--- a/keras/src/layers/core/lambda_layer.py
+++ b/keras/src/layers/core/lambda_layer.py
@@ -167,14 +167,15 @@ class Lambda(Layer):
         )
 
     @staticmethod
-    def _raise_for_lambda_deserialization(arg_name, safe_mode):
+    def _raise_for_lambda_deserialization(safe_mode):
         if safe_mode:
             raise ValueError(
-                f"The `{arg_name}` of this `Lambda` layer is a Python lambda. "
-                "Deserializing it is unsafe. If you trust the source of the "
-                "config artifact, you can override this error "
-                "by passing `safe_mode=False` "
-                "to `from_config()`, or calling "
+                "Requested the deserialization of a `Lambda` layer whose "
+                "`function` is a Python lambda. This carries a potential risk "
+                "of arbitrary code execution and thus it is disallowed by "
+                "default. If you trust the source of the artifact, you can "
+                "override this error by passing `safe_mode=False` to the "
+                "loading function, or calling "
                 "`keras.config.enable_unsafe_deserialization()."
             )
 
@@ -187,7 +188,7 @@ class Lambda(Layer):
             and "class_name" in fn_config
             and fn_config["class_name"] == "__lambda__"
         ):
-            cls._raise_for_lambda_deserialization("function", safe_mode)
+            cls._raise_for_lambda_deserialization(safe_mode)
             inner_config = fn_config["config"]
             fn = python_utils.func_load(
                 inner_config["code"],
@@ -206,7 +207,7 @@ class Lambda(Layer):
                 and "class_name" in fn_config
                 and fn_config["class_name"] == "__lambda__"
             ):
-                cls._raise_for_lambda_deserialization("function", safe_mode)
+                cls._raise_for_lambda_deserialization(safe_mode)
                 inner_config = fn_config["config"]
                 fn = python_utils.func_load(
                     inner_config["code"],

--- a/keras/src/legacy/saving/legacy_h5_format.py
+++ b/keras/src/legacy/saving/legacy_h5_format.py
@@ -11,6 +11,7 @@ from keras.src.legacy.saving import json_utils
 from keras.src.legacy.saving import saving_options
 from keras.src.legacy.saving import saving_utils
 from keras.src.saving import object_registration
+from keras.src.saving import serialization_lib
 from keras.src.utils import io_utils
 
 try:
@@ -72,7 +73,9 @@ def save_model_to_hdf5(model, filepath, overwrite=True, include_optimizer=True):
             f.close()
 
 
-def load_model_from_hdf5(filepath, custom_objects=None, compile=True):
+def load_model_from_hdf5(
+    filepath, custom_objects=None, compile=True, safe_mode=True
+):
     """Loads a model saved via `save_model_to_hdf5`.
 
     Args:
@@ -128,7 +131,9 @@ def load_model_from_hdf5(filepath, custom_objects=None, compile=True):
             model_config = model_config.decode("utf-8")
         model_config = json_utils.decode(model_config)
 
-        with saving_options.keras_option_scope(use_legacy_config=True):
+        legacy_scope = saving_options.keras_option_scope(use_legacy_config=True)
+        safe_mode_scope = serialization_lib.SafeModeScope(safe_mode)
+        with legacy_scope, safe_mode_scope:
             model = saving_utils.model_from_config(
                 model_config, custom_objects=custom_objects
             )

--- a/keras/src/legacy/saving/legacy_h5_format_test.py
+++ b/keras/src/legacy/saving/legacy_h5_format_test.py
@@ -158,8 +158,13 @@ class LegacyH5WholeModelTest(testing.TestCase):
 
         temp_filepath = os.path.join(self.get_temp_dir(), "lambda_model.h5")
         legacy_h5_format.save_model_to_hdf5(model, temp_filepath)
-        loaded = legacy_h5_format.load_model_from_hdf5(temp_filepath)
 
+        with self.assertRaisesRegex(ValueError, "arbitrary code execution"):
+            legacy_h5_format.load_model_from_hdf5(temp_filepath)
+
+        loaded = legacy_h5_format.load_model_from_hdf5(
+            temp_filepath, safe_mode=False
+        )
         self.assertAllClose(mean, loaded.layers[1].arguments["mu"])
         self.assertAllClose(std, loaded.layers[1].arguments["std"])
 
@@ -353,8 +358,13 @@ class LegacyH5BackwardsCompatTest(testing.TestCase):
 
         temp_filepath = os.path.join(self.get_temp_dir(), "lambda_model.h5")
         tf_keras_model.save(temp_filepath)
-        loaded = legacy_h5_format.load_model_from_hdf5(temp_filepath)
 
+        with self.assertRaisesRegex(ValueError, "arbitrary code execution"):
+            legacy_h5_format.load_model_from_hdf5(temp_filepath)
+
+        loaded = legacy_h5_format.load_model_from_hdf5(
+            temp_filepath, safe_mode=False
+        )
         self.assertAllClose(mean, loaded.layers[1].arguments["mu"])
         self.assertAllClose(std, loaded.layers[1].arguments["std"])
 

--- a/keras/src/legacy/saving/saving_utils.py
+++ b/keras/src/legacy/saving/saving_utils.py
@@ -1,4 +1,3 @@
-import json
 import threading
 
 from absl import logging
@@ -80,10 +79,6 @@ def model_from_config(config, custom_objects=None):
             function_dict["config"]["defaults"] = function_config[1]
             function_dict["config"]["closure"] = function_config[2]
             config["config"]["function"] = function_dict
-
-    # TODO(nkovela): Swap find and replace args during Keras 3.0 release
-    # Replace keras refs with keras
-    config = _find_replace_nested_dict(config, "keras.", "keras.")
 
     return serialization.deserialize_keras_object(
         config,
@@ -229,13 +224,6 @@ def _deserialize_metric(metric_config):
         # shape.
         return metric_config
     return metrics_module.deserialize(metric_config)
-
-
-def _find_replace_nested_dict(config, find, replace):
-    dict_str = json.dumps(config)
-    dict_str = dict_str.replace(find, replace)
-    config = json.loads(dict_str)
-    return config
 
 
 def _resolve_compile_arguments_compat(obj, obj_config, module):

--- a/keras/src/legacy/saving/serialization.py
+++ b/keras/src/legacy/saving/serialization.py
@@ -2,7 +2,6 @@
 
 import contextlib
 import inspect
-import json
 import threading
 import weakref
 
@@ -485,12 +484,6 @@ def deserialize_keras_object(
             arg_spec = inspect.getfullargspec(cls.from_config)
             custom_objects = custom_objects or {}
 
-            # TODO(nkovela): Swap find and replace args during Keras 3.0 release
-            # Replace keras refs with keras
-            cls_config = _find_replace_nested_dict(
-                cls_config, "keras.", "keras."
-            )
-
             if "custom_objects" in arg_spec.args:
                 deserialized_obj = cls.from_config(
                     cls_config,
@@ -565,10 +558,3 @@ def validate_config(config):
 def is_default(method):
     """Check if a method is decorated with the `default` wrapper."""
     return getattr(method, "_is_default", False)
-
-
-def _find_replace_nested_dict(config, find, replace):
-    dict_str = json.dumps(config)
-    dict_str = dict_str.replace(find, replace)
-    config = json.loads(dict_str)
-    return config

--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -194,7 +194,10 @@ def load_model(filepath, custom_objects=None, compile=True, safe_mode=True):
         )
     if str(filepath).endswith((".h5", ".hdf5")):
         return legacy_h5_format.load_model_from_hdf5(
-            filepath, custom_objects=custom_objects, compile=compile
+            filepath,
+            custom_objects=custom_objects,
+            compile=compile,
+            safe_mode=safe_mode,
         )
     elif str(filepath).endswith(".keras"):
         raise ValueError(

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -880,7 +880,7 @@ class SavingAPITest(testing.TestCase):
             ]
         )
         model.save(temp_filepath)
-        with self.assertRaisesRegex(ValueError, "Deserializing it is unsafe"):
+        with self.assertRaisesRegex(ValueError, "arbitrary code execution"):
             model = saving_lib.load_model(temp_filepath)
         model = saving_lib.load_model(temp_filepath, safe_mode=False)
 

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -656,12 +656,12 @@ def deserialize_keras_object(
     if config["class_name"] == "__lambda__":
         if safe_mode:
             raise ValueError(
-                "Requested the deserialization of a `lambda` object. "
-                "This carries a potential risk of arbitrary code execution "
-                "and thus it is disallowed by default. If you trust the "
-                "source of the saved model, you can pass `safe_mode=False` to "
-                "the loading function in order to allow `lambda` loading, "
-                "or call `keras.config.enable_unsafe_deserialization()`."
+                "Requested the deserialization of a Python lambda. This "
+                "carries a potential risk of arbitrary code execution and thus "
+                "it is disallowed by default. If you trust the source of the "
+                "artifact, you can override this error by passing "
+                "`safe_mode=False` to the loading function, or calling "
+                "`keras.config.enable_unsafe_deserialization()."
             )
         return python_utils.func_load(inner_config["value"])
     if tf is not None and config["class_name"] == "__typespec__":

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -175,31 +175,28 @@ class SerializationLibTest(testing.TestCase):
         _, new_obj, _ = self.roundtrip(obj, safe_mode=False)
         self.assertEqual(obj["activation"](3), new_obj["activation"](3))
 
-    # TODO
-    # def test_lambda_layer(self):
-    #     lmbda = keras.layers.Lambda(lambda x: x**2)
-    #     with self.assertRaisesRegex(ValueError, "arbitrary code execution"):
-    #         self.roundtrip(lmbda, safe_mode=True)
+    def test_lambda_layer(self):
+        lmbda = keras.layers.Lambda(lambda x: x**2)
+        with self.assertRaisesRegex(ValueError, "arbitrary code execution"):
+            self.roundtrip(lmbda, safe_mode=True)
 
-    #     _, new_lmbda, _ = self.roundtrip(lmbda, safe_mode=False)
-    #     x = ops.random.normal((2, 2))
-    #     y1 = lmbda(x)
-    #     y2 = new_lmbda(x)
-    #     self.assertAllClose(y1, y2, atol=1e-5)
+        _, new_lmbda, _ = self.roundtrip(lmbda, safe_mode=False)
+        x = ops.random.normal((2, 2))
+        y1 = lmbda(x)
+        y2 = new_lmbda(x)
+        self.assertAllClose(y1, y2, atol=1e-5)
 
-    # def test_safe_mode_scope(self):
-    #     lmbda = keras.layers.Lambda(lambda x: x**2)
-    #     with serialization_lib.SafeModeScope(safe_mode=True):
-    #         with self.assertRaisesRegex(
-    #             ValueError, "arbitrary code execution"
-    #         ):
-    #             self.roundtrip(lmbda)
-    #     with serialization_lib.SafeModeScope(safe_mode=False):
-    #         _, new_lmbda, _ = self.roundtrip(lmbda)
-    #     x = ops.random.normal((2, 2))
-    #     y1 = lmbda(x)
-    #     y2 = new_lmbda(x)
-    #     self.assertAllClose(y1, y2, atol=1e-5)
+    def test_safe_mode_scope(self):
+        lmbda = keras.layers.Lambda(lambda x: x**2)
+        with serialization_lib.SafeModeScope(safe_mode=True):
+            with self.assertRaisesRegex(ValueError, "arbitrary code execution"):
+                self.roundtrip(lmbda)
+        with serialization_lib.SafeModeScope(safe_mode=False):
+            _, new_lmbda, _ = self.roundtrip(lmbda)
+        x = ops.random.normal((2, 2))
+        y1 = lmbda(x)
+        y2 = new_lmbda(x)
+        self.assertAllClose(y1, y2, atol=1e-5)
 
     @pytest.mark.requires_trainable_backend
     def test_dict_inputs_outputs(self):

--- a/keras/src/utils/torch_utils.py
+++ b/keras/src/utils/torch_utils.py
@@ -172,10 +172,10 @@ class TorchModuleWrapper(Layer):
                     "Requested the deserialization of a `torch.nn.Module` "
                     "object via `torch.load()`. This carries a potential risk "
                     "of arbitrary code execution and thus it is disallowed by "
-                    "default. If you trust the source of the saved model, you "
-                    "can pass `safe_mode=False` to the loading function in "
-                    "order to allow `torch.nn.Module` loading, or call "
-                    "`keras.config.enable_unsafe_deserialization()`."
+                    "default. If you trust the source of the artifact, you can "
+                    "override this error by passing `safe_mode=False` to the "
+                    "loading function, or calling "
+                    "`keras.config.enable_unsafe_deserialization()."
                 )
 
             # Decode the base64 string back to bytes


### PR DESCRIPTION
Also:
- removed no-op renaming code in legacy saving
- uncommented unit tests in `serialization_lib_test.py`
- made various error messages related to `safe_mode` more consistent