### PR TITLE
Fixes the `kernel` property of Dense and EinsumDense to return unpacked int4 kernels

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -152,11 +152,14 @@ class Dense(Layer):
             and self.quantization_mode == "gptq"
         ):
             return self.quantized_kernel
+        kernel = self._kernel
+        if self.quantization_mode == "int4":
+            kernel = quantizers.unpack_int4(kernel, self._orig_input_dim)
         if self.lora_enabled:
-            return self._kernel + (
-                self.lora_alpha / self.lora_rank
-            ) * ops.matmul(self.lora_kernel_a, self.lora_kernel_b)
-        return self._kernel
+            return kernel + (self.lora_alpha / self.lora_rank) * ops.matmul(
+                self.lora_kernel_a, self.lora_kernel_b
+            )
+        return kernel
 
     def call(self, inputs, training=None):
         x = ops.matmul(inputs, self.kernel)

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -11,6 +11,7 @@ from keras.src import layers
 from keras.src import models
 from keras.src import ops
 from keras.src import optimizers
+from keras.src import quantizers
 from keras.src import random
 from keras.src import saving
 from keras.src import testing
@@ -976,3 +977,13 @@ class DenseTest(testing.TestCase):
         new_layer = layers.Dense.from_config(config)
         new_layer.build((None, 8))
         self.assertEqual(new_layer.quantization_mode, "gptq")
+
+    def test_int4_kernel_returns_unpacked_form(self):
+        """Test that the `kernel` property returns the unpacked int4 kernel."""
+        layer = layers.Dense(units=2)
+        layer.build((None, 2))
+        layer.quantize("int4")
+        packed_kernel = layer._kernel
+        self.assertAllClose(
+            layer.kernel, quantizers.unpack_int4(packed_kernel, 2)
+        )

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -553,7 +553,7 @@ class EinsumDenseTest(testing.TestCase):
             "btd,df->btf",
             (None, 4),
             (1, 2, 4),
-            2e-3,
+            3e-3,
         ),
     )
     def test_quantize_with_specific_equations(

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -11,6 +11,7 @@ from keras.src import layers
 from keras.src import models
 from keras.src import ops
 from keras.src import optimizers
+from keras.src import quantizers
 from keras.src import random
 from keras.src import saving
 from keras.src import testing
@@ -1036,3 +1037,16 @@ class EinsumDenseTest(testing.TestCase):
         new_layer = layers.EinsumDense.from_config(config)
         new_layer.build((None, 3))
         self.assertEqual(new_layer.quantization_mode, "gptq")
+
+    def test_int4_kernel_returns_unpacked_form(self):
+        """Test that the `kernel` property returns the unpacked int4 kernel."""
+        layer = layers.EinsumDense(
+            equation="ab,bc->ac",
+            output_shape=(2,),
+        )
+        layer.build((None, 2))
+        layer.quantize("int4")
+        packed_kernel = layer._kernel
+        self.assertAllClose(
+            layer.kernel, quantizers.unpack_int4(packed_kernel, orig_len=2)
+        )

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1048,5 +1048,5 @@ class EinsumDenseTest(testing.TestCase):
         layer.quantize("int4")
         packed_kernel = layer._kernel
         self.assertAllClose(
-            layer.kernel, quantizers.unpack_int4(packed_kernel, orig_len=2)
+            layer.kernel, quantizers.unpack_int4(packed_kernel, 2)
         )


### PR DESCRIPTION
Fixes the `kernel` property of the `Dense` and `EinsumDense` layers to return the unpacked representation of packed 4-bit integer quantized kernels.

Presently, these methods return the packed representation which might not make sense to external users of this API.