### PR TITLE
[Bug] Fix deserialize_keras_object error for malformed layer configs

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -610,6 +610,12 @@ def deserialize_keras_object(
         raise TypeError(f"Could not parse config: {config}")
 
     if "class_name" not in config or "config" not in config:
+        if not config:
+            raise TypeError(
+                f"Invalid config dict: expected a dict with 'class_name' and "
+                f"'config' keys, but got an empty dict. "
+                f"Received: {config}"
+            )
         return {
             key: deserialize_keras_object(
                 value, custom_objects=custom_objects, safe_mode=safe_mode


### PR DESCRIPTION
Fixes keras-team/keras#22720

## Summary
When `deserialize_keras_object({})` is called with an empty dict, it previously returned an empty dict which would flow through to `Sequential.from_config` and cause a confusing `TypeError: string indices must be integers, not 'str'` error.

This fix adds explicit validation to raise a clear `TypeError` with a helpful message when an empty dict is passed.

## Changes
- Added check in `deserialize_keras_object` in `keras/src/saving/serialization_lib.py` to raise a clear error for empty config dicts
- Error message: `Invalid config dict: expected a dict with 'class_name' and 'config' keys, but got an empty dict.`

## Test case
```python
from keras.src.saving.serialization_lib import deserialize_keras_object
try:
    deserialize_keras_object({})
nexcept TypeError as e:
    print(f"Got expected error: {e}")
```