### PR TITLE
Fix for `draw_bounding_boxes`.

### DIFF
--- a/keras/src/visualization/draw_bounding_boxes.py
+++ b/keras/src/visualization/draw_bounding_boxes.py
@@ -121,9 +121,9 @@ def draw_bounding_boxes(
     images = ops.convert_to_numpy(images)
     if images.dtype.kind == "f" and images.size > 0:
         if images.max() <= 1.0:
-            images = ops.clip(images, 0, 1) * 255
+            images = np.clip(images, 0, 1) * 255
         else:
-            images = ops.clip(images, 0, 255)
+            images = np.clip(images, 0, 255)
     images = images.astype("uint8")
     boxes = ops.convert_to_numpy(bounding_boxes["boxes"])
     labels = ops.convert_to_numpy(bounding_boxes["labels"])


### PR DESCRIPTION
https://github.com/keras-team/keras/pull/22129 added clipping for images before drawing them. However there was a bug causing the freshly converted to numpy image to be converted back to a native tensor, which caused the `image.astype` call to fail. The clipping has to be done with Numpy.