### PR TITLE
[OpenVINO Backend] included tests for bitwise_left_shift and bitwise_right_shift

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -3,8 +3,6 @@ NumpyDtypeTest::test_angle
 NumpyDtypeTest::test_array
 NumpyDtypeTest::test_heaviside
 NumpyDtypeTest::test_kaiser
-NumpyDtypeTest::test_bitwise_left_shift
-NumpyDtypeTest::test_bitwise_right_shift
 NumpyDtypeTest::test_concatenate
 NumpyDtypeTest::test_diagflat
 NumpyDtypeTest::test_einsum


### PR DESCRIPTION
 bitwise_left_shift and bitwise_right_shift for the OpenVINO backend, was previously implemented in #22146, but some tests were left excluded. 
 
 Those tests have been included here.