### PR TITLE
Fix: Issue #22538 Remove symbolic tensor support for blackman operation

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1859,33 +1859,27 @@ def right_shift(x, y):
     return backend.numpy.right_shift(x, y)
 
 
-class Blackman(Operation):
-    def call(self, x):
-        return backend.numpy.blackman(x)
-
-    def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=backend.floatx())
-
-
 @keras_export(["keras.ops.blackman", "keras.ops.numpy.blackman"])
 def blackman(x):
     """Blackman window function.
     The Blackman window is a taper formed by using a weighted cosine.
 
     Args:
-        x: Scalar or 1D Tensor. Window length.
+        x: Scalar or 1D tensor. Window length.
 
     Returns:
         A 1D tensor containing the Blackman window values.
 
     Example:
-    >>> x = keras.ops.convert_to_tensor(5)
     >>> keras.ops.blackman(x)
-    array([-1.3877788e-17,  3.4000000e-01,  1.0000000e+00,  3.4000000e-01,
-           -1.3877788e-17], dtype=float32)
+    array([-1.4901161e-08,  3.4000003e-01,  9.9999994e-01,  3.3999997e-01,
+       -1.4901161e-08], dtype=float32)
     """
     if any_symbolic_tensors((x,)):
-        return Blackman().symbolic_call(x)
+        raise TypeError(
+            "Blackman operation only supports scalar inputs and non-eager tensors. "
+            + f"Received input x = {x} of type {type(x)}"
+        )
     return backend.numpy.blackman(x)
 
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1877,8 +1877,8 @@ def blackman(x):
     """
     if any_symbolic_tensors((x,)):
         raise TypeError(
-            "Blackman operation only supports scalar inputs and non-eager tensors. "
-            + f"Received input x = {x} of type {type(x)}"
+            f"""Blackman operation only supports scalar inputs and
+            non-eager tensors. Received input x = {x} of type {type(x)}"""
         )
     return backend.numpy.blackman(x)
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1877,8 +1877,8 @@ def blackman(x):
     """
     if any_symbolic_tensors((x,)):
         raise TypeError(
-            f"""Blackman operation only supports scalar inputs and
-            non-eager tensors. Received input x = {x} of type {type(x)}"""
+            f"Blackman operation does not support symbolic tensors. "
+            f"Received input x = {x} of type {type(x)}"
         )
     return backend.numpy.blackman(x)
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1439,11 +1439,6 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         x = np.random.randint(1, 100 + 1)
         self.assertEqual(knp.blackman(x).shape[0], x)
 
-    def test_blackman_length_1_symbolic_shape(self):
-        x = KerasTensor((1,), dtype="int32")
-        y = knp.blackman(x)
-        self.assertEqual(y.shape, (1,))
-
     def test_hamming(self):
         x = np.random.randint(1, 100 + 1)
         self.assertEqual(knp.hamming(x).shape[0], x)
@@ -4856,17 +4851,11 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         x = np.random.randint(1, 100 + 1)
         self.assertAllClose(knp.blackman(x), np.blackman(x))
 
-        self.assertAllClose(knp.Blackman()(x), np.blackman(x))
-
     def test_blackman_length_1(self):
         x = 1
         x_tensor = keras.ops.convert_to_tensor(x)
         expected = np.blackman(x)
         out = knp.blackman(x_tensor)
-        self.assertEqual(out.shape[0], x)
-        self.assertAllClose(out, expected)
-
-        out = knp.Blackman()(x_tensor)
         self.assertEqual(out.shape[0], x)
         self.assertAllClose(out, expected)
 
@@ -7737,10 +7726,6 @@ class NumpyDtypeTest(testing.TestCase):
 
         self.assertEqual(
             standardize_dtype(knp.blackman(x).dtype), expected_dtype
-        )
-        self.assertEqual(
-            standardize_dtype(knp.Blackman().symbolic_call(x).dtype),
-            expected_dtype,
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))


### PR DESCRIPTION
## Description
Removed support for symbolic tensors, as the Blackman function depends on the tensor value. This causes runtime errors in JAX and Keras functional graphs.

<!-- Describe your changes here -->
Restricted the blackman function input to Python integers.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
