### PR TITLE
Fix assigning a value to a variable within an autocast scope.

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -276,7 +276,7 @@ class Variable:
         return self._maybe_autocast(self._value)
 
     def assign(self, value):
-        value = self._convert_to_tensor(value, dtype=self.dtype)
+        value = self._convert_to_tensor(value, dtype=self._dtype)
         if not shape_equal(value.shape, self.shape):
             raise ValueError(
                 "The shape of the target variable and "


### PR DESCRIPTION
Previously `assign` would incorrectly cast the value to assign to the autocast dtype instead of the true dtype of the variable.

Because on JAX and OpenVino variables are just a reference to an array, this would cause the variable value to change dtypes.