### PR TITLE
Fix #19127 — Improve error message for named inputs mismatch in `Functional` model

### DIFF
--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -213,8 +213,26 @@ class Functional(Function, Model):
             return output_shapes[0]
         return output_shapes
 
-    def _assert_input_compatibility(self, *args):
-        return super(Model, self)._assert_input_compatibility(*args)
+    def _assert_input_compatibility(self, inputs):
+        if isinstance(self._inputs_struct, dict) and not isinstance(
+            inputs, dict
+        ):
+            # Allow list/tuple with matching length (positional matching)
+            if isinstance(inputs, (list, tuple)):
+                if len(inputs) == len(self._inputs_struct):
+                    return super(
+                        Model, self
+                    )._assert_input_compatibility(inputs)
+            keys = list(self._inputs_struct.keys())
+            raise ValueError(
+                f'Model "{self.name}" expects inputs as a `dict` with '
+                f"the following keys: {keys}. Instead received "
+                f"{type(inputs).__name__}. Pass your data as "
+                "`model.fit({" + ", ".join(
+                    f"'{k}': ..." for k in keys
+                ) + "}, ...)`."
+            )
+        return super(Model, self)._assert_input_compatibility(inputs)
 
     def _maybe_warn_inputs_struct_mismatch(self, inputs, raise_exception=False):
         try:

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -220,17 +220,17 @@ class Functional(Function, Model):
             # Allow list/tuple with matching length (positional matching)
             if isinstance(inputs, (list, tuple)):
                 if len(inputs) == len(self._inputs_struct):
-                    return super(
-                        Model, self
-                    )._assert_input_compatibility(inputs)
+                    return super(Model, self)._assert_input_compatibility(
+                        inputs
+                    )
             keys = list(self._inputs_struct.keys())
             raise ValueError(
                 f'Model "{self.name}" expects inputs as a `dict` with '
                 f"the following keys: {keys}. Instead received "
                 f"{type(inputs).__name__}. Pass your data as "
-                "`model.fit({" + ", ".join(
-                    f"'{k}': ..." for k in keys
-                ) + "}, ...)`."
+                "`model.fit({"
+                + ", ".join(f"'{k}': ..." for k in keys)
+                + "}, ...)`."
             )
         return super(Model, self)._assert_input_compatibility(inputs)
 

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -489,7 +489,9 @@ class FunctionalTest(testing.TestCase):
 
         # Dict input
         model = Functional({"a": input_a, "b": input_b}, outputs)
-        with self.assertRaisesRegex(ValueError, "expects 2 input"):
+        with self.assertRaisesRegex(
+            ValueError, r"expects inputs as a `dict`"
+        ):
             model(np.zeros((2, 3)))
         with self.assertRaisesRegex(
             ValueError, r"expected shape=\(None, 4\), found shape=\(2, 3\)"

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -489,9 +489,7 @@ class FunctionalTest(testing.TestCase):
 
         # Dict input
         model = Functional({"a": input_a, "b": input_b}, outputs)
-        with self.assertRaisesRegex(
-            ValueError, r"expects inputs as a `dict`"
-        ):
+        with self.assertRaisesRegex(ValueError, r"expects inputs as a `dict`"):
             model(np.zeros((2, 3)))
         with self.assertRaisesRegex(
             ValueError, r"expected shape=\(None, 4\), found shape=\(2, 3\)"


### PR DESCRIPTION
**Fixes**: https://github.com/keras-team/keras/issues/19127  
This pull request improves the input validation logic for models with dictionary-based inputs in the Keras Functional API. The main change is to provide clearer error messages when users supply inputs in the wrong format, making it easier to diagnose and fix input-related issues. The corresponding test has also been updated to match the new error message.

Input validation improvements:

* Updated the `_assert_input_compatibility` method in `Model` (in `functional.py`) to check for cases where the model expects a dictionary of inputs but receives a non-dictionary (like a list, tuple, or array). If a list or tuple of matching length is provided, it falls back to positional matching; otherwise, it raises a clearer `ValueError` with guidance on the expected input format.

Testing updates:

* Modified the test `test_bad_input_spec` in `functional_test.py` to expect the new, more descriptive error message when a non-dictionary input is passed to a model expecting a dictionary.

#### Problem

When a `Functional` model is built with dict inputs (e.g. `keras.Input({"a": ..., "b": ...})`), passing a plain array or list to `model.fit()` / `model(...)` raised a confusing error: `"expects 2 input(s)"`. This message gave no hint that the model requires named dict inputs, making it very hard for users to diagnose the problem (see thread in #19127).

#### Root Cause

`Functional._assert_input_compatibility` unconditionally delegated to the parent `Model` implementation, which only checks the input count. It had no awareness that its `_inputs_struct` is a `dict`, so the error path never mentioned dict/named inputs at all.

#### Fix

Override `_assert_input_compatibility` in `Functional` to detect the mismatch early. If the model's input struct is a `dict` but the user passes a non-dict:
- A list/tuple of the correct length is still accepted (positional matching, same as before).
- Anything else raises a clear `ValueError` that names the expected keys and shows the correct calling syntax:
  ```
  Model "my_model" expects inputs as a `dict` with the following keys: ['a', 'b'].
  Instead received ndarray. Pass your data as `model.fit({'a': ..., 'b': ...}, ...)`.
  ```

#### Files Changed
- `keras/src/models/functional.py` — override `_assert_input_compatibility` with dict-aware check
- `keras/src/models/functional_test.py` — update test to match new error text