### PR TITLE
Fixes int64 casting bug for ops.take with `keras.Variable` on TF backend

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2403,7 +2403,9 @@ def take(x, indices, axis=None):
 
     def fix_negative_indices(i):
         # Correct the indices using "fill" mode which is the same as in jax
-        return tf.where(i < 0, i + tf.cast(tf.shape(x)[axis], i.dtype), i)
+        return tf.where(
+            i < 0, tf.cast(i + tf.cast(tf.shape(x)[axis], i.dtype), i.dtype), i
+        )
 
     if isinstance(indices, tf.SparseTensor):
         if x.dtype not in (tf.float16, tf.float32, tf.float64, tf.bfloat16):

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -3265,6 +3265,19 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
             knp.take(x, indices, axis=2), np.take(x, indices, axis=2)
         )
 
+        # Test with a Keras int64 Variable which causes weird casting behavior
+        # in TF.
+        x = rng.standard_normal((2, 3, 4, 5))
+        indices = keras.Variable(
+            initializer="ones",
+            shape=(3,),
+            dtype="int64",
+            trainable=False,
+        )
+        self.assertAllClose(
+            knp.take(x, indices, axis=2), np.take(x, indices, axis=2)
+        )
+
     @parameterized.named_parameters(
         named_product(
             [


### PR DESCRIPTION
## Description of the change
For some reason when using a Keras Variable of type `int64`, TF's casting behavior goes bonkers. This adds an explicit cast to avoid a runtime exception of mismatched dtypes.

The existing code would lead to the following state at the `tf.where(...)` call site (the modified code):
```
>>> i.dtype
int64
>>> tf.shape(x)[axis].dtype
int32
>>> tf.cast(tf.shape(x)[axis], i.dtype).dtype
int64
>>> (i + tf.cast(tf.shape(x)[axis], i.dtype).dtype
int32 
```

As shown above, the addition operation weirdly ends up with `int32` dtype. This change explicitly casts the result to a 64 bit integer to avoid a dtype mismatch between the two arguments of `tf.where`