### PR TITLE
[OpenVINO] Fix arange to use Numpy semantics

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -1,8 +1,3 @@
-AdadeltaTest::test_correctness_with_golden
-AdagradTest::test_correctness_with_golden
-AdamaxTest::test_correctness_with_golden
-AdamTest::test_correctness_with_golden
-AdamWTest::test_correctness_with_golden
 AdditiveAttentionTest::test_attention_basics
 AudioDatasetFromDirectoryTest::test_audio_dataset_from_directory_manual_labels
 CircleTest::test_correctness
@@ -65,7 +60,6 @@ ImageOpsDtypeTest::test_map_coordinates
 ImageOpsDtypeTest::test_perspective_transform
 ImageOpsDtypeTest::test_resize
 ImageOpsDtypeTest::test_scale_and_translate
-LambTest::test_correctness_with_golden
 LayerTest::test_call_context_args_with_func_seq_models_as_layers
 LayerTest::test_complex_dtype_support
 LayerTest::test_end_to_end_masking
@@ -79,14 +73,12 @@ LinalgOpsCorrectnessTest::test_norm_2_2
 LinalgOpsCorrectnessTest::test_norm_2_nuc
 LinalgOpsCorrectnessTest::test_solve_triangular
 LinalgOpsCorrectnessTest::test_svd
-LionTest::test_correctness_with_golden
 MathOpsCorrectnessTest::test_erfinv_operation_basic
 MathOpsCorrectnessTest::test_erfinv_operation_dtype
 MathOpsCorrectnessTest::test_logdet
 MeanTest::test_weighted_dynamic_shapes
 MergingLayersTest::test_average_with_mask
 MetricWrapperTest::test_weighted_dynamic_shape
-NadamTest::test_correctness_with_golden
 NNOpsBehaviorTest::test_invalid_strategy_ctc_decode
 NNOpsCorrectnessTest::test_ctc_decode
 NNOpsCorrectnessTest::test_glu
@@ -104,11 +96,9 @@ QuantizersTest::test_grouped_quantize_with_padding
 RandomBehaviorTest::test_beta_tf_data_compatibility
 ReLUTest::test_relu
 ReshapeTest::test_reshape_with_dynamic_batch_size_and_minus_one
-RMSpropTest::test_correctness_with_golden
 SavingAPITest::test_normalization_kpl
 SavingBattleTest::test_bidirectional_lstm_saving
 SavingTest::test_load_weights_only_with_unbuilt_model
-SGDTest::test_correctness_with_golden
 SimpleRNNTest::test_output_shape
 SparseCategoricalCrossentropyTest::test_all_correct_unweighted
 SparseCategoricalCrossentropyTest::test_binary_segmentation

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -356,6 +356,30 @@ def append(x1, x2, axis=None):
 
 
 def arange(start, stop=None, step=None, dtype=None):
+    # For concrete scalar inputs, delegate to NumPy directly (matches its
+    # semantics exactly). Only build a graph for symbolic inputs.
+    _is_symbolic = (
+        isinstance(start, OpenVINOKerasTensor)
+        or isinstance(stop, OpenVINOKerasTensor)
+        or isinstance(step, OpenVINOKerasTensor)
+    )
+    if not _is_symbolic:
+        _start = 0 if stop is None else start
+        _stop = start if stop is None else stop
+        _step = 1 if step is None else step
+        keras_dtype = (
+            standardize_dtype(dtype)
+            if dtype is not None
+            else dtypes.result_type(
+                type(_start), type(_stop), type(_step), "int32"
+            )
+        )
+        return OpenVINOKerasTensor(
+            ov_opset.constant(
+                np.arange(_start, _stop, _step, dtype=keras_dtype)
+            ).output(0)
+        )
+
     if stop is None:
         start, stop = get_ov_output(0), get_ov_output(start)
     else:

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -4,6 +4,7 @@ import openvino.opset15 as ov_opset
 from openvino import Type
 
 from keras.src.backend import config
+from keras.src.backend.common import KerasVariable
 from keras.src.backend.common import dtypes
 from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.variables import standardize_dtype
@@ -358,10 +359,11 @@ def append(x1, x2, axis=None):
 def arange(start, stop=None, step=None, dtype=None):
     # For concrete scalar inputs, delegate to NumPy directly (matches its
     # semantics exactly). Only build a graph for symbolic inputs.
+    _symbolic_types = (OpenVINOKerasTensor, ov.Output, KerasVariable)
     _is_symbolic = (
-        isinstance(start, OpenVINOKerasTensor)
-        or isinstance(stop, OpenVINOKerasTensor)
-        or isinstance(step, OpenVINOKerasTensor)
+        isinstance(start, _symbolic_types)
+        or isinstance(stop, _symbolic_types)
+        or isinstance(step, _symbolic_types)
     )
     if not _is_symbolic:
         _start = 0 if stop is None else start


### PR DESCRIPTION
10 optimizer test_correctness_with_golden tests were failing for the OpenVINO backend with a shape mismatch: [10] vs [11].

### Cause
`ops.arange(0.1, 1.1, 0.1)` was producing shape [11] instead of [10]. The backend was delegating directly to `ov_opset.range`, which follows the ONNX Range spec and uses ceil((stop - start) / step) to compute the element count. Due to float32 precision, (1.1 - 0.1) / 0.1 evaluates to 10.000...02, so ceil returns 11 instead of 10.

### Fix
For concrete scalar inputs , delegated to `np.arange` directly, matching NumPy's semantics with no floating-point edge cases. For symbolic `OpenVINOKerasTensor` inputs, fall back to ov_opset.range as before.
JAX also does it similarly, but its handled internally within its `arange` function.