### PR TITLE
Add simple example for keras.layers.Resizing

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/resizing.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/resizing.py
@@ -70,17 +70,11 @@ class Resizing(BaseImagePreprocessingLayer):
     Example:
 
     ```python
-    import keras
-
     (x_train, y_train), _ = keras.datasets.cifar10.load_data()
-
     image = x_train[0]
-
     resizer = keras.layers.Resizing(128, 128)
     resized_image = resizer(image)
-
-    print("Original:", image.shape)
-    print("Resized:", resized_image.shape)
+    print("original:", image.shape, "resized:", resized_image.shape)
     ```
     """
 


### PR DESCRIPTION
Adds a minimal example showing how to use keras.layers.Resizing, using a built-in Keras dataset and no external assets.

If this style of example is acceptable, I can add similar minimal examples for other preprocessing layers that currently do not have examples.