### PR TITLE
[OpenVINO backend] Implement conj operation for NumPy support

### DIFF
--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1005,13 +1005,13 @@ def concatenate(xs, axis=0):
 
 
 def conjugate(x):
-    raise NotImplementedError(
-        "`conjugate` is not supported with openvino backend"
-    )
+    # TODO: Implement complex support when OpenVINO adds complex dtypes.
+    # Currently, all supported dtypes are real-valued.
+    return convert_to_tensor(x)
 
 
 def conj(x):
-    raise NotImplementedError("`conj` is not supported with openvino backend")
+    return conjugate(x)
 
 
 def copy(x):


### PR DESCRIPTION
This PR implements the conj() and conjugate() operations for the OpenVINO backend. Since OpenVINO does not currently support complex dtypes, this implementation handles real-valued dtypes, ensuring parity with the Keras 3 API. For real inputs, conjugate() returns the input value unchanged.

Closes https://github.com/openvinotoolkit/openvino/issues/34238
