### PR TITLE
Remove the usage of `JAX_DEFAULT_DTYPE_BITS` and the tests for 64-bit dtypes.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,3 @@
-import os
-
-# When using jax.experimental.enable_x64 in unit test, we want to keep the
-# default dtype with 32 bits, aligning it with Keras's default.
-os.environ["JAX_DEFAULT_DTYPE_BITS"] = "32"
-
 try:
     # When using torch and tensorflow, torch needs to be imported first,
     # otherwise it will segfault upon import. This should force the torch

--- a/keras/src/backend/common/dtypes.py
+++ b/keras/src/backend/common/dtypes.py
@@ -244,6 +244,7 @@ BIT64_TO_BIT32_DTYPE = {
     "int64": "int32",
     "uint64": "uint32",
     "float64": "float32",
+    "complex128": "complex64",
 }
 
 
@@ -275,6 +276,10 @@ def _lattice_result_type(*args):
     precision = config.floatx()[-2:]
     if out_weak_type:
         out_dtype = _resolve_weak_type(out_dtype, precision=precision)
+
+    # Force to be 32-bit dtype when encountering 64-bit dtype.
+    # TODO(hongyu): Add a config to enable 64-bit dtypes.
+    out_dtype = BIT64_TO_BIT32_DTYPE.get(out_dtype, out_dtype)
     return out_dtype
 
 

--- a/keras/src/backend/common/variables_test.py
+++ b/keras/src/backend/common/variables_test.py
@@ -782,47 +782,36 @@ class VariableOpsBehaviorTest(test_case.TestCase):
             float(v)
 
 
-# TODO: Using uint64 will lead to weak type promotion (`float`),
-# resulting in different behavior between JAX and Keras. Currently, we
-# are skipping the test for uint64
-ALL_DTYPES = [
-    x for x in dtypes.ALLOWED_DTYPES if x not in ["string", "uint64"]
-] + [None]
-INT_DTYPES = [x for x in dtypes.INT_TYPES if x != "uint64"]
-FLOAT_DTYPES = dtypes.FLOAT_TYPES
-COMPLEX_DTYPES = ["complex32", "complex64", "complex128"]
-
-if backend.backend() == "torch":
-    # TODO: torch doesn't support uint16, uint32 and uint64, complex
-    ALL_DTYPES = [
-        x
-        for x in ALL_DTYPES
-        if x not in ["uint16", "uint32", "uint64", "complex128", "complex64"]
-    ]
-    INT_DTYPES = [
-        x for x in INT_DTYPES if x not in ["uint16", "uint32", "uint64"]
-    ]
-elif backend.backend() == "openvino":
-    # TODO: openvino doesn't support complex
-    ALL_DTYPES = [x for x in ALL_DTYPES if x not in ["complex128", "complex64"]]
-# Remove float8 dtypes for the following tests
-ALL_DTYPES = [x for x in ALL_DTYPES if x not in dtypes.FLOAT8_TYPES]
-NON_COMPLEX_DTYPES = [x for x in ALL_DTYPES if x and x not in COMPLEX_DTYPES]
-
-
 class VariableOpsDTypeTest(test_case.TestCase):
     """Test the dtype to verify that the behavior matches JAX."""
 
