### PR TITLE
fix: transpose 1D channels_first input in TF depthwise_conv to support dilations

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -1,3 +1,5 @@
+DepthwiseConvBasicTest::test_depthwise_conv1d_basic3
+DepthwiseConvCorrectnessTest::test_depthwise_conv1d3
 EqualizationTest::test_constant_regions
 EqualizationTest::test_different_bin_sizes
 EqualizationTest::test_equalizes_to_all_bins

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -863,12 +863,13 @@ def depthwise_conv(
         dilation_rate = (dilation_rate,) * num_spatial_dims
     if num_spatial_dims == 1:
         # 1D depthwise conv.
-        if data_format == "channels_last":
-            strides = (1,) + strides * 2 + (1,)
-            spatial_start_dim = 1
-        else:
-            strides = (1, 1) + strides * 2
-            spatial_start_dim = 2
+        # `tf.nn.depthwise_conv2d` does not support `channels_first` with
+        # dilations on CPU. Transpose to `channels_last`, compute, and
+        # transpose back to avoid the limitation.
+        if data_format == "channels_first":
+            inputs = tf.transpose(inputs, perm=[0, 2, 1])
+        strides = (1,) + strides * 2 + (1,)
+        spatial_start_dim = 1
         inputs = tf.expand_dims(inputs, spatial_start_dim)
         kernel = tf.expand_dims(kernel, axis=0)
 
@@ -879,10 +880,13 @@ def depthwise_conv(
             kernel,
             strides,
             padding,
-            data_format=tf_data_format,
+            data_format=_convert_data_format("channels_last", 4),
             dilations=dilation_rate,
         )
-        return tf.squeeze(outputs, [spatial_start_dim])
+        outputs = tf.squeeze(outputs, [spatial_start_dim])
+        if data_format == "channels_first":
+            outputs = tf.transpose(outputs, perm=[0, 2, 1])
+        return outputs
 
     if data_format == "channels_last":
         strides = (1,) + strides + (1,)

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -867,8 +867,7 @@ def depthwise_conv(
         # dilations on CPU. Transpose to `channels_last`, compute, and
         # transpose back to avoid the limitation.
         need_transpose = data_format == "channels_first" and all(
-            d.device_type == "CPU"
-            for d in tf.config.list_logical_devices()
+            d.device_type == "CPU" for d in tf.config.list_logical_devices()
         )
         if need_transpose:
             inputs = _transpose_spatial_inputs(inputs)

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -867,7 +867,7 @@ def depthwise_conv(
         # dilations on CPU. Transpose to `channels_last`, compute, and
         # transpose back to avoid the limitation.
         if data_format == "channels_first":
-            inputs = tf.transpose(inputs, perm=[0, 2, 1])
+            inputs = _transpose_spatial_inputs(inputs)
         strides = (1,) + strides * 2 + (1,)
         spatial_start_dim = 1
         inputs = tf.expand_dims(inputs, spatial_start_dim)
@@ -885,7 +885,7 @@ def depthwise_conv(
         )
         outputs = tf.squeeze(outputs, [spatial_start_dim])
         if data_format == "channels_first":
-            outputs = tf.transpose(outputs, perm=[0, 2, 1])
+            outputs = _transpose_spatial_outputs(outputs)
         return outputs
 
     if data_format == "channels_last":

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -866,25 +866,37 @@ def depthwise_conv(
         # `tf.nn.depthwise_conv2d` does not support `channels_first` with
         # dilations on CPU. Transpose to `channels_last`, compute, and
         # transpose back to avoid the limitation.
-        if data_format == "channels_first":
+        need_transpose = data_format == "channels_first" and all(
+            d.device_type == "CPU"
+            for d in tf.config.list_logical_devices()
+        )
+        if need_transpose:
             inputs = _transpose_spatial_inputs(inputs)
-        strides = (1,) + strides * 2 + (1,)
-        spatial_start_dim = 1
+        if need_transpose or data_format == "channels_last":
+            strides = (1,) + strides * 2 + (1,)
+            spatial_start_dim = 1
+        else:
+            strides = (1, 1) + strides * 2
+            spatial_start_dim = 2
         inputs = tf.expand_dims(inputs, spatial_start_dim)
         kernel = tf.expand_dims(kernel, axis=0)
 
         dilation_rate = None if dilation_rate is None else (1,) + dilation_rate
 
+        if need_transpose or data_format == "channels_last":
+            conv_data_format = _convert_data_format("channels_last", 4)
+        else:
+            conv_data_format = _convert_data_format("channels_first", 4)
         outputs = tf.nn.depthwise_conv2d(
             inputs,
             kernel,
             strides,
             padding,
-            data_format=_convert_data_format("channels_last", 4),
+            data_format=conv_data_format,
             dilations=dilation_rate,
         )
         outputs = tf.squeeze(outputs, [spatial_start_dim])
-        if data_format == "channels_first":
+        if need_transpose:
             outputs = _transpose_spatial_outputs(outputs)
         return outputs
 

--- a/keras/src/layers/convolutional/depthwise_conv_test.py
+++ b/keras/src/layers/convolutional/depthwise_conv_test.py
@@ -220,11 +220,6 @@ class DepthwiseConvBasicTest(testing.TestCase):
         input_shape,
         output_shape,
     ):
-        if data_format == "channels_first" and backend.backend() == "openvino":
-            self.skipTest(
-                "OpenVINO backend does not support channels_first for "
-                "depthwise_conv."
-            )
         self.run_layer_test(
             layers.DepthwiseConv1D,
             init_kwargs={
@@ -393,11 +388,6 @@ class DepthwiseConvCorrectnessTest(testing.TestCase):
         data_format,
         dilation_rate,
     ):
-        if data_format == "channels_first" and backend.backend() == "openvino":
-            self.skipTest(
-                "OpenVINO backend does not support channels_first for "
-                "depthwise_conv."
-            )
         layer = layers.DepthwiseConv1D(
             depth_multiplier=depth_multiplier,
             kernel_size=kernel_size,

--- a/keras/src/layers/convolutional/depthwise_conv_test.py
+++ b/keras/src/layers/convolutional/depthwise_conv_test.py
@@ -2,7 +2,6 @@ import numpy as np
 from absl.testing import parameterized
 from numpy.lib.stride_tricks import as_strided
 
-from keras.src import backend
 from keras.src import layers
 from keras.src import testing
 

--- a/keras/src/layers/convolutional/depthwise_conv_test.py
+++ b/keras/src/layers/convolutional/depthwise_conv_test.py
@@ -197,6 +197,16 @@ class DepthwiseConvBasicTest(testing.TestCase):
             "input_shape": (3, 5, 4),
             "output_shape": (3, 2, 24),
         },
+        {
+            "depth_multiplier": 6,
+            "kernel_size": 2,
+            "strides": 1,
+            "padding": "same",
+            "data_format": "channels_first",
+            "dilation_rate": (2,),
+            "input_shape": (3, 4, 10),
+            "output_shape": (3, 24, 10),
+        },
     )
     def test_depthwise_conv1d_basic(
         self,
@@ -359,6 +369,14 @@ class DepthwiseConvCorrectnessTest(testing.TestCase):
             "data_format": "channels_last",
             "dilation_rate": 1,
         },
+        {
+            "depth_multiplier": 6,
+            "kernel_size": 2,
+            "strides": 1,
+            "padding": "same",
+            "data_format": "channels_first",
+            "dilation_rate": (2,),
+        },
     )
     def test_depthwise_conv1d(
         self,
@@ -378,7 +396,10 @@ class DepthwiseConvCorrectnessTest(testing.TestCase):
             dilation_rate=dilation_rate,
         )
 
-        inputs = np.random.normal(size=[2, 8, 4])
+        if data_format == "channels_last":
+            inputs = np.random.normal(size=[2, 8, 4])
+        else:
+            inputs = np.random.normal(size=[2, 4, 8])
         layer.build(input_shape=inputs.shape)
 
         kernel_shape = layer.kernel.shape

--- a/keras/src/layers/convolutional/depthwise_conv_test.py
+++ b/keras/src/layers/convolutional/depthwise_conv_test.py
@@ -2,6 +2,7 @@ import numpy as np
 from absl.testing import parameterized
 from numpy.lib.stride_tricks import as_strided
 
+from keras.src import backend
 from keras.src import layers
 from keras.src import testing
 
@@ -219,6 +220,11 @@ class DepthwiseConvBasicTest(testing.TestCase):
         input_shape,
         output_shape,
     ):
+        if data_format == "channels_first" and backend.backend() == "openvino":
+            self.skipTest(
+                "OpenVINO backend does not support channels_first for "
+                "depthwise_conv."
+            )
         self.run_layer_test(
             layers.DepthwiseConv1D,
             init_kwargs={
@@ -387,6 +393,11 @@ class DepthwiseConvCorrectnessTest(testing.TestCase):
         data_format,
         dilation_rate,
     ):
+        if data_format == "channels_first" and backend.backend() == "openvino":
+            self.skipTest(
+                "OpenVINO backend does not support channels_first for "
+                "depthwise_conv."
+            )
         layer = layers.DepthwiseConv1D(
             depth_multiplier=depth_multiplier,
             kernel_size=kernel_size,


### PR DESCRIPTION
## Summary

`tf.nn.depthwise_conv2d` does not support `channels_first` (NCHW) format with dilations on CPU. When `DepthwiseConv1D` is used with `data_format='channels_first'` and `dilation_rate > 1`, the TF backend's `depthwise_conv` function passed NCHW data directly to `tf.nn.depthwise_conv2d`, which fails at runtime with an `Incompatible shapes` error.

## Root Cause

In `keras/src/backend/tensorflow/nn.py`, the 1D depthwise conv path for `channels_first` set `spatial_start_dim = 2` and expanded the input as `(N, C, 1, W)` in NCHW format. Passing NCHW + dilations to `tf.nn.depthwise_conv2d` is not supported on CPU, causing the op to return incorrect results and ultimately an `Incompatible shapes` error when adding the bias.

## Fix

For the 1D `channels_first` case, use the existing `_transpose_spatial_inputs` and `_transpose_spatial_outputs` helpers to transpose to `channels_last` before the convolution and back after, consistent with the pattern used by `max_pool` and `average_pool` in the same file.

## Changes

- `keras/src/backend/tensorflow/nn.py`: use `_transpose_spatial_inputs/outputs` helpers for 1D channels_first depthwise conv, compute in NHWC format
- `keras/src/layers/convolutional/depthwise_conv_test.py`: add `channels_first` + `dilation_rate=(2,)` test cases to both the basic shape test and the correctness test

Fixes #22534

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.