### PR TITLE
Fixes float64 type promotion issue

### DIFF
--- a/keras/src/backend/common/dtypes.py
+++ b/keras/src/backend/common/dtypes.py
@@ -237,7 +237,7 @@ BIT64_TO_BIT32_DTYPE = {
     # enable the int64 dtype for TF.
     "int64": "int64" if config.backend() == "tensorflow" else "int32",
     "uint64": "uint32",
-    "float64": "float32",
+    "float64": "float64" if config.backend() == "tensorflow" else "float32",
     "complex128": "complex64",
 }
 

--- a/keras/src/backend/common/dtypes_test.py
+++ b/keras/src/backend/common/dtypes_test.py
@@ -93,6 +93,12 @@ class DtypesTest(test_case.TestCase):
                 "bfloat16",
                 "float32",
                 "float64",
+                "int8",
+                "int16",
+                "int32",
+                "int64",
+                "uint8",
+                "uint16",
             ]
         )
     )

--- a/keras/src/backend/common/dtypes_test.py
+++ b/keras/src/backend/common/dtypes_test.py
@@ -86,6 +86,27 @@ class DtypesTest(test_case.TestCase):
         out = backend.result_type(x1.dtype, x2.dtype)
         self.assertEqual(out, "int64")
 
+    @parameterized.named_parameters(
+        named_product(
+            dtype=[
+                "float16",
+                "bfloat16",
+                "float32",
+                "float64",
+            ]
+        )
+    )
+    @pytest.mark.skipif(
+        backend.backend() != "tensorflow", reason="TensorFlow only"
+    )
+    def test_result_type_with_float64(self, dtype):
+        # Float types have a similar issue as int64 in TF.:
+        # https://github.com/keras-team/keras/issues/21677
+        x1 = ops.ones((1,), dtype="float64")
+        x2 = ops.ones((1,), dtype=dtype)
+        out = backend.result_type(x1.dtype, x2.dtype)
+        self.assertEqual(out, "float64")
+
     def test_result_type_with_none(self):
         import jax.numpy as jnp
 


### PR DESCRIPTION
Arithmetic operations on 64-bit floating point numbers incorrectly result in 32-bit result dtypes.

The root cause of the issue is that https://github.com/keras-team/keras/pull/21604 forced 64-bit dtypes to be remapped to 32-bit dtypes to be consistent with JAX's dtype promotion rules. However, this breaks behavior for clients depending on `"float64"` types in their code.