### PR TITLE
Test layers on non-trainable backends.

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -21,13 +21,17 @@ ComputeScaleZeroTest::test_per_tensor_shapes_and_basic_invariants_bits2_sym
 ComputeScaleZeroTest::test_per_tensor_shapes_and_basic_invariants_bits4_sym
 ComputeScaleZeroTest::test_per_tensor_shapes_and_basic_invariants_bits8_sym
 ComputeScaleZeroTest::test_per_tensor_symmetric_on_constant_input_uses_safe_range
+ConvBasicTest::test_lora_rank_argument
 ConvLSTM1DTest::test_correctness
 ConvLSTM2DTest::test_correctness
+ConvLSTM3DTest::test_correctness
 ConvLSTMTest::test_correctness
 CTCTest::test_correctness
 CTCTest::test_dtype_arg
+DenseTest::test_lora_rank_argument
 EarlyStoppingTest::test_early_stopping
 EarlyStoppingTest::test_early_stopping_reuse
+EinsumDenseTest::test_lora_rank_argument
 FalseNegativesTest::test_unweighted
 FalseNegativesTest::test_weighted
 FalsePositivesTest::test_unweighted
@@ -142,6 +146,7 @@ QuantizersTest::test_abs_max_quantizer
 QuantizersTest::test_compute_float8_scale
 QuantizersTest::test_grouped_quantize_with_padding
 RandomBehaviorTest::test_beta_tf_data_compatibility
+ReLUTest::test_relu
 ReshapeTest::test_reshape_with_dynamic_batch_size_and_minus_one
 RMSpropTest::test_correctness_with_golden
 SaveModelTests::test_objects_to_skip
@@ -153,6 +158,7 @@ SavingTest::test_partial_load
 SerializationLibTest::test_custom_fn
 SerializationLibTest::test_custom_layer
 SGDTest::test_correctness_with_golden
+SimpleRNNTest::test_output_shape
 SparseCategoricalCrossentropyTest::test_all_correct_unweighted
 SparseCategoricalCrossentropyTest::test_binary_segmentation
 SparseCategoricalCrossentropyTest::test_dtype_arg
@@ -163,7 +169,6 @@ SparseCategoricalCrossentropyTest::test_sample_weighted
 SparseCategoricalCrossentropyTest::test_scalar_weighted
 SparseCategoricalCrossentropyTest::test_unweighted
 SpectralNormalizationTest::test_apply_layer
-StackedRNNTest::test_return_state_stacked_lstm_cell
 TestNumericalUtils::test_build_pos_neg_masks
 TestTrainer::test_predict_dropout
 TestTrainer::test_predict_flow_eager
@@ -207,5 +212,13 @@ TrueNegativesTest::test_weighted
 TruePositiveTest::test_unweighted
 TruePositiveTest::test_weighted
 UnitNormalizationTest::test_un_basics
+UpSampling2dTest::test_upsampling_2d_bilinear0
+UpSampling2dTest::test_upsampling_2d_bilinear1
+UpSampling2dTest::test_upsampling_2d_bilinear2
+UpSampling2dTest::test_upsampling_2d_bilinear3
+UpSampling2dTest::test_upsampling_2d_bilinear4
+UpSampling2dTest::test_upsampling_2d_bilinear5
+UpSampling2dTest::test_upsampling_2d_bilinear6
+UpSampling2dTest::test_upsampling_2d_bilinear7
 UpSampling2dTest::test_upsampling_2d_lanczos_interpolation_methods
 UpSampling2dTest::test_upsampling_2d_various_interpolation_methods

