### PR TITLE
[OpenVINO backend] suggesting disable reusing compiled model until the bug get fixed

### DIFF
--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -95,11 +95,13 @@ class OpenVINOTrainer(base_trainer.Trainer):
         # OpenVINO compiled model cache is disabled for now.
         # For more information, please visit:
         # https://github.com/openvinotoolkit/openvino/issues/32045
-        # if (
-        #     self.ov_compiled_model is not None
-        #     and get_device() == self.ov_device
-        # ):
-        #     return self.ov_compiled_model
+        use_cache = False
+        if (
+            use_cache
+            and self.ov_compiled_model is not None
+            and get_device() == self.ov_device
+        ):
+            return self.ov_compiled_model
 
         # remove the previous cached compiled model if exists
         del self.ov_compiled_model


### PR DESCRIPTION
@rkazants 
@fchollet 
Based on issue: https://github.com/openvinotoolkit/openvino/issues/32045
Discovered from PR: https://github.com/keras-team/keras-hub/pull/2389
I suggest disabling reusing compiled models until the bug gets fixed.
Note: the bug is not related to the PR: https://github.com/keras-team/keras-hub/pull/2389 itself, it is related to getting the predictions with the same input for the same compiled model being different (for now, this issue has been found only on the Gemma model).