### PR TITLE
more informative error-handling of missing keys during deserialization of sequential model

### DIFF
--- a/keras/src/legacy/saving/saving_utils.py
+++ b/keras/src/legacy/saving/saving_utils.py
@@ -54,9 +54,11 @@ def model_from_config(config, custom_objects=None):
         MODULE_OBJECTS.ALL_OBJECTS["Model"] = models.Model
         MODULE_OBJECTS.ALL_OBJECTS["Sequential"] = models.Sequential
 
-    if "config" not in config:
+    if not isinstance(config, dict) or "config" not in config:
         raise ValueError(
-            f"Missing `config` in model config. Received: config={config}."
+            "The provided configuration is not a valid Keras configuration. "
+            "Expected a dictionary containing a 'config' key. "
+            f"Received: config={config}"
         )
     batch_input_shape = config["config"].pop("batch_input_shape", None)
     if batch_input_shape is not None:

--- a/keras/src/legacy/saving/saving_utils.py
+++ b/keras/src/legacy/saving/saving_utils.py
@@ -54,6 +54,10 @@ def model_from_config(config, custom_objects=None):
         MODULE_OBJECTS.ALL_OBJECTS["Model"] = models.Model
         MODULE_OBJECTS.ALL_OBJECTS["Sequential"] = models.Sequential
 
+    if "config" not in config:
+        raise ValueError(
+            f"Missing `config` in model config. Received: config={config}."
+        )
     batch_input_shape = config["config"].pop("batch_input_shape", None)
     if batch_input_shape is not None:
         if config["class_name"] == "InputLayer":

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -375,15 +375,11 @@ class Sequential(Model):
             build_input_shape = config.get("build_input_shape")
             layer_configs = config["layers"]
         else:
-            if isinstance(config, dict):
-                raise ValueError(
-                    "Either `name` should be specified or `config` should "
-                    "be a list of layers."
-                )
             if not isinstance(config, list):
                 raise ValueError(
-                    "Sequential model config with no specified `name` should "
-                    "be a list of layers. Received: {config}"
+                    "A Sequential model configuration must be either a list "
+                    "of layers or a dictionary containing the 'name' and "
+                    "'layers' keys. Received: config={config}"
                 )
             name = None
             layer_configs = config

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -375,6 +375,16 @@ class Sequential(Model):
             build_input_shape = config.get("build_input_shape")
             layer_configs = config["layers"]
         else:
+            if isinstance(config, dict):
+                raise ValueError(
+                    "Either `name` should be specified or `config` should "
+                    "be a list of layers."
+                )
+            if not isinstance(config, list):
+                raise ValueError(
+                    "Sequential model config with no specified `name` should "
+                    "be a list of layers. Received: {config}"
+                )
             name = None
             layer_configs = config
         model = cls(name=name)

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -8,6 +8,7 @@ import pytest
 import keras
 from keras.src import ops
 from keras.src import testing
+from keras.src.saving import deserialize_keras_object
 from keras.src.saving import object_registration
 from keras.src.saving import serialization_lib
 
@@ -419,6 +420,75 @@ class SerializationLibTest(testing.TestCase):
         self.assertEqual(
             restored_dense_relu_string.activation, keras.activations.relu
         )
+
+    def test_missing_name_for_sequential_model(self):
+        """Tests serialization when sequential model has no name."""
+        serialized = {
+            "class_name": "Sequential",
+            "module": "keras",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "module": "keras.layers",
+                        "config": {"units": 4},
+                    }
+                ],
+            },
+        }
+        with self.assertRaisesRegex(
+            ValueError,
+            "A Sequential model configuration "
+            "must be either a list of layers or a "
+            "dictionary containing the 'name' and 'layers' keys",
+        ):
+            deserialize_keras_object(serialized)
+
+    def test_config_as_list_of_layers(self):
+        """Tests serialization when sequential model config is list of
+        layers."""
+        serialized = {
+            "class_name": "Sequential",
+            "module": "keras",
+            "config": [
+                {
+                    "class_name": "Dense",
+                    "module": "keras.layers",
+                    "config": {"units": 4},
+                },
+                {
+                    "class_name": "Dense",
+                    "module": "keras.layers",
+                    "config": {"units": 2},
+                },
+            ],
+        }
+        model = deserialize_keras_object(serialized)
+        self.assertIsInstance(model, keras.Sequential)
+        self.assertLen(model.layers, 2)
+        self.assertEqual(model.layers[0].units, 4)
+        self.assertEqual(model.layers[1].units, 2)
+
+    def test_malformed_layer_for_sequential_model(self):
+        serialized = {
+            "class_name": "Sequential",
+            "module": "keras",
+            "config": {
+                "name": "sequential_model",
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "module": "keras.layers",
+                        "config": {"units": 4},
+                    },
+                    {},
+                ],
+            },
+        }
+        with self.assertRaisesRegex(
+            ValueError, "Expected a dictionary containing a 'config' key."
+        ):
+            deserialize_keras_object(serialized)
 
 
 @keras.saving.register_keras_serializable()


### PR DESCRIPTION
## Description
This PR fixes https://github.com/keras-team/keras/issues/22720.

It does the following during deserialization of a sequential model:
- requires either `name` and `layer` keys simultaneously be provided under `config`, or `config` to be a list of layer dicts
- raises a `ValueError` upon missing `config` key (e.g. the case of a malformed/empty layer dict originally raised in the linked issue), with a more descriptive error message (I'm fine with making this a `KeyError` if folks deem that better)

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [X] I am a human, and not a bot.
- [X] I will be responsible for responding to review comments in a timely manner.
- [X] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.