--- a/keras/src/layers/activations/activation_test.py
+++ b/keras/src/layers/activations/activation_test.py
@@ -1,12 +1,9 @@
-import pytest
-
 from keras.src import activations
 from keras.src import layers
 from keras.src import testing
 
 
 class ActivationTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_activation_basics(self):
         self.run_layer_test(
             layers.Activation,

--- a/keras/src/layers/activations/elu_test.py
+++ b/keras/src/layers/activations/elu_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import testing
 from keras.src.layers.activations import elu
@@ -10,7 +9,6 @@ class ELUTest(testing.TestCase):
         elu_layer = elu.ELU()
         self.run_class_serialization_test(elu_layer)
 
-    @pytest.mark.requires_trainable_backend
     def test_elu(self):
         self.run_layer_test(
             elu.ELU,

--- a/keras/src/layers/activations/leaky_relu_test.py
+++ b/keras/src/layers/activations/leaky_relu_test.py
@@ -1,12 +1,10 @@
 import numpy as np
-import pytest
 
 from keras.src import testing
 from keras.src.layers.activations import leaky_relu
 
 
 class LeakyReLUTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_leaky_relu(self):
         self.run_layer_test(
             leaky_relu.LeakyReLU,

--- a/keras/src/layers/activations/prelu_test.py
+++ b/keras/src/layers/activations/prelu_test.py
@@ -1,12 +1,10 @@
 import numpy as np
-import pytest
 
 from keras.src import testing
 from keras.src.layers.activations import prelu
 
 
 class PReLUTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_prelu(self):
         self.run_layer_test(
             prelu.PReLU,

--- a/keras/src/layers/activations/relu_test.py
+++ b/keras/src/layers/activations/relu_test.py
@@ -1,12 +1,10 @@
 import numpy as np
-import pytest
 
 from keras.src import testing
 from keras.src.layers.activations import relu
 
 
 class ReLUTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_relu(self):
         self.run_layer_test(
             relu.ReLU,

--- a/keras/src/layers/activations/softmax_test.py
+++ b/keras/src/layers/activations/softmax_test.py
@@ -1,12 +1,10 @@
 import numpy as np
-import pytest
 
 from keras.src import testing
 from keras.src.layers.activations import softmax
 
 
 class SoftmaxTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_softmax(self):
         self.run_layer_test(
             softmax.Softmax,

--- a/keras/src/layers/convolutional/conv_test.py
+++ b/keras/src/layers/convolutional/conv_test.py
@@ -324,7 +324,6 @@ class ConvBasicTest(testing.TestCase):
             "output_shape": (3, 2, 6),
         },
     )
-    @pytest.mark.requires_trainable_backend
     def test_conv1d_basic(
         self,
         filters,
@@ -391,7 +390,6 @@ class ConvBasicTest(testing.TestCase):
             "output_shape": (3, 2, 4, 6),
         },
     )
-    @pytest.mark.requires_trainable_backend
     def test_conv2d_basic(
         self,
         filters,
@@ -458,7 +456,6 @@ class ConvBasicTest(testing.TestCase):
             "output_shape": (3, 2, 4, 2, 6),
         },
     )
-    @pytest.mark.requires_trainable_backend
     def test_conv3d_basic(
         self,
         filters,
@@ -716,7 +713,6 @@ class ConvBasicTest(testing.TestCase):
         model.load_weights(temp_filepath)
         self.assertAllClose(model.predict(x), new_model.predict(x))
 
-    @pytest.mark.requires_trainable_backend
     def test_lora_weight_name(self):
         class MyModel(models.Model):
             def __init__(self):
@@ -736,7 +732,6 @@ class ConvBasicTest(testing.TestCase):
             model.conv2d.lora_kernel_a.path, "mymodel/conv2d/lora_kernel_a"
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_enable_lora_with_alpha(self):
         # Create a `Conv2D` layer with a small kernel for simplicity.
         layer = layers.Conv2D(filters=3, kernel_size=(2, 2), padding="valid")
@@ -786,7 +781,6 @@ class ConvBasicTest(testing.TestCase):
             tpu_rtol=1e-3,
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_lora_rank_argument(self):
         self.run_layer_test(
             layers.Conv2D,

--- a/keras/src/layers/convolutional/conv_transpose_test.py
+++ b/keras/src/layers/convolutional/conv_transpose_test.py
@@ -322,7 +322,6 @@ class ConvTransposeBasicTest(testing.TestCase):
             "output_shape": (2, 16, 6),
         },
     )
-    @pytest.mark.requires_trainable_backend
     def test_conv1d_transpose_basic(
         self,
         filters,
@@ -400,7 +399,6 @@ class ConvTransposeBasicTest(testing.TestCase):
             "output_shape": (1, 224, 224, 2),
         },
     )
-    @pytest.mark.requires_trainable_backend
     def test_conv2d_transpose_basic(
         self,
         filters,
@@ -473,7 +471,6 @@ class ConvTransposeBasicTest(testing.TestCase):
             "output_shape": (2, 16, 9, 17, 6),
         },
     )
-    @pytest.mark.requires_trainable_backend
     def test_conv3d_transpose_basic(
         self,
         filters,

--- a/keras/src/layers/convolutional/depthwise_conv_test.py
+++ b/keras/src/layers/convolutional/depthwise_conv_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 from numpy.lib.stride_tricks import as_strided
 
@@ -199,7 +198,6 @@ class DepthwiseConvBasicTest(testing.TestCase):
             "output_shape": (3, 2, 24),
         },
     )
-    @pytest.mark.requires_trainable_backend
     def test_depthwise_conv1d_basic(
         self,
         depth_multiplier,
@@ -261,7 +259,6 @@ class DepthwiseConvBasicTest(testing.TestCase):
             "output_shape": (3, 2, 2, 24),
         },
     )
-    @pytest.mark.requires_trainable_backend
     def test_depthwise_conv2d_basic(
         self,
         depth_multiplier,

--- a/keras/src/layers/convolutional/separable_conv_test.py
+++ b/keras/src/layers/convolutional/separable_conv_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 
 from keras.src import layers
@@ -50,7 +49,6 @@ class SeparableConvBasicTest(testing.TestCase):
             "output_shape": (3, 2, 6),
         },
     )
-    @pytest.mark.requires_trainable_backend
     def test_separable_conv1d_basic(
         self,
         depth_multiplier,
@@ -117,7 +115,6 @@ class SeparableConvBasicTest(testing.TestCase):
             "output_shape": (3, 2, 2, 6),
         },
     )
-    @pytest.mark.requires_trainable_backend
     def test_separable_conv2d_basic(
         self,
         depth_multiplier,

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -81,7 +81,6 @@ class DenseTest(testing.TestCase):
                 backend.standardize_dtype(layer._kernel.dtype), "int8"
             )
 
-    @pytest.mark.requires_trainable_backend
     def test_dense_basics(self):
         # 2D case, no bias.
         self.run_layer_test(
@@ -347,7 +346,6 @@ class DenseTest(testing.TestCase):
         model.load_weights(temp_filepath)
         self.assertAllClose(model.predict(x), new_model.predict(x))
 
-    @pytest.mark.requires_trainable_backend
     def test_enable_lora_with_alpha(self):
         # Create a `Dense` layer and build it.
         layer = layers.Dense(units=8)
@@ -373,7 +371,6 @@ class DenseTest(testing.TestCase):
             ops.convert_to_numpy(layer.kernel), effective_kernel_expected
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_lora_weight_name(self):
         class MyModel(models.Model):
             def __init__(self):
@@ -393,7 +390,6 @@ class DenseTest(testing.TestCase):
             model.dense.lora_kernel_a.path, "mymodel/dense/lora_kernel_a"
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_lora_rank_argument(self):
         self.run_layer_test(
             layers.Dense,
@@ -586,7 +582,6 @@ class DenseTest(testing.TestCase):
         ("int4", "int4_from_mixed_bfloat16", 1, 2),
         ("float8", "float8_from_mixed_bfloat16", 8, 0),
     )
-    @pytest.mark.requires_trainable_backend
     @pytest.mark.skipif(
         testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
     )

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -313,7 +313,6 @@ class EinsumDenseTest(testing.TestCase):
             "expected_output_shape": (2, 3, 4, 2),
         },
     )
