### PR TITLE
Fix `numpy.mean` with dynamic shape on OpenVino.

### DIFF
--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -77,7 +77,6 @@ def multiply(x1, x2):
 
 def mean(x, axis=None, keepdims=False):
     x_ov = get_ov_output(x)
-    x_shape = x_ov.get_partial_shape().to_shape()
     x_type = x_ov.get_element_type()
 
     was_axis_none = axis is None
@@ -93,7 +92,8 @@ def mean(x, axis=None, keepdims=False):
     result = ov_opset.reduce_mean(x_resolved, axis_resolved, keepdims).output(0)
 
     if keepdims and was_axis_none:
-        result_shape = [1] * len(x_shape)
+        rank = x.get_partial_shape().rank.get_length()
+        result_shape = [1] * rank
         result = ov_opset.reshape(
             result,
             ov_opset.constant(result_shape, Type.i32).output(0),


### PR DESCRIPTION
There was a regression for `numpy.mean` on OpenVino for dynamic shape: https://github.com/keras-team/keras/pull/21746

Which makes KerasHub tests fail: https://github.com/keras-team/keras-hub/pull/2489

This PR was manually tested against KerasHub.