### PR TITLE
Reject raw callables in config during deserialization

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -1,5 +1,6 @@
 """Object config serialization and deserialization logic."""
 
+import functools
 import importlib
 import inspect
 import types
@@ -17,6 +18,15 @@ from keras.src.utils import python_utils
 from keras.src.utils.module_utils import tensorflow as tf
 
 PLAIN_TYPES = (str, int, float, bool)
+
+_RAW_CALLABLE_TYPES = (
+    types.FunctionType,
+    types.BuiltinFunctionType,
+    types.MethodType,
+    types.BuiltinMethodType,
+    functools.partial,
+    functools.partialmethod,
+)
 
 # List of Keras modules with built-in string representations for Keras defaults
 BUILTIN_MODULES = frozenset(
@@ -405,6 +415,24 @@ def serialize_dict(obj):
     return {key: serialize_keras_object(value) for key, value in obj.items()}
 
 
+def _reject_raw_callables(config, path="config"):
+    if isinstance(config, _RAW_CALLABLE_TYPES):
+        raise TypeError(
+            f"Received a raw Python callable at {path!r} during "
+            "deserialization. Configs must contain only serializable "
+            "values; wrap custom callables with "
+            "`@keras.saving.register_keras_serializable()` and pass the "
+            "serialized dict, or pass `safe_mode=False` to allow raw "
+            f"callables. Received: {config!r}"
+        )
+    if isinstance(config, dict):
+        for k, v in config.items():
+            _reject_raw_callables(v, f"{path}.{k}")
+    elif isinstance(config, (list, tuple)):
+        for i, v in enumerate(config):
+            _reject_raw_callables(v, f"{path}[{i}]")
+
+
 @keras_export(
     [
         "keras.saving.deserialize_keras_object",
@@ -620,6 +648,9 @@ def deserialize_keras_object(
     class_name = config["class_name"]
     inner_config = config["config"] or {}
     custom_objects = custom_objects or {}
+
+    if safe_mode:
+        _reject_raw_callables(config)
 
     # Special cases:
     if class_name == "__keras_tensor__":

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -1,5 +1,6 @@
 """Tests for serialization_lib."""
 
+import functools
 import json
 
 import numpy as np
@@ -8,6 +9,7 @@ import pytest
 import keras
 from keras.src import ops
 from keras.src import testing
+from keras.src.constraints import NonNeg
 from keras.src.saving import deserialize_keras_object
 from keras.src.saving import object_registration
 from keras.src.saving import serialization_lib
@@ -576,6 +578,256 @@ class SerializationLibTest(testing.TestCase):
         config = serialization_lib.serialize_keras_object(layer)
         restored = serialization_lib.deserialize_keras_object(config)
         self.assertIsInstance(restored, MyDense)
+
+    def test_raw_callable_in_config_raises_in_safe_mode(self):
+        def smuggled(*args, **kwargs):
+            return 1.0
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "kernel_initializer": smuggled},
+        }
+        with self.assertRaisesRegex(
+            TypeError, "Received a raw Python callable"
+        ):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_raw_callable_in_config_accepted_when_safe_mode_false(self):
+        def smuggled(*args, **kwargs):
+            return 1.0
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "kernel_initializer": smuggled},
+        }
+        layer = serialization_lib.deserialize_keras_object(
+            config, safe_mode=False
+        )
+        self.assertIsInstance(layer, keras.layers.Dense)
+
+    def test_raw_lambda_nested_in_list_raises(self):
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "weights": [lambda w: w]},
+        }
+        with self.assertRaisesRegex(
+            TypeError, "Received a raw Python callable"
+        ):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_functools_partial_in_config_raises(self):
+        partial_fn = functools.partial(print, "hello")
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "kernel_initializer": partial_fn},
+        }
+        with self.assertRaisesRegex(
+            TypeError, "Received a raw Python callable"
+        ):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_raw_callable_in_build_config_raises(self):
+        def smuggled(*args, **kwargs):
+            return 1.0
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4},
+            "build_config": {
+                "input_shape": [None, 8],
+                "smuggled": smuggled,
+            },
+        }
+        with self.assertRaisesRegex(
+            TypeError, "Received a raw Python callable"
+        ):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_raw_callable_at_outer_key_raises(self):
+        def smuggled(*args, **kwargs):
+            return 1.0
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4},
+            "some_extra_key": smuggled,
+        }
+        with self.assertRaisesRegex(
+            TypeError, "Received a raw Python callable"
+        ):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_raw_callable_in_nested_dict_within_list_raises(self):
+        def smuggled(*args, **kwargs):
+            return 1.0
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "items": [{"nested_key": smuggled}]},
+        }
+        with self.assertRaisesRegex(
+            TypeError, "Received a raw Python callable"
+        ):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_lambda_path_still_raises_lambda_error_not_our_error(self):
+        config = {
+            "class_name": "__lambda__",
+            "config": {"value": "gASVKAAAAAAAAACMBG1haW6U"},
+        }
+        with self.assertRaisesRegex(ValueError, "arbitrary code execution"):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_class_instance_value_is_not_rejected(self):
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "kernel_constraint": NonNeg()},
+        }
+        layer = serialization_lib.deserialize_keras_object(config)
+        self.assertIsInstance(layer, keras.layers.Dense)
+
+    def test_class_object_value_is_not_rejected(self):
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "kernel_constraint": NonNeg},
+        }
+        layer = serialization_lib.deserialize_keras_object(config)
+        self.assertIsInstance(layer, keras.layers.Dense)
+
+    def test_serialized_function_dict_value_is_not_rejected(self):
+        layer = keras.layers.Dense(4, activation="relu")
+        layer.build((None, 8))
+        _, restored, _ = self.roundtrip(layer)
+        self.assertIsInstance(restored, keras.layers.Dense)
+        self.assertIs(restored.activation, keras.activations.relu)
+
+    def test_each_raw_callable_type_raises(self):
+        class _Holder:
+            def method(self):
+                return 1
+
+        holder = _Holder()
+
+        def plain_fn():
+            return 1
+
+        rejected_samples = {
+            "FunctionType": plain_fn,
+            "BuiltinFunctionType": len,
+            "MethodType": holder.method,
+            "BuiltinMethodType": [].append,
+            "partial": functools.partial(print, "x"),
+            "partialmethod": functools.partialmethod(lambda self, x: x, 42),
+        }
+        for type_name, value in rejected_samples.items():
+            config = {
+                "class_name": "Dense",
+                "module": "keras.layers",
+                "config": {"units": 4, "smuggled": value},
+            }
+            with self.assertRaisesRegex(
+                TypeError,
+                "Received a raw Python callable",
+                msg=f"Failed to reject {type_name}",
+            ):
+                serialization_lib.deserialize_keras_object(config)
+
+    def test_walk_respects_safe_mode_scope(self):
+        def smuggled(*args, **kwargs):
+            return 1.0
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "kernel_initializer": smuggled},
+        }
+        with serialization_lib.SafeModeScope(safe_mode=False):
+            layer = serialization_lib.deserialize_keras_object(config)
+        self.assertIsInstance(layer, keras.layers.Dense)
+
+    def test_walk_safe_mode_scope_true_overrides_arg(self):
+        def smuggled(*args, **kwargs):
+            return 1.0
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "kernel_initializer": smuggled},
+        }
+        with serialization_lib.SafeModeScope(safe_mode=True):
+            with self.assertRaisesRegex(
+                TypeError, "Received a raw Python callable"
+            ):
+                serialization_lib.deserialize_keras_object(
+                    config, safe_mode=False
+                )
+
+    def test_error_message_includes_path(self):
+        def smuggled(*args, **kwargs):
+            return 1.0
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "kernel_initializer": smuggled},
+        }
+        with self.assertRaisesRegex(
+            TypeError, r"config\.config\.kernel_initializer"
+        ):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_path_for_nested_list_index(self):
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "weights": [lambda w: w]},
+        }
+        with self.assertRaisesRegex(TypeError, r"config\.config\.weights\[0\]"):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_raw_callable_in_compile_config_raises(self):
+        def smuggled(*args, **kwargs):
+            return 1.0
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4},
+            "compile_config": {"loss": smuggled},
+        }
+        with self.assertRaisesRegex(
+            TypeError, "Received a raw Python callable"
+        ):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_tuple_containing_callable_is_rejected(self):
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "hooks": (lambda: None,)},
+        }
+        with self.assertRaisesRegex(
+            TypeError, "Received a raw Python callable"
+        ):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_callable_name_as_string_is_not_rejected(self):
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {"units": 4, "name": "lambda_x_x"},
+        }
+        layer = serialization_lib.deserialize_keras_object(config)
+        self.assertIsInstance(layer, keras.layers.Dense)
 
 
 @keras.saving.register_keras_serializable()


### PR DESCRIPTION
## Description

Fixes #22705.

`deserialize_keras_object` silently accepted raw Python callables embedded in a config dict (the issue's repro nests one under `config["config"]`). The callable flowed through `cls.from_config(inner_config)`, got stored on the reconstructed object, and was invoked later (e.g. during `build()`), with no validation or warning.

This PR walks the outer config recursively and rejects raw callables (`types.FunctionType`, `BuiltinFunctionType`, `MethodType`, `BuiltinMethodType`, `functools.partial`, `functools.partialmethod`) when `safe_mode=True` (the default). The walk runs before `cls.from_config`, `build_from_config`, and `compile_from_config` can see the config, so callables in `config["config"]`, `config["build_config"]`, `config["compile_config"]`, or any other outer-level key are all covered.

`safe_mode=False` preserves the previous silent-accept behavior as an explicit opt-out, mirroring the existing opt-out for lambda deserialization.

Class objects and class instances themselves are not rejected (they have different semantics from raw functions). Bound methods (`MethodType`) are rejected since they are effectively ad-hoc function references.

Existing `__lambda__` safe_mode behavior is preserved: the walk sees the serialized bytecode as a string and passes through, so the pre-existing "arbitrary code execution" error still fires downstream under `safe_mode=True`.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.