### PR TITLE
Replace Kokoro app unlabeling behavior with github workflow.

### DIFF
--- a/.github/workflows/trigger_gpu_tpu_tests.yml
+++ b/.github/workflows/trigger_gpu_tpu_tests.yml
@@ -1,0 +1,26 @@
+name: Trigger GPU & TPU Tests
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  remove_label:
+    name: Remove Label
+    runs-on: ubuntu-latest
+    if: github.event.action == 'labeled' && github.event.label.name == 'kokoro:force-run'
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              label: 'kokoro:force-run'
+            })


### PR DESCRIPTION
Kokoro use to automatically remove the `kokoro:force-run` label to trigger the tests. This no longer works as we don't have any Kokoro tests anymore.

This github workflow has the same behavior.

**Note:** the workflow does not work within the context of this PR, I believe it is normal and it will work once in `master`.