### PR TITLE
[OpenVINO] Add Lanczos interpolation support to resize

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -29,4 +29,3 @@ NumpyOneInputOpsCorrectnessTest::test_real
 RandAugmentTest::test_random_augment_randomness
 RandomSaturationTest::test_random_saturation_full_saturation
 RandomZoomTest::test_connect_with_flatten
-UpSampling2dTest::test_upsampling_2d_lanczos_interpolation_methods

--- a/keras/src/backend/openvino/image.py
+++ b/keras/src/backend/openvino/image.py
@@ -45,6 +45,9 @@ LANCZOS_INTERPOLATIONS = {
     "lanczos3": "lanczos3",
     "lanczos5": "lanczos5",
 }
+ALL_RESIZE_INTERPOLATIONS = tuple(RESIZE_INTERPOLATIONS) + tuple(
+    LANCZOS_INTERPOLATIONS
+)
 
 
 def rgb_to_grayscale(images, data_format=None):
@@ -262,13 +265,10 @@ def resize(
     data_format="channels_last",
 ):
     data_format = backend.standardize_data_format(data_format)
-    valid_interpolations = tuple(RESIZE_INTERPOLATIONS.keys()) + tuple(
-        LANCZOS_INTERPOLATIONS.keys()
-    )
-    if interpolation not in valid_interpolations:
+    if interpolation not in ALL_RESIZE_INTERPOLATIONS:
         raise ValueError(
             "Invalid value for argument `interpolation`. Expected of one "
-            f"{valid_interpolations}. Received: "
+            f"{ALL_RESIZE_INTERPOLATIONS}. Received: "
             f"interpolation={interpolation}"
         )
     if fill_mode != "constant":

--- a/keras/src/backend/openvino/image.py
+++ b/keras/src/backend/openvino/image.py
@@ -39,10 +39,12 @@ RESIZE_INTERPOLATIONS = {
     "nearest": "nearest",
     "bicubic": "cubic",
 }
-UNSUPPORTED_INTERPOLATIONS = (
-    "lanczos3",
-    "lanczos5",
-)
+# Lanczos methods are handled via _ov_scale_and_translate
+# instead of ov_opset.interpolate, which does not support them natively.
+LANCZOS_INTERPOLATIONS = {
+    "lanczos3": "lanczos3",
+    "lanczos5": "lanczos5",
+}
 
 
 def rgb_to_grayscale(images, data_format=None):
@@ -260,16 +262,13 @@ def resize(
     data_format="channels_last",
 ):
     data_format = backend.standardize_data_format(data_format)
-    if interpolation in UNSUPPORTED_INTERPOLATIONS:
-        raise ValueError(
-            "Resizing with Lanczos interpolation is "
-            "not supported by the OpenVINO backend. "
-            f"Received: interpolation={interpolation}."
-        )
-    if interpolation not in RESIZE_INTERPOLATIONS:
+    valid_interpolations = tuple(RESIZE_INTERPOLATIONS.keys()) + tuple(
+        LANCZOS_INTERPOLATIONS.keys()
+    )
+    if interpolation not in valid_interpolations:
         raise ValueError(
             "Invalid value for argument `interpolation`. Expected of one "
-            f"{tuple(RESIZE_INTERPOLATIONS.keys())}. Received: "
+            f"{valid_interpolations}. Received: "
             f"interpolation={interpolation}"
         )
     if fill_mode != "constant":
@@ -428,6 +427,42 @@ def resize(
             "constant",
             fill_value,
         ).output(0)
+
+    if interpolation in LANCZOS_INTERPOLATIONS:
+        # routed through the weight-matrix resampler used by
+        # scale_and_translate, which has lanczos kernel support.
+        post_crop_shape = ov_opset.shape_of(images, Type.i32).output(0)
+        src_h = ov_opset.convert(
+            _gather_dim(post_crop_shape, height_axis_index), Type.f32
+        ).output(0)
+        src_w = ov_opset.convert(
+            _gather_dim(post_crop_shape, width_axis_index), Type.f32
+        ).output(0)
+        scale_h = ov_opset.divide(
+            ov_opset.constant(float(target_height), Type.f32).output(0),
+            src_h,
+        ).output(0)
+        scale_w = ov_opset.divide(
+            ov_opset.constant(float(target_width), Type.f32).output(0),
+            src_w,
+        ).output(0)
+        scale_ov = ov_opset.concat([scale_h, scale_w], axis=0).output(0)
+        translation_ov = ov_opset.constant([0.0, 0.0], dtype=Type.f32).output(0)
+        output_shape_map = {
+            height_axis_index: target_height,
+            width_axis_index: target_width,
+        }
+        spatial_dims = [height_axis_index, width_axis_index]
+        kernel = _ov_kernels[LANCZOS_INTERPOLATIONS[interpolation]]
+        return _ov_scale_and_translate(
+            images,
+            output_shape_map,
+            spatial_dims,
+            scale_ov,
+            translation_ov,
+            kernel,
+            antialias,
+        )
 
     axes = [height_axis % rank, width_axis % rank]
     size = ov_opset.constant([target_height, target_width], Type.i32).output(0)

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -1221,12 +1221,6 @@ class ImageOpsCorrectnessTest(testing.TestCase):
                     f"antialias={antialias}."
                 )
         elif backend.backend() == "openvino":
-            if "lanczos" in interpolation:
-                self.skipTest(
-                    "Resizing with Lanczos interpolation is "
-                    "not supported by the OpenVINO backend. "
-                    f"Received: interpolation={interpolation}."
-                )
             if interpolation == "bicubic":
                 self.skipTest(
                     "Resizing with Bicubic interpolation does not match "


### PR DESCRIPTION
## Description
Previously, lanczos interpolation was not supported when calling resize with the OpenVINO backend, since it was not supported by the interpolate op natively. 

We recently implemented a path for this through `_ov_fill_lanczos_kernel` and  `_ov_scale_and_translate`, which was used by `scale_and_translate`.

This PR routes lanczos through that path in resize.

Closes: openvinotoolkit/openvino/issues/35584

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
