### PR TITLE
Fix validation for malformed layer configs in Sequential.from_config

### DIFF
--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -381,7 +381,8 @@ class Sequential(Model):
         for i,layer_config in enumerate(layer_configs):
             if not isinstance(layer_config, dict):
                 raise ValueError(
-                    f"Layer at index {i} must be a dict. Received: {type(layer_config)}"
+                    f"Layer at index {i} must be a dict. Received: "
+                    f"Received: {type(layer_config)}"
                 )
             if "class_name" not in layer_config:
                 raise ValueError(

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -378,6 +378,15 @@ class Sequential(Model):
             name = None
             layer_configs = config
         model = cls(name=name)
+        for i,layer_config in enumerate(layer_configs):
+            if not isinstance(layer_config, dict):
+                raise ValueError(
+                    f"Layer at index {i} must be a dict. Received: {type(layer_config)}"
+                )
+            if "class_name" not in layer_config:
+                raise ValueError(
+                    f"Layer at index {i} is missing 'class_name'. Received: {layer_config}"
+                )
         for layer_config in layer_configs:
             if "module" not in layer_config:
                 # Legacy format deserialization (no "module" key)

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -385,7 +385,8 @@ class Sequential(Model):
                 )
             if "class_name" not in layer_config:
                 raise ValueError(
-                    f"Layer at index {i} is missing 'class_name'. Received: {layer_config}"
+                    f"Layer at index {i} is missing 'class_name'. "
+                    f"Received: {layer_config}"
                 )
         for layer_config in layer_configs:
             if "module" not in layer_config:


### PR DESCRIPTION
Fixes #22720

## Description

Adds validation for entries in the `layers` list during Sequential
deserialization.

Previously, malformed entries (e.g. `{}`) caused internal TypeError
exceptions due to assumptions about input structure. This change ensures
invalid layer configs are rejected early with a clear ValueError.

## Impact

- Prevents internal errors caused by malformed configs
- Improves input validation and error clarity
- Maintains existing behavior for valid inputs

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.