### PR TITLE
[OpenVINO] Remove passing/skipped tests from exclusion list

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -3,6 +3,7 @@ AdagradTest::test_correctness_with_golden
 AdamaxTest::test_correctness_with_golden
 AdamTest::test_correctness_with_golden
 AdamWTest::test_correctness_with_golden
+AdditiveAttentionTest::test_attention_basics
 AudioDatasetFromDirectoryTest::test_audio_dataset_from_directory_manual_labels
 CircleTest::test_correctness
 CircleTest::test_correctness_weighted


### PR DESCRIPTION
Removed 82 tests from the exclusion list, which are passing now due to a combination of the recent implementations.