### PR TITLE
fix(normalization): sort axis to fix crash with unsorted contiguous axes

### DIFF
--- a/keras/src/layers/normalization/layer_normalization.py
+++ b/keras/src/layers/normalization/layer_normalization.py
@@ -151,8 +151,9 @@ class LayerNormalization(Layer):
         self.autocast = False
 
     def build(self, input_shape):
-        if isinstance(self.axis, list):
-            shape = tuple([input_shape[dim] for dim in self.axis])
+        if isinstance(self.axis, (list, tuple)):
+            self.axis = sorted(self.axis)
+            shape = tuple(input_shape[dim] for dim in self.axis)
         else:
             shape = (input_shape[self.axis],)
             self.axis = [self.axis]

--- a/keras/src/layers/normalization/layer_normalization_test.py
+++ b/keras/src/layers/normalization/layer_normalization_test.py
@@ -133,3 +133,13 @@ class LayerNormalizationTest(testing.TestCase):
         with backend.AutocastScope("float16"):
             layer.gamma.assign(large_value)
             self.assertAllClose(layer.gamma.value, large_value)
+
+    def test_unsorted_axis(self):
+        x = np.random.randn(2, 3, 4).astype("float32")
+        layer_sorted = layers.LayerNormalization(axis=[-2, -1])
+        layer_unsorted = layers.LayerNormalization(axis=[-1, -2])
+        out_sorted = layer_sorted(x)
+        out_unsorted = layer_unsorted(x)
+        self.assertEqual(out_sorted.shape, (2, 3, 4))
+        self.assertEqual(out_unsorted.shape, (2, 3, 4))
+        self.assertAllClose(out_sorted, out_unsorted)

--- a/keras/src/layers/normalization/rms_normalization.py
+++ b/keras/src/layers/normalization/rms_normalization.py
@@ -48,8 +48,9 @@ class RMSNormalization(Layer):
         self.epsilon = epsilon
 
     def build(self, input_shape):
-        if isinstance(self.axis, list):
-            shape = tuple([input_shape[dim] for dim in self.axis])
+        if isinstance(self.axis, (list, tuple)):
+            self.axis = sorted(self.axis)
+            shape = tuple(input_shape[dim] for dim in self.axis)
         else:
             shape = (input_shape[self.axis],)
             self.axis = [self.axis]

--- a/keras/src/layers/normalization/rms_normalization_test.py
+++ b/keras/src/layers/normalization/rms_normalization_test.py
@@ -69,3 +69,13 @@ class RMSNormalizationTest(testing.TestCase):
                 ]
             ],
         )
+
+    def test_unsorted_axis(self):
+        x = np.random.randn(2, 3, 4).astype("float32")
+        layer_sorted = layers.RMSNormalization(axis=[-2, -1])
+        layer_unsorted = layers.RMSNormalization(axis=[-1, -2])
+        out_sorted = layer_sorted(x)
+        out_unsorted = layer_unsorted(x)
+        self.assertEqual(out_sorted.shape, (2, 3, 4))
+        self.assertEqual(out_unsorted.shape, (2, 3, 4))
+        self.assertAllClose(out_sorted, out_unsorted)

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -2997,11 +2997,13 @@ def _rms_normalization(x, scale=None, axis=-1, epsilon=None):
     if scale is not None:
         scale = backend.convert_to_tensor(scale, x.dtype)
 
+    if isinstance(axis, (tuple, list)):
+        axis = sorted(axis)
     if backend.backend() == "torch" and is_continuous_axis(axis):
         import torch.nn.functional as F
 
         if isinstance(axis, (tuple, list)):
-            normalized_shape = tuple([x.shape[dim] for dim in axis])
+            normalized_shape = tuple(x.shape[dim] for dim in axis)
         else:
             normalized_shape = (x.shape[axis],)
         outputs = F.rms_norm(x, normalized_shape, scale, epsilon)
@@ -3124,6 +3126,7 @@ def _layer_normalization(
     broadcast_shape = [1] * ndims
     if isinstance(axis, int):
         axis = [axis]
+    axis = sorted(axis)
     for dim in axis:
         broadcast_shape[dim] = input_shape[dim]
 
@@ -3142,7 +3145,7 @@ def _layer_normalization(
         # when using torch backend,use kernel to improve performance
         import torch.nn.functional as F
 
-        normalized_shape = tuple([input_shape[dim] for dim in axis])
+        normalized_shape = tuple(input_shape[dim] for dim in axis)
         outputs = F.layer_norm(x, normalized_shape, gamma, beta, epsilon)
     else:
         # Calculate the mean & variance along self.axis (layer activations).


### PR DESCRIPTION
## Summary
- Sort `axis` in `RMSNormalization.build()` and `LayerNormalization.build()` so weight shape matches dimension order
- Sort `axis` in `ops.nn._rms_normalization` and `ops.nn._layer_normalization` so `normalized_shape` is correct for PyTorch's `F.rms_norm`/`F.layer_norm`
- Unsorted but contiguous axes like `[-1, -2]` previously caused shape mismatch crashes on the Torch backend
- Adds tests for both layers verifying sorted and unsorted axes produce identical output

Fixes #22201