### PR TITLE
Bug fixes with variable handling in `LossScaleOptimizer`.

### DIFF
--- a/keras/src/optimizers/base_optimizer.py
+++ b/keras/src/optimizers/base_optimizer.py
@@ -631,6 +631,20 @@ class BaseOptimizer(KerasSaveable):
             g_acc.assign(n_g_acc)
 
     def stateless_apply(self, optimizer_variables, grads, trainable_variables):
+        """Stateless version of `apply` that returns modified variables.
+
+        Args:
+            optimizer_variables: list of tensors containing the current values
+                for the optimizer variables. These are native tensors and not
+                `keras.Variable`s.
+            grads: list of gradients to apply.
+            trainable_variables: list of tensors containing the current values
+                for the model variables. These are native tensors and not
+                `keras.Variable`s.
+
+        Returns: A tuple containing two list of tensors, the updated
+            `trainable_variables` and the updated `optimizer_variables`.
+        """
         self._check_super_called()
 
         if not self.built:

--- a/keras/src/optimizers/loss_scale_optimizer_test.py
+++ b/keras/src/optimizers/loss_scale_optimizer_test.py
@@ -29,6 +29,19 @@ class LossScaleOptimizerTest(testing.TestCase):
         optimizer = LossScaleOptimizer(inner_optimizer)
         self.run_class_serialization_test(optimizer)
 
+    def test_apply_with_no_vars(self):
+        self._skip_test_for_stateless(False)
+
+        inner_optimizer = SGD(learning_rate=0.5)
+        optimizer = LossScaleOptimizer(inner_optimizer)
+        grads = [ops.array([1.0, 6.0, 7.0, 2.0]) * optimizer.initial_scale]
+        vars = [backend.Variable([1.0, 2.0, 3.0, 4.0])]
+        optimizer.build(vars)
+        optimizer.apply(grads)
+        self.assertAllClose(
+            vars, [[0.5, -1.0, -0.5, 3.0]], rtol=1e-4, atol=1e-4
+        )
+
     @parameterized.named_parameters(("stateless", True), ("stateful", False))
     def test_finite_step(self, stateless):
         self._skip_test_for_stateless(stateless)
@@ -40,7 +53,9 @@ class LossScaleOptimizerTest(testing.TestCase):
         if stateless:
             optimizer.build(vars)
             vars, _ = optimizer.stateless_apply(
-                optimizer.variables, grads, vars
+                [v.value for v in optimizer.variables],
+                grads,
+                [v.value for v in vars],
             )
         else:
             optimizer.apply(grads, vars)
@@ -60,7 +75,9 @@ class LossScaleOptimizerTest(testing.TestCase):
         if stateless:
             optimizer.build(vars)
             vars, _ = optimizer.stateless_apply(
-                optimizer.variables, grads, vars
+                [v.value for v in optimizer.variables],
+                grads,
+                [v.value for v in vars],
             )
         else:
             optimizer.apply(grads, vars)
@@ -79,7 +96,9 @@ class LossScaleOptimizerTest(testing.TestCase):
         if stateless:
             optimizer.build(vars)
             vars, _ = optimizer.stateless_apply(
-                optimizer.variables, grads, vars
+                [v.value for v in optimizer.variables],
+                grads,
+                [v.value for v in vars],
             )
         else:
             optimizer.apply(grads, vars)
@@ -98,7 +117,9 @@ class LossScaleOptimizerTest(testing.TestCase):
         if stateless:
             optimizer.build(vars)
             vars, _ = optimizer.stateless_apply(
-                optimizer.variables, grads, vars
+                [v.value for v in optimizer.variables],
+                grads,
+                [v.value for v in vars],
             )
         else:
             optimizer.apply(grads, vars)
@@ -112,12 +133,14 @@ class LossScaleOptimizerTest(testing.TestCase):
         optimizer = LossScaleOptimizer(inner_optimizer, initial_scale=400.0)
         vars = [backend.Variable([1.0, 2.0, 3.0, 4.0])]
         optimizer.build(vars)
-        opt_vars = optimizer.variables
+        opt_var_values = [v.value for v in optimizer.variables]
         grads = [ops.array([np.inf, np.inf, np.inf, np.inf])]
         for _ in range(4):
             if stateless:
-                _, opt_vars = optimizer.stateless_apply(opt_vars, grads, vars)
-                for ref_v, v in zip(optimizer.variables, opt_vars):
+                _, opt_var_values = optimizer.stateless_apply(
+                    opt_var_values, grads, [v.value for v in vars]
+                )
+                for ref_v, v in zip(optimizer.variables, opt_var_values):
                     ref_v.assign(v)
             else:
                 optimizer.apply(grads, vars)
@@ -135,12 +158,14 @@ class LossScaleOptimizerTest(testing.TestCase):
         )
         vars = [backend.Variable([1.0, 2.0, 3.0, 4.0])]
         optimizer.build(vars)
-        opt_vars = optimizer.variables
+        opt_var_values = [v.value for v in optimizer.variables]
         grads = [ops.array([1.0, 6.0, 7.0, 2.0])]
         for _ in range(8):
             if stateless:
-                _, opt_vars = optimizer.stateless_apply(opt_vars, grads, vars)
-                for ref_v, v in zip(optimizer.variables, opt_vars):
+                _, opt_var_values = optimizer.stateless_apply(
+                    opt_var_values, grads, [v.value for v in vars]
+                )
+                for ref_v, v in zip(optimizer.variables, opt_var_values):
                     ref_v.assign(v)
             else:
                 optimizer.apply(grads, vars)
