### PR TITLE
Replace `np.reshape(x, newshape=y)` with `np.reshape(x, y)`.

### DIFF
--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -573,7 +573,7 @@ def _compute_affine_transform_coordinates(image, transform):
     # transform the indices
     coordinates = np.einsum("Bhwij, Bjk -> Bhwik", indices, transform)
     coordinates = np.moveaxis(coordinates, source=-1, destination=1)
-    coordinates += np.reshape(offset, newshape=(*offset.shape, 1, 1, 1))
+    coordinates += np.reshape(offset, (*offset.shape, 1, 1, 1))
     if need_squeeze:
         coordinates = np.squeeze(coordinates, axis=0)
     return coordinates


### PR DESCRIPTION
The `newshape` argument to reshape is removed in NumPy 2.4.