### PR TITLE
Fix histogram op for symbolic inputs

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -3161,9 +3161,8 @@ def histogram(x, bins=10, range=None):
 
     x = tf.boolean_mask(x, (x >= min_val) & (x <= max_val))
     bin_edges = tf.linspace(min_val, max_val, bins + 1)
-    bin_edges_list = bin_edges.numpy().tolist()
-    bin_indices = tf.raw_ops.Bucketize(input=x, boundaries=bin_edges_list[1:-1])
-
+    bin_edges = tf.cast(bin_edges, x.dtype)
+    bin_indices = tf.searchsorted(bin_edges[1:-1], x, side="right")
     bin_counts = tf.math.bincount(
         bin_indices, minlength=bins, maxlength=bins, dtype=x.dtype
     )


### PR DESCRIPTION
Accidentally created a branch on the main repo instead of my fork. Creating another PR.

~Resolves #21708~

~On the TensorFlow backend, `ops.histogram` converts a tensor to a Python list [[here](https://github.com/keras-team/keras/blob/4e1edcf1869fceae3c9ead4477211f7d70989c7e/keras/src/backend/tensorflow/numpy.py#L3164)]. The current piece of code uses `tf.raw_ops.Bucketize` which expects boundaries to be a Python list [see [documentation](https://www.tensorflow.org/api_docs/python/tf/raw_ops/Bucketize)].~

~This PR:~

- ~Replaces `tf.raw_ops.Bucketize` with `tf.searchsorted`;~
- ~Adds a unit tests to make sure the op runs with `predict`;~
- ~Also adds a test (unrelated to the specific issue linked above), which ensures we are assigning values which are "on the boundaries" to the correct bucket.~