### PR TITLE
`Embedding.from_config` accepts a float value for `input_dim` (and `outp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ examples/**/*.jpg
 
 pytest.ini
 venv/
+.swe/

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ examples/**/*.jpg
 
 pytest.ini
 venv/
-.swe/

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -103,6 +103,16 @@ class Embedding(Layer):
             warnings.warn(
                 "Argument `input_length` is deprecated. Just remove it."
             )
+        if not isinstance(input_dim, int):
+            raise ValueError(
+                "`input_dim` must be a Python int. "
+                f"Received: input_dim={input_dim!r} (of type {type(input_dim)})"
+            )
+        if not isinstance(output_dim, int):
+            raise ValueError(
+                "`output_dim` must be a Python int. "
+                f"Received: output_dim={output_dim!r} (of type {type(output_dim)})"
+            )
         super().__init__(**kwargs)
         self.input_dim = input_dim
         self.output_dim = output_dim

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -345,6 +345,14 @@ class Embedding(Layer):
     @classmethod
     def from_config(cls, config):
         config = config.copy()
+        for dim_name in ("input_dim", "output_dim"):
+            value = config.get(dim_name)
+            if not isinstance(value, int):
+                raise ValueError(
+                    f"`{dim_name}` must be a Python int. "
+                    f"Received: {dim_name}={value!r} "
+                    f"(of type {type(value)})"
+                )
         config["quantization_config"] = (
             serialization_lib.deserialize_keras_object(
                 config.get("quantization_config", None)

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -862,3 +862,11 @@ class EmbeddingTest(test_case.TestCase):
         # Verify outputs match
         y_after = loaded_model(x)
         self.assertAllClose(y_before, y_after)
+
+    def test_input_dim_output_dim_must_be_int(self):
+        with self.assertRaisesRegex(ValueError, "input_dim"):
+            layers.Embedding(input_dim=3.7, output_dim=2)
+        with self.assertRaisesRegex(ValueError, "output_dim"):
+            layers.Embedding(input_dim=3, output_dim=2.0)
+        # Valid ints should not raise
+        layers.Embedding(input_dim=3, output_dim=2)

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -870,3 +870,20 @@ class EmbeddingTest(test_case.TestCase):
             layers.Embedding(input_dim=3, output_dim=2.0)
         # Valid ints should not raise
         layers.Embedding(input_dim=3, output_dim=2)
+
+    def test_from_config_rejects_float_input_dim(self):
+        with self.assertRaisesRegex(ValueError, "input_dim"):
+            layers.Embedding.from_config({"input_dim": 3.7, "output_dim": 2})
+        with self.assertRaisesRegex(ValueError, "input_dim"):
+            layers.Embedding.from_config({"input_dim": 3.0, "output_dim": 2})
+
+    def test_from_config_rejects_float_output_dim(self):
+        with self.assertRaisesRegex(ValueError, "output_dim"):
+            layers.Embedding.from_config({"input_dim": 3, "output_dim": 2.5})
+        with self.assertRaisesRegex(ValueError, "output_dim"):
+            layers.Embedding.from_config({"input_dim": 3, "output_dim": 2.0})
+
+    def test_from_config_accepts_valid_int_dims(self):
+        layer = layers.Embedding.from_config({"input_dim": 4, "output_dim": 3})
+        self.assertEqual(layer.input_dim, 4)
+        self.assertEqual(layer.output_dim, 3)


### PR DESCRIPTION
## Problem

`Embedding.from_config` accepts a float value for `input_dim` (and `output_dim`) without raising an error, because validation only exists in `__init__` (added by prior sessions) and there is no dedicated `from_config` guard or test covering the `from_config` call path.

## Approach

Add explicit type validation for `input_dim` and `output_dim` directly inside `Embedding.from_config` (before calling `super().from_config`), so that the error is raised at the deserialization boundary with a clear message. Per the user's decision, both non-numeric floats (3.7) and integer-valued floats (3.0) must be rejected — no silent coercion. Then add test cases in `embedding_test.py` that exercise the `from_config` path specifically with float inputs (both fractional and integer-valued floats), confirming a `ValueError` is raised. The existing `test_input_dim_output_dim_must_be_int` test only covers the `__init__` path; the new test must call `Embedding.from_config({...})` directly.

## Review comments

- **WARN** `keras/src/layers/core/embedding.py:348`: The `from_config` validation does not guard against a missing key (i.e., `config.get(dim_name)` returns `None` when the key is absent). `None` is not an `int`, so the error message would read "`input_dim` must be a Python int. Received: input_dim=None (of type <class 'NoneType'>)` — misleading when the real issue is a missing required field. Consider checking `if dim_name not in config` first and raising a more informative error, or at minimum adjusting the message to cover the absent-key case.

- **NIT** `keras/src/layers/core/embedding_test.py:863`: The test `test_input_dim_output_dim_must_be_int` appears to be a duplicate of the test added in a prior session (session-2). Confirm that no pre-existing test with this name already exists in the file before this diff; if one does, this will silently shadow or collide with it. If it is indeed new here, it is fine, but it should be named to distinguish it from any prior coverage.

- **NIT** `keras/src/layers/core/embedding.py:348`: The error message format in `from_config` is slightly inconsistent with the one in `__init__`. In `__init__` the format is `f"Received: {dim_name}={value!r} (of type {type(value)})"` with a single-line f-string, whereas in `__init__` it uses a two-line concatenated string with the same pattern. The inconsistency is cosmetic but worth aligning for maintainability.

- **NIT** `keras/src/layers/core/embedding_test.py:886`: `test_from_config_accepts_valid_int_dims` does not assert that the layer is fully functional (e.g., calling it on sample input). Asserting only `input_dim` and `output_dim` attributes is sufficient for the stated goal, but a brief build/call check would make the happy-path test more robust. This is a nit since the plan only requires confirming no error is raised.


---
_Generated by swe session #3_