### PR TITLE
Remove NumPy warning with NumPy >= 2.

### DIFF
--- a/keras/src/export/tf2onnx_lib.py
+++ b/keras/src/export/tf2onnx_lib.py
@@ -5,9 +5,6 @@ import traceback
 
 import numpy as np
 
-if not hasattr(np, "object"):
-    np.object = object
-
 
 @functools.lru_cache()
 def patch_tf2onnx():
@@ -19,6 +16,9 @@ def patch_tf2onnx():
     from keras.src.utils.module_utils import tf2onnx
 
     logger = logging.getLogger(tf2onnx.__name__)
+
+    if not hasattr(np, "object"):
+        np.object = object
 
     def patched_rewrite_constant_fold(g, ops):
         """


### PR DESCRIPTION
Merely importing keras currently triggers this warning with NumPy 2.

```
keras/src/export/tf2onnx_lib.py:8: FutureWarning: In the future `np.object` will be defined as the corresponding NumPy scalar.
```

Only patch NumPy if and when needed.