### PR TITLE
Use `pull_request_target` event for GPU and TPU tests.

### DIFF
--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -3,7 +3,7 @@ name: Keras GPU Tests
 on:
   push:
     branches: [master]
-  pull_request:
+  pull_request_target:
     types: [unlabeled]
   release:
     types: [created]
@@ -20,7 +20,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'release' ||
-      (github.event_name == 'pull_request' && github.event.action == 'unlabeled' && github.event.label.name == 'kokoro:force-run')
+      (github.event.action == 'unlabeled' && github.event.label.name == 'kokoro:force-run')
 
     strategy:
       fail-fast: false
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Check CUDA Version
         run: nvidia-smi

--- a/.github/workflows/tpu_tests.yml
+++ b/.github/workflows/tpu_tests.yml
@@ -3,7 +3,7 @@ name: Keras TPU Tests
 on:
   push:
     branches: [master]
-  pull_request:
+  pull_request_target:
     types: [unlabeled]
   release:
     types: [created]
@@ -26,7 +26,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'release' ||
-      (github.event_name == 'pull_request' && github.event.action == 'unlabeled' && github.event.label.name == 'kokoro:force-run')
+      (github.event.action == 'unlabeled' && github.event.label.name == 'kokoro:force-run')
 
     container:
       image: python:3.11-slim


### PR DESCRIPTION
This change https://github.com/keras-team/keras/pull/22504 causes the `kokoro:force-run` label to be removed automatically. However, unlike removing the label manually, it does not trigger the GPU / TPU tests.