### PR TITLE
Make `setUp` and `tearDown` call `super` in unit tests.

### DIFF
--- a/keras/src/backend/jax/core_test.py
+++ b/keras/src/backend/jax/core_test.py
@@ -25,8 +25,8 @@ if is_nnx_enabled():
     reason="Test requires NNX backend to be enabled by default for setup.",
 )
 class NnxVariableTest(testing.TestCase):
-    def setup(self):
-        super().setup()
+    def setUp(self):
+        super().setUp()
 
         class NNXModel(nnx.Module):
             def __init__(self, rngs):

--- a/keras/src/backend/jax/distribution_lib_test.py
+++ b/keras/src/backend/jax/distribution_lib_test.py
@@ -18,6 +18,8 @@ from keras.src.distribution import distribution_lib
 @pytest.mark.multi_device
 class JaxDistributionLibTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
+
         self.device_count = jax.device_count()
         self.device_backend = jax.default_backend()
         self.assertGreaterEqual(

--- a/keras/src/callbacks/learning_rate_scheduler_test.py
+++ b/keras/src/callbacks/learning_rate_scheduler_test.py
@@ -12,6 +12,8 @@ from keras.src.utils import numerical_utils
 
 class LearningRateSchedulerTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
+
         (x_train, y_train), _ = test_utils.get_test_data(
             train_samples=10,
             test_samples=10,

--- a/keras/src/callbacks/reduce_lr_on_plateau_test.py
+++ b/keras/src/callbacks/reduce_lr_on_plateau_test.py
@@ -12,6 +12,8 @@ from keras.src.utils import numerical_utils
 
 class ReduceLROnPlateauTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
+
         (x_train, y_train), (x_test, y_test) = test_utils.get_test_data(
             train_samples=10,
             test_samples=10,

--- a/keras/src/callbacks/swap_ema_weights_test.py
+++ b/keras/src/callbacks/swap_ema_weights_test.py
@@ -20,6 +20,8 @@ from keras.src.utils import numerical_utils
 
 class SwapEMAWeightsTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
+
         (x_train, y_train), _ = test_utils.get_test_data(
             train_samples=10,
             test_samples=10,

--- a/keras/src/distribution/distribution_lib_test.py
+++ b/keras/src/distribution/distribution_lib_test.py
@@ -90,6 +90,7 @@ class DeviceMeshTest(testing.TestCase):
 
 class TensorLayoutTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
         self.mesh = distribution_lib.DeviceMesh(
             (4, 2), ["data", "model"], [f"cpu:{i}" for i in range(8)]
         )

--- a/keras/src/dtype_policies/dtype_policy_test.py
+++ b/keras/src/dtype_policies/dtype_policy_test.py
@@ -538,6 +538,7 @@ class QuantizedDTypePolicyTest(test_case.TestCase):
 
 class DTypePolicyGlobalFunctionsTest(test_case.TestCase):
     def setUp(self):
+        super().setUp()
         """Reset the global dtype policy before each test."""
         set_dtype_policy("float32")
 
@@ -676,6 +677,7 @@ class QuantizedDTypePolicyEdgeCasesTest(test_case.TestCase):
 
 class DTypePolicyGlobalFunctionsEdgeCasesTest(test_case.TestCase):
     def setUp(self):
+        super().setUp()
         """Reset the global dtype policy before each test."""
         set_dtype_policy("float32")
 

--- a/keras/src/layers/attention/grouped_query_attention_test.py
+++ b/keras/src/layers/attention/grouped_query_attention_test.py
@@ -19,8 +19,8 @@ class GroupedQueryAttentionTest(testing.TestCase):
         disable_flash_attention()
 
     def tearDown(self):
+        super().tearDown()
         enable_flash_attention()
-        return super().tearDown()
 
     def test_basics(self):
         self.assertFalse(is_flash_attention_enabled())

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -28,8 +28,8 @@ class MultiHeadAttentionTest(testing.TestCase):
         disable_flash_attention()
 
     def tearDown(self):
+        super().tearDown()
         enable_flash_attention()
-        return super().tearDown()
 
     def test_basics(self):
         self.assertFalse(is_flash_attention_enabled())

--- a/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/converters_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/converters_test.py
@@ -18,6 +18,8 @@ from keras.src.layers.preprocessing.image_preprocessing.bounding_boxes.converter
 
 class ConvertersTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
+
         xyxy_box = np.array(
             [[[10, 20, 110, 120], [20, 30, 120, 130]]], dtype="float32"
         )

--- a/keras/src/losses/loss_test.py
+++ b/keras/src/losses/loss_test.py
@@ -19,14 +19,14 @@ class ExampleLoss(Loss):
 
 class LossTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
         self._global_dtype_policy = dtype_policies.dtype_policy.dtype_policy()
         self._floatx = backend.floatx()
-        return super().setUp()
 
     def tearDown(self):
+        super().tearDown()
         dtype_policies.dtype_policy.set_dtype_policy(self._global_dtype_policy)
         backend.set_floatx(self._floatx)
-        return super().tearDown()
 
     def test_squeeze_or_expand(self):
         x1 = ops.ones((3,))

--- a/keras/src/metrics/confusion_metrics_test.py
+++ b/keras/src/metrics/confusion_metrics_test.py
@@ -1140,6 +1140,8 @@ class RecallAtPrecisionTest(testing.TestCase):
 
 class AUCTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
+
         self.num_thresholds = 3
         self.y_pred = np.array([0, 0.5, 0.3, 0.9], dtype="float32")
         self.y_pred_multi_label = np.array(
@@ -1531,6 +1533,8 @@ class AUCTest(testing.TestCase):
 
 class MultiAUCTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
+
         self.num_thresholds = 5
         self.y_pred = np.array(
             [[0, 0.5, 0.3, 0.9], [0.1, 0.2, 0.3, 0.4]], dtype="float32"

--- a/keras/src/metrics/metric_test.py
+++ b/keras/src/metrics/metric_test.py
@@ -45,14 +45,14 @@ class ExampleMetric(Metric):
 
 class MetricTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
         self._global_dtype_policy = dtype_policies.dtype_policy.dtype_policy()
         self._floatx = backend.floatx()
-        return super().setUp()
 
     def tearDown(self):
+        super().tearDown()
         dtype_policies.dtype_policy.set_dtype_policy(self._global_dtype_policy)
         backend.set_floatx(self._floatx)
-        return super().tearDown()
 
     def test_end_to_end_flow(self):
         metric = ExampleMetric(name="mse")

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -19,14 +19,14 @@ from keras.src.testing.test_utils import named_product
 
 class ImageOpsDynamicShapeTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
         # Defaults to channels_last
         self.data_format = backend.image_data_format()
         backend.set_image_data_format("channels_last")
-        return super().setUp()
 
     def tearDown(self):
+        super().tearDown()
         backend.set_image_data_format(self.data_format)
-        return super().tearDown()
 
     def test_rgb_to_grayscale(self):
         # Test channels_last
@@ -251,14 +251,14 @@ class ImageOpsDynamicShapeTest(testing.TestCase):
 
 class ImageOpsStaticShapeTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
         # Defaults to channels_last
         self.data_format = backend.image_data_format()
         backend.set_image_data_format("channels_last")
-        return super().setUp()
 
     def tearDown(self):
+        super().tearDown()
         backend.set_image_data_format(self.data_format)
-        return super().tearDown()
 
     def test_rgb_to_grayscale(self):
         # Test channels_last
@@ -1025,14 +1025,14 @@ def _compute_homography_matrix(start_points, end_points):
 
 class ImageOpsCorrectnessTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
         # Defaults to channels_last
         self.data_format = backend.image_data_format()
         backend.set_image_data_format("channels_last")
-        return super().setUp()
 
     def tearDown(self):
+        super().tearDown()
         backend.set_image_data_format(self.data_format)
-        return super().tearDown()
 
     def test_rgb_to_grayscale(self):
         # Test channels_last
@@ -2085,14 +2085,14 @@ class ImageOpsDtypeTest(testing.TestCase):
         INT_DTYPES = [x for x in INT_DTYPES if x not in ("uint16", "uint32")]
 
     def setUp(self):
+        super().setUp()
         # Defaults to channels_last
         self.data_format = backend.image_data_format()
         backend.set_image_data_format("channels_last")
-        return super().setUp()
 
     def tearDown(self):
+        super().tearDown()
         backend.set_image_data_format(self.data_format)
-        return super().tearDown()
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_affine_transform(self, dtype):
@@ -2258,14 +2258,14 @@ class ImageOpsDtypeTest(testing.TestCase):
 
 class ImageOpsBehaviorTests(testing.TestCase):
     def setUp(self):
+        super().setUp()
         # Defaults to channels_last
         self.data_format = backend.image_data_format()
         backend.set_image_data_format("channels_last")
-        return super().setUp()
 
     def tearDown(self):
+        super().tearDown()
         backend.set_image_data_format(self.data_format)
-        return super().tearDown()
 
     @parameterized.named_parameters(named_product(rank=[2, 5]))
     def test_rgb_to_grayscale_invalid_rank(self, rank):
@@ -2716,8 +2716,14 @@ class ExtractPatches3DTest(testing.TestCase):
     FLOAT_DTYPES = [x for x in dtypes.FLOAT_TYPES if x not in ("float64",)]
 
     def setUp(self):
+        super().setUp()
+        # Defaults to channels_last
+        self.data_format = backend.image_data_format()
         backend.set_image_data_format("channels_last")
-        return super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+        backend.set_image_data_format(self.data_format)
 
     @parameterized.named_parameters(
         named_product(

--- a/keras/src/quantizers/awq_test.py
+++ b/keras/src/quantizers/awq_test.py
@@ -440,7 +440,7 @@ def _get_sequence_classifier():
     inputs = layers.Input(shape=(SEQ_LEN,), dtype="int32")
     x = layers.Embedding(VOCAB_SIZE, embed_dim)(inputs)
     x = SimpleTransformerBlock(embed_dim, num_heads, ff_dim)(x)
-    x = layers.GlobalAveragePooling1D()(x)
+    x = layers.GlobalAveragePooling1D(data_format="channels_last")(x)
     outputs = layers.Dense(NUM_CLASSES)(x)
     return models.Model(inputs, outputs)
 

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -248,14 +248,14 @@ def _load_model_fn(filepath):
 
 class SavingTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
         # Set `_MEMORY_UPPER_BOUND` to zero for testing purpose.
         self.original_value = saving_lib._MEMORY_UPPER_BOUND
         saving_lib._MEMORY_UPPER_BOUND = 0
-        return super().setUp()
 
     def tearDown(self):
+        super().tearDown()
         saving_lib._MEMORY_UPPER_BOUND = self.original_value
-        return super().tearDown()
 
     def _test_inference_after_instantiation(self, model):
         x_ref = np.random.random((2, 4))

--- a/keras/src/testing/test_utils_test.py
+++ b/keras/src/testing/test_utils_test.py
@@ -7,6 +7,7 @@ from keras.src.testing import test_utils
 
 class GetTestDataTest(test_case.TestCase):
     def setUp(self):
+        super().setUp()
         self.train_samples = 100
         self.test_samples = 50
         self.input_shape = (28, 28)
@@ -156,6 +157,7 @@ class GetTestDataTest(test_case.TestCase):
 
 class ClassDistributionTests(test_case.TestCase):
     def setUp(self):
+        super().setUp()
         self.train_samples = 100
         self.test_samples = 50
         self.input_shape = (28, 28)

--- a/keras/src/tree/tree_test.py
+++ b/keras/src/tree/tree_test.py
@@ -76,6 +76,7 @@ class Visitor:
 @parameterized.named_parameters(TEST_CASES)
 class TreeTest(testing.TestCase):
     def setUp(self):
+        super().setUp()
         if dmtree.available and optree.available:
             # If both are available, the annotation on the Keras tracking
             # wrappers will have used optree. For testing purposes, we need to
@@ -86,7 +87,6 @@ class TreeTest(testing.TestCase):
             dmtree_impl.register_tree_node_class(TrackedSet)
             dmtree_impl.register_tree_node_class(TrackedDict)
             dmtree_impl.register_tree_node_class(TrackedOrderedDict)
-        super().setUp()
 
     def assertEqualStrict(self, a, b):
         self.assertEqual(a, b)

--- a/keras/src/utils/code_stats_test.py
+++ b/keras/src/utils/code_stats_test.py
@@ -8,6 +8,7 @@ from keras.src.utils.code_stats import count_loc
 
 class TestCountLoc(test_case.TestCase):
     def setUp(self):
+        super().setUp()
         self.test_dir = self.get_temp_dir()
 
     def create_file(self, filename, content):

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -109,6 +109,7 @@ class IsLinkInDirTest(test_case.TestCase):
 
 class FilterSafePathsTest(test_case.TestCase):
     def setUp(self):
+        super().setUp()
         self.base_dir = os.path.abspath(self.get_temp_dir())
         self.tar_path = os.path.join(self.base_dir, "test.tar")
         self.target_path = os.path.join(self.base_dir, "target.txt")
@@ -177,6 +178,7 @@ class FilterSafePathsTest(test_case.TestCase):
 
 class ExtractArchiveTest(test_case.TestCase):
     def setUp(self):
+        super().setUp()
         """Create temporary directories and files for testing."""
         self.temp_dir = self.get_temp_dir()
         self.file_content = "Hello, world!"
@@ -276,6 +278,7 @@ class ExtractArchiveTest(test_case.TestCase):
 
 class GetFileTest(test_case.TestCase):
     def setUp(self):
+        super().setUp()
         """Set up temporary directories and sample files."""
         self.temp_dir = self.get_temp_dir()
         self.file_path = os.path.join(self.temp_dir, "sample_file.txt")
@@ -567,6 +570,7 @@ class GetFileTest(test_case.TestCase):
 
 class HashFileTest(test_case.TestCase):
     def setUp(self):
+        super().setUp()
         self.test_content = b"Hello, World!"
         self.temp_file = os.path.join(self.get_temp_dir(), "test_file.txt")
         with open(self.temp_file, "wb") as f:
@@ -591,6 +595,7 @@ class HashFileTest(test_case.TestCase):
 
 class TestValidateFile(test_case.TestCase):
     def setUp(self):
+        super().setUp()
         self.temp_file = os.path.join(self.get_temp_dir(), "test_file.txt")
         with open(self.temp_file, "wb") as f:
             f.write(b"Hello, World!")

--- a/keras/src/utils/image_utils_test.py
+++ b/keras/src/utils/image_utils_test.py
@@ -3,6 +3,7 @@ import os
 import numpy as np
 from absl.testing import parameterized
 
+from keras.src import backend
 from keras.src import testing
 from keras.src.utils import img_to_array
 from keras.src.utils import load_img
@@ -10,6 +11,15 @@ from keras.src.utils import save_img
 
 
 class SaveImgTest(testing.TestCase, parameterized.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.data_format = backend.image_data_format()
+        backend.set_image_data_format("channels_last")
+
+    def tearDown(self):
+        super().tearDown()
+        backend.set_image_data_format(self.data_format)
+
     @parameterized.named_parameters(
         ("rgb_explicit_format", (50, 50, 3), "rgb.jpg", "jpg", True),
         ("rgba_explicit_format", (50, 50, 4), "rgba.jpg", "jpg", True),


### PR DESCRIPTION
Many tests defining a `setUp` method were not calling `super().setUp()`.

This also cleans up all `setUp` and `tearDown` method to use a consistent pattern of calling `super` first.

This also fixes some tests that unknowingly relied on the `image_data_format` being reverted to `channels_last` by a unit test instead of keeping the default for the backend.