### PR TITLE
Add note about label noise in CIFAR-10 dataset documentation

### DIFF
--- a/keras/src/datasets/cifar10.py
+++ b/keras/src/datasets/cifar10.py
@@ -59,6 +59,11 @@ def load_data():
     assert y_train.shape == (50000, 1)
     assert y_test.shape == (10000, 1)
     ```
+
+    **Note**: The CIFAR-10 dataset is known to have a small percentage of
+    mislabeled samples, which is inherent to the original dataset. This label
+    noise may impact training and evaluation. For more details, refer to
+    discussions in the research literature on CIFAR-10 label quality.
     """
     dirname = "cifar-10-batches-py-target"
     origin = "https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"


### PR DESCRIPTION
I was working with the CIFAR-10 dataset and noticed that the documentation doesn't mention the known issue of label noise. I kept running into images that seemed mislabeled - airplanes labeled as frogs, horses as cats, etc. At first I thought something was wrong with my code, but after researching, I learned this is a well-known characteristic of the original CIFAR-10 dataset.

I've added a brief note to the `load_data()` docstring to inform users about this label noise issue. This should help new users understand that some label inconsistencies are expected and not due to bugs in their code or the Keras implementation.

The note is concise and placed right after the dataset description, so users will see it before they start working with the data. It mentions that:
- The dataset has a small percentage of mislabeled samples
- This is inherent to the original dataset
- It may impact training and evaluation

Fixes #21631