### PR TITLE
Remove duplication of qr in linalg.py and math.py for all backends

### DIFF
--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -52,16 +52,6 @@ def logsumexp(x, axis=None, keepdims=False):
     return jax.scipy.special.logsumexp(x, axis=axis, keepdims=keepdims)
 
 
-def qr(x, mode="reduced"):
-    if mode not in {"reduced", "complete"}:
-        raise ValueError(
-            "`mode` argument value not supported. "
-            "Expected one of {'reduced', 'complete'}. "
-            f"Received: mode={mode}"
-        )
-    return jnp.linalg.qr(x, mode=mode)
-
-
 def extract_sequences(x, sequence_length, sequence_stride):
     *batch_shape, signal_length = x.shape
     batch_shape = list(batch_shape)

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -78,16 +78,6 @@ def logsumexp(x, axis=None, keepdims=False):
     return scipy.special.logsumexp(x, axis=axis, keepdims=keepdims)
 
 
-def qr(x, mode="reduced"):
-    if mode not in {"reduced", "complete"}:
-        raise ValueError(
-            "`mode` argument value not supported. "
-            "Expected one of {'reduced', 'complete'}. "
-            f"Received: mode={mode}"
-        )
-    return np.linalg.qr(x, mode=mode)
-
-
 def extract_sequences(x, sequence_length, sequence_stride):
     *batch_shape, _ = x.shape
     batch_shape = list(batch_shape)

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -169,10 +169,6 @@ def logsumexp(x, axis=None, keepdims=False):
     return OpenVINOKerasTensor(log_sum_exp)
 
 
-def qr(x, mode="reduced"):
-    raise NotImplementedError("`qr` is not supported with openvino backend")
-
-
 def extract_sequences(x, sequence_length, sequence_stride):
     x = get_ov_output(x)
     x_shape = x.partial_shape

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -49,18 +49,6 @@ def logsumexp(x, axis=None, keepdims=False):
     return tf.math.reduce_logsumexp(x, axis=axis, keepdims=keepdims)
 
 
-def qr(x, mode="reduced"):
-    if mode not in {"reduced", "complete"}:
-        raise ValueError(
-            "`mode` argument value not supported. "
-            "Expected one of {'reduced', 'complete'}. "
-            f"Received: mode={mode}"
-        )
-    if mode == "reduced":
-        return tf.linalg.qr(x)
-    return tf.linalg.qr(x, full_matrices=True)
-
-
 def extract_sequences(x, sequence_length, sequence_stride):
     return tf.signal.frame(
         x,

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -82,18 +82,6 @@ def logsumexp(x, axis=None, keepdims=False):
     return torch.logsumexp(x, dim=axis, keepdim=keepdims)
 
 
-def qr(x, mode="reduced"):
-    x = convert_to_tensor(x)
-    if mode not in {"reduced", "complete"}:
-        raise ValueError(
-            "`mode` argument value not supported. "
-            "Expected one of {'reduced', 'complete'}. "
-            f"Received: mode={mode}"
-        )
-    x = convert_to_tensor(x)
-    return torch.linalg.qr(x, mode=mode)
-
-
 def extract_sequences(x, sequence_length, sequence_stride):
     x = convert_to_tensor(x)
     return torch.unfold_copy(


### PR DESCRIPTION
## Description
keras.ops.qr is defined in linalg.py, and always delegates to linalg.py implementation of qr for all backends. 
This PR removes the duplication of qr in math.py, since there is no path that calls these implementations.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
