### PR TITLE
[OpenVINO] Fix __truediv__  to promote int to float before division

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -270,17 +270,23 @@ class OpenVINOKerasTensor:
     def __truediv__(self, other):
         first = self.output
         other = get_ov_output(other, context_dtype=self.dtype)
-        first, other = align_operand_types(
-            first, other, "OpenVINOKerasTensor::__truediv__"
-        )
+        x1_type = ov_to_keras_type(first.get_element_type())
+        x2_type = ov_to_keras_type(other.get_element_type())
+        result_type = dtypes.result_type(x1_type, x2_type, float)
+        result_type = OPENVINO_DTYPES[result_type]
+        first = ov_opset.convert(first, result_type).output(0)
+        other = ov_opset.convert(other, result_type).output(0)
         return OpenVINOKerasTensor(ov_opset.divide(first, other).output(0))
 
     def __rtruediv__(self, other):
         first = self.output
         other = get_ov_output(other, context_dtype=self.dtype)
-        first, other = align_operand_types(
-            first, other, "OpenVINOKerasTensor::__rtruediv__"
-        )
+        x1_type = ov_to_keras_type(first.get_element_type())
+        x2_type = ov_to_keras_type(other.get_element_type())
+        result_type = dtypes.result_type(x1_type, x2_type, float)
+        result_type = OPENVINO_DTYPES[result_type]
+        first = ov_opset.convert(first, result_type).output(0)
+        other = ov_opset.convert(other, result_type).output(0)
         return OpenVINOKerasTensor(ov_opset.divide(other, first).output(0))
 
     def __floordiv__(self, other):

--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -76,7 +76,7 @@ DTYPES_MIN = {
 }
 
 
-def align_operand_types(x1, x2, op_name):
+def align_operand_types(x1, x2, op_name, force_float=False):
     x1_type = x1.element_type
     x2_type = x2.element_type
     if x1_type.is_dynamic() or x2_type.is_dynamic():
@@ -86,7 +86,10 @@ def align_operand_types(x1, x2, op_name):
         )
     x1_type = ov_to_keras_type(x1_type)
     x2_type = ov_to_keras_type(x2_type)
-    result_type = dtypes.result_type(x1_type, x2_type)
+    if force_float:
+        result_type = dtypes.result_type(x1_type, x2_type, float)
+    else:
+        result_type = dtypes.result_type(x1_type, x2_type)
     result_type = OPENVINO_DTYPES[result_type]
     if x1_type != result_type:
         x1 = ov_opset.convert(x1, result_type).output(0)
@@ -270,23 +273,17 @@ class OpenVINOKerasTensor:
     def __truediv__(self, other):
         first = self.output
         other = get_ov_output(other, context_dtype=self.dtype)
-        x1_type = ov_to_keras_type(first.get_element_type())
-        x2_type = ov_to_keras_type(other.get_element_type())
-        result_type = dtypes.result_type(x1_type, x2_type, float)
-        result_type = OPENVINO_DTYPES[result_type]
-        first = ov_opset.convert(first, result_type).output(0)
-        other = ov_opset.convert(other, result_type).output(0)
+        first, other = align_operand_types(
+            first, other, "OpenVINOKerasTensor::__truediv__", force_float=True
+        )
         return OpenVINOKerasTensor(ov_opset.divide(first, other).output(0))
 
     def __rtruediv__(self, other):
         first = self.output
         other = get_ov_output(other, context_dtype=self.dtype)
-        x1_type = ov_to_keras_type(first.get_element_type())
-        x2_type = ov_to_keras_type(other.get_element_type())
-        result_type = dtypes.result_type(x1_type, x2_type, float)
-        result_type = OPENVINO_DTYPES[result_type]
-        first = ov_opset.convert(first, result_type).output(0)
-        other = ov_opset.convert(other, result_type).output(0)
+        first, other = align_operand_types(
+            first, other, "OpenVINOKerasTensor::__rtruediv__", force_float=True
+        )
         return OpenVINOKerasTensor(ov_opset.divide(other, first).output(0))
 
     def __floordiv__(self, other):

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -18,7 +18,6 @@ LinalgOpsCorrectnessTest::test_solve_triangular
 LinalgOpsCorrectnessTest::test_svd
 MathOpsCorrectnessTest::test_erfinv_operation_basic
 MathOpsCorrectnessTest::test_erfinv_operation_dtype
-MergingLayersTest::test_average_with_mask
 NNOpsCorrectnessTest::test_ctc_decode
 NNOpsCorrectnessTest::test_polar_corectness
 NNOpsDtypeTest::test_ctc_decode


### PR DESCRIPTION
## Description
The Average layer computes output / len(inputs) via Python's / operator. On the OpenVINO backend, __truediv__ was using align_operand_types, which promotes operands to a common type but doesn't force float, so integer inputs stayed int32 and OpenVINO's divide op performed floor division.

Fixed by adding a force_float parameter to align_operand_types that passes float to dtypes.result_type, matching the pattern already used in ops.divide. __truediv__ and __rtruediv__ now pass force_float=True, keeping them consistent with all other operators that go through the shared helper.

Fixes MergingLayersTest::test_average_with_mask returning [0, 1] instead of [0.5, 1].

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
