### PR TITLE
Fix order of arguments in `assertAlmostEqual` and `assertAllEqual`.

### DIFF
--- a/integration_tests/torch_workflow_test.py
+++ b/integration_tests/torch_workflow_test.py
@@ -21,7 +21,7 @@ class TorchWorkflowTest(testing.TestCase):
 
         # Test using Keras layer in a nn.Module.
         # Test forward pass
-        self.assertAllEqual(list(net(torch.empty(100, 10)).shape), [100, 1])
+        self.assertEqual(net(torch.empty(100, 10)).shape, (100, 1))
         # Test KerasVariables are added as nn.Parameter.
         self.assertLen(list(net.parameters()), 2)
 

--- a/keras/src/backend/common/dtypes_test.py
+++ b/keras/src/backend/common/dtypes_test.py
@@ -139,12 +139,12 @@ class DtypesTest(test_case.TestCase):
         )
 
     def test_respect_weak_type_for_complex64(self):
-        self.assertAllEqual(
+        self.assertEqual(
             dtypes._respect_weak_type("complex64", True), "complex"
         )
 
     def test_respect_weak_type_for_complex128(self):
-        self.assertAllEqual(
+        self.assertEqual(
             dtypes._respect_weak_type("complex128", True), "complex"
         )
 

--- a/keras/src/backend/jax/core_test.py
+++ b/keras/src/backend/jax/core_test.py
@@ -47,7 +47,7 @@ class NnxVariableTest(testing.TestCase):
     def test_variable_in_nnx_module(self):
         self.assertTrue(hasattr(self.nnx_model.custom_variable, "_trace_state"))
         self.assertIsNotNone(self.nnx_model.custom_variable._trace_state)
-        self.assertAllEqual(self.nnx_model.custom_variable.value, [[1, 1, 1]])
+        self.assertAllClose(self.nnx_model.custom_variable.value, [[1, 1, 1]])
         self.assertTrue(
             isinstance(self.nnx_model.custom_variable, nnx.Variable)
         )
@@ -58,7 +58,7 @@ class NnxVariableTest(testing.TestCase):
         self.keras_nnx_model.save(path, save_format="keras_v3")
         restored_model = keras.models.load_model(path)
         restored_outputs = restored_model(self.single_dummy_input)
-        self.assertAllEqual(original_outputs, restored_outputs)
+        self.assertAllClose(restored_outputs, original_outputs)
 
     def test_keras_variable_nnx_split_merge_sync(self):
         variable1 = keras.Variable(jnp.array(1.0))

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -122,10 +122,9 @@ def top_k(x, k, sorted=True):
 def in_top_k(targets, predictions, k):
     from keras.src.backend.openvino.numpy import take_along_axis
 
+    one_constant = ov_opset.constant(1, Type.i32)
     # Expand targets: (batch,) → (batch, 1) for use with take_along_axis
-    targets = ov_opset.unsqueeze(
-        get_ov_output(targets), ov_opset.constant(1, Type.i32)
-    ).output(0)
+    targets = ov_opset.unsqueeze(get_ov_output(targets), one_constant).output(0)
     predictions = get_ov_output(predictions)
 
     # top_k returns (batch, k) sorted descending; last col is the k-th largest
@@ -136,9 +135,13 @@ def in_top_k(targets, predictions, k):
     topk_min = ov_opset.gather(
         topk_values, k_minus_1_idx, topk_values_axis
     ).output(0)
+    # Squeeze back (batch, 1) → (batch,)
+    topk_min = ov_opset.squeeze(topk_min, one_constant).output(0)
 
     # Gather the prediction score at each true class index → shape (batch, 1)
     targets_values = take_along_axis(predictions, targets, axis=-1)
+    # Squeeze back (batch, 1) → (batch,)
+    targets_values = ov_opset.squeeze(targets_values, one_constant).output(0)
     # target score >= k-th largest score means it belongs in the top-k
     mask = ov_opset.greater_equal(targets_values, topk_min).output(0)
     return OpenVINOKerasTensor(mask)

--- a/keras/src/layers/attention/attention_test.py
+++ b/keras/src/layers/attention/attention_test.py
@@ -386,8 +386,8 @@ class AttentionTest(testing.TestCase):
         key = np.random.random((2, 3, 4))
         layer = layers.Attention()
         output = layer([query, value, key])
-        self.assertAllEqual(output.shape, value.shape)
-        self.assertAllEqual(
+        self.assertEqual(output.shape, value.shape)
+        self.assertEqual(
             layer.compute_output_shape(
                 input_shape=[query.shape, value.shape, key.shape]
             ),

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -839,9 +839,9 @@ class LayerTest(testing.TestCase):
         backend.set_keras_mask(x, mask)
         y = CustomLayer(dtype="float16")(x)
         self.assertAllEqual(
-            mask,
             backend.get_keras_mask(y),
-            "Masking is not propagated by Autocast",
+            mask,
+            msg="Masking is not propagated by Autocast",
         )
 
     @pytest.mark.skipif(
@@ -1733,7 +1733,7 @@ class LayerTest(testing.TestCase):
         inputs = ops.zeros([10, 5], dtype="complex64")
         layer = MyDenseLayer(10)
         output = layer(inputs)
-        self.assertAllEqual(output.shape, (10, 10))
+        self.assertEqual(output.shape, (10, 10))
 
     def test_call_context_args_with_custom_layers(self):
         class Inner(layers.Layer):

--- a/keras/src/layers/preprocessing/hashing_test.py
+++ b/keras/src/layers/preprocessing/hashing_test.py
@@ -75,7 +75,7 @@ class HashingTest(testing.TestCase):
 
         layer = layers.Hashing(num_bins=3)
         output_data = layer(input_data)
-        self.assertAllEqual(output_data, expected_output)
+        self.assertAllClose(output_data, expected_output)
 
     def test_hash_single_bin(self):
         layer = layers.Hashing(num_bins=1)
@@ -259,12 +259,12 @@ class HashingTest(testing.TestCase):
             [1.0, 0.0, 0.0],
             [0.0, 0.0, 1.0],
         ]
-        expected_output_shape = [None, 3]
+        expected_output_shape = (None, 3)
 
         inputs = layers.Input(shape=(1,), dtype="int32")
         layer = layers.Hashing(num_bins=3, output_mode="one_hot")
         outputs = layer(inputs)
-        self.assertAllEqual(expected_output_shape, outputs.shape)
+        self.assertEqual(outputs.shape, expected_output_shape)
 
         model = models.Model(inputs, outputs)
         output_data = model(input_array)
@@ -274,12 +274,12 @@ class HashingTest(testing.TestCase):
         input_array = np.array([[0, 1, 2, 3, 4]])
 
         expected_output = [[1.0, 1.0, 1.0]]
-        expected_output_shape = [None, 3]
+        expected_output_shape = (None, 3)
 
         inputs = layers.Input(shape=(None,), dtype="int32")
         layer = layers.Hashing(num_bins=3, output_mode="multi_hot")
         outputs = layer(inputs)
-        self.assertAllEqual(expected_output_shape, outputs.shape)
+        self.assertEqual(outputs.shape, expected_output_shape)
 
         model = models.Model(inputs, outputs)
         output_data = model(input_array)
@@ -290,16 +290,18 @@ class HashingTest(testing.TestCase):
             "1d_input",
             [0, 1, 2, 3, 4],
             [2.0, 2.0, 1.0],
-            [3],
+            (3,),
         ),
         (
             "2d_input",
             [[0, 1, 2, 3, 4]],
             [[2.0, 2.0, 1.0]],
-            [None, 3],
+            (None, 3),
         ),
     )
-    def test_count_output(self, input_value, expected_output, output_shape):
+    def test_count_output(
+        self, input_value, expected_output, expected_output_shape
+    ):
         input_array = np.array(input_value)
         if input_array.ndim == 1:
             symbolic_sample_shape = ()
@@ -310,9 +312,9 @@ class HashingTest(testing.TestCase):
         inputs = layers.Input(shape=symbolic_sample_shape, dtype="int32")
         layer = layers.Hashing(num_bins=3, output_mode="count")
         outputs = layer(inputs)
-        self.assertAllEqual(output_shape, outputs.shape)
+        self.assertEqual(outputs.shape, expected_output_shape)
         output_data = layer(input_array)
-        self.assertAllEqual(expected_output, output_data)
+        self.assertAllClose(output_data, expected_output)
 
     @parameterized.named_parameters(
         ("int32", "int32"),
@@ -390,9 +392,7 @@ class HashingTest(testing.TestCase):
     def test_hash_list_input(self, input_data, expected):
         layer = layers.Hashing(num_bins=2)
         out_data = layer(input_data)
-        self.assertAllEqual(
-            expected, backend.convert_to_numpy(out_data).tolist()
-        )
+        self.assertAllClose(out_data, expected)
 
     def test_hashing_invalid_num_bins(self):
         # Test with `num_bins` set to None
@@ -445,7 +445,7 @@ class HashingTest(testing.TestCase):
 #     out_data = layer(inp_data)
 #     # Same hashed output as test_hash_sparse_input_farmhash
 #     expected_output = [[0, 0, 1, 0], [1, 0, 0]]
-#     self.assertAllEqual(expected_output, out_data)
+#     self.assertAllClose(expected_output, out_data)
 
 #     inp_t = layers.Input(shape=(None,), ragged=True, dtype="string")
 #     out_t = layer(inp_t)
@@ -482,8 +482,8 @@ class HashingTest(testing.TestCase):
 #     out_data = layer(inp_data)
 #     # Same hashed output as test_hash_sparse_input_farmhash
 #     expected_output = [[1, 0, 0, 2], [1, 0, 1]]
-#     self.assertAllEqual(expected_output[0], out_data[0])
-#     self.assertAllEqual(expected_output[1], out_data[1])
+#     self.assertAllClose(expected_output[0], out_data[0])
+#     self.assertAllClose(expected_output[1], out_data[1])
 #     inp_t = layers.Input(shape=(None,), ragged=True, dtype="int64")
 #     out_t = layer(inp_t)
 #     model = models.Model(inputs=inp_t, outputs=out_t)
@@ -502,7 +502,7 @@ class HashingTest(testing.TestCase):
 #     out_data = layer(inp_data)
 #     # Same hashed output as test_hash_dense_input_siphash
 #     expected_output = [[0, 1, 0, 1], [0, 0, 1]]
-#     self.assertAllEqual(expected_output, out_data)
+#     self.assertAllClose(expected_output, out_data)
 
 #     inp_t = layers.Input(shape=(None,), ragged=True, dtype="string")
 #     out_t = layer(inp_t)
@@ -512,7 +512,7 @@ class HashingTest(testing.TestCase):
 #     layer_2 = layers.Hashing(num_bins=2, salt=[211, 137])
 #     out_data = layer_2(inp_data)
 #     expected_output = [[1, 0, 1, 0], [1, 1, 0]]
-#     self.assertAllEqual(expected_output, out_data)
+#     self.assertAllClose(expected_output, out_data)
 
 #     out_t = layer_2(inp_t)
 #     model = models.Model(inputs=inp_t, outputs=out_t)
@@ -525,7 +525,7 @@ class HashingTest(testing.TestCase):
 #     out_data = layer(inp_data)
 #     # Same hashed output as test_hash_sparse_input_farmhash
 #     expected_output = [[1, 1, 0, 1], [2, 1, 1]]
-#     self.assertAllEqual(expected_output, out_data)
+#     self.assertAllClose(expected_output, out_data)
 
 #     inp_t = layers.Input(shape=(None,), ragged=True, dtype="int64")
 #     out_t = layer(inp_t)

--- a/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/converters_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/converters_test.py
@@ -126,7 +126,8 @@ class ConvertersTest(testing.TestCase):
             boxes, bounding_box_format="rel_xyxy"
         )
 
-        self.assertAllEqual(clipped_boxes, expected_clipped)
+        for key in expected_clipped:
+            self.assertAllClose(clipped_boxes[key], expected_clipped[key])
 
     def test_affine_identity(self):
         # Test identity transform (no change)

--- a/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/validation_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/validation_test.py
@@ -46,7 +46,7 @@ class DensifyBoundingBoxesTest(test_case.TestCase):
             [2, -1, -1],
         ]
         self.assertAllClose(densified_boxes, expected_boxes)
-        self.assertAllEqual(densified_labels, expected_labels)
+        self.assertAllClose(densified_labels, expected_labels)
 
     def test_densify_ragged_bounding_boxes_unbatched(self):
         ragged_boxes = tf.ragged.constant(
@@ -72,4 +72,4 @@ class DensifyBoundingBoxesTest(test_case.TestCase):
         ]
         expected_labels = [[0], [1], [-1], [-1]]
         self.assertAllClose(densified_boxes, expected_boxes)
-        self.assertAllEqual(densified_labels, expected_labels)
+        self.assertAllClose(densified_labels, expected_labels)

--- a/keras/src/layers/preprocessing/image_preprocessing/max_num_bounding_box_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/max_num_bounding_box_test.py
@@ -45,8 +45,8 @@ class MaxNumBoundingBoxesTest(testing.TestCase):
 
         input_data = {"images": input_image, "bounding_boxes": bounding_boxes}
         output = layer(input_data)
-        self.assertAllEqual(output["bounding_boxes"]["boxes"].shape, (40, 4))
-        self.assertAllEqual(output["bounding_boxes"]["labels"].shape, (40,))
+        self.assertEqual(output["bounding_boxes"]["boxes"].shape, (40, 4))
+        self.assertEqual(output["bounding_boxes"]["labels"].shape, (40,))
 
     def test_output_shapes_with_tf_data(self):
         if backend.config.image_data_format() == "channels_last":
@@ -73,5 +73,5 @@ class MaxNumBoundingBoxesTest(testing.TestCase):
         ds = ds.map(layer)
         ds = ds.batch(1)
         output = next(iter(ds))
-        self.assertAllEqual(output["bounding_boxes"]["boxes"].shape, (1, 40, 4))
-        self.assertAllEqual(output["bounding_boxes"]["labels"].shape, (1, 40))
+        self.assertEqual(output["bounding_boxes"]["boxes"].shape, (1, 40, 4))
+        self.assertEqual(output["bounding_boxes"]["labels"].shape, (1, 40))

--- a/keras/src/layers/preprocessing/text_vectorization_test.py
+++ b/keras/src/layers/preprocessing/text_vectorization_test.py
@@ -315,7 +315,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         # test output sequence length, taking first batch.
         self.assertEqual(len(output[0]), 8)
 
-        self.assertAllEqual(output, [[2, 3, 4, 5, 1, 1, 6, 7]])
+        self.assertAllClose(output, [[2, 3, 4, 5, 1, 1, 6, 7]])
 
     def test_lower_standardization(self):
         layer = layers.TextVectorization(
@@ -345,7 +345,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         7: 'nice',
         8: 'test'}
         """
-        self.assertAllEqual(output, [[2, 1, 5, 6, 1, 1, 7, 1]])
+        self.assertAllClose(output, [[2, 1, 5, 6, 1, 1, 7, 1]])
 
     def test_char_splitting(self):
         layer = layers.TextVectorization(
@@ -354,7 +354,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         output = layer(["abcf"])
         self.assertTrue(backend.is_tensor(output))
         self.assertEqual(len(output[0]), 4)
-        self.assertAllEqual(output, [[2, 3, 4, 1]])
+        self.assertAllClose(output, [[2, 3, 4, 1]])
 
     def test_custom_splitting(self):
         def custom_split(text):
@@ -370,7 +370,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
 
         # after custom split, the outputted index should be the last
         # token in the vocab.
-        self.assertAllEqual(output, [[4]])
+        self.assertAllClose(output, [[4]])
 
     def test_strip_punctuation_standardization(self):
         layer = layers.TextVectorization(
@@ -380,7 +380,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         output = layer(["Hello, World! Test."])
         self.assertTrue(backend.is_tensor(output))
         # Case is preserved, punctuation stripped
-        self.assertAllEqual(output, [[2, 3, 4]])
+        self.assertAllClose(output, [[2, 3, 4]])
 
     def test_no_standardization(self):
         layer = layers.TextVectorization(
@@ -390,7 +390,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         # "Hello" matches, "hello" does not (case-sensitive)
         output = layer(["Hello hello"])
         self.assertTrue(backend.is_tensor(output))
-        self.assertAllEqual(output, [[2, 1]])
+        self.assertAllClose(output, [[2, 1]])
 
     def test_custom_standardize_callable(self):
         def custom_standardize(text):
@@ -403,7 +403,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         )
         output = layer(["foo-bar"])
         self.assertTrue(backend.is_tensor(output))
-        self.assertAllEqual(output, [[2, 3]])
+        self.assertAllClose(output, [[2, 3]])
 
     def test_no_split(self):
         layer = layers.TextVectorization(
@@ -414,7 +414,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         # Each element is looked up as a whole string (no splitting)
         output = layer([["foo"], ["bar"], ["unknown"]])
         self.assertTrue(backend.is_tensor(output))
-        self.assertAllEqual(output, [[2], [3], [1]])
+        self.assertAllClose(output, [[2], [3], [1]])
 
     def test_ngrams_integer(self):
         layer = layers.TextVectorization(

--- a/keras/src/legacy/saving/json_utils_test.py
+++ b/keras/src/legacy/saving/json_utils_test.py
@@ -16,9 +16,7 @@ class JsonUtilsTestAllBackends(testing.TestCase):
         string = json_utils.Encoder().encode(metadata)
         loaded = json_utils.decode(string)
 
-        self.assertEqual(set(loaded.keys()), {"key1", "key2"})
-        self.assertAllEqual(loaded["key1"], (3, 5))
-        self.assertAllEqual(loaded["key2"], [(1, (3, 4)), (1,)])
+        self.assertEqual(loaded, metadata)
 
     def test_encode_decode_enum(self):
         class Enum(enum.Enum):
@@ -28,13 +26,13 @@ class JsonUtilsTestAllBackends(testing.TestCase):
         config = {"key": Enum.CLASS_A, "key2": Enum.CLASS_B}
         string = json_utils.Encoder().encode(config)
         loaded = json_utils.decode(string)
-        self.assertAllEqual({"key": "a", "key2": "b"}, loaded)
+        self.assertEqual(loaded, {"key": "a", "key2": "b"})
 
     def test_encode_decode_bytes(self):
         b_string = b"abc"
         json_string = json_utils.Encoder().encode(b_string)
         loaded = json_utils.decode(json_string)
-        self.assertAllEqual(b_string, loaded)
+        self.assertEqual(loaded, b_string)
 
 
 @pytest.mark.skipif(
@@ -50,10 +48,7 @@ class JsonUtilsTestTF(testing.TestCase):
         string = json_utils.Encoder().encode(metadata)
         loaded = json_utils.decode(string)
 
-        self.assertEqual(set(loaded.keys()), {"key1", "key2"})
-        self.assertEqual(loaded["key1"].rank, None)
-        self.assertAllEqual(loaded["key2"][0].as_list(), [None])
-        self.assertAllEqual(loaded["key2"][1].as_list(), [3, None, 5])
+        self.assertEqual(loaded, metadata)
 
     def test_encode_decode_type_spec(self):
         spec = tf.TensorSpec((1, 5), tf.float32)

--- a/keras/src/metrics/confusion_metrics_test.py
+++ b/keras/src/metrics/confusion_metrics_test.py
@@ -402,7 +402,7 @@ class PrecisionTest(testing.TestCase):
         y_pred = np.array([1, 0, 1, 0])
         y_true = np.array([0, 1, 1, 0])
         result = p_obj(y_true, y_pred)
-        self.assertAlmostEqual(0.5, result)
+        self.assertAlmostEqual(result, 0.5)
 
     def test_unweighted_all_incorrect(self):
         p_obj = metrics.Precision(thresholds=[0.5])
@@ -410,7 +410,7 @@ class PrecisionTest(testing.TestCase):
         y_pred = np.array(inputs)
         y_true = np.array(1 - inputs)
         result = p_obj(y_true, y_pred)
-        self.assertAlmostEqual(0, result)
+        self.assertAlmostEqual(result, 0)
 
     def test_weighted(self):
         p_obj = metrics.Precision()
@@ -424,7 +424,7 @@ class PrecisionTest(testing.TestCase):
         weighted_tp = 3.0 + 4.0
         weighted_positives = (1.0 + 3.0) + (4.0 + 2.0)
         expected_precision = weighted_tp / weighted_positives
-        self.assertAlmostEqual(expected_precision, result)
+        self.assertAlmostEqual(result, expected_precision)
 
     def test_div_by_zero(self):
         p_obj = metrics.Precision()
@@ -438,7 +438,7 @@ class PrecisionTest(testing.TestCase):
         y_pred = np.array([1, 0, 0.6, 0])
         y_true = np.array([0, 1, 1, 0])
         result = p_obj(y_true, y_pred)
-        self.assertAlmostEqual([0.5, 0.0], result, 0)
+        self.assertAlmostEqual(result, [0.5, 0.0], 0)
 
     def test_weighted_with_threshold(self):
         p_obj = metrics.Precision(thresholds=[0.5, 1.0])
@@ -449,7 +449,7 @@ class PrecisionTest(testing.TestCase):
         weighted_tp = 0 + 3.0
         weighted_positives = (0 + 3.0) + (4.0 + 0.0)
         expected_precision = weighted_tp / weighted_positives
-        self.assertAlmostEqual([expected_precision, 0], result, 1e-3)
+        self.assertAlmostEqual(result, [expected_precision, 0])
 
     def test_multiple_updates(self):
         p_obj = metrics.Precision(thresholds=[0.5, 1.0])
@@ -464,14 +464,14 @@ class PrecisionTest(testing.TestCase):
             (0 + 3.0) + (4.0 + 0.0)
         )
         expected_precision = weighted_tp / weighted_positives
-        self.assertAlmostEqual([expected_precision, 0], p_obj.result(), 1e-3)
+        self.assertAlmostEqual(p_obj.result(), [expected_precision, 0])
 
     def test_unweighted_top_k(self):
         p_obj = metrics.Precision(top_k=3)
         y_pred = np.array([0.2, 0.1, 0.5, 0, 0.2])
         y_true = np.array([0, 1, 1, 0, 0])
         result = p_obj(y_true, y_pred)
-        self.assertAlmostEqual(1.0 / 3, result)
+        self.assertAlmostEqual(result, 1.0 / 3)
 
     def test_weighted_top_k(self):
         p_obj = metrics.Precision(top_k=3)
@@ -486,7 +486,7 @@ class PrecisionTest(testing.TestCase):
         tp = (2 + 5) + (3 + 3)
         predicted_positives = (1 + 2 + 5) + (3 + 3 + 3)
         expected_precision = tp / predicted_positives
-        self.assertAlmostEqual(expected_precision, result)
+        self.assertAlmostEqual(result, expected_precision)
 
     def test_unweighted_class_id_should_throw_error_1d(self):
         p_obj = metrics.Precision(class_id=2)
@@ -525,9 +525,9 @@ class PrecisionTest(testing.TestCase):
         )
 
         result = p_obj(y_true, y_pred)
-        self.assertAlmostEqual(1.0, result)
-        self.assertAlmostEqual(1.0, p_obj.true_positives)
-        self.assertAlmostEqual(0.0, p_obj.false_positives)
+        self.assertAlmostEqual(result, 1.0)
+        self.assertAlmostEqual(p_obj.true_positives, 1.0)
+        self.assertAlmostEqual(p_obj.false_positives, 0.0)
 
     def test_unweighted_top_k_and_threshold(self):
         p_obj = metrics.Precision(thresholds=0.7, top_k=2)
@@ -535,9 +535,9 @@ class PrecisionTest(testing.TestCase):
         y_pred = np.array([0.2, 0.8, 0.6, 0, 0.2])
         y_true = np.array([0, 1, 1, 0, 1])
         result = p_obj(y_true, y_pred)
-        self.assertAlmostEqual(1, result)
-        self.assertAlmostEqual(1, p_obj.true_positives)
-        self.assertAlmostEqual(0, p_obj.false_positives)
+        self.assertAlmostEqual(result, 1)
+        self.assertAlmostEqual(p_obj.true_positives, 1)
+        self.assertAlmostEqual(p_obj.false_positives, 0)
 
 
 class RecallTest(testing.TestCase):
@@ -567,14 +567,14 @@ class RecallTest(testing.TestCase):
         r_obj = metrics.Recall()
         y_pred = np.array([1, 0, 1, 0])
         y_true = np.array([0, 1, 1, 0])
-        self.assertAlmostEqual(0.5, r_obj(y_true, y_pred))
+        self.assertAlmostEqual(r_obj(y_true, y_pred), 0.5)
 
     def test_unweighted_all_incorrect(self):
         r_obj = metrics.Recall(thresholds=[0.5])
         inputs = np.random.randint(0, 2, size=(100, 1))
         y_pred = np.array(inputs)
         y_true = np.array(1 - inputs)
-        self.assertAlmostEqual(0, r_obj(y_true, y_pred))
+        self.assertAlmostEqual(r_obj(y_true, y_pred), 0)
 
     def test_weighted(self):
         r_obj = metrics.Recall()
@@ -588,7 +588,7 @@ class RecallTest(testing.TestCase):
         weighted_tp = 3.0 + 1.0
         weighted_t = (2.0 + 3.0) + (4.0 + 1.0)
         expected_recall = weighted_tp / weighted_t
-        self.assertAlmostEqual(expected_recall, result)
+        self.assertAlmostEqual(result, expected_recall)
 
     def test_div_by_zero(self):
         r_obj = metrics.Recall()
@@ -632,7 +632,7 @@ class RecallTest(testing.TestCase):
         r_obj = metrics.Recall(top_k=3)
         y_pred = np.array([0.2, 0.1, 0.5, 0, 0.2])
         y_true = np.array([0, 1, 1, 0, 0])
-        self.assertAlmostEqual(0.5, r_obj(y_true, y_pred))
+        self.assertAlmostEqual(r_obj(y_true, y_pred), 0.5)
 
     def test_weighted_top_k(self):
         r_obj = metrics.Recall(top_k=3)
@@ -647,7 +647,7 @@ class RecallTest(testing.TestCase):
         tp = (2 + 5) + (3 + 3)
         positives = (4 + 2 + 5) + (3 + 3 + 3 + 3)
         expected_recall = tp / positives
-        self.assertAlmostEqual(expected_recall, result)
+        self.assertAlmostEqual(result, expected_recall)
 
     def test_unweighted_class_id_should_throw_error_1d(self):
         r_obj = metrics.Recall(class_id=2)
@@ -686,18 +686,18 @@ class RecallTest(testing.TestCase):
         )
 
         result = r_obj(y_true, y_pred)
-        self.assertAlmostEqual(1.0, result)
-        self.assertAlmostEqual(1.0, r_obj.true_positives)
-        self.assertAlmostEqual(0.0, r_obj.false_negatives)
+        self.assertAlmostEqual(result, 1.0)
+        self.assertAlmostEqual(r_obj.true_positives, 1.0)
+        self.assertAlmostEqual(r_obj.false_negatives, 0.0)
 
     def test_unweighted_top_k_and_threshold(self):
         r_obj = metrics.Recall(thresholds=0.7, top_k=2)
 
         y_pred = np.array([0.2, 0.8, 0.6, 0, 0.2])
         y_true = np.array([1, 1, 1, 0, 1])
-        self.assertAlmostEqual(0.25, r_obj(y_true, y_pred))
-        self.assertAlmostEqual(1, r_obj.true_positives)
-        self.assertAlmostEqual(3, r_obj.false_negatives)
+        self.assertAlmostEqual(r_obj(y_true, y_pred), 0.25)
+        self.assertAlmostEqual(r_obj.true_positives, 1)
+        self.assertAlmostEqual(r_obj.false_negatives, 3)
 
 
 class SensitivityAtSpecificityTest(testing.TestCase):
@@ -729,7 +729,7 @@ class SensitivityAtSpecificityTest(testing.TestCase):
         inputs = np.random.randint(0, 2, size=(100, 1))
         y_pred = np.array(inputs, dtype="float32")
         y_true = np.array(inputs)
-        self.assertAlmostEqual(1, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 1)
 
     def test_unweighted_high_specificity(self):
         s_obj = metrics.SensitivityAtSpecificity(0.8)
@@ -739,7 +739,7 @@ class SensitivityAtSpecificityTest(testing.TestCase):
         y_pred = np.array(pred_values, dtype="float32")
         y_true = np.array(label_values)
 
-        self.assertAlmostEqual(0.8, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 0.8)
 
     def test_unweighted_low_specificity(self):
         s_obj = metrics.SensitivityAtSpecificity(0.4)
@@ -749,7 +749,7 @@ class SensitivityAtSpecificityTest(testing.TestCase):
         y_pred = np.array(pred_values, dtype="float32")
         y_true = np.array(label_values)
 
-        self.assertAlmostEqual(0.6, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 0.6)
 
     def test_unweighted_class_id(self):
         s_obj = metrics.SpecificityAtSensitivity(0.4, class_id=2)
@@ -759,7 +759,7 @@ class SensitivityAtSpecificityTest(testing.TestCase):
         y_pred = ops.transpose(np.array([pred_values] * 3))
         y_true = ops.one_hot(np.array(label_values), num_classes=3)
 
-        self.assertAlmostEqual(0.6, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 0.6)
 
     @parameterized.parameters(["bool", "int32", "float32"])
     def test_weighted(self, label_dtype):
@@ -773,7 +773,7 @@ class SensitivityAtSpecificityTest(testing.TestCase):
         weights = np.array(weight_values)
 
         result = s_obj(y_true, y_pred, sample_weight=weights)
-        self.assertAlmostEqual(0.675, result)
+        self.assertAlmostEqual(result, 0.675)
 
     def test_invalid_specificity(self):
         with self.assertRaisesRegex(
@@ -832,7 +832,7 @@ class SpecificityAtSensitivityTest(testing.TestCase):
         y_pred = np.array(inputs, dtype="float32")
         y_true = np.array(inputs)
 
-        self.assertAlmostEqual(1, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 1)
 
     def test_unweighted_high_sensitivity(self):
         s_obj = metrics.SpecificityAtSensitivity(1.0)
@@ -842,7 +842,7 @@ class SpecificityAtSensitivityTest(testing.TestCase):
         y_pred = np.array(pred_values, dtype="float32")
         y_true = np.array(label_values)
 
-        self.assertAlmostEqual(0.2, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 0.2)
 
     def test_unweighted_low_sensitivity(self):
         s_obj = metrics.SpecificityAtSensitivity(0.4)
@@ -852,7 +852,7 @@ class SpecificityAtSensitivityTest(testing.TestCase):
         y_pred = np.array(pred_values, dtype="float32")
         y_true = np.array(label_values)
 
-        self.assertAlmostEqual(0.6, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 0.6)
 
     def test_unweighted_class_id(self):
         s_obj = metrics.SpecificityAtSensitivity(0.4, class_id=2)
@@ -862,7 +862,7 @@ class SpecificityAtSensitivityTest(testing.TestCase):
         y_pred = ops.transpose(np.array([pred_values] * 3))
         y_true = ops.one_hot(np.array(label_values), num_classes=3)
 
-        self.assertAlmostEqual(0.6, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 0.6)
 
     @parameterized.parameters(["bool", "int32", "float32"])
     def test_weighted(self, label_dtype):
@@ -876,7 +876,7 @@ class SpecificityAtSensitivityTest(testing.TestCase):
         weights = np.array(weight_values)
 
         result = s_obj(y_true, y_pred, sample_weight=weights)
-        self.assertAlmostEqual(0.4, result)
+        self.assertAlmostEqual(result, 0.4)
 
     def test_invalid_sensitivity(self):
         with self.assertRaisesRegex(
@@ -916,7 +916,7 @@ class PrecisionAtRecallTest(testing.TestCase):
         y_pred = np.array(inputs, dtype="float32")
         y_true = np.array(inputs)
 
-        self.assertAlmostEqual(1, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 1)
 
     def test_unweighted_high_recall(self):
         s_obj = metrics.PrecisionAtRecall(0.8)
@@ -927,7 +927,7 @@ class PrecisionAtRecallTest(testing.TestCase):
         y_true = np.array(label_values)
 
         # For 0.5 < decision threshold < 0.6.
-        self.assertAlmostEqual(2.0 / 3, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 2.0 / 3)
 
     def test_unweighted_low_recall(self):
         s_obj = metrics.PrecisionAtRecall(0.6)
@@ -938,7 +938,7 @@ class PrecisionAtRecallTest(testing.TestCase):
         y_true = np.array(label_values)
 
         # For 0.2 < decision threshold < 0.5.
-        self.assertAlmostEqual(0.75, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 0.75)
 
     def test_unweighted_class_id(self):
         s_obj = metrics.PrecisionAtRecall(0.6, class_id=2)
@@ -949,7 +949,7 @@ class PrecisionAtRecallTest(testing.TestCase):
         y_true = ops.one_hot(np.array(label_values), num_classes=3)
 
         # For 0.2 < decision threshold < 0.5.
-        self.assertAlmostEqual(0.75, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 0.75)
 
     @parameterized.parameters(["bool", "int32", "float32"])
     def test_weighted(self, label_dtype):
@@ -964,7 +964,7 @@ class PrecisionAtRecallTest(testing.TestCase):
 
         result = s_obj(y_true, y_pred, sample_weight=weights)
         # For 0.0 < decision threshold < 0.2.
-        self.assertAlmostEqual(0.7, result)
+        self.assertAlmostEqual(result, 0.7)
 
     def test_invalid_sensitivity(self):
         with self.assertRaisesRegex(
@@ -1004,7 +1004,7 @@ class RecallAtPrecisionTest(testing.TestCase):
         y_pred = np.array(inputs, dtype="float32")
         y_true = np.array(inputs)
 
-        self.assertAlmostEqual(1, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 1)
 
     def test_unweighted_high_precision(self):
         s_obj = metrics.RecallAtPrecision(0.75)
@@ -1031,7 +1031,7 @@ class RecallAtPrecisionTest(testing.TestCase):
         y_true = np.array(label_values)
 
         # The precision 0.75 can be reached at thresholds 0.4<=t<0.45.
-        self.assertAlmostEqual(0.5, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 0.5)
 
     def test_unweighted_low_precision(self):
         s_obj = metrics.RecallAtPrecision(2.0 / 3)
@@ -1058,7 +1058,7 @@ class RecallAtPrecisionTest(testing.TestCase):
         y_true = np.array(label_values)
 
         # The precision 5/7 can be reached at thresholds 00.3<=t<0.35.
-        self.assertAlmostEqual(5.0 / 6, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 5.0 / 6)
 
     def test_unweighted_class_id(self):
         s_obj = metrics.RecallAtPrecision(2.0 / 3, class_id=2)
@@ -1085,7 +1085,7 @@ class RecallAtPrecisionTest(testing.TestCase):
         y_true = ops.one_hot(np.array(label_values), num_classes=3)
 
         # The precision 5/7 can be reached at thresholds 00.3<=t<0.35.
-        self.assertAlmostEqual(5.0 / 6, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 5.0 / 6)
 
     @parameterized.parameters(["bool", "int32", "float32"])
     def test_weighted(self, label_dtype):
@@ -1098,7 +1098,7 @@ class RecallAtPrecisionTest(testing.TestCase):
         weights = np.array(weight_values)
 
         result = s_obj(y_true, y_pred, sample_weight=weights)
-        self.assertAlmostEqual(0.6, result)
+        self.assertAlmostEqual(result, 0.6)
 
     def test_unachievable_precision(self):
         s_obj = metrics.RecallAtPrecision(2.0 / 3)
@@ -1109,7 +1109,7 @@ class RecallAtPrecisionTest(testing.TestCase):
 
         # The highest possible precision is 1/2 which is below the required
         # value, expect 0 recall.
-        self.assertAlmostEqual(0, s_obj(y_true, y_pred))
+        self.assertAlmostEqual(s_obj(y_true, y_pred), 0)
 
     def test_invalid_sensitivity(self):
         with self.assertRaisesRegex(

--- a/keras/src/metrics/reduction_metrics_test.py
+++ b/keras/src/metrics/reduction_metrics_test.py
@@ -96,7 +96,7 @@ class MeanTest(testing.TestCase):
         result = backend.compute_output_spec(
             mean_obj, KerasTensor((None, 2)), KerasTensor((None, 2))
         )
-        self.assertAllEqual(result.shape, ())
+        self.assertEqual(result.shape, ())
 
 
 # How users would register a custom function or class to use with
@@ -176,7 +176,7 @@ class MetricWrapperTest(testing.TestCase):
             KerasTensor((None, 5)),
             KerasTensor((None, 5)),
         )
-        self.assertAllEqual(result.shape, ())
+        self.assertEqual(result.shape, ())
 
     def test_binary_accuracy_with_boolean_inputs(self):
         inp = layers.Input(shape=(1,))

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -480,21 +480,21 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         # Test prefix sum
         arr = np.arange(5)
         result = core.associative_scan(f=operator.add, elems=arr)
-        self.assertAllEqual(result, [0, 1, 3, 6, 10])
+        self.assertAllClose(result, [0, 1, 3, 6, 10])
         # Test reverse
         result = core.associative_scan(f=operator.add, elems=arr, reverse=True)
-        self.assertAllEqual(result, [10, 10, 9, 7, 4])
+        self.assertAllClose(result, [10, 10, 9, 7, 4])
 
         # Test multiple dimensions, across different axes
         batched_arr = np.stack([arr, arr + 1, arr + 2])
         result = core.associative_scan(
             f=operator.add, elems=batched_arr, axis=1
         )
-        self.assertAllEqual(result[2], [2, 5, 9, 14, 20])
+        self.assertAllClose(result[2], [2, 5, 9, 14, 20])
         result = core.associative_scan(
             f=operator.add, elems=batched_arr, axis=0
         )
-        self.assertAllEqual(result[:, 0], [0, 1, 3])
+        self.assertAllClose(result[:, 0], [0, 1, 3])
 
         # Test structured input
         elems = {
@@ -506,7 +506,7 @@ class CoreOpsCorrectnessTest(testing.TestCase):
             return {"a": x["a"] + y["b"], "b": x["b"] + y["b"]}
 
         ax0 = core.associative_scan(f=_dict_add, elems=elems, axis=0)
-        self.assertAllEqual(
+        self.assertAllClose(
             ax0["b"],
             [[6, 7, 8], [15, 17, 19]],
         )
@@ -605,19 +605,19 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         x = np.ones((2,))
         x = ops.convert_to_tensor(x)
         x = ops.convert_to_numpy(x)
-        self.assertAllEqual(x, (1, 1))
+        self.assertAllClose(x, (1, 1))
         self.assertIsInstance(x, np.ndarray)
 
         # Empty lists should give an empty array.
         x = ops.convert_to_tensor([])
         np_x = ops.convert_to_numpy(x)
         self.assertTrue(ops.is_tensor(x))
-        self.assertAllEqual(x, [])
+        self.assertAllClose(x, [])
         self.assertIsInstance(np_x, np.ndarray)
 
         # Partially converted.
         x = ops.convert_to_tensor((1, ops.array(2), 3))
-        self.assertAllEqual(x, (1, 2, 3))
+        self.assertAllClose(x, (1, 2, 3))
 
     @pytest.mark.skipif(
         not backend.SUPPORTS_SPARSE_TENSORS,
@@ -1219,11 +1219,11 @@ class CoreOpsCorrectnessTest(testing.TestCase):
     def test_shape(self):
         x = ops.ones((2, 3, 7, 1))
         self.assertEqual(core.shape(x).__class__, tuple)
-        self.assertAllEqual(core.shape(x), (2, 3, 7, 1))
+        self.assertEqual(core.shape(x), (2, 3, 7, 1))
 
         x = KerasTensor((None, 3, None, 1))
         self.assertEqual(core.shape(x).__class__, tuple)
-        self.assertAllEqual(core.shape(x), (None, 3, None, 1))
+        self.assertEqual(core.shape(x), (None, 3, None, 1))
 
     @pytest.mark.skipif(
         not backend.SUPPORTS_SPARSE_TENSORS,
@@ -1241,7 +1241,7 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         else:
             self.fail(f"Sparse is unsupported with backend {backend.backend()}")
 
-        self.assertAllEqual(core.shape(x), (2, 3))
+        self.assertEqual(core.shape(x), (2, 3))
 
     @pytest.mark.skipif(
         not backend.SUPPORTS_SPARSE_TENSORS,
@@ -1251,10 +1251,10 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         import tensorflow as tf
 
         x = tf.ragged.constant([[3, 1, 4, 1], [], [5, 9, 2], [6], []])
-        self.assertAllEqual(core.shape(x), (5, None))
+        self.assertEqual(core.shape(x), (5, None))
 
         x = tf.RaggedTensor.from_row_lengths(tf.zeros([15, 2]), [4, 5, 6])
-        self.assertAllEqual(core.shape(x), (3, None, 2))
+        self.assertEqual(core.shape(x), (3, None, 2))
 
     def test_slice(self):
         # Test 1D.

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1148,7 +1148,7 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor((2, 3))
         y = KerasTensor((2, 3))
         self.assertEqual(knp.where(condition, x, y).shape, (2, 3))
-        self.assertAllEqual(knp.where(condition).shape, (2, 3))
+        self.assertEqual(knp.where(condition).shape, (2, 3))
 
     def test_floor_divide(self):
         x = KerasTensor((2, 3))

--- a/keras/src/quantizers/quantization_config_test.py
+++ b/keras/src/quantizers/quantization_config_test.py
@@ -180,7 +180,7 @@ class QuantizationConfigTest(testing.TestCase):
         Test custom quantizer serialization for model save and load.
         """
         # Setup
-        weight_range = (-100, 100)
+        weight_range = [-100, 100]
         custom_quantizer = AbsMaxQuantizer(axis=0, value_range=weight_range)
         config = Int8QuantizationConfig(
             weight_quantizer=custom_quantizer,

--- a/keras/src/random/random_test.py
+++ b/keras/src/random/random_test.py
@@ -302,7 +302,7 @@ class RandomCorrectnessTest(testing.TestCase):
             )
         else:
             actual_mean = np.mean(values_np.flatten())
-            self.assertAlmostEqual(expected_mean, actual_mean, decimal=2)
+            self.assertAlmostEqual(actual_mean, expected_mean, decimal=2)
 
         # Variance check:
         # For a beta distributed random variable,
@@ -321,7 +321,7 @@ class RandomCorrectnessTest(testing.TestCase):
         else:
             actual_variance = np.var(values_np.flatten())
             self.assertAlmostEqual(
-                expected_variance, actual_variance, decimal=2
+                actual_variance, expected_variance, decimal=2
             )
 
 

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -55,6 +55,11 @@ class TestCase(parameterized.TestCase):
         tpu_rtol=None,
         msg=None,
     ):
