### PR TITLE
Add delay before removing `kokoro:force-run` label.

### DIFF
--- a/.github/workflows/trigger_gpu_tpu_tests.yml
+++ b/.github/workflows/trigger_gpu_tpu_tests.yml
@@ -15,12 +15,23 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action == 'labeled' && github.event.label.name == 'kokoro:force-run'
     steps:
+      - name: Wait 10 seconds
+        run: sleep 10s
+
       - uses: actions/github-script@v8
         with:
           script: |
+            var labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            console.log(labels);
+
             github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
               label: 'kokoro:force-run'
-            })
+            });


### PR DESCRIPTION
This is a follow-up to https://github.com/keras-team/keras/pull/22504

The workflow is currently failing with a `Label does not exist` error.

Trying to add a delay in case this is a race condition and the labels haven't fully been updated yet.