### PR TITLE
Fix CosineDecay documentation to clarify alpha is a multiplier

### DIFF
--- a/keras/src/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/src/optimizers/schedules/learning_rate_schedule.py
@@ -584,9 +584,10 @@ class CosineDecay(LearningRateSchedule):
     schedule applies a linear increase per optimizer step to our learning rate
     from `initial_learning_rate` to `warmup_target` for a duration of
     `warmup_steps`. Afterwards, it applies a cosine decay function taking our
-    learning rate from `warmup_target` to `warmup_target * alpha` for a duration of
-    `decay_steps`. If `warmup_target` is None we skip warmup and our decay
-    will take our learning rate from `initial_learning_rate` to `initial_learning_rate * alpha`.
+    learning rate from `warmup_target` to `warmup_target * alpha` for a
+    duration of `decay_steps`. If `warmup_target` is None we skip warmup and
+    our decay will take our learning rate from `initial_learning_rate` to
+    `initial_learning_rate * alpha`.
     It requires a `step` value to  compute the learning rate. You can
     just pass a backend variable that you increment at each training step.
 


### PR DESCRIPTION
Fixes #21772

The CosineDecay documentation was misleading about how the `alpha` parameter works.

**Current docs say:** learning rate decays "to alpha"
**Reality:** learning rate decays to `initial_learning_rate * alpha`

The parameter description correctly states alpha is "a fraction of initial_learning_rate", but the explanation text contradicted this. Updated the explanation to match the actual implementation and parameter description.