### PR TITLE
Fixes regex fallback logic in DTypePolicyMap to avoid dtype mismatches

### DIFF
--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -35,29 +35,54 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
     However, it is also possible to set a regex as the key. See the docstring of
     `get` for more details.
 
-    See below for a usage example. You can define the naming schema
-    of the `DTypePolicy`, and then retrieve the corresponding `DTypePolicy`
-    instance.
-
-    ```python
-    dtype_policy_map = DTypePolicyMap()
-    dtype_policy_map["layer/dense_0"] = DTypePolicy("bfloat16")
-    dtype_policy_map["layer/dense_1"] = QuantizedDTypePolicy("int8", "bfloat16")
-
-    policy_0 = dtype_policy_map["layer/dense_0"]
-    policy_1 = dtype_policy_map["layer/dense_1"]
-    policy_2 = dtype_policy_map["layer/dense_2"]  # No hit
-    assert policy_0 == DTypePolicy("bfloat16")
-    assert policy_1 == QuantizedDTypePolicy("int8", "bfloat16")
-    assert policy_2 == keras.config.dtype_policy()
-    ```
-
     Args:
         default_policy: An optional `DTypePolicy` instance specifying the
             default dtype policy. If not specified, the value will default to
             `keras.config.dtype_policy()`.
         policy_map: An optional dict that maps string to `DTypePolicy`
             instances. Defaults to `None`
+
+    Example:
+
+    ```python
+    >>> from keras.src import dtype_policies
+    >>> bfloat16 = dtype_policies.DTypePolicy("bfloat16")
+    >>> float16 = dtype_policies.DTypePolicy("float16")
+    >>> float32 = dtype_policies.DTypePolicy("float32")
+    >>> policy_map = DTypePolicyMap(default_policy=float32)
+
+    # Set policies using an exact path and a regex pattern.
+    # Note: "decoder" will only match the exact path, not its children.
+    >>> policy_map["encoder/layer_0/dense"] = bfloat16
+    >>> policy_map["encoder/.*"] = float16
+    >>> policy_map["decoder"] = bfloat16
+
+    # 1. An exact match is found and returned directly.
+    >>> policy_map["encoder/layer_0/dense"].name
+    'bfloat16'
+
+    # 2. A regex match is found for a child layer.
+    # It matches the "encoder/.*" pattern.
+    >>> policy_map["encoder/attention/query"].name
+    'float16'
+
+    # 3. No implicit prefix matching occurs.
+    # "decoder/attention" does not match the key "decoder".
+    # The default policy is returned.
+    >>> policy_map["decoder/attention"].name
+    'float32'
+
+    # 4. A ValueError is raised if a path matches multiple patterns.
+    >>> policy_map["encoder/attention/.*"] = bfloat16
+    # "encoder/attention/query" now matches two patterns:
+    # - "encoder/.*"
+    # - "encoder/attention/.*"
+    >>> try:
+    ...     policy_map["encoder/attention/query"]
+    ... except ValueError as e:
+    ...     print(e)
+    Path 'encoder/attention/query' matches multiple dtype policy ..
+    ```
     """
 
     def __init__(self, default_policy=None, policy_map=None):
@@ -118,6 +143,48 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
         Raises:
             ValueError: If the `key` matches more than one regex pattern in the
             map.
+
+        Example:
+
+        ```python
+        >>> from keras.src import dtype_policies
+        >>> bfloat16 = dtype_policies.DTypePolicy("bfloat16")
+        >>> float16 = dtype_policies.DTypePolicy("float16")
+        >>> float32 = dtype_policies.DTypePolicy("float32")
+        >>> policy_map = DTypePolicyMap(default_policy=float32)
+
+        # Set policies using an exact path and a regex pattern.
+        # Note: "decoder" will only match the exact path, not its children.
+        >>> policy_map["encoder/layer_0/dense"] = bfloat16
+        >>> policy_map["encoder/.*"] = float16
+        >>> policy_map["decoder"] = bfloat16
+
+        # 1. An exact match is found and returned directly.
+        >>> policy_map["encoder/layer_0/dense"].name
+        'bfloat16'
+
+        # 2. A regex match is found for a child layer.
+        # It matches the "encoder/.*" pattern.
+        >>> policy_map["encoder/attention/query"].name
+        'float16'
+
+        # 3. No implicit prefix matching occurs.
+        # "decoder/attention" does not match the key "decoder".
+        # The default policy is returned.
+        >>> policy_map["decoder/attention"].name
+        'float32'
+
+        # 4. A ValueError is raised if a path matches multiple patterns.
+        >>> policy_map["encoder/attention/.*"] = bfloat16
+        # "encoder/attention/query" now matches two patterns:
+        # - "encoder/.*"
+        # - "encoder/attention/.*"
+        >>> try:
+        ...     policy_map["encoder/attention/query"]
+        ... except ValueError as e:
+        ...     print(e)
+        Path 'encoder/attention/query' matches multiple dtype policy ..
+        ```
         """
         # 1. Check for an exact match.
         if key in self._policy_map:

