### PR TITLE
Do not use backend ops in `ProgBar`.

### DIFF
--- a/keras/src/utils/progbar.py
+++ b/keras/src/utils/progbar.py
@@ -3,7 +3,6 @@ import os
 import sys
 import time
 
-from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.utils import io_utils
 
@@ -162,12 +161,7 @@ class Progbar:
             for k in self._values_order:
                 info += f" - {k}:"
                 if isinstance(self._values[k], list):
-                    avg = backend.convert_to_numpy(
-                        backend.numpy.mean(
-                            self._values[k][0] / max(1, self._values[k][1])
-                        )
-                    )
-                    avg = float(avg)
+                    avg = self._values[k][0] / max(1, self._values[k][1])
                     if abs(avg) > 1e-3:
                         info += f" {avg:.4f}"
                     else:
@@ -194,11 +188,7 @@ class Progbar:
                 info += f" -{self._format_time(time_per_unit, self.unit_name)}"
                 for k in self._values_order:
                     info += f" - {k}:"
-                    avg = backend.convert_to_numpy(
-                        backend.numpy.mean(
-                            self._values[k][0] / max(1, self._values[k][1])
-                        )
-                    )
+                    avg = self._values[k][0] / max(1, self._values[k][1])
                     if avg > 1e-3:
                         info += f" {avg:.4f}"
                     else:


### PR DESCRIPTION
The `ProgBar` was using `backend.numpy.mean` causing it to use the accelerator (TPU or GPU) therefore causing a synchronization which defeated the async callback mechanism. This in turn was slowing down training.

All values provided in the `logs` are already Python floats and are all single values. There is therefore no need to do a `mean`, computing the average is simply a division of the running sum by the running count.