### PR TITLE
Fix workflow concurrency for tests.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,8 +14,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/tpu_tests.yml
+++ b/.github/workflows/tpu_tests.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
The tests are not correctly kept on pulls in `master`, when many PRs are submitted in `master` back to back, tests are not run: https://github.com/keras-team/keras/commits/master/

This came from a misunderstanding of `cancel-in-progress`. `cancel-in-progress: true` means that any running job is immediately cancelled are replaced by the new one. `cancel-in-progress: false` means that there can be one running job and one pending job, but if more jobs are queued, the existing pending job is cancelled.

For pulls we don't want to cancel any of them. The way to achieve this is by not having the same `group`. This is done by putting `github.run_id`, which is unique.

We can now put `cancel-in-progress: true` since pulls will never be deduped. That's because `github.head_ref` is only populated for `pull_request`.