### PR TITLE
Fix RandomCrop doing nothing at validation/inference

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
@@ -129,60 +129,59 @@ class RandomCrop(BaseImagePreprocessingLayer):
         return h_start, w_start
 
     def transform_images(self, images, transformation, training=True):
-        if training:
-            images = self.backend.cast(images, self.compute_dtype)
-            crop_box_hstart, crop_box_wstart = transformation
-            crop_height = self.height
-            crop_width = self.width
+        images = self.backend.cast(images, self.compute_dtype)
+        crop_box_hstart, crop_box_wstart = transformation
+        crop_height = self.height
+        crop_width = self.width
 
-            if self.data_format == "channels_last":
-                if len(images.shape) == 4:
-                    images = images[
-                        :,
-                        crop_box_hstart : crop_box_hstart + crop_height,
-                        crop_box_wstart : crop_box_wstart + crop_width,
-                        :,
-                    ]
-                else:
-                    images = images[
-                        crop_box_hstart : crop_box_hstart + crop_height,
-                        crop_box_wstart : crop_box_wstart + crop_width,
-                        :,
-                    ]
+        if self.data_format == "channels_last":
+            if len(images.shape) == 4:
+                images = images[
+                    :,
+                    crop_box_hstart : crop_box_hstart + crop_height,
+                    crop_box_wstart : crop_box_wstart + crop_width,
+                    :,
+                ]
             else:
-                if len(images.shape) == 4:
-                    images = images[
-                        :,
-                        :,
-                        crop_box_hstart : crop_box_hstart + crop_height,
-                        crop_box_wstart : crop_box_wstart + crop_width,
-                    ]
-                else:
-                    images = images[
-                        :,
-                        crop_box_hstart : crop_box_hstart + crop_height,
-                        crop_box_wstart : crop_box_wstart + crop_width,
-                    ]
+                images = images[
+                    crop_box_hstart : crop_box_hstart + crop_height,
+                    crop_box_wstart : crop_box_wstart + crop_width,
+                    :,
+                ]
+        else:
+            if len(images.shape) == 4:
+                images = images[
+                    :,
+                    :,
+                    crop_box_hstart : crop_box_hstart + crop_height,
+                    crop_box_wstart : crop_box_wstart + crop_width,
+                ]
+            else:
+                images = images[
+                    :,
+                    crop_box_hstart : crop_box_hstart + crop_height,
+                    crop_box_wstart : crop_box_wstart + crop_width,
+                ]
 
-            shape = self.backend.shape(images)
-            new_height = shape[self.height_axis]
-            new_width = shape[self.width_axis]
-            if (
-                not isinstance(new_height, int)
-                or not isinstance(new_width, int)
-                or new_height != self.height
-                or new_width != self.width
-            ):
-                # Resize images if size mismatch or
-                # if size mismatch cannot be determined
-                # (in the case of a TF dynamic shape).
-                images = self.backend.image.resize(
-                    images,
-                    size=(self.height, self.width),
-                    data_format=self.data_format,
-                )
-                # Resize may have upcasted the outputs
-                images = self.backend.cast(images, self.compute_dtype)
+        shape = self.backend.shape(images)
+        new_height = shape[self.height_axis]
+        new_width = shape[self.width_axis]
+        if (
+            not isinstance(new_height, int)
+            or not isinstance(new_width, int)
+            or new_height != self.height
+            or new_width != self.width
+        ):
+            # Resize images if size mismatch or
+            # if size mismatch cannot be determined
+            # (in the case of a TF dynamic shape).
+            images = self.backend.image.resize(
+                images,
+                size=(self.height, self.width),
+                data_format=self.data_format,
+            )
+            # Resize may have upcasted the outputs
+            images = self.backend.cast(images, self.compute_dtype)
         return images
 
     def transform_labels(self, labels, transformation, training=True):
