### PR TITLE
Add missing `convert_to_tensor` to `take_along_axis` on JAX.

### DIFF
--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -1196,6 +1196,8 @@ def take(x, indices, axis=None):
 
 
 def take_along_axis(x, indices, axis=None):
+    x = convert_to_tensor(x)
+    indices = convert_to_tensor(indices, sparse=False)
     return jnp.take_along_axis(x, indices, axis=axis)
 
 


### PR DESCRIPTION
This is necessary to support variables in a jitted context.