### PR TITLE
Replace Python `assert`s in code with `raise ValueError`.

### DIFF
--- a/keras/src/applications/efficientnet.py
+++ b/keras/src/applications/efficientnet.py
@@ -358,7 +358,11 @@ def EfficientNet(
     b = 0
     blocks = float(sum(round_repeats(args["repeats"]) for args in blocks_args))
     for i, args in enumerate(blocks_args):
-        assert args["repeats"] > 0
+        if args["repeats"] <= 0:
+            raise ValueError(
+                f"The number of repeats in `EfficientNet` must be > 0. "
+                f"Received: repeats={args['repeats']}"
+            )
         # Update block input and output filters based on depth multiplier.
         args["filters_in"] = round_filters(args["filters_in"])
         args["filters_out"] = round_filters(args["filters_out"])

--- a/keras/src/applications/efficientnet_v2.py
+++ b/keras/src/applications/efficientnet_v2.py
@@ -974,7 +974,11 @@ def EfficientNetV2(
     blocks = float(sum(args["num_repeat"] for args in blocks_args))
 
     for i, args in enumerate(blocks_args):
-        assert args["num_repeat"] > 0
+        if args["num_repeat"] <= 0:
+            raise ValueError(
+                f"The number of repeats in `EfficientNetV2` must be > 0. "
+                f"Received: num_repeat={args['num_repeat']}"
+            )
 
         # Update block input and output filters based on depth multiplier.
         args["input_filters"] = round_filters(

--- a/keras/src/backend/common/backend_utils.py
+++ b/keras/src/backend/common/backend_utils.py
@@ -16,7 +16,11 @@ def _convert_conv_transpose_padding_args_from_keras_to_jax(
     be given a default value.
     """
 
-    assert padding.lower() in {"valid", "same"}
+    if padding.lower() not in {"valid", "same"}:
+        raise ValueError(
+            f"The `padding` argument must be one of 'valid', 'same'. "
+            f"Received: padding={padding}"
+        )
     kernel_size = (kernel_size - 1) * dilation_rate + 1
 
     if padding.lower() == "valid":
@@ -58,7 +62,11 @@ def _convert_conv_transpose_padding_args_from_keras_to_torch(
     the case when both the Torch padding and output_padding values are
     strictly positive.
     """
-    assert padding.lower() in {"valid", "same"}
+    if padding.lower() not in {"valid", "same"}:
+        raise ValueError(
+            f"The `padding` argument must be one of 'valid', 'same'. "
+            f"Received: padding={padding}"
+        )
     original_kernel_size = kernel_size
     kernel_size = (kernel_size - 1) * dilation_rate + 1
 
@@ -210,7 +218,11 @@ def _get_output_shape_given_tf_padding(
     if input_size is None:
         return None
 
-    assert padding.lower() in {"valid", "same"}
+    if padding.lower() not in {"valid", "same"}:
+        raise ValueError(
+            f"The `padding` argument must be one of 'valid', 'same'. "
+            f"Received: padding={padding}"
+        )
 
     kernel_size = (kernel_size - 1) * dilation_rate + 1
 

--- a/keras/src/backend/config.py
+++ b/keras/src/backend/config.py
@@ -297,12 +297,27 @@ if os.path.exists(_config_path):
     except ValueError:
         _config = {}
     _floatx = _config.get("floatx", floatx())
-    assert _floatx in {"float16", "float32", "float64"}
+    if _floatx not in {"float16", "float32", "float64"}:
+        raise ValueError(
+            "Invalid `floatx` configuration. "
+            "Expected one of {'float16', 'float32', 'float64'}. "
+            f"Received: floatx={_floatx}"
+        )
     _epsilon = _config.get("epsilon", epsilon())
-    assert isinstance(_epsilon, float)
+    if not isinstance(_epsilon, float):
+        raise ValueError(
+            "Invalid `epsilon` configuration. "
+            "Expected a float. "
+            f"Received: epsilon={_epsilon}"
+        )
     _backend = _config.get("backend", _BACKEND)
     _image_data_format = _config.get("image_data_format", image_data_format())
-    assert _image_data_format in {"channels_last", "channels_first"}
+    if _image_data_format not in {"channels_last", "channels_first"}:
+        raise ValueError(
+            "Invalid `image_data_format` configuration. "
+            "Expected one of {'channels_last', 'channels_first'}. "
+            f"Received: image_data_format={_image_data_format}"
+        )
     _nnx_enabled_config = _config.get("nnx_enabled", _NNX_ENABLED)
 
     # Apply basic configs that don't cause circular import

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -1594,10 +1594,11 @@ def wrap_flash_attention(
             with decoder_segment_ids.
     """
     if decoder_segment_ids is not None:
-        assert query.shape[2] == decoder_segment_ids.q.shape[1], (
-            "Sharding along sequence dimension not allowed"
-            " in TPU kernel attention"
-        )
+        if query.shape[2] != decoder_segment_ids.q.shape[1]:
+            raise ValueError(
+                "Sharding along sequence dimension not allowed"
+                " in TPU kernel attention"
+            )
 
     if custom_mask is not None:
         mask = splash_attention_mask.NumpyMask(array=custom_mask)
@@ -1826,7 +1827,7 @@ def dot_product_attention(
     G = N // K
     query = jnp.reshape(query, (B, T, K, G, H))
 
-    def _reshape_to_grouped(t):
+    def _reshape_to_grouped(t, t_name):
         if t is not None:
             while t.ndim < 4:
                 if t.ndim == 3 and t.shape[1] == N:
@@ -1837,12 +1838,16 @@ def dot_product_attention(
             if tN == 1:
                 t = jnp.broadcast_to(t[:, :, None, :, :], (tB, tN, G, tT, tS))
             else:
-                assert tN == N
+                if tN != N:
+                    raise ValueError(
+                        f"Expected `{t_name}` to have shape (B, 1, T, S) or "
+                        f"(B, N, T, S) with N={N} but got {t.shape}."
+                    )
                 t = jnp.reshape(t, (tB, K, G, tT, tS))
         return t
 
-    bias = _reshape_to_grouped(bias)
-    mask = _reshape_to_grouped(mask)
+    bias = _reshape_to_grouped(bias, "bias")
+    mask = _reshape_to_grouped(mask, "mask")
     vmapped_fn = jax.vmap(
         _dot_product_attention_core,
         in_axes=(3, None, None, 2, 2, None, None),

--- a/keras/src/backend/numpy/core.py
+++ b/keras/src/backend/numpy/core.py
@@ -237,9 +237,14 @@ def associative_scan(f, elems, reverse=False, axis=0):
 
     def _interleave(a, b, axis):
         """Given two Tensors of static shape, interleave them along axis."""
-        assert (
+        if not (
             a.shape[axis] == b.shape[axis] or a.shape[axis] == b.shape[axis] + 1
-        )
+        ):
+            raise ValueError(
+                "Shapes are incompatible for associative_scan interleaving. "
+                f"a.shape[{axis}]={a.shape[axis]}, "
+                f"b.shape[{axis}]={b.shape[axis]}"
+            )
 
         # we want to get a: [a1, a2], b: [b1, b2]
         # to a: [a1, 0, a2, 0], b: [0, b1, 0, b2]
@@ -356,7 +361,11 @@ def scatter_update(inputs, indices, updates, reduction=None):
 
 def slice(inputs, start_indices, shape):
     # Validate inputs
-    assert len(start_indices) == len(shape)
+    if len(start_indices) != len(shape):
+        raise ValueError(
+            "Length of `start_indices` must match length of `shape`. "
+            f"Received: start_indices={start_indices}, shape={shape}"
+        )
 
     # Generate list of indices arrays for each dimension
     indices = [

--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -493,10 +493,16 @@ class OpenVINOKerasTensor:
     def __len__(self):
         ov_output = self.output
         ov_shape = ov_output.get_partial_shape()
-        assert ov_shape.rank.is_static and ov_shape.rank.get_length() > 0, (
-            "rank must be static and greater than zero"
-        )
-        assert ov_shape[0].is_static, "the first dimension must be static"
+        if not (ov_shape.rank.is_static and ov_shape.rank.get_length() > 0):
+            raise ValueError(
+                "Rank must be static and greater than zero to compute `len()`. "
+                f"rank={ov_shape.rank}"
+            )
+        if not ov_shape[0].is_static:
+            raise ValueError(
+                "The first dimension must be static to compute `len()`. "
+                f"shape={ov_shape}"
+            )
         return ov_shape[0].get_length()
 
     def __bool__(self):
@@ -804,11 +810,8 @@ def convert_to_numpy(x):
             x = x.value
         else:
             return x.value.data
-    assert isinstance(x, OpenVINOKerasTensor), (
-        "unsupported type {} for `convert_to_numpy` in openvino backend".format(
-            type(x)
-        )
-    )
+    if not isinstance(x, OpenVINOKerasTensor):
+        raise ValueError(f"unsupported type {type(x)} for `convert_to_numpy`.")
     # if the tensor is backed by a Constant OV node, extract
     # its data array directly without compiling a model.
     try:
@@ -945,14 +948,16 @@ def slice(inputs, start_indices, shape):
         start_indices = tuple(start_indices)
     if isinstance(shape, (list, np.ndarray)):
         shape = tuple(shape)
-    assert isinstance(start_indices, tuple), (
-        "`slice` is not supported by openvino backend"
-        " for `start_indices` of type {}".format(type(start_indices))
-    )
-    assert isinstance(shape, tuple), (
-        "`slice` is not supported by openvino backend"
-        " for `shape` of type {}".format(type(shape))
-    )
+    if not isinstance(start_indices, tuple):
+        raise ValueError(
+            "`slice` operation requires tuple for `start_indices with the "
+            f"openvino backend. Received: start_indices={start_indices}"
+        )
+    if not isinstance(shape, tuple):
+        raise ValueError(
+            "`slice` operation requires tuple for `shape` with the "
+            f"openvino backend. Received: shape={shape}"
+        )
 
     axes = []
     start = []
@@ -1208,9 +1213,11 @@ def while_loop(
     elif isinstance(loop_vars, (list, np.ndarray)):
         loop_vars = tuple(loop_vars)
     else:
-        assert isinstance(loop_vars, (tuple, dict)), (
-            f"Unsupported type {type(loop_vars)} for loop_vars"
-        )
+        if not isinstance(loop_vars, (tuple, dict)):
+            raise ValueError(
+                "Expected tuple or dict for `loop_vars`, "
+                f"Received: {type(loop_vars)}"
+            )
 
     flat_loop_vars = flatten_structure(loop_vars)
     loop_vars_ov = [get_ov_output(var) for var in flat_loop_vars]

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -652,9 +652,11 @@ def depthwise_conv(
     data_format = backend.standardize_data_format(data_format)
     num_spatial_dims = inputs.get_partial_shape().rank.get_length() - 2
 
-    assert data_format == "channels_last", (
-        "`depthwise_conv` is supported only for channels_last data_format"
-    )
+    if data_format != "channels_last":
+        raise ValueError(
+            "OpenVINO depthwise_conv only supports 'channels_last' "
+            f"data format. Received: data_format={data_format}"
+        )
 
     strides = _adjust_strides_dilation(strides, num_spatial_dims)
     dilation_rate = _adjust_strides_dilation(dilation_rate, num_spatial_dims)

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1025,9 +1025,11 @@ def blackman(x):
 
 
 def broadcast_to(x, shape):
-    assert isinstance(shape, (tuple, list)), (
-        "`broadcast_to` is supported only for tuple and list `shape`"
-    )
+    if not isinstance(shape, (tuple, list)):
+        raise ValueError(
+            f"`broadcast_to` is supported only for tuple and list `shape`. "
+            f"Received: shape={shape} (type {type(shape)})"
+        )
     target_shape = ov_opset.constant(list(shape), Type.i32).output(0)
     x = get_ov_output(x)
     return OpenVINOKerasTensor(ov_opset.broadcast(x, target_shape).output(0))
@@ -3206,10 +3208,12 @@ def pad(x, pad_width, mode="constant", constant_values=None):
                 "provided when `mode == 'constant'`. "
                 f"Received: mode={mode}"
             )
-        assert isinstance(constant_values, int), (
-            "`pad` operation supports only scalar pad value "
-            "in constant mode by openvino backend"
-        )
+        if not isinstance(constant_values, int):
+            raise ValueError(
+                "`pad` operation supports only scalar pad value "
+                "in constant mode with the openvino backend. "
+                f"Received: constant_values={constant_values}"
+            )
         pad_value = ov_opset.constant(
             constant_values, x.get_element_type()
         ).output(0)
@@ -3721,7 +3725,10 @@ def array_split(x, indices_or_sections, axis=0):
 def stack(x, axis=0):
     if isinstance(x, tuple):
         x = list(x)
-    assert isinstance(x, list), "`stack` supports only `x` as list or tuple"
+    if not isinstance(x, list):
+        raise ValueError(
+            f"`stack` supports only `x` as list or tuple. Received: {type(x)}"
+        )
     elems = [get_ov_output(e) for e in x]
     ref = elems[0]
     for i in range(1, len(elems)):

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -1092,7 +1092,8 @@ def _get_logits(output, from_logits, op_type, fn_name):
         # When softmax activation function is used for output operation, we
         # use logits from the softmax function directly to compute loss in order
         # to prevent collapsing zero when training.
-        assert len(output.op.inputs) == 1
+        if len(output.op.inputs) != 1:
+            raise ValueError(f"Expected 1 input for {op_type}.")
         output_ = output.op.inputs[0]
         from_logits_ = True
 

--- a/keras/src/backend/tensorflow/optimizer.py
+++ b/keras/src/backend/tensorflow/optimizer.py
@@ -170,7 +170,12 @@ class TFOptimizer(KerasAutoTrackable, base_optimizer.BaseOptimizer):
             else:
                 reduced_with_nones.append((reduced[reduced_pos], v))
                 reduced_pos += 1
-        assert reduced_pos == len(reduced), "Failed to add all gradients"
+        if reduced_pos != len(reduced):
+            raise ValueError(
+                "Internal error: Failed to add all gradients. Expected to "
+                f"process {len(reduced)} gradients, but processed "
+                f"{reduced_pos}."
+            )
         return reduced_with_nones
 
     def _overwrite_model_variables_with_average_value(

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -472,9 +472,14 @@ def associative_scan(f, elems, reverse=False, axis=0):
 
     def _interleave(a, b, axis):
         """Given two Tensors of static shape, interleave them along axis."""
-        assert (
+        if not (
             a.shape[axis] == b.shape[axis] or a.shape[axis] == b.shape[axis] + 1
-        )
+        ):
+            raise ValueError(
+                "Shapes are incompatible for associative_scan interleaving. "
+                f"a.shape[{axis}]={a.shape[axis]}, "
+                f"b.shape[{axis}]={b.shape[axis]}"
+            )
 
         # we want to get a: [a1, a2], b: [b1, b2]
         # to a: [a1, 0, a2, 0], b: [0, b1, 0, b2]

--- a/keras/src/datasets/boston_housing.py
+++ b/keras/src/datasets/boston_housing.py
@@ -42,7 +42,11 @@ def load_data(path="boston_housing.npz", test_split=0.2, seed=113):
         target scalars. The targets are float scalars typically between 10 and
         50 that represent the home prices in k$.
     """
-    assert 0 <= test_split < 1
+    if not (0 <= test_split < 1):
+        raise ValueError(
+            f"Invalid `test_split` argument: {test_split}. "
+            "It must be between 0 and 1 (exclusive of 1)."
+        )
     origin_folder = (
         "https://storage.googleapis.com/tensorflow/tf-keras-datasets/"
     )

--- a/keras/src/datasets/california_housing.py
+++ b/keras/src/datasets/california_housing.py
@@ -67,7 +67,11 @@ def load_data(
         typically between 25,000 and 500,000 that represent
         the home prices in dollars.
     """
-    assert 0 <= test_split < 1
+    if not (0 <= test_split < 1):
+        raise ValueError(
+            f"Invalid `test_split` argument: {test_split}. "
+            "It must be between 0 and 1 (exclusive of 1)."
+        )
     origin_folder = (
         "https://storage.googleapis.com/tensorflow/tf-keras-datasets/"
     )

--- a/keras/src/export/openvino.py
+++ b/keras/src/export/openvino.py
@@ -49,10 +49,11 @@ def export_openvino(
     model.export("model.xml", format="openvino")
     ```
     """
-    assert filepath.endswith(".xml"), (
-        "The OpenVINO export requires the filepath to end with '.xml'. "
-        f"Got: {filepath}"
-    )
+    if not filepath.endswith(".xml"):
+        raise ValueError(
+            "The OpenVINO export requires the filepath to end with '.xml'. "
+            f"Got: filepath={filepath}"
+        )
 
     import openvino as ov
     import openvino.opset15 as ov_opset

--- a/keras/src/layers/core/wrapper.py
+++ b/keras/src/layers/core/wrapper.py
@@ -16,9 +16,7 @@ class Wrapper(Layer):
     """
 
     def __init__(self, layer, **kwargs):
-        try:
-            assert isinstance(layer, Layer)
-        except Exception:
+        if not isinstance(layer, Layer):
             raise ValueError(
                 f"Layer {layer} supplied to Wrapper isn't "
                 "a supported layer type. Please "

--- a/keras/src/layers/preprocessing/feature_space.py
+++ b/keras/src/layers/preprocessing/feature_space.py
@@ -744,7 +744,11 @@ class FeatureSpace(Layer):
 
         if rebatched:
             if self.output_mode == "concat":
-                assert merged_data.shape[0] == 1
+                if merged_data.shape[0] != 1:
+                    raise ValueError(
+                        "Expected rebatched data to have batch size 1. "
+                        f"Received: shape={merged_data.shape}"
+                    )
                 if (
                     backend.backend() != "tensorflow"
                     and not backend_utils.in_tf_graph()

--- a/keras/src/legacy/backend.py
+++ b/keras/src/legacy/backend.py
@@ -1296,7 +1296,10 @@ def relu(x, alpha=0.0, max_value=None, threshold=0.0):
 @keras_export("keras._legacy.backend.repeat")
 def repeat(x, n):
     """DEPRECATED."""
-    assert ndim(x) == 2
+    if ndim(x) != 2:
+        raise ValueError(
+            f"Expected input `x` to have rank 2. Received: rank(x)={ndim(x)}"
+        )
     x = tf.expand_dims(x, 1)
     pattern = tf.stack([1, n, 1])
     return tf.tile(x, pattern)
@@ -2008,9 +2011,11 @@ def sparse_categorical_crossentropy(
 @keras_export("keras._legacy.backend.spatial_2d_padding")
 def spatial_2d_padding(x, padding=((1, 1), (1, 1)), data_format=None):
     """DEPRECATED."""
-    assert len(padding) == 2
-    assert len(padding[0]) == 2
-    assert len(padding[1]) == 2
+    if len(padding) != 2 or len(padding[0]) != 2 or len(padding[1]) != 2:
+        raise ValueError(
+            "Expected `padding` to be a tuple of 2 tuples of 2 integers. "
+            f"Received: padding={padding}"
+        )
     if data_format is None:
         data_format = backend.image_data_format()
     if data_format not in {"channels_first", "channels_last"}:
@@ -2026,10 +2031,16 @@ def spatial_2d_padding(x, padding=((1, 1), (1, 1)), data_format=None):
 @keras_export("keras._legacy.backend.spatial_3d_padding")
 def spatial_3d_padding(x, padding=((1, 1), (1, 1), (1, 1)), data_format=None):
     """DEPRECATED."""
-    assert len(padding) == 3
-    assert len(padding[0]) == 2
-    assert len(padding[1]) == 2
-    assert len(padding[2]) == 2
+    if (
+        len(padding) != 3
+        or len(padding[0]) != 2
+        or len(padding[1]) != 2
+        or len(padding[2]) != 2
+    ):
+        raise ValueError(
+            "Expected `padding` to be a tuple of 3 tuples of 2 integers. "
+            f"Received: padding={padding}"
+        )
     if data_format is None:
         data_format = backend.image_data_format()
     if data_format not in {"channels_first", "channels_last"}:
@@ -2165,7 +2176,11 @@ def tanh(x):
 @keras_export("keras._legacy.backend.temporal_padding")
 def temporal_padding(x, padding=(1, 1)):
     """DEPRECATED."""
-    assert len(padding) == 2
+    if len(padding) != 2:
+        raise ValueError(
+            "Expected `padding` to be a tuple of 2 integers. "
+            f"Received: padding={padding}"
+        )
     pattern = [[0, 0], [padding[0], padding[1]], [0, 0]]
     return tf.compat.v1.pad(x, pattern)
 

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -451,7 +451,10 @@ class Functional(Function, Model):
             node_index = tensor._keras_history[1]
             tensor_index = tensor._keras_history[2]
             node_key = make_node_key(operation, node_index)
-            assert node_key in self._nodes
+            if node_key not in self._nodes:
+                raise RuntimeError(
+                    f"Internal error: could not find node key {node_key}."
+                )
             new_node_index = node_reindexing_map[node_key]
             return [operation.name, new_node_index, tensor_index]
 
@@ -598,7 +601,10 @@ def functional_from_config(cls, config, custom_objects=None):
     trainable = functional_config["trainable"]
 
     def get_tensor(layer_name, node_index, tensor_index):
-        assert layer_name in created_layers
+        if layer_name not in created_layers:
+            raise RuntimeError(
+                f"Internal error: could not find layer {layer_name}."
+            )
         layer = created_layers[layer_name]
         if isinstance(layer, Functional):
             # Functional models start out with a built-in node.

--- a/keras/src/optimizers/muon.py
+++ b/keras/src/optimizers/muon.py
@@ -268,7 +268,11 @@ class Muon(optimizer.Optimizer):
         the exact UV^T from the SVD.
         """
         shape = ops.shape(x)
-        assert len(shape) >= 2
+        if len(shape) < 2:
+            raise ValueError(
+                "Expected gradient or momentum to have at least 2 dimensions. "
+                f"Received: shape={shape}"
+            )
 
         a, b, c = self.muon_a, self.muon_b, self.muon_c
         if shape[-2] > shape[-1]:

--- a/keras/src/trainers/compile_utils.py
+++ b/keras/src/trainers/compile_utils.py
@@ -726,7 +726,13 @@ class CompileLoss(losses_module.Loss):
                             for i, loss in enumerate(flat_loss)
                             if loss is not None
                         ]
-                        assert len(flat_y_true) == len(flat_loss_non_nones)
+                        if len(flat_y_true) != len(flat_loss_non_nones):
+                            raise ValueError(
+                                "Internal error: the number of values in "
+                                f"`y_true` ({len(flat_y_true)}) must match the "
+                                "number of non-None values in `loss` "
+                                f"({len(flat_loss_non_nones)})."
+                            )
                         y_true = [None] * len(flat_loss)
                         for y_t, (i, loss) in zip(
                             flat_y_true, flat_loss_non_nones


### PR DESCRIPTION
This is the opportunity to provide a more useful error message with the values. The main reason for this replacement is that `assert`s are removed with the `-O` option.

The eventual goal is to remove all `assert`s in the code and turn on automated verification. See https://docs.astral.sh/ruff/rules/assert/ for an explanation of why alternatives should be used instead of `assert`.