### PR TITLE
Fix missing input validation in PReLU and LeakyReLU layers

### DIFF
--- a/keras/src/layers/activations/leaky_relu.py
+++ b/keras/src/layers/activations/leaky_relu.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 
 from keras.src import activations
@@ -42,10 +43,10 @@ class LeakyReLU(Layer):
                 "Argument `alpha` is deprecated. Use `negative_slope` instead."
             )
         super().__init__(**kwargs)
-        if negative_slope is None or negative_slope < 0:
+        if negative_slope is None or math.isnan(negative_slope) or negative_slope < 0:
             raise ValueError(
                 "The negative_slope value of a Leaky ReLU layer "
-                "cannot be None or negative value. Expected a float."
+                "cannot be None, NaN, or a negative value. Expected a float."
                 f" Received: negative_slope={negative_slope}"
             )
         self.negative_slope = negative_slope

--- a/keras/src/layers/activations/prelu.py
+++ b/keras/src/layers/activations/prelu.py
@@ -39,6 +39,10 @@ class PReLU(Layer):
         shared_axes=None,
         **kwargs,
     ):
+        if alpha_initializer is None:
+            raise ValueError(
+                "The `alpha_initializer` argument for PReLU cannot be None."
+            )
         super().__init__(**kwargs)
         self.supports_masking = True
         self.alpha_initializer = initializers.get(alpha_initializer)


### PR DESCRIPTION
Fixes #22162. Add input validation to prevent invalid values that cause silent failures and downstream errors during training.

- PReLU: Validate that alpha_initializer is not None before passing to initializers.get()
- LeakyReLU: Check for NaN values in negative_slope parameter, which previously passed validation because NaN comparisons always return False