-    def setUp(self):
-        from jax.experimental import enable_x64
-
-        self.jax_enable_x64 = enable_x64()
-        self.jax_enable_x64.__enter__()
-        return super().setUp()
-
-    def tearDown(self):
-        self.jax_enable_x64.__exit__(None, None, None)
-        return super().tearDown()
+    ALL_DTYPES = [
+        x
+        for x in dtypes.ALLOWED_DTYPES
+        if x
+        not in (
+            "string",
+            "complex128",
+            # Remove 64-bit dtypes.
+            "float64",
+            "uint64",
+            "int64",
+        )
+        + dtypes.FLOAT8_TYPES  # Remove float8 dtypes for the following tests
+    ] + [None]
+    INT_DTYPES = [x for x in dtypes.INT_TYPES if x not in ("uint64", "int64")]
+    FLOAT_DTYPES = [x for x in dtypes.FLOAT_TYPES if x not in ("float64",)]
+    COMPLEX_DTYPES = ["complex32", "complex64"]
+    if backend.backend() == "torch":
+        ALL_DTYPES = [
+            x for x in ALL_DTYPES if x not in ("uint16", "uint32", "complex64")
+        ]
+        INT_DTYPES = [x for x in INT_DTYPES if x not in ("uint16", "uint32")]
+    elif backend.backend() == "openvino":
+        ALL_DTYPES = [x for x in ALL_DTYPES if x not in ("complex64",)]
+    NON_COMPLEX_DTYPES = [
+        x for x in ALL_DTYPES if x and x not in ["complex32", "complex64"]
+    ]
 
     @parameterized.named_parameters(
         named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -372,6 +372,9 @@ def bincount(x, weights=None, minlength=0, sparse=False):
 def bitwise_and(x, y):
     x = convert_to_tensor(x)
     y = convert_to_tensor(y)
+    dtype = dtypes.result_type(x.dtype, y.dtype)
+    x = x.astype(dtype)
+    y = y.astype(dtype)
     return np.bitwise_and(x, y)
 
 
@@ -387,12 +390,18 @@ def bitwise_not(x):
 def bitwise_or(x, y):
     x = convert_to_tensor(x)
     y = convert_to_tensor(y)
+    dtype = dtypes.result_type(x.dtype, y.dtype)
+    x = x.astype(dtype)
+    y = y.astype(dtype)
     return np.bitwise_or(x, y)
 
 
 def bitwise_xor(x, y):
     x = convert_to_tensor(x)
     y = convert_to_tensor(y)
+    dtype = dtypes.result_type(x.dtype, y.dtype)
+    x = x.astype(dtype)
+    y = y.astype(dtype)
     return np.bitwise_xor(x, y)
 
 
@@ -400,6 +409,9 @@ def bitwise_left_shift(x, y):
     x = convert_to_tensor(x)
     if not isinstance(y, int):
         y = convert_to_tensor(y)
+        dtype = dtypes.result_type(x.dtype, y.dtype)
+        x = x.astype(dtype)
+        y = y.astype(dtype)
     return np.left_shift(x, y)
 
 
@@ -411,6 +423,9 @@ def bitwise_right_shift(x, y):
     x = convert_to_tensor(x)
     if not isinstance(y, int):
         y = convert_to_tensor(y)
+        dtype = dtypes.result_type(x.dtype, y.dtype)
+        x = x.astype(dtype)
+        y = y.astype(dtype)
     return np.right_shift(x, y)
 
 

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -9,7 +9,6 @@ from keras.src.backend.torch.core import cast
 from keras.src.backend.torch.core import convert_to_tensor
 from keras.src.backend.torch.core import get_device
 from keras.src.backend.torch.numpy import expand_dims
-from keras.src.backend.torch.numpy import maximum
 from keras.src.backend.torch.numpy import where
 from keras.src.utils.argument_validation import standardize_tuple
 
@@ -668,7 +667,7 @@ def one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     # manual handling for negatives in the input to one_hot by using max(x, 0).
     # The output will have some invalid results, so we set them back to 0 using
     # `where` afterwards.
-    output = tnn.one_hot(maximum(x, 0), num_classes)
+    output = tnn.one_hot(torch.clamp(x, min=0), num_classes)
     output = where(expand_dims(x, axis=-1) >= 0, output, zero)
     output = convert_to_tensor(output, dtype=dtype)
     dims = output.dim()

--- a/keras/src/initializers/constant_initializers.py
+++ b/keras/src/initializers/constant_initializers.py
@@ -253,14 +253,18 @@ class STFT(Initializer):
                 scaling = ops.sum(ops.abs(win))
 
         _fft_length = (fft_length - 1) * 2
-        freq = (
-            ops.reshape(ops.arange(fft_length, dtype=dtype), (1, 1, fft_length))
-            / _fft_length
+        freq = ops.divide(
+            ops.reshape(
+                ops.arange(fft_length, dtype=dtype), (1, 1, fft_length)
+            ),
+            _fft_length,
         )
         time = ops.reshape(
             ops.arange(frame_length, dtype=dtype), (frame_length, 1, 1)
         )
-        args = -2 * time * freq * ops.arccos(ops.cast(-1, dtype))
+        args = ops.multiply(ops.multiply(-2, time), freq) * ops.arccos(
+            ops.cast(-1, dtype)
+        )
 
         if self.side == "real":
             kernel = ops.cast(ops.cos(args), dtype)
@@ -268,7 +272,7 @@ class STFT(Initializer):
             kernel = ops.cast(ops.sin(args), dtype)
 
         if win is not None:
-            kernel = kernel * win / scaling
+            kernel = ops.divide(ops.multiply(kernel, win), scaling)
         return kernel
 
     def get_config(self):

--- a/keras/src/initializers/constant_initializers_test.py
+++ b/keras/src/initializers/constant_initializers_test.py
@@ -80,14 +80,9 @@ class ConstantInitializersTest(testing.TestCase):
         shape = (256, 1, 513)
         time_range = np.arange(256).reshape((-1, 1, 1))
         freq_range = (np.arange(513) / 1024.0).reshape((1, 1, -1))
-        pi = np.arccos(np.float64(-1))
+        pi = np.arccos(np.float32(-1))
         args = -2 * pi * time_range * freq_range
-
-        tol_kwargs = {}
-        if backend.backend() == "jax":
-            # TODO(mostafa-mahmoud): investigate the cases
-            # of non-small error in jax and torch
-            tol_kwargs = {"atol": 1e-4, "rtol": 1e-6}
+        tol_kwargs = {"atol": 1e-4, "rtol": 1e-6}
 
         initializer = initializers.STFT("real", None)
         values = backend.convert_to_numpy(initializer(shape))
@@ -101,8 +96,8 @@ class ConstantInitializersTest(testing.TestCase):
             True,
         )
         window = scipy.signal.windows.get_window("hamming", 256, True)
-        window = window.astype("float64").reshape((-1, 1, 1))
-        values = backend.convert_to_numpy(initializer(shape, "float64"))
+        window = window.astype("float32").reshape((-1, 1, 1))
+        values = backend.convert_to_numpy(initializer(shape, "float32"))
         self.assertAllClose(np.cos(args) * window, values, **tol_kwargs)
         self.run_class_serialization_test(initializer)
 
@@ -113,9 +108,9 @@ class ConstantInitializersTest(testing.TestCase):
             False,
         )
         window = scipy.signal.windows.get_window("tukey", 256, False)
