### PR TITLE
Hide backend_module param from smart_resize public signature

### DIFF
--- a/keras/src/utils/image_utils.py
+++ b/keras/src/utils/image_utils.py
@@ -374,6 +374,11 @@ def smart_resize(
         the output is a backend-native tensor.
     """
     backend_module = kwargs.pop("backend_module", None) or backend
+    if kwargs:
+        raise TypeError(
+            "smart_resize() got unexpected keyword arguments: "
+            f"{list(kwargs.keys())}"
+        )
     if len(size) != 2:
         raise ValueError(
             f"Expected `size` to be a tuple of 2 integers, but got: {size}."


### PR DESCRIPTION
## Summary

Removes `backend_module` from the public signature of `smart_resize()` and hides it in `**kwargs`, as suggested by @fchollet in #21722.

The parameter is primarily for internal use and was confusing users who tried to pass `keras.backend` expecting it to switch backends (resulting in `AttributeError`). The parameter still works via keyword argument for internal callers, but is no longer exposed in the documentation or function signature.

Fixes #21711