### PR TITLE
Add keras.ops.matrix_rank

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -40,6 +40,7 @@ from keras.src.ops.linalg import inv as inv
 from keras.src.ops.linalg import jvp as jvp
 from keras.src.ops.linalg import lstsq as lstsq
 from keras.src.ops.linalg import lu_factor as lu_factor
+from keras.src.ops.linalg import matrix_rank as matrix_rank
 from keras.src.ops.linalg import norm as norm
 from keras.src.ops.linalg import qr as qr
 from keras.src.ops.linalg import solve as solve

--- a/keras/api/_tf_keras/keras/ops/linalg/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/linalg/__init__.py
@@ -13,6 +13,7 @@ from keras.src.ops.linalg import inv as inv
 from keras.src.ops.linalg import jvp as jvp
 from keras.src.ops.linalg import lstsq as lstsq
 from keras.src.ops.linalg import lu_factor as lu_factor
+from keras.src.ops.linalg import matrix_rank as matrix_rank
 from keras.src.ops.linalg import norm as norm
 from keras.src.ops.linalg import qr as qr
 from keras.src.ops.linalg import solve as solve

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -40,6 +40,7 @@ from keras.src.ops.linalg import inv as inv
 from keras.src.ops.linalg import jvp as jvp
 from keras.src.ops.linalg import lstsq as lstsq
 from keras.src.ops.linalg import lu_factor as lu_factor
+from keras.src.ops.linalg import matrix_rank as matrix_rank
 from keras.src.ops.linalg import norm as norm
 from keras.src.ops.linalg import qr as qr
 from keras.src.ops.linalg import solve as solve

--- a/keras/api/ops/linalg/__init__.py
+++ b/keras/api/ops/linalg/__init__.py
@@ -13,6 +13,7 @@ from keras.src.ops.linalg import inv as inv
 from keras.src.ops.linalg import jvp as jvp
 from keras.src.ops.linalg import lstsq as lstsq
 from keras.src.ops.linalg import lu_factor as lu_factor
+from keras.src.ops.linalg import matrix_rank as matrix_rank
 from keras.src.ops.linalg import norm as norm
 from keras.src.ops.linalg import qr as qr
 from keras.src.ops.linalg import solve as solve

--- a/keras/src/backend/jax/linalg.py
+++ b/keras/src/backend/jax/linalg.py
@@ -101,7 +101,7 @@ def lstsq(a, b, rcond=None):
 
 def matrix_rank(x, tol=None):
     x = convert_to_tensor(x)
-    return jnp.linalg.matrix_rank(x, tol=tol)
+    return jnp.linalg.matrix_rank(x, tol=tol).astype("int32")
 
 
 def jvp(fun, primals, tangents, has_aux=False):

--- a/keras/src/backend/jax/linalg.py
+++ b/keras/src/backend/jax/linalg.py
@@ -101,6 +101,11 @@ def lstsq(a, b, rcond=None):
 
 def matrix_rank(x, tol=None):
     x = convert_to_tensor(x)
+    if x.ndim < 2:
+        raise ValueError(
+            "Expected input to have rank >= 2. "
+            f"Received input with shape {x.shape}."
+        )
     return jnp.linalg.matrix_rank(x, tol=tol).astype("int32")
 
 

--- a/keras/src/backend/jax/linalg.py
+++ b/keras/src/backend/jax/linalg.py
@@ -99,5 +99,10 @@ def lstsq(a, b, rcond=None):
     return jnp.linalg.lstsq(a, b, rcond=rcond)[0]
 
 
+def matrix_rank(x, tol=None):
+    x = convert_to_tensor(x)
+    return jnp.linalg.matrix_rank(x, tol=tol)
+
+
 def jvp(fun, primals, tangents, has_aux=False):
     return jax.jvp(fun, primals, tangents, has_aux=has_aux)

--- a/keras/src/backend/numpy/linalg.py
+++ b/keras/src/backend/numpy/linalg.py
@@ -98,5 +98,10 @@ def lstsq(a, b, rcond=None):
     return np.linalg.lstsq(a, b, rcond=rcond)[0]
 
 