@@ -154,16 +179,104 @@ class LossScaleOptimizerTest(testing.TestCase):
         optimizer = LossScaleOptimizer(inner_optimizer)
         vars = [backend.Variable([1.0, 2.0, 3.0, 4.0])]
         optimizer.build(vars)
-        opt_vars = optimizer.variables
+        opt_var_values = [v.value for v in optimizer.variables]
         grads = [ops.array([1.0, 6.0, 7.0, 2.0])]
 
         self.assertEqual(optimizer.iterations.value, 0)
 
         for i in range(3):
             if stateless:
-                _, opt_vars = optimizer.stateless_apply(opt_vars, grads, vars)
-                for ref_v, v in zip(optimizer.variables, opt_vars):
+                _, opt_var_values = optimizer.stateless_apply(
+                    opt_var_values, grads, [v.value for v in vars]
+                )
+                for ref_v, v in zip(optimizer.variables, opt_var_values):
                     ref_v.assign(v)
             else:
                 optimizer.apply(grads, vars)
             self.assertEqual(optimizer.iterations.value, i + 1)
+
+    def test_serialization(self):
+        inner_optimizer = SGD(learning_rate=0.5)
+        optimizer = LossScaleOptimizer(
+            inner_optimizer,
+            initial_scale=3.0,
+            dynamic_growth_steps=2,
+            name="test_opt",
+        )
+        config = optimizer.get_config()
+        self.assertLen(config, 4)
+        self.assertEqual(config["name"], "test_opt")
+        self.assertEqual(config["initial_scale"], 3.0)
+        self.assertEqual(config["dynamic_growth_steps"], 2)
+        self.assertIn("inner_optimizer", config)
+        LossScaleOptimizer.from_config(config)
+
+    def test_init_dynamic_arg(self):
+        inner_optimizer = SGD(learning_rate=0.5)
+
+        # dynamic=True is supported
+        LossScaleOptimizer(inner_optimizer, dynamic=True)
+
+        # dynamic=False is not supported
+        with self.assertRaisesRegex(ValueError, "set `loss_scale_factor`"):
+            LossScaleOptimizer(inner_optimizer, dynamic=False)
+
+    def test_init_unsupported_arg(self):
+        inner_optimizer = SGD(learning_rate=0.5)
+        with self.assertRaisesRegex(ValueError, "arguments: `foo`, `bar`"):
+            LossScaleOptimizer(inner_optimizer, foo=True, bar=3)
+
+    @parameterized.named_parameters(
+        ("weight_decay", "weight_decay", 0.5),
+        ("clipnorm", "clipnorm", 0.5),
+        ("global_clipnorm", "global_clipnorm", 0.5),
+        ("clipvalue", "clipvalue", 0.5),
+        ("use_ema", "use_ema", True),
+        ("ema_momentum", "ema_momentum", 0.5),
+        ("ema_overwrite_frequency", "ema_overwrite_frequency", 2),
+        ("loss_scale_factor", "loss_scale_factor", 0.5),
+        ("gradient_accumulation_steps", "gradient_accumulation_steps", 2),
+    )
+    def test_init_base_optimizer_unsupported_args(self, arg_name, arg_value):
+        inner_optimizer = SGD(learning_rate=0.5)
+        with self.assertRaisesRegex(ValueError, "on the `inner_optimizer`"):
+            LossScaleOptimizer(inner_optimizer, **{arg_name: arg_value})
+
+    def test_deserialization_backwards_compatibility(self):
+        # Test deserializing with a config that has all the unsupported
+        # arguments from the base optimizer (which are no longer serialized)
+        config = {
+            "name": "loss_scale_optimizer",
+            "weight_decay": None,
+            "clipnorm": None,
+            "global_clipnorm": None,
+            "clipvalue": None,
+            "use_ema": False,
+            "ema_momentum": 0.99,
+            "ema_overwrite_frequency": None,
+            "loss_scale_factor": None,
+            "gradient_accumulation_steps": None,
+            "inner_optimizer": {
+                "module": "keras.optimizers",
+                "class_name": "SGD",
+                "config": {
+                    "name": "SGD",
+                    "learning_rate": 0.5,
+                    "weight_decay": None,
+                    "clipnorm": None,
+                    "global_clipnorm": None,
+                    "clipvalue": None,
+                    "use_ema": False,
+                    "ema_momentum": 0.99,
+                    "ema_overwrite_frequency": None,
+                    "loss_scale_factor": None,
+                    "gradient_accumulation_steps": None,
+                    "momentum": 0.0,
+                    "nesterov": False,
+                },
+                "registered_name": None,
+            },
+            "initial_scale": 2.0,
+            "dynamic_growth_steps": 2,
+        }
+        LossScaleOptimizer.from_config(config)


### PR DESCRIPTION
## overwrite_with_gradient

`overwrite_with_gradient` would be ineffective on JAX in real-world conditions, i.e. within `model.fit`.
    
This is because in the training loop, `stateless_apply` is passed `trainable_variables` as arrays containing the values of the trainable variables, not the variables themselves. Instead, we have to inspect the variables.

## apply with gradients only

`apply(grads)` without the `trainable_variables` argument passed in would not apply anything.
    
This is because the code uses `self._trainable_variables`. But this was an empty array for `LossScaleOptimizer`. This was fixed by adding `super().build(...)`.

## unsupported optimizer arguments
    
Also fail when other arguments from the base optimizer are passed to `LossScaleOptimizer.__init__` since they are not actually supported. They are also no longer returned by `get_config`.

