### PR TITLE
Accept integer-like scalars (numpy ints, 0-d int tensors) for Dense `units`

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -28,29 +28,18 @@ def _coerce_positive_integer(value, arg_name):
     rejects floats, arrays, and symbolic tensors.
     """
     original = value
-    if isinstance(value, bool):
-        # bools are ints in Python; reject explicitly.
-        raise ValueError(
-            f"Received an invalid value for `{arg_name}`, expected a positive "
-            f"integer. Received: {arg_name}={original}"
-        )
     if isinstance(value, np.integer):
         value = int(value)
-    elif isinstance(value, np.ndarray):
-        if value.ndim == 0 and np.issubdtype(value.dtype, np.integer):
-            value = int(value)
+    elif (
+        isinstance(value, np.ndarray)
+        and value.ndim == 0
+        and np.issubdtype(value.dtype, np.integer)
+    ):
+        value = int(value)
     elif not isinstance(value, int) and backend.is_tensor(value):
-        shape = getattr(value, "shape", None)
         dtype = backend.standardize_dtype(value.dtype)
-        if (
-            shape is not None
-            and tuple(shape) == ()
-            and ("int" in dtype or "uint" in dtype)
-        ):
-            try:
-                value = int(value)
-            except Exception:
-                pass
+        if len(value.shape) == 0 and dtype.startswith(("int", "uint")):
+            value = int(value)
     if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
         raise ValueError(
             f"Received an invalid value for `{arg_name}`, expected a positive "

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -1,8 +1,10 @@
 import math
 
 import ml_dtypes
+import numpy as np
 
 from keras.src import activations
+from keras.src import backend
 from keras.src import constraints
 from keras.src import initializers
 from keras.src import ops
@@ -15,6 +17,46 @@ from keras.src.quantizers.quantization_config import QuantizationConfig
 from keras.src.quantizers.quantization_config import get_block_size_for_layer
 from keras.src.quantizers.quantizers import dequantize_with_sz_map
 from keras.src.saving import serialization_lib
+
+
+def _coerce_positive_integer(value, arg_name):
+    """Coerce integer-like scalars (numpy ints, 0-d int tensors) to Python int.
+
+    Users commonly compute layer widths via `ops.prod(input_shape[1:])` or
+    similar, which returns a backend tensor even when all inputs are Python
+    ints. This helper accepts such scalar tensors and numpy integers, and
+    rejects floats, arrays, and symbolic tensors.
+    """
+    original = value
+    if isinstance(value, bool):
+        # bools are ints in Python; reject explicitly.
+        raise ValueError(
+            f"Received an invalid value for `{arg_name}`, expected a positive "
+            f"integer. Received: {arg_name}={original}"
+        )
+    if isinstance(value, np.integer):
+        value = int(value)
+    elif isinstance(value, np.ndarray):
+        if value.ndim == 0 and np.issubdtype(value.dtype, np.integer):
+            value = int(value)
+    elif not isinstance(value, int) and backend.is_tensor(value):
+        shape = getattr(value, "shape", None)
+        dtype = backend.standardize_dtype(value.dtype)
+        if (
+            shape is not None
+            and tuple(shape) == ()
+            and ("int" in dtype or "uint" in dtype)
+        ):
+            try:
+                value = int(value)
+            except Exception:
+                pass
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(
+            f"Received an invalid value for `{arg_name}`, expected a positive "
+            f"integer. Received: {arg_name}={original}"
+        )
+    return value
 
 
 @keras_export("keras.layers.Dense")
@@ -98,11 +140,7 @@ class Dense(Layer):
         quantization_config=None,
         **kwargs,
     ):
-        if not isinstance(units, int) or units <= 0:
-            raise ValueError(
-                "Received an invalid value for `units`, expected a positive "
-                f"integer. Received: units={units}"
-            )
+        units = _coerce_positive_integer(units, "units")
 
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
         self.units = units

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -124,10 +124,23 @@ class DenseTest(testing.TestCase):
         ("float", 2.5),
         ("none", None),
         ("string", "64"),
+        ("bool_true", True),
+        ("bool_false", False),
     )
     def test_dense_invalid_units_raises(self, units):
         with self.assertRaisesRegex(ValueError, "positive integer"):
             layers.Dense(units)
+
+    def test_dense_accepts_integer_like_scalars(self):
+        # numpy integer scalar
+        self.assertEqual(layers.Dense(np.int64(16)).units, 16)
+        self.assertEqual(layers.Dense(np.array(8)).units, 8)
+        # backend scalar tensor with int dtype (e.g. from ops.prod)
+        units_tensor = ops.prod(ops.convert_to_tensor([2, 4]))
+        self.assertEqual(layers.Dense(units_tensor).units, 8)
+        # reproduction from #21655: ops.prod on a Python shape tuple
+        shape_prod = ops.prod((10,))
+        self.assertEqual(layers.Dense(shape_prod).units, 10)
 
     def test_dense_correctness(self):
         # With bias and activation.


### PR DESCRIPTION
## Description

Fixes #21655.

Users commonly compute layer widths from shapes at `build()` time via e.g.
`ops.prod(input_shape[1:])`, but `ops.prod` returns a backend tensor (TF 0-d
`Tensor`, etc.), which `Dense` then rejects:

```python
class ProdLayer(layers.Layer):
    def build(self, input_shape):
        # ops.prod returns a 0-d int tensor, even on a pure Python tuple
        units = ops.prod(input_shape[1:])
        self.dense = layers.Dense(units)   # ValueError: expected a positive integer
```

The strict `isinstance(units, int)` check in `Dense.__init__` rejected all
integer-like scalars — numpy integers, numpy 0-d arrays, and 0-d backend
tensors holding an int — even when they represent a valid positive integer.

This PR replaces the check with `_coerce_positive_integer`, which:

- Accepts Python `int`, `np.integer`, 0-d `np.ndarray` with integer dtype, and
  0-d backend tensors (TF / JAX / Torch) with integer dtype.
- Rejects `bool`, floats, negative values, zero, strings, `None`, multi-dim
  arrays/tensors, and float tensors with the same `"expected a positive
  integer"` error as before.
- Preserves the original `units` value in the error message for clarity.

The existing `test_dense_invalid_units_raises` parameterized test is extended
to cover `True` / `False`, and a new `test_dense_accepts_integer_like_scalars`
test covers the reproduction from #21655 plus numpy scalars and
`ops.prod`-style tensor results. All tests pass on TensorFlow, JAX, and Torch
backends.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.