### PR TITLE
Fix ConcretizationTypeError in dot_product_attention with traced masks

### DIFF
--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -1356,7 +1356,6 @@ def dot_product_attention(
         except jax.errors.ConcretizationTypeError:
             # Mask is traced
             # Fall back to native attention
-            flash_attention = False
             logging.exception(
                 "Failed to apply Splash kernel for flash attention. "
                 "Falling back to JAX native dot_product_attention."


### PR DESCRIPTION
Fix: #21808 

using `dot_product_attention` with a mask inside JAX control flow operations (e.g., `while_loop`, `scan`) on TPU, the code raised a `ConcretizationTypeError`

Added a traced mask detection check before attempting to use TPU flash attention