### PR TITLE
Revamp graph validation in `Function.__init__`.

### DIFF
--- a/keras/src/ops/function_test.py
+++ b/keras/src/ops/function_test.py
@@ -114,10 +114,6 @@ class FunctionTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "incompatible inputs"):
             _ = fn([np.ones((4, 3)), np.ones((2, 3))])
 
-    def test_graph_disconnected_error(self):
-        # TODO
-        pass
-
     def test_serialization(self):
         inputs = Input(shape=(10,))
         outputs = Dense(1)(inputs)
@@ -158,11 +154,11 @@ class FunctionTest(testing.TestCase):
             ],
         )
         with self.assertRaisesRegex(
-            ValueError, "`inputs` not connected to `outputs`"
+            ValueError, "Output .* is not connected to `inputs`"
         ):
             _ = Model(Input(shape=(6,)), model_2(model_1(Input(shape=(6,)))))
 
         with self.assertRaisesRegex(
-            ValueError, "`inputs` not connected to `outputs`"
+            ValueError, "Output .* is not connected to `inputs`"
         ):
             _ = Model(model_1(Input(shape=(6,))), model_2(Input(shape=(3,))))


### PR DESCRIPTION
Problem 1:
- the current validation does not allow functional models where some inputs are passed unmodified as outputs (this was allowed in Keras 2).

Problem 2:
- the current validation does not allow functional models where some inputs are not used (this was allowed in Keras 2).

Problem 3:
- the current validation only verifies that the inputs are used, nothing is verified on the outputs. In particular, it is possible to create a model with some outputs disconnected from the inputs, the construction will succeed. However, calling such a model will fail with an non-descript KeyError.

Solution:
- instead of the verifying how inputs are used, the new validation verifies that all the outputs are reachable from the inputs.

Also improved the error message by specifying which output is not connected to the inputs.