### PR TITLE
keras to torch export

### DIFF
--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -617,32 +617,56 @@ def scatter_update(inputs, indices, updates, reduction=None):
 
 
 def slice(inputs, start_indices, shape):
-    shape_dtype = to_torch_dtype("int64")
     inputs = convert_to_tensor(inputs)
+
+    # Fast path: when both start_indices and shape are Python int sequences,
+    # build the slice objects directly. This avoids creating tensors from
+    # the indices, which would introduce data-dependent expressions that
+    # torch.export cannot trace.
+    if isinstance(start_indices, (list, tuple)) and isinstance(
+        shape, (list, tuple)
+    ):
+        if all(isinstance(s, int) for s in start_indices) and all(
+            isinstance(s, int) for s in shape
+        ):
+            slices = [
+                builtins.slice(start_index, start_index + length)
+                for start_index, length in zip(start_indices, shape)
+            ]
+            return inputs[tuple(slices)]
+
+    # Slow path: tensor-based slicing via torch.narrow for truly dynamic
+    # indices. torch.narrow is a proper ATen op that torch.export can
+    # trace, unlike Python-level iteration over tensor elements.
+    shape_dtype = to_torch_dtype("int64")
     start_indices = convert_to_tensor(start_indices).to(shape_dtype)
     shape = convert_to_tensor(shape).to(shape_dtype)
-
-    python_slice = __builtins__["slice"]
-    slices = [
-        python_slice(start_index, start_index + length)
-        for start_index, length in zip(start_indices, shape)
-    ]
-    return inputs[slices]
+    result = inputs
+    for dim in range(start_indices.shape[0]):
+        result = torch.narrow(result, dim, start_indices[dim], shape[dim])
+    return result
 
 
 def slice_update(inputs, start_indices, updates):
-    shape_dtype = to_torch_dtype("int64")
     inputs = convert_to_tensor(inputs)
-    start_indices = convert_to_tensor(start_indices).to(shape_dtype)
     updates = convert_to_tensor(updates)
 
-    python_slice = __builtins__["slice"]
+    # Fast path: when start_indices is a Python int sequence, use it
+    # directly. This avoids creating tensors from the indices, which would
+    # introduce data-dependent expressions that torch.export cannot trace.
+    if not (
+        isinstance(start_indices, (list, tuple))
+        and all(isinstance(s, int) for s in start_indices)
+    ):
+        start_indices = convert_to_tensor(start_indices, dtype="int64")
+        start_indices = start_indices.tolist()
+
     slices = [
-        python_slice(start_index, start_index + update_length)
+        builtins.slice(start_index, start_index + update_length)
         for start_index, update_length in zip(start_indices, updates.shape)
     ]
     outputs = torch.clone(inputs)
-    outputs[slices] = updates
+    outputs[tuple(slices)] = updates
     return outputs
 
 

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -654,19 +654,40 @@ def slice_update(inputs, start_indices, updates):
     # Fast path: when start_indices is a Python int sequence, use it
     # directly. This avoids creating tensors from the indices, which would
     # introduce data-dependent expressions that torch.export cannot trace.
-    if not (
-        isinstance(start_indices, (list, tuple))
-        and all(isinstance(s, int) for s in start_indices)
+    if isinstance(start_indices, (list, tuple)) and all(
+        isinstance(s, int) for s in start_indices
     ):
-        start_indices = convert_to_tensor(start_indices, dtype="int64")
-        start_indices = start_indices.tolist()
+        slices = [
+            builtins.slice(start_index, start_index + update_length)
+            for start_index, update_length in zip(start_indices, updates.shape)
+        ]
+        outputs = torch.clone(inputs)
+        outputs[tuple(slices)] = updates
+        return outputs
 
-    slices = [
-        builtins.slice(start_index, start_index + update_length)
-        for start_index, update_length in zip(start_indices, updates.shape)
-    ]
-    outputs = torch.clone(inputs)
-    outputs[tuple(slices)] = updates
+    # Slow path: tensor-based start_indices.
+    # We cannot use Python slice objects because they require scalar int
+    # bounds, and extracting scalars from traced tensors creates unbacked
+    # symbols that torch.export cannot resolve.
+    # Instead, we build a flat index list via meshgrid and use
+    # index_put_, which is fully traceable.
+    start_indices = convert_to_tensor(start_indices, dtype="int64")
+    outputs = inputs.clone()
+    update_shape = list(updates.shape)
+    dims = len(update_shape)
+    indices_list = []
+    for dim in range(dims):
+        dim_indices = torch.arange(
+            update_shape[dim],
+            dtype=start_indices.dtype,
+            device=start_indices.device,
+        )
+        dim_indices = dim_indices + start_indices[dim]
+        indices_list.append(dim_indices)
+
+    grids = torch.meshgrid(*indices_list, indexing="ij")
+    flat_indices = [g.flatten() for g in grids]
+    outputs.index_put_(tuple(flat_indices), updates.flatten())
     return outputs
 
 

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -286,13 +286,17 @@ def _transpose_spatial_inputs(inputs):
     """Transpose inputs from channels_last to channels_first format."""
     # Torch pooling does not support `channels_last` format, so
     # we need to transpose to `channels_first` format.
+    # After permute, the tensor may be non-contiguous which causes
+    # failures in view-based ops (e.g., conv2d, torch.export) that
+    # require contiguous memory. Adding .contiguous() ensures
+    # compatible memory layout.
     ndim = inputs.ndim - 2
     if ndim == 1:  # 1D case
-        return torch.permute(inputs, (0, 2, 1))
+        return torch.permute(inputs, (0, 2, 1)).contiguous()
     elif ndim == 2:  # 2D case
-        return torch.permute(inputs, (0, 3, 1, 2))
+        return torch.permute(inputs, (0, 3, 1, 2)).contiguous()
     elif ndim == 3:  # 3D case
-        return torch.permute(inputs, (0, 4, 1, 2, 3))
+        return torch.permute(inputs, (0, 4, 1, 2, 3)).contiguous()
     raise ValueError(
         "Inputs must have ndim=3, 4 or 5, "
         "corresponding to 1D, 2D and 3D inputs. "

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1778,6 +1778,23 @@ def repeat(x, repeats, axis=None):
             device=get_device(),
         )
 
+    # When repeats is a scalar int and axis is specified, use
+    # unsqueeze + expand + reshape instead of repeat_interleave.
+    # repeat_interleave introduces unbacked symbolic integers during
+    # torch.export tracing, preventing static shape inference. This
+    # alternative preserves static output shapes.
+    if isinstance(repeats, int) and axis is not None:
+        if axis < 0:
+            axis = x.ndim + axis
+        shape = list(x.shape)
+        x = x.unsqueeze(axis + 1)
+        expand_shape = [-1] * x.ndim
+        expand_shape[axis + 1] = repeats
+        x = x.expand(expand_shape)
+        new_shape = list(shape)
+        new_shape[axis] = shape[axis] * repeats
+        return x.reshape(new_shape)
+
     repeats = convert_to_tensor(repeats, dtype=int)
 
     return torch.repeat_interleave(x, repeats, dim=axis)

--- a/keras/src/export/__init__.py
+++ b/keras/src/export/__init__.py
@@ -5,3 +5,4 @@ from keras.src.export.openvino import export_openvino
 from keras.src.export.saved_model import ExportArchive
 from keras.src.export.saved_model import export_saved_model
 from keras.src.export.tfsm_layer import TFSMLayer
+from keras.src.export.torch import export_torch

--- a/keras/src/export/torch.py
+++ b/keras/src/export/torch.py
@@ -1,0 +1,152 @@
+"""PyTorch ExportedProgram export utilities."""
+
+import inspect
+import warnings
+
+from keras.src import tree
+from keras.src.export.export_utils import convert_spec_to_tensor
+from keras.src.export.export_utils import get_input_signature
+from keras.src.utils import io_utils
+
+
+def export_torch(
+    model,
+    filepath,
+    input_signature=None,
+    verbose=None,
+    **kwargs,
+):
+    """Export the model as a PyTorch ExportedProgram (`.pt2`) artifact.
+
+    Uses `torch.export.export` to capture the model's computation graph
+    in an Ahead-of-Time (AOT) fashion. The resulting artifact contains
+    only ATen-level operations and can be loaded via `torch.export.load`,
+    run with `ExportedProgram.module()`, or compiled further with
+    `torch.compile`.
+
+    Args:
+        model: The Keras model to export.
+        filepath: `str` or `pathlib.Path` object. Path to save the
+            exported artifact. Must end with `.pt2`.
+        input_signature: Optional input signature. If `None`, inferred
+            from the model's built input spec.
+        verbose: `bool`. Whether to print a message after export.
+            Defaults to `True`.
+        **kwargs: Additional keyword arguments forwarded to
+            `torch.export.export`, including `strict`, `dynamic_shapes`,
+            `prefer_deferred_runtime_asserts_over_guards`, and
+            `preserve_module_call_signature`. For a single-input model,
+            `dynamic_shapes` can be a dict such as
+            `{0: torch.export.Dim("batch", min=1, max=128)}`.
+
+    Example:
+
+    ```python
+    model.export("path/to/model.pt2", format="torch")
+
+    import torch
+    loaded_program = torch.export.load("path/to/model.pt2")
+    output = loaded_program.module()(torch.randn(1, 10))
+    ```
+    """
+    import torch
+
+    filepath = str(filepath)
+    if not filepath.endswith(".pt2"):
+        raise ValueError(
+            "The PyTorch export requires the filepath to end with "
+            f"'.pt2'. Got: {filepath}"
+        )
+
+    export_kwargs = _get_export_kwargs(kwargs)
+    dynamic_shapes = export_kwargs.get("dynamic_shapes")
+
+    if input_signature is None:
+        input_signature = get_input_signature(model)
+
+    replace_none_number = 2 if dynamic_shapes is not None else 1
+    sample_inputs = tree.map_structure(
+        lambda x: convert_spec_to_tensor(
+            x, replace_none_number=replace_none_number
+        ),
+        input_signature,
+    )
+    sample_inputs = tuple(sample_inputs)
+    if dynamic_shapes is not None:
+        export_kwargs["dynamic_shapes"] = _normalize_dynamic_shapes(
+            dynamic_shapes, sample_inputs
+        )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r".*not properly registered as a submodule.*",
+        )
+        try:
+            exported_program = torch.export.export(
+                model,
+                sample_inputs,
+                **export_kwargs,
+            )
+        except Exception as e:
+            raise RuntimeError(
+                "Failed to export model to PyTorch format. "
+                "Common causes: unsupported operations, data-dependent "
+                "control flow, or shape constraints not satisfied. "
+                f"Original error: {e}"
+            ) from e
+
+    torch.export.save(exported_program, filepath)
+
+    actual_verbose = verbose if verbose is not None else True
+    if actual_verbose:
+        io_utils.print_msg(f"Saved PyTorch ExportedProgram at '{filepath}'.")
+    return filepath
+
+
+def _get_export_kwargs(user_kwargs):
+    import torch
+
+    supported_arg_names = {
+        name
+        for name in inspect.signature(torch.export.export).parameters
+        if name not in {"mod", "args", "kwargs"}
+    }
+    unknown_arg_names = sorted(set(user_kwargs).difference(supported_arg_names))
+    if unknown_arg_names:
+        supported_args = ", ".join(sorted(supported_arg_names))
+        unknown_args = ", ".join(unknown_arg_names)
+        raise ValueError(
+            'Unsupported arguments for `format="torch"`: '
+            f"{unknown_args}. Supported arguments are: {supported_args}."
+        )
+
+    export_kwargs = {
+        name: value
+        for name, value in user_kwargs.items()
+        if name in supported_arg_names
+    }
+    # Default to non-strict mode for broader Keras model compatibility.
+    # Strict mode requires all operations to be fully ATen-traceable, which
+    # is too restrictive for Keras models that use Python-level structure.
+    export_kwargs.setdefault("strict", False)
+    return export_kwargs
+
+
+def _normalize_dynamic_shapes(dynamic_shapes, sample_inputs):
+    if isinstance(dynamic_shapes, dict):
+        if "args" in dynamic_shapes or "kwargs" in dynamic_shapes:
+            return dynamic_shapes
+        if len(sample_inputs) == 1:
+            return [(dynamic_shapes,)]
+        return dynamic_shapes
+
+    if isinstance(dynamic_shapes, (list, tuple)):
+        if len(dynamic_shapes) == 1 and isinstance(
+            dynamic_shapes[0], (list, tuple)
+        ):
+            return dynamic_shapes
+        if len(dynamic_shapes) == len(sample_inputs):
+            return [tuple(dynamic_shapes)]
+
+    return dynamic_shapes

--- a/keras/src/export/torch.py
+++ b/keras/src/export/torch.py
@@ -38,6 +38,10 @@ def export_torch(
             `preserve_module_call_signature`. For a single-input model,
             `dynamic_shapes` can be a dict such as
             `{0: torch.export.Dim("batch", min=1, max=128)}`.
+            Note: when `dynamic_shapes` is provided, the sample input used
+            for tracing uses a batch size of 2 instead of 1. This avoids a
+            PyTorch limitation where dimensions of size 1 are specialized
+            to constants during export.
 
     Example:
 
@@ -64,6 +68,11 @@ def export_torch(
     if input_signature is None:
         input_signature = get_input_signature(model)
 
+    # PyTorch limitation: torch.export specializes dimensions of size 1 to
+    # constants during tracing. If a dynamic dim (e.g., batch) has a concrete
+    # sample value of 1, export fails with "specialized it to be a constant".
+    # Using a sample value of 2 (the smallest integer > 1) avoids this.
+    # See: https://github.com/pytorch/pytorch/issues/176349
     replace_none_number = 2 if dynamic_shapes is not None else 1
     sample_inputs = tree.map_structure(
         lambda x: convert_spec_to_tensor(
@@ -137,15 +146,25 @@ def _normalize_dynamic_shapes(dynamic_shapes, sample_inputs):
     if isinstance(dynamic_shapes, dict):
         if "args" in dynamic_shapes or "kwargs" in dynamic_shapes:
             return dynamic_shapes
+        # Keras models use `forward(*args, **kwargs)`. torch.export treats
+        # the entire `args` tuple as a single positional argument when the
+        # forward signature is `*args`. Therefore dynamic_shapes must be a
+        # list/tuple of length 1, where the single element is the spec for
+        # the args tuple. For a single-input model, args = (tensor,), so
+        # the spec is (dynamic_shapes,).
         if len(sample_inputs) == 1:
             return [(dynamic_shapes,)]
         return dynamic_shapes
 
     if isinstance(dynamic_shapes, (list, tuple)):
+        # Already wrapped, e.g. [({0: Dim},)] or [([spec1, spec2],)].
         if len(dynamic_shapes) == 1 and isinstance(
             dynamic_shapes[0], (list, tuple)
         ):
             return dynamic_shapes
+        # Bare list/tuple matching sample_inputs length (always 1 for
+        # Keras). Wrap it in the list required by torch.export's *args
+        # handling.
         if len(dynamic_shapes) == len(sample_inputs):
             return [tuple(dynamic_shapes)]
 

--- a/keras/src/export/torch_test.py
+++ b/keras/src/export/torch_test.py
@@ -385,6 +385,21 @@ class ExportTorchTest(testing.TestCase):
 
         self._verify_export_and_inference(model, ref_input)
 
+    def test_export_with_dynamic_slice_update(self):
+        """slice_update with tensor start_indices is torch.export traceable."""
+
+        class DynamicSliceUpdateModel(models.Model):
+            def call(self, x):
+                start = ops.convert_to_tensor([0, 2])
+                update = ops.slice(x, [0, 0], [1, 2])
+                return ops.slice_update(x, start, update)
+
+        model = DynamicSliceUpdateModel()
+        ref_input = np.random.normal(size=(1, 4)).astype("float32")
+        model(ref_input)
+
+        self._verify_export_and_inference(model, ref_input)
+
     def test_export_with_concrete_shapes(self):
         model = models.Sequential([layers.Dense(1, input_shape=(5,))])
         temp_filepath = os.path.join(self.get_temp_dir(), "concrete_shapes.pt2")

--- a/keras/src/export/torch_test.py
+++ b/keras/src/export/torch_test.py
@@ -1,0 +1,460 @@
+"""Tests for PyTorch ExportedProgram exporting utilities."""
+
+import os
+
+import numpy as np
+import pytest
+import torch
+from absl.testing import parameterized
+
+from keras.src import backend
+from keras.src import layers
+from keras.src import models
+from keras.src import ops
+from keras.src import testing
+from keras.src import tree
+from keras.src.backend.torch.core import get_device
+from keras.src.testing.test_utils import named_product
+
+
+class CustomModel(models.Model):
+    def __init__(self, layer_list):
+        super().__init__()
+        self.layer_list = layer_list
+
+    def call(self, input):
+        output = input
+        for layer in self.layer_list:
+            output = layer(output)
+        return output
+
+
+class DataDependentControlFlowModel(models.Model):
+    """Model with data-dependent control flow, not strictly exportable."""
+
+    def call(self, x):
+        # Accessing bool(tensor) triggers data-dependent guard in strict mode.
+        if bool(x[0, 0] > 0):
+            return x * 2
+        return x
+
+
+class RepeatModel(models.Model):
+    def call(self, x):
+        return ops.repeat(x, 2, axis=1)
+
+
+class SliceModel(models.Model):
+    def call(self, x):
+        update = ops.slice(x, [0, 0], [1, 2])
+        return ops.slice_update(x, [0, 2], update)
+
+
+def get_model(type="sequential", input_shape=(10,), layer_list=None):
+    layer_list = layer_list or [
+        layers.Dense(10, activation="relu"),
+        layers.BatchNormalization(),
+        layers.Dense(1, activation="sigmoid"),
+    ]
+    if type == "sequential":
+        model = models.Sequential(layer_list)
+        model.build(input_shape=(None,) + input_shape)
+        return model
+    if type == "functional":
+        input = output = tree.map_shape_structure(layers.Input, input_shape)
+        for layer in layer_list:
+            output = layer(output)
+        return models.Model(inputs=input, outputs=output)
+    if type == "subclass":
+        model = CustomModel(layer_list)
+        model.build(input_shape=(None,) + input_shape)
+        dummy_input = np.zeros((1,) + input_shape, dtype=np.float32)
+        _ = model(dummy_input)
+        return model
+    if type == "multi_input":
+        input1 = layers.Input(shape=input_shape, name="input1")
+        input2 = layers.Input(shape=input_shape, name="input2")
+        x1 = layers.Dense(10, activation="relu")(input1)
+        x2 = layers.Dense(10, activation="relu")(input2)
+        combined = layers.concatenate([x1, x2])
+        output = layers.Dense(1, activation="sigmoid")(combined)
+        return models.Model(inputs=[input1, input2], outputs=output)
+    if type == "multi_output":
+        inputs = layers.Input(shape=input_shape)
+        shared = layers.Dense(20, activation="relu")(inputs)
+        output1 = layers.Dense(1, activation="sigmoid", name="output1")(shared)
+        output2 = layers.Dense(3, activation="softmax", name="output2")(shared)
+        return models.Model(inputs=inputs, outputs=[output1, output2])
+    raise ValueError(f"Unknown model type: {type}")
+
+
+@pytest.mark.skipif(
+    backend.backend() != "torch",
+    reason="`export_torch` only supports the PyTorch backend.",
+)
+class ExportTorchTest(testing.TestCase):
+    ATOL = 1e-5
+    RTOL = 1e-5
+
+    def _verify_export_and_inference(
+        self, model, ref_input, filepath=None, **export_kwargs
+    ):
+        if filepath is None:
+            filepath = os.path.join(self.get_temp_dir(), "model.pt2")
+
+        ref_output = tree.map_structure(
+            backend.convert_to_numpy, model(ref_input)
+        )
+
+        model.export(filepath, format="torch", **export_kwargs)
+        self.assertTrue(os.path.exists(filepath))
+
+        loaded_program = torch.export.load(filepath)
+        loaded_model = loaded_program.module()
+
+        torch_input = tree.map_structure(backend.convert_to_tensor, ref_input)
+        loaded_output = tree.map_structure(
+            backend.convert_to_numpy, loaded_model(torch_input)
+        )
+
+        self.assertAllClose(
+            ref_output, loaded_output, atol=self.ATOL, rtol=self.RTOL
+        )
+
+        return ref_output, loaded_output
+
+    @parameterized.named_parameters(
+        named_product(model_type=["sequential", "functional"])
+    )
+    def test_standard_model_export(self, model_type):
+        model = get_model(model_type)
+        ref_input = np.random.normal(size=(1, 10)).astype("float32")
+        self._verify_export_and_inference(model, ref_input)
+
+    def test_export_subclass_model(self):
+        model = get_model("subclass")
+        ref_input = np.random.normal(size=(1, 10)).astype("float32")
+        self._verify_export_and_inference(model, ref_input)
+
+    def test_model_with_multiple_inputs(self):
+        model = get_model("multi_input")
+        ref_input1 = np.random.normal(size=(1, 10)).astype("float32")
+        ref_input2 = np.random.normal(size=(1, 10)).astype("float32")
+        ref_input = [ref_input1, ref_input2]
+        self._verify_export_and_inference(model, ref_input)
+
+    def test_multi_output_model_export(self):
+        model = get_model("multi_output")
+        ref_input = np.random.normal(size=(1, 10)).astype("float32")
+        ref_output = tree.map_structure(
+            backend.convert_to_numpy, model(ref_input)
+        )
+
+        temp_filepath = os.path.join(self.get_temp_dir(), "multi_out.pt2")
+        model.export(temp_filepath, format="torch")
+        self.assertTrue(os.path.exists(temp_filepath))
+
+        loaded_program = torch.export.load(temp_filepath)
+        loaded_model = loaded_program.module()
+        loaded_output = tree.map_structure(
+            backend.convert_to_numpy,
+            loaded_model(backend.convert_to_tensor(ref_input)),
+        )
+
+        # Handle both tuple/list and single output cases
+        if isinstance(loaded_output, (tuple, list)):
+            for ref_out, loaded_out in zip(ref_output, loaded_output):
+                self.assertAllClose(
+                    ref_out, loaded_out, atol=self.ATOL, rtol=self.RTOL
+                )
+        else:
+            self.assertAllClose(
+                ref_output, loaded_output, atol=self.ATOL, rtol=self.RTOL
+            )
+
+    def test_export_with_custom_input_signature(self):
+        model = get_model("sequential")
+        ref_input = np.random.normal(size=(1, 10)).astype("float32")
+        model(ref_input)  # Build the model
+
+        input_signature = [layers.InputSpec(shape=(1, 10), dtype="float32")]
+        temp_filepath = os.path.join(self.get_temp_dir(), "custom_sig.pt2")
+
+        model.export(
+            temp_filepath,
+            format="torch",
+            input_signature=input_signature,
+        )
+        self.assertTrue(os.path.exists(temp_filepath))
+
+        loaded_program = torch.export.load(temp_filepath)
+        loaded_model = loaded_program.module()
+        test_input = torch.randn(1, 10).to(get_device())
+        output = loaded_model(test_input)
+        self.assertEqual(backend.convert_to_numpy(output).shape[-1], 1)
+
+        ref_output = tree.map_structure(
+            backend.convert_to_numpy,
+            model(backend.convert_to_numpy(test_input)),
+        )
+        self.assertAllClose(
+            ref_output,
+            backend.convert_to_numpy(output),
+            atol=self.ATOL,
+            rtol=self.RTOL,
+        )
+
+    def test_export_with_verbose(self):
+        model = get_model("sequential")
+        ref_input = np.random.normal(size=(1, 10)).astype("float32")
+        model(ref_input)
+
+        temp_filepath = os.path.join(self.get_temp_dir(), "verbose_model.pt2")
+        model.export(temp_filepath, format="torch", verbose=True)
+        self.assertTrue(os.path.exists(temp_filepath))
+
+        self._verify_export_and_inference(
+            model, ref_input, filepath=temp_filepath
+        )
+
+    def test_export_error_handling(self):
+        model = get_model("sequential")
+        ref_input = np.random.normal(size=(1, 10)).astype("float32")
+        model(ref_input)
+
+        temp_filepath = os.path.join(self.get_temp_dir(), "exported_model.pt2")
+
+        with self.assertRaises(ValueError):
+            model.export(temp_filepath, format="invalid_format")
+
+    def test_export_invalid_filepath(self):
+        model = get_model("sequential")
+        ref_input = np.random.normal(size=(1, 10)).astype("float32")
+        model(ref_input)
+
+        temp_filepath = os.path.join(self.get_temp_dir(), "exported_model.txt")
+
+        # Should raise ValueError for wrong extension
+        with self.assertRaises(ValueError):
+            model.export(temp_filepath, format="torch")
+
+    def test_export_raises_runtime_error_on_export_failure(self):
+        """Exporting an un-traceable model raises RuntimeError."""
+        model = DataDependentControlFlowModel()
+        # Build the model
+        dummy = np.ones((1, 4), dtype="float32")
+        model(dummy)
+
+        temp_filepath = os.path.join(self.get_temp_dir(), "bad_model.pt2")
+        # strict=True prevents non-strict fallback; data-dependent bool()
+        # causes torch.export to raise, which we wrap in RuntimeError.
+        with self.assertRaises(RuntimeError):
+            model.export(temp_filepath, format="torch", strict=True)
+
+    def test_model_with_input_structure(self):
+        ref_input_arr = np.random.normal(size=(1, 10)).astype("float32")
+
+        input1 = layers.Input(shape=(10,), name="input_1")
+        input2 = layers.Input(shape=(10,), name="input_2")
+        output = layers.Add()([input1, input2])
+        model_list = models.Model(inputs=[input1, input2], outputs=output)
+
+        ref_input_list = [ref_input_arr, ref_input_arr * 2]
+        list_filepath = os.path.join(self.get_temp_dir(), "list_input.pt2")
+        self._verify_export_and_inference(
+            model_list, ref_input_list, filepath=list_filepath
+        )
+
+        input_x = layers.Input(shape=(10,), name="x")
+        input_y = layers.Input(shape=(10,), name="y")
+        output = layers.Add()([input_x, input_y])
+        model_dict = models.Model(
+            inputs={"x": input_x, "y": input_y}, outputs=output
+        )
+
+        ref_input_dict = {"x": ref_input_arr, "y": ref_input_arr * 2}
+        temp_filepath = os.path.join(self.get_temp_dir(), "dict_input.pt2")
+        ref_output = tree.map_structure(
+            backend.convert_to_numpy, model_dict(ref_input_dict)
+        )
+
+        model_dict.export(temp_filepath, format="torch")
+        self.assertTrue(os.path.exists(temp_filepath))
+
+        loaded_program = torch.export.load(temp_filepath)
+        loaded_model = loaded_program.module()
+        loaded_output = tree.map_structure(
+            backend.convert_to_numpy,
+            loaded_model(
+                {
+                    "x": backend.convert_to_tensor(ref_input_dict["x"]),
+                    "y": backend.convert_to_tensor(ref_input_dict["y"]),
+                }
+            ),
+        )
+        self.assertAllClose(
+            ref_output, loaded_output, atol=self.ATOL, rtol=self.RTOL
+        )
+
+    def test_model_with_named_inputs(self):
+        input_x = layers.Input(shape=(10,), name="input_x")
+        input_y = layers.Input(shape=(10,), name="input_y")
+        output = layers.Add()([input_x, input_y])
+        model = models.Model(
+            inputs={"x": input_x, "y": input_y}, outputs=output
+        )
+
+        temp_filepath = os.path.join(self.get_temp_dir(), "named_inputs.pt2")
+        model.export(temp_filepath, format="torch")
+
+        loaded_program = torch.export.load(temp_filepath)
+        signature = loaded_program.graph_signature
+
+        input_names = [spec.arg.name for spec in signature.input_specs]
+        self.assertTrue(
+            any("input_x" in name or "x" in name for name in input_names),
+            f"Expected 'input_x' or 'x' in {input_names}",
+        )
+        self.assertTrue(
+            any("input_y" in name or "y" in name for name in input_names),
+            f"Expected 'input_y' or 'y' in {input_names}",
+        )
+
+        ref_input = {
+            "x": np.random.normal(size=(1, 10)).astype("float32"),
+            "y": np.random.normal(size=(1, 10)).astype("float32"),
+        }
+        self._verify_export_and_inference(
+            model, ref_input, filepath=temp_filepath
+        )
+
+    def test_export_with_batch_normalization(self):
+        model = models.Sequential(
+            [
+                layers.Dense(16, input_shape=(10,)),
+                layers.BatchNormalization(),
+                layers.Activation("relu"),
+                layers.Dense(8),
+                layers.BatchNormalization(),
+                layers.Dense(1),
+            ]
+        )
+
+        ref_input = np.random.normal(size=(1, 10)).astype("float32")
+        # Ensure model is built and in eval mode for consistent behavior
+        model(ref_input, training=False)
+        self._verify_export_and_inference(model, ref_input)
+
+    def test_export_functional_with_add_skip_connection(self):
+        """Functional model with a skip connection via Add layer."""
+        inputs = layers.Input(shape=(10,))
+        x = layers.Dense(16, activation="relu")(inputs)
+        residual = layers.Dense(16)(inputs)
+        x = layers.Add()([x, residual])
+        x = layers.Activation("relu")(x)
+        outputs = layers.Dense(1)(x)
+        model = models.Model(inputs=inputs, outputs=outputs)
+
+        ref_input = np.random.normal(size=(1, 10)).astype("float32")
+        self._verify_export_and_inference(model, ref_input)
+
+    def test_export_with_conv2d_channels_last(self):
+        model = models.Sequential(
+            [
+                layers.Input(shape=(8, 8, 3)),
+                layers.Conv2D(4, 3, padding="same", activation="relu"),
+                layers.GlobalAveragePooling2D(),
+                layers.Dense(2),
+            ]
+        )
+        ref_input = np.random.normal(size=(1, 8, 8, 3)).astype("float32")
+
+        self._verify_export_and_inference(model, ref_input)
+
+    def test_export_with_repeat_op(self):
+        model = RepeatModel()
+        ref_input = np.random.normal(size=(1, 3)).astype("float32")
+        model(ref_input)
+
+        self._verify_export_and_inference(model, ref_input)
+
+    def test_export_with_slice_ops(self):
+        model = SliceModel()
+        ref_input = np.random.normal(size=(1, 4)).astype("float32")
+        model(ref_input)
+
+        self._verify_export_and_inference(model, ref_input)
+
+    def test_export_with_concrete_shapes(self):
+        model = models.Sequential([layers.Dense(1, input_shape=(5,))])
+        temp_filepath = os.path.join(self.get_temp_dir(), "concrete_shapes.pt2")
+
+        # Provide concrete input signature
+        from keras.src.layers.input_spec import InputSpec
+
+        input_sig = [InputSpec(shape=(1, 5), dtype="float32")]
+
+        model.export(temp_filepath, format="torch", input_signature=input_sig)
+
+        loaded_program = torch.export.load(temp_filepath)
+        self.assertIsNotNone(loaded_program.graph_signature)
+
+    def test_export_with_none_in_signature(self):
+        model = models.Sequential([layers.Dense(1, input_shape=(5,))])
+        temp_filepath = os.path.join(self.get_temp_dir(), "none_batch.pt2")
+
+        # torch.export will replace None with a concrete value (1 by default)
+        from keras.src.layers.input_spec import InputSpec
+
+        input_sig = [InputSpec(shape=(None, 5), dtype="float32")]
+
+        model.export(temp_filepath, format="torch", input_signature=input_sig)
+        self.assertTrue(os.path.exists(temp_filepath))
+
+    def test_export_with_dynamic_shapes(self):
+        """Export with dynamic batch dimension via torch.export.Dim.
+
+        The exported program is re-run with batch sizes different from
+        the example input used during tracing.
+        """
+        model = models.Sequential([layers.Input(shape=(8,)), layers.Dense(4)])
+
+        temp_filepath = os.path.join(self.get_temp_dir(), "dynamic_batch.pt2")
+        batch = torch.export.Dim("batch", min=1, max=32)
+        model.export(
+            temp_filepath,
+            format="torch",
+            dynamic_shapes={0: batch},
+        )
+        self.assertTrue(os.path.exists(temp_filepath))
+
+        loaded_model = torch.export.load(temp_filepath).module()
+
+        # Verify that the exported program accepts different batch sizes.
+        for batch_size in (1, 4, 8):
+            x = torch.randn(batch_size, 8).to(get_device())
+            out = loaded_model(x)
+            self.assertEqual(out.shape, (batch_size, 4))
+
+    def test_export_with_supported_kwargs(self):
+        model = models.Sequential([layers.Input(shape=(4,)), layers.Dense(1)])
+        ref_input = np.random.normal(size=(1, 4)).astype("float32")
+
+        self._verify_export_and_inference(
+            model,
+            ref_input,
+            prefer_deferred_runtime_asserts_over_guards=True,
+        )
+
+    def test_export_with_unsupported_kwargs(self):
+        model = models.Sequential([layers.Input(shape=(4,)), layers.Dense(1)])
+        temp_filepath = os.path.join(self.get_temp_dir(), "bad_kwarg.pt2")
+
+        with self.assertRaisesRegex(
+            ValueError, 'Unsupported arguments for `format="torch"`'
+        ):
+            model.export(
+                temp_filepath,
+                format="torch",
+                not_a_real_export_kwarg=True,
+            )

--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -665,8 +665,8 @@ class Model(Trainer, base_trainer.Trainer, Layer):
             filepath: `str` or `pathlib.Path` object. The path to save the
                 artifact.
             format: `str`. The export format. Supported values:
-                `"tf_saved_model"`, `"onnx"`, `"openvino"`, and `"litert"`.
-                Defaults to `"tf_saved_model"`.
+                `"tf_saved_model"`, `"onnx"`, `"openvino"`, `"litert"`,
+                and `"torch"`. Defaults to `"tf_saved_model"`.
             verbose: `bool`. Whether to print a message during export. Defaults
                 to `None`, which uses the default value set by different
                 backends and formats.
@@ -696,6 +696,12 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                     `experimental_new_quantizer`, `allow_custom_ops`,
                     `enable_select_tf_ops`, etc. See TensorFlow Lite
                     documentation for all available options.
+                - PyTorch export options: Optional keyword arguments specific
+                    to `format="torch"`. These are passed directly to
+                    `torch.export.export` and include `strict`,
+                    `dynamic_shapes`,
+                    `prefer_deferred_runtime_asserts_over_guards`, and
+                    `preserve_module_call_signature`.
 
         **Note:** This feature is currently supported only with TensorFlow, JAX
         and Torch backends.
@@ -748,13 +754,32 @@ class Model(Trainer, base_trainer.Trainer, Layer):
             interpreter.get_output_details()[0]['index']
         )
         ```
+
+        Here's how to export a PyTorch ExportedProgram for inference.
+
+        ```python
+        # Export the model as a PyTorch ExportedProgram artifact
+        model.export("path/to/model.pt2", format="torch")
+
+        # Load the artifact in a different process/environment
+        import torch
+        loaded_program = torch.export.load("path/to/model.pt2")
+        predictions = loaded_program.module()(input_tensor)
+        ```
         """
         from keras.src.export import export_litert
         from keras.src.export import export_onnx
         from keras.src.export import export_openvino
         from keras.src.export import export_saved_model
+        from keras.src.export import export_torch
 
-        available_formats = ("tf_saved_model", "onnx", "openvino", "litert")
+        available_formats = (
+            "tf_saved_model",
+            "onnx",
+            "openvino",
+            "litert",
+            "torch",
+        )
         if format not in available_formats:
             raise ValueError(
                 f"Unrecognized format={format}. Supported formats are: "
@@ -764,6 +789,10 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         # Check if LiteRT export is available (requires TensorFlow backend)
         if format == "litert" and backend.backend() != "tensorflow":
             raise ImportError("LiteRT export requires TensorFlow backend.")
+
+        # Check if Torch export is available (requires PyTorch backend)
+        if format == "torch" and backend.backend() != "torch":
+            raise ValueError("Torch export requires PyTorch backend.")
 
         if format == "tf_saved_model":
             export_saved_model(
@@ -793,6 +822,14 @@ class Model(Trainer, base_trainer.Trainer, Layer):
             export_litert(
                 self,
                 filepath,
+                input_signature=input_signature,
+                **kwargs,
+            )
+        elif format == "torch":
+            export_torch(
+                self,
+                filepath,
+                verbose=verbose,
                 input_signature=input_signature,
                 **kwargs,
             )


### PR DESCRIPTION
This PR adds torch export path for Keras models using `model.export(..., format="torch")`. It is split out from #22758 so the `.pt2` export support can be reviewed independently from LiteRT conversion.

### What this adds

- Adds `keras.src.export.export_torch` backed by `torch.export.export` and `torch.export.save`.
- Exposes `format="torch"` from `Model.export()` with `.pt2` filepath validation and PyTorch-backend gating.
- Forwards supported `torch.export.export` kwargs, including `strict`, `dynamic_shapes`, `preserve_module_call_signature`, and `prefer_deferred_runtime_asserts_over_guards`.
- Defaults `strict=False` for broader compatibility with Keras models.
- Normalizes single-input `dynamic_shapes` specs for Keras models, whose Torch module signature is `*args, **kwargs`.
- Includes backend Torch fixes needed by real exported models: slice/slice_update tracing, contiguous channels-last transposes, and static-shape-preserving scalar repeat.

### Export flow

```mermaid
flowchart TD
    A[model.export format torch] --> B[Validate .pt2 filepath]
    B --> C[Infer or use input_signature]
    C --> D[Create torch sample inputs]
    D --> E[Normalize torch.export kwargs]
    E --> F[torch.export.export strict false by default]
    F --> G[torch.export.save]
    G --> H[Load later with torch.export.load]
    H --> I[Run ExportedProgram.module]
```

### Tests

- `KERAS_BACKEND=torch PYTHONPATH=/usr/local/google/home/hellorahul/projects/keras /usr/local/google/home/hellorahul/projects/venv313/bin/python -m pytest /usr/local/google/home/hellorahul/projects/keras/keras/src/export/torch_test.py -q --tb=short`
- `KERAS_BACKEND=torch PYTHONPATH=/usr/local/google/home/hellorahul/projects/keras /usr/local/google/home/hellorahul/projects/venv313/bin/python -m pytest /usr/local/google/home/hellorahul/projects/keras/keras/src/ops/core_test.py -q -k "slice" --tb=short`
- `KERAS_BACKEND=torch PYTHONPATH=/usr/local/google/home/hellorahul/projects/keras /usr/local/google/home/hellorahul/projects/venv313/bin/python -m pytest /usr/local/google/home/hellorahul/projects/keras/keras/src/ops/numpy_test.py -q -k "repeat" --tb=short`
- `KERAS_BACKEND=torch PYTHONPATH=/usr/local/google/home/hellorahul/projects/keras /usr/local/google/home/hellorahul/projects/venv313/bin/python -m pytest /usr/local/google/home/hellorahul/projects/keras/keras/src/layers/pooling/adaptive_pooling1d_test.py /usr/local/google/home/hellorahul/projects/keras/keras/src/layers/pooling/adaptive_pooling2d_test.py /usr/local/google/home/hellorahul/projects/keras/keras/src/layers/pooling/adaptive_pooling3d_test.py -q --tb=short`
- Clean temporary worktree: `/usr/local/google/home/hellorahul/.local/bin/pre-commit run --all-files`


- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.