+        """Assert that two arrays are equal up to given tolerances.
+
+        Given two array-like objects, check that their shapes and all elements
+        are equal up to given tolerances.
+        """
         if tpu_atol is not None and uses_tpu():
             atol = tpu_atol
         if tpu_rtol is not None and uses_tpu():
@@ -62,12 +67,12 @@ class TestCase(parameterized.TestCase):
         actual = self.convert_to_numpy(actual)
         desired = self.convert_to_numpy(desired)
         np.testing.assert_allclose(
-            actual, desired, atol=atol, rtol=rtol, err_msg=msg
+            actual, desired, atol=atol, rtol=rtol, err_msg=msg or ""
         )
 
     def assertNotAllClose(self, x1, x2, atol=1e-6, rtol=1e-6, msg=None):
         try:
-            self.assertAllClose(x1, x2, atol=atol, rtol=rtol, msg=msg)
+            self.assertAllClose(x1, x2, atol=atol, rtol=rtol)
         except AssertionError:
             return
         msg = msg or ""
@@ -75,23 +80,32 @@ class TestCase(parameterized.TestCase):
             f"The two values are close at all elements. \n{msg}.\nValues: {x1}"
         )
 
-    def assertAlmostEqual(self, x1, x2, decimal=3, tpu_decimal=None, msg=None):
+    def assertAlmostEqual(
+        self, actual, desired, decimal=3, tpu_decimal=None, msg=None
+    ):
+        """Assert that two arrays are equal up to given decimal places.
+
+        Given two array-like objects, check that their shapes and all elements
+        are equal up to given decimal places.
+        """
         if tpu_decimal is not None and uses_tpu():
             decimal = tpu_decimal
         msg = msg or ""
