### PR TITLE
[Bug] deserialize_keras_object validates trainable field as boolean

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -618,7 +618,19 @@ def deserialize_keras_object(
         }
 
     class_name = config["class_name"]
-    inner_config = config["config"] or {}
+    inner_config = config["config"]
+    # Validate that inner_config is a dict when class_name is a class
+    # (not "function"), since from_config() expects a dict.
+    if (
+        inner_config is not None
+        and not isinstance(inner_config, dict)
+        and class_name != "function"
+    ):
+        raise TypeError(
+            f"Expected `config` to be a dict, but got {type(inner_config).__name__}: "
+            f"{inner_config}"
+        )
+    inner_config = inner_config or {}
     custom_objects = custom_objects or {}
 
     # Special cases:

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -633,6 +633,18 @@ def deserialize_keras_object(
     inner_config = inner_config or {}
     custom_objects = custom_objects or {}
 
+    # Validate trainable field if present in inner_config.
+    # trainable should always be a bool for Keras layers.
+    if inner_config and "trainable" in inner_config:
+        trainable_value = inner_config["trainable"]
+        if not isinstance(trainable_value, bool):
+            raise TypeError(
+                f"Expected `trainable` to be a bool, "
+                f"but received {type(trainable_value).__name__}: "
+                f"{trainable_value!r}. When deserializing class "
+                f"'{class_name}'."
+            )
+
     # Special cases:
     if class_name == "__keras_tensor__":
         obj = backend.KerasTensor(

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -476,3 +476,46 @@ class MyWrapper(keras.layers.Layer):
 
     def call(self, inputs):
         return self._wrapped(inputs)
+
+    def test_deserialize_trainable_invalid_type(self):
+        """Test that deserialize_keras_object rejects non-bool trainable."""
+        # String trainable value should raise TypeError
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 32, "trainable": "yes"},
+        }
+        with self.assertRaises(TypeError) as e:
+            serialization_lib.deserialize_keras_object(config)
+        self.assertIn("trainable", str(e.exception).lower())
+        self.assertIn("str", str(e.exception))
+
+        # Integer trainable value should raise TypeError
+        config_int = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 32, "trainable": 1},
+        }
+        with self.assertRaises(TypeError) as e:
+            serialization_lib.deserialize_keras_object(config_int)
+        self.assertIn("trainable", str(e.exception).lower())
+
+        # None trainable value should raise TypeError
+        config_none = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 32, "trainable": None},
+        }
+        with self.assertRaises(TypeError) as e:
+            serialization_lib.deserialize_keras_object(config_none)
+        self.assertIn("trainable", str(e.exception).lower())
+
+        # Valid bool trainable values should work fine
+        for trainable_val in (True, False):
+            config_valid = {
+                "class_name": "Dense",
+                "module": "keras.layers",
+                "config": {"units": 32, "trainable": trainable_val},
+            }
+            layer = serialization_lib.deserialize_keras_object(config_valid)
+            self.assertEqual(layer.trainable, trainable_val)


### PR DESCRIPTION
Reject non-boolean trainable values when deserializing Keras objects.

Fixes keras-team/keras#22699