### PR TITLE
Validate SeparableConv output shape in build()

### DIFF
--- a/keras/src/layers/convolutional/base_separable_conv.py
+++ b/keras/src/layers/convolutional/base_separable_conv.py
@@ -183,6 +183,10 @@ class BaseSeparableConv(Layer):
             self.filters,
         )
 
+        # compute_output_shape contains some validation logic for the input
+        # shape, and makes sure the output shape has all positive dimensions.
+        self.compute_output_shape(input_shape)
+
         self.depthwise_kernel = self.add_weight(
             name="depthwise_kernel",
             shape=depthwise_kernel_shape,

--- a/keras/src/layers/convolutional/separable_conv_test.py
+++ b/keras/src/layers/convolutional/separable_conv_test.py
@@ -204,6 +204,35 @@ class SeparableConvBasicTest(testing.TestCase):
                 dilation_rate=(2, 1),
             )
 
+    def test_invalid_output_shape_raises(self):
+        # Regression test for https://github.com/keras-team/keras/issues/22496
+        # SeparableConv1D used to silently produce a wrong-shaped output (and
+        # garbage values) on eager inputs when the kernel/stride combination
+        # would yield a non-positive spatial dimension. It must raise the same
+        # `ValueError` that the symbolic path raises. Pin `data_format` so the
+        # spatial dim under test is the same regardless of the backend's
+        # default `image_data_format`.
+        x = np.random.rand(4, 10, 12).astype("float32")
+        layer = layers.SeparableConv1D(
+            64, 11, strides=5, padding="valid", data_format="channels_last"
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"Computed output size would be zero or negative.",
+        ):
+            layer(x)
+
+        # Same for 2D.
+        x2 = np.random.rand(2, 4, 4, 3).astype("float32")
+        layer2 = layers.SeparableConv2D(
+            8, 5, strides=2, padding="valid", data_format="channels_last"
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"Computed output size would be zero or negative.",
+        ):
+            layer2(x2)
+
 
 class SeparableConvCorrectnessTest(testing.TestCase):
     @parameterized.parameters(


### PR DESCRIPTION


## Description
Fixes #22496.

`SeparableConv1D` (and `SeparableConv2D`) silently ran the convolution on out-of-bounds memory when the kernel/stride combination would yield a non-positive spatial dimension. The user's reproducer (`SeparableConv1D(64, 11, strides=5, padding='valid')` on input length 10) returned shape `(4, 10, 64)` filled with garbage values like `1e30`, while `Conv1D` with the same parameters raised a clear `ValueError`.      
                                                       
Root cause: `BaseSeparableConv.build()` never called `self.compute_output_shape(input_shape)`, so the validation logic in `compute_conv_output_shape` (introduced by #22092) was never reached on the eager path. `BaseConv.build()` already calls it for exactly this reason. This PR mirrors that call in `BaseSeparableConv.build()`. 

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

