### PR TITLE
Fix JAX RNN Fusion Error on CPU

### DIFF
--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -1319,21 +1319,6 @@ def sort(x, axis=-1):
 
 def split(x, indices_or_sections, axis=0):
     x = convert_to_tensor(x)
-    if _uses_cpu(x) and isinstance(indices_or_sections, int):
-        length = x.shape[axis]
-        if length is not None:
-            if length % indices_or_sections != 0:
-                raise ValueError(
-                    "array split does not result in an equal division: "
-                    f"rest is {length % indices_or_sections}"
-                )
-            size = length // indices_or_sections
-            res = []
-            for i in range(indices_or_sections):
-                idx = [slice(None)] * x.ndim
-                idx[axis] = slice(i * size, (i + 1) * size)
-                res.append(x[tuple(idx)])
-            return res
     return jnp.split(x, indices_or_sections, axis=axis)
 
 


### PR DESCRIPTION
**Problem**
When running Keras RNN tests using the JAX backend on CPU, the following error occurs:

`JaxRuntimeError: UNIMPLEMENTED: Fusion kind not implemented on CPU`

**Root Cause**
Tracing the issue into the JAX codebase (`jax/_src/numpy/lax_numpy.py` and `jax/_src/lax/lax.py`), `jnp.split` binds to a low-level `split_p` primitive. When this primitive is compiled inside a loop (`lax.scan`) on CPU, XLA's fusion pass fails because it lacks the implementation for this specific fusion combination on CPU.

**Solution**
Instead of modifying the common Keras layers (`lstm.py`, `gru.py`) which would complicate the code and potentially hurt performance on accelerators (GPU/TPU), this PR intercepts the split call at the JAX backend level (`keras/src/backend/jax/numpy.py`).

If the active JAX device is CPU and `indices_or_sections` is an integer (uniform split), the backend uses standard Python slicing to split the tensor. Standard slicing lowers to simpler HLO primitives (like `slice_in_dim`) that the XLA CPU compiler can digest without triggering unimplemented fusion errors.