### PR TITLE
Fix associative_scan infinite recursion when axis size is 0 or 1

### DIFF
--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -479,6 +479,11 @@ def associative_scan(f, elems, reverse=False, axis=0):
 
     def _scan(elems):
         elem_length = _get_dim(elems[0])
+        # Handle trivial cases: 0 or 1 elements need no scanning.
+        # Without this guard, the recursion never reaches the base
+        # cases (elem_length 2 or 3) and overflows the stack.
+        if isinstance(elem_length, int) and elem_length <= 1:
+            return elems
         a = [slice_along_axis(elem, 0, -1, step=2, axis=axis) for elem in elems]
         b = [
             slice_along_axis(elem, 1, None, step=2, axis=axis) for elem in elems

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -470,6 +470,16 @@ class CoreOpsCorrectnessTest(testing.TestCase):
 
         self.assertAllClose(H_seq, H_par)
 
+        # Test axis size 1 (should not cause infinite recursion)
+        single = np.array([5])
+        result = core.associative_scan(f=operator.add, elems=single)
+        self.assertAllEqual(result, [5])
+
+        # Test axis size 0
+        empty = np.array([], dtype="float32")
+        result = core.associative_scan(f=operator.add, elems=empty)
+        self.assertEqual(result.shape, (0,))
+
         # Test Operation call.
         xs = np.arange(5, dtype="float32")
         self.assertAllClose(


### PR DESCRIPTION
The TensorFlow backend's `associative_scan` implementation enters infinite recursion when the scan axis has size 0 or 1. The existing base case check only handles `elem_length == 2` and `elem_length == 3`, so smaller sizes fall through to the recursive case indefinitely.

This adds an early return for `elem_length <= 1` — no scanning is needed when there are zero or one elements along the axis.

Fixes #22050