### PR TITLE
Add Unique op

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -324,6 +324,7 @@ from keras.src.ops.numpy import tril as tril
 from keras.src.ops.numpy import triu as triu
 from keras.src.ops.numpy import true_divide as true_divide
 from keras.src.ops.numpy import trunc as trunc
+from keras.src.ops.numpy import unique as unique
 from keras.src.ops.numpy import unravel_index as unravel_index
 from keras.src.ops.numpy import vander as vander
 from keras.src.ops.numpy import var as var

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -205,6 +205,7 @@ from keras.src.ops.numpy import tril as tril
 from keras.src.ops.numpy import triu as triu
 from keras.src.ops.numpy import true_divide as true_divide
 from keras.src.ops.numpy import trunc as trunc
+from keras.src.ops.numpy import unique as unique
 from keras.src.ops.numpy import unravel_index as unravel_index
 from keras.src.ops.numpy import vander as vander
 from keras.src.ops.numpy import var as var

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -324,6 +324,7 @@ from keras.src.ops.numpy import tril as tril
 from keras.src.ops.numpy import triu as triu
 from keras.src.ops.numpy import true_divide as true_divide
 from keras.src.ops.numpy import trunc as trunc
+from keras.src.ops.numpy import unique as unique
 from keras.src.ops.numpy import unravel_index as unravel_index
 from keras.src.ops.numpy import vander as vander
 from keras.src.ops.numpy import var as var

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -205,6 +205,7 @@ from keras.src.ops.numpy import tril as tril
 from keras.src.ops.numpy import triu as triu
 from keras.src.ops.numpy import true_divide as true_divide
 from keras.src.ops.numpy import trunc as trunc
+from keras.src.ops.numpy import unique as unique
 from keras.src.ops.numpy import unravel_index as unravel_index
 from keras.src.ops.numpy import vander as vander
 from keras.src.ops.numpy import var as var

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -1632,3 +1632,16 @@ def argpartition(x, kth, axis=-1):
 
 def histogram(x, bins=10, range=None):
     return jnp.histogram(x, bins=bins, range=range)
+
+
+def unique(
+    input, sorted=True, return_inverse=False, return_counts=False, axis=None
+):
+    return jnp.unique(
+        ar=input,
+        sorted=sorted,
+        return_inverse=return_inverse,
+        axis=axis,
+        return_counts=return_counts,
+        equal_nan=False,
+    )

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -1675,3 +1675,15 @@ def argpartition(x, kth, axis=-1):
 
 def histogram(x, bins=10, range=None):
     return np.histogram(x, bins=bins, range=range)
+
+
+def unique(
+    input, sorted=True, return_inverse=False, return_counts=False, axis=None
+):
+    return np.unique(
+        ar=input,
+        sorted=sorted,
+        return_inverse=return_inverse,
+        axis=axis,
+        return_counts=return_counts,
+    )

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -243,3 +243,9 @@ TruePositiveTest::test_weighted
 UnitNormalizationTest::test_un_basics
 UpSampling2dTest::test_upsampling_2d_lanczos_interpolation_methods
 UpSampling2dTest::test_upsampling_2d_various_interpolation_methods
+UniqueTest::test_unique_symbolic_static_shape
+UniqueTest::test_unique_symbolic_dynamic_shape
+UniqueTest::test_unique_correctness_1d
+UniqueTest::test_unique_correctness_2d_axis0
+UniqueTest::test_unique_correctness_2d_axis1
+UniqueTest::test_unique_correctness_3d_axis1

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -5502,3 +5502,9 @@ def histogram(x, bins=10, range=None):
     )
 
     return OpenVINOKerasTensor(hist.output(0)), OpenVINOKerasTensor(bin_edges)
+
+
+def unique(
+    input, sorted=True, return_inverse=False, return_counts=False, axis=None
+):
+    raise NotImplementedError("OpenVino backend not supportedUnique op ")

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -3741,3 +3741,69 @@ def histogram(x, bins=10, range=None):
         shape=(bins,),
     )
     return bin_counts, bin_edges
