### PR TITLE
fix(layers): Fix IntegerLookup docstring output shape documentation and add test coverage

### DIFF
--- a/keras/src/layers/preprocessing/integer_lookup.py
+++ b/keras/src/layers/preprocessing/integer_lookup.py
@@ -111,9 +111,12 @@ class IntegerLookup(IndexLookup):
                 appeared in the sample.
             - `"tf_idf"`: As `"multi_hot"`, but the TF-IDF algorithm is
                 applied to find the value in each token slot.
-            For `"int"` output, any shape of input and output is supported.
-            For all other output modes, currently only output up to rank 2
-            is supported. Defaults to `"int"`.
+            For `"int"` output, the output shape matches the input shape.
+            For `"one_hot"` output, the output shape is
+            `input_shape + (vocabulary_size,)`, where `input_shape` may
+            have arbitrary rank. For other output modes (`"multi_hot"`,
+            `"count"`, `"tf_idf"`), the output shape is `(batch_size,
+            vocabulary_size)`. Defaults to `"int"`.
         pad_to_max_tokens: Only applicable when `output_mode` is `"multi_hot"`,
             `"count"`, or `"tf_idf"`. If `True`, the output will have
             its feature axis padded to `max_tokens` even if the number


### PR DESCRIPTION
Well, now that there's a brief pause before the next KerasHub project, it's core Keras time again :)

This PR fixes a documentation mismatch in `IntegerLookup` where the `one_hot` output mode was incorrectly described as only supporting rank-2 inputs. In reality, the layer supports arbitrary input ranks with `output_shape = input_shape + (vocabulary_size,)`. Also, let's add a few additional tests to clarify this behavior and ensure good test coverage.

Closes #21564