--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -147,8 +147,7 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
         elif len(matching_keys) == 1:
             return self._policy_map[matching_keys[0]]
 
-        # 4. If there were no matches, or the single match was a quantized
-        # policy, return the default.
+        # 4. If there were no matches, return the default.
         return self.default_policy
 
     def __setitem__(self, key, policy):

--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -133,7 +133,7 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
         matching_keys = [
             pattern
             for pattern in self._policy_map
-            if re.search(f"^{pattern}(/|$)", key)
+            if re.match(f"{pattern}(/|$)", key)
         ]
 
         # 3. Handle cases based on the number of matches found.

--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -144,8 +144,7 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
                 "sure each path only matches at most "
                 "one dtype policy specification key in the DTypePolicyMap."
             )
-
-        if len(matching_keys) == 1:
+        elif len(matching_keys) == 1:
             return self._policy_map[matching_keys[0]]
 
         # 4. If there were no matches, or the single match was a quantized

--- a/keras/src/dtype_policies/dtype_policy_map_test.py
+++ b/keras/src/dtype_policies/dtype_policy_map_test.py
@@ -169,6 +169,10 @@ class DTypePolicyMapTest(testing.TestCase):
         self.assertEqual(
             policy_map["model/embedding"], policy_map.default_policy
         )
+        self.assertEqual(
+            policy_map["prefix/model/decoder/attention"],
+            policy_map.default_policy,
+        )
 
         # 6. Test multiple regex matches causing a ValueError
         # The path "model/decoder/attention/output" matches two regex keys:


### PR DESCRIPTION
## Issue
The regex fallback logic in `DTypePolicyMap.__getitem__` could incorrectly assign a quantized policy to a non-quantized layer.

This issue arises when deserializing models, particularly from KerasHub, where policies for quantized layers are stored in a `DTypePolicyMap`. The keys for these policies are intended for exact matches. However, the regex fallback can cause a non-quantized layer's path (e.g., `"attention/query_norm"`) to erroneously match a key associated with a quantized policy (e.g., `"attention/query"`).

Consequently, the non-quantized layer receives the wrong policy and fails during the forward pass when it attempts to call a quantized_call method it doesn't have.

## Fix
Changed the fallback logic from implicit component matching to explicit regex matching using `re.fullmatch`. This makes the matching behavior more predictable. Keys in the policy map are now treated as full regular expression patterns that must match the entire layer path.

This means:
1.  A key of `"attention/query"` will only match a layer with the exact path `"attention/query"`.
2.  It will **not match** related paths like `"attention/query/sub_layer"` or `"attention/query_norm"`.
3.  To match all sublayers within a scope, an explicit wildcard must be used and stored in the map, e.g., `"attention/.*"`.

## Testing
Modified the existing tests to cover all possible cases.

## Colab
1. **Failing Case**: This [notebook](https://colab.research.google.com/gist/JyotinderSingh/438b8284ba81df09a2611815fd469fa8/incorrect-dtype-policy-matching-issue-with-keras-layers.ipynb) shows that a quantized `gemma3_1b` KerasHub model fails to perform inference after being saved and loaded. The happens since the the `query_norm` (an `RMSNormalization` layer) matches the regex for another quantized layer called `query` (an `EinsumDense` layer for calculating query values) when resolving the dtype.
3. **Successful Case**: This [notebook](https://colab.research.google.com/gist/JyotinderSingh/37188d481c058930b18f55867b839e05/-fixed-dtype-policy-matching-issue-with-keras-layers.ipynb) shows that the above issue no longer occurs after this fix is applied.