### PR TITLE
Configure concurrency on github test workflows.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' && github.ref != 'refs/heads/master' }}
+
 jobs:
   build:
     strategy:
@@ -38,7 +42,9 @@ jobs:
       KERAS_HOME: .github/workflows/config/${{ matrix.backend }}
       JAX_NUM_CPU_DEVICES: ${{ matrix.multi_device && 4 || 1 }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v6.0.2
+
       - name: Check for changes in keras/src/applications
         uses: dorny/paths-filter@v3
         id: filter
@@ -136,7 +142,8 @@ jobs:
     name: Check the code format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v6.0.2
       - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' && github.ref != 'refs/heads/master' }}
+
 jobs:
 
   test-in-container:
@@ -32,7 +36,7 @@ jobs:
       options: --privileged --network host
 
     steps:
-      - name: Checkout Repository
+      - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v6.0.2
 
       - name: Check CUDA Version

--- a/.github/workflows/tpu_tests.yml
+++ b/.github/workflows/tpu_tests.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' && github.ref != 'refs/heads/master' }}
+
 jobs:
 
   test-in-container:
@@ -33,7 +37,7 @@ jobs:
       options: --privileged --network host
 
     steps:
-      - name: Checkout Repository
+      - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v6.0.2
       
       - name: Install Dependencies


### PR DESCRIPTION
**Problem**: if the tests are triggered multiple times, for instance when pushing an update to the PR, the old tests are not cancelled. The runners are consumed for tests that are no longer useful.

**Solution**: configure the `concurrency` of the workflows to cancel the runs on PRs, but not on master and on releases.

Also log the ref in the title of the checkout action for debugging purposes.