### PR TITLE
Fix TF trainer bug when first input is None

### DIFF
--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -68,7 +68,9 @@ class TensorFlowTrainer(base_trainer.Trainer):
             )
             self._loss_tracker.update_state(
                 loss_module.unscale_loss_for_distribution(loss),
-                sample_weight=tf.shape(tree.flatten(x)[0])[0],
+                sample_weight=tf.shape(
+                    next(i for i in tree.flatten(x) if i is not None)
+                )[0],
             )
             if self.optimizer is not None:
                 loss = self.optimizer.scale_loss(loss)
@@ -96,7 +98,9 @@ class TensorFlowTrainer(base_trainer.Trainer):
         )
         self._loss_tracker.update_state(
             loss_module.unscale_loss_for_distribution(loss),
-            sample_weight=tf.shape(tree.flatten(x)[0])[0],
+            sample_weight=tf.shape(
+                next(i for i in tree.flatten(x) if i is not None)
+            )[0],
         )
         return self.compute_metrics(x, y, y_pred, sample_weight=sample_weight)
 


### PR DESCRIPTION
This PR fixes a Tensorflow trainer bug that arises when the **first** (flatten) input can be None in `model.fit`/`model.evaluate` (which is possible for optional inputs since PR #21548). Note: this PR makes the original code more robust but still assumes that at least one input is not None (to properly extract the batch size).

This fix was originally part of the bigger PR #21609 but is now pushed in a small dedicated PR as agreed with @hertschuh [here](https://github.com/keras-team/keras/pull/21609#issuecomment-3234704300).