### PR TITLE
Add TF support for mixed optional inputs (None/tensor) from generator in model.fit/evaluate/predict

### DIFF
--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -139,6 +139,12 @@ class TensorFlowTrainer(base_trainer.Trainer):
             terms = tf.bitwise.left_shift(flag_vec, shifts)  # shape [n]
             index = tf.reduce_sum(terms)  # scalar int32 in [0, 2^(n-1)]
             ncases = 1 << n  # = 2^n total cases (efficiently computed)
+            if n > 10:
+                warnings.warn(
+                    f"Model has {n} optional inputs. This will create 2^{n} "
+                    "branches in the computational graph, which may be slow to "
+                    "compile and consume a lot of memory."
+                )
 
             # Create a branch function for each possible bitmask combination
             def make_branch(mask: int):

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -68,7 +68,9 @@ class TensorFlowTrainer(base_trainer.Trainer):
             )
             self._loss_tracker.update_state(
                 loss_module.unscale_loss_for_distribution(loss),
-                sample_weight=tf.shape(tree.flatten(x)[0])[0],
+                sample_weight=tf.shape(
+                    next(i for i in tree.flatten(x) if i is not None)
+                )[0],
             )
             if self.optimizer is not None:
                 loss = self.optimizer.scale_loss(loss)
@@ -96,7 +98,9 @@ class TensorFlowTrainer(base_trainer.Trainer):
         )
         self._loss_tracker.update_state(
             loss_module.unscale_loss_for_distribution(loss),
-            sample_weight=tf.shape(tree.flatten(x)[0])[0],
+            sample_weight=tf.shape(
+                next(i for i in tree.flatten(x) if i is not None)
+            )[0],
         )
         return self.compute_metrics(x, y, y_pred, sample_weight=sample_weight)
 

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -1261,14 +1261,14 @@ class ModelTest(testing.TestCase):
     def test_functional_optional_inputs_generator(self, is_optional_none):
         model = _get_model_optional_inputs()
         x1 = np.ones((2, 2))
-        if is_optional_none != "sometimes":
-            x2 = None if is_optional_none else np.ones((2, 2))
         y_true = np.ones((2, 2))
 
         def data_generator(with_y=True):
             for i in range(4):
                 if is_optional_none == "sometimes":
                     x2 = None if i % 2 == 0 else np.ones((2, 2))
+                else:
+                    x2 = None if is_optional_none else np.ones((2, 2))
                 yield ({"x1": x1, "x2": x2},) + ((y_true,) if with_y else ())
 
         model.compile(loss="mse", optimizer="adam")

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -1254,16 +1254,21 @@ class ModelTest(testing.TestCase):
         model.predict(x={"x1": x1, "x2": x2})
 
     @parameterized.named_parameters(
-        ("optional_none", True), ("optional_tensor", False)
+        ("optional_none", True),
+        ("optional_tensor", False),
+        ("optional_mixed", "sometimes"),
     )
     def test_functional_optional_inputs_generator(self, is_optional_none):
         model = _get_model_optional_inputs()
         x1 = np.ones((2, 2))
-        x2 = None if is_optional_none else np.ones((2, 2))
+        if is_optional_none != "sometimes":
+            x2 = None if is_optional_none else np.ones((2, 2))
         y_true = np.ones((2, 2))
 
         def data_generator(with_y=True):
-            for _ in range(4):
+            for i in range(4):
+                if is_optional_none == "sometimes":
+                    x2 = None if i % 2 == 0 else np.ones((2, 2))
                 yield ({"x1": x1, "x2": x2},) + ((y_true,) if with_y else ())
 
         model.compile(loss="mse", optimizer="adam")


### PR DESCRIPTION
This PR is a follow-up to the previous PR #21548 in order to address the last uncovered edge case: supporting optional inputs in model.fit/evaluate/predict with Tensorflow backend when mixed values (sometimes None, sometimes tensor) are produced by the same generator.

Here is a concrete example:

```python
class OptionalInputLayer(layers.Layer):
    def __init__(self):
        super().__init__()
        self.dense = layers.Dense(2)

    def call(self, x, y=None):
        z = x if y is None else x + y
        return self.dense(z)

# Create model with 2 inputs (the second one being optional)
i1 = Input((2,), name="input1")
i2 = Input((2,), name="input2", optional=True)
outputs = OptionalInputLayer()(i1, i2)
model = Model({"input1": i1, "input2": i2}, outputs)
model.compile(loss=losses.MeanSquaredError)

# Train from generator (optional inputs always None or always tensor)
data_generator1 = (({"input1": np.ones((2, 2)), "input2": None}, np.ones((2, 2))) for _ in range(4))
model.fit(x=data_generator1)  # WORKS

# Train from generator (optional inputs with mixed None/tensor values)
data_generator2 = (({"input1": np.ones((2, 2)), "input2": None if i % 2 == 0 else np.ones((2, 2))}, np.ones((2, 2))) for i in range(4))
model.fit(x=data_generator2)  # DOESN'T WORK IN TENSORFLOW (UNTIL THIS PR)
```

As already discussed with @hertschuh in the previous PR, covering this case in Tensorflow backend is not trivial for a few reasons:
- TF Dataset (used by default to provide data in TF backend) doesn't support None values directly, it requires tf.experimental.Optional instead, so there is a need to convert back & forth between these formats
- for None/tensor > tf.experimental.Optional conversion: detecting optional inputs from data requires observing first batches produced by the generator to try to infer, as [already done in present code](https://github.com/keras-team/keras/blob/b9ff57a8213a7353a65ad8e8759e9e134edf6420/keras/src/trainers/data_adapters/generator_data_adapter.py#L62) (since data adapters are independent from model specification)
- for tf.experimental.Optional > None/tensor conversion: the methods `optional.has_value()`& `optional.get_value()` must be used to unwrap to correct content; however they return a tensor which can be symbolic when code is traced (with the default `run_eagerly=False`) so they can't be reliably tested as a Python bool and can only be used inside a TF control flow operator like `tf.cond`/`tf.switch_case` - additionally, these TF operators don't support returning None in one branch and a tensor in the other, so we suggest to both convert optional inputs & call the step function (which returns fixed output shapes without risk of None) inside a big `tf.switch_case` with as many branches as needed to cover every possible optional presence combination

An existing unit test was also extended to test for the newly supported case.