### PR TITLE
[OpenVINO backend] Implements linalg cholesky_inverse operation

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -105,7 +105,6 @@ SegmentSumTest::test_segment_sum_call
 SegmentMaxTest::test_segment_max_call
 TestMathErrors::test_istft_invalid_window_shape_2D_inputs
 LinalgOpsCorrectnessTest::test_cholesky
-LinalgOpsCorrectnessTest::test_cholesky_inverse
 LinalgOpsCorrectnessTest::test_norm_2_nuc
 LinalgOpsCorrectnessTest::test_qr
 LinalgOpsCorrectnessTest::test_solve_triangular

--- a/keras/src/backend/openvino/linalg.py
+++ b/keras/src/backend/openvino/linalg.py
@@ -17,9 +17,20 @@ def cholesky(a, upper=False):
 
 
 def cholesky_inverse(a, upper=False):
-    raise NotImplementedError(
-        "`cholesky_inverse` is not supported with openvino backend."
-    )
+    a = convert_to_tensor(a)
+    a_ov = get_ov_output(a)
+    if upper:
+        # Reconstruct A = U^T @ U, then invert
+        reconstructed_matrix = ov_opset.matmul(a_ov, a_ov, True, False).output(
+            0
+        )
+    else:
+        # Reconstruct A = L @ L^T, then invert
+        reconstructed_matrix = ov_opset.matmul(a_ov, a_ov, False, True).output(
+            0
+        )
+    result = ov_opset.inverse(reconstructed_matrix, adjoint=False).output(0)
+    return OpenVINOKerasTensor(result)
 
 
 def det(a):


### PR DESCRIPTION
This PR implements `cholesky_inverse` in the linalg suite for the OpenVINO backend, using the following approach:

1. Reconstructed the original matrix $A$ from its factor ($L L^T$ or $U^T U$) using ov_opset.matmul.
2. Inverted the result using native ov_opset.inverse.

I have enabled the corresponding tests.

Closes: openvinotoolkit/openvino/issues/34296