### PR TITLE
Improvements to `is_in_jax_tracing_scope` and its uses.

### DIFF
--- a/keras/src/backend/jax/distribution_lib.py
+++ b/keras/src/backend/jax/distribution_lib.py
@@ -80,9 +80,7 @@ def distribute_tensor(tensor, layout):
     if isinstance(layout, TensorLayout):
         layout = layout.backend_layout
 
-    # TODO(scottzhu): This might not be a cheap check, we should consider
-    # have some proper JAX API for doing this check.
-    if jax_utils.is_in_jax_tracing_scope():
+    if jax_utils.is_in_jax_tracing_scope(tensor):
         return jax.lax.with_sharding_constraint(tensor, layout)
 
     # Skip relayout if unnecessary.

--- a/keras/src/utils/jax_layer.py
+++ b/keras/src/utils/jax_layer.py
@@ -497,13 +497,8 @@ class JaxLayer(Layer):
             return None
 
     def _initialize_weights(self, input_shape):
-        if jax_utils.is_in_jax_tracing_scope() or tf.inside_function():
-            # This exception is not actually shown, it is caught and a detailed
-            # warning about calling 'build' is printed.
-            raise ValueError(
-                "'JaxLayer' cannot be built in tracing scope"
-                "or inside tf function"
-            )
+        if tf.inside_function():
+            raise ValueError("'JaxLayer' cannot be built inside tf function")
 
         # Initialize `params` and `state` if needed by calling `init_fn`.
         def create_input(shape):
@@ -511,6 +506,11 @@ class JaxLayer(Layer):
             return jax.numpy.ones(shape)
 
         init_inputs = tree.map_shape_structure(create_input, input_shape)
+        if backend.backend() == "jax" and jax_utils.is_in_jax_tracing_scope(
+            tree.flatten(init_inputs)[0]
+        ):
+            raise ValueError("'JaxLayer' cannot be built in a tracing scope")
+
         init_args = []
         for argument_name in self.init_fn_arguments:
             if argument_name == "rng":

--- a/keras/src/utils/jax_utils.py
+++ b/keras/src/utils/jax_utils.py
@@ -3,9 +3,9 @@ from keras.src import backend
 
 def is_in_jax_tracing_scope(x=None):
     if backend.backend() == "jax":
+        import jax
+
         if x is None:
             x = backend.numpy.ones(())
-        for c in x.__class__.__mro__:
-            if c.__name__ == "Tracer" and c.__module__.startswith("jax"):
-                return True
+        return isinstance(x, jax.core.Tracer)
     return False


### PR DESCRIPTION
- `jax.core.Tracer` is the documented way to detect tracing, there is no need to inspect the class name and module.
- creating a dummy array just for the sake of detecting a tracer is expensive, maximize the cases when the array is passed in. In particular `distribute_tensor` was appearing in xprof a lot as it's called for every input tensor from the dataset.