+
+
+def unique(
+    input, sorted=True, return_inverse=False, return_counts=False, axis=None
+):
+    input = tf.convert_to_tensor(input)
+
+    def tf_lexsort(keys):
+        """Sorts a 2D tensor lexicographically across rows."""
+        num_rows = tf.shape(keys)[0]
+        num_cols = tf.shape(keys)[1]
+        idx = tf.range(num_rows)
+
+        # Radix sort: stable sort from last column to first
+        def body(i, current_idx):
+            col_values = tf.gather(keys[:, i], current_idx)
+            sort_step = tf.argsort(col_values, stable=True)
+            return i - 1, tf.gather(current_idx, sort_step)
+
+        _, final_idx = tf.while_loop(
+            lambda i, _: i >= 0, body, loop_vars=[num_cols - 1, idx]
+        )
+        return final_idx
+
+    # 1. Core unique logic
+    if axis is None:
+        input_flat = tf.reshape(input, [-1])
+        if return_counts:
+            y, idx, counts = tf.unique_with_counts(input_flat)
+        else:
+            y, idx = tf.unique(input_flat)
+            counts = None
+    else:
+        # Use low-level op for axis support
+        y, idx = tf.raw_ops.UniqueV2(
+            x=input, axis=tf.constant([axis], tf.int32)
+        )
+        counts = tf.math.bincount(idx) if return_counts else None
+
+    # 2. Sorting and index re-mapping
+    if sorted:
+        if axis is None:
+            sort_idx = tf.argsort(y)
+        else:
+            # Transpose target axis to front and flatten others for lexsort
+            rank = tf.rank(y)
+            perm = tf.concat(
+                [[axis], tf.range(axis), tf.range(axis + 1, rank)], axis=0
+            )
+            y_flat = tf.reshape(tf.transpose(y, perm), [tf.shape(y)[axis], -1])
+            sort_idx = tf_lexsort(y_flat)
+
+        # Apply sorting to values, counts, and inverse indices
+        y = tf.gather(y, sort_idx, axis=axis if axis is not None else 0)
+        inv_sort_idx = tf.math.invert_permutation(sort_idx)
+        idx = tf.gather(inv_sort_idx, idx)
+        if return_counts:
+            counts = tf.gather(counts, sort_idx)
+
+    # 3. Format return tuple
+    res = (y,)
+    if return_inverse:
+        res += (idx,)
+    if return_counts:
+        res += (counts,)
+    return res[0] if len(res) == 1 else res

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -2315,3 +2315,15 @@ def argpartition(x, kth, axis=-1):
 def histogram(x, bins=10, range=None):
     hist_result = torch.histogram(x, bins=bins, range=range)
     return hist_result.hist, hist_result.bin_edges
+
+
+def unique(
+    input, sorted=True, return_inverse=False, return_counts=False, axis=None
+):
+    return torch.unique(
+        input=input,
+        sorted=sorted,
+        return_inverse=return_inverse,
+        return_counts=return_counts,
+        dim=axis,
+    )

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -9398,3 +9398,134 @@ def array_split(x, indices_or_sections, axis=0):
     return backend.numpy.array_split(
         x, indices_or_sections=indices_or_sections, axis=axis
     )
