### PR TITLE
OpenVino `device_scope` and data adapters tests

### DIFF
--- a/keras/src/backend/openvino/__init__.py
+++ b/keras/src/backend/openvino/__init__.py
@@ -15,6 +15,7 @@ from keras.src.backend.openvino.core import compute_output_spec
 from keras.src.backend.openvino.core import cond
 from keras.src.backend.openvino.core import convert_to_numpy
 from keras.src.backend.openvino.core import convert_to_tensor
+from keras.src.backend.openvino.core import device_scope
 from keras.src.backend.openvino.core import is_tensor
 from keras.src.backend.openvino.core import random_seed_dtype
 from keras.src.backend.openvino.core import shape

--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -13,7 +13,6 @@ from openvino import compile_model
 from keras.src import tree
 from keras.src.backend.common import KerasVariable
 from keras.src.backend.common import dtypes
-from keras.src.backend.common import global_state
 from keras.src.backend.common import standardize_dtype
 from keras.src.backend.common.dtypes import result_type
 from keras.src.backend.common.keras_tensor import KerasTensor
@@ -530,31 +529,11 @@ def ov_to_keras_type(ov_type):
 
 @contextlib.contextmanager
 def device_scope(device_name):
-    current_device = _parse_device_input(device_name)
-    global_state.set_global_attribute("openvino_device", current_device)
+    yield
 
 
 def get_device():
-    device = global_state.get_global_attribute("openvino_device", None)
-    if device is None:
-        return "CPU"
-    return device
-
-
-def _parse_device_input(device_name):
-    if isinstance(device_name, str):
-        # We support string value like "cpu:0", "gpu:1", and need to convert
-        # "gpu" to "cuda"
-        device_name = device_name.upper()
-        device_type, _ = device_name.split(":")
-        return device_type
-    else:
-        raise ValueError(
-            "Invalid value for argument `device_name`. "
-            "Expected a string like 'gpu:0' or 'cpu'. "
-            f"Received: device_name='{device_name}'"
-        )
-    return device_name
+    return "CPU"
 
 
 class Variable(KerasVariable):

--- a/keras/src/backend/openvino/excluded_tests.txt
+++ b/keras/src/backend/openvino/excluded_tests.txt
@@ -36,5 +36,7 @@ keras/src/quantizers
 keras/src/random/seed_generator_test.py
 keras/src/regularizers
 keras/src/saving
-keras/src/trainers
+keras/src/trainers/compile_utils_test.py
+keras/src/trainers/epoch_iterator_test.py
+keras/src/trainers/trainer_test.py
 keras/src/utils

--- a/keras/src/trainers/data_adapters/array_data_adapter_test.py
+++ b/keras/src/trainers/data_adapters/array_data_adapter_test.py
@@ -74,10 +74,7 @@ class TestArrayDataAdapter(testing.TestCase):
         self.assertEqual(adapter.has_partial_batch, True)
         self.assertEqual(adapter.partial_batch_size, 2)
 
-        if backend.backend() == "numpy":
-            it = adapter.get_numpy_iterator()
-            expected_class = np.ndarray
-        elif backend.backend() == "tensorflow":
+        if backend.backend() == "tensorflow":
             it = adapter.get_tf_dataset()
             if array_type == "tf_ragged":
                 expected_class = tf.RaggedTensor
@@ -96,6 +93,9 @@ class TestArrayDataAdapter(testing.TestCase):
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
+        else:
+            it = adapter.get_numpy_iterator()
+            expected_class = np.ndarray
 
         x_order = []
         y_order = []
@@ -128,7 +128,8 @@ class TestArrayDataAdapter(testing.TestCase):
 
             if shuffle == "batch":
                 self.assertAllClose(
-                    sorted(x_batch_order), range(i * 16, i * 16 + bx.shape[0])
+                    sorted(x_batch_order),
+                    list(range(i * 16, i * 16 + bx.shape[0])),
                 )
 
         self.assertAllClose(x_order, y_order)

--- a/keras/src/trainers/data_adapters/generator_data_adapter_test.py
+++ b/keras/src/trainers/data_adapters/generator_data_adapter_test.py
@@ -65,10 +65,7 @@ class GeneratorDataAdapterTest(testing.TestCase):
         )
 
         adapter = generator_data_adapter.GeneratorDataAdapter(make_generator())
-        if backend.backend() == "numpy":
-            it = adapter.get_numpy_iterator()
-            expected_class = np.ndarray
-        elif backend.backend() == "tensorflow":
+        if backend.backend() == "tensorflow":
             it = adapter.get_tf_dataset()
             expected_class = tf.Tensor
         elif backend.backend() == "jax":
@@ -79,6 +76,9 @@ class GeneratorDataAdapterTest(testing.TestCase):
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
+        else:
+            it = adapter.get_numpy_iterator()
+            expected_class = np.ndarray
 
         sample_order = []
         for i, batch in enumerate(it):
@@ -112,14 +112,14 @@ class GeneratorDataAdapterTest(testing.TestCase):
 
         adapter = generator_data_adapter.GeneratorDataAdapter(generator())
 
