### PR TITLE
test: regression tests for Conv kernel_size > input dims (#22414, #22416)

### DIFF
--- a/keras/src/layers/convolutional/conv_test.py
+++ b/keras/src/layers/convolutional/conv_test.py
@@ -825,6 +825,28 @@ class ConvBasicTest(testing.TestCase):
         with self.assertRaises(ValueError):
             layer(inputs)
 
+    @parameterized.parameters(
+        # kernel_size > input spatial dim (issues #22414 and #22416)
+        (layers.Conv1D, (10, 128), 11),
+        (layers.Conv2D, (10, 10, 128), (11, 11)),
+        (layers.Conv3D, (10, 10, 10, 128), (11, 11, 11)),
+        # kernel_size > input in only one spatial dim
+        (layers.Conv2D, (10, 20, 128), (11, 5)),
+        (layers.Conv3D, (10, 20, 30, 128), (5, 21, 5)),
+    )
+    def test_conv_symbolic_kernel_exceeds_input(
+        self, layer_cls, input_shape, kernel_size
+    ):
+        """Raise ValueError when kernel_size > input spatial dims."""
+        inputs = layers.Input(shape=input_shape)
+        layer = layer_cls(
+            filters=1,
+            kernel_size=kernel_size,
+        )
+
+        with self.assertRaises(ValueError):
+            layer(inputs)
+
 
 class ConvCorrectnessTest(testing.TestCase):
     @parameterized.parameters(

--- a/keras/src/ops/operation_utils_test.py
+++ b/keras/src/ops/operation_utils_test.py
@@ -152,6 +152,35 @@ class OperationUtilsTest(testing.TestCase):
         )
         self.assertEqual(output_shape, (1, 4, 4, 3))
 
+    def test_compute_conv_output_shape_kernel_exceeds_input(self):
+        # kernel_size > input spatial dims should raise (issues #22414, #22416)
+        with self.assertRaises(ValueError):
+            operation_utils.compute_conv_output_shape(
+                (1, 10, 10, 128),
+                filters=1,
+                kernel_size=(11, 11),
+                strides=(1, 1),
+                padding="valid",
+            )
+        # Also for 1D
+        with self.assertRaises(ValueError):
+            operation_utils.compute_conv_output_shape(
+                (1, 10, 128),
+                filters=1,
+                kernel_size=(11,),
+                strides=(1,),
+                padding="valid",
+            )
+        # Same padding should NOT raise (output is valid)
+        output_shape = operation_utils.compute_conv_output_shape(
+            (1, 10, 10, 128),
+            filters=1,
+            kernel_size=(11, 11),
+            strides=(1, 1),
+            padding="same",
+        )
+        self.assertEqual(output_shape, (1, 10, 10, 1))
+
     def test_compute_reshape_output_shape(self):
         input_shape = (1, 4, 4, 1)
         target_shape = (16, 1)


### PR DESCRIPTION
## Summary
- Add regression tests for Conv1D, Conv2D, and Conv3D to verify that `ValueError` is raised during symbolic shape inference when `kernel_size` exceeds the input spatial dimensions with `padding="valid"`
- This covers the exact scenario from #22416 (Conv2D) and #22414 (Conv1D), where symbolic execution silently returned shapes like `(None, 0, 0, 1)` instead of raising an error
- The underlying fix was already applied in #22092 (changed `< 0` to `<= 0` in `compute_conv_output_shape`), but the test cases from that PR only covered dilation-induced invalid outputs, not the kernel_size > input case
- Also adds a direct unit test for `compute_conv_output_shape` including a negative test confirming `padding="same"` still works

Fixes #22416
Fixes #22414

## Test plan
- [ ] `test_conv_symbolic_kernel_exceeds_input` verifies Conv1D/Conv2D/Conv3D raise ValueError when kernel_size > input spatial dims
- [ ] `test_compute_conv_output_shape_kernel_exceeds_input` verifies the utility function directly
- [ ] Existing tests remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)