### PR TITLE
[OpenVINO] Implement flash_attn and bias support

### DIFF
--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -1261,8 +1261,14 @@ def dot_product_attention(
             bias = ov_opset.convert(bias, query.get_element_type()).output(0)
         if mask is not None:
             if mask.get_element_type() == Type.boolean:
+                query_dtype = ov_to_keras_type(query.get_element_type())
+                min_val = (
+                    np.finfo(np.float16).min
+                    if query_dtype == "float16"
+                    else np.finfo(np.float32).min
+                )
                 large_neg = ov_opset.constant(
-                    np.finfo(np.float32).min, query.get_element_type()
+                    min_val, query.get_element_type()
                 ).output(0)
                 zero = ov_opset.constant(0.0, query.get_element_type()).output(
                     0

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -1235,16 +1235,6 @@ def dot_product_attention(
     flash_attention=None,
     attn_logits_soft_cap=None,
 ):
-    if bias is not None:
-        raise NotImplementedError(
-            "`dot_product_attention` with `bias` is not supported "
-            "with openvino backend"
-        )
-    if flash_attention:
-        raise NotImplementedError(
-            "`dot_product_attention` with `flash_attention` is not supported "
-            "with openvino backend"
-        )
     if attn_logits_soft_cap is not None:
         raise NotImplementedError(
             "`dot_product_attention` with `attn_logits_soft_cap` is not "
@@ -1265,6 +1255,22 @@ def dot_product_attention(
     key = ov_opset.transpose(key, axes_const)
     value = ov_opset.transpose(value, axes_const)
     mask = get_ov_output(mask) if mask is not None else None
+    if bias is not None:
+        bias = get_ov_output(bias)
+        if bias.get_element_type() != query.get_element_type():
+            bias = ov_opset.convert(bias, query.get_element_type()).output(0)
+        if mask is not None:
+            if mask.get_element_type() == Type.boolean:
+                large_neg = ov_opset.constant(
+                    np.finfo(np.float32).min, query.get_element_type()
+                ).output(0)
+                zero = ov_opset.constant(0.0, query.get_element_type()).output(
+                    0
+                )
+                mask = ov_opset.select(mask, zero, large_neg).output(0)
+            mask = ov_opset.add(mask, bias).output(0)
+        else:
+            mask = bias
     scale = (
         get_ov_output(scale, query.get_element_type())
         if scale is not None

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -2485,11 +2485,6 @@ class NNOpsCorrectnessTest(testing.TestCase):
             mask = mask[None, None, ...]
             mask = np.tile(mask, (2, 4, 1, 1))
         if bias is not None:
-            if backend.backend() == "openvino":
-                self.skipTest(
-                    "openvino does not support `bias` with "
-                    "`dot_product_attention`"
-                )
             if backend.backend() == "torch" and mask is not None:
                 self.skipTest(
                     "torch does not support `mask` and `bias` with "
@@ -2500,10 +2495,10 @@ class NNOpsCorrectnessTest(testing.TestCase):
             )
 
         if flash_attention:
-            if backend.backend() in ("tensorflow", "numpy", "openvino"):
+            if backend.backend() in ("tensorflow", "numpy"):
                 self.skipTest(
-                    "Flash attention is not supported in tensorflow, numpy, "
-                    "and openvino backends."
+                    "Flash attention is not supported in tensorflow and numpy "
+                    "backends."
                 )
             elif backend.backend() == "torch":
                 import torch


### PR DESCRIPTION
## Description

bias is now supported by adding it to the attn mask before passing to scaled_dot_product_attention (which treats attention_mask as additive). Boolean masks are converted to float before addition. 

Removed the flash_attention guard since scaled_dot_product_attention is already a fused kernel that covers it.

Closes: openvinotoolkit/openvino/issues/35585

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
