### PR TITLE
Add Empty operation for keras.ops

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -3100,6 +3100,22 @@ def einsum(subscripts, *operands, **kwargs):
     return backend.numpy.einsum(subscripts, *operands, **kwargs)
 
 
+class Empty(Operation):
+    def __init__(self, dtype=None, *, name=None):
+        super().__init__(name=name)
+        self.dtype = (
+            backend.floatx()
+            if dtype is None
+            else backend.standardize_dtype(dtype)
+        )
+
+    def call(self, x):
+        return backend.numpy.empty(x, dtype=self.dtype)
+
+    def compute_output_spec(self, x):
+        return KerasTensor(x.shape, dtype=self.dtype)
+
+
 @keras_export(["keras.ops.empty", "keras.ops.numpy.empty"])
 def empty(shape, dtype=None):
     """Return a tensor of given shape and type filled with uninitialized data.
@@ -3111,6 +3127,8 @@ def empty(shape, dtype=None):
     Returns:
         The empty tensor.
     """
+    if any_symbolic_tensors((shape,)):
+        return Empty(dtype=dtype).symbolic_call(shape)
     return backend.numpy.empty(shape, dtype=dtype)
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1495,6 +1495,11 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         y = KerasTensor((5,))
         self.assertEqual(knp.dot(x, y).shape, ())
 
+    def test_empty(self):
+        x = KerasTensor((None, 3))
+        self.assertEqual(knp.empty(x).shape, (None, 3))
+        self.assertEqual(knp.empty(x).dtype, backend.floatx())
+
     def test_empty_like(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.empty_like(x).shape, (None, 3))
@@ -2143,6 +2148,11 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
             x = KerasTensor((2, 3))
             y = KerasTensor((2, 3))
             knp.dot(x, y)
+
+    def test_empty(self):
+        x = KerasTensor((2, 3))
+        self.assertEqual(knp.empty(x).shape, (2, 3))
+        self.assertEqual(knp.empty(x).dtype, backend.floatx())
 
     def test_empty_like(self):
         x = KerasTensor((2, 3))


### PR DESCRIPTION
Adds Empty operation that works with both KerasTensor and concrete shapes.