### PR TITLE
Fix #22162: Add input validation for PReLU and LeakyReLU layers

### DIFF
--- a/keras/src/layers/activations/leaky_relu.py
+++ b/keras/src/layers/activations/leaky_relu.py
@@ -42,10 +42,18 @@ class LeakyReLU(Layer):
                 "Argument `alpha` is deprecated. Use `negative_slope` instead."
             )
         super().__init__(**kwargs)
+        import math
+
         if negative_slope is None or negative_slope < 0:
             raise ValueError(
                 "The negative_slope value of a Leaky ReLU layer "
                 "cannot be None or negative value. Expected a float."
+                f" Received: negative_slope={negative_slope}"
+            )
+        if isinstance(negative_slope, float) and math.isnan(negative_slope):
+            raise ValueError(
+                "The negative_slope value of a Leaky ReLU layer "
+                "cannot be NaN. Expected a valid float."
                 f" Received: negative_slope={negative_slope}"
             )
         self.negative_slope = negative_slope

--- a/keras/src/layers/activations/leaky_relu_test.py
+++ b/keras/src/layers/activations/leaky_relu_test.py
@@ -36,3 +36,10 @@ class LeakyReLUTest(testing.TestCase):
                 input_shape=(2, 3, 4),
                 supports_masking=True,
             )
+
+    def test_invalid_nan_negative_slope(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "The negative_slope value of a Leaky ReLU layer cannot be NaN",
+        ):
+            leaky_relu.LeakyReLU(negative_slope=float("nan"))

--- a/keras/src/layers/activations/prelu.py
+++ b/keras/src/layers/activations/prelu.py
@@ -41,6 +41,12 @@ class PReLU(Layer):
     ):
         super().__init__(**kwargs)
         self.supports_masking = True
+        if alpha_initializer is None:
+            raise ValueError(
+                "The `alpha_initializer` argument for PReLU cannot be None. "
+                "Expected a valid initializer. "
+                f"Received: alpha_initializer={alpha_initializer}"
+            )
         self.alpha_initializer = initializers.get(alpha_initializer)
         self.alpha_regularizer = regularizers.get(alpha_regularizer)
         self.alpha_constraint = constraints.get(alpha_constraint)

--- a/keras/src/layers/activations/prelu_test.py
+++ b/keras/src/layers/activations/prelu_test.py
@@ -37,3 +37,10 @@ class PReLUTest(testing.TestCase):
         prelu_layer.alpha.assign(weights)
         ref_out = np_prelu(inputs, weights)
         self.assertAllClose(prelu_layer(inputs), ref_out)
+
+    def test_prelu_invalid_alpha_initializer_none(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "The `alpha_initializer` argument for PReLU cannot be None",
+        ):
+            prelu.PReLU(alpha_initializer=None)


### PR DESCRIPTION
## Summary
Fixes #22162

Adds input validation for `PReLU` and `LeakyReLU` layers to catch invalid configurations at instantiation time rather than during training.

## Changes

### PReLU
- Validates `alpha_initializer` is not `None`
- Raises `ValueError` with clear message if `None` is passed

### LeakyReLU
- Validates `negative_slope` is not `NaN`
- Adds check for `math.isnan(negative_slope)` for float values
- Raises `ValueError` with clear message if `NaN` is passed

## Rationale
Both cases violate the fail-fast principle. Without this validation:
- `PReLU` with `alpha_initializer=None` would fail later during `build()` or training
- `LeakyReLU` with `negative_slope=NaN` would produce non-numeric gradients

## Tests Added
- `test_prelu_invalid_alpha_initializer_none` - verifies PReLU rejects `None`
- `test_invalid_nan_negative_slope` - verifies LeakyReLU rejects `NaN`

## Example

**Before:**
```python
layer = keras.layers.PReLU(alpha_initializer=None)  # Silent failure
layer.build((None, 10))  # Crash later
```

**After:**
```python
layer = keras.layers.PReLU(alpha_initializer=None)
# ValueError: The `alpha_initializer` argument for PReLU cannot be None...
```