@@ -206,58 +205,56 @@ class RandomCrop(BaseImagePreprocessingLayer):
         }
         """
 
-        if training:
-            h_start, w_start = transformation
-            if not self.backend.is_tensor(bounding_boxes["boxes"]):
-                bounding_boxes = densify_bounding_boxes(
-                    bounding_boxes, backend=self.backend
-                )
-            boxes = bounding_boxes["boxes"]
-            # Convert to a standard xyxy as operations are done xyxy by default.
-            boxes = convert_format(
-                boxes=boxes,
-                source=self.bounding_box_format,
-                target="xyxy",
-                height=self.height,
-                width=self.width,
+        h_start, w_start = transformation
+        if not self.backend.is_tensor(bounding_boxes["boxes"]):
+            bounding_boxes = densify_bounding_boxes(
+                bounding_boxes, backend=self.backend
             )
-            h_start = self.backend.cast(h_start, boxes.dtype)
-            w_start = self.backend.cast(w_start, boxes.dtype)
-            if len(self.backend.shape(boxes)) == 3:
-                boxes = self.backend.numpy.stack(
-                    [
-                        self.backend.numpy.maximum(boxes[:, :, 0] - h_start, 0),
-                        self.backend.numpy.maximum(boxes[:, :, 1] - w_start, 0),
-                        self.backend.numpy.maximum(boxes[:, :, 2] - h_start, 0),
-                        self.backend.numpy.maximum(boxes[:, :, 3] - w_start, 0),
-                    ],
-                    axis=-1,
-                )
-            else:
-                boxes = self.backend.numpy.stack(
-                    [
-                        self.backend.numpy.maximum(boxes[:, 0] - h_start, 0),
-                        self.backend.numpy.maximum(boxes[:, 1] - w_start, 0),
-                        self.backend.numpy.maximum(boxes[:, 2] - h_start, 0),
-                        self.backend.numpy.maximum(boxes[:, 3] - w_start, 0),
-                    ],
-                    axis=-1,
-                )
-
-            # Convert to user defined bounding box format
-            boxes = convert_format(
-                boxes=boxes,
-                source="xyxy",
-                target=self.bounding_box_format,
-                height=self.height,
-                width=self.width,
+        boxes = bounding_boxes["boxes"]
+        # Convert to a standard xyxy as operations are done xyxy by default.
+        boxes = convert_format(
+            boxes=boxes,
+            source=self.bounding_box_format,
+            target="xyxy",
+            height=self.height,
+            width=self.width,
+        )
+        h_start = self.backend.cast(h_start, boxes.dtype)
+        w_start = self.backend.cast(w_start, boxes.dtype)
+        if len(self.backend.shape(boxes)) == 3:
+            boxes = self.backend.numpy.stack(
+                [
+                    self.backend.numpy.maximum(boxes[:, :, 0] - h_start, 0),
+                    self.backend.numpy.maximum(boxes[:, :, 1] - w_start, 0),
+                    self.backend.numpy.maximum(boxes[:, :, 2] - h_start, 0),
+                    self.backend.numpy.maximum(boxes[:, :, 3] - w_start, 0),
+                ],
+                axis=-1,
+            )
+        else:
+            boxes = self.backend.numpy.stack(
+                [
+                    self.backend.numpy.maximum(boxes[:, 0] - h_start, 0),
+                    self.backend.numpy.maximum(boxes[:, 1] - w_start, 0),
+                    self.backend.numpy.maximum(boxes[:, 2] - h_start, 0),
+                    self.backend.numpy.maximum(boxes[:, 3] - w_start, 0),
+                ],
+                axis=-1,
             )
 
-            return {
-                "boxes": boxes,
-                "labels": bounding_boxes["labels"],
-            }
-        return bounding_boxes
+        # Convert to user defined bounding box format
+        boxes = convert_format(
+            boxes=boxes,
+            source="xyxy",
+            target=self.bounding_box_format,
+            height=self.height,
+            width=self.width,
+        )
+
+        return {
+            "boxes": boxes,
+            "labels": bounding_boxes["labels"],
+        }
 
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True

--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop_test.py
@@ -126,6 +126,25 @@ class RandomCropTest(testing.TestCase):
             run_training_check=False,
         )
 
+    def test_inference_center_crop(self):
+        """RandomCrop should center-crop at inference, not return input."""
+        np.random.seed(42)
+        height, width = 4, 4
+        if backend.config.image_data_format() == "channels_last":
+            input_shape = (2, 8, 8, 3)
+        else:
+            input_shape = (2, 3, 8, 8)
+        inp = np.random.random(input_shape)
+        layer = layers.RandomCrop(height, width)
+        output = layer(inp, training=False)
+        out_shape = output.shape
+        if backend.config.image_data_format() == "channels_last":
+            self.assertEqual(out_shape, (2, 4, 4, 3))
+        else:
+            self.assertEqual(out_shape, (2, 3, 4, 4))
+        # Output must differ from input since it's cropped
+        self.assertNotEqual(inp.shape, output.shape)
+
     def test_tf_data_compatibility(self):
         layer = layers.RandomCrop(8, 9)
         if backend.config.image_data_format() == "channels_last":


### PR DESCRIPTION
The `RandomCrop` layer's `transform_images` method was guarded by `if training:`, causing it to return the input image unchanged during inference (`training=False`). This meant the layer produced no cropping at all during validation/prediction, leading to shape mismatches when the model expects cropped dimensions.

The `get_random_transformation` method already correctly computes center crop coordinates for `training=False`, but those coordinates were never applied.

This fix removes the `training` guard from `transform_images` (and `transform_bounding_boxes`), so the crop is always applied — random during training, center during inference.

Fixes #21868