-        x1 = self.convert_to_numpy(x1)
-        x2 = self.convert_to_numpy(x2)
-        np.testing.assert_almost_equal(x1, x2, decimal=decimal, err_msg=msg)
+        actual = self.convert_to_numpy(actual)
+        desired = self.convert_to_numpy(desired)
+        np.testing.assert_almost_equal(
+            actual, desired, decimal=decimal, err_msg=msg or ""
+        )
 
-    def assertAllEqual(self, x1, x2, msg=None):
-        self.assertEqual(len(x1), len(x2), msg=msg)
-        for e1, e2 in zip(x1, x2):
-            if isinstance(e1, (list, tuple)) or isinstance(e2, (list, tuple)):
-                self.assertAllEqual(e1, e2, msg=msg)
-            else:
-                e1 = self.convert_to_numpy(e1)
-                e2 = self.convert_to_numpy(e2)
-                np.testing.assert_array_equal(e1, e2, err_msg=msg)
+    def assertAllEqual(self, actual, desired, msg=None):
+        """Assert that two arrays are equal.
+
+        Given two array-like objects, check that their shapes and all elements
+        are equal.
+        """
+        actual = self.convert_to_numpy(actual)
+        desired = self.convert_to_numpy(desired)
+        np.testing.assert_array_equal(actual, desired, err_msg=msg or "")
 
     def assertLen(self, iterable, expected_len, msg=None):
         self.assertEqual(len(iterable), expected_len, msg=msg)

