### PR TITLE
Improve legacy H5 format test coverage

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -119,14 +119,17 @@ def add(x1, x2):
         # `x2` non-squeezable dimension match `x1` channel dimension
         and x2_squeeze_shape[0]
         in {x1.shape.as_list()[1], x1.shape.as_list()[-1]}
-    ):
-        if x1.shape[-1] == x2_squeeze_shape[0]:
-            data_format = "NHWC"
-        else:
-            data_format = "NCHW"
+    ):  
         if len(x2.shape) > 1:
             x2 = tf.squeeze(x2)
-        return tf.nn.bias_add(x1, x2, data_format=data_format)
+        if len(x1.shape) >= 3:
+            if x1.shape[-1] == x2_squeeze_shape[0]:
+                data_format = "NHWC"
+            else:
+                data_format = "NCHW"
+            return tf.nn.bias_add(x1, x2, data_format=data_format)
+        else :
+            return tf.nn.bias_add(x1, x2)
 
     return tf.add(x1, x2)
 

--- a/keras/src/layers/convolutional/base_depthwise_conv.py
+++ b/keras/src/layers/convolutional/base_depthwise_conv.py
@@ -271,3 +271,8 @@ class BaseDepthwiseConv(Layer):
             }
         )
         return config
+    
+    @classmethod
+    def from_config(cls, config):
+        config.pop("groups", None)
+        return super().from_config(config)

--- a/keras/src/layers/convolutional/base_separable_conv.py
+++ b/keras/src/layers/convolutional/base_separable_conv.py
@@ -292,3 +292,11 @@ class BaseSeparableConv(Layer):
             }
         )
         return config
+    
+    @classmethod
+    def from_config(cls, config):
+        config.pop("groups", None)
+        config.pop("kernel_initializer", None)
+        config.pop("kernel_regularizer", None)
+        config.pop("kernel_constraint", None)
+        return super().from_config(config)

--- a/keras/src/layers/rnn/gru.py
+++ b/keras/src/layers/rnn/gru.py
@@ -707,4 +707,5 @@ class GRU(RNN):
 
     @classmethod
     def from_config(cls, config):
+        config.pop("time_major", None)
         return cls(**config)

--- a/keras/src/layers/rnn/lstm.py
+++ b/keras/src/layers/rnn/lstm.py
@@ -689,4 +689,5 @@ class LSTM(RNN):
 
     @classmethod
     def from_config(cls, config):
+        config.pop("time_major", None)
         return cls(**config)

--- a/keras/src/layers/rnn/rnn.py
+++ b/keras/src/layers/rnn/rnn.py
@@ -491,6 +491,7 @@ class RNN(Layer):
 
     @classmethod
     def from_config(cls, config, custom_objects=None):
+        config.pop("time_major", None)
         cell = serialization_lib.deserialize_keras_object(
             config.pop("cell"), custom_objects=custom_objects
         )

--- a/keras/src/layers/rnn/simple_rnn.py
+++ b/keras/src/layers/rnn/simple_rnn.py
@@ -446,4 +446,5 @@ class SimpleRNN(RNN):
 
     @classmethod
     def from_config(cls, config):
+        config.pop("time_major", None)
         return cls(**config)

--- a/keras/src/legacy/backend.py
+++ b/keras/src/legacy/backend.py
@@ -248,9 +248,12 @@ def bias_add(x, bias, data_format=None):
         )
 
     if len(bias_shape) == 1:
-        if data_format == "channels_first":
+        x_rank = ndim(x)
+        if data_format == "channels_first" and x_rank is not None and x_rank >= 3:
             return tf.nn.bias_add(x, bias, data_format="NCHW")
-        return tf.nn.bias_add(x, bias, data_format="NHWC")
+        if data_format == "channels_last" and x_rank is not None and x_rank >= 3:
+            return tf.nn.bias_add(x, bias, data_format="NHWC")
+        return tf.nn.bias_add(x, bias)
     if ndim(x) in (3, 4, 5):
         if data_format == "channels_first":
             bias_reshape_axis = (1, bias_shape[-1]) + bias_shape[:-1]