-    @pytest.mark.requires_trainable_backend
     def test_einsum_dense_basics(
         self,
         equation,
@@ -435,7 +434,6 @@ class EinsumDenseTest(testing.TestCase):
         model.load_weights(temp_filepath)
         self.assertAllClose(model.predict(x), new_model.predict(x))
 
-    @pytest.mark.requires_trainable_backend
     def test_enable_lora_with_alpha(self):
         # Use a simple equation that mimics a `Dense` layer behavior.
         equation = "ab,bc->ac"
@@ -480,7 +478,6 @@ class EinsumDenseTest(testing.TestCase):
             actual_kernel, expected_kernel, tpu_atol=1e-3, tpu_rtol=1e-3
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_lora_rank_argument(self):
         self.run_layer_test(
             layers.EinsumDense,
@@ -764,7 +761,6 @@ class EinsumDenseTest(testing.TestCase):
         ("float8", "float8_from_mixed_bfloat16", 8, 0),
         ("int4", "int4_from_mixed_bfloat16", 1, 2),
     )
-    @pytest.mark.requires_trainable_backend
     def test_quantize_dtype_argument(
         self, dtype, num_trainable_weights, num_non_trainable_weights
     ):

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -61,7 +61,6 @@ class EmbeddingTest(test_case.TestCase):
         y = layer(x)
         self.assertEqual(y.shape, (2, 3, 6))
 
-    @pytest.mark.requires_trainable_backend
     def test_embedding_basics(self):
         self.run_layer_test(
             layers.Embedding,
@@ -254,7 +253,6 @@ class EmbeddingTest(test_case.TestCase):
         model.load_weights(temp_filepath)
         self.assertAllClose(model.predict(x), new_model.predict(x))
 
-    @pytest.mark.requires_trainable_backend
     def test_enable_lora_with_alpha(self):
         # Create an `Embedding` layer without specifying `lora_rank`
         layer = layers.Embedding(input_dim=3, output_dim=2)
@@ -288,7 +286,6 @@ class EmbeddingTest(test_case.TestCase):
             actual_embeddings, expected_embeddings, tpu_atol=1e-3, tpu_rtol=1e-3
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_lora_rank_argument(self):
         self.run_layer_test(
             layers.Embedding,
@@ -478,7 +475,6 @@ class EmbeddingTest(test_case.TestCase):
             2,
         ),  # per-channel (no zero point)
     )
-    @pytest.mark.requires_trainable_backend
     def test_quantize_dtype_argument(
         self, dtype, num_trainable_weights, num_non_trainable_weights
     ):

--- a/keras/src/layers/core/identity_test.py
+++ b/keras/src/layers/core/identity_test.py
@@ -13,7 +13,6 @@ class IdentityTest(testing.TestCase):
             {"testcase_name": "sparse", "sparse": True},
         ]
     )
-    @pytest.mark.requires_trainable_backend
     def test_identity_basics(self, sparse):
         if sparse and not backend.SUPPORTS_SPARSE_TENSORS:
             pytest.skip("Backend does not support sparse tensors.")

--- a/keras/src/layers/core/lambda_layer_test.py
+++ b/keras/src/layers/core/lambda_layer_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import layers
 from keras.src import ops
