### PR TITLE
fix: correct typo 'occurences' to 'occurrences' in function name

### DIFF
--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -272,12 +272,11 @@ class KerasFileEditor:
             )
         else:
             # Ensure unicity
-            def count_occurrences(d, name, count=0):
-                for k in d:
-                    if isinstance(d[k], dict):
-                        count += count_occurrences(d[k], name, count)
-                if name in d:
-                    count += 1
+            def count_occurrences(d, name):
+                count = 1 if name in d else 0
+                for value in d.values():
+                    if isinstance(value, dict):
+                        count += count_occurrences(value, name)
                 return count
 
             occurrences = count_occurrences(self.weights_dict, source_name)


### PR DESCRIPTION
Fixes a typo in the file_editor module where the local function 'count_occurences' should be 'count_occurrences'.