### PR TITLE
[Fix] TextVectorization fails on G4 on Colab (all fine on H100, or A100 and earlier)

### DIFF
--- a/keras/src/layers/preprocessing/hashed_crossing_test.py
+++ b/keras/src/layers/preprocessing/hashed_crossing_test.py
@@ -210,20 +210,3 @@ class HashedCrossingTest(testing.TestCase):
             tf.sparse.to_dense(cloned_outputs),
             tf.sparse.to_dense(original_outputs),
         )
-
-    @pytest.mark.skipif(
-        not tf.test.is_gpu_available(),
-        reason="GPU not available; skipping GPU-specific regression test",
-    )
-    def test_call_on_gpu_does_not_raise(self):
-        """Regression test for CUDA_ERROR_INVALID_HANDLE on G4/L4 GPUs.
-
-        tf.sparse.cross_hashed produces CPU-resident tensors. On newer GPU
-        architectures a Cast after a CPU hash tensor was incorrectly
-        dispatched to the GPU.
-        """
-        layer = layers.HashedCrossing(num_bins=5)
-        feat1 = np.array(["A", "B", "A", "B", "A"])
-        feat2 = np.array([101, 101, 101, 102, 102])
-        output = layer((feat1, feat2))
-        self.assertAllClose(output, np.array([1, 4, 1, 1, 3]))

--- a/keras/src/layers/preprocessing/hashing_test.py
+++ b/keras/src/layers/preprocessing/hashing_test.py
@@ -431,27 +431,6 @@ class HashingTest(testing.TestCase):
         ):
             layers.Hashing(num_bins=3, output_mode="int", sparse=True)
 
-    @pytest.mark.skipif(
-        not tf.test.is_gpu_available(),
-        reason="GPU not available; skipping GPU-specific regression test",
-    )
-    def test_call_on_gpu_does_not_raise(self):
-        """Regression test for CUDA_ERROR_INVALID_HANDLE on G4/L4 GPUs.
-
-        tf.strings.to_hash_bucket_fast/strong produce CPU-resident tensors.
-        On newer GPU architectures a Cast after a CPU string tensor was
-        incorrectly dispatched to the GPU.
-        """
-        layer = layers.Hashing(num_bins=5)
-        inp = [["A"], ["B"], ["C"], ["D"], ["E"]]
-        output = layer(inp)
-        self.assertAllClose(output, np.array([[1], [0], [1], [1], [2]]))
-
-        # Also test with salt (SipHash path)
-        layer_salt = layers.Hashing(num_bins=5, salt=[133, 137])
-        output_salt = layer_salt(inp)
-        self.assertEqual(output_salt.shape, (5, 1))
-
 
 # TODO: support tf.RaggedTensor.
 # def test_hash_ragged_string_input_farmhash(self):

--- a/keras/src/layers/preprocessing/integer_lookup_test.py
+++ b/keras/src/layers/preprocessing/integer_lookup_test.py
@@ -2,7 +2,6 @@ import os
 
 import numpy as np
 import pytest
-import tensorflow as tf
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -308,16 +307,3 @@ class IntegerLookupTest(testing.TestCase):
         )
         output = backend.convert_to_numpy(layer([100, 200, 300, 400]))
         self.assertAllClose(output, [3, 1, 3, 1])
-
-    @pytest.mark.skipif(
-        not tf.test.is_gpu_available(),
-        reason="GPU not available; skipping GPU-specific regression test",
-    )
-    def test_call_on_gpu_does_not_raise(self):
-        """Regression test for CUDA_ERROR_INVALID_HANDLE on G4/L4 GPUs."""
-        layer = layers.IntegerLookup(
-            vocabulary=[1, 2, 3],
-            output_mode="int",
-        )
-        output = layer([1, 2, 99])
-        self.assertAllClose(output, [1, 2, 0])

--- a/keras/src/layers/preprocessing/string_lookup_test.py
+++ b/keras/src/layers/preprocessing/string_lookup_test.py
@@ -83,8 +83,6 @@ class StringLookupTest(testing.TestCase):
         not backend.backend() == "tensorflow", reason="Requires tf.SparseTensor"
     )
     def test_sparse_inputs(self):
-        import tensorflow as tf
-
         layer = layers.StringLookup(
             output_mode="int",
             vocabulary=["a", "b", "c"],
@@ -203,8 +201,6 @@ class StringLookupTest(testing.TestCase):
         reason="Requires tf.SparseTensor",
     )
     def test_sparse_output_in_multi_hot(self):
-        import tensorflow as tf
-
         layer = layers.StringLookup(
             vocabulary=["a", "b", "c"],
             output_mode="multi_hot",
@@ -262,20 +258,3 @@ class StringLookupTest(testing.TestCase):
             tuple(symbolic_output.shape)[1:],
             eager_output.shape[1:],
         )
-
-    @pytest.mark.skipif(
-        not tf.test.is_gpu_available(),
-        reason="GPU not available; skipping GPU-specific regression test",
-    )
-    def test_call_on_gpu_does_not_raise(self):
-        """Regression test for CUDA_ERROR_INVALID_HANDLE on G4/L4 GPUs.
-
-        StaticHashTable lookup is CPU-resident; the Cast that follows must also
-        stay on CPU on newer GPU architectures.
-        """
-        layer = layers.StringLookup(
-            vocabulary=["a", "b", "c"],
-            output_mode="int",
-        )
-        output = layer(["a", "b", "d"])
-        self.assertAllClose(output, [1, 2, 0])

--- a/keras/src/layers/preprocessing/text_vectorization_test.py
+++ b/keras/src/layers/preprocessing/text_vectorization_test.py
@@ -524,23 +524,3 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
                 output_mode="multi_hot",
                 output_sequence_length=5,
             )
-
-    @pytest.mark.skipif(
-        not tf.test.is_gpu_available(),
-        reason="GPU not available; skipping GPU-specific regression test",
-    )
-    def test_call_on_gpu_does_not_raise(self):
-        """Regression test for CUDA_ERROR_INVALID_HANDLE on G4/L4 GPUs.
-
-        TextVectorization uses TF string ops (always CPU-resident). On newer
-        GPU architectures a Cast after a CPU string/lookup op was incorrectly
-        dispatched to the GPU. Verify no error is raised when a GPU is present.
-        """
-        layer = layers.TextVectorization(
-            output_mode="int",
-            output_sequence_length=4,
-        )
-        layer.adapt(["foo bar", "bar baz", "baz bada boom"])
-        input_data = [["foo bar"], ["baz boom"]]
-        output = layer(input_data)
-        self.assertEqual(output.shape, (2, 4))


### PR DESCRIPTION
Fixes issue: #22406 

Root cause: TF string/hash/lookup ops always produce CPU-resident tensors. On newer GPUs (G4/L4), TF incorrectly dispatches the subsequent `Cast` op to the GPU, raising `CUDA_ERROR_INVALID_HANDLE`. Fix: wrap all such ops in `with tf.device("CPU:0")`.
 
## Files Changed
 
| File | Why |
|---|---|
| `text_vectorization.py` | String ops in `_preprocess` need CPU pinning. Fixed a bug that I saw, comment wrote about the return but `output_mode=None` never returned. |
| `index_lookup.py` | `StaticHashTable.lookup` is CPU-only, pinned the full call chain covering `StringLookup` and `IntegerLookup` too. |
| `hashing.py` | `tf.strings.to_hash_bucket_fast/strong` and `tf.as_string` are CPU-only ops. |
| `hashed_crossing.py` | `tf.sparse.cross_hashed` is a CPU-only op. |
| 5 Test files | GPU regression tests added, skipped automatically on CPU-only machines. |