### PR TITLE
Fix: Validate trainable parameter as boolean in deserialize_keras_object

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -733,6 +733,13 @@ def deserialize_keras_object(
     custom_obj_scope = object_registration.CustomObjectScope(custom_objects)
     safe_mode_scope = SafeModeScope(safe_mode)
     with custom_obj_scope, safe_mode_scope:
+        if "trainable" in inner_config and not isinstance(
+            inner_config["trainable"], bool
+        ):
+            raise TypeError(
+                "Invalid type for `trainable` field. "
+                f"Expected bool. Received: {inner_config['trainable']} of type {type(inner_config['trainable'])}."
+            )
         try:
             instance = cls.from_config(inner_config)
         except TypeError as e:


### PR DESCRIPTION
### What this PR does

This PR addresses issue #22699 where `deserialize_keras_object` accepts non-boolean values for the `trainable` field without validation.

### Fix details
In `keras/src/saving/serialization_lib.py`, I have added a type check just before `cls.from_config(inner_config)` is called. If the `trainable` parameter is present in `inner_config` but is not of type `bool`, a `TypeError` will be raised with an appropriate message identifying the invalid type.

Fixes #22699