### PR TITLE
Use a `LazyLoader` for `grain` in `GrainDatasetAdapter`.

### DIFF
--- a/keras/src/trainers/data_adapters/grain_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/grain_dataset_adapter.py
@@ -5,12 +5,8 @@ import numpy as np
 from keras.src import tree
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.trainers.data_adapters.data_adapter import DataAdapter
+from keras.src.utils.module_utils import grain
 from keras.src.utils.module_utils import tensorflow as tf
-
-try:
-    import grain
-except ImportError:
-    grain = None
 
 
 class GrainDatasetAdapter(DataAdapter):


### PR DESCRIPTION
A `LazyLoader` is already used for `grain` in all other contexts where grain is imported: https://github.com/keras-team/keras/blob/2d4dce388280d89a0fe3b1bb0a21690714550b44/keras/src/utils/module_utils.py#L61