### PR TITLE
Always use `run_tpu_tests` label to run the TPU tests.

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -31,7 +31,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  welcome:
+  add_labels:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/tpu_tests.yml
+++ b/.github/workflows/tpu_tests.yml
@@ -1,15 +1,10 @@
-name: Keras Tests
-
-# TODO: Consider enabling all tests (pytest, applications, etc.) with NNX in the future
-# Currently only basic flow tests run with NNX enabled
+name: Keras TPU Tests
 
 on:
   push:
     branches: [ master ]
   pull_request:
     types: [labeled]
-  pull_request_review:
-    types: [submitted]
   release:
     types: [created]
 
@@ -21,12 +16,11 @@ jobs:
   test-in-container:
     name: Run tests on TPU
     runs-on: linux-x86-ct6e-44-1tpu
-    # Only run on approved PRs, pushes to master, releases or "run_tpu_tests" labels
+    # Only run on pushes to master, releases or "run_tpu_tests" labels
     if: |
       github.event_name == 'push' ||
       github.event_name == 'release' ||
-      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'run_tpu_tests') ||
-      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'run_tpu_tests')
 
     strategy:
       fail-fast: false

--- a/.github/workflows/tpu_tests_labeler.yml
+++ b/.github/workflows/tpu_tests_labeler.yml
@@ -1,0 +1,25 @@
+name: Labeler for TPU Tests
+
+on:
+  pull_request_review:
+
+jobs:
+  add_run_tpu_tests_label:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    # Only run on "approved" reviews for the "pull_request_review" event.
+    if: github.event.review.state == 'approved'
+
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: ['run_tpu_tests']
+            })


### PR DESCRIPTION
Problem: the current approach creates two entries for TPU tests: one for `pull_request` and one for `pull_request_review`. But we only want one entry and one run of the tests.

Solution: add a new labeler workflow to label the PR on approval, which in turn triggers the TPU tests.

Also rename `welcome` workflow.