### PR TITLE
[OpenVINO] Implement map, switch, fori_loop, vectorized_map operators

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -883,9 +883,7 @@ def cond(pred, true_fn, false_fn):
 
 
 def vectorized_map(function, elements):
-    raise NotImplementedError(
-        "`vectorized_map` is not supported with openvino backend"
-    )
+    return map(function, elements)
 
 
 # Shape / dtype inference util
@@ -924,6 +922,14 @@ def compute_output_spec(fn, *args, **kwargs):
             convert_openvino_to_keras_tensor, outputs
         )
     return output_spec
+
+
+def map(f, xs):
+    def g(_, x):
+        return (), f(x)
+
+    _, ys = scan(g, (), xs)
+    return ys
 
 
 def scan(f, init, xs=None, length=None, reverse=False, unroll=1):
@@ -1404,6 +1410,18 @@ def slice_update(inputs, start_indices, updates):
     return OpenVINOKerasTensor(result)
 
 
+def switch(index, branches, *operands):
+    # Static dispatch: index is evaluated eagerly, not compiled into the OV graph.
+    idx = int(
+        np.clip(
+            convert_to_numpy(convert_to_tensor(index, "int32")),
+            0,
+            len(branches) - 1,
+        )
+    )
+    return branches[idx](*operands)
+
+
 def while_loop(
     cond,
     body,
@@ -1519,9 +1537,11 @@ def while_loop(
 
 
 def fori_loop(lower, upper, body_fun, init_val):
-    raise NotImplementedError(
-        "`fori_loop` is not supported with openvino backend"
-    )
+    return while_loop(
+        lambda i, val: i < upper,
+        lambda i, val: (i + 1, body_fun(i, val)),
+        (lower, init_val),
+    )[1]
 
 
 def stop_gradient(variable):

--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -1411,7 +1411,8 @@ def slice_update(inputs, start_indices, updates):
 
 
 def switch(index, branches, *operands):
-    # Static dispatch: index is evaluated eagerly, not compiled into the OV graph.
+    # Static dispatch: index is evaluated eagerly, not compiled into the
+    # OV graph.
     idx = int(
         np.clip(
             convert_to_numpy(convert_to_tensor(index, "int32")),

--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -1411,16 +1411,82 @@ def slice_update(inputs, start_indices, updates):
 
 
 def switch(index, branches, *operands):
-    # Static dispatch: index is evaluated eagerly, not compiled into the
-    # OV graph.
-    idx = int(
-        np.clip(
-            convert_to_numpy(convert_to_tensor(index, "int32")),
-            0,
-            len(branches) - 1,
-        )
-    )
-    return branches[idx](*operands)
+    if len(branches) == 1:
+        return branches[0](*operands)
+
+    n = len(branches)
+    index_ov = get_ov_output(convert_to_tensor(index, "int32"))
+    index_ov = ov_opset.clamp(index_ov, 0, n - 1).output(0)
+    operands_ov = [get_ov_output(op_val) for op_val in operands]
+
+    def _trace_branch(branch_fn):
+        params, wrapped = [], []
+        for ov_out in operands_ov:
+            p = ov_opset.parameter(
+                ov_out.get_partial_shape(), ov_out.get_element_type()
+            )
+            params.append(p)
+            wrapped.append(OpenVINOKerasTensor(p.output(0)))
+        raw = branch_fn(*wrapped)
+        if raw is None:
+            flat = []
+        elif isinstance(raw, (list, tuple)):
+            flat = [get_ov_output(o) for o in raw]
+        else:
+            flat = [get_ov_output(raw)]
+        return params, Model(flat, params), raw
+
+    def _build(branch_idx):
+        inner_outputs = None
+        then_params, then_body, then_raw = _trace_branch(branches[branch_idx])
+        if branch_idx == n - 2:
+            else_params, else_body, _ = _trace_branch(branches[branch_idx + 1])
+        else:
+            inner_outputs, _ = _build(branch_idx + 1)
+            else_params, pt_results = [], []
+            for inner_out in inner_outputs:
+                ep = ov_opset.parameter(
+                    inner_out.get_partial_shape(),
+                    inner_out.get_element_type(),
+                )
+                else_params.append(ep)
+                pt_results.append(ep.output(0))
+            else_body = Model(pt_results, else_params)
+
+        cond = ov_opset.equal(
+            index_ov,
+            ov_opset.constant(branch_idx, Type.i32).output(0),
+        ).output(0)
+        if_node = ov_opset.if_op(cond)
+        if_node.set_then_body(then_body)
+        if_node.set_else_body(else_body)
+
+        if inner_outputs is None:
+            for ov_inp, tp, ep in zip(operands_ov, then_params, else_params):
+                if_node.set_input(ov_inp, tp, ep)
+        else:
+            for ov_inp, tp in zip(operands_ov, then_params):
+                if_node.set_input(ov_inp, tp, None)
+            for inner_out, ep in zip(inner_outputs, else_params):
+                if_node.set_input(inner_out, None, ep)
+
+        outputs = [
+            if_node.set_output(then_body.results[i], else_body.results[i])
+            for i in range(len(then_body.results))
+        ]
+        return outputs, then_raw
+
+    final_outputs, template_raw = _build(0)
+    wrapped = [OpenVINOKerasTensor(o) for o in final_outputs]
+
+    if template_raw is None:
+        return None
+    elif isinstance(template_raw, tuple):
+        return tuple(wrapped)
+    elif isinstance(template_raw, list):
+        return list(wrapped)
+    else:
+        return wrapped[0]
 
 
 def while_loop(

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -45,16 +45,8 @@ ComputeScaleZeroTest::test_quantize_with_sz_map_logic
 ConvLSTM1DTest::test_correctness
 ConvLSTM2DTest::test_correctness
 ConvLSTMTest::test_correctness
-CoreOpsBehaviorTests::test_vectorized_map_serialization
-CoreOpsCallsTests::test_fori_loop_basic_functionality
-CoreOpsCallsTests::test_map_basic_call
-CoreOpsCallsTests::test_switch_basic_call
 CoreOpsCallsTests::test_unstack_basic_functionality
-CoreOpsCorrectnessTest::test_fori_loop
-CoreOpsCorrectnessTest::test_map
-CoreOpsCorrectnessTest::test_switch
 CoreOpsCorrectnessTest::test_unstack
-CoreOpsCorrectnessTest::test_vectorized_map
 CTCTest::test_correctness
 CTCTest::test_dtype_arg
 DenseTest::test_dense_quantize_config_int4


### PR DESCRIPTION
This PR implements four missing control-flow operators in the OpenVINO backend:

- `map` 
- `switch` 
- `fori_loop` 
- `vectorized_map` 

Enabled 8 previously excluded tests.

After #22422 and this PR are merged, OpenVINO backend will have level parity for `core.py`.

Closes: openvinotoolkit/openvino/issues/34700