### PR TITLE
Add a timeout to all test workflows.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -34,6 +34,7 @@ jobs:
 
     name: ${{ format('Run tests on CPU ({0}{1})', matrix.backend, matrix.nnx_enabled && ', NNX' || '') }}
     runs-on: linux-x86-n2-16
+    timeout-minutes: 120
 
     env:
       KERAS_HOME: .github/workflows/config/${{ matrix.backend }}

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -20,6 +20,8 @@ jobs:
   test-in-container:
     name: Run tests on GPU
     runs-on: linux-x86-g2-16-l4-1gpu
+    timeout-minutes: 120
+
     # Only run on pushes to master, releases or "kokoro:force-run" unlabel
     if: |
       github.event_name == 'push' ||

--- a/.github/workflows/tpu_tests.yml
+++ b/.github/workflows/tpu_tests.yml
@@ -26,6 +26,8 @@ jobs:
 
     name: ${{ format('Run tests on {0}TPU', matrix.multi_device && 'multi-' || '') }}
     runs-on: ${{ matrix.multi_device && 'linux-x86-ct5lp-112-4tpu' || 'linux-x86-ct6e-44-1tpu' }}
+    timeout-minutes: 120
+
     # Only run on pushes to master, releases or "kokoro:force-run" unlabel
     if: |
       github.event_name == 'push' ||


### PR DESCRIPTION
Apparently self-hosted runners to not have a timeout by default. I'm seeing some test hanging in https://github.com/keras-team/keras/pull/22664

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [X] I will work with the maintainers to push this PR forward until submission.
