### PR TITLE
[OpenVINO backend] Implement separable_conv() layer for NumPy support

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -144,7 +144,6 @@ NNOpsCorrectnessTest::test_conv_transpose_
 NNOpsCorrectnessTest::test_ctc_decode
 NNOpsCorrectnessTest::test_log_softmax_correctness_with_axis_tuple
 NNOpsCorrectnessTest::test_softmax_correctness_with_axis_tuple
-NNOpsCorrectnessTest::test_separable_conv_
 NNOpsCorrectnessTest::test_glu
 NNOpsCorrectnessTest::test_moments
 NNOpsCorrectnessTest::test_normalize

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -520,8 +520,22 @@ def separable_conv(
     data_format=None,
     dilation_rate=1,
 ):
-    raise NotImplementedError(
-        "`separable_conv` is not supported with openvino backend"
+    data_format = backend.standardize_data_format(data_format)
+    depthwise_conv_output = depthwise_conv(
+        inputs,
+        depthwise_kernel,
+        strides,
+        padding,
+        data_format,
+        dilation_rate,
+    )
+    return conv(
+        depthwise_conv_output,
+        pointwise_kernel,
+        strides=1,
+        padding="valid",
+        data_format=data_format,
+        dilation_rate=dilation_rate,
     )
 
 


### PR DESCRIPTION
This PR implements the separable_conv() layer for the OpenVINO backend and enables related tests. Follow the implementation of numpy backend.

Closes https://github.com/openvinotoolkit/openvino/issues/34274