### PR TITLE
[OpenVINO] Adjust test tolerances and exclusions

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -1,7 +1,4 @@
-EqualizationTest::test_constant_regions
-EqualizationTest::test_different_bin_sizes
 EqualizationTest::test_equalizes_to_all_bins
-EqualizationTest::test_grayscale_images
 EqualizationTest::test_input_dtypes_float32
 EqualizationTest::test_input_dtypes_int32
 EqualizationTest::test_input_dtypes_int64

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -26,7 +26,4 @@ NumpyOneInputOpsCorrectnessTest::test_conj
 NumpyOneInputOpsCorrectnessTest::test_imag
 NumpyOneInputOpsCorrectnessTest::test_isreal
 NumpyOneInputOpsCorrectnessTest::test_real
-RandAugmentTest::test_random_augment_randomness
-RandomSaturationTest::test_random_saturation_full_saturation
-RandomZoomTest::test_connect_with_flatten
 UpSampling2dTest::test_upsampling_2d_lanczos_interpolation_methods

--- a/keras/src/layers/preprocessing/image_preprocessing/equalization.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/equalization.py
@@ -143,7 +143,7 @@ class Equalization(BaseImagePreprocessingLayer):
     def _apply_equalization(self, channel, hist):
         cdf = self.backend.numpy.cumsum(hist)
 
-        if self.backend.name == "jax":
+        if self.backend.name in ("jax", "openvino"):
             mask = cdf > 0
             first_nonzero_idx = self.backend.numpy.argmax(mask)
             cdf_min = self.backend.numpy.take(cdf, first_nonzero_idx)

--- a/keras/src/layers/preprocessing/image_preprocessing/random_saturation_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_saturation_test.py
@@ -69,7 +69,9 @@ class RandomSaturationTest(testing.TestCase):
         s_channel = hsv[..., 1]
 
         self.assertAllClose(
-            keras.ops.numpy.max(s_channel), layer.value_range[1]
+            keras.ops.numpy.max(s_channel),
+            layer.value_range[1],
+            atol=1e-1,
         )
 
     def test_random_saturation_randomness(self):

--- a/keras/src/layers/preprocessing/image_preprocessing/random_zoom_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_zoom_test.py
@@ -137,8 +137,8 @@ class RandomZoomTest(testing.TestCase):
         model.predict(np.random.random((1, 6, 6, 3)))
 
     @pytest.mark.skipif(
-        backend.backend() == "numpy",
-        reason="The NumPy backend does not implement fit.",
+        backend.backend() in ("numpy", "openvino"),
+        reason="The NumPy and OpenVINO backends do not implement fit.",
     )
     def test_connect_with_flatten(self):
         model = models.Sequential(


### PR DESCRIPTION
## Description
This PR modifies the test exclusions and tolerance levels to enable more tests for the OpenVINO backend.

Even though they pass, we do not enable all the equalization tests right now, as they are very slow compared to other backends for 512*512 images, and would increase CI burden/duration. These can be be enabled when there is a faster path available. 

| Test | numpy | tensorflow | jax | openvino |
|---|---|---|---|---|
| test_constant_regions (enabled) | <5ms | 0.180s | 1.150s | 0.490s |
| test_different_bin_sizes (enabled) | 0.010s | 0.100s | 2.830s | 2.040s |
| test_equalizes_to_all_bins | 0.290s | 0.290s | 1.790s | timeout|
| test_grayscale_images (enabled) | <5ms | 0.090s | 1.230s | 0.820s |
| test_input_dtypes_float32 | 0.120s | 0.240s | 1.640s | 37.290s |
| test_input_dtypes_int32 | 0.120s | 0.220s | 1.720s | 44.690s |
| test_input_dtypes_int64 | 0.110s | 0.260s | 1.490s | 39.910s |
| test_output_range_0_1 | 0.040s | 0.150s | 1.390s | 32.470s |
| test_output_range_0_255 | 0.040s | 0.180s | 1.490s | 40.350s |



## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
