### PR TITLE
Increase JAX GPU tests timeout to 2 hours

### DIFF
--- a/.kokoro/github/ubuntu/gpu/jax/continuous.cfg
+++ b/.kokoro/github/ubuntu/gpu/jax/continuous.cfg
@@ -12,5 +12,5 @@ env_vars: {
    value: "jax"
 }
 
-# Set timeout to 60 mins from default 180 mins
-timeout_mins: 60
+# Set timeout to 120 mins from default 180 mins
+timeout_mins: 120

--- a/.kokoro/github/ubuntu/gpu/jax/presubmit.cfg
+++ b/.kokoro/github/ubuntu/gpu/jax/presubmit.cfg
@@ -12,5 +12,5 @@ env_vars: {
    value: "jax"
 }
 
-# Set timeout to 60 mins from default 180 mins
-timeout_mins: 60
+# Set timeout to 120 mins from default 180 mins
+timeout_mins: 120


### PR DESCRIPTION
Increase JAX GPU tests timeout to 2 hours (fails for 1 hour and 1.5 hours)