### PR TITLE
[OpenVINO] Fix zeros/ones/empty/full for dynamic shapes

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -156,9 +156,15 @@ def shape_to_ov_output(shape):
 
     Unlike get_ov_output, handles mixed shapes where some dims are
     OpenVINOKerasTensor scalars (from ops.shape() on dynamic tensors).
+    None dims (from tensor.shape) are not supported — use ops.shape(x) instead.
     """
     if not isinstance(shape, (list, tuple)):
         raise ValueError(f"shape must be a list or tuple, got {type(shape)}")
+    if any(e is None for e in shape):
+        raise ValueError(
+            "Shape contains None (dynamic) dimensions. Use ops.shape(x) "
+            "instead of x.shape to get a runtime-resolved shape."
+        )
     if not any(isinstance(e, (OpenVINOKerasTensor, ov.Output)) for e in shape):
         return ov_opset.constant(list(shape), Type.i32).output(0)
     parts = []

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -32,5 +32,4 @@ NumpyOneInputOpsCorrectnessTest::test_real
 RandAugmentTest::test_random_augment_randomness
 RandomSaturationTest::test_random_saturation_full_saturation
 RandomZoomTest::test_connect_with_flatten
-RandomZoomTest::test_dynamic_shape
 UpSampling2dTest::test_upsampling_2d_lanczos_interpolation_methods

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -199,11 +199,9 @@ def ones(shape, dtype=None):
     dtype = standardize_dtype(dtype) or config.floatx()
     ov_type = OPENVINO_DTYPES[dtype]
     const_one = ov_opset.constant(1, ov_type).output(0)
-    if isinstance(shape, tuple):
-        shape = list(shape)
-    elif isinstance(shape, int):
+    if isinstance(shape, int):
         shape = [shape]
-    output_shape = ov_opset.constant(shape, dtype=Type.i32).output(0)
+    output_shape = shape_to_ov_output(list(shape))
     ones = ov_opset.broadcast(const_one, output_shape)
     return OpenVINOKerasTensor(ones.output(0))
 
@@ -212,11 +210,9 @@ def zeros(shape, dtype=None):
     dtype = standardize_dtype(dtype) or config.floatx()
     ov_type = OPENVINO_DTYPES[dtype]
     const_zero = ov_opset.constant(0, dtype=ov_type).output(0)
-    if isinstance(shape, tuple):
-        shape = list(shape)
-    elif isinstance(shape, int):
+    if isinstance(shape, int):
         shape = [shape]
-    output_shape = ov_opset.constant(shape, dtype=Type.i32).output(0)
+    output_shape = shape_to_ov_output(list(shape))
     zeros = ov_opset.broadcast(const_zero, output_shape)
     return OpenVINOKerasTensor(zeros.output(0))
 
@@ -1840,11 +1836,9 @@ def dstack(xs):
 def empty(shape, dtype=None):
     dtype = standardize_dtype(dtype) or config.floatx()
     ov_type = OPENVINO_DTYPES[dtype]
-    if isinstance(shape, tuple):
-        shape = list(shape)
-    elif isinstance(shape, int):
+    if isinstance(shape, int):
         shape = [shape]
-    shape_node = ov_opset.constant(shape, Type.i32).output(0)
+    shape_node = shape_to_ov_output(list(shape))
     const_zero = ov_opset.constant(0, dtype=ov_type).output(0)
     empty_tensor = ov_opset.broadcast(const_zero, shape_node).output(0)
     return OpenVINOKerasTensor(empty_tensor)
@@ -2017,9 +2011,9 @@ def full(shape, fill_value, dtype=None):
     dtype = standardize_dtype(dtype) or config.floatx()
     ov_type = OPENVINO_DTYPES[dtype]
     fill_value = get_ov_output(fill_value, ov_type)
-    if isinstance(shape, tuple):
-        shape = list(shape)
-    target_shape = ov_opset.constant(shape, Type.i32)
+    if isinstance(shape, int):
+        shape = [shape]
+    target_shape = shape_to_ov_output(list(shape))
     return OpenVINOKerasTensor(
         ov_opset.broadcast(fill_value, target_shape).output(0)
     )

--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -86,23 +86,23 @@ class OpenVINOTrainer(base_trainer.Trainer):
 
         self.test_function = test_step
 
-    def _parameterize_data(self, data):
+    def _parameterize_data(self, data, dynamic_batch_size=False):
         if isinstance(data, (list, tuple)):
             parametrize_data = []
             for elem in data:
-                param_elem = self._parameterize_data(elem)
+                param_elem = self._parameterize_data(elem, dynamic_batch_size)
                 parametrize_data.append(param_elem)
         elif isinstance(data, dict):
             parametrize_data = dict()
             for elem_name, elem in data.items():
-                param_elem = self._parameterize_data(elem)
+                param_elem = self._parameterize_data(elem, dynamic_batch_size)
                 parametrize_data[elem_name] = param_elem
         elif isinstance(data, OpenVINOKerasTensor):
             parametrize_data = data
         elif isinstance(data, np.ndarray) or np.isscalar(data):
             ov_type = OPENVINO_DTYPES[str(data.dtype)]
             ov_shape = list(data.shape)
-            if len(ov_shape) > 0:
+            if dynamic_batch_size and len(ov_shape) > 0:
                 ov_shape[0] = -1
             param = ov_opset.parameter(shape=ov_shape, dtype=ov_type)
             parametrize_data = OpenVINOKerasTensor(param.output(0))
@@ -139,7 +139,9 @@ class OpenVINOTrainer(base_trainer.Trainer):
         del self.ov_compiled_model
 
         # prepare parameterized input
-        self.struct_params = self._parameterize_data(data)
+        self.struct_params = self._parameterize_data(
+            data, dynamic_batch_size=True
+        )
         # construct OpenVINO graph during calling Keras Model
         if self._call_has_training_arg:
             self.struct_outputs = self(self.struct_params, training=False)

--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -86,23 +86,23 @@ class OpenVINOTrainer(base_trainer.Trainer):
 
         self.test_function = test_step
 
-    def _parameterize_data(self, data, dynamic_batch_size=False):
+    def _parameterize_data(self, data):
         if isinstance(data, (list, tuple)):
             parametrize_data = []
             for elem in data:
-                param_elem = self._parameterize_data(elem, dynamic_batch_size)
+                param_elem = self._parameterize_data(elem)
                 parametrize_data.append(param_elem)
         elif isinstance(data, dict):
             parametrize_data = dict()
             for elem_name, elem in data.items():
-                param_elem = self._parameterize_data(elem, dynamic_batch_size)
+                param_elem = self._parameterize_data(elem)
                 parametrize_data[elem_name] = param_elem
         elif isinstance(data, OpenVINOKerasTensor):
             parametrize_data = data
         elif isinstance(data, np.ndarray) or np.isscalar(data):
             ov_type = OPENVINO_DTYPES[str(data.dtype)]
             ov_shape = list(data.shape)
-            if dynamic_batch_size and len(ov_shape) > 0:
+            if len(ov_shape) > 0:
                 ov_shape[0] = -1
             param = ov_opset.parameter(shape=ov_shape, dtype=ov_type)
             parametrize_data = OpenVINOKerasTensor(param.output(0))
@@ -139,9 +139,7 @@ class OpenVINOTrainer(base_trainer.Trainer):
         del self.ov_compiled_model
 
         # prepare parameterized input
-        self.struct_params = self._parameterize_data(
-            data, dynamic_batch_size=True
-        )
+        self.struct_params = self._parameterize_data(data)
         # construct OpenVINO graph during calling Keras Model
         if self._call_has_training_arg:
             self.struct_outputs = self(self.struct_params, training=False)


### PR DESCRIPTION
## Description
ops.zeros, ops.ones, ops.empty, and ops.full previously built the output shape by calling ov_opset.constant(shape, Type.i32) directly. This crashes when any element of the shape is an OpenVINOKerasTensor scalar, returned by ops.shape(x) on a tensor with dynamic dimensions, such as one produced during graph construction with a dynamic batch axis.

Fix: All four ops now call shape_to_ov_output() (introduced in #22692), which handles mixed static/dynamic shape tuples by building per-dim constants and concatenating them into a single i32 shape tensor. A guard is also added to shape_to_ov_output to raise a clear error if None appears in the shape tuple, directing callers to use ops.shape(x) rather than x.shape to obtain a runtime-resolved shape.

Note: This PR does not revert #22681. The _parameterize_data dynamic batch workaround in the trainer is left in place; fixing that properly will be tracked separately.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
