### PR TITLE
fix: replace bare except with except Exception in model.py (2 sites)

### DIFF
--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -601,7 +601,7 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                 try:
                     self.build(config["input_shape"])
                     status = True
-                except:
+                except Exception:
                     pass
             self._build_shapes_dict = config
 
@@ -613,7 +613,7 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                 try:
                     self.build(**config["shapes_dict"])
                     status = True
-                except:
+                except Exception:
                     pass
             self._build_shapes_dict = config["shapes_dict"]
 


### PR DESCRIPTION
## Summary

Replace 2 bare `except:` clauses with `except Exception:` in `keras/src/models/model.py`.

Both occurrences silently catch everything — including `SystemExit` and `KeyboardInterrupt` — then use `pass`, discarding the exception entirely. Scoping to `Exception` preserves the intended behavior (swallowing normal runtime errors during shape config restoration) while correctly allowing system-level signals to propagate.

**Change (applied at lines 604 and 616):**
```python
# Before
except:
    pass

# After
except Exception:
    pass
```

## Testing
No behavior change for application-level exceptions — style/correctness fix only. Both sites attempt to restore build shapes from config and silently continue on failure.