### PR TITLE
docs: clarify safe_mode limitations in deserialize_keras_object

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -20,7 +20,7 @@ PLAIN_TYPES = (str, int, float, bool)
 
 # List of Keras modules with built-in string representations for Keras defaults
 BUILTIN_MODULES = frozenset(
-    {
+
         "activations",
         "constraints",
         "initializers",
@@ -501,10 +501,23 @@ def deserialize_keras_object(
         config: Python dict describing the object.
         custom_objects: Python dict containing a mapping between custom
             object names the corresponding classes or functions.
-        safe_mode: Boolean, whether to disallow unsafe `lambda` deserialization.
-            When `safe_mode=False`, loading an object has the potential to
-            trigger arbitrary code execution. This argument is only
-            applicable to the Keras v3 model format. Defaults to `True`.
+        safe_mode: Boolean, defaults to `False`. If `True`, disables
+            unsafe lambda deserialization. Note that this does not isolate
+            built-in class name resolution from the custom object registry.
+            If a custom object has been registered under the same name as a
+            built-in class (e.g., `"Dense"`) via
+            `keras.utils.get_custom_objects()`, `safe_mode=True` will still
+            resolve to the custom object instead of the built-in class.
+            `safe_mode` only protects against Lambda layer deserialization
+            and does not provide broader registry isolation.
+
+            .. warning::
+                ``safe_mode=True`` only protects against Lambda layer
+                deserialization. It does not isolate built-in class name
+                resolution from ``keras.utils.get_custom_objects()`` or
+                ``keras.utils.CustomObjectScope()``. Built-in class names
+                can still be silently redirected if the custom object
+                registry has been modified.
 
     Returns:
         The object described by the `config` dictionary.


### PR DESCRIPTION
Fixes #22466

## Problem
The `safe_mode` parameter documentation in `deserialize_keras_object` 
only stated it protects against unsafe Lambda deserialization. 
This was misleading as users might assume broader safety guarantees.

## Changes
Updated the `safe_mode` docstring in `keras/src/saving/serialization_lib.py` to clarify:
- It only protects against Lambda layer deserialization
- It does NOT isolate built-in class names from 
  `keras.utils.get_custom_objects()` or `keras.utils.CustomObjectScope()` overrides
- Added `.. warning::` block for visibility in Sphinx docs