### PR TITLE
dd warnings for shuffle=True parameter on dataset adapters

### DIFF
--- a/keras/src/trainers/data_adapters/__init__.py
+++ b/keras/src/trainers/data_adapters/__init__.py
@@ -1,4 +1,5 @@
 import types
+import warnings
 
 from keras.src.distribution import distribution_lib
 from keras.src.trainers.data_adapters import array_data_adapter
@@ -65,16 +66,18 @@ def get_data_adapter(
             raise_unsupported_arg(
                 "sample_weights", "the sample weights", "tf.data.Dataset"
             )
+        if shuffle:
+            warnings.warn(
+                "`shuffle=True` was passed, but will be ignored since the "
+                "data `x` was provided as a tf.data.Dataset. The Dataset is "
+                "expected to already be shuffled "
+                "(via `.shuffle(buffer_size)`).",
+                stacklevel=2,
+            )
         return TFDatasetAdapter(
             x, class_weight=class_weight, distribution=distribution
         )
-        # TODO: should we warn or not?
-        # warnings.warn(
-        #     "`shuffle=True` was passed, but will be ignored since the "
-        #     "data `x` was provided as a tf.data.Dataset. The Dataset is "
-        #     "expected to already be shuffled "
-        #     "(via `.shuffle(tf.data.AUTOTUNE)`)"
-        # )
+        
     elif isinstance(x, py_dataset_adapter.PyDataset):
         if y is not None:
             raise_unsupported_arg("y", "the targets", "PyDataset")
@@ -82,14 +85,15 @@ def get_data_adapter(
             raise_unsupported_arg(
                 "sample_weights", "the sample weights", "PyDataset"
             )
+        if getattr(x, "num_batches", None) is None and shuffle:
+            warnings.warn(
+                "`shuffle=True` was passed, but will be ignored since the "
+                "data `x` was provided as an infinite PyDataset. The "
+                "PyDataset is expected to already be shuffled.",
+                stacklevel=2,
+            )
         return PyDatasetAdapter(x, class_weight=class_weight, shuffle=shuffle)
-        # TODO: should we warn or not?
-        # if x.num_batches is None and shuffle:
-        #     warnings.warn(
-        #         "`shuffle=True` was passed, but will be ignored since the "
-        #         "data `x` was provided as a infinite PyDataset. The "
-        #         "PyDataset is expected to already be shuffled."
-        # )
+        
     elif is_torch_dataloader(x):
         if y is not None:
             raise_unsupported_arg("y", "the targets", "torch DataLoader")
@@ -107,13 +111,15 @@ def get_data_adapter(
                 "#supporting-sampleweight-amp-classweight for more details. "
                 f"Received: class_weight={class_weight}"
             )
+        if shuffle:
+            warnings.warn(
+                "`shuffle=True` was passed, but will be ignored since the "
+                "data `x` was provided as a torch DataLoader. The DataLoader "
+                "is expected to already be shuffled.",
+                stacklevel=2,
+            )
         return TorchDataLoaderAdapter(x)
-        # TODO: should we warn or not?
-        # warnings.warn(
-        #     "`shuffle=True` was passed, but will be ignored since the "
-        #     "data `x` was provided as a torch DataLoader. The DataLoader "
-        #     "is expected to already be shuffled."
-        # )
+        
     elif is_grain_dataset(x):
         if y is not None:
             raise_unsupported_arg(
@@ -133,13 +139,15 @@ def get_data_adapter(
                 "class_weight. "
                 f"Received: class_weight={class_weight}"
             )
+        if shuffle:
+            warnings.warn(
+                "`shuffle=True` was passed, but will be ignored since the "
+                "data `x` was provided as a grain dataset. The grain dataset "
+                "is expected to already be shuffled.",
+                stacklevel=2,
+            )
         return GrainDatasetAdapter(x)
-        # TODO: should we warn or not?
-        # warnings.warn(
-        #     "`shuffle=True` was passed, but will be ignored since the "
-        #     "data `x` was provided as a grain dataset. The grain dataset "
-        #     "is expected to already be shuffled."
-        # )
+        
     elif isinstance(x, types.GeneratorType):
         if y is not None:
             raise_unsupported_arg("y", "the targets", "PyDataset")
@@ -152,13 +160,14 @@ def get_data_adapter(
                 "Argument `class_weight` is not supported for Python "
                 f"generator inputs. Received: class_weight={class_weight}"
             )
+        if shuffle:
+            warnings.warn(
+                "`shuffle=True` was passed, but will be ignored since the "
+                "data `x` was provided as a generator. The generator "
+                "is expected to yield already-shuffled data.",
+                stacklevel=2,
+            )
         return GeneratorDataAdapter(x)
-        # TODO: should we warn or not?
-        # warnings.warn(
-        #     "`shuffle=True` was passed, but will be ignored since the "
-        #     "data `x` was provided as a generator. The generator "
-        #     "is expected to yield already-shuffled data."
-        # )
     else:
         raise ValueError(f"Unrecognized data type: x={x} (of type {type(x)})")
 

--- a/keras/src/trainers/data_adapters/__init__.py
+++ b/keras/src/trainers/data_adapters/__init__.py
@@ -77,7 +77,7 @@ def get_data_adapter(
         return TFDatasetAdapter(
             x, class_weight=class_weight, distribution=distribution
         )
-        
+
     elif isinstance(x, py_dataset_adapter.PyDataset):
         if y is not None:
             raise_unsupported_arg("y", "the targets", "PyDataset")
@@ -93,7 +93,7 @@ def get_data_adapter(
                 stacklevel=2,
             )
         return PyDatasetAdapter(x, class_weight=class_weight, shuffle=shuffle)
-        
+
     elif is_torch_dataloader(x):
         if y is not None:
             raise_unsupported_arg("y", "the targets", "torch DataLoader")
@@ -119,7 +119,7 @@ def get_data_adapter(
                 stacklevel=2,
             )
         return TorchDataLoaderAdapter(x)
-        
+
     elif is_grain_dataset(x):
         if y is not None:
             raise_unsupported_arg(
@@ -147,7 +147,7 @@ def get_data_adapter(
                 stacklevel=2,
             )
         return GrainDatasetAdapter(x)
-        
+
     elif isinstance(x, types.GeneratorType):
         if y is not None:
             raise_unsupported_arg("y", "the targets", "PyDataset")


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
This PR resolves several `TODO` comments in `keras/src/trainers/data_adapters/__init__.py` regarding `shuffle=True`. 

Previously, when users passed `shuffle=True` to `.fit()` alongside dataset types that internally manage their own shuffling (such as `tf.data.Dataset`, PyTorch `DataLoader`, Grain datasets, Python generators, or infinite `PyDataset`s), Keras would silently ignore the parameter. 

This update adds helpful warnings (using `stacklevel=2` to ensure they point back to user code) to alert users when their `shuffle=True` argument is ignored, advising them to implement shuffling directly via the underlying dataset object (e.g., using `.shuffle(buffer_size)` for `tf.data.Dataset`).

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
