### PR TITLE
Fix convolution operations for batch size 0

### DIFF
--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -764,7 +764,7 @@ def conv(
         dimension_numbers=dimension_numbers,
         feature_group_count=feature_group_count,
     )
-    if result.size == 0:
+    if result.size == 0 and inputs.size != 0:
         raise ValueError(
             "The convolution operation resulted in an empty output. "
             "This can happen if the input is too small for the given "

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -664,7 +664,7 @@ def conv(
             feature_group_count=feature_group_count,
         )
     )
-    if result.size == 0:
+    if result.size == 0 and inputs.size != 0:
         raise ValueError(
             "The convolution operation resulted in an empty output. "
             "This can happen if the input is too small for the given "

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -805,6 +805,7 @@ def conv(
         if (
             result_shape.is_fully_defined()
             and math.prod(result_shape.as_list()) == 0
+            and math.prod(inputs.shape.as_list()) != 0
         ):
             raise ValueError(
                 "The convolution operation resulted in an empty output. "


### PR DESCRIPTION
In #21796, a check was introduced for convolution operations that aims to consistently throw if too big kernel sizes are used, resulting in 0 dimensions in the output tensor. Currently, this check only compares the output size for being 0 and therefore additionally throws when passing a batch size of 0. Passing 0-batches can happen, e.g., when using multimodal models without image inputs and should be supported.

This PR performs the check introduced in #21796 only when the tensor size is not 0 already for the input tensor.