### PR TITLE
Directly trigger the GPU TPU tests instead of using `unlabel`.

### DIFF
--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -3,10 +3,9 @@ name: Keras GPU Tests
 on:
   push:
     branches: [master]
-  pull_request_target:
-    types: [unlabeled]
   release:
     types: [created]
+  workflow_call:
 
 permissions:
   contents: read
@@ -16,11 +15,6 @@ jobs:
   test-in-container:
     name: Run tests on GPU
     runs-on: linux-x86-g2-16-l4-1gpu
-    # Only run on pushes to master, releases or "kokoro:force-run" unlabel
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'release' ||
-      (github.event.action == 'unlabeled' && github.event.label.name == 'kokoro:force-run')
 
     strategy:
       fail-fast: false

--- a/.github/workflows/tpu_tests.yml
+++ b/.github/workflows/tpu_tests.yml
@@ -3,10 +3,9 @@ name: Keras TPU Tests
 on:
   push:
     branches: [master]
-  pull_request_target:
-    types: [unlabeled]
   release:
     types: [created]
+  workflow_call:
 
 permissions:
   contents: read
@@ -22,11 +21,6 @@ jobs:
 
     name: ${{ format('Run tests on {0}TPU', matrix.multi_device && 'multi-' || '') }}
     runs-on: ${{ matrix.multi_device && 'linux-x86-ct5lp-112-4tpu' || 'linux-x86-ct6e-44-1tpu' }}
-    # Only run on pushes to master, releases or "kokoro:force-run" unlabel
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'release' ||
-      (github.event.action == 'unlabeled' && github.event.label.name == 'kokoro:force-run')
 
     container:
       image: python:3.11-slim

--- a/.github/workflows/trigger_gpu_tpu_tests.yml
+++ b/.github/workflows/trigger_gpu_tpu_tests.yml
@@ -1,7 +1,7 @@
 name: Trigger GPU & TPU Tests
 
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled]
 
 permissions:
@@ -10,12 +10,19 @@ permissions:
   pull-requests: write
 
 jobs:
-  remove_label:
-    name: Remove Label
+  trigger:
+    name: Trigger and Remove Label
     runs-on: ubuntu-latest
     if: github.event.action == 'labeled' && github.event.label.name == 'kokoro:force-run'
     steps:
-      - uses: actions/github-script@v8
+      - name: Trigger GPU Tests
+        uses: ./.github/workflows/gpu_tests.yml
+
+      - name: Trigger TPU Tests
+        uses: ./.github/workflows/tpu_tests.yml
+
+      - name: Remove Label
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.removeLabel({


### PR DESCRIPTION
`trigger_gpu_tpu_tests.yml` now calls `gpu_tests.yml` and `tpu_tests.yml` directly.