### PR TITLE
Issue 22538 Extension: Removing symbolic tensor support from multiple window functions.

### DIFF
--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -845,17 +845,28 @@ def bartlett(x):
     two_const_f64 = ov_opset.constant(2.0, Type.f64)
     if x.get_element_type() != Type.i64:
         x = ov_opset.convert(x, Type.i64)
-    half = ov_opset.convert(
-        ov_opset.divide(ov_opset.subtract(x, one_const), two_const), Type.f64
-    )
+    denom_i64 = ov_opset.subtract(x, one_const)
+    is_one = ov_opset.equal(denom_i64, zero_const)
+    one_f64 = ov_opset.constant(1.0, Type.f64)
+
+    half = ov_opset.convert(ov_opset.divide(denom_i64, two_const), Type.f64)
     n = ov_opset.range(zero_const, x, one_const, Type.f64)
     condition = ov_opset.less_equal(n, half)
+
+    safe_denom = ov_opset.select(
+        is_one, one_f64, ov_opset.convert(denom_i64, Type.f64)
+    )
+
     first_half = ov_opset.divide(
         ov_opset.multiply(two_const_f64, n),
-        ov_opset.convert(ov_opset.subtract(x, one_const), Type.f64),
+        safe_denom,
     )
     second_half = ov_opset.subtract(two_const_f64, first_half)
     window = ov_opset.select(condition, first_half, second_half)
+
+    ones = ov_opset.broadcast(one_f64, ov_opset.shape_of(window))
+    window = ov_opset.select(is_one, ones, window)
+
     window = ov_opset.convert(window, OPENVINO_DTYPES[config.floatx()]).output(
         0
     )
@@ -875,10 +886,15 @@ def hamming(x):
 
     one_i64 = ov_opset.constant(1, Type.i64)
     denom_i64 = ov_opset.subtract(m_i64, one_i64)
-    denom = ov_opset.convert(denom_i64, Type.f64)
+    is_one = ov_opset.equal(denom_i64, ov_opset.constant(0, Type.i64))
+    one_f64 = ov_opset.constant(1.0, Type.f64)
+
+    safe_denom = ov_opset.select(
+        is_one, one_f64, ov_opset.convert(denom_i64, Type.f64)
+    )
 
     two_pi = ov_opset.constant(2.0 * np.pi, Type.f64)
-    two_pi_over_m_minus_1 = ov_opset.divide(two_pi, denom)
+    two_pi_over_m_minus_1 = ov_opset.divide(two_pi, safe_denom)
 
     x = ov_opset.multiply(two_pi_over_m_minus_1, n)
     c = ov_opset.cos(x)
@@ -887,6 +903,11 @@ def hamming(x):
     a = ov_opset.constant(0.54, Type.f64)
     b = ov_opset.constant(0.46, Type.f64)
     hamming_window = ov_opset.subtract(a, ov_opset.multiply(b, c))
+
+    # Fix for x=1: return [1.] instead of [0.08]
+    ones = ov_opset.broadcast(one_f64, ov_opset.shape_of(hamming_window))
+    hamming_window = ov_opset.select(is_one, ones, hamming_window)
+
     hamming_window = ov_opset.convert(
         hamming_window, OPENVINO_DTYPES[config.floatx()]
     )

--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -2165,6 +2165,7 @@ def sobel_edges(images, data_format=None):
         return SobelEdges(data_format=data_format).symbolic_call(images)
     return backend.image.sobel_edges(
         images, data_format=backend.standardize_data_format(data_format)
+    )
 
 
 class SSIM(Operation):

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1341,14 +1341,6 @@ def average(x, axis=None, weights=None):
     return backend.numpy.average(x, axis=axis, weights=weights)
 
 
-class Bartlett(Operation):
-    def call(self, x):
-        return backend.numpy.bartlett(x)
-
-    def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=backend.floatx())
-
-
 @keras_export(["keras.ops.bartlett", "keras.ops.numpy.bartlett"])
 def bartlett(x):
     """Bartlett window function.
@@ -1366,16 +1358,11 @@ def bartlett(x):
     array([0. , 0.5, 1. , 0.5, 0. ], dtype=float32)
     """
     if any_symbolic_tensors((x,)):
