### PR TITLE
Fix/20256 early stopping reset

### DIFF
--- a/keras/src/callbacks/early_stopping.py
+++ b/keras/src/callbacks/early_stopping.py
@@ -88,6 +88,7 @@ class EarlyStopping(MonitorCallback):
         # Allow instances to be re-used
         self.wait = 0
         self.stopped_epoch = 0
+        self.best = None
         self.best_weights = None
         self.best_epoch = 0
 

--- a/keras/src/callbacks/early_stopping_test.py
+++ b/keras/src/callbacks/early_stopping_test.py
@@ -127,6 +127,33 @@ class EarlyStoppingTest(testing.TestCase):
         self.assertGreaterEqual(len(history2.epoch), patience)
 
     @pytest.mark.requires_trainable_backend
+    def test_early_stopping_reuse_across_models(self):
+        # Regression test for https://github.com/keras-team/keras/issues/20256
+        # When reusing EarlyStopping across multiple model.fit() calls with
+        # different models, self.best must be reset so that the new model
+        # isn't compared against a stale best value from a previous run.
+        patience = 5
+        data = np.random.random((100, 1))
+        labels = np.where(data > 0.5, 1, 0)
+
+        stopper = callbacks.EarlyStopping(
+            monitor="loss", patience=patience
+        )
+
+        for _ in range(3):
+            model = models.Sequential(
+                [
+                    layers.Dense(10, activation="relu"),
+                    layers.Dense(1, activation="sigmoid"),
+                ]
+            )
+            model.compile(optimizer="sgd", loss="binary_crossentropy")
+            history = model.fit(
+                data, labels, callbacks=[stopper], verbose=0, epochs=50
+            )
+            self.assertGreater(len(history.epoch), patience)
+
+    @pytest.mark.requires_trainable_backend
     def test_early_stopping_with_baseline(self):
         baseline = 0.6
         x_train = np.random.random((10, 5))

--- a/keras/src/callbacks/early_stopping_test.py
+++ b/keras/src/callbacks/early_stopping_test.py
@@ -136,9 +136,7 @@ class EarlyStoppingTest(testing.TestCase):
         data = np.random.random((100, 1))
         labels = np.where(data > 0.5, 1, 0)
 
-        stopper = callbacks.EarlyStopping(
-            monitor="loss", patience=patience
-        )
+        stopper = callbacks.EarlyStopping(monitor="loss", patience=patience)
 
         for _ in range(3):
             model = models.Sequential(

--- a/keras/src/callbacks/reduce_lr_on_plateau.py
+++ b/keras/src/callbacks/reduce_lr_on_plateau.py
@@ -74,6 +74,7 @@ class ReduceLROnPlateau(MonitorCallback):
 
     def _reset(self):
         """Resets wait counter and cooldown counter."""
+        self.best = None
         self.cooldown_counter = 0
         self.wait = 0
 


### PR DESCRIPTION
This pull request addresses issues related to the reuse of callback instances in Keras, specifically ensuring that stateful attributes are properly reset when callbacks like `EarlyStopping` and `ReduceLROnPlateau` are used multiple times. It also adds a regression test to prevent future issues with callback reuse across different models.

**Callback state reset improvements:**

* [`keras/src/callbacks/early_stopping.py`](diffhunk://#diff-01b4bdc450ecd306338de7bc427b01facf83de62d0797aeae408e7bfd2280748R91): Ensures `self.best` is reset to `None` in `on_train_begin` to avoid comparing against stale best values when reusing the same `EarlyStopping` instance across multiple training runs.
* [`keras/src/callbacks/reduce_lr_on_plateau.py`](diffhunk://#diff-cad0f916892ed87a3a90beab5554f70c84ae54251e91816e7744d67d69d2232fR77): Resets `self.best` to `None` in the `_reset` method, ensuring correct behavior when the `ReduceLROnPlateau` callback is reused.

**Testing and regression coverage:**

* [`keras/src/callbacks/early_stopping_test.py`](diffhunk://#diff-20c33dfba91907f564248a437095b5fd1bb55c69d291361c0bc0b30130b7e9d1R129-R153): Adds a regression test to verify that `EarlyStopping` can be reused across multiple models without retaining stale state, addressing a previously reported issue.**Fixes**: https://github.com/keras-team/keras/issues/20256  


#### Problem

When the same `EarlyStopping` (or `ReduceLROnPlateau`) callback instance is reused across multiple `model.fit()` calls (a common pattern in hyperparameter loops), `self.best` is never cleared in `_reset()`. This means the second `fit()` starts with a `best` value from the previous run: if the first model had a very low loss, the second model may stop immediately on epoch 1 simply because its loss hasn't beaten a stale threshold from an entirely different model.

#### Root Cause

`EarlyStopping._reset()` and `ReduceLROnPlateau._reset()` reset `wait`, `stopped_epoch`, and `best_weights`, but forgot to reset `best` to `None`. The `MonitorCallback` base initializes `best` in `__init__`, but `_reset()` is what runs at the start of each `fit()` — so after the first run, `best` is permanently stale.

#### Fix

Add `self.best = None` to both `EarlyStopping._reset()` and `ReduceLROnPlateau._reset()`. A `None` sentinel is already handled by the comparison logic in both callbacks (it forces acceptance of the first epoch's value).

#### Files Changed
- `keras/src/callbacks/early_stopping.py` — add `self.best = None` in `_reset()`
- `keras/src/callbacks/reduce_lr_on_plateau.py` — add `self.best = None` in `_reset()`
- `keras/src/callbacks/early_stopping_test.py` — regression test: shared callback reused across 3 models in a loop, each run must last > patience epochs