### PR TITLE
Fix LayerNormalization rms_scaling to use mean of squares instead of variance

### DIFF
--- a/keras/src/layers/normalization/layer_normalization_test.py
+++ b/keras/src/layers/normalization/layer_normalization_test.py
@@ -123,7 +123,9 @@ class LayerNormalizationTest(testing.TestCase):
         )
         inputs = np.arange(5).astype("float32")[None, :]
         out = layer(inputs)
-        self.assertAllClose(out, [[0.0, 0.70693, 1.41386, 2.12079, 2.82772]])
+        self.assertAllClose(
+            out, [[0.0, 0.40821, 0.81643, 1.22464, 1.63286]], atol=1e-4
+        )
 
     def test_large_value_within_autocast_scope(self):
         layer = layers.LayerNormalization()

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -3140,9 +3140,11 @@ def _layer_normalization(
         return v
 
     if rms_scaling:
-        variance = backend.numpy.var(x, axis=axis, keepdims=True)
-        inv = backend.math.rsqrt(variance + epsilon)
-        outputs = outputs = x * inv
+        mean_square = backend.numpy.mean(
+            backend.numpy.square(x), axis=axis, keepdims=True
+        )
+        inv = backend.math.rsqrt(mean_square + epsilon)
+        outputs = x * inv
         if gamma is not None:
             outputs = outputs * backend.cast(_broadcast(gamma), x.dtype)
     elif backend.config.backend() == "torch" and is_continuous_axis(axis):


### PR DESCRIPTION
## Summary
- When `rms_scaling=True`, LayerNormalization was using `var(x)` (variance, which subtracts the mean) instead of `mean(x^2)` (mean of squares)
- True RMS normalization should compute `1/sqrt(mean(x^2) + epsilon)`, not `1/sqrt(var(x) + epsilon)`
- This is a correctness fix: RMS norm by definition does not center inputs around the mean

Fixes #21234