### PR TITLE
Disallow TFSMLayer deserialization in safe_mode to prevent external SavedModel execution

### DIFF
--- a/keras/src/export/tfsm_layer.py
+++ b/keras/src/export/tfsm_layer.py
@@ -174,7 +174,9 @@ class TFSMLayer(layers.Layer):
             A TFSMLayer instance.
         """
         # Follow the same pattern as Lambda layer for safe_mode handling
-        safe_mode = safe_mode or serialization_lib.in_safe_mode()
+        effective_safe_mode = safe_mode if safe_mode is not None else serialization_lib.in_safe_mode()
+
+        if effective_safe_mode is not False:
 
         if safe_mode:
             raise ValueError(


### PR DESCRIPTION
TFSMLayer currently loads external TensorFlow SavedModels during deserialization
without respecting Keras `safe_mode`. Although TensorFlow does not execute
SavedModel functions at load time, the attacker-controlled graph is registered
during deserialization and executed during normal model invocation, violating
the security guarantees of `safe_mode=True`.

This change disallows instantiation of `TFSMLayer` when `safe_mode` is enabled,
both during direct construction and during deserialization via `from_config()`.
This matches the existing security model used by other potentially unsafe Keras
components (e.g. Lambda layers) and prevents loading of untrusted executable
graph artifacts without explicit user opt-in.

Specifically:
- Add a `safe_mode` check in `TFSMLayer.__init__` to prevent loading external
  SavedModels when unsafe deserialization is not explicitly enabled.
- Override `from_config()` to block deserialization of `TFSMLayer` when
  `safe_mode=True`, preventing config-based gadget abuse.
- Provide clear error messages guiding users to explicitly opt out via
  `safe_mode=False` or `keras.config.enable_unsafe_deserialization()` when the
  source is trusted.

This change preserves backward compatibility for trusted workflows while
closing a safe_mode bypass that could otherwise lead to attacker-controlled
graph execution during inference.

Security report:
https://huntr.com/bounties/7e78d6f1-6977-4300-b595-e81bdbda331c