### PR TITLE
Non cumulative model.predict

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -694,7 +694,7 @@ class JAXTrainer(base_trainer.Trainer):
             return outputs
 
         self._jax_state_synced = True
-        outputs = None if accumulate else []
+        outputs = None
         non_trainable_variables = None
         with epoch_iterator.catch_stop_iteration():
             for begin_step, end_step, iterator in epoch_iterator:
@@ -733,9 +733,10 @@ class JAXTrainer(base_trainer.Trainer):
         callbacks.on_predict_end()
         self._jax_state = None
         if accumulate:
+            if outputs is None:
+                return None
             return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)
-        else:
-            return None
+        return outputs
 
     def train_on_batch(
         self,

--- a/keras/src/backend/numpy/trainer.py
+++ b/keras/src/backend/numpy/trainer.py
@@ -210,7 +210,7 @@ class NumpyTrainer(base_trainer.Trainer):
         self.make_predict_function()
         self.stop_predicting = False
         callbacks.on_predict_begin()
-        outputs = None if accumulate else []
+        outputs = None
         for begin_step, end_step, data in epoch_iterator:
             callbacks.on_predict_batch_begin(begin_step)
             batch_outputs = self.predict_function(data)
@@ -221,9 +221,10 @@ class NumpyTrainer(base_trainer.Trainer):
                 break
         callbacks.on_predict_end()
         if accumulate:
+            if outputs is None:
+                return None
             return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)
