### PR TITLE
Unify the way tests are skipped.

### DIFF
--- a/keras/src/backend/common/remat_test.py
+++ b/keras/src/backend/common/remat_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from keras.src import backend
 from keras.src import layers
@@ -11,10 +12,6 @@ from keras.src.layers import activations
 
 
 class TestRematScope(testing.TestCase):
-    def setUp(self):
-        """Reset global state before each test."""
-        global_state.clear_session()
-
     def test_remat_scope_activation(self):
         self.assertIsNone(
             get_current_remat_mode()
@@ -81,12 +78,12 @@ class TestRematScope(testing.TestCase):
             RematScope(mode="invalid")  # Invalid mode should raise ValueError
 
 
+@pytest.mark.skipif(
+    backend.backend() in ("openvino", "numpy"),
+    reason="remat not supported on OpenVino and Numpy",
+)
 class RematTest(testing.TestCase):
     def test_remat_basic_call(self):
-        if backend.backend() in ("openvino", "numpy"):
-            self.skipTest(
-                "remat is not supported in openvino and numpy backends."
-            )
         # Generate dummy data
         data_size = 10**5
         x_train = np.random.normal(size=(data_size, 4))
@@ -118,11 +115,6 @@ class RematTest(testing.TestCase):
         )
 
     def test_remat_with_kwargs(self):
-        if backend.backend() in ("openvino", "numpy"):
-            self.skipTest(
-                "remat is not supported in openvino and numpy backends."
-            )
-
         # Define a function that uses keyword arguments
         def fn_with_kwargs(x, scale=1.0, offset=0.0):
             return x * scale + offset

--- a/keras/src/backend/common/variables_test.py
+++ b/keras/src/backend/common/variables_test.py
@@ -248,12 +248,10 @@ class VariablePropertiesTest(test_case.TestCase):
             )
         self.assertEqual(backend.standardize_dtype(v.value.dtype), "float32")
 
