### PR TITLE
[OpenVINO backend] fix __sub__

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -179,6 +179,10 @@ class OpenVINOKerasTensor:
         first, other = align_operand_types(
             first, other, "OpenVINOKerasTensor::__sub__"
         )
+        if first.get_element_type() == Type.boolean:
+            return OpenVINOKerasTensor(
+                ov_opset.logical_xor(first, other).output(0)
+            )
         return OpenVINOKerasTensor(ov_opset.subtract(first, other).output(0))
 
     def __rsub__(self, other):


### PR DESCRIPTION
@fchollet 
@hertschuh 
Found an issue in OpenVINOKerasTensor `__sub__`
If the input tensors are boolean, it raises an error:
```
FAILED keras_hub/src/models/gemma/gemma_causal_lm_test.py::GemmaCausalLMTest::test_score_logits - RuntimeError: Check 'args_et.is_dynamic() || is_supported_et' failed at src/core/src/op/util/binary_elementwise_arithmetic.cpp:26:
While validating node 'opset1::Subtract Subtract_1356251 (opset1::Convert Convert_1356249[0]:boolean[2,8], opset1::Convert Convert_1356250[0]:boolean[2,8]) -> ()' with friendly_name 'Subtract_1356251':
This operation does not support inputs with element type: boolean
```
while `numpy` applies the `xor` operation.