### PR TITLE
Replace cast+multiply masking with ops.where to reduce memory

### DIFF
--- a/keras/src/activations/activations.py
+++ b/keras/src/activations/activations.py
@@ -90,9 +90,7 @@ class ReLU(ops.Operation):
         if threshold != 0:
             # computes x for x > threshold else 0
             threshold = ops.cast(threshold, dtype=x.dtype)
-            x = x * backend.cast(
-                backend.numpy.greater(x, threshold), dtype=x.dtype
-            )
+            x = ops.where(backend.numpy.greater(x, threshold), x, 0)
         elif max_value == 6:
             # if no threshold, then can use nn.relu6 native op for performance
             x = backend.nn.relu6(x)

--- a/keras/src/constraints/constraints.py
+++ b/keras/src/constraints/constraints.py
@@ -124,7 +124,7 @@ class NonNeg(Constraint):
 
     def __call__(self, w):
         w = backend.convert_to_tensor(w)
-        return ops.where(ops.greater_equal(w, 0.0), w, 0.0)
+        return ops.maximum(w, 0)
 
 
 @keras_export(["keras.constraints.UnitNorm", "keras.constraints.unit_norm"])

--- a/keras/src/constraints/constraints.py
+++ b/keras/src/constraints/constraints.py
@@ -124,7 +124,7 @@ class NonNeg(Constraint):
 
     def __call__(self, w):
         w = backend.convert_to_tensor(w)
-        return ops.multiply(w, ops.greater_equal(w, 0.0))
+        return ops.where(ops.greater_equal(w, 0.0), w, 0.0)
 
 
 @keras_export(["keras.constraints.UnitNorm", "keras.constraints.unit_norm"])

--- a/keras/src/layers/attention/attention.py
+++ b/keras/src/layers/attention/attention.py
@@ -178,7 +178,7 @@ class Attention(Layer):
             max_value = 65504.0 if scores.dtype == "float16" else 1.0e9
             if len(padding_mask.shape) == 2:
                 padding_mask = ops.expand_dims(padding_mask, axis=-2)
-            scores -= max_value * ops.cast(padding_mask, dtype=scores.dtype)
+            scores = ops.where(padding_mask, scores - max_value, scores)
 
         weights = ops.softmax(scores, axis=-1)
         if training and self.dropout > 0:
@@ -237,7 +237,7 @@ class Attention(Layer):
         if q_mask is not None:
             # Mask of shape [batch_size, Tq, 1].
             q_mask = ops.expand_dims(q_mask, axis=-1)
-            attention_output *= ops.cast(q_mask, dtype=attention_output.dtype)
+            attention_output = ops.where(q_mask, attention_output, 0)
         if return_attention_scores:
             return (attention_output, attention_scores)
         else:

--- a/keras/src/layers/core/masking.py
+++ b/keras/src/layers/core/masking.py
@@ -62,7 +62,7 @@ class Masking(Layer):
             ops.not_equal(inputs, self.mask_value), axis=-1, keepdims=True
         )
         # Set masked outputs to 0
-        outputs = inputs * backend.cast(boolean_mask, dtype=inputs.dtype)
+        outputs = ops.where(boolean_mask, inputs, 0)
         # Compute the mask and outputs simultaneously.
         backend.set_keras_mask(outputs, mask=ops.squeeze(boolean_mask, axis=-1))
         return outputs

--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -455,6 +455,8 @@ class BatchNormalization(Layer):
             keepdims=True,
         )
         mean = masked_input_sum / (sum_of_weights + backend.epsilon())
+        # Explicit del to free large intermediates in eager mode (e.g. Torch).
+        # No effect under jit/tf.function, but harmless.
         del masked_inputs, masked_input_sum
 
         difference = ops.where(mask_broadcasted, inputs - mean, 0)

--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -440,9 +440,7 @@ class BatchNormalization(Layer):
             )
 
         mask_broadcasted = ops.expand_dims(mask, axis=-1)
-        mask_broadcasted = ops.broadcast_to(
-            mask_broadcasted, ops.shape(inputs)
-        )
+        mask_broadcasted = ops.broadcast_to(mask_broadcasted, ops.shape(inputs))
         mask_broadcasted = ops.cast(mask_broadcasted, "bool")
         masked_inputs = ops.where(mask_broadcasted, inputs, 0)
 

