### PR TITLE
fix(preprocessing): preserve segmentation mask dtype in augmentation layers

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/aug_mix.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/aug_mix.py
@@ -1,6 +1,7 @@
 import random as py_random
 
 import keras.src.layers as layers
+from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
@@ -313,9 +314,15 @@ class AugMix(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(
             segmentation_masks, transformation, training=training
         )
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def compute_output_shape(self, input_shape):
         return input_shape

--- a/keras/src/layers/preprocessing/image_preprocessing/center_crop.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/center_crop.py
@@ -1,3 +1,4 @@
+from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
@@ -177,9 +178,15 @@ class CenterCrop(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(
             segmentation_masks, transformation, training=training
         )
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def transform_images(self, images, transformation=None, training=True):
         inputs = self.backend.cast(images, self.compute_dtype)

--- a/keras/src/layers/preprocessing/image_preprocessing/cut_mix.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/cut_mix.py
@@ -1,3 +1,4 @@
+from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
@@ -220,9 +221,15 @@ class CutMix(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(
             segmentation_masks, transformation, training
         )
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def compute_output_shape(self, input_shape):
         return input_shape

--- a/keras/src/layers/preprocessing/image_preprocessing/max_num_bounding_box.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/max_num_bounding_box.py
@@ -1,3 +1,4 @@
+from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
@@ -88,7 +89,13 @@ class MaxNumBoundingBoxes(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation=None, training=True
     ):
-        return self.transform_images(segmentation_masks)
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(segmentation_masks)
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def compute_output_shape(self, input_shape):
         if isinstance(input_shape, dict) and "bounding_boxes" in input_shape:

--- a/keras/src/layers/preprocessing/image_preprocessing/rand_augment.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/rand_augment.py
@@ -1,4 +1,5 @@
 import keras.src.layers as layers
+from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
@@ -255,9 +256,15 @@ class RandAugment(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(
             segmentation_masks, transformation, training=training
         )
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def compute_output_shape(self, input_shape):
         return input_shape

--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
@@ -262,7 +262,13 @@ class RandomCrop(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(segmentation_masks, transformation)
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(segmentation_masks, transformation)
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def compute_output_shape(self, input_shape, *args, **kwargs):
         input_shape = list(input_shape)

--- a/keras/src/layers/preprocessing/image_preprocessing/random_elastic_transform.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_elastic_transform.py
@@ -1,3 +1,4 @@
+from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
@@ -264,9 +265,15 @@ class RandomElasticTransform(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(
             segmentation_masks, transformation, training=training
         )
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def compute_output_shape(self, input_shape):
         return input_shape

--- a/keras/src/layers/preprocessing/image_preprocessing/random_flip.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_flip.py
@@ -1,3 +1,4 @@
+from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
@@ -188,9 +189,15 @@ class RandomFlip(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(
             segmentation_masks, transformation, training=training
         )
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def _flip_inputs(self, inputs, transformation):
         if transformation is None:

--- a/keras/src/layers/preprocessing/image_preprocessing/random_perspective.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_perspective.py
@@ -1,3 +1,4 @@
+from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
@@ -326,9 +327,15 @@ class RandomPerspective(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(
             segmentation_masks, transformation, training=training
         )
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def compute_output_shape(self, input_shape):
         return input_shape

--- a/keras/src/layers/preprocessing/image_preprocessing/random_rotation.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_rotation.py
@@ -1,3 +1,4 @@
+from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
@@ -175,9 +176,15 @@ class RandomRotation(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(
             segmentation_masks, transformation, training=training
         )
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def get_random_transformation(self, data, training=True, seed=None):
         ops = self.backend

--- a/keras/src/layers/preprocessing/image_preprocessing/random_shear.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_shear.py
@@ -1,3 +1,4 @@
+from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
@@ -390,9 +391,15 @@ class RandomShear(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(
             segmentation_masks, transformation, training=training
         )
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def get_config(self):
         base_config = super().get_config()

--- a/keras/src/layers/preprocessing/image_preprocessing/random_translation.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_translation.py
@@ -1,3 +1,4 @@
+from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.image_preprocessing.base_image_preprocessing_layer import (  # noqa: E501
     BaseImagePreprocessingLayer,
@@ -278,9 +279,15 @@ class RandomTranslation(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(
             segmentation_masks, transformation, training=training
         )
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def get_random_transformation(self, data, training=True, seed=None):
         if not training:

--- a/keras/src/layers/preprocessing/image_preprocessing/random_zoom.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_zoom.py
@@ -304,9 +304,15 @@ class RandomZoom(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
+        original_dtype = segmentation_masks.dtype
+        output = self.transform_images(
             segmentation_masks, transformation, training=training
         )
+        if output.dtype == original_dtype:
+            return output
+        if backend.is_int_dtype(original_dtype):
+            output = self.backend.numpy.round(output)
+        return self.backend.cast(output, original_dtype)
 
     def get_random_transformation(self, data, training=True, seed=None):
         if not training:


### PR DESCRIPTION
## Summary

Multiple image augmentation layers in `keras.layers.preprocessing` cast segmentation masks to `float32` when they should preserve the original dtype (e.g., `uint8`). This happens because `transform_segmentation_masks()` delegates to `transform_images()`, which internally casts inputs to the layer's `compute_dtype`.

This PR fixes 13 augmentation layers to preserve the original segmentation mask dtype by:
1. Saving the input dtype before calling `transform_images()`
2. Rounding the output for integer dtypes (to handle interpolation artifacts)
3. Casting back to the original dtype

### Affected layers
- `AugMix`
- `CenterCrop`
- `CutMix`
- `MaxNumBoundingBoxes`
- `RandAugment`
- `RandomCrop`
- `RandomElasticTransform`
- `RandomFlip`
- `RandomPerspective`
- `RandomRotation`
- `RandomShear`
- `RandomTranslation`
- `RandomZoom`

### Reproduction

```python
import numpy as np
import keras
from keras import layers

masks = np.random.randint(0, 5, (2, 32, 32, 1), dtype=np.uint8)
data = {
    'images': np.random.rand(2, 32, 32, 3).astype('float32'),
    'segmentation_masks': masks,
}

layer = layers.RandomFlip()
output = layer(data, training=True)
print(output['segmentation_masks'].dtype)  # Before: float32, After: uint8
```

Fixes #20857