### PR TITLE
Implement round and divide_no_nan ops for OpenVINO backend

### DIFF
--- a/keras/src/backend/common/variables_test.py
+++ b/keras/src/backend/common/variables_test.py
@@ -819,9 +819,6 @@ class VariableOpsCorrectnessTest(test_case.TestCase):
         result = v2**v1
         self.assertAllClose(result, np.array([4.0, 25.0, 216.0]))
 
-    @skip_if_backend(
-        "openvino", "`round` is not supported with openvino backend"
-    )
     def test_round(self):
         v = backend.Variable(initializer=np.array([1.1, 2.2, 3.3]))
         self.assertAllClose(round(v), np.array([1.0, 2.0, 3.0]))

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -26,7 +26,6 @@ NumpyDtypeTest::test_nextafter
 NumpyDtypeTest::test_power
 NumpyDtypeTest::test_ptp
 NumpyDtypeTest::test_quantile
-NumpyDtypeTest::test_round
 NumpyDtypeTest::test_searchsorted
 NumpyDtypeTest::test_signbit
 NumpyDtypeTest::test_std
@@ -55,7 +54,6 @@ NumpyOneInputOpsCorrectnessTest::test_nanmin
 NumpyOneInputOpsCorrectnessTest::test_nansum
 NumpyOneInputOpsCorrectnessTest::test_real
 NumpyOneInputOpsCorrectnessTest::test_reshape
-NumpyOneInputOpsCorrectnessTest::test_round
 NumpyOneInputOpsCorrectnessTest::test_ptp
 NumpyOneInputOpsCorrectnessTest::test_searchsorted
 NumpyOneInputOpsCorrectnessTest::test_signbit
@@ -72,7 +70,6 @@ NumpyTwoInputOpsCorrectnessTest::test_bitwise_or
 NumpyTwoInputOpsCorrectnessTest::test_bitwise_right_shift
 NumpyTwoInputOpsCorrectnessTest::test_bitwise_xor
 NumpyTwoInputOpsCorrectnessTest::test_cross
-NumpyTwoInputOpsCorrectnessTest::test_divide_no_nan
 NumpyTwoInputOpsCorrectnessTest::test_einsum
 NumpyTwoInputOpsCorrectnessTest::test_gcd
 NumpyTwoInputOpsCorrectnessTest::test_inner

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -2682,7 +2682,23 @@ def tensordot(x1, x2, axes=2):
 
 
 def round(x, decimals=0):
-    raise NotImplementedError("`round` is not supported with openvino backend")
+    x = get_ov_output(x)
+    x_type = x.get_element_type()
+    if x_type.is_integral() or x_type == Type.boolean:
+        x = ov_opset.convert(x, OPENVINO_DTYPES[config.floatx()])
+
+    if decimals == 0:
+        result = ov_opset.round(x, "half_to_even")
+    else:
+        factor = ov_opset.constant(10.0**decimals, x.get_element_type())
+        scaled = ov_opset.multiply(x, factor)
+        rounded = ov_opset.round(scaled, "half_to_even")
+        result = ov_opset.divide(rounded, factor)
+
+    if x_type.is_integral():
+        result = ov_opset.convert(result, x_type)
+
+    return OpenVINOKerasTensor(result.output(0))
 
 
 def tile(x, repeats):
@@ -2859,9 +2875,20 @@ def divide(x1, x2):
 
 
 def divide_no_nan(x1, x2):
-    raise NotImplementedError(
-        "`divide_no_nan` is not supported with openvino backend"
-    )
+    element_type = None
+    if isinstance(x1, OpenVINOKerasTensor):
+        element_type = x1.output.get_element_type()
+    if isinstance(x2, OpenVINOKerasTensor):
+        element_type = x2.output.get_element_type()
+    x1 = get_ov_output(x1, element_type)
+    x2 = get_ov_output(x2, element_type)
+    x1, x2 = _align_operand_types(x1, x2, "divide_no_nan()")
+
+    zero = ov_opset.constant(0, x2.get_element_type())
+    div = ov_opset.divide(x1, x2)
+    is_zero = ov_opset.equal(x2, zero)
+    result = ov_opset.select(is_zero, zero, div)
+    return OpenVINOKerasTensor(result.output(0))
 
 
 def true_divide(x1, x2):


### PR DESCRIPTION
Implemented round & divide_no_nan function for OpenVINO backend.
Tests are now included and passing.