### PR TITLE
[OpenVINO Backend] included tests for numpy.trunc

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -18,7 +18,6 @@ NumpyDtypeTest::test_quantile
 NumpyDtypeTest::test_signbit
 NumpyDtypeTest::test_std
 NumpyDtypeTest::test_subtract
-NumpyDtypeTest::test_trunc
 NumpyDtypeTest::test_var
 NumpyDtypeTest::test_view
 HistogramTest
@@ -33,7 +32,6 @@ NumpyOneInputOpsCorrectnessTest::test_real
 NumpyOneInputOpsCorrectnessTest::test_reshape
 NumpyOneInputOpsCorrectnessTest::test_signbit
 NumpyOneInputOpsCorrectnessTest::test_slogdet
-NumpyOneInputOpsCorrectnessTest::test_trunc
 NumpyOneInputOpsCorrectnessTest::test_vectorize
 NumpyOneInputOpsCorrectnessTest::test_view
 NumpyTwoInputOpsCorrectnessTest::test_einsum


### PR DESCRIPTION
These tests were included previously in #22134, but got excluded again most likely due to a faulty rebase.

Those tests have been included again here.