### PR TITLE
Use channels_last memory format for torch conv ops

### DIFF
--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -322,6 +322,21 @@ def _transpose_conv_kernel(kernel):
     return kernel
 
 
+def _get_channels_last_memory_format(ndim):
+    if ndim == 4:
+        return torch.channels_last
+    elif ndim == 5:
+        return torch.channels_last_3d
+    return None
+
+
+def _maybe_convert_to_channels_last(tensor):
+    mem_fmt = _get_channels_last_memory_format(tensor.ndim)
+    if mem_fmt is not None and not tensor.is_contiguous(memory_format=mem_fmt):
+        return tensor.contiguous(memory_format=mem_fmt)
+    return tensor
+
+
 def max_pool(
     inputs,
     pool_size,
@@ -566,6 +581,10 @@ def conv(
 
     kernel = _transpose_conv_kernel(kernel)
 
+    if data_format == "channels_last":
+        inputs = _maybe_convert_to_channels_last(inputs)
+        kernel = _maybe_convert_to_channels_last(kernel)
+
     # calc. groups snippet
     in_channels = inputs.shape[1]
     kernel_in_channels = kernel.shape[1]
@@ -701,6 +720,11 @@ def conv_transpose(
         inputs = _transpose_spatial_inputs(inputs)
     # Transpose kernel from keras format to torch format.
     kernel = _transpose_conv_kernel(kernel)
+
+    if data_format == "channels_last":
+        inputs = _maybe_convert_to_channels_last(inputs)
+        kernel = _maybe_convert_to_channels_last(kernel)
+
     kernel_spatial_shape = kernel.shape[2:]
     if isinstance(dilation_rate, int):
         dilation_rate = [dilation_rate] * len(kernel_spatial_shape)


### PR DESCRIPTION
## Summary

- Ensures conv and conv_transpose tensors use PyTorch's `channels_last` memory format when `data_format="channels_last"`, allowing PyTorch to route to cuDNN's native NHWC kernels instead of internally copying tensors.
- After `_transpose_conv_kernel`, the permuted kernel has non-standard strides that prevent cuDNN's optimized NHWC path. `contiguous(memory_format=channels_last)` fixes this with one copy.
- No effect on conv1d (PyTorch has no channels_last for 3D tensors) or `channels_first` data format (already optimal).

Addresses #18457.