### PR TITLE
Allow Initializers to handle the distribution layout.

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -40,6 +40,9 @@ class Variable:
             to `"none"`.
         name: Optional. A unique name for the variable. Automatically generated
             if not set.
+        layout: Optional. Sharding layout for the variable. Can be a
+            `keras.distribution.TensorLayout` or a backend-specific layout.
+        kwargs: Additional backend-specific keyword arguments.
 
     Attributes:
         shape: The shape of the variable (tuple of integers).
@@ -51,7 +54,6 @@ class Variable:
         value: The current value of the variable (NumPy array or tensor).
         name: The name of the variable (string).
         path: The path of the variable within the Keras model or layer (string).
-        kwargs: Additional backend-specific keyword arguments.
 
     Examples:
 
@@ -99,9 +101,9 @@ class Variable:
         aggregation="none",
         synchronization="auto",
         name=None,
+        layout=None,
         **kwargs,
     ):
-        del kwargs
         name = name or auto_name(self.__class__.__name__)
         if not isinstance(name, str) or "/" in name:
             raise ValueError(
@@ -153,6 +155,8 @@ class Variable:
         self._autocast = bool(autocast)
         self._aggregation = aggregation
         self._synchronization = synchronization
+        self._layout = layout
+
         # `self._overwrite_with_gradient` is an internal property to determine
         # whether this variable should be overwritten by the computed gradient.
         # Ref: https://github.com/google/flax/blob/main/flax/linen/fp8_ops.py

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -1,3 +1,4 @@
+import inspect
 import math
 
 import jax
@@ -26,24 +27,12 @@ IS_THREAD_SAFE = True
 
 
 class JaxVariable(KerasVariable):
-    def __init__(self, *args, layout=None, **kwargs):
-        # Intercept layout parameter so that it is available
-        # during initialization.
-        self._layout = layout
-        super().__init__(*args, **kwargs)
-
     def _initialize_layout(self):
         # We can't import the keras/distribution/distribution_lib
         # due to circular dependency.
         distribution = global_state.get_global_attribute("distribution")
         if self._layout is None and distribution is not None:
-            tensor_layout = distribution.get_variable_layout(self)
-            from keras.src.distribution import TensorLayout
-
-            if isinstance(tensor_layout, TensorLayout):
-                self._layout = tensor_layout.backend_layout
-            else:
-                self._layout = tensor_layout
+            self._layout = distribution.get_variable_layout(self)
 
     def _initialize(self, value):
         # Note that variable.shape is needed by distribution_lib
@@ -52,13 +41,36 @@ class JaxVariable(KerasVariable):
         self._direct_assign(value)
 
     def _initialize_with_initializer(self, initializer):
+        from keras.src.distribution.distribution_lib import TensorLayout
+
         self._initialize_layout()
-        layout = self._layout
-        shape = self._shape
-        if should_shard_at_init(layout, shape):
+        jax_layout = (
+            self._layout.backend_layout
+            if isinstance(self._layout, TensorLayout)
+            else self._layout
+        )
+
+        if self._layout is None:
+            super()._initialize_with_initializer(initializer)
+        elif "layout" in inspect.signature(initializer).parameters:
+            with jax.set_mesh(jax_layout.mesh):
+                # Force explicit axes in this context, otherwise `out_sharding`
+                # in ops ends up being ignored.
+
+                @jax.sharding.explicit_axes
+                def explicit_initializer():
+                    explicit_layout = jax.sharding.NamedSharding(
+                        jax.sharding.get_abstract_mesh(), jax_layout.spec
+                    )
+                    return initializer(
+                        self._shape, dtype=self._dtype, layout=explicit_layout
+                    )
+
+                self._value = explicit_initializer(in_sharding=None)
+        elif should_shard_at_init(jax_layout, self._shape):
             jitted_initializer = jax.jit(
                 initializer.__call__,
-                out_shardings=layout,
+                out_shardings=jax_layout,
                 static_argnames=["shape", "dtype"],
             )
             value = jitted_initializer(shape=self._shape, dtype=self._dtype)
@@ -112,9 +124,6 @@ if config.is_nnx_enabled():
             # Initialize nnx.Variable first
             nnx.Variable.__init__(self, value=dummy_value, **nnx_metadata)
 
-            # Now we can safely set layout
-            self._layout = layout
-
             # Initialize JaxVariable (which will call KerasVariable.__init__
             # and set up the real value).
             JaxVariable.__init__(
@@ -127,6 +136,7 @@ if config.is_nnx_enabled():
                 aggregation=aggregation,
                 synchronization=synchronization,
                 name=name,
+                layout=layout,
             )
 
             # The real value is now set in self._value, sync it to raw_value
@@ -313,9 +323,6 @@ if config.is_nnx_enabled():
 
 
 def should_shard_at_init(init_layout, shape):
-    if not isinstance(init_layout, jax.sharding.NamedSharding):
-        return False
-
     size_threshold = 250 * 1024 * 1024
     # We multiply by the mesh size here to take into account the worst case
     # scenario of the array being first duplicated in the memory of one device

--- a/keras/src/initializers/initializer.py
+++ b/keras/src/initializers/initializer.py
@@ -5,13 +5,26 @@ from keras.src.api_export import keras_export
 class Initializer:
     """Initializer base class: all Keras initializers inherit from this class.
 
-    Initializers should implement a `__call__()` method with the following
-    signature:
+    Initializers should implement a `__call__()` method with one of two possible
+    signatures. If your initializer does not handle distribution layouts, it
+    should use this signature:
 
     ```python
-    def __call__(self, shape, dtype=None, **kwargs):
+    def __call__(self, shape, dtype=None):
         # returns a tensor of shape `shape` and dtype `dtype`
-        # containing values drawn from a distribution of your choice.
+        # containing values drawn using a function of your choice.
+    ```
+
+    If your initializer handles distribution layouts, it should use this
+    signature. `layout` can either be a `keras.distribution.TensorLayout` or a
+    backend-specific layout. If the given `layout` is not `None`, the returned
+    value must be distributed according to `layout`.
+
+    ```python
+    def __call__(self, shape, dtype=None, layout=None):
+        # returns a tensor of shape `shape`, dtype `dtype` and distributed
+        # across devices according to the layout `layout`.
+        # containing values drawn using a function of your choice.
     ```
 
     Optionally, you can also implement the method `get_config()` and the class
@@ -26,7 +39,7 @@ class Initializer:
             self.mean = mean
             self.stddev = stddev
 
-        def __call__(self, shape, dtype=None, **kwargs):
+        def __call__(self, shape, dtype=None):
             return keras.random.normal(
                 shape, mean=self.mean, stddev=self.stddev, dtype=dtype
             )

--- a/keras/src/initializers/initializer_test.py
+++ b/keras/src/initializers/initializer_test.py
@@ -1,0 +1,89 @@
+import jax
+import pytest
+
+from keras.src import backend
+from keras.src import initializers
+from keras.src import testing
+from keras.src.distribution import distribution_lib
+
+
+class InitializerWithLayout(initializers.Initializer):
+    def __call__(self, shape, dtype=None, layout=None):
+        if isinstance(layout, distribution_lib.TensorLayout):
+            layout = layout.backend_layout
+        return jax.numpy.ones(shape, dtype=dtype, out_sharding=layout)
+
+
+@pytest.mark.skipif(backend.backend() != "jax", reason="JAX only")
+@pytest.mark.multi_device
+class InitializersLayoutTest(testing.TestCase):
+    def test_initializer_with_data_parallel_layout(self):
+        distribution = distribution_lib.DataParallel()
+
+        shape = (2, 3)
+        expected_sharding = distribution.get_variable_layout(
+            backend.Variable("zeros", shape, "float32")
+        ).backend_layout
+
+        with distribution.scope():
+            var = backend.Variable(InitializerWithLayout(), shape, "float32")
+
+        self.assertAllClose(var.value, 1)
+        self.assertTrue(
+            var.value.sharding.is_equivalent_to(expected_sharding, len(shape)),
+            msg=f"Actual: {var.value.sharding}, Expected: {expected_sharding}",
+        )
+
+    def test_initializer_with_model_parallel_layout(self):
+        device_count = distribution_lib.get_device_count()
+        self.assertGreaterEqual(
+            device_count, 4, "Number of devices must be at least 4"
+        )
+        self.assertEqual(device_count % 2, 0, "Number of devices must be even")
+        mesh_shape = (device_count // 2, 2)
+        device_mesh = distribution_lib.DeviceMesh(
+            mesh_shape, axis_names=("batch", "model")
+        )
+
+        layout_map = distribution_lib.LayoutMap(device_mesh)
+        layout_map["kernel"] = distribution_lib.TensorLayout([None, "model"])
+        layout_map["bias"] = distribution_lib.TensorLayout(["model"])
+        distribution = distribution_lib.ModelParallel(layout_map=layout_map)
+
+        shape = (2, 4)
+        expected_kernel_sharding = distribution.get_variable_layout(
+            backend.Variable("zeros", shape, "float32", name="kernel")
+        ).backend_layout
+        expected_bias_sharding = distribution.get_variable_layout(
+            backend.Variable("zeros", shape, "float32", name="bias")
+        ).backend_layout
+
+        with distribution.scope():
+            kernel = backend.Variable(
+                InitializerWithLayout(), shape, "float32", name="kernel"
+            )
+            bias = backend.Variable(
+                InitializerWithLayout(), shape, "float32", name="bias"
+            )
+
+        self.assertAllClose(kernel.value, 1)
+        self.assertTrue(
+            kernel.value.sharding.is_equivalent_to(
+                expected_kernel_sharding, len(shape)
+            ),
+            msg=(
+                f"Actual: {kernel.value.sharding}, "
+                f"Expected: {expected_kernel_sharding}"
+            ),
+        )
+
+        self.assertAllClose(bias.value, 1)
+        self.assertTrue(
+            bias.value.sharding.is_equivalent_to(
+                expected_bias_sharding, len(shape)
+            ),
+            msg=(
+                f"Actual: {bias.value.sharding}, "
+                f"Expected: {expected_bias_sharding}"
+            ),
+        )


### PR DESCRIPTION
### Problem

Some variables are so large that they don't fit on a single accelerator. Currently, the sharding is usually applied after the initializer has be called, which created the value on the first accelerator. Alternatively, we create a jitted function that is able to apply the sharding, but jitting has a cost (jitting all initializers is prohibitively slow) and some limitations.

### Solution

This change allows users to implemented their own initializer which handles the layout, meaning its able to return a sharded array. This allow things as simple as:
```python
class MyInitializer(keras.initializers.Initializer):
    def __call__(self, shape, dtype=None, layout=None):
        return jnp.ones(shape, dtype=dtype, out_sharding=layout)
```

- Also made `layout` a backend independent argument in `Variable.__init__` to allow support on other backends in the future.

### What's Next

- Upgrade all random ops and some numpy ops to optionally accept a `layout` argument like JAX.
- Plumb the layout argument in all the Keras built-in initializers.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