-        window = window.astype("float64").reshape((-1, 1, 1))
+        window = window.astype("float32").reshape((-1, 1, 1))
         window = window / np.sqrt(np.sum(window**2))
-        values = backend.convert_to_numpy(initializer(shape, "float64"))
+        values = backend.convert_to_numpy(initializer(shape, "float32"))
         self.assertAllClose(np.sin(args) * window, values, **tol_kwargs)
         self.run_class_serialization_test(initializer)
 
@@ -125,9 +120,9 @@ class ConstantInitializersTest(testing.TestCase):
             "spectrum",
         )
         window = np.arange(1, 257)
-        window = window.astype("float64").reshape((-1, 1, 1))
+        window = window.astype("float32").reshape((-1, 1, 1))
         window = window / np.sum(window)
-        values = backend.convert_to_numpy(initializer(shape, "float64"))
+        values = backend.convert_to_numpy(initializer(shape, "float32"))
         self.assertAllClose(np.sin(args) * window, values, **tol_kwargs)
         self.run_class_serialization_test(initializer)
 

--- a/keras/src/layers/preprocessing/stft_spectrogram_test.py
+++ b/keras/src/layers/preprocessing/stft_spectrogram_test.py
@@ -11,7 +11,7 @@ from keras.src import testing
 
 
 class TestSpectrogram(testing.TestCase):
