### PR TITLE
Disables implicit GPTQ quantization using dtype_policy setter

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -757,6 +757,13 @@ class Layer(BackendLayer, Operation):
             self._dtype_policy = policy
         if policy.quantization_mode is not None:
             if self.built and not getattr(self, "_is_quantized", False):
+                if policy.quantization_mode == "gptq":
+                    raise ValueError(
+                        f"{value=} enables GPTQ quantization mode."
+                        "This is unsupported since GPTQ requires "
+                        "a calibration dataset and a GPTQConfig."
+                        "Use the `.quantize()` method instead."
+                    )
                 self.quantize(policy.quantization_mode)
 
     @property

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -759,10 +759,12 @@ class Layer(BackendLayer, Operation):
             if self.built and not getattr(self, "_is_quantized", False):
                 if policy.quantization_mode == "gptq":
                     raise ValueError(
-                        f"{value=} enables GPTQ quantization mode."
-                        "This is unsupported since GPTQ requires "
-                        "a calibration dataset and a GPTQConfig."
-                        "Use the `.quantize()` method instead."
+                        "Implicitly enabling GPTQ quantization by setting "
+                        f"`dtype_policy` to '{value}' is not supported. "
+                        "GPTQ requires a calibration dataset and a "
+                        "`GPTQConfig` object.\n\n"
+                        "Please use the `.quantize('gptq', config=...)` method "
+                        "on the layer or model instead."
                     )
                 self.quantize(policy.quantization_mode)
 

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -237,7 +237,7 @@ class LayerTest(testing.TestCase):
         """Tests error being raised when dtype is set to GPTQ."""
         with self.assertRaisesRegex(
             ValueError,
-            "enables GPTQ quantization mode.This is unsupported",
+            "Implicitly enabling GPTQ quantization.*is not supported",
         ):
             layer = layers.Dense(3)
             layer.build((2, 4))

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -233,6 +233,16 @@ class LayerTest(testing.TestCase):
         self.assertLen(mock_remat.rematted_functions, 1)
         next(iter(mock_remat.rematted_functions.values())).assert_called()
 
+    def test_gptq_quantization_by_setting_dtype(self):
+        """Tests error being raised when dtype is set to GPTQ."""
+        with self.assertRaisesRegex(
+            ValueError,
+            "enables GPTQ quantization mode.This is unsupported",
+        ):
+            layer = layers.Dense(3)
+            layer.build((2, 4))
+            layer.dtype_policy = "gptq/4/-1_from_float32"
+
     def test_functional_model_with_remat(self):
         if backend.backend() in ("openvino", "numpy"):
             self.skipTest(


### PR DESCRIPTION
GPTQ requires a sophisticated config and a calibration dataset to function, which makes the implicit quantization behavior using the dtype_policy setter unsuitable.