### PR TITLE
Fix stale return_attention_scores flag in Attention.compute_output_spec

### DIFF
--- a/keras/src/layers/attention/attention.py
+++ b/keras/src/layers/attention/attention.py
@@ -268,29 +268,23 @@ class Attention(Layer):
         training=None,
         use_causal_mask=False,
     ):
-        # Validate and unpack inputs
         self._validate_inputs(inputs, mask)
         query = inputs[0]
         value = inputs[1]
         key = inputs[2] if len(inputs) > 2 else value
 
-        # Compute primary output shape
-        output_shape = self.compute_output_shape(
-            [query.shape, value.shape, key.shape]
-        )
+        output_shape = (*query.shape[:-1], value.shape[-1])
         output_spec = KerasTensor(output_shape, dtype=self.compute_dtype)
 
-        # Handle attention scores if requested
-        if self._return_attention_scores or return_attention_scores:
+        if return_attention_scores:
             scores_shape = (
                 query.shape[0],
                 query.shape[1],
                 key.shape[1],
             )  # (batch_size, Tq, Tv)
-            attention_scores_spec = KerasTensor(
+            return output_spec, KerasTensor(
                 scores_shape, dtype=self.compute_dtype
             )
-            return (output_spec, attention_scores_spec)
 
         return output_spec
 

--- a/keras/src/layers/attention/attention.py
+++ b/keras/src/layers/attention/attention.py
@@ -85,8 +85,6 @@ class Attention(Layer):
                 f"Received: score_mode={score_mode}"
             )
 
-        self._return_attention_scores = False
-
     def build(self, input_shape):
         self._validate_inputs(input_shape)
         self.scale = None
@@ -221,7 +219,6 @@ class Attention(Layer):
         use_causal_mask=False,
     ):
         self._validate_inputs(inputs=inputs, mask=mask)
-        self._return_attention_scores = return_attention_scores
         q = inputs[0]
         v = inputs[1]
         k = inputs[2] if len(inputs) > 2 else v
@@ -250,15 +247,9 @@ class Attention(Layer):
         return ops.convert_to_tensor(mask[0])
 
     def compute_output_shape(self, input_shape):
-        query_shape, value_shape, key_shape = input_shape
-        if key_shape is None:
-            key_shape = value_shape
-
-        output_shape = (*query_shape[:-1], value_shape[-1])
-        if self._return_attention_scores:
-            scores_shape = (query_shape[0], query_shape[1], key_shape[1])
-            return output_shape, scores_shape
-        return output_shape
+        query_shape = input_shape[0]
+        value_shape = input_shape[1]
+        return (*query_shape[:-1], value_shape[-1])
 
     def compute_output_spec(
         self,
@@ -273,7 +264,9 @@ class Attention(Layer):
         value = inputs[1]
         key = inputs[2] if len(inputs) > 2 else value
 
-        output_shape = (*query.shape[:-1], value.shape[-1])
+        output_shape = self.compute_output_shape(
+            [query.shape, value.shape, key.shape]
+        )
         output_spec = KerasTensor(output_shape, dtype=self.compute_dtype)
 
         if return_attention_scores:

--- a/keras/src/layers/attention/attention_test.py
+++ b/keras/src/layers/attention/attention_test.py
@@ -464,3 +464,19 @@ class AttentionTest(testing.TestCase):
         )
         self.assertEqual(output.shape, (None, 3, 5))  # Output shape
         self.assertEqual(attention_scores.shape, (None, 3, 4))
+
+    def test_symbolic_call_does_not_leak_return_attention_scores(self):
+        # `Attention` used to stash `return_attention_scores` on an instance
+        # flag in `call()`, so a later symbolic call that set it to `False`
+        # still returned a `(output, scores)` tuple from `compute_output_spec`.
+        # The symbolic path must trust only the explicit parameter.
+        attention = layers.Attention()
+        q_eager = np.random.rand(2, 3, 5).astype("float32")
+        v_eager = np.random.rand(2, 4, 5).astype("float32")
+        attention([q_eager, v_eager], return_attention_scores=True)
+
+        x = layers.Input(shape=(3, 5))
+        y = layers.Input(shape=(4, 5))
+        output = attention([x, y])
+        self.assertNotIsInstance(output, (tuple, list))
+        self.assertEqual(output.shape, (None, 3, 5))

--- a/keras/src/layers/attention/attention_test.py
+++ b/keras/src/layers/attention/attention_test.py
@@ -468,8 +468,9 @@ class AttentionTest(testing.TestCase):
     def test_symbolic_call_does_not_leak_return_attention_scores(self):
         # `Attention` used to stash `return_attention_scores` on an instance
         # flag in `call()`, so a later symbolic call that set it to `False`
-        # still returned a `(output, scores)` tuple from `compute_output_spec`.
-        # The symbolic path must trust only the explicit parameter.
+        # still returned a `(output, scores)` tuple from `compute_output_spec`
+        # and `compute_output_shape`. Both paths must trust only the explicit
+        # argument.
         attention = layers.Attention()
         q_eager = np.random.rand(2, 3, 5).astype("float32")
         v_eager = np.random.rand(2, 4, 5).astype("float32")
@@ -480,3 +481,8 @@ class AttentionTest(testing.TestCase):
         output = attention([x, y])
         self.assertNotIsInstance(output, (tuple, list))
         self.assertEqual(output.shape, (None, 3, 5))
+
+        self.assertEqual(
+            attention.compute_output_shape([x.shape, y.shape]),
+            (None, 3, 5),
+        )


### PR DESCRIPTION
## Description
`Attention.compute_output_spec` reads `self._return_attention_scores or return_attention_scores`. The cached attribute is set from the first `call()` and never reset, so once a layer has been called with `return_attention_scores=True`, every later symbolic call reports a tuple output even when the caller passes `False`. The runtime `call()` only honors the per-call argument, so spec and output disagree.
This drops the cached-flag fallback in `compute_output_spec` so the spec matches `call()`. A regression test covers the True-then-False order. `compute_output_shape` is unchanged since it has no per-call signal.
## Contributor Agreement
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.