### PR TITLE
Reduce memeory usage in sparse_categorical_crossentropy 

### DIFF
--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -839,10 +839,9 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
         squeeze = True
     else:
         squeeze = False
-
-    class_axis = axis % output.dim()
-    if class_axis != 1:
-        output = output.movedim(class_axis, 1)
+        class_axis = axis % output.dim()
+        if class_axis != 1:
+            output = output.movedim(class_axis, 1)
 
     if from_logits:
         result = tnn.cross_entropy(output, target, reduction="none")


### PR DESCRIPTION
## Summary                                                                                                         
        
  - Replace one_hot + manual multiply with native F.cross_entropy / F.nll_loss in the PyTorch backend's     sparse_categorical_crossentropy
  - This avoids allocating a full (batch, ..., num_classes) one-hot matrix, which for large vocabularies can be gigabytes per step                                                                              

Fixes #21035 