### PR TITLE
`OrbaxCheckpoint` now recovers the step number when a model is reloaded.

### DIFF
--- a/keras/src/callbacks/model_checkpoint.py
+++ b/keras/src/callbacks/model_checkpoint.py
@@ -194,7 +194,7 @@ class ModelCheckpoint(MonitorCallback):
         self.save_weights_only = save_weights_only
         self.save_freq = save_freq
         self._batches_seen_since_last_saving = 0
-        self._last_batch_seen = 0
+        self._last_batch_seen = None
 
         if self.save_freq != "epoch" and not isinstance(self.save_freq, int):
             raise ValueError(
@@ -239,7 +239,8 @@ class ModelCheckpoint(MonitorCallback):
         """Handles batch-level saving logic, supports steps_per_execution."""
         if self.save_freq == "epoch":
             return False
-        if batch <= self._last_batch_seen:  # New epoch.
+        if self._last_batch_seen is None or batch <= self._last_batch_seen:
+            # New epoch.
             add_batches = batch + 1  # batches are zero-indexed.
         else:
             add_batches = batch - self._last_batch_seen

--- a/keras/src/callbacks/orbax_checkpoint.py
+++ b/keras/src/callbacks/orbax_checkpoint.py
@@ -135,8 +135,7 @@ class OrbaxCheckpoint(MonitorCallback):
         self.save_on_background = save_on_background
         self.save_weights_only = save_weights_only
         self._batches_seen_since_last_saving = 0
-        self._last_batch_seen = 0
-        self._current_epoch = 0  # Keep track of epoch
+        self._last_batch_seen = None
         self._total_batches_seen = 0  # Global batch counter for step tracking
         self._async_futures = []  # Track async save futures
 
@@ -180,6 +179,12 @@ class OrbaxCheckpoint(MonitorCallback):
                 1
             ),
         )
+
+    def set_model(self, model):
+        super().set_model(model)
+        if hasattr(model, "optimizer") and model.optimizer is not None:
+            # Recover the number of batches seen for a reloaded model
+            self._total_batches_seen = int(model.optimizer.iterations)
 
     def _is_multihost_initialized(self):
         """Check if multi-host environment is initialized."""
@@ -234,7 +239,8 @@ class OrbaxCheckpoint(MonitorCallback):
         if self.save_freq == "epoch":
             return False
 
-        if batch <= self._last_batch_seen:  # New epoch.
+        if self._last_batch_seen is None or batch <= self._last_batch_seen:
+            # New epoch.
             add_batches = batch + 1
         else:
             add_batches = batch - self._last_batch_seen
@@ -326,7 +332,6 @@ class OrbaxCheckpoint(MonitorCallback):
                 self._save_checkpoint(step=step, logs=logs)
 
     def on_epoch_end(self, epoch, logs=None):
-        self._current_epoch = epoch
         if self.monitor_op is None:
             self._set_monitor_op()  # From MonitorCallback
 

--- a/keras/src/callbacks/orbax_checkpoint_test.py
+++ b/keras/src/callbacks/orbax_checkpoint_test.py
@@ -12,16 +12,21 @@ from keras.src import testing
 from keras.src import utils
 from keras.src.callbacks.orbax_checkpoint import OrbaxCheckpoint
 from keras.src.saving import register_keras_serializable
+from keras.src.testing.test_utils import named_product
 
 
 class OrbaxCheckpointTest(testing.TestCase, parameterized.TestCase):
-    def _create_test_model(self):
+    def _create_test_model(self, steps_per_execution=1):
         """Create a simple test model compatible with 2-device sharding."""
         inputs = layers.Input(shape=(10,), name="input_layer")
         x = layers.Dense(6, name="dense_layer")(inputs)  # 6 units (div by 2)
         outputs = layers.Dense(2, name="output_layer")(x)
         model = models.Model(inputs, outputs, name="test_model")
-        model.compile(optimizer="adam", loss="mse")
+        model.compile(
+            optimizer="adam",
+            loss="mse",
+            steps_per_execution=steps_per_execution,
+        )
         return model
 
     def _create_dummy_data(self, num_samples=100):
@@ -594,3 +599,37 @@ class OrbaxCheckpointTest(testing.TestCase, parameterized.TestCase):
         loaded_vocab = loaded_string_lookup.get_vocabulary()
 
         self.assertEqual(original_vocab, loaded_vocab)
+
+    @parameterized.named_parameters(named_product(steps_per_execution=(1, 2)))
+    @pytest.mark.requires_trainable_backend
+    def test_training_resumption(self, steps_per_execution):
+        if backend.backend() == "torch" and steps_per_execution != 1:
+            pytest.skip("steps_per_execution unsupported on torch")
+
+        model = self._create_test_model(steps_per_execution)
+        x, y = self._create_dummy_data(num_samples=50)
+        checkpoint_dir = self.get_temp_dir()
+
+        # Train with specified configuration
+        oc1 = OrbaxCheckpoint(checkpoint_dir, save_freq=1, max_to_keep=10)
+        model.fit(x, y, epochs=2, batch_size=25, callbacks=[oc1], verbose=0)
+
+        # Verify checkpoint files were created
+        checkpoint_files_1 = os.listdir(checkpoint_dir)
+        self.assertGreater(
+            len(checkpoint_files_1), 0, "Should have checkpoint files"
+        )
+
+        reloaded_model = saving.load_model(checkpoint_dir)
+        # Resume training with the same folder for checkpoints
+        oc2 = OrbaxCheckpoint(checkpoint_dir, save_freq=1, max_to_keep=10)
+        reloaded_model.fit(
+            x, y, epochs=1, batch_size=25, callbacks=[oc2], verbose=0
+        )
+
+        checkpoint_files_2 = os.listdir(checkpoint_dir)
+        self.assertGreater(
+            len(checkpoint_files_2),
+            len(checkpoint_files_1),
+            "Should have more checkpoint files",
+        )


### PR DESCRIPTION
This allows training, reloading and resuming training while using the same checkpoint folder. Orbax needs an ever increasing step number that is not already used. We use the iteration count from the optimizer to achieve this.

Also fixed an off by one error on the number of batches seen in the case when `steps_per_iteration` is greater than 1. This error existed in `ModelCheckpoint` too. It comes from the fact that the `+1` which is needed to go from a 0 based index needs to be applied to the first epoch too.