--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -443,6 +443,7 @@ class BatchNormalization(Layer):
         mask_broadcasted = ops.broadcast_to(
             mask_broadcasted, ops.shape(inputs)
         )
+        mask_broadcasted = ops.cast(mask_broadcasted, "bool")
         masked_inputs = ops.where(mask_broadcasted, inputs, 0)
 
         masked_input_sum = ops.sum(

--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -439,33 +439,36 @@ class BatchNormalization(Layer):
                 synchronized=self.synchronized,
             )
 
-        mask_weights = ops.cast(mask, inputs.dtype)
-        mask_weights_broadcasted = ops.expand_dims(mask_weights, axis=-1)
-        broadcasted_mask = ops.broadcast_to(
-            mask_weights_broadcasted, ops.shape(inputs)
+        mask_broadcasted = ops.expand_dims(mask, axis=-1)
+        mask_broadcasted = ops.broadcast_to(
+            mask_broadcasted, ops.shape(inputs)
         )
-        weighted_inputs = broadcasted_mask * inputs
+        masked_inputs = ops.where(mask_broadcasted, inputs, 0)
 
-        weighted_input_sum = ops.sum(
-            weighted_inputs,
+        masked_input_sum = ops.sum(
+            masked_inputs,
             self._reduction_axes,
             keepdims=True,
         )
         sum_of_weights = ops.sum(
-            broadcasted_mask,
+            ops.cast(mask_broadcasted, inputs.dtype),
             self._reduction_axes,
             keepdims=True,
         )
-        mean = weighted_input_sum / (sum_of_weights + backend.epsilon())
+        mean = masked_input_sum / (sum_of_weights + backend.epsilon())
+        del masked_inputs, masked_input_sum
 
-        difference = weighted_inputs - mean
+        difference = ops.where(mask_broadcasted, inputs - mean, 0)
         squared_difference = ops.square(difference)
+        del difference
         weighted_distsq = ops.sum(
-            broadcasted_mask * squared_difference,
+            squared_difference,
             self._reduction_axes,
             keepdims=True,
         )
+        del squared_difference
         variance = weighted_distsq / (sum_of_weights + backend.epsilon())
+        del weighted_distsq
 
         return ops.squeeze(mean), ops.squeeze(variance)
 

--- a/keras/src/layers/pooling/global_average_pooling1d.py
+++ b/keras/src/layers/pooling/global_average_pooling1d.py
@@ -71,14 +71,14 @@ class GlobalAveragePooling1D(BaseGlobalPooling):
     def call(self, inputs, mask=None):
         steps_axis = 1 if self.data_format == "channels_last" else 2
         if mask is not None:
-            mask = backend.cast(mask, inputs[0].dtype)
-            mask = ops.expand_dims(
+            mask_expanded = ops.expand_dims(
                 mask, 2 if self.data_format == "channels_last" else 1
             )
-            inputs *= mask
+            inputs = ops.where(mask_expanded, inputs, 0)
+            float_mask = ops.cast(mask_expanded, inputs.dtype)
             return ops.sum(
                 inputs, axis=steps_axis, keepdims=self.keepdims
-            ) / ops.sum(mask, axis=steps_axis, keepdims=self.keepdims)
+            ) / ops.sum(float_mask, axis=steps_axis, keepdims=self.keepdims)
         else:
             return ops.mean(inputs, axis=steps_axis, keepdims=self.keepdims)
 

--- a/keras/src/layers/pooling/global_average_pooling1d.py
+++ b/keras/src/layers/pooling/global_average_pooling1d.py
@@ -1,4 +1,3 @@
-from keras.src import backend
 from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.layers.pooling.base_global_pooling import BaseGlobalPooling

--- a/keras/src/layers/pooling/global_average_pooling1d.py
+++ b/keras/src/layers/pooling/global_average_pooling1d.py
@@ -74,6 +74,7 @@ class GlobalAveragePooling1D(BaseGlobalPooling):
             mask_expanded = ops.expand_dims(
                 mask, 2 if self.data_format == "channels_last" else 1
             )
+            mask_expanded = ops.cast(mask_expanded, "bool")
             inputs = ops.where(mask_expanded, inputs, 0)
             float_mask = ops.cast(mask_expanded, inputs.dtype)
             return ops.sum(

--- a/keras/src/losses/loss.py
+++ b/keras/src/losses/loss.py
@@ -197,7 +197,6 @@ def reduce_weighted_values(
 def apply_mask(sample_weight, mask, dtype, reduction):
     """Applies any mask on predictions to sample weights."""
     if mask is not None:
-        mask = ops.cast(mask, dtype=dtype)
         if reduction in ("mean", "sum_over_batch_size"):
             # Valid entries have weight `total/valid`, while invalid ones
             # have 0. When summed over batch, they will be reduced to:
@@ -210,17 +209,20 @@ def apply_mask(sample_weight, mask, dtype, reduction):
                 ops.prod(ops.convert_to_tensor(ops.shape(mask), dtype="int32")),
                 dtype,
             )
-            valid = ops.sum(mask)  # May be 0!
-            mask *= ops.divide_no_nan(total, valid)
+            valid = ops.sum(ops.cast(mask, dtype=dtype))  # May be 0!
+            mask_weight = ops.divide_no_nan(total, valid)
+            float_mask = ops.where(mask, mask_weight, 0)
+        else:
+            float_mask = ops.cast(mask, dtype=dtype)
 
         if sample_weight is not None:
             sample_weight = ops.cast(sample_weight, dtype=dtype)
-            mask, sample_weight = squeeze_or_expand_to_same_rank(
-                mask, sample_weight
+            float_mask, sample_weight = squeeze_or_expand_to_same_rank(
+                float_mask, sample_weight
             )
-            sample_weight *= mask
+            sample_weight *= float_mask
         else:
-            sample_weight = mask
+            sample_weight = float_mask
     return sample_weight
 
 

--- a/keras/src/losses/loss.py
+++ b/keras/src/losses/loss.py
@@ -211,7 +211,7 @@ def apply_mask(sample_weight, mask, dtype, reduction):
             )
             valid = ops.sum(ops.cast(mask, dtype=dtype))  # May be 0!
             mask_weight = ops.divide_no_nan(total, valid)
-            float_mask = ops.where(mask, mask_weight, 0)
+            float_mask = ops.where(ops.cast(mask, "bool"), mask_weight, 0)
         else:
             float_mask = ops.cast(mask, dtype=dtype)
 

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2346,11 +2346,8 @@ def sparse_categorical_crossentropy(
     if ignore_class is not None:
         res_shape = ops.shape(y_pred)[:-1]
         valid_mask = ops.not_equal(y_true, ops.cast(ignore_class, y_pred.dtype))
-        y_true = ops.multiply(y_true, ops.cast(valid_mask, y_true.dtype))
-        y_pred = ops.multiply(
-            y_pred,
-            ops.cast(ops.expand_dims(valid_mask, -1), y_pred.dtype),
-        )
+        y_true = ops.where(valid_mask, y_true, 0)
+        y_pred = ops.where(ops.expand_dims(valid_mask, -1), y_pred, 0)
 
     res = ops.sparse_categorical_crossentropy(
         y_true,

--- a/keras/src/metrics/confusion_metrics.py
+++ b/keras/src/metrics/confusion_metrics.py
@@ -667,7 +667,7 @@ class SensitivitySpecificityBase(Metric):
         feasible = predicate(constrained, self.value)
         # Mask values based on whether they satisfy the constraint and take max.
         return ops.max(
-            ops.multiply(dependent, ops.cast(feasible, dependent.dtype)),
+            ops.where(feasible, dependent, 0),
             initial=0,
         )
 

--- a/keras/src/metrics/iou_metrics.py
+++ b/keras/src/metrics/iou_metrics.py
@@ -131,9 +131,7 @@ class _IoUBase(Metric):
             y_true = ops.where(valid_mask, y_true, 0)
             y_pred = ops.where(valid_mask, y_pred, 0)
             if sample_weight is not None:
-                sample_weight = ops.where(
-                    valid_mask, sample_weight, 0
-                )
+                sample_weight = ops.where(valid_mask, sample_weight, 0)
 
         y_pred = ops.cast(y_pred, dtype=self.dtype)
         y_true = ops.cast(y_true, dtype=self.dtype)

--- a/keras/src/metrics/iou_metrics.py
+++ b/keras/src/metrics/iou_metrics.py
@@ -128,11 +128,11 @@ class _IoUBase(Metric):
                 self.ignore_class, y_true.dtype
             )
             valid_mask = ops.not_equal(y_true, ignore_class)
-            y_true = y_true * ops.cast(valid_mask, y_true.dtype)
-            y_pred = y_pred * ops.cast(valid_mask, y_pred.dtype)
+            y_true = ops.where(valid_mask, y_true, 0)
+            y_pred = ops.where(valid_mask, y_pred, 0)
             if sample_weight is not None:
-                sample_weight = sample_weight * ops.cast(
-                    valid_mask, sample_weight.dtype
+                sample_weight = ops.where(
+                    valid_mask, sample_weight, 0
                 )
 
         y_pred = ops.cast(y_pred, dtype=self.dtype)

--- a/keras/src/metrics/metrics_utils.py
+++ b/keras/src/metrics/metrics_utils.py
@@ -565,14 +565,16 @@ def update_confusion_matrix_variables(
             weights_tiled = ops.multiply(weights_tiled, label_weights_tiled)
 
     def weighted_assign_add(label, pred, weights, var):
-        label_and_pred = ops.cast(ops.logical_and(label, pred), dtype=var.dtype)
+        label_and_pred = ops.logical_and(label, pred)
         if weights is not None:
-            label_and_pred = ops.where(
-                ops.logical_and(label, pred),
+            result = ops.where(
+                label_and_pred,
                 ops.cast(weights, dtype=var.dtype),
                 0,
             )
-        var.assign(var + ops.sum(label_and_pred, 1))
+        else:
+            result = ops.cast(label_and_pred, dtype=var.dtype)
+        var.assign(var + ops.sum(result, 1))
 
     loop_vars = {
         ConfusionMatrix.TRUE_POSITIVES: (label_is_pos, pred_is_pos),

--- a/keras/src/metrics/metrics_utils.py
+++ b/keras/src/metrics/metrics_utils.py
@@ -567,7 +567,11 @@ def update_confusion_matrix_variables(
     def weighted_assign_add(label, pred, weights, var):
         label_and_pred = ops.cast(ops.logical_and(label, pred), dtype=var.dtype)
         if weights is not None:
-            label_and_pred *= ops.cast(weights, dtype=var.dtype)
+            label_and_pred = ops.where(
+                ops.logical_and(label, pred),
+                ops.cast(weights, dtype=var.dtype),
+                0,
+            )
         var.assign(var + ops.sum(label_and_pred, 1))
 
     loop_vars = {

--- a/keras/src/metrics/regression_metrics.py
+++ b/keras/src/metrics/regression_metrics.py
@@ -508,7 +508,8 @@ class R2Score(reduction_metrics.Metric):
 
         sample_weight = ops.broadcast_to(sample_weight, ops.shape(y_true))
 
-        weighted_y_true = y_true * ops.cast(sample_weight, y_true.dtype)
+        sample_weight = ops.cast(sample_weight, y_true.dtype)
+        weighted_y_true = y_true * sample_weight
         self.sum.assign(self.sum + ops.sum(weighted_y_true, axis=0))
         self.squared_sum.assign(
             self.squared_sum + ops.sum(y_true * weighted_y_true, axis=0)
@@ -516,7 +517,7 @@ class R2Score(reduction_metrics.Metric):
         self.total_mse.assign(
             self.total_mse
             + ops.sum(
-                (y_true - y_pred) ** 2 * ops.cast(sample_weight, y_true.dtype),
+                (y_true - y_pred) ** 2 * sample_weight,
                 axis=0,
             )
         )


### PR DESCRIPTION
## Summary
- Replace `tensor * ops.cast(bool_mask, tensor.dtype)` with `ops.where(bool_mask, tensor, 0)` across 12 files
- On the torch backend these cast+multiply patterns run eagerly, so every intermediate sticks around in memory. `ops.where` skips the float copy of the mask entirely.
- Fixes the layer forward passes (attention, batch norm, masking, pooling, activations, constraints) and losses/metrics (sparse categorical crossentropy, loss masking, IoU, confusion metrics, R2)
- Added `del` on batch norm intermediates for earlier garbage collection

Fixes #22386