+def matrix_rank(x, tol=None):
+    x = convert_to_tensor(x)
+    return np.linalg.matrix_rank(x, tol=tol)
+
+
 def jvp(fun, primals, tangents, has_aux=False):
     raise NotImplementedError("JVP is not supported by the Numpy backend.")

--- a/keras/src/backend/numpy/linalg.py
+++ b/keras/src/backend/numpy/linalg.py
@@ -100,6 +100,11 @@ def lstsq(a, b, rcond=None):
 
 def matrix_rank(x, tol=None):
     x = convert_to_tensor(x)
+    if x.ndim < 2:
+        raise ValueError(
+            "Expected input to have rank >= 2. "
+            f"Received input with shape {x.shape}."
+        )
     return np.linalg.matrix_rank(x, tol=tol).astype("int32")
 
 

--- a/keras/src/backend/numpy/linalg.py
+++ b/keras/src/backend/numpy/linalg.py
@@ -100,7 +100,7 @@ def lstsq(a, b, rcond=None):
 
 def matrix_rank(x, tol=None):
     x = convert_to_tensor(x)
-    return np.linalg.matrix_rank(x, tol=tol)
+    return np.linalg.matrix_rank(x, tol=tol).astype("int32")
 
 
 def jvp(fun, primals, tangents, has_aux=False):

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -11,6 +11,7 @@ FeatureSpaceTest::test_saving
 LayerTest::test_complex_dtype_support
 LinalgOpsCorrectnessTest::test_eig
 LinalgOpsCorrectnessTest::test_lstsq
+LinalgOpsCorrectnessTest::test_matrix_rank
 LinalgOpsCorrectnessTest::test_norm_2_-2
 LinalgOpsCorrectnessTest::test_norm_2_2
 LinalgOpsCorrectnessTest::test_norm_2_nuc

--- a/keras/src/backend/openvino/linalg.py
+++ b/keras/src/backend/openvino/linalg.py
@@ -1590,5 +1590,11 @@ def lstsq(a, b, rcond=None):
     raise NotImplementedError("`lstsq` is not supported with openvino backend")
 
 
+def matrix_rank(x, tol=None):
+    raise NotImplementedError(
+        "`matrix_rank` is not supported with openvino backend"
+    )
+
+
 def jvp(fun, primals, tangents, has_aux=False):
     raise NotImplementedError("`jvp` is not supported with openvino backend")

--- a/keras/src/backend/tensorflow/linalg.py
+++ b/keras/src/backend/tensorflow/linalg.py
@@ -246,6 +246,11 @@ def lstsq(a, b, rcond=None):
     return x
 
 
+def matrix_rank(x, tol=None):
+    x = convert_to_tensor(x)
+    return tf.linalg.matrix_rank(x, tol=tol)
+
+
 def jvp(fun, primals, tangents, has_aux=False):
     primal_flat = tf.nest.flatten(primals)
     tangent_flat = tf.nest.flatten(tangents)

--- a/keras/src/backend/torch/linalg.py
+++ b/keras/src/backend/torch/linalg.py
@@ -82,5 +82,14 @@ def lstsq(a, b, rcond=None):
     return torch.linalg.lstsq(a, b, rcond=rcond)[0]
 
 
+def matrix_rank(x, tol=None):
+    x = convert_to_tensor(x)
+    if tol is None:
+        return torch.linalg.matrix_rank(x)
+    # `torch.linalg.matrix_rank` uses `atol` for the absolute threshold
+    # that numpy's `tol` also represents.
+    return torch.linalg.matrix_rank(x, atol=tol)
+
+
 def jvp(fun, primals, tangents, has_aux=False):
     return torch.func.jvp(fun, primals, tangents, has_aux=has_aux)

--- a/keras/src/backend/torch/linalg.py
+++ b/keras/src/backend/torch/linalg.py
@@ -84,13 +84,9 @@ def lstsq(a, b, rcond=None):
 
 def matrix_rank(x, tol=None):
     x = convert_to_tensor(x)
