### PR TITLE
Strengthen HDF5 dataset verification in H5IOStore and KerasFileEditor

### DIFF
--- a/keras/src/legacy/saving/legacy_h5_format.py
+++ b/keras/src/legacy/saving/legacy_h5_format.py
@@ -12,6 +12,8 @@ from keras.src.legacy.saving import saving_options
 from keras.src.legacy.saving import saving_utils
 from keras.src.saving import object_registration
 from keras.src.saving import serialization_lib
+from keras.src.saving.saving_lib import _verify_h5_dataset
+from keras.src.saving.saving_lib import _verify_h5_group
 from keras.src.utils import io_utils
 
 try:
@@ -139,7 +141,11 @@ def load_model_from_hdf5(
             )
 
             # set weights
-            load_weights_from_hdf5_group(f["model_weights"], model)
+            load_weights_from_hdf5_group(
+                f["model_weights"],
+                model,
+                _root_h5_file=f,
+            )
 
         if compile:
             # instantiate optimizer
@@ -182,7 +188,7 @@ def load_model_from_hdf5(
                     )
 
                 optimizer_weight_values = (
-                    load_optimizer_weights_from_hdf5_group(f)
+                    load_optimizer_weights_from_hdf5_group(f, _root_h5_file=f)
                 )
                 try:
                     model.optimizer.set_weights(optimizer_weight_values)
@@ -323,7 +329,12 @@ def save_attributes_to_hdf5_group(group, name, data):
         group.attrs[name] = data
 
 
-def load_weights_from_hdf5_group(f, model, skip_mismatch=False):
+def load_weights_from_hdf5_group(
+    f,
+    model,
+    skip_mismatch=False,
+    _root_h5_file=None,
+):
     """Implements topological (order-based) weight loading.
 
     Args:
@@ -336,6 +347,8 @@ def load_weights_from_hdf5_group(f, model, skip_mismatch=False):
         ValueError: in case of mismatch between provided layers
             and weights file.
     """
+    if _root_h5_file is None:
+        _root_h5_file = f if isinstance(f, h5py.File) else f.file
     if "keras_version" in f.attrs:
         original_keras_version = f.attrs["keras_version"]
         if hasattr(original_keras_version, "decode"):
@@ -358,7 +371,7 @@ def load_weights_from_hdf5_group(f, model, skip_mismatch=False):
     layer_names = load_attributes_from_hdf5_group(f, "layer_names")
     filtered_layer_names = []
     for name in layer_names:
-        g = f[name]
+        g = _verify_h5_group(f[name], _root_h5_file)
         weight_names = load_attributes_from_hdf5_group(g, "weight_names")
         if weight_names:
             filtered_layer_names.append(name)
@@ -371,10 +384,13 @@ def load_weights_from_hdf5_group(f, model, skip_mismatch=False):
         )
 
     for k, name in enumerate(layer_names):
-        g = f[name]
+        g = _verify_h5_group(f[name], _root_h5_file)
         layer = filtered_layers[k]
         symbolic_weights = _legacy_weights(layer)
-        weight_values = load_subset_weights_from_hdf5_group(g)
+        weight_values = load_subset_weights_from_hdf5_group(
+            g,
+            _root_h5_file=_root_h5_file,
+        )
         if len(weight_values) != len(symbolic_weights):
             raise ValueError(
                 f"Weight count mismatch for layer #{k} (named {layer.name} in "
@@ -391,6 +407,7 @@ def load_weights_from_hdf5_group(f, model, skip_mismatch=False):
         )
 
     if "top_level_model_weights" in f:
