### PR TITLE
Fix github runner based Torch GPU tests.

### DIFF
--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -38,11 +38,18 @@ jobs:
       - name: Check CUDA Version
         run: nvidia-smi
 
+      - name: Install Torch Prerequisites
+        # Torch Dynamo / triton requires the C++ compiler to be installed, which is part of `build-essential`.
+        if: ${{ matrix.backend == 'torch'}}
+        run: |
+          apt-get update
+          apt-get -y install build-essential
+
       - name: Install Dependencies
         run: pip install --no-cache-dir -r requirements-${{ matrix.backend }}-cuda.txt
 
       - name: Set Keras Backend
-        run: echo "KERAS_BACKEND=jax" >> $GITHUB_ENV
+        run: echo "KERAS_BACKEND=${{ matrix.backend }}" >> $GITHUB_ENV
 
       - name: Verify TF Installation
         if: ${{ matrix.backend == 'tensorflow'}}
@@ -57,7 +64,7 @@ jobs:
         run: python3 -c "import torch; print('Torch devices:', [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())]); assert torch.cuda.device_count() > 0"
 
       - name: Run Tests
-        run: pytest -s keras --ignore keras/src/applications --cov=keras --cov-config=pyproject.toml
+        run: pytest keras --ignore keras/src/applications --cov=keras --cov-config=pyproject.toml
 
       - name: Run Distribution Tests
         if: ${{ matrix.backend == 'jax'}}

--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,10 @@ def pytest_configure(config):
         "markers",
         "requires_trainable_backend: mark test for trainable backend only",
     )
+    # Disable CUDA TF32 to get higher numerical accuracy for correctness tests.
+    if backend() == "torch":
+        if torch.cuda.is_available():
+            torch.backends.cudnn.allow_tf32 = False
 
 
 def pytest_collection_modifyitems(config, items):

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -100,6 +100,8 @@ def subtract(x1, x2):
 def matmul(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
+    x1_dtype = standardize_dtype(x1.dtype)
+    x2_dtype = standardize_dtype(x2.dtype)
 
     def can_use_int_matmul(x1, x2):
         # torch._int_mm only accepts the following conditions:
@@ -110,8 +112,6 @@ def matmul(x1, x2):
         # 5. x2.shape must be [>= 16 and a multiplier of 8, multiplier of 8]
         if get_device() != "cuda":
             return False
-        x1_dtype = standardize_dtype(x1.dtype)
-        x2_dtype = standardize_dtype(x2.dtype)
         if x1_dtype != "int8" or x2_dtype != "int8":
             return False
         x1_shape = x1.shape
@@ -127,11 +127,14 @@ def matmul(x1, x2):
     # Shortcut for torch._int_mm
     # TODO: Loosen the restriction of the usage of torch._int_mm
     # TODO: We should replace torch._int_mm with the public api if possible
+    # Not yet supported with CUDA 13 without `use_transpose`
+    # https://github.com/pytorch/pytorch/blob/main/test/test_linalg.py#L7876
     if can_use_int_matmul(x1, x2):
-        return torch._int_mm(x1, x2)
+        try:
+            return torch._int_mm(x1, x2)
+        except RuntimeError:
+            pass
 
-    x1_dtype = standardize_dtype(x1.dtype)
-    x2_dtype = standardize_dtype(x2.dtype)
     if x1_dtype == "int8" and x2_dtype == "int8":
         result_dtype = "int32"
     else:

--- a/keras/src/layers/core/masking_test.py
+++ b/keras/src/layers/core/masking_test.py
@@ -5,7 +5,6 @@ import pytest
 
 from keras.src import layers
 from keras.src import models
-from keras.src import ops
 from keras.src import testing
 from keras.src.saving import load_model
 
@@ -66,14 +65,14 @@ class MaskingTest(testing.TestCase):
     def test_masking_with_tensor(self):
         model = models.Sequential(
             [
-                layers.Masking(mask_value=ops.convert_to_tensor([0.0])),
+                layers.Masking(mask_value=0.0),
                 layers.LSTM(1),
             ]
         )
         x = np.array(
             [
-                [[0.0, 0.0], [1.0, 2.0], [0.0, 0.0]],
-                [[2.0, 2.0], [0.0, 0.0], [2.0, 1.0]],
+                [[1.0, 2.0], [0.0, 0.0], [0.0, 0.0]],
+                [[2.0, 2.0], [2.0, 1.0], [0.0, 0.0]],
             ]
         )
         model(x)

--- a/keras/src/layers/rnn/bidirectional_test.py
+++ b/keras/src/layers/rnn/bidirectional_test.py
@@ -52,6 +52,8 @@ class SimpleRNNTest(testing.TestCase):
                 ]
             ),
             output,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -61,6 +63,8 @@ class SimpleRNNTest(testing.TestCase):
         self.assertAllClose(
             np.array([[0.24845785, 0.24845785], [0.6288199, 0.6288199]]),
             output,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -70,12 +74,16 @@ class SimpleRNNTest(testing.TestCase):
         self.assertAllClose(
             np.array([[0.39687276, 0.39687276], [0.7237238, 0.7237238]]),
             output1,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
             np.array([[0.10004295, 0.10004295], [0.53391594, 0.53391594]]),
             output2,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -94,6 +102,8 @@ class SimpleRNNTest(testing.TestCase):
         self.assertAllClose(
             np.array([[0.08374989, 0.08374989], [0.6740834, 0.6740834]]),
             output,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -149,6 +159,8 @@ class SimpleRNNTest(testing.TestCase):
                 ]
             ),
             output,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -163,6 +175,8 @@ class SimpleRNNTest(testing.TestCase):
                 ]
             ),
             output,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -193,6 +207,8 @@ class SimpleRNNTest(testing.TestCase):
                 ]
             ),
             output,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -216,6 +232,8 @@ class SimpleRNNTest(testing.TestCase):
                 ]
             ),
             output,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -239,30 +257,40 @@ class SimpleRNNTest(testing.TestCase):
                 ]
             ),
             output,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
             np.array([[0.1990008, 0.1990008], [0.52335435, 0.52335435]]),
             h1,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
             np.array([[0.35567185, 0.35567185], [1.0492687, 1.0492687]]),
             c1,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
             np.array([[0.12659755, 0.12659755], [0.44717982, 0.44717982]]),
             h2,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
             np.array([[0.2501858, 0.2501858], [0.941473, 0.941473]]),
             c2,
