### PR TITLE
Pass the `shape` when creating a `tf.Variable`.

### DIFF
--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -41,6 +41,7 @@ class Variable(
         else:
             self._value = tf.Variable(
                 value,
+                shape=self._shape,
                 dtype=self._dtype,
                 trainable=self.trainable,
                 name=self.name,


### PR DESCRIPTION
The `value` passed can be an initializer and the calling of the initializer may be delayed. Passing the shape immediately when creating the `Variable` helps in some scenarios, for instance when `UninitializedVariable` instances are used.

Note that this also works when `self._shape` is `None`.