### PR TITLE
Validate inner config dict type in deserialize_keras_object

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -728,6 +728,16 @@ def deserialize_keras_object(
             f"Full object config: {config}"
         )
 
+    # Check the raw value: `inner_config = config["config"] or {}` would
+    # hide falsy non-dicts (e.g. `[]`) by coercing them to `{}`.
+    raw_inner_config = config["config"]
+    if raw_inner_config is not None and not isinstance(raw_inner_config, dict):
+        raise ValueError(
+            f"Cannot deserialize '{class_name}': expected the `config` field "
+            f"to be a dict, got {type(raw_inner_config)} "
+            f"(value: {raw_inner_config}). Full object config: {config}"
+        )
+
     # Instantiate the class from its config inside a custom object scope
     # so that we can catch any custom objects that the config refers to.
     custom_obj_scope = object_registration.CustomObjectScope(custom_objects)

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -404,6 +404,18 @@ class SerializationLibTest(testing.TestCase):
         self.assertEqual(restored_conv_leaky.activation.negative_slope, 0.15)
         self.assertEqual(restored_conv_leaky.activation.name, "my_leaky")
 
+    def test_invalid_inner_config_type(self):
+        for invalid_config_value in ([1, 2, 3], [], "oops", 0):
+            bad_config = {
+                "class_name": "Dense",
+                "module": "keras.layers",
+                "config": invalid_config_value,
+            }
+            with self.assertRaisesRegex(
+                ValueError, r"expected the `config` field to be a dict"
+            ):
+                serialization_lib.deserialize_keras_object(bad_config)
+
     def test_layer_string_as_activation(self):
         """Tests serialization when activation is a string."""
 


### PR DESCRIPTION
## Description

Fixes #22701.

When the `config` field of an object dict was not a dict (e.g. a list passed by mistake or by a malformed config), `deserialize_keras_object` surfaced the failure as an internal `AttributeError: 'list' object has no attribute 'get'` raised from inside `cls.from_config(...)`.

This change validates `config["config"]` at the input boundary and raises a clear `ValueError` that includes the bad type, value, and full config, so malformed inputs are rejected at the edge rather than deep in class-specific code. The check inspects the raw value in `config["config"]` rather than the `inner_config = config["config"] or {}` local, so falsy non-dicts (e.g. `[]`, `0`) can't sneak through by being coerced into an empty dict.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

