### PR TITLE
Adds store serialization tests for GPTQ

### DIFF
--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -864,7 +864,8 @@ class DenseTest(testing.TestCase):
         gptq_store = {
             # bias
             "0": np.random.random((16,)).astype("float32"),
-            "1": np.random.randint(0, 16, size=(16, 8), dtype="uint8"),
+            # quantized_kernel
+            "1": np.random.randint(0, 16, size=(8, 8), dtype="uint8"),
             # kernel_scale.
             "2": np.random.random((16, 1)).astype("float32"),
             # kernel_zero

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -862,6 +862,17 @@ class DenseTest(testing.TestCase):
             # outputs_grad_amax_history.
             "7": np.random.random((1024,)).astype("float32"),
         }
+        gptq_store = {
+            # bias
+            "0": np.random.random((16,)).astype("float32"),
+            "1": np.random.randint(0, 16, size=(16, 8), dtype="uint8"),
+            # kernel_scale.
+            "2": np.random.random((16, 1)).astype("float32"),
+            # kernel_zero
+            "3": np.random.random((16, 1)).astype("uint8"),
+            # g_idx
+            "4": np.random.random((8,)).astype("float32"),
+        }
 
         # Test float32 layer.
         layer = layers.Dense(units=16)
@@ -898,6 +909,16 @@ class DenseTest(testing.TestCase):
         self.assertAllClose(layer.kernel_amax_history, float8_store["5"])
         self.assertAllClose(layer.outputs_grad_scale, float8_store["6"])
         self.assertAllClose(layer.outputs_grad_amax_history, float8_store["7"])
+
+        # Test gptq-quantized layer.
+        layer = layers.Dense(units=16, dtype="gptq/4/8_from_float32")
+        layer.build((None, 8))
+        layer.load_own_variables(gptq_store)
+        self.assertAllClose(layer.bias, gptq_store["0"])
+        self.assertAllClose(layer.quantized_kernel, gptq_store["1"])
+        self.assertAllClose(layer.kernel_scale, gptq_store["2"])
+        self.assertAllClose(layer.kernel_zero, gptq_store["3"])
+        self.assertAllClose(layer.g_idx, gptq_store["4"])
 
     def test_int4_gptq_kernel_returns_unpacked_form(self):
         """Test that the `kernel` property returns the unpacked int4 GPTQ

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -831,7 +831,6 @@ class DenseTest(testing.TestCase):
     def test_legacy_load_own_variables(self):
         # In previous versions, `load_own_variables` accepted a store with
         # numeric keys.
-        # TODO(JyotinderSingh): add gptq_store test.
         float32_store = {
             "0": np.random.random((8, 16)).astype("float32"),
             "1": np.random.random((16,)).astype("float32"),

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1043,7 +1043,6 @@ class EinsumDenseTest(testing.TestCase):
     def test_legacy_load_own_variables(self):
         # In previous versions, `load_own_variables` accepted a store with
         # numeric keys.
-        # TODO(JyotinderSingh): add gptq_store test.
         float32_store = {
             "0": np.random.random((3, 8, 32)).astype("float32"),
             "1": np.random.random((32,)).astype("float32"),

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1076,7 +1076,8 @@ class EinsumDenseTest(testing.TestCase):
         gptq_store = {
             # bias
             "0": np.random.random((32,)).astype("float32"),
-            "1": np.random.randint(0, 16, size=(32, 24), dtype="uint8"),
+            # quantized_kernel
+            "1": np.random.randint(0, 16, size=(16, 24), dtype="uint8"),
             # kernel_scale.
             "2": np.random.random((32, 3)).astype("float32"),
             # kernel_zero


### PR DESCRIPTION
This PR adds missing store tests for validating the (de)?serialization flow when using GPTQ quantization

cc: @james77777778 