### PR TITLE
Allow `searchsorted` to take a dynamically sized tensor.

### DIFF
--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -1031,7 +1031,9 @@ def searchsorted(sorted_sequence, values, side="left"):
             f"sorted_sequence.shape={sorted_sequence.shape}"
         )
     out_type = (
-        "int32" if len(sorted_sequence) <= np.iinfo(np.int32).max else "int64"
+        "int32"
+        if sorted_sequence.shape[0] <= np.iinfo(np.int32).max
+        else "int64"
     )
     return np.searchsorted(sorted_sequence, values, side=side).astype(out_type)
 

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2302,8 +2302,11 @@ def searchsorted(sorted_sequence, values, side="left"):
             "to extend it to N-D sequences. Received: "
             f"sorted_sequence.shape={sorted_sequence.shape}"
         )
+    sequence_len = sorted_sequence.shape[0]
     out_type = (
-        "int32" if len(sorted_sequence) <= np.iinfo(np.int32).max else "int64"
+        "int32"
+        if sequence_len is not None and sequence_len <= np.iinfo(np.int32).max
+        else "int64"
     )
     return tf.searchsorted(
         sorted_sequence, values, side=side, out_type=out_type

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1440,7 +1440,7 @@ def searchsorted(sorted_sequence, values, side="left"):
             "to extend it to N-D sequences. Received: "
             f"sorted_sequence.shape={sorted_sequence.shape}"
         )
-    out_int32 = len(sorted_sequence) <= np.iinfo(np.int32).max
+    out_int32 = sorted_sequence.shape[0] <= np.iinfo(np.int32).max
     return torch.searchsorted(
         sorted_sequence, values, side=side, out_int32=out_int32
     )

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -5589,9 +5589,11 @@ class SearchSorted(Operation):
                 "searchsorted only supports 1-D sorted sequences. Use"
                 "keras.ops.vectorized_map to extend to N-D sequences."
             )
+        sequence_len = sorted_sequence.shape[0]
         out_type = (
             "int32"
-            if sorted_sequence.shape[0] <= np.iinfo(np.int32).max
+            if sequence_len is not None
+            and sequence_len <= np.iinfo(np.int32).max
             else "int64"
         )
         return KerasTensor(values.shape, dtype=out_type)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -337,6 +337,14 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
             (2, None, 1),
         )
 
+    def test_searchsorted(self):
+        a = KerasTensor((None,))
+        v = KerasTensor((2, 3))
+
+        output = knp.searchsorted(a, v)
+        self.assertEqual(output.shape, v.shape)
+        self.assertEqual(output.dtype, "int64")
+
     def test_take(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.take(x, 1).shape, ())


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras/issues/21465

Replaces https://github.com/keras-team/keras/pull/21472