### PR TITLE
Fix TF-IDF weights save/load in IndexLookup preprocessing layers

### DIFF
--- a/keras/src/layers/preprocessing/index_lookup_test.py
+++ b/keras/src/layers/preprocessing/index_lookup_test.py
@@ -634,6 +634,11 @@ class IndexLookupLayerTest(testing.TestCase):
         }
         layer = layers.IndexLookup(**kwargs)
         layer.adapt(adapt_data)
+
+        # Verify adapted vocabulary and idf_weights are set
+        original_vocab = layer.get_vocabulary()
+        original_idf_weights = layer.idf_weights.numpy()
+
         model = models.Sequential(
             [
                 layers.Input(shape=(None,), dtype="string"),
@@ -643,8 +648,21 @@ class IndexLookupLayerTest(testing.TestCase):
         output_1 = model(batch_input_data)
         path = os.path.join(self.get_temp_dir(), "model_tf_idf_adapted.keras")
         model.save(path)
-        model = saving_api.load_model(path)
-        output_2 = model(batch_input_data)
+
+        # Load and verify vocabulary and weights are restored
+        loaded_model = saving_api.load_model(path)
+        loaded_layer = loaded_model.layers[0]
+
+        # Verify vocabulary is the same
+        self.assertEqual(loaded_layer.get_vocabulary(), original_vocab)
+
+        # Verify idf_weights are restored correctly
+        self.assertAllClose(
+            loaded_layer.idf_weights.numpy(), original_idf_weights
+        )
+
+        # Verify outputs match
+        output_2 = loaded_model(batch_input_data)
         self.assertAllClose(output_1, output_2)
 
     @pytest.mark.skipif(
@@ -696,6 +714,11 @@ class IndexLookupLayerTest(testing.TestCase):
         }
         layer = layers.IndexLookup(**kwargs)
         layer.adapt(adapt_data)
+
+        # Verify adapted vocabulary and idf_weights are set
+        original_vocab = layer.get_vocabulary()
+        original_idf_weights = layer.idf_weights.numpy()
+
         model = models.Sequential(
             [
                 layers.Input(shape=(None,), dtype="int64"),
@@ -707,8 +730,21 @@ class IndexLookupLayerTest(testing.TestCase):
             self.get_temp_dir(), "model_tf_idf_int_adapted.keras"
         )
         model.save(path)
-        model = saving_api.load_model(path)
-        output_2 = model(batch_input_data)
+
+        # Load and verify vocabulary and weights are restored
+        loaded_model = saving_api.load_model(path)
+        loaded_layer = loaded_model.layers[0]
+
+        # Verify vocabulary is the same
+        self.assertEqual(loaded_layer.get_vocabulary(), original_vocab)
+
+        # Verify idf_weights are restored correctly
+        self.assertAllClose(
+            loaded_layer.idf_weights.numpy(), original_idf_weights
+        )
+
+        # Verify outputs match
+        output_2 = loaded_model(batch_input_data)
         self.assertAllClose(output_1, output_2)
 
     @pytest.mark.skipif(

--- a/keras/src/layers/preprocessing/index_lookup_test.py
+++ b/keras/src/layers/preprocessing/index_lookup_test.py
@@ -634,11 +634,8 @@ class IndexLookupLayerTest(testing.TestCase):
         }
         layer = layers.IndexLookup(**kwargs)
         layer.adapt(adapt_data)
-
-        # Verify adapted vocabulary and idf_weights are set
         original_vocab = layer.get_vocabulary()
         original_idf_weights = layer.idf_weights.numpy()
-
         model = models.Sequential(
             [
                 layers.Input(shape=(None,), dtype="string"),
@@ -648,20 +645,12 @@ class IndexLookupLayerTest(testing.TestCase):
         output_1 = model(batch_input_data)
         path = os.path.join(self.get_temp_dir(), "model_tf_idf_adapted.keras")
         model.save(path)
-
-        # Load and verify vocabulary and weights are restored
         loaded_model = saving_api.load_model(path)
         loaded_layer = loaded_model.layers[0]
-
-        # Verify vocabulary is the same
         self.assertEqual(loaded_layer.get_vocabulary(), original_vocab)
-
-        # Verify idf_weights are restored correctly
         self.assertAllClose(
             loaded_layer.idf_weights.numpy(), original_idf_weights
         )
-
-        # Verify outputs match
         output_2 = loaded_model(batch_input_data)
         self.assertAllClose(output_1, output_2)
 
@@ -684,6 +673,8 @@ class IndexLookupLayerTest(testing.TestCase):
             "idf_weights": idf_weights,
         }
         layer = layers.IndexLookup(**kwargs)
+        original_vocab = layer.get_vocabulary()
+        original_idf_weights = layer.idf_weights.numpy()
         model = models.Sequential(
             [
                 layers.Input(shape=(None,), dtype="string"),
@@ -693,8 +684,13 @@ class IndexLookupLayerTest(testing.TestCase):
         output_1 = model(batch_input_data)
         path = os.path.join(self.get_temp_dir(), "model_tf_idf_preset.keras")
         model.save(path)
-        model = saving_api.load_model(path)
-        output_2 = model(batch_input_data)
+        loaded_model = saving_api.load_model(path)
+        loaded_layer = loaded_model.layers[0]
+        self.assertEqual(loaded_layer.get_vocabulary(), original_vocab)
+        self.assertAllClose(
+            loaded_layer.idf_weights.numpy(), original_idf_weights
+        )
+        output_2 = loaded_model(batch_input_data)
         self.assertAllClose(output_1, output_2)
 
     @pytest.mark.skipif(
@@ -714,11 +710,8 @@ class IndexLookupLayerTest(testing.TestCase):
         }
         layer = layers.IndexLookup(**kwargs)
         layer.adapt(adapt_data)
-
-        # Verify adapted vocabulary and idf_weights are set
         original_vocab = layer.get_vocabulary()
         original_idf_weights = layer.idf_weights.numpy()
-
         model = models.Sequential(
             [
                 layers.Input(shape=(None,), dtype="int64"),
@@ -730,20 +723,12 @@ class IndexLookupLayerTest(testing.TestCase):
             self.get_temp_dir(), "model_tf_idf_int_adapted.keras"
         )
         model.save(path)
-
-        # Load and verify vocabulary and weights are restored
         loaded_model = saving_api.load_model(path)
         loaded_layer = loaded_model.layers[0]
-
-        # Verify vocabulary is the same
         self.assertEqual(loaded_layer.get_vocabulary(), original_vocab)
-
-        # Verify idf_weights are restored correctly
         self.assertAllClose(
             loaded_layer.idf_weights.numpy(), original_idf_weights
         )
-
-        # Verify outputs match
         output_2 = loaded_model(batch_input_data)
         self.assertAllClose(output_1, output_2)
 
@@ -766,6 +751,8 @@ class IndexLookupLayerTest(testing.TestCase):
             "idf_weights": idf_weights,
         }
         layer = layers.IndexLookup(**kwargs)
+        original_vocab = layer.get_vocabulary()
+        original_idf_weights = layer.idf_weights.numpy()
         model = models.Sequential(
             [
                 layers.Input(shape=(None,), dtype="int64"),
@@ -777,8 +764,13 @@ class IndexLookupLayerTest(testing.TestCase):
             self.get_temp_dir(), "model_tf_idf_int_preset.keras"
         )
         model.save(path)
-        model = saving_api.load_model(path)
-        output_2 = model(batch_input_data)
+        loaded_model = saving_api.load_model(path)
+        loaded_layer = loaded_model.layers[0]
+        self.assertEqual(loaded_layer.get_vocabulary(), original_vocab)
+        self.assertAllClose(
+            loaded_layer.idf_weights.numpy(), original_idf_weights
+        )
+        output_2 = loaded_model(batch_input_data)
         self.assertAllClose(output_1, output_2)
 
     @pytest.mark.skipif(
@@ -799,6 +791,8 @@ class IndexLookupLayerTest(testing.TestCase):
         }
         layer = layers.IndexLookup(**kwargs)
         layer.adapt(adapt_data)
+        original_vocab = layer.get_vocabulary()
+        original_idf_weights = layer.idf_weights.numpy()
         model = models.Sequential(
             [
                 layers.Input(shape=(None,), dtype="string"),
@@ -806,11 +800,15 @@ class IndexLookupLayerTest(testing.TestCase):
             ]
         )
         output_1 = model(batch_input_data)
-        # Verify output has padded shape
         self.assertEqual(output_1.shape[-1], 10)
         path = os.path.join(self.get_temp_dir(), "model_tf_idf_padded.keras")
         model.save(path)
-        model = saving_api.load_model(path)
-        output_2 = model(batch_input_data)
+        loaded_model = saving_api.load_model(path)
+        loaded_layer = loaded_model.layers[0]
+        self.assertEqual(loaded_layer.get_vocabulary(), original_vocab)
+        self.assertAllClose(
+            loaded_layer.idf_weights.numpy(), original_idf_weights
+        )
+        output_2 = loaded_model(batch_input_data)
         self.assertAllClose(output_1, output_2)
         self.assertEqual(output_2.shape[-1], 10)


### PR DESCRIPTION
Fixes #22004 
## Problem

When saving and loading models with `IndexLookup`, `StringLookup`, `IntegerLookup`, or `TextVectorization` layers that use `output_mode="tf_idf"`, the model would fail to load with an error because `idf_weights` weren't properly initialized during deserialization.

The issue occurs because:
1. `load_own_variables()` is called before `load_assets()` during model loading
2. `load_own_variables()` expects `self.idf_weights` to exist, but it was only created when a vocabulary was provided at construction
3. The previous code in `load_assets()` tried to call `set_vocabulary(values, idf_weights=False)`, which would fail validation since `idf_weights=None` is required for tf-idf mode

## Fix

1. When `output_mode="tf_idf"` but no vocabulary is provided at construction, create a placeholder `idf_weights` variable with dynamic shape. This ensures the variable exists when `load_own_variables()` is called.

2.  In `load_assets()`, extract the already-loaded IDF weights (loaded via `load_own_variables()`) and pass them correctly to `set_vocabulary()` instead of passing `False`.

## Test Coverage
Added 6 new tests to verify save/load works correctly for tf-idf mode:
- `test_save_load_tf_idf_adapted` for IntegerLookup
- `test_save_load_tf_idf_preset_vocabulary` for IntegerLookup
- `test_save_load_tf_idf_adapted` for StringLookup
- `test_save_load_tf_idf_preset_vocabulary` for StringLookup
- `test_save_load_tf_idf_adapted_vocabulary` for TextVectorization
- `test_save_load_tf_idf_preset_vocabulary` for TextVectorization

Ran the tests and the keras test suite. Also ran the minimal error creating code documented in #22004, now it runs without errors. All tests pass successfully. This change is fully backward compatible, and models without tf-idf continue to work as before. The fix only affects the save/load path for tf-idf models, which was broken.