### PR TITLE
Silence git security error with recent git.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -46,6 +46,7 @@ jobs:
           apt-get -y install curl
           apt-get -y install git
           apt-get -y install gnupg
+          git config --global --add safe.directory '*'
 
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v6


### PR DESCRIPTION
Fixes `fatal: detected dubious ownership in repository at '/__w/keras/keras'`

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
