### PR TITLE
Fix: use raw string for CALIBRATION_TEXT

### DIFF
--- a/keras/src/quantizers/gptq_test.py
+++ b/keras/src/quantizers/gptq_test.py
@@ -25,7 +25,7 @@ NUM_SAMPLES = 16
 W_BITS = 4
 NUM_CLASSES = 32
 
-CALIBRATION_TEXT = """
+CALIBRATION_TEXT = r"""
 GPTQ (Generative Pre-trained Transformer Quantization) is an advanced 
 post-training quantization (PTQ) algorithm designed to compress large 
 language models with minimal accuracy degradation. It addresses the 


### PR DESCRIPTION
Use a raw string to prevent LaTeX codes from being interpreted as escape sequences.

```
/nix/store/cfapjd2rvqrpry4grb0kljnp8bvnvfxz-python3-3.13.8/lib/python3.13/ast.py:50: in parse
    return compile(source, filename, mode, flags,
E     File "/build/source/keras/src/quantizers/gptq_test.py", line 37
E       matrix $\hat{W}$ that minimizes the mean squared error of the layer's
E               ^^
E   SyntaxError: invalid escape sequence '\h'
```