### PR TITLE
fix: replace bare except with except Exception in python_utils

### DIFF
--- a/keras/src/utils/python_utils.py
+++ b/keras/src/utils/python_utils.py
@@ -188,7 +188,7 @@ def pythonify_logs(logs):
                 if backend.is_tensor(value):
                     value = backend.convert_to_numpy(value)
                 value = float(value)
-            except:
+            except Exception:
                 pass
             result[key] = value
     return result


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except Exception:` in `keras/src/utils/python_utils.py`.

A bare `except:` catches every possible exception including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` — which is almost never intentional and violates PEP 8. Since this block uses `pass` (no re-raise), `Exception` is the correct scope: it covers all normal runtime errors while allowing the interpreter to handle system-level signals properly.

**Change:**
```python
# Before
except:
    pass

# After
except Exception:
    pass
```

## Testing
No behavior change for normal application exceptions — style/correctness fix only.