### PR TITLE
[OpenVINO] Improve efficiency by using native ops

### DIFF
--- a/keras/src/backend/openvino/linalg.py
+++ b/keras/src/backend/openvino/linalg.py
@@ -1096,15 +1096,11 @@ def norm(x, ord=None, axis=None, keepdims=False):
     # Ref: jax.numpy.linalg.norm
     if num_axes == 1:
         if ord is None or ord == 2:
-            # L2 norm: sqrt(sum(x * conj(x)))
-            x_conj = x_ov
-            x_sq = ov_opset.multiply(x_conj, x_conj).output(0)
             axis_for_const = list(axis) if isinstance(axis, tuple) else axis
             axis_const = ov_opset.constant(axis_for_const, Type.i32).output(0)
-            norm_result = ov_opset.reduce_sum(
-                x_sq, axis_const, keepdims
-            ).output(0)
-            norm_result = ov_opset.sqrt(norm_result).output(0)
+            norm_result = ov_opset.reduce_l2(x_ov, axis_const, keepdims).output(
+                0
+            )
         elif ord == float("inf"):
             axis_for_const = list(axis) if isinstance(axis, tuple) else axis
             axis_const = ov_opset.constant(axis_for_const, Type.i32).output(0)
@@ -1130,13 +1126,11 @@ def norm(x, ord=None, axis=None, keepdims=False):
                 not_equal_float, axis_const, keepdims
             ).output(0)
         elif ord == 1:
-            # L1 norm: sum(|x|)
             axis_for_const = list(axis) if isinstance(axis, tuple) else axis
             axis_const = ov_opset.constant(axis_for_const, Type.i32).output(0)
