### PR TITLE
Stabilize flaky `test_dropout` and fix `rate=1.0` across backends

### DIFF
--- a/keras/src/backend/jax/random.py
+++ b/keras/src/backend/jax/random.py
@@ -69,6 +69,10 @@ def _get_concrete_noise_shape(inputs, noise_shape):
 
 
 def dropout(inputs, rate, noise_shape=None, seed=None):
+    if rate == 1.0:
+        return jax.numpy.zeros_like(inputs)
+    if rate == 0.0:
+        return inputs
     seed = jax_draw_seed(seed)
     keep_prob = 1.0 - rate
     # The `noise_shape` may contain `None` so we need to convert it

--- a/keras/src/backend/numpy/random.py
+++ b/keras/src/backend/numpy/random.py
@@ -67,11 +67,14 @@ def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
 
 
 def dropout(inputs, rate, noise_shape=None, seed=None):
+    if rate == 1.0:
+        return np.zeros_like(inputs)
+    if rate == 0.0:
+        return inputs
     dtype = inputs.dtype
     seed = draw_seed(seed)
 
     keep_prob = 1.0 - rate
-
     # If noise_shape is not provided, use the shape of inputs
     if noise_shape is None:
         noise_shape = inputs.shape

--- a/keras/src/backend/tensorflow/random.py
+++ b/keras/src/backend/tensorflow/random.py
@@ -83,6 +83,10 @@ def _get_concrete_noise_shape(inputs, noise_shape):
 
 
 def dropout(inputs, rate, noise_shape=None, seed=None):
+    if rate == 1.0:
+        return tf.zeros_like(inputs)
+    if rate == 0.0:
+        return inputs
     seed = _cast_seed(draw_seed(seed))
     noise_shape = _get_concrete_noise_shape(inputs, noise_shape)
     return tf.nn.experimental.stateless_dropout(

--- a/keras/src/backend/torch/random.py
+++ b/keras/src/backend/torch/random.py
@@ -135,6 +135,10 @@ def _get_concrete_noise_shape(inputs, noise_shape):
 
 
 def dropout(inputs, rate, noise_shape=None, seed=None):
+    if rate == 1.0:
+        return torch.zeros_like(inputs, device=get_device())
+    if rate == 0.0:
+        return inputs
     if (
         seed is not None
         and not (isinstance(seed, SeedGenerator) and seed._initial_seed is None)

--- a/keras/src/random/random_test.py
+++ b/keras/src/random/random_test.py
@@ -105,11 +105,14 @@ class RandomCorrectnessTest(testing.TestCase):
         self.assertGreaterEqual(ops.max(res), mean - 2 * stddev)
 
     def test_dropout(self):
-        x = ops.ones((3, 5))
+        x = ops.ones((10, 10))
         self.assertAllClose(random.dropout(x, rate=0, seed=0), x)
-        x_res = random.dropout(x, rate=0.8, seed=0)
+        x_res = random.dropout(x, rate=0.5, seed=0)
         self.assertGreater(ops.max(x_res), ops.max(x))
-        self.assertGreater(ops.sum(x_res == 0), 2)
+        self.assertAllClose(ops.max(x_res), 2.0)
+        self.assertGreater(ops.cast(ops.sum(x_res == 0), "int32"), 2)
+        x_res = random.dropout(x, rate=1.0, seed=0)
+        self.assertAllClose(x_res, ops.zeros((10, 10)))
 
     def test_dropout_noise_shape(self):
         inputs = ops.ones((2, 3, 5, 7))


### PR DESCRIPTION
This PR addresses statistical flakiness in `RandomCorrectnessTest::test_dropout` and fixes a crash/incorrect behavior when `rate=1.0` is used in various backends.

## Changes
- Increased from `(3, 5)` to `(10, 10)` in `test_dropout` to ensure statistical stability ($P(\text{all-dropped}) < 10^{-30}$).
- Added checks for `rate=0`, `rate=0.5` (with precision check), and `rate=1.0`.
- Added explicit `if rate == 1.0: return zeros` and `if rate == 0.0: return inputs` guards in TensorFlow, JAX, Torch, and NumPy backends.
    - **TensorFlow**: Fixed `ValueError` crash for `rate=1.0`.
    - **JAX/Torch/NumPy**: Prevented potential division-by-zero (`NaN`/`inf`) when calculating the scaling factor.

Keras `Dropout` layers allow `rate=1.0` in their validation logic, but backend implementations like TensorFlow's `stateless_dropout` enforce the range `[0, 1)`. By adding these guards at the Keras backend level, we ensure a consistent and robust API across all supported frameworks.

### Verification
Verified with `pytest keras/src/random/random_test.py -k test_dropout` across:
- **TensorFlow**: Passed
- **JAX**: Passed
- **Torch**: Passed
- **NumPy**: Passed
- **OpenVINO**: Passed 

Closes: #22311
