### PR TITLE
 🔧 Fix `keras.ops.diag()` XLA JIT crash on tensor slicing on TF backend.

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1359,11 +1359,7 @@ def deg2rad(x):
 def diag(x, k=0):
     x = convert_to_tensor(x)
     if len(x.shape) == 1:
-        return tf.cond(
-            tf.equal(tf.size(x), 0),
-            lambda: tf.zeros([builtins.abs(k), builtins.abs(k)], dtype=x.dtype),
-            lambda: tf.linalg.diag(x, k=k),
-        )
+        return tf.linalg.diag(x, k=k)
     elif len(x.shape) == 2:
         return diagonal(x, offset=k)
     else:


### PR DESCRIPTION
## Summary
`keras.ops.diag()` uses `tf.cond()` wrapper that generates dynamic shapes (`f32[<=n,<=n]`), causing XLA `OpDynamismSupport` to fail with `RET_CHECK` when slicing the result in `@tf.function(jit_compile=True)`.

**tf.linalg.diag() works perfectly** - direct static shapes.

## Minimal Repro
```
import keras
import tensorflow as tf

@tf.function(jit_compile=True)
def spectral_graph_laplacian(use_tf_diag=True):
    n = 8
    feats_all = keras.random.normal((n, 64))
    
    feats_norm = keras.ops.normalize(feats_all, axis=-1)
    W = keras.ops.matmul(feats_norm, keras.ops.transpose(feats_norm))
    mask = 1.0 - keras.ops.eye(n)
    W = W * mask
    
    diag_vals = keras.ops.sum(W, axis=1)
    
    # SINGLE LINE DIFFERENCE
    if use_tf_diag:
        D = tf.linalg.diag(diag_vals)      # ✅ XLA-safe
    else:
        D = keras.ops.diag(diag_vals)      # ❌ Dynamic shapes
    
    L = D - W
    _, v = keras.ops.linalg.eigh(L)
    return v[:, 1]

print("=== Spectral Graph Test ===")
print("keras.ops.diag():")
try:
    result1 = spectral_graph_laplacian(use_tf_diag=False)
    print(f"  ✅ WORKS: shape {result1.shape}")
except Exception as e:
    print(f"  ❌ CRASH: {str(e)}")

print("\ntf.linalg.diag():")
try:
    result2 = spectral_graph_laplacian(use_tf_diag=True)
    print(f"  ✅ WORKS: shape {result2.shape}")
except Exception as e:
    print(f"  ❌ CRASH: {str(e)}")
```

```
=== Spectral Graph Test ===
keras.ops.diag():
  ❌ CRASH: RET_CHECK failure (external/local_xla/xla/service/dynamic_padder.cc:1992) op_support != OpDynamismSupport::kNoSupport Dynamic input unexpectedly found for unsupported instruction: %slice.441 = f32[<=8,1]{1,0} slice(f32[<=8,<=8]{1,0} %get-tuple-element.439), slice={[0:8], [1:2]}, metadata={op_type="StridedSlice" op_name="strided_slice" source_file="/usr/local/lib/python3.12/dist-packages/tensorflow/python/framework/ops.py" source_line=1200} [Op:__inference_spectral_graph_laplacian_3080]

tf.linalg.diag():
  ✅ WORKS: shape (8,)
```

## Empty Tensor Handling (tf.cond Purpose)
Original `tf.cond` preserved empty case correctness, however, i see that tf.linalg.diag already handles it as well exactly in the same way. That makes this problematic tf.cond a redundant condition and possibly affect XLA graph compilation for no reason.

```
import keras, tensorflow as tf

@tf.function(jit_compile=True)
def test_empty_diag(use_tf_diag=True, k=1):
    empty_vec = tf.constant([], dtype=tf.float32)
    
    if use_tf_diag:
        D = tf.linalg.diag(empty_vec, k=k)
    else:
        D = keras.ops.diag(empty_vec, k=k)
    
    return D

for k in range(10):
    keras_D = test_empty_diag(use_tf_diag=False, k=k)
    tf_D = test_empty_diag(use_tf_diag=True, k=k)
    assert keras_D.shape == tf_D.shape, f"k={k}: shapes {keras_D.shape} != {tf_D.shape}"
    assert tf.reduce_all(tf.equal(keras_D, tf_D)), f"k={k}: values differ"
    print(f"✅ k={k}: shapes {keras_D.shape}, all zeros ✓")
```
```
✅ k=0: shapes (0, 0), all zeros ✓
✅ k=1: shapes (1, 1), all zeros ✓
✅ k=2: shapes (2, 2), all zeros ✓
✅ k=3: shapes (3, 3), all zeros ✓
✅ k=4: shapes (4, 4), all zeros ✓
✅ k=5: shapes (5, 5), all zeros ✓
✅ k=6: shapes (6, 6), all zeros ✓
✅ k=7: shapes (7, 7), all zeros ✓
✅ k=8: shapes (8, 8), all zeros ✓
✅ k=9: shapes (9, 9), all zeros ✓
```

