### PR TITLE
Fix Torch ONNX export not respecting InputSpec.name

### DIFF
--- a/keras/src/export/onnx.py
+++ b/keras/src/export/onnx.py
@@ -86,8 +86,6 @@ def export_onnx(
         if name is None:
             name = f"input_{i}"
         input_names.append(name)
-else:
-    input_names = [f"input_{i}" for i in range(len(model.inputs))]
 
     if backend.backend() in ("tensorflow", "jax"):
         from keras.src.utils.module_utils import tf2onnx

--- a/keras/src/export/onnx.py
+++ b/keras/src/export/onnx.py
@@ -166,7 +166,7 @@ def export_onnx(
                     filepath,
                     verbose=actual_verbose,
                     opset_version=opset_version,
-                    input_names=input_names
+                    input_names=input_names,
                 )
     else:
         raise NotImplementedError(

--- a/keras/src/export/onnx.py
+++ b/keras/src/export/onnx.py
@@ -80,12 +80,10 @@ def export_onnx(
                 "The model provided has never called. "
                 "It must be called at least once before export."
             )
-    input_names = []
-    for i, spec in enumerate(input_signature):
-        name = getattr(spec, "name", None)
-        if name is None:
-            name = f"input_{i}"
-        input_names.append(name)
+    input_names = [
+        getattr(spec, "name", None) or f"input_{i}"
+        for i, spec in enumerate(input_signature)
+    ]
 
     if backend.backend() in ("tensorflow", "jax"):
         from keras.src.utils.module_utils import tf2onnx

--- a/keras/src/export/onnx.py
+++ b/keras/src/export/onnx.py
@@ -80,6 +80,14 @@ def export_onnx(
                 "The model provided has never called. "
                 "It must be called at least once before export."
             )
+    input_names = []
+    for i, spec in enumerate(input_signature):
+        name = getattr(spec, "name", None)
+        if name is None:
+            name = f"input_{i}"
+        input_names.append(name)
+else:
+    input_names = [f"input_{i}" for i in range(len(model.inputs))]
 
     if backend.backend() in ("tensorflow", "jax"):
         from keras.src.utils.module_utils import tf2onnx
@@ -143,6 +151,7 @@ def export_onnx(
                     sample_inputs,
                     verbose=actual_verbose,
                     opset_version=opset_version,
+                    input_names=input_names,
                     dynamo=True,
                 )
                 if hasattr(onnx_program, "optimize"):
@@ -161,6 +170,7 @@ def export_onnx(
                     filepath,
                     verbose=actual_verbose,
                     opset_version=opset_version,
+                    input_names=input_names
                 )
     else:
         raise NotImplementedError(

--- a/keras/src/export/onnx_test.py
+++ b/keras/src/export/onnx_test.py
@@ -281,9 +281,7 @@ class ExportONNXTest(testing.TestCase):
         ref_input = np.random.normal(size=(batch_size, 10)).astype("float32")
 
         # Test with custom input name
-        input_spec = [
-            InputSpec(name="custom_input", shape=(batch_size, 10))
-        ]
+        input_spec = [InputSpec(name="custom_input", shape=(batch_size, 10))]
         onnx.export_onnx(model, temp_filepath, input_signature=input_spec)
 
         onnx_model = onnx_lib.load(temp_filepath)

--- a/keras/src/export/onnx_test.py
+++ b/keras/src/export/onnx_test.py
@@ -14,9 +14,9 @@ from keras.src import ops
 from keras.src import testing
 from keras.src import tree
 from keras.src.export import onnx
+from keras.src.layers.input_spec import InputSpec as InputSpec
 from keras.src.saving import saving_lib
 from keras.src.testing.test_utils import named_product
-from keras.src.layers.input_spec import InputSpec as InputSpec
 
 
 class CustomModel(models.Model):
@@ -281,7 +281,11 @@ class ExportONNXTest(testing.TestCase):
         ref_input = np.random.normal(size=(batch_size, 10)).astype("float32")
 
         # Test with custom input name
-        input_spec = [InputSpec(name="custom_input", shape=(batch_size, 10))]
+        input_spec = [
+            InputSpec(
+                name="custom_input", shape=(batch_size, 10), dtype="float32"
+            )
+        ]
         onnx.export_onnx(model, temp_filepath, input_signature=input_spec)
 
         onnx_model = onnx_lib.load(temp_filepath)

--- a/keras/src/export/onnx_test.py
+++ b/keras/src/export/onnx_test.py
@@ -16,6 +16,7 @@ from keras.src import tree
 from keras.src.export import onnx
 from keras.src.saving import saving_lib
 from keras.src.testing.test_utils import named_product
+from keras.src.layers.input_spec import InputSpec as InputSpec
 
 
 class CustomModel(models.Model):
@@ -281,7 +282,7 @@ class ExportONNXTest(testing.TestCase):
 
         # Test with custom input name
         input_spec = [
-            ops.InputSpec(name="custom_input", shape=(batch_size, 10))
+            InputSpec(name="custom_input", shape=(batch_size, 10))
         ]
         onnx.export_onnx(model, temp_filepath, input_signature=input_spec)
 

--- a/keras/src/export/onnx_test.py
+++ b/keras/src/export/onnx_test.py
@@ -279,6 +279,7 @@ class ExportONNXTest(testing.TestCase):
         model = get_model("sequential")
         batch_size = 3 if backend.backend() != "torch" else 1
         ref_input = np.random.normal(size=(batch_size, 10)).astype("float32")
+        ref_output = model(ref_input)
 
         # Test with custom input name
         input_spec = [
@@ -296,5 +297,4 @@ class ExportONNXTest(testing.TestCase):
         ort_inputs = {
             k.name: v for k, v in zip(ort_session.get_inputs(), [ref_input])
         }
-        ref_output = model(ref_input)
         self.assertAllClose(ref_output, ort_session.run(None, ort_inputs)[0])


### PR DESCRIPTION
Fixes #21637 

### Summary
Currently, when exporting a Keras model with the Torch backend to ONNX, the provided InputSpec.name is ignored. Instead, inputs are saved as generic names such as args_0, which makes exported models harder to use and integrate with downstream pipelines.

This PR updates the Torch backend export logic to properly propagate InputSpec.name into torch.onnx.export via the input_names argument. If a name is not provided, it gracefully falls back to the existing default (input_i). 

### Example
Example

```
spec = [keras.InputSpec(name="input", shape=(1, 10, 16), dtype="float32")]
model.export("test.onnx", format="onnx", input_signature=spec)
```

Before:
ONNX model input name → args_0

After:
ONNX model input name → input


Please let me know what else is needed on this..