### PR TITLE
docs: Improve docstring for RMSNormalization layer

### DIFF
--- a/keras/src/layers/normalization/rms_normalization.py
+++ b/keras/src/layers/normalization/rms_normalization.py
@@ -13,12 +13,10 @@ class RMSNormalization(Layer):
     [Root Mean Square Layer Normalization](https://arxiv.org/pdf/1910.07467)
     by Biao Zhang et al.
 
+    The layer scales the normalized outputs via a learnable scaling factor
+    (`scale`).
 
-    If `scale` is enabled, the layer will scale the normalized outputs via
-    a learnable scaling factor.
-
-    So, with scaling enabled, the normalization equations
-    are as follows:
+    The normalization equations are as follows:
 
     Let the intermediate activations for a mini-batch to be the `inputs`.
 
@@ -39,7 +37,18 @@ class RMSNormalization(Layer):
 
     Args:
         axis: int. The axis on which to perform the normalization.
+            Typically, this is the features axis. `-1` is the last dimension
+            in the input. Defaults to `-1`.
         epsilon: float. A small number to add to avoid division by zero.
+            Defaults to `1e-6`.
+
+    Input shape:
+        Arbitrary. Use the keyword argument `input_shape` (tuple of integers,
+        does not include the samples axis) when using this layer as the first
+        layer in a model.
+
+    Output shape:
+        Same shape as input.
     """
 
     def __init__(self, axis=-1, epsilon=1e-6, **kwargs):
@@ -62,15 +71,6 @@ class RMSNormalization(Layer):
         self.built = True
 
     def call(self, x):
-        """Applies RMS normalization to the input tensor.
-
-        Args:
-            x: Input tensor of shape (batch_size, input_dim).
-
-        Returns:
-            The RMS-normalized tensor of the same shape (batch_size, input_dim),
-            scaled by the learned `scale` parameter.
-        """
         return ops.rms_normalization(
             x, scale=self.scale, axis=self.axis, epsilon=self.epsilon
         )


### PR DESCRIPTION
## Summary

This PR improves the docstring for the `RMSNormalization` layer to provide better documentation for users.

## Changes

1. **Fixed misleading statement about scale parameter**: The docstring previously said "If `scale` is enabled, the layer will scale the normalized outputs via a learnable scaling factor." This was misleading because the layer always uses a scale parameter (created in `build()`). Updated to clarify that the layer always scales the normalized outputs.

2. **Added default values for parameters**: Added default values (`-1` for `axis`, `1e-6` for `epsilon`) to the Args section for clarity.

3. **Improved axis parameter description**: Added more detail about the axis parameter, mentioning that it is typically the features axis and `-1` is the last dimension.

4. **Added Input shape and Output shape sections**: Added these sections to match the documentation style of other normalization layers (e.g., GroupNormalization).

5. **Removed redundant call method docstring**: The call method docstring was inconsistent with other normalization layers (LayerNormalization, GroupNormalization) which do not have call method docstrings. The shape description in the docstring was also inaccurate for arbitrary input shapes.

## Testing

- The code changes are documentation-only and do not affect functionality.
- The example in the docstring works as expected.

## Related

This follows the Keras documentation style as described in CONTRIBUTING.md.