### PR TITLE
Fixes INT4 quantization pack/unpack on TPU

### DIFF
--- a/.github/workflows/tpu_tests.yml
+++ b/.github/workflows/tpu_tests.yml
@@ -45,13 +45,4 @@ jobs:
         run: python3 -c "import jax; print('JAX devices:', jax.devices()); assert jax.default_backend() == 'tpu'"
 
       - name: Run Tests
-        run: >-
-          pytest -vs
-          keras/src/layers/core/dense_test.py::DenseTest::test_int4_quantization_block_size_grouped_block_64
-          keras/src/layers/core/dense_test.py::DenseTest::test_int4_quantization_block_size_grouped_block_128
-          keras/src/layers/core/dense_test.py::DenseTest::test_int4_quantization_block_size_per_channel_none
-          keras/src/layers/core/dense_test.py::DenseTest::test_int4_quantization_block_size_per_channel_neg1
-          keras/src/layers/core/einsum_dense_test.py::EinsumDenseTest::test_int4_quantization_block_size_grouped_block_64
-          keras/src/layers/core/einsum_dense_test.py::EinsumDenseTest::test_int4_quantization_block_size_grouped_block_128
-          keras/src/layers/core/einsum_dense_test.py::EinsumDenseTest::test_int4_quantization_block_size_per_channel_none
-          keras/src/layers/core/einsum_dense_test.py::EinsumDenseTest::test_int4_quantization_block_size_per_channel_neg1
+        run: pytest keras --ignore keras/src/applications --cov=keras --cov-config=pyproject.toml


### PR DESCRIPTION
## Summary

- Fix `pack_int4` producing corrupted values on TPU due to `int8` bitwise `left_shift` overflow
- Move `pack_int4` bitwise operations from device-side (XLA) to numpy

## Problem

8 `test_int4_quantization_block_size` tests (across `Dense` and `EinsumDense`) were failing on TPU with MSE values of 0.2–1.2 (threshold: 0.01), while passing on CPU.

**Root cause:** `pack_int4` uses `left_shift(int8, 4)` to pack two nibbles into one byte. When the high nibble value is >= 8 (i.e., the original value was negative), this shift produces 128+, which overflows signed `int8` (max 127). On CPU, JAX/numpy wraps correctly via two's complement. On TPU, XLA produces incorrect results, the hypothesis points to int8 -> int32 promotion during the bitwise op followed by a saturating (rather than truncating) narrowing cast back to int8. This corrupted some of the packed int4 weight values.

Note: I still need to reliably reproduce this issue outside of the quantization code path, will probably open a bug with XLA after that.

## Fix

Moved all packing logic to numpy. Since `pack_int4` is only called during quantization (not inference), there is no performance impact. Numpy correctly handles int8 overflow with two's complement wrapping.