-    DTYPE = "float32" if backend.backend() == "torch" else "float64"
+    DTYPE = "float32"
 
     @staticmethod
     def _calc_spectrograms(
@@ -340,12 +340,7 @@ class TestSpectrogram(testing.TestCase):
             mask |= np.isclose(np.cos(y), np.cos(y_true), **tol_kwargs)
             mask |= np.isclose(np.sin(y), np.sin(y_true), **tol_kwargs)
 
-            if backend.backend() == "tensorflow":
-                self.assertTrue(np.all(mask))
-            else:
-                # TODO(mostafa-mahmoud): investigate the rare cases
-                # of non-small error in jax and torch
-                self.assertLess(np.mean(~mask), 2e-4)
+            self.assertLess(np.mean(~mask), 2e-4)
 
     @pytest.mark.skipif(
         backend.backend() != "tensorflow",

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -984,34 +984,27 @@ class MathOpsCorrectnessTest(testing.TestCase):
 class MathDtypeTest(testing.TestCase):
     """Test the floating dtype to verify that the behavior matches JAX."""
 
-    # TODO: Using uint64 will lead to weak type promotion (`float`),
-    # resulting in different behavior between JAX and Keras. Currently, we
-    # are skipping the test for uint64
     ALL_DTYPES = [
-        x for x in dtypes.ALLOWED_DTYPES if x not in ["string", "uint64"]
+        x
+        for x in dtypes.ALLOWED_DTYPES
+        if x
+        not in (
+            "string",
+            "complex64",
+            "complex128",
+            # Remove 64-bit dtypes.
+            "float64",
+            "uint64",
+            "int64",
+        )
+        + dtypes.FLOAT8_TYPES  # Remove float8 dtypes for the following tests
     ] + [None]
-    INT_DTYPES = [x for x in dtypes.INT_TYPES if x != "uint64"]
-    FLOAT_DTYPES = dtypes.FLOAT_TYPES
+    INT_DTYPES = [x for x in dtypes.INT_TYPES if x not in ("uint64", "int64")]
+    FLOAT_DTYPES = [x for x in dtypes.FLOAT_TYPES if x not in ("float64",)]
 
     if backend.backend() == "torch":
-        # TODO: torch doesn't support uint16, uint32 and uint64
-        ALL_DTYPES = [
-            x for x in ALL_DTYPES if x not in ["uint16", "uint32", "uint64"]
-        ]
-        INT_DTYPES = [
-            x for x in INT_DTYPES if x not in ["uint16", "uint32", "uint64"]
-        ]
-
-    def setUp(self):
-        from jax.experimental import enable_x64
-
-        self.jax_enable_x64 = enable_x64()
-        self.jax_enable_x64.__enter__()
-        return super().setUp()
-
-    def tearDown(self):
-        self.jax_enable_x64.__exit__(None, None, None)
-        return super().tearDown()
+        ALL_DTYPES = [x for x in ALL_DTYPES if x not in ("uint16", "uint32")]
+        INT_DTYPES = [x for x in INT_DTYPES if x not in ("uint16", "uint32")]
 
 
 class ExtractSequencesOpTest(testing.TestCase):

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -2550,20 +2550,9 @@ class NNOpsCorrectnessTest(testing.TestCase):
 
 
 class NNOpsDtypeTest(testing.TestCase):
-    """Test the dtype to verify that the behavior matches JAX."""
+    """Test the floating dtype to verify that the behavior matches JAX."""
 
-    FLOAT_DTYPES = dtypes.FLOAT_TYPES
-
-    def setUp(self):
-        from jax.experimental import enable_x64
-
-        self.jax_enable_x64 = enable_x64()
-        self.jax_enable_x64.__enter__()
-        return super().setUp()
-
-    def tearDown(self):
-        self.jax_enable_x64.__exit__(None, None, None)
-        return super().tearDown()
+    FLOAT_DTYPES = [x for x in dtypes.FLOAT_TYPES if x not in ("float64",)]
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_elu(self, dtype):

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -4720,19 +4720,6 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertEqual(standardize_dtype(y.dtype), "float32")
         self.assertAllClose(y, ref_y)
 
-    @pytest.mark.skipif(
-        backend.backend() == "jax", reason="JAX does not support float64."
-    )
-    def test_sqrt_float64(self):
-        x = np.array([[1, 4, 9], [16, 25, 36]], dtype="float64")
-        ref_y = np.sqrt(x)
-        y = knp.sqrt(x)
-        self.assertEqual(standardize_dtype(y.dtype), "float64")
-        self.assertAllClose(y, ref_y)
-        y = knp.Sqrt()(x)
-        self.assertEqual(standardize_dtype(y.dtype), "float64")
-        self.assertAllClose(y, ref_y)
-
     def test_sqrt_int32(self):
         x = np.array([[1, 4, 9], [16, 25, 36]], dtype="int32")
         ref_y = np.sqrt(x)

--- a/keras/src/optimizers/adam_test.py
+++ b/keras/src/optimizers/adam_test.py
@@ -51,7 +51,7 @@ class AdamTest(testing.TestCase):
     def test_correctness_with_golden(self):
         optimizer = Adam(amsgrad=True)
 
-        x = backend.Variable(np.ones([10]))
+        x = backend.Variable(np.ones([10], dtype="float32"))
         grads = ops.arange(0.1, 1.1, 0.1)
         first_grads = ops.full((10,), 0.01)
 

--- a/keras/src/optimizers/adamax_test.py
+++ b/keras/src/optimizers/adamax_test.py
@@ -53,7 +53,7 @@ class AdamaxTest(testing.TestCase):
             learning_rate=0.2, beta_1=0.85, beta_2=0.95, epsilon=1e-6
         )
 
-        x = backend.Variable(np.ones([10]))
+        x = backend.Variable(np.ones([10], dtype="float32"))
         grads = ops.arange(0.1, 1.1, 0.1)
         first_grads = ops.full((10,), 0.01)
 

--- a/keras/src/optimizers/adamw_test.py
+++ b/keras/src/optimizers/adamw_test.py
@@ -63,7 +63,7 @@ class AdamWTest(testing.TestCase):
     def test_correctness_with_golden(self):
         optimizer = AdamW(learning_rate=1.0, weight_decay=0.5, epsilon=2)
 
-        x = backend.Variable(np.ones([10]))
+        x = backend.Variable(np.ones([10], dtype="float32"))
         grads = ops.arange(0.1, 1.1, 0.1)
         first_grads = ops.full((10,), 0.01)
 

--- a/keras/src/optimizers/lamb_test.py
+++ b/keras/src/optimizers/lamb_test.py
@@ -50,7 +50,7 @@ class LambTest(testing.TestCase):
     def test_correctness_with_golden(self):
         optimizer = Lamb()
 
-        x = backend.Variable(np.ones([10]))
+        x = backend.Variable(np.ones([10], dtype="float32"))
         grads = ops.arange(0.1, 1.1, 0.1)
         first_grads = ops.full((10,), 0.01)
 

--- a/keras/src/optimizers/nadam_test.py
+++ b/keras/src/optimizers/nadam_test.py
@@ -63,7 +63,7 @@ class NadamTest(testing.TestCase):
             epsilon=1e-5,
         )
 
