### PR TITLE
Ensures compiled metrics resolve output names correctly

### DIFF
--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -148,6 +148,7 @@ class CompileMetrics(metrics_module.Metric):
         self.built = False
         self.name = "compile_metrics"
         self.output_names = output_names
+        self._resolved_output_names = None
 
     @property
     def metrics(self):
@@ -175,10 +176,16 @@ class CompileMetrics(metrics_module.Metric):
 
     def build(self, y_true, y_pred):
         num_outputs = 1  # default
-        if self.output_names:
+        # Resolve output names. If y_pred is a dict, prefer its keys.
+        if isinstance(y_pred, dict):
+            keys = sorted(list(y_pred.keys()))
+            if self.output_names and set(self.output_names) == set(keys):
+                # If there is a perfect match, use the user-provided order.
+                output_names = self.output_names
+            else:
+                output_names = keys
+        elif self.output_names:
             output_names = self.output_names
-        elif isinstance(y_pred, dict):
-            output_names = sorted(list(y_pred.keys()))
         elif isinstance(y_pred, (list, tuple)):
             num_outputs = len(y_pred)
             if all(hasattr(x, "_keras_history") for x in y_pred):
@@ -187,6 +194,7 @@ class CompileMetrics(metrics_module.Metric):
                 output_names = None
         else:
             output_names = None
+        self._resolved_output_names = output_names
         if output_names:
             num_outputs = len(output_names)
 
@@ -316,9 +324,10 @@ class CompileMetrics(metrics_module.Metric):
         return flat_metrics
 
     def _flatten_y(self, y):
-        if isinstance(y, dict) and self.output_names:
+        names = getattr(self, "_resolved_output_names", self.output_names)
+        if isinstance(y, dict) and names:
             result = []
-            for name in self.output_names:
+            for name in names:
                 if name in y:
                     result.append(y[name])
             return result

--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -324,7 +324,7 @@ class CompileMetrics(metrics_module.Metric):
         return flat_metrics
 
     def _flatten_y(self, y):
-        names = getattr(self, "_resolved_output_names", self.output_names)
+        names = self._resolved_output_names
         if isinstance(y, dict) and names:
             result = []
             for name in names:


### PR DESCRIPTION
## Issue
Fixes #21675

In Keras 3.x, compiling models with dict outputs and dict metrics can fail when `CompileMetrics` receives `output_names` that don't match the dict keys of `y_pred`. The builder prefers `output_names` (often internal op names like `['dense', 'dense_1']`) over actual dict keys (e.g., `{'a', 'b'}`), causing `ValueError ("key 'a' does not correspond to any model output"`)

This change ensures that `CompileMetrics.build` resolves output names by preferring dict keys when `y_pred` is a dict, and honors `self.output_names` only if its set matches the dict key set (to preserve stable ordering). It stores the resolved names `(_resolved_output_names`) and uses them consistently for flattening (`_flatten_y`) and metric name prefixing, preserving correct mapping of dict outputs.

## Testing
Added `test_dict_outputs_ignore_mismatched_output_names` validating that dict metrics build and run when `output_names` are op-style names that don't match user dict keys, and verifies metric naming (`a_*`/`b_*`) and correct values.

## Colab
[colab notebook demonstrating complete training loop](https://colab.research.google.com/gist/JyotinderSingh/ad3a5d489f015734450ac1f21c39967b/keras-3-dictionary-metrix-fix.ipynb)