### PR TITLE
[Fix] deserialize_keras_object accepts arbitrary registered_name values without validation

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -17,6 +17,7 @@ from keras.src.utils import python_utils
 from keras.src.utils.module_utils import tensorflow as tf
 
 PLAIN_TYPES = (str, int, float, bool)
+MISSING = object()
 
 # List of Keras modules with built-in string representations for Keras defaults
 BUILTIN_MODULES = frozenset(
@@ -717,6 +718,7 @@ def deserialize_keras_object(
     # Below: classes and functions.
     module = config.get("module", None)
     registered_name = config.get("registered_name", class_name)
+    validate_registered_name = config.get("registered_name", None)
 
     if class_name == "function":
         fn_name = inner_config
@@ -727,6 +729,7 @@ def deserialize_keras_object(
             obj_type="function",
             full_config=config,
             custom_objects=custom_objects,
+            validate_registered_name=validate_registered_name,
         )
 
     # Below, handling of all classes.
@@ -743,6 +746,7 @@ def deserialize_keras_object(
         obj_type="class",
         full_config=config,
         custom_objects=custom_objects,
+        validate_registered_name=validate_registered_name,
     )
 
     if isinstance(cls, types.FunctionType):
@@ -787,8 +791,17 @@ def deserialize_keras_object(
 
 
 def _retrieve_class_or_fn(
-    name, registered_name, module, obj_type, full_config, custom_objects=None
+    name,
+    registered_name,
+    module,
+    obj_type,
+    full_config,
+    custom_objects=None,
+    validate_registered_name=MISSING,
 ):
+    if validate_registered_name is MISSING:
+        validate_registered_name = registered_name
+
     # If there is a custom object registered via
     # `register_keras_serializable()`, that takes precedence.
     if obj_type == "function":
@@ -819,7 +832,7 @@ def _retrieve_class_or_fn(
             obj = api_export.get_symbol_from_name(api_name)
             if obj is not None:
                 _validate_no_registered_name_for_keras_object(
-                    registered_name, obj_type, full_config
+                    validate_registered_name, obj_type, full_config
                 )
                 return obj
 
@@ -832,7 +845,7 @@ def _retrieve_class_or_fn(
                 obj = api_export.get_symbol_from_name(f"keras.{mod}.{name}")
                 if obj is not None:
                     _validate_no_registered_name_for_keras_object(
-                        registered_name, obj_type, full_config
+                        validate_registered_name, obj_type, full_config
                     )
                     return obj
 

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -259,6 +259,12 @@ def serialize_keras_object(obj):
         }
 
     inner_config = _get_class_or_fn_config(obj)
+
+    if isinstance(obj, types.FunctionType):
+        config_with_public_fn = serialize_with_public_fn(obj, inner_config)
+        if config_with_public_fn is not None:
+            return config_with_public_fn
+
     config_with_public_class = serialize_with_public_class(
         obj.__class__, inner_config
     )
@@ -352,11 +358,16 @@ def serialize_with_public_fn(fn, config, fn_module_name=None):
     is already known, returns corresponding config.
     """
     if fn_module_name:
+        keras_api_name = f"{fn_module_name}.{config}"
         return {
             "module": fn_module_name,
             "class_name": "function",
             "config": config,
-            "registered_name": config,
+            "registered_name": (
+                None
+                if api_export.get_symbol_from_name(keras_api_name) is not None
+                else config
+            ),
         }
     keras_api_name = api_export.get_name_from_symbol(fn)
     if keras_api_name:
@@ -365,7 +376,7 @@ def serialize_with_public_fn(fn, config, fn_module_name=None):
             "module": ".".join(parts[:-1]),
             "class_name": "function",
             "config": config,
-            "registered_name": config,
+            "registered_name": None,
         }
     else:
         registered_name = object_registration.get_registered_name(fn)
@@ -407,53 +418,16 @@ def serialize_dict(obj):
     return {key: serialize_keras_object(value) for key, value in obj.items()}
 
 
-def _is_keras_namespace(module):
-    if not module:
-        return False
-    return module.split(".", maxsplit=1)[0] in KERAS_PACKAGES
-
-
-def _validate_registered_name(
-    name,
-    registered_name,
-    module,
-    obj_type,
-    full_config,
-    custom_objects=None,
+def _validate_no_registered_name_for_keras_object(
+    registered_name, obj_type, full_config
 ):
     if registered_name is None:
         return
-    if not isinstance(registered_name, str):
-        raise TypeError(
-            "The `registered_name` field must be a string or `None`. "
-            f"Received: {registered_name!r}. Full object config: {full_config}"
-        )
-    if not registered_name:
-        raise TypeError(
-            "The `registered_name` field must be a non-empty string or "
-            f"`None`. Full object config: {full_config}"
-        )
-
-    # Function configs reuse `registered_name` to carry the function alias.
-    if obj_type == "function":
-        return
-
-    # Internal Keras classes may serialize `registered_name` as the class name.
-    if registered_name == name:
-        return
-
-    custom_obj = object_registration.get_registered_object(
-        registered_name, custom_objects=custom_objects
-    )
-    if custom_obj is not None:
-        return
-
     raise TypeError(
-        f"Could not deserialize {obj_type} '{name}' because "
-        f"`registered_name={registered_name!r}` is not a known custom "
-        "object registration. For Keras classes, `registered_name` must be "
-        "`None`, the class name for legacy/internal configs, or a registered "
-        f"custom object key. Full object config: {full_config}"
+        f"Could not deserialize Keras {obj_type} because `registered_name` "
+        "must be `None` when the object is resolved from the Keras API. "
+        f"Received: registered_name={registered_name!r}. "
+        f"Full object config: {full_config}"
     )
 
 
@@ -604,14 +578,6 @@ def deserialize_keras_object(
                 raise ValueError(
                     f"Unknown `config` as a `dict`, config={config}"
                 )
-            _validate_registered_name(
-                config["class_name"],
-                config.get("registered_name", config["class_name"]),
-                config.get("module", None),
-                ("function" if config["class_name"] == "function" else "class"),
-                config,
-                custom_objects=custom_objects,
-            )
 
             # Check case where config is function or class and in custom objects
             if custom_objects and (
@@ -751,14 +717,6 @@ def deserialize_keras_object(
     # Below: classes and functions.
     module = config.get("module", None)
     registered_name = config.get("registered_name", class_name)
-    _validate_registered_name(
-        class_name,
-        registered_name,
-        module,
-        "function" if class_name == "function" else "class",
-        config,
-        custom_objects=custom_objects,
-    )
 
     if class_name == "function":
         fn_name = inner_config
@@ -860,6 +818,9 @@ def _retrieve_class_or_fn(
 
             obj = api_export.get_symbol_from_name(api_name)
             if obj is not None:
+                _validate_no_registered_name_for_keras_object(
+                    registered_name, obj_type, full_config
+                )
                 return obj
 
         # Configs of Keras built-in functions do not contain identifying
@@ -870,6 +831,9 @@ def _retrieve_class_or_fn(
             for mod in BUILTIN_MODULES:
                 obj = api_export.get_symbol_from_name(f"keras.{mod}.{name}")
                 if obj is not None:
+                    _validate_no_registered_name_for_keras_object(
+                        registered_name, obj_type, full_config
+                    )
                     return obj
 
             # Workaround for serialization bug in Keras <= 3.6 whereby custom

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -31,6 +31,8 @@ BUILTIN_MODULES = frozenset(
     }
 )
 
+KERAS_PACKAGES = frozenset({"keras", "keras_hub", "keras_cv", "keras_nlp"})
+
 LOADING_APIS = frozenset(
     {
         "keras.config.enable_unsafe_deserialization",
@@ -405,6 +407,56 @@ def serialize_dict(obj):
     return {key: serialize_keras_object(value) for key, value in obj.items()}
 
 
+def _is_keras_namespace(module):
+    if not module:
+        return False
+    return module.split(".", maxsplit=1)[0] in KERAS_PACKAGES
+
+
+def _validate_registered_name(
+    name,
+    registered_name,
+    module,
+    obj_type,
+    full_config,
+    custom_objects=None,
+):
+    if registered_name is None:
+        return
+    if not isinstance(registered_name, str):
+        raise TypeError(
+            "The `registered_name` field must be a string or `None`. "
+            f"Received: {registered_name!r}. Full object config: {full_config}"
+        )
+    if not registered_name:
+        raise TypeError(
+            "The `registered_name` field must be a non-empty string or "
+            f"`None`. Full object config: {full_config}"
+        )
+
+    # Function configs reuse `registered_name` to carry the function alias.
+    if obj_type == "function":
+        return
+
+    # Internal Keras classes may serialize `registered_name` as the class name.
+    if not _is_keras_namespace(module) or registered_name == name:
+        return
+
+    custom_obj = object_registration.get_registered_object(
+        registered_name, custom_objects=custom_objects
+    )
+    if custom_obj is not None:
+        return
+
+    raise TypeError(
+        f"Could not deserialize {obj_type} '{name}' because "
+        f"`registered_name={registered_name!r}` is not a known custom "
+        "object registration. For Keras classes, `registered_name` must be "
+        "`None`, the class name for legacy/internal configs, or a registered "
+        f"custom object key. Full object config: {full_config}"
+    )
+
+
 @keras_export(
     [
         "keras.saving.deserialize_keras_object",
@@ -552,6 +604,18 @@ def deserialize_keras_object(
                 raise ValueError(
                     f"Unknown `config` as a `dict`, config={config}"
                 )
+            _validate_registered_name(
+                config["class_name"],
+                config.get("registered_name", config["class_name"]),
+                config.get("module", None),
+                (
+                    "function"
+                    if config["class_name"] == "function"
+                    else "class"
+                ),
+                config,
+                custom_objects=custom_objects,
+            )
 
             # Check case where config is function or class and in custom objects
             if custom_objects and (
@@ -691,6 +755,14 @@ def deserialize_keras_object(
     # Below: classes and functions.
     module = config.get("module", None)
     registered_name = config.get("registered_name", class_name)
+    _validate_registered_name(
+        class_name,
+        registered_name,
+        module,
+        "function" if class_name == "function" else "class",
+        config,
+        custom_objects=custom_objects,
+    )
 
     if class_name == "function":
         fn_name = inner_config
@@ -817,7 +889,7 @@ def _retrieve_class_or_fn(
         # Otherwise, attempt to retrieve the class object given the `module`
         # and `class_name`. Import the module, find the class.
         package = module.split(".", maxsplit=1)[0]
-        if package in {"keras", "keras_hub", "keras_cv", "keras_nlp"}:
+        if package in KERAS_PACKAGES:
             try:
                 mod = importlib.import_module(module)
                 obj = vars(mod).get(name, None)

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -439,7 +439,7 @@ def _validate_registered_name(
         return
 
     # Internal Keras classes may serialize `registered_name` as the class name.
-    if not _is_keras_namespace(module) or registered_name == name:
+    if registered_name == name:
         return
 
     custom_obj = object_registration.get_registered_object(
@@ -608,11 +608,7 @@ def deserialize_keras_object(
                 config["class_name"],
                 config.get("registered_name", config["class_name"]),
                 config.get("module", None),
-                (
-                    "function"
-                    if config["class_name"] == "function"
-                    else "class"
-                ),
+                ("function" if config["class_name"] == "function" else "class"),
                 config,
                 custom_objects=custom_objects,
             )

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -594,7 +594,10 @@ def deserialize_keras_object(
             # Case where config is function but not in custom objects
             elif config["class_name"] == "function":
                 fn_module_name = config["module"]
-                if fn_module_name == "builtins":
+                if (
+                    fn_module_name == "builtins"
+                    or config.get("registered_name") is None
+                ):
                     config = config["config"]
                 else:
                     config = config["registered_name"]

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -95,6 +95,40 @@ class SerializationLibTest(testing.TestCase):
         self.assertEqual(layer.trainable, restored.trainable)
         self.assertEqual(layer.compute_dtype, restored.compute_dtype)
 
+    def test_builtin_class_rejects_invalid_registered_name(self):
+        for registered_name in ["builtins.eval", "subprocess.Popen", ""]:
+            config = {
+                "class_name": "Dense",
+                "module": "keras.layers",
+                "registered_name": registered_name,
+                "config": {"units": 1},
+            }
+
+            with self.assertRaisesRegex(TypeError, "registered_name"):
+                serialization_lib.deserialize_keras_object(config)
+
+    def test_builtin_class_accepts_none_registered_name(self):
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "registered_name": None,
+            "config": {"units": 1},
+        }
+
+        obj = serialization_lib.deserialize_keras_object(config)
+        self.assertIsInstance(obj, keras.layers.Dense)
+
+    def test_builtin_class_accepts_class_name_registered_name(self):
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "registered_name": "Dense",
+            "config": {"units": 1},
+        }
+
+        obj = serialization_lib.deserialize_keras_object(config)
+        self.assertIsInstance(obj, keras.layers.Dense)
+
     def test_numpy_get_item_layer(self):
         def tuples_to_lists_str(x):
             return str(x).replace("(", "[").replace(")", "]")

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -95,8 +95,13 @@ class SerializationLibTest(testing.TestCase):
         self.assertEqual(layer.trainable, restored.trainable)
         self.assertEqual(layer.compute_dtype, restored.compute_dtype)
 
-    def test_builtin_class_rejects_invalid_registered_name(self):
-        for registered_name in ["builtins.eval", "subprocess.Popen", ""]:
+    def test_builtin_class_rejects_ignored_registered_name(self):
+        for registered_name in [
+            "builtins.eval",
+            "subprocess.Popen",
+            "",
+            "Dense",
+        ]:
             config = {
                 "class_name": "Dense",
                 "module": "keras.layers",
@@ -118,16 +123,41 @@ class SerializationLibTest(testing.TestCase):
         obj = serialization_lib.deserialize_keras_object(config)
         self.assertIsInstance(obj, keras.layers.Dense)
 
-    def test_builtin_class_accepts_class_name_registered_name(self):
+    def test_builtin_function_rejects_ignored_registered_name(self):
         config = {
-            "class_name": "Dense",
-            "module": "keras.layers",
-            "registered_name": "Dense",
-            "config": {"units": 1},
+            "class_name": "function",
+            "module": "builtins",
+            "registered_name": "function",
+            "config": "relu",
+        }
+
+        with self.assertRaisesRegex(TypeError, "registered_name"):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_builtin_function_accepts_none_registered_name(self):
+        config = {
+            "class_name": "function",
+            "module": "builtins",
+            "registered_name": None,
+            "config": "relu",
         }
 
         obj = serialization_lib.deserialize_keras_object(config)
-        self.assertIsInstance(obj, keras.layers.Dense)
+        self.assertIs(obj, keras.activations.relu)
+
+    def test_custom_object_allows_arbitrary_registered_name(self):
+        config = {
+            "class_name": "CustomLayer",
+            "module": None,
+            "registered_name": "third.party.CustomLayer",
+            "config": {"factor": 2},
+        }
+
+        obj = serialization_lib.deserialize_keras_object(
+            config,
+            custom_objects={"third.party.CustomLayer": CustomLayer},
+        )
+        self.assertIsInstance(obj, CustomLayer)
 
     def test_numpy_get_item_layer(self):
         def tuples_to_lists_str(x):


### PR DESCRIPTION
Fixes: #22703 

## Root cause 
```deserialize_keras_object()``` accepted any registered_name string for class configs, but if that name did not resolve to a real registered custom object, Keras silently ignored it and fell back to module + class_name. That made values like "builtins.eval" look accepted even though they were meaningless.

## Fix
Added validation so class deserialization now rejects invalid or empty registered_name values instead of ignoring them. The change still preserves compatibility for valid cases like None, real registered custom-object keys, and the legacy/internal fallback where registered_name matches the class name.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
