### PR TITLE
[OpenVINO] Fix backend applying dropout during predict

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -48,5 +48,4 @@ RandomPerspectiveTest::test_random_perspective_bounding_boxes_with_small_scale
 RandomSaturationTest::test_random_saturation_full_saturation
 RandomZoomTest::test_connect_with_flatten
 RandomZoomTest::test_dynamic_shape
-TestTrainer::test_predict_dropout
 UpSampling2dTest::test_upsampling_2d_lanczos_interpolation_methods

--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -143,7 +143,10 @@ class OpenVINOTrainer(base_trainer.Trainer):
             data, dynamic_batch_size=True
         )
         # construct OpenVINO graph during calling Keras Model
-        self.struct_outputs = self(self.struct_params)
+        if self._call_has_training_arg:
+            self.struct_outputs = self(self.struct_params, training=False)
+        else:
+            self.struct_outputs = self(self.struct_params)
 
         parameters = []
         for p in tree.flatten(self.struct_params):


### PR DESCRIPTION
## Description
`_get_compiled_model` was calling self(self.struct_params) without training=False when tracing the Keras model into an OpenVINO graph. This caused training-mode ops (e.g. Dropout) to be into the compiled model, so dropout was incorrectly applied during inference.

All other backends (TF, Torch, JAX, NumPy) guard their predict/test steps with _call_has_training_arg and pass training=False. This PR mirrors that pattern in the OpenVINO _get_compiled_model path.


## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
