### PR TITLE
Pin `ai-edge-litert` version to fix CI

### DIFF
--- a/keras/src/export/litert_test.py
+++ b/keras/src/export/litert_test.py
@@ -36,9 +36,9 @@ if backend.backend() == "tensorflow":
 
 # Model types to test (LSTM only if AI Edge LiteRT is available)
 model_types = ["sequential", "functional"]
-# TODO: `"lstm"` does not work with ai-edge-litert==1.3.0. Unfortunately, for TF
-# 2.20.0, this is the only version which works. Uncomment this part when we
-# upgrade TF and ai-edge-litert.
+# TODO(#21914): `"lstm"` does not work with ai-edge-litert==1.3.0.
+# Unfortunately, for TF 2.20.0, this is the only version which works. Uncomment
+# this part when we upgrade TF and ai-edge-litert.
 # if AI_EDGE_LITERT_AVAILABLE:
 #     model_types.append("lstm")
 

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -2,7 +2,7 @@
 tensorflow[and-cuda]~=2.20.0
 tf2onnx
 # This is the only version which works with TF 2.20.0.
-# TODO: Update this version when TF is updated.
+# TODO(#21914): Update this version when TF is updated.
 ai-edge-litert==1.3.0
 
 # Torch cpu-only version (needed for testing).

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ tensorflow-cpu~=2.20.0;sys_platform != 'darwin'
 tensorflow~=2.20.0;sys_platform == 'darwin'
 tf2onnx
 # This is the only version which works with TF 2.20.0.
-# TODO: Update this version when TF is updated.
+# TODO(#21914): Update this version when TF is updated.
 ai-edge-litert==1.3.0
 
 # Torch.


### PR DESCRIPTION
The only version of `ai-edge-litert` which works with TF 2.20.0 is 1.3.0. Pinning the version for now, and added TODO statements for when we upgrade TF.

Created an issue to track this: https://github.com/keras-team/keras/issues/21914