### PR TITLE
fix: guard against unbounded tensor allocation in Layer.__call__

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -101,8 +101,11 @@ def _validate_tensor_size(tensor):
 
     if num_elements > MAX_TENSOR_ELEMENTS:
         raise ValueError(
-            "Refusing to allocate tensor with excessive size "
-            f"({num_elements} > {MAX_TENSOR_ELEMENTS})"
+            f"A tensor of size {num_elements} was created, which is larger "
+            f"than the maximum allowed size of {MAX_TENSOR_ELEMENTS}. "
+            "This is a safeguard to prevent excessive memory allocation. "
+            "If this allocation is intended, you can increase the limit by "
+            "setting the `KERAS_MAX_TENSOR_ELEMENTS` environment variable."
         )
 
 


### PR DESCRIPTION
## Summary
This PR adds a framework-level safeguard to prevent unbounded tensor allocations during layer execution, mitigating a potential denial-of-service vector when loading or executing untrusted `.keras` models.

## Problem
Keras currently allows model-defined layers to request arbitrarily large output tensors during execution (e.g. via shape-controlled ops such as `tf.image.resize`). Because no framework-level limits are enforced, a malicious or untrusted model can trigger excessive memory allocation, leading to process crashes or resource exhaustion.

This is particularly relevant in deployment scenarios where `.keras` models are fetched from external sources (model hubs, CI pipelines, inference services) and executed automatically.

## Solution
This change introduces:
- A configurable upper bound on tensor size via the `KERAS_MAX_TENSOR_ELEMENTS` environment variable (default: `1e8`)
- A lightweight runtime validation step in `Layer.__call__` that rejects outputs exceeding this limit
- Safe handling of dynamic shapes and symbolic tensors (no impact on tracing or graph construction)

## Key details
- Enforcement occurs **after eager execution** and **before layout transforms or activity regularization**
- Symbolic tensors (`KerasTensor`) are explicitly excluded
- The default limit is conservative and can be tuned or disabled by users if needed

## Security impact
- Prevents untrusted models from triggering uncontrolled memory allocation
- Mitigates **CWE-770: Allocation of Resources Without Limits or Throttling**
- Reduces denial-of-service risk in automated and multi-tenant ML environments

## Backward compatibility
- No behavior change for normal models
- Dynamic shapes are unaffected
- Opt-out / tuning supported via environment variable

## Related
- Security disclosure submitted via Huntr [LINK](https://huntr.com/bounties/77da6b2e-de64-4ca9-808c-f3f263dacc9b)
- CWE-770: Allocation of Resources Without Limits or Throttling
