### PR TITLE
[OpenVINO] Removed depthwise_conv test exclusions

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -1,5 +1,3 @@
-DepthwiseConvBasicTest::test_depthwise_conv1d_basic3
-DepthwiseConvCorrectnessTest::test_depthwise_conv1d3
 EqualizationTest::test_constant_regions
 EqualizationTest::test_different_bin_sizes
 EqualizationTest::test_equalizes_to_all_bins

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -723,12 +723,6 @@ def depthwise_conv(
     data_format = backend.standardize_data_format(data_format)
     num_spatial_dims = inputs.get_partial_shape().rank.get_length() - 2
 
-    if data_format != "channels_last":
-        raise ValueError(
-            "OpenVINO depthwise_conv only supports 'channels_last' "
-            f"data format. Received: data_format={data_format}"
-        )
-
     strides = _adjust_strides_dilation(strides, num_spatial_dims)
     dilation_rate = _adjust_strides_dilation(dilation_rate, num_spatial_dims)
     pad_mode, pads_begin, pads_end = _adjust_padding(padding)


### PR DESCRIPTION
## Description
The existing helpers handle both formats correctly -> _adjust_input transposes channels_last -> NCHW and leaves channels_first as-is, and _adjust_outputs does the inverse. It doesn't need to be excluded.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
