### PR TITLE
Clarify alpha arg description in CosineDecay docstring

### DIFF
--- a/keras/src/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/src/optimizers/schedules/learning_rate_schedule.py
@@ -651,7 +651,8 @@ class CosineDecay(LearningRateSchedule):
         initial_learning_rate: A Python float. The initial learning rate.
         decay_steps: A Python int. Number of steps to decay over.
         alpha: A Python float. Minimum learning rate value for decay as a
-            fraction of `initial_learning_rate`.
+            fraction of `warmup_target` or, if `warmup_target` is None,
+            `initial_learning_rate`.
         name: String. Optional name of the operation.  Defaults to
             `"CosineDecay"`.
         warmup_target: A Python float. The target learning rate for our


### PR DESCRIPTION
Related to #21772 and #21827 

Descriptions of `alpha` in CosineDecay docstring conflict: in explanation text it says it applies to `warmup_target` or `initial_learning_rate` (if `warmup_target` is None), but in the parameter description it says `alpha` is a fraction of `initial_learning_rate`. 

Actual behavior is that `alpha` is applied to the initial learning rate *after* warmup. If there is no warmup, that is `initial_learning_rate`. Otherwise, it is `warmup_target`. 

Updated parameter description to clarify this.

#21827 fixed the explanation text but not the parameter description.