### PR TITLE
Allow plain callables as Regularizers.

### DIFF
--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -374,13 +374,11 @@ class Variable:
 
     @regularizer.setter
     def regularizer(self, value):
-        from keras.src.regularizers import Regularizer
-
-        if value is not None and not isinstance(value, Regularizer):
+        if value is not None and not callable(value):
             raise ValueError(
-                "Invalid value for attribute `regularizer`. Expected an "
-                "instance of `keras.regularizers.Regularizer`, or `None`. "
-                f"Received: regularizer={value}"
+                "Invalid value for attribute `regularizer`. Expected a "
+                "callable (such as a `keras.regularizers.Regularizer` "
+                f"instance) or `None`. Received: regularizer={value}"
             )
         self._regularizer = value
 

--- a/keras/src/backend/common/variables_test.py
+++ b/keras/src/backend/common/variables_test.py
@@ -214,6 +214,43 @@ class VariablePropertiesTest(test_case.TestCase):
         restored.build((None, 3))
         self.assertIs(restored.kernel_constraint, half_constraint)
 
+    def test_regularizer_setter_accepts_plain_callable(self):
+        from keras.src.regularizers import L1
+
+        v = backend.Variable(initializer="ones", shape=(2,))
+
+        def reg_fn(w):
+            return w * w
+
+        v.regularizer = reg_fn
+        self.assertIs(v.regularizer, reg_fn)
+
+        v.regularizer = L1()
+        self.assertIsInstance(v.regularizer, L1)
+
+        v.regularizer = None
+        self.assertIsNone(v.regularizer)
+
+        with self.assertRaisesRegex(
+            ValueError, "Invalid value for attribute `regularizer`"
+        ):
+            v.regularizer = "not callable"
+
+    def test_registered_callable_regularizer_survives_serialization(self):
+        from keras.src.layers import Dense
+        from keras.src.saving import register_keras_serializable
+
+        @register_keras_serializable(package="test")
+        def reg_fn(w):
+            return w * w
+
+        layer = Dense(4, kernel_regularizer=reg_fn)
+        layer.build((None, 3))
+        config = layer.get_config()
+        restored = Dense.from_config(config)
+        restored.build((None, 3))
+        self.assertIs(restored.kernel_regularizer, reg_fn)
+
     def test_autocasting_float(self):
         # Tests autocasting of float variables
         v = backend.Variable(


### PR DESCRIPTION
Similar to https://github.com/keras-team/keras/pull/22730 but for regularizers.

Note that Keras 2 supported plain callables.

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
