### PR TITLE
Remove `testing.uses_cpu()` and re-implement for JAX.

### DIFF
--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -1,6 +1,7 @@
 import builtins
 import math
 
+import jax
 import jax.experimental.sparse as jax_sparse
 import jax.numpy as jnp
 from jax import export as jax_export
@@ -14,6 +15,18 @@ from keras.src.backend.jax import nn
 from keras.src.backend.jax import sparse
 from keras.src.backend.jax.core import cast
 from keras.src.backend.jax.core import convert_to_tensor
+
+
+def _uses_cpu(x):
+    if hasattr(x, "device"):
+        device = x.device
+        if not isinstance(device, jax.Device):
+            # Array is sharded.
+            return False
+        return device.platform == "cpu"
+    else:
+        # This is a Tracer, not a concrete Array.
+        return jax.default_backend() == "cpu"
 
 
 def rot90(array, k=1, axes=(0, 1)):
@@ -402,11 +415,9 @@ def arctanh(x):
 
 
 def argmax(x, axis=None, keepdims=False):
-    from keras.src.testing.test_case import uses_cpu
-
     x = convert_to_tensor(x)
     dtype = standardize_dtype(x.dtype)
-    if "float" not in dtype or not uses_cpu() or x.ndim == 0:
+    if "float" not in dtype or x.ndim == 0 or not _uses_cpu(x):
         return jnp.argmax(x, axis=axis, keepdims=keepdims)
 
     # Fix the flush-to-zero (FTZ) issue based on this issue:
@@ -419,11 +430,9 @@ def argmax(x, axis=None, keepdims=False):
 
 
 def argmin(x, axis=None, keepdims=False):
-    from keras.src.testing.test_case import uses_cpu
-
     x = convert_to_tensor(x)
     dtype = standardize_dtype(x.dtype)
-    if "float" not in dtype or not uses_cpu() or x.ndim == 0:
+    if "float" not in dtype or x.ndim == 0 or not _uses_cpu(x):
         return jnp.argmin(x, axis=axis, keepdims=keepdims)
 
     # Fix the flush-to-zero (FTZ) issue based on this issue:

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -949,11 +949,9 @@ def argmax(x, axis=None, keepdims=False):
 
 
 def argmin(x, axis=None, keepdims=False):
-    from keras.src.testing.test_case import uses_cpu
-
     x = convert_to_tensor(x)
     dtype = standardize_dtype(x.dtype)
-    if "float" not in dtype or not uses_cpu() or x.ndim == 0:
+    if "float" not in dtype or x.ndim == 0:
         _x = x
         if axis is None:
             x = tf.reshape(x, [-1])

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1277,8 +1277,8 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.argmax(x, keepdims=True).shape, (None, 3, 3))
 
     @pytest.mark.skipif(
-        keras.config.backend() == "openvino" or testing.uses_tpu(),
-        reason="OpenVINO doesn't support this change",
+        keras.config.backend() == "openvino" or testing.jax_uses_tpu(),
+        reason="OpenVINO and JAX TPU don't support this",
     )
     def test_argmax_negative_zero(self):
         input_data = np.array(
@@ -1287,14 +1287,8 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.argmax(input_data), 2)
 
     @pytest.mark.skipif(
-        keras.config.backend() == "openvino"
-        or keras.config.backend() == "tensorflow"
-        or testing.uses_tpu(),
-        reason="""
-        OpenVINO and TensorFlow don't support this 
-        change, TensorFlow behavior for this case is under
-        evaluation and may change within this PR
-        """,
+        keras.config.backend() == "openvino" or testing.jax_uses_tpu(),
+        reason="OpenVINO and JAX TPU don't support this",
     )
     def test_argmin_negative_zero(self):
         input_data = np.array(

--- a/keras/src/testing/__init__.py
+++ b/keras/src/testing/__init__.py
@@ -1,5 +1,6 @@
 from keras.src.testing.test_case import TestCase
 from keras.src.testing.test_case import jax_uses_gpu
+from keras.src.testing.test_case import jax_uses_tpu
 from keras.src.testing.test_case import tensorflow_uses_gpu
 from keras.src.testing.test_case import torch_uses_gpu
 from keras.src.testing.test_case import uses_gpu

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -650,6 +650,10 @@ def uses_gpu():
     return False
 
 
+def jax_uses_tpu():
+    return backend.backend() == "jax" and uses_tpu()
+
+
 def uses_tpu():
     # Condition used to skip tests when using the TPU
     try:
@@ -658,13 +662,6 @@ def uses_tpu():
             return True
     except AttributeError:
         return False
-    return False
-
-
-def uses_cpu():
-    devices = distribution.list_devices()
-    if any(d.startswith("cpu") for d in devices):
-        return True
     return False
 
 


### PR DESCRIPTION
Problem 1:
- `jax/numpy.py` was importing and using `testing.uses_cpu`. This kind of dependency from real code to test code is not allowed as the testing code is not even supposed to be in the wheel.
- The implementation of `uses_cpu` was inefficient and the wrong criteria for the use case. For instance, this case would not be handled correctly:
```python
with keras.device("cpu:0"):
  y = keras.ops.argmin(x)
```

Problem 2:
- The Tensorflow implementation of `argmin` and `argmax` were inconsistent. One was applying the flush-to-zero fix only on CPU and the other was applying it and all devices.

Solution:
- Remove `testing.uses_cpu`, which is never used in tests.
- Re-implemented `uses_cpu` for JAX for `argmin` and `argmax`.
- Removed the `uses_cpu` criteria on Tensorflow for `argmin` and `argmax` after verifying that the flush-to-zero fix is needed on all devices.
- Added `jax_uses_tpu` for the the flush-to-zero test for `argmin` and `argmax`.