### PR TITLE
Fix incorrect example in `ops.associative_scan` docstring

### DIFF
--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -277,7 +277,7 @@ def associative_scan(f, elems, reverse=False, axis=0):
     [0, 1, 3, 6, 10]
 
     >>> sum_fn = lambda x, y: [x[0] + y[0], x[1] + y[1], x[2] + y[2]]
-    >>> xs = [keras.ops.array([[1, 2]]) for _ in range(3)]
+    >>> xs = [keras.ops.array([1, 2]) for _ in range(3)]
     >>> ys = keras.ops.associative_scan(sum_fn, xs, axis=0)
     >>> ys
     [[1, 3], [1, 3], [1, 3]]


### PR DESCRIPTION

This PR fixes an incorrect example in the `ops.associative_scan` docstring.

In the second example:
```python
>>> sum_fn = lambda x, y: [x[0] + y[0], x[1] + y[1], x[2] + y[2]]
>>> xs = [keras.ops.array([[1, 2]]) for _ in range(3)]
>>> ys = keras.ops.associative_scan(sum_fn, xs, axis=0)
>>> ys
[[1, 3], [1, 3], [1, 3]]
```
 it uses arrays with shape `(1, 2)` and `axis=0`, which is not a valid demonstration of an associative scan and does not correctly return the expected results shown in the example.

The changes in this PR:

```python
# Before (incorrect)
xs = [keras.ops.array([[1, 2]]) for _ in range(3)]

# After (correct)
xs = [keras.ops.array([1, 2]) for _ in range(3)]
```

While testing this fix, I discovered a related bug in the TensorFlow backend where the function enters infinite recursion when the scan axis dimension size is 0 or 1. See issue #22050  for details.