### PR TITLE
Add `Muon` to the list of all optimizer classes.

### DIFF
--- a/keras/src/optimizers/__init__.py
+++ b/keras/src/optimizers/__init__.py
@@ -25,6 +25,7 @@ ALL_OBJECTS = {
     Adagrad,
     Adamax,
     Adafactor,
+    Muon,
     Nadam,
     Ftrl,
     Lion,


### PR DESCRIPTION
This allows referring to `Muon` by the string `"muon"` for instance in `compile`.

Note that the class `Muon` was already imported.