### PR TITLE
fix: support axis parameter in sparse_categorical_crossentropy

### DIFF
--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -977,8 +977,6 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
 def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
     target = jnp.array(target, dtype="int32")
     output = jnp.array(output)
-    if len(target.shape) == len(output.shape) and target.shape[-1] == 1:
-        target = jnp.squeeze(target, axis=-1)
 
     if len(output.shape) < 1:
         raise ValueError(
@@ -986,10 +984,25 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
             "Received: "
             f"output.shape={output.shape}"
         )
-    if target.shape != output.shape[:-1]:
+
+    # Normalize axis to positive index
+    positive_axis = axis if axis >= 0 else len(output.shape) + axis
+
+    # Squeeze target if it has an extra dimension of size 1 at the axis
+    if (
+        len(target.shape) == len(output.shape)
+        and target.shape[positive_axis] == 1
+    ):
+        target = jnp.squeeze(target, axis=positive_axis)
+
+    # Compute expected shape by removing the class dimension from output
+    output_shape_without_class = list(output.shape)
+    del output_shape_without_class[positive_axis]
+
+    if list(target.shape) != output_shape_without_class:
         raise ValueError(
             "Arguments `target` and `output` must have the same shape "
-            "up until the last dimension: "
+            f"except for the class dimension at axis={axis}: "
             f"target.shape={target.shape}, output.shape={output.shape}"
         )
     if from_logits:

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -828,10 +828,10 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
     ):
         target = torch.squeeze(target, dim=positive_axis)
 
-    output_shape_without_class_dim = list(output.shape)
-    del output_shape_without_class_dim[positive_axis]
+    output_shape_without_class = list(output.shape)
+    del output_shape_without_class[positive_axis]
 
-    if list(target.shape) != output_shape_without_class_dim:
+    if list(target.shape) != output_shape_without_class:
         raise ValueError(
             "Arguments `target` and `output` must have the same shape "
             f"except for the class dimension at axis={axis}: "

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -811,22 +811,30 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
     target = convert_to_tensor(target, dtype=torch.long)
     output = convert_to_tensor(output)
 
-    if len(target.shape) == len(output.shape) and target.shape[-1] == 1:
-        target = torch.squeeze(target, dim=-1)
-
     if len(output.shape) < 1:
         raise ValueError(
             "Argument `output` must be at least rank 1. "
             "Received: "
             f"output.shape={output.shape}"
         )
+
+    # Normalize axis to positive index
+    positive_axis = axis if axis >= 0 else len(output.shape) + axis
+
+    # Squeeze target if it has an extra dimension of size 1 at the axis
+    if (
+        len(target.shape) == len(output.shape)
+        and target.shape[positive_axis] == 1
+    ):
+        target = torch.squeeze(target, dim=positive_axis)
+
     output_shape_without_class_dim = list(output.shape)
-    del output_shape_without_class_dim[axis]
+    del output_shape_without_class_dim[positive_axis]
 
     if list(target.shape) != output_shape_without_class_dim:
         raise ValueError(
             "Arguments `target` and `output` must have the same shape "
-            "up until the last dimension: "
+            f"except for the class dimension at axis={axis}: "
             f"target.shape={target.shape}, output.shape={output.shape}"
         )
     if from_logits:

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1,5 +1,3 @@
-import re
-
 import numpy as np
 import pytest
 
@@ -1358,6 +1356,7 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
         self.assertAllClose(output, expected.sum() / 16.0)  # 16 pixels
 
     def test_binary_segmentation_different_axis(self):
+        # Test axis=0 with perfect predictions (all correct)
         y_true = np.array(
             [[0, 1, 1, 0], [1, 0, 1, 0], [0, 0, 1, 1], [1, 1, 0, 1]]
         )
@@ -1370,62 +1369,39 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
             ]
         )
         y_pred_reshaped = np.moveaxis(y_pred, source=2, destination=0)
-        if backend.backend() == "tensorflow":
-            expected_message = (
-                "Only axis=-1 is currently supported. Received: axis=0"
-            )
-            escaped_message = re.escape(expected_message)
+        output = losses.SparseCategoricalCrossentropy(axis=0)(
+            y_true, y_pred_reshaped
+        )
+        self.assertAllClose(output, 0.0)
 
