### PR TITLE
Validate input_dim and output_dim in Embedding

### DIFF
--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -98,6 +98,26 @@ class Embedding(Layer):
         quantization_config=None,
         **kwargs,
     ):
+        if (
+            not isinstance(input_dim, int)
+            or isinstance(input_dim, bool)
+            or input_dim <= 0
+        ):
+            raise ValueError(
+                "`input_dim` must be a positive integer. "
+                f"Received: input_dim={input_dim} "
+                f"(of type {type(input_dim).__name__})."
+            )
+        if (
+            not isinstance(output_dim, int)
+            or isinstance(output_dim, bool)
+            or output_dim <= 0
+        ):
+            raise ValueError(
+                "`output_dim` must be a positive integer. "
+                f"Received: output_dim={output_dim} "
+                f"(of type {type(output_dim).__name__})."
+            )
         input_length = kwargs.pop("input_length", None)
         if input_length is not None:
             warnings.warn(

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -181,6 +181,28 @@ class EmbeddingTest(test_case.TestCase):
         layer.build((None, 2))
         self.assertIsInstance(layer.embeddings.constraint, constraints.NonNeg)
 
+    def test_invalid_input_dim(self):
+        for bad_value in (3.7, 4.0, "3", None, True, False, -1, 0):
+            with self.assertRaisesRegex(
+                ValueError, "`input_dim` must be a positive integer"
+            ):
+                layers.Embedding(input_dim=bad_value, output_dim=8)
+        with self.assertRaisesRegex(
+            TypeError, "`input_dim` must be a positive integer"
+        ):
+            layers.Embedding.from_config({"input_dim": 3.7, "output_dim": 8})
+
+    def test_invalid_output_dim(self):
+        for bad_value in (3.7, 4.0, "3", None, True, False, -1, 0):
+            with self.assertRaisesRegex(
+                ValueError, "`output_dim` must be a positive integer"
+            ):
+                layers.Embedding(input_dim=10, output_dim=bad_value)
+        with self.assertRaisesRegex(
+            TypeError, "`output_dim` must be a positive integer"
+        ):
+            layers.Embedding.from_config({"input_dim": 10, "output_dim": 3.7})
+
     def test_weights_constructor_arg(self):
         layer = layers.Embedding(3, 4, weights=np.ones((3, 4)))
         self.assertAllClose(layer.embeddings.numpy(), np.ones((3, 4)))


### PR DESCRIPTION
## Description

Fixes #22700.

Previously `Embedding(input_dim=3.7, ...)` and `Embedding.from_config({"input_dim": 3.7, ...})` silently accepted non-integer or non-positive values, leading to silent truncation and confusing downstream errors.

This change raises `ValueError` at construction time for any non-int or non-positive value for both `input_dim` and `output_dim`. The check matches the existing pattern in `Dense` (`keras/src/layers/core/dense.py:101`), so it is consistent with project convention.

### Test plan

- [x] Added `test_invalid_input_dim` and `test_invalid_output_dim` covering float, string, `None`, negative, and zero values
- [x] Added an assertion for the `from_config` path reproduced in #22700
- [x] `pytest keras/src/layers/core/embedding_test.py` — 51 passed
- [x] `pytest keras/src/layers/core/reversible_embedding_test.py` (subclass) — 41 passed
- [x] `pre-commit` runs clean on both modified files

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.