### PR TITLE
Accept plain callables as constraint in Variable setter

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -390,13 +390,11 @@ class Variable:
 
     @constraint.setter
     def constraint(self, value):
-        from keras.src.constraints import Constraint
-
-        if value is not None and not isinstance(value, Constraint):
+        if value is not None and not callable(value):
             raise ValueError(
-                "Invalid value for attribute `constraint`. Expected an "
-                "instance of `keras.constraints.Constraint`, or `None`. "
-                f"Received: constraint={value}"
+                "Invalid value for attribute `constraint`. Expected a "
+                "callable (such as a `keras.constraints.Constraint` instance) "
+                f"or `None`. Received: constraint={value}"
             )
         self._constraint = value
 

--- a/keras/src/backend/common/variables_test.py
+++ b/keras/src/backend/common/variables_test.py
@@ -177,6 +177,43 @@ class VariablePropertiesTest(test_case.TestCase):
             v.trainable = False
             self.assertFalse(v._value.requires_grad)
 
+    def test_constraint_setter_accepts_plain_callable(self):
+        from keras.src.constraints import NonNeg
+
+        v = backend.Variable(initializer="ones", shape=(2,))
+
+        def clip_fn(w):
+            return w * 0.5
+
+        v.constraint = clip_fn
+        self.assertIs(v.constraint, clip_fn)
+
+        v.constraint = NonNeg()
+        self.assertIsInstance(v.constraint, NonNeg)
+
+        v.constraint = None
+        self.assertIsNone(v.constraint)
+
+        with self.assertRaisesRegex(
+            ValueError, "Invalid value for attribute `constraint`"
+        ):
+            v.constraint = "not callable"
+
+    def test_registered_callable_constraint_survives_serialization(self):
+        from keras.src.layers import Dense
+        from keras.src.saving import register_keras_serializable
+
+        @register_keras_serializable(package="test_22221")
+        def half_constraint(w):
+            return w * 0.5
+
+        layer = Dense(4, kernel_constraint=half_constraint)
+        layer.build((None, 3))
+        config = layer.get_config()
+        restored = Dense.from_config(config)
+        restored.build((None, 3))
+        self.assertIs(restored.kernel_constraint, half_constraint)
+
     def test_autocasting_float(self):
         # Tests autocasting of float variables
         v = backend.Variable(


### PR DESCRIPTION
## Description

Fixes #22221.

`Layer.add_weight(constraint=...)` was rejecting plain callables, even though `constraints.get()` already accepts them and the optimizer only calls `constraint(variable)`. This relaxes the `Variable.constraint` setter check from `isinstance(..., Constraint)` to `callable(...)`.

Earlier attempt #22235 used a more defensive wrapper-class approach that got maintainer pushback ('for calling, the function itself works') and was auto-closed after 28 days of inactivity. This PR takes the simpler path @hertschuh suggested there.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.