### PR TITLE
fix: handle dict output shapes in model.summary()

### DIFF
--- a/keras/src/utils/summary_utils.py
+++ b/keras/src/utils/summary_utils.py
@@ -111,8 +111,9 @@ def format_layer_shape(layer):
                 )
         except NotImplementedError:
             return "?"
-    if len(output_shapes) == 1:
-        return output_shapes[0]
+    flat_shapes = tree.flatten(output_shapes)
+    if len(flat_shapes) == 1:
+        return flat_shapes[0]
     out = str(output_shapes)
     out = out.replace("'", "")
     return out


### PR DESCRIPTION
## Summary
Fixes #22445.
**Root cause:** `format_layer_shape` in `summary_utils.py` used `output_shapes[0]` to extract a single output shape, which raises `KeyError: 0` when `output_shapes` is a dict (e.g. from layers returning `{'head1': tensor}`). Dicts use string keys, not integer indices.
**Fix:** Use `tree.flatten(output_shapes)` to extract shapes from any structure (list, tuple, or dict) before indexing.
## Changes
- `keras/src/utils/summary_utils.py`: Changed `output_shapes[0]` to `tree.flatten(output_shapes)[0]` in `format_layer_shape`
## Testing
- Verified fix addresses reported scenario (model.summary() with dict-returning nested layers)
- Change is minimal and follows existing code patterns
- `tree` is already imported in the file

Made with [Cursor](https://cursor.com)