### PR TITLE
fix image.extract_patches strides handling

### DIFF
--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -565,6 +565,8 @@ class ExtractPatches(Operation):
         if isinstance(size, int):
             size = (size, size)
         self.size = size
+        if strides is None:
+            strides = size
         self.strides = strides
         self.dilation_rate = dilation_rate
         self.padding = padding
@@ -583,8 +585,6 @@ class ExtractPatches(Operation):
     def compute_output_spec(self, images):
         images_shape = list(images.shape)
         original_ndim = len(images_shape)
-        if not self.strides:
-            strides = (self.size[0], self.size[1])
         if self.data_format == "channels_last":
             channels_in = images_shape[-1]
         else:
@@ -597,7 +597,7 @@ class ExtractPatches(Operation):
             images_shape,
             filters,
             kernel_size,
-            strides=strides,
+            strides=self.strides,
             padding=self.padding,
             data_format=self.data_format,
             dilation_rate=self.dilation_rate,

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -106,6 +106,10 @@ class ImageOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(out.shape, (None, 4, 4, 75))
         out = kimage.extract_patches(x, 5)
         self.assertEqual(out.shape, (None, 4, 4, 75))
+        out = kimage.extract_patches(x, 5, strides=1)
+        self.assertEqual(out.shape, (None, 16, 16, 75))
+        out = kimage.extract_patches(x, 5, strides=(2, 3))
+        self.assertEqual(out.shape, (None, 8, 6, 75))
 
         # Test channels_first
         backend.set_image_data_format("channels_first")
@@ -115,6 +119,10 @@ class ImageOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(out.shape, (None, 75, 4, 4))
         out = kimage.extract_patches(x, 5)
         self.assertEqual(out.shape, (None, 75, 4, 4))
+        out = kimage.extract_patches(x, 5, strides=1)
+        self.assertEqual(out.shape, (None, 75, 16, 16))
+        out = kimage.extract_patches(x, 5, strides=(2, 3))
+        self.assertEqual(out.shape, (None, 75, 8, 6))
 
     def test_extract_patches_3d(self):
         # Test channels_last


### PR DESCRIPTION
In the `keras.ops.image.extract_patches` function, the current codebase has reference to `strides` that is undefined in `compute_output_spec` when it is actually provided instead of left as `None` by default. This PR fixes the issue and added a few lines in tests for it.