### PR TITLE
Improve error message when layer/model input validation fails.

### DIFF
--- a/keras/src/layers/input_spec.py
+++ b/keras/src/layers/input_spec.py
@@ -185,24 +185,24 @@ def assert_input_compatibility(input_spec, inputs, layer_name):
         if spec.ndim is not None and not spec.allow_last_axis_squeeze:
             if ndim != spec.ndim:
                 raise ValueError(
-                    f'Input {input_index} of layer "{layer_name}" '
-                    "is incompatible with the layer: "
+                    f"Input {input_index} with name '{spec.name}' of layer "
+                    f"'{layer_name}' is incompatible with the layer: "
                     f"expected ndim={spec.ndim}, found ndim={ndim}. "
                     f"Full shape received: {shape}"
                 )
         if spec.max_ndim is not None:
             if ndim is not None and ndim > spec.max_ndim:
                 raise ValueError(
-                    f'Input {input_index} of layer "{layer_name}" '
-                    "is incompatible with the layer: "
+                    f"Input {input_index} with name '{spec.name}' of layer "
+                    f"'{layer_name}' is incompatible with the layer: "
                     f"expected max_ndim={spec.max_ndim}, "
                     f"found ndim={ndim}"
                 )
         if spec.min_ndim is not None:
             if ndim is not None and ndim < spec.min_ndim:
                 raise ValueError(
-                    f'Input {input_index} of layer "{layer_name}" '
-                    "is incompatible with the layer: "
+                    f"Input {input_index} with name '{spec.name}' of layer "
+                    f"'{layer_name}' is incompatible with the layer: "
                     f"expected min_ndim={spec.min_ndim}, "
                     f"found ndim={ndim}. "
                     f"Full shape received: {shape}"
@@ -212,8 +212,8 @@ def assert_input_compatibility(input_spec, inputs, layer_name):
             dtype = backend.standardize_dtype(x.dtype)
             if dtype != spec.dtype:
                 raise ValueError(
-                    f'Input {input_index} of layer "{layer_name}" '
-                    "is incompatible with the layer: "
+                    f"Input {input_index} with name '{spec.name}' of layer "
+                    f"'{layer_name}' is incompatible with the layer: "
                     f"expected dtype={spec.dtype}, "
                     f"found dtype={dtype}"
                 )
@@ -226,11 +226,10 @@ def assert_input_compatibility(input_spec, inputs, layer_name):
                     None,
                 }:
                     raise ValueError(
-                        f'Input {input_index} of layer "{layer_name}" is '
-                        f"incompatible with the layer: expected axis {axis} "
-                        f"of input shape to have value {value}, "
-                        "but received input with "
-                        f"shape {shape}"
+                        f"Input {input_index} with name '{spec.name}' of layer "
+                        f"'{layer_name}' is incompatible with the layer: "
+                        f"expected axis {axis} of input shape to have value "
+                        f"{value}, but received input with shape {shape}"
                     )
         # Check shape.
         if spec.shape is not None:
@@ -244,8 +243,8 @@ def assert_input_compatibility(input_spec, inputs, layer_name):
                 if spec_dim is not None and dim is not None:
                     if spec_dim != dim:
                         raise ValueError(
-                            f'Input {input_index} of layer "{layer_name}" is '
-                            "incompatible with the layer: "
-                            f"expected shape={spec.shape}, "
-                            f"found shape={shape}"
+                            f"Input {input_index} with name '{spec.name}' of "
+                            f"layer '{layer_name}' is incompatible with the "
+                            f"layer: expected shape={spec.shape}, found "
+                            f"shape={shape}"
                         )

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -254,9 +254,9 @@ class Functional(Function, Model):
         return converted
 
     def _adjust_input_rank(self, flat_inputs):
-        flat_ref_shapes = [x.shape for x in self._inputs]
         adjusted = []
-        for x, ref_shape in zip(flat_inputs, flat_ref_shapes):
+        for i, x in enumerate(flat_inputs):
+            ref_shape = self._inputs[i].shape
             if x is None:
                 adjusted.append(x)
                 continue
@@ -273,8 +273,11 @@ class Functional(Function, Model):
                 if ref_shape[-1] == 1:
                     adjusted.append(ops.expand_dims(x, axis=-1))
                     continue
+            flat_paths_and_inputs = tree.flatten_with_path(self._inputs_struct)
+            path = ".".join(str(p) for p in flat_paths_and_inputs[i][0])
             raise ValueError(
-                f"Invalid input shape for input {x}. Expected shape "
+                f"Invalid input shape for input {x} with name "
+                f"'{self._inputs[i].name}' and path '{path}'. Expected shape "
                 f"{ref_shape}, but input has incompatible shape {x.shape}"
             )
         # Add back metadata.

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -374,6 +374,24 @@ class FunctionalTest(testing.TestCase):
         self.assertEqual(out_val.shape, (2, 3, 3))
 
     @pytest.mark.requires_trainable_backend
+    def test_rank_standardization_failure(self):
+        # Simple input and rank too high
+        inputs = Input(shape=(3,), name="foo")
+        outputs = layers.Dense(3)(inputs)
+        model = Functional(inputs, outputs)
+        with self.assertRaisesRegex(ValueError, "name 'foo' .* path ''"):
+            model(np.random.random((2, 3, 4)))
+
+        # Deeply nested input and rank too low
+        inputs = [{"foo": Input(shape=(3,), name="my_input")}]
+        outputs = layers.Dense(3)(inputs[0]["foo"])
+        model = Functional(inputs, outputs)
+        with self.assertRaisesRegex(
+            ValueError, "name 'my_input' .* path '0.foo'"
+        ):
+            model(np.random.random(()))
+
+    @pytest.mark.requires_trainable_backend
     def test_dtype_standardization(self):
         float_input = Input(shape=(2,), dtype="float16")
         int_input = Input(shape=(2,), dtype="int32")


### PR DESCRIPTION
Provide the input name and the input path when available.