### PR TITLE
Add missing `name` to `SeedGenerator.get_config`.

### DIFF
--- a/keras/src/random/seed_generator.py
+++ b/keras/src/random/seed_generator.py
@@ -29,7 +29,7 @@ class SeedGenerator:
     a local `StateGenerator` with either a deterministic or random initial
     state.
 
-    Remark concerning the JAX backen: Note that the use of a local
+    Remark concerning the JAX backend: Note that the use of a local
     `StateGenerator` as seed argument is required for JIT compilation of
     RNG with the JAX backend, because the use of global state is not
     supported.
@@ -111,7 +111,7 @@ class SeedGenerator:
         return new_seed_value
 
     def get_config(self):
-        return {"seed": self._initial_seed}
+        return {"seed": self._initial_seed, "name": self.name}
 
     @classmethod
     def from_config(cls, config):

--- a/keras/src/random/seed_generator_test.py
+++ b/keras/src/random/seed_generator_test.py
@@ -91,5 +91,5 @@ class SeedGeneratorTest(testing.TestCase):
             traced_function()
 
     def test_seed_generator_serialization(self):
-        random_generator = seed_generator.SeedGenerator(seed=42)
+        random_generator = seed_generator.SeedGenerator(seed=42, name="sg")
         self.run_class_serialization_test(random_generator)


### PR DESCRIPTION
The name should be saved and restored during serialization/deserialization.

Also fixed a typo in docstring.