### PR TITLE
Add `tensorboard` as an explicit dependency.

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -12,6 +12,7 @@ requests
 h5py
 ml-dtypes
 protobuf
+tensorboard
 tensorboard-plugin-profile
 rich
 build


### PR DESCRIPTION
We were relying on `tensorflow` automatically installing `tensorboard`, but this is no longer the case with TensorFlow 2.21.

Note that the tensorboard integration is tested with all backends.