### PR TITLE
Refactor ExtractPatches to handle both 2D and 3D

### DIFF
--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -622,6 +622,15 @@ class ExtractPatches(Operation):
                 out_shape = out_shape[1:]
         return KerasTensor(shape=out_shape, dtype=images.dtype)
 
+    def get_config(self):
+        return {
+            "size": self.size,
+            "strides": self.strides,
+            "dilation_rate": self.dilation_rate,
+            "padding": self.padding,
+            "data_format": self.data_format,
+        }
+
 
 @keras_export("keras.ops.image.extract_patches")
 def extract_patches(


### PR DESCRIPTION
Follow-up to #21980 as requested by hertschuh.

## Summary
Consolidates ExtractPatches and ExtractPatches3D into a single unified class that handles both 2D and 3D patch extraction.

## Changes
- Renamed _extract_patches to _extract_patches_2d
- Created new _extract_patches dispatcher that routes to _extract_patches_2d or _extract_patches_3d based on size argument
- Updated ExtractPatches class to handle both 2D and 3D via is_3d flag
- Simplified extract_patches function to use single code path
- Removed ExtractPatches3D class

## Tests
All existing extract_patches tests pass.