### PR TITLE
Fix Progbar crash when target is zero (empty dataset)

### DIFF
--- a/keras/src/utils/progbar.py
+++ b/keras/src/utils/progbar.py
@@ -120,11 +120,11 @@ class Progbar:
                 message += "\n"
 
             if self.target is not None:
-                numdigits = int(math.log10(self.target)) + 1
+                numdigits = int(math.log10(max(1, self.target))) + 1
                 bar = (f"%{numdigits}d/%d") % (current, self.target)
                 bar = f"\x1b[1m{bar}\x1b[0m "
                 special_char_len += 8
-                prog = float(current) / self.target
+                prog = float(current) / self.target if self.target > 0 else 1
                 prog_width = int(self.width * prog)
 
                 if prog_width > 0:
@@ -187,7 +187,7 @@ class Progbar:
 
         elif self.verbose == 2:
             if finalize:
-                numdigits = int(math.log10(self.target)) + 1
+                numdigits = int(math.log10(max(1, self.target))) + 1
                 count = f"%{numdigits}d/%d" % (current, self.target)
                 info = f"{count} - {now - self._start:.0f}s"
                 info += f" -{self._format_time(time_per_unit, self.unit_name)}"

--- a/keras/src/utils/progbar_test.py
+++ b/keras/src/utils/progbar_test.py
@@ -25,3 +25,13 @@ class ProgbarTest(testing.TestCase):
         pb = progbar.Progbar(target=1, verbose=1)
 
         pb.update(1, values=[("values", values)], finalize=True)
+
+    @parameterized.named_parameters(
+        [
+            ("verbose_1", 1),
+            ("verbose_2", 2),
+        ]
+    )
+    def test_zero_target(self, verbose):
+        pb = progbar.Progbar(target=0, verbose=verbose)
+        pb.update(0, finalize=True)


### PR DESCRIPTION
When `Progbar` is initialized with `target=0` (e.g. from an empty dataset), calling `update()` crashes with `ValueError: math domain error` from `math.log10(0)` on line 123, and would also hit a `ZeroDivisionError` from `float(current) / self.target` on line 127.

This fix uses `max(1, self.target)` for the `log10` calculation and guards the division to avoid both crashes, allowing the progress bar to display gracefully with zero steps.

Adds a test for `target=0` with both `verbose=1` and `verbose=2`.

Fixes #19687