### PR TITLE
Use float32 for LoRA weights to avoid the risk of underflow and overflow.

### DIFF
--- a/keras/src/layers/convolutional/base_conv.py
+++ b/keras/src/layers/convolutional/base_conv.py
@@ -230,11 +230,17 @@ class BaseConv(Layer):
             raise AttributeError(
                 "You must build the layer before accessing `kernel`."
             )
+        kernel = self._kernel
         if self.lora_enabled:
-            return self._kernel + (
-                self.lora_alpha / self.lora_rank
-            ) * ops.matmul(self.lora_kernel_a, self.lora_kernel_b)
-        return self._kernel
+            kernel = ops.cast(
+                ops.add(
+                    kernel,
+                    (self.lora_alpha / self.lora_rank)
+                    * ops.matmul(self.lora_kernel_a, self.lora_kernel_b),
+                ),
+                dtype=self.variable_dtype,
+            )
+        return kernel
 
     def convolution_op(self, inputs, kernel):
         return ops.conv(
@@ -296,16 +302,21 @@ class BaseConv(Layer):
                 "lora is already enabled. This can only be done once per layer."
             )
         self._tracker.unlock()
+
+        # LoRA weights should be float32 to avoid the risk of underflow or
+        # overflow during fine-tuning.
         self.lora_kernel_a = self.add_weight(
             name="lora_kernel_a",
             shape=self._kernel.shape[:-1] + (rank,),
             initializer=initializers.get(a_initializer),
+            dtype="float32",
             regularizer=self.kernel_regularizer,
         )
         self.lora_kernel_b = self.add_weight(
             name="lora_kernel_b",
             shape=(rank, self.filters),
             initializer=initializers.get(b_initializer),
+            dtype="float32",
             regularizer=self.kernel_regularizer,
         )
         self._kernel.trainable = False

--- a/keras/src/layers/convolutional/base_conv.py
+++ b/keras/src/layers/convolutional/base_conv.py
@@ -238,7 +238,7 @@ class BaseConv(Layer):
                     (self.lora_alpha / self.lora_rank)
                     * ops.matmul(self.lora_kernel_a, self.lora_kernel_b),
                 ),
-                dtype=self.variable_dtype,
+                dtype=self.compute_dtype,
             )
         return kernel
 
@@ -253,10 +253,7 @@ class BaseConv(Layer):
         )
 
     def call(self, inputs):
-        outputs = self.convolution_op(
-            inputs,
-            self.kernel,
-        )
+        outputs = self.convolution_op(inputs, self.kernel)
         if self.use_bias:
             if self.data_format == "channels_last":
                 bias_shape = (1,) * (self.rank + 1) + (self.filters,)
@@ -305,6 +302,8 @@ class BaseConv(Layer):
 
         # LoRA weights should be float32 to avoid the risk of underflow or
         # overflow during fine-tuning.
