### PR TITLE
Fix TPU tests in master.

### DIFF
--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -3247,6 +3247,18 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         elif backend.backend() == "jax":
             import jax.experimental.sparse as jax_sparse
 
+            if (
+                x_sparse
+                and y_sparse
+                and len(x_shape) == 4
+                and dtype in ("float32", "float64", "int32")
+                and testing.jax_uses_tpu()
+            ):
+                pytest.skip(
+                    "Sparse sparse matmul crashes for rank 4 and float32 with "
+                    "JAX on some TPUs"
+                )
+
             dense_to_sparse = functools.partial(
                 jax_sparse.BCOO.fromdense, n_batch=len(x_shape) - 2
             )


### PR DESCRIPTION
The sparse sparse matmul with rank 4 and float32/float64/int32 crashes on TPU v6 (but not TPU v5) with JAX 0.10.0.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
