### PR TITLE
Fix Muon optimizer with TensorFlow backend.

### DIFF
--- a/keras/src/optimizers/muon_test.py
+++ b/keras/src/optimizers/muon_test.py
@@ -1,10 +1,13 @@
 import numpy as np
+import pytest
 
 from keras.src import backend
 from keras.src import ops
 from keras.src import testing
 from keras.src.layers import Dense
 from keras.src.layers import Embedding
+from keras.src.layers import Input
+from keras.src.models import Sequential
 from keras.src.optimizers.muon import Muon
 
 
@@ -35,34 +38,22 @@ class MuonTest(testing.TestCase):
         grads = ops.array([1.0, 6.0, 7.0, 2.0])
         vars = backend.Variable([1.0, 2.0, 3.0, 4.0], name="test_vars")
         optimizer.build([vars])
-        optimizer._adamw_update_step(grads, vars, 0.5)
+        optimizer.update_step(grads, vars, 0.5)
         self.assertAllClose(vars, [0.5, 1.5, 2.5, 3.5], rtol=1e-4, atol=1e-4)
 
     def test_should_use_adamw(self):
         vars = backend.Variable([[1.0, 2.0], [3.0, 4.0]])
         optimizer = Muon(exclude_layers=["var"])
-        self.assertAllClose(
-            True,
-            optimizer._should_use_adamw(vars),
-        )
+        self.assertTrue(optimizer._should_use_adamw(vars))
         embedding = Embedding(2, 2)
         embedding.build()
-        self.assertAllClose(
-            True,
-            optimizer._should_use_adamw(embedding.weights[0]),
-        )
+        self.assertTrue(optimizer._should_use_adamw(embedding.weights[0]))
         vars = backend.Variable([[1.0, 2.0], [3.0, 4.0]])
         optimizer = Muon()
-        self.assertAllClose(
-            False,
-            optimizer._should_use_adamw(vars),
-        )
+        self.assertFalse(optimizer._should_use_adamw(vars))
         dense = Dense(2)
         dense.build([None, 2])
-        self.assertAllClose(
-            False,
-            optimizer._should_use_adamw(dense.weights[0]),
-        )
+        self.assertFalse(optimizer._should_use_adamw(dense.weights[0]))
 
     def test_muon_single_step(self):
         optimizer = Muon(
@@ -72,7 +63,7 @@ class MuonTest(testing.TestCase):
         grads = ops.array([[1.0, 6.0], [7.0, 2.0]])
         vars = backend.Variable([[1.0, 2.0], [3.0, 4.0]])
         optimizer.build([vars])
-        optimizer._muon_update_step(grads, vars, 0.5)
+        optimizer.update_step(grads, vars, 0.5)
         self.assertAllClose(
             vars,
             [[0.988775, 1.887053], [2.873428, 3.97035]],
@@ -120,3 +111,12 @@ class MuonTest(testing.TestCase):
         x = ops.ones((4, 2))
         want = x * 0.2 * 2
         self.assertAllClose(opt.lr_adjust(x), want)
+
+    @pytest.mark.requires_trainable_backend
+    def test_model_fit(self):
+        model = Sequential([Input((10,)), Dense(5), Dense(1, name="last")])
+        x = ops.ones((1, 10))
+        y = ops.ones((1, 1))
+        optimizer = Muon(learning_rate=1e-3, exclude_layers=["last"])
+        model.compile(optimizer=optimizer, loss="mse")
+        model.fit(x, y)


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras/issues/21793

The variable path cannot be accessed in the `update_step` as the variable passed is the underlying `tf.Variable` and not the `keras.Variable`. Instead, we rely on the variable index.