+        _verify_h5_group(f["top_level_model_weights"], _root_h5_file)
         symbolic_weights = list(
             # model.weights
             v
@@ -398,7 +415,8 @@ def load_weights_from_hdf5_group(f, model, skip_mismatch=False):
             if v in model.weights
         )
         weight_values = load_subset_weights_from_hdf5_group(
-            f["top_level_model_weights"]
+            f["top_level_model_weights"],
+            _root_h5_file=_root_h5_file,
         )
         if len(weight_values) != len(symbolic_weights):
             raise ValueError(
@@ -462,7 +480,12 @@ def _set_weights(
         instance.finalize_state()
 
 
-def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
+def load_weights_from_hdf5_group_by_name(
+    f,
+    model,
+    skip_mismatch=False,
+    _root_h5_file=None,
+):
     """Implements name-based weight loading (instead of topological loading).
 
     Layers that have no matching name are skipped.
@@ -478,6 +501,8 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
         ValueError: in case of mismatch between provided layers
             and weights file and skip_match=False.
     """
+    if _root_h5_file is None:
+        _root_h5_file = f if isinstance(f, h5py.File) else f.file
     if "keras_version" in f.attrs:
         original_keras_version = f.attrs["keras_version"]
         if hasattr(original_keras_version, "decode"):
@@ -501,8 +526,11 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
             index.setdefault(layer.name, []).append(layer)
 
     for k, name in enumerate(layer_names):
-        g = f[name]
-        weight_values = load_subset_weights_from_hdf5_group(g)
+        g = _verify_h5_group(f[name], _root_h5_file)
+        weight_values = load_subset_weights_from_hdf5_group(
+            g,
+            _root_h5_file=_root_h5_file,
+        )
         for layer in index.get(name, []):
             symbolic_weights = _legacy_weights(layer)
             if len(weight_values) != len(symbolic_weights):
@@ -531,11 +559,13 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
             )
 
     if "top_level_model_weights" in f:
+        _verify_h5_group(f["top_level_model_weights"], _root_h5_file)
         symbolic_weights = (
             model._trainable_variables + model._non_trainable_variables
         )
         weight_values = load_subset_weights_from_hdf5_group(
-            f["top_level_model_weights"]
+            f["top_level_model_weights"],
+            _root_h5_file=_root_h5_file,
         )
 
         if len(weight_values) != len(symbolic_weights):
@@ -565,7 +595,10 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
             )
 
 
-def load_subset_weights_from_hdf5_group(f):
+def load_subset_weights_from_hdf5_group(
+    f,
+    _root_h5_file=None,
+):
     """Load layer weights of a model from hdf5.
 
     Args:
@@ -578,11 +611,19 @@ def load_subset_weights_from_hdf5_group(f):
         ValueError: in case of mismatch between provided model
             and weights file.
     """
+    if _root_h5_file is None:
+        _root_h5_file = f if isinstance(f, h5py.File) else f.file
     weight_names = load_attributes_from_hdf5_group(f, "weight_names")
-    return [np.asarray(f[weight_name]) for weight_name in weight_names]
+    return [
+        np.asarray(_verify_h5_dataset(f[wn], _root_h5_file))
+        for wn in weight_names
+    ]
 
 
-def load_optimizer_weights_from_hdf5_group(hdf5_group):
+def load_optimizer_weights_from_hdf5_group(
+    hdf5_group,
+    _root_h5_file=None,
+):
     """Load optimizer weights from a HDF5 group.
 
     Args:
@@ -591,12 +632,20 @@ def load_optimizer_weights_from_hdf5_group(hdf5_group):
     Returns:
         data: List of optimizer weight names.
     """
-    weights_group = hdf5_group["optimizer_weights"]
+    if _root_h5_file is None:
+        _root_h5_file = (
+            hdf5_group if isinstance(hdf5_group, h5py.File) else hdf5_group.file
+        )
+    weights_group = _verify_h5_group(
+        hdf5_group["optimizer_weights"],
+        _root_h5_file,
+    )
     optimizer_weight_names = load_attributes_from_hdf5_group(
         weights_group, "weight_names"
     )
     return [
-        weights_group[weight_name] for weight_name in optimizer_weight_names
+        _verify_h5_dataset(weights_group[wn], _root_h5_file)
+        for wn in optimizer_weight_names
     ]
 
 

