### PR TITLE
Replace Python `assert`s with `self.assertXXX` in unit tests.

### DIFF
--- a/keras/src/callbacks/callback_test.py
+++ b/keras/src/callbacks/callback_test.py
@@ -9,6 +9,8 @@ from keras.src.callbacks.callback import Callback
 class CallbackTest(testing.TestCase):
     @pytest.mark.requires_trainable_backend
     def test_model_state_is_current_on_epoch_end(self):
+        test_obj = self
+
         class TestModel(models.Model):
             def __init__(self):
                 super().__init__()
@@ -22,7 +24,7 @@ class CallbackTest(testing.TestCase):
 
         class CBK(Callback):
             def on_batch_end(self, batch, logs):
-                assert np.int32(self.model.iterations) == batch + 1
+                test_obj.assertEqual(int(self.model.iterations), batch + 1)
 
         model = TestModel()
         model.compile(optimizer="sgd", loss="mse")

--- a/keras/src/callbacks/csv_logger_test.py
+++ b/keras/src/callbacks/csv_logger_test.py
@@ -61,10 +61,10 @@ class CSVLoggerTest(testing.TestCase):
             verbose=0,
         )
 
-        assert os.path.exists(filepath)
+        self.assertTrue(os.path.exists(filepath))
         with open(filepath) as csvfile:
             dialect = csv.Sniffer().sniff(csvfile.read())
-        assert dialect.delimiter == sep
+        self.assertEqual(dialect.delimiter, sep)
         del model
         del cbks
 
@@ -95,10 +95,10 @@ class CSVLoggerTest(testing.TestCase):
         with open(filepath) as csvfile:
             list_lines = csvfile.readlines()
             for line in list_lines:
-                assert line.count(sep) == 4
-            assert len(list_lines) == 5
+                self.assertEqual(line.count(sep), 4)
+            self.assertLen(list_lines, 5)
             output = " ".join(list_lines)
-            assert len(re.findall("epoch", output)) == 1
+            self.assertLen(re.findall("epoch", output), 1)
 
         os.remove(filepath)
 
@@ -115,7 +115,7 @@ class CSVLoggerTest(testing.TestCase):
             epochs=5,
             verbose=0,
         )
-        assert os.path.exists(filepath)
+        self.assertTrue(os.path.exists(filepath))
         # Verify that validation loss is registered at val. freq
         with open(filepath) as csvfile:
             rows = csv.DictReader(csvfile, delimiter=sep)

--- a/keras/src/callbacks/early_stopping_test.py
+++ b/keras/src/callbacks/early_stopping_test.py
@@ -146,7 +146,7 @@ class EarlyStoppingTest(testing.TestCase):
         hist = model.fit(
             x_train, y_train, callbacks=[stopper], verbose=0, epochs=20
         )
-        assert len(hist.epoch) >= patience
+        self.assertGreaterEqual(len(hist.epoch), patience)
 
     def test_early_stopping_final_weights_when_restoring_model_weights(self):
         class DummyModel:

--- a/keras/src/export/saved_model_test.py
+++ b/keras/src/export/saved_model_test.py
@@ -613,9 +613,11 @@ class ExportArchiveTest(testing.TestCase):
         self.assertLen(revived_model.non_trainable_variables, 2)
 
         # Assert all variables wrapped as `tf.Variable`
