### PR TITLE
Add example for arctanh

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -924,6 +924,11 @@ def arctanh(x):
 
     Returns:
         Output tensor of same shape as `x`.
+
+    Example:
+    >>> x = keras.ops.convert_to_tensor([0, -0.5])
+    >>> keras.ops.arctanh(x)
+    array([ 0.        , -0.54930615], dtype=float32)
     """
     if any_symbolic_tensors((x,)):
         return Arctanh().symbolic_call(x)


### PR DESCRIPTION
I’ve added an example for arctanh.

- current
<img width="801" height="345" alt="image" src="https://github.com/user-attachments/assets/35e5f590-dce0-4de9-a49a-1c51f11bc617" />

- updated
<img width="737" height="428" alt="image" src="https://github.com/user-attachments/assets/e853561a-5545-4832-8046-82d8bb18cfdf" />
