### PR TITLE
Mark multi-device tests and run them separately on CPU.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,15 +21,22 @@ jobs:
         python-version: ['3.11']
         backend: [tensorflow, jax, torch, numpy, openvino]
         nnx_enabled: [false]
+        multi_device: [false]
         include:
           - python-version: '3.11'
             backend: jax
             nnx_enabled: true
-    name: ${{ matrix.backend == 'jax' && format('Run tests ({0}, {1}, nnx_enabled = {2})', matrix.python-version, matrix.backend, matrix.nnx_enabled) || format('Run tests ({0}, {1})', matrix.python-version, matrix.backend) }}
+            multi_device: false
+          - python-version: '3.11'
+            backend: jax
+            nnx_enabled: false
+            multi_device: true
+    name: ${{ format('Run tests ({0}, {1}{2})', matrix.python-version, matrix.backend, matrix.nnx_enabled && ', NNX' || matrix.multi_device && ', multi-CPU' || '') }}
     runs-on: ubuntu-latest
     env:
       PYTHON: ${{ matrix.python-version }}
       KERAS_HOME: .github/workflows/config/${{ matrix.backend }}
+      JAX_NUM_CPU_DEVICES: ${{ matrix.multi_device && 4 || 1 }}
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Check for changes in keras/src/applications
@@ -107,11 +114,13 @@ jobs:
         run: |
           if [ "${{ matrix.backend }}" == "openvino" ]; then
             IGNORE_FILE="keras/src/backend/openvino/excluded_tests.txt"
-            IGNORE_ARGS=$(awk '{print "--ignore=" $0}' "$IGNORE_FILE")
+            PYTEST_ARGS=$(awk '{print "--ignore=" $0}' "$IGNORE_FILE")
+          elif [ "${{ matrix.multi_device }}" == "true" ]; then
+            PYTEST_ARGS="-m multi_device"
           else
-            IGNORE_ARGS=""
+            PYTEST_ARGS=""
           fi
-          pytest keras --ignore keras/src/applications --cov=keras --cov-config=pyproject.toml $IGNORE_ARGS
+          pytest keras --ignore keras/src/applications --cov=keras --cov-config=pyproject.toml $PYTEST_ARGS
           coverage xml --omit='keras/src/applications/*,keras/api' -o core-coverage.xml
       - name: Codecov keras
         if: ${{ matrix.nnx_enabled == false }}

--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,11 @@ def pytest_configure(config):
         "markers",
         "requires_trainable_backend: mark test for trainable backend only",
     )
+    config.addinivalue_line(
+        "markers",
+        "multi_device: mark test for running with multiple devices only",
+    )
+
     # Disable CUDA TF32 to get higher numerical accuracy for correctness tests.
     if backend() == "torch":
         if torch.cuda.is_available():
