### PR TITLE
Adds 4-bit packing support to GPTQ Quantization

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -422,7 +422,7 @@ class Dense(Layer):
         weight_bits = self._get_gptq_weight_bits(config)
         if weight_bits == 4:
             # For 4-bit weights, we pack two values per byte.
-            units = math.ceil(kernel_shape[1] / 2)
+            units = (kernel_shape[1] + 1) // 2
         else:
             units = kernel_shape[1]
 

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -463,7 +463,7 @@ class Dense(Layer):
         if not self.is_gptq_calibrated:
             W = self._kernel
         else:
-            should_unpack = self.dtype_policy.weight_bits == 4
+            should_unpack = self._get_gptq_weight_bits(config=None) == 4
             W = (
                 quantizers.unpack_int4(
                     self.quantized_kernel,
@@ -474,15 +474,13 @@ class Dense(Layer):
                 if should_unpack
                 else self.quantized_kernel
             )
-            W = (
-                ops.transpose(
-                    dequantize_with_sz_map(
-                        W,
-                        self.kernel_scale,
-                        self.kernel_zero,
-                        self.g_idx,
-                    )
-                ),
+            W = ops.transpose(
+                dequantize_with_sz_map(
+                    W,
+                    self.kernel_scale,
+                    self.kernel_zero,
+                    self.g_idx,
+                )
             )
 
         y = ops.matmul(inputs, W)

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -899,6 +899,23 @@ class DenseTest(testing.TestCase):
         self.assertAllClose(layer.outputs_grad_scale, float8_store["6"])
         self.assertAllClose(layer.outputs_grad_amax_history, float8_store["7"])
 
+    def test_int4_gptq_kernel_returns_unpacked_form(self):
+        """Test that the `kernel` property returns the unpacked int4 GPTQ
+        kernel."""
+        layer = layers.Dense(units=2)
+        layer.build((None, 2))
+        layer.quantize(
+            "gptq",
+            config=GPTQConfig(
+                dataset=None, tokenizer=None, weight_bits=4, group_size=8
+            ),
+        )
+        layer.is_gptq_calibrated = True  # Bypass calibration check
+        packed_kernel = layer.quantized_kernel
+        self.assertAllClose(
+            layer.kernel, quantizers.unpack_int4(packed_kernel, 2)
+        )
+
     def test_gptq_kernel_packing(self):
         """Validates that 4-bit GPTQ packing reduces the kernel size."""
         layer = layers.Dense(units=16, use_bias=False)

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -898,3 +898,20 @@ class DenseTest(testing.TestCase):
         self.assertAllClose(layer.kernel_amax_history, float8_store["5"])
         self.assertAllClose(layer.outputs_grad_scale, float8_store["6"])
         self.assertAllClose(layer.outputs_grad_amax_history, float8_store["7"])
+
+    def test_gptq_kernel_packing(self):
+        """Validates that 4-bit GPTQ packing reduces the kernel size."""
+        layer = layers.Dense(units=16, use_bias=False)
+        layer.build((None, 8))
+
+        original_kernel_params = ops.prod(layer._kernel.shape)
+
+        layer.quantize(
+            "gptq",
+            config=GPTQConfig(
+                dataset=None, tokenizer=None, weight_bits=4, group_size=8
+            ),
+        )
+
+        quantized_kernel_params = ops.prod(layer.quantized_kernel.shape)
+        self.assertEqual(quantized_kernel_params, original_kernel_params // 2)

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -537,7 +537,6 @@ class EinsumDense(Layer):
         else:
             n_groups = math.ceil(rows / group_size)
 
-
         self.gptq_unpacked_column_size = columns
 
         weight_bits = self._get_gptq_weight_bits(config)
@@ -581,13 +580,13 @@ class EinsumDense(Layer):
         if not self.is_gptq_calibrated:
             W = self._kernel
         else:
-            should_unpack = self.dtype_policy.weight_bits == 4
+            should_unpack = self._get_gptq_weight_bits(config=None) == 4
             W = (
                 quantizers.unpack_int4(
                     self.quantized_kernel,
                     orig_len=self.gptq_unpacked_column_size,
                     axis=0,
-                    dtype="int8",
+                    dtype="uint8",
                 )
                 if should_unpack
                 else self.quantized_kernel

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -13,11 +13,8 @@ from keras.src import ops
 from keras.src import quantizers
 from keras.src import regularizers
 from keras.src.api_export import keras_export
-from keras.src.dtype_policies.dtype_policy import GPTQDTypePolicy
-from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
 from keras.src.layers.input_spec import InputSpec
 from keras.src.layers.layer import Layer
-from keras.src.quantizers.gptq_config import GPTQConfig
 from keras.src.quantizers.quantizers import dequantize_with_sz_map
 
 
@@ -207,16 +204,20 @@ class EinsumDense(Layer):
 
     @property
     def kernel(self):
+        from keras.src.quantizers import gptq_core
+
         if not self.built:
             raise AttributeError(
                 "You must build the layer before accessing `kernel`."
             )
 
-        mode = getattr(self, "quantization_mode", None)
+        mode = self.quantization_mode
         is_gptq = mode == "gptq"
         is_int4 = mode == "int4"
         calibrated = bool(getattr(self, "is_gptq_calibrated", False))
-        gptq_bits = self._get_gptq_weight_bits(None) if is_gptq else None
+        gptq_bits = (
+            gptq_core.get_weight_bits_for_layer(self, None) if is_gptq else None
+        )
 
         # Decide the source tensor first (packed vs already-quantized vs plain
         # kernel)
@@ -243,7 +244,7 @@ class EinsumDense(Layer):
                 )
 
         # Apply LoRA if enabled
-        if getattr(self, "lora_enabled", False):
+        if self.lora_enabled:
             kernel = kernel + (self.lora_alpha / self.lora_rank) * ops.matmul(
                 self.lora_kernel_a, self.lora_kernel_b
             )
@@ -522,6 +523,8 @@ class EinsumDense(Layer):
             group_size: int; contiguous input-group size for quantization
                 (=-1 means per-output-channel with no grouping).
         """
+        from keras.src.quantizers import gptq_core
+
         # Ensures the forward pass uses the original high-precision kernel
         # until calibration has been performed.
         self.is_gptq_calibrated = False
@@ -554,15 +557,12 @@ class EinsumDense(Layer):
             else:
                 raise ValueError("Could not determine row/column split.")
 
-        group_size = self._get_gptq_group_size(config)
-        if group_size == -1:
-            n_groups = 1
-        else:
-            n_groups = math.ceil(rows / group_size)
+        group_size = gptq_core.get_group_size_for_layer(self, config)
+        n_groups = 1 if group_size == -1 else math.ceil(rows / group_size)
 
         self.gptq_unpacked_column_size = columns
 
-        weight_bits = self._get_gptq_weight_bits(config)
+        weight_bits = gptq_core.get_weight_bits_for_layer(self, config)
         # For 4-bit weights, we pack two values per byte.
         kernel_columns = (columns + 1) // 2 if weight_bits == 4 else columns
 
@@ -600,10 +600,14 @@ class EinsumDense(Layer):
         )
 
     def _gptq_call(self, inputs, training=False):
+        from keras.src.quantizers import gptq_core
+
         if not self.is_gptq_calibrated:
             W = self._kernel
         else:
-            should_unpack = self._get_gptq_weight_bits(config=None) == 4
+            should_unpack = (
+                gptq_core.get_weight_bits_for_layer(self, config=None) == 4
+            )
             W = (
                 quantizers.unpack_int4(
                     self.quantized_kernel,
@@ -1208,87 +1212,6 @@ class EinsumDense(Layer):
             self._custom_gradient_equation,
             self._kernel_reverse_transpose_axes,
         ) = _analyze_quantization_info(self.equation, self.input_spec.ndim)
-
-    def _get_gptq_group_size(self, config):
-        """Determine the group size for GPTQ quantization.
-
-        The group size can be specified either through the `config` argument
-        or through the `dtype_policy` if it is of type `GPTQDTypePolicy`.
-
-        The config argument is usually available when quantizing the layer
-        via the `quantize` method. If the layer was deserialized from a
-        saved model, the group size should be specified in the `dtype_policy`.
-
-        Args:
-            config: An optional configuration object that may contain the
-                `group_size` attribute.
-        Returns:
-            int. The determined group size for GPTQ quantization.
-        Raises:
-            ValueError: If the group size is not specified in either the
-                `config` or the `dtype_policy`.
-        """
-        if config and isinstance(config, GPTQConfig):
-            return config.group_size
-        elif isinstance(self.dtype_policy, GPTQDTypePolicy):
-            return self.dtype_policy.group_size
-        elif isinstance(self.dtype_policy, DTypePolicyMap):
-            policy = self.dtype_policy[self.path]
-            if not isinstance(policy, GPTQDTypePolicy):
-                # This should never happen based on how we set the
-                # quantization mode, but we check just in case.
-                raise ValueError(
-                    "Expected a `dtype_policy` of type `GPTQDTypePolicy`."
-                    f"Got: {type(policy)}"
-                )
-            return policy.group_size
-        else:
-            raise ValueError(
-                "For GPTQ quantization, the group_size must be specified"
-                "either through a `dtype_policy` of type "
-                "`GPTQDTypePolicy` or the `config` argument."
-            )
-
-    def _get_gptq_weight_bits(self, config):
-        """Determine the number of weight bits for GPTQ quantization.
-
-        The number of weight bits can be specified either through the `config`
-        argument or through the `dtype_policy` if it is of type
-        `GPTQDTypePolicy`.
-
-        The config argument is usually available when quantizing the layer
-        via the `quantize` method. If the layer was deserialized from a
-        saved model, the weight bits should be specified in the `dtype_policy`.
-
-        Args:
-            config: An optional configuration object that may contain the
-                `weight_bits` attribute.
-        Returns:
-            int. The determined number of weight bits for GPTQ quantization.
-        Raises:
-            ValueError: If the weight bits is not specified in either the
-                `config` or the `dtype_policy`.
-        """
-        if config and isinstance(config, GPTQConfig):
-            return config.weight_bits
-        elif isinstance(self.dtype_policy, GPTQDTypePolicy):
-            return self.dtype_policy.weight_bits
-        elif isinstance(self.dtype_policy, DTypePolicyMap):
-            policy = self.dtype_policy[self.path]
-            if not isinstance(policy, GPTQDTypePolicy):
-                # This should never happen based on how we set the
-                # quantization mode, but we check just in case.
-                raise ValueError(
-                    "Expected a `dtype_policy` of type `GPTQDTypePolicy`."
-                    f"Got: {type(policy)}"
-                )
-            return policy.weight_bits
-        else:
-            raise ValueError(
-                "For GPTQ quantization, the weight_bits must be specified"
-                "either through a `dtype_policy` of type "
-                "`GPTQDTypePolicy` or the `config` argument."
-            )
 
 
 def _analyze_einsum_string(equation, bias_axes, input_shape, output_shape):

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -211,20 +211,43 @@ class EinsumDense(Layer):
             raise AttributeError(
                 "You must build the layer before accessing `kernel`."
             )
-        if (
-            getattr(self, "is_gptq_calibrated", False)
-            and self.quantization_mode == "gptq"
-        ):
-            return self.quantized_kernel
-        kernel = self._kernel
-        if self.quantization_mode == "int4":
-            kernel = quantizers.unpack_int4(
-                kernel, self._orig_length_along_pack_axis, self._int4_pack_axis
-            )
-        if self.lora_enabled:
-            return kernel + (self.lora_alpha / self.lora_rank) * ops.matmul(
+
+        mode = getattr(self, "quantization_mode", None)
+        is_gptq = mode == "gptq"
+        is_int4 = mode == "int4"
+        calibrated = bool(getattr(self, "is_gptq_calibrated", False))
+        gptq_bits = self._get_gptq_weight_bits(None) if is_gptq else None
+
+        # Decide the source tensor first (packed vs already-quantized vs plain
+        # kernel)
+        if is_gptq and calibrated and gptq_bits != 4:
+            # calibrated GPTQ, not 4-bit, no unpacking needed
+            kernel = self.quantized_kernel
+        else:
+            # Start with the stored kernel
+            kernel = getattr(self, "_kernel", None)
+
+            # Handle int4 unpacking cases in one place
+            if is_int4:
+                kernel = quantizers.unpack_int4(
+                    kernel,
+                    self._orig_length_along_pack_axis,
+                    self._int4_pack_axis,
+                )
+            elif is_gptq and calibrated and gptq_bits == 4:
+                kernel = quantizers.unpack_int4(
+                    self.quantized_kernel,
+                    orig_len=self.gptq_unpacked_column_size,
+                    axis=0,
+                    dtype="uint8",
+                )
+
+        # Apply LoRA if enabled
+        if getattr(self, "lora_enabled", False):
+            kernel = kernel + (self.lora_alpha / self.lora_rank) * ops.matmul(
                 self.lora_kernel_a, self.lora_kernel_b
             )
+
         return kernel
 
     def compute_output_shape(self, _):

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1115,3 +1115,28 @@ class EinsumDenseTest(testing.TestCase):
         self.assertAllClose(layer.kernel_amax_history, float8_store["5"])
         self.assertAllClose(layer.outputs_grad_scale, float8_store["6"])
         self.assertAllClose(layer.outputs_grad_amax_history, float8_store["7"])
+
+    def test_gptq_kernel_packing(self):
+        """Validates that 4-bit GPTQ packing reduces the kernel size."""
+        config = dict(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes="d",
+        )
+        layer = layers.EinsumDense(**config)
+        layer.build((None, 3))
+
+        original_kernel_params = ops.prod(layer._kernel.shape)
+
+        layer.quantize(
+            "gptq",
+            config=GPTQConfig(
+                dataset=None, tokenizer=None, weight_bits=4, group_size=8
+            ),
+        )
+
+        quantized_kernel_params = ops.prod(layer.quantized_kernel.shape)
+        self.assertEqual(
+            quantized_kernel_params,
+            original_kernel_params // 2,
+        )

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1116,6 +1116,26 @@ class EinsumDenseTest(testing.TestCase):
         self.assertAllClose(layer.outputs_grad_scale, float8_store["6"])
         self.assertAllClose(layer.outputs_grad_amax_history, float8_store["7"])
 
+    def test_int4_gptq_kernel_returns_unpacked_form(self):
+        """Test that the `kernel` property returns the unpacked int4 GPTQ
+        kernel."""
+        layer = layers.EinsumDense(
+            equation="ab,bc->ac",
+            output_shape=(2,),
+        )
+        layer.build((None, 2))
+        layer.quantize(
+            "gptq",
+            config=GPTQConfig(
+                dataset=None, tokenizer=None, weight_bits=4, group_size=8
+            ),
+        )
+        layer.is_gptq_calibrated = True  # Bypass calibration check
+        packed_kernel = layer.quantized_kernel
+        self.assertAllClose(
+            layer.kernel, quantizers.unpack_int4(packed_kernel, 2)
+        )
+
     def test_gptq_kernel_packing(self):
         """Validates that 4-bit GPTQ packing reduces the kernel size."""
         config = dict(

--- a/keras/src/quantizers/gptq.py
+++ b/keras/src/quantizers/gptq.py
@@ -477,9 +477,7 @@ class GPTQ:
             quantized, self.original_layer.quantized_kernel.dtype
         )
 
-        if self.config.weight_bits == 4 and isinstance(
-            self.original_layer, Dense
-        ):
+        if self.config.weight_bits == 4:
             # For 4-bit weights, we need to pack them into bytes
             quantized, _, _ = quantizers.pack_int4(
                 quantized, axis=0, dtype="uint8"

--- a/keras/src/quantizers/gptq.py
+++ b/keras/src/quantizers/gptq.py
@@ -2,6 +2,7 @@ import types
 from functools import partial
 
 from keras.src import ops
+from keras.src import quantizers
 from keras.src.layers import Dense
 from keras.src.layers import EinsumDense
 from keras.src.ops import linalg
@@ -475,6 +476,14 @@ class GPTQ:
         quantized = ops.cast(
             quantized, self.original_layer.quantized_kernel.dtype
         )
+
+        if self.config.weight_bits == 4 and isinstance(
+            self.original_layer, Dense
+        ):
+            # For 4-bit weights, we need to pack them into bytes
+            quantized, _, _ = quantizers.pack_int4(
+                quantized, axis=0, dtype="uint8"
+            )
 
         del self.original_layer._kernel
         self.original_layer.quantized_kernel.assign(quantized)

--- a/keras/src/quantizers/gptq_test.py
+++ b/keras/src/quantizers/gptq_test.py
@@ -131,7 +131,7 @@ class GPTQTest(testing.TestCase):
         dense_gptq.update_hessian_with_batch(calibration_data)
         dense_gptq.quantize_and_correct_layer()
 
-        self.assertEqual(dense.kernel.dtype, "uint8")
+        self.assertEqual(backend.standardize_dtype(dense.kernel.dtype), "uint8")
 
         dense_gptq.free()
         self.assertIsNone(getattr(dense_gptq, "hessian", None))

--- a/keras/src/quantizers/quantizers_test.py
+++ b/keras/src/quantizers/quantizers_test.py
@@ -134,7 +134,6 @@ class QuantizersTest(testing.TestCase):
         },
     ]
 
-    # DTYPE_PARAMS remains the same
     DTYPE_PARAMS = [
         {"testcase_name": "int8", "dtype": "int8", "minval": -8, "maxval": 8},
         {"testcase_name": "uint8", "dtype": "uint8", "minval": 0, "maxval": 16},

--- a/keras/src/quantizers/quantizers_test.py
+++ b/keras/src/quantizers/quantizers_test.py
@@ -14,6 +14,7 @@ from keras.src.quantizers.quantizers import dequantize_with_sz_map
 from keras.src.quantizers.quantizers import dequantize_with_zero_point
 from keras.src.quantizers.quantizers import quantize_with_sz_map
 from keras.src.quantizers.quantizers import quantize_with_zero_point
+from keras.src.testing.test_utils import named_product
 
 
 class QuantizersTest(testing.TestCase):
@@ -113,49 +114,58 @@ class QuantizersTest(testing.TestCase):
         # A loose assertion due to an expected quantization error
         self.assertAllClose(qdq_values, values, atol=5e-1)
 
+    SHAPE_AXIS_SCENARIOS = [
+        # 1. 2D Tensors
+        # Covers the unpack fast path (rank=2, axis=0) for both parities
+        {"testcase_name": "2d_axis0_odd", "shape": (5, 8), "axis": 0},
+        {"testcase_name": "2d_axis0_even", "shape": (4, 8), "axis": 0},
+        # Covers the general path and a negative axis for 2D tensors
+        {"testcase_name": "2d_axis1_odd", "shape": (8, 7), "axis": 1},
+        {"testcase_name": "2d_axis_neg1_even", "shape": (8, 6), "axis": -1},
+        # 2. Higher-Rank Tensors
+        # Covers a middle axis for a complex shape with both parities
+        {"testcase_name": "4d_axis1_odd", "shape": (2, 5, 4, 6), "axis": 1},
+        {"testcase_name": "4d_axis2_even", "shape": (2, 4, 8, 6), "axis": 2},
+        # Covers the last axis of a complex shape with a negative index
+        {
+            "testcase_name": "4d_axis_neg1_odd",
+            "shape": (2, 4, 6, 7),
+            "axis": -1,
+        },
+    ]
+
+    # DTYPE_PARAMS remains the same
+    DTYPE_PARAMS = [
+        {"testcase_name": "int8", "dtype": "int8", "minval": -8, "maxval": 8},
+        {"testcase_name": "uint8", "dtype": "uint8", "minval": 0, "maxval": 16},
+    ]
+
     @parameterized.named_parameters(
-        ("even_rows", (4, 5), 0),
-        ("odd_rows", (5, 5), 0),
-        ("even_rows_axis_0_negative", (4, 5), -1),
-        ("odd_rows_axis_0_negative", (5, 5), -1),
-        ("even_rows_axis_1", (4, 6), 1),
-        ("odd_rows_axis_1", (4, 7), 1),
-        ("3d_even_rows_axis_0", (4, 5, 3), 0),
-        ("3d_odd_rows_axis_0", (5, 5, 3), 0),
-        ("3d_even_rows_axis_1", (4, 6, 3), 1),
-        ("3d_odd_rows_axis_1", (4, 7, 3), 1),
-        ("3d_even_rows_axis_2", (4, 5, 6), 2),
-        ("3d_odd_rows_axis_2", (4, 5, 7), 2),
-        ("4d_odd_rows_axis_0", (2, 3, 5, 4), 0),
-        ("4d_odd_rows_axis_1", (2, 3, 5, 4), 1),
-        ("4d_odd_rows_axis_2", (2, 3, 5, 4), 2),
-        ("4d_odd_rows_axis_3", (2, 3, 5, 4), 3),
-        ("4d_even_rows_axis_0", (2, 4, 5, 4), 0),
-        ("4d_even_rows_axis_1", (2, 4, 5, 4), 1),
-        ("4d_even_rows_axis_2", (2, 4, 5, 4), 2),
-        ("4d_even_rows_axis_3", (2, 4, 5, 4), 3),
-        ("4d_even_rows_axis_0_negative", (2, 4, 5, 4), -1),
-        ("4d_even_rows_axis_1_negative", (2, 4, 5, 4), -2),
-        ("4d_even_rows_axis_2_negative", (2, 4, 5, 4), -3),
-        ("4d_even_rows_axis_3_negative", (2, 4, 5, 4), -4),
+        named_product(SHAPE_AXIS_SCENARIOS, DTYPE_PARAMS)
     )
-    def test_pack_unpack_int4(self, shape, axis):
-        # Create a random tensor with int4 values [-8, 7]
+    def test_pack_unpack_int4(self, shape, axis, dtype, minval, maxval):
+        # Create a random tensor with int4 values in the specified range and
+        # dtype
         arr = ops.cast(
-            ops.floor(random.uniform(shape, minval=-8, maxval=8)), "int8"
+            ops.floor(random.uniform(shape, minval=minval, maxval=maxval)),
+            dtype,
         )
 
-        # Pack the tensor
-        packed, packed_shape, orig_len = quantizers.pack_int4(arr, axis=axis)
+        # Pack the tensor using the specified dtype
+        packed, packed_shape, orig_len = quantizers.pack_int4(
+            arr, axis=axis, dtype=dtype
+        )
 
-        # Unpack the tensor
-        unpacked = quantizers.unpack_int4(packed, orig_len, axis=axis)
+        # Unpack the tensor using the specified dtype
+        unpacked = quantizers.unpack_int4(
+            packed, orig_len, axis=axis, dtype=dtype
+        )
 
-        # Verify that the packed tensor is int8
-        self.assertDType(packed, "int8")
+        # Verify that the packed tensor has the correct dtype
+        self.assertDType(packed, dtype)
 
-        # Verify that the unpacked tensor is int8
-        self.assertDType(unpacked, "int8")
+        # Verify that the unpacked tensor has the correct dtype
+        self.assertDType(unpacked, dtype)
 
         # The unpacked tensor should be the same as the original tensor
         self.assertAllClose(unpacked, arr)


### PR DESCRIPTION
## Summary

Integrates native 4-bit kernel packing for GPTQ in `Dense` and `EinsumDense`. Kernels are stored packed (two nibbles/byte) and unpacked only at call time. This change also extends `pack_int4`/`unpack_int4` to support both `"int8"` and `"uint8"` paths.

This change reduces the memory requirements for 4-bit integer quantized kernels by half.

## New Logical Flow

1. Build (`_gptq_build`): Allocate `quantized_kernel` with packed columns when `weight_bits==4`
    (`units = ceil(cols/2)` for `Dense`; analogous for `EinsumDense`, storing `gptq_unpacked_column_size`).
2. Quantize (`gptq.py`): If 4-bit: `pack_int4(..., axis=0, dtype="uint8")` before assigning.
3. Call (`_gptq_call`): If 4-bit: `unpack_int4(..., axis=0, dtype="uint8")` → `dequantize_with_sz_map(...)` → matmul, Otherwise: dequantize directly.

## Tests

1. Packing reduction: Ensures param count halves after 4-bit quantize for both `Dense` and `EinsumDense`.
2. Parameterized shapes/axes (+ negative axes, higher ranks) × dtypes (`int8`, `uint8`): `pack_int4` → `unpack_int4` preserves dtype and values.
3. `EinsumDense.get_config` includes `gptq_unpacked_column_size`; GPTQ serialization still passes.