### PR TITLE
Fix segment_max: infer num_segments from max(segment_ids) + 1

### DIFF
--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -32,8 +32,7 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
         return tf.math.segment_max(data, segment_ids)
     else:
         if num_segments is None:
-            unique_segment_ids, _ = tf.unique(segment_ids)
-            num_segments = tf.shape(unique_segment_ids)[0]
+            num_segments = tf.cast(tf.reduce_max(segment_ids) + 1, tf.int32)
         return tf.math.unsorted_segment_max(data, segment_ids, num_segments)
 
 

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -19,7 +19,7 @@ def _segment_reduction_fn(data, segment_ids, reduction_method, num_segments):
         .view(*data.shape)
         .type(torch.int64)
     )
-    num_segments = num_segments or len(torch.unique(segment_ids))
+    num_segments = num_segments or torch.max(segment_ids) + 1
 
     # .scatter_add does not support -1 in the indices.
     # Add all out-of-bound indices value to an extra dimension after


### PR DESCRIPTION
## Description
Update num_segments inference logic to correctly derive the number of segments from segment_ids by using max(segment_ids) + 1, instead of using the length of segment_ids. This aligns the implementation with the documented behavior and ensures correct handling of non-dense segment IDs.

```
num_segments: An integer representing the total number of
    segments. If not specified, it is inferred from the maximum
    value in `segment_ids`.
```

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
