### PR TITLE
Fix RandomZoom zero-scale validation and missing labels KeyError

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/bounding_box.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/bounding_box.py
@@ -118,7 +118,8 @@ class BoundingBox:
             )
 
         ops = self.backend
-        boxes, labels = bounding_boxes["boxes"], bounding_boxes["labels"]
+        boxes = bounding_boxes["boxes"]
+        labels = bounding_boxes.get("labels", None)
         if width is not None:
             width = ops.cast(width, boxes.dtype)
         if height is not None:
@@ -132,9 +133,10 @@ class BoundingBox:
             y2 = ops.numpy.clip(y2, 0, height)
             boxes = ops.numpy.concatenate([x1, y1, x2, y2], axis=-1)
 
-            areas = self._compute_area(boxes)
-            areas = ops.numpy.squeeze(areas, axis=-1)
-            labels = ops.numpy.where(areas > 0, labels, -1)
+            if labels is not None:
+                areas = self._compute_area(boxes)
+                areas = ops.numpy.squeeze(areas, axis=-1)
+                labels = ops.numpy.where(areas > 0, labels, -1)
         elif bounding_box_format == "rel_xyxy":
             x1, y1, x2, y2 = ops.numpy.split(boxes, 4, axis=-1)
             x1 = ops.numpy.clip(x1, 0.0, 1.0)
@@ -143,13 +145,15 @@ class BoundingBox:
             y2 = ops.numpy.clip(y2, 0.0, 1.0)
             boxes = ops.numpy.concatenate([x1, y1, x2, y2], axis=-1)
 
-            areas = self._compute_area(boxes)
-            areas = ops.numpy.squeeze(areas, axis=-1)
-            labels = ops.numpy.where(areas > 0, labels, -1)
+            if labels is not None:
+                areas = self._compute_area(boxes)
+                areas = ops.numpy.squeeze(areas, axis=-1)
+                labels = ops.numpy.where(areas > 0, labels, -1)
 
         result = bounding_boxes.copy()
         result["boxes"] = boxes
-        result["labels"] = labels
+        if labels is not None:
+            result["labels"] = labels
         return result
 
     def affine(

--- a/keras/src/layers/preprocessing/image_preprocessing/random_zoom.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_zoom.py
@@ -100,7 +100,7 @@ class RandomZoom(BaseImagePreprocessingLayer):
     _FACTOR_VALIDATION_ERROR = (
         "The `height_factor` and `width_factor` arguments "
         "should be a number (or a list of two numbers) "
-        "in the range [-1.0, 1.0]. "
+        "in the range (-1.0, 1.0]. "
     )
     _SUPPORTED_FILL_MODE = ("reflect", "wrap", "constant", "nearest")
     _SUPPORTED_INTERPOLATION = ("nearest", "bilinear")
@@ -167,7 +167,7 @@ class RandomZoom(BaseImagePreprocessingLayer):
         return lower, upper
 
     def _check_factor_range(self, input_number):
-        if input_number > 1.0 or input_number < -1.0:
+        if input_number > 1.0 or input_number <= -1.0:
             raise ValueError(
                 self._FACTOR_VALIDATION_ERROR
                 + f"Received: input_number={input_number}"


### PR DESCRIPTION
## Summary

Fixes two bugs in `RandomZoom`:

1. **Zero-scale factor validation**: `_check_factor_range` now rejects `-1.0` (changed `<` to `<=`), which previously created a zero-scale transformation matrix (`1.0 + (-1.0) = 0`), leading to singular matrix errors or NaN outputs.

2. **Missing labels KeyError**: `clip_to_image_size` in `BoundingBox` now treats the `labels` key as optional using `.get()`, so bounding box dicts with only `boxes` no longer crash with `KeyError: 'labels'`.

Fixes #22247