### PR TITLE
Add support for cache in custom `TrackableView`.

### DIFF
--- a/keras/src/export/saved_model.py
+++ b/keras/src/export/saved_model.py
@@ -509,10 +509,12 @@ class BackendSavedModelExportArchive(BackendExportArchive):
 
         # `tf.train.TrackableView` hardcodes the `save_type` to "checkpoint".
         # We need to subclass to use a `save_type` of "savedmodel".
+        savedmodel_cache = {}
+
         class SavedModelTrackableView(tf.train.TrackableView):
             @classmethod
             def children(cls, obj, save_type="savedmodel", **kwargs):
-                return super().children(obj, save_type, **kwargs)
+                return super().children(obj, save_type, cache=savedmodel_cache)
 
         # Next, track lookup tables.
         # Hopefully, one day this will be automated at the tf.function level.


### PR DESCRIPTION
In some contexts, `_trackable_children` requires a `cache` argument to be passed as part of the `kwargs`.