-        return Bartlett().symbolic_call(x)
+        raise TypeError(
+            f"Bartlett operation does not support symbolic tensors. "
+            f"Received input x = {x} of type {type(x)}"
+        )
     return backend.numpy.bartlett(x)
-
-
-class Hamming(Operation):
-    def call(self, x):
-        return backend.numpy.hamming(x)
-
-    def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=backend.floatx())
 
 
 @keras_export(["keras.ops.hamming", "keras.ops.numpy.hamming"])
@@ -1397,16 +1384,11 @@ def hamming(x):
     array([0.08, 0.54, 1.  , 0.54, 0.08], dtype=float32)
     """
     if any_symbolic_tensors((x,)):
-        return Hamming().symbolic_call(x)
+        raise TypeError(
+            f"Hamming operation does not support symbolic tensors. "
+            f"Received input x = {x} of type {type(x)}"
+        )
     return backend.numpy.hamming(x)
-
-
-class Hanning(Operation):
-    def call(self, x):
-        return backend.numpy.hanning(x)
-
-    def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=backend.floatx())
 
 
 @keras_export(["keras.ops.hanning", "keras.ops.numpy.hanning"])
@@ -1428,7 +1410,10 @@ def hanning(x):
     array([0. , 0.5, 1. , 0.5, 0. ], dtype=float32)
     """
     if any_symbolic_tensors((x,)):
-        return Hanning().symbolic_call(x)
+        raise TypeError(
+            f"Hanning operation does not support symbolic tensors. "
+            f"Received input x = {x} of type {type(x)}"
+        )
     return backend.numpy.hanning(x)
 
 
@@ -1470,18 +1455,6 @@ def heaviside(x1, x2):
     return backend.numpy.heaviside(x1, x2)
 
 
-class Kaiser(Operation):
-    def __init__(self, beta, *, name=None):
-        super().__init__(name=name)
-        self.beta = beta
-
-    def call(self, x):
-        return backend.numpy.kaiser(x, self.beta)
-
-    def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=backend.floatx())
-
-
 @keras_export(["keras.ops.kaiser", "keras.ops.numpy.kaiser"])
 def kaiser(x, beta):
     """Kaiser window function.
@@ -1504,7 +1477,10 @@ def kaiser(x, beta):
        7.7268669e-06], dtype=float32)
     """
     if any_symbolic_tensors((x,)):
-        return Kaiser(beta).symbolic_call(x)
+        raise TypeError(
+            f"Kaiser operation does not support symbolic tensors. "
+            f"Received input x = {x} of type {type(x)}"
+        )
     return backend.numpy.kaiser(x, beta)
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -5112,7 +5112,7 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
     def test_bartlett(self):
         x = np.random.randint(1, 100 + 1)
         self.assertAllClose(knp.bartlett(x), np.bartlett(x))
-    
+
     def test_bartlett_length_1(self):
         x = 1
         x_tensor = keras.ops.convert_to_tensor(x)
@@ -5136,7 +5136,7 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
     def test_hamming(self):
         x = np.random.randint(1, 100 + 1)
         self.assertAllClose(knp.hamming(x), np.hamming(x))
-    
+
     def test_hamming_length_1(self):
         x = 1
         x_tensor = keras.ops.convert_to_tensor(x)
@@ -5161,7 +5161,7 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         x = np.random.randint(1, 100 + 1)
         beta = float(np.random.randint(10, 20 + 1))
         self.assertAllClose(knp.kaiser(x, beta), np.kaiser(x, beta))
-    
+
     def test_kaiser_length_1(self):
         x = 1
         x_tensor = keras.ops.convert_to_tensor(x)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -5112,8 +5112,14 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
     def test_bartlett(self):
         x = np.random.randint(1, 100 + 1)
         self.assertAllClose(knp.bartlett(x), np.bartlett(x))
-
-        self.assertAllClose(knp.Bartlett()(x), np.bartlett(x))
+    
+    def test_bartlett_length_1(self):
+        x = 1
+        x_tensor = keras.ops.convert_to_tensor(x)
+        expected = np.bartlett(x)
+        out = knp.bartlett(x_tensor)
+        self.assertEqual(out.shape[0], x)
+        self.assertAllClose(out, expected)
 
     def test_blackman(self):
         x = np.random.randint(1, 100 + 1)
