### PR TITLE
Pass Python strings to TextVectorization standardize on non-TF backends

### DIFF
--- a/keras/src/layers/preprocessing/text_vectorization.py
+++ b/keras/src/layers/preprocessing/text_vectorization.py
@@ -410,7 +410,8 @@ class TextVectorization(Layer):
         Arguments:
             data: The data to train on. It can be passed either as a
                 batched `tf.data.Dataset`, as a list of strings,
-                or as a NumPy array.
+                as a NumPy array, or as any iterable of batches (e.g.
+                a generator yielding batches of strings).
             steps: Integer or `None`.
                 Total number of steps (batches of samples) to process.
                 If `data` is a `tf.data.Dataset`, and `steps` is `None`,
@@ -425,11 +426,18 @@ class TextVectorization(Layer):
                 data = data.take(steps)
             for batch in data:
                 self.update_state(batch)
+        elif hasattr(data, "__iter__") and not (
+            isinstance(data, (list, tuple, np.ndarray))
+            or backend.is_tensor(data)
+            or tf.is_tensor(data)
+        ):
+            for i, batch in enumerate(data):
+                if steps is not None and i >= steps:
+                    break
+                self.update_state(batch)
         else:
             data = tf_utils.ensure_tensor(data, dtype="string")
             if data.shape.rank == 1:
-                # A plain list of strings
-                # is treated as as many documents
                 data = tf.expand_dims(data, -1)
             self.update_state(data)
         self.finalize_state()
@@ -558,57 +566,69 @@ class TextVectorization(Layer):
         return tf.constant(np.asarray(result), dtype=tf.string)
 
     def _preprocess(self, inputs):
