### PR TITLE
implement vsplit operation for all backends

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -313,6 +313,7 @@ from keras.src.ops.numpy import var as var
 from keras.src.ops.numpy import vdot as vdot
 from keras.src.ops.numpy import vectorize as vectorize
 from keras.src.ops.numpy import view as view
+from keras.src.ops.numpy import vsplit as vsplit
 from keras.src.ops.numpy import vstack as vstack
 from keras.src.ops.numpy import where as where
 from keras.src.ops.numpy import zeros as zeros

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -195,6 +195,7 @@ from keras.src.ops.numpy import var as var
 from keras.src.ops.numpy import vdot as vdot
 from keras.src.ops.numpy import vectorize as vectorize
 from keras.src.ops.numpy import view as view
+from keras.src.ops.numpy import vsplit as vsplit
 from keras.src.ops.numpy import vstack as vstack
 from keras.src.ops.numpy import where as where
 from keras.src.ops.numpy import zeros as zeros

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -313,6 +313,7 @@ from keras.src.ops.numpy import var as var
 from keras.src.ops.numpy import vdot as vdot
 from keras.src.ops.numpy import vectorize as vectorize
 from keras.src.ops.numpy import view as view
+from keras.src.ops.numpy import vsplit as vsplit
 from keras.src.ops.numpy import vstack as vstack
 from keras.src.ops.numpy import where as where
 from keras.src.ops.numpy import zeros as zeros

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -195,6 +195,7 @@ from keras.src.ops.numpy import var as var
 from keras.src.ops.numpy import vdot as vdot
 from keras.src.ops.numpy import vectorize as vectorize
 from keras.src.ops.numpy import view as view
+from keras.src.ops.numpy import vsplit as vsplit
 from keras.src.ops.numpy import vstack as vstack
 from keras.src.ops.numpy import where as where
 from keras.src.ops.numpy import zeros as zeros

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -1355,6 +1355,7 @@ def vstack(xs):
 
 
 def vsplit(x, indices_or_sections):
+    x = convert_to_tensor(x)
     return jnp.vsplit(x, indices_or_sections)
 
 

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -1354,6 +1354,10 @@ def vstack(xs):
     return jnp.vstack(xs)
 
 
+def vsplit(x, indices_or_sections):
+    return jnp.vsplit(x, indices_or_sections)
+
+
 def vectorize(pyfunc, *, excluded=None, signature=None):
     if excluded is None:
         excluded = set()

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -1311,6 +1311,11 @@ def vstack(xs):
     return np.vstack(xs)
 
 
+def vsplit(x, indices_or_sections):
+    x = convert_to_tensor(x)
+    return np.vsplit(x, indices_or_sections)
+
+
 def vectorize(pyfunc, *, excluded=None, signature=None):
     return np.vectorize(pyfunc, excluded=excluded, signature=signature)
 

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -3115,6 +3115,10 @@ def vstack(xs):
     return OpenVINOKerasTensor(ov_opset.concat(elems, axis).output(0))
 
 
+def vsplit(x, indices_or_sections):
+    return split(x, indices_or_sections, axis=0)
+
+
 def vectorize(pyfunc, *, excluded=None, signature=None):
     raise NotImplementedError(
         "`vectorize` is not supported with openvino backend"

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -3030,6 +3030,10 @@ def vstack(xs):
     return tf.concat(xs, axis=0)
 
 
+def vsplit(x, indices_or_sections):
+    return tf.experimental.numpy.vsplit(x, indices_or_sections)
+
+
 def _vmap_fn(fn, in_axes=0):
     if in_axes != 0:
         raise ValueError(

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -3031,7 +3031,7 @@ def vstack(xs):
 
 
 def vsplit(x, indices_or_sections):
-    return tf.experimental.numpy.vsplit(x, indices_or_sections)
+    return split(x, indices_or_sections, axis=0)
 
 
 def _vmap_fn(fn, in_axes=0):

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1843,6 +1843,13 @@ def vstack(xs):
     return torch.vstack(xs)
 
 
+def vsplit(x, indices_or_sections):
+    x = convert_to_tensor(x)
+    if not isinstance(indices_or_sections, int):
+        indices_or_sections = convert_to_tensor(indices_or_sections).tolist()
+    return list(torch.vsplit(x, indices_or_sections))
+
+
 def vectorize(pyfunc, *, excluded=None, signature=None):
     return vectorize_impl(
         pyfunc, torch.vmap, excluded=excluded, signature=signature


### PR DESCRIPTION
Added new `vsplit` ops, which split a tensor into multiple sub-tensors vertically. 
Supported across all backends (NumPy, TensorFlow, Torch, JAX, OpenVINO).