### PR TITLE
Fix stale current_shard_path in ShardedH5IOStore get

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1320,7 +1320,8 @@ class ShardedH5IOStore(H5IOStore):
 
         if filename is not None and filename != self.current_shard_path.name:
             self.close()
-            self.h5_file = self._get_h5_file(self.path.with_name(filename))
+            self.current_shard_path = self.path.with_name(filename)
+            self.h5_file = self._get_h5_file(self.current_shard_path)
         return super().get(path)
 
     def close(self):

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1319,6 +1319,32 @@ class SavingH5IOStoreTest(testing.TestCase):
         for key in ["a", "b"]:
             self.assertIn(key, vars_store.keys())
 
+    def test_sharded_h5_io_store_cross_shard_read(self):
+        name = "cross_shard_read"
+        temp_filepath = Path(os.path.join(self.get_temp_dir(), f"{name}.json"))
+        a = np.random.random((1000, 1000)).astype("float32")
+        b = np.random.random((1000, 1000)).astype("float32")
+
+        store = saving_lib.ShardedH5IOStore(
+            temp_filepath, max_shard_size=0.005, mode="w"
+        )
+        vars_store = store.make("layer_a")
+        vars_store["0"] = a
+        vars_store = store.make("layer_b")
+        vars_store["0"] = b
+        store.close()
+
+        self.assertTrue(
+            os.path.exists(temp_filepath.with_name(f"{name}_00001.weights.h5"))
+        )
+
+        store = saving_lib.ShardedH5IOStore(temp_filepath, mode="r")
+        store.get("layer_b")
+        vars_store = store.get("layer_a")
+        self.assertLen(vars_store.keys(), 1)
+        self.assertAllClose(vars_store["0"], a)
+        store.close()
+
     def test_sharded_h5_io_store_exception_raised(self):
         temp_filepath = Path(os.path.join(self.get_temp_dir(), "store.h5"))
 


### PR DESCRIPTION
## Description
While fine-tuning Gemma 4 Instruct 26B on a TPU v5litepod-8 (see https://github.com/keras-team/kinetic/pull/204), I found a silent weight loading issue. The model trained fine, but when loading weights back, some layers were empty. No error, no warning, just wrong values. After debugging, the issue was in Keras, not in the training setup.

What I found is that `ShardedH5IOStore.get()` switches H5 files when weights are in a different shard, but it does not update `current_shard_path`. After the first switch, `current_shard_path` becomes outdated. This affects large models that span multiple shards, like Gemma 4 26B.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [X] I am a human, and not a bot.
- [X] I will be responsible for responding to review comments in a timely manner.
- [X] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
