### PR TITLE
Align metrics.get() metric name with identifier alias (tf.keras parity)

### DIFF
--- a/keras/src/metrics/__init__.py
+++ b/keras/src/metrics/__init__.py
@@ -204,9 +204,21 @@ def get(identifier):
     if callable(obj):
         if inspect.isclass(obj):
             if isinstance(identifier, str):
-                try:
+                sig = inspect.signature(obj.__init__)
+                params = sig.parameters
+
+                required_params = [
+                    p
+                    for p in params.values()
+                    if (
+                        p.name not in ("self", "name")
+                        and p.default is inspect.Parameter.empty
+                    )
+                ]
+
+                if "name" in params and not required_params:
                     obj = obj(name=identifier)
-                except TypeError:
+                else:
                     obj = obj()
             else:
                 obj = obj()


### PR DESCRIPTION
- Ensures metrics created via metrics.get("alias") use the alias as the default metric name when the alias resolves to a Metric class instance.
- This is a Keras 3–specific behavior: since aliases like "mse" resolve to Metric objects, using the alias as the name (when no explicit name is provided) improves clarity and avoids default class-name-based naming.
