### PR TITLE
fix: raise ValueError in deserialize_keras_object when required Keras config keys are missing

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -611,14 +611,10 @@ def deserialize_keras_object(
 
     if "class_name" not in config or "config" not in config:
         if "module" in config or "registered_name" in config:
-            missing = [
-                k
-                for k in ("class_name", "config")
-                if k not in config
-            ]
+            missing = [k for k in ("class_name", "config") if k not in config]
             raise ValueError(
-                "A Keras config dict is missing required keys "
-                f"{missing}. Received: config={config}"
+                f"A Keras config dict is missing required keys {missing}. "
+                f"Received: config={config}"
             )
         return {
             key: deserialize_keras_object(

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -610,6 +610,16 @@ def deserialize_keras_object(
         raise TypeError(f"Could not parse config: {config}")
 
     if "class_name" not in config or "config" not in config:
+        if "module" in config or "registered_name" in config:
+            missing = [
+                k
+                for k in ("class_name", "config")
+                if k not in config
+            ]
+            raise ValueError(
+                "A Keras config dict is missing required keys "
+                f"{missing}. Received: config={config}"
+            )
         return {
             key: deserialize_keras_object(
                 value, custom_objects=custom_objects, safe_mode=safe_mode

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -420,9 +420,8 @@ class SerializationLibTest(testing.TestCase):
             restored_dense_relu_string.activation, keras.activations.relu
         )
 
-
     def test_deserialize_missing_class_name_raises(self):
-        # Missing class_name but module is present — should raise, not return dict
+        # Missing class_name but module present: should raise, not return dict
         config = {"module": "keras.layers", "config": {"units": 32}}
         with self.assertRaisesRegex(ValueError, "missing required keys"):
             serialization_lib.deserialize_keras_object(config)

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -421,6 +421,24 @@ class SerializationLibTest(testing.TestCase):
         )
 
 
+    def test_deserialize_missing_class_name_raises(self):
+        # Missing class_name but module is present — should raise, not return dict
+        config = {"module": "keras.layers", "config": {"units": 32}}
+        with self.assertRaisesRegex(ValueError, "missing required keys"):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_deserialize_missing_class_name_with_registered_name_raises(self):
+        config = {"registered_name": "MyLayer", "config": {"units": 32}}
+        with self.assertRaisesRegex(ValueError, "missing required keys"):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_deserialize_plain_dict_no_keras_keys_passthrough(self):
+        # Plain dict without Keras-specific keys should still work
+        config = {"foo": "bar", "baz": 42}
+        result = serialization_lib.deserialize_keras_object(config)
+        self.assertEqual(result, {"foo": "bar", "baz": 42})
+
+
 @keras.saving.register_keras_serializable()
 class MyDense(keras.layers.Layer):
     def __init__(


### PR DESCRIPTION

Fixes #22704

## Description
`deserialize_keras_object` silently returned a raw `dict` when the input was missing `class_name` but contained Keras-specific keys like `module` or `registered_name`. This made it impossible for callers to detect a failed deserialization.
**Root cause:** The block meant to handle plain Python dicts also accidentally caught malformed Keras configs.
**Fix:** Added a guard — if the incomplete dict contains `module` or `registered_name` (keys that only appear in Keras-serialized objects), raise a descriptive `ValueError` listing exactly which keys are missing. Plain dicts without those keys continue to pass through unchanged, preserving existing behavior. This is consistent with the same validation already present in the `module_objects` code path.
**Tests added** (`serialization_lib_test.py`):
- `test_deserialize_missing_class_name_raises` — reproduces the exact bug
- `test_deserialize_missing_class_name_with_registered_name_raises` — same bug via `registered_name`
- `test_deserialize_plain_dict_no_keras_keys_passthrough` — regression guard for plain dicts

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
