### PR TITLE
fix:integerlookup one_hot shape inference for 2D inputs

### DIFF
--- a/keras/src/layers/preprocessing/index_lookup.py
+++ b/keras/src/layers/preprocessing/index_lookup.py
@@ -558,31 +558,25 @@ class IndexLookup(Layer):
     def compute_output_shape(self, input_shape):
         if self.output_mode == "int":
             return input_shape
-        depth = (
+
+        depth = self._get_output_depth()
+        input_shape = tuple(input_shape)
+
+        if self.output_mode == "one_hot":
+            return input_shape + (depth,)
+
+        return input_shape[:-1] + (depth,)
+
+    def _get_output_depth(self):
+        return (
             self.max_tokens
             if self.pad_to_max_tokens and self.max_tokens is not None
             else self.vocabulary_size()
         )
-        input_shape = tuple(input_shape)
-        if self.output_mode == "one_hot":
-            return input_shape + (depth,)
-        return input_shape[:-1] + (depth,)
 
     def compute_output_spec(self, inputs):
-        if self.output_mode == "int":
-            output_dtype = "int64"
-        else:
-            output_dtype = backend.floatx()
-        input_shape = inputs.shape
-        if self.output_mode == "one_hot":
-            depth = (
-                self.max_tokens
-                if self.pad_to_max_tokens and self.max_tokens is not None
-                else self.vocabulary_size()
-            )
-            output_shape = input_shape + (depth,)
-        else:
-            output_shape = self.compute_output_shape(input_shape)
+        output_dtype = "int64" if self.output_mode == "int" else backend.floatx()
+        output_shape = self.compute_output_shape(inputs.shape)
         return backend.KerasTensor(output_shape, dtype=output_dtype)
 
     def adapt(self, data, steps=None):

--- a/keras/src/layers/preprocessing/index_lookup.py
+++ b/keras/src/layers/preprocessing/index_lookup.py
@@ -202,9 +202,7 @@ class IndexLookup(Layer):
         # Remember original `vocabulary` as `input_vocabulary` for serialization
         # via `get_config`. However, if `vocabulary` is a file path or a URL, we
         # serialize the vocabulary as an asset and clear the original path/URL.
-        self.input_vocabulary = (
-            vocabulary if not isinstance(vocabulary, str) else None
-        )
+        self.input_vocabulary = vocabulary if not isinstance(vocabulary, str) else None
         self.input_idf_weights = idf_weights
 
         # We set this hidden attr to
@@ -231,9 +229,7 @@ class IndexLookup(Layer):
             # Masks should map to 0 for int output and be dropped otherwise. Max
             # ints will be dropped from the bincount op.
             mask_value = (
-                0
-                if self.output_mode == "int"
-                else tf.as_dtype(self._value_dtype).max
+                0 if self.output_mode == "int" else tf.as_dtype(self._value_dtype).max
             )
             if self.num_oov_indices == 0:
                 # If there are no OOV indices, we map OOV tokens to -1 and error
@@ -251,9 +247,7 @@ class IndexLookup(Layer):
                 self._default_value = -1
         if self.mask_token is not None:
             self._mask_key = tf.convert_to_tensor(mask_key, self._key_dtype)
-            self._mask_value = tf.convert_to_tensor(
-                mask_value, self._value_dtype
-            )
+            self._mask_value = tf.convert_to_tensor(mask_value, self._value_dtype)
 
         if self.output_mode == "tf_idf":
             if self._has_input_vocabulary and idf_weights is None:
@@ -288,16 +282,12 @@ class IndexLookup(Layer):
                 default_value=0,
             )
             if self.output_mode == "tf_idf":