-        assert isinstance(export_archive.variables[0], tf.Variable)
-        assert isinstance(export_archive.trainable_variables[0], tf.Variable)
-        assert isinstance(
+        self.assertIsInstance(export_archive.variables[0], tf.Variable)
+        self.assertIsInstance(
+            export_archive.trainable_variables[0], tf.Variable
+        )
+        self.assertIsInstance(
             export_archive.non_trainable_variables[0], tf.Variable
         )
 
@@ -688,8 +690,10 @@ class ExportArchiveTest(testing.TestCase):
         self.assertLen(revived_model.non_trainable_variables, 0)
 
         # Assert all variables wrapped as `tf.Variable`
-        assert isinstance(export_archive.variables[0], tf.Variable)
-        assert isinstance(export_archive.trainable_variables[0], tf.Variable)
+        self.assertIsInstance(export_archive.variables[0], tf.Variable)
+        self.assertIsInstance(
+            export_archive.trainable_variables[0], tf.Variable
+        )
 
     def test_layer_export(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_layer")

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -672,11 +672,7 @@ class MultiHeadAttentionTest(testing.TestCase):
         value = random.uniform((2, 4, 16))
         output = mha(query=query, value=value)
 
-        assert output.shape == (
-            2,
-            4,
-            8,
-        ), f"Expected shape (2, 4, 8), got {output.shape}"
+        self.assertEqual(output.shape, (2, 4, 8))
 
     def test_multi_head_attention_output_shape_as_tuple(self):
         """Test MultiHeadAttention with output_shape as a tuple."""
@@ -687,12 +683,7 @@ class MultiHeadAttentionTest(testing.TestCase):
         value = random.uniform((2, 4, 16))
         output = mha(query=query, value=value)
 
-        assert output.shape == (
-            2,
-            4,
-            8,
-            8,
-        ), f"Expected shape (2, 4, 8, 8), got {output.shape}"
+        self.assertEqual(output.shape, (2, 4, 8, 8))
 
     def test_multi_head_attention_output_shape_error(self):
         with self.assertRaisesRegex(ValueError, r"Invalid `output_shape`"):

--- a/keras/src/layers/core/masking_test.py
+++ b/keras/src/layers/core/masking_test.py
@@ -50,7 +50,7 @@ class MaskingTest(testing.TestCase):
                 return input_shape
 
             def call(self, inputs, mask=None):
-                assert mask is not None
+                test_obj.assertIsNotNone(mask)
                 test_obj.assertAllClose(mask, expected_mask)
                 return inputs
 

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -41,7 +41,7 @@ class LayerTest(testing.TestCase):
         # Case: single output
         class TestLayer(layers.Layer):
             def call(self, x):
-                assert False  # Should never be called.
+                raise RuntimeError("Should never be called.")
 
             def compute_output_shape(self, input_shape):
                 return input_shape
@@ -54,7 +54,7 @@ class LayerTest(testing.TestCase):
         # Case: tuple output
         class TestLayer(layers.Layer):
             def call(self, x):
-                assert False  # Should never be called.
+                raise RuntimeError("Should never be called.")
 
             def compute_output_shape(self, input_shape):
                 return (input_shape, input_shape)
@@ -69,7 +69,7 @@ class LayerTest(testing.TestCase):
         # Case: list output
         class TestLayer(layers.Layer):
             def call(self, x):
-                assert False  # Should never be called.
+                raise RuntimeError("Should never be called.")
 
             def compute_output_shape(self, input_shape):
                 return [input_shape, input_shape]
@@ -84,7 +84,7 @@ class LayerTest(testing.TestCase):
         # Case: dict output
         class TestLayer(layers.Layer):
             def call(self, x):
-                assert False  # Should never be called.
+                raise RuntimeError("Should never be called.")
 
             def compute_output_shape(self, input_shape):
                 return {"1": input_shape, "2": input_shape}
@@ -99,7 +99,7 @@ class LayerTest(testing.TestCase):
         # Case: nested tuple output
         class TestLayer(layers.Layer):
             def call(self, x):
-                assert False  # Should never be called.
+                raise RuntimeError("Should never be called.")
 
             def compute_output_shape(self, input_shape):
                 return (
@@ -125,7 +125,7 @@ class LayerTest(testing.TestCase):
         # Case: nested dict output
         class TestLayer(layers.Layer):
             def call(self, x):
-                assert False  # Should never be called.
+                raise RuntimeError("Should never be called.")
 
             def compute_output_shape(self, input_shape):
                 return {
@@ -826,8 +826,7 @@ class LayerTest(testing.TestCase):
         backend.backend() == "numpy", reason="masking not supported with numpy"
     )
     def test_keras_mask_with_autocast(self):
-        assertAllEqual = self.assertAllEqual
-        assertDType = self.assertDType
+        test_obj = self
 
         class CustomLayer(layers.Layer):
             def __init__(self, **kwargs):
@@ -835,15 +834,15 @@ class LayerTest(testing.TestCase):
                 self.supports_masking = True
 
             def call(self, x, mask=None):
-                assert mask is not None
-                assertDType(x, "float16")
+                test_obj.assertIsNotNone(mask)
+                test_obj.assertDType(x, "float16")
                 return x
 
         x = ops.zeros((1, 2), dtype="float32")
         mask = ops.array([True, False])
         backend.set_keras_mask(x, mask)
         y = CustomLayer(dtype="float16")(x)
-        assertAllEqual(
+        self.assertAllEqual(
             mask,
             backend.get_keras_mask(y),
             "Masking is not propagated by Autocast",
@@ -870,13 +869,15 @@ class LayerTest(testing.TestCase):
         backend.backend() == "numpy", reason="masking not supported with numpy"
     )
     def test_masking(self):
+        test_obj = self
+
         class BasicMaskedLayer(layers.Layer):
             def __init__(self):
                 super().__init__()
                 self.supports_masking = True
 
             def call(self, x, mask=None):
-                assert mask is not None
+                test_obj.assertIsNotNone(mask)
                 return x
 
         layer = BasicMaskedLayer()
@@ -893,10 +894,10 @@ class LayerTest(testing.TestCase):
                 self.supports_masking = True
 
             def call(self, x, mask=None):
-                assert isinstance(x, list)
-                assert len(x) == 2
-                assert isinstance(mask, list)
-                assert len(mask) == 2
+                test_obj.assertIsInstance(x, list)
+                test_obj.assertLen(x, 2)
+                test_obj.assertIsInstance(mask, list)
+                test_obj.assertLen(mask, 2)
                 return x
 
         layer = NestedInputMaskedLayer()
@@ -919,8 +920,8 @@ class LayerTest(testing.TestCase):
                 self.supports_masking = True
 
             def call(self, x1, x2, x1_mask=None, x2_mask=None):
-                assert x1_mask is not None
-                assert x2_mask is not None
+                test_obj.assertIsNotNone(x1_mask)
+                test_obj.assertIsNotNone(x2_mask)
                 return x1 + x2
 
         layer = PositionalInputsMaskedLayer()
@@ -933,10 +934,10 @@ class LayerTest(testing.TestCase):
                 self.supports_masking = True
 
             def call(self, x1, x2, x1_mask=None, x2_mask=None):
-                assert isinstance(x1, tuple)
-                assert x1_mask is not None
-                assert x2_mask is not None
-                assert isinstance(x1_mask, tuple)
+                test_obj.assertIsInstance(x1, tuple)
+                test_obj.assertIsNotNone(x1_mask)
+                test_obj.assertIsNotNone(x2_mask)
+                test_obj.assertIsInstance(x1_mask, tuple)
                 return x1[0] + x1[1] + x2
 
         layer = PositionalNestedInputsMaskedLayer()
@@ -958,7 +959,7 @@ class LayerTest(testing.TestCase):
                 self.supports_masking = True
 
             def call(self, x, mask=None):
-                assert mask is not None
+                test_obj.assertIsNotNone(mask)
                 backend.set_keras_mask(x, None)  # Unset mask
                 return x
 

--- a/keras/src/layers/reshaping/up_sampling2d_test.py
+++ b/keras/src/layers/reshaping/up_sampling2d_test.py
@@ -53,11 +53,11 @@ class UpSampling2dTest(testing.TestCase):
         layer.build(inputs.shape)
         np_output = layer(inputs=backend.Variable(inputs))
         if data_format == "channels_first":
-            assert np_output.shape[2] == length_row * input_num_row
-            assert np_output.shape[3] == length_col * input_num_col
+            self.assertEqual(np_output.shape[2], length_row * input_num_row)
+            self.assertEqual(np_output.shape[3], length_col * input_num_col)
         else:
-            assert np_output.shape[1] == length_row * input_num_row
-            assert np_output.shape[2] == length_col * input_num_col
+            self.assertEqual(np_output.shape[1], length_row * input_num_row)
+            self.assertEqual(np_output.shape[2], length_col * input_num_col)
 
         # compare with numpy
         if data_format == "channels_first":

--- a/keras/src/layers/reshaping/up_sampling3d_test.py
+++ b/keras/src/layers/reshaping/up_sampling3d_test.py
@@ -67,13 +67,13 @@ class UpSampling3dTest(testing.TestCase):
         layer.build(inputs.shape)
         np_output = layer(inputs=backend.Variable(inputs))
         if data_format == "channels_first":
-            assert np_output.shape[2] == length_dim1 * input_len_dim1
-            assert np_output.shape[3] == length_dim2 * input_len_dim2
-            assert np_output.shape[4] == length_dim3 * input_len_dim3
+            self.assertEqual(np_output.shape[2], length_dim1 * input_len_dim1)
+            self.assertEqual(np_output.shape[3], length_dim2 * input_len_dim2)
+            self.assertEqual(np_output.shape[4], length_dim3 * input_len_dim3)
         else:  # tf
-            assert np_output.shape[1] == length_dim1 * input_len_dim1
-            assert np_output.shape[2] == length_dim2 * input_len_dim2
-            assert np_output.shape[3] == length_dim3 * input_len_dim3
+            self.assertEqual(np_output.shape[1], length_dim1 * input_len_dim1)
+            self.assertEqual(np_output.shape[2], length_dim2 * input_len_dim2)
+            self.assertEqual(np_output.shape[3], length_dim3 * input_len_dim3)
 
         # compare with numpy
         if data_format == "channels_first":

--- a/keras/src/metrics/reduction_metrics_test.py
+++ b/keras/src/metrics/reduction_metrics_test.py
@@ -190,4 +190,4 @@ class MetricWrapperTest(testing.TestCase):
         metric = metrics.BinaryAccuracy()
         metric.update_state(y, res)
         result = metric.result()
-        assert result == 1.0
+        self.assertEqual(result, 1.0)

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -316,9 +316,11 @@ class FunctionalTest(testing.TestCase):
 
     @pytest.mark.requires_trainable_backend
     def test_training_arg(self):
+        test_obj = self
+
         class Canary(layers.Layer):
             def call(self, x, training=False):
-                assert training
+                test_obj.assertTrue(training)
                 return x
 
             def compute_output_spec(self, x, training=False):

--- a/keras/src/models/sequential_test.py
+++ b/keras/src/models/sequential_test.py
@@ -204,9 +204,11 @@ class SequentialTest(testing.TestCase):
         self.assertEqual(y.shape, (1, 1))
 
     def test_dict_inputs(self):
+        test_obj = self
+
         class DictLayer(layers.Layer):
             def call(self, inputs):
-                assert isinstance(inputs, dict)
+                test_obj.assertIsInstance(inputs, dict)
                 return inputs
 
         model = Sequential([DictLayer()])
@@ -216,9 +218,11 @@ class SequentialTest(testing.TestCase):
         model.summary()
 
     def test_list_inputs(self):
+        test_obj = self
+
         class ListLayer(layers.Layer):
             def call(self, inputs):
-                assert isinstance(inputs, list)
+                test_obj.assertIsInstance(inputs, list)
                 return inputs
 
         model = Sequential([ListLayer()])
@@ -278,6 +282,8 @@ class SequentialTest(testing.TestCase):
         model.summary()
 
     def test_serialization(self):
+        test_obj = self
+
         # Unbuilt deferred
         model = Sequential(name="seq")
         model.add(layers.Dense(4))
@@ -302,7 +308,7 @@ class SequentialTest(testing.TestCase):
         # Weird
         class DictLayer(layers.Layer):
             def call(self, inputs):
-                assert isinstance(inputs, dict)
+                test_obj.assertIsInstance(inputs, dict)
                 return inputs
 
         model = Sequential([DictLayer()])
@@ -342,7 +348,7 @@ class SequentialTest(testing.TestCase):
         model.add(layers.Dense(4))
 
         result = pickle.loads(pickle.dumps(model))
-        assert len(result.layers) == 1
+        self.assertLen(result.layers, 1)
 
     def test_bad_layer(self):
         model = Sequential(name="seq")

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -374,7 +374,7 @@ class ImageOpsStaticShapeTest(testing.TestCase):
         out = kimage.map_coordinates(
             image_uint8, coordinates, order=1, fill_mode="constant"
         )
-        assert out.shape == coordinates.shape[1:]
+        self.assertEqual(out.shape, coordinates.shape[1:])
 
     def test_map_coordinates_float32(self):
         image_float32 = tf.ones((1, 1, 3), dtype=tf.float32)
@@ -386,7 +386,7 @@ class ImageOpsStaticShapeTest(testing.TestCase):
         out = kimage.map_coordinates(
             image_float32, coordinates, order=1, fill_mode="constant"
         )
-        assert out.shape == coordinates.shape[1:]
+        self.assertEqual(out.shape, coordinates.shape[1:])
 
     def test_map_coordinates_nearest(self):
         image_uint8 = tf.ones((1, 1, 3), dtype=tf.uint8)
@@ -398,7 +398,7 @@ class ImageOpsStaticShapeTest(testing.TestCase):
         out = kimage.map_coordinates(
             image_uint8, coordinates, order=1, fill_mode="nearest"
         )
-        assert out.shape == coordinates.shape[1:]
+        self.assertEqual(out.shape, coordinates.shape[1:])
 
     def test_map_coordinates_manual_cast(self):
         image_uint8 = tf.ones((1, 1, 3), dtype=tf.uint8)
@@ -414,7 +414,7 @@ class ImageOpsStaticShapeTest(testing.TestCase):
             ),
             dtype=tf.uint8,
         )
-        assert out.shape == coordinates.shape[1:]
+        self.assertEqual(out.shape, coordinates.shape[1:])
 
     def test_pad_images(self):
         # Test channels_last

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -4730,7 +4730,7 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
     def test_view(self):
         x = np.array(1, dtype="int16")
         result = knp.view(x, dtype="float16")
-        assert backend.standardize_dtype(result.dtype) == "float16"
+        self.assertEqual(backend.standardize_dtype(result.dtype), "float16")
 
         with self.assertRaises(Exception):
             result = knp.view(x, dtype="int8")
@@ -4740,7 +4740,7 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
 
         x = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype="int16")
         result = knp.view(x, dtype="int16")
-        assert backend.standardize_dtype(result.dtype) == "int16"
+        self.assertEqual(backend.standardize_dtype(result.dtype), "int16")
 
         self.assertEqual(
             backend.standardize_dtype(knp.view(x, dtype="int16").dtype), "int16"

--- a/keras/src/quantizers/gptq_config_test.py
+++ b/keras/src/quantizers/gptq_config_test.py
@@ -49,7 +49,7 @@ class TestGPTQConfig(testing.TestCase):
         config = GPTQConfig(
             dataset=None, tokenizer=None, weight_bits=4, group_size=64
         )
-        assert config.dtype_policy_string() == "gptq/4/64"
+        self.assertEqual(config.dtype_policy_string(), "gptq/4/64")
 
     def test_gptq_config_serialization(self):
         config = GPTQConfig(

--- a/keras/src/random/random_test.py
+++ b/keras/src/random/random_test.py
@@ -237,7 +237,7 @@ class RandomCorrectnessTest(testing.TestCase):
         # Hence, we do an element wise comparison between `counts` array
         # and the (generated) `values` array.
         values_np = ops.convert_to_numpy(values)
-        assert np.greater_equal(np.array(counts), values_np).all()
+        self.assertTrue(np.greater_equal(np.array(counts), values_np).all())
 
         # Following test computes the probabilities of each event
         # by dividing number of times an event occurs (which is the generated

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -117,7 +117,8 @@ class ListInputModel(Trainer, layers.Layer):
         )
 
     def call(self, x):
-        assert isinstance(x, (list, tuple))
+        if not isinstance(x, (list, tuple)):
+            raise ValueError("x must be a list or tuple")
         return self.dense_1(x[0]) + self.dense_2(x[1])
 
 
@@ -336,12 +337,14 @@ class StepCount(Callback):
         self.epoch_end_count += 1
 
     def on_batch_begin(self, batch, logs=None):
-        assert batch == self.begin_count * self.steps_per_execution
+        if batch != self.begin_count * self.steps_per_execution:
+            raise ValueError("Batch index is not correct")
         self.begin_count += 1
 
     def on_batch_end(self, batch, logs=None):
         self.end_count += 1
-        assert batch == self.end_count * self.steps_per_execution - 1
+        if batch != self.end_count * self.steps_per_execution - 1:
+            raise ValueError("Batch index is not correct")
 
 
 class TestTrainer(testing.TestCase):
@@ -942,6 +945,8 @@ class TestTrainer(testing.TestCase):
         reason="Memory optimization is only implemented in JAX",
     )
     def test_fit_eval_flow_for_jax_model_weights(self):
+        test_obj = self
+
         model = ExampleModel(units=3)
         epochs = 3
         batch_size = 20
@@ -958,19 +963,19 @@ class TestTrainer(testing.TestCase):
             # will trigger a sync of the jax training state back to the model.
             def on_train_batch_end(self, batch, logs=None):
                 for v in self._model.trainable_variables:
-                    assert v._value is None
+                    test_obj.assertIsNone(v._value)
                 for v in self._model.non_trainable_variables:
-                    assert v._value is None
+                    test_obj.assertIsNone(v._value)
                 for v in self._model.optimizer.variables:
-                    assert v._value is None
+                    test_obj.assertIsNone(v._value)
                 for v in self._model.metrics_variables:
-                    assert v._value is None
+                    test_obj.assertIsNone(v._value)
 
             def on_test_batch_end(self, batch, logs=None):
                 for v in self._model.non_trainable_variables:
-                    assert v._value is None
+                    test_obj.assertIsNone(v._value)
                 for v in self._model.metrics_variables:
-                    assert v._value is None
+                    test_obj.assertIsNone(v._value)
 
         model.compile(
             optimizer=optimizers.SGD(),
@@ -1712,6 +1717,8 @@ class TestTrainer(testing.TestCase):
         reason="`steps_per_execution` not implemented for torch yet",
     )
     def test_steps_per_execution_steps_count_without_training(self):
+        test_obj = self
+
         class StepCount(Callback):
             def __init__(self):
                 super().__init__()
@@ -1720,11 +1727,11 @@ class TestTrainer(testing.TestCase):
                 self.batches = [0, 3, 6]
 
             def on_test_batch_begin(self, batch, logs=None):
-                assert batch == self.batches[self.test_count]
+                test_obj.assertEqual(batch, self.batches[self.test_count])
                 self.test_count += 1
 
             def on_predict_batch_begin(self, batch, logs=None):
-                assert batch == self.batches[self.predict_count]
+                test_obj.assertEqual(batch, self.batches[self.predict_count])
                 self.predict_count += 1
 
         x = np.ones((100, 4))
@@ -1988,7 +1995,7 @@ class TestTrainer(testing.TestCase):
             batch_size=4,
             validation_data=(x_test, y_test),
         )
