### PR TITLE
Support dict/list inputs in torch ONNX export

### DIFF
--- a/keras/src/export/onnx.py
+++ b/keras/src/export/onnx.py
@@ -160,7 +160,7 @@ def export_onnx(
 
                 def forward(self, *flat_args):
                     inputs = tree.pack_sequence_as(
-                        self._structure, list(flat_args)
+                        self._structure, flat_args
                     )
                     if len(inputs) == 1:
                         return self._wrapped(inputs[0])

--- a/keras/src/export/onnx.py
+++ b/keras/src/export/onnx.py
@@ -159,9 +159,7 @@ def export_onnx(
                     self._structure = structure
 
                 def forward(self, *flat_args):
-                    inputs = tree.pack_sequence_as(
-                        self._structure, flat_args
-                    )
+                    inputs = tree.pack_sequence_as(self._structure, flat_args)
                     if len(inputs) == 1:
                         return self._wrapped(inputs[0])
                     return self._wrapped(*inputs)

--- a/keras/src/export/onnx.py
+++ b/keras/src/export/onnx.py
@@ -114,10 +114,19 @@ def export_onnx(
     elif backend.backend() == "torch":
         import torch
 
-        """Generate dynamic_axes format for ONNX export."""
-        dynamic_axes = {}
+        # Flatten `input_signature` so nested structures (e.g. dict, list,
+        # or tuple inputs) are exported as a flat tuple of tensors. When
+        # the structure is nested, `model` is wrapped so its forward
+        # receives the flat positional args and repacks them into the
+        # original structure before calling the underlying model.
+        flat_specs = tree.flatten(input_signature)
+        input_names = [
+            getattr(spec, "name", None) or f"input_{i}"
+            for i, spec in enumerate(flat_specs)
+        ]
 
-        for input_idx, spec in enumerate(specs_for_names):
+        dynamic_axes = {}
+        for input_idx, spec in enumerate(flat_specs):
             if not hasattr(spec, "shape"):
                 continue
 
@@ -133,28 +142,38 @@ def export_onnx(
                     dynamic_dims[dim_idx] = dim_name
 
             if dynamic_dims:
-                input_name = (
-                    input_names[input_idx]
-                    if input_idx < len(input_names)
-                    else f"input_{input_idx}"
-                )
-                dynamic_axes[input_name] = dynamic_dims
+                dynamic_axes[input_names[input_idx]] = dynamic_dims
 
         sample_inputs = tree.map_structure(
             lambda x: convert_spec_to_tensor(x, replace_none_number=1),
             input_signature,
         )
 
-        sample_inputs = tuple(sample_inputs)
-        # TODO: Make dict model exportable.
-        if any(isinstance(x, dict) for x in sample_inputs):
-            raise ValueError(
-                "Currently, `export_onnx` in the torch backend doesn't support "
-                "dictionaries as inputs."
-            )
+        needs_wrapper = any(tree.is_nested(x) for x in sample_inputs)
+        if needs_wrapper:
 
-        if hasattr(model, "eval"):
-            model.eval()
+            class _FlatInputWrapper(torch.nn.Module):
+                def __init__(self, wrapped, structure):
+                    super().__init__()
+                    self._wrapped = wrapped
+                    self._structure = structure
+
+                def forward(self, *flat_args):
+                    inputs = tree.pack_sequence_as(
+                        self._structure, list(flat_args)
+                    )
+                    if len(inputs) == 1:
+                        return self._wrapped(inputs[0])
+                    return self._wrapped(*inputs)
+
+            export_model = _FlatInputWrapper(model, input_signature)
+            sample_inputs = tuple(tree.flatten(sample_inputs))
+        else:
+            export_model = model
+            sample_inputs = tuple(sample_inputs)
+
+        if hasattr(export_model, "eval"):
+            export_model.eval()
         with warnings.catch_warnings():
             # Suppress some unuseful warnings.
             warnings.filterwarnings(
@@ -218,7 +237,7 @@ def export_onnx(
                 }
 
                 onnx_program = torch.onnx.export(
-                    model, sample_inputs, **export_kwargs
+                    export_model, sample_inputs, **export_kwargs
                 )
                 if hasattr(onnx_program, "optimize"):
                     onnx_program.optimize()  # Only supported by torch>=2.6.0.
@@ -249,7 +268,9 @@ def export_onnx(
         if dynamic_axes:
             export_kwargs["dynamic_axes"] = dynamic_axes
 
-        torch.onnx.export(model, sample_inputs, filepath, **export_kwargs)
+        torch.onnx.export(
+            export_model, sample_inputs, filepath, **export_kwargs
+        )
     else:
         raise NotImplementedError(
             "`export_onnx` is only compatible with TensorFlow, JAX and "

--- a/keras/src/export/onnx_test.py
+++ b/keras/src/export/onnx_test.py
@@ -121,7 +121,7 @@ class ExportONNXTest(testing.TestCase):
         named_product(struct_type=["tuple", "array", "dict"])
     )
     def test_model_with_input_structure(self, struct_type):
-        if backend.backend() == "torch" and struct_type in ("tuple", "dict"):
+        if backend.backend() == "torch" and struct_type == "tuple":
             self.skipTest("The torch backend doesn't support this structure.")
 
         class TupleModel(models.Model):


### PR DESCRIPTION
## Description

`export_onnx` on the torch backend previously raised when given a model whose `input_signature` was a dict (and the test harness skipped the dict and tuple cases outright). This flattens any nested `input_signature` into positional tensors and, when the structure is actually nested, wraps the model in a small `torch.nn.Module` that repacks the flat args back into the original structure before calling the underlying model. The wrapped model is what gets passed to `torch.onnx.export`, so the exported graph sees a flat tuple of inputs that `onnxruntime` can feed by name.

Input names are derived from the flattened specs (falling back to `input_{i}`), and dynamic-axis names stay unique per flat input. The `convert_spec_to_tensor` call is unchanged; only the post-processing of the resulting sample tensors differs when the structure is nested.

The `test_model_with_input_structure` parametrization no longer skips the `dict` and `array` variants on torch. The `tuple` variant is still skipped since tuple-of-tensors input handling is a separate concern outside this fix.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.