### PR TITLE
Don't fail `Variable.__repr__` if the value cannot be retrieved.

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -282,7 +282,7 @@ class Variable:
                 "The shape of the target variable and "
                 "the shape of the target value in "
                 "`variable.assign(value)` must match. "
-                f"variable.shape={self.value.shape}, "
+                f"variable.shape={self.shape}, "
                 f"Received: value.shape={value.shape}. "
                 f"Target variable: {self}"
             )
@@ -399,7 +399,11 @@ class Variable:
     def __repr__(self):
         value = None
         if hasattr(self, "_value") and self._value is not None:
-            value = backend.core.convert_to_numpy(self._value)
+            try:
+                value = backend.core.convert_to_numpy(self._value)
+            except:
+                # In some cases the conversion to numpy can fail.
+                pass
         value_str = f", value={value}" if value is not None else ""
         return (
             f"<Variable path={self.path}, shape={self.shape}, "


### PR DESCRIPTION
Under some conditions, converting the variable value to numpy may fail. We don't want to fail `__repr__` in this case. I my example, this was preventing this exception from being raised and osbcuring the real issue:

https://github.com/keras-team/keras/blob/master/keras/src/backend/common/variables.py#L281-L288

Additionally, the exception was not reporting the shape used for comparison (`self.shape`).