+        # When deploying the model, these weights should be merged with the
+        # original kernel while maintaining the original kernel's dtype.
         self.lora_kernel_a = self.add_weight(
             name="lora_kernel_a",
             shape=self._kernel.shape[:-1] + (rank,),

--- a/keras/src/layers/convolutional/conv_test.py
+++ b/keras/src/layers/convolutional/conv_test.py
@@ -652,6 +652,9 @@ class ConvBasicTest(testing.TestCase):
         self.assertLen(layer.non_trainable_weights, 1)
         if backend.backend() == "torch":
             self.assertLen(layer.torch_params, 4)
+        self.assertDType(layer.lora_kernel_a, "float32")
+        self.assertDType(layer.lora_kernel_b, "float32")
+
         # Try eager call
         x = np.random.random((64,) + input_shape[1:])
         y = np.random.random((64,) + output_shape[1:])

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -207,8 +207,13 @@ class Dense(Layer):
 
         # Apply LoRA once at the end.
         if self.lora_enabled:
-            kernel = kernel + (self.lora_alpha / self.lora_rank) * ops.matmul(
-                self.lora_kernel_a, self.lora_kernel_b
+            kernel = ops.cast(
+                ops.add(
+                    kernel,
+                    (self.lora_alpha / self.lora_rank)
+                    * ops.matmul(self.lora_kernel_a, self.lora_kernel_b),
+                ),
+                dtype=self.variable_dtype,
             )
 
         return kernel
@@ -265,16 +270,20 @@ class Dense(Layer):
         else:
             input_dim_for_lora = self.kernel.shape[0]
 
+        # LoRA weights should be float32 to avoid the risk of underflow or
+        # overflow during fine-tuning.
         self.lora_kernel_a = self.add_weight(
             name="lora_kernel_a",
             shape=(input_dim_for_lora, rank),
             initializer=initializers.get(a_initializer),
+            dtype="float32",
             regularizer=self.kernel_regularizer,
         )
         self.lora_kernel_b = self.add_weight(
             name="lora_kernel_b",
             shape=(rank, self.kernel.shape[1]),
             initializer=initializers.get(b_initializer),
+            dtype="float32",
             regularizer=self.kernel_regularizer,
         )
         self._kernel.trainable = False
@@ -810,6 +819,7 @@ class Dense(Layer):
             lora_x = ops.matmul(inputs, self.lora_kernel_a)
             lora_x = ops.matmul(lora_x, self.lora_kernel_b)
             x = ops.add(x, (self.lora_alpha / self.lora_rank) * lora_x)
+            x = ops.cast(x, self.compute_dtype)
         if self.bias is not None:
             x = ops.add(x, self.bias)
         if self.activation is not None:
@@ -918,7 +928,7 @@ class Dense(Layer):
             lora_x = ops.matmul(inputs, self.lora_kernel_a)
             lora_x = ops.matmul(lora_x, self.lora_kernel_b)
             x = ops.add(x, (self.lora_alpha / self.lora_rank) * lora_x)
-
+            x = ops.cast(x, self.compute_dtype)
         if self.bias is not None:
             x = ops.add(x, self.bias)
         if self.activation is not None:

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -213,7 +213,7 @@ class Dense(Layer):
                     (self.lora_alpha / self.lora_rank)
                     * ops.matmul(self.lora_kernel_a, self.lora_kernel_b),
                 ),
-                dtype=self.variable_dtype,
+                dtype=self.compute_dtype,
             )
 
         return kernel
@@ -272,6 +272,8 @@ class Dense(Layer):
 
         # LoRA weights should be float32 to avoid the risk of underflow or
         # overflow during fine-tuning.