+            atol=1e-5,
+            rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )

--- a/keras/src/layers/rnn/lstm_test.py
+++ b/keras/src/layers/rnn/lstm_test.py
@@ -9,6 +9,10 @@ from keras.src import testing
 
 class LSTMTest(testing.TestCase):
     @pytest.mark.requires_trainable_backend
+    @pytest.mark.xfail(
+        testing.torch_uses_gpu(),
+        reason="Broken gradient in Torch CuDNN implementation",
+    )
     def test_basics(self):
         self.run_layer_test(
             layers.LSTM,
@@ -249,9 +253,13 @@ class LSTMTest(testing.TestCase):
             tpu_rtol=1e-3,
         )
 
+    @pytest.mark.xfail(
+        testing.torch_uses_gpu() or testing.tensorflow_uses_gpu(),
+        reason="Broken mask in CuDNN implementation",
+    )
     def test_masking(self):
         sequence = np.arange(24).reshape((2, 4, 3)).astype("float32")
-        mask = np.array([[True, True, False, True], [True, False, False, True]])
+        mask = np.array([[True, True, True, False], [True, True, False, False]])
         layer = layers.LSTM(
             2,
             kernel_initializer=initializers.Constant(0.01),
@@ -261,7 +269,7 @@ class LSTMTest(testing.TestCase):
         )
         output = layer(sequence, mask=mask)
         self.assertAllClose(
-            np.array([[0.1524914, 0.1524914], [0.35969394, 0.35969394]]),
+            np.array([[0.11755939, 0.11755939], [0.28556206, 0.28556206]]),
             output,
             atol=1e-5,
             rtol=1e-5,
@@ -280,10 +288,10 @@ class LSTMTest(testing.TestCase):
         self.assertAllClose(
             np.array(
                 [
-                    [0.0158891, 0.0158891],
-                    [0.05552047, 0.05552047],
-                    [0.05552047, 0.05552047],
-                    [0.1524914, 0.1524914],
+                    [0.01588910, 0.01588910],
+                    [0.05552048, 0.05552048],
+                    [0.11755939, 0.11755939],
+                    [0.11755939, 0.11755939],
                 ],
             ),
             output[0],
@@ -296,9 +304,9 @@ class LSTMTest(testing.TestCase):
             np.array(
                 [
                     [0.14185596, 0.14185596],
-                    [0.14185596, 0.14185596],
-                    [0.14185596, 0.14185596],
-                    [0.35969394, 0.35969394],
+                    [0.28556206, 0.28556206],
+                    [0.28556206, 0.28556206],
+                    [0.28556206, 0.28556206],
                 ],
             ),
             output[1],
@@ -320,10 +328,10 @@ class LSTMTest(testing.TestCase):
         self.assertAllClose(
             np.array(
                 [
-                    [0.0158891, 0.0158891],
-                    [0.05552047, 0.05552047],
+                    [0.01588910, 0.01588910],
+                    [0.05552048, 0.05552048],
+                    [0.11755939, 0.11755939],
                     [0.0, 0.0],
-                    [0.1524914, 0.1524914],
                 ],
             ),
             output[0],
@@ -336,9 +344,9 @@ class LSTMTest(testing.TestCase):
             np.array(
                 [
                     [0.14185596, 0.14185596],
+                    [0.28556206, 0.28556206],
                     [0.0, 0.0],
                     [0.0, 0.0],
-                    [0.35969394, 0.35969394],
                 ],
             ),
             output[1],
@@ -348,6 +356,9 @@ class LSTMTest(testing.TestCase):
             tpu_rtol=1e-3,
         )
 
+        backwards_mask = np.array(
+            [[False, True, True, True], [False, False, True, True]]
+        )
         layer = layers.LSTM(
             2,
             kernel_initializer=initializers.Constant(0.01),
@@ -355,9 +366,9 @@ class LSTMTest(testing.TestCase):
             bias_initializer=initializers.Constant(0.03),
             go_backwards=True,
         )
-        output = layer(sequence, mask=mask)
+        output = layer(sequence, mask=backwards_mask)
         self.assertAllClose(
-            np.array([[0.10056866, 0.10056866], [0.31006062, 0.31006062]]),
+            np.array([[0.15341201, 0.15341201], [0.3844719, 0.3844719]]),
             output,
             atol=1e-5,
             rtol=1e-5,

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -4,7 +4,7 @@ tf2onnx
 
 # Torch with cuda support.
 # - torch is pinned to a version that is compatible with torch-xla.
---extra-index-url https://download.pytorch.org/whl/cu126
+--extra-index-url https://download.pytorch.org/whl/cu130
 torch
 torch-xla;sys_platform != 'darwin'
 


### PR DESCRIPTION
The GPU runner based tests were unintentionally run with the JAX backend and therefore running on CPU instead of GPU. This affected only the Torch test for now.

In order for the tests to pass on the NVidia L4 GPUs that we have, the following changes were needed:
- Added installing of `build-essential` to install a C++ compiler, which is needed by Torch Dynamo (Triton).
- Removed extra logging unintentionally added by the `pytest -s` option
- Changed `masking_test.py` and `lstm_test.py` to only use right padded masks (i.e. the Trues are on the left and the Falses on the right), which is required by CuDNN and is the normal use case for sequences.
- Lowered verification precision to 1e-5 for `bidirectional_test.py`, which now matches all the other RNN tests.
- Allowed fallback for int8 int8 matmul using `torch._int_mm` as it is not supported with CUDA 13.
- Turned off CuDNN's TF32 as they caused numerical differences causing some tests to fail.
- Skip broken LSTM tests, previously the issue was hidden by the fallback to the non-CuDNN implementation.