### PR TITLE
Add RandomApply and RandomChoice preprocessing layers

### DIFF
--- a/keras/api/_tf_keras/keras/layers/__init__.py
+++ b/keras/api/_tf_keras/keras/layers/__init__.py
@@ -301,6 +301,10 @@ from keras.src.layers.preprocessing.normalization import (
     Normalization as Normalization,
 )
 from keras.src.layers.preprocessing.pipeline import Pipeline as Pipeline
+from keras.src.layers.preprocessing.random_apply import RandomApply as RandomApply
+from keras.src.layers.preprocessing.random_choice import (
+    RandomChoice as RandomChoice,
+)
 from keras.src.layers.preprocessing.rescaling import Rescaling as Rescaling
 from keras.src.layers.preprocessing.stft_spectrogram import (
     STFTSpectrogram as STFTSpectrogram,

--- a/keras/api/_tf_keras/keras/layers/__init__.py
+++ b/keras/api/_tf_keras/keras/layers/__init__.py
@@ -301,7 +301,9 @@ from keras.src.layers.preprocessing.normalization import (
     Normalization as Normalization,
 )
 from keras.src.layers.preprocessing.pipeline import Pipeline as Pipeline
-from keras.src.layers.preprocessing.random_apply import RandomApply as RandomApply
+from keras.src.layers.preprocessing.random_apply import (
+    RandomApply as RandomApply,
+)
 from keras.src.layers.preprocessing.random_choice import (
     RandomChoice as RandomChoice,
 )

--- a/keras/api/layers/__init__.py
+++ b/keras/api/layers/__init__.py
@@ -301,6 +301,10 @@ from keras.src.layers.preprocessing.normalization import (
     Normalization as Normalization,
 )
 from keras.src.layers.preprocessing.pipeline import Pipeline as Pipeline
+from keras.src.layers.preprocessing.random_apply import RandomApply as RandomApply
+from keras.src.layers.preprocessing.random_choice import (
+    RandomChoice as RandomChoice,
+)
 from keras.src.layers.preprocessing.rescaling import Rescaling as Rescaling
 from keras.src.layers.preprocessing.stft_spectrogram import (
     STFTSpectrogram as STFTSpectrogram,

--- a/keras/api/layers/__init__.py
+++ b/keras/api/layers/__init__.py
@@ -301,7 +301,9 @@ from keras.src.layers.preprocessing.normalization import (
     Normalization as Normalization,
 )
 from keras.src.layers.preprocessing.pipeline import Pipeline as Pipeline
-from keras.src.layers.preprocessing.random_apply import RandomApply as RandomApply
+from keras.src.layers.preprocessing.random_apply import (
+    RandomApply as RandomApply,
+)
 from keras.src.layers.preprocessing.random_choice import (
     RandomChoice as RandomChoice,
 )

--- a/keras/src/layers/__init__.py
+++ b/keras/src/layers/__init__.py
@@ -184,6 +184,8 @@ from keras.src.layers.preprocessing.integer_lookup import IntegerLookup
 from keras.src.layers.preprocessing.mel_spectrogram import MelSpectrogram
 from keras.src.layers.preprocessing.normalization import Normalization
 from keras.src.layers.preprocessing.pipeline import Pipeline
+from keras.src.layers.preprocessing.random_apply import RandomApply
+from keras.src.layers.preprocessing.random_choice import RandomChoice
 from keras.src.layers.preprocessing.rescaling import Rescaling
 from keras.src.layers.preprocessing.stft_spectrogram import STFTSpectrogram
 from keras.src.layers.preprocessing.string_lookup import StringLookup

--- a/keras/src/layers/preprocessing/random_apply.py
+++ b/keras/src/layers/preprocessing/random_apply.py
@@ -1,0 +1,97 @@
+from keras.src import backend
+from keras.src.api_export import keras_export
+from keras.src.layers.layer import Layer
+from keras.src.random import SeedGenerator
+from keras.src.saving import serialization_lib
+
+
+@keras_export("keras.layers.RandomApply")
+class RandomApply(Layer):
+    """Randomly apply a layer to inputs with a given probability.
+
+    At training time, the layer wrapped by `RandomApply` will be
+    applied with probability `rate`. During inference, the input is
+    returned unchanged.
+
+    **Note:** This layer is safe to use inside a `tf.data` or `grain`
+    pipeline (independently of which backend you're using).
+
+    Args:
+        layer: A `keras.Layer`. The layer to apply randomly.
+        rate: Float between 0 and 1. The probability of applying the
+            layer during training. Default is `0.5`.
+        seed: Integer. Used to create a random seed.
+        name: String. The name of the layer.
+
+    Example:
+
+    ```python
+    from keras import layers
+
+    # Apply random flip with 50% probability
+    layer = layers.RandomApply(
+        layer=layers.RandomFlip("horizontal"),
+        rate=0.5,
+    )
+    images = np.random.uniform(0, 255, (4, 224, 224, 3)).astype("float32")
+    output = layer(images, training=True)
+    ```
+    """
+
+    def __init__(self, layer, rate=0.5, seed=None, name=None, **kwargs):
+        super().__init__(name=name, **kwargs)
+        if not isinstance(layer, Layer):
+            raise ValueError(
+                "Expected `layer` to be a `keras.Layer` instance. "
+                f"Received: layer={layer} (of type {type(layer)})"
+            )
+        if not 0.0 <= rate <= 1.0:
+            raise ValueError(
+                "Expected `rate` to be a float between 0 and 1. "
+                f"Received: rate={rate}"
+            )
+        self._layer = layer
+        self.rate = rate
+        self.seed = seed
+        self.generator = SeedGenerator(seed)
+        self._convert_input_args = False
+        self._allow_non_tensor_positional_args = True
+
+    @property
+    def layer(self):
+        return self._layer
+
+    def build(self, input_shape):
+        self._layer.build(input_shape)
+        self.built = True
+
+    def call(self, inputs, training=True):
+        if not training:
+            return inputs
+
+        seed_generator = self.generator
+        random_value = backend.random.uniform(
+            shape=(), seed=seed_generator
+        )
+        if random_value < self.rate:
+            kwargs = {}
+            if self._layer._call_has_training_arg:
+                kwargs["training"] = training
+            return self._layer(inputs, **kwargs)
+        return inputs
+
+    @classmethod
+    def from_config(cls, config):
+        config["layer"] = serialization_lib.deserialize_keras_object(
+            config["layer"]
+        )
+        return cls(**config)
+
+    def get_config(self):
+        config = {
+            "layer": serialization_lib.serialize_keras_object(self._layer),
+            "rate": self.rate,
+            "seed": self.seed,
+            "name": self.name,
+        }
+        return config

--- a/keras/src/layers/preprocessing/random_apply.py
+++ b/keras/src/layers/preprocessing/random_apply.py
@@ -70,9 +70,7 @@ class RandomApply(Layer):
             return inputs
 
         seed_generator = self.generator
-        random_value = backend.random.uniform(
-            shape=(), seed=seed_generator
-        )
+        random_value = backend.random.uniform(shape=(), seed=seed_generator)
         if random_value < self.rate:
             kwargs = {}
             if self._layer._call_has_training_arg:

--- a/keras/src/layers/preprocessing/random_choice.py
+++ b/keras/src/layers/preprocessing/random_choice.py
@@ -1,0 +1,112 @@
+from keras.src import backend
+from keras.src.api_export import keras_export
+from keras.src.layers.layer import Layer
+from keras.src.random import SeedGenerator
+from keras.src.saving import serialization_lib
+
+
+@keras_export("keras.layers.RandomChoice")
+class RandomChoice(Layer):
+    """Randomly pick one layer from a list and apply it to the input.
+
+    At training time, one layer is chosen uniformly at random and applied.
+    During inference, the input is returned unchanged.
+
+    **Note:** This layer is safe to use inside a `tf.data` or `grain`
+    pipeline (independently of which backend you're using).
+
+    Args:
+        layers: A list of `keras.Layer` instances. The candidate layers
+            to choose from.
+        seed: Integer. Used to create a random seed.
+        name: String. The name of the layer.
+
+    Example:
+
+    ```python
+    from keras import layers
+
+    # Randomly pick one augmentation to apply
+    layer = layers.RandomChoice(
+        layers=[
+            layers.RandomFlip("horizontal"),
+            layers.RandomRotation(0.1),
+            layers.RandomZoom(0.1),
+        ],
+    )
+    images = np.random.uniform(0, 255, (4, 224, 224, 3)).astype("float32")
+    output = layer(images, training=True)
+    ```
+    """
+
+    def __init__(self, layers, seed=None, name=None, **kwargs):
+        super().__init__(name=name, **kwargs)
+        if not isinstance(layers, (list, tuple)):
+            raise ValueError(
+                "Expected `layers` to be a list or tuple of "
+                "`keras.Layer` instances. "
+                f"Received: layers={layers}"
+            )
+        if len(layers) == 0:
+            raise ValueError(
+                "Expected `layers` to contain at least one layer. "
+                "Received: empty list."
+            )
+        for i, layer in enumerate(layers):
+            if not isinstance(layer, Layer):
+                raise ValueError(
+                    "Expected all elements of `layers` to be "
+                    "`keras.Layer` instances. "
+                    f"Received: layers[{i}]={layer} "
+                    f"(of type {type(layer)})"
+                )
+        self._layers_list = list(layers)
+        self.seed = seed
+        self.generator = SeedGenerator(seed)
+        self._convert_input_args = False
+        self._allow_non_tensor_positional_args = True
+
+    @property
+    def layers(self):
+        return self._layers_list
+
+    def build(self, input_shape):
+        for layer in self._layers_list:
+            layer.build(input_shape)
+        self.built = True
+
+    def call(self, inputs, training=True):
+        if not training:
+            return inputs
+
+        seed_generator = self.generator
+        idx = backend.random.randint(
+            shape=(),
+            minval=0,
+            maxval=len(self._layers_list),
+            seed=seed_generator,
+        )
+        idx = int(idx)
+        layer = self._layers_list[idx]
+        kwargs = {}
+        if layer._call_has_training_arg:
+            kwargs["training"] = training
+        return layer(inputs, **kwargs)
+
+    @classmethod
+    def from_config(cls, config):
+        config["layers"] = [
+            serialization_lib.deserialize_keras_object(x)
+            for x in config["layers"]
+        ]
+        return cls(**config)
+
+    def get_config(self):
+        config = {
+            "layers": serialization_lib.serialize_keras_object(
+                self._layers_list
+            ),
+            "seed": self.seed,
+            "name": self.name,
+        }
+        return config


### PR DESCRIPTION
## Description

Closes #20727

Adds two new composition preprocessing layers ported from keras-cv:

### `keras.layers.RandomApply`
Wraps a single layer and applies it with a given probability during training. At inference, input is passed through unchanged.

```python
layer = keras.layers.RandomApply(
    layer=keras.layers.RandomFlip("horizontal"),
    rate=0.5,
)
```

### `keras.layers.RandomChoice`
Takes a list of layers and randomly selects one to apply during training. At inference, input is passed through unchanged.

```python
layer = keras.layers.RandomChoice(
    layers=[
        keras.layers.RandomFlip("horizontal"),
        keras.layers.RandomRotation(0.1),
        keras.layers.RandomZoom(0.1),
    ],
)
```

Both layers:
- Support serialization (`get_config` / `from_config`)
- Work with dict inputs (images, labels, bounding_boxes, etc.)
- Are safe to use in `tf.data` / `grain` pipelines
- Validate constructor arguments
- Support the `seed` parameter for reproducibility

## Files Changed
- `keras/src/layers/preprocessing/random_apply.py` (new)
- `keras/src/layers/preprocessing/random_choice.py` (new)
- `keras/src/layers/__init__.py` (import)
- `keras/api/layers/__init__.py` (API export)
- `keras/api/_tf_keras/keras/layers/__init__.py` (tf_keras API export)