-        else:
-            return None
+        return outputs
 
     @traceback_utils.filter_traceback
     def evaluate(

--- a/keras/src/backend/numpy/trainer.py
+++ b/keras/src/backend/numpy/trainer.py
@@ -170,7 +170,7 @@ class NumpyTrainer(base_trainer.Trainer):
 
     @traceback_utils.filter_traceback
     def predict(
-        self, x, batch_size=None, verbose="auto", steps=None, callbacks=None
+        self, x, batch_size=None, verbose="auto", steps=None, callbacks=None, accumulate=True
     ):
         # Create an iterator that yields batches of input data.
         epoch_iterator = EpochIterator(
@@ -210,16 +210,20 @@ class NumpyTrainer(base_trainer.Trainer):
         self.make_predict_function()
         self.stop_predicting = False
         callbacks.on_predict_begin()
-        outputs = None
+        outputs = None if accumulate else []
         for begin_step, end_step, data in epoch_iterator:
             callbacks.on_predict_batch_begin(begin_step)
             batch_outputs = self.predict_function(data)
-            outputs = append_to_outputs(batch_outputs, outputs)
+            if accumulate:
+                outputs = append_to_outputs(batch_outputs, outputs)
             callbacks.on_predict_batch_end(end_step, {"outputs": batch_outputs})
             if self.stop_predicting:
                 break
         callbacks.on_predict_end()
-        return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)
+        if accumulate:
+            return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)
+        else:
+            return None
 
     @traceback_utils.filter_traceback
     def evaluate(

--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -171,7 +171,7 @@ class OpenVINOTrainer(base_trainer.Trainer):
 
     @traceback_utils.filter_traceback
     def predict(
-        self, x, batch_size=None, verbose="auto", steps=None, callbacks=None
+        self, x, batch_size=None, verbose="auto", steps=None, callbacks=None, accumulate=True
     ):
         # Create an iterator that yields batches of input data.
         epoch_iterator = EpochIterator(
@@ -212,16 +212,20 @@ class OpenVINOTrainer(base_trainer.Trainer):
         self.make_predict_function()
         self.stop_predicting = False
         callbacks.on_predict_begin()
-        outputs = None
+        outputs = None if accumulate else []
         for begin_step, end_step, data in epoch_iterator.enumerate_epoch():
             callbacks.on_predict_batch_begin(begin_step)
             batch_outputs = self.predict_function(data)
-            outputs = append_to_outputs(batch_outputs, outputs)
+            if accumulate:
+                outputs = append_to_outputs(batch_outputs, outputs)
             callbacks.on_predict_batch_end(end_step, {"outputs": batch_outputs})
             if self.stop_predicting:
                 break
         callbacks.on_predict_end()
-        return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)
+        if accumulate:
+            return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)
+        else:
+            return None
 
     @traceback_utils.filter_traceback
     def evaluate(

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -521,7 +521,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
     @traceback_utils.filter_traceback
     def predict(
-        self, x, batch_size=None, verbose="auto", steps=None, callbacks=None
+        self, x, batch_size=None, verbose="auto", steps=None, callbacks=None, accumulate=True
     ):
         # Create an iterator that yields batches of input data.
         epoch_iterator = TFEpochIterator(
@@ -580,23 +580,27 @@ class TensorFlowTrainer(base_trainer.Trainer):
         self.make_predict_function()
         self.stop_predicting = False
         callbacks.on_predict_begin()
-        outputs = None
+        outputs = None if accumulate else []
         with epoch_iterator.catch_stop_iteration():
             for begin_step, end_step, iterator in epoch_iterator:
                 callbacks.on_predict_batch_begin(begin_step)
                 data = get_data(iterator)
                 batch_outputs = self.predict_function(data)
-                outputs = append_to_outputs(batch_outputs, outputs)
+                if accumulate:
+                    outputs = append_to_outputs(batch_outputs, outputs)
                 callbacks.on_predict_batch_end(
                     end_step, {"outputs": batch_outputs}
                 )
                 if self.stop_predicting:
                     break
         callbacks.on_predict_end()
-        outputs = tree.map_structure_up_to(
-            batch_outputs, potentially_ragged_concat, outputs
-        )
-        return tree.map_structure(convert_to_np_if_not_ragged, outputs)
+        if accumulate:
+            outputs = tree.map_structure_up_to(
+                batch_outputs, potentially_ragged_concat, outputs
+            )
+            return tree.map_structure(convert_to_np_if_not_ragged, outputs)
+        else:
+            return None
 
     def train_on_batch(
         self,

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -580,7 +580,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
         self.make_predict_function()
         self.stop_predicting = False
         callbacks.on_predict_begin()
-        outputs = None if accumulate else []
+        outputs = None
         with epoch_iterator.catch_stop_iteration():
             for begin_step, end_step, iterator in epoch_iterator:
                 callbacks.on_predict_batch_begin(begin_step)
@@ -595,12 +595,13 @@ class TensorFlowTrainer(base_trainer.Trainer):
                     break
         callbacks.on_predict_end()
         if accumulate:
+            if outputs is None:
+                return None
             outputs = tree.map_structure_up_to(
                 batch_outputs, potentially_ragged_concat, outputs
             )
             return tree.map_structure(convert_to_np_if_not_ragged, outputs)
-        else:
-            return None
+        return outputs
 
     def train_on_batch(
         self,

--- a/keras/src/backend/torch/trainer.py
+++ b/keras/src/backend/torch/trainer.py
@@ -438,7 +438,7 @@ class TorchTrainer(base_trainer.Trainer):
         self.make_predict_function()
         self.stop_predicting = False
         callbacks.on_predict_begin()
-        outputs = None if accumulate else []
+        outputs = None
         for begin_step, end_step, data in epoch_iterator:
             callbacks.on_predict_batch_begin(begin_step)
             batch_outputs = self.predict_function(data)
@@ -449,10 +449,11 @@ class TorchTrainer(base_trainer.Trainer):
                 break
         callbacks.on_predict_end()
         if accumulate:
+            if outputs is None:
+                return None
             outputs = tree.map_structure(backend.convert_to_numpy, outputs)
             return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)
-        else:
-            return None
+        return outputs
 
     def train_on_batch(
         self,

--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -807,7 +807,7 @@ class Trainer:
         raise NotImplementedError
 
     def predict(
-        self, x, batch_size=None, verbose="auto", steps=None, callbacks=None
+        self, x, batch_size=None, verbose="auto", steps=None, callbacks=None, accumulate=True
     ):
         """Generates output predictions for the input samples.
 
@@ -858,9 +858,13 @@ class Trainer:
                 repeating dataset, it will run indefinitely.
             callbacks: List of `keras.callbacks.Callback` instances.
                 List of callbacks to apply during prediction.
+            accumulate: Boolean. Whether to accumulate predictions in memory.
+                If `False`, predictions are not returned and must be handled
+                via callbacks to avoid memory issues with large datasets.
+                Defaults to `True`.
 
         Returns:
-            NumPy array(s) of predictions.
+            NumPy array(s) of predictions if `accumulate=True`, otherwise `None`.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
there was a feature request for non cumulative model.predict, where we don't store the outputs and return it directly.
#21642 In case of very large datasets and limited memory, it is more feasible to retrieve the outputs using a callback and store to storage, instead of storing everything in memory.

This PR fixes #21642.