### PR TITLE
Trigger TPU tests on kokoro label removal rather than addition.

### DIFF
--- a/.github/workflows/tpu_tests.yml
+++ b/.github/workflows/tpu_tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    types: [labeled]
+    types: [unlabeled]
   release:
     types: [created]
 
@@ -16,11 +16,11 @@ jobs:
   test-in-container:
     name: Run tests on TPU
     runs-on: linux-x86-ct6e-44-1tpu
-    # Only run on pushes to master, releases or "kokoro:force-run" label
+    # Only run on pushes to master, releases or "kokoro:force-run" unlabel
     if: |
       github.event_name == 'push' ||
       github.event_name == 'release' ||
-      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'kokoro:force-run')
+      (github.event_name == 'pull_request' && github.event.action == 'unlabeled' && github.event.label.name == 'kokoro:force-run')
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
**Problem**: when a PR is approved, `google-ml-butler` adds 2 labels: `kokoro-force-run` and `ready to pull` in this order. The TPU tests workflow is triggered twice, once for each, but it is skipped for `ready to pull`. While the actual TPU tests are still run, what's shown in the UI is the skipped worflow because it was triggered last. So it's not directly possible to see the results of the TPU tests.

**Solution**: this changes the workflow to trigger on labeled removed. This works because kokoro immediately removes the label once it's set and it only removes one label at a time.

We will probably need to revisit once we migrate off of kokoro.