### PR TITLE
Optimize _merge_scores in numpy backend

### DIFF
--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -1197,11 +1197,9 @@ def _ctc_beam_search_decode(
     def _merge_scores(unique_inverse, scores):
         scores_max = np.max(scores)
         scores_exp = np.exp(scores - scores_max)
-        scores = np.zeros_like(scores)
-        for i, u in enumerate(unique_inverse):
-            scores[u] += scores_exp[i]
-        scores = np.log(scores) + scores_max
-        return scores
+        new_scores = np.zeros_like(scores)
+        np.add.at(new_scores, unique_inverse, scores_exp)
+        return np.log(new_scores) + scores_max
 
     def _prune_paths(paths, scores, masked):
         paths, unique_inverse = np.unique(paths, return_inverse=True, axis=0)


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
Replace Python loop with np.add.at for vectorized score accumulation
in _ctc_beam_search_decode. This improves performance by moving
the accumulation logic into optimized C-loops.

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

> **Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
