### PR TITLE
Unpin as many Python packages versions as possible.

### DIFF
--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,10 +1,10 @@
 # Tensorflow cpu-only version (needed for testing).
-tensorflow-cpu~=2.20.0
+tensorflow-cpu
 tf2onnx
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.9.1+cpu
+torch
 
 # Jax with cuda support.
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html

--- a/requirements-jax-tpu.txt
+++ b/requirements-jax-tpu.txt
@@ -1,10 +1,10 @@
 # Tensorflow cpu-only version (needed for testing).
-tensorflow-cpu~=2.20.0
+tensorflow-cpu
 tf2onnx
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.9.1+cpu
+torch
 
 # Jax with cuda support.
 --find-links https://storage.googleapis.com/jax-releases/libtpu_releases.html

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,5 +1,5 @@
 # Tensorflow with cuda support.
-tensorflow[and-cuda]~=2.20.0
+tensorflow[and-cuda]
 tf2onnx
 # This is the only version which works with TF 2.20.0.
 # TODO(#21914): Update this version when TF is updated.
@@ -7,7 +7,7 @@ ai-edge-litert==1.3.0
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.9.1+cpu
+torch
 
 # Jax cpu-only version (needed for testing).
 jax[cpu]

--- a/requirements-tensorflow-tpu.txt
+++ b/requirements-tensorflow-tpu.txt
@@ -6,7 +6,7 @@ tf2onnx
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.9.1+cpu
+torch
 
 # Jax cpu-only version (needed for testing).
 jax

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,12 +1,12 @@
 # Tensorflow cpu-only version (needed for testing).
-tensorflow-cpu~=2.20.0
+tensorflow-cpu
 tf2onnx
 
 # Torch with cuda support.
 # - torch is pinned to a version that is compatible with torch-xla.
 --extra-index-url https://download.pytorch.org/whl/cu126
-torch==2.9.1+cu126
-torch-xla==2.9.0;sys_platform != 'darwin'
+torch
+torch-xla;sys_platform != 'darwin'
 
 # Jax cpu-only version (needed for testing).
 jax[cpu]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Tensorflow.
 # Note: when the version of Tensorflow is changed, the version tf_keras must be
 # changed in .github/workflows/actions.yml (pip install --no-deps tf_keras).
-tensorflow-cpu~=2.20.0;sys_platform != 'darwin'
-tensorflow~=2.20.0;sys_platform == 'darwin'
+tensorflow-cpu;sys_platform != 'darwin'
+tensorflow;sys_platform == 'darwin'
 tf2onnx
 # This is the only version which works with TF 2.20.0.
 # TODO(#21914): Update this version when TF is updated.
@@ -10,14 +10,14 @@ ai-edge-litert==1.3.0;sys_platform != 'win32'
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.9.1+cpu
-torch-xla==2.9.0;sys_platform != 'darwin'
+torch
+torch-xla;sys_platform != 'darwin'
 
 # Jax.
 # Pinned to 0.8.0 on CPU for CI compatibility with older backends.
 # Note that we test against the latest JAX on GPU.
-jax[cpu]==0.8.1
-flax==0.12.2
+jax[cpu]
+flax
 
 # Common deps.
 -r requirements-common.txt


### PR DESCRIPTION
in the requirements*.txt file.

This is to:
- workaround this Dependabot issue with the torch package: https://github.com/dependabot/dependabot-core/issues/13887
- catch breakages as soon as possible