### PR TITLE
Remove reliance on `__jax_array__` to unwrap variables.

### DIFF
--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -56,7 +56,12 @@ class JaxVariable(KerasVariable):
 
     # Overload native accessor.
     def __jax_array__(self):
-        return self.value
+        # TODO UNDO
+        import traceback
+
+        print("### __jax_array__")
+        traceback.print_stack()
+        raise ValueError("__jax_array__")
 
 
 Variable = JaxVariable

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -396,6 +396,8 @@ def depthwise_conv(
     feature_group_count = (
         inputs.shape[-1] if data_format == "channels_last" else inputs.shape[1]
     )
+    kernel = convert_to_tensor(kernel)
+    inputs = convert_to_tensor(inputs)
     kernel = jnp.reshape(
         kernel,
         kernel.shape[:-2] + (1, feature_group_count * kernel.shape[-1]),

--- a/keras/src/backend/jax/optimizer.py
+++ b/keras/src/backend/jax/optimizer.py
@@ -36,13 +36,14 @@ class JaxOptimizer(base_optimizer.BaseOptimizer):
             new_g_accs = jax.lax.cond(
                 is_update_step,
                 lambda: [jnp.zeros(g.shape, dtype=g.dtype) for g in acc_grads],
-                lambda: [g + acc_g for g, acc_g in zip(grads, acc_grads)],
+                lambda: [g + acc_g.value for g, acc_g in zip(grads, acc_grads)],
             )
 
             grads = jax.lax.cond(
                 is_update_step,
                 lambda: [
-                    (g + acc_g) / steps for g, acc_g in zip(grads, acc_grads)
+                    (g + acc_g.value) / steps
+                    for g, acc_g in zip(grads, acc_grads)
                 ],
                 lambda: list(grads),
             )

--- a/keras/src/layers/attention/attention.py
+++ b/keras/src/layers/attention/attention.py
@@ -121,7 +121,7 @@ class Attention(Layer):
         if self.score_mode == "dot":
             scores = ops.matmul(query, ops.transpose(key, axes=[0, 2, 1]))
             if self.scale is not None:
-                scores *= self.scale
+                scores = ops.multiply(scores, self.scale)
         elif self.score_mode == "concat":
             # Reshape tensors to enable broadcasting.
             # Reshape into [batch_size, Tq, 1, dim].

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -678,7 +678,7 @@ class LayerTest(testing.TestCase):
             def call(self, x):
                 # Should not autocast.
                 assertDType(self.v, "float32")
-                return ops.cast(x, "float32") + self.v
+                return ops.add(ops.cast(x, "float32"), self.v)
 
         # A layer that is explicitly full precision.
         class InnerLayerTwo(layers.Layer):
@@ -694,7 +694,7 @@ class LayerTest(testing.TestCase):
             def call(self, x):
                 # Should not autocast.
                 assertDType(self.v, "float32")
-                return x + self.v
+                return ops.add(x, self.v)
 
         # A layer that is explicitly mixed precision but with autocast=False
         # weight.
@@ -732,7 +732,7 @@ class LayerTest(testing.TestCase):
                 # Should autocast.
                 assertDType(self.v, "float16")
                 return self.inner_three(
-                    self.inner_two(self.inner_one(x + self.v))
+                    self.inner_two(self.inner_one(ops.add(x, self.v)))
                 )
 
         layer = MixedPrecisionLayer()
@@ -935,7 +935,7 @@ class LayerTest(testing.TestCase):
                 x = x + backend.random.normal(
                     shape=(), seed=self._seed_generator
                 )
-                return x + self.tw + self.ntw
+                return ops.add(x, ops.add(self.tw, self.ntw))
 
         data = np.random.random((3, 4))
         layer = TestLayer()

--- a/keras/src/layers/normalization/layer_normalization_test.py
+++ b/keras/src/layers/normalization/layer_normalization_test.py
@@ -99,8 +99,8 @@ class LayerNormalizationTest(testing.TestCase):
         ).astype("float32")
 
         out = layer(inputs)
-        out -= layer.beta
-        out /= layer.gamma
+        out = ops.subtract(out, layer.beta)
+        out = ops.divide(out, layer.gamma)
 
         self.assertAllClose(ops.mean(out), 0.0, atol=1e-1)
         self.assertAllClose(ops.std(out), 1.0, atol=1e-1)

--- a/keras/src/layers/normalization/rms_normalization_test.py
+++ b/keras/src/layers/normalization/rms_normalization_test.py
@@ -38,10 +38,12 @@ class RMSNormalizationTest(testing.TestCase):
         inputs = ops.convert_to_tensor(inputs)
 
         out = layer(inputs)
-        expected = (
-            inputs
-            * ops.rsqrt(ops.mean(ops.square(inputs), axis=-1, keepdims=True))
-            * layer.scale
+        expected = ops.multiply(
+            ops.multiply(
+                inputs,
+                ops.rsqrt(ops.mean(ops.square(inputs), axis=-1, keepdims=True)),
+            ),
+            layer.scale,
         )
 
         self.assertAllClose(out, expected, atol=1e-1)

--- a/keras/src/layers/rnn/gru.py
+++ b/keras/src/layers/rnn/gru.py
@@ -261,7 +261,7 @@ class GRUCell(Layer, DropoutRNNCell):
             matrix_x = ops.matmul(inputs, self.kernel)
             if self.use_bias:
                 # biases: bias_z_i, bias_r_i, bias_h_i
-                matrix_x += input_bias
+                matrix_x = ops.add(matrix_x, input_bias)
 
             x_z, x_r, x_h = ops.split(matrix_x, 3, axis=-1)
 

--- a/keras/src/layers/rnn/lstm.py
+++ b/keras/src/layers/rnn/lstm.py
@@ -276,9 +276,9 @@ class LSTMCell(Layer, DropoutRNNCell):
 
             z = ops.matmul(inputs, self.kernel)
 
-            z += ops.matmul(h_tm1, self.recurrent_kernel)
+            z = ops.add(z, ops.matmul(h_tm1, self.recurrent_kernel))
             if self.use_bias:
-                z += self.bias
+                z = ops.add(z, self.bias)
 
             z = ops.split(z, 4, axis=1)
             c, o = self._compute_carry_and_output_fused(z, c_tm1)

--- a/keras/src/layers/rnn/simple_rnn.py
+++ b/keras/src/layers/rnn/simple_rnn.py
@@ -160,7 +160,7 @@ class SimpleRNNCell(Layer, DropoutRNNCell):
             sequence = sequence * dp_mask
         h = ops.matmul(sequence, self.kernel)
         if self.bias is not None:
-            h += self.bias
+            h = ops.add(h, self.bias)
 
         if training and rec_dp_mask is not None:
             prev_output = prev_output * rec_dp_mask

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -1185,7 +1185,9 @@ class CoreOpsCorrectnessTest(testing.TestCase):
                 self.b = self.add_weight(shape=(1,), initializer="zeros")
 
             def call(self, x, training=False):
-                return x * ops.stop_gradient(self.w) + self.b
+                return ops.add(
+                    ops.multiply(x, ops.stop_gradient(self.w)), self.b
+                )
 
         model = models.Sequential([ExampleLayer()])
         model.compile(

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -1443,7 +1443,7 @@ def depthwise_conv(
     """
     data_format = standardize_data_format(data_format)
     padding = padding.lower()
-    if any_symbolic_tensors((inputs,)):
+    if any_symbolic_tensors((inputs, kernel)):
         return DepthwiseConv(
             strides, padding, data_format, dilation_rate
         ).symbolic_call(inputs, kernel)

--- a/keras/src/optimizers/base_optimizer.py
+++ b/keras/src/optimizers/base_optimizer.py
@@ -969,10 +969,15 @@ class BaseOptimizer(KerasSaveable):
             ):
                 if average is not None:
                     not_first_step = ops.not_equal(self.iterations, 0)
-                    momentum = (
-                        ops.cast(not_first_step, var.dtype) * self.ema_momentum
+                    momentum = ops.multiply(
+                        ops.cast(not_first_step, var.dtype), self.ema_momentum
                     )
-                    average.assign(momentum * average + (1 - momentum) * var)
+                    average.assign(
+                        ops.add(
+                            ops.multiply(momentum, average),
+                            ops.multiply(ops.subtract(1, momentum), var),
+                        )
+                    )
 
     def _overwrite_model_variables_with_average_value(
         self, trainable_variables

--- a/keras/src/optimizers/loss_scale_optimizer_test.py
+++ b/keras/src/optimizers/loss_scale_optimizer_test.py
@@ -40,7 +40,9 @@ class LossScaleOptimizerTest(testing.TestCase):
         if stateless:
             optimizer.build(vars)
             vars, _ = optimizer.stateless_apply(
-                optimizer.variables, grads, vars
+                [v.value for v in optimizer.variables],
+                grads,
+                [v.value for v in vars],
             )
         else:
             optimizer.apply(grads, vars)
@@ -60,7 +62,9 @@ class LossScaleOptimizerTest(testing.TestCase):
         if stateless:
             optimizer.build(vars)
             vars, _ = optimizer.stateless_apply(
-                optimizer.variables, grads, vars
+                [v.value for v in optimizer.variables],
+                grads,
+                [v.value for v in vars],
             )
         else:
             optimizer.apply(grads, vars)
@@ -79,7 +83,9 @@ class LossScaleOptimizerTest(testing.TestCase):
         if stateless:
             optimizer.build(vars)
             vars, _ = optimizer.stateless_apply(
-                optimizer.variables, grads, vars
+                [v.value for v in optimizer.variables],
+                grads,
+                [v.value for v in vars],
             )
         else:
             optimizer.apply(grads, vars)
@@ -98,7 +104,9 @@ class LossScaleOptimizerTest(testing.TestCase):
         if stateless:
             optimizer.build(vars)
             vars, _ = optimizer.stateless_apply(
-                optimizer.variables, grads, vars
+                [v.value for v in optimizer.variables],
+                grads,
+                [v.value for v in vars],
             )
         else:
             optimizer.apply(grads, vars)
@@ -112,12 +120,14 @@ class LossScaleOptimizerTest(testing.TestCase):
         optimizer = LossScaleOptimizer(inner_optimizer, initial_scale=400.0)
         vars = [backend.Variable([1.0, 2.0, 3.0, 4.0])]
         optimizer.build(vars)
-        opt_vars = optimizer.variables
+        opt_var_values = [v.value for v in optimizer.variables]
         grads = [ops.array([np.inf, np.inf, np.inf, np.inf])]
         for _ in range(4):
             if stateless:
-                _, opt_vars = optimizer.stateless_apply(opt_vars, grads, vars)
-                for ref_v, v in zip(optimizer.variables, opt_vars):
+                _, opt_var_values = optimizer.stateless_apply(
+                    opt_var_values, grads, [v.value for v in vars]
+                )
+                for ref_v, v in zip(optimizer.variables, opt_var_values):
                     ref_v.assign(v)
             else:
                 optimizer.apply(grads, vars)
@@ -135,12 +145,14 @@ class LossScaleOptimizerTest(testing.TestCase):
         )
         vars = [backend.Variable([1.0, 2.0, 3.0, 4.0])]
         optimizer.build(vars)
-        opt_vars = optimizer.variables
+        opt_var_values = [v.value for v in optimizer.variables]
         grads = [ops.array([1.0, 6.0, 7.0, 2.0])]
         for _ in range(8):
             if stateless:
-                _, opt_vars = optimizer.stateless_apply(opt_vars, grads, vars)
-                for ref_v, v in zip(optimizer.variables, opt_vars):
+                _, opt_var_values = optimizer.stateless_apply(
+                    opt_var_values, grads, [v.value for v in vars]
+                )
+                for ref_v, v in zip(optimizer.variables, opt_var_values):
                     ref_v.assign(v)
             else:
                 optimizer.apply(grads, vars)
@@ -154,15 +166,17 @@ class LossScaleOptimizerTest(testing.TestCase):
         optimizer = LossScaleOptimizer(inner_optimizer)
         vars = [backend.Variable([1.0, 2.0, 3.0, 4.0])]
         optimizer.build(vars)
-        opt_vars = optimizer.variables
+        opt_var_values = [v.value for v in optimizer.variables]
         grads = [ops.array([1.0, 6.0, 7.0, 2.0])]
 
         self.assertEqual(optimizer.iterations.value, 0)
 
         for i in range(3):
             if stateless:
-                _, opt_vars = optimizer.stateless_apply(opt_vars, grads, vars)
-                for ref_v, v in zip(optimizer.variables, opt_vars):
+                _, opt_var_values = optimizer.stateless_apply(
+                    opt_var_values, grads, [v.value for v in vars]
+                )
+                for ref_v, v in zip(optimizer.variables, opt_var_values):
                     ref_v.assign(v)
             else:
                 optimizer.apply(grads, vars)


### PR DESCRIPTION
Several months ago JAX deprecated passing `__jax_array__`-implementing objects directly, to, e.g., a `jit`-ted function. JAX has emitted a warning since that time. In a future release of JAX this will become a hard error.