### PR TITLE
Add bias support to `dot_product_attention` for torch backend.

### DIFF
--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -2492,9 +2492,14 @@ class NNOpsCorrectnessTest(testing.TestCase):
             mask = mask[None, None, ...]
             mask = np.tile(mask, (2, 4, 1, 1))
         if bias is not None:
-            if backend.backend() in ("torch", "openvino"):
+            if backend.backend() == "openvino":
                 self.skipTest(
-                    "torch and openvino do not support `bias` with "
+                    "openvino does not support `bias` with "
+                    "`dot_product_attention`"
+                )
+            if backend.backend() == "torch" and mask is not None:
+                self.skipTest(
+                    "torch does not support `mask` and `bias` with "
                     "`dot_product_attention`"
                 )
             bias = np.arange(math.prod(bias_shape), dtype=float).reshape(
@@ -2510,6 +2515,11 @@ class NNOpsCorrectnessTest(testing.TestCase):
             elif backend.backend() == "torch":
                 import torch
 
+                if bias is not None:
+                    self.skipTest(
+                        "Flash attention doesn't support `bias` in torch "
+                        "backend."
+                    )
                 if mask is not None:
                     self.skipTest(
                         "Flash attention doesn't support `mask=None` in torch "


### PR DESCRIPTION
According to https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html

`scaled_dot_product_attention` uses the `attn_mask` to handle both masks and attention biases. This PR adds support for a `bias` argument by leveraging this functionality.

The tests have been updated.