### PR TITLE
[OpenVINO] Partial upgrade to opset16 for select operations

### DIFF
--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -90,16 +90,48 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
 def segment_max(data, segment_ids, num_segments=None, sorted=False):
     data = get_ov_output(data)
     segment_ids = get_ov_output(segment_ids)
-    num_segments_node = (
-        None
-        if num_segments is None
-        else ov_opset.constant(
+
+    zero = ov_opset.constant(0, Type.i32).output(0)
+    zero_1d = ov_opset.constant([0], Type.i32).output(0)
+    one_1d = ov_opset.constant([1], Type.i32).output(0)
+
+    if num_segments is None:
+        max_id = ov_opset.reduce_max(
+            segment_ids, zero_1d, keep_dims=False
+        ).output(0)
+        num_segments = ov_opset.add(
+            max_id, ov_opset.constant(1, max_id.get_element_type())
+        ).output(0)
+    else:
+        num_segments = ov_opset.constant(
             num_segments, segment_ids.get_element_type()
         ).output(0)
-    )
-    result = ov_segment_max(
-        data, segment_ids, num_segments_node, fill_mode="LOWEST"
+
+    is_neg = ov_opset.less(
+        segment_ids,
+        ov_opset.constant(0, segment_ids.get_element_type()),
     ).output(0)
+    safe_seg = ov_opset.select(is_neg, num_segments, segment_ids).output(0)
+
+    # ov_segment_max requires sorted segment_ids.
+    n = ov_opset.squeeze(
+        ov_opset.shape_of(safe_seg, output_type=Type.i32), zero_1d
+    ).output(0)
+    topk = ov_opset.topk(safe_seg, n, axis=0, mode="min", sort="value")
+    sorted_seg = topk.output(0)
+    sort_idx = topk.output(1)
+    sorted_data = ov_opset.gather(data, sort_idx, zero).output(0)
+
+    nseg_plus1 = ov_opset.add(
+        num_segments, ov_opset.constant(1, num_segments.get_element_type())
+    ).output(0)
+    result = ov_segment_max(
+        sorted_data, sorted_seg, nseg_plus1, fill_mode="LOWEST"
+    ).output(0)
+
+    nseg_1d = ov_opset.unsqueeze(num_segments, zero).output(0)
+    result = ov_opset.slice(result, zero_1d, nseg_1d, one_1d, zero_1d).output(0)
+
     return OpenVINOKerasTensor(result)
 
 

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -2,6 +2,7 @@ import numpy as np
 import openvino.opset15 as ov_opset
 import scipy.signal
 from openvino import Type
+from openvino.opset16 import istft as ov_istft
 from openvino.opset16 import segment_max as ov_segment_max
 
 from keras.src.backend.openvino.core import OpenVINOKerasTensor
@@ -624,134 +625,198 @@ def istft(
 
     ori_dtype = x[0].dtype
 
-    x0 = get_ov_output(x[0])
-    ori_partial_shape = x0.get_partial_shape()
-    num_dims = ori_partial_shape.rank.get_length()
-    ori_shape_list = [
-        None if dim.is_dynamic else dim.get_length()
-        for dim in ori_partial_shape
-    ]
+    if window is None:
+        # ov_istft always applies OLA normalization via window, so the
+        # unnormalized window=None case uses the manual irfft + OLA path,
+        # matching TF and Torch backend.
+        frames = irfft(x, fft_length)
+        frames = get_ov_output(frames)
 
-    l_pad = (fft_length - sequence_length) // 2
-    r_pad = fft_length - sequence_length - l_pad
+        element_type = frames.get_element_type()
+        if element_type == Type.f64:
+            frames = ov_opset.convert(frames, Type.f32).output(0)
 
-    if window is not None:
-        if isinstance(window, str):
-            win = scipy.signal.get_window(window, sequence_length)
-        else:
-            win = np.asarray(window, dtype=np.float64)
-        if len(win.shape) != 1 or win.shape[-1] != sequence_length:
-            raise ValueError(
-                "The shape of `window` must be equal to [sequence_length]."
-                f"Received: window shape={win.shape}"
+        ori_partial_shape = frames.get_partial_shape()
+        num_dims = ori_partial_shape.rank.get_length()
+        ori_shape_list = [
+            None if dim.is_dynamic else dim.get_length()
+            for dim in ori_partial_shape
+        ]
+
+        if num_dims == 2:
+            frames = ov_opset.unsqueeze(
+                frames, ov_opset.constant(0, Type.i32)
+            ).output(0)
+        elif num_dims > 2:
+            frames_shp = ov_opset.shape_of(frames, output_type=Type.i32).output(
+                0
             )
-        win = np.pad(win, [[l_pad, r_pad]])
+            num_seq_node = ov_opset.gather(
+                frames_shp,
+                ov_opset.constant(num_dims - 2, Type.i32),
+                ov_opset.constant(0, Type.i32),
+            ).output(0)
+            flatten_shp = ov_opset.concat(
+                [
+                    ov_opset.constant([-1], Type.i32).output(0),
+                    ov_opset.unsqueeze(
+                        num_seq_node, ov_opset.constant(0, Type.i32)
+                    ).output(0),
+                    ov_opset.constant([fft_length], Type.i32).output(0),
+                ],
+                0,
+            ).output(0)
+            frames = ov_opset.reshape(frames, flatten_shp, False).output(0)
 
-        denom = np.square(win)
-        overlaps = -(-fft_length // sequence_stride)
-        denom = np.pad(denom, [(0, overlaps * sequence_stride - fft_length)])
-        denom = denom.reshape([overlaps, sequence_stride])
-        denom = denom.sum(axis=0, keepdims=True)
-        denom = np.tile(denom, [overlaps, 1])
-        denom = denom.reshape([overlaps * sequence_stride])
-        win = win / denom[:fft_length]
-    else:
-        win = None
+        frames, _ = _overlap_sequences_ov(frames, sequence_stride, fft_length)
 
-    frames = irfft(x, fft_length)
-    frames = get_ov_output(frames)
-
-    element_type = frames.get_element_type()
-    if element_type == Type.f64:
-        frames = ov_opset.convert(frames, Type.f32).output(0)
-        element_type = Type.f32
-
-    if win is not None:
-        win_node = ov_opset.constant(win.astype(np.float32), Type.f32).output(0)
-        if element_type != Type.f32:
-            win_node = ov_opset.convert(win_node, element_type).output(0)
-        frames = ov_opset.multiply(frames, win_node).output(0)
-
-    if num_dims == 2:
-        frames = ov_opset.unsqueeze(
-            frames, ov_opset.constant(0, Type.i32)
-        ).output(0)
-    elif num_dims > 2:
-        frames_shp = ov_opset.shape_of(frames, output_type=Type.i32).output(0)
-        num_seq_node = ov_opset.gather(
-            frames_shp,
-            ov_opset.constant(num_dims - 2, Type.i32),
-            ov_opset.constant(0, Type.i32),
-        ).output(0)
-        flatten_shp = ov_opset.concat(
-            [
-                ov_opset.constant([-1], Type.i32).output(0),
-                ov_opset.unsqueeze(
-                    num_seq_node, ov_opset.constant(0, Type.i32)
-                ).output(0),
-                ov_opset.constant([fft_length], Type.i32).output(0),
-            ],
-            0,
-        ).output(0)
-        frames = ov_opset.reshape(frames, flatten_shp, False).output(0)
-
-    frames, output_size = _overlap_sequences_ov(
-        frames, sequence_stride, fft_length
-    )
-
-    start_val = fft_length // 2 if center else 0
-
-    if length is not None:
-        frames = ov_opset.slice(
-            frames,
-            ov_opset.constant([start_val], Type.i32).output(0),
-            ov_opset.constant([start_val + length], Type.i32).output(0),
-            ov_opset.constant([1], Type.i32).output(0),
-            ov_opset.constant([1], Type.i32).output(0),
-        ).output(0)
-    else:
-        if start_val > 0:
+        start_val = fft_length // 2 if center else 0
+        if length is not None:
             frames = ov_opset.slice(
                 frames,
                 ov_opset.constant([start_val], Type.i32).output(0),
-                ov_opset.constant([INT32_MAX], Type.i32).output(0),
+                ov_opset.constant([start_val + length], Type.i32).output(0),
                 ov_opset.constant([1], Type.i32).output(0),
                 ov_opset.constant([1], Type.i32).output(0),
             ).output(0)
-        if center:
-            cur_len = ov_opset.gather(
-                ov_opset.shape_of(frames, output_type=Type.i32).output(0),
-                ov_opset.constant(1, Type.i32),
-                ov_opset.constant(0, Type.i32),
+        else:
+            if start_val > 0:
+                frames = ov_opset.slice(
+                    frames,
+                    ov_opset.constant([start_val], Type.i32).output(0),
+                    ov_opset.constant([INT32_MAX], Type.i32).output(0),
+                    ov_opset.constant([1], Type.i32).output(0),
+                    ov_opset.constant([1], Type.i32).output(0),
+                ).output(0)
+            if center:
+                cur_len = ov_opset.gather(
+                    ov_opset.shape_of(frames, output_type=Type.i32).output(0),
+                    ov_opset.constant(1, Type.i32),
+                    ov_opset.constant(0, Type.i32),
+                ).output(0)
+                end_node = ov_opset.subtract(
+                    cur_len,
+                    ov_opset.constant(fft_length // 2, Type.i32),
+                ).output(0)
+                frames = ov_opset.slice(
+                    frames,
+                    ov_opset.constant([0], Type.i32).output(0),
+                    ov_opset.unsqueeze(
+                        end_node, ov_opset.constant(0, Type.i32)
+                    ).output(0),
+                    ov_opset.constant([1], Type.i32).output(0),
+                    ov_opset.constant([1], Type.i32).output(0),
+                ).output(0)
+
+        if num_dims == 2:
+            frames = ov_opset.squeeze(
+                frames, ov_opset.constant([0], Type.i32)
             ).output(0)
-            end_node = ov_opset.subtract(
-                cur_len,
-                ov_opset.constant(fft_length // 2, Type.i32),
-            ).output(0)
-            frames = ov_opset.slice(
+        elif num_dims > 2:
+            batch_dims = ori_shape_list[:-2]
+            target_shape = [d if d is not None else -1 for d in batch_dims] + [
+                -1
+            ]
+            frames = ov_opset.reshape(
                 frames,
-                ov_opset.constant([0], Type.i32).output(0),
-                ov_opset.unsqueeze(
-                    end_node, ov_opset.constant(0, Type.i32)
-                ).output(0),
-                ov_opset.constant([1], Type.i32).output(0),
-                ov_opset.constant([1], Type.i32).output(0),
+                ov_opset.constant(target_shape, Type.i32).output(0),
+                False,
             ).output(0)
 
-    if num_dims == 2:
-        frames = ov_opset.squeeze(
-            frames, ov_opset.constant([0], Type.i32)
+        if ori_dtype == "float64":
+            frames = ov_opset.convert(frames, Type.f64).output(0)
+
+        return OpenVINOKerasTensor(frames)
+
+    if isinstance(window, str):
+        win = scipy.signal.get_window(window, sequence_length)
+    else:
+        win = np.asarray(window, dtype=np.float64)
+    if len(win.shape) != 1 or win.shape[-1] != sequence_length:
+        raise ValueError(
+            "The shape of `window` must be equal to [sequence_length]."
+            f"Received: window shape={win.shape}"
+        )
+
+    x_real = get_ov_output(x[0])
+    x_imag = get_ov_output(x[1])
+
+    element_type = x_real.get_element_type()
+    if element_type == Type.f64:
+        x_real = ov_opset.convert(x_real, Type.f32).output(0)
+        x_imag = ov_opset.convert(x_imag, Type.f32).output(0)
+
+    real_exp = ov_opset.unsqueeze(
+        x_real, ov_opset.constant(-1, Type.i32)
+    ).output(0)
+    imag_exp = ov_opset.unsqueeze(
+        x_imag, ov_opset.constant(-1, Type.i32)
+    ).output(0)
+    stacked = ov_opset.concat([real_exp, imag_exp], axis=-1).output(0)
+
+    rank = stacked.get_partial_shape().rank.get_length()
+    perm = list(range(rank - 3)) + [rank - 2, rank - 3, rank - 1]
+    data = ov_opset.transpose(
+        stacked, ov_opset.constant(perm, Type.i32)
+    ).output(0)
+
+    # ov_istft only accepts rank 3 or 4; flatten leading batch dims if needed
+    num_batch_dims = rank - 3
+    if num_batch_dims > 1:
+        data_shape_node = ov_opset.shape_of(data, output_type=Type.i32).output(
+            0
+        )
+        trailing = ov_opset.slice(
+            data_shape_node,
+            ov_opset.constant([num_batch_dims], Type.i32),
+            ov_opset.constant([INT32_MAX], Type.i32),
+            ov_opset.constant([1], Type.i32),
+            ov_opset.constant([0], Type.i32),
         ).output(0)
-    elif num_dims > 2:
-        batch_dims = ori_shape_list[:-2]
-        target_shape = [d if d is not None else -1 for d in batch_dims] + [-1]
-        target_shape_node = ov_opset.constant(target_shape, Type.i32).output(0)
-        frames = ov_opset.reshape(frames, target_shape_node, False).output(0)
+        data = ov_opset.reshape(
+            data,
+            ov_opset.concat(
+                [ov_opset.constant([-1], Type.i32).output(0), trailing], axis=0
+            ).output(0),
+            False,
+        ).output(0)
+
+    win_node = ov_opset.constant(win.astype(np.float32), Type.f32).output(0)
+    frame_size_node = ov_opset.constant(fft_length, Type.i32).output(0)
+    frame_step_node = ov_opset.constant(sequence_stride, Type.i32).output(0)
+    signal_length_node = (
+        ov_opset.constant(length, Type.i32).output(0)
+        if length is not None
+        else None
+    )
+
+    result = ov_istft(
+        data,
+        win_node,
+        frame_size_node,
+        frame_step_node,
+        center=center,
+        normalized=False,
+        signal_length=signal_length_node,
+    ).output(0)
+
+    if num_batch_dims > 1:
+        ori_partial_shape = x_real.get_partial_shape()
+        batch_shape = [
+            None if dim.is_dynamic else dim.get_length()
+            for dim in ori_partial_shape
+        ][:-2]
+        target_shape = [d if d is not None else -1 for d in batch_shape] + [-1]
+        result = ov_opset.reshape(
+            result,
+            ov_opset.constant(target_shape, Type.i32).output(0),
+            False,
+        ).output(0)
 
     if ori_dtype == "float64":
-        frames = ov_opset.convert(frames, Type.f64).output(0)
+        result = ov_opset.convert(result, Type.f64).output(0)
 
-    return OpenVINOKerasTensor(frames)
+    return OpenVINOKerasTensor(result)
 
 
 def rsqrt(x):

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -2,6 +2,7 @@ import numpy as np
 import openvino.opset15 as ov_opset
 import scipy.signal
 from openvino import Type
+from openvino.opset16 import segment_max as ov_segment_max
 
 from keras.src.backend.openvino.core import OpenVINOKerasTensor
 from keras.src.backend.openvino.core import cast
@@ -105,7 +106,19 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
 
 
 def segment_max(data, segment_ids, num_segments=None, sorted=False):
-    return _segment_reduction_fn(data, segment_ids, "max", num_segments, sorted)
+    data = get_ov_output(data)
+    segment_ids = get_ov_output(segment_ids)
+    num_segments_node = (
+        None
+        if num_segments is None
+        else ov_opset.constant(
+            num_segments, segment_ids.get_element_type()
+        ).output(0)
+    )
+    result = ov_segment_max(
+        data, segment_ids, num_segments_node, fill_mode="LOWEST"
+    ).output(0)
+    return OpenVINOKerasTensor(result)
 
 
 def top_k(x, k, sorted=True):

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -13,9 +13,7 @@ from keras.src.backend.openvino.numpy import stack
 INT32_MAX = 2**31 - 1
 
 
-def _segment_reduction_fn(
-    data, segment_ids, reduction_method, num_segments, sorted
-):
+def segment_sum(data, segment_ids, num_segments=None, sorted=False):
     data = get_ov_output(data)
     segment_ids = get_ov_output(segment_ids)
 
@@ -70,24 +68,11 @@ def _segment_reduction_fn(
             num_segments_plus_1, ov_opset.constant(0, Type.i32)
         ).output(0)
 
-    if reduction_method == "max":
-        from keras.src.backend.openvino.core import DTYPES_MIN
-
-        data_type = data.get_element_type()
-        if data_type.is_real():
-            init_val = np.array(-np.inf, dtype=np.float32)
-        else:
-            init_val = DTYPES_MIN[data_type]
-    else:
-        init_val = 0
-
-    init_val_node = ov_opset.constant(init_val, data.get_element_type()).output(
-        0
-    )
+    init_val_node = ov_opset.constant(0, data.get_element_type()).output(0)
     buffer = ov_opset.broadcast(init_val_node, buffer_shape).output(0)
 
     scattered = ov_opset.scatter_nd_update(
-        buffer, indices, data, reduction=reduction_method
+        buffer, indices, data, reduction="sum"
     ).output(0)
 
     start = ov_opset.constant([0], Type.i32).output(0)
@@ -99,10 +84,6 @@ def _segment_reduction_fn(
     result = ov_opset.slice(scattered, start, end, step, axes).output(0)
 
     return OpenVINOKerasTensor(result)
-
-
-def segment_sum(data, segment_ids, num_segments=None, sorted=False):
-    return _segment_reduction_fn(data, segment_ids, "sum", num_segments, sorted)
 
 
 def segment_max(data, segment_ids, num_segments=None, sorted=False):

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -622,6 +622,13 @@ def istft(
                 "If a string is passed to `window`, it must be one of "
                 f'`"hann"`, `"hamming"`. Received: window={window}'
             )
+    elif window is not None:
+        win = np.asarray(window, dtype=np.float64)
+        if len(win.shape) != 1 or win.shape[-1] != sequence_length:
+            raise ValueError(
+                "The shape of `window` must be equal to [sequence_length]."
+                f"Received: window shape={win.shape}"
+            )
 
     ori_dtype = x[0].dtype
 
@@ -732,11 +739,6 @@ def istft(
         win = scipy.signal.get_window(window, sequence_length)
     else:
         win = np.asarray(window, dtype=np.float64)
-    if len(win.shape) != 1 or win.shape[-1] != sequence_length:
-        raise ValueError(
-            "The shape of `window` must be equal to [sequence_length]."
-            f"Received: window shape={win.shape}"
-        )
 
     x_real = get_ov_output(x[0])
     x_imag = get_ov_output(x[1])

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -126,6 +126,22 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
         ov_opset.constant(1, num_segments_node.get_element_type()),
     ).output(0)
 
+    # opset16 SegmentMax requires sorted segment_ids; sort both tensors
+    n = ov_opset.gather(
+        ov_opset.shape_of(safe_segment_ids, output_type=Type.i32),
+        ov_opset.constant(0, Type.i32),
+        ov_opset.constant(0, Type.i32),
+    ).output(0)
+    sort_indices = ov_opset.topk(
+        safe_segment_ids, n, axis=0, mode="min", sort="value"
+    ).output(1)
+    safe_segment_ids = ov_opset.gather(
+        safe_segment_ids, sort_indices, ov_opset.constant(0, Type.i32)
+    ).output(0)
+    data = ov_opset.gather(
+        data, sort_indices, ov_opset.constant(0, Type.i32)
+    ).output(0)
+
     result = ov_segment_max16(
         data,
         safe_segment_ids,
@@ -141,6 +157,16 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
     axes = ov_opset.constant([0], Type.i32).output(0)
     step = ov_opset.constant([1], Type.i32).output(0)
     result = ov_opset.slice(result, start, end, step, axes).output(0)
+
+    # fill_mode="LOWEST" fills empty segments with the most negative finite
+    # float, but Keras expects -inf; replace it
+    data_type = data.get_element_type()
+    if data_type.is_real():
+        np_dtype = np.float32 if data_type == Type.f32 else np.float64
+        flt_min = ov_opset.constant(np.finfo(np_dtype).min, data_type).output(0)
+        neg_inf = ov_opset.constant(-np.inf, data_type).output(0)
+        is_empty = ov_opset.equal(result, flt_min).output(0)
+        result = ov_opset.select(is_empty, neg_inf, result).output(0)
 
     return OpenVINOKerasTensor(result)
 
@@ -569,6 +595,9 @@ def istft(
         win = np.ones(fft_length, dtype=np.float32)
 
     win_node = ov_opset.constant(win, Type.f32).output(0)
+    cd_type = complex_data.get_element_type()
+    if cd_type != Type.f32:
+        win_node = ov_opset.convert(win_node, cd_type).output(0)
     frame_size_node = ov_opset.constant(fft_length, Type.i32).output(0)
     frame_step_node = ov_opset.constant(sequence_stride, Type.i32).output(0)
 

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -11,12 +11,8 @@ from keras.src.backend.openvino.core import get_ov_output
 from keras.src.backend.openvino.core import standardize_dtype
 from keras.src.backend.openvino.numpy import stack
 
-INT32_MAX = 2**31 - 1
 
-
-def _segment_reduction_fn(
-    data, segment_ids, reduction_method, num_segments, sorted
-):
+def segment_sum(data, segment_ids, num_segments=None, sorted=False):
     data = get_ov_output(data)
     segment_ids = get_ov_output(segment_ids)
 
@@ -71,15 +67,11 @@ def _segment_reduction_fn(
             num_segments_plus_1, ov_opset.constant(0, Type.i32)
         ).output(0)
 
-    init_val = 0
-
-    init_val_node = ov_opset.constant(init_val, data.get_element_type()).output(
-        0
-    )
+    init_val_node = ov_opset.constant(0, data.get_element_type()).output(0)
     buffer = ov_opset.broadcast(init_val_node, buffer_shape).output(0)
 
     scattered = ov_opset.scatter_nd_update(
-        buffer, indices, data, reduction=reduction_method
+        buffer, indices, data, reduction="sum"
     ).output(0)
 
     start = ov_opset.constant([0], Type.i32).output(0)
@@ -91,10 +83,6 @@ def _segment_reduction_fn(
     result = ov_opset.slice(scattered, start, end, step, axes).output(0)
 
     return OpenVINOKerasTensor(result)
-
-
-def segment_sum(data, segment_ids, num_segments=None, sorted=False):
-    return _segment_reduction_fn(data, segment_ids, "sum", num_segments, sorted)
 
 
 def segment_max(data, segment_ids, num_segments=None, sorted=False):
@@ -113,7 +101,6 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
             num_segments, segment_ids.get_element_type()
         ).output(0)
 
-    # Route negative IDs to a garbage slot beyond valid range
     is_negative = ov_opset.less(
         segment_ids, ov_opset.constant(0, segment_ids.get_element_type())
     ).output(0)
@@ -126,21 +113,22 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
         ov_opset.constant(1, num_segments_node.get_element_type()),
     ).output(0)
 
-    # opset16 SegmentMax requires sorted segment_ids; sort both tensors
-    n = ov_opset.gather(
-        ov_opset.shape_of(safe_segment_ids, output_type=Type.i32),
-        ov_opset.constant(0, Type.i32),
-        ov_opset.constant(0, Type.i32),
-    ).output(0)
-    sort_indices = ov_opset.topk(
-        safe_segment_ids, n, axis=0, mode="min", sort="value"
-    ).output(1)
-    safe_segment_ids = ov_opset.gather(
-        safe_segment_ids, sort_indices, ov_opset.constant(0, Type.i32)
-    ).output(0)
-    data = ov_opset.gather(
-        data, sort_indices, ov_opset.constant(0, Type.i32)
-    ).output(0)
+    # SegmentMax requires sorted ids
+    if not sorted:
+        n = ov_opset.gather(
+            ov_opset.shape_of(safe_segment_ids, output_type=Type.i32),
+            ov_opset.constant(0, Type.i32),
+            ov_opset.constant(0, Type.i32),
+        ).output(0)
+        sort_indices = ov_opset.topk(
+            safe_segment_ids, n, axis=0, mode="min", sort="value"
+        ).output(1)
+        safe_segment_ids = ov_opset.gather(
+            safe_segment_ids, sort_indices, ov_opset.constant(0, Type.i32)
+        ).output(0)
+        data = ov_opset.gather(
+            data, sort_indices, ov_opset.constant(0, Type.i32)
+        ).output(0)
 
     result = ov_segment_max16(
         data,
@@ -149,7 +137,6 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
         fill_mode="LOWEST",
     ).output(0)
 
-    # Slice away the garbage slot
     start = ov_opset.constant([0], Type.i32).output(0)
     end = ov_opset.unsqueeze(
         num_segments_node, ov_opset.constant(0, Type.i32)
@@ -158,13 +145,19 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
     step = ov_opset.constant([1], Type.i32).output(0)
     result = ov_opset.slice(result, start, end, step, axes).output(0)
 
-    # fill_mode="LOWEST" fills empty segments with the most negative finite
-    # float, but Keras expects -inf; replace it
+    # fill_mode="LOWEST" uses FLT_MIN, not -inf; fix empty segments
     data_type = data.get_element_type()
     if data_type.is_real():
-        np_dtype = np.float32 if data_type == Type.f32 else np.float64
+        _NP_DTYPE_MAP = {
+            Type.f16: np.float16,
+            Type.f32: np.float32,
+            Type.f64: np.float64,
+        }
+        np_dtype = _NP_DTYPE_MAP.get(data_type, np.float32)
         flt_min = ov_opset.constant(np.finfo(np_dtype).min, data_type).output(0)
-        neg_inf = ov_opset.constant(-np.inf, data_type).output(0)
+        neg_inf = ov_opset.constant(
+            np.array(-np.inf, dtype=np_dtype), data_type
+        ).output(0)
         is_empty = ov_opset.equal(result, flt_min).output(0)
         result = ov_opset.select(is_empty, neg_inf, result).output(0)
 
@@ -544,17 +537,17 @@ def istft(
 
     ori_partial_shape = x0.get_partial_shape()
     num_dims = ori_partial_shape.rank.get_length()
-    ori_shape_list = [
-        None if dim.is_dynamic else dim.get_length()
-        for dim in ori_partial_shape
-    ]
 
-    # Stack real/imag on last axis → [..., frames, fft//2+1, 2]
     x0_exp = ov_opset.unsqueeze(x0, ov_opset.constant(-1, Type.i32)).output(0)
     x1_exp = ov_opset.unsqueeze(x1, ov_opset.constant(-1, Type.i32)).output(0)
     complex_data = ov_opset.concat([x0_exp, x1_exp], axis=-1).output(0)
 
-    # opset16 ISTFT expects [batch, frames, bins, 2]; flatten extra batch dims.
+    # Input is [..., frames, bins, 2]; op expects [..., bins, frames, 2]
+    perm = list(range(num_dims - 2)) + [num_dims - 1, num_dims - 2, num_dims]
+    complex_data = ov_opset.transpose(
+        complex_data, ov_opset.constant(perm, Type.i32)
+    ).output(0)
+
     if num_dims == 2:
         complex_data = ov_opset.unsqueeze(
             complex_data, ov_opset.constant(0, Type.i32)
@@ -615,17 +608,34 @@ def istft(
         signal_length=signal_length_node,
     ).output(0)
 
-    # Restore batch dims: result is [batch, signal] or [1, signal]
     if num_dims == 2:
         result = ov_opset.squeeze(
             result, ov_opset.constant([0], Type.i32)
         ).output(0)
     elif num_dims > 3:
-        batch_dims = ori_shape_list[:-2]
-        target_shape = [d if d is not None else -1 for d in batch_dims] + [-1]
-        result = ov_opset.reshape(
-            result, ov_opset.constant(target_shape, Type.i32).output(0), False
+        x0_shape = ov_opset.shape_of(x0, output_type=Type.i32).output(0)
+        batch_shape = ov_opset.slice(
+            x0_shape,
+            ov_opset.constant([0], Type.i32).output(0),
+            ov_opset.constant([num_dims - 2], Type.i32).output(0),
+            ov_opset.constant([1], Type.i32).output(0),
+            ov_opset.constant([0], Type.i32).output(0),
         ).output(0)
+        signal_len = ov_opset.gather(
+            ov_opset.shape_of(result, output_type=Type.i32).output(0),
+            ov_opset.constant(1, Type.i32),
+            ov_opset.constant(0, Type.i32),
+        ).output(0)
+        target_shape = ov_opset.concat(
+            [
+                batch_shape,
+                ov_opset.unsqueeze(
+                    signal_len, ov_opset.constant(0, Type.i32)
+                ).output(0),
+            ],
+            axis=0,
+        ).output(0)
+        result = ov_opset.reshape(result, target_shape, False).output(0)
 
     if ori_dtype == "float64":
         result = ov_opset.convert(result, Type.f64).output(0)

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -100,12 +100,48 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
 def segment_max(data, segment_ids, num_segments=None, sorted=False):
     data = get_ov_output(data)
     segment_ids = get_ov_output(segment_ids)
-    num_seg_node = None
-    if num_segments is not None:
-        num_seg_node = ov_opset.constant(num_segments, Type.i32).output(0)
-    result = ov_segment_max16(
-        data, segment_ids, num_segments=num_seg_node, fill_mode="LOWEST"
+
+    if num_segments is None:
+        max_id = ov_opset.reduce_max(
+            segment_ids, ov_opset.constant([0], Type.i32), keep_dims=False
+        ).output(0)
+        num_segments_node = ov_opset.add(
+            max_id, ov_opset.constant(1, max_id.get_element_type())
+        ).output(0)
+    else:
+        num_segments_node = ov_opset.constant(
+            num_segments, segment_ids.get_element_type()
+        ).output(0)
+
+    # Route negative IDs to a garbage slot beyond valid range
+    is_negative = ov_opset.less(
+        segment_ids, ov_opset.constant(0, segment_ids.get_element_type())
     ).output(0)
+    safe_segment_ids = ov_opset.select(
+        is_negative, num_segments_node, segment_ids
+    ).output(0)
+
+    num_segments_plus_1 = ov_opset.add(
+        num_segments_node,
+        ov_opset.constant(1, num_segments_node.get_element_type()),
+    ).output(0)
+
+    result = ov_segment_max16(
+        data,
+        safe_segment_ids,
+        num_segments=num_segments_plus_1,
+        fill_mode="LOWEST",
+    ).output(0)
+
+    # Slice away the garbage slot
+    start = ov_opset.constant([0], Type.i32).output(0)
+    end = ov_opset.unsqueeze(
+        num_segments_node, ov_opset.constant(0, Type.i32)
+    ).output(0)
+    axes = ov_opset.constant([0], Type.i32).output(0)
+    step = ov_opset.constant([1], Type.i32).output(0)
+    result = ov_opset.slice(result, start, end, step, axes).output(0)
+
     return OpenVINOKerasTensor(result)
 
 
@@ -480,10 +516,40 @@ def istft(
     x0 = get_ov_output(x[0])
     x1 = get_ov_output(x[1])
 
+    ori_partial_shape = x0.get_partial_shape()
+    num_dims = ori_partial_shape.rank.get_length()
+    ori_shape_list = [
+        None if dim.is_dynamic else dim.get_length()
+        for dim in ori_partial_shape
+    ]
+
     # Stack real/imag on last axis → [..., frames, fft//2+1, 2]
     x0_exp = ov_opset.unsqueeze(x0, ov_opset.constant(-1, Type.i32)).output(0)
     x1_exp = ov_opset.unsqueeze(x1, ov_opset.constant(-1, Type.i32)).output(0)
     complex_data = ov_opset.concat([x0_exp, x1_exp], axis=-1).output(0)
+
+    # opset16 ISTFT expects [batch, frames, bins, 2]; flatten extra batch dims.
+    if num_dims == 2:
+        complex_data = ov_opset.unsqueeze(
+            complex_data, ov_opset.constant(0, Type.i32)
+        ).output(0)
+    elif num_dims > 3:
+        cd_shape = ov_opset.shape_of(complex_data, output_type=Type.i32).output(
+            0
+        )
+        frames_bins_2 = ov_opset.slice(
+            cd_shape,
+            ov_opset.constant([num_dims - 2], Type.i32).output(0),
+            ov_opset.constant([num_dims + 1], Type.i32).output(0),
+            ov_opset.constant([1], Type.i32).output(0),
+            ov_opset.constant([0], Type.i32).output(0),
+        ).output(0)
+        flat_shape = ov_opset.concat(
+            [ov_opset.constant([-1], Type.i32).output(0), frames_bins_2], axis=0
+        ).output(0)
+        complex_data = ov_opset.reshape(complex_data, flat_shape, False).output(
+            0
+        )
 
     l_pad = (fft_length - sequence_length) // 2
     r_pad = fft_length - sequence_length - l_pad
@@ -519,6 +585,18 @@ def istft(
         normalized=False,
         signal_length=signal_length_node,
     ).output(0)
+
+    # Restore batch dims: result is [batch, signal] or [1, signal]
+    if num_dims == 2:
+        result = ov_opset.squeeze(
+            result, ov_opset.constant([0], Type.i32)
+        ).output(0)
+    elif num_dims > 3:
+        batch_dims = ori_shape_list[:-2]
+        target_shape = [d if d is not None else -1 for d in batch_dims] + [-1]
+        result = ov_opset.reshape(
+            result, ov_opset.constant(target_shape, Type.i32).output(0), False
+        ).output(0)
 
     if ori_dtype == "float64":
         result = ov_opset.convert(result, Type.f64).output(0)

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -2,6 +2,8 @@ import numpy as np
 import openvino.opset15 as ov_opset
 import scipy.signal
 from openvino import Type
+from openvino.opset16.ops import istft as ov_istft16
+from openvino.opset16.ops import segment_max as ov_segment_max16
 
 from keras.src.backend.openvino.core import OpenVINOKerasTensor
 from keras.src.backend.openvino.core import cast
@@ -69,16 +71,7 @@ def _segment_reduction_fn(
             num_segments_plus_1, ov_opset.constant(0, Type.i32)
         ).output(0)
 
-    if reduction_method == "max":
-        from keras.src.backend.openvino.core import DTYPES_MIN
-
-        data_type = data.get_element_type()
-        if data_type.is_real():
-            init_val = np.array(-np.inf, dtype=np.float32)
-        else:
-            init_val = DTYPES_MIN[data_type]
-    else:
-        init_val = 0
+    init_val = 0
 
     init_val_node = ov_opset.constant(init_val, data.get_element_type()).output(
         0
@@ -105,7 +98,15 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
 
 
 def segment_max(data, segment_ids, num_segments=None, sorted=False):
-    return _segment_reduction_fn(data, segment_ids, "max", num_segments, sorted)
+    data = get_ov_output(data)
+    segment_ids = get_ov_output(segment_ids)
+    num_seg_node = None
+    if num_segments is not None:
+        num_seg_node = ov_opset.constant(num_segments, Type.i32).output(0)
+    result = ov_segment_max16(
+        data, segment_ids, num_segments=num_seg_node, fill_mode="LOWEST"
+    ).output(0)
+    return OpenVINOKerasTensor(result)
 
 
 def top_k(x, k, sorted=True):
@@ -459,160 +460,6 @@ def stft(
     return OpenVINOKerasTensor(out_real), OpenVINOKerasTensor(out_imag)
 
 
-def _overlap_sequences_ov(x, sequence_stride, fft_length):
-    """Perform overlap-and-add using OpenVINO ops.
-
-    Takes a tensor x of shape [batch, num_sequences, fft_length] and
-    reconstructs a time-domain signal by striding each frame by
-    `sequence_stride` and summing the overlapping contributions.
-
-    Returns the reconstructed signal and its length as an OV scalar node.
-    """
-    nstep = 1 + (fft_length - 1) // sequence_stride
-    padded_len = nstep * sequence_stride
-    pad_amount = padded_len - fft_length
-
-    zero = ov_opset.constant(0, Type.i32).output(0)
-
-    # Extract dynamic batch size and number of sequences from input shape.
-    x_shape = ov_opset.shape_of(x, output_type=Type.i32).output(0)
-    flat_batch = ov_opset.gather(
-        x_shape, ov_opset.constant(0, Type.i32), zero
-    ).output(0)
-    num_sequences = ov_opset.gather(
-        x_shape, ov_opset.constant(1, Type.i32), zero
-    ).output(0)
-
-    # Compute expected output length: (num_sequences - 1) * stride + fft_length
-    output_size = ov_opset.add(
-        ov_opset.multiply(
-            ov_opset.constant(sequence_stride, Type.i32),
-            ov_opset.subtract(num_sequences, ov_opset.constant(1, Type.i32)),
-        ),
-        ov_opset.constant(fft_length, Type.i32),
-    ).output(0)
-
-    # Pad each frame along the last axis so its length is a multiple of stride.
-    if pad_amount > 0:
-        pad_begin = ov_opset.constant([0, 0, 0], Type.i32).output(0)
-        pad_end = ov_opset.constant([0, 0, pad_amount], Type.i32).output(0)
-        x = ov_opset.pad(x, pad_begin, pad_end, "constant").output(0)
-
-    # Reshape to [batch, num_sequences, nstep, sequence_stride] to expose
-    # the overlap structure within each frame.
-    overlap_shape = ov_opset.concat(
-        [
-            ov_opset.unsqueeze(
-                flat_batch, ov_opset.constant(0, Type.i32)
-            ).output(0),
-            ov_opset.unsqueeze(
-                num_sequences, ov_opset.constant(0, Type.i32)
-            ).output(0),
-            ov_opset.constant([nstep, sequence_stride], Type.i32).output(0),
-        ],
-        0,
-    ).output(0)
-    x = ov_opset.reshape(x, overlap_shape, False).output(0)
-
-    # Transpose to [batch, nstep, num_sequences, sequence_stride] so that
-    # overlapping frames become adjacent along axis 2.
-    x = ov_opset.transpose(x, ov_opset.constant([0, 2, 1, 3], Type.i32)).output(
-        0
-    )
-
-    # Pad num_sequences axis by num_sequences to create interleaved zeros,
-    # enabling a flat reshape that places each frame at its strided offset.
-    pad_begin_n = ov_opset.constant([0, 0, 0, 0], Type.i32).output(0)
-    pad_end_n = ov_opset.concat(
-        [
-            ov_opset.constant([0, 0], Type.i32).output(0),
-            ov_opset.unsqueeze(
-                num_sequences, ov_opset.constant(0, Type.i32)
-            ).output(0),
-            ov_opset.constant([0], Type.i32).output(0),
-        ],
-        0,
-    ).output(0)
-    x = ov_opset.pad(x, pad_begin_n, pad_end_n, "constant").output(0)
-
-    # overlapping_dim_size = 2 * num_sequences - 1: the number of distinct
-    # stride-aligned positions covered by all frames after interleaving.
-    overlapping_dim_size = ov_opset.subtract(
-        ov_opset.multiply(ov_opset.constant(2, Type.i32), num_sequences),
-        ov_opset.constant(1, Type.i32),
-    ).output(0)
-
-    # Flatten to [batch, nstep * 2 * sequence_stride * num_sequences] so the
-    # interleaved frame data forms a contiguous sequence.
-    total_inner = ov_opset.multiply(
-        ov_opset.constant(nstep * 2 * sequence_stride, Type.i32),
-        num_sequences,
-    ).output(0)
-    flatten_shape = ov_opset.concat(
-        [
-            ov_opset.unsqueeze(
-                flat_batch, ov_opset.constant(0, Type.i32)
-            ).output(0),
-            ov_opset.unsqueeze(
-                total_inner, ov_opset.constant(0, Type.i32)
-            ).output(0),
-        ],
-        0,
-    ).output(0)
-    x = ov_opset.reshape(x, flatten_shape, False).output(0)
-
-    # Slice away the trailing padding introduced by the interleaving step.
-    slice_len = ov_opset.multiply(
-        overlapping_dim_size,
-        ov_opset.constant(nstep * sequence_stride, Type.i32),
-    ).output(0)
-    x = ov_opset.slice(
-        x,
-        ov_opset.constant([0], Type.i32).output(0),
-        ov_opset.unsqueeze(slice_len, ov_opset.constant(0, Type.i32)).output(0),
-        ov_opset.constant([1], Type.i32).output(0),
-        ov_opset.constant([1], Type.i32).output(0),
-    ).output(0)
-
-    # Reshape to [batch, nstep, overlapping_dim_size * sequence_stride] and
-    # reduce-sum over the nstep axis to accumulate overlapping frame values.
-    inner_size = ov_opset.multiply(
-        overlapping_dim_size, ov_opset.constant(sequence_stride, Type.i32)
-    ).output(0)
-    sum_shape = ov_opset.concat(
-        [
-            ov_opset.unsqueeze(
-                flat_batch, ov_opset.constant(0, Type.i32)
-            ).output(0),
-            ov_opset.constant([nstep], Type.i32).output(0),
-            ov_opset.unsqueeze(
-                inner_size, ov_opset.constant(0, Type.i32)
-            ).output(0),
-        ],
-        0,
-    ).output(0)
-    x = ov_opset.reshape(x, sum_shape, False).output(0)
-
-    x = ov_opset.reduce_sum(
-        x,
-        ov_opset.constant([1], Type.i32).output(0),
-        keep_dims=False,
-    ).output(0)
-
-    # Trim the result to the expected signal length.
-    x = ov_opset.slice(
-        x,
-        ov_opset.constant([0], Type.i32).output(0),
-        ov_opset.unsqueeze(output_size, ov_opset.constant(0, Type.i32)).output(
-            0
-        ),
-        ov_opset.constant([1], Type.i32).output(0),
-        ov_opset.constant([1], Type.i32).output(0),
-    ).output(0)
-
-    return x, output_size
-
-
 def istft(
     x,
     sequence_length,
@@ -630,14 +477,13 @@ def istft(
             )
 
     ori_dtype = x[0].dtype
-
     x0 = get_ov_output(x[0])
-    ori_partial_shape = x0.get_partial_shape()
-    num_dims = ori_partial_shape.rank.get_length()
-    ori_shape_list = [
-        None if dim.is_dynamic else dim.get_length()
-        for dim in ori_partial_shape
-    ]
+    x1 = get_ov_output(x[1])
+
+    # Stack real/imag on last axis → [..., frames, fft//2+1, 2]
+    x0_exp = ov_opset.unsqueeze(x0, ov_opset.constant(-1, Type.i32)).output(0)
+    x1_exp = ov_opset.unsqueeze(x1, ov_opset.constant(-1, Type.i32)).output(0)
+    complex_data = ov_opset.concat([x0_exp, x1_exp], axis=-1).output(0)
 
     l_pad = (fft_length - sequence_length) // 2
     r_pad = fft_length - sequence_length - l_pad
@@ -652,113 +498,32 @@ def istft(
                 "The shape of `window` must be equal to [sequence_length]."
                 f"Received: window shape={win.shape}"
             )
-        win = np.pad(win, [[l_pad, r_pad]])
-
-        denom = np.square(win)
-        overlaps = -(-fft_length // sequence_stride)
-        denom = np.pad(denom, [(0, overlaps * sequence_stride - fft_length)])
-        denom = denom.reshape([overlaps, sequence_stride])
-        denom = denom.sum(axis=0, keepdims=True)
-        denom = np.tile(denom, [overlaps, 1])
-        denom = denom.reshape([overlaps * sequence_stride])
-        win = win / denom[:fft_length]
+        win = np.pad(win, [[l_pad, r_pad]]).astype(np.float32)
     else:
-        win = None
+        win = np.ones(fft_length, dtype=np.float32)
 
-    frames = irfft(x, fft_length)
-    frames = get_ov_output(frames)
+    win_node = ov_opset.constant(win, Type.f32).output(0)
+    frame_size_node = ov_opset.constant(fft_length, Type.i32).output(0)
+    frame_step_node = ov_opset.constant(sequence_stride, Type.i32).output(0)
 
-    element_type = frames.get_element_type()
-    if element_type == Type.f64:
-        frames = ov_opset.convert(frames, Type.f32).output(0)
-        element_type = Type.f32
-
-    if win is not None:
-        win_node = ov_opset.constant(win.astype(np.float32), Type.f32).output(0)
-        if element_type != Type.f32:
-            win_node = ov_opset.convert(win_node, element_type).output(0)
-        frames = ov_opset.multiply(frames, win_node).output(0)
-
-    if num_dims == 2:
-        frames = ov_opset.unsqueeze(
-            frames, ov_opset.constant(0, Type.i32)
-        ).output(0)
-    elif num_dims > 2:
-        frames_shp = ov_opset.shape_of(frames, output_type=Type.i32).output(0)
-        num_seq_node = ov_opset.gather(
-            frames_shp,
-            ov_opset.constant(num_dims - 2, Type.i32),
-            ov_opset.constant(0, Type.i32),
-        ).output(0)
-        flatten_shp = ov_opset.concat(
-            [
-                ov_opset.constant([-1], Type.i32).output(0),
-                ov_opset.unsqueeze(
-                    num_seq_node, ov_opset.constant(0, Type.i32)
-                ).output(0),
-                ov_opset.constant([fft_length], Type.i32).output(0),
-            ],
-            0,
-        ).output(0)
-        frames = ov_opset.reshape(frames, flatten_shp, False).output(0)
-
-    frames, output_size = _overlap_sequences_ov(
-        frames, sequence_stride, fft_length
-    )
-
-    start_val = fft_length // 2 if center else 0
-
+    signal_length_node = None
     if length is not None:
-        frames = ov_opset.slice(
-            frames,
-            ov_opset.constant([start_val], Type.i32).output(0),
-            ov_opset.constant([start_val + length], Type.i32).output(0),
-            ov_opset.constant([1], Type.i32).output(0),
-            ov_opset.constant([1], Type.i32).output(0),
-        ).output(0)
-    else:
-        if start_val > 0:
-            frames = ov_opset.slice(
-                frames,
-                ov_opset.constant([start_val], Type.i32).output(0),
-                ov_opset.constant([INT32_MAX], Type.i32).output(0),
-                ov_opset.constant([1], Type.i32).output(0),
-                ov_opset.constant([1], Type.i32).output(0),
-            ).output(0)
-        if center:
-            cur_len = ov_opset.gather(
-                ov_opset.shape_of(frames, output_type=Type.i32).output(0),
-                ov_opset.constant(1, Type.i32),
-                ov_opset.constant(0, Type.i32),
-            ).output(0)
-            end_node = ov_opset.subtract(
-                cur_len,
-                ov_opset.constant(fft_length // 2, Type.i32),
-            ).output(0)
-            frames = ov_opset.slice(
-                frames,
-                ov_opset.constant([0], Type.i32).output(0),
-                ov_opset.unsqueeze(
-                    end_node, ov_opset.constant(0, Type.i32)
-                ).output(0),
-                ov_opset.constant([1], Type.i32).output(0),
-                ov_opset.constant([1], Type.i32).output(0),
-            ).output(0)
+        signal_length_node = ov_opset.constant(length, Type.i32).output(0)
 
-    if num_dims == 2:
-        frames = ov_opset.squeeze(
-            frames, ov_opset.constant([0], Type.i32)
-        ).output(0)
-    elif num_dims > 2:
-        batch_dims = ori_shape_list[:-2]
-        target_shape = [d if d is not None else -1 for d in batch_dims] + [-1]
-        target_shape_node = ov_opset.constant(target_shape, Type.i32).output(0)
-        frames = ov_opset.reshape(frames, target_shape_node, False).output(0)
+    result = ov_istft16(
+        complex_data,
+        win_node,
+        frame_size_node,
+        frame_step_node,
+        center=center,
+        normalized=False,
+        signal_length=signal_length_node,
+    ).output(0)
 
     if ori_dtype == "float64":
-        frames = ov_opset.convert(frames, Type.f64).output(0)
+        result = ov_opset.convert(result, Type.f64).output(0)
 
-    return OpenVINOKerasTensor(frames)
+    return OpenVINOKerasTensor(result)
 
 
 def rsqrt(x):

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -583,9 +583,18 @@ def istft(
                 "The shape of `window` must be equal to [sequence_length]."
                 f"Received: window shape={win.shape}"
             )
-        win = np.pad(win, [[l_pad, r_pad]]).astype(np.float32)
+        win = np.pad(win, [[l_pad, r_pad]])
     else:
-        win = np.ones(fft_length, dtype=np.float32)
+        win = np.ones(fft_length, dtype=np.float64)
+
+    denom = np.square(win)
+    overlaps = -(-fft_length // sequence_stride)
+    denom = np.pad(denom, [(0, overlaps * sequence_stride - fft_length)])
+    denom = denom.reshape([overlaps, sequence_stride]).sum(
+        axis=0, keepdims=True
+    )
+    denom = np.tile(denom, [overlaps, 1]).reshape([overlaps * sequence_stride])
+    win = (win / denom[:fft_length]).astype(np.float32)
 
     win_node = ov_opset.constant(win, Type.f32).output(0)
     cd_type = complex_data.get_element_type()

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -1,6 +1,8 @@
 import numpy as np
 import openvino.opset15 as ov_opset
 from openvino import Type
+from openvino.opset16.ops import avg_pool as ov_avg_pool16
+from openvino.opset16.ops import one_hot as ov_one_hot16
 
 import keras.src.backend.openvino.numpy as onp
 from keras.src import backend
@@ -285,7 +287,7 @@ def average_pool(
     return _pool(
         inputs,
         pool_size,
-        ov_opset.avg_pool,
+        ov_avg_pool16,
         strides,
         padding,
         data_format,
@@ -469,6 +471,8 @@ def _pool(
         "pads_end": pads_end,
         **kwargs,
     }
+    if pooling_func is ov_avg_pool16:
+        pool_kwargs["dilations"] = [1] * num_spatial_dims
     pooled = pooling_func(inputs, **pool_kwargs).output(0)
     adjusted_pooled = _adjust_outputs(pooled, num_spatial_dims, data_format)
     return OpenVINOKerasTensor(adjusted_pooled)
@@ -788,12 +792,13 @@ def one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     ov_dtype = OPENVINO_DTYPES[dtype]
     on_value = get_ov_output(1, ov_dtype)
     off_value = get_ov_output(0, ov_dtype)
-    one_hot_encoded = ov_opset.one_hot(
+    one_hot_encoded = ov_one_hot16(
         x,
         depth=num_classes,
-        axis=axis,
         on_value=on_value,
         off_value=off_value,
+        axis=axis,
+        negative_indices_mode="ignore_negative",
     ).output(0)
     return OpenVINOKerasTensor(one_hot_encoded)
 

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -1,8 +1,6 @@
 import numpy as np
 import openvino.opset15 as ov_opset
 from openvino import Type
-from openvino.opset16.ops import avg_pool as ov_avg_pool16
-from openvino.opset16.ops import one_hot as ov_one_hot16
 
 import keras.src.backend.openvino.numpy as onp
 from keras.src import backend
@@ -287,7 +285,7 @@ def average_pool(
     return _pool(
         inputs,
         pool_size,
-        ov_avg_pool16,
+        ov_opset.avg_pool,
         strides,
         padding,
         data_format,
@@ -471,8 +469,6 @@ def _pool(
         "pads_end": pads_end,
         **kwargs,
     }
-    if pooling_func is ov_avg_pool16:
-        pool_kwargs["dilations"] = [1] * num_spatial_dims
     pooled = pooling_func(inputs, **pool_kwargs).output(0)
     adjusted_pooled = _adjust_outputs(pooled, num_spatial_dims, data_format)
     return OpenVINOKerasTensor(adjusted_pooled)
@@ -792,13 +788,12 @@ def one_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     ov_dtype = OPENVINO_DTYPES[dtype]
     on_value = get_ov_output(1, ov_dtype)
     off_value = get_ov_output(0, ov_dtype)
-    one_hot_encoded = ov_one_hot16(
+    one_hot_encoded = ov_opset.one_hot(
         x,
         depth=num_classes,
+        axis=axis,
         on_value=on_value,
         off_value=off_value,
-        axis=axis,
-        negative_indices_mode="ignore_negative",
     ).output(0)
     return OpenVINOKerasTensor(one_hot_encoded)
 

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -901,7 +901,7 @@ class MathOpsCorrectnessTest(testing.TestCase):
             window=window,
             center=center,
         )
-        if backend.backend() in ("numpy", "jax", "torch"):
+        if backend.backend() in ("numpy", "jax", "torch", "openvino"):
             # these backends have different implementation for the boundary of
             # the output, so we need to truncate 5% before assertAllClose
             truncated_len = int(output.shape[-1] * 0.05)
@@ -933,7 +933,7 @@ class MathOpsCorrectnessTest(testing.TestCase):
             window=window,
             center=center,
         )
-        if backend.backend() in ("numpy", "jax", "torch"):
+        if backend.backend() in ("numpy", "jax", "torch", "openvino"):
             # these backends have different implementation for the boundary of
             # the output, so we need to truncate 5% before assertAllClose
             truncated_len = int(output.shape[-1] * 0.05)

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -517,7 +517,7 @@ class MathOpsCorrectnessTest(testing.TestCase):
             num_segments = np.max(segment_ids).item() + 1
         expected_shape = (num_segments,) + data_dims
         if segment_reduce_op == kmath.segment_max:
-            if backend.backend() == "tensorflow":
+            if backend.backend() in ("tensorflow", "openvino"):
                 empty_fill_value = -np.finfo(np.float32).max
             else:
                 empty_fill_value = -np.inf


### PR DESCRIPTION
As discussed previously in #22446, introducing a partial upgrade to OpenVINO's opset16, for the ops `istft` and `segment_max`. (these are newly added in this opset)


We are not going for a complete upgrade, because there is a bug in opset16 due to some missing ops. It has been fixed upstream, and will be corrected in 2026.2.

Also refactored the helper fn _segment_reduction_fn into segment_sum, since it is the only caller now.

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.