### PR TITLE
Fix unit testing in CI

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,7 +1,7 @@
 pre-commit
 namex>=0.0.8
 ruff
-# pytest 9.0.0 introduced some breaking changes - see https://github.com/pytest-dev/pytest/issues/13895
+# pytest 9.0.0 introduced some breaking changes with SkipTest - see https://github.com/pytest-dev/pytest/issues/13895
 pytest<9.0.0
 numpy
 scipy


### PR DESCRIPTION
In the [9.0.0 release of pytest](https://pypi.org/project/pytest/#history), the behavior was updated to report an error when a `SkipTest` is raised rather than skipping, as discussed in [this issue](https://github.com/pytest-dev/pytest/issues/13895). This is causing various tests in `sklearn_test.py` to fail in CI as there is an estimator check sklearn applies for non-deterministic tags, and raises a `SkipTest` based on their presence:

```python
def check_pipeline_consistency(name, estimator_orig):
    if get_tags(estimator_orig).non_deterministic:
        msg = name + " is non deterministic"
        raise SkipTest(msg)
```

To mitigate this problem, we can pin `pytest` to less than 9.0.0 for the time being, which will currently install 8.4.2. If they decide to restore the old behavior in a future release of 9.x, this pin can be removed.

Alternatively, the tests can be updated to expect a `SkipTest` to be raised, although this feels less ergonomic and would have to be reverted if the behavior does get restored.