### PR TITLE
[OpenVINO] Fix pad to accept float scalar constant_values

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -12,7 +12,6 @@ FeatureSpaceTest::test_advanced_usage
 FeatureSpaceTest::test_basic_usage
 FeatureSpaceTest::test_basic_usage_no_strings
 FeatureSpaceTest::test_saving
-GroupedQuantizationParametersTest::test_grouped_weight_shapes_non_divisible
 ImageOpsBehaviorTests::test_affine_transform
 ImageOpsBehaviorTests::test_elastic_transform
 ImageOpsBehaviorTests::test_gaussian_blur
@@ -54,7 +53,6 @@ NumpyOneInputOpsCorrectnessTest::test_imag
 NumpyOneInputOpsCorrectnessTest::test_isreal
 NumpyOneInputOpsCorrectnessTest::test_nanmedian
 NumpyOneInputOpsCorrectnessTest::test_real
-QuantizersTest::test_grouped_quantize_with_padding
 RandAugmentTest::test_layer
 RandAugmentTest::test_rand_augment_basic
 RandAugmentTest::test_random_augment_randomness

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -3749,7 +3749,7 @@ def pad(x, pad_width, mode="constant", constant_values=None):
                 "provided when `mode == 'constant'`. "
                 f"Received: mode={mode}"
             )
-        if not isinstance(constant_values, int):
+        if not isinstance(constant_values, (int, float)):
             raise ValueError(
                 "`pad` operation supports only scalar pad value "
                 "in constant mode with the openvino backend. "

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -3749,7 +3749,9 @@ def pad(x, pad_width, mode="constant", constant_values=None):
                 "provided when `mode == 'constant'`. "
                 f"Received: mode={mode}"
             )
-        if not isinstance(constant_values, (int, float)):
+        if not isinstance(
+            constant_values, (int, float, np.integer, np.floating)
+        ):
             raise ValueError(
                 "`pad` operation supports only scalar pad value "
                 "in constant mode with the openvino backend. "


### PR DESCRIPTION
## Description
The ov pad was rejecting any non-int constant_values with a ValueError, but float scalars (e.g. 0.0) are equally valid. This caused compute_quantization_parameters and abs_max_quantize_grouped_with_zero_point to fail when padding inputs whose dimension isn't divisible by block_size.

Widened the isinstance check from int to (int, float).
Removed the relevent tests from exclusion lists.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
