### PR TITLE
Replace the jax `distribute_variable` with `distribute_tensor`.

### DIFF
--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -68,7 +68,7 @@ class JaxVariable(KerasVariable):
 
     def _direct_assign(self, value):
         if self._layout is not None:
-            value = distribution_lib.distribute_variable(value, self._layout)
+            value = distribution_lib.distribute_tensor(value, self._layout)
         self._value = value
 
     def _convert_to_tensor(self, value, dtype=None):
@@ -216,9 +216,7 @@ if config.is_nnx_enabled():
         def _direct_assign(self, value):
             # Apply JAX-specific distribution if layout is present
             if self._layout is not None:
-                value = distribution_lib.distribute_variable(
-                    value, self._layout
-                )
+                value = distribution_lib.distribute_tensor(value, self._layout)
 
             # Apply on_set_value hook if it exists
             if (

--- a/keras/src/backend/jax/distribution_lib.py
+++ b/keras/src/backend/jax/distribution_lib.py
@@ -40,26 +40,6 @@ def get_device_count(device_type=None):
     return jax.device_count(device_type)
 
 
-def distribute_variable(value, layout):
-    """Create a distributed variable for JAX.
-
-    Since JAX doesn't have a variable class, this will just return a `jax.Array`
-    with the corresponding layout/sharding specified.
-
-    Note that this function should be used in eager context, not in jitted
-    function.
-
-    Args:
-        value: the initial value of the variable.
-        layout: `TensorLayout` for the created variable, or a
-            JAX-supported layout instance (e.g. `jax.sharding.Sharding`).
-
-    Returns:
-        jax.Array which is the distributed variable.
-    """
-    return distribute_tensor(value, layout)
-
-
 def distribute_tensor(tensor, layout):
     """Distribute the tensor based on the layout.
 

--- a/keras/src/backend/jax/distribution_lib_test.py
+++ b/keras/src/backend/jax/distribution_lib_test.py
@@ -104,41 +104,6 @@ class JaxDistributionLibTest(testing.TestCase):
         result = distribution_lib.distribute_tensor(inputs, target_layout)
         self.assertTrue(result.sharding.is_equivalent_to(target_layout, ndim=2))
 
-    def test_distribute_variable(self):
-        # This test only verify the single worker/process behavior.
-        jax_mesh = jax.sharding.Mesh(
-            np.array(jax.devices()).reshape(2, 4), ("batch", "model")
-        )
-
-        variable = jax.numpy.array(np.random.normal(size=(16, 8)))
-        target_layout = jax.sharding.NamedSharding(
-            jax_mesh, jax.sharding.PartitionSpec("model", None)
-        )
-
-        result = backend_dlib.distribute_variable(variable, target_layout)
-        # Note that the returned tensor has a different sharding implementation
-        # which is GSPMDSharding, but it should be equivalent as the target
-        # layout specified.
-        self.assertTrue(result.sharding.is_equivalent_to(target_layout, ndim=2))
-
-    def test_distribute_input_data(self):
-        # This test only verify the single worker/process behavior.
-        # The multi-process test lives in g3.
-        jax_mesh = jax.sharding.Mesh(
-            np.array(jax.devices()).reshape(2, 4), ("batch", "model")
-        )
-
-        input_data = jax.numpy.array(np.random.normal(size=(16, 8)))
-        target_layout = jax.sharding.NamedSharding(
-            jax_mesh, jax.sharding.PartitionSpec("batch", None)
-        )
-
-        result = backend_dlib.distribute_variable(input_data, target_layout)
-        # Note that the returned tensor has a different sharding implementation
-        # which is GSPMDSharding, but it should be equivalent as the target
-        # layout specified.
-        self.assertTrue(result.sharding.is_equivalent_to(target_layout, ndim=2))
-
     def test_distribute_tensor_with_jax_layout(self):
         jax_mesh = jax.sharding.Mesh(
             np.array(jax.devices()).reshape(2, 4), ("batch", "model")
@@ -165,48 +130,6 @@ class JaxDistributionLibTest(testing.TestCase):
 
         # Test without jit.
         result = distribution_lib.distribute_tensor(inputs, target_layout)
-        self.assertTrue(
-            result.sharding.is_equivalent_to(target_layout.sharding, ndim=2)
-        )
-
-    def test_distribute_variable_with_jax_layout(self):
-        # This test only verify the single worker/process behavior.
-        jax_mesh = jax.sharding.Mesh(
-            np.array(jax.devices()).reshape(2, 4), ("batch", "model")
-        )
-
-        variable = jax.numpy.array(np.random.normal(size=(16, 8)))
-        target_layout = self._create_jax_layout(
-            sharding=jax.sharding.NamedSharding(
-                jax_mesh, jax.sharding.PartitionSpec("model", None)
-            )
-        )
-
-        result = backend_dlib.distribute_variable(variable, target_layout)
-        # Note that the returned tensor has a different sharding implementation
-        # which is GSPMDSharding, but it should be equivalent as the target
-        # layout specified.
-        self.assertTrue(
-            result.sharding.is_equivalent_to(target_layout.sharding, ndim=2)
-        )
-
-    def test_distribute_input_data_with_jax_layout(self):
-        # This test only verify the single worker/process behavior.
-        jax_mesh = jax.sharding.Mesh(
-            np.array(jax.devices()).reshape(2, 4), ("batch", "model")
-        )
-
-        input_data = jax.numpy.array(np.random.normal(size=(16, 8)))
-        target_layout = self._create_jax_layout(
-            sharding=jax.sharding.NamedSharding(
-                jax_mesh, jax.sharding.PartitionSpec("batch", None)
-            )
-        )
-
-        result = backend_dlib.distribute_variable(input_data, target_layout)
-        # Note that the returned tensor has a different sharding implementation
-        # which is GSPMDSharding, but it should be equivalent as the target
-        # layout specified.
         self.assertTrue(
             result.sharding.is_equivalent_to(target_layout.sharding, ndim=2)
         )


### PR DESCRIPTION
- `distribute_variable` is just an alias to `distribute_tensor`.
- It doesn't actually handle variables, it handles a tensor before assigning it as a value to a variable. So the name is misleading.
- It is not part of the contract between the cross-backend `keras/src/distribution/distribution_lib.py` and each backend implementation. It was added ad-hoc to the JAX implementation only.
- Also removed a lot of redundant tests, some incorrectly named `test_distribute_input_data`.