@@ -5130,21 +5136,40 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
     def test_hamming(self):
         x = np.random.randint(1, 100 + 1)
         self.assertAllClose(knp.hamming(x), np.hamming(x))
-
-        self.assertAllClose(knp.Hamming()(x), np.hamming(x))
+    
+    def test_hamming_length_1(self):
+        x = 1
+        x_tensor = keras.ops.convert_to_tensor(x)
+        expected = np.hamming(x)
+        out = knp.hamming(x_tensor)
+        self.assertEqual(out.shape[0], x)
+        self.assertAllClose(out, expected)
 
     def test_hanning(self):
         x = np.random.randint(1, 100 + 1)
         self.assertAllClose(knp.hanning(x), np.hanning(x))
 
-        self.assertAllClose(knp.Hanning()(x), np.hanning(x))
+    def test_hanning_length_1(self):
+        x = 1
+        x_tensor = keras.ops.convert_to_tensor(x)
+        expected = np.hanning(x)
+        out = knp.hanning(x_tensor)
+        self.assertEqual(out.shape[0], x)
+        self.assertAllClose(out, expected)
 
     def test_kaiser(self):
         x = np.random.randint(1, 100 + 1)
         beta = float(np.random.randint(10, 20 + 1))
         self.assertAllClose(knp.kaiser(x, beta), np.kaiser(x, beta))
-
-        self.assertAllClose(knp.Kaiser(beta)(x), np.kaiser(x, beta))
+    
+    def test_kaiser_length_1(self):
+        x = 1
+        x_tensor = keras.ops.convert_to_tensor(x)
+        beta = float(np.random.randint(10, 20 + 1))
+        expected = np.kaiser(x, beta)
+        out = knp.kaiser(x_tensor, beta)
+        self.assertEqual(out.shape[0], x)
+        self.assertAllClose(out, expected)
 
     @parameterized.named_parameters(
         named_product(sparse_input=(False, True), sparse_arg=(False, True))
@@ -7982,10 +8007,6 @@ class NumpyDtypeTest(testing.TestCase):
         self.assertEqual(
             standardize_dtype(knp.bartlett(x).dtype), expected_dtype
         )
-        self.assertEqual(
-            standardize_dtype(knp.Bartlett().symbolic_call(x).dtype),
-            expected_dtype,
-        )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_blackman(self, dtype):
@@ -8004,10 +8025,6 @@ class NumpyDtypeTest(testing.TestCase):
         self.assertEqual(
             standardize_dtype(knp.hamming(x).dtype), expected_dtype
         )
-        self.assertEqual(
-            standardize_dtype(knp.Hamming().symbolic_call(x).dtype),
-            expected_dtype,
-        )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_hanning(self, dtype):
@@ -8016,10 +8033,6 @@ class NumpyDtypeTest(testing.TestCase):
 
         self.assertEqual(
             standardize_dtype(knp.hanning(x).dtype), expected_dtype
-        )
-        self.assertEqual(
-            standardize_dtype(knp.Hanning().symbolic_call(x).dtype),
-            expected_dtype,
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
@@ -8030,10 +8043,6 @@ class NumpyDtypeTest(testing.TestCase):
 
         self.assertEqual(
             standardize_dtype(knp.kaiser(x, beta).dtype), expected_dtype
-        )
-        self.assertEqual(
-            standardize_dtype(knp.Kaiser(beta).symbolic_call(x).dtype),
-            expected_dtype,
         )
 
     @parameterized.named_parameters(named_product(dtype=INT_DTYPES))


### PR DESCRIPTION
## Description
Removed symbolic tensor support for Bartlett, Hanning, Hamming and Kaiser window functions. Verified that each window function returns output [1.0] for window length of size 1. Made changes in bartlett and hamming functions in openvino backend to handle input of length 1.

Key Changes:
- Removed each window function class.
- Added tests for window length 1.
- Removed symbolic tensor tests.
- Updated hamming and bartlett function in openvino backend
- Also fixed a syntactical error/typo found by ruff.

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