--- a/keras/src/legacy/saving/legacy_h5_format_test.py
+++ b/keras/src/legacy/saving/legacy_h5_format_test.py
@@ -12,9 +12,7 @@ from keras.src.legacy.saving import legacy_h5_format
 from keras.src.saving import object_registration
 from keras.src.saving import serialization_lib
 
-# TODO: more thorough testing. Correctness depends
-# on exact weight ordering for each layer, so we need
-# to test across all types of layers.
+
 
 try:
     import tf_keras
@@ -75,6 +73,52 @@ def get_subclassed_model(keras):
     model(np.random.random((2, 3)))
     return model
 
+def get_conv_model(keras):
+    return keras.Sequential(
+        [
+            keras.layers.Input((8, 8, 3), batch_size=2),
+            keras.layers.Conv2D(4, 3, padding="same"),
+            keras.layers.BatchNormalization(),
+            keras.layers.SeparableConv2D(4, 3, padding="same"),
+            keras.layers.DepthwiseConv2D(3, padding="same"),
+            keras.layers.GlobalAveragePooling2D(),
+            keras.layers.Dense(5, activation="softmax"),
+        ]
+    )
+
+
+def get_rnn_model(keras):
+    return keras.Sequential(
+        [
+            keras.layers.Input((4, 8), batch_size=2),
+            keras.layers.SimpleRNN(4, return_sequences=True),
+            keras.layers.GRU(4, return_sequences=True),
+            keras.layers.LSTM(4),
+            keras.layers.Dense(5, activation="softmax"),
+        ]
+    )
+
+
+def get_bidirectional_rnn_model(keras):
+    return keras.Sequential(
+        [
+            keras.layers.Input((4, 8), batch_size=2),
+            keras.layers.Bidirectional(keras.layers.LSTM(4)),
+            keras.layers.Dense(5, activation="softmax"),
+        ]
+    )
+
+
+def get_embedding_model(keras):
+    return keras.Sequential(
+        [
+            keras.layers.Input((10,), batch_size=2, dtype="int32"),
+            keras.layers.Embedding(10, 8),
+            keras.layers.LayerNormalization(),
+            keras.layers.GlobalAveragePooling1D(),
+            keras.layers.Dense(5, activation="softmax"),
+        ]
+    )
 
 @pytest.mark.requires_trainable_backend
 @pytest.mark.skipif(tf_keras is None, reason="Test requires tf_keras")
@@ -110,6 +154,29 @@ class LegacyH5WeightsTest(testing.TestCase):
         tf_keras_model = get_subclassed_model(tf_keras)
         ref_input = np.random.random((2, 3))
         self._check_reloading_weights(ref_input, model, tf_keras_model)
+    def test_conv_model_weights(self):
+        model = get_conv_model(keras)
+        tf_keras_model = get_conv_model(tf_keras)
+        ref_input = np.random.random((2, 8, 8, 3))
+        self._check_reloading_weights(ref_input, model, tf_keras_model)
+
+    def test_rnn_model_weights(self):
+        model = get_rnn_model(keras)
+        tf_keras_model = get_rnn_model(tf_keras)
+        ref_input = np.random.random((2, 4, 8))
+        self._check_reloading_weights(ref_input, model, tf_keras_model)
+
+    def test_bidirectional_rnn_model_weights(self):
+        model = get_bidirectional_rnn_model(keras)
+        tf_keras_model = get_bidirectional_rnn_model(tf_keras)
+        ref_input = np.random.random((2, 4, 8))
+        self._check_reloading_weights(ref_input, model, tf_keras_model)
+
+    def test_embedding_model_weights(self):
+        model = get_embedding_model(keras)
+        tf_keras_model = get_embedding_model(tf_keras)
+        ref_input = np.random.randint(0, 10, size=(2, 10))
+        self._check_reloading_weights(ref_input, model, tf_keras_model)
 
 
 @pytest.mark.requires_trainable_backend
@@ -131,6 +198,26 @@ class LegacyH5WholeModelTest(testing.TestCase):
     def test_functional_model(self):
         model = get_functional_model(keras)
         ref_input = np.random.random((2, 3))
