### PR TITLE
Add debug mode

### DIFF
--- a/keras/api/_tf_keras/keras/config/__init__.py
+++ b/keras/api/_tf_keras/keras/config/__init__.py
@@ -5,15 +5,20 @@ since your modifications would be overwritten.
 """
 
 from keras.src.backend.config import backend as backend
+from keras.src.backend.config import disable_debug_mode as disable_debug_mode
 from keras.src.backend.config import (
     disable_flash_attention as disable_flash_attention,
 )
+from keras.src.backend.config import enable_debug_mode as enable_debug_mode
 from keras.src.backend.config import (
     enable_flash_attention as enable_flash_attention,
 )
 from keras.src.backend.config import epsilon as epsilon
 from keras.src.backend.config import floatx as floatx
 from keras.src.backend.config import image_data_format as image_data_format
+from keras.src.backend.config import (
+    is_debug_mode_enabled as is_debug_mode_enabled,
+)
 from keras.src.backend.config import (
     is_flash_attention_enabled as is_flash_attention_enabled,
 )

--- a/keras/api/config/__init__.py
+++ b/keras/api/config/__init__.py
@@ -5,15 +5,20 @@ since your modifications would be overwritten.
 """
 
 from keras.src.backend.config import backend as backend
+from keras.src.backend.config import disable_debug_mode as disable_debug_mode
 from keras.src.backend.config import (
     disable_flash_attention as disable_flash_attention,
 )
+from keras.src.backend.config import enable_debug_mode as enable_debug_mode
 from keras.src.backend.config import (
     enable_flash_attention as enable_flash_attention,
 )
 from keras.src.backend.config import epsilon as epsilon
 from keras.src.backend.config import floatx as floatx
 from keras.src.backend.config import image_data_format as image_data_format
+from keras.src.backend.config import (
+    is_debug_mode_enabled as is_debug_mode_enabled,
+)
 from keras.src.backend.config import (
     is_flash_attention_enabled as is_flash_attention_enabled,
 )

--- a/keras/src/backend/config.py
+++ b/keras/src/backend/config.py
@@ -22,6 +22,8 @@ _NNX_ENABLED = False
 _MAX_EPOCHS = None
 _MAX_STEPS_PER_EPOCH = None
 
+_DEBUG_MODE = False
+
 
 @keras_export(["keras.config.floatx", "keras.backend.floatx"])
 def floatx():
@@ -172,6 +174,42 @@ def set_image_data_format(data_format):
             f"Received: data_format={data_format}"
         )
     _IMAGE_DATA_FORMAT = data_format
+
+
+@keras_export("keras.config.enable_debug_mode")
+def enable_debug_mode():
+    """Enable raw-backend error propagation.
+
+    When enabled, any exception raised by the underlying backend
+    (TensorFlow, JAX or PyTorch) is re-raised **without** Keras-level
+    wrapping or simplification, making full trace-backs visible for
+    debugging.
+
+    The default is off (``False``).
+    """
+    global _DEBUG_MODE
+    _DEBUG_MODE = True
+
+
+@keras_export("keras.config.disable_debug_mode")
+def disable_debug_mode():
+    """Disable raw-backend error propagation.
+
+    Restores the default behaviour where Keras may wrap or simplify
+    backend exceptions.
+    """
+    global _DEBUG_MODE
+    _DEBUG_MODE = False
+
+
+@keras_export("keras.config.is_debug_mode_enabled")
+def is_debug_mode_enabled():
+    """Query whether raw-backend error propagation is active.
+
+    Returns:
+        bool: ``True`` if debug mode is on, ``False`` otherwise.
+    """
+    return _DEBUG_MODE
 
 
 @keras_export("keras.config.enable_flash_attention")

--- a/keras/src/utils/traceback_utils.py
+++ b/keras/src/utils/traceback_utils.py
@@ -8,6 +8,7 @@ from keras.src import backend
 from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.backend.common import global_state
+from keras.src.backend.config import is_debug_mode_enabled
 
 _EXCLUDED_PATHS = (
     os.path.abspath(os.path.join(__file__, "..", "..")),
@@ -113,6 +114,8 @@ def filter_traceback(fn):
             return fn(*args, **kwargs)
 
         filtered_tb = None
+        if is_debug_mode_enabled():
+            return fn(*args, **kwargs)
         try:
             return fn(*args, **kwargs)
         except Exception as e:
@@ -152,6 +155,8 @@ def inject_argument_info_in_traceback(fn, object_name=None):
 
         signature = None
         bound_signature = None
+        if is_debug_mode_enabled():
+            return fn(*args, **kwargs)
         try:
             return fn(*args, **kwargs)
         except Exception as e:


### PR DESCRIPTION
In many cases we need to pinpoint the exact line that throws an error.  
Keras, however, currently hides this information because the block

```python
try:
    return fn(*args, **kwargs)
except Exception as e:
    if hasattr(e, "_keras_call_info_injected"):
        # Only inject info for the innermost failing call
        raise e
```

swallows the original traceback.  
All you see is the exception message, not the precise location where it occurred.  

The new debug mode removes this wrapper and lets the raw backend exception propagate, so you can see the exact file and line number that triggered the failure.