### PR TITLE
Fix broken example indentation in Keras io

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -3927,10 +3927,10 @@ def isreal(x):
         Output boolean tensor.
 
     Example:
-        >>> from keras import ops
-        >>> x = ops.array([1+1j, 1+0j, 4.5, 3, 2, 2j], dtype="complex64")
-        >>> ops.isreal(x)
-        array([False,  True,  True,  True,  True, False])
+    >>> from keras import ops
+    >>> x = ops.array([1+1j, 1+0j, 4.5, 3, 2, 2j], dtype="complex64")
+    >>> ops.isreal(x)
+    array([False,  True,  True,  True,  True, False])
     """
     if any_symbolic_tensors((x,)):
         return Isreal().symbolic_call(x)
@@ -5509,10 +5509,10 @@ def unravel_index(indices, shape):
         Tuple of arrays for each dimension with unraveled indices.
 
     Example:
-        >>> indices = 5
-        >>> shape = (3, 3)
-        >>> unravel_index(indices, shape)
-        (1, 2)  # 5 is at row 1, column 2 in a 3x3 array
+    >>> indices = 5
+    >>> shape = (3, 3)
+    >>> unravel_index(indices, shape)
+    (1, 2)  # 5 is at row 1, column 2 in a 3x3 array
     """
     if any_symbolic_tensors((indices,)):
         return UnravelIndex(shape).symbolic_call(indices)


### PR DESCRIPTION
Fix broken indentation in the Keras I/O example.

- Before

<img width="662" height="392" alt="image" src="https://github.com/user-attachments/assets/4548ed6f-a1f1-48a1-a6c7-c66f256feed3" />
<img width="660" height="382" alt="image" src="https://github.com/user-attachments/assets/62483532-1753-4de2-bf86-cc2177e3772b" />

- After

<img width="726" height="472" alt="image" src="https://github.com/user-attachments/assets/6f97910a-6438-40c9-b54c-a29fb3289fdd" />
<img width="726" height="472" alt="image" src="https://github.com/user-attachments/assets/64764ae8-8293-453b-a546-2bb8ef96c836" />
