### PR TITLE
Use jax2onnx for direct JAX-to-ONNX export

### DIFF
--- a/keras/src/export/onnx.py
+++ b/keras/src/export/onnx.py
@@ -91,7 +91,7 @@ def export_onnx(
         for i, spec in enumerate(specs_for_names)
     ]
 
-    if backend.backend() in ("tensorflow", "jax"):
+    if backend.backend() == "tensorflow":
         from keras.src.utils.module_utils import tf2onnx
 
         input_signature = tree.map_structure(
@@ -107,6 +107,9 @@ def export_onnx(
             opset=opset_version,
             output_path=filepath,
         )
+
+    elif backend.backend() == "jax":
+        _export_onnx_jax(model, filepath, input_signature, opset_version)
 
     elif backend.backend() == "torch":
         import torch
@@ -257,38 +260,62 @@ def export_onnx(
         io_utils.print_msg(f"Saved artifact at '{filepath}'.")
 
 
-def _check_jax_kwargs(kwargs):
-    kwargs = kwargs.copy()
-    if "is_static" not in kwargs:
-        kwargs["is_static"] = True
-    if "jax2tf_kwargs" not in kwargs:
-        # TODO: These options will be deprecated in JAX. We need to
-        # find another way to export ONNX.
-        kwargs["jax2tf_kwargs"] = {
-            "enable_xla": False,
-            "native_serialization": False,
-        }
-    if kwargs["is_static"] is not True:
-        raise ValueError(
-            "`is_static` must be `True` in `kwargs` when using the jax backend."
+def _export_onnx_jax(model, filepath, input_signature, opset_version):
+    """Export a JAX-backend Keras model to ONNX using jax2onnx.
+
+    Converts the model directly from JAX to ONNX without going through
+    TensorFlow, avoiding the deprecated jax2tf options (``enable_xla``
+    and ``native_serialization``).
+    """
+    import jax
+    import numpy as np
+
+    from keras.src.utils.module_utils import jax2onnx
+
+    # Flatten specs from the (possibly nested) input_signature.
+    flat_specs = tree.flatten(input_signature)
+
+    # Build input names from the flat specs.
+    flat_input_names = [
+        getattr(spec, "name", None) or f"input_{i}"
+        for i, spec in enumerate(flat_specs)
+    ]
+
+    # Convert Keras InputSpecs to jax2onnx-compatible input descriptors
+    # with string names for dynamic (None) dimensions.
+    jax_inputs = []
+    for i, spec in enumerate(flat_specs):
+        shape = []
+        for dim_idx, dim in enumerate(spec.shape):
+            if dim is None:
+                shape.append("batch" if dim_idx == 0 else f"dim_{i}_{dim_idx}")
+            else:
+                shape.append(dim)
+        jax_inputs.append(
+            jax.ShapeDtypeStruct(tuple(shape), np.dtype(spec.dtype))
         )
-    if kwargs["jax2tf_kwargs"]["enable_xla"] is not False:
-        raise ValueError(
-            "`enable_xla` must be `False` in `kwargs['jax2tf_kwargs']` "
-            "when using the jax backend."
-        )
-    if kwargs["jax2tf_kwargs"]["native_serialization"] is not False:
-        raise ValueError(
-            "`native_serialization` must be `False` in "
-            "`kwargs['jax2tf_kwargs']` when using the jax backend."
-        )
-    return kwargs
+
+    # Wrapper that restructures flat positional args back into whatever
+    # nested form the model expects (single tensor, list, tuple, dict).
+    def predict_fn(*flat_args):
+        args = tree.pack_sequence_as(input_signature, flat_args)
+        if len(args) == 1:
+            return model(args[0], training=False)
+        return model(*args, training=False)
+
+    export_kwargs = {
+        "input_names": flat_input_names,
+        "return_mode": "file",
+        "output_path": str(filepath),
+    }
+    if opset_version is not None:
+        export_kwargs["opset"] = opset_version
+
+    jax2onnx.to_onnx(predict_fn, inputs=jax_inputs, **export_kwargs)
 
 
 def get_concrete_fn(model, input_signature, **kwargs):
     """Get the `tf.function` associated with the model."""
-    if backend.backend() == "jax":
-        kwargs = _check_jax_kwargs(kwargs)
     export_archive = ExportArchive()
     export_archive.track_and_add_endpoint(
         DEFAULT_ENDPOINT_NAME, model, input_signature, **kwargs

--- a/keras/src/export/onnx_test.py
+++ b/keras/src/export/onnx_test.py
@@ -79,8 +79,8 @@ def get_model(type="sequential", input_shape=(10,), layer_list=None):
 )
 @pytest.mark.skipif(testing.uses_gpu(), reason="Fails on GPU")
 @pytest.mark.skipif(
-    np.version.version.startswith("2."),
-    reason="ONNX export is currently incompatible with NumPy 2.0",
+    np.version.version.startswith("2.") and backend.backend() != "jax",
+    reason="ONNX export via tf2onnx is incompatible with NumPy 2.0",
 )
 class ExportONNXTest(testing.TestCase):
     @parameterized.named_parameters(
@@ -89,6 +89,11 @@ class ExportONNXTest(testing.TestCase):
         )
     )
     def test_standard_model_export(self, model_type):
+        if model_type == "lstm" and backend.backend() == "jax":
+            self.skipTest(
+                "Bidirectional LSTM uses reverse scan, which jax2onnx "
+                "does not support yet."
+            )
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
         model = get_model(model_type)
         batch_size = 3 if backend.backend() != "torch" else 1

--- a/keras/src/utils/module_utils.py
+++ b/keras/src/utils/module_utils.py
@@ -78,6 +78,7 @@ torch_xla = LazyModule(
 optree = LazyModule("optree")
 dmtree = LazyModule("tree")
 tf2onnx = LazyModule("tf2onnx")
+jax2onnx = LazyModule("jax2onnx")
 grain = LazyModule("grain")
 litert = LazyModule("ai_edge_litert")
 ocp = OrbaxLazyModule(

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ torch-xla;sys_platform != 'darwin'
 # Note that we test against the latest JAX on GPU.
 jax[cpu]
 flax
+jax2onnx
 
 # Common deps.
 -r requirements-common.txt


### PR DESCRIPTION
## Summary

- JAX ONNX export is broken on JAX >= 0.4.36 because the old pipeline required `enable_xla=False` and `native_serialization=False` in `jax2tf`, both of which were removed from JAX
- Replace the `jax2tf` + `tf2onnx` pipeline with [`jax2onnx`](https://github.com/enpasos/jax2onnx) for direct JAX-to-ONNX conversion -- no TensorFlow intermediary needed
- Also unblocks NumPy 2.0 compatibility for JAX-backend ONNX export (the `tf2onnx` path was incompatible)
- Bidirectional LSTMs (reverse scan) are not yet supported by `jax2onnx` and are skipped in tests until upstream adds support