+
+
+class Unique(Operation):
+    def __init__(
+        self,
+        return_index=False,
+        return_inverse=False,
+        return_counts=False,
+        axis=None,
+        sorted=True,
+        *,
+        name=None,
+    ):
+        super().__init__(name=name)
+        self.return_index = return_index
+        self.return_inverse = return_inverse
+        self.return_counts = return_counts
+        self.axis = axis
+        self.sorted = sorted
+
+    def call(self, x):
+        return backend.numpy.unique(
+            x,
+            return_index=self.return_index,
+            return_inverse=self.return_inverse,
+            return_counts=self.return_counts,
+            axis=self.axis,
+            sorted=self.sorted,
+        )
+
+    def compute_output_spec(self, x):
+        # Output shapes cannot be determined statically because the number of
+        # unique values is data-dependent. Use None for unknown dimensions.
+        if self.axis is None:
+            unique_shape = (None,)
+        else:
+            unique_shape = list(x.shape)
+            unique_shape[self.axis] = None
+            unique_shape = tuple(unique_shape)
+
+        outputs = [KerasTensor(unique_shape, dtype=x.dtype)]
+
+        if self.return_index:
+            index_shape = (None,)
+            outputs.append(KerasTensor(index_shape, dtype="int32"))
+        if self.return_inverse:
+            if self.axis is None:
+                inverse_shape = (None,)
+            else:
+                inverse_shape = (x.shape[self.axis],)
+            outputs.append(KerasTensor(inverse_shape, dtype="int32"))
+        if self.return_counts:
+            counts_shape = (None,)
+            outputs.append(KerasTensor(counts_shape, dtype="int32"))
+
+        if len(outputs) == 1:
+            return outputs[0]
+        return tuple(outputs)
+
+
+@keras_export(["keras.ops.unique", "keras.ops.numpy.unique"])
+def unique(
+    x,
+    return_index=False,
+    return_inverse=False,
+    return_counts=False,
+    axis=None,
+    sorted=True,
+):
+    """Find the unique elements of a tensor.
+
+    Returns the sorted unique elements of the input tensor. Optionally,
+    return the indices of the first occurrences, the indices to reconstruct
+    the original tensor, and the counts of each unique element.
+
+    Args:
+        x: Input tensor.
+        return_index: If `True`, also return the indices of the first
+            occurrence of each unique value (along the specified axis or
+            flattened). Defaults to `False`.
+        return_inverse: If `True`, also return the indices that can be used
+            to reconstruct `x` from the unique values. Defaults to `False`.
+        return_counts: If `True`, also return the number of times each
+            unique value appears in `x`. Defaults to `False`.
+        axis: Axis along which to operate. If `None`, the tensor is flattened
+            before computing unique values. If an integer, unique slices along
+            that axis are returned. Defaults to `None`.
+        sorted: If `True`, the unique values are sorted. If `False`, they
+            appear in the order they first occur. Defaults to `True`.
+
+    Returns:
+        A tensor of unique values, or tuple `(unique, indices, inverse, counts)`
+        depending on the boolean flags.
+
+    Example:
+    >>> import keras
+    >>> x = keras.ops.array([3, 4, 1, 3, 1])
+    >>> keras.ops.unique(x)
+    array([1, 3, 4])
+
+    >>> unique, inverse = keras.ops.unique(x, return_inverse=True)
+    >>> print(unique)
+    array([1, 3, 4])
+    >>> print(inverse)
+    array([1, 2, 0, 1, 0])
+
+    >>> x = keras.ops.array([[1, 2], [2, 3], [1, 2]])
+    >>> keras.ops.unique(x, axis=0)
+    array([[1, 2],
+           [2, 3]])
+
+    Note:
+        The handling of NaN values varies by backend. JAX treats NaNs as equal
+        by default, while PyTorch and TensorFlow do not.
+    """
+    if any_symbolic_tensors((x,)):
+        return Unique(
+            return_index=return_index,
+            return_inverse=return_inverse,
+            return_counts=return_counts,
+            axis=axis,
+            sorted=sorted,
+        ).symbolic_call(x)
+    return backend.numpy.unique(
+        x,
+        return_index=return_index,
+        return_inverse=return_inverse,
+        return_counts=return_counts,
+        axis=axis,
+        sorted=sorted,
+    )

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -11373,3 +11373,158 @@ class TileTest(testing.TestCase):
         output = TileLayer()(inputs)
 
         self.assertEqual(output.shape, (None, 6, 2, 2))
