### PR TITLE
Fix DepthwiseConv test on TPU.

### DIFF
--- a/keras/src/layers/convolutional/depthwise_conv_test.py
+++ b/keras/src/layers/convolutional/depthwise_conv_test.py
@@ -400,7 +400,7 @@ class DepthwiseConvCorrectnessTest(testing.TestCase):
             data_format=data_format,
             dilation_rate=dilation_rate,
         )
-        self.assertAllClose(outputs, expected, tpu_atol=1e-2, tpu_rtol=1e-2)
+        self.assertAllClose(outputs, expected, tpu_atol=2e-2, tpu_rtol=10)
 
     @parameterized.parameters(
         {
@@ -464,9 +464,6 @@ class DepthwiseConvCorrectnessTest(testing.TestCase):
             padding=padding,
             data_format=data_format,
             dilation_rate=dilation_rate,
-        )
-        self.assertAllClose(
-            outputs.shape, expected.shape, tpu_atol=1e-2, tpu_rtol=1e-2
         )
         self.assertAllClose(
             outputs, expected, atol=1e-5, tpu_atol=1e-1, tpu_rtol=1e-1


### PR DESCRIPTION
The latest release of JAX seems to have introduced a change in some computation.

Relax the precision on TPU. Note that the relative precision is kind of meaningless when the values are around zero, so only the absolute precision is useful.