-    @parameterized.parameters(
-        *(
-            (
-                dtype
-                for dtype in dtypes.ALLOWED_DTYPES
-                if dtype not in ["string", "complex64", "complex28"]
+    @parameterized.named_parameters(
+        named_product(
+            dtype=(
+                dtype for dtype in dtypes.ALLOWED_DTYPES if dtype != "string"
             )
         )
     )

--- a/keras/src/backend/tests/device_scope_test.py
+++ b/keras/src/backend/tests/device_scope_test.py
@@ -5,13 +5,10 @@ from keras.src import testing
 
 
 class DeviceTest(testing.TestCase):
-    @pytest.mark.skipif(backend.backend() != "tensorflow", reason="tf only")
+    @pytest.mark.skipif(
+        not testing.tensorflow_uses_gpu(), reason="tf on GPU only"
+    )
     def test_tf_device_scope(self):
-        import tensorflow as tf
-
-        if not tf.config.list_physical_devices("GPU"):
-            self.skipTest("Need at least one GPU for testing")
-
         with backend.device("cpu:0"):
             t = backend.numpy.ones((2, 1))
             self.assertIn("CPU:0", t.device)
@@ -28,41 +25,34 @@ class DeviceTest(testing.TestCase):
             t = backend.numpy.ones((2, 1))
             self.assertIn("GPU:0", t.device)
 
-    @pytest.mark.skipif(backend.backend() != "jax", reason="jax only")
+    @pytest.mark.skipif(not testing.jax_uses_gpu(), reason="jax on GPU only")
     def test_jax_device_scope(self):
         import jax
 
-        def get_device(t):
-            # After updating to Jax 0.4.33, Directly access via t.device attr.
-            return list(t.devices())[0]
-
-        platform = jax.default_backend()
-
-        if platform != "gpu":
-            self.skipTest("Need at least one GPU for testing")
-
         with backend.device("cpu:0"):
             t = backend.numpy.ones((2, 1))
-            self.assertEqual(get_device(t), jax.devices("cpu")[0])
+            self.assertEqual(t.device, jax.devices("cpu")[0])
         with backend.device("CPU:0"):
             t = backend.numpy.ones((2, 1))
-            self.assertEqual(get_device(t), jax.devices("cpu")[0])
+            self.assertEqual(t.device, jax.devices("cpu")[0])
 
         # When leaving the scope, the device should be back with gpu:0
         t = backend.numpy.ones((2, 1))
-        self.assertEqual(get_device(t), jax.devices("gpu")[0])
+        self.assertEqual(t.device, jax.devices("gpu")[0])
 
         # Also verify the explicit gpu device
         with backend.device("gpu:0"):
             t = backend.numpy.ones((2, 1))
-            self.assertEqual(get_device(t), jax.devices("gpu")[0])
+            self.assertEqual(t.device, jax.devices("gpu")[0])
 
     @pytest.mark.skipif(backend.backend() != "jax", reason="jax only")
     def test_invalid_jax_device(self):
         with self.assertRaisesRegex(ValueError, "Received: device_name='123'"):
             backend.device(123).__enter__()
 
-    @pytest.mark.skipif(backend.backend() != "torch", reason="torch only")
+    @pytest.mark.skipif(
+        not testing.torch_uses_gpu(), reason="torch on GPU only"
+    )
     def test_torch_device_scope(self):
         import torch
 
@@ -72,10 +62,6 @@ class DeviceTest(testing.TestCase):
         with backend.device("CPU:0"):
             t = backend.numpy.ones((2, 1))
             self.assertEqual(t.device, torch.device("cpu"))
-
-        # Need at least one GPU for the following testing.
-        if not torch.cuda.is_available():
-            return
 
         # When leaving the scope, the device should be back with gpu:0
         t = backend.numpy.ones((2, 1))

--- a/keras/src/export/onnx_test.py
+++ b/keras/src/export/onnx_test.py
@@ -77,12 +77,7 @@ def get_model(type="sequential", input_shape=(10,), layer_list=None):
         "backends."
     ),
 )
-@pytest.mark.skipif(
-    testing.jax_uses_gpu()
-    or testing.tensorflow_uses_gpu()
-    or testing.torch_uses_gpu(),
-    reason="Fails on GPU",
-)
+@pytest.mark.skipif(testing.uses_gpu(), reason="Fails on GPU")
 @pytest.mark.skipif(
     np.version.version.startswith("2."),
     reason="ONNX export is currently incompatible with NumPy 2.0",

--- a/keras/src/layers/attention/grouped_query_attention_test.py
+++ b/keras/src/layers/attention/grouped_query_attention_test.py
@@ -60,6 +60,10 @@ class GroupedQueryAttentionTest(testing.TestCase):
             run_training_check=False,
         )
 
+    @pytest.mark.skipif(
+        backend.backend() not in ("jax", "torch"),
+        reason="Flash attention only supported on JAX and Torch",
+    )
     def test_basics_with_flash_attention(self):
         enable_flash_attention()
         init_kwargs = {
@@ -73,12 +77,7 @@ class GroupedQueryAttentionTest(testing.TestCase):
             "value_shape": (2, 4, 16),
         }
         expected_output_shape = (2, 8, 16)
-        if backend.backend() in ("tensorflow", "numpy"):
-            self.skipTest(
-                "Flash attention is not supported in tensorflow and numpy "
-                "backends."
-            )
-        elif backend.backend() == "torch":
+        if backend.backend() == "torch":
             try:
                 self.run_layer_test(
                     layers.GroupedQueryAttention,

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -68,14 +68,13 @@ class MultiHeadAttentionTest(testing.TestCase):
             run_training_check=False,
         )
 
+    @pytest.mark.skipif(
+        backend.backend() not in ("jax", "torch"),
+        reason="Flash attention only supported on JAX and Torch",
+    )
     def test_basics_with_flash_attention(self):
         enable_flash_attention()
-        if backend.backend() in ("tensorflow", "numpy"):
-            self.skipTest(
-                "Flash attention is not supported in tensorflow and numpy "
-                "backends."
-            )
-        elif backend.backend() == "torch":
+        if backend.backend() == "torch":
             try:
                 self.run_layer_test(
                     layers.MultiHeadAttention,

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -538,7 +538,9 @@ class DenseTest(testing.TestCase):
         ("int4", "int4_from_float32", 5),  # bias + kernel + scale + zero + gidx
         ("float8", "float8_from_float32", 8),
     )
-    @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_quantize_by_setting_dtype_policy(
         self, policy, expected_num_variables
     ):
@@ -585,7 +587,9 @@ class DenseTest(testing.TestCase):
         ("float8", "float8_from_mixed_bfloat16", 8, 0),
     )
     @pytest.mark.requires_trainable_backend
