### PR TITLE
Fix torch `quantize` memory issue.

### DIFF
--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -808,6 +808,14 @@ class ModelTest(testing.TestCase):
                     layer.dtype_policy.name, f"{mode}_from_float32"
                 )
                 self.assertEqual(layer.dtype_policy.quantization_mode, mode)
+        if mode == "int8":
+            self.assertLen(model.variables, 6)
+            if backend.backend() == "torch":
+                self.assertLen(list(model.named_parameters()), 6)
+        elif mode == "float8":
+            self.assertLen(model.variables, 16)
+            if backend.backend() == "torch":
+                self.assertLen(list(model.named_parameters()), 16)
 
     @parameterized.named_parameters(
         ("int8", "int8"),


### PR DESCRIPTION
Fixes #21518

This PR fixes a gc issue with quantization in the torch backend.
Previously, gc failed because removed variables were still referenced in other layers' `self._torch_params`. The solution is to retrack `self._torch_params` after the quantization.

Here is an example colab: https://colab.research.google.com/drive/1AVvIFS2j0J8ONYSN80MlcblMypv3dsZy?usp=sharing

<img width="500" alt="image" src="https://github.com/user-attachments/assets/21d38024-fa70-4db1-9fc1-d4e86ac44beb" />
