### PR TITLE
Update excluded_concrete_tests.txt

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -16,7 +16,7 @@ NumpyDtypeTest::test_multiply
 NumpyDtypeTest::test_nextafter
 NumpyDtypeTest::test_power
 NumpyDtypeTest::test_quantile
-NumpyDtypeTest::test_signbit
+ 
 NumpyDtypeTest::test_std
 NumpyDtypeTest::test_subtract
 NumpyDtypeTest::test_var
@@ -30,7 +30,7 @@ NumpyOneInputOpsCorrectnessTest::test_isreal
 NumpyOneInputOpsCorrectnessTest::test_nanvar
 NumpyOneInputOpsCorrectnessTest::test_real
 NumpyOneInputOpsCorrectnessTest::test_reshape
-NumpyOneInputOpsCorrectnessTest::test_signbit
+ 
 NumpyOneInputOpsCorrectnessTest::test_slogdet
 NumpyOneInputOpsCorrectnessTest::test_vectorize
 NumpyOneInputOpsCorrectnessTest::test_view


### PR DESCRIPTION
### Summary
This PR implements the `numpy.signbit` operation for the OpenVINO backend in Keras 3.

### Changes
- Implemented `signbit` in `keras/src/backend/openvino/numpy.py` using `ov_opset.less(x, zero)`.
- Followed the robust implementation by explicitly defining the `zero` constant with the input's element type.
- Removed `signbit` from `excluded_concrete_tests.txt` to enable automated tests.

### Verification
Verified with local tests for the OpenVINO backend:
- `NumpyOneInputOpsDynamicShapeTest::test_signbit` PASSED
- `NumpyOneInputOpsStaticShapeTest::test_signbit` PASSED

Fixes #34017

Hi @rkazants, I've implemented the logic and enabled the tests. The CLA is also signed. Please review this. Thanks!