### PR TITLE
[OpenVINO] Fix ndim() to return Python int instead of graph tensor

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -87,7 +87,6 @@ NumpyOneInputOpsCorrectnessTest::test_real
 QuantizersTest::test_compute_float8_scale
 QuantizersTest::test_grouped_quantize_with_padding
 ReshapeTest::test_reshape_with_dynamic_batch_size_and_minus_one
-SavingAPITest::test_normalization_kpl
 SavingBattleTest::test_bidirectional_lstm_saving
 SavingTest::test_load_weights_only_with_unbuilt_model
 SimpleRNNTest::test_output_shape

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -3659,8 +3659,8 @@ def ndim(x):
     if not rank.is_static:
         raise ValueError(
             "Cannot determine `ndim`: tensor has a dynamically-ranked "
-            "PartialShape. All tensors in the OpenVINO backend are expected "
-            "to have a statically-known rank."
+            "PartialShape. The OpenVINO backend requires a statically-known "
+            "rank for this operation."
         )
     return rank.get_length()
 

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -3655,9 +3655,7 @@ def nan_to_num(x, nan=0.0, posinf=None, neginf=None):
 
 def ndim(x):
     x = get_ov_output(x)
-    shape_tensor = ov_opset.shape_of(x, Type.i64).output(0)
-    rank_tensor = ov_opset.shape_of(shape_tensor, Type.i64).output(0)
-    return OpenVINOKerasTensor(rank_tensor)
+    return x.get_partial_shape().rank.get_length()
 
 
 def nonzero(x):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -3655,7 +3655,14 @@ def nan_to_num(x, nan=0.0, posinf=None, neginf=None):
 
 def ndim(x):
     x = get_ov_output(x)
-    return x.get_partial_shape().rank.get_length()
+    rank = x.get_partial_shape().rank
+    if not rank.is_static:
+        raise ValueError(
+            "Cannot determine `ndim`: tensor has a dynamically-ranked "
+            "PartialShape. All tensors in the OpenVINO backend are expected "
+            "to have a statically-known rank."
+        )
+    return rank.get_length()
 
 
 def nonzero(x):


### PR DESCRIPTION
`ndim()` in the OpenVINO backend was building an OV graph node to represent the rank, returning an OpenVINOKerasTensor. However, the number of dimensions is a static, compile-time property of a tensor's type, not a runtime value. It never changes during inference and must be a Python int for use in Python control flow.

All other backends return an int.

This PR adds a fix which reads the rank directly from the OV partial shape, `get_partial_shape().rank.get_length()` which is always known at graph-build time.