### PR TITLE
fix(utils): fix is_continuous_axis for reverse-ordered axes

### DIFF
--- a/keras/src/utils/python_utils.py
+++ b/keras/src/utils/python_utils.py
@@ -17,7 +17,7 @@ def is_continuous_axis(axis):
 
     negative_order_flag = True
     for i in range(len(axis) - 1):
-        if axis[i + 1] - axis[i] != 1:
+        if axis[i + 1] - axis[i] != -1:
             negative_order_flag = False
             break
     return positive_order_flag or negative_order_flag

--- a/keras/src/utils/python_utils_test.py
+++ b/keras/src/utils/python_utils_test.py
@@ -99,3 +99,17 @@ class PythonUtilsTest(testing.TestCase):
         bad_encoded_code = "This isn't valid base64!"
         with self.assertRaises(AttributeError):
             python_utils.func_load(bad_encoded_code)
+
+    def test_is_continuous_axis(self):
+        # Single axis
+        self.assertTrue(python_utils.is_continuous_axis(1))
+        self.assertTrue(python_utils.is_continuous_axis([1]))
+        # Forward-ordered continuous
+        self.assertTrue(python_utils.is_continuous_axis([1, 2, 3]))
+        self.assertTrue(python_utils.is_continuous_axis([-2, -1]))
+        # Reverse-ordered continuous
+        self.assertTrue(python_utils.is_continuous_axis([3, 2, 1]))
+        self.assertTrue(python_utils.is_continuous_axis([-1, -2]))
+        # Non-continuous
+        self.assertFalse(python_utils.is_continuous_axis([1, 3]))
+        self.assertFalse(python_utils.is_continuous_axis([-1, -3]))


### PR DESCRIPTION
## Summary
- Fix copy-paste bug in `is_continuous_axis` where `negative_order_flag` checked `!= 1` instead of `!= -1`
- This made the function unable to detect reverse-ordered continuous axes (e.g. `[3, 2, 1]` or `[-1, -2]`)
- The second loop was identical to the first, making `negative_order_flag` always equal `positive_order_flag`
- Adds comprehensive tests for forward, reverse, and non-continuous axis lists

Fixes #22298