### PR TITLE
Update keras3 Softmax mask handling to be more numerically robust.

### DIFF
--- a/keras/src/layers/activations/softmax.py
+++ b/keras/src/layers/activations/softmax.py
@@ -56,7 +56,8 @@ class Softmax(Layer):
             # other (masked) positions to -1e.9.
             if backend.standardize_dtype(mask.dtype) != "bool":
                 mask = backend.numpy.greater(
-                    mask, backend.cast(0.5, dtype=mask.dtype))
+                    mask, backend.cast(0.5, dtype=mask.dtype)
+                )
             inputs = backend.numpy.where(
                 mask, inputs, _large_negative_number(inputs.dtype)
             )


### PR DESCRIPTION
The original impl of masking is essentially `(1.0 - mask) * -1e-9 + inputs`; this can be sensitive to numerical noise on `mask` (imagine if it is slightly off from either 1 or 0; then we would be adding a very large perturbation to the inputs).

Using comparison and where ops are much more numerically robust. Also for cases where we get floating point masks coming in, we add a binarization step to make it compatible w/ the `where` op.