### PR TITLE
feat(openvino): implement numpy.nanstd and numpy.nancumsum in OpenVINO backend

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -490,16 +490,12 @@ NNOpsDynamicShapeTest::test_glu
 NumpyDtypeTest::test_array
 NumpyDtypeTest::test_maximum_python_types
 NumpyDtypeTest::test_minimum_python_types
-NumpyDtypeTest::test_nancumsum
-NumpyDtypeTest::test_nanstd
 NumpyDtypeTest::test_power
 NumpyDtypeTest::test_view
 NumpyOneInputOpsCorrectnessTest::test_array
 NumpyOneInputOpsCorrectnessTest::test_conj
 NumpyOneInputOpsCorrectnessTest::test_imag
 NumpyOneInputOpsCorrectnessTest::test_isreal
-NumpyOneInputOpsCorrectnessTest::test_nancumsum
-NumpyOneInputOpsCorrectnessTest::test_nanstd
 NumpyOneInputOpsCorrectnessTest::test_real
 NumpyOneInputOpsCorrectnessTest::test_reshape
 NumpyOneInputOpsCorrectnessTest::test_slogdet

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -2848,9 +2848,13 @@ def moveaxis(x, source, destination):
 
 
 def nancumsum(x, axis=None, dtype=None):
-    raise NotImplementedError(
-        "`nancumsum` is not supported with openvino backend"
-    )
+    x = get_ov_output(x)
+    x_type = x.get_element_type()
+    if not x_type.is_integral() and x_type != Type.boolean:
+        nan_mask = ov_opset.is_nan(x)
+        zero = ov_opset.constant(0, x_type)
+        x = ov_opset.select(nan_mask, zero, x).output(0)
+    return cumsum(OpenVINOKerasTensor(x), axis=axis, dtype=dtype)
 
 
 def nanmax(x, axis=None, keepdims=False):
@@ -2980,7 +2984,9 @@ def nanprod(x, axis=None, keepdims=False):
 
 
 def nanstd(x, axis=None, keepdims=False):
-    raise NotImplementedError("`nanstd` is not supported with openvino backend")
+    var = nanvar(x, axis=axis, keepdims=keepdims)
+    var_out = get_ov_output(var)
+    return OpenVINOKerasTensor(ov_opset.sqrt(var_out).output(0))
 
 
 def nansum(x, axis=None, keepdims=False):


### PR DESCRIPTION
## Summary

Implements two previously unimplemented NumPy operations in the Keras OpenVINO backend.

Addresses openvinotoolkit/openvino#34401

## `numpy.nancumsum`

Computes cumulative sum ignoring NaN values.

```python
def nancumsum(x, axis=None, dtype=None):
    x = get_ov_output(x)
    x_type = x.get_element_type()
    if not x_type.is_integral() and x_type != Type.boolean:
        nan_mask = ov_opset.is_nan(x)
        zero = ov_opset.constant(0, x_type)
        x = ov_opset.select(nan_mask, zero, x).output(0)
    return cumsum(OpenVINOKerasTensor(x), axis=axis, dtype=dtype)
```

For floating-point types: replaces NaN values with 0 before calling `cumsum` — matching `numpy.nancumsum` semantics. For integer/boolean types: delegates directly to `cumsum` (no NaN possible).

## `numpy.nanstd`

Computes standard deviation ignoring NaN values.

```python
def nanstd(x, axis=None, keepdims=False):
    var = nanvar(x, axis=axis, keepdims=keepdims)
    var_out = get_ov_output(var)
    return OpenVINOKerasTensor(ov_opset.sqrt(var_out).output(0))
```

Implemented as `sqrt(nanvar(...))`, reusing the existing `nanvar` which already handles NaN masking, axis reduction, and dtype promotion correctly.

## Tests

Removed 4 test exclusions from `excluded_concrete_tests.txt`:
- `NumpyDtypeTest::test_nancumsum`
- `NumpyDtypeTest::test_nanstd`
- `NumpyOneInputOpsCorrectnessTest::test_nancumsum`
- `NumpyOneInputOpsCorrectnessTest::test_nanstd`

Made with [Cursor](https://cursor.com)