+
+
+class UniqueTest(testing.TestCase):
+    @pytest.mark.skipif(
+        keras.config.backend() == "openvino",
+        reason="OpenVINO does not support unique",
+    )
+    def test_unique_symbolic_static_shape(self):
+        x = KerasTensor([2, 3], dtype="float32")
+        # axis=None
+        y = knp.unique(x)
+        self.assertEqual(y.shape, (None,))
+        self.assertTrue(y.dtype, "float32")
+        y = knp.unique(x, return_index=True)
+        self.assertEqual(y[0].shape, (None,))
+        self.assertEqual(y[1].shape, (None,))
+        y = knp.unique(x, return_inverse=True)
+        self.assertEqual(y[0].shape, (None,))
+        self.assertEqual(y[1].shape, (None,))
+        y = knp.unique(x, return_counts=True)
+        self.assertEqual(y[0].shape, (None,))
+        self.assertEqual(y[1].shape, (None,))
+        # axis=0
+        y = knp.unique(x, axis=0)
+        self.assertEqual(y.shape, (None, 3))
+        y = knp.unique(x, axis=0, return_index=True)
+        self.assertEqual(y[0].shape, (None, 3))
+        self.assertEqual(y[1].shape, (None,))
+        y = knp.unique(x, axis=0, return_inverse=True)
+        self.assertEqual(y[0].shape, (None, 3))
+        self.assertEqual(y[1].shape, (2,))
+        y = knp.unique(x, axis=0, return_counts=True)
+        self.assertEqual(y[0].shape, (None, 3))
+        self.assertEqual(y[1].shape, (None,))
+
+    @pytest.mark.skipif(
+        keras.config.backend() == "openvino",
+        reason="OpenVINO does not support unique",
+    )
+    def test_unique_symbolic_dynamic_shape(self):
+        x = KerasTensor([None, 3], dtype="float32")
+        # axis=None
+        y = knp.unique(x)
+        self.assertEqual(y.shape, (None,))
+        y = knp.unique(x, return_inverse=True)
+        self.assertEqual(y[1].shape, (None,))
+        # axis=0
+        y = knp.unique(x, axis=0)
+        self.assertEqual(y.shape, (None, 3))
+        y = knp.unique(x, axis=0, return_inverse=True)
+        self.assertEqual(y[1].shape, (None,))
+        y = knp.unique(x, axis=0, return_counts=True)
+        self.assertEqual(y[1].shape, (None,))
+
+    @pytest.mark.skipif(
+        keras.config.backend() == "openvino",
+        reason="OpenVINO does not support unique",
+    )
+    def test_unique_correctness_1d(self):
+        rng = np.random.default_rng(0)
+        x = rng.integers(0, 10, size=20)
+        for return_index, return_inverse, return_counts in itertools.product(
+            [False, True], repeat=3
+        ):
+            # Test with integer input
+            result = knp.unique(
+                x,
+                return_index=return_index,
+                return_inverse=return_inverse,
+                return_counts=return_counts,
+            )
+            expected = np.unique(
+                x,
+                return_index=return_index,
+                return_inverse=return_inverse,
+                return_counts=return_counts,
+            )
+            # Compare each part
+            for r, e in zip(result, expected):
+                self.assertAllClose(r, e)
+            # Test with float input (no NaN)
+            xf = x.astype("float32")
+            result = knp.unique(
+                xf,
+                return_index=return_index,
+                return_inverse=return_inverse,
+                return_counts=return_counts,
+            )
+            expected = np.unique(
+                xf,
+                return_index=return_index,
+                return_inverse=return_inverse,
+                return_counts=return_counts,
+            )
+            for r, e in zip(result, expected):
+                self.assertAllClose(r, e)
+
+        # Test sorted=False (skip JAX if needed)
+        if keras.config.backend() != "jax":
+            x = np.array([3, 1, 2, 1, 2, 3])
+            result = knp.unique(x, sorted=False)
+            expected = np.unique(
+                x,
+                return_index=False,
+                return_inverse=False,
+                return_counts=False,
+                sorted=False,
+            )
+            self.assertAllClose(result, expected)
+
+    @pytest.mark.skipif(
+        keras.config.backend() == "openvino",
+        reason="OpenVINO does not support unique",
+    )
+    def test_unique_correctness_2d_axis0(self):
+        x = np.array([[1, 2], [2, 3], [1, 2], [3, 4], [2, 3]])
+        for return_index, return_inverse, return_counts in itertools.product(
+            [False, True], repeat=3
+        ):
+            result = knp.unique(
+                x,
+                axis=0,
+                return_index=return_index,
+                return_inverse=return_inverse,
+                return_counts=return_counts,
+            )
+            expected = np.unique(
+                x,
+                axis=0,
+                return_index=return_index,
+                return_inverse=return_inverse,
+                return_counts=return_counts,
+            )
+            for r, e in zip(result, expected):
+                self.assertAllClose(r, e)
+
+    @pytest.mark.skipif(
+        keras.config.backend() == "openvino",
+        reason="OpenVINO does not support unique",
+    )
+    def test_unique_correctness_2d_axis1(self):
+        x = np.array([[1, 2, 1], [2, 3, 2], [1, 2, 1]])
+        result = knp.unique(x, axis=1)
+        expected = np.unique(x, axis=1)
+        self.assertAllClose(result, expected)
+
+    @pytest.mark.skipif(
+        keras.config.backend() == "openvino",
+        reason="OpenVINO does not support unique",
+    )
+    def test_unique_correctness_3d_axis1(self):
+        x = np.random.randint(0, 3, size=(4, 5, 6))
+        result = knp.unique(x, axis=1)
+        expected = np.unique(x, axis=1)
+        self.assertAllClose(result, expected)


### PR DESCRIPTION
Provide an implementation of `keras.ops.numpy.unique`
Referencing:
https://docs.jax.dev/en/latest/_autosummary/jax.numpy.unique.html
https://pytorch.org/docs/stable/generated/torch.unique.html

Include backends for TensorFlow, JAX, PyTorch, and NumPy.
However, do not include the OpenVINO backend for now.