### PR TITLE
Torch dynamic shapes

### DIFF
--- a/keras/src/export/onnx_test.py
+++ b/keras/src/export/onnx_test.py
@@ -111,9 +111,6 @@ class ExportONNXTest(testing.TestCase):
         }
         self.assertAllClose(ref_output, ort_session.run(None, ort_inputs)[0])
         # Test with a different batch size
-        if backend.backend() == "torch":
-            # TODO: Dynamic shape is not supported yet in the torch backend
-            return
         ort_inputs = {
             k.name: v
             for k, v in zip(
@@ -193,9 +190,6 @@ class ExportONNXTest(testing.TestCase):
         onnx.export_onnx(revived_model, temp_filepath)
 
         # Test with a different batch size
-        if backend.backend() == "torch":
-            # TODO: Dynamic shape is not supported yet in the torch backend
-            return
         bigger_ref_input = tree.map_structure(
             lambda x: np.concatenate([x, x], axis=0), ref_input
         )
@@ -238,9 +232,6 @@ class ExportONNXTest(testing.TestCase):
         }
         self.assertAllClose(ref_output, ort_session.run(None, ort_inputs)[0])
         # Test with a different batch size
-        if backend.backend() == "torch":
-            # TODO: Dynamic shape is not supported yet in the torch backend
-            return
         ort_inputs = {
             k.name: v
             for k, v in zip(

--- a/keras/src/export/saved_model_test.py
+++ b/keras/src/export/saved_model_test.py
@@ -78,9 +78,6 @@ class ExportSavedModelTest(testing.TestCase):
         revived_model = tf.saved_model.load(temp_filepath)
         self.assertAllClose(ref_output, revived_model.serve(ref_input))
         # Test with a different batch size
-        if backend.backend() == "torch":
-            # TODO: Dynamic shape is not supported yet in the torch backend
-            return
         revived_model.serve(tf.random.normal((6, 10)))
 
     @parameterized.named_parameters(
@@ -171,9 +168,6 @@ class ExportSavedModelTest(testing.TestCase):
         revived_model = tf.saved_model.load(temp_filepath)
         self.assertAllClose(ref_output, revived_model.serve(ref_input))
         # Test with a different batch size
-        if backend.backend() == "torch":
-            # TODO: Dynamic shape is not supported yet in the torch backend
-            return
         revived_model.serve(tf.random.normal((6, 10)))
 
     @parameterized.named_parameters(
@@ -233,9 +227,6 @@ class ExportSavedModelTest(testing.TestCase):
         saved_model.export_saved_model(revived_model, self.get_temp_dir())
 
         # Test with a different batch size
-        if backend.backend() == "torch":
-            # TODO: Dynamic shape is not supported yet in the torch backend
-            return
         bigger_input = tree.map_structure(
             lambda x: tf.concat([x, x], axis=0), ref_input
         )
@@ -262,9 +253,6 @@ class ExportSavedModelTest(testing.TestCase):
             ref_output, revived_model.serve(ref_input_x, ref_input_y)
         )
         # Test with a different batch size
-        if backend.backend() == "torch":
-            # TODO: Dynamic shape is not supported yet in the torch backend
-            return
         revived_model.serve(
             tf.random.normal((6, 10)), tf.random.normal((6, 10))
         )


### PR DESCRIPTION
## Description

Implements dynamic shape support for the torch backend export, addressing the TODO in keras/src/backend/torch/export.py.

Previously, exporting models with the torch backend would bake in fixed shapes, causing tests with different batch sizes to fail.

## Changes

- Modified track_and_add_endpoint in keras/src/backend/torch/export.py to:
  - Build dynamic_shapes from input_signature where shape has None
  - Use torch.export.Dim to mark dynamic dimensions
  - Changed replace_none_number from 1 to 2 to avoid torch dimension specialization
- Removed early returns in tests that were skipping dynamic shape verification:
  - keras/src/export/saved_model_test.py
  - keras/src/export/onnx_test.py