### PR TITLE
docs: Add guide on device placement using keras.device()

### DIFF
--- a/keras/src/backend/__init__.py
+++ b/keras/src/backend/__init__.py
@@ -82,9 +82,10 @@ def device(device_name):
     multi-device setups.
 
     Args:
-        device_name: String specifying the device in format `"device_type:device_index"`.
-            For example: `"cpu:0"`, `"gpu:0"`, `"gpu:1"`.
-            For PyTorch backend, `"gpu"` is automatically converted to `"cuda"`.
+        device_name: String specifying the device in format
+            `"device_type:device_index"`. For example: `"cpu:0"`, `"gpu:0"`,
+            `"gpu:1"`. For the PyTorch backend, `"gpu"` is automatically
+            converted to `"cuda"`.
 
     Example:
 
@@ -127,8 +128,8 @@ def device(device_name):
     Use cases:
 
     - **Memory management**: Keep large tensors on CPU to save GPU memory
-    - **Data preprocessing**: Process data on CPU before moving to GPU for training
-    - **GPU / TPU setups**: Control what runs on GPU / TPU vs CPU 
+    - **Data preprocessing**: Process data on CPU before training on GPU
+    - **GPU / TPU setups**: Control what runs on GPU / TPU vs CPU
     - **Multi-device setups**: Control which device receives which tensors
 
     Device naming conventions:


### PR DESCRIPTION
This PR adds documentation for the keras.device() context manager, which provides backend-agnostic device placement for tensor allocation.

Changes
Added a new section "Controlling device placement" to 
guides/training_with_built_in_methods.py
 that covers:

Using the device context manager - Basic usage with code examples
Device naming conventions - Explains the device_type:device_index format
Practical examples - CPU preprocessing with GPU training pattern
Motivation
This addresses issue #21988 where a user requested backend-agnostic device placement. The functionality already exists via keras.device() but was not documented in the guides.

Related Issues
Closes #21988