### PR TITLE
Test: Activate `random.randint` test in OpenVINO BackEnd

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -108,13 +108,6 @@ RandomDTypeTest::test_binomial_float16
 RandomDTypeTest::test_binomial_float32
 RandomDTypeTest::test_binomial_float64
 RandomDTypeTest::test_normal_bfloat16
-RandomDTypeTest::test_randint_int16
-RandomDTypeTest::test_randint_int32
-RandomDTypeTest::test_randint_int64
-RandomDTypeTest::test_randint_int8
-RandomDTypeTest::test_randint_uint16
-RandomDTypeTest::test_randint_uint32
-RandomDTypeTest::test_randint_uint8
 RandomDTypeTest::test_truncated_normal_bfloat16
 RandomDTypeTest::test_uniform_bfloat16
 SegmentSumTest::test_segment_sum_call


### PR DESCRIPTION
Hi, devs.

I am working on the issue: https://github.com/openvinotoolkit/openvino/issues/34308
And i found some minor error in OpenVINO Backend's `random.randint` function test.

`randint` function is developed. 

https://github.com/keras-team/keras/blob/f22348ed4a0a09d27898e45947878d4320a6889b/keras/src/backend/openvino/random.py#L94-L127

But, the test is not activate. (randint test was skipped.)

this PR activate randint test code.

Thanks.

### before:
<img width="1337" height="603" alt="img1" src="https://github.com/user-attachments/assets/1f9f6545-7a15-42b0-beac-40297c0138ae" />

### after:
<img width="1339" height="593" alt="img2" src="https://github.com/user-attachments/assets/171d39ff-d27e-4ef7-8727-079bb067ece4" />

