### PR TITLE
Fix typo in contrast adjustment method

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/random_contrast.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_contrast.py
@@ -92,8 +92,8 @@ class RandomContrast(BaseImagePreprocessingLayer):
 
     def transform_images(self, images, transformation, training=True):
         if training:
-            constrast_factor = transformation["contrast_factor"]
-            outputs = self._adjust_constrast(images, constrast_factor)
+            contrast_factor = transformation["contrast_factor"]
+            outputs = self._adjust_contrast(images, contrast_factor)
             outputs = self.backend.numpy.clip(
                 outputs, self.value_range[0], self.value_range[1]
             )
@@ -117,7 +117,7 @@ class RandomContrast(BaseImagePreprocessingLayer):
     ):
         return segmentation_masks
 
-    def _adjust_constrast(self, inputs, contrast_factor):
+    def _adjust_contrast(self, inputs, contrast_factor):
         if self.data_format == "channels_first":
             height_axis = -2
             width_axis = -1


### PR DESCRIPTION
while working on #21978 i noticed in  `random_contrast.py` that contrast was mispelled as constrast. thought to fix that typo there only but i feel a fresh pr is better for this.