-            with pytest.raises(ValueError, match=escaped_message):
-                losses.SparseCategoricalCrossentropy(axis=0)(
-                    y_true, y_pred_reshaped
-                )
-        elif backend.backend() == "jax":
-            expected_message = (
-                "Arguments `target` and `output` "
-                "must have the same shape up until"
-                " the last dimension: target.shape=(4, 4),"
-                " output.shape=(2, 4, 4)"
-            )
-            escaped_message = re.escape(expected_message)
+        # Test axis=0 with some incorrect predictions
+        y_true = np.array(
+            [[0, 1, 1, 0], [1, 0, 1, 0], [0, 0, 1, 1], [1, 1, 0, 1]]
+        )
+        y_pred = np.array(
+            [
+                [[1.0, 0.0], [0.0, 1.0], [0.0, 1.0], [0.2, 0.8]],
+                [[0.0, 1.0], [1.0, 0.0], [0.0, 1.0], [1.0, 0.0]],
+                [[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]],
+                [[0.0, 1.0], [0.0, 1.0], [1.0, 0.0], [0.6, 0.4]],
+            ]
+        )
+        y_pred_reshaped = np.moveaxis(y_pred, source=2, destination=0)
+        expected = np.array([-np.log(0.2), -np.log(0.4)])
+        output = losses.SparseCategoricalCrossentropy(axis=0)(
+            y_true, y_pred_reshaped
+        )
+        self.assertAllClose(output, expected.sum() / 16.0)
 
-            with pytest.raises(ValueError, match=escaped_message):
-                losses.SparseCategoricalCrossentropy(axis=0)(
-                    y_true, y_pred_reshaped
-                )
-        elif backend.backend() == "torch":
-            output = losses.SparseCategoricalCrossentropy(axis=0)(
-                y_true, y_pred_reshaped
-            )
-            self.assertAllClose(output, 0.0)
-
-        if backend.backend() == "torch":
-            y_true = np.array(
-                [[0, 1, 1, 0], [1, 0, 1, 0], [0, 0, 1, 1], [1, 1, 0, 1]]
-            )
-            y_pred = np.array(
-                [
-                    [[1.0, 0.0], [0.0, 1.0], [0.0, 1.0], [0.2, 0.8]],
-                    [[0.0, 1.0], [1.0, 0.0], [0.0, 1.0], [1.0, 0.0]],
-                    [[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]],
-                    [[0.0, 1.0], [0.0, 1.0], [1.0, 0.0], [0.6, 0.4]],
-                ]
-            )
-            y_pred_reshaped = np.moveaxis(y_pred, source=2, destination=0)
-            expected = np.array([-np.log(0.2), -np.log(0.4)])
-            output = losses.SparseCategoricalCrossentropy(axis=0)(
-                y_true, y_pred_reshaped
-            )
-            self.assertAllClose(output, expected.sum() / 16.0)
-
-            y_true = np.array([y_true, y_true, y_true])
-            y_pred_reshaped = np.array(
-                [y_pred_reshaped, y_pred_reshaped, y_pred_reshaped]
-            )
-            output = losses.SparseCategoricalCrossentropy(axis=1)(
-                y_true, y_pred_reshaped
-            )
-            self.assertAllClose(output, expected.sum() / 16.0)
+        # Test axis=1 with batched data
+        y_true = np.array([y_true, y_true, y_true])
+        y_pred_reshaped = np.array(
+            [y_pred_reshaped, y_pred_reshaped, y_pred_reshaped]
+        )
+        output = losses.SparseCategoricalCrossentropy(axis=1)(
+            y_true, y_pred_reshaped
+        )
+        self.assertAllClose(output, expected.sum() / 16.0)
 
     def test_multi_class_segmentation(self):
         y_true = np.array(
@@ -1504,6 +1480,7 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
         self.assertAllClose(output, expected.sum() / 16.0)  # 16 pixels
 
     def test_multi_class_segmentation_different_axis(self):
+        # Test axis=0 with perfect predictions (all correct) for 3 classes
         y_true = np.array(
             [[0, 1, 2, 0], [1, 0, 1, 0], [0, 0, 1, 1], [1, 1, 0, 1]]
         )
@@ -1536,87 +1513,65 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
             ]
         )
         y_pred_reshaped = np.moveaxis(y_pred, source=2, destination=0)
-        if backend.backend() == "tensorflow":
-            expected_message = (
-                "Only axis=-1 is currently supported. Received: axis=0"
-            )
-            escaped_message = re.escape(expected_message)
+        output = losses.SparseCategoricalCrossentropy(axis=0)(
+            y_true, y_pred_reshaped
+        )
+        self.assertAllClose(output, 0.0)
 
