### PR TITLE
Fix handling of SaS metrics for Jax

### DIFF
--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -3,6 +3,7 @@ import math
 
 import jax.experimental.sparse as jax_sparse
 import jax.numpy as jnp
+from jax import core
 from jax import export as jax_export
 
 from keras.src.backend import config
@@ -1001,6 +1002,11 @@ def ndim(x):
 
 
 def nonzero(x):
+    if isinstance(x, core.Tracer):
+        # needed because this is called for several metric calculations,
+        # which will supply tracer values during `fit` execution
+        return jnp.nonzero(x, size=core.get_aval(x).size)[0]
+
     return jnp.nonzero(x)
 
 

--- a/keras/src/metrics/confusion_metrics_test.py
+++ b/keras/src/metrics/confusion_metrics_test.py
@@ -787,6 +787,20 @@ class SensitivityAtSpecificityTest(testing.TestCase):
         ):
             metrics.SensitivityAtSpecificity(0.4, num_thresholds=-1)
 
+    @pytest.mark.requires_trainable_backend
+    def test_handles_sas_metrics(self):
+        # Test for https://github.com/keras-team/keras/issues/19376
+        model = models.Sequential(
+            [
+                layers.Input((1,)),
+                layers.Dense(1),
+            ]
+        )
+        sas = metrics.SpecificityAtSensitivity(0.5, name="sas")
+
+        model.compile(optimizer="adam", loss="crossentropy", metrics=[sas])
+        model.fit(np.ones((5, 1)), np.ones((5, 1)))
+
 
 class SpecificityAtSensitivityTest(testing.TestCase):
     def test_config(self):


### PR DESCRIPTION
Currently, if training a model with metrics `SpecificityAtSensitivity` or `SensitivityAtSpecificity` with the `jax` backend, it will fail with:

```
>     calculated_size: int = core.concrete_dim_or_error(calculated_size_,
        "The size argument of jnp.nonzero must be statically specified "
        "to use jnp.nonzero within JAX transformations.")
E     jax.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected: traced array with shape int32[]
E     The size argument of jnp.nonzero must be statically specified to use jnp.nonzero within JAX transformations.
E     The error occurred while tracing the function wrapped_fn at /Users/danielcahall/PycharmProjects/keras/keras/src/backend/jax/core.py:342 for jit. This concrete value was not available in Python because it depends on the values of the arguments args[1] and args[2].
E     
```

when calling `nonzero` due to the dynamic sizing. To mitigate this, we can evaluate if we're operating on a `Tracer` with a dynamic shape, and if so, explicitly provide a size to the `nonzero` call. As this returns a tuple of 1 element, we take the first (0th) element. 

This addresses part of https://github.com/keras-team/keras/issues/19376. I believe the bugs reported for other backends have been resolved, as I could not reproduce the issues detailed there.

**Note**: 
- should the import be local rather than at the top of the module?
- As this was primarily an issue with Jax, should the test exclude other backends? 