### PR TITLE
Fix FeatureSpace and IndexLookup tests convert_to_numpy for TF tensors

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -10,10 +10,6 @@ EqualizationTest::test_input_dtypes_int64
 EqualizationTest::test_output_range_0_1
 EqualizationTest::test_output_range_0_255
 FeatureSpaceTest::test_saving
-ImageOpsCorrectnessTest::test_extract_patches
-ImageOpsCorrectnessTest::test_pad_images
-IndexLookupLayerTest::test_oov_method_ignored_for_string_dtype
-IndexLookupLayerTest::test_salt_produces_different_output_than_farmhash
 LayerTest::test_complex_dtype_support
 LinalgOpsCorrectnessTest::test_cholesky
 LinalgOpsCorrectnessTest::test_eig

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -9,10 +9,6 @@ EqualizationTest::test_input_dtypes_int32
 EqualizationTest::test_input_dtypes_int64
 EqualizationTest::test_output_range_0_1
 EqualizationTest::test_output_range_0_255
-FeatureSpaceTest::test_adapt_with_dict
-FeatureSpaceTest::test_advanced_usage
-FeatureSpaceTest::test_basic_usage
-FeatureSpaceTest::test_basic_usage_no_strings
 FeatureSpaceTest::test_saving
 ImageOpsCorrectnessTest::test_extract_patches
 ImageOpsCorrectnessTest::test_pad_images

--- a/keras/src/layers/preprocessing/feature_space.py
+++ b/keras/src/layers/preprocessing/feature_space.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from keras.src import backend
 from keras.src import layers
 from keras.src import tree
@@ -753,7 +755,7 @@ class FeatureSpace(Layer):
                     backend.backend() != "tensorflow"
                     and not backend_utils.in_tf_graph()
                 ):
-                    merged_data = backend.convert_to_numpy(merged_data)
+                    merged_data = np.array(merged_data)
                 merged_data = tf.squeeze(merged_data, axis=0)
             else:
                 for name, x in merged_data.items():

--- a/keras/src/layers/preprocessing/index_lookup_test.py
+++ b/keras/src/layers/preprocessing/index_lookup_test.py
@@ -787,8 +787,8 @@ class IndexLookupLayerTest(testing.TestCase):
         }
         layer_floormod = layers.IndexLookup(oov_method="floormod", **kwargs)
         layer_farmhash = layers.IndexLookup(oov_method="farmhash", **kwargs)
-        out_floormod = backend.convert_to_numpy(layer_floormod(oov_data))
-        out_farmhash = backend.convert_to_numpy(layer_farmhash(oov_data))
+        out_floormod = np.array(layer_floormod(oov_data))
+        out_farmhash = np.array(layer_farmhash(oov_data))
         self.assertAllClose(out_floormod, out_farmhash)
 
     def test_salt_config_serialization(self):
@@ -854,8 +854,8 @@ class IndexLookupLayerTest(testing.TestCase):
             )
             layer_farmhash = layers.IndexLookup(**base_kwargs)
             layer_siphash = layers.IndexLookup(salt=[137, 42], **base_kwargs)
-            out_farmhash = backend.convert_to_numpy(layer_farmhash(oov_data))
-            out_siphash = backend.convert_to_numpy(layer_siphash(oov_data))
+            out_farmhash = np.array(layer_farmhash(oov_data))
+            out_siphash = np.array(layer_siphash(oov_data))
             self.assertFalse(
                 np.array_equal(out_farmhash, out_siphash),
                 msg=f"Expected different outputs for dtype={dtype}",


### PR DESCRIPTION
## Description
Fix convert_to_numpy for TF tensors in IndexLookup tests and FeatureSpace, same as addressed in #22594.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