+        # When deploying the model, these weights should be merged with the
+        # original kernel while maintaining the original kernel's dtype.
         self.lora_kernel_a = self.add_weight(
             name="lora_kernel_a",
             shape=(input_dim_for_lora, rank),

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -289,6 +289,9 @@ class DenseTest(testing.TestCase):
         self.assertLen(layer.non_trainable_weights, 1)
         if backend.backend() == "torch":
             self.assertLen(layer.torch_params, 4)
+        self.assertDType(layer.lora_kernel_a, "float32")
+        self.assertDType(layer.lora_kernel_b, "float32")
+
         # Try eager call
         x = np.random.random((64, 8))
         y = np.random.random((64, 16))

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -264,8 +264,13 @@ class EinsumDense(Layer):
 
         # Apply LoRA if enabled
         if self.lora_enabled:
-            kernel = kernel + (self.lora_alpha / self.lora_rank) * ops.matmul(
-                self.lora_kernel_a, self.lora_kernel_b
+            kernel = ops.cast(
+                ops.add(
+                    kernel,
+                    (self.lora_alpha / self.lora_rank)
+                    * ops.matmul(self.lora_kernel_a, self.lora_kernel_b),
+                ),
+                dtype=self.variable_dtype,
             )
 
         return kernel
@@ -317,16 +322,20 @@ class EinsumDense(Layer):
         else:
             kernel_shape_for_lora = self.kernel.shape
 
+        # LoRA weights should be float32 to avoid the risk of underflow or
+        # overflow during fine-tuning.
         self.lora_kernel_a = self.add_weight(
             name="lora_kernel_a",
             shape=(kernel_shape_for_lora[:-1] + (rank,)),
             initializer=initializers.get(a_initializer),
+            dtype="float32",
             regularizer=self.kernel_regularizer,
         )
         self.lora_kernel_b = self.add_weight(
             name="lora_kernel_b",
             shape=(rank, kernel_shape_for_lora[-1]),
             initializer=initializers.get(b_initializer),
+            dtype="float32",
             regularizer=self.kernel_regularizer,
         )
         self._kernel.trainable = False
@@ -980,6 +989,7 @@ class EinsumDense(Layer):
             lora_x = ops.einsum(self.equation, inputs, self.lora_kernel_a)
             lora_x = ops.matmul(lora_x, self.lora_kernel_b)
             x = ops.add(x, (self.lora_alpha / self.lora_rank) * lora_x)
+            x = ops.cast(x, dtype=self.compute_dtype)
         if self.bias is not None:
             x = ops.add(x, self.bias)
         if self.activation is not None:
@@ -1121,7 +1131,7 @@ class EinsumDense(Layer):
             lora_x = ops.einsum(self.equation, inputs, self.lora_kernel_a)
             lora_x = ops.matmul(lora_x, self.lora_kernel_b)
             x = ops.add(x, (self.lora_alpha / self.lora_rank) * lora_x)
-
+            x = ops.cast(x, dtype=self.compute_dtype)
         # Bias & activation
         if self.bias is not None:
             x = ops.add(x, self.bias)
@@ -1444,8 +1454,9 @@ class EinsumDense(Layer):
             )
 
         # 2. Merge the LoRA update in the float domain
-        lora_update = (self.lora_alpha / self.lora_rank) * ops.matmul(
-            self.lora_kernel_a, self.lora_kernel_b
+        lora_update = (
+            (self.lora_alpha / self.lora_rank)
+            * ops.matmul(self.lora_kernel_a, self.lora_kernel_b),
         )
         merged_kernel = ops.add(kernel_fp, lora_update)
 

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -1454,9 +1454,8 @@ class EinsumDense(Layer):
             )
 
         # 2. Merge the LoRA update in the float domain
-        lora_update = (
-            (self.lora_alpha / self.lora_rank)
-            * ops.matmul(self.lora_kernel_a, self.lora_kernel_b),
+        lora_update = (self.lora_alpha / self.lora_rank) * ops.matmul(
+            self.lora_kernel_a, self.lora_kernel_b
         )
         merged_kernel = ops.add(kernel_fp, lora_update)
 

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -270,7 +270,7 @@ class EinsumDense(Layer):
                     (self.lora_alpha / self.lora_rank)
                     * ops.matmul(self.lora_kernel_a, self.lora_kernel_b),
                 ),
-                dtype=self.variable_dtype,
+                dtype=self.compute_dtype,
             )
 
         return kernel
@@ -324,6 +324,8 @@ class EinsumDense(Layer):
 
         # LoRA weights should be float32 to avoid the risk of underflow or
         # overflow during fine-tuning.
+        # When deploying the model, these weights should be merged with the
+        # original kernel while maintaining the original kernel's dtype.
         self.lora_kernel_a = self.add_weight(
             name="lora_kernel_a",
             shape=(kernel_shape_for_lora[:-1] + (rank,)),

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -373,6 +373,9 @@ class EinsumDenseTest(testing.TestCase):
         self.assertLen(layer.non_trainable_weights, 1)
         if backend.backend() == "torch":
             self.assertLen(layer.torch_params, 3)
+        self.assertDType(layer.lora_kernel_a, "float32")
+        self.assertDType(layer.lora_kernel_b, "float32")
+
         # Try eager call
         x = np.random.random((64, 3))
         y = np.random.random((64, 8, 32))

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -158,8 +158,15 @@ class Embedding(Layer):
                 embeddings, self._orig_output_dim, axis=-1
             )
         if self.lora_enabled:
-            return embeddings + (self.lora_alpha / self.lora_rank) * ops.matmul(
-                self.lora_embeddings_a, self.lora_embeddings_b
+            embeddings = ops.cast(
+                ops.add(
+                    embeddings,
+                    (self.lora_alpha / self.lora_rank)
+                    * ops.matmul(
+                        self.lora_embeddings_a, self.lora_embeddings_b
+                    ),
+                ),
+                dtype=self.variable_dtype,
             )
         return embeddings
 
@@ -206,16 +213,21 @@ class Embedding(Layer):
                 "lora is already enabled. This can only be done once per layer."
             )
         self._tracker.unlock()
+
+        # LoRA weights should be float32 to avoid the risk of underflow or
+        # overflow during fine-tuning.
         self.lora_embeddings_a = self.add_weight(
             name="lora_embeddings_a",
             shape=(self.input_dim, rank),
             initializer=initializers.get(a_initializer),
+            dtype="float32",
             regularizer=self.embeddings_regularizer,
         )
         self.lora_embeddings_b = self.add_weight(
             name="lora_embeddings_b",
             shape=(rank, self.output_dim),
             initializer=initializers.get(b_initializer),
+            dtype="float32",
             regularizer=self.embeddings_regularizer,
         )
         self.embeddings.trainable = False
@@ -478,6 +490,7 @@ class Embedding(Layer):
             outputs = ops.add(
                 outputs, (self.lora_alpha / self.lora_rank) * lora_outputs
             )
+            outputs = ops.cast(outputs, dtype=self.compute_dtype)
         return outputs
 
     def _int4_call(self, inputs, training=None):
@@ -519,6 +532,7 @@ class Embedding(Layer):
             outputs = ops.add(
                 outputs, (self.lora_alpha / self.lora_rank) * lora_outputs
             )
+            outputs = ops.cast(outputs, dtype=self.compute_dtype)
         return outputs
 
     def quantize(self, mode=None, type_check=True, config=None):

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -166,7 +166,7 @@ class Embedding(Layer):
                         self.lora_embeddings_a, self.lora_embeddings_b
                     ),
                 ),
-                dtype=self.variable_dtype,
+                dtype=self.compute_dtype,
             )
         return embeddings
 
@@ -216,6 +216,8 @@ class Embedding(Layer):
 
         # LoRA weights should be float32 to avoid the risk of underflow or
         # overflow during fine-tuning.
+        # When deploying the model, these weights should be merged with the
+        # original embedding while maintaining the original embedding's dtype.
         self.lora_embeddings_a = self.add_weight(
             name="lora_embeddings_a",
             shape=(self.input_dim, rank),

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -196,6 +196,9 @@ class EmbeddingTest(test_case.TestCase):
         self.assertLen(layer.non_trainable_weights, 1)
         if backend.backend() == "torch":
             self.assertLen(layer.torch_params, 3)
+        self.assertDType(layer.lora_embeddings_a, "float32")
+        self.assertDType(layer.lora_embeddings_b, "float32")
+
         # Try eager call
         x = np.random.randint(0, 9, size=(64, 3))
         y = np.random.random((64, 3, 16))


### PR DESCRIPTION
## Description
As reported in https://github.com/keras-team/keras-hub/issues/2629

We should use high precision (float32) for LoRA weights to stabilize the finetuning.

References:
- https://huggingface.co/docs/peft/developer_guides/troubleshooting (`autocast_adapter_dtype`)
- https://github.com/huggingface/peft/issues/2421
- https://github.com/huggingface/peft/blob/c75485a2144a15a526e0290835a7439daefc3925/src/peft/tuners/lora/layer.py#L966-L968 (`huggingface/peft` impl)

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.