-        if backend.backend() == "numpy":
-            it = adapter.get_numpy_iterator()
-        elif backend.backend() == "tensorflow":
+        if backend.backend() == "tensorflow":
             it = adapter.get_tf_dataset()
         elif backend.backend() == "jax":
             it = adapter.get_jax_iterator()
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
+        else:
+            it = adapter.get_numpy_iterator()
 
         for i, batch in enumerate(it):
             self.assertEqual(len(batch), 2)

--- a/keras/src/trainers/data_adapters/tf_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/tf_dataset_adapter_test.py
@@ -25,10 +25,7 @@ class TestTFDatasetAdapter(testing.TestCase):
         self.assertEqual(adapter.has_partial_batch, None)
         self.assertEqual(adapter.partial_batch_size, None)
 
-        if backend.backend() == "numpy":
-            it = adapter.get_numpy_iterator()
-            expected_class = np.ndarray
-        elif backend.backend() == "tensorflow":
+        if backend.backend() == "tensorflow":
             it = adapter.get_tf_dataset()
             expected_class = tf.Tensor
         elif backend.backend() == "jax":
@@ -37,6 +34,9 @@ class TestTFDatasetAdapter(testing.TestCase):
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
+        else:
+            it = adapter.get_numpy_iterator()
+            expected_class = np.ndarray
 
         for i, batch in enumerate(it):
             self.assertEqual(len(batch), 2)
@@ -312,10 +312,7 @@ class TestTFDatasetAdapter(testing.TestCase):
         self.assertIsNone(adapter.has_partial_batch)
         self.assertIsNone(adapter.partial_batch_size)
 
-        if backend.backend() == "numpy":
-            it = adapter.get_numpy_iterator()
-            expected_class = np.ndarray
-        elif backend.backend() == "tensorflow":
+        if backend.backend() == "tensorflow":
             it = adapter.get_tf_dataset()
             expected_class = tf.Tensor
         elif backend.backend() == "jax":
@@ -324,6 +321,9 @@ class TestTFDatasetAdapter(testing.TestCase):
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
+        else:
+            it = adapter.get_numpy_iterator()
+            expected_class = np.ndarray
 
         batch_count = 0
         for batch in it:

--- a/keras/src/trainers/data_adapters/torch_data_loader_adapter_test.py
+++ b/keras/src/trainers/data_adapters/torch_data_loader_adapter_test.py
@@ -26,10 +26,7 @@ class TestTorchDataLoaderAdapter(testing.TestCase):
         self.assertEqual(adapter.has_partial_batch, True)
         self.assertEqual(adapter.partial_batch_size, 2)
 
-        if backend.backend() == "numpy":
-            it = adapter.get_numpy_iterator()
-            expected_class = np.ndarray
-        elif backend.backend() == "tensorflow":
+        if backend.backend() == "tensorflow":
             it = adapter.get_tf_dataset()
             expected_class = tf.Tensor
         elif backend.backend() == "jax":
@@ -38,6 +35,9 @@ class TestTorchDataLoaderAdapter(testing.TestCase):
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
+        else:
+            it = adapter.get_numpy_iterator()
+            expected_class = np.ndarray
 
         for i, batch in enumerate(it):
             self.assertEqual(len(batch), 2)
@@ -94,10 +94,7 @@ class TestTorchDataLoaderAdapter(testing.TestCase):
             self.assertIsNone(adapter.has_partial_batch)
             self.assertIsNone(adapter.partial_batch_size)
 
-        if backend.backend() == "numpy":
-            it = adapter.get_numpy_iterator()
-            expected_class = np.ndarray
-        elif backend.backend() == "tensorflow":
+        if backend.backend() == "tensorflow":
             it = adapter.get_tf_dataset()
             expected_class = tf.Tensor
         elif backend.backend() == "jax":
@@ -106,6 +103,9 @@ class TestTorchDataLoaderAdapter(testing.TestCase):
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
             expected_class = torch.Tensor
+        else:
+            it = adapter.get_numpy_iterator()
+            expected_class = np.ndarray
 
         batch_count = 0
         for i, batch in enumerate(it):
@@ -148,14 +148,14 @@ class TestTorchDataLoaderAdapter(testing.TestCase):
         self.assertEqual(adapter.has_partial_batch, True)
         self.assertEqual(adapter.partial_batch_size, 2)
 
-        if backend.backend() == "numpy":
-            it = adapter.get_numpy_iterator()
-        elif backend.backend() == "tensorflow":
+        if backend.backend() == "tensorflow":
             it = adapter.get_tf_dataset()
         elif backend.backend() == "jax":
             it = adapter.get_jax_iterator()
         elif backend.backend() == "torch":
             it = adapter.get_torch_dataloader()
+        else:
+            it = adapter.get_numpy_iterator()
 
         for i, batch in enumerate(it):
             self.assertEqual(len(batch), 2)


### PR DESCRIPTION
The `device` scope feature was not working because of a missing import as well as incorrect device name logic. The existing device name logic had been copied from the torch implementation but is not applicable to OpenVino.

Also turned on all the data adapter related tests for OpenVino, which happen to exercise the `device` scope. Data adapters are used with `predict` and `evaluate` and are useful with OpenVino even without training support.