### PR TITLE
Add support for dynamic dimensions in `ops.slice.compute_output_spec`.

### DIFF
--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -401,19 +401,31 @@ class Slice(Operation):
         return backend.core.slice(inputs, start_indices, self.shape)
 
     def compute_output_spec(self, inputs, start_indices):
-        if any(s == -1 for s in self.shape) and isinstance(
-            start_indices, KerasTensor
+        if len(self.shape) != len(inputs.shape):
+            raise ValueError(
+                "The number of dimensions in `inputs` must match the number of "
+                f"dimensions in `shape`. Received inputs.shape={inputs.shape} "
+                f"and shape={self.shape}"
+            )
+        if hasattr(start_indices, "__len__") and len(start_indices) != len(
+            inputs.shape
         ):
             raise ValueError(
-                "When using -1 in `shape`, `start_indices` should not be a "
-                "KerasTensor. "
+                "The number of dimensions in `start_indices` must match the "
+                "number of dimensions in `inputs`. Received "
+                f"start_indices={start_indices} and inputs.shape={inputs.shape}"
             )
-        # If self.shape[i] is -1, all remaining elements in dimension i are
-        # included in the slice.
-        final_shape = tuple(
-            inputs.shape[i] - start_indices[i] if s == -1 else s
-            for i, s in enumerate(self.shape)
-        )
+
+        final_shape = []
+        for i, (input_dim, slice_dim) in enumerate(
+            zip(inputs.shape, self.shape)
+        ):
+            if slice_dim != -1:
+                final_shape.append(slice_dim)
+            elif isinstance(start_indices, KerasTensor) or input_dim is None:
+                final_shape.append(None)
+            else:
+                final_shape.append(input_dim - start_indices[i])
         return KerasTensor(final_shape, dtype=inputs.dtype)
 
 

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -309,11 +309,38 @@ class CoreOpsStaticShapeTest(testing.TestCase):
         shape = (-1, -1)
         self.assertEqual(core.slice(inputs, start_indices, shape).shape, (2, 2))
 
-    def test_slice_negative_one_shape_raises(self):
+    def test_slice_negative_one_shape_tensor_indices(self):
         inputs = KerasTensor(shape=(3, 3), dtype="float32")
         start_indices = KerasTensor(shape=(2,), dtype="int32")
         shape = (-1, -1)
-        with self.assertRaises(ValueError):
+        self.assertEqual(
+            core.slice(inputs, start_indices, shape).shape, (None, None)
+        )
+
+    def test_slice_negative_one_shape_dynamic_input_shape(self):
+        inputs = KerasTensor(shape=(None, 3), dtype="float32")
+        start_indices = (1, 1)
+        shape = (-1, -1)
+        self.assertEqual(
+            core.slice(inputs, start_indices, shape).shape, (None, 2)
+        )
+
+    def test_slice_invalid_inputs(self):
+        inputs = KerasTensor(shape=(3, 3), dtype="float32")
+        start_indices = (1, 1)
+        shape = (2, 2, 2)
+        with self.assertRaisesRegex(
+            ValueError,
+            "dimensions in `inputs` must match.* dimensions in `shape`",
+        ):
+            core.slice(inputs, start_indices, shape)
+
+        start_indices = (1, 1, 1)
+        shape = (2, 2)
+        with self.assertRaisesRegex(
+            ValueError,
+            "dimensions in `start_indices` must match.* dimensions in `inputs`",
+        ):
             core.slice(inputs, start_indices, shape)
 
     def test_slice_update(self):


### PR DESCRIPTION
Also added verification that the shape of the inputs, the `shape` parameter and the `indices` have the same length.