### PR TITLE
Validate registered_name in deserialize_keras_object

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -760,6 +760,20 @@ def deserialize_keras_object(
     return instance
 
 
+def _assert_no_registered_name_for_builtin(full_config, name, resolved_name):
+    explicit = full_config.get("registered_name")
+    if not explicit:
+        return
+    if explicit in (name, full_config.get("class_name")):
+        return
+    raise ValueError(
+        f"`registered_name={explicit!r}` was provided in the config, but "
+        f"'{resolved_name}' resolved to a Keras built-in and does not use "
+        "registered names. Remove the `registered_name` field from the "
+        f"config. Full object config: {full_config}"
+    )
+
+
 def _retrieve_class_or_fn(
     name, registered_name, module, obj_type, full_config, custom_objects=None
 ):
@@ -792,6 +806,9 @@ def _retrieve_class_or_fn(
 
             obj = api_export.get_symbol_from_name(api_name)
             if obj is not None:
+                _assert_no_registered_name_for_builtin(
+                    full_config, name, api_name
+                )
                 return obj
 
         # Configs of Keras built-in functions do not contain identifying
@@ -802,6 +819,9 @@ def _retrieve_class_or_fn(
             for mod in BUILTIN_MODULES:
                 obj = api_export.get_symbol_from_name(f"keras.{mod}.{name}")
                 if obj is not None:
+                    _assert_no_registered_name_for_builtin(
+                        full_config, name, f"keras.{mod}.{name}"
+                    )
                     return obj
 
             # Workaround for serialization bug in Keras <= 3.6 whereby custom

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -490,6 +490,93 @@ class SerializationLibTest(testing.TestCase):
         ):
             deserialize_keras_object(serialized)
 
+    def test_registered_name_for_keras_builtin_raises(self):
+        for bad_name in (
+            "builtins.eval",
+            "subprocess.Popen",
+            "not.a.real.name",
+            "my_pkg>MyDense",
+        ):
+            with self.assertRaisesRegex(
+                ValueError, "resolved to a Keras built-in"
+            ):
+                serialization_lib.deserialize_keras_object(
+                    {
+                        "class_name": "Dense",
+                        "module": "keras.layers",
+                        "registered_name": bad_name,
+                        "config": {"units": 1},
+                    }
+                )
+
+    def test_registered_name_matching_class_name_passes_through(self):
+        obj = serialization_lib.deserialize_keras_object(
+            {
+                "class_name": "Dense",
+                "module": "keras.layers",
+                "registered_name": "Dense",
+                "config": {"units": 1},
+            }
+        )
+        self.assertIsInstance(obj, keras.layers.Dense)
+
+    def test_none_or_missing_registered_name_passes_through(self):
+        for config in (
+            {
+                "class_name": "Dense",
+                "module": "keras.layers",
+                "registered_name": None,
+                "config": {"units": 1},
+            },
+            {
+                "class_name": "Dense",
+                "module": "keras.layers",
+                "config": {"units": 1},
+            },
+        ):
+            obj = serialization_lib.deserialize_keras_object(config)
+            self.assertIsInstance(obj, keras.layers.Dense)
+
+    def test_empty_string_registered_name_passes_through(self):
+        obj = serialization_lib.deserialize_keras_object(
+            {
+                "class_name": "Dense",
+                "module": "keras.layers",
+                "registered_name": "",
+                "config": {"units": 1},
+            }
+        )
+        self.assertIsInstance(obj, keras.layers.Dense)
+
+    def test_registered_name_for_keras_builtin_function_raises(self):
+        with self.assertRaisesRegex(ValueError, "resolved to a Keras built-in"):
+            serialization_lib.deserialize_keras_object(
+                {
+                    "class_name": "function",
+                    "module": "builtins",
+                    "registered_name": "some_other_name",
+                    "config": "relu",
+                }
+            )
+
+    def test_registered_name_matching_function_name_passes_through(self):
+        for registered_name in ("function", "kl_divergence"):
+            obj = serialization_lib.deserialize_keras_object(
+                {
+                    "class_name": "function",
+                    "module": "builtins",
+                    "registered_name": registered_name,
+                    "config": "kl_divergence",
+                }
+            )
+            self.assertIs(obj, keras.metrics.kl_divergence)
+
+    def test_registered_custom_object_still_resolves(self):
+        layer = MyDense(units=4)
+        config = serialization_lib.serialize_keras_object(layer)
+        restored = serialization_lib.deserialize_keras_object(config)
+        self.assertIsInstance(restored, MyDense)
+
 
 @keras.saving.register_keras_serializable()
 class MyDense(keras.layers.Layer):


### PR DESCRIPTION
## Description

Fixes #22703.

When `deserialize_keras_object` falls through the custom-object registry and resolves a class or function as a Keras built-in via module-based lookup, any `registered_name` in the config is silently ignored. A config with `registered_name` pointing at a custom class would instead return a same-named Keras built-in.

This PR raises `ValueError` when:

- The object resolved via the Keras module path (`keras` or `keras.*`)
- AND `registered_name` in the config is a non-empty string

Empty string and `None` continue to pass through as the canonical "no registered_name" values. Custom objects that resolve via `get_registered_object` are unaffected.

### Approach

Rewritten per the review feedback on an earlier version: verification now kicks in only when `registered_name` is ignored (i.e., the object resolved as a Keras built-in), rather than validating the `registered_name` value itself against the registry. This matches the design intent that registered names can be any 3rd-party key.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.