### PR TITLE
feat: upgrade openvino backend to opset15

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy as np
 import openvino as ov
-import openvino.opset14 as ov_opset
+import openvino.opset15 as ov_opset
 from openvino import Model
 from openvino import Tensor
 from openvino import Type

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -1,4 +1,4 @@
-import openvino.opset14 as ov_opset
+import openvino.opset15 as ov_opset
 from openvino import Type
 
 from keras.src.backend.openvino.core import OpenVINOKerasTensor

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -1,4 +1,4 @@
-import openvino.opset14 as ov_opset
+import openvino.opset15 as ov_opset
 from openvino import Type
 
 from keras.src import backend

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1,5 +1,5 @@
 import numpy as np
-import openvino.opset14 as ov_opset
+import openvino.opset15 as ov_opset
 from openvino import Type
 
 from keras.src.backend import config

--- a/keras/src/backend/openvino/random.py
+++ b/keras/src/backend/openvino/random.py
@@ -1,5 +1,5 @@
 import numpy as np
-import openvino.opset14 as ov_opset
+import openvino.opset15 as ov_opset
 from openvino import Type
 
 from keras.src.backend.config import floatx

--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -1,6 +1,6 @@
 import numpy as np
 import openvino as ov
-import openvino.opset14 as ov_opset
+import openvino.opset15 as ov_opset
 
 from keras.src import backend
 from keras.src import callbacks as callbacks_module

--- a/keras/src/export/openvino.py
+++ b/keras/src/export/openvino.py
@@ -55,7 +55,7 @@ def export_openvino(
     )
 
     import openvino as ov
-    import openvino.opset14 as ov_opset
+    import openvino.opset15 as ov_opset
 
     from keras.src.backend.openvino.core import OPENVINO_DTYPES
     from keras.src.backend.openvino.core import OpenVINOKerasTensor


### PR DESCRIPTION
This PR updates the `OpenVINO` backend to use `opset15`.

Also executed the test cases after updating the `opset` version.

<img width="1647" height="101" alt="image" src="https://github.com/user-attachments/assets/0ce20107-e8be-4133-a5f1-3e404ffd96a8" />

@rkazants @hertschuh Can you please review the PR.