### PR TITLE
Add higher-order B-spline interpolation (orders 2-5) to map_coordinates

### DIFF
--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -955,9 +955,12 @@ def map_coordinates(
     Args:
         inputs: The input array.
         coordinates: The coordinates at which inputs is evaluated.
-        order: The order of the spline interpolation. The order must be `0` or
-            `1`. `0` indicates the nearest neighbor and `1` indicates the linear
-            interpolation.
+        order: The order of the spline interpolation (0-5). `0` indicates
+            nearest neighbor, `1` indicates linear interpolation, and `2`-`5`
+            indicate B-spline interpolation of the corresponding order.
+            Note: orders 2-5 are supported by the PyTorch and NumPy
+            backends. The JAX and TensorFlow backends support orders
+            0-1 only.
         fill_mode: Points outside the boundaries of the inputs are filled
             according to the given mode. Available methods are `"constant"`,
             `"nearest"`, `"wrap"` and `"mirror"` and `"reflect"`. Defaults to


### PR DESCRIPTION
## Summary
  - Add support for B-spline interpolation orders 2-5 (quadratic through quintic) in `map_coordinates` for the torch and numpy
  backends
  - Implements IIR B-spline prefiltering with causal/anticausal initialization matching scipy's `ni_splines.c` for all boundary
  modes
  - Handles all 5 fill modes: constant, mirror, nearest, reflect, wrap
  - Torch backend includes full B-spline weight computation, prefilter gain/poles, and boundary-aware coefficient lookup
  - Numpy backend delegates to `scipy.ndimage.map_coordinates` directly for order > 1

## Tests
  - Verify all 40 new parameterized tests pass (`test_map_coordinates_higher_order`) across orders 2-5, 5 fill modes, 1D and
  3D shapes
  - Verify existing `map_coordinates` tests (orders 0-1) still pass
  - Test on both torch and numpy backends