### PR TITLE
Do not allow external links in HDF5 files.

### DIFF
--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -509,8 +509,14 @@ class KerasFileEditor:
             # ------------------------------------------------------
 
             # Skip any objects that are not proper datasets
-            if not hasattr(value, "shape") or not hasattr(value, "dtype"):
+            if not isinstance(value, h5py.Dataset):
                 continue
+
+            if value.external:
+                raise ValueError(
+                    "Not allowed: H5 file Dataset with external links: "
+                    f"{value.external}"
+                )
 
             shape = value.shape
             dtype = value.dtype

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1319,24 +1319,6 @@ class SavingH5IOStoreTest(testing.TestCase):
         for key in ["a", "b"]:
             self.assertIn(key, vars_store.keys())
 
-        # Items.
-        for key, value in vars_store.items():
-            if key == "a":
-                self.assertAllClose(value, a)
-            elif key == "b":
-                self.assertAllClose(value, b)
-            else:
-                raise ValueError(f"Unexpected key: {key}")
-
-        # Values.
-        for value in vars_store.values():
-            if backend.standardize_dtype(value.dtype) == "float32":
-                self.assertAllClose(value, a)
-            elif backend.standardize_dtype(value.dtype) == "int32":
-                self.assertAllClose(value, b)
-            else:
-                raise ValueError(f"Unexpected value: {value}")
-
     def test_sharded_h5_io_store_exception_raised(self):
         temp_filepath = Path(os.path.join(self.get_temp_dir(), "store.h5"))
 


### PR DESCRIPTION
Keras never uses this feature.

- verify that we get H5 Groups when expected, otherwise, merely by doing `[key]` we may be loading an external Dataset.
- verify that the H5 Datasets are not external links and fail if they are.
- remove unused methods `items` and `values` in `H5IOStore` and `ShardedH5IOStore`. They are not used, the implementation of `MutableMapping` was incomplete anyway and these methods we return unverified Datasets.
- fixed logic related to `failed_saveables` in `load_state`.
- preserve the order of keys in the implementation of `ShardedH5IOStore.keys()`.