-    @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_quantize_dtype_argument(
         self, dtype, num_trainable_weights, num_non_trainable_weights
     ):
@@ -606,7 +610,9 @@ class DenseTest(testing.TestCase):
         ("int4", "int4", 3, 4, 7),  # +2 non-trainable for zero and g_idx
     )
     @pytest.mark.requires_trainable_backend
-    @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_quantize_lora_integration(
         self,
         mode,
@@ -694,7 +700,9 @@ class DenseTest(testing.TestCase):
             )
 
     @pytest.mark.requires_trainable_backend
-    @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_quantize_float8(self):
         import ml_dtypes
 
@@ -1229,11 +1237,11 @@ class DenseTest(testing.TestCase):
         ("per_channel_none", None),
         ("per_channel_neg1", -1),
     )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_quantization_block_size(self, block_size):
         """Test int4 quantization with different block_size configurations."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         input_dim, output_dim = 256, 64
         layer = layers.Dense(units=output_dim)
         layer.build((None, input_dim))
@@ -1269,11 +1277,11 @@ class DenseTest(testing.TestCase):
         ("grouped_block_128", 128),
         ("per_channel_none", None),
     )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_block_size_serialization(self, block_size):
         """Test that block_size is preserved through serialization."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         layer = layers.Dense(units=32)
         layer.build((None, 128))
 
@@ -1309,11 +1317,11 @@ class DenseTest(testing.TestCase):
         ("grouped_block_64", 64),
         ("per_channel", None),
     )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_block_size_with_lora(self, block_size):
         """Test int4 quantization with LoRA and different block_size."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         input_dim, output_dim = 128, 64
         layer = layers.Dense(units=output_dim)
         layer.build((None, input_dim))
@@ -1328,11 +1336,11 @@ class DenseTest(testing.TestCase):
         y = layer(x)
         self.assertEqual(y.shape, (2, output_dim))
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_grouped_vs_perchannel_scale_shapes(self):
         """Test that grouped and per-channel have different scale shapes."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         input_dim, output_dim = 256, 64
         block_size = 64
 
@@ -1360,11 +1368,11 @@ class DenseTest(testing.TestCase):
         ("grouped_block_64", 64),
         ("grouped_block_128", 128),
     )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_subchannel_g_idx_created(self, block_size):
         """Test that g_idx is created for sub-channel int4 quantization."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         input_dim, output_dim = 256, 64
         layer = layers.Dense(units=output_dim)
         layer.build((None, input_dim))
@@ -1382,11 +1390,11 @@ class DenseTest(testing.TestCase):
         expected_g_idx = np.arange(input_dim) // block_size
         self.assertAllClose(layer.g_idx, expected_g_idx)
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_perchannel_no_g_idx(self):
         """Test that per-channel int4 does NOT create g_idx."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         layer = layers.Dense(units=32)
         layer.build((None, 64))
 
@@ -1396,11 +1404,11 @@ class DenseTest(testing.TestCase):
         # Verify g_idx is NOT created for per-channel
         self.assertFalse(hasattr(layer, "g_idx"))
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_subchannel_g_idx_serialization(self):
         """Test that g_idx is properly serialized and deserialized."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         input_dim, output_dim = 128, 32
         block_size = 64
 

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1398,11 +1398,11 @@ class EinsumDenseTest(testing.TestCase):
         ("per_channel_none", None),
         ("per_channel_neg1", -1),
     )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_quantization_block_size(self, block_size):
         """Test int4 quantization with different block_size configurations."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         # Use simple 2D equation: ab,bc->ac (like Dense)
         layer = layers.EinsumDense(
             equation="ab,bc->ac",
@@ -1446,11 +1446,11 @@ class EinsumDenseTest(testing.TestCase):
         ("grouped_block_128", 128),
         ("per_channel_none", None),
     )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_block_size_serialization(self, block_size):
         """Test that block_size is preserved through serialization."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         layer = layers.EinsumDense(
             equation="ab,bc->ac",
             output_shape=(32,),
@@ -1490,11 +1490,11 @@ class EinsumDenseTest(testing.TestCase):
         ("grouped_block_64", 64),
         ("per_channel", None),
     )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_block_size_with_lora(self, block_size):
         """Test int4 quantization with LoRA and different block_size."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         layer = layers.EinsumDense(
             equation="ab,bc->ac",
             output_shape=(64,),
