### PR TITLE
fix: replace 32 bare except clauses with except Exception

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -401,7 +401,7 @@ class Variable:
         if hasattr(self, "_value") and self._value is not None:
             try:
                 value = backend.core.convert_to_numpy(self._value)
-            except:
+            except Exception:
                 # In some cases the conversion to numpy can fail.
                 pass
         value_str = f", value={value}" if value is not None else ""

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -1508,7 +1508,7 @@ def _can_use_flash_attention(query, key, value, bias, raise_error=False):
                 check_is_flash_attention_kwargs.pop(param)
         check_is_flash_attention(**check_is_flash_attention_kwargs)
         return True
-    except:
+    except Exception:
         if raise_error:
             raise
         return False

--- a/keras/src/backend/numpy/trainer.py
+++ b/keras/src/backend/numpy/trainer.py
@@ -118,7 +118,7 @@ class NumpyTrainer(base_trainer.Trainer):
             # Build all model state with `backend.compute_output_spec`.
             try:
                 y_pred = backend.compute_output_spec(self, x)
-            except:
+            except Exception:
                 raise RuntimeError(
                     "Unable to automatically build the model. "
                     "Please build it yourself before calling "

--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -199,7 +199,7 @@ def shape(x):
         if shape[i] is None:
             try:
                 shape[i] = dynamic[i]
-            except:
+            except Exception:
                 # With RaggedTensors, accessing a ragged dimension will fail,
                 # we leave it as None.
                 pass

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -330,7 +330,7 @@ def compute_output_spec(fn, *args, **kwargs):
                     (args, kwargs),
                 )
                 return fn(*meta_args, **meta_kwargs)
-        except:
+        except Exception:
             with device_scope(DEFAULT_DEVICE):
                 # If the `"meta"` device placement fails, fall back to tracing
                 # eagerly with tensors on the default device. This will be
@@ -738,7 +738,7 @@ class CustomGradientFunction(torch.autograd.Function):
         ctx.save_for_backward(*args)
         try:
             output, ctx.grad_fn = forward_fn(*args, **kwargs)
-        except:
+        except Exception:
             output = forward_fn(*args, **kwargs)
             ctx.grad_fn = lambda *args, **kwargs: torch.full((), float("nan"))
         return output

--- a/keras/src/callbacks/backup_and_restore.py
+++ b/keras/src/callbacks/backup_and_restore.py
@@ -42,7 +42,7 @@ class BackupAndRestore(Callback):
     ...   model.fit(np.arange(100).reshape(5, 20), np.zeros(5), epochs=10,
     ...             batch_size=1, callbacks=[callback, InterruptingCallback()],
     ...             verbose=0)