--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -452,7 +452,15 @@ class KerasFileEditor:
     def resave_weights(self, filepath):
         self.save(filepath)
 
-    def _extract_weights_from_store(self, data, metadata=None, inner_path=""):
+    def _extract_weights_from_store(
+        self,
+        data,
+        metadata=None,
+        inner_path="",
+        root_h5_file=None,
+    ):
+        if root_h5_file is None:
+            root_h5_file = data
         metadata = metadata or {}
 
         # ------------------------------------------------------
@@ -479,6 +487,7 @@ class KerasFileEditor:
             # CASE 1 — HDF5 GROUP → RECURSE
             # ------------------------------------------------------
             if isinstance(value, h5py.Group):
+                saving_lib._verify_h5_group(value, root_h5_file)
                 # Skip empty groups
                 if len(value) == 0:
                     continue
@@ -493,6 +502,7 @@ class KerasFileEditor:
                         value["vars"],
                         metadata=metadata,
                         inner_path=current_inner_path,
+                        root_h5_file=root_h5_file,
                     )
                 else:
                     # Recurse normally
@@ -500,6 +510,7 @@ class KerasFileEditor:
                         value,
                         metadata=metadata,
                         inner_path=current_inner_path,
+                        root_h5_file=root_h5_file,
                     )
 
                 continue  # finished processing this key
@@ -512,11 +523,7 @@ class KerasFileEditor:
             if not isinstance(value, h5py.Dataset):
                 continue
 
-            if value.external:
-                raise ValueError(
-                    "Not allowed: H5 file Dataset with external links: "
-                    f"{value.external}"
-                )
+            saving_lib._verify_h5_dataset(value, root_h5_file)
 
             shape = value.shape
             dtype = value.dtype

--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -309,15 +309,22 @@ def load_weights(model, filepath, skip_mismatch=False, **kwargs):
                 "You can install it via `pip install h5py`"
             )
         with h5py.File(filepath, "r") as f:
+            root_h5_file = f
             if "layer_names" not in f.attrs and "model_weights" in f:
                 f = f["model_weights"]
             if by_name:
                 legacy_h5_format.load_weights_from_hdf5_group_by_name(
-                    f, model, skip_mismatch
+                    f,
+                    model,
+                    skip_mismatch,
+                    _root_h5_file=root_h5_file,
                 )
             else:
                 legacy_h5_format.load_weights_from_hdf5_group(
-                    f, model, skip_mismatch
+                    f,
+                    model,
+                    skip_mismatch,
+                    _root_h5_file=root_h5_file,
                 )
     elif is_orbax_checkpoint(filepath):
         # Load weights from Orbax checkpoint

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -990,6 +990,76 @@ class DiskIOStore:
             file_utils.rmtree(self.tmp_dir)
 
 
