### PR TITLE
Fix: draw_bounding_boxes float32 to uint8 conversion

### DIFF
--- a/keras/src/visualization/draw_bounding_boxes.py
+++ b/keras/src/visualization/draw_bounding_boxes.py
@@ -119,8 +119,11 @@ def draw_bounding_boxes(
 
     # To numpy array
     images = ops.convert_to_numpy(images)
-    if images.dtype.kind == "f" and images.size > 0 and images.max() <= 1.0:
-        images = ops.clip(images, 0, 1) * 255
+    if images.dtype.kind == "f" and images.size > 0:
+        if images.max() <= 1.0:
+            images = ops.clip(images, 0, 1) * 255
+        else:
+            images = ops.clip(images, 0, 255)
     images = images.astype("uint8")
     boxes = ops.convert_to_numpy(bounding_boxes["boxes"])
     labels = ops.convert_to_numpy(bounding_boxes["labels"])


### PR DESCRIPTION
fixes: #22128 

Scale float32 images in [0, 1] range by 255 before casting to uint8.
Previously, direct casting truncated all values to near-zero, making
the output image almost entirely black.

Now the conversion checks if the image dtype is floating-point:
- If max <= 1.0: scale by 255, then cast to uint8
- If max > 1.0: cast directly to uint8
- Non-float dtypes: cast directly to uint8