### PR TITLE
Fix order of arguments was calling `assertAllClose`.

### DIFF
--- a/keras/src/activations/activations_test.py
+++ b/keras/src/activations/activations_test.py
@@ -70,7 +70,7 @@ class ActivationsTest(testing.TestCase):
 
         result = activations.softmax(x[np.newaxis, :])[0]
         expected = _ref_softmax(x[0])
-        self.assertAllClose(result[0], expected, rtol=1e-05)
+        self.assertAllClose(result[0], expected, rtol=1e-5)
 
     def test_softmax_2d_axis_0(self):
         x = np.random.random((2, 5))
@@ -78,7 +78,7 @@ class ActivationsTest(testing.TestCase):
         expected = np.zeros((2, 5))
         for i in range(5):
             expected[:, i] = _ref_softmax(x[:, i])
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_softmax_3d_axis_tuple(self):
         x = np.random.random((2, 3, 5))
@@ -86,13 +86,13 @@ class ActivationsTest(testing.TestCase):
         expected = np.zeros((2, 3, 5))
         for i in range(2):
             expected[i, :, :] = _ref_softmax(x[i, :, :])
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_softmax_1d(self):
         x = np.random.random(5)
         result = activations.softmax(x)
         expected = _ref_softmax(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_softmax_higher_dim(self):
         x = np.random.random((2, 3, 4, 5))
@@ -101,7 +101,7 @@ class ActivationsTest(testing.TestCase):
         for i in range(2):
             for j in range(3):
                 expected[i, j, :, :] = _ref_softmax(x[i, j, :, :])
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_softmax_higher_dim_multiple_axes(self):
         x = np.random.random((2, 3, 4, 5, 6))
@@ -110,7 +110,7 @@ class ActivationsTest(testing.TestCase):
         for i in range(2):
             for j in range(3):
                 expected[i, j, :, :, :] = _ref_softmax(x[i, j, :, :, :])
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_softmax_negative_axis(self):
         x = np.random.random((2, 5))
@@ -118,13 +118,13 @@ class ActivationsTest(testing.TestCase):
         expected = np.zeros((2, 5))
         for i in range(2):
             expected[i, :] = _ref_softmax(x[i, :])
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_temporal_softmax(self):
         x = np.random.random((2, 2, 3)) * 10
         result = activations.softmax(x[np.newaxis, :])[0]
         expected = _ref_softmax(x[0, 0])
-        self.assertAllClose(result[0, 0], expected, rtol=1e-05)
+        self.assertAllClose(result[0, 0], expected, rtol=1e-5)
 
     def test_log_softmax_2d_axis_0(self):
         x = np.random.random((2, 5))
@@ -132,7 +132,7 @@ class ActivationsTest(testing.TestCase):
         expected = np.zeros((2, 5))
         for i in range(5):
             expected[:, i] = _ref_log_softmax(x[:, i])
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_log_softmax_3d_axis_tuple(self):
         x = np.random.random((2, 3, 5))
@@ -140,13 +140,13 @@ class ActivationsTest(testing.TestCase):
         expected = np.zeros((2, 3, 5))
         for i in range(2):
             expected[i, :, :] = _ref_log_softmax(x[i, :, :])
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_log_softmax_1d(self):
         x = np.random.random(5)
         result = activations.log_softmax(x)
         expected = _ref_log_softmax(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_log_softmax_higher_dim(self):
         x = np.random.random((2, 3, 4, 5))
@@ -155,7 +155,7 @@ class ActivationsTest(testing.TestCase):
         for i in range(2):
             for j in range(3):
                 expected[i, j, :, :] = _ref_log_softmax(x[i, j, :, :])
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_log_softmax_higher_dim_multiple_axes(self):
         x = np.random.random((2, 3, 4, 5, 6))
@@ -164,7 +164,7 @@ class ActivationsTest(testing.TestCase):
         for i in range(2):
             for j in range(3):
                 expected[i, j, :, :, :] = _ref_log_softmax(x[i, j, :, :, :])
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_log_softmax_negative_axis(self):
         x = np.random.random((2, 5))
@@ -172,13 +172,13 @@ class ActivationsTest(testing.TestCase):
         expected = np.zeros((2, 5))
         for i in range(2):
             expected[i, :] = _ref_log_softmax(x[i, :])
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_temporal_log_softmax(self):
         x = np.random.random((2, 2, 3)) * 10
         result = activations.log_softmax(x[np.newaxis, :])[0]
         expected = _ref_log_softmax(x[0, 0])
-        self.assertAllClose(result[0, 0], expected, rtol=1e-05)
+        self.assertAllClose(result[0, 0], expected, rtol=1e-5)
 
     def test_selu(self):
         alpha = 1.6732632423543772848170429916717
@@ -186,7 +186,7 @@ class ActivationsTest(testing.TestCase):
 
         positive_values = np.array([[1, 2]], dtype=backend.floatx())
         result = activations.selu(positive_values[np.newaxis, :])[0]
-        self.assertAllClose(result, positive_values * scale, rtol=1e-05)
+        self.assertAllClose(result, positive_values * scale, rtol=1e-5)
 
         negative_values = np.array([[-1, -2]], dtype=backend.floatx())
         result = activations.selu(negative_values[np.newaxis, :])[0]
@@ -198,32 +198,32 @@ class ActivationsTest(testing.TestCase):
         x = np.random.uniform(0, 1, (2, 5))
         result = activations.softplus(x[np.newaxis, :])[0]
         expected = np.vectorize(_ref_softplus)(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test with 1D array
         x_1d = np.random.uniform(-10, 10, 5)
         result_1d = activations.softplus(x_1d)
         expected_1d = np.vectorize(_ref_softplus)(x_1d)
-        self.assertAllClose(result_1d, expected_1d, rtol=1e-05)
+        self.assertAllClose(result_1d, expected_1d, rtol=1e-5)
 
         # Test with 3D array
         x_3d = np.random.uniform(-10, 10, (3, 3, 3))
         result_3d = activations.softplus(x_3d)
         expected_3d = np.vectorize(_ref_softplus)(x_3d)
-        self.assertAllClose(result_3d, expected_3d, rtol=1e-05)
+        self.assertAllClose(result_3d, expected_3d, rtol=1e-5)
 
         # Test near zero values
         x_zero = np.random.uniform(-1e-7, 1e-7, (2, 5))
         result_zero = activations.softplus(x_zero)
         expected_zero = np.vectorize(_ref_softplus)(x_zero)
-        self.assertAllClose(result_zero, expected_zero, rtol=1e-05)
+        self.assertAllClose(result_zero, expected_zero, rtol=1e-5)
 
         # Test large positive values
         x_large_positive = np.random.uniform(10, 100, (2, 5))
         result_large_positive = activations.softplus(x_large_positive)
         expected_large_positive = np.vectorize(_ref_softplus)(x_large_positive)
         self.assertAllClose(
-            result_large_positive, expected_large_positive, rtol=1e-05
+            result_large_positive, expected_large_positive, rtol=1e-5
         )
 
         # Test large negative values
@@ -231,7 +231,7 @@ class ActivationsTest(testing.TestCase):
         result_large_negative = activations.softplus(x_large_negative)
         expected_large_negative = np.vectorize(_ref_softplus)(x_large_negative)
         self.assertAllClose(
-            result_large_negative, expected_large_negative, rtol=1e-05
+            result_large_negative, expected_large_negative, rtol=1e-5
         )
 
     def test_softsign(self):
@@ -239,32 +239,32 @@ class ActivationsTest(testing.TestCase):
         x = np.random.uniform(0, 1, (2, 5))
         result = activations.softsign(x[np.newaxis, :])[0]
         expected = np.vectorize(_ref_softsign)(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test with 1D array
         x_1d = np.random.uniform(-10, 10, 5)
         result_1d = activations.softsign(x_1d)
         expected_1d = np.vectorize(_ref_softsign)(x_1d)
-        self.assertAllClose(result_1d, expected_1d, rtol=1e-05)
+        self.assertAllClose(result_1d, expected_1d, rtol=1e-5)
 
         # Test with 3D array
         x_3d = np.random.uniform(-10, 10, (3, 3, 3))
         result_3d = activations.softsign(x_3d)
         expected_3d = np.vectorize(_ref_softsign)(x_3d)
-        self.assertAllClose(result_3d, expected_3d, rtol=1e-05)
+        self.assertAllClose(result_3d, expected_3d, rtol=1e-5)
 
         # Test near zero values
         x_zero = np.random.uniform(-1e-7, 1e-7, (2, 5))
         result_zero = activations.softsign(x_zero)
         expected_zero = np.vectorize(_ref_softsign)(x_zero)
-        self.assertAllClose(result_zero, expected_zero, rtol=1e-05)
+        self.assertAllClose(result_zero, expected_zero, rtol=1e-5)
 
         # Test large positive values
         x_large_positive = np.random.uniform(10, 100, (2, 5))
         result_large_positive = activations.softsign(x_large_positive)
         expected_large_positive = np.vectorize(_ref_softsign)(x_large_positive)
         self.assertAllClose(
-            result_large_positive, expected_large_positive, rtol=1e-05
+            result_large_positive, expected_large_positive, rtol=1e-5
         )
 
         # Test large negative values
@@ -272,7 +272,7 @@ class ActivationsTest(testing.TestCase):
         result_large_negative = activations.softsign(x_large_negative)
         expected_large_negative = np.vectorize(_ref_softsign)(x_large_negative)
         self.assertAllClose(
-            result_large_negative, expected_large_negative, rtol=1e-05
+            result_large_negative, expected_large_negative, rtol=1e-5
         )
 
     def test_sigmoid(self):
@@ -280,32 +280,32 @@ class ActivationsTest(testing.TestCase):
         x = np.random.uniform(0, 1, (2, 5))
         result = activations.sigmoid(x[np.newaxis, :])[0]
         expected = np.vectorize(_ref_sigmoid)(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test with 1D array
         x_1d = np.random.uniform(-10, 10, 5)
         result_1d = activations.sigmoid(x_1d)
         expected_1d = np.vectorize(_ref_sigmoid)(x_1d)
-        self.assertAllClose(result_1d, expected_1d, rtol=1e-05)
+        self.assertAllClose(result_1d, expected_1d, rtol=1e-5)
 
         # Test with 3D array
         x_3d = np.random.uniform(-10, 10, (3, 3, 3))
         result_3d = activations.sigmoid(x_3d)
         expected_3d = np.vectorize(_ref_sigmoid)(x_3d)
-        self.assertAllClose(result_3d, expected_3d, rtol=1e-05)
+        self.assertAllClose(result_3d, expected_3d, rtol=1e-5)
 
         # Test near zero values
         x_zero = np.random.uniform(-1e-7, 1e-7, (2, 5))
         result_zero = activations.sigmoid(x_zero)
         expected_zero = np.vectorize(_ref_sigmoid)(x_zero)
-        self.assertAllClose(result_zero, expected_zero, rtol=1e-05)
+        self.assertAllClose(result_zero, expected_zero, rtol=1e-5)
 
         # Test large positive values
         x_large_positive = np.random.uniform(10, 100, (2, 5))
         result_large_positive = activations.sigmoid(x_large_positive)
         expected_large_positive = np.vectorize(_ref_sigmoid)(x_large_positive)
         self.assertAllClose(
-            result_large_positive, expected_large_positive, rtol=1e-05
+            result_large_positive, expected_large_positive, rtol=1e-5
         )
 
         # Test large negative values
@@ -313,7 +313,7 @@ class ActivationsTest(testing.TestCase):
         result_large_negative = activations.sigmoid(x_large_negative)
         expected_large_negative = np.vectorize(_ref_sigmoid)(x_large_negative)
         self.assertAllClose(
-            result_large_negative, expected_large_negative, rtol=1e-05
+            result_large_negative, expected_large_negative, rtol=1e-5
         )
 
     def test_hard_sigmoid(self):
@@ -321,19 +321,19 @@ class ActivationsTest(testing.TestCase):
         x = np.random.uniform(0, 1, (2, 5))
         result = activations.hard_sigmoid(x[np.newaxis, :])[0]
         expected = np.vectorize(_ref_hard_sigmoid)(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test with 1D array
         x_1d = np.random.uniform(-10, 10, 5)
         result_1d = activations.hard_sigmoid(x_1d)
         expected_1d = np.vectorize(_ref_hard_sigmoid)(x_1d)
-        self.assertAllClose(result_1d, expected_1d, rtol=1e-05)
+        self.assertAllClose(result_1d, expected_1d, rtol=1e-5)
 
         # Test with 3D array
         x_3d = np.random.uniform(-10, 10, (3, 3, 3))
         result_3d = activations.hard_sigmoid(x_3d)
         expected_3d = np.vectorize(_ref_hard_sigmoid)(x_3d)
-        self.assertAllClose(result_3d, expected_3d, rtol=1e-05)
+        self.assertAllClose(result_3d, expected_3d, rtol=1e-5)
 
         # Test with strictly positive values much larger than 1
         x_positive_above_1 = np.random.uniform(
@@ -342,7 +342,7 @@ class ActivationsTest(testing.TestCase):
         result_positive_above_1 = activations.hard_sigmoid(x_positive_above_1)
         expected_positive_above_1 = np.ones((2, 5))
         self.assertAllClose(
-            result_positive_above_1, expected_positive_above_1, rtol=1e-05
+            result_positive_above_1, expected_positive_above_1, rtol=1e-5
         )
 
     def test_sparse_sigmoid(self):
@@ -350,19 +350,19 @@ class ActivationsTest(testing.TestCase):
         x = np.random.uniform(0, 1, (2, 5))
         result = activations.sparse_sigmoid(x[np.newaxis, :])[0]
         expected = np.vectorize(_ref_sparse_sigmoid)(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test with 1D array
         x_1d = np.random.uniform(-10, 10, 5)
         result_1d = activations.sparse_sigmoid(x_1d)
         expected_1d = np.vectorize(_ref_sparse_sigmoid)(x_1d)
-        self.assertAllClose(result_1d, expected_1d, rtol=1e-05)
+        self.assertAllClose(result_1d, expected_1d, rtol=1e-5)
 
         # Test with 3D array
         x_3d = np.random.uniform(-10, 10, (3, 3, 3))
         result_3d = activations.sparse_sigmoid(x_3d)
         expected_3d = np.vectorize(_ref_sparse_sigmoid)(x_3d)
-        self.assertAllClose(result_3d, expected_3d, rtol=1e-05)
+        self.assertAllClose(result_3d, expected_3d, rtol=1e-5)
 
         # Test large positive values
         x_large_positive = np.random.uniform(10, 100, (2, 5))
@@ -371,7 +371,7 @@ class ActivationsTest(testing.TestCase):
             x_large_positive
         )
         self.assertAllClose(
-            result_large_positive, expected_large_positive, rtol=1e-05
+            result_large_positive, expected_large_positive, rtol=1e-5
         )
 
         # Test large negative values
@@ -381,7 +381,7 @@ class ActivationsTest(testing.TestCase):
             x_large_negative
         )
         self.assertAllClose(
-            result_large_negative, expected_large_negative, rtol=1e-05
+            result_large_negative, expected_large_negative, rtol=1e-5
         )
 
     def test_log_sigmoid(self):
@@ -389,19 +389,19 @@ class ActivationsTest(testing.TestCase):
         x = np.random.uniform(0, 1, (2, 5))
         result = activations.log_sigmoid(x[np.newaxis, :])[0]
         expected = np.vectorize(_ref_log_sigmoid)(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test with 1D array
         x_1d = np.random.uniform(-10, 10, 5)
         result_1d = activations.log_sigmoid(x_1d)
         expected_1d = np.vectorize(_ref_log_sigmoid)(x_1d)
-        self.assertAllClose(result_1d, expected_1d, rtol=1e-05)
+        self.assertAllClose(result_1d, expected_1d, rtol=1e-5)
 
         # Test with 3D array
         x_3d = np.random.uniform(-10, 10, (3, 3, 3))
         result_3d = activations.log_sigmoid(x_3d)
         expected_3d = np.vectorize(_ref_log_sigmoid)(x_3d)
-        self.assertAllClose(result_3d, expected_3d, rtol=1e-05)
+        self.assertAllClose(result_3d, expected_3d, rtol=1e-5)
 
         # Test large positive values
         x_large_positive = np.random.uniform(10, 100, (2, 5))
@@ -410,7 +410,7 @@ class ActivationsTest(testing.TestCase):
             x_large_positive
         )
         self.assertAllClose(
-            result_large_positive, expected_large_positive, rtol=1e-05
+            result_large_positive, expected_large_positive, rtol=1e-5
         )
 
         # Test large negative values
@@ -420,7 +420,7 @@ class ActivationsTest(testing.TestCase):
             x_large_negative
         )
         self.assertAllClose(
-            result_large_negative, expected_large_negative, rtol=1e-05
+            result_large_negative, expected_large_negative, rtol=1e-5
         )
 
     def test_hard_silu(self):
@@ -428,33 +428,33 @@ class ActivationsTest(testing.TestCase):
         x = np.random.uniform(-3, 3, (2, 5)).astype("float32")
         result = activations.hard_silu(x[np.newaxis, :])[0]
         expected = np.vectorize(_ref_hard_silu)(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test with 1D array
         x_1d = np.random.uniform(-10, 10, 5).astype("float32")
         result_1d = activations.hard_silu(x_1d)
         expected_1d = np.vectorize(_ref_hard_silu)(x_1d)
-        self.assertAllClose(result_1d, expected_1d, rtol=1e-05)
+        self.assertAllClose(result_1d, expected_1d, rtol=1e-5)
 
         # Test with 3D array
         x_3d = np.random.uniform(-10, 10, (3, 3, 3)).astype("float32")
         result_3d = activations.hard_silu(x_3d)
         expected_3d = np.vectorize(_ref_hard_silu)(x_3d)
-        self.assertAllClose(result_3d, expected_3d, rtol=1e-05)
+        self.assertAllClose(result_3d, expected_3d, rtol=1e-5)
 
         # Test with strictly positive values much larger than 3
         x_positive_above_3 = np.random.uniform(5, 10, (2, 5)).astype("float32")
         result_positive_above_3 = activations.hard_silu(x_positive_above_3)
         expected_positive_above_3 = x_positive_above_3
         self.assertAllClose(
-            result_positive_above_3, expected_positive_above_3, rtol=1e-05
+            result_positive_above_3, expected_positive_above_3, rtol=1e-5
         )
 
         # Test with strictly negative values much smaller than -3
         x_negatives = np.random.uniform(-10, -5, (2, 5)).astype("float32")
         result = activations.hard_silu(x_negatives)
         expected_zeros = np.zeros_like(x_negatives)
-        self.assertAllClose(result, expected_zeros, rtol=1e-05)
+        self.assertAllClose(result, expected_zeros, rtol=1e-5)
 
     def test_relu_negative_slope(self):
         # Define the input tensor
@@ -464,7 +464,7 @@ class ActivationsTest(testing.TestCase):
         result_negative_slope = activations.relu(x, negative_slope=0.5)
         expected_negative_slope = np.array([-5.0, -2.5, 0.0, 5.0, 10.0])
         self.assertAllClose(
-            result_negative_slope, expected_negative_slope, rtol=1e-05
+            result_negative_slope, expected_negative_slope, rtol=1e-5
         )
 
     def test_relu_max_value(self):
@@ -474,7 +474,7 @@ class ActivationsTest(testing.TestCase):
         # Test with only max_value
         result_max_value = activations.relu(x, max_value=5.0)
         expected_max_value = np.array([0.0, 0.0, 0.0, 5.0, 5.0])
-        self.assertAllClose(result_max_value, expected_max_value, rtol=1e-05)
+        self.assertAllClose(result_max_value, expected_max_value, rtol=1e-5)
 
     def test_relu_threshold(self):
         # Define the input tensor
@@ -483,7 +483,7 @@ class ActivationsTest(testing.TestCase):
         # Test with only threshold
         result_threshold = activations.relu(x, threshold=5.0)
         expected_threshold = np.array([-0.0, -0.0, 0.0, 0.0, 10.0])
-        self.assertAllClose(result_threshold, expected_threshold, rtol=1e-05)
+        self.assertAllClose(result_threshold, expected_threshold, rtol=1e-5)
 
     def test_relu_combined_threshold_and_max_value(self):
         # Define the input tensor
@@ -492,7 +492,7 @@ class ActivationsTest(testing.TestCase):
         # Test with threshold and max_value
         result_combined = activations.relu(x, threshold=5.0, max_value=5.0)
         expected_combined = np.array([0.0, 0.0, 0.0, 0.0, 5.0])
-        self.assertAllClose(result_combined, expected_combined, rtol=1e-05)
+        self.assertAllClose(result_combined, expected_combined, rtol=1e-5)
 
     def test_relu_combined_all_parameters(self):
         # Define the input tensor
@@ -503,61 +503,61 @@ class ActivationsTest(testing.TestCase):
             x, negative_slope=0.5, max_value=5.0, threshold=5.0
         )
         expected_combined = np.array([-7.5, -5.0, -2.5, 0.0, 5.0])
-        self.assertAllClose(result_combined, expected_combined, rtol=1e-05)
+        self.assertAllClose(result_combined, expected_combined, rtol=1e-5)
 
     def test_relu_to_trigger_relu6(self):
         x = np.array([-10, -5, 0.0, 5, 10, 12])
         result_relu6 = activations.relu(x, max_value=6.0)
         expected_relu6 = np.array([0.0, 0.0, 0.0, 5.0, 6.0, 6.0])
-        self.assertAllClose(result_relu6, expected_relu6, rtol=1e-05)
+        self.assertAllClose(result_relu6, expected_relu6, rtol=1e-5)
 
     def test_relu_to_trigger_leaky(self):
         x = np.array([-10, -5, 0.0, 5, 10])
         result_leaky = activations.relu(x, negative_slope=0.5)
         expected_leaky = np.array([-5.0, -2.5, 0.0, 5.0, 10.0])
-        self.assertAllClose(result_leaky, expected_leaky, rtol=1e-05)
+        self.assertAllClose(result_leaky, expected_leaky, rtol=1e-5)
 
     def test_relu(self):
         # Basic test for positive values
         positive_values = np.random.uniform(0.1, 10, (2, 5))
         result = activations.relu(positive_values[np.newaxis, :])[0]
-        self.assertAllClose(result, positive_values, rtol=1e-05)
+        self.assertAllClose(result, positive_values, rtol=1e-5)
 
         # Basic test for negative values
         negative_values = np.random.uniform(-10, -0.1, (2, 5))
         result = activations.relu(negative_values[np.newaxis, :])[0]
         expected = np.zeros((2, 5))
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test with 1D array
         x_1d = np.random.uniform(-10, 10, 5)
         result_1d = activations.relu(x_1d)
         expected_1d = np.maximum(0, x_1d)
-        self.assertAllClose(result_1d, expected_1d, rtol=1e-05)
+        self.assertAllClose(result_1d, expected_1d, rtol=1e-5)
 
         # Test with 3D array
         x_3d = np.random.uniform(-10, 10, (3, 3, 3))
         result_3d = activations.relu(x_3d)
         expected_3d = np.maximum(0, x_3d)
-        self.assertAllClose(result_3d, expected_3d, rtol=1e-05)
+        self.assertAllClose(result_3d, expected_3d, rtol=1e-5)
 
         # Test near zero values
         x_zero = np.random.uniform(-1e-7, 1e-7, (2, 5))
         result_zero = activations.relu(x_zero)
         expected_zero = np.maximum(0, x_zero)
-        self.assertAllClose(result_zero, expected_zero, rtol=1e-05)
+        self.assertAllClose(result_zero, expected_zero, rtol=1e-5)
 
         # Test large positive values
         x_large_positive = np.random.uniform(1e4, 1e5, (2, 5))
         result_large_positive = activations.relu(x_large_positive)
-        self.assertAllClose(result_large_positive, x_large_positive, rtol=1e-05)
+        self.assertAllClose(result_large_positive, x_large_positive, rtol=1e-5)
 
         # Test large negative values
         x_large_negative = np.random.uniform(-1e5, -1e4, (2, 5))
         result_large_negative = activations.relu(x_large_negative)
         expected_large_negative = np.zeros((2, 5))
         self.assertAllClose(
-            result_large_negative, expected_large_negative, rtol=1e-05
+            result_large_negative, expected_large_negative, rtol=1e-5
         )
 
     def test_leaky_relu(self):
@@ -570,7 +570,7 @@ class ActivationsTest(testing.TestCase):
             positive_values[np.newaxis, :], negative_slope=0.01
         )[0]
         expected = leaky_relu_vectorized(positive_values, alpha=0.01)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test negative values
         negative_values = np.random.uniform(-1, 0, (2, 5))
@@ -578,7 +578,7 @@ class ActivationsTest(testing.TestCase):
             negative_values[np.newaxis, :], negative_slope=0.01
         )[0]
         expected = leaky_relu_vectorized(negative_values, alpha=0.01)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test for negative_slope = 0.3
         # Test positive values
@@ -587,7 +587,7 @@ class ActivationsTest(testing.TestCase):
             positive_values[np.newaxis, :], negative_slope=0.3
         )[0]
         expected = leaky_relu_vectorized(positive_values, alpha=0.3)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test negative values
         negative_values = np.random.uniform(-1, 0, (2, 5))
@@ -595,7 +595,7 @@ class ActivationsTest(testing.TestCase):
             negative_values[np.newaxis, :], negative_slope=0.3
         )[0]
         expected = leaky_relu_vectorized(negative_values, alpha=0.3)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_relu6(self):
         relu6_vectorized = np.vectorize(_ref_relu6)
@@ -604,19 +604,19 @@ class ActivationsTest(testing.TestCase):
         positive_values = np.random.uniform(0, 5.9, (2, 5))
         result = activations.relu6(positive_values[np.newaxis, :])[0]
         expected = relu6_vectorized(positive_values)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test positive values greater than 6
         positive_values_above_6 = np.random.uniform(6.1, 10, (2, 5))
         result = activations.relu6(positive_values_above_6[np.newaxis, :])[0]
         expected = relu6_vectorized(positive_values_above_6)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test negative values
         negative_values = np.random.uniform(-1, 0, (2, 5))
         result = activations.relu6(negative_values[np.newaxis, :])[0]
         expected = relu6_vectorized(negative_values)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_silu(self):
         silu_vectorized = np.vectorize(_ref_silu)
@@ -625,19 +625,19 @@ class ActivationsTest(testing.TestCase):
         positive_values = np.random.uniform(0, 5.9, (2, 5))
         result = activations.silu(positive_values[np.newaxis, :])[0]
         expected = silu_vectorized(positive_values)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test values around zero (to ensure sigmoid behaves correctly)
         around_zero_values = np.random.uniform(-1, 1, (2, 5))
         result = activations.silu(around_zero_values[np.newaxis, :])[0]
         expected = silu_vectorized(around_zero_values)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test negative values
         negative_values = np.random.uniform(-5.9, 0, (2, 5))
         result = activations.silu(negative_values[np.newaxis, :])[0]
         expected = silu_vectorized(negative_values)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_gelu(self):
         def gelu(x, approximate=False):
@@ -661,12 +661,12 @@ class ActivationsTest(testing.TestCase):
         x = np.random.random((2, 5))
         result = activations.gelu(x[np.newaxis, :])[0]
         expected = gelu(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         x = np.random.random((2, 5))
         result = activations.gelu(x[np.newaxis, :], approximate=True)[0]
         expected = gelu(x, True)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_celu(self):
         def celu(x, alpha=1.0):
@@ -677,12 +677,12 @@ class ActivationsTest(testing.TestCase):
         x = np.random.random((2, 5))
         result = activations.celu(x[np.newaxis, :])[0]
         expected = celu(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         x = np.random.random((2, 5))
         result = activations.celu(x[np.newaxis, :], alpha=0.5)[0]
         expected = celu(x, alpha=0.5)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_glu(self):
         def glu(x, axis=-1):
@@ -692,12 +692,12 @@ class ActivationsTest(testing.TestCase):
         x = np.random.random((2, 4))
         result = activations.glu(x[np.newaxis, :])[0]
         expected = glu(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         x = np.random.random((2, 4))
         result = activations.glu(x[np.newaxis, :], axis=-2)[0]
         expected = glu(x, axis=-2)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_tanh_shrink(self):
         def tanh_shrink(x):
@@ -706,7 +706,7 @@ class ActivationsTest(testing.TestCase):
         x = np.random.random((2, 5))
         result = activations.tanh_shrink(x[np.newaxis, :])[0]
         expected = tanh_shrink(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_hard_tanh(self):
         def hard_tanh(x):
@@ -715,7 +715,7 @@ class ActivationsTest(testing.TestCase):
         x = np.random.random((2, 5))
         result = activations.hard_tanh(x[np.newaxis, :])[0]
         expected = hard_tanh(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_hard_shrink(self):
         def hard_shrink(x):
@@ -724,7 +724,7 @@ class ActivationsTest(testing.TestCase):
         x = np.random.random((2, 5))
         result = activations.hard_shrink(x[np.newaxis, :])[0]
         expected = hard_shrink(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_threshold(self):
         def threshold(x, threshold_value, value):
@@ -735,7 +735,7 @@ class ActivationsTest(testing.TestCase):
         x = np.random.random((2, 5))
         result = activations.threshold(x[np.newaxis, :], 0, 0)[0]
         expected = threshold(x, 0, 0)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_squareplus(self):
         def squareplus(x, b=4):
@@ -745,7 +745,7 @@ class ActivationsTest(testing.TestCase):
         x = np.random.random((2, 5))
         result = activations.squareplus(x[np.newaxis, :])[0]
         expected = squareplus(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_soft_shrink(self):
         def soft_shrink(x, threshold=0.5):
@@ -758,7 +758,7 @@ class ActivationsTest(testing.TestCase):
         x = np.random.random((2, 5))
         result = activations.soft_shrink(x[np.newaxis, :])[0]
         expected = soft_shrink(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_sparse_plus(self):
         def sparse_plus(x):
@@ -771,12 +771,12 @@ class ActivationsTest(testing.TestCase):
         x = np.random.random((2, 5))
         result = activations.sparse_plus(x[np.newaxis, :])[0]
         expected = sparse_plus(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
     def test_elu(self):
         x = np.random.random((2, 5))
         result = activations.elu(x[np.newaxis, :])[0]
-        self.assertAllClose(result, x, rtol=1e-05)
+        self.assertAllClose(result, x, rtol=1e-5)
         negative_values = np.array([[-1, -2]], dtype=backend.floatx())
         result = activations.elu(negative_values[np.newaxis, :])[0]
         true_result = np.exp(negative_values) - 1
@@ -787,145 +787,145 @@ class ActivationsTest(testing.TestCase):
         x = np.random.random((2, 5))
         result = activations.tanh(x[np.newaxis, :])[0]
         expected = np.tanh(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Basic test for the tanh activation function
         x = np.random.uniform(-10, 10, (2, 5))
         result = activations.tanh(x[np.newaxis, :])[0]
         expected = np.tanh(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test with 1D array
         x_1d = np.random.uniform(-10, 10, 5)
         result_1d = activations.tanh(x_1d)
         expected_1d = np.tanh(x_1d)
-        self.assertAllClose(result_1d, expected_1d, rtol=1e-05)
+        self.assertAllClose(result_1d, expected_1d, rtol=1e-5)
 
         # Test with 3D array
         x_3d = np.random.uniform(-10, 10, (3, 3, 3))
         result_3d = activations.tanh(x_3d)
         expected_3d = np.tanh(x_3d)
-        self.assertAllClose(result_3d, expected_3d, rtol=1e-05)
+        self.assertAllClose(result_3d, expected_3d, rtol=1e-5)
 
         # Test with strictly positive values
         x_positive = np.random.uniform(0, 10, (2, 5))
         result_positive = activations.tanh(x_positive)
         expected_positive = np.tanh(x_positive)
-        self.assertAllClose(result_positive, expected_positive, rtol=1e-05)
+        self.assertAllClose(result_positive, expected_positive, rtol=1e-5)
 
         # Test with strictly negative values
         x_negative = np.random.uniform(-10, 0, (2, 5))
         result_negative = activations.tanh(x_negative)
         expected_negative = np.tanh(x_negative)
-        self.assertAllClose(result_negative, expected_negative, rtol=1e-05)
+        self.assertAllClose(result_negative, expected_negative, rtol=1e-5)
 
         # Test near zero values
         x_zero = np.random.uniform(-1e-7, 1e-7, (2, 5))
         result_zero = activations.tanh(x_zero)
         expected_zero = np.tanh(x_zero)
-        self.assertAllClose(result_zero, expected_zero, rtol=1e-05)
+        self.assertAllClose(result_zero, expected_zero, rtol=1e-5)
 
         # Test large values to check stability
         x_large = np.random.uniform(1e4, 1e5, (2, 5))
         result_large = activations.tanh(x_large)
         expected_large = np.tanh(x_large)
-        self.assertAllClose(result_large, expected_large, rtol=1e-05)
+        self.assertAllClose(result_large, expected_large, rtol=1e-5)
 
     def test_exponential(self):
         # Basic test for the exponential activation function
         x = np.random.random((2, 5))
         result = activations.exponential(x[np.newaxis, :])[0]
         expected = np.exp(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         x = np.random.uniform(-10, 10, (2, 5))
         result = activations.exponential(x[np.newaxis, :])[0]
         expected = np.exp(x)
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test with 1D array
         x_1d = np.random.uniform(-10, 10, 5)
         result_1d = activations.exponential(x_1d)
         expected_1d = np.exp(x_1d)
-        self.assertAllClose(result_1d, expected_1d, rtol=1e-05)
+        self.assertAllClose(result_1d, expected_1d, rtol=1e-5)
 
         # Test with 3D array
         x_3d = np.random.uniform(-10, 10, (3, 3, 3))
         result_3d = activations.exponential(x_3d)
         expected_3d = np.exp(x_3d)
-        self.assertAllClose(result_3d, expected_3d, rtol=1e-05)
+        self.assertAllClose(result_3d, expected_3d, rtol=1e-5)
 
         # Test with strictly positive values
         x_positive = np.random.uniform(0, 10, (2, 5))
         result_positive = activations.exponential(x_positive)
         expected_positive = np.exp(x_positive)
-        self.assertAllClose(result_positive, expected_positive, rtol=1e-05)
+        self.assertAllClose(result_positive, expected_positive, rtol=1e-5)
 
         # Test with strictly negative values
         x_negative = np.random.uniform(-10, 0, (2, 5))
         result_negative = activations.exponential(x_negative)
         expected_negative = np.exp(x_negative)
-        self.assertAllClose(result_negative, expected_negative, rtol=1e-05)
+        self.assertAllClose(result_negative, expected_negative, rtol=1e-5)
 
         # Test near zero values
         x_zero = np.random.uniform(-1e-7, 1e-7, (2, 5))
         result_zero = activations.exponential(x_zero)
         expected_zero = np.exp(x_zero)
-        self.assertAllClose(result_zero, expected_zero, rtol=1e-05)
+        self.assertAllClose(result_zero, expected_zero, rtol=1e-5)
 
         # Test large values to check stability
         x_large = np.random.uniform(1e4, 1e5, (2, 5))
         result_large = activations.exponential(x_large)
         expected_large = np.exp(x_large)
-        self.assertAllClose(result_large, expected_large, rtol=1e-05)
+        self.assertAllClose(result_large, expected_large, rtol=1e-5)
 
     def test_mish(self):
         # Basic test for the mish activation function
         x = np.random.random((2, 5))
         result = activations.mish(x[np.newaxis, :])[0]
         expected = x * np.tanh(_ref_softplus(x))
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         x = np.random.uniform(-10, 10, (2, 5))
         result = activations.mish(x[np.newaxis, :])[0]
         expected = x * np.tanh(_ref_softplus(x))
-        self.assertAllClose(result, expected, rtol=1e-05)
+        self.assertAllClose(result, expected, rtol=1e-5)
 
         # Test with 1D array
         x_1d = np.random.uniform(-10, 10, 5)
         result_1d = activations.mish(x_1d)
         expected_1d = x_1d * np.tanh(_ref_softplus(x_1d))
-        self.assertAllClose(result_1d, expected_1d, rtol=1e-05)
+        self.assertAllClose(result_1d, expected_1d, rtol=1e-5)
 
         # Test with 3D array
         x_3d = np.random.uniform(-10, 10, (3, 3, 3))
         result_3d = activations.mish(x_3d)
         expected_3d = x_3d * np.tanh(_ref_softplus(x_3d))
-        self.assertAllClose(result_3d, expected_3d, rtol=1e-05)
+        self.assertAllClose(result_3d, expected_3d, rtol=1e-5)
 
         # Test with strictly positive values
         x_positive = np.random.uniform(0, 10, (2, 5))
         result_positive = activations.mish(x_positive)
         expected_positive = x_positive * np.tanh(_ref_softplus(x_positive))
-        self.assertAllClose(result_positive, expected_positive, rtol=1e-05)
+        self.assertAllClose(result_positive, expected_positive, rtol=1e-5)
 
         # Test with strictly negative values
         x_negative = np.random.uniform(-10, 0, (2, 5))
         result_negative = activations.mish(x_negative)
         expected_negative = x_negative * np.tanh(_ref_softplus(x_negative))
-        self.assertAllClose(result_negative, expected_negative, rtol=1e-05)
+        self.assertAllClose(result_negative, expected_negative, rtol=1e-5)
 
         # Test near zero values
         x_zero = np.random.uniform(-1e-7, 1e-7, (2, 5))
         result_zero = activations.mish(x_zero)
         expected_zero = x_zero * np.tanh(_ref_softplus(x_zero))
-        self.assertAllClose(result_zero, expected_zero, rtol=1e-05)
+        self.assertAllClose(result_zero, expected_zero, rtol=1e-5)
 
         # Test large values to check stability
         x_large = np.random.uniform(1e4, 1e5, (2, 5))
         result_large = activations.mish(x_large)
         expected_large = x_large * np.tanh(_ref_softplus(x_large))
-        self.assertAllClose(result_large, expected_large, rtol=1e-05)
+        self.assertAllClose(result_large, expected_large, rtol=1e-5)
 
     def test_linear(self):
         x = np.random.random((10, 5))
@@ -955,33 +955,33 @@ class ActivationsTest(testing.TestCase):
         x_1d = np.linspace(1, 12, num=12)
         expected_result = np.zeros_like(x_1d)
         expected_result[-1] = 1.0
-        self.assertAllClose(expected_result, activations.sparsemax(x_1d))
+        self.assertAllClose(activations.sparsemax(x_1d), expected_result)
 
         # result check with 2d
         x_2d = np.linspace(1, 12, num=12).reshape(-1, 2)
         expected_result = np.zeros_like(x_2d)
         expected_result[:, -1] = 1.0
-        self.assertAllClose(expected_result, activations.sparsemax(x_2d))
+        self.assertAllClose(activations.sparsemax(x_2d), expected_result)
 
         # result check with 3d
         x_3d = np.linspace(1, 12, num=12).reshape(-1, 1, 3)
         expected_result = np.zeros_like(x_3d)
         expected_result[:, :, -1] = 1.0
-        self.assertAllClose(expected_result, activations.sparsemax(x_3d))
+        self.assertAllClose(activations.sparsemax(x_3d), expected_result)
 
         # result check with axis=-2 with 2d input
         x_2d = np.linspace(1, 12, num=12).reshape(-1, 2)
         expected_result = np.zeros_like(x_2d)
         expected_result[-1, :] = 1.0
         self.assertAllClose(
-            expected_result, activations.sparsemax(x_2d, axis=-2)
+            activations.sparsemax(x_2d, axis=-2), expected_result
         )
 
         # result check with axis=-2 with 3d input
         x_3d = np.linspace(1, 12, num=12).reshape(-1, 1, 3)
         expected_result = np.ones_like(x_3d)
         self.assertAllClose(
-            expected_result, activations.sparsemax(x_3d, axis=-2)
+            activations.sparsemax(x_3d, axis=-2), expected_result
         )
 
         # result check with axis=-3 with 3d input
@@ -989,14 +989,14 @@ class ActivationsTest(testing.TestCase):
         expected_result = np.zeros_like(x_3d)
         expected_result[-1, :, :] = 1.0
         self.assertAllClose(
-            expected_result, activations.sparsemax(x_3d, axis=-3)
+            activations.sparsemax(x_3d, axis=-3), expected_result
         )
 
         # result check with axis=-3 with 4d input
         x_4d = np.linspace(1, 12, num=12).reshape(-1, 1, 1, 2)
         expected_result = np.ones_like(x_4d)
         self.assertAllClose(
-            expected_result, activations.sparsemax(x_4d, axis=-3)
+            activations.sparsemax(x_4d, axis=-3), expected_result
         )
 
     def test_get_method(self):

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -138,7 +138,7 @@ def all(x, axis=None, keepdims=False):
     return np.all(x, axis=axis, keepdims=keepdims)
 
 
-def allclose(x1, x2, rtol=1e-05, atol=1e-08, equal_nan=False):
+def allclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
     return np.allclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
 

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -243,7 +243,7 @@ def all(x, axis=None, keepdims=False):
     )
 
 
-def allclose(x1, x2, rtol=1e-05, atol=1e-08, equal_nan=False):
+def allclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
     if (
         not isinstance(x1, OpenVINOKerasTensor)
         and not isinstance(x2, OpenVINOKerasTensor)

--- a/keras/src/backend/tensorflow/saved_model_test.py
+++ b/keras/src/backend/tensorflow/saved_model_test.py
@@ -254,7 +254,7 @@ class SavedModelTest(testing.TestCase):
         tf.saved_model.save(model, path)
         restored_model = tf.saved_model.load(path)
         output = restored_model.call(*inp)
-        self.assertAllClose(expected, output, rtol=1e-4, atol=1e-4)
+        self.assertAllClose(output, expected, rtol=1e-4, atol=1e-4)
 
     def test_list_trackable_children_tracking(self):
         @object_registration.register_keras_serializable(package="my_package")
@@ -282,10 +282,10 @@ class SavedModelTest(testing.TestCase):
         tf.saved_model.save(model, path)
         restored_model = tf.saved_model.load(path)
         self.assertAllClose(
-            expected,
             restored_model.signatures["serving_default"](
                 tf.convert_to_tensor(inp, dtype=tf.float32)
             )["output_0"],
+            expected,
             rtol=1e-4,
             atol=1e-4,
         )
@@ -316,10 +316,10 @@ class SavedModelTest(testing.TestCase):
         tf.saved_model.save(model, path)
         restored_model = tf.saved_model.load(path)
         self.assertAllClose(
-            expected,
             restored_model.signatures["serving_default"](
                 tf.convert_to_tensor(inp, dtype=tf.float32)
             )["output_0"],
+            expected,
             rtol=1e-4,
             atol=1e-4,
         )

--- a/keras/src/callbacks/model_checkpoint_test.py
+++ b/keras/src/callbacks/model_checkpoint_test.py
@@ -545,7 +545,7 @@ class ModelCheckpointTest(testing.TestCase):
         new_weights = new_model.get_weights()
         self.assertEqual(len(ref_weights), len(new_weights))
         for ref_w, w in zip(ref_weights, new_weights):
-            self.assertAllClose(ref_w, w)
+            self.assertAllClose(w, ref_w)
 
         # Model Checkpoint load model weights
         model = get_model()
@@ -580,4 +580,4 @@ class ModelCheckpointTest(testing.TestCase):
         new_weights = new_model.get_weights()
         self.assertEqual(len(ref_weights), len(new_weights))
         for ref_w, w in zip(ref_weights, new_weights):
-            self.assertAllClose(ref_w, w)
+            self.assertAllClose(w, ref_w)

--- a/keras/src/constraints/constraints_test.py
+++ b/keras/src/constraints/constraints_test.py
@@ -25,7 +25,7 @@ class ConstraintsTest(testing.TestCase):
             ]
         ).T
         output = constraint_fn(x)
-        self.assertAllClose(target, output)
+        self.assertAllClose(output, target)
 
     def test_non_neg(self):
         constraint_fn = constraints.NonNeg()

--- a/keras/src/export/litert_test.py
+++ b/keras/src/export/litert_test.py
@@ -208,7 +208,7 @@ class ExportLitertTest(testing.TestCase):
         interpreter.invoke()
         litert_output = _get_interpreter_outputs(interpreter)
 
-        self.assertAllClose(ref_output, litert_output, atol=1e-4, rtol=1e-4)
+        self.assertAllClose(litert_output, ref_output, atol=1e-4, rtol=1e-4)
 
     @parameterized.named_parameters(
         named_product(struct_type=["tuple", "array", "dict"])
@@ -264,14 +264,14 @@ class ExportLitertTest(testing.TestCase):
         interpreter.invoke()
         litert_output = _get_interpreter_outputs(interpreter)
 
-        self.assertAllClose(ref_output, litert_output, atol=1e-4, rtol=1e-4)
+        self.assertAllClose(litert_output, ref_output, atol=1e-4, rtol=1e-4)
 
         # Verify export still works after saving/loading via saving_lib.
         archive_path = os.path.join(self.get_temp_dir(), "revived.keras")
         saving_lib.save_model(model, archive_path)
         revived_model = saving_lib.load_model(archive_path)
         revived_output = _convert_to_numpy(revived_model(ref_input))
-        self.assertAllClose(ref_output, revived_output)
+        self.assertAllClose(revived_output, ref_output)
 
     def test_model_with_multiple_inputs(self):
         """Test exporting models with multiple inputs and batch resizing."""
@@ -300,7 +300,7 @@ class ExportLitertTest(testing.TestCase):
         interpreter.invoke()
         litert_output = _get_interpreter_outputs(interpreter)
 
-        self.assertAllClose(ref_output, litert_output, atol=1e-4, rtol=1e-4)
+        self.assertAllClose(litert_output, ref_output, atol=1e-4, rtol=1e-4)
 
         # Test with a different batch size by resizing interpreter inputs.
         larger_x = np.concatenate([ref_input_x, ref_input_x], axis=0)
@@ -318,7 +318,7 @@ class ExportLitertTest(testing.TestCase):
         larger_output = _get_interpreter_outputs(interpreter)
         larger_ref_output = _convert_to_numpy(model([larger_x, larger_y]))
         self.assertAllClose(
-            larger_ref_output, larger_output, atol=1e-4, rtol=1e-4
+            larger_output, larger_ref_output, atol=1e-4, rtol=1e-4
         )
 
     def test_export_with_custom_input_signature(self):
@@ -453,7 +453,7 @@ class ExportLitertTest(testing.TestCase):
         interpreter.invoke()
         litert_output = _get_interpreter_outputs(interpreter)
 
-        self.assertAllClose(ref_output, litert_output, atol=1e-4, rtol=1e-4)
+        self.assertAllClose(litert_output, ref_output, atol=1e-4, rtol=1e-4)
 
     def test_export_with_optimizations_default(self):
         """Test export with DEFAULT optimization."""
@@ -485,7 +485,7 @@ class ExportLitertTest(testing.TestCase):
         litert_output = _get_interpreter_outputs(interpreter)
 
         # Quantized model should be close but not exact
-        self.assertAllClose(ref_output, litert_output, atol=1e-2, rtol=1e-2)
+        self.assertAllClose(litert_output, ref_output, atol=1e-2, rtol=1e-2)
 
     def test_export_with_optimizations_sparsity(self):
         """Test export with EXPERIMENTAL_SPARSITY optimization."""
@@ -811,7 +811,7 @@ class ExportLitertTest(testing.TestCase):
         else:
             litert_output = list(sig_output.values())
 
-        self.assertAllClose(ref_output, litert_output, atol=1e-4, rtol=1e-4)
+        self.assertAllClose(litert_output, ref_output, atol=1e-4, rtol=1e-4)
 
     def test_signature_def_with_functional_model(self):
         """Test that SignatureDef preserves input/output names for
@@ -887,7 +887,7 @@ class ExportLitertTest(testing.TestCase):
         else:
             litert_output = list(sig_output.values())
 
-        self.assertAllClose(ref_output, litert_output, atol=1e-4, rtol=1e-4)
+        self.assertAllClose(litert_output, ref_output, atol=1e-4, rtol=1e-4)
 
     def test_signature_def_with_multi_input_model(self):
         """Test that SignatureDef preserves names for multi-input models."""
@@ -971,7 +971,7 @@ class ExportLitertTest(testing.TestCase):
         else:
             litert_output = list(sig_output.values())
 
-        self.assertAllClose(ref_output, litert_output, atol=1e-4, rtol=1e-4)
+        self.assertAllClose(litert_output, ref_output, atol=1e-4, rtol=1e-4)
 
     def test_signature_def_with_multi_output_model(self):
         """Test that SignatureDef handles multi-output models correctly."""
@@ -1036,7 +1036,7 @@ class ExportLitertTest(testing.TestCase):
         sig_output_values = list(sig_output.values())
         for i, ref_out in enumerate(ref_outputs):
             self.assertAllClose(
-                ref_out, sig_output_values[i], atol=1e-4, rtol=1e-4
+                sig_output_values[i], ref_out, atol=1e-4, rtol=1e-4
             )
 
     def test_dict_input_adapter_creation(self):
@@ -1085,7 +1085,7 @@ class ExportLitertTest(testing.TestCase):
         interpreter.invoke()
         litert_output = _get_interpreter_outputs(interpreter)
 
-        self.assertAllClose(ref_output, litert_output, atol=1e-4, rtol=1e-4)
+        self.assertAllClose(litert_output, ref_output, atol=1e-4, rtol=1e-4)
 
     def test_dict_input_signature_inference(self):
         """Test automatic inference of dict input signatures."""
@@ -1170,7 +1170,7 @@ class ExportLitertTest(testing.TestCase):
         interpreter.invoke()
         litert_output = _get_interpreter_outputs(interpreter)
 
-        self.assertAllClose(ref_output, litert_output, atol=1e-4, rtol=1e-4)
+        self.assertAllClose(litert_output, ref_output, atol=1e-4, rtol=1e-4)
 
     def test_dict_input_numerical_accuracy(self):
         """Test numerical accuracy of dict input models with complex ops."""
@@ -1218,7 +1218,7 @@ class ExportLitertTest(testing.TestCase):
         litert_output = _get_interpreter_outputs(interpreter)
 
         # Should have good numerical accuracy
-        self.assertAllClose(ref_output, litert_output, atol=1e-5, rtol=1e-5)
+        self.assertAllClose(litert_output, ref_output, atol=1e-5, rtol=1e-5)
 
     def test_dict_input_preserves_variable_sharing(self):
         """Test that adapter preserves variable sharing from original model."""
@@ -1274,7 +1274,7 @@ class ExportLitertTest(testing.TestCase):
         interpreter.invoke()
         litert_output = _get_interpreter_outputs(interpreter)
 
-        self.assertAllClose(ref_output, litert_output, atol=1e-4, rtol=1e-4)
+        self.assertAllClose(litert_output, ref_output, atol=1e-4, rtol=1e-4)
 
     def test_dict_input_multi_output_model(self):
         """Test dict input model with multiple outputs exports successfully."""

--- a/keras/src/export/onnx_test.py
+++ b/keras/src/export/onnx_test.py
@@ -101,7 +101,7 @@ class ExportONNXTest(testing.TestCase):
         ort_inputs = {
             k.name: v for k, v in zip(ort_session.get_inputs(), [ref_input])
         }
-        self.assertAllClose(ref_output, ort_session.run(None, ort_inputs)[0])
+        self.assertAllClose(ort_session.run(None, ort_inputs)[0], ref_output)
         # Test with a different batch size
         ort_inputs = {
             k.name: v
@@ -162,7 +162,7 @@ class ExportONNXTest(testing.TestCase):
             ort_inputs = {
                 k.name: v for k, v in zip(ort_session.get_inputs(), ref_input)
             }
-        self.assertAllClose(ref_output, ort_session.run(None, ort_inputs)[0])
+        self.assertAllClose(ort_session.run(None, ort_inputs)[0], ref_output)
 
         # Test with keras.saving_lib
         temp_filepath = os.path.join(
@@ -177,7 +177,7 @@ class ExportONNXTest(testing.TestCase):
                 "DictModel": DictModel,
             },
         )
-        self.assertAllClose(ref_output, revived_model(ref_input))
+        self.assertAllClose(revived_model(ref_input), ref_output)
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_model2")
         onnx.export_onnx(revived_model, temp_filepath)
 
@@ -222,7 +222,7 @@ class ExportONNXTest(testing.TestCase):
                 ort_session.get_inputs(), [ref_input_x, ref_input_y]
             )
         }
-        self.assertAllClose(ref_output, ort_session.run(None, ort_inputs)[0])
+        self.assertAllClose(ort_session.run(None, ort_inputs)[0], ref_output)
         # Test with a different batch size
         ort_inputs = {
             k.name: v
@@ -255,8 +255,8 @@ class ExportONNXTest(testing.TestCase):
             k.name: v for k, v in zip(ort_session.get_inputs(), [ref_input])
         }
         self.assertAllClose(
-            ref_output,
             ort_session.run(None, ort_inputs)[0],
+            ref_output,
             tpu_atol=1e-3,
             tpu_rtol=2e-3,
         )
@@ -291,7 +291,7 @@ class ExportONNXTest(testing.TestCase):
         ort_inputs = {
             k.name: v for k, v in zip(ort_session.get_inputs(), [ref_input])
         }
-        self.assertAllClose(ref_output, ort_session.run(None, ort_inputs)[0])
+        self.assertAllClose(ort_session.run(None, ort_inputs)[0], ref_output)
 
     @parameterized.named_parameters(
         named_product(

--- a/keras/src/export/openvino_test.py
+++ b/keras/src/export/openvino_test.py
@@ -119,7 +119,7 @@ class ExportOpenVINOTest(testing.TestCase):
 
         ov_output = compiled_model([ref_input])[compiled_model.output(0)]
 
-        self.assertAllClose(ref_output, ov_output)
+        self.assertAllClose(ov_output, ref_output)
 
         larger_input = np.concatenate([ref_input, ref_input], axis=0)
         compiled_model([larger_input])
@@ -178,7 +178,7 @@ class ExportOpenVINOTest(testing.TestCase):
             ov_inputs = list(ref_input)
 
         ov_output = compiled_model(ov_inputs)[compiled_model.output(0)]
-        self.assertAllClose(ref_output, ov_output)
+        self.assertAllClose(ov_output, ref_output)
 
         # Test with keras.saving_lib
         temp_filepath = os.path.join(
@@ -193,7 +193,7 @@ class ExportOpenVINOTest(testing.TestCase):
                 "DictModel": DictModel,
             },
         )
-        self.assertAllClose(ref_output, revived_model(ref_input))
+        self.assertAllClose(revived_model(ref_input), ref_output)
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_model2.xml")
         try:
             openvino.export_openvino(revived_model, temp_filepath)
@@ -243,7 +243,7 @@ class ExportOpenVINOTest(testing.TestCase):
         ov_output = compiled_model([ref_input_x, ref_input_y])[
             compiled_model.output(0)
         ]
-        self.assertAllClose(ref_output, ov_output)
+        self.assertAllClose(ov_output, ref_output)
         larger_input_x = np.concatenate([ref_input_x, ref_input_x], axis=0)
         larger_input_y = np.concatenate([ref_input_y, ref_input_y], axis=0)
         compiled_model([larger_input_x, larger_input_y])

--- a/keras/src/export/saved_model_test.py
+++ b/keras/src/export/saved_model_test.py
@@ -76,7 +76,7 @@ class ExportSavedModelTest(testing.TestCase):
 
         saved_model.export_saved_model(model, temp_filepath)
         revived_model = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_model.serve(ref_input))
+        self.assertAllClose(revived_model.serve(ref_input), ref_output)
         # Test with a different batch size
         revived_model.serve(tf.random.normal((6, 10)))
 
@@ -166,7 +166,7 @@ class ExportSavedModelTest(testing.TestCase):
 
         saved_model.export_saved_model(model, temp_filepath)
         revived_model = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_model.serve(ref_input))
+        self.assertAllClose(revived_model.serve(ref_input), ref_output)
         # Test with a different batch size
         revived_model.serve(tf.random.normal((6, 10)))
 
@@ -208,7 +208,7 @@ class ExportSavedModelTest(testing.TestCase):
 
         saved_model.export_saved_model(model, temp_filepath)
         revived_model = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_model.serve(ref_input))
+        self.assertAllClose(revived_model.serve(ref_input), ref_output)
 
         # Test with keras.saving_lib
         temp_filepath = os.path.join(
@@ -223,7 +223,7 @@ class ExportSavedModelTest(testing.TestCase):
                 "DictModel": DictModel,
             },
         )
-        self.assertAllClose(ref_output, revived_model(ref_input))
+        self.assertAllClose(revived_model(ref_input), ref_output)
         saved_model.export_saved_model(revived_model, self.get_temp_dir())
 
         # Test with a different batch size
@@ -250,7 +250,7 @@ class ExportSavedModelTest(testing.TestCase):
         saved_model.export_saved_model(model, temp_filepath)
         revived_model = tf.saved_model.load(temp_filepath)
         self.assertAllClose(
-            ref_output, revived_model.serve(ref_input_x, ref_input_y)
+            revived_model.serve(ref_input_x, ref_input_y), ref_output
         )
         # Test with a different batch size
         revived_model.serve(
@@ -286,7 +286,7 @@ class ExportSavedModelTest(testing.TestCase):
         )
         revived_model = tf.saved_model.load(temp_filepath)
         self.assertAllClose(
-            ref_output, revived_model.serve(ops.convert_to_numpy(ref_input))
+            revived_model.serve(ops.convert_to_numpy(ref_input)), ref_output
         )
 
     def test_input_signature_error(self):
@@ -325,7 +325,7 @@ class ExportSavedModelTest(testing.TestCase):
             jax2tf_kwargs=jax2tf_kwargs,
         )
         revived_model = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_model.serve(ref_input))
+        self.assertAllClose(revived_model.serve(ref_input), ref_output)
 
 
 @pytest.mark.skipif(
@@ -368,7 +368,7 @@ class ExportArchiveTest(testing.TestCase):
         )
         export_archive.write_out(temp_filepath)
         revived_model = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_model.call(ref_input))
+        self.assertAllClose(revived_model.call(ref_input), ref_output)
         # Test with a different batch size
         revived_model.call(tf.random.normal((6, 10)))
 
@@ -397,7 +397,7 @@ class ExportArchiveTest(testing.TestCase):
             ),
         )
         self.assertAllClose(
-            ref_output, revived_model.function_aliases["call_alias"](ref_input)
+            revived_model.function_aliases["call_alias"](ref_input), ref_output
         )
         # Test with a different batch size
         revived_model.function_aliases["call_alias"](tf.random.normal((6, 10)))
@@ -434,7 +434,7 @@ class ExportArchiveTest(testing.TestCase):
         )
         export_archive.write_out(temp_filepath)
         revived_model = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_model.call(ref_input))
+        self.assertAllClose(revived_model.call(ref_input), ref_output)
         # Test with a different batch size
         revived_model.call([tf.random.normal((6, 8)), tf.random.normal((6, 6))])
         # Test with a different batch size and different dynamic sizes
@@ -478,7 +478,7 @@ class ExportArchiveTest(testing.TestCase):
             )
         export_archive.write_out(temp_filepath)
         revived_model = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_model.call(ref_input))
+        self.assertAllClose(revived_model.call(ref_input), ref_output)
 
     @pytest.mark.skipif(
         backend.backend() != "jax",
@@ -520,7 +520,7 @@ class ExportArchiveTest(testing.TestCase):
         )
         export_archive.write_out(temp_filepath)
         revived_model = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_model.call(ref_input))
+        self.assertAllClose(revived_model.call(ref_input), ref_output)
 
     @pytest.mark.skipif(
         backend.backend() != "tensorflow",
@@ -555,7 +555,7 @@ class ExportArchiveTest(testing.TestCase):
 
         revived_model = tf.saved_model.load(temp_filepath)
         self.assertFalse(hasattr(revived_model, "_tracked"))
-        self.assertAllClose(ref_output, revived_model.call(ref_input))
+        self.assertAllClose(revived_model.call(ref_input), ref_output)
         self.assertLen(revived_model.variables, 8)
         self.assertLen(revived_model.trainable_variables, 6)
         self.assertLen(revived_model.non_trainable_variables, 2)
@@ -607,7 +607,7 @@ class ExportArchiveTest(testing.TestCase):
         # Reload and verify outputs
         revived_model = tf.saved_model.load(temp_filepath)
         self.assertFalse(hasattr(revived_model, "_tracked"))
-        self.assertAllClose(ref_output, revived_model.serve(ref_input))
+        self.assertAllClose(revived_model.serve(ref_input), ref_output)
         self.assertLen(revived_model.variables, 8)
         self.assertLen(revived_model.trainable_variables, 6)
         self.assertLen(revived_model.non_trainable_variables, 2)
@@ -684,7 +684,7 @@ class ExportArchiveTest(testing.TestCase):
         # Reload and verify outputs
         revived_model = tf.saved_model.load(temp_filepath)
         self.assertFalse(hasattr(revived_model, "_tracked"))
-        self.assertAllClose(ref_output, revived_model.serve(ref_input))
+        self.assertAllClose(revived_model.serve(ref_input), ref_output)
         self.assertLen(revived_model.variables, 6)
         self.assertLen(revived_model.trainable_variables, 6)
         self.assertLen(revived_model.non_trainable_variables, 0)
@@ -711,7 +711,7 @@ class ExportArchiveTest(testing.TestCase):
         )
         export_archive.write_out(temp_filepath)
         revived_layer = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_layer.call(ref_input))
+        self.assertAllClose(revived_layer.call(ref_input), ref_output)
 
     def test_multi_input_output_functional_model(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
@@ -775,7 +775,7 @@ class ExportArchiveTest(testing.TestCase):
 
         saved_model.export_saved_model(model, temp_filepath)
         revived_model = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_model.serve(ref_input))
+        self.assertAllClose(revived_model.serve(ref_input), ref_output)
 
     @pytest.mark.skipif(
         backend.backend() != "tensorflow",
@@ -805,7 +805,7 @@ class ExportArchiveTest(testing.TestCase):
             input_signature=[tf.TensorSpec(shape=[1], dtype=tf.string)],
         )
         revived_model = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_model.serve(ref_input))
+        self.assertAllClose(revived_model.serve(ref_input), ref_output)
 
     def test_track_multiple_layers(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
@@ -829,8 +829,8 @@ class ExportArchiveTest(testing.TestCase):
         )
         export_archive.write_out(temp_filepath)
         revived_layer = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output_1, revived_layer.call_1(ref_input_1))
-        self.assertAllClose(ref_output_2, revived_layer.call_2(ref_input_2))
+        self.assertAllClose(revived_layer.call_1(ref_input_1), ref_output_1)
+        self.assertAllClose(revived_layer.call_2(ref_input_2), ref_output_2)
 
     def test_non_standard_layer_signature(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_layer")
@@ -851,7 +851,7 @@ class ExportArchiveTest(testing.TestCase):
         )
         export_archive.write_out(temp_filepath)
         revived_layer = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_layer.call(x1, x2))
+        self.assertAllClose(revived_layer.call(x1, x2), ref_output)
 
     def test_non_standard_layer_signature_with_kwargs(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_layer")
@@ -872,7 +872,7 @@ class ExportArchiveTest(testing.TestCase):
         )
         export_archive.write_out(temp_filepath)
         revived_layer = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_layer.call(query=x1, value=x2))
+        self.assertAllClose(revived_layer.call(query=x1, value=x2), ref_output)
         # Test with a different batch size
         revived_layer.call(
             query=tf.random.normal((6, 2, 2)), value=tf.random.normal((6, 2, 2))
@@ -1001,7 +1001,7 @@ class ExportArchiveTest(testing.TestCase):
 
         model.export(temp_filepath)
         revived_model = tf.saved_model.load(temp_filepath)
-        self.assertAllClose(ref_output, revived_model.serve(ref_input))
+        self.assertAllClose(revived_model.serve(ref_input), ref_output)
         # Test with a different batch size
         revived_model.serve(tf.random.normal((6, 10)))
 

--- a/keras/src/layers/convolutional/conv_transpose_test.py
+++ b/keras/src/layers/convolutional/conv_transpose_test.py
@@ -902,7 +902,7 @@ class ConvTransposeCorrectnessTest(testing.TestCase):
                 )
                 with pytest.warns(UserWarning):
                     kc_res = kc_layer(input)
-                self.assertAllClose(expected_res, kc_res, atol=1e-5)
+                self.assertAllClose(kc_res, expected_res, atol=1e-5)
                 return
 
             # torch_padding > 0 and torch_output_padding > 0 case
@@ -920,12 +920,12 @@ class ConvTransposeCorrectnessTest(testing.TestCase):
             if torch_padding > 0 and torch_output_padding > 0:
                 with pytest.raises(AssertionError):
                     kc_res = kc_layer(input)
-                    self.assertAllClose(expected_res, kc_res, atol=1e-5)
+                    self.assertAllClose(kc_res, expected_res, atol=1e-5)
                 return
 
         # Compare results
         kc_res = kc_layer(input)
-        self.assertAllClose(expected_res, kc_res, atol=1e-5)
+        self.assertAllClose(kc_res, expected_res, atol=1e-5)
 
     @parameterized.product(
         kernel_size=list(range(1, 5)),

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1046,7 +1046,7 @@ class LayerTest(testing.TestCase):
         for ref_v, v in zip(
             layer1.non_trainable_variables, non_trainable_variables
         ):
-            self.assertAllClose(ref_v, v)
+            self.assertAllClose(v, ref_v)
 
         # Test with loss collection
         layer3 = TestLayer()
@@ -1062,10 +1062,10 @@ class LayerTest(testing.TestCase):
         for ref_v, v in zip(
             layer1.non_trainable_variables, non_trainable_variables
         ):
-            self.assertAllClose(ref_v, v)
+            self.assertAllClose(v, ref_v)
         self.assertLen(losses, 2)
         for ref_loss, loss in zip(layer1.losses, losses):
-            self.assertAllClose(ref_loss, loss)
+            self.assertAllClose(loss, ref_loss)
 
     def test_trainable_setting(self):
         class NonTrainableWeightsLayer(layers.Layer):

--- a/keras/src/layers/preprocessing/category_encoding_test.py
+++ b/keras/src/layers/preprocessing/category_encoding_test.py
@@ -109,7 +109,7 @@ class CategoryEncodingTest(testing.TestCase):
             num_tokens=num_tokens, output_mode="multi_hot", sparse=sparse
         )
         output_data = layer(input_data)
-        self.assertAllClose(expected_output, output_data)
+        self.assertAllClose(output_data, expected_output)
         self.assertEqual(expected_output_shape, output_data.shape)
         self.assertSparse(output_data, sparse)
 
@@ -133,7 +133,7 @@ class CategoryEncodingTest(testing.TestCase):
             num_tokens=num_tokens, output_mode="multi_hot", sparse=sparse
         )
         output_data = layer(input_data)
-        self.assertAllClose(expected_output, output_data)
+        self.assertAllClose(output_data, expected_output)
         self.assertEqual(expected_output_shape, output_data.shape)
         self.assertSparse(output_data, sparse)
 
@@ -174,7 +174,7 @@ class CategoryEncodingTest(testing.TestCase):
             num_tokens=num_tokens, output_mode="one_hot", sparse=sparse
         )
         output_data = layer(input_data)
-        self.assertAllClose(expected_output, output_data)
+        self.assertAllClose(output_data, expected_output)
         self.assertEqual(expected_output_shape, output_data.shape)
         self.assertSparse(output_data, sparse)
 
@@ -241,7 +241,7 @@ class CategoryEncodingTest(testing.TestCase):
             num_tokens=num_tokens, output_mode="one_hot", sparse=sparse
         )
         output_data = layer(input_data)
-        self.assertAllClose(expected_output, output_data)
+        self.assertAllClose(output_data, expected_output)
         self.assertEqual(expected_output_shape, output_data.shape)
         self.assertSparse(output_data, sparse)
 
@@ -311,7 +311,7 @@ class CategoryEncodingTest(testing.TestCase):
             ]
         )
         output = layer._encode(input_array)
-        self.assertAllClose(expected_output, output)
+        self.assertAllClose(output, expected_output)
 
     def test_encode_one_hot_batched_samples(self):
         layer = layers.CategoryEncoding(num_tokens=4, output_mode="one_hot")
@@ -323,18 +323,18 @@ class CategoryEncodingTest(testing.TestCase):
             ]
         )
         output = layer._encode(input_array)
-        self.assertAllClose(expected_output, output)
+        self.assertAllClose(output, expected_output)
 
     def test_count_single_sample(self):
         layer = layers.CategoryEncoding(num_tokens=4, output_mode="count")
         input_array = np.array([1, 2, 3, 1])
         expected_output = np.array([0, 2, 1, 1])
         output = layer(input_array)
-        self.assertAllClose(expected_output, output)
+        self.assertAllClose(output, expected_output)
 
     def test_count_batched_samples(self):
         layer = layers.CategoryEncoding(num_tokens=4, output_mode="count")
         input_array = np.array([[1, 2, 3, 1], [0, 3, 1, 0]])
         expected_output = np.array([[0, 2, 1, 1], [2, 1, 0, 1]])
         output = layer(input_array)
-        self.assertAllClose(expected_output, output)
+        self.assertAllClose(output, expected_output)

--- a/keras/src/layers/preprocessing/hashed_crossing_test.py
+++ b/keras/src/layers/preprocessing/hashed_crossing_test.py
@@ -65,6 +65,7 @@ class HashedCrossingTest(testing.TestCase):
         output = layer((feat1, feat2))
         self.assertSparse(output, sparse)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.0, 1.0, 0.0, 0.0, 0.0],
@@ -74,7 +75,6 @@ class HashedCrossingTest(testing.TestCase):
                     [0.0, 0.0, 0.0, 1.0, 0.0],
                 ]
             ),
-            output,
         )
 
     def test_tf_data_compatibility(self):
@@ -87,7 +87,7 @@ class HashedCrossingTest(testing.TestCase):
             .map(lambda x1, x2: layer((x1, x2)))
         )
         output = next(iter(ds)).numpy()
-        self.assertAllClose(np.array([1, 4, 1, 1, 3]), output)
+        self.assertAllClose(output, np.array([1, 4, 1, 1, 3]))
 
     def test_static_shape_preserved(self):
         layer = layers.HashedCrossing(num_bins=5)

--- a/keras/src/layers/preprocessing/hashing_test.py
+++ b/keras/src/layers/preprocessing/hashing_test.py
@@ -81,7 +81,7 @@ class HashingTest(testing.TestCase):
         layer = layers.Hashing(num_bins=1)
         inp = np.asarray([["A"], ["B"], ["C"], ["D"], ["E"]])
         output = layer(inp)
-        self.assertAllClose([[0], [0], [0], [0], [0]], output)
+        self.assertAllClose(output, [[0], [0], [0], [0], [0]])
 
     def test_hash_dense_input_farmhash(self):
         layer = layers.Hashing(num_bins=2)
@@ -90,7 +90,7 @@ class HashingTest(testing.TestCase):
         )
         output = layer(inp)
         # Assert equal for hashed output that should be true on all platforms.
-        self.assertAllClose([[0], [0], [1], [0], [0]], output)
+        self.assertAllClose(output, [[0], [0], [1], [0], [0]])
 
     def test_hash_dense_input_mask_value_farmhash(self):
         empty_mask_layer = layers.Hashing(num_bins=3, mask_value="")
@@ -102,28 +102,28 @@ class HashingTest(testing.TestCase):
         omar_mask_output = omar_mask_layer(inp)
         # Outputs should be one more than test_hash_dense_input_farmhash (the
         # zeroth bin is now reserved for masks).
-        self.assertAllClose([[1], [1], [2], [1], [1]], empty_mask_output)
+        self.assertAllClose(empty_mask_output, [[1], [1], [2], [1], [1]])
         # 'omar' should map to 0.
-        self.assertAllClose([[0], [1], [2], [1], [1]], omar_mask_output)
+        self.assertAllClose(omar_mask_output, [[0], [1], [2], [1], [1]])
 
     def test_hash_dense_list_input_farmhash(self):
         layer = layers.Hashing(num_bins=2)
         inp = [["omar"], ["stringer"], ["marlo"], ["wire"], ["skywalker"]]
         output = layer(inp)
         # Assert equal for hashed output that should be true on all platforms.
-        self.assertAllClose([[0], [0], [1], [0], [0]], output)
+        self.assertAllClose(output, [[0], [0], [1], [0], [0]])
 
         inp = ["omar", "stringer", "marlo", "wire", "skywalker"]
         output = layer(inp)
         # Assert equal for hashed output that should be true on all platforms.
-        self.assertAllClose([0, 0, 1, 0, 0], output)
+        self.assertAllClose(output, [0, 0, 1, 0, 0])
 
     def test_hash_dense_int_input_farmhash(self):
         layer = layers.Hashing(num_bins=3)
         inp = np.asarray([[0], [1], [2], [3], [4]])
         output = layer(inp)
         # Assert equal for hashed output that should be true on all platforms.
-        self.assertAllClose([[1], [0], [1], [0], [2]], output)
+        self.assertAllClose(output, [[1], [0], [1], [0], [2]])
 
     def test_hash_dense_input_siphash(self):
         layer = layers.Hashing(num_bins=2, salt=[133, 137])
@@ -133,19 +133,19 @@ class HashingTest(testing.TestCase):
         output = layer(inp)
         # Assert equal for hashed output that should be true on all platforms.
         # Note the result is different from FarmHash.
-        self.assertAllClose([[0], [1], [0], [1], [0]], output)
+        self.assertAllClose(output, [[0], [1], [0], [1], [0]])
 
         layer_2 = layers.Hashing(num_bins=2, salt=[211, 137])
         output_2 = layer_2(inp)
         # Note the result is different from (133, 137).
-        self.assertAllClose([[1], [0], [1], [0], [1]], output_2)
+        self.assertAllClose(output_2, [[1], [0], [1], [0], [1]])
 
     def test_hash_dense_int_input_siphash(self):
         layer = layers.Hashing(num_bins=3, salt=[133, 137])
         inp = np.asarray([[0], [1], [2], [3], [4]])
         output = layer(inp)
         # Assert equal for hashed output that should be true on all platforms.
-        self.assertAllClose([[1], [1], [2], [0], [1]], output)
+        self.assertAllClose(output, [[1], [1], [2], [0], [1]])
 
     @pytest.mark.skipif(
         backend.backend() != "tensorflow", reason="Uses tf.SparseTensor."
@@ -160,7 +160,7 @@ class HashingTest(testing.TestCase):
         )
         output = layer(inp)
         self.assertAllClose(indices, output.indices)
-        self.assertAllClose([0, 0, 1, 0, 0], output.values)
+        self.assertAllClose(output.values, [0, 0, 1, 0, 0])
 
     @pytest.mark.skipif(
         backend.backend() != "tensorflow", reason="Uses tf.SparseTensor."
@@ -180,9 +180,9 @@ class HashingTest(testing.TestCase):
         self.assertAllClose(indices, empty_mask_output.indices)
         # Outputs should be one more than test_hash_sparse_input_farmhash (the
         # zeroth bin is now reserved for masks).
-        self.assertAllClose([1, 1, 2, 1, 1], empty_mask_output.values)
+        self.assertAllClose(empty_mask_output.values, [1, 1, 2, 1, 1])
         # 'omar' should map to 0.
-        self.assertAllClose([0, 1, 2, 1, 1], omar_mask_output.values)
+        self.assertAllClose(omar_mask_output.values, [0, 1, 2, 1, 1])
 
     @pytest.mark.skipif(
         backend.backend() != "tensorflow", reason="Uses tf.SparseTensor."
@@ -195,7 +195,7 @@ class HashingTest(testing.TestCase):
         )
         output = layer(inp)
         self.assertAllClose(indices, output.indices)
-        self.assertAllClose([1, 0, 1, 0, 2], output.values)
+        self.assertAllClose(output.values, [1, 0, 1, 0, 2])
 
     @pytest.mark.skipif(
         backend.backend() != "tensorflow", reason="Uses tf.SparseTensor."
@@ -211,12 +211,12 @@ class HashingTest(testing.TestCase):
         output = layer(inp)
         self.assertAllClose(output.indices, indices)
         # The result should be same with test_hash_dense_input_siphash.
-        self.assertAllClose([0, 1, 0, 1, 0], output.values)
+        self.assertAllClose(output.values, [0, 1, 0, 1, 0])
 
         layer_2 = layers.Hashing(num_bins=2, salt=[211, 137])
         output = layer_2(inp)
         # The result should be same with test_hash_dense_input_siphash.
-        self.assertAllClose([1, 0, 1, 0, 1], output.values)
+        self.assertAllClose(output.values, [1, 0, 1, 0, 1])
 
     @pytest.mark.skipif(
         backend.backend() != "tensorflow", reason="Uses tf.SparseTensor."
@@ -229,7 +229,7 @@ class HashingTest(testing.TestCase):
         )
         output = layer(inp)
         self.assertAllClose(indices, output.indices)
-        self.assertAllClose([1, 1, 2, 0, 1], output.values)
+        self.assertAllClose(output.values, [1, 1, 2, 0, 1])
 
     def test_invalid_inputs(self):
         with self.assertRaisesRegex(ValueError, "cannot be `None`"):
@@ -268,7 +268,7 @@ class HashingTest(testing.TestCase):
 
         model = models.Model(inputs, outputs)
         output_data = model(input_array)
-        self.assertAllClose(expected_output, output_data)
+        self.assertAllClose(output_data, expected_output)
 
     def test_multi_hot_output(self):
         input_array = np.array([[0, 1, 2, 3, 4]])
@@ -283,7 +283,7 @@ class HashingTest(testing.TestCase):
 
         model = models.Model(inputs, outputs)
         output_data = model(input_array)
-        self.assertAllClose(expected_output, output_data)
+        self.assertAllClose(output_data, expected_output)
 
     @parameterized.named_parameters(
         (

--- a/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/iou_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/iou_test.py
@@ -39,7 +39,7 @@ class IoUTest(testing.TestCase):
         )
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
-        self.assertAllClose(expected_result, result)
+        self.assertAllClose(result, expected_result)
 
     def test_batched_compute_iou(self):
         bb1 = [100, 101, 200, 201]
@@ -79,7 +79,7 @@ class IoUTest(testing.TestCase):
         )
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
-        self.assertAllClose(expected_result, result)
+        self.assertAllClose(result, expected_result)
 
     def test_batched_boxes1_unbatched_boxes2(self):
         bb1 = [100, 101, 200, 201]
@@ -108,7 +108,7 @@ class IoUTest(testing.TestCase):
         )
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
-        self.assertAllClose(expected_result, result)
+        self.assertAllClose(result, expected_result)
 
     def test_unbatched_boxes1_batched_boxes2(self):
         bb1 = [100, 101, 200, 201]
@@ -147,7 +147,7 @@ class IoUTest(testing.TestCase):
         )
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
-        self.assertAllClose(expected_result, result)
+        self.assertAllClose(result, expected_result)
 
 
 class CIoUTest(testing.TestCase):

--- a/keras/src/layers/preprocessing/image_preprocessing/center_crop_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/center_crop_test.py
@@ -92,7 +92,7 @@ class CenterCropTest(testing.TestCase):
             )
         else:
             ref_out = self.np_center_crop(img, size[0], size[1])
-        self.assertAllClose(ref_out, out)
+        self.assertAllClose(out, ref_out)
 
         # unbatched case
         if data_format == "channels_first":
@@ -120,7 +120,7 @@ class CenterCropTest(testing.TestCase):
                 size[0],
                 size[1],
             )
-        self.assertAllClose(ref_out, out)
+        self.assertAllClose(out, ref_out)
 
     @parameterized.parameters(
         [
@@ -143,7 +143,7 @@ class CenterCropTest(testing.TestCase):
         ref_out = layers.Resizing(
             size[0], size[1], data_format=data_format, crop_to_aspect_ratio=True
         )(img)
-        self.assertAllClose(ref_out, out)
+        self.assertAllClose(out, ref_out)
 
         # unbatched case
         if data_format == "channels_first":
@@ -158,7 +158,7 @@ class CenterCropTest(testing.TestCase):
         ref_out = layers.Resizing(
             size[0], size[1], data_format=data_format, crop_to_aspect_ratio=True
         )(img)
-        self.assertAllClose(ref_out, out)
+        self.assertAllClose(out, ref_out)
 
     def test_tf_data_compatibility(self):
         if backend.config.image_data_format() == "channels_last":
@@ -207,7 +207,7 @@ class CenterCropTest(testing.TestCase):
         ref_out = layers.Resizing(
             size[0], size[1], data_format=data_format, crop_to_aspect_ratio=True
         )(img)
-        self.assertAllClose(ref_out, out)
+        self.assertAllClose(out, ref_out)
 
     @parameterized.named_parameters(
         (

--- a/keras/src/layers/preprocessing/image_preprocessing/cut_mix_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/cut_mix_test.py
@@ -68,7 +68,7 @@ class CutMixTest(testing.TestCase):
 
         output = layer.transform_images(inputs, transformation)
 
-        self.assertAllClose(expected_output, output)
+        self.assertAllClose(output, expected_output)
 
     def test_tf_data_compatibility(self):
         data_format = backend.config.image_data_format()

--- a/keras/src/layers/preprocessing/image_preprocessing/random_erasing_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_erasing_test.py
@@ -74,7 +74,7 @@ class RandomErasingTest(testing.TestCase):
 
         print(output)
 
-        self.assertAllClose(expected_output, output)
+        self.assertAllClose(output, expected_output)
 
     def test_tf_data_compatibility(self):
         data_format = backend.config.image_data_format()

--- a/keras/src/layers/preprocessing/image_preprocessing/random_gaussian_blur_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_gaussian_blur_test.py
@@ -75,8 +75,8 @@ class RandomGaussianBlurTest(testing.TestCase):
         output = layer.transform_images(inputs, transformation)
 
         self.assertAllClose(
-            expected_output,
             output,
+            expected_output,
             atol=1e-4,
             rtol=1e-4,
             tpu_atol=1e-2,

--- a/keras/src/layers/preprocessing/image_preprocessing/random_perspective_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_perspective_test.py
@@ -79,7 +79,7 @@ class RandomPerspectiveTest(testing.TestCase):
         }
         output = layer.transform_images(inputs, transformation)
 
-        self.assertAllClose(expected_output, output, atol=1e-4, rtol=1e-4)
+        self.assertAllClose(output, expected_output, atol=1e-4, rtol=1e-4)
 
     def test_tf_data_compatibility(self):
         data_format = backend.config.image_data_format()

--- a/keras/src/layers/preprocessing/image_preprocessing/random_posterization_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_posterization_test.py
@@ -42,7 +42,7 @@ class RandomPosterizationTest(testing.TestCase):
         expected_output = np.asarray(
             [[[128.0, 128.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]
         )
-        self.assertAllClose(expected_output, output)
+        self.assertAllClose(output, expected_output)
 
     def test_random_posterization_value_range_0_to_1(self):
         image = keras.random.uniform(shape=(3, 3, 3), minval=0, maxval=1)

--- a/keras/src/layers/preprocessing/image_preprocessing/random_rotation_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_rotation_test.py
@@ -74,4 +74,4 @@ class RandomRotationTest(testing.TestCase):
             ]
         ).reshape(input_shape[1:])
         output = next(iter(ds)).numpy()
-        self.assertAllClose(expected_output, output)
+        self.assertAllClose(output, expected_output)

--- a/keras/src/layers/preprocessing/image_preprocessing/random_zoom_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_zoom_test.py
@@ -123,7 +123,7 @@ class RandomZoomTest(testing.TestCase):
             ]
         ).reshape(input_shape)
         output = next(iter(ds)).numpy()
-        self.assertAllClose(expected_output, output)
+        self.assertAllClose(output, expected_output)
 
     def test_dynamic_shape(self):
         inputs = layers.Input((None, None, 3))

--- a/keras/src/layers/preprocessing/image_preprocessing/resizing_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/resizing_test.py
@@ -74,7 +74,7 @@ class ResizingTest(testing.TestCase):
         )
         if data_format == "channels_first":
             ref_out = ref_out.transpose(0, 3, 1, 2)
-        self.assertAllClose(ref_out, out)
+        self.assertAllClose(out, ref_out)
 
     @parameterized.parameters([("channels_first",), ("channels_last",)])
     def test_up_sampling_numeric(self, data_format):
@@ -94,7 +94,7 @@ class ResizingTest(testing.TestCase):
         )
         if data_format == "channels_first":
             ref_out = ref_out.transpose(0, 3, 1, 2)
-        self.assertAllClose(ref_out, out)
+        self.assertAllClose(out, ref_out)
 
     @parameterized.parameters([("channels_first",), ("channels_last",)])
     def test_crop_to_aspect_ratio(self, data_format):
@@ -122,7 +122,7 @@ class ResizingTest(testing.TestCase):
         )
         if data_format == "channels_first":
             ref_out = ref_out.transpose(0, 3, 1, 2)
-        self.assertAllClose(ref_out, out)
+        self.assertAllClose(out, ref_out)
 
     @parameterized.parameters([("channels_first",), ("channels_last",)])
     def test_unbatched_image(self, data_format):
@@ -144,7 +144,7 @@ class ResizingTest(testing.TestCase):
         )
         if data_format == "channels_first":
             ref_out = ref_out.transpose(2, 0, 1)
-        self.assertAllClose(ref_out, out)
+        self.assertAllClose(out, ref_out)
 
     def test_tf_data_compatibility(self):
         if backend.config.image_data_format() == "channels_last":

--- a/keras/src/layers/preprocessing/stft_spectrogram_test.py
+++ b/keras/src/layers/preprocessing/stft_spectrogram_test.py
@@ -323,12 +323,12 @@ class TestSpectrogram(testing.TestCase):
             init_args["mode"] = "magnitude"
             y_true, y = self._calc_spectrograms(x, **init_args)
             self.assertEqual(np.shape(y_true), np.shape(y))
-            self.assertAllClose(y_true, y, **tol_kwargs)
+            self.assertAllClose(y, y_true, **tol_kwargs)
 
             init_args["mode"] = "psd"
             y_true, y = self._calc_spectrograms(x, **init_args)
             self.assertEqual(np.shape(y_true), np.shape(y))
-            self.assertAllClose(y_true, y, **tol_kwargs)
+            self.assertAllClose(y, y_true, **tol_kwargs)
 
             init_args["mode"] = "angle"
             y_true, y = self._calc_spectrograms(x, **init_args)

--- a/keras/src/layers/rnn/bidirectional_test.py
+++ b/keras/src/layers/rnn/bidirectional_test.py
@@ -43,13 +43,13 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.39687276, 0.39687276, 0.10004295, 0.10004295],
                     [0.7237238, 0.7237238, 0.53391594, 0.53391594],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -59,8 +59,8 @@ class SimpleRNNTest(testing.TestCase):
         layer = layers.Bidirectional(layer=forward_layer, merge_mode="ave")
         output = layer(sequence)
         self.assertAllClose(
-            np.array([[0.24845785, 0.24845785], [0.6288199, 0.6288199]]),
             output,
+            np.array([[0.24845785, 0.24845785], [0.6288199, 0.6288199]]),
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -70,16 +70,16 @@ class SimpleRNNTest(testing.TestCase):
         layer = layers.Bidirectional(layer=forward_layer, merge_mode=None)
         output1, output2 = layer(sequence)
         self.assertAllClose(
-            np.array([[0.39687276, 0.39687276], [0.7237238, 0.7237238]]),
             output1,
+            np.array([[0.39687276, 0.39687276], [0.7237238, 0.7237238]]),
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
-            np.array([[0.10004295, 0.10004295], [0.53391594, 0.53391594]]),
             output2,
+            np.array([[0.10004295, 0.10004295], [0.53391594, 0.53391594]]),
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -98,8 +98,8 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
-            np.array([[0.08374989, 0.08374989], [0.6740834, 0.6740834]]),
             output,
+            np.array([[0.08374989, 0.08374989], [0.6740834, 0.6740834]]),
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -116,6 +116,7 @@ class SimpleRNNTest(testing.TestCase):
         layer = layers.Bidirectional(layer=forward_layer, merge_mode="sum")
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [
@@ -130,7 +131,6 @@ class SimpleRNNTest(testing.TestCase):
                     ],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -150,13 +150,13 @@ class SimpleRNNTest(testing.TestCase):
         layer(sequence)
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.26234663, 0.26234663, 0.16959146, 0.16959146],
                     [0.6137073, 0.6137073, 0.5381646, 0.5381646],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -166,13 +166,13 @@ class SimpleRNNTest(testing.TestCase):
         layer(sequence)
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.26234663, 0.26234663, 0.16959146, 0.16959146],
                     [0.6137073, 0.6137073, 0.5381646, 0.5381646],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -198,13 +198,13 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence, initial_state=initial_state)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.20794602, 0.4577124, 0.14046375, 0.48191673],
                     [0.6682636, 0.6711909, 0.60943645, 0.60950446],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -223,13 +223,13 @@ class SimpleRNNTest(testing.TestCase):
         mask = np.array([[True, True, False, True], [True, False, False, True]])
         output = layer(sequence, mask=mask)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.19393763, 0.19393763, 0.11669192, 0.11669192],
                     [0.30818558, 0.30818558, 0.28380975, 0.28380975],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -248,45 +248,45 @@ class SimpleRNNTest(testing.TestCase):
         layer = layers.Bidirectional(layer=forward_layer)
         output, h1, c1, h2, c2 = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.1990008, 0.1990008, 0.12659755, 0.12659755],
                     [0.52335435, 0.52335435, 0.44717982, 0.44717982],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
-            np.array([[0.1990008, 0.1990008], [0.52335435, 0.52335435]]),
             h1,
+            np.array([[0.1990008, 0.1990008], [0.52335435, 0.52335435]]),
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
-            np.array([[0.35567185, 0.35567185], [1.0492687, 1.0492687]]),
             c1,
+            np.array([[0.35567185, 0.35567185], [1.0492687, 1.0492687]]),
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
-            np.array([[0.12659755, 0.12659755], [0.44717982, 0.44717982]]),
             h2,
+            np.array([[0.12659755, 0.12659755], [0.44717982, 0.44717982]]),
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
-            np.array([[0.2501858, 0.2501858], [0.941473, 0.941473]]),
             c2,
+            np.array([[0.2501858, 0.2501858], [0.941473, 0.941473]]),
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,

--- a/keras/src/layers/rnn/conv_lstm1d_test.py
+++ b/keras/src/layers/rnn/conv_lstm1d_test.py
@@ -70,10 +70,7 @@ class ConvLSTM1DTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
-            expected_output,
-            output,
-            tpu_atol=1e-3,
-            tpu_rtol=1e-3,
+            output, expected_output, tpu_atol=1e-3, tpu_rtol=1e-3
         )
 
     def test_symbolic_invalid_strides_dilation_rate(self):

--- a/keras/src/layers/rnn/conv_lstm2d_test.py
+++ b/keras/src/layers/rnn/conv_lstm2d_test.py
@@ -82,10 +82,7 @@ class ConvLSTM2DTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
-            expected_output,
-            output,
-            tpu_atol=1e-3,
-            tpu_rtol=1e-3,
+            output, expected_output, tpu_atol=1e-3, tpu_rtol=1e-3
         )
 
     def test_symbolic_invalid_strides_dilation_rate(self):

--- a/keras/src/layers/rnn/conv_lstm3d_test.py
+++ b/keras/src/layers/rnn/conv_lstm3d_test.py
@@ -100,10 +100,7 @@ class ConvLSTM3DTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
-            expected_output,
-            output,
-            tpu_atol=1e-4,
-            tpu_rtol=1e-4,
+            output, expected_output, tpu_atol=1e-4, tpu_rtol=1e-4
         )
 
     def test_symbolic_invalid_strides_dilation_rate(self):

--- a/keras/src/layers/rnn/gru_test.py
+++ b/keras/src/layers/rnn/gru_test.py
@@ -58,6 +58,7 @@ class GRUTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.5217289, 0.5217289, 0.5217289],
@@ -65,7 +66,6 @@ class GRUTest(testing.TestCase):
                     [0.39384964, 0.39384964, 0.3938496],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -81,6 +81,7 @@ class GRUTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.24406259, 0.24406259, 0.24406259],
@@ -88,7 +89,6 @@ class GRUTest(testing.TestCase):
                     [0.3928808, 0.3928808, 0.3928808],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -104,6 +104,7 @@ class GRUTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.5217289, 0.5217289, 0.5217289],
@@ -111,7 +112,6 @@ class GRUTest(testing.TestCase):
                     [0.39384964, 0.39384964, 0.3938496],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -127,6 +127,7 @@ class GRUTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.51447755, 0.51447755, 0.51447755],
@@ -134,7 +135,6 @@ class GRUTest(testing.TestCase):
                     [0.40208298, 0.40208298, 0.40208298],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -150,6 +150,7 @@ class GRUTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.49988455, 0.49988455, 0.49988455],
@@ -157,7 +158,6 @@ class GRUTest(testing.TestCase):
                     [0.4103359, 0.4103359, 0.4103359],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -176,13 +176,13 @@ class GRUTest(testing.TestCase):
         layer(sequence)
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.29542392, 0.29542392, 0.29542392, 0.29542392],
                     [0.5885018, 0.5885018, 0.5885018, 0.5885018],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -190,13 +190,13 @@ class GRUTest(testing.TestCase):
         layer(sequence)
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.29542392, 0.29542392, 0.29542392, 0.29542392],
                     [0.5885018, 0.5885018, 0.5885018, 0.5885018],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -212,8 +212,8 @@ class GRUTest(testing.TestCase):
         )
         output = layer(sequence, initial_state=initial_state)
         self.assertAllClose(
-            np.array([[0.23774096, 0.33508456], [0.83659905, 1.0227708]]),
             output,
+            np.array([[0.23774096, 0.33508456], [0.83659905, 1.0227708]]),
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -227,8 +227,8 @@ class GRUTest(testing.TestCase):
         )
         output = layer(sequence, initial_state=initial_state)
         self.assertAllClose(
-            np.array([[0.13486053, 0.23261218], [0.78257304, 0.9691353]]),
             output,
+            np.array([[0.13486053, 0.23261218], [0.78257304, 0.9691353]]),
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -247,8 +247,8 @@ class GRUTest(testing.TestCase):
         )
         output, state = layer(sequence, initial_state=initial_state)
         self.assertAllClose(
-            np.array([[0.23774096, 0.33508456], [0.83659905, 1.0227708]]),
             output,
+            np.array([[0.23774096, 0.33508456], [0.83659905, 1.0227708]]),
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -270,8 +270,8 @@ class GRUTest(testing.TestCase):
         )
         output, state = layer(sequence, initial_state=initial_state)
         self.assertAllClose(
-            np.array([[0.13486053, 0.23261218], [0.78257304, 0.9691353]]),
             output,
+            np.array([[0.13486053, 0.23261218], [0.78257304, 0.9691353]]),
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -294,8 +294,8 @@ class GRUTest(testing.TestCase):
         )
         output = layer(sequence, mask=mask)
         self.assertAllClose(
-            np.array([[0.19393763, 0.19393763], [0.30818558, 0.30818558]]),
             output,
+            np.array([[0.19393763, 0.19393763], [0.30818558, 0.30818558]]),
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -309,28 +309,28 @@ class GRUTest(testing.TestCase):
         )
         output = layer(sequence, mask=mask)
         self.assertAllClose(
+            output[0],
             np.array(
                 [
                     [0.03606692, 0.03606692],
                     [0.09497581, 0.09497581],
                     [0.09497581, 0.09497581],
                     [0.19393763, 0.19393763],
-                ],
+                ]
             ),
-            output[0],
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
+            output[1],
             np.array(
                 [
                     [0.16051409, 0.16051409],
                     [0.16051409, 0.16051409],
                     [0.16051409, 0.16051409],
                     [0.30818558, 0.30818558],
-                ],
+                ]
             ),
-            output[1],
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -345,28 +345,28 @@ class GRUTest(testing.TestCase):
         )
         output = layer(sequence, mask=mask)
         self.assertAllClose(
+            output[0],
             np.array(
                 [
                     [0.03606692, 0.03606692],
                     [0.09497581, 0.09497581],
                     [0.0, 0.0],
                     [0.19393763, 0.19393763],
-                ],
+                ]
             ),
-            output[0],
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
+            output[1],
             np.array(
                 [
                     [0.16051409, 0.16051409],
                     [0.0, 0.0],
                     [0.0, 0.0],
                     [0.30818558, 0.30818558],
-                ],
+                ]
             ),
-            output[1],
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -380,8 +380,8 @@ class GRUTest(testing.TestCase):
         )
         output = layer(sequence, mask=mask)
         self.assertAllClose(
-            np.array([[0.11669192, 0.11669192], [0.28380975, 0.28380975]]),
             output,
+            np.array([[0.11669192, 0.11669192], [0.28380975, 0.28380975]]),
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -399,6 +399,7 @@ class GRUTest(testing.TestCase):
         layer = layers.GRU.from_config(config)
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.5217289, 0.5217289, 0.5217289],
@@ -406,7 +407,6 @@ class GRUTest(testing.TestCase):
                     [0.39384964, 0.39384964, 0.3938496],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )

--- a/keras/src/layers/rnn/lstm_test.py
+++ b/keras/src/layers/rnn/lstm_test.py
@@ -58,6 +58,7 @@ class LSTMTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.6288687, 0.6288687, 0.6288687],
@@ -65,7 +66,6 @@ class LSTMTest(testing.TestCase):
                     [0.9460773, 0.9460773, 0.9460773],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -82,6 +82,7 @@ class LSTMTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.35622165, 0.35622165, 0.35622165],
@@ -89,7 +90,6 @@ class LSTMTest(testing.TestCase):
                     [0.8872726, 0.8872726, 0.8872726],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -106,6 +106,7 @@ class LSTMTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.6288687, 0.6288687, 0.6288687],
@@ -113,7 +114,6 @@ class LSTMTest(testing.TestCase):
                     [0.9460773, 0.9460773, 0.9460773],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -130,6 +130,7 @@ class LSTMTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.57019705, 0.57019705, 0.57019705],
@@ -137,7 +138,6 @@ class LSTMTest(testing.TestCase):
                     [0.9459622, 0.9459622, 0.9459622],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -154,6 +154,7 @@ class LSTMTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.54986924, 0.54986924, 0.54986924],
@@ -161,7 +162,6 @@ class LSTMTest(testing.TestCase):
                     [0.9443936, 0.9443936, 0.9443936],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -180,13 +180,13 @@ class LSTMTest(testing.TestCase):
         layer(sequence)
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.3124785, 0.3124785, 0.3124785, 0.3124785],
                     [0.6863672, 0.6863672, 0.6863672, 0.6863672],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -196,13 +196,13 @@ class LSTMTest(testing.TestCase):
         layer(sequence)
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.3124785, 0.3124785, 0.3124785, 0.3124785],
                     [0.6863672, 0.6863672, 0.6863672, 0.6863672],
                 ]
             ),
-            output,
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -223,8 +223,8 @@ class LSTMTest(testing.TestCase):
         )
         output = layer(sequence, initial_state=initial_state)
         self.assertAllClose(
-            np.array([[0.20574439, 0.3558822], [0.64930826, 0.66276]]),
             output,
+            np.array([[0.20574439, 0.3558822], [0.64930826, 0.66276]]),
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -240,8 +240,8 @@ class LSTMTest(testing.TestCase):
         )
         output = layer(sequence, initial_state=initial_state)
         self.assertAllClose(
-            np.array([[0.13281618, 0.2790356], [0.5839337, 0.5992567]]),
             output,
+            np.array([[0.13281618, 0.2790356], [0.5839337, 0.5992567]]),
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -264,8 +264,8 @@ class LSTMTest(testing.TestCase):
         )
         output = layer(sequence, mask=mask)
         self.assertAllClose(
-            np.array([[0.11755939, 0.11755939], [0.28556206, 0.28556206]]),
             output,
+            np.array([[0.11755939, 0.11755939], [0.28556206, 0.28556206]]),
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -281,30 +281,30 @@ class LSTMTest(testing.TestCase):
         )
         output = layer(sequence, mask=mask)
         self.assertAllClose(
+            output[0],
             np.array(
                 [
                     [0.01588910, 0.01588910],
                     [0.05552048, 0.05552048],
                     [0.11755939, 0.11755939],
                     [0.11755939, 0.11755939],
-                ],
+                ]
             ),
-            output[0],
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
+            output[1],
             np.array(
                 [
                     [0.14185596, 0.14185596],
                     [0.28556206, 0.28556206],
                     [0.28556206, 0.28556206],
                     [0.28556206, 0.28556206],
-                ],
+                ]
             ),
-            output[1],
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -321,30 +321,30 @@ class LSTMTest(testing.TestCase):
         )
         output = layer(sequence, mask=mask)
         self.assertAllClose(
+            output[0],
             np.array(
                 [
                     [0.01588910, 0.01588910],
                     [0.05552048, 0.05552048],
                     [0.11755939, 0.11755939],
                     [0.0, 0.0],
-                ],
+                ]
             ),
-            output[0],
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
+            output[1],
             np.array(
                 [
                     [0.14185596, 0.14185596],
                     [0.28556206, 0.28556206],
                     [0.0, 0.0],
                     [0.0, 0.0],
-                ],
+                ]
             ),
-            output[1],
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,
@@ -363,8 +363,8 @@ class LSTMTest(testing.TestCase):
         )
         output = layer(sequence, mask=backwards_mask)
         self.assertAllClose(
-            np.array([[0.15341201, 0.15341201], [0.3844719, 0.3844719]]),
             output,
+            np.array([[0.15341201, 0.15341201], [0.3844719, 0.3844719]]),
             atol=1e-5,
             rtol=1e-5,
             tpu_atol=1e-3,

--- a/keras/src/layers/rnn/rnn_test.py
+++ b/keras/src/layers/rnn/rnn_test.py
@@ -253,109 +253,109 @@ class RNNTest(testing.TestCase):
         sequence = np.ones((1, 2, 3))
         layer = layers.RNN(OneStateRNNCell(2), return_sequences=False)
         output = layer(sequence)
-        self.assertAllClose(np.array([[9.0, 9.0]]), output)
+        self.assertAllClose(output, np.array([[9.0, 9.0]]))
 
         layer = layers.RNN(OneStateRNNCell(2), return_sequences=True)
         output = layer(sequence)
-        self.assertAllClose(np.array([[[3.0, 3.0], [9.0, 9.0]]]), output)
+        self.assertAllClose(output, np.array([[[3.0, 3.0], [9.0, 9.0]]]))
 
         layer = layers.RNN(
             OneStateRNNCell(2), return_sequences=False, return_state=True
         )
         output, state = layer(sequence)
-        self.assertAllClose(np.array([[9.0, 9.0]]), output)
-        self.assertAllClose(np.array([[9.0, 9.0]]), state)
+        self.assertAllClose(output, np.array([[9.0, 9.0]]))
+        self.assertAllClose(state, np.array([[9.0, 9.0]]))
 
         layer = layers.RNN(
             OneStateRNNCell(2), return_sequences=True, return_state=True
         )
         output, state = layer(sequence)
-        self.assertAllClose(np.array([[[3.0, 3.0], [9.0, 9.0]]]), output)
-        self.assertAllClose(np.array([[9.0, 9.0]]), state)
+        self.assertAllClose(output, np.array([[[3.0, 3.0], [9.0, 9.0]]]))
+        self.assertAllClose(state, np.array([[9.0, 9.0]]))
 
     def test_forward_pass_two_states(self):
         sequence = np.ones((1, 2, 3))
         layer = layers.RNN(TwoStatesRNNCell(2), return_sequences=False)
         output = layer(sequence)
-        self.assertAllClose(np.array([[18.0, 18.0]]), output)
+        self.assertAllClose(output, np.array([[18.0, 18.0]]))
 
         layer = layers.RNN(TwoStatesRNNCell(2), return_sequences=True)
         output = layer(sequence)
-        self.assertAllClose(np.array([[[6.0, 6.0], [18.0, 18.0]]]), output)
+        self.assertAllClose(output, np.array([[[6.0, 6.0], [18.0, 18.0]]]))
 
         layer = layers.RNN(
             TwoStatesRNNCell(2), return_sequences=False, return_state=True
         )
         output, state1, state2 = layer(sequence)
-        self.assertAllClose(np.array([[18.0, 18.0]]), output)
-        self.assertAllClose(np.array([[9.0, 9.0]]), state1)
-        self.assertAllClose(np.array([[9.0, 9.0]]), state2)
+        self.assertAllClose(output, np.array([[18.0, 18.0]]))
+        self.assertAllClose(state1, np.array([[9.0, 9.0]]))
+        self.assertAllClose(state2, np.array([[9.0, 9.0]]))
 
         layer = layers.RNN(
             TwoStatesRNNCell(2), return_sequences=True, return_state=True
         )
         output, state1, state2 = layer(sequence)
-        self.assertAllClose(np.array([[[6.0, 6.0], [18.0, 18.0]]]), output)
-        self.assertAllClose(np.array([[9.0, 9.0]]), state1)
-        self.assertAllClose(np.array([[9.0, 9.0]]), state2)
+        self.assertAllClose(output, np.array([[[6.0, 6.0], [18.0, 18.0]]]))
+        self.assertAllClose(state1, np.array([[9.0, 9.0]]))
+        self.assertAllClose(state2, np.array([[9.0, 9.0]]))
 
     def test_passing_initial_state_single_state(self):
         sequence = np.ones((2, 3, 2))
         state = np.ones((2, 2))
         layer = layers.RNN(OneStateRNNCell(2), return_sequences=False)
         output = layer(sequence, initial_state=state)
-        self.assertAllClose(np.array([[22.0, 22.0], [22.0, 22.0]]), output)
+        self.assertAllClose(output, np.array([[22.0, 22.0], [22.0, 22.0]]))
 
         layer = layers.RNN(
             OneStateRNNCell(2), return_sequences=False, return_state=True
         )
         output, state = layer(sequence, initial_state=state)
-        self.assertAllClose(np.array([[22.0, 22.0], [22.0, 22.0]]), output)
-        self.assertAllClose(np.array([[22.0, 22.0], [22.0, 22.0]]), state)
+        self.assertAllClose(output, np.array([[22.0, 22.0], [22.0, 22.0]]))
+        self.assertAllClose(state, np.array([[22.0, 22.0], [22.0, 22.0]]))
 
     def test_passing_initial_state_two_states(self):
         sequence = np.ones((2, 3, 2))
         state = [np.ones((2, 2)), np.ones((2, 2))]
         layer = layers.RNN(TwoStatesRNNCell(2), return_sequences=False)
         output = layer(sequence, initial_state=state)
-        self.assertAllClose(np.array([[44.0, 44.0], [44.0, 44.0]]), output)
+        self.assertAllClose(output, np.array([[44.0, 44.0], [44.0, 44.0]]))
 
         layer = layers.RNN(
             TwoStatesRNNCell(2), return_sequences=False, return_state=True
         )
         output, state_1, state_2 = layer(sequence, initial_state=state)
-        self.assertAllClose(np.array([[44.0, 44.0], [44.0, 44.0]]), output)
-        self.assertAllClose(np.array([[22.0, 22.0], [22.0, 22.0]]), state_1)
-        self.assertAllClose(np.array([[22.0, 22.0], [22.0, 22.0]]), state_2)
+        self.assertAllClose(output, np.array([[44.0, 44.0], [44.0, 44.0]]))
+        self.assertAllClose(state_1, np.array([[22.0, 22.0], [22.0, 22.0]]))
+        self.assertAllClose(state_2, np.array([[22.0, 22.0], [22.0, 22.0]]))
 
     def test_statefulness_single_state(self):
         sequence = np.ones((1, 2, 3))
         layer = layers.RNN(OneStateRNNCell(2), stateful=True)
         layer(sequence)
         output = layer(sequence)
-        self.assertAllClose(np.array([[45.0, 45.0]]), output)
+        self.assertAllClose(output, np.array([[45.0, 45.0]]))
 
         layer = layers.RNN(OneStateRNNCell(2), stateful=True, return_state=True)
         layer(sequence)
         output, state = layer(sequence)
-        self.assertAllClose(np.array([[45.0, 45.0]]), output)
-        self.assertAllClose(np.array([[45.0, 45.0]]), state)
+        self.assertAllClose(output, np.array([[45.0, 45.0]]))
+        self.assertAllClose(state, np.array([[45.0, 45.0]]))
 
     def test_statefulness_two_states(self):
         sequence = np.ones((1, 2, 3))
         layer = layers.RNN(TwoStatesRNNCell(2), stateful=True)
         layer(sequence)
         output = layer(sequence)
-        self.assertAllClose(np.array([[90.0, 90.0]]), output)
+        self.assertAllClose(output, np.array([[90.0, 90.0]]))
 
         layer = layers.RNN(
             TwoStatesRNNCell(2), stateful=True, return_state=True
         )
         layer(sequence)
         output, state_1, state_2 = layer(sequence)
-        self.assertAllClose(np.array([[90.0, 90.0]]), output)
-        self.assertAllClose(np.array([[45.0, 45.0]]), state_1)
-        self.assertAllClose(np.array([[45.0, 45.0]]), state_2)
+        self.assertAllClose(output, np.array([[90.0, 90.0]]))
+        self.assertAllClose(state_1, np.array([[45.0, 45.0]]))
+        self.assertAllClose(state_2, np.array([[45.0, 45.0]]))
 
     def test_go_backwards(self):
         sequence = np.arange(24).reshape((2, 3, 4)).astype("float32")
@@ -363,8 +363,8 @@ class RNNTest(testing.TestCase):
         layer(sequence)
         output = layer(sequence)
         self.assertAllClose(
-            np.array([[202.0, 202.0], [538.0, 538.0]]),
             output,
+            np.array([[202.0, 202.0], [538.0, 538.0]]),
             tpu_atol=1e-4,
             tpu_rtol=1e-4,
         )
@@ -373,14 +373,14 @@ class RNNTest(testing.TestCase):
         layer(sequence)
         output, state = layer(sequence)
         self.assertAllClose(
-            np.array([[954.0, 954.0], [3978.0, 3978.0]]),
             output,
+            np.array([[954.0, 954.0], [3978.0, 3978.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
         self.assertAllClose(
-            np.array([[954.0, 954.0], [3978.0, 3978.0]]),
             state,
+            np.array([[954.0, 954.0], [3978.0, 3978.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )

--- a/keras/src/layers/rnn/simple_rnn_test.py
+++ b/keras/src/layers/rnn/simple_rnn_test.py
@@ -45,13 +45,13 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.405432, 0.405432, 0.405432, 0.405432],
                     [0.73605347, 0.73605347, 0.73605347, 0.73605347],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -64,13 +64,13 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.405432, 0.405432, 0.405432, 0.405432],
                     [0.73605347, 0.73605347, 0.73605347, 0.73605347],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -84,13 +84,13 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.11144729, 0.11144729, 0.11144729, 0.11144729],
                     [0.5528889, 0.5528889, 0.5528889, 0.5528889],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -104,13 +104,13 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.11144729, 0.11144729, 0.11144729, 0.11144729],
                     [0.5528889, 0.5528889, 0.5528889, 0.5528889],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -127,13 +127,13 @@ class SimpleRNNTest(testing.TestCase):
         layer(sequence)
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.40559256, 0.40559256, 0.40559256, 0.40559256],
                     [0.7361247, 0.7361247, 0.7361247, 0.7361247],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -141,13 +141,13 @@ class SimpleRNNTest(testing.TestCase):
         layer(sequence)
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.40559256, 0.40559256, 0.40559256, 0.40559256],
                     [0.7361247, 0.7361247, 0.7361247, 0.7361247],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -163,13 +163,13 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence, initial_state=initial_state)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.33621645, 0.33621645, 0.33621645, 0.33621645],
                     [0.6262637, 0.6262637, 0.6262637, 0.6262637],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -183,13 +183,13 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence, initial_state=initial_state)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.07344437, 0.07344437, 0.07344437, 0.07344437],
                     [0.43043602, 0.43043602, 0.43043602, 0.43043602],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -206,13 +206,13 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence, mask=mask)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.32951632, 0.32951632, 0.32951632, 0.32951632],
                     [0.61799484, 0.61799484, 0.61799484, 0.61799484],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -226,28 +226,28 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence, mask=mask)
         self.assertAllClose(
+            output[0],
             np.array(
                 [
                     [0.0599281, 0.0599281],
                     [0.15122814, 0.15122814],
                     [0.15122814, 0.15122814],
                     [0.32394567, 0.32394567],
-                ],
+                ]
             ),
-            output[0],
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
+            output[1],
             np.array(
                 [
                     [0.3969304, 0.3969304],
                     [0.3969304, 0.3969304],
                     [0.3969304, 0.3969304],
                     [0.608085, 0.608085],
-                ],
+                ]
             ),
-            output[1],
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -262,28 +262,28 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence, mask=mask)
         self.assertAllClose(
+            output[0],
             np.array(
                 [
                     [0.0599281, 0.0599281],
                     [0.15122814, 0.15122814],
                     [0.0, 0.0],
                     [0.32394567, 0.32394567],
-                ],
+                ]
             ),
-            output[0],
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
         self.assertAllClose(
+            output[1],
             np.array(
                 [
                     [0.3969304, 0.3969304],
                     [0.0, 0.0],
                     [0.0, 0.0],
                     [0.608085, 0.608085],
-                ],
+                ]
             ),
-            output[1],
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
@@ -297,13 +297,13 @@ class SimpleRNNTest(testing.TestCase):
         )
         output = layer(sequence, mask=mask)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [0.07376196, 0.07376196, 0.07376196, 0.07376196],
                     [0.43645123, 0.43645123, 0.43645123, 0.43645123],
                 ]
             ),
-            output,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )

--- a/keras/src/layers/rnn/stacked_rnn_cells_test.py
+++ b/keras/src/layers/rnn/stacked_rnn_cells_test.py
@@ -136,8 +136,8 @@ class StackedRNNTest(testing.TestCase):
         layer = layers.RNN([OneStateRNNCell(3), OneStateRNNCell(2)])
         output = layer(sequence)
         self.assertAllClose(
-            np.array([[786.0, 786.0], [4386.0, 4386.0]]),
             output,
+            np.array([[786.0, 786.0], [4386.0, 4386.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
@@ -147,13 +147,13 @@ class StackedRNNTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [[18.0, 18.0], [156.0, 156.0], [786.0, 786.0]],
                     [[162.0, 162.0], [1020.0, 1020.0], [4386.0, 4386.0]],
                 ]
             ),
-            output,
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
@@ -163,17 +163,17 @@ class StackedRNNTest(testing.TestCase):
         )
         output, state_1, state_2 = layer(sequence)
         self.assertAllClose(
-            np.array([[786.0, 786.0], [4386.0, 4386.0]]),
             output,
+            np.array([[786.0, 786.0], [4386.0, 4386.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
         self.assertAllClose(
-            np.array([[158.0, 158.0, 158.0], [782.0, 782.0, 782.0]]), state_1
+            state_1, np.array([[158.0, 158.0, 158.0], [782.0, 782.0, 782.0]])
         )
         self.assertAllClose(
-            np.array([[786.0, 786.0], [4386.0, 4386.0]]),
             state_2,
+            np.array([[786.0, 786.0], [4386.0, 4386.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
@@ -185,25 +185,25 @@ class StackedRNNTest(testing.TestCase):
         )
         output, state_1, state_2 = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [[18.0, 18.0], [156.0, 156.0], [786.0, 786.0]],
                     [[162.0, 162.0], [1020.0, 1020.0], [4386.0, 4386.0]],
                 ]
             ),
-            output,
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
         self.assertAllClose(
-            np.array([[158.0, 158.0, 158.0], [782.0, 782.0, 782.0]]),
             state_1,
+            np.array([[158.0, 158.0, 158.0], [782.0, 782.0, 782.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
         self.assertAllClose(
-            np.array([[786.0, 786.0], [4386.0, 4386.0]]),
             state_2,
+            np.array([[786.0, 786.0], [4386.0, 4386.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
@@ -213,8 +213,8 @@ class StackedRNNTest(testing.TestCase):
         layer = layers.RNN([TwoStatesRNNCell(3), TwoStatesRNNCell(2)])
         output = layer(sequence)
         self.assertAllClose(
-            np.array([[3144.0, 3144.0], [17544.0, 17544.0]]),
             output,
+            np.array([[3144.0, 3144.0], [17544.0, 17544.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
@@ -224,13 +224,13 @@ class StackedRNNTest(testing.TestCase):
         )
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [
                     [[72.0, 72.0], [624.0, 624.0], [3144.0, 3144.0]],
                     [[648.0, 648.0], [4080.0, 4080.0], [17544.0, 17544.0]],
                 ]
             ),
-            output,
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
@@ -241,32 +241,32 @@ class StackedRNNTest(testing.TestCase):
         output, state_1, state_2 = layer(sequence)
 
         self.assertAllClose(
-            np.array([[3144.0, 3144.0], [17544.0, 17544.0]]),
             output,
+            np.array([[3144.0, 3144.0], [17544.0, 17544.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
         self.assertAllClose(
-            np.array([[158.0, 158.0, 158.0], [782.0, 782.0, 782.0]]),
             state_1[0],
-            tpu_atol=1e-2,
-            tpu_rtol=1e-2,
-        )
-        self.assertAllClose(
             np.array([[158.0, 158.0, 158.0], [782.0, 782.0, 782.0]]),
+            tpu_atol=1e-2,
+            tpu_rtol=1e-2,
+        )
+        self.assertAllClose(
             state_1[1],
+            np.array([[158.0, 158.0, 158.0], [782.0, 782.0, 782.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
         self.assertAllClose(
-            np.array([[1572.0, 1572.0], [8772.0, 8772.0]]),
             state_2[0],
+            np.array([[1572.0, 1572.0], [8772.0, 8772.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
         self.assertAllClose(
-            np.array([[1572.0, 1572.0], [8772.0, 8772.0]]),
             state_2[1],
+            np.array([[1572.0, 1572.0], [8772.0, 8772.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
@@ -279,8 +279,8 @@ class StackedRNNTest(testing.TestCase):
         layer(sequence)
         output = layer(sequence)
         self.assertAllClose(
-            np.array([[34092.0, 34092.0], [173196.0, 173196.0]]),
             output,
+            np.array([[34092.0, 34092.0], [173196.0, 173196.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
@@ -293,8 +293,8 @@ class StackedRNNTest(testing.TestCase):
         layer(sequence)
         output = layer(sequence)
         self.assertAllClose(
-            np.array([[136368.0, 136368.0], [692784.0, 692784.0]]),
             output,
+            np.array([[136368.0, 136368.0], [692784.0, 692784.0]]),
             tpu_atol=1e-2,
             tpu_rtol=1e-2,
         )
@@ -328,4 +328,4 @@ class StackedRNNTest(testing.TestCase):
         rnn_cells = [layers.LSTMCell(**cell_kwargs) for _ in range(2)]
         stacked_rnn = layers.RNN(rnn_cells)
         output = stacked_rnn(sequence, mask=mask)
-        self.assertAllClose(np.array([[0.7793], [0.5998]]), output, atol=1e-4)
+        self.assertAllClose(output, np.array([[0.7793], [0.5998]]), atol=1e-4)

--- a/keras/src/layers/rnn/time_distributed_test.py
+++ b/keras/src/layers/rnn/time_distributed_test.py
@@ -43,10 +43,10 @@ class TimeDistributedTest(testing.TestCase):
         layer = layers.TimeDistributed(layer=layer)
         output = layer(sequence)
         self.assertAllClose(
+            output,
             np.array(
                 [[[0.06], [0.22]], [[0.38], [0.53999996]], [[0.7], [0.86]]]
             ),
-            output,
         )
 
     def test_masking(self):
@@ -74,8 +74,7 @@ class TimeDistributedTest(testing.TestCase):
         mask = np.array([[False, True], [True, False], [True, True]])
         output = layer(sequence, mask=mask)
         self.assertAllClose(
-            np.array([[[0], [0.22]], [[0.38], [0]], [[0.7], [0.86]]]),
-            output,
+            output, np.array([[[0], [0.22]], [[0.38], [0]], [[0.7], [0.86]]])
         )
 
     @pytest.mark.requires_trainable_backend

--- a/keras/src/legacy/saving/legacy_h5_format_test.py
+++ b/keras/src/legacy/saving/legacy_h5_format_test.py
@@ -87,11 +87,11 @@ class LegacyH5WeightsTest(testing.TestCase):
         tf_keras_model.save_weights(temp_filepath)
         model.load_weights(temp_filepath)
         output = model(ref_input)
-        self.assertAllClose(ref_output, output, atol=1e-5)
+        self.assertAllClose(output, ref_output, atol=1e-5)
         model.set_weights(initial_weights)
         model.load_weights(temp_filepath)
         output = model(ref_input)
-        self.assertAllClose(ref_output, output, atol=1e-5)
+        self.assertAllClose(output, ref_output, atol=1e-5)
 
     def test_sequential_model_weights(self):
         model = get_sequential_model(keras)
@@ -121,7 +121,7 @@ class LegacyH5WholeModelTest(testing.TestCase):
         legacy_h5_format.save_model_to_hdf5(model, temp_filepath)
         loaded = legacy_h5_format.load_model_from_hdf5(temp_filepath)
         output = loaded(ref_input)
-        self.assertAllClose(ref_output, output, atol=1e-5)
+        self.assertAllClose(output, ref_output, atol=1e-5)
 
     def test_sequential_model(self):
         model = get_sequential_model(keras)
@@ -188,7 +188,7 @@ class LegacyH5WholeModelTest(testing.TestCase):
             _ = loaded.optimizer
 
         # Compare output
-        self.assertAllClose(ref_output, output, atol=1e-5)
+        self.assertAllClose(output, ref_output, atol=1e-5)
 
     def test_custom_sequential_registered_no_scope(self):
         @object_registration.register_keras_serializable(package="my_package")
@@ -328,7 +328,7 @@ class LegacyH5BackwardsCompatTest(testing.TestCase):
         tf_keras_model.save(temp_filepath)
         loaded = legacy_h5_format.load_model_from_hdf5(temp_filepath)
         output = loaded(ref_input)
-        self.assertAllClose(ref_output, output, atol=1e-5)
+        self.assertAllClose(output, ref_output, atol=1e-5)
 
     def test_sequential_model(self):
         model = get_sequential_model(keras)
@@ -404,7 +404,7 @@ class LegacyH5BackwardsCompatTest(testing.TestCase):
             _ = loaded.optimizer
 
         # Compare output
-        self.assertAllClose(ref_output, output, atol=1e-5)
+        self.assertAllClose(output, ref_output, atol=1e-5)
 
     @pytest.mark.skipif(tf_keras is None, reason="Test requires tf_keras")
     def test_custom_sequential_registered_no_scope(self):
@@ -548,7 +548,7 @@ class LegacyH5BackwardsCompatTest(testing.TestCase):
         self.assertEqual(loaded_layer.sublayers[1].name, "MySubLayer")
 
         # Compare output
-        self.assertAllClose(ref_output, output, atol=1e-5)
+        self.assertAllClose(output, ref_output, atol=1e-5)
 
 
 @pytest.mark.requires_trainable_backend

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1183,7 +1183,7 @@ class CategoricalCrossentropyTest(testing.TestCase):
             from_logits=True, reduction=None
         )
         loss = cce_obj(y_true, logits)
-        self.assertAllClose((0.001822, 0.000459, 0.169846), loss)
+        self.assertAllClose(loss, (0.001822, 0.000459, 0.169846))
 
     def test_label_smoothing(self):
         logits = np.array([[100.0, -100.0, -100.0]])
@@ -1308,7 +1308,7 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
             from_logits=True, reduction=None
         )
         loss = cce_obj(y_true, logits)
-        self.assertAllClose((0.001822, 0.000459, 0.169846), loss)
+        self.assertAllClose(loss, (0.001822, 0.000459, 0.169846))
 
     def test_ignore_class(self):
         y_true = np.array([[-1, 2]])
@@ -1317,7 +1317,7 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
             from_logits=True, ignore_class=-1, reduction=None
         )
         loss = cce_obj(y_true, logits)
-        self.assertAllClose([[0.0, 1.480129]], loss)
+        self.assertAllClose(loss, [[0.0, 1.480129]])
 
         y_true = np.array([[[-1], [2]]])
         logits = np.array([[[0.854, 0.698, 0.598], [0.088, 0.86, 0.018]]])
@@ -1325,7 +1325,7 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
             from_logits=True, ignore_class=-1, reduction=None
         )
         loss = cce_obj(y_true, logits)
-        self.assertAllClose([[0.0, 1.480129]], loss)
+        self.assertAllClose(loss, [[0.0, 1.480129]])
 
     def test_binary_segmentation(self):
         y_true = np.array(
@@ -1815,10 +1815,7 @@ class CategoricalFocalCrossentropyTest(testing.TestCase):
             from_logits=True, reduction=None
         )
         loss = cce_obj(y_true, logits)
-        self.assertAllClose(
-            (1.5096224e-09, 2.4136547e-11, 1.0360638e-03),
-            loss,
-        )
+        self.assertAllClose(loss, (1.5096224e-09, 2.4136547e-11, 1.0360638e-03))
 
     def test_label_smoothing(self):
         logits = np.array([[4.9, -0.5, 2.05]])

--- a/keras/src/metrics/confusion_metrics_test.py
+++ b/keras/src/metrics/confusion_metrics_test.py
@@ -37,7 +37,7 @@ class FalsePositivesTest(testing.TestCase):
         )
 
         fp_obj.update_state(y_true, y_pred)
-        self.assertAllClose(7.0, fp_obj.result())
+        self.assertAllClose(fp_obj.result(), 7.0)
 
     def test_weighted(self):
         fp_obj = metrics.FalsePositives()
@@ -49,7 +49,7 @@ class FalsePositivesTest(testing.TestCase):
         )
         sample_weight = np.array((1.0, 1.5, 2.0, 2.5))
         result = fp_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(14.0, result)
+        self.assertAllClose(result, 14.0)
 
     def test_unweighted_with_thresholds(self):
         fp_obj = metrics.FalsePositives(thresholds=[0.15, 0.5, 0.85])
@@ -67,7 +67,7 @@ class FalsePositivesTest(testing.TestCase):
         )
 
         fp_obj.update_state(y_true, y_pred)
-        self.assertAllClose([7.0, 4.0, 2.0], fp_obj.result())
+        self.assertAllClose(fp_obj.result(), [7.0, 4.0, 2.0])
 
     def test_weighted_with_thresholds(self):
         fp_obj = metrics.FalsePositives(thresholds=[0.15, 0.5, 0.85])
@@ -91,7 +91,7 @@ class FalsePositivesTest(testing.TestCase):
         )
 
         result = fp_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose([125.0, 42.0, 12.0], result)
+        self.assertAllClose(result, [125.0, 42.0, 12.0])
 
     def test_threshold_limit(self):
         with self.assertRaisesRegex(
@@ -131,7 +131,7 @@ class FalseNegativesTest(testing.TestCase):
         )
 
         fn_obj.update_state(y_true, y_pred)
-        self.assertAllClose(3.0, fn_obj.result())
+        self.assertAllClose(fn_obj.result(), 3.0)
 
     def test_weighted(self):
         fn_obj = metrics.FalseNegatives()
@@ -143,7 +143,7 @@ class FalseNegativesTest(testing.TestCase):
         )
         sample_weight = np.array((1.0, 1.5, 2.0, 2.5))
         result = fn_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(5.0, result)
+        self.assertAllClose(result, 5.0)
 
     def test_unweighted_with_thresholds(self):
         fn_obj = metrics.FalseNegatives(thresholds=[0.15, 0.5, 0.85])
@@ -161,7 +161,7 @@ class FalseNegativesTest(testing.TestCase):
         )
 
         fn_obj.update_state(y_true, y_pred)
-        self.assertAllClose([1.0, 4.0, 6.0], fn_obj.result())
+        self.assertAllClose(fn_obj.result(), [1.0, 4.0, 6.0])
 
     def test_weighted_with_thresholds(self):
         fn_obj = metrics.FalseNegatives(thresholds=[0.15, 0.5, 0.85])
@@ -180,7 +180,7 @@ class FalseNegativesTest(testing.TestCase):
         sample_weight = ((3.0,), (5.0,), (7.0,), (4.0,))
 
         result = fn_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose([4.0, 16.0, 23.0], result)
+        self.assertAllClose(result, [4.0, 16.0, 23.0])
 
     def test_threshold_limit(self):
         with self.assertRaisesRegex(
@@ -220,7 +220,7 @@ class TrueNegativesTest(testing.TestCase):
         )
 
         tn_obj.update_state(y_true, y_pred)
-        self.assertAllClose(3.0, tn_obj.result())
+        self.assertAllClose(tn_obj.result(), 3.0)
 
     def test_weighted(self):
         tn_obj = metrics.TrueNegatives()
@@ -232,7 +232,7 @@ class TrueNegativesTest(testing.TestCase):
         )
         sample_weight = np.array((1.0, 1.5, 2.0, 2.5))
         result = tn_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(4.0, result)
+        self.assertAllClose(result, 4.0)
 
     def test_unweighted_with_thresholds(self):
         tn_obj = metrics.TrueNegatives(thresholds=[0.15, 0.5, 0.85])
@@ -250,7 +250,7 @@ class TrueNegativesTest(testing.TestCase):
         )
 
         tn_obj.update_state(y_true, y_pred)
-        self.assertAllClose([2.0, 5.0, 7.0], tn_obj.result())
+        self.assertAllClose(tn_obj.result(), [2.0, 5.0, 7.0])
 
     def test_weighted_with_thresholds(self):
         tn_obj = metrics.TrueNegatives(thresholds=[0.15, 0.5, 0.85])
@@ -269,7 +269,7 @@ class TrueNegativesTest(testing.TestCase):
         sample_weight = ((0.0, 2.0, 3.0, 5.0),)
 
         result = tn_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose([5.0, 15.0, 23.0], result)
+        self.assertAllClose(result, [5.0, 15.0, 23.0])
 
     def test_threshold_limit(self):
         with self.assertRaisesRegex(
@@ -309,7 +309,7 @@ class TruePositiveTest(testing.TestCase):
         )
 
         tp_obj.update_state(y_true, y_pred)
-        self.assertAllClose(7.0, tp_obj.result())
+        self.assertAllClose(tp_obj.result(), 7.0)
 
     def test_weighted(self):
         tp_obj = metrics.TruePositives()
@@ -321,7 +321,7 @@ class TruePositiveTest(testing.TestCase):
         )
         sample_weight = np.array((1.0, 1.5, 2.0, 2.5))
         result = tp_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(12.0, result)
+        self.assertAllClose(result, 12.0)
 
     def test_unweighted_with_thresholds(self):
         tp_obj = metrics.TruePositives(thresholds=[0.15, 0.5, 0.85])
@@ -339,7 +339,7 @@ class TruePositiveTest(testing.TestCase):
         )
 
         tp_obj.update_state(y_true, y_pred)
-        self.assertAllClose([6.0, 3.0, 1.0], tp_obj.result())
+        self.assertAllClose(tp_obj.result(), [6.0, 3.0, 1.0])
 
     def test_weighted_with_thresholds(self):
         tp_obj = metrics.TruePositives(thresholds=[0.15, 0.5, 0.85])
@@ -358,7 +358,7 @@ class TruePositiveTest(testing.TestCase):
         sample_weight = 37.0
 
         result = tp_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose([222.0, 111.0, 37.0], result)
+        self.assertAllClose(result, [222.0, 111.0, 37.0])
 
     def test_threshold_limit(self):
         with self.assertRaisesRegex(
@@ -600,7 +600,7 @@ class RecallTest(testing.TestCase):
         r_obj = metrics.Recall(thresholds=[0.5, 0.7])
         y_pred = np.array([1, 0, 0.6, 0])
         y_true = np.array([0, 1, 1, 0])
-        self.assertAllClose([0.5, 0.0], r_obj(y_true, y_pred), 0)
+        self.assertAllClose(r_obj(y_true, y_pred), [0.5, 0.0], 0)
 
     def test_weighted_with_threshold(self):
         r_obj = metrics.Recall(thresholds=[0.5, 1.0])
@@ -611,7 +611,7 @@ class RecallTest(testing.TestCase):
         weighted_tp = 0 + 3.0
         weighted_positives = (0 + 3.0) + (4.0 + 0.0)
         expected_recall = weighted_tp / weighted_positives
-        self.assertAllClose([expected_recall, 0], result, 1e-3)
+        self.assertAllClose(result, [expected_recall, 0], 1e-3)
 
     def test_multiple_updates(self):
         r_obj = metrics.Recall(thresholds=[0.5, 1.0])
@@ -626,7 +626,7 @@ class RecallTest(testing.TestCase):
             (0 + 3.0) + (4.0 + 0.0)
         )
         expected_recall = weighted_tp / weighted_positives
-        self.assertAllClose([expected_recall, 0], r_obj.result(), 1e-3)
+        self.assertAllClose(r_obj.result(), [expected_recall, 0], 1e-3)
 
     def test_unweighted_top_k(self):
         r_obj = metrics.Recall(top_k=3)

--- a/keras/src/metrics/hinge_metrics_test.py
+++ b/keras/src/metrics/hinge_metrics_test.py
@@ -22,7 +22,7 @@ class HingeTest(testing.TestCase):
         y_pred = np.array([[-0.3, 0.2, -0.1, 1.6], [-0.25, -1.0, 0.5, 0.6]])
         hinge_obj.update_state(y_true, y_pred)
         result = hinge_obj.result()
-        self.assertAllClose(0.506, result, atol=1e-3)
+        self.assertAllClose(result, 0.506, atol=1e-3)
 
     def test_weighted(self):
         hinge_obj = hinge_metrics.Hinge()
@@ -30,7 +30,7 @@ class HingeTest(testing.TestCase):
         y_pred = np.array([[-0.3, 0.2, -0.1, 1.6], [-0.25, -1.0, 0.5, 0.6]])
         sample_weight = np.array([1.5, 2.0])
         result = hinge_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(0.493, result, atol=1e-3)
+        self.assertAllClose(result, 0.493, atol=1e-3)
 
 
 class SquaredHingeTest(testing.TestCase):
@@ -55,7 +55,7 @@ class SquaredHingeTest(testing.TestCase):
         y_pred = np.array([[-0.3, 0.2, -0.1, 1.6], [-0.25, -1.0, 0.5, 0.6]])
         sq_hinge_obj.update_state(y_true, y_pred)
         result = sq_hinge_obj.result()
-        self.assertAllClose(0.364, result, atol=1e-3)
+        self.assertAllClose(result, 0.364, atol=1e-3)
 
     def test_weighted(self):
         sq_hinge_obj = hinge_metrics.SquaredHinge()
@@ -63,7 +63,7 @@ class SquaredHingeTest(testing.TestCase):
         y_pred = np.array([[-0.3, 0.2, -0.1, 1.6], [-0.25, -1.0, 0.5, 0.6]])
         sample_weight = np.array([1.5, 2.0])
         result = sq_hinge_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(0.347, result, atol=1e-3)
+        self.assertAllClose(result, 0.347, atol=1e-3)
 
 
 class CategoricalHingeTest(testing.TestCase):
@@ -104,7 +104,7 @@ class CategoricalHingeTest(testing.TestCase):
         )
         cat_hinge_obj.update_state(y_true, y_pred)
         result = cat_hinge_obj.result()
-        self.assertAllClose(0.5, result, atol=1e-5)
+        self.assertAllClose(result, 0.5, atol=1e-5)
 
     def test_weighted(self):
         cat_hinge_obj = hinge_metrics.CategoricalHinge()
@@ -128,4 +128,4 @@ class CategoricalHingeTest(testing.TestCase):
         )
         sample_weight = np.array((1.0, 1.5, 2.0, 2.5))
         result = cat_hinge_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(0.5, result, atol=1e-5)
+        self.assertAllClose(result, 0.5, atol=1e-5)

--- a/keras/src/metrics/probabilistic_metrics_test.py
+++ b/keras/src/metrics/probabilistic_metrics_test.py
@@ -140,7 +140,7 @@ class BinaryCrossentropyTest(testing.TestCase):
         )
         result = bce_obj(y_true, logits)
         expected_value = (10.0 + 5.0 * label_smoothing) / 3.0
-        self.assertAllClose(expected_value, result, atol=1e-3)
+        self.assertAllClose(result, expected_value, atol=1e-3)
 
 
 class CategoricalCrossentropyTest(testing.TestCase):

--- a/keras/src/metrics/reduction_metrics_test.py
+++ b/keras/src/metrics/reduction_metrics_test.py
@@ -136,7 +136,7 @@ class MetricWrapperTest(testing.TestCase):
 
         mse_obj.update_state(y_true, y_pred)
         result = mse_obj.result()
-        self.assertAllClose(0.5, result, atol=1e-5)
+        self.assertAllClose(result, 0.5, atol=1e-5)
 
     def test_weighted(self):
         mse_obj = reduction_metrics.MeanMetricWrapper(
@@ -150,7 +150,7 @@ class MetricWrapperTest(testing.TestCase):
         )
         sample_weight = np.array([1.0, 1.5, 2.0, 2.5])
         result = mse_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(0.54285, result, atol=1e-5)
+        self.assertAllClose(result, 0.54285, atol=1e-5)
 
     def test_weighted_broadcast(self):
         mse_obj = reduction_metrics.MeanMetricWrapper(
@@ -164,7 +164,7 @@ class MetricWrapperTest(testing.TestCase):
         )
         sample_weight = np.array([[1.0, 0.0, 0.5, 0.0, 1.0]])
         result = mse_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(0.45, result, atol=1e-5)
+        self.assertAllClose(result, 0.45, atol=1e-5)
 
     def test_weighted_dynamic_shape(self):
         mse_obj = reduction_metrics.MeanMetricWrapper(

--- a/keras/src/metrics/regression_metrics_test.py
+++ b/keras/src/metrics/regression_metrics_test.py
@@ -21,7 +21,7 @@ class MeanSquaredErrorTest(testing.TestCase):
 
         mse_obj.update_state(y_true, y_pred)
         result = mse_obj.result()
-        self.assertAllClose(0.5, result, atol=1e-5)
+        self.assertAllClose(result, 0.5, atol=1e-5)
 
     def test_weighted(self):
         mse_obj = metrics.MeanSquaredError()
@@ -33,7 +33,7 @@ class MeanSquaredErrorTest(testing.TestCase):
         )
         sample_weight = np.array([1.0, 1.5, 2.0, 2.5])
         result = mse_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(0.54285, result, atol=1e-5)
+        self.assertAllClose(result, 0.54285, atol=1e-5)
 
 
 class CosineSimilarityTest(testing.TestCase):
@@ -115,7 +115,7 @@ class MeanAbsoluteErrorTest(testing.TestCase):
 
         mae_obj.update_state(y_true, y_pred)
         result = mae_obj.result()
-        self.assertAllClose(0.5, result, atol=1e-5)
+        self.assertAllClose(result, 0.5, atol=1e-5)
 
     def test_weighted(self):
         mae_obj = metrics.MeanAbsoluteError()
@@ -127,7 +127,7 @@ class MeanAbsoluteErrorTest(testing.TestCase):
         )
         sample_weight = np.array([1.0, 1.5, 2.0, 2.5])
         result = mae_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(0.54285, result, atol=1e-5)
+        self.assertAllClose(result, 0.54285, atol=1e-5)
 
 
 class MeanAbsolutePercentageErrorTest(testing.TestCase):
@@ -161,7 +161,7 @@ class MeanAbsolutePercentageErrorTest(testing.TestCase):
         )
 
         result = mape_obj(y_true, y_pred)
-        self.assertAllClose(35e7, result, atol=1e-5)
+        self.assertAllClose(result, 35e7, atol=1e-5)
 
     def test_weighted(self):
         mape_obj = metrics.MeanAbsolutePercentageError()
@@ -180,7 +180,7 @@ class MeanAbsolutePercentageErrorTest(testing.TestCase):
 
         sample_weight = np.array([1.0, 1.5, 2.0, 2.5])
         result = mape_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(40e7, result, atol=1e-5)
+        self.assertAllClose(result, 40e7, atol=1e-5)
 
 
 class MeanSquaredLogarithmicErrorTest(testing.TestCase):
@@ -209,7 +209,7 @@ class MeanSquaredLogarithmicErrorTest(testing.TestCase):
 
         msle_obj.update_state(y_true, y_pred)
         result = msle_obj.result()
-        self.assertAllClose(0.24022, result, atol=1e-5)
+        self.assertAllClose(result, 0.24022, atol=1e-5)
 
     def test_weighted(self):
         msle_obj = metrics.MeanSquaredLogarithmicError()
@@ -221,7 +221,7 @@ class MeanSquaredLogarithmicErrorTest(testing.TestCase):
         )
         sample_weight = np.array([1.0, 1.5, 2.0, 2.5])
         result = msle_obj(y_true, y_pred, sample_weight=sample_weight)
-        self.assertAllClose(0.26082, result, atol=1e-5)
+        self.assertAllClose(result, 0.26082, atol=1e-5)
 
 
 class RootMeanSquaredErrorTest(testing.TestCase):

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -1179,7 +1179,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             antialias=antialias,
         )
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-4)
+        self.assertAllClose(out, ref_out, atol=1e-4)
 
         x = np.random.random((2, 30, 30, 3)).astype("float32") * 255
         out = kimage.resize(
@@ -1195,7 +1195,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             antialias=antialias,
         )
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-4)
+        self.assertAllClose(out, ref_out, atol=1e-4)
 
         # Test channels_first
         backend.set_image_data_format("channels_first")
@@ -1214,7 +1214,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )
         ref_out = tf.transpose(ref_out, [2, 0, 1])
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-4)
+        self.assertAllClose(out, ref_out, atol=1e-4)
 
         x = np.random.random((2, 3, 30, 30)).astype("float32") * 255
         out = kimage.resize(
@@ -1231,7 +1231,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )
         ref_out = tf.transpose(ref_out, [0, 3, 1, 2])
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-4)
+        self.assertAllClose(out, ref_out, atol=1e-4)
 
         # Test class
         out = kimage.Resize(
@@ -1239,7 +1239,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             interpolation=interpolation,
             antialias=antialias,
         )(x)
-        self.assertAllClose(ref_out, out, atol=1e-4)
+        self.assertAllClose(out, ref_out, atol=1e-4)
 
     def test_resize_uint8_round(self):
         x = np.array([0, 1, 254, 255], dtype="uint8").reshape(1, 2, 2, 1)
@@ -1458,7 +1458,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             fill_mode=fill_mode,
         )
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-2, tpu_atol=10, tpu_rtol=10)
+        self.assertAllClose(out, ref_out, atol=1e-2, tpu_atol=10, tpu_rtol=10)
 
         x = np.random.uniform(size=(2, 50, 50, 3)).astype("float32") * 255
         transform = np.random.uniform(size=(2, 6)).astype("float32")
@@ -1483,7 +1483,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             axis=0,
         )
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-2, tpu_atol=10, tpu_rtol=10)
+        self.assertAllClose(out, ref_out, atol=1e-2, tpu_atol=10, tpu_rtol=10)
 
         # Test channels_first
         backend.set_image_data_format("channels_first")
@@ -1504,7 +1504,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )
         ref_out = np.transpose(ref_out, [2, 0, 1])
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-2, tpu_atol=1, tpu_rtol=1)
+        self.assertAllClose(out, ref_out, atol=1e-2, tpu_atol=1, tpu_rtol=1)
 
         x = np.random.uniform(size=(2, 3, 50, 50)).astype("float32") * 255
         transform = np.random.uniform(size=(2, 6)).astype("float32")
@@ -1532,13 +1532,13 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )
         ref_out = np.transpose(ref_out, [0, 3, 1, 2])
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-2, tpu_atol=10, tpu_rtol=10)
+        self.assertAllClose(out, ref_out, atol=1e-2, tpu_atol=10, tpu_rtol=10)
 
         # Test class
         out = kimage.AffineTransform(
             interpolation=interpolation, fill_mode=fill_mode
         )(x, transform)
-        self.assertAllClose(ref_out, out, atol=1e-2, tpu_atol=10, tpu_rtol=10)
+        self.assertAllClose(out, ref_out, atol=1e-2, tpu_atol=10, tpu_rtol=10)
 
     @parameterized.named_parameters(
         named_product(
@@ -1579,7 +1579,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             padding=padding.upper(),
         )
         self.assertEqual(tuple(patches_out.shape), tuple(patches_ref.shape))
-        self.assertAllClose(patches_ref, patches_out, atol=1e-2)
+        self.assertAllClose(patches_out, patches_ref, atol=1e-2)
 
         # Test channels_first
         if backend.backend() == "tensorflow":
@@ -1604,7 +1604,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )
         patches_ref = tf.transpose(patches_ref, [0, 3, 1, 2])
         self.assertEqual(tuple(patches_out.shape), tuple(patches_ref.shape))
-        self.assertAllClose(patches_ref, patches_out, atol=1e-2)
+        self.assertAllClose(patches_out, patches_ref, atol=1e-2)
 
         # Test class
         patches_out = kimage.ExtractPatches(
@@ -1613,7 +1613,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             dilation_rate=dilation_rate,
             padding=padding,
         )(image)
-        self.assertAllClose(patches_ref, patches_out, atol=1e-2)
+        self.assertAllClose(patches_out, patches_ref, atol=1e-2)
 
     @parameterized.named_parameters(
         named_product(
@@ -1691,7 +1691,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         self.assertEqual(
             tuple(padded_image.shape), tuple(ref_padded_image.shape)
         )
-        self.assertAllClose(ref_padded_image, padded_image)
+        self.assertAllClose(padded_image, ref_padded_image)
 
         # Test channels_first
         backend.set_image_data_format("channels_first")
@@ -1716,7 +1716,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         self.assertEqual(
             tuple(padded_image.shape), tuple(ref_padded_image.shape)
         )
-        self.assertAllClose(ref_padded_image, padded_image)
+        self.assertAllClose(padded_image, ref_padded_image)
 
         # Test class
         padded_image = kimage.PadImages(
@@ -1727,7 +1727,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             target_height,
             target_width,
         )(image)
-        self.assertAllClose(ref_padded_image, padded_image)
+        self.assertAllClose(padded_image, ref_padded_image)
 
     @parameterized.parameters(
         [
@@ -1773,7 +1773,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         self.assertEqual(
             tuple(cropped_image.shape), tuple(ref_cropped_image.shape)
         )
-        self.assertAllClose(ref_cropped_image, cropped_image)
+        self.assertAllClose(cropped_image, ref_cropped_image)
 
         # Test channels_first
         backend.set_image_data_format("channels_first")
@@ -1798,7 +1798,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         self.assertEqual(
             tuple(cropped_image.shape), tuple(ref_cropped_image.shape)
         )
-        self.assertAllClose(ref_cropped_image, cropped_image)
+        self.assertAllClose(cropped_image, ref_cropped_image)
 
         # Test class
         cropped_image = kimage.CropImages(
@@ -1809,7 +1809,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             target_height,
             target_width,
         )(image)
-        self.assertAllClose(ref_cropped_image, cropped_image)
+        self.assertAllClose(cropped_image, ref_cropped_image)
 
     @parameterized.named_parameters(
         named_product(
@@ -1832,7 +1832,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )
 
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-2, rtol=1e-2)
+        self.assertAllClose(out, ref_out, atol=1e-2, rtol=1e-2)
 
         # Test channels_first
         backend.set_image_data_format("channels_first")
@@ -1853,7 +1853,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )
 
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-2, rtol=1e-2)
+        self.assertAllClose(out, ref_out, atol=1e-2, rtol=1e-2)
 
     def test_gaussian_blur(self):
         # Test channels_last
@@ -1878,7 +1878,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )
 
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-2, rtol=1e-2)
+        self.assertAllClose(out, ref_out, atol=1e-2, rtol=1e-2)
 
         # Test channels_first
         backend.set_image_data_format("channels_first")
@@ -1901,7 +1901,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )
 
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-2, rtol=1e-2)
+        self.assertAllClose(out, ref_out, atol=1e-2, rtol=1e-2)
 
     def test_gaussian_blur_even_kernel_size(self):
         """Test gaussian_blur with even kernel sizes"""
@@ -1934,7 +1934,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
 
         self.assertEqual(tuple(out.shape), (32, 32, 3))
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-2, rtol=1e-2)
+        self.assertAllClose(out, ref_out, atol=1e-2, rtol=1e-2)
 
         # Test channels_first with different even kernel sizes
         backend.set_image_data_format("channels_first")
@@ -1958,7 +1958,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
 
         self.assertEqual(tuple(out.shape), (3, 32, 32))
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-2, rtol=1e-2)
+        self.assertAllClose(out, ref_out, atol=1e-2, rtol=1e-2)
 
     def test_elastic_transform(self):
         # Test channels_last
@@ -2072,7 +2072,7 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             antialias=antialias,
         )
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
-        self.assertAllClose(ref_out, out, atol=1e-4)
+        self.assertAllClose(out, ref_out, atol=1e-4)
 
 
 class ImageOpsDtypeTest(testing.TestCase):

--- a/keras/src/ops/linalg_test.py
+++ b/keras/src/ops/linalg_test.py
@@ -536,13 +536,13 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
         x = np.random.random((4, 5))
         q, r = linalg.qr(x, mode="reduced")
         qref, rref = np.linalg.qr(x, mode="reduced")
-        self.assertAllClose(qref, q)
-        self.assertAllClose(rref, r)
+        self.assertAllClose(q, qref)
+        self.assertAllClose(r, rref)
 
         q, r = linalg.qr(x, mode="complete")
         qref, rref = np.linalg.qr(x, mode="complete")
-        self.assertAllClose(qref, q)
-        self.assertAllClose(rref, r)
+        self.assertAllClose(q, qref)
+        self.assertAllClose(r, rref)
 
     def test_solve(self):
         x1 = np.array([[1, 2], [4, 5]], dtype="float32")

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -717,8 +717,8 @@ class MathOpsCorrectnessTest(testing.TestCase):
         ref = np.fft.fft(complex_arr)
         real_ref = np.real(ref)
         imag_ref = np.imag(ref)
-        self.assertAllClose(real_ref, real_output)
-        self.assertAllClose(imag_ref, imag_output)
+        self.assertAllClose(real_output, real_ref)
+        self.assertAllClose(imag_output, imag_ref)
 
     def test_fft2(self):
         real = np.random.random((2, 4, 3))
@@ -729,8 +729,8 @@ class MathOpsCorrectnessTest(testing.TestCase):
         ref = np.fft.fft2(complex_arr)
         real_ref = np.real(ref)
         imag_ref = np.imag(ref)
-        self.assertAllClose(real_ref, real_output)
-        self.assertAllClose(imag_ref, imag_output)
+        self.assertAllClose(real_output, real_ref)
+        self.assertAllClose(imag_output, imag_ref)
 
     def test_ifft2(self):
         real = np.random.random((2, 4, 3)).astype(np.float32)
@@ -741,8 +741,8 @@ class MathOpsCorrectnessTest(testing.TestCase):
         ref = np.fft.ifft2(complex_arr)
         real_ref = np.real(ref)
         imag_ref = np.imag(ref)
-        self.assertAllClose(real_ref, real_output)
-        self.assertAllClose(imag_ref, imag_output)
+        self.assertAllClose(real_output, real_ref)
+        self.assertAllClose(imag_output, imag_ref)
 
     @parameterized.parameters([(None,), (3,), (15,)])
     def test_rfft(self, n):
@@ -752,8 +752,8 @@ class MathOpsCorrectnessTest(testing.TestCase):
         ref = np.fft.rfft(x, n=n)
         real_ref = np.real(ref)
         imag_ref = np.imag(ref)
-        self.assertAllClose(real_ref, real_output, atol=1e-5, rtol=1e-5)
-        self.assertAllClose(imag_ref, imag_output, atol=1e-5, rtol=1e-5)
+        self.assertAllClose(real_output, real_ref, atol=1e-5, rtol=1e-5)
+        self.assertAllClose(imag_output, imag_ref, atol=1e-5, rtol=1e-5)
 
         # Test N-D case.
         x = np.random.random((2, 3, 10))
@@ -761,8 +761,8 @@ class MathOpsCorrectnessTest(testing.TestCase):
         ref = np.fft.rfft(x, n=n)
         real_ref = np.real(ref)
         imag_ref = np.imag(ref)
-        self.assertAllClose(real_ref, real_output, atol=1e-5, rtol=1e-5)
-        self.assertAllClose(imag_ref, imag_output, atol=1e-5, rtol=1e-5)
+        self.assertAllClose(real_output, real_ref, atol=1e-5, rtol=1e-5)
+        self.assertAllClose(imag_output, imag_ref, atol=1e-5, rtol=1e-5)
 
     @parameterized.parameters([(None,), (3,), (15,)])
     def test_irfft(self, n):
@@ -804,8 +804,8 @@ class MathOpsCorrectnessTest(testing.TestCase):
         real_ref, imag_ref = _stft(
             x, sequence_length, sequence_stride, fft_length, window, center
         )
-        self.assertAllClose(real_ref, real_output, atol=1e-5, rtol=1e-5)
-        self.assertAllClose(imag_ref, imag_output, atol=1e-5, rtol=1e-5)
+        self.assertAllClose(real_output, real_ref, atol=1e-5, rtol=1e-5)
+        self.assertAllClose(imag_output, imag_ref, atol=1e-5, rtol=1e-5)
 
         # Test N-D case.
         x = np.random.random((2, 3, 32))
@@ -815,8 +815,8 @@ class MathOpsCorrectnessTest(testing.TestCase):
         real_ref, imag_ref = _stft(
             x, sequence_length, sequence_stride, fft_length, window, center
         )
-        self.assertAllClose(real_ref, real_output, atol=1e-5, rtol=1e-5)
-        self.assertAllClose(imag_ref, imag_output, atol=1e-5, rtol=1e-5)
+        self.assertAllClose(real_output, real_ref, atol=1e-5, rtol=1e-5)
+        self.assertAllClose(imag_output, imag_ref, atol=1e-5, rtol=1e-5)
 
     @parameterized.parameters(
         [
@@ -914,7 +914,7 @@ class MathOpsCorrectnessTest(testing.TestCase):
         output_from_erf_op = kmath.erf(sample_values)
 
         # Assert that the outputs are close
-        self.assertAllClose(expected_output, output_from_erf_op, atol=1e-4)
+        self.assertAllClose(output_from_erf_op, expected_output, atol=1e-4)
 
     def test_erf_operation_dtype(self):
         # Test for float32 and float64 data types
@@ -924,14 +924,14 @@ class MathOpsCorrectnessTest(testing.TestCase):
             )
             expected_output = scipy.special.erf(sample_values)
             output_from_erf_op = kmath.erf(sample_values)
-            self.assertAllClose(expected_output, output_from_erf_op, atol=1e-4)
+            self.assertAllClose(output_from_erf_op, expected_output, atol=1e-4)
 
     def test_erf_operation_edge_cases(self):
         # Test for edge cases
         edge_values = np.array([1e5, -1e5, 1e-5, -1e-5], dtype=np.float64)
         expected_output = scipy.special.erf(edge_values)
         output_from_edge_erf_op = kmath.erf(edge_values)
-        self.assertAllClose(expected_output, output_from_edge_erf_op, atol=1e-4)
+        self.assertAllClose(output_from_edge_erf_op, expected_output, atol=1e-4)
 
     def test_erfinv_operation_basic(self):
         # Sample values for testing
@@ -944,7 +944,7 @@ class MathOpsCorrectnessTest(testing.TestCase):
         output_from_erfinv_op = kmath.erfinv(sample_values)
 
         # Assert that the outputs are close
-        self.assertAllClose(expected_output, output_from_erfinv_op, atol=1e-4)
+        self.assertAllClose(output_from_erfinv_op, expected_output, atol=1e-4)
 
     def test_erfinv_operation_dtype(self):
         # Test for float32 and float64 data types
@@ -955,7 +955,7 @@ class MathOpsCorrectnessTest(testing.TestCase):
             expected_output = scipy.special.erfinv(sample_values)
             output_from_erfinv_op = kmath.erfinv(sample_values)
             self.assertAllClose(
-                expected_output, output_from_erfinv_op, atol=1e-4
+                output_from_erfinv_op, expected_output, atol=1e-4
             )
 
     def test_erfinv_operation_edge_cases(self):
@@ -964,7 +964,7 @@ class MathOpsCorrectnessTest(testing.TestCase):
         expected_output = scipy.special.erfinv(edge_values)
         output_from_edge_erfinv_op = kmath.erfinv(edge_values)
         self.assertAllClose(
-            expected_output, output_from_edge_erfinv_op, atol=1e-4
+            output_from_edge_erfinv_op, expected_output, atol=1e-4
         )
 
     def test_logdet(self):

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -302,7 +302,7 @@ def all(x, axis=None, keepdims=False):
 
 
 class AllClose(Operation):
-    def __init__(self, rtol=1e-05, atol=1e-08, equal_nan=False, *, name=None):
+    def __init__(self, rtol=1e-5, atol=1e-8, equal_nan=False, *, name=None):
         super().__init__(name=name)
         self.rtol = rtol
         self.atol = atol
@@ -322,7 +322,7 @@ class AllClose(Operation):
 
 
 @keras_export(["keras.ops.allclose", "keras.ops.numpy.allclose"])
-def allclose(x1, x2, rtol=1e-05, atol=1e-08, equal_nan=False):
+def allclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
     """Returns True if two arrays are element-wise equal within a tolerance.
 
     The tolerance values are positive, typically very small numbers.  The

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -250,8 +250,8 @@ class LoadWeightsTests(test_case.TestCase):
             self.assertAllClose(
                 orig.astype("float32"),
                 loaded.astype("float32"),
-                atol=0.001,
-                rtol=0.01,
+                atol=1e-3,
+                rtol=1e-2,
             )
 
     def test_load_weights_invalid_kwargs(self):

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -266,8 +266,8 @@ class SavingTest(testing.TestCase):
         loaded_model = saving_lib.load_model(temp_filepath)
         self.assertFalse(model.compiled)
         for w_ref, w in zip(model.variables, loaded_model.variables):
-            self.assertAllClose(w_ref, w)
-        self.assertAllClose(y_ref, loaded_model(x_ref))
+            self.assertAllClose(w, w_ref)
+        self.assertAllClose(loaded_model(x_ref), y_ref)
 
     @parameterized.named_parameters(
         ("subclassed", _get_subclassed_model),
@@ -299,8 +299,8 @@ class SavingTest(testing.TestCase):
         self.assertTrue(model.compiled)
         self.assertTrue(loaded_model.built)
         for w_ref, w in zip(model.variables, loaded_model.variables):
-            self.assertAllClose(w_ref, w)
-        self.assertAllClose(out_ref, loaded_model(x_ref))
+            self.assertAllClose(w, w_ref)
+        self.assertAllClose(loaded_model(x_ref), out_ref)
 
         self.assertEqual(
             model.optimizer.__class__, loaded_model.optimizer.__class__
@@ -311,11 +311,11 @@ class SavingTest(testing.TestCase):
         for w_ref, w in zip(
             model.optimizer.variables, loaded_model.optimizer.variables
         ):
-            self.assertAllClose(w_ref, w)
+            self.assertAllClose(w, w_ref)
 
         new_metrics = loaded_model.evaluate(x_ref, y_ref)
         for ref_m, m in zip(ref_metrics, new_metrics):
-            self.assertAllClose(ref_m, m)
+            self.assertAllClose(m, ref_m)
 
     @parameterized.named_parameters(
         ("subclassed", _get_subclassed_model),
@@ -590,7 +590,7 @@ class SavingTest(testing.TestCase):
         new_weights = new_model.layers[0].get_weights()
         self.assertEqual(len(ref_weights), len(new_weights))
         for ref_w, w in zip(ref_weights, new_weights):
-            self.assertAllClose(ref_w, w)
+            self.assertAllClose(w, ref_w)
         self.assertAllClose(
             np.array(new_model.layers[1].kernel), new_layer_kernel_value
         )
@@ -615,7 +615,7 @@ class SavingTest(testing.TestCase):
             new_weights = new_model.layers[layer_index].get_weights()
             self.assertEqual(len(ref_weights), len(new_weights))
             for ref_w, w in zip(ref_weights, new_weights):
-                self.assertAllClose(ref_w, w)
+                self.assertAllClose(w, ref_w)
         self.assertAllClose(
             np.array(new_model.layers[2].kernel), new_layer_kernel_value
         )
@@ -899,7 +899,7 @@ class SavingAPITest(testing.TestCase):
         model.save(temp_filepath)
         model = saving_lib.load_model(temp_filepath)
         out = model(data)
-        self.assertAllClose(ref_out, out, atol=1e-6)
+        self.assertAllClose(out, ref_out, atol=1e-6)
 
         # Without adapt
         model = keras.Sequential(
@@ -915,7 +915,7 @@ class SavingAPITest(testing.TestCase):
         model.save(temp_filepath)
         model = saving_lib.load_model(temp_filepath)
         out = model(data)
-        self.assertAllClose(ref_out, out, atol=1e-6)
+        self.assertAllClose(out, ref_out, atol=1e-6)
 
 
 # This class is properly registered with a `get_config()` method.
@@ -1057,7 +1057,7 @@ class SavingBattleTest(testing.TestCase):
         model.save(temp_filepath)
         new_model = keras.saving.load_model(temp_filepath)
         out = new_model(x)
-        self.assertAllClose(ref_out, out, atol=1e-6)
+        self.assertAllClose(out, ref_out, atol=1e-6)
 
     def test_legacy_h5_format(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "custom_model.h5")
@@ -1073,7 +1073,7 @@ class SavingBattleTest(testing.TestCase):
         model.save(temp_filepath)
         new_model = keras.saving.load_model(temp_filepath)
         out = new_model(x)
-        self.assertAllClose(ref_out, out, atol=1e-6)
+        self.assertAllClose(out, ref_out, atol=1e-6)
 
     def test_nested_functional_model_saving(self):
         def func(in_size=4, out_size=2, name=None):
@@ -1130,7 +1130,7 @@ class SavingBattleTest(testing.TestCase):
         x = np.random.random((1, 3, 2))
         ref_out = model(x)
         out = new_model(x)
-        self.assertAllClose(ref_out, out)
+        self.assertAllClose(out, ref_out)
 
     def test_remove_weights_only_saving_and_loading(self):
         def is_remote_path(path):

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -47,8 +47,8 @@ class TestCase(parameterized.TestCase):
 
     def assertAllClose(
         self,
-        x1,
-        x2,
+        actual,
+        desired,
         atol=1e-6,
         rtol=1e-6,
         tpu_atol=None,
@@ -59,9 +59,11 @@ class TestCase(parameterized.TestCase):
             atol = tpu_atol
         if tpu_rtol is not None and uses_tpu():
             rtol = tpu_rtol
-        x1 = self.convert_to_numpy(x1)
-        x2 = self.convert_to_numpy(x2)
-        np.testing.assert_allclose(x1, x2, atol=atol, rtol=rtol, err_msg=msg)
+        actual = self.convert_to_numpy(actual)
+        desired = self.convert_to_numpy(desired)
+        np.testing.assert_allclose(
+            actual, desired, atol=atol, rtol=rtol, err_msg=msg
+        )
 
     def assertNotAllClose(self, x1, x2, atol=1e-6, rtol=1e-6, msg=None):
         try:

--- a/keras/src/utils/timeseries_dataset_utils_test.py
+++ b/keras/src/utils/timeseries_dataset_utils_test.py
@@ -27,7 +27,7 @@ class TimeseriesDatasetTest(testing.TestCase):
                 # Last batch: size 2
                 self.assertEqual(inputs.shape, (2, 9))
             # Check target values
-            self.assertAllClose(targets, inputs[:, 0] * 2)
+            self.assertAllClose(inputs[:, 0] * 2, targets)
             for j in range(min(5, len(inputs))):
                 # Check each sample in the batch
                 self.assertAllClose(

--- a/keras/src/utils/torch_utils_test.py
+++ b/keras/src/utils/torch_utils_test.py
@@ -160,9 +160,9 @@ class TorchUtilsTest(testing.TestCase):
         new_model.compile(optimizer="sgd", loss="mse")
         new_model.load_weights(temp_filepath)
         for ref_w, new_w in zip(model.get_weights(), new_model.get_weights()):
-            self.assertAllClose(ref_w, new_w, atol=1e-5)
+            self.assertAllClose(new_w, ref_w, atol=1e-5)
         loss = new_model.evaluate(x_test, y_test)
-        self.assertAllClose(ref_loss, loss, atol=1e-5)
+        self.assertAllClose(loss, ref_loss, atol=1e-5)
 
     def test_serialize_model_autowrapping(self):
         # Test loading saved model
@@ -177,9 +177,9 @@ class TorchUtilsTest(testing.TestCase):
 
         new_model = saving.load_model(temp_filepath)
         for ref_w, new_w in zip(model.get_weights(), new_model.get_weights()):
-            self.assertAllClose(ref_w, new_w, atol=1e-5)
+            self.assertAllClose(new_w, ref_w, atol=1e-5)
         loss = new_model.evaluate(x_test, y_test)
-        self.assertAllClose(ref_loss, loss, atol=1e-5)
+        self.assertAllClose(loss, ref_loss, atol=1e-5)
 
     @parameterized.parameters(
         {"use_batch_norm": False, "num_torch_layers": 1},
@@ -203,9 +203,9 @@ class TorchUtilsTest(testing.TestCase):
         new_model.compile(optimizer="sgd", loss="mse")
         new_model.load_weights(temp_filepath)
         for ref_w, new_w in zip(model.get_weights(), new_model.get_weights()):
-            self.assertAllClose(ref_w, new_w, atol=1e-5)
+            self.assertAllClose(new_w, ref_w, atol=1e-5)
         loss = new_model.evaluate(x_test, y_test)
-        self.assertAllClose(ref_loss, loss, atol=1e-5)
+        self.assertAllClose(loss, ref_loss, atol=1e-5)
 
     @parameterized.parameters(
         {"use_batch_norm": False, "num_torch_layers": 1},
@@ -226,9 +226,9 @@ class TorchUtilsTest(testing.TestCase):
 
         new_model = saving.load_model(temp_filepath)
         for ref_w, new_w in zip(model.get_weights(), new_model.get_weights()):
-            self.assertAllClose(ref_w, new_w, atol=1e-5)
+            self.assertAllClose(new_w, ref_w, atol=1e-5)
         loss = new_model.evaluate(x_test, y_test)
-        self.assertAllClose(ref_loss, loss, atol=1e-5)
+        self.assertAllClose(loss, ref_loss, atol=1e-5)
 
     def test_from_config(self):
         module = torch.nn.Sequential(torch.nn.Linear(2, 4))
@@ -236,7 +236,7 @@ class TorchUtilsTest(testing.TestCase):
         config = mw.get_config()
         new_mw = TorchModuleWrapper.from_config(config)
         for ref_w, new_w in zip(mw.get_weights(), new_mw.get_weights()):
-            self.assertAllClose(ref_w, new_w, atol=1e-5)
+            self.assertAllClose(new_w, ref_w, atol=1e-5)
 
     def test_build_model(self):
         x = keras.Input([4])


### PR DESCRIPTION
`TestCase.assertAllClose()` had `x1` and `x2` as argument names, making it look like the order of arguments is not important. However, under the hood it uses `np.testing.assert_allclose`, which has `actual` and `desired` as argument names. This created confusing error messages in case of failure whereby NumPy prints error messages like `DESIRED: ... ACTUAL: ...` but the values are flipped.

This PR renames the argument and flips the arguments in many tests.

It also standardizes how we represent `atol` and `rtol` using the exponent notation.