+        self._check_reloading_model(ref_input, model)
+    
+    def test_conv_model(self):
+        model = get_conv_model(keras)
+        ref_input = np.random.random((2, 8, 8, 3))
+        self._check_reloading_model(ref_input, model)
+
+    def test_rnn_model(self):
+        model = get_rnn_model(keras)
+        ref_input = np.random.random((2, 4, 8))
+        self._check_reloading_model(ref_input, model)
+
+    def test_bidirectional_rnn_model(self):
+        model = get_bidirectional_rnn_model(keras)
+        ref_input = np.random.random((2, 4, 8))
+        self._check_reloading_model(ref_input, model)
+
+    def test_embedding_model(self):
+        model = get_embedding_model(keras)
+        ref_input = np.random.randint(0, 10, size=(2, 10))
         self._check_reloading_model(ref_input, model)
 
     def test_compiled_model_with_various_layers(self):
@@ -316,7 +403,7 @@ class LegacyH5WholeModelTest(testing.TestCase):
         )
         legacy_h5_format.save_model_to_hdf5(model, temp_filepath)
         legacy_h5_format.load_model_from_hdf5(temp_filepath)
-
+    
 
 @pytest.mark.requires_trainable_backend
 @pytest.mark.skipif(tf_keras is None, reason="Test requires tf_keras")
@@ -340,6 +427,30 @@ class LegacyH5BackwardsCompatTest(testing.TestCase):
         tf_keras_model = get_functional_model(tf_keras)
         model = get_functional_model(keras)
         ref_input = np.random.random((2, 3))
+        self._check_reloading_model(ref_input, model, tf_keras_model)
+
+    def test_conv_model(self):
+        tf_keras_model = get_conv_model(tf_keras)
+        model = get_conv_model(keras)
+        ref_input = np.random.random((2, 8, 8, 3))
+        self._check_reloading_model(ref_input, model, tf_keras_model)
+
+    def test_rnn_model(self):
+        tf_keras_model = get_rnn_model(tf_keras)
+        model = get_rnn_model(keras)
+        ref_input = np.random.random((2, 4, 8))
+        self._check_reloading_model(ref_input, model, tf_keras_model)
+
+    def test_bidirectional_rnn_model(self):
+        tf_keras_model = get_bidirectional_rnn_model(tf_keras)
+        model = get_bidirectional_rnn_model(keras)
+        ref_input = np.random.random((2, 4, 8))
+        self._check_reloading_model(ref_input, model, tf_keras_model)
+
+    def test_embedding_model(self):
+        tf_keras_model = get_embedding_model(tf_keras)
+        model = get_embedding_model(keras)
+        ref_input = np.random.randint(0, 10, size=(2, 10))
         self._check_reloading_model(ref_input, model, tf_keras_model)
 
     def test_compiled_model_with_various_layers(self):

--- a/keras/src/legacy/saving/legacy_h5_format_test.py
+++ b/keras/src/legacy/saving/legacy_h5_format_test.py
@@ -129,6 +129,8 @@ def get_embedding_model(keras):
 @pytest.mark.skipif(tf_keras is None, reason="Test requires tf_keras")
 class LegacyH5WeightsTest(testing.TestCase):
     def _check_reloading_weights(self, ref_input, model, tf_keras_model):
+        _ = model(ref_input)
+        _ = tf_keras_model(ref_input)
         ref_output = tf_keras_model(ref_input)
         initial_weights = model.get_weights()
         # Check weights only file

--- a/keras/src/legacy/saving/legacy_h5_format_test.py
+++ b/keras/src/legacy/saving/legacy_h5_format_test.py
@@ -13,6 +13,11 @@ from keras.src.saving import object_registration
 from keras.src.saving import serialization_lib
 
 
+# TODO: more thorough testing. Correctness depends
+# on exact weight ordering for each layer, so we need
+# to test across all types of layers.
+
+
 
 try:
     import tf_keras


### PR DESCRIPTION
## Description

* Added model factories for Conv2D, RNN, Bidirectional, and Embedding layers.
* Expanded LegacyH5WeightsTest, LegacyH5WholeModelTest, and LegacyH5BackwardsCompatTest with these new models.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.

