### PR TITLE
Remove nightly tests with Python 3.13.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,54 +57,6 @@ jobs:
         run: |
           pytest keras --ignore keras/src/applications --cov=keras --cov-config=pyproject.toml
 
-  build-python-latest:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.13"]
-        backend: [tensorflow, jax, torch, numpy]
-    name: Run tests (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
-    env:
-      PYTHON: ${{ matrix.python-version }}
-      KERAS_BACKEND: ${{ matrix.backend }}
-    steps:
-      - uses: actions/checkout@v5
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          python -m pip install --upgrade pip setuptools
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-      - name: pip cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-latest-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt --progress-bar off --upgrade
-          pip uninstall -y keras keras-nightly
-          pip install -e "." --progress-bar off --upgrade
-      - name: Test integrations
-        if: ${{ matrix.backend != 'numpy'}}
-        run: |
-          python integration_tests/import_test.py
-      - name: Test TF-specific integrations
-        if: ${{ matrix.backend == 'tensorflow'}}
-        run: |
-          python integration_tests/tf_distribute_training_test.py
-      - name: Test Torch-specific integrations
-        if: ${{ matrix.backend == 'torch'}}
-        run: |
-          pytest integration_tests/torch_workflow_test.py
-      - name: Test with pytest
-        run: |
-          pytest keras --ignore keras/src/applications --cov=keras --cov-config=pyproject.toml
-
   format:
     name: Check the code format
     runs-on: ubuntu-latest
@@ -134,7 +86,7 @@ jobs:
 
   nightly:
     name: Build Wheel file and upload
-    needs: [build, build-python-latest, format]
+    needs: [build, format]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
This is a revert of https://github.com/keras-team/keras/pull/21566

These tests have never passed: https://github.com/keras-team/keras/actions/runs/20325149006/job/58388669940

The issue is that some of our dependencies are not available for Python 3.13.

Additionally, nightly job are not monitored, so if they fail, it can go unnoticed for months.