### PR TITLE
Exclude conv transpose tests on TPU.

### DIFF
--- a/keras/src/backend/jax/excluded_tpu_tests.txt
+++ b/keras/src/backend/jax/excluded_tpu_tests.txt
@@ -1,3 +1,4 @@
+ConvTransposeBasicTest
 ExportArchiveTest::test_jax_endpoint_registration_tf_function
 ExportArchiveTest::test_jax_multi_unknown_endpoint_registration
 ExportArchiveTest::test_layer_export


### PR DESCRIPTION
These have been crashing randomly about 30% of the time: https://github.com/keras-team/keras/actions/workflows/tpu_tests.yml