### PR TITLE
Refactors AbsMaxQuantizer to accept axis in `__call__`

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -413,7 +413,7 @@ class Dense(Layer):
     def _int8_build(self, kernel_shape, config=None):
         self.inputs_quantizer = (
             QuantizationConfig.activation_quantizer_or_default(
-                config, quantizers.AbsMaxQuantizer(axis=-1)
+                config, quantizers.AbsMaxQuantizer()
             )
         )
 
@@ -526,7 +526,7 @@ class Dense(Layer):
         # Per-channel int8 quantizer for the last axis (features).
         self.inputs_quantizer = (
             QuantizationConfig.activation_quantizer_or_default(
-                config, quantizers.AbsMaxQuantizer(axis=-1)
+                config, quantizers.AbsMaxQuantizer()
             )
         )
         input_dim, output_dim = kernel_shape
@@ -618,7 +618,7 @@ class Dense(Layer):
 
             output_scale = kernel_scale
             if self.inputs_quantizer:
-                inputs, inputs_scale = self.inputs_quantizer(inputs)
+                inputs, inputs_scale = self.inputs_quantizer(inputs, axis=-1)
                 output_scale = ops.multiply(output_scale, inputs_scale)
 
             x = ops.matmul(inputs, kernel)
@@ -674,7 +674,7 @@ class Dense(Layer):
             output_scale = kernel_scale
 
             if self.inputs_quantizer:
-                inputs, inputs_scale = self.inputs_quantizer(inputs)
+                inputs, inputs_scale = self.inputs_quantizer(inputs, axis=-1)
                 output_scale = ops.multiply(output_scale, inputs_scale)
 
             x = ops.matmul(inputs, unpacked_kernel)

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -24,7 +24,7 @@ from keras.src.quantizers.quantizers import AbsMaxQuantizer
 
 class DenseTest(testing.TestCase):
     @parameterized.named_parameters(
-        ("int8", "int8", {"axis": 0}, {"axis": -1}),
+        ("int8", "int8", {"axis": 0}, {}),
         (
             "int4",
             "int4",
@@ -62,7 +62,6 @@ class DenseTest(testing.TestCase):
         if activation_quantizer_args is not None:
             # Verify inputs_quantizer is set correctly
             self.assertIsInstance(layer.inputs_quantizer, AbsMaxQuantizer)
-            self.assertEqual(layer.inputs_quantizer.axis, (-1,))
         else:
             # Verify inputs_quantizer is None
             self.assertIsNone(layer.inputs_quantizer)

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -71,7 +71,6 @@ class EinsumDenseTest(testing.TestCase):
         if activation_quantizer_args is not None:
             # Verify inputs_quantizer is set correctly
             self.assertIsInstance(layer.inputs_quantizer, AbsMaxQuantizer)
-            self.assertEqual(layer.inputs_quantizer.axis, (1,))
         else:
             # Verify inputs_quantizer is None
             self.assertIsNone(layer.inputs_quantizer)

--- a/keras/src/layers/core/reversible_embedding_test.py
+++ b/keras/src/layers/core/reversible_embedding_test.py
@@ -258,5 +258,4 @@ class ReversibleEmbeddingTest(test_case.TestCase):
         )
         quantizer = new_layer.quantization_config.weight_quantizer
         self.assertIsInstance(quantizer, AbsMaxQuantizer)
-        self.assertEqual(quantizer.axis, (-1,))
         self.assertAllEqual(quantizer.value_range, weight_range)

--- a/keras/src/quantizers/quantization_config.py
+++ b/keras/src/quantizers/quantization_config.py
@@ -76,7 +76,7 @@ class Int8QuantizationConfig(QuantizationConfig):
         from keras.src.quantizers.quantizers import AbsMaxQuantizer
 
         if activation_quantizer == "default":
-            activation_quantizer = AbsMaxQuantizer(axis=-1)
+            activation_quantizer = AbsMaxQuantizer()
         super().__init__(weight_quantizer, activation_quantizer)
         if self.weight_quantizer is not None:
             if self.weight_quantizer.output_dtype != "int8":
@@ -105,7 +105,7 @@ class Int4QuantizationConfig(QuantizationConfig):
         from keras.src.quantizers.quantizers import AbsMaxQuantizer
 
         if activation_quantizer == "default":
-            activation_quantizer = AbsMaxQuantizer(axis=-1)
+            activation_quantizer = AbsMaxQuantizer()
         super().__init__(weight_quantizer, activation_quantizer)
         if self.weight_quantizer is not None:
             if self.weight_quantizer.value_range != (-8, 7):

--- a/keras/src/quantizers/quantizers_test.py
+++ b/keras/src/quantizers/quantizers_test.py
@@ -17,7 +17,7 @@ from keras.src.testing.test_utils import named_product
 
 class QuantizersTest(testing.TestCase):
     def test_get_method(self):
-        quantizer = quantizers.get("abs_max_quantizer", axis=-1)
+        quantizer = quantizers.get("abs_max_quantizer")
         self.assertTrue(quantizer, quantizers.AbsMaxQuantizer)
 
         quantizer = quantizers.get(None)
@@ -28,10 +28,10 @@ class QuantizersTest(testing.TestCase):
 
     def test_abs_max_quantizer(self):
         values = random.uniform([3, 4, 5], minval=-1, maxval=1, dtype="float32")
-        quantizer = quantizers.AbsMaxQuantizer(axis=-1)
+        quantizer = quantizers.AbsMaxQuantizer()
 
         # Test quantizing
-        quantized_values, scale = quantizer(values)
+        quantized_values, scale = quantizer(values, axis=-1)
         self.assertDType(quantized_values, "int8")
         self.assertDType(scale, "float32")
         self.assertEqual(tuple(quantized_values.shape), (3, 4, 5))
@@ -53,11 +53,11 @@ class QuantizersTest(testing.TestCase):
         values = random.uniform(
             [3, 4, 5], minval=-1, maxval=1, dtype="bfloat16"
         )
-        quantized_values, scale = quantizer(values)
+        quantized_values, scale = quantizer(values, axis=-1)
         self.assertDType(quantized_values, "int8")
         self.assertDType(scale, "bfloat16")
         values = random.uniform([3, 4, 5], minval=-1, maxval=1, dtype="float16")
-        quantized_values, scale = quantizer(values)
+        quantized_values, scale = quantizer(values, axis=-1)
         self.assertDType(quantized_values, "int8")
         self.assertDType(scale, "float16")
 


### PR DESCRIPTION
This PR modifies the `AbsMaxQuantizer` to allow specifying the quantization axis dynamically during the `__call__` method, rather than strictly defining it at initialization. This change improves flexibility and aligns the quantizer with cases where the reduction axis might depend on the specific input shape or context (e.g., inside specific layer implementations).

**This is not a breaking change**. The axis argument in `__init__` is preserved for backward compatibility, though using axis in `__call__` is now preferred.