### PR TITLE
Skip tree.flatten in any_symbolic_tensors for non-nested args

### DIFF
--- a/keras/src/backend/common/keras_tensor.py
+++ b/keras/src/backend/common/keras_tensor.py
@@ -400,19 +400,11 @@ class KerasTensor:
 
 
 def any_symbolic_tensors(args=None, kwargs=None):
-    if args is not None:
-        for x in args:
+    for items in (args or (), kwargs.values() if kwargs else ()):
+        for x in items:
             if isinstance(x, KerasTensor):
                 return True
-            if isinstance(x, (list, tuple, dict)):
-                for nested in tree.flatten(x):
-                    if isinstance(nested, KerasTensor):
-                        return True
-    if kwargs is not None:
-        for x in kwargs.values():
-            if isinstance(x, KerasTensor):
-                return True
-            if isinstance(x, (list, tuple, dict)):
+            if tree.is_nested(x):
                 for nested in tree.flatten(x):
                     if isinstance(nested, KerasTensor):
                         return True

--- a/keras/src/backend/common/keras_tensor.py
+++ b/keras/src/backend/common/keras_tensor.py
@@ -400,11 +400,22 @@ class KerasTensor:
 
 
 def any_symbolic_tensors(args=None, kwargs=None):
-    args = args or ()
-    kwargs = kwargs or {}
-    for x in tree.flatten((args, kwargs)):
-        if isinstance(x, KerasTensor):
-            return True
+    if args is not None:
+        for x in args:
+            if isinstance(x, KerasTensor):
+                return True
+            if isinstance(x, (list, tuple, dict)):
+                for nested in tree.flatten(x):
+                    if isinstance(nested, KerasTensor):
+                        return True
+    if kwargs is not None:
+        for x in kwargs.values():
+            if isinstance(x, KerasTensor):
+                return True
+            if isinstance(x, (list, tuple, dict)):
+                for nested in tree.flatten(x):
+                    if isinstance(nested, KerasTensor):
+                        return True
     return False
 
 


### PR DESCRIPTION
## Summary

   Reduces `Layer.__call__` overhead on the torch backend by avoiding a `tree.flatten` call in `any_symbolic_tensors` when the arguments are not nested (the common case).

   ## Benchmark

   CPU-only torch, 4x64 float32 input, 20000 iterations x 7 trials, median ns per `Layer.__call__`. Reproducible via a small script using only `keras` and `torch`.

   | layer | master | this PR | delta |
   |---|---:|---:|---:|
   | `Identity` | 94.2 us | 52.7 us | **−44%** |
   | `Dense(8)` | 193.3 us | 105.2 us | **−46%** |
   | `ReLU` | 122.4 us | 64.2 us | **−48%** |

   Keras `3.15.0`, torch `2.10.0+cu128`, Python 3.11, CPU.
## Contributor Agreement
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

