### PR TITLE
Implement segment_min function in keras.ops

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -59,6 +59,7 @@ from keras.src.ops.math import logsumexp as logsumexp
 from keras.src.ops.math import rfft as rfft
 from keras.src.ops.math import rsqrt as rsqrt
 from keras.src.ops.math import segment_max as segment_max
+from keras.src.ops.math import segment_min as segment_min
 from keras.src.ops.math import segment_sum as segment_sum
 from keras.src.ops.math import stft as stft
 from keras.src.ops.math import top_k as top_k

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -59,6 +59,7 @@ from keras.src.ops.math import logsumexp as logsumexp
 from keras.src.ops.math import rfft as rfft
 from keras.src.ops.math import rsqrt as rsqrt
 from keras.src.ops.math import segment_max as segment_max
+from keras.src.ops.math import segment_min as segment_min
 from keras.src.ops.math import segment_sum as segment_sum
 from keras.src.ops.math import stft as stft
 from keras.src.ops.math import top_k as top_k

--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -30,6 +30,17 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
     )
 
 
+def segment_min(data, segment_ids, num_segments=None, sorted=False):
+    if num_segments is None:
+        raise ValueError(
+            "Argument `num_segments` must be set when using the JAX backend. "
+            "Received: num_segments=None"
+        )
+    return jax.ops.segment_min(
+        data, segment_ids, num_segments, indices_are_sorted=sorted
+    )
+
+
 def top_k(x, k, sorted=True):
     # Jax does not supported `sorted`, but in the case where `sorted=False`,
     # order is not guaranteed, so OK to return sorted output.

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -24,6 +24,8 @@ def _segment_reduction_fn(
 
     if reduction_method == np.maximum:
         result = np.ones(data_shape, dtype=valid_data.dtype) * -np.inf
+    elif reduction_method == np.minimum:
+        result = np.ones(data_shape, dtype=valid_data.dtype) * np.inf
     else:
         result = np.zeros(data_shape, dtype=valid_data.dtype)
 

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -51,6 +51,12 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
     )
 
 
+def segment_min(data, segment_ids, num_segments=None, sorted=False):
+    return _segment_reduction_fn(
+        data, segment_ids, np.minimum, num_segments, sorted
+    )
+
+
 def top_k(x, k, sorted=True):
     if sorted:
         # Take the k largest values.

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -77,6 +77,14 @@ def _segment_reduction_fn(
             init_val = np.array(-np.inf, dtype=np.float32)
         else:
             init_val = DTYPES_MIN[data_type]
+    elif reduction_method == "min":
+        from keras.src.backend.openvino.core import DTYPES_MAX
+
+        data_type = data.get_element_type()
+        if data_type.is_real():
+            init_val = np.array(np.inf, dtype=np.float32)
+        else:
+            init_val = DTYPES_MAX[data_type]
     else:
         init_val = 0
 
@@ -106,6 +114,10 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
 
 def segment_max(data, segment_ids, num_segments=None, sorted=False):
     return _segment_reduction_fn(data, segment_ids, "max", num_segments, sorted)
+
+
+def segment_min(data, segment_ids, num_segments=None, sorted=False):
+    return _segment_reduction_fn(data, segment_ids, "min", num_segments, sorted)
 
 
 def top_k(x, k, sorted=True):

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -37,6 +37,22 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
         return tf.math.unsorted_segment_max(data, segment_ids, num_segments)
 
 
+def segment_min(data, segment_ids, num_segments=None, sorted=False):
+    if sorted:
+        if num_segments is not None:
+            raise ValueError(
+                "Argument `num_segments` cannot be set when sorted is True "
+                "when using the tensorflow backend."
+                f"Received: num_segments={num_segments}, sorted={sorted}."
+            )
+        return tf.math.segment_min(data, segment_ids)
+    else:
+        if num_segments is None:
+            unique_segment_ids, _ = tf.unique(segment_ids)
+            num_segments = tf.shape(unique_segment_ids)[0]
+        return tf.math.unsorted_segment_min(data, segment_ids, num_segments)
+
+
 def top_k(x, k, sorted=True):
     return tf.math.top_k(x, k, sorted=sorted)
 

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -61,6 +61,12 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
     return _segment_reduction_fn(data, segment_ids, "amax", num_segments)
 
 
+def segment_min(data, segment_ids, num_segments=None, sorted=False):
+    data = convert_to_tensor(data)
+    segment_ids = convert_to_tensor(segment_ids)
+    return _segment_reduction_fn(data, segment_ids, "amin", num_segments)
+
+
 def top_k(x, k, sorted=True):
     x = convert_to_tensor(x)
     return torch.topk(x, k, sorted=sorted)

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -36,6 +36,8 @@ def _segment_reduction_fn(data, segment_ids, reduction_method, num_segments):
 
     if reduction_method == "amax":
         result = torch.ones(*shape, device=get_device()) * -float("Inf")
+    elif reduction_method == "amin":
+        result = torch.ones(*shape, device=get_device()) * float("Inf")
     else:
         result = torch.zeros(*shape, device=get_device())
 

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -133,6 +133,51 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
     )
 
 
