### PR TITLE
Update requirements for TensorFlow

### DIFF
--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,6 +1,7 @@
 # Tensorflow with cuda support.
 tensorflow[and-cuda]
 tf2onnx
+ai-edge-litert
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
This pull request makes a small change to the `requirements-tensorflow-cuda.txt` file, specifically by removing the pinned version of the `ai-edge-litert` package. This likely reflects an update or removal of a dependency that was previously required for compatibility with TensorFlow 2.20.0.Remove specific version pinning for ai-edge-litert.