### PR TITLE
[Bug] `keras.ops.argmax` returns incorrect shape for Keras Input when `keepdims=True`

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -996,12 +996,9 @@ class Argmax(Operation):
         return backend.numpy.argmax(x, axis=self.axis, keepdims=self.keepdims)
 
     def compute_output_spec(self, x):
-        if self.keepdims:
-            return KerasTensor(x.shape, dtype="int32")
-        if self.axis is None:
-            return KerasTensor([], dtype="int32")
         return KerasTensor(
-            reduce_shape(x.shape, axis=[self.axis]), dtype="int32"
+            reduce_shape(x.shape, axis=self.axis, keepdims=self.keepdims),
+            dtype="int32",
         )
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1349,11 +1349,17 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
     def test_argmax(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.argmax(x).shape, ())
-        self.assertEqual(knp.argmax(x, keepdims=True).shape, (None, 1))
+        self.assertEqual(knp.argmax(x, keepdims=True).shape, (1, 1))
+        self.assertEqual(knp.argmax(x, axis=0, keepdims=True).shape, (1, 3))
+        self.assertEqual(knp.argmax(x, axis=1, keepdims=True).shape, (None, 1))
 
         x = KerasTensor((None, 3, 3))
         self.assertEqual(knp.argmax(x, axis=1).shape, (None, 3))
-        self.assertEqual(knp.argmax(x, keepdims=True).shape, (None, 1, 1))
+        self.assertEqual(knp.argmax(x, keepdims=True).shape, (1, 1, 1))
+        self.assertEqual(knp.argmax(x, axis=0, keepdims=True).shape, (1, 3, 3))
+        self.assertEqual(
+            knp.argmax(x, axis=1, keepdims=True).shape, (None, 1, 3)
+        )
 
     @pytest.mark.skipif(
         keras.config.backend() == "openvino" or testing.jax_uses_tpu(),
@@ -2366,6 +2372,8 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
     def test_argmax(self):
         x = KerasTensor((2, 3))
         self.assertEqual(knp.argmax(x).shape, ())
+        self.assertEqual(knp.argmax(x, axis=0).shape, (3,))
+        self.assertEqual(knp.argmax(x, axis=1).shape, (2,))
         self.assertEqual(knp.argmax(x, keepdims=True).shape, (1, 1))
 
     def test_argmin(self):

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1349,11 +1349,11 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
     def test_argmax(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.argmax(x).shape, ())
-        self.assertEqual(knp.argmax(x, keepdims=True).shape, (None, 3))
+        self.assertEqual(knp.argmax(x, keepdims=True).shape, (None, 1))
 
         x = KerasTensor((None, 3, 3))
         self.assertEqual(knp.argmax(x, axis=1).shape, (None, 3))
-        self.assertEqual(knp.argmax(x, keepdims=True).shape, (None, 3, 3))
+        self.assertEqual(knp.argmax(x, keepdims=True).shape, (None, 1, 1))
 
     @pytest.mark.skipif(
         keras.config.backend() == "openvino" or testing.jax_uses_tpu(),
@@ -2366,7 +2366,7 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
     def test_argmax(self):
         x = KerasTensor((2, 3))
         self.assertEqual(knp.argmax(x).shape, ())
-        self.assertEqual(knp.argmax(x, keepdims=True).shape, (2, 3))
+        self.assertEqual(knp.argmax(x, keepdims=True).shape, (1, 1))
 
     def test_argmin(self):
         x = KerasTensor((2, 3))


### PR DESCRIPTION
Hi, there.

### Tasks
- [x] Test: Fix test code.
- [x] Feat: Implement code logic.
- [x] Request Review

### Related Issue
- Fixes: #22523

Thanks.