### PR TITLE
Validate layer entries in Sequential.from_config

### DIFF
--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -378,7 +378,18 @@ class Sequential(Model):
             name = None
             layer_configs = config
         model = cls(name=name)
-        for layer_config in layer_configs:
+        for idx, layer_config in enumerate(layer_configs):
+            if (
+                not isinstance(layer_config, dict)
+                or "class_name" not in layer_config
+                or "config" not in layer_config
+            ):
+                raise ValueError(
+                    f"Cannot deserialize Sequential model: entry at index "
+                    f"{idx} of `layers` is not a valid layer config. Expected "
+                    f"a dict with `class_name` and `config` keys, got: "
+                    f"{layer_config} (type {type(layer_config)})."
+                )
             if "module" not in layer_config:
                 # Legacy format deserialization (no "module" key)
                 # used for H5 and SavedModel formats

--- a/keras/src/models/sequential_test.py
+++ b/keras/src/models/sequential_test.py
@@ -317,6 +317,58 @@ class SequentialTest(testing.TestCase):
         )
         self.assertLen(revived.layers, 1)
 
+    def test_from_config_rejects_malformed_layer_entry(self):
+        cfg = {
+            "name": "seq",
+            "layers": [
+                {
+                    "class_name": "Dense",
+                    "module": "keras.layers",
+                    "config": {"units": 4},
+                },
+                {},
+                {
+                    "class_name": "Dense",
+                    "module": "keras.layers",
+                    "config": {"units": 2},
+                },
+            ],
+        }
+        with self.assertRaisesRegex(
+            ValueError,
+            r"entry at index 1 of `layers` is not a valid layer config",
+        ):
+            Sequential.from_config(cfg)
+
+        cfg_non_dict = {
+            "name": "seq",
+            "layers": [
+                {
+                    "class_name": "Dense",
+                    "module": "keras.layers",
+                    "config": {"units": 4},
+                },
+                "not-a-layer",
+            ],
+        }
+        with self.assertRaisesRegex(
+            ValueError,
+            r"entry at index 1 of `layers` is not a valid layer config",
+        ):
+            Sequential.from_config(cfg_non_dict)
+
+        cfg_missing_config = {
+            "name": "seq",
+            "layers": [
+                {"class_name": "Dense", "module": "keras.layers"},
+            ],
+        }
+        with self.assertRaisesRegex(
+            ValueError,
+            r"entry at index 0 of `layers` is not a valid layer config",
+        ):
+            Sequential.from_config(cfg_missing_config)
+
     def test_serialization_with_lambda_layer(self):
         # https://github.com/keras-team/keras/issues/20074
         inputs = np.random.random(size=(1, 10, 4)).astype("float32")


### PR DESCRIPTION
## Description

Fixes #22720.

A malformed entry inside the `layers` list (for example, an empty dict) used to surface as a cryptic internal `TypeError: string indices must be integers, not 'str'` raised from deep inside the legacy loader (`saving_utils.model_from_config`). The malformed entry was never rejected at the input boundary, so the failure leaked implementation details to users loading external model configs.

Validate each entry at the start of the loop before dispatching to either the legacy or the modern deserialization path: the entry must be a dict and must contain both `class_name` and `config` (both paths require them to reconstruct a layer). Otherwise raise `ValueError` identifying the offending index, value, and type, so callers can pinpoint and fix bad inputs.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

