### PR TITLE
Fix: config keys for `chain_depth` and `num_chains` in `aug_mix.py`

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/aug_mix.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/aug_mix.py
@@ -316,8 +316,8 @@ class AugMix(BaseImagePreprocessingLayer):
     def get_config(self):
         config = {
             "value_range": self.value_range,
-            "num_chains": self.chain_depth,
-            "chain_depth": self.num_chains,
+            "num_chains": self.num_chains,
+            "chain_depth": self.chain_depth,
             "factor": self.factor,
             "alpha": self.alpha,
             "all_ops": self.all_ops,


### PR DESCRIPTION
Fixed bug in `AugMix.get_config()` where `num_chains` and `chain_depth` were swapped