### PR TITLE
Fix: Remove redundant epsilon in loss mask weight calculation

### DIFF
--- a/keras/src/losses/loss_test.py
+++ b/keras/src/losses/loss_test.py
@@ -287,17 +287,3 @@ class LossTest(testing.TestCase):
         loss_fn = ExampleLoss()
         loss = loss_fn(y_true, y_pred)
         self.assertDType(loss, backend.floatx())
-
-    def test_divide_no_nan(self):
-        x = np.array([1.0, 2.0, 3.0, 4.0])
-        y = np.zeros_like(x)
-
-        # divide_no_nan should return 0, not inf, when dividing by 0
-        self.assertAllClose(
-            ops.divide_no_nan(x, y),
-            y,
-        )
-
-        y = np.array([2.0, 0.0, 4.0, 0.0])
-        expected = np.array([0.5, 0.0, 0.75, 0.0])
-        self.assertAllClose(ops.divide_no_nan(x, y), expected)


### PR DESCRIPTION
This PR fixes incorrect use of epsilon in mask weight calculation that caused numerical instability when all mask values are False.

In `keras/src/losses/loss.py`, the mask weight calculation used:

```
valid = ops.sum(mask)  # May be 0!
mask *= total/ valid + backend.epsilon()
```

This is problematic because:
- Adding backend.epsilon() i feel defeats this purpose by ensuring b is never actually zero
- When valid = 0 (all mask values are False), this computes total / epsilon ≈ 10^7, causing mask weights to explode to huge values instead of becoming 0
