### PR TITLE
Add verbose logging when ModelCheckpoint callback is done saving ...

### DIFF
--- a/keras/src/callbacks/model_checkpoint.py
+++ b/keras/src/callbacks/model_checkpoint.py
@@ -285,7 +285,8 @@ class ModelCheckpoint(MonitorCallback):
                     self.model.save(filepath, overwrite=True)
                 if self.verbose > 0:
                     io_utils.print_msg(
-                        f"\nEpoch {epoch + 1}: finished saving model to {filepath}"
+                        f"\nEpoch {epoch + 1}: "
+                        f"finished saving model to {filepath}"
                     )
         except IsADirectoryError:  # h5py 3.x
             raise IOError(


### PR DESCRIPTION
... a model.

This is useful for collecting information on how long model checkpointing takes, together with existing verbose logging on initiating the save. This is similar to the "calling checkpoint listeners before/after saving checkpoint xxx" logging that existed in the TF1 session run hook.