### PR TITLE
Resets graph after quantization for KerasHub models

### DIFF
--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -481,6 +481,8 @@ class Model(Trainer, base_trainer.Trainer, Layer):
             self.train_function = None
             self.test_function = None
             self.predict_function = None
+            # Required for KerasHub CausalLM models
+            self.generate_function = None
             self._post_quantize(mode, **kwargs)
 
     def _post_quantize(self, mode, **kwargs):


### PR DESCRIPTION
## Issue
Presently the compiled graph for KerasHub models using `generate_function` for forward pass is not reset correctly after quantization. This results in the original graph compiled using the full-precision weights to continue to be used for inference.

## Description
This change explicitly resets the `generate_function` after quantization to allow it to be recompiled with the new weights.