-            with pytest.raises(ValueError, match=escaped_message):
-                losses.SparseCategoricalCrossentropy(axis=0)(
-                    y_true, y_pred_reshaped
-                )
-        elif backend.backend() == "jax":
-            expected_message = (
-                "Arguments `target` and `output` "
-                "must have the same shape up until"
-                " the last dimension: target.shape=(4, 4),"
-                " output.shape=(3, 4, 4)"
-            )
-            escaped_message = re.escape(expected_message)
-
-            with pytest.raises(ValueError, match=escaped_message):
-                losses.SparseCategoricalCrossentropy(axis=0)(
-                    y_true, y_pred_reshaped
-                )
-        elif backend.backend() == "torch":
-            output = losses.SparseCategoricalCrossentropy(axis=0)(
-                y_true, y_pred_reshaped
-            )
-            self.assertAllClose(output, 0.0)
-
-        if backend.backend() == "torch":
-            y_true = np.array(
-                [[0, 1, 2, 0], [1, 0, 1, 0], [0, 0, 1, 1], [1, 1, 0, 1]]
-            )
-            y_pred = np.array(
+        # Test axis=0 with some incorrect predictions for 3 classes
+        y_true = np.array(
+            [[0, 1, 2, 0], [1, 0, 1, 0], [0, 0, 1, 1], [1, 1, 0, 1]]
+        )
+        y_pred = np.array(
+            [
                 [
-                    [
-                        [1.0, 0.0, 0.0],
-                        [0.0, 1.0, 0.0],
-                        [0.0, 0.0, 1.0],
-                        [0.2, 0.0, 0.8],
-                    ],
-                    [
-                        [0.7, 0.3, 0.0],
-                        [1.0, 0.0, 0.0],
-                        [0.0, 1.0, 0.0],
-                        [1.0, 0.0, 0.0],
-                    ],
-                    [
-                        [1.0, 0.0, 0.0],
-                        [1.0, 0.0, 0.0],
-                        [0.0, 1.0, 0.0],
-                        [0.0, 1.0, 0.0],
-                    ],
-                    [
-                        [0.0, 1.0, 0.0],
-                        [0.0, 1.0, 0.0],
-                        [0.5, 0.5, 0.0],
-                        [0.0, 1.0, 0.0],
-                    ],
-                ]
-            )
-            expected = np.array(
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                    [0.2, 0.0, 0.8],
+                ],
                 [
-                    -np.log(0.2),
-                    -np.log(0.3),
-                    -np.log(0.5),
-                ]
-            )
-            y_pred_reshaped = np.moveaxis(y_pred, source=2, destination=0)
-            output = losses.SparseCategoricalCrossentropy(axis=0)(
-                y_true, y_pred_reshaped
-            )
-            self.assertAllClose(output, expected.sum() / 16.0)
-            y_true = np.array([y_true, y_true, y_true])
-            y_pred_reshaped = np.array(
-                [y_pred_reshaped, y_pred_reshaped, y_pred_reshaped]
-            )
-            output = losses.SparseCategoricalCrossentropy(axis=1)(
-                y_true, y_pred_reshaped
-            )
-            self.assertAllClose(output, expected.sum() / 16.0)
+                    [0.7, 0.3, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                ],
+                [
+                    [1.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                ],
+                [
+                    [0.0, 1.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.5, 0.5, 0.0],
+                    [0.0, 1.0, 0.0],
+                ],
+            ]
+        )
+        expected = np.array(
+            [
+                -np.log(0.2),
+                -np.log(0.3),
+                -np.log(0.5),
+            ]
+        )
+        y_pred_reshaped = np.moveaxis(y_pred, source=2, destination=0)
+        output = losses.SparseCategoricalCrossentropy(axis=0)(
+            y_true, y_pred_reshaped
+        )
+        self.assertAllClose(output, expected.sum() / 16.0)
+
+        # Test axis=1 with batched data
+        y_true = np.array([y_true, y_true, y_true])
+        y_pred_reshaped = np.array(
+            [y_pred_reshaped, y_pred_reshaped, y_pred_reshaped]
+        )
+        output = losses.SparseCategoricalCrossentropy(axis=1)(
+            y_true, y_pred_reshaped
+        )
+        self.assertAllClose(output, expected.sum() / 16.0)
 
     def test_dtype_arg(self):
         y_true = np.array([[0], [1], [2]], dtype="int64")


### PR DESCRIPTION
## Summary
Fixes #21097 - `sparse_categorical_crossentropy` now properly supports the `axis` parameter across all backends.

Previously, the function ignored the `axis` parameter when checking tensor dimensions, causing errors when using `channels_first` data format (axis=1) for segmentation tasks.

## Changes
- Fixed `compute_output_spec` in `keras/src/ops/nn.py` to use axis parameter
- Added full axis support in TensorFlow backend (was previously axis=-1 only)
- Fixed shape checking in JAX, PyTorch, and NumPy backends to use axis parameter
- Fixed squeeze and shape handling in `keras/src/losses/losses.py`
- Updated tests to verify correct behavior across all backends

## Test plan
- [x] Tested with PyTorch, TensorFlow, and JAX backends
- [x] Verified axis=1 works for channels_first segmentation use case
- [x] All existing SparseCategoricalCrossentropy tests pass
- [x] Pre-commit checks pass