### PR TITLE
Add SSIM  to keras.ops.image

### DIFF
--- a/keras/api/_tf_keras/keras/ops/image/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/image/__init__.py
@@ -18,3 +18,4 @@ from keras.src.ops.image import resize as resize
 from keras.src.ops.image import rgb_to_grayscale as rgb_to_grayscale
 from keras.src.ops.image import rgb_to_hsv as rgb_to_hsv
 from keras.src.ops.image import scale_and_translate as scale_and_translate
+from keras.src.ops.image import ssim as ssim

--- a/keras/api/ops/image/__init__.py
+++ b/keras/api/ops/image/__init__.py
@@ -18,3 +18,4 @@ from keras.src.ops.image import resize as resize
 from keras.src.ops.image import rgb_to_grayscale as rgb_to_grayscale
 from keras.src.ops.image import rgb_to_hsv as rgb_to_hsv
 from keras.src.ops.image import scale_and_translate as scale_and_translate
+from keras.src.ops.image import ssim as ssim


### PR DESCRIPTION
## Description
Adds keras.ops.image.ssim to compute the Structural Similarity Index (SSIM) between images, addressing #18428.
## Changes

Added ssim function to keras.ops.image
Uses Gaussian filter (11x11, sigma=1.5) matching TensorFlow's implementation
Supports both channels_last and channels_first data formats
Added tests for dynamic shapes and correctness against tf.image.ssim