-    if tol is None:
-        res = torch.linalg.matrix_rank(x)
-    else:
-        # `torch.linalg.matrix_rank` uses `atol` for the absolute threshold
-        # that numpy's `tol` also represents.
-        res = torch.linalg.matrix_rank(x, atol=tol)
-    return res.to(torch.int32)
+    # `torch.linalg.matrix_rank` uses `atol` for the absolute threshold
+    # that numpy's `tol` also represents.
+    return torch.linalg.matrix_rank(x, atol=tol).to(torch.int32)
 
 
 def jvp(fun, primals, tangents, has_aux=False):

--- a/keras/src/backend/torch/linalg.py
+++ b/keras/src/backend/torch/linalg.py
@@ -85,10 +85,12 @@ def lstsq(a, b, rcond=None):
 def matrix_rank(x, tol=None):
     x = convert_to_tensor(x)
     if tol is None:
-        return torch.linalg.matrix_rank(x)
-    # `torch.linalg.matrix_rank` uses `atol` for the absolute threshold
-    # that numpy's `tol` also represents.
-    return torch.linalg.matrix_rank(x, atol=tol)
+        res = torch.linalg.matrix_rank(x)
+    else:
+        # `torch.linalg.matrix_rank` uses `atol` for the absolute threshold
+        # that numpy's `tol` also represents.
+        res = torch.linalg.matrix_rank(x, atol=tol)
+    return res.to(torch.int32)
 
 
 def jvp(fun, primals, tangents, has_aux=False):

--- a/keras/src/ops/linalg.py
+++ b/keras/src/ops/linalg.py
@@ -691,6 +691,53 @@ def lstsq(a, b, rcond=None):
     return backend.linalg.lstsq(a, b, rcond=rcond)
 
 
+class MatrixRank(Operation):
+    def __init__(self, tol=None, *, name=None):
+        super().__init__(name=name)
+        self.tol = tol
+
+    def call(self, x):
+        return _matrix_rank(x, tol=self.tol)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        return KerasTensor(x.shape[:-2], dtype="int32")
+
+
+@keras_export(["keras.ops.matrix_rank", "keras.ops.linalg.matrix_rank"])
+def matrix_rank(x, tol=None):
+    """Return the matrix rank of one or more matrices using SVD.
+
+    The rank is the number of singular values that exceed `tol`. If `tol`
+    is `None`, each backend uses its own default threshold derived from
+    the largest singular value and the matrix dimensions.
+
+    Args:
+        x: Input tensor of shape `(..., M, N)`.
+        tol: Absolute threshold below which singular values are treated
+            as zero. If `None` (default), the backend's default is used.
+
+    Returns:
+        An integer tensor of shape `(...,)` with the rank of each matrix
+        in the batch.
+
+    Example:
+
+    >>> a = keras.ops.convert_to_tensor([[1., 2.], [2., 4.]])
+    >>> keras.ops.matrix_rank(a)
+    1
+    """
+    if any_symbolic_tensors((x,)):
+        return MatrixRank(tol=tol).symbolic_call(x)
+    return _matrix_rank(x, tol=tol)
+
+
+def _matrix_rank(x, tol=None):
+    x = backend.convert_to_tensor(x)
+    _assert_2d(x)
+    return backend.linalg.matrix_rank(x, tol=tol)
+
+
 def _assert_1d(*arrays):
     for a in arrays:
         if a.ndim < 1:

--- a/keras/src/ops/linalg.py
+++ b/keras/src/ops/linalg.py
@@ -697,7 +697,7 @@ class MatrixRank(Operation):
         self.tol = tol
 
     def call(self, x):
-        return _matrix_rank(x, tol=self.tol)
+        return backend.linalg.matrix_rank(x, tol=self.tol)
 
     def compute_output_spec(self, x):
         _assert_2d(x)