+class SegmentMin(SegmentReduction):
+    def call(self, data, segment_ids):
+        _segment_reduce_validation(data, segment_ids)
+        return backend.math.segment_min(
+            data,
+            segment_ids,
+            num_segments=self.num_segments,
+            sorted=self.sorted,
+        )
+
+
+@keras_export("keras.ops.segment_min")
+def segment_min(data, segment_ids, num_segments=None, sorted=False):
+    """Computes the min of segments in a tensor.
+
+    Args:
+        data: Input tensor.
+        segment_ids: A N-D tensor containing segment indices for each
+            element in `data`. data.shape[:len(segment_ids.shape)] should match.
+        num_segments: An integer representing the total number of
+            segments. If not specified, it is inferred from the maximum
+            value in `segment_ids`.
+        sorted: A boolean indicating whether `segment_ids` is sorted.
+            Defaults to `False`.
+
+    Returns:
+        A tensor containing the min of segments, where each element
+        represents the min of the corresponding segment in `data`.
+
+    Example:
+
+    >>> data = keras.ops.convert_to_tensor([1, 2, 10, 20, 100, 200])
+    >>> segment_ids = keras.ops.convert_to_tensor([0, 0, 1, 1, 2, 2])
+    >>> num_segments = 3
+    >>> keras.ops.segment_min(data, segment_ids, num_segments)
+    array([1, 10, 100], dtype=int32)
+    """
+    _segment_reduce_validation(data, segment_ids)
+    if any_symbolic_tensors((data,)):
+        return SegmentMin(num_segments, sorted).symbolic_call(data, segment_ids)
+    return backend.math.segment_min(
+        data, segment_ids, num_segments=num_segments, sorted=sorted
+    )
+
+
 class TopK(Operation):
     def __init__(self, k, sorted=True, *, name=None):
         super().__init__(name=name)

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1127,6 +1127,24 @@ class SegmentMaxTest(testing.TestCase):
         self.assertAllClose(output, expected_output)
 
 
+class SegmentMinTest(testing.TestCase):
+    def test_segment_min_call(self):
+        data = np.array([[1, 4, 7], [2, 5, 8], [3, 6, 9]], dtype=np.float32)
+        segment_ids = np.array([0, 0, 1], dtype=np.int32)
+        num_segments = 2
+        sorted_segments = False
+
+        segment_min_op = kmath.SegmentMin(
+            num_segments=num_segments, sorted=sorted_segments
+        )
+
+        output = segment_min_op.call(data, segment_ids)
+
+        expected_output = np.array([[1, 4, 7], [3, 6, 9]], dtype=np.float32)
+
+        self.assertAllClose(output, expected_output)
+
+
 class TopKTest(testing.TestCase):
     def test_top_k_call_values(self):
         data = np.array([[1, 3, 2], [4, 6, 5]], dtype=np.float32)


### PR DESCRIPTION
## Description
Adds `keras.ops.segment_min`, which computes the minimum value within each segment of a tensor, based on provided segment IDs.
Compatible across NumPy, TensorFlow, PyTorch, JAX and OpenVino backends.


## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
