### PR TITLE
[OpenVINO] Implement cond operator; enable tests for Hinge loss funcs and CosineDecay

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -864,10 +864,9 @@ def cond(pred, true_fn, false_fn):
             pred_ov = ov_opset.convert(pred_ov, Type.boolean).output(0)
 
     def _select(t, f):
-        t_ov = get_ov_output(t)
-        f_ov = get_ov_output(f)
-        if t_ov.get_element_type() != f_ov.get_element_type():
-            f_ov = ov_opset.convert(f_ov, t_ov.get_element_type()).output(0)
+        t_ov, f_ov = align_operand_types(
+            get_ov_output(t), get_ov_output(f), "cond"
+        )
         return OpenVINOKerasTensor(
             ov_opset.select(pred_ov, t_ov, f_ov).output(0)
         )

--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -850,7 +850,31 @@ def cast(x, dtype):
 
 
 def cond(pred, true_fn, false_fn):
-    raise NotImplementedError("`cond` is not supported with openvino backend")
+    true_val = true_fn()
+    false_val = false_fn()
+
+    if true_val is None:
+        return None
+
+    if isinstance(pred, bool):
+        pred_ov = ov_opset.constant(pred, Type.boolean).output(0)
+    else:
+        pred_ov = get_ov_output(pred)
+        if pred_ov.get_element_type() != Type.boolean:
+            pred_ov = ov_opset.convert(pred_ov, Type.boolean).output(0)
+
+    def _select(t, f):
+        t_ov = get_ov_output(t)
+        f_ov = get_ov_output(f)
+        if t_ov.get_element_type() != f_ov.get_element_type():
+            f_ov = ov_opset.convert(f_ov, t_ov.get_element_type()).output(0)
+        return OpenVINOKerasTensor(
+            ov_opset.select(pred_ov, t_ov, f_ov).output(0)
+        )
+
+    if isinstance(true_val, (list, tuple)):
+        return type(true_val)(_select(t, f) for t, f in zip(true_val, false_val))
+    return _select(true_val, false_val)
 
 
 def vectorized_map(function, elements):

--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -872,7 +872,9 @@ def cond(pred, true_fn, false_fn):
         )
 
     if isinstance(true_val, (list, tuple)):
-        return type(true_val)(_select(t, f) for t, f in zip(true_val, false_val))
+        return type(true_val)(
+            _select(t, f) for t, f in zip(true_val, false_val)
+        )
     return _select(true_val, false_val)
 
 

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -61,13 +61,6 @@ CoreOpsCorrectnessTest::test_scan
 CoreOpsCorrectnessTest::test_switch
 CoreOpsCorrectnessTest::test_unstack
 CoreOpsCorrectnessTest::test_vectorized_map
-CosineDecayRestartsTest::test_alpha
-CosineDecayRestartsTest::test_decay
-CosineDecayRestartsTest::test_float64
-CosineDecayRestartsTest::test_mmul
-CosineDecayRestartsTest::test_tmul
-CosineDecayTest::test_warmup
-CosineDecayTest::test_warmup_decay
 CTCTest::test_correctness
 CTCTest::test_dtype_arg
 DenseTest::test_dense_quantize_config_int4

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -55,7 +55,6 @@ CoreOpsCallsTests::test_scan_basic_call
 CoreOpsCallsTests::test_switch_basic_call
 CoreOpsCallsTests::test_unstack_basic_functionality
 CoreOpsCorrectnessTest::test_associative_scan
-CoreOpsCorrectnessTest::test_cond
 CoreOpsCorrectnessTest::test_fori_loop
 CoreOpsCorrectnessTest::test_map
 CoreOpsCorrectnessTest::test_scan
@@ -162,10 +161,6 @@ GRUTest::test_masking
 GRUTest::test_pass_initial_state
 GRUTest::test_pass_return_state
 GRUTest::test_statefulness
-HingeTest::test_dtype_arg
-HingeTest::test_unweighted
-HingeTest::test_weighted
-HingeTest::test_zero_weighted
 HistogramTest::test_histogram_predict_jit_compile_false
 HistogramTest::test_histogram_predict_jit_compile_true
 ImageDatasetFromDirectoryTest::test_image_dataset_from_directory_binary_grain
@@ -414,10 +409,6 @@ SparseCategoricalCrossentropyTest::test_sample_weighted
 SparseCategoricalCrossentropyTest::test_scalar_weighted
 SparseCategoricalCrossentropyTest::test_unweighted
 SpectralNormalizationTest::test_apply_layer
-SquaredHingeTest::test_dtype_arg
-SquaredHingeTest::test_unweighted
-SquaredHingeTest::test_weighted
-SquaredHingeTest::test_zero_weighted
 StackedRNNTest::test_correctness_single_state_stack
 StackedRNNTest::test_correctness_two_states_stack
 StackedRNNTest::test_return_state_stacked_lstm_cell


### PR DESCRIPTION
This PR implements `cond` operator for the OpenVINO backend using `ov_opset.select`, which evaluates both branches as graph nodes and selects the result based on pred. 

Enabled 16 previously excluded tests for cond, CosineDecay ,Hinge, and SquaredHinge, which now pass due to the implementation.

Closes: openvinotoolkit/openvino/issues/34672