### PR TITLE
Validate integer type for input_dim and output_dim in Embedding layer

### DIFF
--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -104,6 +104,24 @@ class Embedding(Layer):
                 "Argument `input_length` is deprecated. Just remove it."
             )
         super().__init__(**kwargs)
+        if not isinstance(input_dim, int):
+            if isinstance(input_dim, float) and input_dim.is_integer():
+                input_dim = int(input_dim)
+            else:
+                raise ValueError(
+                    "Argument `input_dim` must be an integer. "
+                    f"Received: input_dim={input_dim} "
+                    f"(of type {type(input_dim).__name__})"
+                )
+        if not isinstance(output_dim, int):
+            if isinstance(output_dim, float) and output_dim.is_integer():
+                output_dim = int(output_dim)
+            else:
+                raise ValueError(
+                    "Argument `output_dim` must be an integer. "
+                    f"Received: output_dim={output_dim} "
+                    f"(of type {type(output_dim).__name__})"
+                )
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.embeddings_initializer = initializers.get(embeddings_initializer)

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -104,24 +104,22 @@ class Embedding(Layer):
                 "Argument `input_length` is deprecated. Just remove it."
             )
         super().__init__(**kwargs)
-        if not isinstance(input_dim, int):
-            if isinstance(input_dim, float) and input_dim.is_integer():
-                input_dim = int(input_dim)
-            else:
+        for name, value in [("input_dim", input_dim), ("output_dim", output_dim)]:
+            if isinstance(value, bool) or not (
+                isinstance(value, (int, float)) and value == int(value)
+            ):
                 raise ValueError(
-                    "Argument `input_dim` must be an integer. "
-                    f"Received: input_dim={input_dim} "
-                    f"(of type {type(input_dim).__name__})"
+                    f"Argument `{name}` must be an integer. "
+                    f"Received: {name}={value} "
+                    f"(of type {type(value).__name__})"
                 )
-        if not isinstance(output_dim, int):
-            if isinstance(output_dim, float) and output_dim.is_integer():
-                output_dim = int(output_dim)
-            else:
+            if value <= 0:
                 raise ValueError(
-                    "Argument `output_dim` must be an integer. "
-                    f"Received: output_dim={output_dim} "
-                    f"(of type {type(output_dim).__name__})"
+                    f"Argument `{name}` must be a positive integer. "
+                    f"Received: {name}={value}"
                 )
+        input_dim = int(input_dim)
+        output_dim = int(output_dim)
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.embeddings_initializer = initializers.get(embeddings_initializer)

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -61,6 +61,36 @@ class EmbeddingTest(test_case.TestCase):
         y = layer(x)
         self.assertEqual(y.shape, (2, 3, 6))
 
+    def test_embedding_invalid_input_dim_type(self):
+        with self.assertRaisesRegex(ValueError, "must be an integer"):
+            layers.Embedding(input_dim="ten", output_dim=3)
+        with self.assertRaisesRegex(ValueError, "must be an integer"):
+            layers.Embedding(input_dim=True, output_dim=3)
+        with self.assertRaisesRegex(ValueError, "must be an integer"):
+            layers.Embedding(input_dim=4.7, output_dim=3)
+
+    def test_embedding_invalid_output_dim_type(self):
+        with self.assertRaisesRegex(ValueError, "must be an integer"):
+            layers.Embedding(input_dim=4, output_dim="three")
+        with self.assertRaisesRegex(ValueError, "must be an integer"):
+            layers.Embedding(input_dim=4, output_dim=False)
+
+    def test_embedding_non_positive_dims(self):
+        with self.assertRaisesRegex(ValueError, "must be a positive integer"):
+            layers.Embedding(input_dim=0, output_dim=3)
+        with self.assertRaisesRegex(ValueError, "must be a positive integer"):
+            layers.Embedding(input_dim=-1, output_dim=3)
+        with self.assertRaisesRegex(ValueError, "must be a positive integer"):
+            layers.Embedding(input_dim=4, output_dim=0)
+        with self.assertRaisesRegex(ValueError, "must be a positive integer"):
+            layers.Embedding(input_dim=4, output_dim=-5)
+
+    def test_embedding_float_whole_number_dims(self):
+        # Whole-number floats should be silently converted to int
+        layer = layers.Embedding(input_dim=4.0, output_dim=3.0)
+        self.assertEqual(layer.input_dim, 4)
+        self.assertEqual(layer.output_dim, 3)
+
     def test_embedding_basics(self):
         self.run_layer_test(
             layers.Embedding,


### PR DESCRIPTION
## Description

Fixes #22700

Added integer validation for input_dim and output_dim in Embedding.__init__. Whole-number floats are silently converted; non-whole floats raise ValueError.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.