### PR TITLE
Add RandomRotation segmentation example (fill_mode constant vs crop)

### DIFF
--- a/examples/vision/random_rotation_segmentation.py
+++ b/examples/vision/random_rotation_segmentation.py
@@ -1,0 +1,83 @@
+"""
+RandomRotation with segmentation masks (Keras 3).
+
+This example demonstrates how keras.layers.RandomRotation behaves
+when applied to images and segmentation masks using structured
+dictionary inputs.
+
+We compare:
+- fill_mode="constant": introduces border fill values
+- fill_mode="crop": removes border artifacts by cropping the valid region
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from keras import layers, ops
+
+
+def create_sample():
+    image = np.zeros((128, 128, 1), dtype="float32")
+    image[32:96, 32:96, 0] = 1.0
+
+    mask = np.zeros((128, 128, 1), dtype="int32")
+    mask[32:96, 32:96, 0] = 1
+
+    return image, mask
+
+
+def apply_rotation(layer, image, mask):
+    inputs = {
+        "images": ops.expand_dims(image, axis=0),
+        "segmentation_masks": ops.expand_dims(mask, axis=0),
+    }
+
+    outputs = layer(inputs, training=True)
+
+    return (
+        ops.squeeze(outputs["images"], axis=0),
+        ops.squeeze(outputs["segmentation_masks"], axis=0),
+    )
+
+
+def show(image, mask, title):
+    fig, axs = plt.subplots(1, 2, figsize=(6, 3))
+
+    axs[0].imshow(image[..., 0], cmap="gray")
+    axs[0].set_title("Image")
+    axs[0].axis("off")
+
+    axs[1].imshow(mask[..., 0], cmap="gray")
+    axs[1].set_title("Segmentation Mask")
+    axs[1].axis("off")
+
+    fig.suptitle(title)
+    plt.tight_layout()
+    plt.show()
+
+
+def main():
+    image, mask = create_sample()
+
+    rotation_constant = layers.RandomRotation(
+        factor=0.4,
+        fill_mode="constant",
+        fill_value=0.0,
+        seed=42,
+    )
+
+    rotation_crop = layers.RandomRotation(
+        factor=0.4,
+        fill_mode="crop",
+        seed=42,
+    )
+
+    img_const, mask_const = apply_rotation(rotation_constant, image, mask)
+    img_crop, mask_crop = apply_rotation(rotation_crop, image, mask)
+
+    show(image, mask, "Original")
+    show(img_const, mask_const, 'RandomRotation(fill_mode="constant")')
+    show(img_crop, mask_crop, 'RandomRotation(fill_mode="crop")')
+
+
+if __name__ == "__main__":
+    main()

--- a/keras/src/layers/preprocessing/image_preprocessing/random_rotation.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_rotation.py
@@ -75,6 +75,38 @@ class RandomRotation(BaseImagePreprocessingLayer):
             `image_data_format` value found in your Keras config file at
             `~/.keras/keras.json`. If you never set it, then it will be
             `"channels_last"`.
+    Examples:
+
+    Basic image rotation:
+
+    >>> import tensorflow as tf
+    >>> from keras import layers
+    >>> images = tf.random.uniform((2, 128, 128, 3))
+    >>> layer = layers.RandomRotation(factor=0.2)
+    >>> output = layer(images)
+    >>> output.shape
+    TensorShape([2, 128, 128, 3])
+
+    Synchronized image and segmentation mask rotation:
+
+    >>> images = tf.random.uniform((1, 128, 128, 3))
+    >>> masks = tf.random.uniform(
+    ...     (1, 128, 128, 1), maxval=2, dtype=tf.int32
+    ... )
+    >>> data = {
+    ...     "images": images,
+    ...     "segmentation_masks": masks,
+    ... }
+    >>> layer = layers.RandomRotation(
+    ...     factor=0.25,
+    ...     fill_mode="crop"
+    ... )
+    >>> output = layer(data)
+    >>> output["images"].shape
+    TensorShape([1, 128, 128, 3])
+    >>> output["segmentation_masks"].shape
+    TensorShape([1, 128, 128, 1])
+
     """
 
     _SUPPORTED_FILL_MODE = ("reflect", "wrap", "constant", "nearest")


### PR DESCRIPTION
This PR adds a visual keras-io example demonstrating how
keras.layers.RandomRotation behaves for segmentation tasks.

It compares fill_mode="constant" vs fill_mode="crop" using
structured dict inputs to ensure synchronized transforms
for images and segmentation masks.

Related to keras-team/keras#21954

cc @innat @mattdangerw