-                self.token_document_counts = (
-                    tf.lookup.experimental.MutableHashTable(
-                        key_dtype=vocabulary_dtype,
-                        value_dtype="int64",
-                        default_value=0,
-                    )
+                self.token_document_counts = tf.lookup.experimental.MutableHashTable(
+                    key_dtype=vocabulary_dtype,
+                    value_dtype="int64",
+                    default_value=0,
                 )
-                self.num_documents = tf.Variable(
-                    0, dtype="int64", trainable=False
-                )
+                self.num_documents = tf.Variable(0, dtype="int64", trainable=False)
 
     def get_vocabulary(self, include_special_tokens=True):
         """Returns the current vocabulary of the layer.
@@ -322,18 +312,14 @@ class IndexLookup(Layer):
                 self._tensor_vocab_to_numpy(vocab),
                 indices.numpy(),
             )
-        lookup = collections.defaultdict(
-            lambda: self.oov_token, zip(indices, vocab)
-        )
+        lookup = collections.defaultdict(lambda: self.oov_token, zip(indices, vocab))
         vocab = [lookup[x] for x in range(self.vocabulary_size())]
         if self.mask_token is not None and self.output_mode == "int":
             vocab[0] = self.mask_token
         if not include_special_tokens:
             vocab = vocab[self._token_start_index() :]
         if self.vocabulary_dtype == "string":
-            return [
-                i.decode("utf-8") if isinstance(i, bytes) else i for i in vocab
-            ]
+            return [i.decode("utf-8") if isinstance(i, bytes) else i for i in vocab]
         else:
             return vocab
 
@@ -345,10 +331,7 @@ class IndexLookup(Layer):
           indices.
         """
         if tf.executing_eagerly():
-            return (
-                int(self.lookup_table.size().numpy())
-                + self._token_start_index()
-            )
+            return int(self.lookup_table.size().numpy()) + self._token_start_index()
         else:
             return self.lookup_table.size() + self._token_start_index()
 
@@ -422,9 +405,7 @@ class IndexLookup(Layer):
                 )
 
             if not tf.io.gfile.exists(vocabulary):
-                raise ValueError(
-                    f"Vocabulary file {vocabulary} does not exist."
-                )
+                raise ValueError(f"Vocabulary file {vocabulary} does not exist.")
             if self.output_mode == "tf_idf":
                 raise ValueError(
                     "output_mode `'tf_idf'` does not support loading a "
@@ -458,8 +439,7 @@ class IndexLookup(Layer):
 
         if vocabulary.size == 0:
             raise ValueError(
-                "Cannot set an empty vocabulary. "
-                f"Received: vocabulary={vocabulary}"
+                "Cannot set an empty vocabulary. " f"Received: vocabulary={vocabulary}"
             )
 
         oov_start = self._oov_start_index()
@@ -467,9 +447,7 @@ class IndexLookup(Layer):
         special_tokens = [self.mask_token] * oov_start + [
             self.oov_token
         ] * self.num_oov_indices
-        found_special_tokens = np.array_equal(
-            special_tokens, vocabulary[:token_start]
-        )
+        found_special_tokens = np.array_equal(special_tokens, vocabulary[:token_start])
         if found_special_tokens:
             tokens = vocabulary[token_start:]
         else:
@@ -496,11 +474,7 @@ class IndexLookup(Layer):
             )
         # Only error out for oov_token when invert=True. When invert=False,
         # oov_token is unused during lookup.
