### PR TITLE
[OpenVINO] Fix dynamic/symbolic shape handling in get_ov_output and broadcast_to

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -128,28 +128,7 @@ def get_ov_output(x, ov_type=None, context_dtype=None):
     elif isinstance(x, (list, tuple)):
         if isinstance(x, tuple):
             x = list(x)
-        target_type = ov_type if ov_type is not None else Type.i32
-        if any(isinstance(e, (OpenVINOKerasTensor, ov.Output)) for e in x):
-            # Mixed or fully-symbolic shape: concat individual dim tensors
-            parts = []
-            for e in x:
-                elem = get_ov_output(e, ov_type=target_type)
-                if elem.get_element_type() != target_type:
-                    elem = ov_opset.convert(elem, target_type).output(0)
-                # Ensure rank-1 shape for concat
-                scalar_shape = elem.get_partial_shape()
-                if (
-                    scalar_shape.rank.is_static
-                    and scalar_shape.rank.get_length() == 0
-                ):
-                    elem = ov_opset.reshape(
-                        elem,
-                        ov_opset.constant([1], Type.i32).output(0),
-                        False,
-                    ).output(0)
-                parts.append(elem)
-            x = ov_opset.concat(parts, 0).output(0)
-        elif ov_type is None:
+        if ov_type is None:
             x = ov_opset.constant(x).output(0)
         else:
             x = ov_opset.constant(x, ov_type).output(0)
@@ -170,6 +149,36 @@ def get_ov_output(x, ov_type=None, context_dtype=None):
             "unsupported type of `x` to create ov.Output: {}".format(type(x))
         )
     return x
+
+
+def shape_to_ov_output(shape):
+    """Convert a shape tuple/list to an i32 ov.Output.
+
+    Unlike get_ov_output, handles mixed shapes where some dims are
+    OpenVINOKerasTensor scalars (from ops.shape() on dynamic tensors).
+    """
+    if not isinstance(shape, (list, tuple)):
+        raise ValueError(f"shape must be a list or tuple, got {type(shape)}")
+    if not any(isinstance(e, (OpenVINOKerasTensor, ov.Output)) for e in shape):
+        return ov_opset.constant(list(shape), Type.i32).output(0)
+    parts = []
+    for e in shape:
+        if isinstance(e, OpenVINOKerasTensor):
+            elem = e.output
+        elif isinstance(e, ov.Output):
+            elem = e
+        else:
+            elem = ov_opset.constant([e], Type.i32).output(0)
+        if elem.get_element_type() != Type.i32:
+            elem = ov_opset.convert(elem, Type.i32).output(0)
+        # Scalar dims need to be reshaped to [1] for concat
+        ps = elem.get_partial_shape()
+        if ps.rank.is_static and ps.rank.get_length() == 0:
+            elem = ov_opset.reshape(
+                elem, ov_opset.constant([1], Type.i32).output(0), False
+            ).output(0)
+        parts.append(elem)
+    return ov_opset.concat(parts, 0).output(0)
 
 
 # wrapper for OpenVINO symbolic tensor ov.Output

--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -133,12 +133,7 @@ def get_ov_output(x, ov_type=None, context_dtype=None):
             # Mixed or fully-symbolic shape: concat individual dim tensors
             parts = []
             for e in x:
-                if isinstance(e, OpenVINOKerasTensor):
-                    elem = e.output
-                elif isinstance(e, ov.Output):
-                    elem = e
-                else:
-                    elem = ov_opset.constant([e], target_type).output(0)
+                elem = get_ov_output(e, ov_type=target_type)
                 if elem.get_element_type() != target_type:
                     elem = ov_opset.convert(elem, target_type).output(0)
                 # Ensure rank-1 shape for concat

--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -128,7 +128,33 @@ def get_ov_output(x, ov_type=None, context_dtype=None):
     elif isinstance(x, (list, tuple)):
         if isinstance(x, tuple):
             x = list(x)
