### PR TITLE
Add validation for invalid Sequential layer configs

### DIFF
--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -370,18 +370,31 @@ class Sequential(Model):
 
     @classmethod
     def from_config(cls, config, custom_objects=None):
-        if "name" in config:
-            name = config["name"]
+        if isinstance(config, dict) and "layers" in config:
+            name = config.get("name")
             build_input_shape = config.get("build_input_shape")
             layer_configs = config["layers"]
         else:
             name = None
+            build_input_shape = None
             layer_configs = config
+
         model = cls(name=name)
         for layer_config in layer_configs:
+            if not isinstance(layer_config, dict) or not layer_config:
+                raise TypeError(
+                    "Invalid layer config in Sequential.from_config(). "
+                    "Expected a non-empty dict. "
+                    f"Received: {layer_config!r}"
+                )
+            if "class_name" not in layer_config or "config" not in layer_config:
+                raise TypeError(
+                    "Invalid layer config in Sequential.from_config(). "
+                    "Expected keys 'class_name' and 'config'. "
+                    f"Received: {layer_config!r}"
+                )
+
             if "module" not in layer_config:
-                # Legacy format deserialization (no "module" key)
-                # used for H5 and SavedModel formats
                 layer = saving_utils.model_from_config(
                     layer_config,
                     custom_objects=custom_objects,
@@ -392,9 +405,9 @@ class Sequential(Model):
                     custom_objects=custom_objects,
                 )
             model.add(layer)
+
         if (
             not model._functional
-            and "build_input_shape" in locals()
             and build_input_shape
             and isinstance(build_input_shape, (tuple, list))
         ):

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -382,7 +382,7 @@ class Sequential(Model):
         model = cls(name=name)
         for layer_config in layer_configs:
             if not isinstance(layer_config, dict) or not layer_config:
-                raise TypeError(
+                raise ValueError(
                     "Invalid layer config in Sequential.from_config(). "
                     "Expected a non-empty dict. "
                     f"Received: {layer_config!r}"

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -388,7 +388,7 @@ class Sequential(Model):
                     f"Received: {layer_config!r}"
                 )
             if "class_name" not in layer_config or "config" not in layer_config:
-                raise TypeError(
+                raise ValueError(
                     "Invalid layer config in Sequential.from_config(). "
                     "Expected keys 'class_name' and 'config'. "
                     f"Received: {layer_config!r}"

--- a/keras/src/models/sequential_test.py
+++ b/keras/src/models/sequential_test.py
@@ -391,3 +391,30 @@ class SequentialTest(testing.TestCase):
             AttributeError, r"Use `add\(\)` and `pop\(\)`"
         ):
             model.layers = [layers.Dense(4)]
+
+    def test_deserialization_with_invalid_layer_config(self):
+        payload = {
+            "class_name": "Sequential",
+            "module": "keras",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "module": "keras.layers",
+                        "config": {"units": 4},
+                    },
+                    {},
+                    {
+                        "class_name": "Dense",
+                        "module": "keras.layers",
+                        "config": {"units": 2},
+                    },
+                ]
+            },
+        }
+
+        with self.assertRaisesRegex(
+            TypeError,
+            r"Invalid layer config in Sequential\.from_config\(\)",
+        ):
+            saving.deserialize_keras_object(payload)

--- a/keras/src/models/sequential_test.py
+++ b/keras/src/models/sequential_test.py
@@ -414,7 +414,7 @@ class SequentialTest(testing.TestCase):
         }
 
         with self.assertRaisesRegex(
-            TypeError,
+            ValueError,
             r"Invalid layer config in Sequential\.from_config\(\)",
         ):
             saving.deserialize_keras_object(payload)


### PR DESCRIPTION
## Summary
Add validation in `Sequential.from_config()` for invalid layer configs.

## Problem
Deserializing a `Sequential` model with an invalid layer config such as `{}` raised a low-level internal error instead of a clear validation error.

## Solution
Validate each layer config in `Sequential.from_config()` before deserializing it, and raise a clearer `TypeError` when the layer config is invalid.

## Testing
- Added a regression test in `keras/src/models/sequential_test.py`
- Ran:
  - `pytest keras/src/models/sequential_test.py`

## Contributor Agreement
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.