### PR TITLE
Fix test failure in guides writing_your_own_callbacks.py

### DIFF
--- a/guides/writing_your_own_callbacks.py
+++ b/guides/writing_your_own_callbacks.py
@@ -333,7 +333,7 @@ class EarlyStoppingAtMinLoss(keras.callbacks.Callback):
         # The epoch the training stops at.
         self.stopped_epoch = 0
         # Initialize the best as infinity.
-        self.best = np.Inf
+        self.best = np.inf
 
     def on_epoch_end(self, epoch, logs=None):
         current = logs.get("loss")


### PR DESCRIPTION
When running tests under `guides`, I noticed `writing_your_own_callbacks.py` failing with error:
```
AttributeError: `np.Inf` was removed in the NumPy 2.0 release. Use `np.inf` instead.` exception
```

As `numpy` has been released to 2.3.3, raising this small fix to make `writing_your_own_callbacks.py` able to run along with latest `numpy` version.

The change has been verified against `keras=3.11.3` version.