### PR TITLE
Store defaults of optional arguments in auto-config

### DIFF
--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -146,13 +146,9 @@ class Operation(KerasSaveable):
             # Remove argument "name", as it is provided by get_config.
             kwargs.pop("name", None)
             if argspec.varargs is not None:
-                # Varargs cannot be meaningfully converted to a dictionary.
-                # Backward compatibility: if the signature contains varargs
-                # only store the first argument in varargs.
-                if len(kwargs[argspec.varargs]) > 0:
-                    kwargs[argspec.varargs] = kwargs[argspec.varargs][0]
-                else:
-                    kwargs.pop(argspec.varargs)
+                # Varargs cannot be meaningfully converted to a dictionary,
+                # so they are ignored.
+                kwargs.pop(argspec.varargs)
         except TypeError:
             # Raised by signature.bind when the supplied args and kwargs
             # do not match the signature.

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -130,11 +130,32 @@ class Operation(KerasSaveable):
                 vars(instance)["_object__state"] = nnx.object.ObjectState()
 
         # Generate a config to be returned by default by `get_config()`.
+        auto_config = True
+
         signature = inspect.signature(cls.__init__)
         argspec = inspect.getfullargspec(cls.__init__)
 
         try:
             bound_parameters = signature.bind(None, *args, **kwargs)
+        except TypeError:
+            # Raised by signature.bind when the supplied args and kwargs
+            # do not match the signature.
+            auto_config = False
+
+        if auto_config and any(
+            [
+                param.kind == inspect.Parameter.POSITIONAL_ONLY
+                for name, param in signature.parameters.items()
+                if name != argspec.args[0]
+            ]
+        ):
+            # cls.__init__ takes positional only arguments, which
+            # cannot be restored via cls(**config)
+            auto_config = False
+            # Create variable to show appropriate warning in get_config.
+            instance._auto_config_error_args = True
+
+        if auto_config:
             # Include default values in the config.
             bound_parameters.apply_defaults()
             # Extract all arguments as a dictionary.
@@ -146,20 +167,18 @@ class Operation(KerasSaveable):
             # Remove argument "name", as it is provided by get_config.
             kwargs.pop("name", None)
             if argspec.varargs is not None:
-                # Varargs cannot be meaningfully converted to a dictionary,
-                # so they are ignored.
-                kwargs.pop(argspec.varargs)
-        except TypeError:
-            # Raised by signature.bind when the supplied args and kwargs
-            # do not match the signature.
-            pass
+                # Varargs cannot be meaningfully converted to a dictionary.
+                varargs = kwargs.pop(argspec.varargs)
+                if len(varargs) > 0:
+                    auto_config = False
+                    # Store variable to show appropriate warning in get_config.
+                    instance._auto_config_error_args = True
 
         # For safety, we only rely on auto-configs for a small set of
         # serializable types.
         supported_types = (str, int, float, bool, type(None))
         try:
             flat_arg_values = tree.flatten(kwargs)
-            auto_config = True
             for value in flat_arg_values:
                 if not isinstance(value, supported_types):
                     auto_config = False
@@ -214,30 +233,61 @@ class Operation(KerasSaveable):
                 config.pop("name", None)
             return config
         else:
-            raise NotImplementedError(
-                textwrap.dedent(
-                    f"""
-        Object {self.__class__.__name__} was created by passing
-        non-serializable argument values in `__init__()`,
-        and therefore the object must override `get_config()` in
-        order to be serializable. Please implement `get_config()`.
+            if getattr(self, "_auto_config_error_args", False):
+                raise NotImplementedError(
+                    textwrap.dedent(
+                        f"""
+            Object {self.__class__.__name__} was created by passing
+            positional only or variadic positional arguments (e.g.,
+            `*args`) to `__init__()`, which is not supported by the
+            automatic config generation. Please remove all positional
+            only and variadic arguments from `__init__()`
+            or override `get_config()` and `from_config()` to make
+            the object serializatble.
 
-        Example:
+            Example:
 
-        class CustomLayer(keras.layers.Layer):
-            def __init__(self, arg1, arg2, **kwargs):
-                super().__init__(**kwargs)
-                self.arg1 = arg1
-                self.arg2 = arg2
+            class CustomLayer(keras.layers.Layer):
+                def __init__(self, arg1, arg2, **kwargs):
+                    super().__init__(**kwargs)
+                    self.arg1 = arg1
+                    self.arg2 = arg2
 
-            def get_config(self):
-                config = super().get_config()
-                config.update({"arg1": self.arg1,
-                    "arg2": self.arg2,
-                })
-                return config"""
+                def get_config(self):
+                    config = super().get_config()
+                    config.update({{
+                            "arg1": self.arg1,
+                        "arg2": self.arg2,
+                    }})
+                    return config"""
+                    )
                 )
-            )
+            else:
+                raise NotImplementedError(
+                    textwrap.dedent(
+                        f"""
+            Object {self.__class__.__name__} was created by passing
+            non-serializable argument values in `__init__()`,
+            and therefore the object must override `get_config()` in
+            order to be serializable. Please implement `get_config()`.
+
+            Example:
+
+            class CustomLayer(keras.layers.Layer):
+                def __init__(self, arg1, arg2, **kwargs):
+                    super().__init__(**kwargs)
+                    self.arg1 = arg1
+                    self.arg2 = arg2
+
+                def get_config(self):
+                    config = super().get_config()
+                    config.update({{
+                            "arg1": self.arg1,
+                        "arg2": self.arg2,
+                    }})
+                    return config"""
+                    )
+                )
 
     @classmethod
     def from_config(cls, config):


### PR DESCRIPTION
Dear Keras team,

I'm a co-developer of the [BayesFlow](https://github.com/bayesflow-org/BayesFlow) library. We are currently facing the challenge that we want to be able to adapt the defaults of our networks when we find better configurations, but do so without breaking model loading for models that were saved to disk with the old defaults. We currently use the auto-config functionality to keep our code simple, and ideally we would like to continue to do so. Our problem is the following:

The current auto-config implementation only stores the supplied arguments, but not the values of the optional arguments of the constructor. As a consequence, loading a model fails when the default value of an optional argument has changed, even when the rest of the code of the model remains unchanged.

This PR extends the auto-config functionality to also store default values, while otherwise being (as far as I can tell) compatible with the previous implementation. This ensures that the "old defaults" are serialized, so changing defaults is no longer a problem. Is this a change you would be willing to include, or do you see any downsides with this approach?

See also https://github.com/bayesflow-org/bayesflow/issues/566.

P.S.: A minor thing I encountered when looking at the current implementation is that variable arguments cannot be handled properly, as they cannot be properly converted to a dictionary. Currently, an argument `*args` is ignored without a warning, which might lead users to thinking it is handled automatically.

Edit: correct description of how `*args` is handled by the current implementation.
