### PR TITLE
Skip flaky test on Torch.

### DIFF
--- a/keras/src/ops/linalg_test.py
+++ b/keras/src/ops/linalg_test.py
@@ -620,6 +620,9 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
         ("rcond", 1, 1e-3),
     )
     def test_lstsq(self, b_rank, rcond):
+        if backend.backend() == "torch" and rcond is not None:
+            pytest.skip("lstsq results with rcond are inconsistent on torch")
+
         a = np.random.random((5, 7)).astype("float32")
         a_symb = backend.KerasTensor((5, 7))
         if b_rank == 1:


### PR DESCRIPTION
`lstsq` with `rcond` argument gives inconsistent results.

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
