### PR TITLE
Fix plain callable rejection for constraint and regularizer

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -371,13 +371,17 @@ class Variable:
     @regularizer.setter
     def regularizer(self, value):
         from keras.src.regularizers import Regularizer
+        from keras.src.regularizers import get as get_regularizer
 
         if value is not None and not isinstance(value, Regularizer):
-            raise ValueError(
-                "Invalid value for attribute `regularizer`. Expected an "
-                "instance of `keras.regularizers.Regularizer`, or `None`. "
-                f"Received: regularizer={value}"
-            )
+            if callable(value):
+                value = get_regularizer(value)
+            else:
+                raise ValueError(
+                    "Invalid value for attribute `regularizer`. Expected an "
+                    "instance of `keras.regularizers.Regularizer`, a callable, "
+                    f"or `None`. Received: regularizer={value}"
+                )
         self._regularizer = value
 
     @property
@@ -387,13 +391,17 @@ class Variable:
     @constraint.setter
     def constraint(self, value):
         from keras.src.constraints import Constraint
+        from keras.src.constraints import get as get_constraint
 
         if value is not None and not isinstance(value, Constraint):
-            raise ValueError(
-                "Invalid value for attribute `constraint`. Expected an "
-                "instance of `keras.constraints.Constraint`, or `None`. "
-                f"Received: constraint={value}"
-            )
+            if callable(value):
+                value = get_constraint(value)
+            else:
+                raise ValueError(
+                    "Invalid value for attribute `constraint`. Expected an "
+                    "instance of `keras.constraints.Constraint`, a callable, "
+                    f"or `None`. Received: constraint={value}"
+                )
         self._constraint = value
 
     def __repr__(self):

--- a/keras/src/backend/common/variables_test.py
+++ b/keras/src/backend/common/variables_test.py
@@ -1229,3 +1229,31 @@ class TestStandardizeShapeWithTensorflow(test_case.TestCase):
         self.assertIs(type(standardized_shape), tuple)
         for d in standardized_shape:
             self.assertIsInstance(d, int)
+
+
+class VariableConstraintRegularizerTest(test_case.TestCase):
+    def test_plain_callable_constraint_on_variable(self):
+        """Test that a plain callable can be set as a constraint."""
+        from keras.src.constraints import Constraint
+
+        v = backend.Variable(initializer=np.ones((2, 2)))
+        v.constraint = lambda w: w * 0.5
+        self.assertIsInstance(v.constraint, Constraint)
+
+    def test_plain_callable_regularizer_on_variable(self):
+        """Test that a plain callable can be set as a regularizer."""
+        from keras.src.regularizers import Regularizer
+
+        v = backend.Variable(initializer=np.ones((2, 2)))
+        v.regularizer = lambda w: 0.01 * ops.sum(w)
+        self.assertIsInstance(v.regularizer, Regularizer)
+
+    def test_non_callable_constraint_raises(self):
+        v = backend.Variable(initializer=np.ones((2, 2)))
+        with self.assertRaisesRegex(ValueError, "constraint"):
+            v.constraint = "not_a_callable"
+
+    def test_non_callable_regularizer_raises(self):
+        v = backend.Variable(initializer=np.ones((2, 2)))
+        with self.assertRaisesRegex(ValueError, "regularizer"):
+            v.regularizer = "not_a_callable"

--- a/keras/src/constraints/__init__.py
+++ b/keras/src/constraints/__init__.py
@@ -53,8 +53,27 @@ def get(identifier):
     if callable(obj):
         if inspect.isclass(obj):
             obj = obj()
+        if not isinstance(obj, Constraint):
+            obj = _CallableConstraint(obj)
         return obj
     else:
         raise ValueError(
             f"Could not interpret constraint identifier: {identifier}"
+        )
+
+
+class _CallableConstraint(Constraint):
+    """Wraps a plain callable as a `Constraint` instance."""
+
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __call__(self, w):
+        return self.fn(w)
+
+    def get_config(self):
+        raise NotImplementedError(
+            "A plain callable used as a constraint cannot be serialized. "
+            "Please subclass `keras.constraints.Constraint` and implement "
+            "`get_config()` for serialization support."
         )

