### PR TITLE
Verify GPU memory consistency for Huber loss (delta=0.5)

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -1972,7 +1972,9 @@ def huber(y_true, y_pred, delta=1.0):
     delta = ops.convert_to_tensor(delta, dtype=y_pred.dtype)
     error = ops.subtract(y_pred, y_true)
     abs_error = ops.abs(error)
-    half = ops.convert_to_tensor(0.5, dtype=abs_error.dtype)
+    half = ops.cast(ops.convert_to_tensor(0.5), dtype=abs_error.dtype)
+    delta = ops.cast(delta, dtype=abs_error.dtype)
+
     return ops.mean(
         ops.where(
             abs_error <= delta,


### PR DESCRIPTION
fix: #21804 

**Description:**
This PR fixes minor dtype inconsistencies and ensures GPU memory consistency when computing the Huber loss in keras.losses.Huber.

**Background:**
During internal testing (test_huber_memory_usage_debug_05), it was observed that GPU memory usage slightly differed when using delta=0.5, although the Huber loss logic should behave identically across delta values. The issue was not with the computation itself but with how tensors of different dtypes were handled internally before casting.

**Fix:**
- To make computation deterministic and prevent redundant GPU memory conversions:
- Explicitly cast half (0.5 constant) and delta to match abs_error.dtype using ops.cast.
- This ensures all tensors involved in computation share the same dtype and eliminates any implicit conversions.

**Verification:**
To verify, I manually ran:
`pytest keras/src/losses/losses_test.py::HuberLossTest::test_huber_memory_usage_debug_05 -v -s`
and manually changed the delta value in the test each time (e.g., 0.5, 1.0, 10.0).
Verified that GPU memory usage remains stable across all delta values when running the test individually.

**Result:**
✅ Stable GPU memory usage across deltas