### PR TITLE
[OpenVINO Backend] Fix OpenVINO matmul int8 dtype promotion to int32

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -4,7 +4,6 @@ NumpyDtypeTest::test_array
 NumpyDtypeTest::test_heaviside
 HistogramTest::test_histogram_predict_jit_compile_false
 HistogramTest::test_histogram_predict_jit_compile_true
-NumpyDtypeTest::test_matmul_
 NumpyDtypeTest::test_maximum_python_types
 NumpyDtypeTest::test_minimum_python_types
 NumpyDtypeTest::test_multiply

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -86,6 +86,16 @@ def matmul(x1, x2):
         element_type = x2.output.get_element_type()
     x1 = get_ov_output(x1, element_type)
     x2 = get_ov_output(x2, element_type)
+
+    # When both inputs are int8, promote to int32 to align with other backends.
+    if (
+        ov_to_keras_type(x1.get_element_type()) == "int8"
+        and ov_to_keras_type(x2.get_element_type()) == "int8"
+    ):
+        int32_type = OPENVINO_DTYPES["int32"]
+        x1 = ov_opset.convert(x1, int32_type).output(0)
+        x2 = ov_opset.convert(x2, int32_type).output(0)
+
     x1, x2 = _align_operand_types(x1, x2, "matmul()")
     return OpenVINOKerasTensor(ov_opset.matmul(x1, x2, False, False).output(0))
 


### PR DESCRIPTION
This PR fixes dtype promotion issues in the OpenVINO backend for the `matmul` operation.

### Changes
- matmul in numpy.py — when both inputs are int8, explicitly converts to int32 via `ov_opset.convert` before the matmul operation (matching other backends)
- excluded_concrete_tests.txt — removed relevent tests

Closes: openvinotoolkit/openvino/issues/34256