--- a/keras/src/constraints/constraints_test.py
+++ b/keras/src/constraints/constraints_test.py
@@ -99,3 +99,21 @@ class ConstraintsTest(testing.TestCase):
             "axis": 1,
         }
         self.assertEqual(config, expected_config)
+
+    def test_plain_callable_constraint(self):
+        def my_constraint(w):
+            return w * 0.5
+
+        obj = constraints.get(my_constraint)
+        self.assertIsInstance(obj, constraints.Constraint)
+        x = np.array([2.0, 4.0, 6.0])
+        output = obj(x)
+        self.assertAllClose(output, [1.0, 2.0, 3.0])
+
+    def test_plain_callable_constraint_get_config_raises(self):
+        def my_constraint(w):
+            return w
+
+        obj = constraints.get(my_constraint)
+        with self.assertRaises(NotImplementedError):
+            obj.get_config()

--- a/keras/src/regularizers/__init__.py
+++ b/keras/src/regularizers/__init__.py
@@ -53,8 +53,27 @@ def get(identifier):
     if callable(obj):
         if inspect.isclass(obj):
             obj = obj()
+        if not isinstance(obj, Regularizer):
+            obj = _CallableRegularizer(obj)
         return obj
     else:
         raise ValueError(
             f"Could not interpret regularizer identifier: {identifier}"
+        )
+
+
+class _CallableRegularizer(Regularizer):
+    """Wraps a plain callable as a `Regularizer` instance."""
+
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __call__(self, x):
+        return self.fn(x)
+
+    def get_config(self):
+        raise NotImplementedError(
+            "A plain callable used as a regularizer cannot be serialized. "
+            "Please subclass `keras.regularizers.Regularizer` and implement "
+            "`get_config()` for serialization support."
         )

--- a/keras/src/regularizers/regularizers_test.py
+++ b/keras/src/regularizers/regularizers_test.py
@@ -132,6 +132,21 @@ class RegularizersTest(testing.TestCase):
         self.assertAlmostEqual(config_from_config["factor"], factor, 7)
         self.assertEqual(config_from_config["mode"], mode)
 
+    def test_plain_callable_regularizer(self):
+        def my_regularizer(x):
+            return 0.01 * backend.convert_to_numpy(x).sum()
+
+        obj = regularizers.get(my_regularizer)
+        self.assertIsInstance(obj, regularizers.Regularizer)
+
+    def test_plain_callable_regularizer_get_config_raises(self):
+        def my_regularizer(x):
+            return 0.0
+
+        obj = regularizers.get(my_regularizer)
+        with self.assertRaises(NotImplementedError):
+            obj.get_config()
+
 
 class ValidateFloatArgTest(testing.TestCase):
     def test_validate_float_with_valid_args(self):


### PR DESCRIPTION
## Summary
- Wrap plain callables in adapter classes (`_CallableConstraint` / `_CallableRegularizer`) in `constraints.get()` and `regularizers.get()` so they pass `isinstance` checks in `Variable` setters
- Update `Variable.constraint` and `Variable.regularizer` setters to also wrap callables via `get()` as a defensive fallback
- Adapters raise `NotImplementedError` on `get_config()` to clearly indicate serialization is unsupported for plain callables

## Test plan
- [x] Unit tests for `constraints.get()` with plain callable
- [x] Unit tests for `regularizers.get()` with plain callable
- [x] Unit tests for `Variable.constraint` and `Variable.regularizer` setters with plain callables
- [x] Non-callable values still raise `ValueError`
- [x] Integration test: `add_weight(constraint=<plain callable>)` works end-to-end
- [x] Existing constraint and regularizer tests still pass

Fixes #22221