-            x_abs = ov_opset.abs(x_ov).output(0)
-            norm_result = ov_opset.reduce_sum(
-                x_abs, axis_const, keepdims
-            ).output(0)
+            norm_result = ov_opset.reduce_l1(x_ov, axis_const, keepdims).output(
+                0
+            )
         elif isinstance(ord, str):
             raise ValueError(
                 f"Invalid `ord` argument for vector norm. Received: ord={ord}"

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -135,11 +135,8 @@ def hard_sigmoid(x):
 
 
 def hard_silu(x):
-    hard_sigmoid_output = get_ov_output(hard_sigmoid(x))
     x = get_ov_output(x)
-    return OpenVINOKerasTensor(
-        ov_opset.multiply(x, hard_sigmoid_output).output(0)
-    )
+    return OpenVINOKerasTensor(ov_opset.hswish(x).output(0))
 
 
 def elu(x, alpha=1.0):

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -1317,63 +1317,17 @@ def fold(x, output_size, kernel_size, dilation=1, padding=0, stride=1):
     sH, sW = _pair(stride)
 
     x = get_ov_output(x)
-
-    # Derive CKK and C dynamically from the input shape to support dynamic dims.
-    shape_x = ov_opset.shape_of(x).output(0)
-    one_i64 = ov_opset.constant([1], Type.i64).output(0)
-    two_i64 = ov_opset.constant([2], Type.i64).output(0)
-    step_i64 = ov_opset.constant([1], Type.i64).output(0)
-    CKK_1d = ov_opset.slice(shape_x, one_i64, two_i64, step_i64).output(0)
-    KK_node = ov_opset.constant([kH * kW], Type.i64).output(0)
-    C_1d = ov_opset.divide(CKK_1d, KK_node).output(0)
-    CKK_scalar = ov_opset.squeeze(CKK_1d, [0]).output(0)
-
-    nH = (oH + 2 * pH - dH * (kH - 1) - 1) // sH + 1
-    nW = (oW + 2 * pW - dW * (kW - 1) - 1) // sW + 1
-
-    # Reshape: (N, CKK, L) -> (N, CKK, nH, nW); 0 copies the dim from input.
-    new_shape = ov_opset.constant([0, 0, nH, nW], Type.i64).output(0)
-    x = ov_opset.reshape(x, new_shape, True).output(0)
-
-    # Build identity kernel dynamically: shape (CKK, CKK) via one_hot,
-    # then reshape to (CKK, C, kH, kW).
-    indices = ov_opset.range(
-        ov_opset.constant(0, Type.i64),
-        CKK_scalar,
-        ov_opset.constant(1, Type.i64),
-        Type.i64,
-    ).output(0)
-    on_val = ov_opset.constant(1, Type.f32).output(0)
-    off_val = ov_opset.constant(0, Type.f32).output(0)
-    eye = ov_opset.one_hot(
-        indices, depth=CKK_scalar, on_value=on_val, off_value=off_val, axis=-1
-    ).output(0)
-    kernel_shape = ov_opset.concat(
-        [CKK_1d, C_1d, ov_opset.constant([kH, kW], Type.i64).output(0)], axis=0
-    ).output(0)
-    kernel = ov_opset.reshape(eye, kernel_shape, False).output(0)
-    kernel = ov_opset.convert(kernel, x.get_element_type()).output(0)
-
-    oH_pad = oH + 2 * pH
-    oW_pad = oW + 2 * pW
-
-    output_shape_node = ov_opset.constant([oH_pad, oW_pad], Type.i64).output(0)
-    result = ov_opset.convolution_backprop_data(
+    output_size_node = ov_opset.constant([oH, oW], Type.i64).output(0)
+    kernel_size_node = ov_opset.constant([kH, kW], Type.i64).output(0)
+    result = ov_opset.col2im(
         x,
-        kernel,
+        output_size_node,
+        kernel_size_node,
         strides=[sH, sW],
-        output_shape=output_shape_node,
         dilations=[dH, dW],
-        auto_pad="VALID",
+        pads_begin=[pH, pW],
+        pads_end=[pH, pW],
     ).output(0)
-
-    if pH > 0 or pW > 0:
-        axes = ov_opset.constant([2, 3], Type.i32).output(0)
-        start = ov_opset.constant([pH, pW], Type.i32).output(0)
-        stop = ov_opset.constant([oH_pad - pH, oW_pad - pW], Type.i32).output(0)
-        step = ov_opset.constant([1, 1], Type.i32).output(0)
-        result = ov_opset.slice(result, start, stop, step, axes).output(0)
-
     return OpenVINOKerasTensor(result)
 
 

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -196,27 +196,26 @@ def log_softmax(x, axis=-1):
     x = get_ov_output(x)
     if isinstance(axis, (tuple, list)) and not axis:
         return OpenVINOKerasTensor(x)
-    restore_shape = None
     if axis is None:
         restore_shape = ov_opset.shape_of(x)
         flatten_shape = ov_opset.constant([-1], Type.i32).output(0)
         x = ov_opset.reshape(x, flatten_shape, False).output(0)
-        axes = [0]
-    elif isinstance(axis, (tuple, list)):
-        axes = sorted(axis)
-    else:
-        axes = [axis]
-    axes_const = ov_opset.constant(axes, Type.i32).output(0)
-    x_max = ov_opset.reduce_max(x, axes_const, True).output(0)
-    x_shifted = ov_opset.subtract(x, x_max).output(0)
-    sum_exp = ov_opset.reduce_sum(
-        ov_opset.exp(x_shifted).output(0), axes_const, True
-    ).output(0)
-    log_sum_exp = ov_opset.log(sum_exp).output(0)
-    result = ov_opset.subtract(x_shifted, log_sum_exp).output(0)
-    if restore_shape is not None:
+        result = ov_opset.log_softmax(x, 0).output(0)
         result = ov_opset.reshape(result, restore_shape, False).output(0)
-    return OpenVINOKerasTensor(result)
+        return OpenVINOKerasTensor(result)
+    if isinstance(axis, (tuple, list)):
+        axes = sorted(axis)
+        axes_const = ov_opset.constant(axes, Type.i32).output(0)
+        x_max = ov_opset.reduce_max(x, axes_const, True).output(0)
+        x_shifted = ov_opset.subtract(x, x_max).output(0)
+        sum_exp = ov_opset.reduce_sum(
+            ov_opset.exp(x_shifted).output(0), axes_const, True
+        ).output(0)
+        result = ov_opset.subtract(
+            x_shifted, ov_opset.log(sum_exp).output(0)
+        ).output(0)
+        return OpenVINOKerasTensor(result)
+    return OpenVINOKerasTensor(ov_opset.log_softmax(x, axis).output(0))
 
 
 def sparsemax(x, axis=-1):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -4379,29 +4379,19 @@ def take_along_axis(x, indices, axis=None):
     ).output(0)
     indices = ov_opset.convert(indices, Type.i32).output(0)
 
-    x_target_parts, indices_target_parts = [], []
-
-    for i in range(x_rank):
-        dim_idx = ov_opset.constant([i], dtype=Type.i32).output(0)
-        x_dim = ov_opset.gather(x_shape, dim_idx, zero_const).output(0)
-        indices_dim = ov_opset.gather(
-            indices_shape, dim_idx, zero_const
-        ).output(0)
-
-        if i == axis:
-            # For axis dimension: keep original dimensions
-            x_target_parts.append(x_dim)
-            indices_target_parts.append(indices_dim)
-        else:
-            # For other dimensions: use maximum for broadcasting
-            max_dim = ov_opset.maximum(x_dim, indices_dim).output(0)
-            x_target_parts.append(max_dim)
-            indices_target_parts.append(max_dim)
-
-    x_target_shape = ov_opset.concat(x_target_parts, axis=0).output(0)
-    indices_target_shape = ov_opset.concat(indices_target_parts, axis=0).output(
-        0
-    )
+    # Compute broadcast targets: non-axis dims use element-wise max of both
+    # shapes; axis dim is kept separately for x and indices.
+    max_shape = ov_opset.maximum(x_shape, indices_shape).output(0)
+    x_axis_dim = ov_opset.gather(x_shape, axis_index, zero_const).output(0)
+    indices_axis_dim = ov_opset.gather(
+        indices_shape, axis_index, zero_const
+    ).output(0)
+    x_target_shape = ov_opset.scatter_elements_update(
+        max_shape, axis_index, x_axis_dim, zero_const
+    ).output(0)
+    indices_target_shape = ov_opset.scatter_elements_update(
+        max_shape, axis_index, indices_axis_dim, zero_const
+    ).output(0)
 
     # Broadcast to target shapes and gather elements
     x_broadcasted = ov_opset.broadcast(x, x_target_shape).output(0)


### PR DESCRIPTION
## Description
This PR improves the efficiency of several OpenVINO backend operations by replacing decompositions with native OpenVINO ops wherever possible.

#### take_along_axis
- Before: Broadcast shape computation grew with tensor rank. O(rank) ops (e.g. 13 ops for rank=4: 3×rank + 1 concat).
- After: Fixed 5 ops regardless of rank.

#### hard_silu / hard swish
- Before: hard_sigmoid (constants + hard_sigmoid node) + multiply -> 4 OV nodes.
- After: native hswish op.

#### L2 norm 
- Before: multiply -> reduce_sum -> sqrt,  3 ops.
- After: native reduce_l2 op.

#### L1 norm 
- Before: abs -> reduce_sum,  2 ops.
- After: native reduce_l1 op.

#### fold
- Before: (range + one_hot + reshape) + convolution_backprop_data + conditional slice for padding,  ~15 ops.
- After:  native col2im op.

#### log_softmax
- Before: reduce_max -> subtract -> exp -> reduce_sum -> log -> subtract, 6 ops (single-axis path).
- After:  native log_softmax op, multi-axis tuple path unchanged.


## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
