### PR TITLE
Don't let unit test modify the source folder.

### DIFF
--- a/keras/src/legacy/saving/legacy_h5_format_test.py
+++ b/keras/src/legacy/saving/legacy_h5_format_test.py
@@ -388,6 +388,7 @@ class LegacyH5BackwardsCompatTest(testing.TestCase):
         # Compare output
         self.assertAllClose(ref_output, output, atol=1e-5)
 
+    @pytest.mark.skipif(tf_keras is None, reason="Test requires tf_keras")
     def test_custom_sequential_registered_no_scope(self):
         @tf_keras.saving.register_keras_serializable(package="my_package")
         class MyDense(tf_keras.layers.Dense):
@@ -411,6 +412,7 @@ class LegacyH5BackwardsCompatTest(testing.TestCase):
         ref_input = np.array([5])
         self._check_reloading_model(ref_input, model, tf_keras_model)
 
+    @pytest.mark.skipif(tf_keras is None, reason="Test requires tf_keras")
     def test_custom_functional_registered_no_scope(self):
         @tf_keras.saving.register_keras_serializable(package="my_package")
         class MyDense(tf_keras.layers.Dense):

--- a/keras/src/utils/code_stats_test.py
+++ b/keras/src/utils/code_stats_test.py
@@ -8,15 +8,7 @@ from keras.src.utils.code_stats import count_loc
 
 class TestCountLoc(test_case.TestCase):
     def setUp(self):
-        self.test_dir = "test_directory"
-        os.makedirs(self.test_dir, exist_ok=True)
-
-    def tearDown(self):
-        for root, dirs, files in os.walk(self.test_dir, topdown=False):
-            for name in files:
-                os.remove(os.path.join(root, name))
-            for name in dirs:
-                os.rmdir(os.path.join(root, name))
+        self.test_dir = self.get_temp_dir()
 
     def create_file(self, filename, content):
         with open(

--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -53,8 +53,8 @@ def is_link_in_dir(info, base):
     return is_path_in_dir(info.linkname, base_dir=tip)
 
 
-def filter_safe_zipinfos(members):
-    base_dir = resolve_path(".")
+def filter_safe_zipinfos(members, base_dir):
+    base_dir = resolve_path(base_dir)
     for finfo in members:
         valid_path = False
         if is_path_in_dir(finfo.filename, base_dir):
@@ -68,8 +68,8 @@ def filter_safe_zipinfos(members):
             )
 
 
-def filter_safe_tarinfos(members):
-    base_dir = resolve_path(".")
+def filter_safe_tarinfos(members, base_dir):
+    base_dir = resolve_path(base_dir)
     for finfo in members:
         valid_path = False
         if finfo.issym() or finfo.islnk():
@@ -99,7 +99,7 @@ def extract_open_archive(archive, path="."):
     if isinstance(archive, zipfile.ZipFile):
         # Zip archive.
         archive.extractall(
-            path, members=filter_safe_zipinfos(archive.infolist())
+            path, members=filter_safe_zipinfos(archive.infolist(), path)
         )
     else:
         # Tar archive.
@@ -111,7 +111,7 @@ def extract_open_archive(archive, path="."):
             extractall_kwargs = {"filter": "data"}
         archive.extractall(
             path,
-            members=filter_safe_tarinfos(archive),
+            members=filter_safe_tarinfos(archive, path),
             **extractall_kwargs,
         )
 
@@ -563,6 +563,3 @@ def makedirs(path):
         else:
             _raise_if_no_gfile(path)
     return os.makedirs(path)
-
-
-"/fo"


### PR DESCRIPTION
This required changing some tests to use a temporary folder instead of the current one.

Changed some unit tests to use a temporary folder instead of the current one. This uses `self.get_temp_dir()`, which auto cleans up and makes the tests easier.

Also fixed `file_utils.filter_safe_zipinfos` and `filter_safe_tarinfos` to resolve links within the context of the destination folder instead of hardcoding `"."` as the destination path.