### PR TITLE
Remove incorrect but dead code in `BaseOptimizer.stateless_apply`.

### DIFF
--- a/keras/src/optimizers/base_optimizer.py
+++ b/keras/src/optimizers/base_optimizer.py
@@ -680,20 +680,12 @@ class BaseOptimizer(KerasSaveable):
             self.apply(grads)
 
         # Gather updated variables
-        trainable_variables = []
-        for v in self._trainable_variables:
-            new_v = scope.get_current_value(v)
-            if new_v is not None:
-                trainable_variables.append(new_v)
-            else:
-                trainable_variables.append(v)
-        optimizer_variables = []
-        for v in self.variables:
-            new_v = scope.get_current_value(v)
-            if new_v is not None:
-                optimizer_variables.append(new_v)
-            else:
-                optimizer_variables.append(v)
+        trainable_variables = [
+            scope.get_current_value(v) for v in self._trainable_variables
+        ]
+        optimizer_variables = [
+            scope.get_current_value(v) for v in self.variables
+        ]
         return trainable_variables, optimizer_variables
 
     def scale_loss(self, loss):


### PR DESCRIPTION
In the code that extracts the new variable values from the `StatelessScope`, `BaseOptimizer.stateless_apply` has logic to fallback to returning the variable itself if the variable value is not in the scope.

This is incorrect for two reasons:
- A variable is not a JAX object, `jax.jit` will fail if we ever return a variable.
- At that point, the variable has a `None` value and is not useable: https://github.com/keras-team/keras/blob/master/keras/src/backend/jax/trainer.py#L949-L951

Luckily, this is dead code because the scope has the full mapping of all the variables and this fallback is never used.