### PR TITLE
Validate trainable arg as bool in Layer.__init__

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -305,9 +305,9 @@ class Layer(BackendLayer, Operation):
         self.supports_jit = True
 
         if not isinstance(trainable, bool):
-            raise TypeError(
+            raise ValueError(
                 "Expected `trainable` to be a boolean. "
-                f"Received: trainable={trainable} (of type "
+                f"Received: trainable={trainable!r} (of type "
                 f"{type(trainable).__name__})"
             )
         self._trainable = trainable

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -304,6 +304,12 @@ class Layer(BackendLayer, Operation):
         self._called = False
         self.supports_jit = True
 
+        if not isinstance(trainable, bool):
+            raise TypeError(
+                "Expected `trainable` to be a boolean. "
+                f"Received: trainable={trainable} (of type "
+                f"{type(trainable).__name__})"
+            )
         self._trainable = trainable
         self._losses = []
         self._loss_ids = set()

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -307,8 +307,8 @@ class Layer(BackendLayer, Operation):
         if not isinstance(trainable, bool):
             raise ValueError(
                 "Expected `trainable` to be a boolean. "
-                f"Received: trainable={trainable!r} (of type "
-                f"{type(trainable).__name__})"
+                f"Received: trainable={trainable} (of type "
+                f"{type(trainable)})"
             )
         self._trainable = trainable
         self._losses = []

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1383,11 +1383,11 @@ class LayerTest(testing.TestCase):
         # config passed to `deserialize_keras_object`) were silently accepted,
         # leaving `layer.trainable` as a non-bool and breaking downstream
         # strict-boolean checks.
-        with self.assertRaisesRegex(TypeError, "to be a boolean"):
+        with self.assertRaisesRegex(ValueError, "to be a boolean"):
             layers.Dense(2, trainable="yes")
-        with self.assertRaisesRegex(TypeError, "to be a boolean"):
+        with self.assertRaisesRegex(ValueError, "to be a boolean"):
             layers.Dense(2, trainable=1)
-        with self.assertRaisesRegex(TypeError, "to be a boolean"):
+        with self.assertRaisesRegex(ValueError, "to be a boolean"):
             layers.Dense(2, trainable=None)
 
     def test_trainable_init_arg(self):

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1378,6 +1378,18 @@ class LayerTest(testing.TestCase):
         self.assertEqual(layer.w.dtype, "int8")
         self.assertEqual(layer.w.trainable, False)
 
+    def test_trainable_init_arg_validation(self):
+        # Issue #22699: non-boolean `trainable` values (e.g. from a malformed
+        # config passed to `deserialize_keras_object`) were silently accepted,
+        # leaving `layer.trainable` as a non-bool and breaking downstream
+        # strict-boolean checks.
+        with self.assertRaisesRegex(TypeError, "to be a boolean"):
+            layers.Dense(2, trainable="yes")
+        with self.assertRaisesRegex(TypeError, "to be a boolean"):
+            layers.Dense(2, trainable=1)
+        with self.assertRaisesRegex(TypeError, "to be a boolean"):
+            layers.Dense(2, trainable=None)
+
     def test_trainable_init_arg(self):
         inputs = layers.Input(shape=(1,))
         layer = layers.Dense(2, trainable=False)

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -1379,10 +1379,6 @@ class LayerTest(testing.TestCase):
         self.assertEqual(layer.w.trainable, False)
 
     def test_trainable_init_arg_validation(self):
-        # Issue #22699: non-boolean `trainable` values (e.g. from a malformed
-        # config passed to `deserialize_keras_object`) were silently accepted,
-        # leaving `layer.trainable` as a non-bool and breaking downstream
-        # strict-boolean checks.
         with self.assertRaisesRegex(ValueError, "to be a boolean"):
             layers.Dense(2, trainable="yes")
         with self.assertRaisesRegex(ValueError, "to be a boolean"):


### PR DESCRIPTION
## Description

Fixes #22699.

`deserialize_keras_object` (and direct construction) silently accepted non-boolean values for the `trainable` argument, leaving `layer.trainable` set to a non-bool and breaking downstream strict boolean checks. For example, a malformed config with `"trainable": "yes"` would make `layer.trainable == "yes"` (str).

This change raises `ValueError` at construction time when `trainable` is not a `bool`, catching malformed configs early at the input boundary (per the Keras style guide, which prescribes `ValueError` for user input validation).

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

