### PR TITLE
Remove duplicate `norm` implementation in `math`.

### DIFF
--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -3,10 +3,7 @@ import math
 import jax
 import jax.numpy as jnp
 
-from keras.src.backend import config
 from keras.src.backend import standardize_dtype
-from keras.src.backend.common import dtypes
-from keras.src.backend.jax.core import cast
 from keras.src.backend.jax.core import convert_to_tensor
 from keras.src.utils.module_utils import scipy
 
@@ -277,16 +274,6 @@ def solve(a, b):
     a = convert_to_tensor(a)
     b = convert_to_tensor(b)
     return jnp.linalg.solve(a, b)
-
-
-def norm(x, ord=None, axis=None, keepdims=False):
-    x = convert_to_tensor(x)
-    if standardize_dtype(x.dtype) == "int64":
-        dtype = config.floatx()
-    else:
-        dtype = dtypes.result_type(x.dtype, float)
-    x = cast(x, dtype)
-    return jnp.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
 
 
 def logdet(x):

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from keras.src.backend import standardize_dtype
-from keras.src.backend.common import dtypes
 from keras.src.backend.jax.math import fft as jax_fft
 from keras.src.backend.jax.math import fft2 as jax_fft2
 from keras.src.backend.numpy.core import convert_to_tensor
@@ -302,16 +301,6 @@ def solve(a, b):
     a = convert_to_tensor(a)
     b = convert_to_tensor(b)
     return np.linalg.solve(a, b)
-
-
-def norm(x, ord=None, axis=None, keepdims=False):
-    x = convert_to_tensor(x)
-    dtype = standardize_dtype(x.dtype)
-    if "int" in dtype or dtype == "bool":
-        dtype = dtypes.result_type(x.dtype, "float32")
-    return np.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims).astype(
-        dtype
-    )
 
 
 def logdet(x):

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -122,7 +122,3 @@ def erfinv(x):
 
 def solve(a, b):
     raise NotImplementedError("`solve` is not supported with openvino backend")
-
-
-def norm(x, ord=None, axis=None, keepdims=False):
-    raise NotImplementedError("`norm` is not supported with openvino backend")

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -1,8 +1,6 @@
 import tensorflow as tf
 
-from keras.src.backend import config
 from keras.src.backend import standardize_dtype
-from keras.src.backend.common import dtypes
 from keras.src.backend.tensorflow.core import cast
 from keras.src.backend.tensorflow.core import convert_to_tensor
 
@@ -277,103 +275,6 @@ def solve(a, b):
     a = convert_to_tensor(a)
     b = convert_to_tensor(b)
     return tf.linalg.solve(a, b)
-
-
-def norm(x, ord=None, axis=None, keepdims=False):
-    from keras.src.backend.tensorflow.numpy import moveaxis
-
-    x = convert_to_tensor(x)
-    x_shape = x.shape
-    ndim = x_shape.rank
-
-    if axis is None:
-        axis = tuple(range(ndim))
-    elif isinstance(axis, int):
-        axis = (axis,)
-
-    axis = axis[0] if len(axis) == 1 else axis
-    num_axes = 1 if isinstance(axis, int) else len(axis)
-
-    if num_axes == 1 and ord is None:
-        ord = "euclidean"
-    elif num_axes == 2 and ord is None:
-        ord = "fro"
-
-    if standardize_dtype(x.dtype) == "int64":
-        dtype = config.floatx()
-    else:
-        dtype = dtypes.result_type(x.dtype, float)
-    x = cast(x, dtype)
-
-    # Fast path to utilize `tf.linalg.norm`
-    if (num_axes == 1 and ord in ("euclidean", 1, 2, float("inf"))) or (
-        num_axes == 2 and ord in ("euclidean", "fro", 1, 2, float("inf"))
-    ):
-        return tf.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
-
-    # Ref: jax.numpy.linalg.norm
-    if num_axes == 1 and ord not in ("fro", "nuc"):
-        if ord == float("-inf"):
-            return tf.math.reduce_min(
-                tf.math.abs(x), axis=axis, keepdims=keepdims
-            )
-        elif ord == 0:
-            return tf.math.reduce_sum(
-                tf.cast(tf.not_equal(x, 0), dtype=x.dtype),
-                axis=axis,
-                keepdims=keepdims,
-            )
-        else:
-            ord = convert_to_tensor(ord, dtype=x.dtype)
-            out = tf.math.reduce_sum(
-                tf.pow(tf.math.abs(x), ord), axis=axis, keepdims=keepdims
-            )
-            return tf.pow(out, 1.0 / ord)
-    elif num_axes == 2 and ord in ("nuc", float("-inf"), -2, -1):
-        row_axis, col_axis = axis[0], axis[1]
-        row_axis = row_axis + ndim if row_axis < 0 else row_axis
-        col_axis = col_axis + ndim if col_axis < 0 else col_axis
-        if ord == float("-inf"):
-            if not keepdims and row_axis > col_axis:
-                row_axis -= 1
-            x = tf.math.reduce_min(
-                tf.reduce_sum(tf.math.abs(x), axis=col_axis, keepdims=keepdims),
-                axis=row_axis,
-                keepdims=keepdims,
-            )
-        elif ord == -1:
-            if not keepdims and col_axis > row_axis:
-                col_axis -= 1
-            x = tf.math.reduce_min(
-                tf.reduce_sum(tf.math.abs(x), axis=row_axis, keepdims=keepdims),
-                axis=col_axis,
-                keepdims=keepdims,
-            )
-        else:
-            x = moveaxis(x, axis, (-2, -1))
-            if ord == -2:
-                x = tf.math.reduce_min(
-                    tf.linalg.svd(x, compute_uv=False), axis=-1
-                )
-            else:
-                x = tf.math.reduce_sum(
-                    tf.linalg.svd(x, compute_uv=False), axis=-1
-                )
-            if keepdims:
-                x = tf.expand_dims(x, axis[0])
-                x = tf.expand_dims(x, axis[1])
-        return x
-
-    if num_axes == 1:
-        raise ValueError(
-            f"Invalid `ord` argument for vector norm. Received: ord={ord}"
-        )
-    elif num_axes == 2:
-        raise ValueError(
-            f"Invalid `ord` argument for matrix norm. Received: ord={ord}"
-        )
-    else:
-        raise ValueError(f"Invalid axis values. Received: axis={axis}")
 
 
 def logdet(x):

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -2,10 +2,7 @@ import math
 
 import torch
 
-from keras.src.backend import config
 from keras.src.backend import standardize_dtype
-from keras.src.backend.common import dtypes
-from keras.src.backend.torch.core import cast
 from keras.src.backend.torch.core import convert_to_tensor
 from keras.src.backend.torch.core import get_device
 from keras.src.backend.torch.numpy import pad
@@ -402,16 +399,6 @@ def solve(a, b):
     a = convert_to_tensor(a)
     b = convert_to_tensor(b)
     return torch.linalg.solve(a, b)
-
-
-def norm(x, ord=None, axis=None, keepdims=False):
-    x = convert_to_tensor(x)
-    if standardize_dtype(x.dtype) == "int64":
-        dtype = config.floatx()
-    else:
-        dtype = dtypes.result_type(x.dtype, float)
-    x = cast(x, dtype)
-    return torch.linalg.norm(x, ord=ord, dim=axis, keepdim=keepdims)
 
 
 def logdet(x):


### PR DESCRIPTION
The `keras.ops.norm` is implemented in `linalg` and is available at `keras.ops.linalg.norm`.

There was a duplicate implementation in the `math.py` files, but this code is unreachable.