### PR TITLE
[OpenVINO backend] Remove deprecated openvino.runtime import

### DIFF
--- a/keras/src/export/openvino.py
+++ b/keras/src/export/openvino.py
@@ -55,7 +55,7 @@ def export_openvino(
     )
 
     import openvino as ov
-    from openvino import opset14 as ov_opset
+    import openvino.opset14 as ov_opset
 
     from keras.src.backend.openvino.core import OPENVINO_DTYPES
     from keras.src.backend.openvino.core import OpenVINOKerasTensor


### PR DESCRIPTION
`openvino.runtime` is deprecated in favor of flat `openvino` and is set to be removed in the upcoming 26.0 OpenVINO release.

- https://github.com/openvinotoolkit/openvino/pull/32698