### PR TITLE
Do not use `os.path.sep` to detect `/` in names.

### DIFF
--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -1,5 +1,4 @@
 import inspect
-import os.path
 import textwrap
 
 from keras.src import backend
@@ -20,10 +19,10 @@ class Operation(KerasSaveable):
     def __init__(self, name=None):
         if name is None:
             name = auto_name(self.__class__.__name__)
-        if not isinstance(name, str) or os.path.sep in name:
+        if not isinstance(name, str) or "/" in name:
             raise ValueError(
                 "Argument `name` must be a string and "
-                f"cannot contain character `{os.path.sep}`. "
+                f"cannot contain character `/`. "
                 f"Received: name={name} (of type {type(name)})"
             )
         self.name = name


### PR DESCRIPTION
Operation and layer names do not represent a filesystem path and should not be OS dependent. Namescope paths always use "/" as a separator, which is what we should be looking for.

This reverts https://github.com/keras-team/keras/pull/21343 just for `Operation`.

Note that [the unit test](https://github.com/keras-team/keras/blob/master/keras/src/ops/operation_test.py#L331) was correct. Simply, we never run it on Windows, which is why this was not caught.