@@ -1512,11 +1512,11 @@ class EinsumDenseTest(testing.TestCase):
         y = layer(x)
         self.assertEqual(y.shape, (2, 64))
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_grouped_vs_perchannel_scale_shapes(self):
         """Test that grouped and per-channel have different scale shapes."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         input_dim, output_dim = 256, 64
         block_size = 64
 
@@ -1552,13 +1552,13 @@ class EinsumDenseTest(testing.TestCase):
         ("ab_bcd_acd_grouped", "ab,bcd->acd", (8, 32), (None, 64), 32),
         ("ab_bcd_acd_pc", "ab,bcd->acd", (8, 32), (None, 64), None),
     )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_block_size_various_equations(
         self, equation, output_shape, input_shape, block_size
     ):
         """Test int4 quantization with different equations and block_size."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         layer = layers.EinsumDense(
             equation=equation,
             output_shape=output_shape,
@@ -1589,13 +1589,13 @@ class EinsumDenseTest(testing.TestCase):
         ("mha_value_grouped", "ab,bcd->acd", (8, 32), (None, 64), 32),
         ("mha_value_pc", "ab,bcd->acd", (8, 32), (None, 64), None),
     )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_grouped_multi_reduced_axes(
         self, equation, output_shape, input_shape, block_size
     ):
         """Test int4 grouped quantization with multiple reduced axes."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         layer = layers.EinsumDense(
             equation=equation,
             output_shape=output_shape,
@@ -1617,11 +1617,11 @@ class EinsumDenseTest(testing.TestCase):
         mse = ops.mean(ops.square(y_float - y_quantized))
         self.assertLess(mse, 0.1)
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_multi_reduced_axes_scale_shape(self):
         """Test that scale shape is correct for multi-reduced-axis equations."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         # Equation: bnh,nhd->bd (two reduced axes: n, h)
         # Kernel shape: (n=4, h=32, d=64)
         # Reduced axes: n, h (total reduced dim = 4 * 32 = 128)
@@ -1644,11 +1644,11 @@ class EinsumDenseTest(testing.TestCase):
         # (n_groups, columns) where n_groups is at index 0
         self.assertEqual(kernel_scale.shape[0], 2)
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_multi_reduced_axes_serialization(self):
         """Test serialization with multi-reduced-axis equations."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         # Equation: bnh,nhd->bd (two reduced axes: n, h)
         layer = layers.EinsumDense(
             equation="bnh,nhd->bd",
@@ -1672,11 +1672,11 @@ class EinsumDenseTest(testing.TestCase):
         y_after = loaded_model(x)
         self.assertAllClose(y_before, y_after, atol=1e-5)
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_multi_reduced_vs_single_reduced(self):
         """Compare grouped quantization: single vs multi-reduced axes."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         block_size = 64
 
         # Single reduced axis: bd,df->bf (reduced: d)
@@ -1717,11 +1717,11 @@ class EinsumDenseTest(testing.TestCase):
         ("grouped_block_64", 64),
         ("grouped_block_128", 128),
     )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_subchannel_g_idx_created(self, block_size):
         """Test that g_idx is created for sub-channel int4 quantization."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         layer = layers.EinsumDense(
             equation="ab,bc->ac",
             output_shape=(32,),
@@ -1742,11 +1742,11 @@ class EinsumDenseTest(testing.TestCase):
         expected_g_idx = np.arange(128) // block_size
         self.assertAllClose(layer.g_idx, expected_g_idx)
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_perchannel_no_g_idx(self):
         """Test that per-channel int4 does NOT create g_idx."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         layer = layers.EinsumDense(
             equation="ab,bc->ac",
             output_shape=(32,),
@@ -1760,11 +1760,11 @@ class EinsumDenseTest(testing.TestCase):
         # Verify g_idx is NOT created for per-channel
         self.assertFalse(hasattr(layer, "g_idx"))
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_subchannel_g_idx_serialization(self):
         """Test that g_idx is properly serialized and deserialized."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         layer = layers.EinsumDense(
             equation="ab,bc->ac",
             output_shape=(32,),

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -796,11 +796,11 @@ class EmbeddingTest(test_case.TestCase):
         ("grouped_block_4", 4),
         ("grouped_block_8", 8),
     )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_subchannel_g_idx_created(self, block_size):
         """Test that g_idx is created for sub-channel int4 quantization."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         input_dim, output_dim = 10, 16
         layer = layers.Embedding(input_dim=input_dim, output_dim=output_dim)
         layer.build()
