### PR TITLE
Update dependencies and `dependabot.yml`.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,9 @@ updates:
         patterns:
           - "*"
     ignore:
-        # TODO: ignore all updates for JAX GPU due to cuda version issue
+      # 2.19.1 is the last version of the TensorFlow that supports TPUs.
+      - dependency-name: "tensorflow-tpu"
+      # TODO: ignore all updates for JAX GPU due to cuda version issue
       - dependency-name: "jax[cuda12_pip]"
+      # TODO(#21914): Update this version when TF is updated
+      - dependency-name: "ai-edge-litert"

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -4,7 +4,7 @@ tf2onnx
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.9.0+cpu
+torch==2.9.1+cpu
 
 # Jax with cuda support.
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html

--- a/requirements-jax-tpu.txt
+++ b/requirements-jax-tpu.txt
@@ -4,7 +4,7 @@ tf2onnx
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.9.1+cpu
 
 # Jax with cuda support.
 --find-links https://storage.googleapis.com/jax-releases/libtpu_releases.html

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -7,7 +7,7 @@ ai-edge-litert==1.3.0
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.9.0+cpu
+torch==2.9.1+cpu
 
 # Jax cpu-only version (needed for testing).
 jax[cpu]

--- a/requirements-tensorflow-tpu.txt
+++ b/requirements-tensorflow-tpu.txt
@@ -1,3 +1,4 @@
+# 2.19.1 is the last version of the TensorFlow that supports TPUs.
 --find-links https://storage.googleapis.com/libtpu-tf-releases/index.html
 tensorflow-tpu==2.19.1
 
@@ -5,7 +6,7 @@ tf2onnx
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.9.1+cpu
 
 # Jax cpu-only version (needed for testing).
 jax

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -4,9 +4,9 @@ tf2onnx
 
 # Torch with cuda support.
 # - torch is pinned to a version that is compatible with torch-xla.
---extra-index-url https://download.pytorch.org/whl/cu121
-torch==2.9.0
-torch-xla==2.8.1;sys_platform != 'darwin'
+--extra-index-url https://download.pytorch.org/whl/cu126
+torch==2.9.1+cu126
+torch-xla==2.9.0;sys_platform != 'darwin'
 
 # Jax cpu-only version (needed for testing).
 jax[cpu]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,14 +10,14 @@ ai-edge-litert==1.3.0
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
-torch-xla==2.6.0;sys_platform != 'darwin'
+torch==2.9.1+cpu
+torch-xla==2.9.0;sys_platform != 'darwin'
 
 # Jax.
 # Pinned to 0.8.0 on CPU for CI compatibility with older backends.
 # Note that we test against the latest JAX on GPU.
 jax[cpu]==0.8.1
-flax==0.12.1
+flax==0.12.2
 
 # Common deps.
 -r requirements-common.txt


### PR DESCRIPTION
- Update Torch to 2.9.1
- Update `dependabot.yml` to ignore `tensorflow-tpu` (permanently) and `ai-edge-litert` (for now)
- Update `requirements-torch-cuda.txt` in way that I hope will prevent Dependabot from appending `+cpu` to the Torch version, which breaks CUDA tests every time