### PR TITLE
feat: add euclidean_distance_transform op (#22038)

### DIFF
--- a/keras/api/_tf_keras/keras/ops/image/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/image/__init__.py
@@ -7,6 +7,9 @@ since your modifications would be overwritten.
 from keras.src.ops.image import affine_transform as affine_transform
 from keras.src.ops.image import crop_images as crop_images
 from keras.src.ops.image import elastic_transform as elastic_transform
+from keras.src.ops.image import (
+    euclidean_distance_transform as euclidean_distance_transform,
+)
 from keras.src.ops.image import extract_patches as extract_patches
 from keras.src.ops.image import extract_patches_3d as extract_patches_3d
 from keras.src.ops.image import gaussian_blur as gaussian_blur

--- a/keras/api/ops/image/__init__.py
+++ b/keras/api/ops/image/__init__.py
@@ -7,6 +7,9 @@ since your modifications would be overwritten.
 from keras.src.ops.image import affine_transform as affine_transform
 from keras.src.ops.image import crop_images as crop_images
 from keras.src.ops.image import elastic_transform as elastic_transform
+from keras.src.ops.image import (
+    euclidean_distance_transform as euclidean_distance_transform,
+)
 from keras.src.ops.image import extract_patches as extract_patches
 from keras.src.ops.image import extract_patches_3d as extract_patches_3d
 from keras.src.ops.image import gaussian_blur as gaussian_blur

--- a/keras/src/backend/jax/image.py
+++ b/keras/src/backend/jax/image.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 from keras.src import backend
 from keras.src.backend.jax.core import convert_to_tensor
 from keras.src.random.seed_generator import draw_seed
+from keras.src.utils.module_utils import scipy
 
 RESIZE_INTERPOLATIONS = (
     "bilinear",
@@ -907,8 +908,6 @@ def euclidean_distance_transform(images, sampling=None):
     Returns:
         Distance transform with the same shape as input.
     """
-    from scipy import ndimage
-
     images = convert_to_tensor(images)
     original_shape = images.shape
     original_ndim = len(original_shape)
@@ -928,7 +927,7 @@ def euclidean_distance_transform(images, sampling=None):
 
         if images_np.ndim == 2:
             binary = images_np != 0
-            return ndimage.distance_transform_edt(
+            return scipy.ndimage.distance_transform_edt(
                 binary, sampling=sampling
             ).astype(np.float32)
 
@@ -945,7 +944,7 @@ def euclidean_distance_transform(images, sampling=None):
         for b in range(batch_size):
             for c in range(num_channels):
                 binary = images_np[b, :, :, c] != 0
-                result[b, :, :, c] = ndimage.distance_transform_edt(
+                result[b, :, :, c] = scipy.ndimage.distance_transform_edt(
                     binary, sampling=sampling
                 )
 

--- a/keras/src/backend/jax/image.py
+++ b/keras/src/backend/jax/image.py
@@ -2,6 +2,7 @@ import functools
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from keras.src import backend
 from keras.src.backend.jax.core import convert_to_tensor
@@ -923,8 +924,6 @@ def euclidean_distance_transform(images, sampling=None):
 
     def _edt_impl(images_np):
         """Apply EDT using scipy."""
-        import numpy as np
-
         if images_np.ndim == 2:
             binary = images_np != 0
             return scipy.ndimage.distance_transform_edt(

--- a/keras/src/backend/jax/image.py
+++ b/keras/src/backend/jax/image.py
@@ -917,7 +917,7 @@ def euclidean_distance_transform(images, sampling=None):
     if original_ndim not in (2, 3, 4):
         raise ValueError(
             "Invalid images rank: expected rank 2 (single grayscale image), "
-            "rank 3 (single image or batch of grayscale images), "
+            "rank 3 (single image with channels), "
             "or rank 4 (batch of images). Received input with shape: "
             f"images.shape={images.shape}"
         )
@@ -933,14 +933,12 @@ def euclidean_distance_transform(images, sampling=None):
             ).astype(np.float32)
 
         # Handle 3D and 4D cases
+        # 3D input is interpreted as (H, W, C) - single image with channels
         if images_np.ndim == 3:
             images_np = np.expand_dims(images_np, axis=0)
 
         batch_size = images_np.shape[0]
-        num_channels = images_np.shape[3] if images_np.ndim == 4 else 1
-
-        if images_np.ndim == 3:
-            images_np = np.expand_dims(images_np, axis=-1)
+        num_channels = images_np.shape[3]
 
         result = np.zeros_like(images_np, dtype=np.float32)
 
@@ -953,10 +951,7 @@ def euclidean_distance_transform(images, sampling=None):
 
         # Restore original ndim
         if original_ndim == 3:
-            if len(original_shape) == 3 and original_shape[-1] == num_channels:
-                result = np.squeeze(result, axis=0)
-            else:
-                result = np.squeeze(result, axis=-1)
+            result = np.squeeze(result, axis=0)
 
         return result.astype(np.float32)
 

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -1203,3 +1203,72 @@ def scale_and_translate(
         kernel,
         antialias,
     )
+
+
+def euclidean_distance_transform(images, sampling=None):
+    """Computes the Euclidean distance transform of binary images.
+
+    Args:
+        images: Input binary image or batch of images.
+        sampling: Spacing of elements along each dimension.
+
+    Returns:
+        Distance transform with the same shape as input.
+    """
+    images = convert_to_tensor(images)
+    original_shape = images.shape
+    original_ndim = len(original_shape)
+
+    # Validate input rank
+    if original_ndim not in (2, 3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 2 (single grayscale image), "
+            "rank 3 (single image or batch of grayscale images), "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    # For 2D input, process directly
+    if original_ndim == 2:
+        # Convert to binary: non-zero values become True (foreground)
+        binary = images != 0
+        result = scipy.ndimage.distance_transform_edt(binary, sampling=sampling)
+        return result.astype(np.float32)
+
+    # For 3D input: could be (H, W, C) single image or (B, H, W) grayscale batch
+    # For 4D input: (B, H, W, C) batch of images
+    # Process each 2D slice (each channel of each batch item) independently
+
+    if original_ndim == 3:
+        # Assume (H, W, C) single image - add batch dimension
+        images = np.expand_dims(images, axis=0)
+
+    batch_size = images.shape[0]
+    num_channels = images.shape[3] if len(images.shape) == 4 else 1
+
+    if len(images.shape) == 3:
+        # (B, H, W) grayscale batch
+        images = np.expand_dims(images, axis=-1)
+        num_channels = 1
+
+    # Prepare output array
+    result = np.zeros_like(images, dtype=np.float32)
+
+    # Process each channel of each image independently
+    for b in range(batch_size):
+        for c in range(num_channels):
+            binary = images[b, :, :, c] != 0
+            result[b, :, :, c] = scipy.ndimage.distance_transform_edt(
+                binary, sampling=sampling
+            )
+
+    # Restore original shape
+    if original_ndim == 3:
+        if original_shape[-1] == num_channels:
+            # Was (H, W, C)
+            result = np.squeeze(result, axis=0)
+        else:
+            # Was (B, H, W) grayscale
+            result = np.squeeze(result, axis=-1)
+
+    return result

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -1223,7 +1223,7 @@ def euclidean_distance_transform(images, sampling=None):
     if original_ndim not in (2, 3, 4):
         raise ValueError(
             "Invalid images rank: expected rank 2 (single grayscale image), "
-            "rank 3 (single image or batch of grayscale images), "
+            "rank 3 (single image with channels), "
             "or rank 4 (batch of images). Received input with shape: "
             f"images.shape={images.shape}"
         )
@@ -1239,17 +1239,12 @@ def euclidean_distance_transform(images, sampling=None):
     # For 4D input: (B, H, W, C) batch of images
     # Process each 2D slice (each channel of each batch item) independently
 
+    # 3D input is interpreted as (H, W, C) - single image with channels
     if original_ndim == 3:
-        # Assume (H, W, C) single image - add batch dimension
         images = np.expand_dims(images, axis=0)
 
     batch_size = images.shape[0]
-    num_channels = images.shape[3] if len(images.shape) == 4 else 1
-
-    if len(images.shape) == 3:
-        # (B, H, W) grayscale batch
-        images = np.expand_dims(images, axis=-1)
-        num_channels = 1
+    num_channels = images.shape[3]
 
     # Prepare output array
     result = np.zeros_like(images, dtype=np.float32)
@@ -1264,11 +1259,6 @@ def euclidean_distance_transform(images, sampling=None):
 
     # Restore original shape
     if original_ndim == 3:
-        if original_shape[-1] == num_channels:
-            # Was (H, W, C)
-            result = np.squeeze(result, axis=0)
-        else:
-            # Was (B, H, W) grayscale
-            result = np.squeeze(result, axis=-1)
+        result = np.squeeze(result, axis=0)
 
     return result

--- a/keras/src/backend/openvino/image.py
+++ b/keras/src/backend/openvino/image.py
@@ -87,3 +87,9 @@ def scale_and_translate(
     raise NotImplementedError(
         "`scale_and_translate` is not supported with openvino backend"
     )
+
+
+def euclidean_distance_transform(images, sampling=None):
+    raise NotImplementedError(
+        "`euclidean_distance_transform` is not supported with openvino backend"
+    )

--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -1096,7 +1096,7 @@ def euclidean_distance_transform(images, sampling=None):
     if original_ndim not in (2, 3, 4):
         raise ValueError(
             "Invalid images rank: expected rank 2 (single grayscale image), "
-            "rank 3 (single image or batch of grayscale images), "
+            "rank 3 (single image with channels), "
             "or rank 4 (batch of images). Received input with shape: "
             f"images.shape={images.shape}"
         )
@@ -1113,15 +1113,12 @@ def euclidean_distance_transform(images, sampling=None):
         if images_np.ndim == 2:
             return _edt_2d(images_np, sampling)
 
+        # 3D input is interpreted as (H, W, C) - single image with channels
         if images_np.ndim == 3:
-            # Add batch dimension
             images_np = np.expand_dims(images_np, axis=0)
 
         batch_size = images_np.shape[0]
-        num_channels = images_np.shape[3] if images_np.ndim == 4 else 1
-
-        if images_np.ndim == 3:
-            images_np = np.expand_dims(images_np, axis=-1)
+        num_channels = images_np.shape[3]
 
         result = np.zeros_like(images_np, dtype=np.float32)
 
@@ -1134,10 +1131,7 @@ def euclidean_distance_transform(images, sampling=None):
 
         # Restore original ndim if needed
         if original_ndim == 3:
-            if len(original_shape) == 3 and original_shape[-1] == num_channels:
-                result = np.squeeze(result, axis=0)
-            else:
-                result = np.squeeze(result, axis=-1)
+            result = np.squeeze(result, axis=0)
 
         return result.astype(np.float32)
 

--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -9,6 +9,7 @@ from keras.src import backend
 from keras.src.backend.tensorflow.core import convert_to_tensor
 from keras.src.backend.tensorflow.numpy import moveaxis
 from keras.src.random.seed_generator import draw_seed
+from keras.src.utils.module_utils import scipy
 
 RESIZE_INTERPOLATIONS = (
     "bilinear",
@@ -1086,8 +1087,6 @@ def euclidean_distance_transform(images, sampling=None):
     Returns:
         Distance transform with the same shape as input.
     """
-    from scipy import ndimage
-
     images = convert_to_tensor(images)
     original_shape = images.shape
     original_ndim = len(original_shape)
@@ -1104,9 +1103,9 @@ def euclidean_distance_transform(images, sampling=None):
     def _edt_2d(image, sampling):
         """Apply EDT to a single 2D image."""
         binary = image != 0
-        return ndimage.distance_transform_edt(binary, sampling=sampling).astype(
-            np.float32
-        )
+        return scipy.ndimage.distance_transform_edt(
+            binary, sampling=sampling
+        ).astype(np.float32)
 
     def _edt_batch(images_np, sampling):
         """Apply EDT to a batch of images."""
@@ -1125,7 +1124,7 @@ def euclidean_distance_transform(images, sampling=None):
         for b in range(batch_size):
             for c in range(num_channels):
                 binary = images_np[b, :, :, c] != 0
-                result[b, :, :, c] = ndimage.distance_transform_edt(
+                result[b, :, :, c] = scipy.ndimage.distance_transform_edt(
                     binary, sampling=sampling
                 )
 

--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -1074,3 +1074,77 @@ def scale_and_translate(
         kernel,
         antialias,
     )
+
+
+def euclidean_distance_transform(images, sampling=None):
+    """Computes the Euclidean distance transform of binary images.
+
+    Args:
+        images: Input binary image or batch of images.
+        sampling: Spacing of elements along each dimension.
+
+    Returns:
+        Distance transform with the same shape as input.
+    """
+    from scipy import ndimage
+
+    images = convert_to_tensor(images)
+    original_shape = images.shape
+    original_ndim = len(original_shape)
+
+    # Validate input rank
+    if original_ndim not in (2, 3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 2 (single grayscale image), "
+            "rank 3 (single image or batch of grayscale images), "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    def _edt_2d(image, sampling):
+        """Apply EDT to a single 2D image."""
+        binary = image != 0
+        return ndimage.distance_transform_edt(binary, sampling=sampling).astype(
+            np.float32
+        )
+
+    def _edt_batch(images_np, sampling):
+        """Apply EDT to a batch of images."""
+        if images_np.ndim == 2:
+            return _edt_2d(images_np, sampling)
+
+        if images_np.ndim == 3:
+            # Add batch dimension
+            images_np = np.expand_dims(images_np, axis=0)
+
+        batch_size = images_np.shape[0]
+        num_channels = images_np.shape[3] if images_np.ndim == 4 else 1
+
+        if images_np.ndim == 3:
+            images_np = np.expand_dims(images_np, axis=-1)
+
+        result = np.zeros_like(images_np, dtype=np.float32)
+
+        for b in range(batch_size):
+            for c in range(num_channels):
+                binary = images_np[b, :, :, c] != 0
+                result[b, :, :, c] = ndimage.distance_transform_edt(
+                    binary, sampling=sampling
+                )
+
+        # Restore original ndim if needed
+        if original_ndim == 3:
+            if len(original_shape) == 3 and original_shape[-1] == num_channels:
+                result = np.squeeze(result, axis=0)
+            else:
+                result = np.squeeze(result, axis=-1)
+
+        return result.astype(np.float32)
+
+    result = tf.numpy_function(
+        lambda x: _edt_batch(x, sampling),
+        [images],
+        tf.float32,
+    )
+    result.set_shape(original_shape)
+    return result

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -1190,3 +1190,67 @@ def scale_and_translate(
         kernel,
         antialias,
     )
+
+
+def euclidean_distance_transform(images, sampling=None):
+    """Computes the Euclidean distance transform of binary images.
+
+    Args:
+        images: Input binary image or batch of images.
+        sampling: Spacing of elements along each dimension.
+
+    Returns:
+        Distance transform with the same shape as input.
+    """
+    from scipy import ndimage
+
+    images = convert_to_tensor(images)
+    original_shape = images.shape
+    original_ndim = len(original_shape)
+    device = images.device
+
+    # Validate input rank
+    if original_ndim not in (2, 3, 4):
+        raise ValueError(
+            "Invalid images rank: expected rank 2 (single grayscale image), "
+            "rank 3 (single image or batch of grayscale images), "
+            "or rank 4 (batch of images). Received input with shape: "
+            f"images.shape={images.shape}"
+        )
+
+    # Convert to numpy for scipy processing
+    images_np = images.cpu().numpy()
+
+    # For 2D input, process directly
+    if original_ndim == 2:
+        binary = images_np != 0
+        result = ndimage.distance_transform_edt(binary, sampling=sampling)
+        return torch.tensor(result, dtype=torch.float32, device=device)
+
+    # Handle 3D and 4D cases
+    if original_ndim == 3:
+        images_np = np.expand_dims(images_np, axis=0)
+
+    batch_size = images_np.shape[0]
+    num_channels = images_np.shape[3] if images_np.ndim == 4 else 1
+
+    if images_np.ndim == 3:
+        images_np = np.expand_dims(images_np, axis=-1)
+
+    result = np.zeros_like(images_np, dtype=np.float32)
+
+    for b in range(batch_size):
+        for c in range(num_channels):
+            binary = images_np[b, :, :, c] != 0
+            result[b, :, :, c] = ndimage.distance_transform_edt(
+                binary, sampling=sampling
+            )
+
+    # Restore original ndim
+    if original_ndim == 3:
+        if len(original_shape) == 3 and original_shape[-1] == num_channels:
+            result = np.squeeze(result, axis=0)
+        else:
+            result = np.squeeze(result, axis=-1)
+
+    return torch.tensor(result, dtype=torch.float32, device=device)

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -1213,7 +1213,7 @@ def euclidean_distance_transform(images, sampling=None):
     if original_ndim not in (2, 3, 4):
         raise ValueError(
             "Invalid images rank: expected rank 2 (single grayscale image), "
-            "rank 3 (single image or batch of grayscale images), "
+            "rank 3 (single image with channels), "
             "or rank 4 (batch of images). Received input with shape: "
             f"images.shape={images.shape}"
         )
@@ -1228,14 +1228,12 @@ def euclidean_distance_transform(images, sampling=None):
         return torch.tensor(result, dtype=torch.float32, device=device)
 
     # Handle 3D and 4D cases
+    # 3D input is interpreted as (H, W, C) - single image with channels
     if original_ndim == 3:
         images_np = np.expand_dims(images_np, axis=0)
 
     batch_size = images_np.shape[0]
-    num_channels = images_np.shape[3] if images_np.ndim == 4 else 1
-
-    if images_np.ndim == 3:
-        images_np = np.expand_dims(images_np, axis=-1)
+    num_channels = images_np.shape[3]
 
     result = np.zeros_like(images_np, dtype=np.float32)
 
@@ -1248,9 +1246,6 @@ def euclidean_distance_transform(images, sampling=None):
 
     # Restore original ndim
     if original_ndim == 3:
-        if len(original_shape) == 3 and original_shape[-1] == num_channels:
-            result = np.squeeze(result, axis=0)
-        else:
-            result = np.squeeze(result, axis=-1)
+        result = np.squeeze(result, axis=0)
 
     return torch.tensor(result, dtype=torch.float32, device=device)

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -13,6 +13,7 @@ from keras.src.backend.torch.core import convert_to_tensor
 from keras.src.backend.torch.core import get_device
 from keras.src.backend.torch.core import to_torch_dtype
 from keras.src.random.seed_generator import draw_seed
+from keras.src.utils.module_utils import scipy
 
 RESIZE_INTERPOLATIONS = {
     "bilinear": "bilinear",
@@ -1202,8 +1203,6 @@ def euclidean_distance_transform(images, sampling=None):
     Returns:
         Distance transform with the same shape as input.
     """
-    from scipy import ndimage
-
     images = convert_to_tensor(images)
     original_shape = images.shape
     original_ndim = len(original_shape)
@@ -1224,7 +1223,7 @@ def euclidean_distance_transform(images, sampling=None):
     # For 2D input, process directly
     if original_ndim == 2:
         binary = images_np != 0
-        result = ndimage.distance_transform_edt(binary, sampling=sampling)
+        result = scipy.ndimage.distance_transform_edt(binary, sampling=sampling)
         return torch.tensor(result, dtype=torch.float32, device=device)
 
     # Handle 3D and 4D cases
@@ -1240,7 +1239,7 @@ def euclidean_distance_transform(images, sampling=None):
     for b in range(batch_size):
         for c in range(num_channels):
             binary = images_np[b, :, :, c] != 0
-            result[b, :, :, c] = ndimage.distance_transform_edt(
+            result[b, :, :, c] = scipy.ndimage.distance_transform_edt(
                 binary, sampling=sampling
             )
 

--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -1910,3 +1910,97 @@ def scale_and_translate(
         method,
         antialias,
     )
+
+
+class EuclideanDistanceTransform(Operation):
+    def __init__(self, sampling=None, *, name=None):
+        super().__init__(name=name)
+        self.sampling = sampling
+
+    def call(self, images):
+        return backend.image.euclidean_distance_transform(
+            images, sampling=self.sampling
+        )
+
+    def compute_output_spec(self, images):
+        if len(images.shape) not in (2, 3, 4):
+            raise ValueError(
+                "Invalid images rank: expected rank 2, 3, or 4. "
+                f"Received input with shape: images.shape={images.shape}"
+            )
+        return KerasTensor(images.shape, dtype="float32")
+
+
+@keras_export("keras.ops.image.euclidean_distance_transform")
+def euclidean_distance_transform(images, sampling=None):
+    """Computes the Euclidean distance transform of binary images.
+
+    The Euclidean distance transform computes the shortest Euclidean distance
+    from each foreground (non-zero) pixel to the nearest background (zero)
+    pixel. Background pixels have a distance of 0.
+
+    This operation is commonly used for:
+    - Binary image analysis and segmentation
+    - Preprocessing for watershed algorithms
+    - Feature extraction and shape analysis
+    - Loss calculation in image segmentation tasks
+
+    Args:
+        images: Input binary image or batch of binary images. Must be 2D, 3D,
+            or 4D. For 2D input, shape is `(height, width)`. For 3D input,
+            shape is `(height, width, channels)` or
+            `(batch, height, width)` for grayscale batches. For 4D input,
+            shape is `(batch, height, width, channels)`. Non-zero values are
+            treated as foreground (1), zero values as background (0).
+        sampling: Spacing of elements along each dimension. If a sequence,
+            must be of length equal to the number of spatial dimensions.
+            If a single number, this is used for all dimensions. If `None`
+            (default), a spacing of unity (1.0) is used along all dimensions.
+
+    Returns:
+        Distance transform image(s) with the same shape as the input, where
+        each foreground pixel value represents the Euclidean distance to the
+        nearest background pixel. Output dtype is `float32`.
+
+    Examples:
+
+    >>> import numpy as np
+    >>> from keras import ops
+    >>> # Simple 2D binary image
+    >>> image = np.array([[0, 0, 0, 0, 0],
+    ...                   [0, 1, 1, 1, 0],
+    ...                   [0, 1, 1, 1, 0],
+    ...                   [0, 1, 1, 1, 0],
+    ...                   [0, 0, 0, 0, 0]], dtype="float32")
+    >>> result = ops.image.euclidean_distance_transform(image)
+    >>> result
+    array([[0.        , 0.        , 0.        , 0.        , 0.        ],
+           [0.        , 1.        , 1.        , 1.        , 0.        ],
+           [0.        , 1.        , 1.4142135 , 1.        , 0.        ],
+           [0.        , 1.        , 1.        , 1.        , 0.        ],
+           [0.        , 0.        , 0.        , 0.        , 0.        ]],
+          dtype=float32)
+
+    >>> # Batched 4D input
+    >>> images = np.zeros((2, 5, 5, 1), dtype="float32")
+    >>> images[0, 1:4, 1:4, 0] = 1
+    >>> images[1, 2:4, 2:4, 0] = 1
+    >>> result = ops.image.euclidean_distance_transform(images)
+    >>> result.shape
+    (2, 5, 5, 1)
+
+    >>> # With custom sampling (anisotropic pixels)
+    >>> image = np.array([[0, 0, 0],
+    ...                   [0, 1, 0],
+    ...                   [0, 0, 0]], dtype="float32")
+    >>> result = ops.image.euclidean_distance_transform(
+    ...     image, sampling=(2.0, 1.0)
+    ... )
+    >>> result[1, 1]  # Distance considering 2:1 aspect ratio
+    1.0
+    """
+    if any_symbolic_tensors((images,)):
+        return EuclideanDistanceTransform(sampling=sampling).symbolic_call(
+            images
+        )
+    return backend.image.euclidean_distance_transform(images, sampling=sampling)

--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -1948,8 +1948,7 @@ def euclidean_distance_transform(images, sampling=None):
     Args:
         images: Input binary image or batch of binary images. Must be 2D, 3D,
             or 4D. For 2D input, shape is `(height, width)`. For 3D input,
-            shape is `(height, width, channels)` or
-            `(batch, height, width)` for grayscale batches. For 4D input,
+            shape is `(height, width, channels)`. For 4D input,
             shape is `(batch, height, width, channels)`. Non-zero values are
             treated as foreground (1), zero values as background (0).
         sampling: Spacing of elements along each dimension. If a sequence,


### PR DESCRIPTION
## Summary
- Add `euclidean_distance_transform` operation to compute the Euclidean distance from each foreground pixel to the nearest background pixel
- Implements support for TensorFlow, JAX, PyTorch, and NumPy backends using `scipy.ndimage.distance_transform_edt`
- OpenVINO backend raises `NotImplementedError`

## Test plan
- [x] Added unit tests for 2D, 3D, and 4D input shapes
- [x] Tests for sampling parameter
- [x] Tests for edge cases (all background, all foreground)
- [x] Verified against scipy reference implementation
- [x] Tests pass on TensorFlow, JAX, and Torch backends

Closes #22038