### PR TITLE
[OpenVino] Revert change to `_parameterize_data`.

### DIFF
--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -86,23 +86,23 @@ class OpenVINOTrainer(base_trainer.Trainer):
 
         self.test_function = test_step
 
-    def _parameterize_data(self, data):
+    def _parameterize_data(self, data, dynamic_batch_size=False):
         if isinstance(data, (list, tuple)):
             parametrize_data = []
             for elem in data:
-                param_elem = self._parameterize_data(elem)
+                param_elem = self._parameterize_data(elem, dynamic_batch_size)
                 parametrize_data.append(param_elem)
         elif isinstance(data, dict):
             parametrize_data = dict()
             for elem_name, elem in data.items():
-                param_elem = self._parameterize_data(elem)
+                param_elem = self._parameterize_data(elem, dynamic_batch_size)
                 parametrize_data[elem_name] = param_elem
         elif isinstance(data, OpenVINOKerasTensor):
             parametrize_data = data
         elif isinstance(data, np.ndarray) or np.isscalar(data):
             ov_type = OPENVINO_DTYPES[str(data.dtype)]
             ov_shape = list(data.shape)
-            if len(ov_shape) > 0:
+            if dynamic_batch_size and len(ov_shape) > 0:
                 ov_shape[0] = -1
             param = ov_opset.parameter(shape=ov_shape, dtype=ov_type)
             parametrize_data = OpenVINOKerasTensor(param.output(0))
@@ -139,7 +139,9 @@ class OpenVINOTrainer(base_trainer.Trainer):
         del self.ov_compiled_model
 
         # prepare parameterized input
-        self.struct_params = self._parameterize_data(data)
+        self.struct_params = self._parameterize_data(
+            data, dynamic_batch_size=True
+        )
         # construct OpenVINO graph during calling Keras Model
         self.struct_outputs = self(self.struct_params)
 


### PR DESCRIPTION
This is a follow-up to https://github.com/keras-team/keras/pull/22670
    
The change in `_parameterize_data` to make the batch size dynamic breaks `generate` in KerasHub. The dynamic batch size aspect is now opt-in.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
