### PR TITLE
Updates to `dependabot.yml`.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,5 @@ updates:
     ignore:
       # 2.19.1 is the last version of the TensorFlow that supports TPUs.
       - dependency-name: "tensorflow-tpu"
-      # TODO: ignore all updates for JAX GPU due to cuda version issue
-      - dependency-name: "jax[cuda12_pip]"
-      # TODO(#21914): Update this version when TF is updated
-      - dependency-name: "ai-edge-litert"
+      # 2.20.0 is required by our TensorFlow GPU setup (2.21 won't work)
+      - dependency-name: "tensorflow[and-cuda]"


### PR DESCRIPTION
- We can unpin `jax[and-cuda]` now that we've migrated to github runners for GPUs
- We have unpinned `ai-edge-litert` in the requirements files
- We do need to pin `tensorflow[and-cuda]` to 2.20.0 as 2.21 doesn't work with our setup

This is to prevent PRs like this: https://github.com/keras-team/keras/pull/22604