### PR TITLE
Fix fake quant gradient output shape and use `jax.grad` for tests.

### DIFF
--- a/keras/src/quantizers/quantizers.py
+++ b/keras/src/quantizers/quantizers.py
@@ -281,7 +281,7 @@ def fake_quant_with_min_max_vars(
             ops.add(ops.multiply(-nudged_min, inv_scale), 0.5)
         )
         x_clamped = ops.clip(
-            x, ops.cast(nudged_min, x.dtype), ops.cast(nudged_max, x.dtype)
+            ops.cast(x, nudged_min.dtype), nudged_min, nudged_max
         )
         x_clamped_shifted = ops.subtract(x_clamped, nudged_min)
         result = ops.multiply(
@@ -318,6 +318,7 @@ def fake_quant_with_min_max_vars(
                 grad_min = ops.sum(grad_min, axis=axes)
             else:
                 grad_min = ops.sum(grad_min)
+            grad_min = ops.reshape(grad_min, ops.shape(min_val))
 
             # Gradient for max_val
             # When x is clipped to max, the gradient flows to max_val
@@ -327,6 +328,7 @@ def fake_quant_with_min_max_vars(
                 grad_max = ops.sum(grad_max, axis=axes)
             else:
                 grad_max = ops.sum(grad_max)
+            grad_max = ops.reshape(grad_max, ops.shape(max_val))
 
             return dx, grad_min, grad_max
 

--- a/keras/src/quantizers/quantizers_test.py
+++ b/keras/src/quantizers/quantizers_test.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 import pytest
 from absl.testing import parameterized
@@ -194,6 +192,19 @@ class QuantizersTest(testing.TestCase):
                 "narrow_range": False,
                 "input_mins": [0.0],
                 "input_maxs": [255.0],
+                "num_bits": 8,
+                "expected_nudged_input_mins": [0.0],
+                "expected_nudged_input_maxs": [255.0],
+                "expected_steps": [1.0],
+                "axis": None,
+            },
+            {
+                "testcase_name": (
+                    "wide_8bits_scalar_input_mins_0.0_input_maxs_255.0"
+                ),
+                "narrow_range": False,
+                "input_mins": 0.0,
+                "input_maxs": 255.0,
                 "num_bits": 8,
                 "expected_nudged_input_mins": [0.0],
                 "expected_nudged_input_maxs": [255.0],
@@ -432,7 +443,7 @@ class QuantizersTest(testing.TestCase):
         expected_nudged_input_maxs,
         expected_steps,
     ):
-        num_channels = len(input_mins)
+        num_channels = len(expected_nudged_input_mins)
         inputs_list = []
         expected_list = []
         initial_gradients_list = []
@@ -538,19 +549,18 @@ class QuantizersTest(testing.TestCase):
             ):
                 # Define the function to compute gradients for
                 def quantize_fn(x):
-                    return quantizers.fake_quant_with_min_max_vars(
-                        x, input_mins, input_maxs, num_bits, narrow_range, axis
+                    return ops.sum(
+                        quantizers.fake_quant_with_min_max_vars(
+                            x,
+                            input_mins,
+                            input_maxs,
+                            num_bits,
+                            narrow_range,
+                            axis,
+                        )
                     )
 
-                _, f_vjp = jax.vjp(quantize_fn, inputs)
-
-                if getattr(jax.config, "jax_vjp3", False):
-                    input_gradients = f_vjp.opaque_residuals[0]
-                elif sys.version_info >= (3, 10):
-                    input_gradients = f_vjp.args[0].args[0][0]
-                else:
-                    input_gradients = f_vjp.args[0].args[0][1]
-
+                input_gradients = jax.grad(quantize_fn)(inputs)
                 return ops.multiply(initial_gradients, input_gradients)
 
         gradients = test_op(


### PR DESCRIPTION
- Add support for `fake_quant_with_min_max_vars` to take `min_vals` and `max_vals` as scalars instead of arrays of shape [1].
- Added resizing of gradients of `min_vals` and `max_vals` to match the inputs. `jax.grad` is stricter on the shapes than the other backends.
- Changed tests to use `jax.grad` instead of `jax.vjp`. The `jax.jvp` API has been unstable and tests are failing in some context.
- Added test to cover the case when `min_vals` and `max_vals` are scalars.