### PR TITLE
TPU tests now verify that we can detect TPUs and fails it not.

### DIFF
--- a/.github/workflows/tpu_tests.yml
+++ b/.github/workflows/tpu_tests.yml
@@ -36,18 +36,13 @@ jobs:
         uses: actions/checkout@v6.0.1
       
       - name: Install Dependencies
-        run: |
-          pip install --no-cache-dir -r requirements-${{ matrix.backend }}-tpu.txt \
+        run: pip install --no-cache-dir -r requirements-${{ matrix.backend }}-tpu.txt
       
       - name: Set Keras Backend
         run: echo "KERAS_BACKEND=jax" >> $GITHUB_ENV
 
-      - name: Run Verification and Tests
-        run: |
-          echo "Successfully running inside the public python container!"
-          echo "Verifying JAX installation..."
-          python3 -c "import jax; print(f'JAX backend: {jax.default_backend()}'); print(f'JAX devices : {jax.devices()}')"
+      - name: Verify JAX Installation
+        run: python3 -c "import jax; print('JAX devices:', jax.devices()); assert jax.default_backend() == 'tpu'"
 
-          pytest keras --ignore keras/src/applications \
-                      --cov=keras \
-                      --cov-config=pyproject.toml
+      - name: Run Tests
+        run: pytest keras --ignore keras/src/applications --cov=keras --cov-config=pyproject.toml


### PR DESCRIPTION
This is to prevent silently falling back to running tests on CPU and thinking the tests pass on TPU.

Also some minor cleanup of the workflow file.