### PR TITLE
Fix quantile/nanquantile symbolic shape for list q values

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -5982,6 +5982,8 @@ class Nanquantile(Operation):
         if hasattr(q, "shape"):
             if len(q.shape) > 0:
                 output_shape = (q.shape[0],) + output_shape
+        elif isinstance(q, (list, tuple)) and len(q) > 1:
+            output_shape = (len(q),) + output_shape
 
         if backend.standardize_dtype(x.dtype) == "int64":
             dtype = backend.floatx()
@@ -6697,6 +6699,8 @@ class Quantile(Operation):
         if hasattr(q, "shape"):
             if len(q.shape) > 0:
                 output_shape = (q.shape[0],) + output_shape
+        elif isinstance(q, (list, tuple)) and len(q) > 1:
+            output_shape = (len(q),) + output_shape
         if backend.standardize_dtype(x.dtype) == "int64":
             dtype = backend.floatx()
         else:


### PR DESCRIPTION
## Summary

Fix `keras.ops.quantile` and `keras.ops.nanquantile` returning incorrect symbolic output shape when `q` is a list/tuple.

When `q` is passed as a plain list (e.g. `[0.0, 0.5, 1.0]`), it has no `shape` attribute, so `compute_output_spec` skipped prepending the q dimension. For example, `quantile(Input(shape=(4,3)), q=[0.0, 0.5, 1.0], axis=[1,2])` returned shape `(None,)` instead of `(3, None)`.

The fix adds an `elif isinstance(q, (list, tuple))` check in both `Quantile` and `NanQuantile` classes.

Fixes #22530