### PR TITLE
[OpenVINO backend] Implement real, imag, and isreal operations for NumPy support

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -7,7 +7,6 @@ NumpyDtypeTest::test_concatenate
 NumpyDtypeTest::test_einsum
 HistogramTest::test_histogram_predict_jit_compile_false
 HistogramTest::test_histogram_predict_jit_compile_true
-NumpyDtypeTest::test_isreal
 NumpyDtypeTest::test_nanvar
 NumpyDtypeTest::test_matmul_
 NumpyDtypeTest::test_maximum_python_types
@@ -38,11 +37,9 @@ NumpyTwoInputOpsCorrectnessTest::test_einsum
 NumpyTwoInputOpsCorrectnessTest::test_nextafter
 NumpyTwoInputOpsCorrectnessTest::test_quantile
 NumpyOneInputOpsDynamicShapeTest::test_angle
-NumpyOneInputOpsDynamicShapeTest::test_isreal
 NumpyOneInputOpsDynamicShapeTest::test_kaiser
 NumpyOneInputOpsDynamicShapeTest::test_view
 NumpyOneInputOpsStaticShapeTest::test_angle
-NumpyOneInputOpsStaticShapeTest::test_isreal
 NumpyOneInputOpsStaticShapeTest::test_view
 NumpyTwoInputOpsDynamicShapeTest::test_nextafter
 NumpyTwoInputOpsStaticShapeTest::test_nextafter

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1802,7 +1802,9 @@ def identity(n, dtype=None):
 
 
 def imag(x):
-    raise NotImplementedError("`imag` is not supported with openvino backend")
+    # Implement properly when OpenVINO supports complex inputs
+    x = convert_to_tensor(x)
+    return zeros(x.shape, dtype=x.dtype)
 
 
 def inner(x1, x2):
@@ -1939,7 +1941,9 @@ def _is_inf(x, pos=True):
 
 
 def isreal(x):
-    raise NotImplementedError("`isreal` is not supported with openvino backend")
+    # Implement complex support when OpenVINO adds complex dtypes.
+    x = convert_to_tensor(x)
+    return ones(x.shape, dtype="bool")
 
 
 def kron(x1, x2):
@@ -2942,7 +2946,9 @@ def ravel(x):
 
 
 def real(x):
-    raise NotImplementedError("`real` is not supported with openvino backend")
+    # TODO: Implement complex support when OpenVINO adds complex dtypes.
+    # Currently, all supported dtypes are real-valued.
+    return convert_to_tensor(x)
 
 
 def reciprocal(x):


### PR DESCRIPTION
This PR implements the `real()`, `imag()`, and `isreal()` operations for the OpenVINO backend. While OpenVINO does not yet natively support complex dtypes (complex64/128), this implementation provides support for all currently supported real-valued dtypes (float32, int32, etc.), ensuring Keras 3 API parity.

## Changes

### Implementation (`keras/src/backend/openvino/numpy.py`)

1. **Implemented `real(x)`**
   - Returns the input tensor directly, as all currently supported OpenVINO dtypes are real-valued.
2. **Implemented `imag(x)`**
   - Returns a tensor of zeros matching the shape and dtype of the input.
3. **Implemented `isreal(x)`**
   - Returns a boolean tensor of `True` matching the shape of the input.

### Test Exclusions (`keras/src/backend/openvino/excluded_concrete_tests.txt`)

Temporary exclusions for:
- `NumpyOneInputOpsCorrectnessTest::test_imag`
- `NumpyOneInputOpsCorrectnessTest::test_isreal`
- `NumpyOneInputOpsCorrectnessTest::test_real`

## Future Work
Once OpenVINO adds support for `complex64`/`complex128`:
1. Update these operations to handle complex-to-real decomposition or native extraction.
2. Remove the exclusions from `excluded_concrete_tests.txt`.

## Related Issues
Closes openvinotoolkit/openvino#34106