### PR TITLE
[OpenVINO Backend] Improve implementation for numpy.var and numpy.std

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -9,9 +9,7 @@ NumpyDtypeTest::test_maximum_python_types
 NumpyDtypeTest::test_minimum_python_types
 NumpyDtypeTest::test_multiply
 NumpyDtypeTest::test_power
-NumpyDtypeTest::test_std
 NumpyDtypeTest::test_subtract
-NumpyDtypeTest::test_var
 NumpyDtypeTest::test_view
 NumpyOneInputOpsCorrectnessTest::test_angle
 NumpyOneInputOpsCorrectnessTest::test_array

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -3576,7 +3576,7 @@ def stack(x, axis=0):
 
 def std(x, axis=None, keepdims=False):
     var_x = var(x, axis, keepdims)
-    std_dev = ov_opset.sqrt(var_x).output(0)
+    std_dev = ov_opset.sqrt(var_x.output).output(0)
     return OpenVINOKerasTensor(std_dev)
 
 
@@ -4321,9 +4321,12 @@ def var(x, axis=None, keepdims=False):
     x_type = x.get_element_type()
     x, axis = _resolve_axis(x, axis)
 
-    work_dtype = Type.f64 if x_type.is_integral() else x.get_element_type()
-    if x_type.is_integral():
+    if x_type.is_integral() or x_type == Type.boolean:
+        work_dtype = OPENVINO_DTYPES[config.floatx()]
         x = ov_opset.convert(x, work_dtype).output(0)
+    else:
+        work_dtype = x_type
+
     if axis is None:
         const_zero = ov_opset.constant(0, dtype=work_dtype).output(0)
         return OpenVINOKerasTensor(


### PR DESCRIPTION
This PR fixes the failing tests for numpy.var and numpy.std operations for the OpenVINO Backend

### Changes 
- `var`: Updates var to upcast integral and boolean inputs to `config.floatx()` instead of strictly float64.

- `std`: Fixes bfloat16 precision downgrade to float16. Replaced `ov_opset.sqrt(var_x)` with `ov_opset.sqrt(var_x.output)` so the binding evaluates the raw OpenVINO output node directly.

Releted tests have been excluded from `keras\src\backend\openvino\excluded_concrete_tests.txt`.

Closes: https://github.com/openvinotoolkit/openvino/issues/34254