### PR TITLE
Accept integer-like types for layer dimension parameters

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -1,4 +1,5 @@
 import math
+import operator
 
 import ml_dtypes
 
@@ -98,7 +99,14 @@ class Dense(Layer):
         quantization_config=None,
         **kwargs,
     ):
-        if not isinstance(units, int) or units <= 0:
+        try:
+            units = operator.index(units)
+        except (TypeError, OverflowError):
+            raise ValueError(
+                "Received an invalid value for `units`, expected a positive "
+                f"integer. Received: units={units}"
+            )
+        if units <= 0:
             raise ValueError(
                 "Received an invalid value for `units`, expected a positive "
                 f"integer. Received: units={units}"

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -130,6 +130,16 @@ class DenseTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "positive integer"):
             layers.Dense(units)
 
+    def test_dense_accepts_integer_like_units(self):
+        """layers.Dense should accept numpy integers and ops.prod results."""
+        layer = layers.Dense(np.int32(10))
+        self.assertEqual(layer.units, 10)
+        self.assertIsInstance(layer.units, int)
+
+        layer = layers.Dense(np.int64(5))
+        self.assertEqual(layer.units, 5)
+        self.assertIsInstance(layer.units, int)
+
     def test_dense_correctness(self):
         # With bias and activation.
         layer = layers.Dense(units=2, activation="relu")

--- a/keras/src/layers/reshaping/repeat_vector.py
+++ b/keras/src/layers/reshaping/repeat_vector.py
@@ -1,3 +1,5 @@
+import operator
+
 from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.layers.input_spec import InputSpec
@@ -27,11 +29,13 @@ class RepeatVector(Layer):
 
     def __init__(self, n, **kwargs):
         super().__init__(**kwargs)
-        self.n = n
-        if not isinstance(n, int):
+        try:
+            n = operator.index(n)
+        except (TypeError, OverflowError):
             raise TypeError(
                 f"Expected an integer value for `n`, got {type(n)}."
             )
+        self.n = n
         self.input_spec = InputSpec(ndim=2)
 
     def compute_output_shape(self, input_shape):

--- a/keras/src/layers/reshaping/repeat_vector_test.py
+++ b/keras/src/layers/reshaping/repeat_vector_test.py
@@ -30,6 +30,16 @@ class FlattenTest(testing.TestCase):
         repeated = layers.RepeatVector(n=3)(input_layer)
         self.assertEqual(repeated.shape, (2, 3, None))
 
+    def test_repeat_vector_accepts_integer_like_n(self):
+        """RepeatVector should accept numpy integers."""
+        layer = layers.RepeatVector(n=np.int32(3))
+        self.assertEqual(layer.n, 3)
+        self.assertIsInstance(layer.n, int)
+
+        layer = layers.RepeatVector(n=np.int64(5))
+        self.assertEqual(layer.n, 5)
+        self.assertIsInstance(layer.n, int)
+
     def test_repeat_vector_with_invalid_n(self):
         with self.assertRaisesRegex(
             TypeError, "Expected an integer value for `n`"


### PR DESCRIPTION
## Summary

`Dense(units=...)` and `RepeatVector(n=...)` use strict `isinstance(x, int)` checks that reject valid integer-like types such as `numpy.int32`, `numpy.int64`, and backend tensors returned by `ops.prod()`. This makes it impossible to write `Dense(ops.prod(input_shape[1:]))` without an explicit `int()` cast.

- Replace `isinstance(units, int)` with `operator.index()` in `Dense.__init__()`, which accepts any type implementing the `__index__` protocol (Python ints, numpy integers, 0-d backend tensors) while still rejecting floats, strings, and None
- Apply the same fix to `RepeatVector.__init__()`
- Add tests for numpy integer acceptance in both layers

Fixes https://github.com/keras-team/keras/issues/21655