### PR TITLE
Fix cross output shape for symbolic inputs

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2314,9 +2314,9 @@ class Cross(Operation):
         else:
             value_size = []
 
-        # Normalize axisc so negative indices insert correctly.
-        ndim = len(output_shape) + len(value_size)
-        axisc = self.axisc if self.axisc >= 0 else ndim + self.axisc
+        axisc = canonicalize_axis(
+            self.axisc, len(output_shape) + len(value_size)
+        )
         output_shape = output_shape[:axisc] + value_size + output_shape[axisc:]
 
         dtype = dtypes.result_type(x1.dtype, x2.dtype)


### PR DESCRIPTION
## Summary

Fix `keras.ops.cross` returning incorrect symbolic output shape (e.g. `(3, None)` instead of `(None, 3)`).

Two bugs in `compute_output_spec`:
1. Used `self.axisa` instead of `self.axisb` to index `x2_shape` (line 2296)
2. Negative `axisc` (-1) caused incorrect insertion position via Python slicing — normalized to positive index before inserting

Fixes #22525