### PR TITLE
Validate registered_name field in deserialize_keras_object

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -690,7 +690,9 @@ def deserialize_keras_object(
 
     # Below: classes and functions.
     module = config.get("module", None)
-    registered_name = config.get("registered_name", class_name)
+    registered_name = _get_validated_registered_name(
+        config, class_name, custom_objects
+    )
 
     if class_name == "function":
         fn_name = inner_config
@@ -758,6 +760,38 @@ def deserialize_keras_object(
             instance, config["shared_object_id"]
         )
     return instance
+
+
+def _get_validated_registered_name(config, class_name, custom_objects):
+    """Return the `registered_name` field after type/value validation."""
+    if "registered_name" not in config:
+        return class_name
+    registered_name = config["registered_name"]
+    if registered_name is not None and not isinstance(registered_name, str):
+        raise ValueError(
+            "`registered_name` must be None or a string, got "
+            f"{type(registered_name)} "
+            f"(value: {registered_name}). Full config: {config}"
+        )
+    if registered_name == "":
+        registered_name = None
+    if (
+        registered_name is not None
+        and registered_name != class_name
+        and object_registration.get_registered_object(
+            registered_name, custom_objects=custom_objects
+        )
+        is None
+    ):
+        warnings.warn(
+            f"Ignoring `registered_name={registered_name}`: it is not "
+            "registered via `keras.saving.register_keras_serializable` and "
+            "was not found in `custom_objects`. The object will be "
+            "resolved from `class_name` and `module` instead. Valid "
+            "registered names have the format 'package>name'.",
+            stacklevel=3,
+        )
+    return registered_name
 
 
 def _retrieve_class_or_fn(

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -1,6 +1,7 @@
 """Tests for serialization_lib."""
 
 import json
+import warnings
 
 import numpy as np
 import pytest
@@ -403,6 +404,60 @@ class SerializationLibTest(testing.TestCase):
         # Verify configuration of the activation layer is preserved
         self.assertEqual(restored_conv_leaky.activation.negative_slope, 0.15)
         self.assertEqual(restored_conv_leaky.activation.name, "my_leaky")
+
+    def test_registered_name_validation(self):
+        with self.assertRaisesRegex(ValueError, "must be None or a string"):
+            serialization_lib.deserialize_keras_object(
+                {
+                    "class_name": "Dense",
+                    "module": "keras.layers",
+                    "registered_name": 123,
+                    "config": {"units": 1},
+                }
+            )
+
+        with pytest.warns(UserWarning, match="Ignoring `registered_name"):
+            obj = serialization_lib.deserialize_keras_object(
+                {
+                    "class_name": "Dense",
+                    "module": "keras.layers",
+                    "registered_name": "builtins.eval",
+                    "config": {"units": 1},
+                }
+            )
+            self.assertIsInstance(obj, keras.layers.Dense)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            obj_empty = serialization_lib.deserialize_keras_object(
+                {
+                    "class_name": "Dense",
+                    "module": "keras.layers",
+                    "registered_name": "",
+                    "config": {"units": 1},
+                }
+            )
+            obj_none = serialization_lib.deserialize_keras_object(
+                {
+                    "class_name": "Dense",
+                    "module": "keras.layers",
+                    "registered_name": None,
+                    "config": {"units": 1},
+                }
+            )
+            self.assertIsInstance(obj_empty, keras.layers.Dense)
+            self.assertIsInstance(obj_none, keras.layers.Dense)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            serialization_lib.deserialize_keras_object(
+                {
+                    "class_name": "Dense",
+                    "module": "keras.layers",
+                    "registered_name": "Dense",
+                    "config": {"units": 1},
+                }
+            )
 
     def test_layer_string_as_activation(self):
         """Tests serialization when activation is a string."""


### PR DESCRIPTION
## Description

Fixes #22703.

The `registered_name` field of a serialized object config was accepted without validation: arbitrary strings like `"builtins.eval"` or `"subprocess.Popen"` passed through silently, non-string types were accepted, and empty string vs. `None` were treated equivalently without being documented as such. The values were not actually dangerous (the existing `_retrieve_class_or_fn` lookup only resolves entries from the Keras registry / `custom_objects`, so unknown names fall through), but the field gave no feedback at all when it was meaningless.

This change adds a small validation step when reading the field:

- reject non-string, non-`None` values with `ValueError` (per the Keras style guide, user input validation uses `ValueError`);
- normalize empty string to `None` so the two behave the same;
- warn when an explicitly provided non-empty value neither resolves via `custom_objects` / `GLOBAL_CUSTOM_OBJECTS` / the active custom object scope nor equals `class_name` (the legacy default). In that case the field has no effect on deserialization, so the warning tells the user their value is being ignored and points at the expected `package>name` format.

The documented patterns (None for built-ins, `package>name` for registered classes, `registered_name == class_name` for legacy configs) continue to load without warnings, so existing saved models are unaffected.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

