### PR TITLE
Fix TPU tests by installing `jax2onnx`. Enable ONNX tests.

### DIFF
--- a/keras/src/export/onnx_test.py
+++ b/keras/src/export/onnx_test.py
@@ -77,11 +77,6 @@ def get_model(type="sequential", input_shape=(10,), layer_list=None):
         "backends."
     ),
 )
-@pytest.mark.skipif(testing.uses_gpu(), reason="Fails on GPU")
-@pytest.mark.skipif(
-    np.version.version.startswith("2.") and backend.backend() != "jax",
-    reason="ONNX export via tf2onnx is incompatible with NumPy 2.0",
-)
 class ExportONNXTest(testing.TestCase):
     @parameterized.named_parameters(
         named_product(
@@ -89,11 +84,8 @@ class ExportONNXTest(testing.TestCase):
         )
     )
     def test_standard_model_export(self, model_type):
-        if model_type == "lstm" and backend.backend() == "jax":
-            self.skipTest(
-                "Bidirectional LSTM uses reverse scan, which jax2onnx "
-                "does not support yet."
-            )
+        if model_type == "lstm" and backend.backend() in ("jax", "tensorflow"):
+            self.skipTest("Bidirectional LSTM is unsupported.")
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
         model = get_model(model_type)
         batch_size = 3 if backend.backend() != "torch" else 1
@@ -124,8 +116,8 @@ class ExportONNXTest(testing.TestCase):
         named_product(struct_type=["tuple", "array", "dict"])
     )
     def test_model_with_input_structure(self, struct_type):
-        if backend.backend() == "torch" and struct_type == "dict":
-            self.skipTest("The torch backend doesn't support the dict model.")
+        if backend.backend() == "torch" and struct_type in ("tuple", "dict"):
+            self.skipTest("The torch backend doesn't support this structure.")
 
         class TupleModel(models.Model):
             def call(self, inputs):
@@ -262,7 +254,12 @@ class ExportONNXTest(testing.TestCase):
         ort_inputs = {
             k.name: v for k, v in zip(ort_session.get_inputs(), [ref_input])
         }
-        self.assertAllClose(ref_output, ort_session.run(None, ort_inputs)[0])
+        self.assertAllClose(
+            ref_output,
+            ort_session.run(None, ort_inputs)[0],
+            tpu_atol=1e-3,
+            tpu_rtol=2e-3,
+        )
 
         if opset_version is not None:
             onnx_model = onnx_lib.load(temp_filepath)
@@ -301,6 +298,10 @@ class ExportONNXTest(testing.TestCase):
             model_type=["sequential", "functional"],
             dynamic_type=["batch_only", "height_width"],
         )
+    )
+    @pytest.mark.skipif(
+        backend.backend() == "torch",
+        reason="Dynamic shapes are not supported with torch",
     )
     def test_dynamic_shapes_export(self, model_type, dynamic_type):
         """Test ONNX export with various dynamic shape configurations.
@@ -373,6 +374,10 @@ class ExportONNXTest(testing.TestCase):
             self.assertEqual(result[0].shape[0], expected_batch_size)
             self.assertEqual(result[0].shape[1], 10)  # Number of classes
 
+    @pytest.mark.skipif(
+        backend.backend() == "torch",
+        reason="Dynamic shapes are not supported with torch",
+    )
     def test_multi_input_dynamic_shapes(self):
         """Test ONNX export with multi-input model having dynamic shapes."""
 

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -27,7 +27,8 @@ onnxruntime
 # https://github.com/keras-team/keras/issues/21390
 # onnxscript==0.3.2 breaks LSTM model export.
 onnxscript!=0.3.2
-openvino
+jax2onnx
+tf2onnx
 grain
 # for orbax_checkpoint_test.py
 orbax-checkpoint

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,6 +1,5 @@
 # Tensorflow cpu-only version (needed for testing).
 tensorflow-cpu
-tf2onnx
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-jax-tpu.txt
+++ b/requirements-jax-tpu.txt
@@ -1,6 +1,5 @@
 # Tensorflow cpu-only version (needed for testing).
 tensorflow-cpu
-tf2onnx
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,6 +1,5 @@
 # Tensorflow with cuda support.
 tensorflow[and-cuda]==2.20.0
-tf2onnx
 ai-edge-litert
 
 # Torch cpu-only version (needed for testing).

--- a/requirements-tensorflow-tpu.txt
+++ b/requirements-tensorflow-tpu.txt
@@ -2,8 +2,6 @@
 --find-links https://storage.googleapis.com/libtpu-tf-releases/index.html
 tensorflow-tpu==2.19.1
 
-tf2onnx
-
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,6 +1,5 @@
 # Tensorflow cpu-only version (needed for testing).
 tensorflow-cpu
-tf2onnx
 
 # Torch with cuda support.
 # - torch is pinned to a version that is compatible with torch-xla.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # changed in .github/workflows/actions.yml (pip install --no-deps tf_keras).
 tensorflow-cpu;sys_platform != 'darwin'
 tensorflow;sys_platform == 'darwin'
-tf2onnx
 ai-edge-litert
 
 # Torch.
@@ -16,7 +15,9 @@ torch-xla;sys_platform != 'darwin'
 # Note that we test against the latest JAX on GPU.
 jax[cpu]
 flax
-jax2onnx
+
+# OpenVino
+openvino
 
 # Common deps.
 -r requirements-common.txt


### PR DESCRIPTION
TPU tests for ONNX export are failing because `jax2onnx` is not installed.

- Moved `jax2onnx` to `requirements-common.txt`
- Moved `tf2onnx` to `requirements-common.txt` instead of repeating it
- Moved	`openvino` to `requirements.txt` because we're not using it on GPU or TPU

ONNX export tests were effectively completely disable except for JAX because if a check what would skip when using NumPy >= 2.0.

- Re-enabled `onnx_test` for torch and tensorflow
- Skip failing tests
- Tweak precision on TPU
