### PR TITLE
Added backend checks

### DIFF
--- a/keras/src/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter.py
@@ -9,6 +9,7 @@ from contextlib import closing
 
 import numpy as np
 
+from keras import backend
 from keras.src.api_export import keras_export
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.trainers.data_adapters.data_adapter import DataAdapter
@@ -89,6 +90,15 @@ class PyDataset:
                    for file_name in batch_x]), np.array(batch_y)
     ```
     """
+
+    backend_name = backend.backend()
+
+    if backend_name not in ("tensorflow", "numpy", "torch", "jax", "openvino"):
+        raise ValueError(
+            f"Incompatible backend '{backend_name}'"
+            "Supported backends TensorFlow , numpy , torch , jax , "
+            "openvino backend."
+        )
 
     def __init__(self, workers=1, use_multiprocessing=False, max_queue_size=10):
         self._workers = workers

--- a/keras/src/trainers/data_adapters/tf_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/tf_dataset_adapter.py
@@ -1,3 +1,4 @@
+from keras import backend
 from keras.src import tree
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.trainers.data_adapters.data_adapter import DataAdapter
@@ -5,6 +6,15 @@ from keras.src.trainers.data_adapters.data_adapter import DataAdapter
 
 class TFDatasetAdapter(DataAdapter):
     """Adapter that handles `tf.data.Dataset`."""
+
+    backend_name = backend.backend()
+
+    if backend_name not in ("tensorflow", "numpy", "torch", "jax", "openvino"):
+        raise ValueError(
+            f"Incompatible backend '{backend_name}'"
+            "Supported backends TensorFlow , numpy , torch , jax , "
+            "openvino backend."
+        )
 
     def __init__(self, dataset, class_weight=None, distribution=None):
         """Initialize the TFDatasetAdapter.

--- a/keras/src/trainers/data_adapters/torch_data_loader_adapter.py
+++ b/keras/src/trainers/data_adapters/torch_data_loader_adapter.py
@@ -2,6 +2,7 @@ import itertools
 
 import numpy as np
 
+from keras import backend
 from keras.src import tree
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.trainers.data_adapters.data_adapter import DataAdapter
@@ -12,6 +13,21 @@ class TorchDataLoaderAdapter(DataAdapter):
 
     def __init__(self, dataloader):
         import torch
+
+        backend_name = backend.backend()
+
+        if backend_name not in (
+            "tensorflow",
+            "numpy",
+            "torch",
+            "jax",
+            "openvino",
+        ):
+            raise ValueError(
+                f"Incompatible backend '{backend_name}'"
+                "Supported backends TensorFlow , numpy , torch , jax , "
+                "openvino backend."
+            )
 
         if not isinstance(dataloader, torch.utils.data.DataLoader):
             raise ValueError(


### PR DESCRIPTION
This PR improves backend compatibility checks for DatasetAdapter.
It raises clear errors when a unsupported backend (other than numpy, torch, tf, jax) is used.

Changes

Added backend-type validation to DatasetAdapter.init in:

-tf_dataset_adapter.py

-py_dataset_adapter.py

-torch_data_loader_adapter.py