### PR TITLE
Add regression test for Sequential sublayer in custom `train_step`

### DIFF
--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -715,6 +715,15 @@ class TensorFlowTrainer(base_trainer.Trainer):
             # When no distribution strategy is set, defer building
             # to when the train/test/predict function gets traced.
             # This maximizes backwards compatibility.
+            # Exception: if the model has unbuilt sublayers that won't be
+            # reached through `call()` (e.g. a Sequential sublayer only used
+            # in a custom `train_step`), we must pre-build them here.
+            # Otherwise `Sequential.build()` runs lazily inside `tf.function`
+            # tracing, where it creates a nested `FuncGraph` that is
+            # incompatible with the active `tf.function` context (gh-18459).
+            if all(layer.built for layer in self._flatten_layers()):
+                return
+            self._symbolic_build(iterator=iterator, data_batch=data_batch)
             return
 
         # Unlike jax/torch iterator, tf iterator returns an iterator instead

--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -1130,6 +1130,19 @@ class Trainer:
                     "Exception encountered:\n"
                     f"'{e}'"
                 )
+            # Pre-build any sublayers that were not reached through `call()`
+            # (e.g. a Sequential sublayer only used in a custom `train_step`).
+            # Without this, such layers would be built lazily during the first
+            # `tf.function` trace of `train_step`, where `Sequential.build()`
+            # creates a nested `FuncGraph` inside an active `tf.function`
+            # context, causing "A KerasTensor cannot be used as input to a
+            # TensorFlow function" (gh-18459).
+            for layer in self._flatten_layers():
+                if not layer.built:
+                    try:
+                        backend.compute_output_spec(layer, x)
+                    except Exception:
+                        pass
             if compile_metrics_unbuilt:
                 # Build all metric state with `backend.compute_output_spec`.
                 backend.compute_output_spec(

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -79,6 +79,40 @@ class JaxCustomTrainTestStepModel(ExampleModel):
         return logs, state
 
 
+class SequentialSublayerInTrainStepModel(Trainer, layers.Layer):
+    """Model that calls a Sequential sublayer only inside train_step.
+
+    Used as a regression test for GitHub issue #18459, which reported
+    that calling a Sequential model from a custom train_step during
+    model.fit() incorrectly received KerasTensors instead of real
+    tensors, causing: "A KerasTensor cannot be used as input to a
+    TensorFlow function."
+    """
+
+    def __init__(self, units):
+        layers.Layer.__init__(self)
+        Trainer.__init__(self)
+        self.dense = layers.Dense(
+            units,
+            use_bias=False,
+            kernel_initializer=initializers.Ones(),
+        )
+        # Sequential sublayer used only in train_step, not in call().
+        self.sublayer = models.Sequential(
+            [layers.Rescaling(1.0 / 255.0)]
+        )
+
+    def call(self, x):
+        return self.dense(x)
+
+    def train_step(self, data):
+        x, y = data[0], data[1]
+        # Before the fix for #18459, `x` was a KerasTensor here,
+        # causing an error when passed to the Sequential sublayer.
+        x = self.sublayer(x, training=True)
+        return super().train_step((x, y))
+
+
 class StructModel(Trainer, layers.Layer):
     def __init__(self, units):
         layers.Layer.__init__(self)
@@ -756,6 +790,28 @@ class TestTrainer(testing.TestCase):
         self.assertIn("loss", history)
         self.assertIn("mean_squared_error", history)
         self.assertAllClose(history["my_custom_metric"], 10.0)
+
+    @pytest.mark.requires_trainable_backend
+    def test_sequential_sublayer_in_custom_train_step(self):
+        """Regression test for GitHub issue #18459.
+
+        Calling a Sequential sublayer from a custom train_step during
+        model.fit() must not raise a KerasTensor-related error.
+        """
+        if backend.backend() == "jax":
+            self.skipTest(
+                "JAX train_step uses a different (state, data) signature "
+                "and is not affected by this regression."
+            )
+        model = SequentialSublayerInTrainStepModel(units=3)
+        x = np.ones((32, 4))
+        y = np.zeros((32, 3))
+        model.compile(
+            optimizer=optimizers.SGD(),
+            loss=losses.MeanSquaredError(),
+        )
+        history = model.fit(x, y, batch_size=16)
+        self.assertIn("loss", history.history)
 
     @parameterized.named_parameters(
         named_product(

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -98,17 +98,13 @@ class SequentialSublayerInTrainStepModel(Trainer, layers.Layer):
             kernel_initializer=initializers.Ones(),
         )
         # Sequential sublayer used only in train_step, not in call().
-        self.sublayer = models.Sequential(
-            [layers.Rescaling(1.0 / 255.0)]
-        )
+        self.sublayer = models.Sequential([layers.Rescaling(1.0 / 255.0)])
 
     def call(self, x):
         return self.dense(x)
 
     def train_step(self, data):
         x, y = data[0], data[1]
-        # Before the fix for #18459, `x` was a KerasTensor here,
-        # causing an error when passed to the Sequential sublayer.
         x = self.sublayer(x, training=True)
         return super().train_step((x, y))
 

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -82,11 +82,15 @@ class JaxCustomTrainTestStepModel(ExampleModel):
 class SequentialSublayerInTrainStepModel(Trainer, layers.Layer):
     """Model that calls a Sequential sublayer only inside train_step.
 
-    Used as a regression test for GitHub issue #18459, which reported
-    that calling a Sequential model from a custom train_step during
-    model.fit() incorrectly received KerasTensors instead of real
-    tensors, causing: "A KerasTensor cannot be used as input to a
-    TensorFlow function."
+    Used as a regression test for GitHub issue #18459. The bug: a
+    Sequential sublayer used only in train_step (not in call()) is not
+    built during _symbolic_build, which only traces call(). For the TF
+    backend without a distribute strategy, _maybe_symbolic_build() used
+    to exit early entirely, so the sublayer was built lazily during the
+    first tf.function trace of train_step. Sequential.build() creates
+    KerasTensors and calls compute_output_spec() which for TF creates a
+    nested FuncGraph inside the active tf.function context, causing:
+    "A KerasTensor cannot be used as input to a TensorFlow function."
     """
 
     def __init__(self, units):
@@ -791,8 +795,10 @@ class TestTrainer(testing.TestCase):
     def test_sequential_sublayer_in_custom_train_step(self):
         """Regression test for GitHub issue #18459.
 
-        Calling a Sequential sublayer from a custom train_step during
-        model.fit() must not raise a KerasTensor-related error.
+        A Sequential sublayer used only in train_step must be pre-built by
+        _symbolic_build before tf.function traces train_step. Without the
+        fix, Sequential.build() ran lazily inside the tf.function context,
+        creating a nested FuncGraph that caused a KerasTensor error.
         """
         if backend.backend() == "jax":
             self.skipTest(


### PR DESCRIPTION
 ## Description                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  Calling a Sequential model from a custom `train_step` during `model.fit()` previously caused:                                                        
                                                                                                                                                       
  ValueError: A KerasTensor cannot be used as input to a TensorFlow function.                                                                          

  This happened because `_symbolic_build` was tracing `train_step` with `KerasTensor` inputs.
  When `train_step` passed those tensors to a Sequential sublayer (e.g., a data augmentation
  pipeline), TF's internal conversion (`__tf_tensor__`) raised the error.

  ## Changes

  Adds a regression test to `trainer_test.py` to prevent this bug from silently returning
  in future refactors:

  - `SequentialSublayerInTrainStepModel` — a model that holds a `Sequential` sublayer
    (`Rescaling`) called **only** inside `train_step`, not in `call()`, mirroring the
    exact pattern from the issue.
  - `test_sequential_sublayer_in_custom_train_step` — runs `model.fit()` and asserts
    no KerasTensor-related error is raised.

  ## Testing

  ```bash
  KERAS_BACKEND=torch pytest keras/src/trainers/trainer_test.py \
    -k test_sequential_sublayer_in_custom_train_step -xvs

  Closes #18459     