### PR TITLE
Fix compute_output_spec for Blackman operation

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1864,6 +1864,9 @@ class Blackman(Operation):
         return backend.numpy.blackman(x)
 
     def compute_output_spec(self, x):
+        if x.shape == ():
+            # x is a scalar (window length), output should be 1D
+            return KerasTensor((None,), dtype=backend.floatx())
         return KerasTensor(x.shape, dtype=backend.floatx())
 
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1864,10 +1864,9 @@ class Blackman(Operation):
         return backend.numpy.blackman(x)
 
     def compute_output_spec(self, x):
-        if x.shape == ():
-            # x is a scalar (window length), output should be 1D
-            return KerasTensor((None,), dtype=backend.floatx())
-        return KerasTensor(x.shape, dtype=backend.floatx())
+        # The output is always a 1D window of length equal to the value of x.
+        # Since the value is unknown symbolically, the shape is (None,).
+        return KerasTensor((None,), dtype=backend.floatx())
 
 
 @keras_export(["keras.ops.blackman", "keras.ops.numpy.blackman"])


### PR DESCRIPTION
Good day

## Summary
This PR fixes the incorrect shape inference for the `Blackman` operation when the input is a scalar tensor (window length).

## Problem
When calling `keras.ops.blackman(x)` where `x` is a scalar tensor (e.g., `keras.Input(shape=())`), the `compute_output_spec` method was incorrectly returning a tensor with the same shape as the input (i.e., `()`), instead of the correct output shape `(x,)` or `(None,)` for symbolic tensors.

The Blackman window function produces a 1D tensor of length equal to the window length, so the output should always be 1D, not a scalar.

## Fix
Modified `compute_output_spec` in the `Blackman` class to check if the input shape is `()` (scalar), and if so, return a 1D tensor with shape `(None,)` to indicate an unknown-length 1D output.

```python
def compute_output_spec(self, x):
    if x.shape == ():
        # x is a scalar (window length), output should be 1D
        return KerasTensor((None,), dtype=backend.floatx())
    return KerasTensor(x.shape, dtype=backend.floatx())
```

## Issue Reference
This PR addresses the shape inference issue mentioned in keras-team/keras#22538.

## Testing
- Existing tests for `blackman` should continue to pass
- The fix correctly handles symbolic tensor inputs with scalar shape

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof
