### PR TITLE
Don't call `pythonify_logs` within `get_metrics_result`.

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -19,6 +19,7 @@ from keras.src.trainers.data_adapters import array_slicing
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.trainers.epoch_iterator import EpochIterator
 from keras.src.utils import traceback_utils
+from keras.src.utils.python_utils import pythonify_logs
 
 if is_nnx_enabled():
     from flax import nnx
@@ -641,9 +642,10 @@ class JAXTrainer(base_trainer.Trainer):
         # Reattach state back to model (if not already done by a callback).
         self.jax_state_sync()
 
-        logs = self._get_metrics_result_or_logs(logs)
+        logs = pythonify_logs(self._get_metrics_result_or_logs(logs))
         callbacks.on_test_end(logs)
         self._jax_state = None
+
         if return_dict:
             return logs
         return self._flatten_metrics_in_order(logs)
@@ -800,7 +802,7 @@ class JAXTrainer(base_trainer.Trainer):
         self.jax_state_sync()
 
         # Format return values
-        logs = tree.map_structure(lambda x: np.array(x), logs)
+        logs = pythonify_logs(logs)
         if return_dict:
             return logs
         return self._flatten_metrics_in_order(logs)
@@ -841,7 +843,7 @@ class JAXTrainer(base_trainer.Trainer):
         self.jax_state_sync()
 
         # Format return values.
-        logs = tree.map_structure(lambda x: np.array(x), logs)
+        logs = pythonify_logs(logs)
         if return_dict:
             return logs
         return self._flatten_metrics_in_order(logs)

--- a/keras/src/backend/numpy/trainer.py
+++ b/keras/src/backend/numpy/trainer.py
@@ -10,6 +10,7 @@ from keras.src.trainers import trainer as base_trainer
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.trainers.epoch_iterator import EpochIterator
 from keras.src.utils import traceback_utils
+from keras.src.utils.python_utils import pythonify_logs
 
 
 class NumpyTrainer(base_trainer.Trainer):
@@ -282,7 +283,7 @@ class NumpyTrainer(base_trainer.Trainer):
             callbacks.on_test_batch_end(end_step, logs)
             if self.stop_evaluating:
                 break
-        logs = self._get_metrics_result_or_logs(logs)
+        logs = pythonify_logs(self._get_metrics_result_or_logs(logs))
         callbacks.on_test_end(logs)
 
         if return_dict:
@@ -317,7 +318,7 @@ class NumpyTrainer(base_trainer.Trainer):
         self.make_test_function()
 
         logs = self.test_function([data])
-        logs = tree.map_structure(lambda x: np.array(x), logs)
+        logs = pythonify_logs(logs)
         if return_dict:
             return logs
         return self._flatten_metrics_in_order(logs)

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -2,7 +2,6 @@ import contextlib
 import functools
 import warnings
 
-import numpy as np
 import tensorflow as tf
 from tensorflow.python.eager import context as tf_context
 
@@ -17,6 +16,7 @@ from keras.src.trainers.data_adapters import array_slicing
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.trainers.epoch_iterator import EpochIterator
 from keras.src.utils import traceback_utils
+from keras.src.utils.python_utils import pythonify_logs
 
 
 class TensorFlowTrainer(base_trainer.Trainer):
@@ -512,7 +512,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
                 callbacks.on_test_batch_end(end_step, logs)
                 if self.stop_evaluating:
                     break
-        logs = self._get_metrics_result_or_logs(logs)
+        logs = pythonify_logs(self._get_metrics_result_or_logs(logs))
         callbacks.on_test_end(logs)
 
         if return_dict:
@@ -627,7 +627,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
             yield (x, y, sample_weight)
 
         logs = self.train_function(data())
-        logs = tree.map_structure(lambda x: np.array(x), logs)
+        logs = pythonify_logs(logs)
         if return_dict:
             return logs
         return self._flatten_metrics_in_order(logs)
@@ -649,7 +649,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
         self.make_test_function()
 
         logs = self.test_function(data())
-        logs = tree.map_structure(lambda x: np.array(x), logs)
+        logs = pythonify_logs(logs)
         if return_dict:
             return logs
         return self._flatten_metrics_in_order(logs)

--- a/keras/src/backend/torch/trainer.py
+++ b/keras/src/backend/torch/trainer.py
@@ -14,6 +14,7 @@ from keras.src.trainers.data_adapters import array_slicing
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.trainers.epoch_iterator import EpochIterator
 from keras.src.utils import traceback_utils
+from keras.src.utils.python_utils import pythonify_logs
 
 
 class TorchTrainer(base_trainer.Trainer):
@@ -386,7 +387,7 @@ class TorchTrainer(base_trainer.Trainer):
             callbacks.on_test_batch_end(end_step, logs)
             if self.stop_evaluating:
                 break
-        logs = self._get_metrics_result_or_logs(logs)
+        logs = pythonify_logs(self._get_metrics_result_or_logs(logs))
         callbacks.on_test_end(logs)
 
         if return_dict:
@@ -478,7 +479,7 @@ class TorchTrainer(base_trainer.Trainer):
         self.make_train_function()
 
         logs = self.train_function([data])
-        logs = tree.map_structure(lambda x: np.array(x), logs)
+        logs = pythonify_logs(logs)
         if return_dict:
             return logs
         return self._flatten_metrics_in_order(logs)
@@ -499,7 +500,7 @@ class TorchTrainer(base_trainer.Trainer):
         self.make_test_function()
 
         logs = self.test_function([data])
-        logs = tree.map_structure(lambda x: np.array(x), logs)
+        logs = pythonify_logs(logs)
         if return_dict:
             return logs
         return self._flatten_metrics_in_order(logs)

--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -12,7 +12,6 @@ from keras.src.saving import serialization_lib
 from keras.src.trainers.compile_utils import CompileLoss
 from keras.src.trainers.compile_utils import CompileMetrics
 from keras.src.trainers.data_adapters import data_adapter_utils
-from keras.src.utils import python_utils
 from keras.src.utils import traceback_utils
 from keras.src.utils import tracking
 
@@ -507,7 +506,7 @@ class Trainer:
                 return_metrics.update(result)
             else:
                 return_metrics[metric.name] = result
-        return python_utils.pythonify_logs(return_metrics)
+        return return_metrics
 
     def fit(
         self,


### PR DESCRIPTION
- `get_metrics_result` is called within `train_step`, which means that it gets jitted. In a jitted context, we should only manipulate backend tensors.
- `pythonify_logs` is already called within `CallbackList` before dispatching to the callbacks. `CallbackList` is also what takes care of calling `pythonify` logs asynchronously when possible.
- `pythonify_logs` was added for the last logs in `evaluate` for every backend to turn the logs to python floats before returning the result.
- `pythonify_logs` was used instead of `np.array` in `train_on_batch` and `test_on_batch` as `np.array` doesn't work out of the box on torch on GPU for instance.