### PR TITLE
Fix TracerBoolConversionError when using add_loss with JAX JIT

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1281,9 +1281,12 @@ class Layer(BackendLayer, Operation):
         if backend.in_stateless_scope():
             scope = backend.get_stateless_scope()
             if scope.collect_losses:
-                for x in scope.losses:
-                    if id(x) in self._loss_ids:
-                        scope.losses.remove(x)
+                # Filter by identity (id) rather than using list.remove(),
+                # which compares by value. Value comparison on JAX tracers
+                # during JIT causes TracerBoolConversionError.
+                scope.losses[:] = [
+                    x for x in scope.losses if id(x) not in self._loss_ids
+                ]
         self._losses.clear()
         self._loss_ids.clear()
         for layer in self._layers:


### PR DESCRIPTION
## Summary 
Fixes #21605.

When a layer that uses add_loss() is called multiple times in a functional model (e.g. a shared TimeDistributed wrapper on two inputs), the second call triggers _clear_losses(), which tries to remove the first call's losses from the StatelessScope using list.remove(). The problem is list.remove() compares by value, and under JAX JIT, comparing two tracers with == gives back a traced boolean that Python can't use as a concrete bool.  

Replaced list.remove() with a list comprehension that filters by id() instead. _loss_ids already tracks identity for each loss, so nothing else needed to change.
                                                                                                                                 
## Test plan                                                 

  - Reproduced the original bug and confirmed it's fixed                                                                         
  - Verified losses still get collected and applied (not silently dropped)
  - layer_test.py and time_distributed_test.py pass on both JAX and torch                                                        
              