### PR TITLE
[OpenVINO] Fix predict for models with non JIT compatible layers

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -7,7 +7,6 @@ EqualizationTest::test_input_dtypes_int32
 EqualizationTest::test_input_dtypes_int64
 EqualizationTest::test_output_range_0_1
 EqualizationTest::test_output_range_0_255
-FeatureSpaceTest::test_saving
 LayerTest::test_complex_dtype_support
 LinalgOpsCorrectnessTest::test_eig
 LinalgOpsCorrectnessTest::test_lstsq

--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -9,7 +9,6 @@ from keras.src.backend.openvino.core import OPENVINO_DTYPES
 from keras.src.backend.openvino.core import OpenVINOKerasTensor
 from keras.src.backend.openvino.core import get_device
 from keras.src.trainers import trainer as base_trainer
-from keras.src.trainers import trainer as trainer_module
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.trainers.epoch_iterator import EpochIterator
 from keras.src.utils import traceback_utils
@@ -47,11 +46,12 @@ class OpenVINOTrainer(base_trainer.Trainer):
 
     def test_step(self, data):
         x, y, sample_weight = data_adapter_utils.unpack_x_y_sample_weight(data)
-        if not trainer_module.model_supports_jit(self):
+        if not base_trainer.model_supports_jit(self):
             if self._call_has_training_arg:
                 y_pred = self(x, training=False)
             else:
                 y_pred = self(x)
+            y_pred = tree.map_structure(backend.convert_to_numpy, y_pred)
         else:
             ov_compiled_model = self._get_compiled_model(x)
             flatten_x = tree.flatten(x)
@@ -68,10 +68,12 @@ class OpenVINOTrainer(base_trainer.Trainer):
 
     def predict_step(self, data):
         x, _, _ = data_adapter_utils.unpack_x_y_sample_weight(data)
-        if not trainer_module.model_supports_jit(self):
+        if not base_trainer.model_supports_jit(self):
             if self._call_has_training_arg:
-                return self(x, training=False)
-            return self(x)
+                y_pred = self(x, training=False)
+            else:
+                y_pred = self(x)
+            return tree.map_structure(backend.convert_to_numpy, y_pred)
         ov_compiled_model = self._get_compiled_model(x)
         flatten_x = tree.flatten(x)
         ov_result = ov_compiled_model(flatten_x)

--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -9,6 +9,7 @@ from keras.src.backend.openvino.core import OPENVINO_DTYPES
 from keras.src.backend.openvino.core import OpenVINOKerasTensor
 from keras.src.backend.openvino.core import get_device
 from keras.src.trainers import trainer as base_trainer
+from keras.src.trainers import trainer as trainer_module
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.trainers.epoch_iterator import EpochIterator
 from keras.src.utils import traceback_utils
@@ -46,10 +47,16 @@ class OpenVINOTrainer(base_trainer.Trainer):
 
     def test_step(self, data):
         x, y, sample_weight = data_adapter_utils.unpack_x_y_sample_weight(data)
-        ov_compiled_model = self._get_compiled_model(x)
-        flatten_x = tree.flatten(x)
-        ov_result = ov_compiled_model(flatten_x)
-        y_pred = self._unpack_inference_outputs(ov_result.to_tuple())
+        if not trainer_module.model_supports_jit(self):
+            if self._call_has_training_arg:
+                y_pred = self(x, training=False)
+            else:
+                y_pred = self(x)
+        else:
+            ov_compiled_model = self._get_compiled_model(x)
+            flatten_x = tree.flatten(x)
+            ov_result = ov_compiled_model(flatten_x)
+            y_pred = self._unpack_inference_outputs(ov_result.to_tuple())
         loss = self._compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight, training=False
         )
@@ -61,6 +68,10 @@ class OpenVINOTrainer(base_trainer.Trainer):
 
     def predict_step(self, data):
         x, _, _ = data_adapter_utils.unpack_x_y_sample_weight(data)
+        if not trainer_module.model_supports_jit(self):
+            if self._call_has_training_arg:
+                return self(x, training=False)
+            return self(x)
         ov_compiled_model = self._get_compiled_model(x)
         flatten_x = tree.flatten(x)
         ov_result = ov_compiled_model(flatten_x)


### PR DESCRIPTION
## Description
Models with supports_jit=False layers (eg HashedCrossing) crashed previously during predict with the OpenVINO backend because the trainer tried to trace them with symbolic tensors. 

This PR adds an eager fallback when supports_jit=False, which is the pattern used by tf,  torch and JAX.

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