-        x = backend.Variable(np.ones([10]))
+        x = backend.Variable(np.ones([10], dtype="float32"))
         grads = ops.arange(0.1, 1.1, 0.1)
         first_grads = ops.full((10,), 0.01)
 

--- a/keras/src/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/src/optimizers/schedules/learning_rate_schedule.py
@@ -692,9 +692,11 @@ class CosineDecay(LearningRateSchedule):
 
     def _decay_function(self, step, decay_steps, decay_from_lr, dtype):
         with ops.name_scope(self.name):
-            completed_fraction = step / decay_steps
+            completed_fraction = ops.divide(step, decay_steps)
             pi = ops.array(math.pi, dtype=dtype)
-            cosine_decayed = 0.5 * (1.0 + ops.cos(pi * completed_fraction))
+            cosine_decayed = 0.5 * (
+                1.0 + ops.cos(ops.multiply(pi, completed_fraction))
+            )
             decayed = (1 - self.alpha) * cosine_decayed + self.alpha
             return ops.multiply(decay_from_lr, decayed)
 
@@ -866,10 +868,13 @@ class CosineDecayRestarts(LearningRateSchedule):
                         / ops.log(t_mul)
                     )
 
-                    sum_r = (1.0 - t_mul**i_restart) / (1.0 - t_mul)
-                    completed_fraction = (
-                        completed_fraction - sum_r
-                    ) / t_mul**i_restart
+                    sum_r = ops.divide(
+                        1.0 - ops.power(t_mul, i_restart), (1.0 - t_mul)
+                    )
+                    completed_fraction = ops.divide(
+                        ops.subtract(completed_fraction, sum_r),
+                        ops.power(t_mul, i_restart),
+                    )
 
                 else:
                     i_restart = ops.floor(completed_fraction)
