### PR TITLE
Run multi-device tests on our 4 TPU machines.

### DIFF
--- a/.github/workflows/tpu_tests.yml
+++ b/.github/workflows/tpu_tests.yml
@@ -14,18 +14,19 @@ permissions:
 jobs:
 
   test-in-container:
-    name: Run tests on TPU
-    runs-on: linux-x86-ct6e-44-1tpu
+    strategy:
+      fail-fast: false
+      matrix:
+        multi_device: [false, true]
+        backend: [jax]
+
+    name: ${{ format('Run tests on {0}TPU', matrix.multi_device && 'multi-' || '') }}
+    runs-on: ${{ matrix.multi_device && 'linux-x86-ct5lp-112-4tpu' || 'linux-x86-ct6e-44-1tpu' }}
     # Only run on pushes to master, releases or "kokoro:force-run" unlabel
     if: |
       github.event_name == 'push' ||
       github.event_name == 'release' ||
       (github.event_name == 'pull_request' && github.event.action == 'unlabeled' && github.event.label.name == 'kokoro:force-run')
-
-    strategy:
-      fail-fast: false
-      matrix:
-        backend: [jax]
 
     container:
       image: python:3.11-slim
@@ -45,4 +46,9 @@ jobs:
         run: python3 -c "import jax; print('JAX devices:', jax.devices()); assert jax.default_backend() == 'tpu'"
 
       - name: Run Tests
+        if: ${{ !matrix.multi_device }}
         run: pytest keras --ignore keras/src/applications --cov=keras --cov-config=pyproject.toml
+
+      - name: Run Multi-device Tests
+        if: ${{ matrix.multi_device }}
+        run: pytest keras -m multi_device --cov=keras --cov-config=pyproject.toml

--- a/keras/src/backend/jax/distribution_lib_test.py
+++ b/keras/src/backend/jax/distribution_lib_test.py
@@ -19,6 +19,7 @@ from keras.src.distribution import distribution_lib
 class JaxDistributionLibTest(testing.TestCase):
     def setUp(self):
         self.device_count = jax.device_count()
+        self.device_backend = jax.default_backend()
         self.assertGreaterEqual(
             self.device_count, 4, "Number of devices must be at least 4"
         )
@@ -39,7 +40,8 @@ class JaxDistributionLibTest(testing.TestCase):
     def test_get_device_count(self):
         self.assertEqual(backend_dlib.get_device_count(), self.device_count)
         self.assertEqual(
-            backend_dlib.get_device_count("cpu"), self.device_count
+            backend_dlib.get_device_count(self.device_backend),
+            self.device_count,
         )
 
     def test_list_devices(self):
@@ -47,12 +49,13 @@ class JaxDistributionLibTest(testing.TestCase):
             len(distribution_lib.list_devices()), self.device_count
         )
         self.assertEqual(
-            len(distribution_lib.list_devices("cpu")), self.device_count
+            len(distribution_lib.list_devices(self.device_backend)),
+            self.device_count,
         )
 
     def test_device_conversion(self):
-        devices = distribution_lib.list_devices("cpu")
-        jax_devices = jax.devices("cpu")
+        devices = distribution_lib.list_devices(self.device_backend)
+        jax_devices = jax.devices(self.device_backend)
 
         for d, jax_d in zip(devices, jax_devices):
             converted_jax_device = backend_dlib._to_backend_device(d)


### PR DESCRIPTION
We have runners with 4 TPUs.

Also changed `keras/src/backend/jax/distribution_lib_test.py` to not hardcode "cpu" for the devices.