### PR TITLE
`Embedding.from_config` does not validate that `input_dim` and `output_d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ examples/**/*.jpg
 
 pytest.ini
 venv/
+.swe/

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ examples/**/*.jpg
 
 pytest.ini
 venv/
-.swe/

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -103,6 +103,16 @@ class Embedding(Layer):
             warnings.warn(
                 "Argument `input_length` is deprecated. Just remove it."
             )
+        if not isinstance(input_dim, int):
+            raise ValueError(
+                "`input_dim` must be a Python int. "
+                f"Received: input_dim={input_dim!r} (of type {type(input_dim)})"
+            )
+        if not isinstance(output_dim, int):
+            raise ValueError(
+                "`output_dim` must be a Python int. "
+                f"Received: output_dim={output_dim!r} (of type {type(output_dim)})"
+            )
         super().__init__(**kwargs)
         self.input_dim = input_dim
         self.output_dim = output_dim

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -345,6 +345,14 @@ class Embedding(Layer):
     @classmethod
     def from_config(cls, config):
         config = config.copy()
+        for dim_name in ("input_dim", "output_dim"):
+            value = config.get(dim_name)
+            if not isinstance(value, int):
+                raise ValueError(
+                    f"`{dim_name}` must be a Python int. "
+                    f"Received: {dim_name}={value!r} "
+                    f"(of type {type(value)})"
+                )
         config["quantization_config"] = (
             serialization_lib.deserialize_keras_object(
                 config.get("quantization_config", None)

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -862,3 +862,11 @@ class EmbeddingTest(test_case.TestCase):
         # Verify outputs match
         y_after = loaded_model(x)
         self.assertAllClose(y_before, y_after)
+
+    def test_input_dim_output_dim_must_be_int(self):
+        with self.assertRaisesRegex(ValueError, "input_dim"):
+            layers.Embedding(input_dim=3.7, output_dim=2)
+        with self.assertRaisesRegex(ValueError, "output_dim"):
+            layers.Embedding(input_dim=3, output_dim=2.0)
+        # Valid ints should not raise
+        layers.Embedding(input_dim=3, output_dim=2)

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -870,3 +870,20 @@ class EmbeddingTest(test_case.TestCase):
             layers.Embedding(input_dim=3, output_dim=2.0)
         # Valid ints should not raise
         layers.Embedding(input_dim=3, output_dim=2)
+
+    def test_from_config_rejects_float_input_dim(self):
+        with self.assertRaisesRegex(ValueError, "input_dim"):
+            layers.Embedding.from_config({"input_dim": 3.7, "output_dim": 2})
+        with self.assertRaisesRegex(ValueError, "input_dim"):
+            layers.Embedding.from_config({"input_dim": 3.0, "output_dim": 2})
+
+    def test_from_config_rejects_float_output_dim(self):
+        with self.assertRaisesRegex(ValueError, "output_dim"):
+            layers.Embedding.from_config({"input_dim": 3, "output_dim": 2.5})
+        with self.assertRaisesRegex(ValueError, "output_dim"):
+            layers.Embedding.from_config({"input_dim": 3, "output_dim": 2.0})
+
+    def test_from_config_accepts_valid_int_dims(self):
+        layer = layers.Embedding.from_config({"input_dim": 4, "output_dim": 3})
+        self.assertEqual(layer.input_dim, 4)
+        self.assertEqual(layer.output_dim, 3)


### PR DESCRIPTION
## Problem

`Embedding.from_config` does not validate that `input_dim` and `output_dim` are Python ints before constructing the layer, allowing float values (e.g. 3.7) to be silently accepted as valid configuration, potentially causing silent truncation or unexpected behavior when the layer is built.

## Approach

Add explicit type validation in `Embedding.from_config` (keras/src/layers/core/embedding.py) to check that `input_dim` and `output_dim` in the config dict are Python `int` instances before calling `super().from_config(config)`. Raise a descriptive `ValueError` matching the style of the existing validation in `__init__` if either value is not an `int`. Add corresponding test cases in `embedding_test.py` that call `Embedding.from_config` with float values and assert a `ValueError` is raised.

## Review comments

- **WARN** `keras/src/layers/core/embedding.py:348`: If `input_dim` or `output_dim` is absent from the config dict, `config.get(dim_name)` returns `None`, causing the validator to raise "`input_dim` must be a Python int. Received: input_dim=None (of type <class 'NoneType'>)". A missing required key is a different error condition from a wrong type, and the current message is misleading. Consider checking `if dim_name not in config` first and raising a KeyError or a more descriptive ValueError, or at minimum noting the missing-key case in the message.

- **NIT** `keras/src/layers/core/embedding.py:348`: Python's `bool` is a subclass of `int`, so `isinstance(True, int)` returns `True`. `input_dim=True` or `output_dim=False` would silently pass validation as 1 and 0 respectively. This is consistent with the `__init__` validation added in earlier sessions, but if stricter rejection is desired, add `and not isinstance(value, bool)` to each check.

- **NIT** `keras/src/layers/core/embedding_test.py:882`: `test_from_config_accepts_valid_int_dims` passes a bare minimal config `{"input_dim": 4, "output_dim": 3}` missing many keys that `from_config` may expect (e.g. `quantization_config` deserialization path). If `serialization_lib.deserialize_keras_object(None)` or subsequent layer construction raises for other reasons, this test fails for reasons unrelated to type validation. Consider deriving the config from `Embedding(4, 3).get_config()` to test the real round-trip path.


---
_Generated by swe session #4_