### PR TITLE
Implement hypot function in keras.ops

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -195,6 +195,7 @@ from keras.src.ops.numpy import hanning as hanning
 from keras.src.ops.numpy import heaviside as heaviside
 from keras.src.ops.numpy import histogram as histogram
 from keras.src.ops.numpy import hstack as hstack
+from keras.src.ops.numpy import hypot as hypot
 from keras.src.ops.numpy import identity as identity
 from keras.src.ops.numpy import imag as imag
 from keras.src.ops.numpy import inner as inner

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -83,6 +83,7 @@ from keras.src.ops.numpy import hanning as hanning
 from keras.src.ops.numpy import heaviside as heaviside
 from keras.src.ops.numpy import histogram as histogram
 from keras.src.ops.numpy import hstack as hstack
+from keras.src.ops.numpy import hypot as hypot
 from keras.src.ops.numpy import identity as identity
 from keras.src.ops.numpy import imag as imag
 from keras.src.ops.numpy import inner as inner

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -195,6 +195,7 @@ from keras.src.ops.numpy import hanning as hanning
 from keras.src.ops.numpy import heaviside as heaviside
 from keras.src.ops.numpy import histogram as histogram
 from keras.src.ops.numpy import hstack as hstack
+from keras.src.ops.numpy import hypot as hypot
 from keras.src.ops.numpy import identity as identity
 from keras.src.ops.numpy import imag as imag
 from keras.src.ops.numpy import inner as inner

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -83,6 +83,7 @@ from keras.src.ops.numpy import hanning as hanning
 from keras.src.ops.numpy import heaviside as heaviside
 from keras.src.ops.numpy import histogram as histogram
 from keras.src.ops.numpy import hstack as hstack
+from keras.src.ops.numpy import hypot as hypot
 from keras.src.ops.numpy import identity as identity
 from keras.src.ops.numpy import imag as imag
 from keras.src.ops.numpy import inner as inner

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -58,6 +58,12 @@ def heaviside(x1, x2):
     return jnp.heaviside(x1, x2)
 
 
