### PR TITLE
Remove duplicate implementation of the `solve` op in `math`.

### DIFF
--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -270,12 +270,6 @@ def erfinv(x):
     return jax.lax.erf_inv(x)
 
 
-def solve(a, b):
-    a = convert_to_tensor(a)
-    b = convert_to_tensor(b)
-    return jnp.linalg.solve(a, b)
-
-
 def logdet(x):
     from keras.src.backend.jax.numpy import slogdet
 

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -297,12 +297,6 @@ def erfinv(x):
     return np.array(scipy.special.erfinv(x))
 
 
-def solve(a, b):
-    a = convert_to_tensor(a)
-    b = convert_to_tensor(b)
-    return np.linalg.solve(a, b)
-
-
 def logdet(x):
     from keras.src.backend.numpy.numpy import slogdet
 

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -425,7 +425,3 @@ def erf(x):
 
 def erfinv(x):
     raise NotImplementedError("`erfinv` is not supported with openvino backend")
-
-
-def solve(a, b):
-    raise NotImplementedError("`solve` is not supported with openvino backend")

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -271,12 +271,6 @@ def erfinv(x):
     return tf.math.erfinv(x)
 
 
-def solve(a, b):
-    a = convert_to_tensor(a)
-    b = convert_to_tensor(b)
-    return tf.linalg.solve(a, b)
-
-
 def logdet(x):
     x = convert_to_tensor(x)
     return tf.linalg.logdet(x)

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -395,12 +395,6 @@ def erfinv(x):
     return torch.erfinv(x)
 
 
-def solve(a, b):
-    a = convert_to_tensor(a)
-    b = convert_to_tensor(b)
-    return torch.linalg.solve(a, b)
-
-
 def logdet(x):
     x = convert_to_tensor(x)
     return torch.logdet(x)


### PR DESCRIPTION
`solve` is declared in https://github.com/keras-team/keras/blob/master/keras/src/ops/linalg.py#L487-L488 as `ops.linalg.solve`.

The backend specific duplicates in `**/math.py` are just dead code because there is no such op in https://github.com/keras-team/keras/blob/master/keras/src/ops/math.py