--- a/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
@@ -247,9 +247,9 @@ class PyDatasetAdapterTest(testing.TestCase):
             # of the batch (2 elements in each batch)
             for sub_elem in range(2):
                 self.assertAllEqual(batch[0][sub_elem], x[index * 2 + sub_elem])
-                self.assertEqual(batch[1][sub_elem], y[index * 2 + sub_elem])
+                self.assertAllEqual(batch[1][sub_elem], y[index * 2 + sub_elem])
                 class_key = np.int32(batch[1][sub_elem])
-                self.assertEqual(batch[2][sub_elem], class_w[class_key])
+                self.assertAllEqual(batch[2][sub_elem], class_w[class_key])
 
         self.assertEqual(index, 1)  # 2 batches
 


### PR DESCRIPTION
Follow-up to https://github.com/keras-team/keras/pull/22569

Both had `x1` and `x2` as argument names, making it look like the order of arguments is not important. However, under the hood it uses `np.testing.assert_almost_equal` and `np.testing.assert_array_equal`, which has `actual` and `desired` as argument names. This created confusing error messages in case of failure whereby NumPy prints error messages like `DESIRED: ... ACTUAL: ...` but the values were flipped.

This PR renames the argument and flips the arguments in many tests.

- Changed `assertAllEqual` to simply map to `np.testing.assert_array_equal`, which is similar to `assertAllClose`, but can be used for string arrays. This is how it was used anyway in most places. The recursive aspect was incorrectly used (e.g. checking for keys in dictionaries instead of actually comparing the values).
- Switched to `assertEqual` for all shape verifications.
- Replaced some `assertAllEqual` with `assertAllClose` for tensors, as this is more logical for outputs in general and also works for ints and bools.
- Fixed flaky int4 quantization test in `dense_test.py`.
- Fixed OpenVino's `in_top_k` which was returning a result with an extra dimension.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
