### PR TITLE
Warn when trainable state changes after compile()

### DIFF
--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -210,6 +210,8 @@ class Trainer:
         self.test_function = None
         self.predict_function = None
 
+        self._compiled_trainable_variable_ids = None
+
         self._compile_config = serialization_lib.SerializableDict(
             optimizer=optimizer,
             loss=loss,
@@ -1070,6 +1072,20 @@ class Trainer:
             return results[0]
         return results
 
+    def _check_trainable_state_drift(self):
+        current_ids = {id(v) for v in self.trainable_variables}
+        if self._compiled_trainable_variable_ids is None:
+            self._compiled_trainable_variable_ids = current_ids
+            return
+        if current_ids != self._compiled_trainable_variable_ids:
+            warnings.warn(
+                "The model's trainable state has changed since `compile()` "
+                "was called. Toggling `layer.trainable` or "
+                "`model.trainable` after `compile()` does not take effect "
+                "until `compile()` is called again.",
+                stacklevel=2,
+            )
+
     def _assert_compile_called(self, method_name=None):
         if not self.compiled:
             msg = "You must call `compile()` before "
@@ -1159,6 +1175,9 @@ class Trainer:
         if optimizer_unbuilt:
             # Build optimizer
             self.optimizer.build(self.trainable_variables)
+
+        self._check_trainable_state_drift()
+
         self._post_build()
 
 

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest import mock
 
 import jax
@@ -1764,6 +1765,31 @@ class TestTrainer(testing.TestCase):
         loss1 = model.evaluate(x, y, batch_size=80)
         loss2 = model.evaluate(x, y, batch_size=100)
         self.assertAllClose(loss1, loss2)
+
+    @pytest.mark.requires_trainable_backend
+    @pytest.mark.skipif(
+        backend.backend() == "tensorflow",
+        reason=(
+            "TF builds lazily during function tracing so the drift check is "
+            "not reached on the default (no-distribute) path."
+        ),
+    )
+    def test_warns_when_trainable_toggled_after_compile(self):
+        x = np.random.rand(16, 4)
+        y = np.ones((16, 1))
+
+        model = ExampleModel(units=1)
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(x, y, batch_size=4, epochs=1, verbose=0)
+
+        model.trainable = False
+        with self.assertWarnsRegex(
+            UserWarning, "trainable state has changed"
+        ):
+            try:
+                model.fit(x, y, batch_size=4, epochs=1, verbose=0)
+            except ValueError:
+                pass
 
     @pytest.mark.requires_trainable_backend
     def test_adds_loss_scaling_optimizer(self):


### PR DESCRIPTION
## Summary
Toggling `.trainable` after `compile()` silently doesn't take effect until `compile()` is called again. This flags the mismatch at runtime.

Snapshots `{id(v) for v in self.trainable_variables}` at `_symbolic_build` time and emits a `UserWarning` on later fit/evaluate calls if the set has drifted. `compile()` resets the snapshot.

No gradient-path change: the 4 backend trainers are untouched. This replaces the earlier enforcement approach in this PR, which would have changed observable training behavior for seeded code.

Known gap: TF without a distribute strategy lazy-builds during tracing and skips `_symbolic_build`, so the warning doesn't fire there. Test is skipped on TF for that reason.

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.