### PR TITLE
Fix bounding box docstring references

### DIFF
--- a/keras/src/visualization/draw_bounding_boxes.py
+++ b/keras/src/visualization/draw_bounding_boxes.py
@@ -44,7 +44,9 @@ def draw_bounding_boxes(
                `(batch_size, num_boxes)` containing the confidence scores for
                each bounding box.
         bounding_box_format: A string specifying the format of the bounding
-            boxes. Refer [keras-io](TODO)
+            boxes. See `keras.utils.bounding_boxes.convert_format` for
+            supported formats (e.g., "xyxy", "yxyx", "xywh",
+            "center_xywh", "center_yxhw", and the "rel_*" variants).
         class_mapping: A dictionary mapping class IDs (integers) to class labels
             (strings).  Used to display class labels next to the bounding boxes.
             Defaults to None (no labels displayed).

--- a/keras/src/visualization/plot_bounding_box_gallery.py
+++ b/keras/src/visualization/plot_bounding_box_gallery.py
@@ -45,8 +45,10 @@ def plot_bounding_box_gallery(
     Args:
         images: A 4D tensor or NumPy array of images. Shape should be
             `(batch_size, height, width, channels)`.
-        bounding_box_format: The format of the bounding boxes.
-            Refer [keras-io](TODO)
+        bounding_box_format: The format of the bounding boxes. See
+            `keras.utils.bounding_boxes.convert_format` for supported formats
+            (e.g., "xyxy", "yxyx", "xywh", "center_xywh", "center_yxhw",
+            and the "rel_*" variants).
         y_true: A dictionary containing the ground truth bounding boxes and
             labels. Should have the same structure as the `bounding_boxes`
             argument in `keras.visualization.draw_bounding_boxes`.
@@ -63,8 +65,8 @@ def plot_bounding_box_gallery(
         font_scale: The scale of the font used for labels. Defaults to 1.0.
         text_thickness: The thickness of the bounding box text. Defaults to
             `line_thickness`.
-        class_mapping: A dictionary mapping class IDs to class names.  Used f
-            or both ground truth and predicted boxes if `ground_truth_mapping`
+        class_mapping: A dictionary mapping class IDs to class names. Used for
+            both ground truth and predicted boxes if `ground_truth_mapping`
             and `prediction_mapping` are not provided. Defaults to `None`.
         ground_truth_mapping:  A dictionary mapping class IDs to class names
             specifically for ground truth boxes. Overrides `class_mapping`
@@ -90,8 +92,8 @@ def plot_bounding_box_gallery(
        The output of `keras.visualization.plot_image_gallery`.
 
     Raises:
-        ValueError: If `images` is not a 4D tensor/array or if both `legend` a
-        nd `legend_handles` are specified.
+        ValueError: If `images` is not a 4D tensor/array or if both `legend`
+            and `legend_handles` are specified.
         ImportError: if matplotlib is not installed
     """
     if patches is None:


### PR DESCRIPTION
PR description:

Replaced placeholder “keras-io” references with the correct Keras API reference for bounding box formats.
Cleaned up docstring text 
No functional changes; docstring-only.