+def hypot(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return jnp.hypot(x1, x2)
+
+
 def kaiser(x, beta):
     x = convert_to_tensor(x)
     return jnp.kaiser(x, beta)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -333,6 +333,12 @@ def heaviside(x1, x2):
     return np.heaviside(x1, x2).astype(dtype)
 
 
+def hypot(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return np.hypot(x1, x2)
+
+
 def kaiser(x, beta):
     x = convert_to_tensor(x)
     return np.kaiser(x, beta).astype(config.floatx())

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -333,12 +333,6 @@ def heaviside(x1, x2):
     return np.heaviside(x1, x2).astype(dtype)
 
 
-def hypot(x1, x2):
-    x1 = convert_to_tensor(x1)
-    x2 = convert_to_tensor(x2)
-    return np.hypot(x1, x2)
-
-
 def kaiser(x, beta):
     x = convert_to_tensor(x)
     return np.kaiser(x, beta).astype(config.floatx())
@@ -669,6 +663,19 @@ def hstack(xs):
             lambda x: convert_to_tensor(x).astype(dtype), xs
         )
     return np.hstack(xs)
+
+
+def hypot(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    if dtype in ["int8", "int16", "int32", "uint8", "uint16", "uint32"]:
+        dtype = config.floatx()
+    elif dtype in ["int64"]:
+        dtype = "float64"
+
+    return np.hypot(x1, x2).astype(dtype)
 
 
 def identity(n, dtype=None):

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -12,6 +12,7 @@ NumpyDtypeTest::test_blackman
 NumpyDtypeTest::test_hamming
 NumpyDtypeTest::test_hanning
 NumpyDtypeTest::test_heaviside
+NumpyDtypeTest::test_hypot
 NumpyDtypeTest::test_kaiser
 NumpyDtypeTest::test_bitwise
 NumpyDtypeTest::test_cbrt
@@ -142,6 +143,7 @@ NumpyTwoInputOpsCorrectnessTest::test_digitize
 NumpyTwoInputOpsCorrectnessTest::test_divide_no_nan
 NumpyTwoInputOpsCorrectnessTest::test_einsum
 NumpyTwoInputOpsCorrectnessTest::test_heaviside
+NumpyTwoInputOpsCorrectnessTest::test_hypot
 NumpyTwoInputOpsCorrectnessTest::test_inner
 NumpyTwoInputOpsCorrectnessTest::test_isin
 NumpyTwoInputOpsCorrectnessTest::test_linspace
@@ -164,8 +166,10 @@ NumpyOneInputOpsStaticShapeTest::test_cbrt
 NumpyOneInputOpsStaticShapeTest::test_isneginf
 NumpyOneInputOpsStaticShapeTest::test_isposinf
 NumpyTwoInputOpsDynamicShapeTest::test_heaviside
+NumpyTwoInputOpsDynamicShapeTest::test_hypot
 NumpyTwoInputOpsDynamicShapeTest::test_isin
 NumpyTwoInputOpsStaticShapeTest::test_heaviside
+NumpyTwoInputOpsStaticShapeTest::test_hypot
 NumpyTwoInputOpsStaticShapeTest::test_isin
 CoreOpsBehaviorTests::test_associative_scan_invalid_arguments
 CoreOpsBehaviorTests::test_scan_invalid_arguments

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -487,10 +487,6 @@ def heaviside(x1, x2):
     )
 
 
-def hypot(x1, x2):
-    raise NotImplementedError("`hypot` is not supported with openvino backend")
-
-
 def kaiser(x, beta):
     raise NotImplementedError("`kaiser` is not supported with openvino backend")
 
@@ -904,6 +900,10 @@ def hstack(xs):
             elems[0], elems[i], "hstack()"
         )
     return OpenVINOKerasTensor(ov_opset.concat(elems, axis).output(0))
+
+
+def hypot(x1, x2):
+    raise NotImplementedError("`hypot` is not supported with openvino backend")
 
 
 def identity(n, dtype=None):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -487,6 +487,10 @@ def heaviside(x1, x2):
     )
 
 
+def hypot(x1, x2):
+    raise NotImplementedError("`hypot` is not supported with openvino backend")
+
+
 def kaiser(x, beta):
     raise NotImplementedError("`kaiser` is not supported with openvino backend")
 

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -176,17 +176,6 @@ def heaviside(x1, x2):
     )
 
 
-def hypot(x1, x2):
-    x1 = convert_to_tensor(x1)
-    x2 = convert_to_tensor(x2)
-
-    ret = tf.math.sqrt(
-        tf.cast(tf.math.square(x1), config.floatx())
-        + tf.cast(tf.math.square(x2), config.floatx())
-    )
-    return ret
-
-
 def kaiser(x, beta):
     x = convert_to_tensor(x, dtype=tf.int32)
     return tf.signal.kaiser_window(x, beta=beta)
@@ -1568,6 +1557,22 @@ def hstack(xs):
     if len(xs[0].shape) == 1:
         return tf.concat(xs, axis=0)
     return tf.concat(xs, axis=1)
+
+
+def hypot(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    if dtype in ["int8", "int16", "int32", "uint8", "uint16", "uint32"]:
+        dtype = config.floatx()
+    elif dtype in ["int64"]:
+        dtype = "float64"
+
+    x1 = tf.cast(x1, dtype)
+    x2 = tf.cast(x2, dtype)
+
+    return tf.math.sqrt(tf.math.square(x1) + tf.math.square(x2))
 
 
 def identity(n, dtype=None):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1572,7 +1572,13 @@ def hypot(x1, x2):
     x1 = tf.cast(x1, dtype)
     x2 = tf.cast(x2, dtype)
 
-    return tf.math.sqrt(tf.math.square(x1) + tf.math.square(x2))
+    x1_abs = tf.abs(x1)
+    x2_abs = tf.abs(x2)
+    max_val = tf.maximum(x1_abs, x2_abs)
+    min_val = tf.minimum(x1_abs, x2_abs)
+
+    ratio = tf.math.divide_no_nan(min_val, max_val)
+    return max_val * tf.sqrt(1.0 + tf.square(ratio))
 
 
 def identity(n, dtype=None):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -176,6 +176,17 @@ def heaviside(x1, x2):
     )
 
 
