### PR TITLE
fix: pytorch onnx export with dynamic shapes

### DIFF
--- a/keras/src/export/onnx_test.py
+++ b/keras/src/export/onnx_test.py
@@ -295,3 +295,158 @@ class ExportONNXTest(testing.TestCase):
             k.name: v for k, v in zip(ort_session.get_inputs(), [ref_input])
         }
         self.assertAllClose(ref_output, ort_session.run(None, ort_inputs)[0])
+
+    @parameterized.named_parameters(
+        named_product(
+            model_type=["sequential", "functional"],
+            dynamic_type=["batch_only", "height_width"],
+        )
+    )
+    def test_dynamic_shapes_export(self, model_type, dynamic_type):
+        """Test ONNX export with various dynamic shape configurations.
+
+        Tests two scenarios:
+        - batch_only: Only batch dimension is dynamic, spatial dims fixed
+        - height_width: Batch, height, width are dynamic, channels fixed
+        """
+
+        temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
+
+        # Define input shapes based on dynamic type
+        if dynamic_type == "batch_only":
+            input_shape = (32, 32, 3)  # Only batch is dynamic (None)
+            test_shapes = [(1, 32, 32, 3), (2, 32, 32, 3), (4, 32, 32, 3)]
+        elif dynamic_type == "height_width":
+            input_shape = (None, None, 3)  # Height and width are dynamic
+            test_shapes = [(1, 28, 28, 3), (1, 64, 64, 3), (1, 128, 96, 3)]
+
+        # Create model with appropriate layers for dynamic shapes
+        layer_list = [
+            layers.Conv2D(16, 3, padding="same", activation="relu"),
+            layers.GlobalAveragePooling2D(),
+            layers.Dense(10, activation="softmax"),
+        ]
+
+        if model_type == "sequential":
+            model = models.Sequential(
+                [layers.Input(shape=input_shape)] + layer_list
+            )
+        elif model_type == "functional":
+            input_layer = layers.Input(shape=input_shape)
+            output = input_layer
+            for layer in layer_list:
+                output = layer(output)
+            model = models.Model(inputs=input_layer, outputs=output)
+
+        # Build model with initial input
+        initial_input = np.random.normal(size=test_shapes[0]).astype(np.float32)
+        model(initial_input)
+
+        # Export to ONNX
+        onnx.export_onnx(model, temp_filepath)
+
+        # Verify with ONNX Runtime
+        ort_session = onnxruntime.InferenceSession(temp_filepath)
+        input_info = ort_session.get_inputs()[0]
+
+        # Check that dynamic dimensions are preserved
+        input_shape_onnx = input_info.shape
+        if dynamic_type == "batch_only":
+            # Batch should be dynamic, others static
+            self.assertTrue(isinstance(input_shape_onnx[0], str))  # Dynamic
+            self.assertEqual(input_shape_onnx[1:], [32, 32, 3])  # Static
+        elif dynamic_type == "height_width":
+            # Batch, height, width should be dynamic, channels static
+            self.assertTrue(isinstance(input_shape_onnx[0], str))  # Dynamic
+            self.assertTrue(isinstance(input_shape_onnx[1], str))  # Dynamic
+            self.assertTrue(isinstance(input_shape_onnx[2], str))  # Dynamic
+            self.assertEqual(input_shape_onnx[3], 3)  # Static
+
+        # Test inference with different input shapes
+        for test_shape in test_shapes:
+            test_input = np.random.randn(*test_shape).astype(np.float32)
+            ort_inputs = {input_info.name: test_input}
+            result = ort_session.run(None, ort_inputs)
+
+            # Verify output shape matches expected batch size
+            expected_batch_size = test_shape[0]
+            self.assertEqual(result[0].shape[0], expected_batch_size)
+            self.assertEqual(result[0].shape[1], 10)  # Number of classes
+
+    def test_multi_input_dynamic_shapes(self):
+        """Test ONNX export with multi-input model having dynamic shapes."""
+
+        temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
+
+        # Create multi-input model with dynamic shapes
+        text_input = layers.Input(
+            shape=(None, 64), name="text_input"
+        )  # Variable sequence length
+        image_input = layers.Input(
+            shape=(None, None, 3), name="image_input"
+        )  # Variable image size
+
+        # Process text input
+        text_features = layers.Dense(128, activation="relu")(text_input)
+        text_pooled = layers.GlobalAveragePooling1D()(text_features)
+
+        # Process image input
+        image_features = layers.Conv2D(32, 1, activation="relu")(
+            image_input
+        )  # Use 1x1 conv to avoid size issues
+        image_pooled = layers.GlobalAveragePooling2D()(image_features)
+
+        # Combine features
+        combined = layers.Concatenate()([text_pooled, image_pooled])
+        output = layers.Dense(5, activation="softmax")(combined)
+
+        model = models.Model(inputs=[text_input, image_input], outputs=output)
+
+        # Build model
+        sample_text = np.random.normal(size=(1, 20, 64)).astype(np.float32)
+        sample_image = np.random.normal(size=(1, 32, 32, 3)).astype(np.float32)
+        model([sample_text, sample_image])
+
+        # Export to ONNX
+        onnx.export_onnx(model, temp_filepath)
+
+        # Verify with ONNX Runtime
+        ort_session = onnxruntime.InferenceSession(temp_filepath)
+        inputs_info = ort_session.get_inputs()
+
+        # Check that both inputs have dynamic dimensions
+        text_shape = inputs_info[0].shape
+        image_shape = inputs_info[1].shape
+
+        # Text input: [batch, seq_len, features] - batch and seq_len dynamic
+        self.assertTrue(isinstance(text_shape[0], str))  # Dynamic
+        self.assertTrue(isinstance(text_shape[1], str))  # Dynamic
+        self.assertEqual(text_shape[2], 64)  # Static
+
+        # Image input: [batch, height, width, channels] - batch, h, w dynamic
+        self.assertTrue(isinstance(image_shape[0], str))  # Dynamic
+        self.assertTrue(isinstance(image_shape[1], str))  # Dynamic
+        self.assertTrue(isinstance(image_shape[2], str))  # Dynamic
+        self.assertEqual(image_shape[3], 3)  # Static
+
+        # Test inference with different input shapes
+        test_cases = [
+            ((1, 10, 64), (1, 28, 28, 3)),
+            ((2, 15, 64), (2, 64, 64, 3)),
+            ((1, 25, 64), (1, 48, 32, 3)),
+        ]
+
+        for text_shape, image_shape in test_cases:
+            text_input_data = np.random.randn(*text_shape).astype(np.float32)
+            image_input_data = np.random.randn(*image_shape).astype(np.float32)
+
+            ort_inputs = {
+                inputs_info[0].name: text_input_data,
+                inputs_info[1].name: image_input_data,
+            }
+            result = ort_session.run(None, ort_inputs)
+
+            # Verify output shape matches expected batch size
+            expected_batch_size = text_shape[0]
+            self.assertEqual(result[0].shape[0], expected_batch_size)
+            self.assertEqual(result[0].shape[1], 5)  # Number of classes


### PR DESCRIPTION
# Fix PyTorch ONNX Export Dynamic Shapes - Issue #22076
## Description
_Fixes PyTorch ONNX export to properly preserve dynamic dimensions from input signatures instead of converting them to fixed size 1._

## Issue
When exporting Keras models to ONNX with PyTorch backend, dynamic dimensions (specified as None in input signatures) were being converted to fixed dimensions of size 1. This made exported models unusable with variable input sizes at inference time.

## Example Problem:

Input signature: (None, None, None, 1)
Exported ONNX shape: [1, 1, 1, 1] ❌
Expected ONNX shape: ['batch_size', 'seq_len_or_height', 'width_or_depth', 1] ✅

## Solution
Generate Dynamic Shape Metadata: Extract dynamic dimensions from input signatures and create proper dynamic_shapes (TorchDynamo) and dynamic_axes (TorchScript) parameters.

Closes #22076