-        assert getattr(model, "_eval_epoch_iterator", None) is None
+        self.assertIsNone(getattr(model, "_eval_epoch_iterator", None))
 
         # Try model.fit with reshaped validation_data
         # This will throw an exception which is intended
@@ -2013,76 +2020,84 @@ class TestTrainer(testing.TestCase):
             batch_size=4,
             validation_data=(x_test, y_test),
         )
-        assert getattr(model, "_eval_epoch_iterator", None) is None
+        self.assertIsNone(getattr(model, "_eval_epoch_iterator", None))
 
     @pytest.mark.requires_trainable_backend
     def test_callback_methods_keys(self):
+        test_obj = self
+
         class CustomCallback(Callback):
             def on_train_begin(self, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == []
+                test_obj.assertEqual(keys, [])
 
             def on_train_end(self, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == [
-                    "loss",
-                    "mean_absolute_error",
-                    "val_loss",
-                    "val_mean_absolute_error",
-                ]
+                test_obj.assertEqual(
+                    keys,
+                    [
+                        "loss",
+                        "mean_absolute_error",
+                        "val_loss",
+                        "val_mean_absolute_error",
+                    ],
+                )
 
             def on_epoch_begin(self, epoch, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == []
+                test_obj.assertEqual(keys, [])
 
             def on_epoch_end(self, epoch, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == [
-                    "loss",
-                    "mean_absolute_error",
-                    "val_loss",
-                    "val_mean_absolute_error",
-                ]
+                test_obj.assertEqual(
+                    keys,
+                    [
+                        "loss",
+                        "mean_absolute_error",
+                        "val_loss",
+                        "val_mean_absolute_error",
+                    ],
+                )
 
             def on_test_begin(self, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == []
+                test_obj.assertEqual(keys, [])
 
             def on_test_end(self, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == ["loss", "mean_absolute_error"]
+                test_obj.assertEqual(keys, ["loss", "mean_absolute_error"])
 
             def on_predict_begin(self, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == []
+                test_obj.assertEqual(keys, [])
 
             def on_predict_end(self, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == []
+                test_obj.assertEqual(keys, [])
 
             def on_train_batch_begin(self, batch, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == []
+                test_obj.assertEqual(keys, [])
 
             def on_train_batch_end(self, batch, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == ["loss", "mean_absolute_error"]
+                test_obj.assertEqual(keys, ["loss", "mean_absolute_error"])
 
             def on_test_batch_begin(self, batch, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == []
+                test_obj.assertEqual(keys, [])
 
             def on_test_batch_end(self, batch, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == ["loss", "mean_absolute_error"]
+                test_obj.assertEqual(keys, ["loss", "mean_absolute_error"])
 
             def on_predict_batch_begin(self, batch, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == []
+                test_obj.assertEqual(keys, [])
 
             def on_predict_batch_end(self, batch, logs=None):
                 keys = sorted(list(logs.keys()))
-                assert keys == ["outputs"]
+                test_obj.assertEqual(keys, ["outputs"])
 
         model = ExampleModel(units=3)
         model.compile(

--- a/keras/src/utils/audio_dataset_utils_test.py
+++ b/keras/src/utils/audio_dataset_utils_test.py
@@ -134,12 +134,12 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
         dataset = audio_dataset_utils.audio_dataset_from_directory(
             directory, batch_size=8, output_sequence_length=30, label_mode="int"
         )
-        test_case = self
+        test_obj = self
 
         @tf.function
         def symbolic_fn(ds):
             for x, _ in ds.take(1):
-                test_case.assertListEqual(x.shape.as_list(), [None, 30, None])
+                test_obj.assertListEqual(x.shape.as_list(), [None, 30, None])
 
         symbolic_fn(dataset)
 

--- a/keras/src/utils/image_dataset_utils_test.py
+++ b/keras/src/utils/image_dataset_utils_test.py
@@ -164,7 +164,7 @@ class ImageDatasetFromDirectoryTest(testing.TestCase):
         dataset = image_dataset_utils.image_dataset_from_directory(
             directory, batch_size=8, image_size=(18, 18), label_mode="int"
         )
-        test_case = self
+        test_obj = self
         if backend.config.image_data_format() == "channels_last":
             output_shape = [None, 18, 18, 3]
         else:
@@ -173,7 +173,7 @@ class ImageDatasetFromDirectoryTest(testing.TestCase):
         @tf.function
         def symbolic_fn(ds):
             for x, _ in ds.take(1):
-                test_case.assertListEqual(x.shape.as_list(), output_shape)
+                test_obj.assertListEqual(x.shape.as_list(), output_shape)
 
         symbolic_fn(dataset)
 

--- a/keras/src/utils/numerical_utils_test.py
+++ b/keras/src/utils/numerical_utils_test.py
@@ -50,7 +50,7 @@ class TestNumericalUtils(testing.TestCase):
             )
         )
         one_hot = numerical_utils.to_categorical(label, NUM_CLASSES)
-        assert backend.is_tensor(one_hot)
+        self.assertTrue(backend.is_tensor(one_hot))
         self.assertAllClose(one_hot, expected)
 
     @parameterized.parameters([1, 2, 3])


### PR DESCRIPTION
The `unittest` `self.assertXXX` are more specific and provide useful context in case of failure, for instance the diff between the expected and actual values.

The eventual goal is to remove all `assert`s in the code and turn on automated verification. See https://docs.astral.sh/ruff/rules/assert/ for an explanation of why alternatives should be used instead of `assert`.