-    ... except:
+    ... except Exception:
     ...   pass
     >>> history = model.fit(np.arange(100).reshape(5, 20), np.zeros(5),
     ...                     epochs=10, batch_size=1, callbacks=[callback],

--- a/keras/src/callbacks/orbax_checkpoint_test.py
+++ b/keras/src/callbacks/orbax_checkpoint_test.py
@@ -411,7 +411,7 @@ class OrbaxCheckpointTest(testing.TestCase, parameterized.TestCase):
             else:
                 try:
                     set_distribution(None)
-                except:
+                except Exception:
                     pass
 
     @pytest.mark.requires_trainable_backend

--- a/keras/src/dtype_policies/__init__.py
+++ b/keras/src/dtype_policies/__init__.py
@@ -106,7 +106,7 @@ def get(identifier):
             return DTypePolicy(identifier)
     try:
         return DTypePolicy(backend.standardize_dtype(identifier))
-    except:
+    except Exception:
         raise ValueError(
             "Cannot interpret `dtype` argument. Expected a string "
             f"or an instance of DTypePolicy. Received: dtype={identifier}"

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -132,7 +132,7 @@ class MultiHeadAttention(Layer):
                 output_shape = (output_shape,)
             try:
                 output_shape = tuple(output_shape)
-            except:
+            except Exception:
                 raise ValueError(
                     f"Invalid `output_shape`: {output_shape}. When "
                     "specified, the `output_shape` should be of type tuple, "

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -712,7 +712,7 @@ class MultiHeadAttentionTest(testing.TestCase):
         for sublayer in layer._flatten_layers():
             try:
                 sublayer.quantize("int8")
-            except:
+            except Exception:
                 pass
 
         # Verify weights dtype

--- a/keras/src/layers/core/lambda_layer.py
+++ b/keras/src/layers/core/lambda_layer.py
@@ -91,7 +91,7 @@ class Lambda(Layer):
                 )
                 output_spec = backend.compute_output_spec(self.call, inputs)
                 return tree.map_structure(lambda x: x.shape, output_spec)
-            except:
+            except Exception:
                 raise NotImplementedError(
                     "We could not automatically infer the shape of "
                     "the Lambda's output. Please specify the `output_shape` "

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1182,7 +1182,7 @@ class Layer(BackendLayer, Operation):
             if not isinstance(output_shape, (list, tuple, dict)):
                 try:
                     output_shape = tuple(output_shape)
-                except:
+                except Exception:
                     raise ValueError(
                         "Method `compute_output_shape()` of layer "
                         f"{self.__class__.__name__} is returning "
@@ -1546,7 +1546,7 @@ class Layer(BackendLayer, Operation):
         try:
             backend.compute_output_spec(self.call, input_tensors)
             return True
-        except:
+        except Exception:
             return False
 
     def _build_by_run_for_kwargs(self, shapes_dict):
@@ -1561,7 +1561,7 @@ class Layer(BackendLayer, Operation):
             try:
                 backend.compute_output_spec(self.call, **input_tensors)
                 return True
-            except:
+            except Exception:
                 return False
         else:
             # Not supported: nested input keyword arguments.

--- a/keras/src/legacy/saving/legacy_h5_format_test.py
+++ b/keras/src/legacy/saving/legacy_h5_format_test.py
@@ -18,7 +18,7 @@ from keras.src.saving import serialization_lib
 
 try:
     import tf_keras
-except:
+except Exception:
     tf_keras = None
 
 

--- a/keras/src/legacy/saving/saving_utils.py
+++ b/keras/src/legacy/saving/saving_utils.py
@@ -245,7 +245,7 @@ def try_build_compiled_arguments(model):
             model.compiled_loss.build(model.outputs)
         if not model.compiled_metrics.built:
             model.compiled_metrics.build(model.outputs, model.outputs)
-    except:
+    except Exception:
         logging.warning(
             "Compiled the loaded model, but the compiled metrics have "
             "yet to be built. `model.compile_metrics` will be empty "

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -224,7 +224,7 @@ class Functional(Function, Model):
                 tree.lists_to_tuples(inputs),
                 tree.lists_to_tuples(self._inputs_struct),
             )
-        except:
+        except Exception:
             model_inputs_struct = tree.map_structure(
                 lambda x: x.name, self._inputs_struct
             )

--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -601,7 +601,7 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                 try:
                     self.build(config["input_shape"])
                     status = True
-                except:
+                except Exception:
                     pass
             self._build_shapes_dict = config
 
@@ -613,7 +613,7 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                 try:
                     self.build(**config["shapes_dict"])
                     status = True
-                except:
+                except Exception:
                     pass
             self._build_shapes_dict = config["shapes_dict"]
 

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -164,7 +164,7 @@ class Sequential(Model):
     def build(self, input_shape=None):
         try:
             input_shape = standardize_shape(input_shape)
-        except:
+        except Exception:
             # Do not attempt to build if the model does not have a single
             # input tensor.
             return

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -1104,7 +1104,7 @@ class Cond(Operation):
     def _check_output_spec(self, true_fn_spec, false_fn_spec):
         try:
             tree.assert_same_structure(true_fn_spec, false_fn_spec)
-        except:
+        except Exception:
             return False
 
         def check_leaf(t_spec, f_spec):

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -223,7 +223,7 @@ def _save_model_to_fileobj(model, fileobj, weights_format):
                             weights_file_path.name, mode="w"
                         )
                         write_zf = True
-                except:
+                except Exception:
                     # If we can't use the local disk for any reason, write the
                     # weights into memory first, which consumes more memory.
                     weights_store = H5IOStore(
@@ -249,7 +249,7 @@ def _save_model_to_fileobj(model, fileobj, weights_format):
                 inner_path="",
                 visited_saveables=set(),
             )
-        except:
+        except Exception:
             # Skip the final `zf.write` if any exception is raised
             write_zf = False
             if weights_store:
@@ -469,7 +469,7 @@ def _load_model_from_fileobj(fileobj, custom_objects, compile, safe_mode):
                             pathlib.Path(extract_dir.name, _VARS_FNAME_H5),
                             mode="r",
                         )
-                except:
+                except Exception:
                     # If we can't use the local disk for any reason, read the
                     # weights from the zip archive on the fly, which is less
                     # efficient.

--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -654,7 +654,7 @@ class CompileLoss(losses_module.Loss):
 
         try:
             output_names = tree.pack_sequence_as(y_pred, flat_output_names)
-        except:
+        except Exception:
             inferred_flat_output_names = self._get_y_pred_output_names(y_pred)
             output_names = tree.pack_sequence_as(
                 y_pred, inferred_flat_output_names
@@ -746,14 +746,14 @@ class CompileLoss(losses_module.Loss):
 
             try:
                 y_true = tree.pack_sequence_as(y_pred, y_true)
-            except:
+            except Exception:
                 # Check case where y_true has the same structure but uses
                 # different (but reconcilable) container types,
                 # e.g `list` vs `tuple`.
                 try:
                     tree.assert_same_paths(y_true, y_pred)
                     y_true = tree.pack_sequence_as(y_pred, tree.flatten(y_true))
-                except:
+                except Exception:
                     try:
                         # Check case where loss is partially defined over y_pred
                         flat_y_true = tree.flatten(y_true)
@@ -770,7 +770,7 @@ class CompileLoss(losses_module.Loss):
                         ):
                             y_true[i] = y_t
                         y_true = tree.pack_sequence_as(self._user_loss, y_true)
-                    except:
+                    except Exception:
                         y_true_struct = tree.map_structure(
                             lambda _: "*", y_true
                         )

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -2002,7 +2002,7 @@ class TestTrainer(testing.TestCase):
                     y_test.reshape((-1, 16, 3)),
                 ),
             )
-        except:
+        except Exception:
             pass
 
         # Try model.fit with correct validation_data this should work.

--- a/keras/src/utils/python_utils.py
+++ b/keras/src/utils/python_utils.py
@@ -194,7 +194,7 @@ def pythonify_logs(logs):
                 if backend.is_tensor(value):
                     value = backend.convert_to_numpy(value)
                 value = float(value)
-            except:
+            except Exception:
                 pass
             result[key] = value
     return result

--- a/keras/src/wrappers/fixes.py
+++ b/keras/src/wrappers/fixes.py
@@ -19,7 +19,7 @@ def _validate_data(estimator, *args, **kwargs):
         return validate_data(estimator, *args, **kwargs)
     except ImportError:
         return estimator._validate_data(*args, **kwargs)
-    except:
+    except Exception:
         raise
 
 


### PR DESCRIPTION
## What
Replace 32 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.