### PR TITLE
Do not use `os.path.join` for variable paths.

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -1,5 +1,3 @@
-import os.path
-
 import numpy as np
 
 from keras.src import backend
@@ -144,7 +142,7 @@ class Variable:
         self._name = name
         parent_path = current_path()
         if parent_path:
-            self._path = os.path.join(current_path(), name)
+            self._path = f"{parent_path}/{name}"
         else:
             self._path = name
         self._shape = None

--- a/keras/src/backend/common/variables_test.py
+++ b/keras/src/backend/common/variables_test.py
@@ -328,6 +328,10 @@ class VariablePropertiesTest(test_case.TestCase):
         v = backend.Variable(initializer=np.ones((2, 2)), name="test_var")
         self.assertEqual(v.path, "test_var")
 
+        with backend.name_scope("test_scope"):
+            v = backend.Variable(initializer=np.ones((2, 2)), name="test_var")
+            self.assertEqual(v.path, "test_scope/test_var")
+
     def test_overwrite_with_gradient_setter(self):
         v = backend.Variable(
             initializer=initializers.RandomNormal(),


### PR DESCRIPTION
Variable paths do not represent a filesystem path and should not be OS dependent, they should always use "/" as a separator.

This reverts https://github.com/keras-team/keras/pull/21343 just for variables.