### PR TITLE
Skip `PyDataset` tests on TPU.

### DIFF
--- a/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
@@ -93,7 +93,10 @@ class ExceptionPyDataset(py_dataset_adapter.PyDataset):
         raise ValueError("Expected exception")
 
 
-@pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Flaky on GPU")
+@pytest.mark.skipif(
+    testing.tensorflow_uses_gpu() or testing.uses_tpu(),
+    reason="Flaky on TPU and GPU",
+)
 class PyDatasetAdapterTest(testing.TestCase):
     @parameterized.named_parameters(
         named_product(


### PR DESCRIPTION
They appear to crash on TPU fairly regularly. https://github.com/keras-team/keras/actions/runs/20584540139/job/59118551243