### PR TITLE
benchmarks: add RandomRotation tf.data performance benchmark

### DIFF
--- a/benchmarks/layer_benchmark/random_rotation_benchmark.py
+++ b/benchmarks/layer_benchmark/random_rotation_benchmark.py
@@ -3,7 +3,7 @@
 from absl import app
 from absl import flags
 
-from keras.benchmarks.layer_benchmark.base_benchmark import LayerBenchmark
+from benchmarks.layer_benchmark.base_benchmark import LayerBenchmark
 
 FLAGS = flags.FLAGS
 


### PR DESCRIPTION
This PR adds a simple benchmark script for measuring the performance of
keras.layers.RandomRotation when used inside a tf.data pipeline.

The benchmark compares eager execution vs tf.function wrapping and
measures end-to-end dataset iteration time.

Motivation:
There is currently no reference benchmark for Keras preprocessing layers.
This script helps evaluate performance characteristics and potential
regressions.

Related issue:
https://github.com/keras-team/keras/issues/21954

cc @mattdangerw