@@ -818,11 +818,11 @@ class EmbeddingTest(test_case.TestCase):
         expected_g_idx = np.arange(output_dim) // block_size
         self.assertAllClose(layer.g_idx, expected_g_idx)
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_perchannel_no_g_idx(self):
         """Test that per-channel int4 does NOT create g_idx."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         layer = layers.Embedding(input_dim=10, output_dim=16)
         layer.build()
 
@@ -832,11 +832,11 @@ class EmbeddingTest(test_case.TestCase):
         # Verify g_idx is NOT created for per-channel
         self.assertFalse(hasattr(layer, "g_idx"))
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_subchannel_g_idx_serialization(self):
         """Test that g_idx is properly serialized and deserialized."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         input_dim, output_dim = 10, 16
         block_size = 8
 

--- a/keras/src/layers/core/reversible_embedding_test.py
+++ b/keras/src/layers/core/reversible_embedding_test.py
@@ -437,11 +437,11 @@ class ReversibleEmbeddingTest(test_case.TestCase):
         ("grouped_block_4", 4),
         ("grouped_block_8", 8),
     )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_subchannel_g_idx_created(self, block_size):
         """Test that g_idx is created for sub-channel int4 quantization."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         input_dim, output_dim = 10, 16
         layer = layers.ReversibleEmbedding(
             input_dim=input_dim, output_dim=output_dim
@@ -461,11 +461,11 @@ class ReversibleEmbeddingTest(test_case.TestCase):
         expected_g_idx = np.arange(output_dim) // block_size
         self.assertAllClose(layer.g_idx, expected_g_idx)
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_perchannel_no_g_idx(self):
         """Test that per-channel int4 does NOT create g_idx."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         layer = layers.ReversibleEmbedding(input_dim=10, output_dim=16)
         layer.build()
 
@@ -475,11 +475,11 @@ class ReversibleEmbeddingTest(test_case.TestCase):
         # Verify g_idx is NOT created for per-channel
         self.assertFalse(hasattr(layer, "g_idx"))
 
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
     def test_int4_subchannel_g_idx_serialization(self):
         """Test that g_idx is properly serialized and deserialized."""
-        if testing.tensorflow_uses_gpu():
-            self.skipTest("Segfault on TF GPU")
-
         input_dim, output_dim = 10, 16
         block_size = 8
 

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -16,7 +16,6 @@ from keras.src import testing
 from keras.src.backend.common import global_state
 from keras.src.backend.common.remat import RematScope
 from keras.src.models import Model
-from keras.src.utils import traceback_utils
 
 
 class MockRemat:
@@ -243,12 +242,11 @@ class LayerTest(testing.TestCase):
             layer.build((2, 4))
             layer.dtype_policy = "gptq/4/-1_from_float32"
 
+    @pytest.mark.skipif(
+        backend.backend() in ("openvino", "numpy"),
+        reason="remat not supported on OpenVino and Numpy",
+    )
     def test_functional_model_with_remat(self):