@@ -7,7 +6,6 @@ from keras.src import testing
 
 
 class LambdaTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_lambda_basics(self):
         self.run_layer_test(
             layers.Lambda,

--- a/keras/src/layers/core/masking_test.py
+++ b/keras/src/layers/core/masking_test.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-import pytest
 
 from keras.src import layers
 from keras.src import models
@@ -10,7 +9,6 @@ from keras.src.saving import load_model
 
 
 class MaskingTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_masking_basics(self):
         self.run_layer_test(
             layers.Masking,

--- a/keras/src/layers/core/reversible_embedding_test.py
+++ b/keras/src/layers/core/reversible_embedding_test.py
@@ -75,7 +75,6 @@ class ReversibleEmbeddingTest(test_case.TestCase):
         ("tie_weights", True),
         ("untie_weights", False),
     )
-    @pytest.mark.requires_trainable_backend
     def test_reversible_embedding_basics(self, tie_weights):
         self.run_layer_test(
             layers.ReversibleEmbedding,
@@ -212,7 +211,6 @@ class ReversibleEmbeddingTest(test_case.TestCase):
         ("int4_tie_weights", "int4_from_mixed_bfloat16", True, 0, 2),
         ("int4_untie_weights", "int4_from_mixed_bfloat16", False, 0, 4),
     )
-    @pytest.mark.requires_trainable_backend
     def test_quantize_dtype_argument(
         self,
         dtype,

--- a/keras/src/layers/core/wrapper_test.py
+++ b/keras/src/layers/core/wrapper_test.py
@@ -1,5 +1,3 @@
-import pytest
-
 from keras.src import layers
 from keras.src import ops
 from keras.src import testing
@@ -13,7 +11,6 @@ class ExampleWrapper(layers.Wrapper):
 
 
 class WrapperTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_wrapper_basics(self):
         self.run_layer_test(
             ExampleWrapper,

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -604,7 +604,6 @@ class LayerTest(testing.TestCase):
         expected_loss = 0.0 if batch_size == 0 else 0.2
         self.assertAllClose(layer.losses[0], expected_loss)
 
-    @pytest.mark.requires_trainable_backend
     def test_add_loss(self):
         class LossLayer(layers.Layer):
             def call(self, x):

--- a/keras/src/layers/merging/merging_test.py
+++ b/keras/src/layers/merging/merging_test.py
@@ -242,7 +242,7 @@ class MergingLayersTest(testing.TestCase):
 
         output = layers.Add()([x1, x2])
         self.assertAllClose(output, [[[0, 0], [1, 2], [1, 2], [6, 8]]])
-        self.assertIsNone(getattr(output, "_keras_mask", None))
+        self.assertIsNone(backend.get_keras_mask(output))
 
         x2 = mask(x2)
         output = layers.Add()([x1, x2])
@@ -256,7 +256,7 @@ class MergingLayersTest(testing.TestCase):
 
         output = layers.Subtract()([x1, x2])
         self.assertAllClose(output, [[[0, 0], [1, 2], [-1, -2], [0, 0]]])
-        self.assertIsNone(getattr(output, "_keras_mask", None))
+        self.assertIsNone(backend.get_keras_mask(output))
 
         x2 = mask(x2)
         output = layers.Subtract()([x1, x2])
@@ -270,7 +270,7 @@ class MergingLayersTest(testing.TestCase):
 
         output = layers.Average()([x1, x2])
         self.assertAllClose(output, [[[0, 0], [0.5, 1], [0.5, 1], [3, 4]]])
-        self.assertIsNone(getattr(output, "_keras_mask", None))
+        self.assertIsNone(backend.get_keras_mask(output))
 
         x2 = mask(x2)
         output = layers.Average()([x1, x2])
@@ -284,7 +284,7 @@ class MergingLayersTest(testing.TestCase):
 
         output = layers.Multiply()([x1, x2])
         self.assertAllClose(output, [[[0, 0], [0, 0], [1, 2], [9, 16]]])
-        self.assertIsNone(getattr(output, "_keras_mask", None))
+        self.assertIsNone(backend.get_keras_mask(output))
 
         x2 = mask(x2)
         output = layers.Multiply()([x1, x2])
@@ -300,7 +300,7 @@ class MergingLayersTest(testing.TestCase):
 
         output = layers.Maximum()([x1, x2])
         self.assertAllClose(output, [[[0, 0], [0, 0], [-1, -2], [-3, -4]]])
-        self.assertIsNone(getattr(output, "_keras_mask", None))
+        self.assertIsNone(backend.get_keras_mask(output))
 
         x2 = mask(x2)
         output = layers.Maximum()([x1, x2])
@@ -314,7 +314,7 @@ class MergingLayersTest(testing.TestCase):
 
         output = layers.Minimum()([x1, x2])
         self.assertAllClose(output, [[[0, 0], [0, 0], [1, 2], [3, 4]]])
-        self.assertIsNone(getattr(output, "_keras_mask", None))
+        self.assertIsNone(backend.get_keras_mask(output))
 
         x2 = mask(x2)
         output = layers.Minimum()([x1, x2])

--- a/keras/src/layers/normalization/batch_normalization_test.py
+++ b/keras/src/layers/normalization/batch_normalization_test.py
@@ -13,7 +13,6 @@ from keras.src.models import Model
 
 
 class BatchNormalizationTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_bn_basics(self):
         # vector case
         self.run_layer_test(
@@ -240,7 +239,6 @@ class BatchNormalizationTest(testing.TestCase):
         self.assertAllClose(layer.moving_mean, ops.ones((4,)), atol=1e-6)
         self.assertAllClose(layer.moving_variance, ops.zeros((4,)), atol=1e-6)
 
-    @pytest.mark.requires_trainable_backend
     def test_renorm_basics(self):
         # Test basic renorm functionality
         self.run_layer_test(
@@ -326,7 +324,6 @@ class BatchNormalizationTest(testing.TestCase):
 
         self.assertAllClose(out, out_renorm, atol=1e-5, rtol=1e-5)
 
-    @pytest.mark.requires_trainable_backend
     def test_renorm_correctness(self):
         epsilon = 1e-3
         momentum = 0.9

--- a/keras/src/layers/normalization/group_normalization_test.py
+++ b/keras/src/layers/normalization/group_normalization_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import constraints
 from keras.src import layers
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class GroupNormalizationTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_groupnorm(self):
         self.run_layer_test(
             layers.GroupNormalization,

--- a/keras/src/layers/normalization/layer_normalization_test.py
+++ b/keras/src/layers/normalization/layer_normalization_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import backend
 from keras.src import layers
@@ -9,7 +8,6 @@ from keras.src import testing
 
 
 class LayerNormalizationTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_ln_basics(self):
         self.run_layer_test(
             layers.LayerNormalization,

--- a/keras/src/layers/normalization/rms_normalization_test.py
+++ b/keras/src/layers/normalization/rms_normalization_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import layers
 from keras.src import ops
@@ -7,7 +6,6 @@ from keras.src import testing
 
 
 class RMSNormalizationTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_ln_basics(self):
         self.run_layer_test(
             layers.RMSNormalization,

--- a/keras/src/layers/normalization/spectral_normalization_test.py
+++ b/keras/src/layers/normalization/spectral_normalization_test.py
@@ -9,7 +9,6 @@ from keras.src import testing
 
 
 class SpectralNormalizationTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_basic_spectralnorm(self):
         self.run_layer_test(
             layers.SpectralNormalization,
@@ -35,7 +34,6 @@ class SpectralNormalizationTest(testing.TestCase):
             run_training_check=False,
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_spectralnorm_higher_dim(self):
         self.run_layer_test(
             layers.SpectralNormalization,

--- a/keras/src/layers/normalization/unit_normalization_test.py
+++ b/keras/src/layers/normalization/unit_normalization_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import backend
 from keras.src import layers
@@ -12,7 +11,6 @@ def squared_l2_norm(x):
 
 
 class UnitNormalizationTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_un_basics(self):
         self.run_layer_test(
             layers.UnitNormalization,

--- a/keras/src/layers/pooling/average_pooling_test.py
+++ b/keras/src/layers/pooling/average_pooling_test.py
@@ -134,7 +134,6 @@ def np_avgpool3d(x, pool_size, strides, padding, data_format):
     return out
 
 
-@pytest.mark.requires_trainable_backend
 class AveragePoolingBasicTest(testing.TestCase):
     @parameterized.parameters(
         (2, 1, "valid", "channels_last", (3, 5, 4), (3, 4, 4)),
@@ -164,6 +163,7 @@ class AveragePoolingBasicTest(testing.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            run_mixed_precision_check=False,
             assert_built_after_instantiation=True,
         )
 
@@ -199,6 +199,7 @@ class AveragePoolingBasicTest(testing.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            run_mixed_precision_check=False,
             assert_built_after_instantiation=True,
         )
 

--- a/keras/src/layers/pooling/global_average_pooling_test.py
+++ b/keras/src/layers/pooling/global_average_pooling_test.py
@@ -1,12 +1,10 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 
 from keras.src import layers
 from keras.src import testing
 
 
-@pytest.mark.requires_trainable_backend
 class GlobalAveragePoolingBasicTest(testing.TestCase):
     @parameterized.parameters(
         ("channels_last", False, (3, 5, 4), (3, 4)),

--- a/keras/src/layers/pooling/global_max_pooling_test.py
+++ b/keras/src/layers/pooling/global_max_pooling_test.py
@@ -1,12 +1,10 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 
 from keras.src import layers
 from keras.src import testing
 
 
-@pytest.mark.requires_trainable_backend
 class GlobalMaxPoolingBasicTest(testing.TestCase):
     @parameterized.parameters(
         ("channels_last", False, (3, 5, 4), (3, 4)),

--- a/keras/src/layers/pooling/max_pooling_test.py
+++ b/keras/src/layers/pooling/max_pooling_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 from numpy.lib.stride_tricks import as_strided
 
@@ -133,7 +132,6 @@ def np_maxpool3d(x, pool_size, strides, padding, data_format):
     return out
 
 
-@pytest.mark.requires_trainable_backend
 class MaxPoolingBasicTest(testing.TestCase):
     @parameterized.parameters(
         (2, 1, "valid", "channels_last", (3, 5, 4), (3, 4, 4)),

--- a/keras/src/layers/preprocessing/data_layer_test.py
+++ b/keras/src/layers/preprocessing/data_layer_test.py
@@ -1,6 +1,5 @@
 import grain
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -39,7 +38,6 @@ class RandomRGBToHSVLayer(DataLayer):
 
 
 class DataLayerTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             RandomRGBToHSVLayer,

--- a/keras/src/layers/preprocessing/image_preprocessing/aug_mix_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/aug_mix_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class RandAugmentTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.AugMix,

--- a/keras/src/layers/preprocessing/image_preprocessing/auto_contrast_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/auto_contrast_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import layers
 from keras.src import ops
@@ -7,7 +6,6 @@ from keras.src import testing
 
 
 class AutoContrastTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.AutoContrast,

--- a/keras/src/layers/preprocessing/image_preprocessing/center_crop_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/center_crop_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 from tensorflow import data as tf_data
 
@@ -33,7 +32,6 @@ class CenterCropTest(testing.TestCase):
                 ..., h_start : h_start + h_new, w_start : w_start + w_new
             ]
 
-    @pytest.mark.requires_trainable_backend
     def test_center_crop_basics(self):
         self.run_layer_test(
             layers.CenterCrop,

--- a/keras/src/layers/preprocessing/image_preprocessing/clahe_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/clahe_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 from tensorflow import data as tf_data
 
@@ -13,7 +12,6 @@ class ContrastLimitedAdaptiveHistogramEqualizationTest(testing.TestCase):
         self.assertTrue(np.all(array >= min_val))
         self.assertTrue(np.all(array <= max_val))
 
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.ContrastLimitedAdaptiveHistogramEqualization,

--- a/keras/src/layers/preprocessing/image_preprocessing/cut_mix_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/cut_mix_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class CutMixTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.CutMix,

--- a/keras/src/layers/preprocessing/image_preprocessing/equalization_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/equalization_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 from tensorflow import data as tf_data
 
@@ -13,7 +12,6 @@ class EqualizationTest(testing.TestCase):
         self.assertTrue(np.all(array >= min_val))
         self.assertTrue(np.all(array <= max_val))
 
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.Equalization,

--- a/keras/src/layers/preprocessing/image_preprocessing/mix_up_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/mix_up_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -9,7 +8,6 @@ from keras.src.backend import convert_to_tensor
 
 
 class MixUpTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.MixUp,

--- a/keras/src/layers/preprocessing/image_preprocessing/rand_augment_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/rand_augment_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class RandAugmentTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandAugment,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_brightness_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_brightness_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class RandomBrightnessTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomBrightness,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_color_degeneration_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_color_degeneration_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 import keras
@@ -9,7 +8,6 @@ from keras.src import testing
 
 
 class RandomColorDegenerationTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomColorDegeneration,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_color_jitter_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_color_jitter_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class RandomColorJitterTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomColorJitter,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_contrast_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_contrast_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class RandomContrastTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomContrast,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_elastic_transform_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_elastic_transform_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class RandomElasticTransformTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomElasticTransform,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_erasing_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_erasing_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class RandomErasingTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomErasing,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_gaussian_blur_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_gaussian_blur_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -9,7 +8,6 @@ from keras.src.backend import convert_to_tensor
 
 
 class RandomGaussianBlurTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomGaussianBlur,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_grayscale_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_grayscale_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 from tensorflow import data as tf_data
 
@@ -10,7 +9,6 @@ from keras.src import testing
 
 
 class RandomGrayscaleTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomGrayscale,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_hue_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_hue_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 import keras
@@ -9,7 +8,6 @@ from keras.src import testing
 
 
 class RandomHueTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomHue,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_invert_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_invert_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class RandomInvertTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomInvert,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_perspective_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_perspective_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 from tensorflow import data as tf_data
 
@@ -9,7 +8,6 @@ from keras.src import testing
 
 
 class RandomPerspectiveTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomPerspective,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_posterization_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_posterization_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 import keras
@@ -9,7 +8,6 @@ from keras.src import testing
 
 
 class RandomPosterizationTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomPosterization,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_saturation_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_saturation_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 import keras
@@ -9,7 +8,6 @@ from keras.src import testing
 
 
 class RandomSaturationTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomSaturation,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_sharpness_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_sharpness_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 import keras
@@ -9,7 +8,6 @@ from keras.src import testing
 
 
 class RandomSharpnessTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomSharpness,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_shear_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_shear_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 from tensorflow import data as tf_data
 
@@ -11,7 +10,6 @@ from keras.src.utils import backend_utils
 
 
 class RandomShearTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.RandomShear,

--- a/keras/src/layers/preprocessing/image_preprocessing/solarization_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/solarization_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 
 from keras.src import layers
@@ -22,7 +21,6 @@ class SolarizationTest(testing.TestCase):
         output = layer(input)
         self.assertAllClose(output, expected_output)
 
-    @pytest.mark.requires_trainable_backend
     def test_layer(self):
         self.run_layer_test(
             layers.Solarization,

--- a/keras/src/layers/preprocessing/mel_spectrogram_test.py
+++ b/keras/src/layers/preprocessing/mel_spectrogram_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 from tensorflow import data as tf_data
 
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class MelSpectrogramTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_mel_spectrogram_basics(self):
         self.run_layer_test(
             layers.MelSpectrogram,

--- a/keras/src/layers/preprocessing/normalization_test.py
+++ b/keras/src/layers/preprocessing/normalization_test.py
@@ -10,7 +10,6 @@ from keras.src.trainers.data_adapters.py_dataset_adapter import PyDataset
 
 
 class NormalizationTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_normalization_basics(self):
         self.run_layer_test(
             layers.Normalization,
@@ -408,7 +407,6 @@ class NormalizationTest(testing.TestCase):
         self.assertAllClose(np.var(output, axis=0), 1.0, atol=1e-5)
         self.assertAllClose(np.mean(output, axis=0), 0.0, atol=1e-5)
 
-    @pytest.mark.requires_trainable_backend
     def test_adapt_grain_dataset(self):
         grain = pytest.importorskip("grain")
         x = np.random.random((24, 3)).astype("float32")

--- a/keras/src/layers/preprocessing/rescaling_test.py
+++ b/keras/src/layers/preprocessing/rescaling_test.py
@@ -1,6 +1,5 @@
 import grain
 import numpy as np
-import pytest
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -9,7 +8,6 @@ from keras.src import testing
 
 
 class RescalingTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_rescaling_basics(self):
         self.run_layer_test(
             layers.Rescaling,
@@ -23,7 +21,6 @@ class RescalingTest(testing.TestCase):
             supports_masking=True,
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_rescaling_dtypes(self):
         # int scale
         self.run_layer_test(
@@ -100,7 +97,6 @@ class RescalingTest(testing.TestCase):
         layer(x)
         backend.set_image_data_format(config)
 
-    @pytest.mark.requires_trainable_backend
     def test_numpy_args(self):
         # https://github.com/keras-team/keras/issues/20072
         self.run_layer_test(

--- a/keras/src/layers/preprocessing/stft_spectrogram_test.py
+++ b/keras/src/layers/preprocessing/stft_spectrogram_test.py
@@ -55,7 +55,6 @@ class TestSpectrogram(testing.TestCase):
         y_true = np.transpose(spec, [0, 2, 1])
         return y_true, y
 
-    @pytest.mark.requires_trainable_backend
     def test_spectrogram_channels_broadcasting(self):
         rnd = np.random.RandomState(41)
         audio = rnd.uniform(-1, 1, size=(3, 16000, 7))
@@ -103,7 +102,6 @@ class TestSpectrogram(testing.TestCase):
         backend.backend() == "tensorflow",
         reason="TF doesn't support channels_first",
     )
-    @pytest.mark.requires_trainable_backend
     def test_spectrogram_channels_first(self):
         rnd = np.random.RandomState(41)
         audio = rnd.uniform(-1, 1, size=(3, 16000, 7))
@@ -179,7 +177,6 @@ class TestSpectrogram(testing.TestCase):
             supports_masking=False,
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_spectrogram_basics(self):
         self.run_layer_test(
             layers.STFTSpectrogram,
@@ -297,7 +294,6 @@ class TestSpectrogram(testing.TestCase):
 
         model.predict(generator())
 
-    @pytest.mark.requires_trainable_backend
     def test_spectrogram_error(self):
         rnd = np.random.RandomState(41)
         x = rnd.uniform(low=-1, high=1, size=(4, 160000, 1)).astype(self.DTYPE)

--- a/keras/src/layers/regularization/activity_regularization_test.py
+++ b/keras/src/layers/regularization/activity_regularization_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import layers
 from keras.src.testing import test_case
@@ -12,7 +11,6 @@ class ActivityRegularizationTest(test_case.TestCase):
         self.assertLen(layer.losses, 1)
         self.assertAllClose(layer.losses[0], 4 * 0.3 + 2 * 0.2)
 
-    @pytest.mark.requires_trainable_backend
     def test_activity_regularization_basics(self):
         self.run_layer_test(
             layers.ActivityRegularization,

--- a/keras/src/layers/regularization/alpha_dropout_test.py
+++ b/keras/src/layers/regularization/alpha_dropout_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import backend
 from keras.src import layers
@@ -7,7 +6,6 @@ from keras.src import testing
 
 
 class AlphaDropoutTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_alpha_dropout_basics(self):
         self.run_layer_test(
             layers.AlphaDropout,

--- a/keras/src/layers/regularization/dropout_test.py
+++ b/keras/src/layers/regularization/dropout_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import backend
 from keras.src import layers
@@ -7,7 +6,6 @@ from keras.src import testing
 
 
 class DropoutTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_dropout_basics(self):
         self.run_layer_test(
             layers.Dropout,

--- a/keras/src/layers/regularization/gaussian_dropout_test.py
+++ b/keras/src/layers/regularization/gaussian_dropout_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import backend
 from keras.src import layers
@@ -7,7 +6,6 @@ from keras.src import testing
 
 
 class GaussianDropoutTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_gaussian_dropout_basics(self):
         self.run_layer_test(
             layers.GaussianDropout,

--- a/keras/src/layers/regularization/gaussian_noise_test.py
+++ b/keras/src/layers/regularization/gaussian_noise_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import backend
 from keras.src import layers
@@ -7,7 +6,6 @@ from keras.src import testing
 
 
 class GaussianNoiseTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_gaussian_noise_basics(self):
         self.run_layer_test(
             layers.GaussianNoise,

--- a/keras/src/layers/regularization/spatial_dropout_test.py
+++ b/keras/src/layers/regularization/spatial_dropout_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import backend
 from keras.src import layers
@@ -7,7 +6,6 @@ from keras.src.testing import test_case
 
 
 class SpatialDropoutTest(test_case.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_spatial_dropout_1d(self):
         self.run_layer_test(
             layers.SpatialDropout1D,
@@ -25,7 +23,6 @@ class SpatialDropoutTest(test_case.TestCase):
             assert_built_after_instantiation=True,
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_spatial_dropout_2d(self):
         self.run_layer_test(
             layers.SpatialDropout2D,
@@ -43,7 +40,6 @@ class SpatialDropoutTest(test_case.TestCase):
             assert_built_after_instantiation=True,
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_spatial_dropout_3d(self):
         self.run_layer_test(
             layers.SpatialDropout3D,

--- a/keras/src/layers/reshaping/cropping1d_test.py
+++ b/keras/src/layers/reshaping/cropping1d_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import layers
 from keras.src import ops
@@ -7,7 +6,6 @@ from keras.src import testing
 
 
 class Cropping1DTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_cropping_1d(self):
         inputs = np.random.rand(3, 5, 7)
 
@@ -47,7 +45,6 @@ class Cropping1DTest(testing.TestCase):
             expected_output=ops.convert_to_tensor(inputs[:, 1:5, :]),
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_cropping_1d_with_dynamic_spatial_dim(self):
         input_layer = layers.Input(batch_shape=(1, None, 7))
         cropped = layers.Cropping1D((1, 2))(input_layer)

--- a/keras/src/layers/reshaping/cropping2d_test.py
+++ b/keras/src/layers/reshaping/cropping2d_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 
 from keras.src import backend
@@ -33,7 +32,6 @@ class Cropping2DTest(testing.TestCase):
             {"data_format": "channels_last"},
         ),
     )
-    @pytest.mark.requires_trainable_backend
     def test_cropping_2d(self, cropping, data_format, expected_ranges):
         if data_format == "channels_first":
             inputs = np.random.rand(3, 5, 7, 9)

--- a/keras/src/layers/reshaping/cropping3d_test.py
+++ b/keras/src/layers/reshaping/cropping3d_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 
 from keras.src import backend
@@ -30,7 +29,6 @@ class Cropping3DTest(testing.TestCase):
             {"data_format": "channels_last"},
         ),
     )
-    @pytest.mark.requires_trainable_backend
     def test_cropping_3d(
         self,
         dim1_cropping,
@@ -89,7 +87,6 @@ class Cropping3DTest(testing.TestCase):
             {"data_format": "channels_last"},
         ),
     )
-    @pytest.mark.requires_trainable_backend
     def test_cropping_3d_with_same_cropping(
         self, cropping, data_format, expected
     ):

--- a/keras/src/layers/reshaping/flatten_test.py
+++ b/keras/src/layers/reshaping/flatten_test.py
@@ -17,7 +17,6 @@ class FlattenTest(testing.TestCase):
             {"testcase_name": "sparse", "sparse": True},
         ]
     )
-    @pytest.mark.requires_trainable_backend
     def test_flatten(self, sparse):
         if sparse and not backend.SUPPORTS_SPARSE_TENSORS:
             pytest.skip("Backend does not support sparse tensors.")
@@ -87,7 +86,6 @@ class FlattenTest(testing.TestCase):
             run_training_check=not sparse,
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_flatten_with_scalar_channels(self):
         inputs = np.random.random((10,)).astype("float32")
         expected_output = ops.convert_to_tensor(np.expand_dims(inputs, -1))

--- a/keras/src/layers/reshaping/permute_test.py
+++ b/keras/src/layers/reshaping/permute_test.py
@@ -15,7 +15,6 @@ class PermuteTest(testing.TestCase):
             {"testcase_name": "sparse", "sparse": True},
         ]
     )
-    @pytest.mark.requires_trainable_backend
     def test_permute(self, sparse):
         if sparse and not backend.SUPPORTS_SPARSE_TENSORS:
             pytest.skip("Backend does not support sparse tensors.")

--- a/keras/src/layers/reshaping/repeat_vector_test.py
+++ b/keras/src/layers/reshaping/repeat_vector_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import layers
 from keras.src import ops
@@ -7,7 +6,6 @@ from keras.src import testing
 
 
 class FlattenTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_repeat_vector(self):
         inputs = np.random.random((2, 5)).astype("float32")
         expected_output = ops.convert_to_tensor(

--- a/keras/src/layers/reshaping/reshape_test.py
+++ b/keras/src/layers/reshaping/reshape_test.py
@@ -17,7 +17,6 @@ class ReshapeTest(testing.TestCase):
             {"testcase_name": "sparse", "sparse": True},
         ]
     )
-    @pytest.mark.requires_trainable_backend
     def test_reshape(self, sparse):
         if sparse and not backend.SUPPORTS_SPARSE_TENSORS:
             pytest.skip("Backend does not support sparse tensors.")

--- a/keras/src/layers/reshaping/up_sampling1d_test.py
+++ b/keras/src/layers/reshaping/up_sampling1d_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import layers
 from keras.src import testing
@@ -7,7 +6,6 @@ from keras.src.backend.common.keras_tensor import KerasTensor
 
 
 class UpSamplingTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_upsampling_1d(self):
         self.run_layer_test(
             layers.UpSampling1D,

--- a/keras/src/layers/reshaping/up_sampling2d_test.py
+++ b/keras/src/layers/reshaping/up_sampling2d_test.py
@@ -23,7 +23,6 @@ class UpSampling2dTest(testing.TestCase):
         length_row=[2],
         length_col=[2, 3],
     )
-    @pytest.mark.requires_trainable_backend
     def test_upsampling_2d(self, data_format, length_row, length_col):
         num_samples = 2
         stack_size = 2
@@ -75,7 +74,6 @@ class UpSampling2dTest(testing.TestCase):
         length_row=[2],
         length_col=[2, 3],
     )
-    @pytest.mark.requires_trainable_backend
     def test_upsampling_2d_bilinear(
         self, data_format, use_set_image_data_format, length_row, length_col
     ):

--- a/keras/src/layers/reshaping/up_sampling3d_test.py
+++ b/keras/src/layers/reshaping/up_sampling3d_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from absl.testing import parameterized
 
 from keras.src import backend
@@ -14,7 +13,6 @@ class UpSampling3dTest(testing.TestCase):
         length_dim2=[2],
         length_dim3=[3],
     )
-    @pytest.mark.requires_trainable_backend
     def test_upsampling_3d(
         self, data_format, length_dim1, length_dim2, length_dim3
     ):

--- a/keras/src/layers/rnn/bidirectional_test.py
+++ b/keras/src/layers/rnn/bidirectional_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import initializers
 from keras.src import layers
@@ -7,7 +6,6 @@ from keras.src import testing
 
 
 class SimpleRNNTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_basics(self):
         self.run_layer_test(
             layers.Bidirectional,
@@ -295,7 +293,6 @@ class SimpleRNNTest(testing.TestCase):
             tpu_rtol=1e-3,
         )
 
-    @pytest.mark.requires_trainable_backend
     def test_output_shape(self):
         x = np.array([[[101, 202], [303, 404]]])
         for merge_mode in ["ave", "concat", "mul", "sum", None]:

--- a/keras/src/layers/rnn/conv_lstm1d_test.py
+++ b/keras/src/layers/rnn/conv_lstm1d_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import backend
 from keras.src import initializers
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class ConvLSTM1DTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_basics(self):
         channels_last = backend.config.image_data_format() == "channels_last"
         self.run_layer_test(

--- a/keras/src/layers/rnn/conv_lstm2d_test.py
+++ b/keras/src/layers/rnn/conv_lstm2d_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import backend
 from keras.src import initializers
@@ -8,7 +7,6 @@ from keras.src import testing
 
 
 class ConvLSTM2DTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_basics(self):
         channels_last = backend.config.image_data_format() == "channels_last"
         self.run_layer_test(

--- a/keras/src/layers/rnn/conv_lstm3d_test.py
+++ b/keras/src/layers/rnn/conv_lstm3d_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import backend
 from keras.src import initializers
@@ -7,8 +6,7 @@ from keras.src import layers
 from keras.src import testing
 
 
-class ConvLSTM1DTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
+class ConvLSTM3DTest(testing.TestCase):
     def test_basics(self):
         channels_last = backend.config.image_data_format() == "channels_last"
         self.run_layer_test(

--- a/keras/src/layers/rnn/dropout_rnn_cell_test.py
+++ b/keras/src/layers/rnn/dropout_rnn_cell_test.py
@@ -1,5 +1,3 @@
-import pytest
-
 from keras.src import backend
 from keras.src import layers
 from keras.src import ops
@@ -51,7 +49,6 @@ class DropoutRNNCellTest(testing.TestCase):
         layer = layers.RNN(cell)
         self.assertEqual(len(layer.non_trainable_variables), 1)
 
-    @pytest.mark.requires_trainable_backend
     def test_basics(self):
         self.run_layer_test(
             layers.RNN,

--- a/keras/src/layers/rnn/gru_test.py
+++ b/keras/src/layers/rnn/gru_test.py
@@ -9,7 +9,6 @@ from keras.src import testing
 
 
 class GRUTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_basics(self):
         self.run_layer_test(
             layers.GRU,

--- a/keras/src/layers/rnn/lstm_test.py
+++ b/keras/src/layers/rnn/lstm_test.py
@@ -8,7 +8,6 @@ from keras.src import testing
 
 
 class LSTMTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_basics(self):
         self.run_layer_test(
             layers.LSTM,

--- a/keras/src/layers/rnn/rnn_test.py
+++ b/keras/src/layers/rnn/rnn_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import layers
 from keras.src import ops
@@ -66,7 +65,6 @@ class TwoStatesRNNCell(layers.Layer):
 
 
 class RNNTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_basics(self):
         self.run_layer_test(
             layers.RNN,

--- a/keras/src/layers/rnn/simple_rnn_test.py
+++ b/keras/src/layers/rnn/simple_rnn_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import initializers
 from keras.src import layers
@@ -7,7 +6,6 @@ from keras.src import testing
 
 
 class SimpleRNNTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_basics(self):
         self.run_layer_test(
             layers.SimpleRNN,

--- a/keras/src/layers/rnn/stacked_rnn_cells_test.py
+++ b/keras/src/layers/rnn/stacked_rnn_cells_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from keras.src import layers
 from keras.src import testing
@@ -8,7 +7,6 @@ from keras.src.layers.rnn.rnn_test import TwoStatesRNNCell
 
 
 class StackedRNNTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_basics(self):
         self.run_layer_test(
             layers.RNN,

--- a/keras/src/layers/rnn/time_distributed_test.py
+++ b/keras/src/layers/rnn/time_distributed_test.py
@@ -10,7 +10,6 @@ from keras.src.models import Sequential
 
 
 class TimeDistributedTest(testing.TestCase):
-    @pytest.mark.requires_trainable_backend
     def test_basics(self):
         self.run_layer_test(
             layers.TimeDistributed,

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -580,7 +580,10 @@ class TestCase(parameterized.TestCase):
                 tpu_rtol=tpu_rtol,
             )
 
-            if run_training_check:
+            if run_training_check and backend.backend() not in (
+                "numpy",
+                "openvino",
+            ):
                 run_training_step(layer, input_data, output_data)
 
             # Never test mixed precision on torch CPU. Torch lacks support.


### PR DESCRIPTION
Many import layer tests were skipped on the basis that the `run_layer_tests` calls `fit`, which is not supported on NumPy and OpenVino. However, all the other tests are valuable.

Instead, we skip the `fit` test in `run_layer_tests`.