### PR TITLE
Check for Python `assert`s during the code check.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ select = [
     "E",  # pycodestyle error
     "F",  # Pyflakes
     "I",  # isort
+    "S101",  # flake8-bandit / use of assert detected
 ]
 ignore = [
     "E722",  # do not use bare 'except'
@@ -68,7 +69,8 @@ ignore = [
 "**/__init__.py" = ["E501", "F401"]  # lines too long; imported but unused
 "**/random.py" = ["F401"]  # imported but unused
 "examples/*" = ["I", "E"]
-"guides/*" = ["I", "E", "F"]
+"guides/*" = ["I", "E", "F", "S"]
+"integration_tests/*" = ["S101"]  # use of assert detected
 
 [tool.ruff.lint.isort]
 force-single-line = true


### PR DESCRIPTION
As a follow-up to https://github.com/keras-team/keras/pull/22400 and https://github.com/keras-team/keras/pull/22420 add ruff check to prevent re-introduction of Python `assert`s.

See https://docs.astral.sh/ruff/rules/assert/ for an explanation of why alternatives should be used instead of `assert`.

