### PR TITLE
Improvements to `*_uses_gpu` and `*_uses_tpu`.

### DIFF
--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1324,16 +1324,9 @@ class NNOpsStaticShapeTest(testing.TestCase):
 
 
 class NNOpsCorrectnessTest(testing.TestCase):
-    @pytest.mark.skipif(backend.backend() != "jax", reason="JAX only")
+    @pytest.mark.skipif(not testing.jax_uses_tpu(), reason="JAX on TPU only")
     def test_dot_product_attention_inside_scan(self):
         import jax
-
-        try:
-            if jax.devices()[0].platform != "tpu":
-                self.skipTest("TPU-specific test")
-        except:
-            self.skipTest("TPU-specific test")
-
         import jax.numpy as jnp
 
         def attention_scan_body(carry, x):

--- a/keras/src/testing/__init__.py
+++ b/keras/src/testing/__init__.py
@@ -2,6 +2,7 @@ from keras.src.testing.test_case import TestCase
 from keras.src.testing.test_case import jax_uses_gpu
 from keras.src.testing.test_case import jax_uses_tpu
 from keras.src.testing.test_case import tensorflow_uses_gpu
+from keras.src.testing.test_case import tensorflow_uses_tpu
 from keras.src.testing.test_case import torch_uses_gpu
 from keras.src.testing.test_case import uses_gpu
 from keras.src.testing.test_case import uses_tpu

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -8,7 +8,6 @@ import numpy as np
 from absl.testing import parameterized
 
 from keras.src import backend
-from keras.src import distribution
 from keras.src import ops
 from keras.src import tree
 from keras.src import utils
@@ -626,43 +625,68 @@ class TestCase(parameterized.TestCase, unittest.TestCase):
                         self.assertEqual(dtype, "float32")
 
 
-def tensorflow_uses_gpu():
-    return backend.backend() == "tensorflow" and uses_gpu()
+def _jax_uses(device_type):
+    import jax
+
+    return jax.default_backend() == device_type
+
+
+def _tensorflow_uses(device_type):
+    import tensorflow as tf
+
+    return len(tf.config.list_physical_devices(device_type.upper())) > 0
+
+
+def _torch_uses(device_type):
+    if device_type == "gpu":
+        from keras.src.backend.torch.core import get_device
+
+        return get_device() == "cuda"
+    return device_type == "cpu"
+
+
+def uses_gpu():
+    if not hasattr(uses_gpu, "_value"):
+        if backend.backend() == "tensorflow":
+            uses_gpu._value = _tensorflow_uses("gpu")
+        elif backend.backend() == "jax":
+            uses_gpu._value = _jax_uses("gpu")
+        elif backend.backend() == "torch":
+            uses_gpu._value = _torch_uses("gpu")
+        else:
+            uses_gpu._value = False
+    return uses_gpu._value
+
+
+def uses_tpu():
+    if not hasattr(uses_tpu, "_value"):
+        if backend.backend() == "tensorflow":
+            uses_tpu._value = _tensorflow_uses("tpu")
+        elif backend.backend() == "jax":
+            uses_tpu._value = _jax_uses("tpu")
+        else:
+            uses_tpu._value = False
+    return uses_tpu._value
 
 
 def jax_uses_gpu():
     return backend.backend() == "jax" and uses_gpu()
 
 
-def torch_uses_gpu():
-    if backend.backend() != "torch":
-        return False
-    from keras.src.backend.torch.core import get_device
-
-    return get_device() == "cuda"
-
-
-def uses_gpu():
-    # Condition used to skip tests when using the GPU
-    devices = distribution.list_devices()
-    if any(d.startswith("gpu") for d in devices):
-        return True
-    return False
-
-
 def jax_uses_tpu():
     return backend.backend() == "jax" and uses_tpu()
 
 
-def uses_tpu():
-    # Condition used to skip tests when using the TPU
-    try:
-        devices = distribution.list_devices()
-        if any(d.startswith("tpu") for d in devices):
-            return True
-    except AttributeError:
-        return False
-    return False
+def tensorflow_uses_gpu():
+    return backend.backend() == "tensorflow" and uses_gpu()
+
+
+def tensorflow_uses_tpu():
+    return backend.backend() == "tensorflow" and uses_tpu()
+
+
+def torch_uses_gpu():
+    return backend.backend() == "torch" and uses_gpu()
 
 
 def create_keras_tensors(input_shape, dtype, sparse, ragged):


### PR DESCRIPTION
Problems:
- The `uses_gpu` and `uses_tpu` utilities crash when the backend in not tensorflow, jax or torch. That's because they rely on `distribution_lib`.
- `uses_gpu` and `uses_tpu` are pretty heavyweight in that they retrieve the list of all devices (which we don't cache) just to check the type.

Solution:
- Added `tensorflow_uses_tpu` utility.
- Reimplemented `uses_gpu` and `uses_tpu` per backend in a way that is faster than listing devices.
- Adding caching for `uses_gpu` and `uses_tpu`.