### PR TITLE
Reject malformed object configs in deserialize_keras_object

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -610,6 +610,18 @@ def deserialize_keras_object(
         raise TypeError(f"Could not parse config: {config}")
 
     if "class_name" not in config or "config" not in config:
+        # If the dict looks like an object config (has any of these markers)
+        # but is missing a required field, treat it as malformed rather than
+        # a plain user dict.
+        _object_config_markers = ("class_name", "module", "registered_name")
+        if any(key in config for key in _object_config_markers):
+            missing = [k for k in ("class_name", "config") if k not in config]
+            missing_str = ", ".join(f"`{k}`" for k in missing)
+            raise ValueError(
+                "Malformed object config: expected a dict with both "
+                f"`class_name` and `config` keys, but missing {missing_str}. "
+                f"Full config: {config}"
+            )
         return {
             key: deserialize_keras_object(
                 value, custom_objects=custom_objects, safe_mode=safe_mode

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -404,6 +404,20 @@ class SerializationLibTest(testing.TestCase):
         self.assertEqual(restored_conv_leaky.activation.negative_slope, 0.15)
         self.assertEqual(restored_conv_leaky.activation.name, "my_leaky")
 
+    def test_incomplete_top_level_object_config(self):
+        with self.assertRaisesRegex(ValueError, r"Malformed object config"):
+            serialization_lib.deserialize_keras_object(
+                {"module": "keras.layers", "config": {"units": 32}}
+            )
+        with self.assertRaisesRegex(ValueError, r"Malformed object config"):
+            serialization_lib.deserialize_keras_object(
+                {"class_name": "Dense", "module": "keras.layers"}
+            )
+        self.assertEqual(
+            serialization_lib.deserialize_keras_object({"a": 1, "b": "hello"}),
+            {"a": 1, "b": "hello"},
+        )
+
     def test_layer_string_as_activation(self):
         """Tests serialization when activation is a string."""
 


### PR DESCRIPTION
## Description

Fixes #22704.

If the input dict was missing either `class_name` or `config`, `deserialize_keras_object` silently returned the raw dict, so callers had to add defensive type checks to distinguish a real deserialized object from a pass-through dict. For example, `{"module": "keras.layers", "config": {"units": 32}}` was returned unchanged instead of being flagged as a malformed object config.

This change tightens the fallback branch: when the input dict carries any object-config-only key (`class_name`, `module`, or `registered_name`) but is still missing one of the required fields (`class_name`/`config`), raise `ValueError` listing the missing keys. Plain user dicts that don't contain any of those markers still pass through unchanged so existing behavior is preserved.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