@@ -28,6 +33,8 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
+    has_multiple_devices = False
+
     openvino_skipped_tests = []
     if backend() == "openvino":
         with open(
@@ -44,6 +51,8 @@ def pytest_collection_modifyitems(config, items):
     if backend() == "jax":
         import jax
 
+        has_multiple_devices = jax.device_count() > 1
+
         if jax.default_backend() == "tpu":
             with open(
                 "keras/src/backend/jax/excluded_tpu_tests.txt", "r"
@@ -59,9 +68,18 @@ def pytest_collection_modifyitems(config, items):
         backend() in ["numpy", "openvino"],
         reason="Trainer not implemented for NumPy and OpenVINO backend.",
     )
+    requires_multiple_devices = (
+        None
+        if has_multiple_devices
+        else pytest.mark.skip(reason="Requires multiple devices")
+    )
+
     for item in items:
         if "requires_trainable_backend" in item.keywords:
             item.add_marker(requires_trainable_backend)
+        if requires_multiple_devices and "multi_device" in item.keywords:
+            item.add_marker(requires_multiple_devices)
+
         # also, skip concrete tests for openvino, listed in the special file
         # this is more granular mechanism to exclude tests rather
         # than using --ignore option

--- a/keras/src/backend/jax/distribution_lib_test.py
+++ b/keras/src/backend/jax/distribution_lib_test.py
@@ -1,7 +1,6 @@
 """Test for distribution_lib.py."""
 
 import functools
-import os
 from unittest import mock
 
 import jax
@@ -9,30 +8,25 @@ import numpy as np
 import pytest
 from jax.experimental import layout as jax_layout
 
-from keras.src import backend
 from keras.src import layers
 from keras.src import models
 from keras.src import testing
 from keras.src.backend import distribution_lib as backend_dlib
 from keras.src.distribution import distribution_lib
 
-if backend.backend() == "jax":
-    # Due to https://github.com/google/jax/issues/17188, we can't
-    # override the XLA flag after the JAX back init. We have to
-    # run this at top level to let JAX pick the flag value.
-    xla_flags = os.getenv("XLA_FLAGS") or ""
-    # Don't override user-specified device count, or other XLA flags.
-    if "xla_force_host_platform_device_count" not in xla_flags:
-        os.environ["XLA_FLAGS"] = (
-            f"{xla_flags} --xla_force_host_platform_device_count=8"
-        )
 
-
-@pytest.mark.skipif(
-    backend.backend() != "jax" or len(jax.devices()) != 8,
-    reason="Backend specific test and requires 8 devices",
-)
+@pytest.mark.multi_device
 class JaxDistributionLibTest(testing.TestCase):
+    def setUp(self):
+        self.device_count = jax.device_count()
+        self.assertGreaterEqual(
+            self.device_count, 4, "Number of devices must be at least 4"
+        )
+        self.assertEqual(
+            self.device_count % 2, 0, "Number of devices must be even"
+        )
+        self.mesh_shape = (self.device_count // 2, 2)
+
     def _create_jax_layout(self, sharding):
         # Use jax_layout.Format or jax_layout.Layout if available.
         if hasattr(jax_layout, "Format"):
@@ -43,13 +37,18 @@ class JaxDistributionLibTest(testing.TestCase):
         return sharding
 
     def test_get_device_count(self):
-        self.assertEqual(backend_dlib.get_device_count(), 8)
-        self.assertEqual(backend_dlib.get_device_count("cpu"), 8)
+        self.assertEqual(backend_dlib.get_device_count(), self.device_count)
+        self.assertEqual(
+            backend_dlib.get_device_count("cpu"), self.device_count
+        )
 
     def test_list_devices(self):
-        self.assertEqual(len(distribution_lib.list_devices()), 8)
-        self.assertEqual(len(distribution_lib.list_devices("cpu")), 8)
-        self.assertEqual(len(distribution_lib.list_devices("cpu")), 8)
+        self.assertEqual(
+            len(distribution_lib.list_devices()), self.device_count
+        )
+        self.assertEqual(
+            len(distribution_lib.list_devices("cpu")), self.device_count
+        )
 
     def test_device_conversion(self):
         devices = distribution_lib.list_devices("cpu")
@@ -82,10 +81,12 @@ class JaxDistributionLibTest(testing.TestCase):
 
     def test_distribute_tensor(self):
         jax_mesh = jax.sharding.Mesh(
-            np.array(jax.devices()).reshape(2, 4), ("batch", "model")
+            np.array(jax.devices()).reshape(self.mesh_shape), ("batch", "model")
         )
 
-        inputs = jax.numpy.array(np.random.normal(size=(16, 8)))
+        inputs = jax.numpy.array(
+            np.random.normal(size=(self.mesh_shape[0] * 4, 8))
+        )
         target_layout = jax.sharding.NamedSharding(
             jax_mesh, jax.sharding.PartitionSpec("batch", None)
         )
@@ -106,10 +107,12 @@ class JaxDistributionLibTest(testing.TestCase):
 
     def test_distribute_tensor_with_jax_layout(self):
         jax_mesh = jax.sharding.Mesh(
-            np.array(jax.devices()).reshape(2, 4), ("batch", "model")
+            np.array(jax.devices()).reshape(self.mesh_shape), ("batch", "model")
         )
 
-        inputs = jax.numpy.array(np.random.normal(size=(16, 8)))
+        inputs = jax.numpy.array(
+            np.random.normal(size=(self.mesh_shape[0] * 4, 8))
+        )
         target_layout = self._create_jax_layout(
             sharding=jax.sharding.NamedSharding(
                 jax_mesh, jax.sharding.PartitionSpec("batch", None)
@@ -139,22 +142,18 @@ class JaxDistributionLibTest(testing.TestCase):
         self.assertEqual(backend_dlib.num_processes(), 1)
 
     def test_to_backend_mesh(self):
-        devices = [f"cpu:{i}" for i in range(8)]
-        shape = (4, 2)
         axis_names = ["batch", "model"]
 
-        mesh = distribution_lib.DeviceMesh(shape, axis_names, devices)
+        mesh = distribution_lib.DeviceMesh(self.mesh_shape, axis_names)
         jax_mesh = backend_dlib._to_backend_mesh(mesh)
 
         self.assertIsInstance(jax_mesh, jax.sharding.Mesh)
-        self.assertEqual(jax_mesh.devices.shape, shape)
+        self.assertEqual(jax_mesh.devices.shape, self.mesh_shape)
         self.assertEqual(jax_mesh.axis_names, ("batch", "model"))
 
     def test_to_backend_layout(self):
         axes = ["data", None]
-        mesh = distribution_lib.DeviceMesh(
-            (4, 2), ["data", "model"], [f"cpu:{i}" for i in range(8)]
-        )
+        mesh = distribution_lib.DeviceMesh(self.mesh_shape, ["data", "model"])
         layout = distribution_lib.TensorLayout(axes, mesh)
         jax_sharding = backend_dlib._to_backend_layout(layout)
         jax_mesh = backend_dlib._to_backend_mesh(mesh)
@@ -175,10 +174,9 @@ class JaxDistributionLibTest(testing.TestCase):
             backend_dlib._to_backend_layout(layout)
 
     def test_variable_assignment_reuse_layout(self):
-        shape = (4, 2)
         axis_names = ["batch", "model"]
         device_mesh = distribution_lib.DeviceMesh(
-            shape, axis_names, backend_dlib.list_devices()
+            self.mesh_shape, axis_names, backend_dlib.list_devices()
         )
         layout_map = distribution_lib.LayoutMap(device_mesh)
         layout_map[".*dense.*kernel"] = distribution_lib.TensorLayout(
@@ -213,9 +211,7 @@ class JaxDistributionLibTest(testing.TestCase):
         self.assertEqual(dense_layer.bias._value.sharding.spec, ("model",))
 
     def test_e2e_data_parallel_model(self):
-        distribution = distribution_lib.DataParallel(
-            devices=backend_dlib.list_devices()
-        )
+        distribution = distribution_lib.DataParallel()
 
         with distribution.scope():
             inputs = layers.Input(shape=[28, 28, 1])
@@ -229,18 +225,17 @@ class JaxDistributionLibTest(testing.TestCase):
         for weight in model.weights:
             self.assertTrue(weight._value.sharding.is_fully_replicated)
 
-        inputs = np.random.normal(size=(32, 28, 28, 1))
-        labels = np.random.normal(size=(32, 10))
+        inputs = np.random.normal(size=(self.device_count * 8, 28, 28, 1))
+        labels = np.random.normal(size=(self.device_count * 8, 10))
 
         with distribution.scope():
             model.compile(loss="mse")
-            model.fit(inputs, labels)
+            model.fit(inputs, labels, batch_size=self.device_count)
 
     def test_e2e_model_parallel_model(self):
-        shape = (4, 2)
         axis_names = ["batch", "model"]
         device_mesh = distribution_lib.DeviceMesh(
-            shape, axis_names, backend_dlib.list_devices()
+            self.mesh_shape, axis_names, backend_dlib.list_devices()
         )
 
         layout_map = distribution_lib.LayoutMap(device_mesh)
@@ -268,18 +263,17 @@ class JaxDistributionLibTest(testing.TestCase):
             else:
                 self.assertTrue(weight._value.sharding.is_fully_replicated)
 
-        inputs = np.random.normal(size=(32, 28, 28, 1))
-        labels = np.random.normal(size=(32, 10))
+        inputs = np.random.normal(size=(self.device_count * 8, 28, 28, 1))
+        labels = np.random.normal(size=(self.device_count * 8, 10))
 
         with distribution.scope():
             model.compile(loss="mse")
-            model.fit(inputs, labels)
+            model.fit(inputs, labels, batch_size=self.device_count)
 
     def test_e2e_model_parallel_with_output_sharding(self):
-        shape = (4, 2)
         axis_names = ["batch", "model"]
         device_mesh = distribution_lib.DeviceMesh(
-            shape, axis_names, backend_dlib.list_devices()
+            self.mesh_shape, axis_names, backend_dlib.list_devices()
         )
 
         layout_map = distribution_lib.LayoutMap(device_mesh)
@@ -312,12 +306,12 @@ class JaxDistributionLibTest(testing.TestCase):
             else:
                 self.assertTrue(weight._value.sharding.is_fully_replicated)
 
-        inputs = np.random.normal(size=(32, 28, 28, 1))
-        labels = np.random.normal(size=(32, 10))
+        inputs = np.random.normal(size=(self.device_count * 8, 28, 28, 1))
+        labels = np.random.normal(size=(self.device_count * 8, 10))
 
         with distribution.scope():
             model.compile(loss="mse")
-            model.fit(inputs, labels)
+            model.fit(inputs, labels, batch_size=self.device_count)
 
         # Note that the intermediate_tensor_layout is only captured during the
         # actual training, and not at the model building time.
@@ -332,13 +326,11 @@ class JaxDistributionLibTest(testing.TestCase):
         )
 
     def test_distribute_data_input(self):
-        per_process_batch = jax.numpy.arange(24).reshape(
-            6, 4
-        )  # Example input array
-        devices = jax.devices()[:4]  # Simulate 4 devices
-        batch_dim_size, model_dim_size = 2, 2
+        per_process_batch = jax.numpy.arange(
+            3 * self.mesh_shape[0] * 5
+        ).reshape((3 * self.mesh_shape[0], 5))  # Example input array
         mesh = jax.sharding.Mesh(
-            np.array(devices).reshape(batch_dim_size, model_dim_size),
+            np.array(jax.devices()).reshape(self.mesh_shape),
             axis_names=["batch", "model"],
         )
         layout = jax.sharding.NamedSharding(
@@ -351,18 +343,13 @@ class JaxDistributionLibTest(testing.TestCase):
 
         # Check the shape of the global batch array
         self.assertEqual(
-            result.shape, (6, 4)
-        )  # (per_replica_batch_size * num_model_replicas_total, 4)
+            result.shape, (3 * self.mesh_shape[0], 5)
+        )  # (per_replica_batch_size * num_model_replicas_total, 5)
 
         # Check the sharding of the global batch array
-        self.assertEqual(len(result.addressable_shards), len(devices))
-        # Since batch_dim_size=2, there are 2 model replicas so there is one
-        # replication of data for model replica #1 and another replication of
-        # data for model replica #2. Within each model replica, the data is
-        # sharded to two shards. Therefore, each shard has 1/2 of
-        # per_process_batch.
+        self.assertEqual(len(result.addressable_shards), self.device_count)
         for shard in result.addressable_shards:
-            self.assertEqual(shard.data.shape, (3, 4))
+            self.assertEqual(shard.data.shape, (3, 5))
 
 
 class ShardingCaptureLayer(layers.Layer):

--- a/keras/src/backend/jax/trainer_test.py
+++ b/keras/src/backend/jax/trainer_test.py
@@ -1,6 +1,8 @@
 import warnings
 
+import jax
 import numpy as np
+import pytest
 from absl.testing import parameterized
 
 from keras.src import backend
@@ -11,13 +13,9 @@ from keras.src.backend import distribution_lib as backend_dlib
 from keras.src.distribution import distribution_lib
 
 
+@pytest.mark.skipif(backend.backend() != "jax", reason="JAX only")
+@pytest.mark.multi_device
 class JAXTrainerTest(testing.TestCase, parameterized.TestCase):
-    def _skip_if_not_distributed(self):
-        if backend.backend() != "jax":
-            self.skipTest("Requires JAX backend")
-        if len(backend_dlib.list_devices()) < 2:
-            self.skipTest("Requires at least 2 devices")
-
     def _make_distribution(self, dist_type):
         if dist_type == "data_parallel":
             return distribution_lib.DataParallel()
@@ -40,9 +38,6 @@ class JAXTrainerTest(testing.TestCase, parameterized.TestCase):
     )
     def test_warns_when_model_built_outside_scope(self, dist_type):
         """Model built outside distribution -> mixed warning on compile."""
-        self._skip_if_not_distributed()
-        import jax
-
         n = len(backend_dlib.list_devices())
         units = n * max(1, 4 // n)
         dist = self._make_distribution(dist_type)
@@ -81,8 +76,6 @@ class JAXTrainerTest(testing.TestCase, parameterized.TestCase):
     )
     def test_no_warning_when_model_built_inside_scope(self, dist_type):
         """Model built inside distribution scope -> no warning."""
-        self._skip_if_not_distributed()
-
         n = len(backend_dlib.list_devices())
         units = n * max(1, 4 // n)
         dist = self._make_distribution(dist_type)

--- a/keras/src/callbacks/orbax_checkpoint_test.py
+++ b/keras/src/callbacks/orbax_checkpoint_test.py
@@ -16,6 +16,7 @@ from keras.src.distribution import LayoutMap
 from keras.src.distribution import ModelParallel
 from keras.src.distribution import TensorLayout
 from keras.src.distribution import distribution as get_distribution
+from keras.src.distribution import get_device_count
 from keras.src.distribution import set_distribution
 from keras.src.saving import register_keras_serializable
 from keras.src.testing.test_utils import named_product
@@ -57,14 +58,7 @@ class OrbaxCheckpointTest(testing.TestCase, parameterized.TestCase):
         Calls self.skipTest if fewer than 2 devices are available or if
         the fixed layer sizes don't divide evenly by num_devices.
         """
-        import jax
-
-        devices = jax.devices()
-        num_devices = len(devices)
-        if num_devices < 2:
-            self.skipTest(
-                "Test requires distributed setup with multiple devices"
-            )
+        num_devices = get_device_count()
         if (
             self._DIST_DENSE_UNITS % num_devices != 0
             or self._DIST_OUT_UNITS % num_devices != 0
@@ -74,9 +68,7 @@ class OrbaxCheckpointTest(testing.TestCase, parameterized.TestCase):
                 f"dense_units={self._DIST_DENSE_UNITS} or "
                 f"out_units={self._DIST_OUT_UNITS}"
             )
-        device_mesh = DeviceMesh(
-            (num_devices,), axis_names=["data"], devices=devices
-        )
+        device_mesh = DeviceMesh((num_devices,), axis_names=["data"])
         return num_devices, device_mesh, get_distribution()
 
     def _build_distributed_model(self, dense_units, out_units):
@@ -361,6 +353,7 @@ class OrbaxCheckpointTest(testing.TestCase, parameterized.TestCase):
         backend.backend() != "jax",
         reason="Requires JAX backend for distribution",
     )
+    @pytest.mark.multi_device
     def test_distributed_checkpoint_functionality(self):
         """Test OrbaxCheckpoint with distributed training.
 
@@ -446,6 +439,7 @@ class OrbaxCheckpointTest(testing.TestCase, parameterized.TestCase):
         backend.backend() != "jax",
         reason="Requires JAX backend for distribution",
     )
+    @pytest.mark.multi_device
     def test_distributed_checkpoint_resharding(self):
         """Test loading an Orbax checkpoint under a *different* layout.
 

--- a/keras/src/distribution/__init__.py
+++ b/keras/src/distribution/__init__.py
@@ -6,6 +6,7 @@ from keras.src.distribution.distribution_lib import ModelParallel
 from keras.src.distribution.distribution_lib import TensorLayout
 from keras.src.distribution.distribution_lib import distribute_tensor
 from keras.src.distribution.distribution_lib import distribution
+from keras.src.distribution.distribution_lib import get_device_count
 from keras.src.distribution.distribution_lib import initialize
 from keras.src.distribution.distribution_lib import list_devices
 from keras.src.distribution.distribution_lib import set_distribution


### PR DESCRIPTION
Currently, we are running multi-device tests with JAX
- always on CPU (with a "fake" multi-cpu setup)
- theoretically on GPU with kokoro (although both `distribution_lib_test.py` are skipped)
- never on TPU

### CPU

[This code](https://github.com/keras-team/keras/blob/master/keras/src/backend/jax/distribution_lib_test.py#L25-L28) is run while collecting the list of unit tests and unintentionally applies to everything instead of just `jax/distribution_lib_test.py`.

### GPU

We currently use 4 T4s for JAX GPU tests, however https://github.com/keras-team/keras/pull/22462 will move them to a single L4.

### TPU

A subsequent PR will add multi-TPU tests.

### This PR:

- Makes the normal JAX CPU tests run on a single CPU
- Adds a JAX multi-CPU check to run all the tests tagged with `pytest.mark.multi_device`
- Makes `jax/distribution_lib_test.py` work with any number of devices (as long as it's even and greater than 4) instead of the hardcoded 8
- Tags tests from `jax/distribution_lib_test.py`, `jax/trainer_test.py`, `orbax_checkpoint_test.py` with `pytest.mark.multi_device` so that we can run them with `pytest -m multi_device`


