### PR TITLE
Document complex dtype limitation in ops.correlate

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -7734,6 +7734,15 @@ def correlate(x1, x2, mode="valid"):
 
     Returns:
         Output tensor, cross-correlation of `x1` and `x2`.
+
+    Notes:
+        Complex-valued inputs are currently not fully supported on the
+        TensorFlow and PyTorch backends. When complex tensors are passed,
+        they are cast to floating-point types and the imaginary component
+        is discarded.
+
+        This behavior is documented for clarity and may change in the
+        future. See discussion in issue #21617.
     """
     if any_symbolic_tensors((x1, x2)):
         return Correlate(mode=mode).symbolic_call(x1, x2)


### PR DESCRIPTION
This PR documents the current limitation of `keras.ops.correlate` with complex
dtypes on the TensorFlow and PyTorch backends, where complex inputs are cast to
floating-point types and imaginary components are dropped.

This clarification aligns with the discussion in issue #21617.
