### PR TITLE
Fix missing close paren in sobel_edges return statement

### DIFF
--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -2165,6 +2165,7 @@ def sobel_edges(images, data_format=None):
         return SobelEdges(data_format=data_format).symbolic_call(images)
     return backend.image.sobel_edges(
         images, data_format=backend.standardize_data_format(data_format)
+    )
 
 
 class SSIM(Operation):


### PR DESCRIPTION
## Description

`keras/src/ops/image.py:2167` is missing the closing parenthesis on `backend.image.sobel_edges(...)` after #22149 landed. Master currently fails ruff format with a `SyntaxError`, which blocks CI on every open PR.

This adds the missing `)`.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.