-        if backend.backend() in ("openvino", "numpy"):
-            self.skipTest(
-                "remat is not supported in openvino and numpy backends."
-            )
-        traceback_utils.enable_traceback_filtering()
         mock_remat = MockRemat()
         with mock.patch(
             "keras.src.backend.common.remat.remat", wraps=mock_remat

--- a/keras/src/layers/preprocessing/integer_lookup_test.py
+++ b/keras/src/layers/preprocessing/integer_lookup_test.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -214,9 +215,11 @@ class IntegerLookupTest(testing.TestCase):
         with self.assertRaises(ValueError):
             layers.IntegerLookup(num_oov_indices=-1)
 
+    @pytest.mark.skipif(
+        backend.backend() != "tensorflow",
+        reason="sparse=True only supported on TensorFlow",
+    )
     def test_sparse_output(self):
-        if backend.backend() != "tensorflow":
-            self.skipTest("sparse=True only supported on TensorFlow")
         layer = layers.IntegerLookup(
             vocabulary=[1, 2, 3],
             output_mode="multi_hot",

--- a/keras/src/ops/linalg_test.py
+++ b/keras/src/ops/linalg_test.py
@@ -404,9 +404,10 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
             x = np.random.rand(4, 3, 4)
             linalg.det(x)
 
+    @pytest.mark.skipif(
+        testing.jax_uses_tpu(), reason="Unsupported on JAX with TPU"
+    )
     def test_eig(self):
-        if testing.uses_tpu():
-            self.skipTest("Skipping test with JAX + TPU as it's not supported")
         x = np.random.rand(2, 3, 3)
         x = x @ x.transpose((0, 2, 1))
         w, v = map(ops.convert_to_numpy, linalg.eig(x))

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -2809,9 +2809,6 @@ class NNOpsDtypeTest(testing.TestCase):
         import jax.nn as jnn
         import jax.numpy as jnp
 
-        if dtype == "bfloat16":
-            self.skipTest("Weirdness with numpy")
-
         x = knp.ones((2), dtype=dtype)
         x_jax = jnp.ones((2), dtype=dtype)
         expected_dtype = standardize_dtype(jnn.squareplus(x_jax).dtype)

--- a/keras/src/quantizers/quantizers_test.py
+++ b/keras/src/quantizers/quantizers_test.py
@@ -568,7 +568,7 @@ class QuantizersTest(testing.TestCase):
         gradients = test_op(
             inputs, input_min, input_max, num_bits, narrow_range, axis
         )
-        if backend.backend() != "jax" or not testing.jax_uses_gpu():
+        if not testing.jax_uses_gpu():
             # JAX GPU produces less precise numbers, causing the CI to fail.
             # For example, 127.5 / 255.0 results in 0.49999997 instead of 0.5.
             self.assertAllClose(gradients, expected_backprops_wrt_input)

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -731,7 +731,7 @@ class SavingTest(testing.TestCase):
         reason="JAX backend doesn't support Python's multiprocessing",
     )
     @pytest.mark.skipif(
-        testing.tensorflow_uses_gpu() or testing.torch_uses_gpu(),
+        testing.uses_gpu(),
         reason="This test doesn't support GPU",
     )
     def test_load_model_concurrently(self):

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -1,7 +1,6 @@
 import json
 import shutil
 import tempfile
-import unittest
 from pathlib import Path
 
 import numpy as np
@@ -20,7 +19,7 @@ from keras.src.models import Model
 from keras.src.utils import traceback_utils
 
 
-class TestCase(parameterized.TestCase, unittest.TestCase):
+class TestCase(parameterized.TestCase):
     maxDiff = None
 
     def __init__(self, *args, **kwargs):

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -499,18 +499,6 @@ class TestTrainer(testing.TestCase):
     )
     @pytest.mark.requires_trainable_backend
     def test_fit_flow(self, run_eagerly, jit_compile, use_steps_per_epoch):
-        if not run_eagerly and not jit_compile and use_steps_per_epoch:
-            if False and backend.backend() == "tensorflow":
-                self.skipTest(
-                    "TODO: Graph mode without XLA in TF backend leads to "
-                    "unexpected logs, need further checks."
-                )
-        if jit_compile and backend.backend() == "torch":
-            self.skipTest(
-                "TODO: compilation with torch backend leads to "
-                "unexpected logs, need further checks."
-            )
-
         model = ExampleModel(units=3)
         epochs = 3
         batch_size = 20
@@ -706,13 +694,6 @@ class TestTrainer(testing.TestCase):
     def test_fit_with_val_split(
         self, run_eagerly, jit_compile, use_steps_per_epoch
     ):
-        if not run_eagerly and not jit_compile and use_steps_per_epoch:
-            if backend.backend() == "tensorflow":
-                self.skipTest(
-                    "TODO: Graph mode without XLA in TF backend leads to "
-                    "unexpected logs, need further checks."
-                )
-
         model = ExampleModel(units=3)
         epochs = 3
         batch_size = 20
@@ -2893,9 +2874,8 @@ class JAXTrainerCorrectnessTest(test_case.TestCase, parameterized.TestCase):
         ("single_device", False),
         ("distributed", True),
     )
+    @pytest.mark.skipif(backend.backend() != "jax", reason="JAX only")
     def test_jit_fit_with_out_shardings_logic(self, distributed):
-        if keras.backend.backend() != "jax":
-            self.skipTest("This test requires the JAX backend.")
         x = np.random.rand(64, 8).astype("float32")
         y = np.random.rand(64, 1).astype("float32")
 


### PR DESCRIPTION
- Unify the way tests are skipped by turning `if ... pytest.skip()` into `@pytest.mark.skipif` wherever possible.
- Also do not skip the tests that actually pass.