### PR TITLE
[OpenVINO backend] Implement linalg inv and solve operations

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -128,13 +128,11 @@ LinalgOpsCorrectnessTest::test_cholesky
 LinalgOpsCorrectnessTest::test_cholesky_inverse
 LinalgOpsCorrectnessTest::test_norm_2_nuc
 LinalgOpsCorrectnessTest::test_qr
-LinalgOpsCorrectnessTest::test_solve
 LinalgOpsCorrectnessTest::test_solve_triangular
 LinalgOpsCorrectnessTest::test_svd
 LinalgOpsCorrectnessTest::test_det
 LinalgOpsCorrectnessTest::test_eig
 LinalgOpsCorrectnessTest::test_eigh
-LinalgOpsCorrectnessTest::test_inv
 LinalgOpsCorrectnessTest::test_lstsq
 LinalgOpsCorrectnessTest::test_lu_factor
 LinalgOpsCorrectnessTest::test_norm_2_-2


### PR DESCRIPTION
This PR implements `linalg.inv` and `linalg.solve` for the OpenVINO backend, removing them from the NotImplementedError list.
 
These additions improve NumPy parity and allow the backend to support operations requiring linear system solutions.

### Future Optimizations
The current implementation of solve uses the inverse method ($A^{-1}B$). While this achieves parity, future optimizations could explore using a more numerically stable decomposition (e.g., LU) if OpenVINO adds a dedicated Solve op to the opset.

Closes: openvinotoolkit/openvino/issues/34269