-        if (
-            self.oov_token is not None
-            and self.invert
-            and self.oov_token in tokens
-        ):
+        if self.oov_token is not None and self.invert and self.oov_token in tokens:
             oov_index = np.argwhere(vocabulary == self.oov_token)[-1]
             raise ValueError(
                 "Found reserved OOV token at unexpected location in "
@@ -551,9 +525,7 @@ class IndexLookup(Layer):
             # zeros as well.
             back_padding_value = 0
             if self.pad_to_max_tokens and self.max_tokens is not None:
-                back_padding = (
-                    self.max_tokens - front_padding - len(idf_weights)
-                )
+                back_padding = self.max_tokens - front_padding - len(idf_weights)
             else:
                 back_padding = 0
             weights = np.pad(
@@ -588,18 +560,12 @@ class IndexLookup(Layer):
             return input_shape
         depth = (
             self.max_tokens
-            if self.pad_to_max_tokens
-            else self._frozen_vocab_size
+            if self.pad_to_max_tokens and self.max_tokens is not None
+            else self.vocabulary_size()
         )
         input_shape = tuple(input_shape)
         if self.output_mode == "one_hot":
-            # One-hot encodes each element: (batch, d1, ..., dN) -> (batch, d1,
-            # ..., dN, depth)
-            if len(input_shape) > 1 and input_shape[-1] == 1:
-                return input_shape[:-1] + (depth,)
             return input_shape + (depth,)
-        # multi_hot, count, tf_idf: treat last dim as sample dim, output
-        # (batch, ..., depth)
         return input_shape[:-1] + (depth,)
 
     def compute_output_spec(self, inputs):
@@ -607,7 +573,16 @@ class IndexLookup(Layer):
             output_dtype = "int64"
         else:
             output_dtype = backend.floatx()
-        output_shape = self.compute_output_shape(inputs.shape)
+        input_shape = inputs.shape
+        if self.output_mode == "one_hot":
+            depth = (
+                self.max_tokens
+                if self.pad_to_max_tokens and self.max_tokens is not None
+                else self.vocabulary_size()
+            )
+            output_shape = input_shape + (depth,)
+        else:
+            output_shape = self.compute_output_shape(input_shape)
         return backend.KerasTensor(output_shape, dtype=output_dtype)
 
     def adapt(self, data, steps=None):
@@ -643,9 +618,7 @@ class IndexLookup(Layer):
             data = tf.expand_dims(data, 0)
 
         tokens, counts = self._num_tokens(data)
-        self.token_counts.insert(
-            tokens, counts + self.token_counts.lookup(tokens)
-        )
+        self.token_counts.insert(tokens, counts + self.token_counts.lookup(tokens))
 
         if self.output_mode == "tf_idf":
             # Dedupe each row of our dataset.
@@ -663,9 +636,7 @@ class IndexLookup(Layer):
             if isinstance(data, tf.RaggedTensor):
                 self.num_documents.assign_add(data.nrows())
             else:
-                self.num_documents.assign_add(
-                    tf.shape(data, out_type="int64")[0]
-                )
+                self.num_documents.assign_add(tf.shape(data, out_type="int64")[0])
 
     def finalize_state(self):
         if self._has_input_vocabulary or tf.equal(self.token_counts.size(), 0):
@@ -738,9 +709,7 @@ class IndexLookup(Layer):
 
         self.token_counts.remove(self.token_counts.export()[0])
         if self.output_mode == "tf_idf":
-            self.token_document_counts.remove(
-                self.token_document_counts.export()[0]
-            )
+            self.token_document_counts.remove(self.token_document_counts.export()[0])
             self.num_documents.assign(0)
 
     def call(self, inputs):
@@ -771,19 +740,11 @@ class IndexLookup(Layer):
                 lookups = tf.squeeze(lookups, -1)
             return lookups
 
-        depth = (
-            self.max_tokens
-            if self.pad_to_max_tokens
-            else self._frozen_vocab_size
-        )
-        idf_weights = (
-            self.idf_weights_const if self.output_mode == "tf_idf" else None
-        )
+        depth = self.max_tokens if self.pad_to_max_tokens else self._frozen_vocab_size
+        idf_weights = self.idf_weights_const if self.output_mode == "tf_idf" else None
         output = numerical_utils.encode_categorical_inputs(
             lookups,
-            output_mode=(
-                "count" if self.output_mode == "tf_idf" else self.output_mode
-            ),
+            output_mode=("count" if self.output_mode == "tf_idf" else self.output_mode),
             depth=depth,
             dtype=self._value_dtype,
             sparse=self.sparse,
@@ -900,22 +861,16 @@ class IndexLookup(Layer):
 
     def _uninitialized_lookup_table(self):
         with tf.init_scope():
-            initializer = get_null_initializer(
-                self._key_dtype, self._value_dtype
-            )
+            initializer = get_null_initializer(self._key_dtype, self._value_dtype)
             return tf.lookup.StaticHashTable(initializer, self._default_value)
 
     def _lookup_table_from_tokens(self, tokens):
         with tf.init_scope():
             token_start = self._token_start_index()
             token_end = token_start + tf.size(tokens)
-            indices_dtype = (
-                self._key_dtype if self.invert else self._value_dtype
-            )
+            indices_dtype = self._key_dtype if self.invert else self._value_dtype
             indices = tf.range(token_start, token_end, dtype=indices_dtype)
-            keys, values = (
-                (indices, tokens) if self.invert else (tokens, indices)
-            )
+            keys, values = (indices, tokens) if self.invert else (tokens, indices)
             initializer = tf.lookup.KeyValueTensorInitializer(
                 keys, values, self._key_dtype, self._value_dtype
             )
@@ -949,11 +904,7 @@ class IndexLookup(Layer):
             return tf.expand_dims(inputs, axis)
 
     def _oov_start_index(self):
-        return (
-            1
-            if self.mask_token is not None and self.output_mode == "int"
-            else 0
-        )
+        return 1 if self.mask_token is not None and self.output_mode == "int" else 0
 
     def _token_start_index(self):
         return self._oov_start_index() + self.num_oov_indices

--- a/keras/src/layers/preprocessing/index_lookup_test.py
+++ b/keras/src/layers/preprocessing/index_lookup_test.py
@@ -11,9 +11,7 @@ from keras.src import testing
 from keras.src.saving import saving_api
 
 
-@pytest.mark.skipif(
-    backend.backend() == "numpy", reason="Failing for numpy backend."
-)
+@pytest.mark.skipif(backend.backend() == "numpy", reason="Failing for numpy backend.")
 class IndexLookupLayerTest(testing.TestCase):
     def test_basics_string_vocab(self):
         # Case: adapt + list inputs
@@ -28,9 +26,7 @@ class IndexLookupLayerTest(testing.TestCase):
         }
         layer = layers.IndexLookup(**kwargs)
         layer.adapt(adapt_data)
-        self.assertEqual(
-            layer.get_vocabulary(), ["", "[OOV]", "one", "two", "three"]
-        )
+        self.assertEqual(layer.get_vocabulary(), ["", "[OOV]", "one", "two", "three"])
         self.assertEqual(
             layer.get_vocabulary(include_special_tokens=False),
             ["one", "two", "three"],
@@ -47,9 +43,7 @@ class IndexLookupLayerTest(testing.TestCase):
         # Case: fixed vocab + list inputs
         vocabulary = ["one", "two", "three"]
         layer = layers.IndexLookup(vocabulary=vocabulary, **kwargs)
-        self.assertEqual(
-            layer.get_vocabulary(), ["", "[OOV]", "one", "two", "three"]
-        )
+        self.assertEqual(layer.get_vocabulary(), ["", "[OOV]", "one", "two", "three"])
         self.assertEqual(
             layer.get_vocabulary(include_special_tokens=False),
             ["one", "two", "three"],
@@ -61,12 +55,8 @@ class IndexLookupLayerTest(testing.TestCase):
 
         # Case: fixed vocab with special tokens + list inputs
         vocabulary_with_special_tokens = ["", "[OOV]", "one", "two", "three"]
-        layer = layers.IndexLookup(
-            vocabulary=vocabulary_with_special_tokens, **kwargs
-        )
-        self.assertEqual(
-            layer.get_vocabulary(), ["", "[OOV]", "one", "two", "three"]
-        )
+        layer = layers.IndexLookup(vocabulary=vocabulary_with_special_tokens, **kwargs)
+        self.assertEqual(layer.get_vocabulary(), ["", "[OOV]", "one", "two", "three"])
         self.assertEqual(
             layer.get_vocabulary(include_special_tokens=False),
             ["one", "two", "three"],
@@ -79,9 +69,7 @@ class IndexLookupLayerTest(testing.TestCase):
         # Case: set vocabulary
         layer = layers.IndexLookup(**kwargs)
         layer.set_vocabulary(vocabulary)
-        self.assertEqual(
-            layer.get_vocabulary(), ["", "[OOV]", "one", "two", "three"]
-        )
+        self.assertEqual(layer.get_vocabulary(), ["", "[OOV]", "one", "two", "three"])
         self.assertEqual(
             layer.get_vocabulary(include_special_tokens=False),
             ["one", "two", "three"],
@@ -94,9 +82,7 @@ class IndexLookupLayerTest(testing.TestCase):
         # Case: set vocabulary (with special tokens)
         layer = layers.IndexLookup(**kwargs)
         layer.set_vocabulary(vocabulary_with_special_tokens)
-        self.assertEqual(
-            layer.get_vocabulary(), ["", "[OOV]", "one", "two", "three"]
-        )
+        self.assertEqual(layer.get_vocabulary(), ["", "[OOV]", "one", "two", "three"])
         self.assertEqual(
             layer.get_vocabulary(include_special_tokens=False),
             ["one", "two", "three"],
@@ -148,9 +134,7 @@ class IndexLookupLayerTest(testing.TestCase):
 
         # Case: fixed vocab with special tokens + list inputs
         vocabulary_with_special_tokens = [0, -1, 1, 2, 3]
-        layer = layers.IndexLookup(
-            vocabulary=vocabulary_with_special_tokens, **kwargs
-        )
+        layer = layers.IndexLookup(vocabulary=vocabulary_with_special_tokens, **kwargs)
         self.assertEqual(layer.get_vocabulary(), [0, -1, 1, 2, 3])
         self.assertEqual(
             layer.get_vocabulary(include_special_tokens=False),
@@ -309,6 +293,48 @@ class IndexLookupLayerTest(testing.TestCase):
             eager_output.shape[1:],
             msg="Symbolic and eager output shapes must match (except batch)",
         )
+
+    def test_integer_lookup_one_hot_compute_output_spec_2d(self):
+        """compute_output_spec for one_hot must preserve 2D input dims.
+
+        Regression test for shape collapse where output was (None, depth)
+        instead of (None, sequence_length, depth) for 2D symbolic inputs.
+        """
+        layer = layers.IntegerLookup(
+            vocabulary=[1, 2, 3],
+            num_oov_indices=2,
+            mask_token=0,
+            output_mode="one_hot",
+        )
+
+        inp = layers.Input(shape=(5,), dtype="int32")
+        spec = layer.compute_output_spec(inp)
+
+        # depth = 3 vocab + 2 OOV = 5
+        self.assertEqual(spec.shape, (None, 5, 5))
+
+    def test_integer_lookup_one_hot_symbolic_shape_2d_input(self):
+        """one_hot symbolic output must preserve 2D input dims.
+
+        Regression test for shape collapse in symbolic mode.
+        """
+        layer = layers.IntegerLookup(
+            vocabulary=[12, 36, 1138, 42],
+            num_oov_indices=3,
+            mask_token=-1,
+            output_mode="one_hot",
+        )
+
+        inp = layers.Input(shape=(3,), dtype="int64")
+        out = layer(inp)
+
+        # depth = 4 vocab + 3 OOV = 7
+        self.assertEqual(tuple(out.shape), (None, 3, 7))
+        x = np.array([[12, 36, 1138], [42, 999, 12]])
+        eager_out = layer(x)
+
+        self.assertEqual(eager_out.shape, (2, 3, 7))
+        self.assertEqual(tuple(out.shape)[1:], eager_out.shape[1:])
 
     def test_one_hot_compute_output_shape_multi_hot_consistency(self):
         """multi_hot/count/tf_idf last dim is sample in output shape."""
@@ -477,9 +503,7 @@ class IndexLookupLayerTest(testing.TestCase):
         }
         layer = layers.IndexLookup(**kwargs)
         layer.adapt(adapt_data)
-        self.assertEqual(
-            layer.get_vocabulary(), ["", "[OOV]", "one", "two", "three"]
-        )
+        self.assertEqual(layer.get_vocabulary(), ["", "[OOV]", "one", "two", "three"])
         self.assertEqual(
             layer.get_vocabulary(include_special_tokens=False),
             ["one", "two", "three"],
@@ -578,9 +602,7 @@ class IndexLookupLayerTest(testing.TestCase):
             )
 
     def test_unrecognized_kwargs(self):
-        with self.assertRaisesRegex(
-            ValueError, "Unrecognized keyword argument"
-        ):
+        with self.assertRaisesRegex(ValueError, "Unrecognized keyword argument"):
             layers.IndexLookup(
                 num_oov_indices=1,
                 max_tokens=None,
@@ -693,9 +715,7 @@ class IndexLookupLayerTest(testing.TestCase):
         layer.set_vocabulary(vocabulary)
 
         vocab_before = layer.get_vocabulary(include_special_tokens=True)
-        vocab_before_no_special = layer.get_vocabulary(
-            include_special_tokens=False
-        )
+        vocab_before_no_special = layer.get_vocabulary(include_special_tokens=False)
 
         sample_input = ["apple", "banana", "unknown"]
         output_before = layer(sample_input).numpy()
@@ -708,9 +728,7 @@ class IndexLookupLayerTest(testing.TestCase):
         layer2.load_assets(tmpdir)
 
         vocab_after = layer2.get_vocabulary(include_special_tokens=True)
-        vocab_after_no_special = layer2.get_vocabulary(
-            include_special_tokens=False
-        )
+        vocab_after_no_special = layer2.get_vocabulary(include_special_tokens=False)
 
         self.assertEqual(vocab_before, vocab_after)
         self.assertEqual(vocab_before_no_special, vocab_after_no_special)


### PR DESCRIPTION
This PR fixes a regression in IntegerLookup with `output_mode="one_hot"` where 2D inputs `(batch, sequence_length)` were incorrectly producing output shapes in symbolic mode.
Fixes: #22520 