### PR TITLE
[OpenVINO backend] Add numpy.inner support

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -9,7 +9,6 @@ NumpyDtypeTest::test_concatenate
 NumpyDtypeTest::test_cumprod
 NumpyDtypeTest::test_diagflat
 NumpyDtypeTest::test_einsum
-NumpyDtypeTest::test_inner
 NumpyDtypeTest::test_isreal
 NumpyDtypeTest::test_lcm
 NumpyDtypeTest::test_nanmax
@@ -59,7 +58,6 @@ NumpyTwoInputOpsCorrectnessTest::test_bitwise_or
 NumpyTwoInputOpsCorrectnessTest::test_bitwise_right_shift
 NumpyTwoInputOpsCorrectnessTest::test_bitwise_xor
 NumpyTwoInputOpsCorrectnessTest::test_einsum
-NumpyTwoInputOpsCorrectnessTest::test_inner
 NumpyTwoInputOpsCorrectnessTest::test_lcm
 NumpyTwoInputOpsCorrectnessTest::test_nextafter
 NumpyTwoInputOpsCorrectnessTest::test_quantile


### PR DESCRIPTION
## Summary
- Implement `numpy.inner` for the OpenVINO Keras 3 backend by flattening both inputs and computing the dot product via `ov_opset.matmul`, following the same pattern as the existing `vdot` implementation
- Remove `inner` from `excluded_concrete_tests.txt` to enable the previously skipped tests

Fixes openvinotoolkit/openvino#34128
Ref openvinotoolkit/openvino#34017

## Test plan
- [ ] `NumpyDtypeTest::test_inner` passes
- [ ] `NumpyTwoInputOpsCorrectnessTest::test_inner` passes