### PR TITLE
feat(openvino): implement numpy.angle in OpenVINO backend

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -487,7 +487,6 @@ NNOpsDtypeTest::test_ctc_decode
 NNOpsDtypeTest::test_glu_
 NNOpsDtypeTest::test_polar_
 NNOpsDynamicShapeTest::test_glu
-NumpyDtypeTest::test_angle
 NumpyDtypeTest::test_array
 NumpyDtypeTest::test_maximum_python_types
 NumpyDtypeTest::test_minimum_python_types
@@ -495,7 +494,6 @@ NumpyDtypeTest::test_nancumsum
 NumpyDtypeTest::test_nanstd
 NumpyDtypeTest::test_power
 NumpyDtypeTest::test_view
-NumpyOneInputOpsCorrectnessTest::test_angle
 NumpyOneInputOpsCorrectnessTest::test_array
 NumpyOneInputOpsCorrectnessTest::test_conj
 NumpyOneInputOpsCorrectnessTest::test_imag
@@ -507,9 +505,7 @@ NumpyOneInputOpsCorrectnessTest::test_reshape
 NumpyOneInputOpsCorrectnessTest::test_slogdet
 NumpyOneInputOpsCorrectnessTest::test_vectorize
 NumpyOneInputOpsCorrectnessTest::test_view
-NumpyOneInputOpsDynamicShapeTest::test_angle
 NumpyOneInputOpsDynamicShapeTest::test_view
-NumpyOneInputOpsStaticShapeTest::test_angle
 NumpyOneInputOpsStaticShapeTest::test_view
 OptimizerTest::test_constraints_are_applied
 OptimizerTest::test_ema

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -285,7 +285,21 @@ def allclose(x1, x2, rtol=1e-05, atol=1e-08, equal_nan=False):
 
 
 def angle(x):
-    raise NotImplementedError("`angle` is not supported with openvino backend")
+    x = get_ov_output(x)
+    x_type = x.get_element_type()
+    keras_x_type = ov_to_keras_type(x_type)
+    result_dtype = dtypes.result_type(keras_x_type, float)
+    ov_type = OPENVINO_DTYPES[result_dtype]
+    x = ov_opset.convert(x, ov_type).output(0)
+    # OpenVINO does not support complex dtypes, so the imaginary part is zero.
+    # angle(x) = atan2(imag(x), real(x)) = atan2(0, x)
+    zero = ov_opset.constant(0.0, ov_type)
+    zeros_like_x = ov_opset.broadcast(
+        zero, ov_opset.shape_of(x)
+    ).output(0)
+    return arctan2(
+        OpenVINOKerasTensor(zeros_like_x), OpenVINOKerasTensor(x)
+    )
 
 
 def any(x, axis=None, keepdims=False):


### PR DESCRIPTION
## Summary

Implements the `numpy.angle` operation for the Keras OpenVINO backend.

Closes openvinotoolkit/openvino#34034 (part of the Keras 3 OpenVINO backend GFI campaign).

## Implementation Details

`numpy.angle` computes the element-wise phase angle (in radians) of a complex tensor.

Since OpenVINO does not support complex dtypes, `imag(x)` is always zero for any supported input. The implementation uses the identity:

```
angle(x) = atan2(imag(x), real(x)) = atan2(0, x)
```

For real-valued inputs this yields:
- `0` for positive values (since `atan2(0, positive) = 0`)
- `π` for negative values (since `atan2(0, negative) = π`)
- `0` for zero

**Dtype handling:** The input is promoted to float following the same rules used by the numpy/torch/tensorflow backends:
- `int64` → `config.floatx()`
- other types → `result_type(x.dtype, float)`

**Implementation:**
```python
def angle(x):
    x = get_ov_output(x)
    x_type = x.get_element_type()
    keras_x_type = ov_to_keras_type(x_type)
    result_dtype = dtypes.result_type(keras_x_type, float)
    ov_type = OPENVINO_DTYPES[result_dtype]
    x = ov_opset.convert(x, ov_type).output(0)
    zero = ov_opset.constant(0.0, ov_type)
    zeros_like_x = ov_opset.broadcast(zero, ov_opset.shape_of(x)).output(0)
    return arctan2(OpenVINOKerasTensor(zeros_like_x), OpenVINOKerasTensor(x))
```

## Tests

Removed 4 exclusions from `excluded_concrete_tests.txt`:
- `NumpyDtypeTest::test_angle`
- `NumpyOneInputOpsCorrectnessTest::test_angle`
- `NumpyOneInputOpsDynamicShapeTest::test_angle`
- `NumpyOneInputOpsStaticShapeTest::test_angle`

Made with [Cursor](https://cursor.com)