### PR TITLE
Fix EfficientNetV2 and Inception failures in ApplicationsTest

### DIFF
--- a/keras/src/applications/applications_test.py
+++ b/keras/src/applications/applications_test.py
@@ -253,10 +253,10 @@ class ApplicationsTest(testing.TestCase):
         backend.set_image_data_format(image_data_format)
 
         if image_data_format == "channels_first":
-            input_shape = (4, 123, 123)
+            input_shape = (4, 200, 200)
             last_dim_axis = 1
         else:
-            input_shape = (123, 123, 4)
+            input_shape = (200, 200, 4)
             last_dim_axis = -1
 
         inputs_custom = Input(shape=input_shape, name="custom_input")

--- a/keras/src/applications/efficientnet_v2.py
+++ b/keras/src/applications/efficientnet_v2.py
@@ -935,14 +935,8 @@ def EfficientNetV2(
         num_channels = input_shape[bn_axis - 1]
         if name.split("-")[-1].startswith("b") and num_channels == 3:
             x = layers.Rescaling(scale=1.0 / 255)(x)
-            if backend.image_data_format() == "channels_first":
-                mean = [[[[0.485]], [[0.456]], [[0.406]]]]  # shape [1,3,1,1]
-                variance = [
-                    [[[0.229**2]], [[0.224**2]], [[0.225**2]]]
-                ]  # shape [1,3,1,1]
-            else:
-                mean = [0.485, 0.456, 0.406]
-                variance = [0.229**2, 0.224**2, 0.225**2]
+            mean = [0.485, 0.456, 0.406]
+            variance = [0.229**2, 0.224**2, 0.225**2]
             x = layers.Normalization(
                 mean=mean,
                 variance=variance,


### PR DESCRIPTION
Fixes two failing tests in applications:

1. EfficientNetV2 was pre-emptively reshaping inputs into 4D, however the Normalization layer expects (mean rank <= number of axes). Flattened to a 1D list.
2. Inception's conv shape needs to be >75x75 but was being flattened below that. Increased shape to 200.