### PR TITLE
Use `filter="data"` option of `TarFile.extractall`.

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -943,7 +943,7 @@ class DiskIOStore:
         if self.archive:
             self.tmp_dir = get_temp_dir()
             if self.mode == "r":
-                self.archive.extractall(path=self.tmp_dir)
+                file_utils.extract_open_archive(self.archive, self.tmp_dir)
             self.working_dir = file_utils.join(
                 self.tmp_dir, self.root_path
             ).replace("\\", "/")

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -142,7 +142,7 @@ class FilterSafePathsTest(test_case.TestCase):
         with tarfile.open(self.tar_path, "w") as tar:
             tar.add(__file__, arcname="safe_path.txt")
         with tarfile.open(self.tar_path, "r") as tar:
-            members = list(file_utils.filter_safe_paths(tar.getmembers()))
+            members = list(file_utils.filter_safe_tarinfos(tar.getmembers()))
             self.assertEqual(len(members), 1)
             self.assertEqual(members[0].name, "safe_path.txt")
 
@@ -156,7 +156,7 @@ class FilterSafePathsTest(test_case.TestCase):
         with tarfile.open(self.tar_path, "w") as tar:
             tar.add(symlink_path, arcname="symlink.txt")
         with tarfile.open(self.tar_path, "r") as tar:
-            members = list(file_utils.filter_safe_paths(tar.getmembers()))
+            members = list(file_utils.filter_safe_tarinfos(tar.getmembers()))
             self.assertEqual(len(members), 1)
             self.assertEqual(members[0].name, "symlink.txt")
         os.remove(symlink_path)
@@ -173,7 +173,7 @@ class FilterSafePathsTest(test_case.TestCase):
             )  # Path intended to be outside of base dir
         with tarfile.open(self.tar_path, "r") as tar:
             with patch("warnings.warn") as mock_warn:
-                _ = list(file_utils.filter_safe_paths(tar.getmembers()))
+                _ = list(file_utils.filter_safe_tarinfos(tar.getmembers()))
                 warning_msg = (
                     "Skipping invalid path during archive extraction: "
                     "'../../invalid.txt'."
@@ -196,7 +196,7 @@ class FilterSafePathsTest(test_case.TestCase):
             tar.add(symlink_path, arcname="symlink.txt")
 
         with tarfile.open(self.tar_path, "r") as tar:
-            members = list(file_utils.filter_safe_paths(tar.getmembers()))
+            members = list(file_utils.filter_safe_tarinfos(tar.getmembers()))
             self.assertEqual(len(members), 1)
             self.assertEqual(members[0].name, "symlink.txt")
             self.assertTrue(


### PR DESCRIPTION
For Python versions between 3.12 (inclusive) and 3.14 (exclusive).

The "data" filter performs a number of additional checks on links and paths. The `filter` option was added in Python 3.12. The `filter="data"` option became the default in Python 3.14.

Also:
- added similar path filtering when extracting zip archives
- shared the extraction code between `file_utils` and `saving_lib`