@@ -729,12 +729,6 @@ def matrix_rank(x, tol=None):
     """
     if any_symbolic_tensors((x,)):
         return MatrixRank(tol=tol).symbolic_call(x)
-    return _matrix_rank(x, tol=tol)
-
-
-def _matrix_rank(x, tol=None):
-    x = backend.convert_to_tensor(x)
-    _assert_2d(x)
     return backend.linalg.matrix_rank(x, tol=tol)
 
 

--- a/keras/src/ops/linalg_test.py
+++ b/keras/src/ops/linalg_test.py
@@ -86,6 +86,18 @@ class LinalgOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(lu.shape, (None, 2, 3))
         self.assertEqual(p.shape, (None, 2))
 
+    def test_matrix_rank(self):
+        x = KerasTensor([None, 4, 5])
+        out = linalg.matrix_rank(x)
+        self.assertEqual(out.shape, (None,))
+
+        x = KerasTensor([None, 3, 3])
+        self.assertEqual(linalg.matrix_rank(x).shape, (None,))
+
+        x = KerasTensor([None])
+        with self.assertRaises(ValueError):
+            linalg.matrix_rank(x)
+
     def test_norm(self):
         x = KerasTensor((None, 3))
         self.assertEqual(linalg.norm(x).shape, ())
@@ -261,6 +273,15 @@ class LinalgOpsStaticShapeTest(testing.TestCase):
         lu, p = linalg.lu_factor(x)
         self.assertEqual(lu.shape, (10, 2, 3))
         self.assertEqual(p.shape, (10, 2))
+
+    def test_matrix_rank(self):
+        x = KerasTensor([4, 3, 5])
+        out = linalg.matrix_rank(x)
+        self.assertEqual(out.shape, (4,))
+
+        x = KerasTensor([10])
+        with self.assertRaises(ValueError):
+            linalg.matrix_rank(x)
 
     def test_norm(self):
         x = KerasTensor((10, 3))
@@ -615,6 +636,40 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
 
         out_symb = linalg.lstsq(a_symb, b_symb)
         self.assertEqual(out_symb.shape, out.shape)
+
+    def test_matrix_rank(self):
+        # Full-rank tall matrix: rank equals number of columns.
+        rng = np.random.default_rng(42)
+        a_full = rng.standard_normal((6, 3)).astype("float32")
+        self.assertEqual(
+            int(ops.convert_to_numpy(linalg.matrix_rank(a_full))), 3
+        )
+
+        # Rank-1 matrix (outer product).
+        u = rng.standard_normal((5,)).astype("float32")
+        v = rng.standard_normal((4,)).astype("float32")
+        a_rank1 = np.outer(u, v)
+        self.assertEqual(
+            int(ops.convert_to_numpy(linalg.matrix_rank(a_rank1))), 1
+        )
+
+        # Batched rank: two stacked full-rank 3x3 matrices.
+        batched = rng.standard_normal((2, 3, 3)).astype("float32")
+        out = linalg.matrix_rank(batched)
+        self.assertAllClose(ops.convert_to_numpy(out), [3, 3])
+
+        # tol argument collapses singular values below the threshold.
+        a_near_singular = np.array(
+            [[1.0, 2.0], [2.0, 4.000001]], dtype="float32"
+        )
+        rank_loose = int(
+            ops.convert_to_numpy(linalg.matrix_rank(a_near_singular, tol=1e-2))
+        )
+        self.assertEqual(rank_loose, 1)
+
+        # Symbolic shape propagation.
+        a_symb = backend.KerasTensor((4, 3, 5), dtype="float32")
+        self.assertEqual(linalg.matrix_rank(a_symb).shape, (4,))
 
 
 class QrOpTest(testing.TestCase):


### PR DESCRIPTION
## Description

Adds `keras.ops.matrix_rank` (and `keras.ops.linalg.matrix_rank`), which returns the rank of one or more matrices via SVD. Fills the gap in `keras.ops.linalg` alongside `inv`, `solve`, `lstsq`, and (in-flight) `pinv`.

Each trainable backend delegates to its native implementation (`tf.linalg.matrix_rank`, `jnp.linalg.matrix_rank`, `torch.linalg.matrix_rank`, `np.linalg.matrix_rank`). The `tol` argument maps to the native threshold semantics on each backend (absolute singular-value cutoff; when `None`, the backend's default is used). OpenVINO raises `NotImplementedError` and the correctness test is added to its exclusion list, matching the existing `lstsq` / `pinv` pattern.

Tests cover square / rectangular / batched inputs, symbolic shape inference, and a rank-deficient correctness case. All 3 new tests pass locally on numpy, jax, torch, and tensorflow backends.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.