### PR TITLE
Do not always make batch size dynamic during export.

### DIFF
--- a/keras/src/backend/tensorflow/layer.py
+++ b/keras/src/backend/tensorflow/layer.py
@@ -94,22 +94,18 @@ class TFLayer(KerasAutoTrackable):
             A TensorSpec, list or dict mirroring the model inputs, or
             `None` when specs cannot be inferred.
         """
-        # Prefer the base implementation if available
-        try:
-            return super()._get_save_spec(dynamic_batch)
-        except AttributeError:
-            # Lazy import to avoid circular dependency
-            from keras.src.export.export_utils import make_tf_tensor_spec
+        # Lazy import to avoid circular dependency
+        from keras.src.export.export_utils import make_tf_tensor_spec
 
-            # Fall back to building specs from `self.inputs`
-            inputs = getattr(self, "inputs", None)
-            if inputs is None:
-                return None
+        # Fall back to building specs from `self.inputs`
+        inputs = getattr(self, "inputs", None)
+        if inputs is None:
+            return None
 
-            return tree.map_structure(
-                lambda x: make_tf_tensor_spec(x, dynamic_batch=dynamic_batch),
-                inputs,
-            )
+        return tree.map_structure(
+            lambda x: make_tf_tensor_spec(x, dynamic_batch=dynamic_batch),
+            inputs,
+        )
 
     @property
     def _default_save_signature(self):

--- a/keras/src/export/export_utils.py
+++ b/keras/src/export/export_utils.py
@@ -102,7 +102,7 @@ def make_input_spec(x):
     return input_spec
 
 
-def make_tf_tensor_spec(x, dynamic_batch=True):
+def make_tf_tensor_spec(x, dynamic_batch=False):
     """Create a TensorSpec from various input types.
 
     Args:


### PR DESCRIPTION
This is a follow-up of https://github.com/keras-team/keras/pull/21674

This PR changed the signature of `make_tf_tensor_spec` from `(x)` to `(x, dynamic_batch=True)`, thereby adding the ability to make the batch size dynamic.

This PR also adds `_get_save_spec(self, dynamic_batch=True)` which uses `make_tf_tensor_spec` and forwards the `dynamic_batch` argument.

However, the default before this change for other export (SavedModel, ONNX) was to keep the batch size untouched. In particular, when a user manually provides an `input_signature` to [`ExportArchive.add_endpoint`](https://github.com/keras-team/keras/blob/master/keras/src/export/saved_model.py#L362), we should honor it. The user controls whether the batch size is dynamic or not in the `input_signature`.

This PR changes the default of `make_tf_tensor_spec` back to `dynamic_batch=False` to revert SavedModel and ONNX exports to the previous behavior.

Also removed call to `return super()._get_save_spec(dynamic_batch)` which can never succeed as `TFLayer` is a top level class (ignoring the auto-tracking stuff).