-        if ov_type is None:
+        target_type = ov_type if ov_type is not None else Type.i32
+        if any(isinstance(e, (OpenVINOKerasTensor, ov.Output)) for e in x):
+            # Mixed or fully-symbolic shape: concat individual dim tensors
+            parts = []
+            for e in x:
+                if isinstance(e, OpenVINOKerasTensor):
+                    elem = e.output
+                elif isinstance(e, ov.Output):
+                    elem = e
+                else:
+                    elem = ov_opset.constant([e], target_type).output(0)
+                if elem.get_element_type() != target_type:
+                    elem = ov_opset.convert(elem, target_type).output(0)
+                # Ensure rank-1 shape for concat
+                scalar_shape = elem.get_partial_shape()
+                if (
+                    scalar_shape.rank.is_static
+                    and scalar_shape.rank.get_length() == 0
+                ):
+                    elem = ov_opset.reshape(
+                        elem,
+                        ov_opset.constant([1], Type.i32).output(0),
+                        False,
+                    ).output(0)
+                parts.append(elem)
+            x = ov_opset.concat(parts, 0).output(0)
+        elif ov_type is None:
             x = ov_opset.constant(x).output(0)
         else:
             x = ov_opset.constant(x, ov_type).output(0)

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -41,9 +41,7 @@ LinalgOpsCorrectnessTest::test_svd
 MathOpsCorrectnessTest::test_erfinv_operation_basic
 MathOpsCorrectnessTest::test_erfinv_operation_dtype
 MathOpsCorrectnessTest::test_logdet
-MeanTest::test_weighted_dynamic_shapes
 MergingLayersTest::test_average_with_mask
-MetricWrapperTest::test_weighted_dynamic_shape
 NNOpsCorrectnessTest::test_ctc_decode
 NNOpsCorrectnessTest::test_polar_corectness
 NNOpsDtypeTest::test_ctc_decode

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -211,9 +211,11 @@ def zeros(shape, dtype=None):
     dtype = standardize_dtype(dtype) or config.floatx()
     ov_type = OPENVINO_DTYPES[dtype]
     const_zero = ov_opset.constant(0, dtype=ov_type).output(0)
-    if isinstance(shape, int):
+    if isinstance(shape, tuple):
+        shape = list(shape)
+    elif isinstance(shape, int):
         shape = [shape]
-    output_shape = get_ov_output(list(shape), ov_type=Type.i32)
+    output_shape = ov_opset.constant(shape, dtype=Type.i32).output(0)
     zeros = ov_opset.broadcast(const_zero, output_shape)
     return OpenVINOKerasTensor(zeros.output(0))
 

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -199,9 +199,11 @@ def ones(shape, dtype=None):
     dtype = standardize_dtype(dtype) or config.floatx()
     ov_type = OPENVINO_DTYPES[dtype]
     const_one = ov_opset.constant(1, ov_type).output(0)
-    if isinstance(shape, int):
+    if isinstance(shape, tuple):
+        shape = list(shape)
+    elif isinstance(shape, int):
         shape = [shape]
-    output_shape = shape_to_ov_output(list(shape))
+    output_shape = ov_opset.constant(shape, dtype=Type.i32).output(0)
     ones = ov_opset.broadcast(const_one, output_shape)
     return OpenVINOKerasTensor(ones.output(0))
 
@@ -210,9 +212,11 @@ def zeros(shape, dtype=None):
     dtype = standardize_dtype(dtype) or config.floatx()
     ov_type = OPENVINO_DTYPES[dtype]
     const_zero = ov_opset.constant(0, dtype=ov_type).output(0)
-    if isinstance(shape, int):
+    if isinstance(shape, tuple):
+        shape = list(shape)
+    elif isinstance(shape, int):
         shape = [shape]
-    output_shape = shape_to_ov_output(list(shape))
+    output_shape = ov_opset.constant(shape, dtype=Type.i32).output(0)
     zeros = ov_opset.broadcast(const_zero, output_shape)
     return OpenVINOKerasTensor(zeros.output(0))
 

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -18,6 +18,7 @@ from keras.src.backend.openvino.core import (
 from keras.src.backend.openvino.core import convert_to_tensor
 from keras.src.backend.openvino.core import get_ov_output
 from keras.src.backend.openvino.core import ov_to_keras_type
+from keras.src.backend.openvino.core import shape_to_ov_output
 from keras.src.backend.openvino.core import while_loop
 
 
@@ -1180,7 +1181,7 @@ def broadcast_to(x, shape):
             f"`broadcast_to` is supported only for tuple and list `shape`. "
             f"Received: shape={shape} (type {type(shape)})"
         )
