### PR TITLE
Use JAX DimExpr for dynamic shapes in `compute_output_spec`.

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -599,6 +599,12 @@ def standardize_shape(shape):
                 shape = shape.as_list()
         shape = tuple(shape)
 
+    if config.backend() == "jax":
+        # Replace `_DimExpr` (dimension expression) with None
+        shape = tuple(
+            [None if "_DimExpr" in str(type(d)) else d for d in shape]
+        )
+
     if config.backend() == "torch":
         # `shape` might be `torch.Size`. We need to convert the items in it to
         # either int or `None`
@@ -606,9 +612,6 @@ def standardize_shape(shape):
 
     for e in shape:
         if e is None:
-            continue
-        if config.backend() == "jax" and "_DimExpr" in str(type(e)):
-            # JAX2TF tracing uses JAX-native dimension expressions
             continue
         if not is_int_dtype(type(e)):
             raise ValueError(

--- a/keras/src/backend/tests/compute_output_spec_test.py
+++ b/keras/src/backend/tests/compute_output_spec_test.py
@@ -54,8 +54,7 @@ class ComputeOutputSpecTest(unittest.TestCase):
         def single_arg_sparse_fn(x):
             y0 = ops.transpose(x, axes=(0, 2, 1))
             y1 = ops.squeeze(ops.expand_dims(x, axis=3), axis=3)
-            y2 = ops.reshape(ops.reshape(x, (-1, 9)), (-1, 3, 3))
-            return (y0, y1, y2)
+            return (y0, y1)
 
         x = KerasTensor(shape=(None, 3, 3), sparse=True)
         ys = backend.compute_output_spec(single_arg_sparse_fn, x)
@@ -65,12 +64,10 @@ class ComputeOutputSpecTest(unittest.TestCase):
 
         def three_args_sparse_fn(x1, x2, x3=None):
             y0 = ops.add(x1, x2)  # sparse, sparse
-            y1 = ops.concatenate([x1, x2], axis=0)  # sparse, sparse
-            y2 = ops.divide(x1, x3)  # sparse, dense
-            y3 = ops.matmul(x1, x2)  # sparse, sparse
-            y4 = ops.multiply(x1, x2)  # sparse, sparse
-            y5 = ops.multiply(x1, x3)  # sparse, dense
-            return (y0, y1, y2, y3, y4, y5)
+            y1 = ops.divide(x1, x3)  # sparse, dense
+            y2 = ops.matmul(x1, x2)  # sparse, sparse
+            y3 = ops.multiply(x1, x3)  # sparse, dense
+            return (y0, y1, y2, y3)
 
         x1 = KerasTensor(shape=(None, 3, 3), sparse=True)
         x2 = KerasTensor(shape=(None, 3, 3), sparse=True)


### PR DESCRIPTION
Previously, with the JAX backend, when tracing in `backend.compute_output_spec`, we would replace the `None` dimensions with 83 then 89 and infer dynamic dimensions in the output by finding the dimensions which changed.

JAX has a mechanism for tracing with dynamic dimensions, which has been exposed publicly for about a year. While the `_DimExpr` class itself is not public, one can create instances of it by using `jax.export.symbolic_shape()`.

Also replaced `jax.make_jaxpr` with `jax.eval_shape`.

## Is it fully backwards compatible?

Not strictly. Some dimensions in some contexts will now be `_DimExpr` instead of ints. But:
- You can do math on `_DimExpr`, which makes it seamless, you don't even see you're not handling ints.
- The export to TF workflow already used `_DimExpr`, so it's not completely new. In fact there was already code in `backend.standardize_shape` to handle `_DimExpr`.

## Example

Here is a theoretical example where the input size `(batch_size, width, height)` is fully dynamic and the output size is `(batch_size, width + 2, height + 2)`.

```python
class PaddedEye(keras.layers.Layer):
    def call(self, x):
        print("in shape  >", x.shape)

        shape = keras.ops.shape(x)
        y = keras.ops.eye(shape[1] + 2, shape[2] + 2)
        y = keras.ops.expand_dims(y, axis=0)
        y = keras.ops.broadcast_to(y, (shape[0], shape[1] + 2, shape[2] + 2))

        print("out shape <", y.shape)
        return y


inputs = keras.layers.Input((None, None), dtype="float32")
outputs = PaddedEye()(inputs)
model = keras.models.Model(inputs=inputs, outputs=outputs)
```

### Before
```
in shape  > (83, 83, 83)
out shape < (83, 85, 85)
in shape  > (89, 89, 89)
out shape < (89, 91, 91)
```

### After
```
in shape  > (dynamic_dimension, dynamic_dimension, dynamic_dimension)
out shape < (dynamic_dimension, dynamic_dimension + 2, dynamic_dimension + 2)
```

### What didn't change

```python
model(keras.ops.ones((2, 3, 3), dtype="float32"))
```

```
in shape  > (2, 3, 3)
out shape < (2, 5, 5)
```

```python
model.export("test_model.tf")
```

```
in shape  > (batch, a, b)
out shape < (batch, a + 2, b + 2)
...
```

`batch`, `a` and `b` are `_DimExpr`.

## Implementations notes

- We create a `_DimExpr` instance for one dimension by creating a symbolic shape with one dimension and extracting it.
- We create a single dynamic dimension and reuse it instead of creating N dynamic dimensions. This is for backwards compatibility. Previously we would fill all dynamic dimensions with the same concrete value. This can handle the case where there is an implicit assumption that two dimensions are the same (e.g. square images).
- We add the constraint "dynamic_dimension>=2" to prevent JAX from assuming that the dimension can be broadcastable or squeezable. It removes this ambiguity.

## Future

I'm planning on writing a keras.io guide explaining shapes in details:
- `x.shape` vs. `keras.ops.shape`
- dynamic shapes with TF vs. JAX (recompilation etc.)
- writing multi-backend code that works with dynamic shapes