+def _verify_h5_dataset(dataset, trusted_h5_file):
+    """Verify an HDF5 dataset is safe to read.
+
+    Checks three layers of HDF5 cross-file mechanisms:
+    1. H5D_EXTERNAL raw storage (dataset.external)
+    2. Same-file invariant (ExternalLink resolution)
+    3. Virtual Dataset layout (H5D_VIRTUAL)
+
+    Args:
+        dataset: An h5py.Dataset to verify.
+        trusted_h5_file: The h5py.File that should
+            own this dataset.
+
+    Raises:
+        ValueError: If the dataset fails any check.
+    """
+    if not isinstance(dataset, h5py.Dataset):
+        raise ValueError(
+            f"Invalid H5 file, expected Dataset, received {type(dataset)}"
+        )
+    if dataset.external:
+        raise ValueError(
+            "Not allowed: H5 file Dataset with "
+            f"external links: {dataset.external}"
+        )
+    ds_fname = os.path.normcase(dataset.file.filename)
+    trusted_fname = os.path.normcase(trusted_h5_file.filename)
+    if ds_fname != trusted_fname:
+        raise ValueError(
+            "Not allowed: H5 Dataset resolved from "
+            "a different file "
+            f"(got {dataset.file.filename!r}, "
+            f"expected {trusted_h5_file.filename!r})"
+        )
+    if dataset.is_virtual:
+        raise ValueError(
+            "Not allowed: H5 Dataset uses virtual "
+            f"sources: {dataset.virtual_sources()!r}"
+        )
+    return dataset
+
+
+def _verify_h5_group(group, trusted_h5_file):
+    """Verify an HDF5 group belongs to the trusted file.
+
+    Args:
+        group: An h5py.Group to verify.
+        trusted_h5_file: The h5py.File that should
+            own this group.
+
+    Raises:
+        ValueError: If the group is not an h5py.Group
+            or resolves from another file.
+    """
+    if not isinstance(group, h5py.Group):
+        raise ValueError(
+            f"Invalid H5 file, expected Group but received {type(group)}"
+        )
+    grp_fname = os.path.normcase(group.file.filename)
+    trusted_fname = os.path.normcase(trusted_h5_file.filename)
+    if grp_fname != trusted_fname:
+        raise ValueError(
+            "Not allowed: H5 Group resolved from "
+            "a different file "
+            f"(got {group.file.filename!r}, "
+            f"expected {trusted_h5_file.filename!r})"
+        )
+    return group
+
+
 class H5IOStore:
     """Numerical variable store backed by HDF5.
 
@@ -1042,23 +1112,10 @@ class H5IOStore:
         return self.h5_file.__bool__()
 
     def _verify_group(self, group):
-        if not isinstance(group, h5py.Group):
-            raise ValueError(
-                f"Invalid H5 file, expected Group but received {type(group)}"
-            )
-        return group
+        return _verify_h5_group(group, self.h5_file)
 
     def _verify_dataset(self, dataset):
-        if not isinstance(dataset, h5py.Dataset):
-            raise ValueError(
-                f"Invalid H5 file, expected Dataset, received {type(dataset)}"
-            )
-        if dataset.external:
-            raise ValueError(
-                "Not allowed: H5 file Dataset with external links: "
-                f"{dataset.external}"
-            )
-        return dataset
+        return _verify_h5_dataset(dataset, self.h5_file)
 
     def _get_h5_file(self, path_or_io, mode=None):
         mode = mode or self.mode

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1015,8 +1015,8 @@ def _verify_h5_dataset(dataset, trusted_h5_file):
             "Not allowed: H5 file Dataset with "
             f"external links: {dataset.external}"
         )
-    ds_fname = os.path.normcase(dataset.file.filename)
-    trusted_fname = os.path.normcase(trusted_h5_file.filename)
+    ds_fname = os.path.normcase(os.path.abspath(dataset.file.filename))
+    trusted_fname = os.path.normcase(os.path.abspath(trusted_h5_file.filename))
     if ds_fname != trusted_fname:
         raise ValueError(
             "Not allowed: H5 Dataset resolved from "
@@ -1048,8 +1048,8 @@ def _verify_h5_group(group, trusted_h5_file):
         raise ValueError(
             f"Invalid H5 file, expected Group but received {type(group)}"
         )
-    grp_fname = os.path.normcase(group.file.filename)
-    trusted_fname = os.path.normcase(trusted_h5_file.filename)
+    grp_fname = os.path.normcase(os.path.abspath(group.file.filename))
+    trusted_fname = os.path.normcase(os.path.abspath(trusted_h5_file.filename))
     if grp_fname != trusted_fname:
         raise ValueError(
             "Not allowed: H5 Group resolved from "

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1015,6 +1015,8 @@ def _verify_h5_dataset(dataset, trusted_h5_file):
             "Not allowed: H5 file Dataset with "
             f"external links: {dataset.external}"
         )
+    # Compare absolute, normalized paths so a relative caller path and an
+    # h5py-resolved absolute path for the same file do not falsely diverge.
     ds_fname = os.path.normcase(os.path.abspath(dataset.file.filename))
     trusted_fname = os.path.normcase(os.path.abspath(trusted_h5_file.filename))
     if ds_fname != trusted_fname:

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -8,6 +8,7 @@ from io import BytesIO
 from pathlib import Path
 from unittest import mock
 
+import h5py
 import numpy as np
 import pytest
 from absl.testing import parameterized
@@ -1360,4 +1361,54 @@ class SavingH5IOStoreTest(testing.TestCase):
         ):
             del vars_store["abc"]
 
+        store.close()
+
+    def test_verify_rejects_external_link(self):
+        temp_dir = self.get_temp_dir()
+        target_path = os.path.join(temp_dir, "target.h5")
+        main_path = os.path.join(temp_dir, "main.weights.h5")
+
+        with h5py.File(target_path, "w") as f:
+            grp = f.create_group("dense/vars")
+            grp.create_dataset(
+                "0",
+                data=np.zeros((4,), dtype="float32"),
+            )
+
+        with h5py.File(main_path, "w") as f:
+            f["dense"] = h5py.ExternalLink(target_path, "/dense")
+
+        store = saving_lib.H5IOStore(main_path, mode="r")
+        with self.assertRaisesRegex(
+            ValueError,
+            r"resolved from a different file",
+        ):
+            store.get("dense")
+        store.close()
+
+    def test_verify_rejects_virtual_dataset(self):
+        temp_dir = self.get_temp_dir()
+        target_path = os.path.join(temp_dir, "target.h5")
+        main_path = os.path.join(temp_dir, "main.weights.h5")
+        shape = (4,)
+
+        with h5py.File(target_path, "w") as f:
+            f.create_dataset(
+                "data",
+                data=np.zeros(shape, dtype="float32"),
+            )
+
+        layout = h5py.VirtualLayout(shape=shape, dtype="float32")
+        layout[:] = h5py.VirtualSource(target_path, "data", shape=shape)
+        with h5py.File(main_path, "w") as f:
+            grp = f.create_group("dense/vars")
+            grp.create_virtual_dataset("0", layout)
+
+        store = saving_lib.H5IOStore(main_path, mode="r")
+        vs = store.get("dense")
+        with self.assertRaisesRegex(
+            ValueError,
+            r"virtual sources",
+        ):
+            vs["0"]
         store.close()


### PR DESCRIPTION
## Description

Completes the defense-in-depth measures for HDF5 dataset verification
introduced in PR #22057 (CVE-2026-1669).

The existing `_verify_dataset` guard checks `dataset.external`
(H5D_EXTERNAL storage). This PR adds two additional checks:

1. **Same-file invariant**: rejects datasets/groups whose owning
   HDF5 file differs from the file being loaded. Catches datasets
   reached via `h5py.ExternalLink`.

2. **Virtual Dataset check**: rejects datasets with `H5D_VIRTUAL`
   layout, whose data is mapped from external source files.

Both checks are applied via shared module-level functions used by
`H5IOStore`, `KerasFileEditor`, and the legacy `.h5`/`.hdf5` loading
path (`legacy_h5_format.py`).

### Files changed

- `keras/src/saving/saving_lib.py` — shared verification functions +
  `H5IOStore` thin wrappers
- `keras/src/saving/file_editor.py` — `KerasFileEditor` weight
  extraction uses shared verification
- `keras/src/legacy/saving/legacy_h5_format.py` — legacy loading
  functions now verify groups and datasets
- `keras/src/saving/saving_api.py` — propagate trusted file reference
  to legacy loading path
- `keras/src/saving/saving_lib_test.py` — tests for ExternalLink and
  Virtual Dataset rejection

## Reference

- PR #22057 (original CVE-2026-1669 fix)
- [CWE-610: Externally Controlled Reference to Resource in Another Sphere](https://cwe.mitre.org/data/definitions/610.html)

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.