-    target_shape = get_ov_output(list(shape), ov_type=Type.i32)
+    target_shape = shape_to_ov_output(list(shape))
     x = get_ov_output(x)
     return OpenVINOKerasTensor(ov_opset.broadcast(x, target_shape).output(0))
 

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -211,11 +211,9 @@ def zeros(shape, dtype=None):
     dtype = standardize_dtype(dtype) or config.floatx()
     ov_type = OPENVINO_DTYPES[dtype]
     const_zero = ov_opset.constant(0, dtype=ov_type).output(0)
-    if isinstance(shape, tuple):
-        shape = list(shape)
-    elif isinstance(shape, int):
+    if isinstance(shape, int):
         shape = [shape]
-    output_shape = ov_opset.constant(shape, dtype=Type.i32).output(0)
+    output_shape = get_ov_output(list(shape), ov_type=Type.i32)
     zeros = ov_opset.broadcast(const_zero, output_shape)
     return OpenVINOKerasTensor(zeros.output(0))
 
@@ -1180,7 +1178,7 @@ def broadcast_to(x, shape):
             f"`broadcast_to` is supported only for tuple and list `shape`. "
             f"Received: shape={shape} (type {type(shape)})"
         )
-    target_shape = ov_opset.constant(list(shape), Type.i32).output(0)
+    target_shape = get_ov_output(list(shape), ov_type=Type.i32)
     x = get_ov_output(x)
     return OpenVINOKerasTensor(ov_opset.broadcast(x, target_shape).output(0))
 

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -199,11 +199,9 @@ def ones(shape, dtype=None):
     dtype = standardize_dtype(dtype) or config.floatx()
     ov_type = OPENVINO_DTYPES[dtype]
     const_one = ov_opset.constant(1, ov_type).output(0)
-    if isinstance(shape, tuple):
-        shape = list(shape)
-    elif isinstance(shape, int):
+    if isinstance(shape, int):
         shape = [shape]
-    output_shape = ov_opset.constant(shape, dtype=Type.i32).output(0)
+    output_shape = shape_to_ov_output(list(shape))
     ones = ov_opset.broadcast(const_one, output_shape)
     return OpenVINOKerasTensor(ones.output(0))
 
@@ -212,11 +210,9 @@ def zeros(shape, dtype=None):
     dtype = standardize_dtype(dtype) or config.floatx()
     ov_type = OPENVINO_DTYPES[dtype]
     const_zero = ov_opset.constant(0, dtype=ov_type).output(0)
-    if isinstance(shape, tuple):
-        shape = list(shape)
-    elif isinstance(shape, int):
+    if isinstance(shape, int):
         shape = [shape]
-    output_shape = ov_opset.constant(shape, dtype=Type.i32).output(0)
+    output_shape = shape_to_ov_output(list(shape))
     zeros = ov_opset.broadcast(const_zero, output_shape)
     return OpenVINOKerasTensor(zeros.output(0))
 


### PR DESCRIPTION
## Description
When ops.shape() is called on a tensor with dynamic dimensions, it returns a tuple where unknown dims are OpenVINOKerasTensor scalars rather than Python ints. Any downstream op receiving this tuple as a shape argument would fail because get_ov_output's list/tuple branch unconditionally called ov_opset.constant(x), which internally calls np.array() on each element, triggering the symbolic tensor's `__array__` guard:

`RuntimeError: An OpenVINOKerasTensor is symbolic: it's a placeholder for a shape and a dtype.`

My fix for this:
**get_ov_output**: When the input list/tuple contains any OpenVINOKerasTensor or ov.Output element, build the shape tensor dynamically, convert each element to a rank-1 [1] output (scalar dims are reshaped, static ints become constant([v])), align dtypes, then concat along axis 0. All-static lists continue through the existing ov_opset.constant path.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

