### PR TITLE
Validate registered_name/class_name consistency in deserialize_keras_object

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -774,6 +774,25 @@ def _retrieve_class_or_fn(
             registered_name, custom_objects=custom_objects
         )
     if custom_obj is not None:
+        # Validate consistency between `registered_name` and `class_name`.
+        # A correctly serialized config always has `class_name` equal to the
+        # resolved class's `__name__` (see `serialize_with_public_class`).
+        # A mismatch indicates a tampered or malformed config where
+        # `registered_name` resolves to a different object than what
+        # `class_name` / `module` claim to describe.
+        if (
+            obj_type == "class"
+            and name is not None
+            and getattr(custom_obj, "__name__", None) is not None
+            and custom_obj.__name__ != name
+        ):
+            raise ValueError(
+                f"Inconsistent deserialization config: `registered_name` "
+                f"'{registered_name}' resolves to class "
+                f"'{custom_obj.__name__}', but the config specifies "
+                f"`class_name='{name}'`. These values must be consistent. "
+                f"Full object config: {full_config}"
+            )
         return custom_obj
 
     if module:

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -167,6 +167,25 @@ class SerializationLibTest(testing.TestCase):
         y2 = new_layer(x)
         self.assertAllClose(y1, y2, atol=1e-5)
 
+    def test_inconsistent_registered_name_raises(self):
+        @object_registration.register_keras_serializable(
+            package="test_inconsistent", name="Dense"
+        )
+        class AliasedLayer(keras.layers.Layer):
+            def call(self, inputs):
+                return inputs
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "registered_name": "test_inconsistent>Dense",
+            "config": {},
+        }
+        with self.assertRaisesRegex(
+            ValueError, "Inconsistent deserialization config"
+        ):
+            serialization_lib.deserialize_keras_object(config)
+
     def test_lambda_fn(self):
         obj = {"activation": lambda x: x**2}
         with self.assertRaisesRegex(ValueError, "arbitrary code execution"):


### PR DESCRIPTION
## Description

Fixes #22706.

`deserialize_keras_object` prioritizes `registered_name` over `class_name`
and `module` when resolving an object from a config dict, and does not
validate that the resolved class actually matches the `class_name` / `module`
that the config claims to describe. As reported in #22706, this can lead to
configurations that appear to describe one class while instantiating another:

```python
@register_keras_serializable(package="test", name="Dense")
class EvilLayer(keras.layers.Layer): ...

deserialize_keras_object({
    "class_name": "Dense",
    "module": "keras.layers",
    "registered_name": "test>Dense",
    "config": {},
})  # silently returns an EvilLayer
```

A correctly serialized config always has `class_name` equal to the resolved
class's `__name__` (see `serialize_with_public_class`), so this PR adds a
validation step in `_retrieve_class_or_fn`: when a class is resolved via
`registered_name`, we now check that `class_name` matches the resolved class's
`__name__` and raise a `ValueError` with the full config if not.

A regression test (`test_inconsistent_registered_name_raises`) is added. All
existing saving tests continue to pass.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.