-        if callable(self._standardize) and backend.backend() != "tensorflow":
-            # On non-TensorFlow backends, hand the user-provided callable a
-            # NumPy array of unicode strings so it can use `np.char` /
-            # `np.strings` ops rather than being passed a `tf.EagerTensor`.
-            inputs = self._apply_python_standardize(inputs)
-        else:
-            inputs = tf_utils.ensure_tensor(inputs, dtype=tf.string)
-            if self._standardize in ("lower", "lower_and_strip_punctuation"):
-                inputs = tf.strings.lower(inputs)
-            if self._standardize in (
-                "strip_punctuation",
-                "lower_and_strip_punctuation",
+        with tf.device("CPU:0"):
+            if (
+                callable(self._standardize)
+                and backend.backend() != "tensorflow"
             ):
-                inputs = tf.strings.regex_replace(
-                    inputs, r'[!"#$%&()\*\+,-\./:;<=>?@\[\\\]^_`{|}~\']', ""
-                )
-            if callable(self._standardize):
-                inputs = self._standardize(inputs)
-
-        if self._split is not None:
-            # If we are splitting, we validate that the 1st axis is of dimension
-            # 1 and so can be squeezed out. We do this here instead of after
-            # splitting for performance reasons - it's more expensive to squeeze
-            # a ragged tensor.
-            if inputs.shape.rank > 1:
-                if inputs.shape[-1] != 1:
-                    raise ValueError(
-                        "When using `TextVectorization` to tokenize strings, "
-                        "the input rank must be 1 or the last shape dimension "
-                        f"must be 1. Received: inputs.shape={inputs.shape} "
-                        f"with rank={inputs.shape.rank}"
+                # On non-TensorFlow backends, hand the user-provided callable
+                # a NumPy array of unicode strings so it can use `np.char` /
+                # `np.strings` ops rather than `tf.strings` (which would
+                # require a `tf.EagerTensor` and TF as a hard dependency
+                # outside TF backend code).
+                inputs = self._apply_python_standardize(inputs)
+            else:
+                inputs = tf_utils.ensure_tensor(inputs, dtype=tf.string)
+                if self._standardize in (
+                    "lower",
+                    "lower_and_strip_punctuation",
+                ):
+                    inputs = tf.strings.lower(inputs)
+                if self._standardize in (
+                    "strip_punctuation",
+                    "lower_and_strip_punctuation",
+                ):
+                    inputs = tf.strings.regex_replace(
+                        inputs,
+                        r'[!"#$%&()\*\+,-\./:;<=>?@\[\\\]^_`{|}~\']',
+                        "",
                     )
-                else:
-                    inputs = tf.squeeze(inputs, axis=-1)
-            if self._split == "whitespace":
-                # This treats multiple whitespaces as one whitespace, and strips
-                # leading and trailing whitespace.
-                inputs = tf.strings.split(inputs)
-            elif self._split == "character":
-                inputs = tf.strings.unicode_split(inputs, "UTF-8")
-            elif callable(self._split):
-                inputs = self._split(inputs)
+                if callable(self._standardize):
+                    inputs = self._standardize(inputs)
 
-        # Note that 'inputs' here can be either ragged or dense depending on the
-        # configuration choices for this Layer. The strings.ngrams op, however,
-        # does support both ragged and dense inputs.
-        if self._ngrams is not None:
-            inputs = tf.strings.ngrams(
-                inputs, ngram_width=self._ngrams, separator=" "
-            )
-        return inputs
+            if self._split is not None:
+                # If we are splitting, we validate that the 1st axis is of
+                # dimension 1 and so can be squeezed out. We do this here
+                # instead of after splitting for performance reasons - it's
+                # more expensive to squeeze a ragged tensor.
+                if inputs.shape.rank > 1:
+                    if inputs.shape[-1] != 1:
+                        raise ValueError(
+                            "When using `TextVectorization` to tokenize "
+                            "strings, the input rank must be 1 or the last "
+                            f"shape dimension must be 1. Received: "
+                            f"inputs.shape={inputs.shape} with "
+                            f"rank={inputs.shape.rank}"
+                        )
+                    else:
+                        inputs = tf.squeeze(inputs, axis=-1)
+                if self._split == "whitespace":
+                    # This treats multiple whitespaces as one whitespace,
+                    # and strips leading and trailing whitespace.
+                    inputs = tf.strings.split(inputs)
+                elif self._split == "character":
+                    inputs = tf.strings.unicode_split(inputs, "UTF-8")
+                elif callable(self._split):
+                    inputs = self._split(inputs)
+
+            # Note that 'inputs' here can be either ragged or dense depending
+            # on the configuration choices for this Layer. The strings.ngrams
+            # op, however, does support both ragged and dense inputs.
+            if self._ngrams is not None:
+                inputs = tf.strings.ngrams(
+                    inputs, ngram_width=self._ngrams, separator=" "
+                )
+            return inputs
 
     def call(self, inputs):
         if not isinstance(
@@ -617,10 +637,6 @@ class TextVectorization(Layer):
             inputs = tf.convert_to_tensor(backend.convert_to_numpy(inputs))
 
         inputs = self._preprocess(inputs)
-
-        # If we're not doing any output processing, return right away.
-        if self._output_mode is None:
-            outputs = inputs
 
         lookup_data = self._lookup_layer.call(inputs)
 

--- a/keras/src/layers/preprocessing/text_vectorization.py
+++ b/keras/src/layers/preprocessing/text_vectorization.py
@@ -532,40 +532,39 @@ class TextVectorization(Layer):
         """
         self._lookup_layer.set_vocabulary(vocabulary, idf_weights=idf_weights)
 
-    def _apply_python_standardize(self, inputs):
+    def _apply_standardize_with_np_arrays(self, inputs):
         """Run a callable `standardize` on a NumPy string array.
 
-        Used on non-TensorFlow backends so that the user callable receives
-        a NumPy array of unicode strings (suitable for `np.char` /
-        `np.strings` operations) rather than a `tf.EagerTensor`.
+        Used on non-TensorFlow backends so the user callable receives a NumPy
+        array of unicode strings (suitable for `np.char` / `np.strings` ops)
+        rather than a `tf.EagerTensor`.
         """
-        if isinstance(inputs, tf.Tensor):
-            np_inputs = inputs.numpy()
-        elif isinstance(inputs, np.ndarray):
+        if isinstance(inputs, np.ndarray):
             np_inputs = inputs
+        elif backend.is_tensor(inputs):
+            np_inputs = backend.convert_to_numpy(inputs)
         else:
             np_inputs = np.asarray(inputs)
 
-        def _decode(value):
-            if isinstance(value, (bytes, bytearray)):
-                return value.decode(self._encoding)
-            return str(value)
+        if np_inputs.dtype.kind == "S":
+            np_inputs = np.char.decode(np_inputs, self._encoding)
+        elif np_inputs.dtype.kind == "O":
+            # Object arrays (e.g. from tf.string tensors) contain `bytes`.
+            np_inputs = np.char.decode(
+                np_inputs.astype(np.bytes_), self._encoding
+            )
 
-        if np_inputs.ndim == 0:
-            decoded = np.array(_decode(np_inputs.item()), dtype=np.str_)
-        else:
-            flat = np_inputs.reshape(-1)
-            decoded = np.array(
-                [_decode(item) for item in flat], dtype=np.str_
-            ).reshape(np_inputs.shape)
-
-        result = self._standardize(decoded)
+        result = self._standardize(np_inputs)
 
         if isinstance(result, tf.Tensor):
             return tf.cast(result, tf.string)
         return tf.constant(np.asarray(result), dtype=tf.string)
 
     def _preprocess(self, inputs):
+        if not isinstance(
+            inputs, (tf.Tensor, tf.RaggedTensor, np.ndarray, list, tuple)
+        ) and backend.is_tensor(inputs):
+            inputs = backend.convert_to_numpy(inputs)
         with tf.device("CPU:0"):
             if (
                 callable(self._standardize)
@@ -576,7 +575,7 @@ class TextVectorization(Layer):
                 # `np.strings` ops rather than `tf.strings` (which would
                 # require a `tf.EagerTensor` and TF as a hard dependency
                 # outside TF backend code).
-                inputs = self._apply_python_standardize(inputs)
+                inputs = self._apply_standardize_with_np_arrays(inputs)
             else:
                 inputs = tf_utils.ensure_tensor(inputs, dtype=tf.string)
                 if self._standardize in (
@@ -631,11 +630,6 @@ class TextVectorization(Layer):
             return inputs
 
     def call(self, inputs):
-        if not isinstance(
-            inputs, (tf.Tensor, tf.RaggedTensor, np.ndarray, list, tuple)
-        ):
-            inputs = tf.convert_to_tensor(backend.convert_to_numpy(inputs))
-
         inputs = self._preprocess(inputs)
 
         lookup_data = self._lookup_layer.call(inputs)

--- a/keras/src/layers/preprocessing/text_vectorization.py
+++ b/keras/src/layers/preprocessing/text_vectorization.py
@@ -526,20 +526,79 @@ class TextVectorization(Layer):
         """
         self._lookup_layer.set_vocabulary(vocabulary, idf_weights=idf_weights)
 
+    def _apply_python_standardize(self, inputs):
+        """Run a callable `standardize` on Python strings, then re-tensor.
+
+        Used on non-TensorFlow backends so that user callables can rely on
+        plain Python string operations (`.lower()`, `re.sub`, ...) instead
+        of receiving a `tf.EagerTensor`.
+        """
+        if isinstance(inputs, tf.Tensor):
+            np_inputs = inputs.numpy()
+        elif isinstance(inputs, np.ndarray):
+            np_inputs = inputs
+        else:
+            np_inputs = np.asarray(inputs)
+
+        def _decode(item):
+            if isinstance(item, (bytes, bytearray)):
+                return item.decode(self._encoding)
+            return item
+
+        def _to_str(value):
+            # Coerce the result of `self._standardize` back into a plain
+            # Python str so it can be packed into a `tf.constant` below.
+            # This also lets users return a `tf.Tensor` from a tf-style
+            # callable on non-TF backends without breaking the layer.
+            if isinstance(value, tf.Tensor):
+                value = value.numpy()
+            if isinstance(value, np.ndarray):
+                value = value.item()
+            if isinstance(value, (bytes, bytearray)):
+                return value.decode(self._encoding)
+            return str(value)
+
+        if np_inputs.ndim == 0:
+            result = self._standardize(_decode(np_inputs.item()))
+            return tf.constant(_to_str(result), dtype=tf.string)
+
+        flat = np_inputs.reshape(-1)
+        results = [_to_str(self._standardize(_decode(item))) for item in flat]
+        reshaped = (
+            np.array(results, dtype=object).reshape(np_inputs.shape).tolist()
+        )
+        return tf.constant(reshaped, dtype=tf.string)
+
     def _preprocess(self, inputs):
         with tf.device("CPU:0"):
-            inputs = tf_utils.ensure_tensor(inputs, dtype=tf.string)
-            if self._standardize in ("lower", "lower_and_strip_punctuation"):
-                inputs = tf.strings.lower(inputs)
-            if self._standardize in (
-                "strip_punctuation",
-                "lower_and_strip_punctuation",
+            if (
+                callable(self._standardize)
+                and backend.backend() != "tensorflow"
             ):
-                inputs = tf.strings.regex_replace(
-                    inputs, r'[!"#$%&()\*\+,-\./:;<=>?@\[\\\]^_`{|}~\']', ""
-                )
-            if callable(self._standardize):
-                inputs = self._standardize(inputs)
+                # On non-TensorFlow backends, run the user-provided callable
+                # on Python strings rather than leaking a `tf.EagerTensor`
+                # into user code. The callable is invoked per element so that
+                # idiomatic Python string operations (e.g. `s.lower()`,
+                # `re.sub`) just work.
+                inputs = self._apply_python_standardize(inputs)
+            else:
+                inputs = tf_utils.ensure_tensor(inputs, dtype=tf.string)
+                if self._standardize in (
+                    "lower",
+                    "lower_and_strip_punctuation",
+                ):
+                    inputs = tf.strings.lower(inputs)
+                if self._standardize in (
+                    "strip_punctuation",
+                    "lower_and_strip_punctuation",
+                ):
+                    inputs = tf.strings.regex_replace(
+                        inputs,
+                        r'[!"#$%&()\*\+,-\./:;<=>?@\[\\\]^_`{|}~\']',
+                        "",
+                    )
+                if callable(self._standardize):
+                    inputs = self._standardize(inputs)
 
             if self._split is not None:
                 # If we are splitting, we validate that the 1st axis is of

--- a/keras/src/layers/preprocessing/text_vectorization.py
+++ b/keras/src/layers/preprocessing/text_vectorization.py
@@ -410,8 +410,7 @@ class TextVectorization(Layer):
         Arguments:
             data: The data to train on. It can be passed either as a
                 batched `tf.data.Dataset`, as a list of strings,
-                as a NumPy array, or as any iterable of batches (e.g.
-                a generator yielding batches of strings).
+                or as a NumPy array.
             steps: Integer or `None`.
                 Total number of steps (batches of samples) to process.
                 If `data` is a `tf.data.Dataset`, and `steps` is `None`,
@@ -426,18 +425,11 @@ class TextVectorization(Layer):
                 data = data.take(steps)
             for batch in data:
                 self.update_state(batch)
-        elif hasattr(data, "__iter__") and not (
-            isinstance(data, (list, tuple, np.ndarray))
-            or backend.is_tensor(data)
-            or tf.is_tensor(data)
-        ):
-            for i, batch in enumerate(data):
-                if steps is not None and i >= steps:
-                    break
-                self.update_state(batch)
         else:
             data = tf_utils.ensure_tensor(data, dtype="string")
             if data.shape.rank == 1:
+                # A plain list of strings
+                # is treated as as many documents
                 data = tf.expand_dims(data, -1)
             self.update_state(data)
         self.finalize_state()
@@ -566,69 +558,57 @@ class TextVectorization(Layer):
         return tf.constant(np.asarray(result), dtype=tf.string)
 
     def _preprocess(self, inputs):
-        with tf.device("CPU:0"):
-            if (
-                callable(self._standardize)
-                and backend.backend() != "tensorflow"
+        if callable(self._standardize) and backend.backend() != "tensorflow":
+            # On non-TensorFlow backends, hand the user-provided callable a
+            # NumPy array of unicode strings so it can use `np.char` /
+            # `np.strings` ops rather than being passed a `tf.EagerTensor`.
+            inputs = self._apply_python_standardize(inputs)
+        else:
+            inputs = tf_utils.ensure_tensor(inputs, dtype=tf.string)
+            if self._standardize in ("lower", "lower_and_strip_punctuation"):
+                inputs = tf.strings.lower(inputs)
+            if self._standardize in (
+                "strip_punctuation",
+                "lower_and_strip_punctuation",
             ):
-                # On non-TensorFlow backends, hand the user-provided callable
-                # a NumPy array of unicode strings so it can use `np.char` /
-                # `np.strings` ops rather than `tf.strings` (which would
-                # require a `tf.EagerTensor` and TF as a hard dependency
-                # outside TF backend code).
-                inputs = self._apply_python_standardize(inputs)
-            else:
-                inputs = tf_utils.ensure_tensor(inputs, dtype=tf.string)
-                if self._standardize in (
-                    "lower",
-                    "lower_and_strip_punctuation",
-                ):
-                    inputs = tf.strings.lower(inputs)
-                if self._standardize in (
-                    "strip_punctuation",
-                    "lower_and_strip_punctuation",
-                ):
-                    inputs = tf.strings.regex_replace(
-                        inputs,
-                        r'[!"#$%&()\*\+,-\./:;<=>?@\[\\\]^_`{|}~\']',
-                        "",
-                    )
-                if callable(self._standardize):
-                    inputs = self._standardize(inputs)
-
-            if self._split is not None:
-                # If we are splitting, we validate that the 1st axis is of
-                # dimension 1 and so can be squeezed out. We do this here
-                # instead of after splitting for performance reasons - it's
-                # more expensive to squeeze a ragged tensor.
-                if inputs.shape.rank > 1:
-                    if inputs.shape[-1] != 1:
-                        raise ValueError(
-                            "When using `TextVectorization` to tokenize "
-                            "strings, the input rank must be 1 or the last "
-                            f"shape dimension must be 1. Received: "
-                            f"inputs.shape={inputs.shape} with "
-                            f"rank={inputs.shape.rank}"
-                        )
-                    else:
-                        inputs = tf.squeeze(inputs, axis=-1)
-                if self._split == "whitespace":
-                    # This treats multiple whitespaces as one whitespace,
-                    # and strips leading and trailing whitespace.
-                    inputs = tf.strings.split(inputs)
-                elif self._split == "character":
-                    inputs = tf.strings.unicode_split(inputs, "UTF-8")
-                elif callable(self._split):
-                    inputs = self._split(inputs)
-
-            # Note that 'inputs' here can be either ragged or dense depending
-            # on the configuration choices for this Layer. The strings.ngrams
-            # op, however, does support both ragged and dense inputs.
-            if self._ngrams is not None:
-                inputs = tf.strings.ngrams(
-                    inputs, ngram_width=self._ngrams, separator=" "
+                inputs = tf.strings.regex_replace(
+                    inputs, r'[!"#$%&()\*\+,-\./:;<=>?@\[\\\]^_`{|}~\']', ""
                 )
-            return inputs
+            if callable(self._standardize):
+                inputs = self._standardize(inputs)
+
+        if self._split is not None:
+            # If we are splitting, we validate that the 1st axis is of dimension
+            # 1 and so can be squeezed out. We do this here instead of after
+            # splitting for performance reasons - it's more expensive to squeeze
+            # a ragged tensor.
+            if inputs.shape.rank > 1:
+                if inputs.shape[-1] != 1:
+                    raise ValueError(
+                        "When using `TextVectorization` to tokenize strings, "
+                        "the input rank must be 1 or the last shape dimension "
+                        f"must be 1. Received: inputs.shape={inputs.shape} "
+                        f"with rank={inputs.shape.rank}"
+                    )
+                else:
+                    inputs = tf.squeeze(inputs, axis=-1)
+            if self._split == "whitespace":
+                # This treats multiple whitespaces as one whitespace, and strips
+                # leading and trailing whitespace.
+                inputs = tf.strings.split(inputs)
+            elif self._split == "character":
+                inputs = tf.strings.unicode_split(inputs, "UTF-8")
+            elif callable(self._split):
+                inputs = self._split(inputs)
+
+        # Note that 'inputs' here can be either ragged or dense depending on the
+        # configuration choices for this Layer. The strings.ngrams op, however,
+        # does support both ragged and dense inputs.
+        if self._ngrams is not None:
+            inputs = tf.strings.ngrams(
+                inputs, ngram_width=self._ngrams, separator=" "
+            )
+        return inputs
 
     def call(self, inputs):
         if not isinstance(
@@ -637,6 +617,10 @@ class TextVectorization(Layer):
             inputs = tf.convert_to_tensor(backend.convert_to_numpy(inputs))
 
         inputs = self._preprocess(inputs)
+
+        # If we're not doing any output processing, return right away.
+        if self._output_mode is None:
+            outputs = inputs
 
         lookup_data = self._lookup_layer.call(inputs)
 

--- a/keras/src/layers/preprocessing/text_vectorization.py
+++ b/keras/src/layers/preprocessing/text_vectorization.py
@@ -49,8 +49,14 @@ class TextVectorization(Layer):
        serializables (see `keras.saving.register_keras_serializable`
        for more details).
     2. When using a custom callable for `standardize`, the data received
-       by the callable will be exactly as passed to this layer. The callable
-       should return a tensor of the same shape as the input.
+       by the callable depends on the active Keras backend. With the
+       TensorFlow backend, the callable receives a `tf.Tensor` of dtype
+       `string`, so it should use `tf.strings` operations. With any other
+       backend (JAX, NumPy, PyTorch, OpenVINO) the callable receives a
+       NumPy array of unicode strings, so it should use `np.char` /
+       `np.strings` operations (or any vectorized string logic of your
+       choice). The callable should return data of the same shape as the
+       input.
     3. When using a custom callable for `split`, the data received by the
        callable will have the 1st dimension squeezed out - instead of
        `[["string to split"], ["another string to split"]]`, the Callable will
@@ -527,11 +533,11 @@ class TextVectorization(Layer):
         self._lookup_layer.set_vocabulary(vocabulary, idf_weights=idf_weights)
 
     def _apply_python_standardize(self, inputs):
-        """Run a callable `standardize` on Python strings, then re-tensor.
+        """Run a callable `standardize` on a NumPy string array.
 
-        Used on non-TensorFlow backends so that user callables can rely on
-        plain Python string operations (`.lower()`, `re.sub`, ...) instead
-        of receiving a `tf.EagerTensor`.
+        Used on non-TensorFlow backends so that the user callable receives
+        a NumPy array of unicode strings (suitable for `np.char` /
+        `np.strings` operations) rather than a `tf.EagerTensor`.
         """
         if isinstance(inputs, tf.Tensor):
             np_inputs = inputs.numpy()
@@ -540,34 +546,24 @@ class TextVectorization(Layer):
         else:
             np_inputs = np.asarray(inputs)
 
-        def _decode(item):
-            if isinstance(item, (bytes, bytearray)):
-                return item.decode(self._encoding)
-            return item
-
-        def _to_str(value):
-            # Coerce the result of `self._standardize` back into a plain
-            # Python str so it can be packed into a `tf.constant` below.
-            # This also lets users return a `tf.Tensor` from a tf-style
-            # callable on non-TF backends without breaking the layer.
-            if isinstance(value, tf.Tensor):
-                value = value.numpy()
-            if isinstance(value, np.ndarray):
-                value = value.item()
+        def _decode(value):
             if isinstance(value, (bytes, bytearray)):
                 return value.decode(self._encoding)
             return str(value)
 
         if np_inputs.ndim == 0:
-            result = self._standardize(_decode(np_inputs.item()))
-            return tf.constant(_to_str(result), dtype=tf.string)
+            decoded = np.array(_decode(np_inputs.item()), dtype=np.str_)
+        else:
+            flat = np_inputs.reshape(-1)
+            decoded = np.array(
+                [_decode(item) for item in flat], dtype=np.str_
+            ).reshape(np_inputs.shape)
 
-        flat = np_inputs.reshape(-1)
-        results = [_to_str(self._standardize(_decode(item))) for item in flat]
-        reshaped = (
-            np.array(results, dtype=object).reshape(np_inputs.shape).tolist()
-        )
-        return tf.constant(reshaped, dtype=tf.string)
+        result = self._standardize(decoded)
+
+        if isinstance(result, tf.Tensor):
+            return tf.cast(result, tf.string)
+        return tf.constant(np.asarray(result), dtype=tf.string)
 
     def _preprocess(self, inputs):
         with tf.device("CPU:0"):
@@ -575,11 +571,11 @@ class TextVectorization(Layer):
                 callable(self._standardize)
                 and backend.backend() != "tensorflow"
             ):
-                # On non-TensorFlow backends, run the user-provided callable
-                # on Python strings rather than leaking a `tf.EagerTensor`
-                # into user code. The callable is invoked per element so that
-                # idiomatic Python string operations (e.g. `s.lower()`,
-                # `re.sub`) just work.
+                # On non-TensorFlow backends, hand the user-provided callable
+                # a NumPy array of unicode strings so it can use `np.char` /
+                # `np.strings` ops rather than `tf.strings` (which would
+                # require a `tf.EagerTensor` and TF as a hard dependency
+                # outside TF backend code).
                 inputs = self._apply_python_standardize(inputs)
             else:
                 inputs = tf_utils.ensure_tensor(inputs, dtype=tf.string)

--- a/keras/src/layers/preprocessing/text_vectorization_test.py
+++ b/keras/src/layers/preprocessing/text_vectorization_test.py
@@ -1,5 +1,6 @@
 import os
 
+import grain
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -38,6 +39,44 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         output = layer(input_data)
         self.assertTrue(backend.is_tensor(output))
         self.assertAllClose(output, np.array([[4, 1, 3, 0], [1, 2, 0, 0]]))
+        self.assertIn("foo", [str(v) for v in layer.get_vocabulary()])
+
+    def test_adapt_with_generator(self):
+        def text_gen():
+            yield ["hello world", "foo bar"]
+            yield ["baz qux", "hello foo"]
+
+        layer = layers.TextVectorization()
+        layer.adapt(text_gen())
+        vocab = layer.get_vocabulary()
+        self.assertIn("hello", [str(v) for v in vocab])
+        self.assertIn("foo", [str(v) for v in vocab])
+
+    def test_adapt_with_infinite_generator_and_steps(self):
+        def text_gen():
+            while True:
+                yield ["hello world", "foo bar"]
+
+        layer = layers.TextVectorization()
+        layer.adapt(text_gen(), steps=3)
+        vocab = layer.get_vocabulary()
+        self.assertIn("hello", [str(v) for v in vocab])
+
+    def test_adapt_with_grain_dataset(self):
+        texts = ["hello world", "foo bar", "baz qux", "hello foo"]
+
+        class Source(grain.sources.RandomAccessDataSource):
+            def __getitem__(self, idx):
+                return texts[idx]
+
+            def __len__(self):
+                return len(texts)
+
+        dataset = grain.MapDataset.source(Source()).batch(batch_size=2)
+        layer = layers.TextVectorization()
+        layer.adapt(dataset)
+        vocab = layer.get_vocabulary()
+        self.assertIn("hello", [str(v) for v in vocab])
 
     def test_fixed_vocabulary(self):
         max_tokens = 5000

--- a/keras/src/layers/preprocessing/text_vectorization_test.py
+++ b/keras/src/layers/preprocessing/text_vectorization_test.py
@@ -405,6 +405,39 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         self.assertTrue(backend.is_tensor(output))
         self.assertAllEqual(output, [[2, 3]])
 
+    def test_python_standardize_callable_non_tf_backend(self):
+        # Regression test for https://github.com/keras-team/keras/issues/22626
+        # On non-TF backends, a callable standardize function should be able
+        # to use plain Python string operations rather than receiving a
+        # `tf.EagerTensor`.
+        if backend.backend() == "tensorflow":
+            self.skipTest("Test is for non-TensorFlow backends only.")
+
+        import re
+        import string
+
+        strip_chars = string.punctuation
+        seen_types = []
+
+        def py_standardize(text):
+            seen_types.append(type(text).__name__)
+            text = text.lower()
+            return re.sub(f"[{re.escape(strip_chars)}]", "", text)
+
+        layer = layers.TextVectorization(standardize=py_standardize)
+        layer.adapt(["Hello, world."])
+        # The callable must have been invoked with a string-like Python object
+        # (str / numpy str), never with a tf.EagerTensor.
+        self.assertTrue(len(seen_types) > 0)
+        for t in seen_types:
+            self.assertNotEqual(t, "EagerTensor")
+        vocab = layer.get_vocabulary()
+        self.assertIn("hello", vocab)
+        self.assertIn("world", vocab)
+        # And the layer must produce sensible output afterwards.
+        output = layer(["Hello, world."])
+        self.assertTrue(backend.is_tensor(output))
+
     def test_no_split(self):
         layer = layers.TextVectorization(
             split=None,

--- a/keras/src/layers/preprocessing/text_vectorization_test.py
+++ b/keras/src/layers/preprocessing/text_vectorization_test.py
@@ -407,34 +407,31 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
 
     def test_python_standardize_callable_non_tf_backend(self):
         # Regression test for https://github.com/keras-team/keras/issues/22626
-        # On non-TF backends, a callable standardize function should be able
-        # to use plain Python string operations rather than receiving a
-        # `tf.EagerTensor`.
+        # On non-TF backends, a callable `standardize` should receive a NumPy
+        # array of unicode strings (so users can compose `np.char` / numpy
+        # string ops) rather than a `tf.EagerTensor`.
         if backend.backend() == "tensorflow":
             self.skipTest("Test is for non-TensorFlow backends only.")
 
-        import re
-        import string
-
-        strip_chars = string.punctuation
         seen_types = []
+        seen_dtypes = []
 
-        def py_standardize(text):
+        def np_standardize(text):
             seen_types.append(type(text).__name__)
-            text = text.lower()
-            return re.sub(f"[{re.escape(strip_chars)}]", "", text)
+            seen_dtypes.append(text.dtype.kind)
+            lowered = np.char.lower(text)
+            return np.char.replace(lowered, ",", "")
 
-        layer = layers.TextVectorization(standardize=py_standardize)
+        layer = layers.TextVectorization(standardize=np_standardize)
         layer.adapt(["Hello, world."])
-        # The callable must have been invoked with a string-like Python object
-        # (str / numpy str), never with a tf.EagerTensor.
         self.assertTrue(len(seen_types) > 0)
         for t in seen_types:
-            self.assertNotEqual(t, "EagerTensor")
+            self.assertEqual(t, "ndarray")
+        for k in seen_dtypes:
+            self.assertEqual(k, "U")
         vocab = layer.get_vocabulary()
         self.assertIn("hello", vocab)
-        self.assertIn("world", vocab)
-        # And the layer must produce sensible output afterwards.
+        self.assertIn("world.", vocab)
         output = layer(["Hello, world."])
         self.assertTrue(backend.is_tensor(output))
 

--- a/keras/src/layers/preprocessing/text_vectorization_test.py
+++ b/keras/src/layers/preprocessing/text_vectorization_test.py
@@ -1,6 +1,5 @@
 import os
 
-import grain
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -39,44 +38,6 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         output = layer(input_data)
         self.assertTrue(backend.is_tensor(output))
         self.assertAllClose(output, np.array([[4, 1, 3, 0], [1, 2, 0, 0]]))
-        self.assertIn("foo", [str(v) for v in layer.get_vocabulary()])
-
-    def test_adapt_with_generator(self):
-        def text_gen():
-            yield ["hello world", "foo bar"]
-            yield ["baz qux", "hello foo"]
-
-        layer = layers.TextVectorization()
-        layer.adapt(text_gen())
-        vocab = layer.get_vocabulary()
-        self.assertIn("hello", [str(v) for v in vocab])
-        self.assertIn("foo", [str(v) for v in vocab])
-
-    def test_adapt_with_infinite_generator_and_steps(self):
-        def text_gen():
-            while True:
-                yield ["hello world", "foo bar"]
-
-        layer = layers.TextVectorization()
-        layer.adapt(text_gen(), steps=3)
-        vocab = layer.get_vocabulary()
-        self.assertIn("hello", [str(v) for v in vocab])
-
-    def test_adapt_with_grain_dataset(self):
-        texts = ["hello world", "foo bar", "baz qux", "hello foo"]
-
-        class Source(grain.sources.RandomAccessDataSource):
-            def __getitem__(self, idx):
-                return texts[idx]
-
-            def __len__(self):
-                return len(texts)
-
-        dataset = grain.MapDataset.source(Source()).batch(batch_size=2)
-        layer = layers.TextVectorization()
-        layer.adapt(dataset)
-        vocab = layer.get_vocabulary()
-        self.assertIn("hello", [str(v) for v in vocab])
 
     def test_fixed_vocabulary(self):
         max_tokens = 5000


### PR DESCRIPTION
## Description
Fixes #22626.
 
When using `TextVectorization` with a custom `standardize` callable on the JAX or torch backend, the callable was receiving a `tf.EagerTensor` instead of a Python string. Idiomatic Python like `input_string.lower()` then crashed with `AttributeError: 'EagerTensor' object has no attribute 'lower'`, contradicting the layer's documented backend-agnostic behavior outside the compiled graph.                          
                                       
This PR routes callable standardize through a new `_apply_python_standardize` helper on non-TF backends: it decodes the input to plain Python strings, invokes the callable per element, and re-packs the result so the existing TF-backed split / ngrams pipeline can take it from there. Results that  come back as a `tf.Tensor` (i.e. tf-style callables run on a  non-TF backend) are coerced back to `str` so they survive the re-pack. TF backend behavior is unchanged.         

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.