+def hypot(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+
+    ret = tf.math.sqrt(
+        tf.cast(tf.math.square(x1), config.floatx())
+        + tf.cast(tf.math.square(x2), config.floatx())
+    )
+    return ret
+
+
 def kaiser(x, beta):
     x = convert_to_tensor(x, dtype=tf.int32)
     return tf.signal.kaiser_window(x, beta=beta)

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -461,12 +461,6 @@ def heaviside(x1, x2):
     return torch.heaviside(x1, x2)
 
 
-def hypot(x1, x2):
-    x1 = convert_to_tensor(x1)
-    x2 = convert_to_tensor(x2)
-    return torch.hypot(x1, x2)
-
-
 def kaiser(x, beta):
     x = convert_to_tensor(x)
     return torch.signal.windows.kaiser(x, beta=beta)
@@ -858,6 +852,22 @@ def greater_equal(x1, x2):
 def hstack(xs):
     xs = [convert_to_tensor(x) for x in xs]
     return torch.hstack(xs)
+
+
+def hypot(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+
+    dtype = dtypes.result_type(x1.dtype, x2.dtype)
+    if dtype in ["int8", "int16", "int32", "uint8", "uint16", "uint32"]:
+        dtype = config.floatx()
+    elif dtype == "int64":
+        dtype = "float64"
+
+    x1 = cast(x1, dtype)
+    x2 = cast(x2, dtype)
+
+    return torch.hypot(x1, x2)
 
 
 def identity(n, dtype=None):

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -461,6 +461,12 @@ def heaviside(x1, x2):
     return torch.heaviside(x1, x2)
 
 
+def hypot(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return torch.hypot(x1, x2)
+
+
 def kaiser(x, beta):
     x = convert_to_tensor(x)
     return torch.signal.windows.kaiser(x, beta=beta)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1355,48 +1355,6 @@ def heaviside(x1, x2):
     return backend.numpy.heaviside(x1, x2)
 
 
-class Hypot(Operation):
-    def call(self, x1, x2):
-        return backend.numpy.hypot(x1, x2)
-
-    def compute_output_spec(self, x1, x2):
-        dtype = dtypes.result_type(x1.dtype, x2.dtype)
-        if dtype in ["int8", "int16", "int32", "uint8", "uint16", "uint32"]:
-            dtype = backend.floatx()
-        elif dtype == "int64":
-            dtype = "float64"
-        return KerasTensor(broadcast_shapes(x1.shape, x2.shape), dtype=dtype)
-
-
-@keras_export(["keras.ops.hypot", "keras.ops.numpy.hypot"])
-def hypot(x1, x2):
-    """Return element-wise hypotenuse for the given legs
-    of a right angle triangle.
-
-    Args:
-        x1: A tensor, representing the first leg of the right triangle.
-        x2: A tensor, representing the second leg of the right triangle.
-
-    Returns:
-        A tensor with a shape determined by broadcasting `x1` and `x2`.
-
-    Example:
-    >>> x1 = keras.ops.convert_to_tensor([3.0, 4.0, 5.0])
-    >>> x2 = keras.ops.convert_to_tensor([4.0, 3.0, 12.0])
-    >>> keras.ops.hypot(x1, x2)
-    array([5., 5., 13.], dtype=float32)
-
-    >>> x1 = keras.ops.convert_to_tensor([[1, 2], [3, 4]])
-    >>> x2 = keras.ops.convert_to_tensor([1, 1])
-    >>> keras.ops.hypot(x1, x2)
-    array([[1.41421356 2.23606798],
-          [3.16227766 4.12310563]], dtype=float32)
-    """
-    if any_symbolic_tensors((x1, x2)):
-        return Hypot().symbolic_call(x1, x2)
-    return backend.numpy.hypot(x1, x2)
-
-
 class Kaiser(Operation):
     def __init__(self, beta, *, name=None):
         super().__init__(name=name)
@@ -3554,6 +3512,51 @@ def hstack(xs):
     if any_symbolic_tensors((xs,)):
         return Hstack().symbolic_call(xs)
     return backend.numpy.hstack(xs)
+
+
+class Hypot(Operation):
+    def call(self, x1, x2):
+        return backend.numpy.hypot(x1, x2)
+
+    def compute_output_spec(self, x1, x2):
+        dtype = dtypes.result_type(x1.dtype, x2.dtype)
+        if dtype in ["int8", "int16", "int32", "uint8", "uint16", "uint32"]:
+            dtype = backend.floatx()
+        elif dtype == "int64":
+            dtype = "float64"
+        return KerasTensor(broadcast_shapes(x1.shape, x2.shape), dtype=dtype)
+
+
+@keras_export(["keras.ops.hypot", "keras.ops.numpy.hypot"])
+def hypot(x1, x2):
+    """Compute the element-wise hypotenuse of
+    right triangles with legs `x1` and `x2`.
+
+    This is equivalent to computing `sqrt(x1**2 + x2**2)` element-wise,
+    with shape determined by broadcasting.
+
+    Args:
+        x1: A tensor, representing the first leg of the right triangle.
+        x2: A tensor, representing the second leg of the right triangle.
+
+    Returns:
+        A tensor with a shape determined by broadcasting `x1` and `x2`.
+
+    Example:
+    >>> x1 = keras.ops.convert_to_tensor([3.0, 4.0, 5.0])
+    >>> x2 = keras.ops.convert_to_tensor([4.0, 3.0, 12.0])
+    >>> keras.ops.hypot(x1, x2)
+    array([5., 5., 13.], dtype=float32)
+
+    >>> x1 = keras.ops.convert_to_tensor([[1, 2], [3, 4]])
+    >>> x2 = keras.ops.convert_to_tensor([1, 1])
+    >>> keras.ops.hypot(x1, x2)
+    array([[1.41421356 2.23606798],
+          [3.16227766 4.12310563]], dtype=float32)
+    """
+    if any_symbolic_tensors((x1, x2)):
+        return Hypot().symbolic_call(x1, x2)
+    return backend.numpy.hypot(x1, x2)
 
 
 @keras_export(["keras.ops.identity", "keras.ops.numpy.identity"])

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -3529,8 +3529,7 @@ class Hypot(Operation):
 
 @keras_export(["keras.ops.hypot", "keras.ops.numpy.hypot"])
 def hypot(x1, x2):
-    """Compute the element-wise hypotenuse of
-    right triangles with legs `x1` and `x2`.
+    """Element-wise hypotenuse of right triangles with legs `x1` and `x2`.
 
     This is equivalent to computing `sqrt(x1**2 + x2**2)` element-wise,
     with shape determined by broadcasting.

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1355,6 +1355,48 @@ def heaviside(x1, x2):
     return backend.numpy.heaviside(x1, x2)
 
 
+class Hypot(Operation):
+    def call(self, x1, x2):
+        return backend.numpy.hypot(x1, x2)
+
+    def compute_output_spec(self, x1, x2):
+        dtype = dtypes.result_type(x1.dtype, x2.dtype)
+        if dtype in ["int8", "int16", "int32", "uint8", "uint16", "uint32"]:
+            dtype = backend.floatx()
+        elif dtype == "int64":
+            dtype = "float64"
+        return KerasTensor(broadcast_shapes(x1.shape, x2.shape), dtype=dtype)
+
+
+@keras_export(["keras.ops.hypot", "keras.ops.numpy.hypot"])
+def hypot(x1, x2):
+    """Return element-wise hypotenuse for the given legs
+    of a right angle triangle.
+
+    Args:
+        x1: A tensor, representing the first leg of the right triangle.
+        x2: A tensor, representing the second leg of the right triangle.
+
+    Returns:
+        A tensor with a shape determined by broadcasting `x1` and `x2`.
+
+    Example:
+    >>> x1 = keras.ops.convert_to_tensor([3.0, 4.0, 5.0])
+    >>> x2 = keras.ops.convert_to_tensor([4.0, 3.0, 12.0])
+    >>> keras.ops.hypot(x1, x2)
+    array([5., 5., 13.], dtype=float32)
+
+    >>> x1 = keras.ops.convert_to_tensor([[1, 2], [3, 4]])
+    >>> x2 = keras.ops.convert_to_tensor([1, 1])
+    >>> keras.ops.hypot(x1, x2)
+    array([[1.41421356 2.23606798],
+          [3.16227766 4.12310563]], dtype=float32)
+    """
+    if any_symbolic_tensors((x1, x2)):
+        return Hypot().symbolic_call(x1, x2)
+    return backend.numpy.hypot(x1, x2)
+
+
 class Kaiser(Operation):
     def __init__(self, beta, *, name=None):
         super().__init__(name=name)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -95,6 +95,11 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
         y = KerasTensor((None, 3))
         self.assertEqual(knp.heaviside(x, y).shape, (None, 3))
 
+    def test_hypot(self):
+        x = KerasTensor((None, 3))
+        y = KerasTensor((None, 3))
+        self.assertEqual(knp.hypot(x, y).shape, (None, 3))
+
     def test_subtract(self):
         x = KerasTensor((None, 3))
         y = KerasTensor((2, None))
@@ -519,6 +524,11 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor((2, 3))
         y = KerasTensor((1, 3))
         self.assertEqual(knp.heaviside(x, y).shape, (2, 3))
+
+    def test_hypot(self):
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3))
+        self.assertEqual(knp.hypot(x, y).shape, (2, 3))
 
     def test_subtract(self):
         x = KerasTensor((2, 3))
@@ -2399,6 +2409,17 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         y = np.array(4)
         self.assertAllClose(knp.heaviside(x, y), np.heaviside(x, y))
         self.assertAllClose(knp.Heaviside()(x, y), np.heaviside(x, y))
+
+    def test_hypot(self):
+        x = np.array([[1, 2, 3], [3, 2, 1]])
+        y = np.array([[4, 5, 6], [6, 5, 4]])
+        self.assertAllClose(knp.hypot(x, y), np.hypot(x, y))
+        self.assertAllClose(knp.Hypot()(x, y), np.hypot(x, y))
+
+        x = np.array([[1, 2, 3], [3, 2, 1]])
+        y = np.array(4)
+        self.assertAllClose(knp.hypot(x, y), np.hypot(x, y))
+        self.assertAllClose(knp.Hypot()(x, y), np.hypot(x, y))
 
     def test_subtract(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
@@ -7498,6 +7519,27 @@ class NumpyDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knp.Hstack().symbolic_call([x1, x2]).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_hypot(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((1, 1), dtype=dtype1)
+        x2 = knp.ones((1, 1), dtype=dtype2)
+        x1_jax = jnp.ones((1, 1), dtype=dtype1)
+        x2_jax = jnp.ones((1, 1), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.hypot(x1_jax, x2_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.hypot(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Hypot().symbolic_call(x1, x2).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
Adds keras.ops.hypot, which computes the element-wise hypotenuse of right triangles given two tensor inputs (x1 and x2).
Equivalent to computing sqrt(x1**2 + x2**2) with broadcasting support.

Supported across NumPy, TensorFlow, PyTorch, and JAX backends.
Not supported on OpenVINO.