@@ -883,18 +888,20 @@ class CosineDecayRestarts(LearningRateSchedule):
                 lambda: compute_step(completed_fraction, geometric=True),
             )
 
-            m_fac = m_mul**i_restart
+            m_fac = ops.power(m_mul, i_restart)
             cosine_decayed = (
                 0.5
                 * m_fac
                 * (
                     1.0
                     + ops.cos(
-                        ops.array(math.pi, dtype=dtype) * completed_fraction
+                        ops.multiply(
+                            ops.array(math.pi, dtype=dtype), completed_fraction
+                        )
                     )
                 )
             )
-            decayed = (1 - alpha) * cosine_decayed + alpha
+            decayed = ops.add(ops.multiply((1 - alpha), cosine_decayed), alpha)
 
             return ops.multiply(initial_learning_rate, decayed)
 

--- a/keras/src/random/random_test.py
+++ b/keras/src/random/random_test.py
@@ -440,26 +440,12 @@ class RandomBehaviorTest(testing.TestCase):
 
 
 class RandomDTypeTest(testing.TestCase):
-    INT_DTYPES = [x for x in dtypes.INT_TYPES if x != "uint64"]
-    FLOAT_DTYPES = dtypes.FLOAT_TYPES
+    """Test the dtype to verify that the behavior matches JAX."""
+
+    INT_DTYPES = [x for x in dtypes.INT_TYPES if x not in ("uint64", "int64")]
+    FLOAT_DTYPES = [x for x in dtypes.FLOAT_TYPES if x not in ("float64",)]
     if backend.backend() == "torch":
-        # TODO: torch doesn't support uint16, uint32 and uint64
-        INT_DTYPES = [
-            x for x in INT_DTYPES if x not in ["uint16", "uint32", "uint64"]
-        ]
-
-    def setUp(self):
-        if backend.backend() == "jax":
-            from jax.experimental import enable_x64
-
-            self.jax_enable_x64 = enable_x64()
-            self.jax_enable_x64.__enter__()
-        return super().setUp()
-
-    def tearDown(self):
-        if backend.backend() == "jax":
-            self.jax_enable_x64.__exit__(None, None, None)
-        return super().tearDown()
+        INT_DTYPES = [x for x in INT_DTYPES if x not in ("uint16", "uint32")]
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_normal(self, dtype):


### PR DESCRIPTION
This PR removes the usage of `JAX_DEFAULT_DTYPE_BITS=32` which is considered deprecated in JAX.

To reflect this change, the 64-bit dtype tests have also been removed.

TODO:
We might need a flag to enable 64-bit dtypes when using `backend.result_type`.