### PR TITLE
Fix rel_center_xywh bounding box conversion using wrong height/width multipliers

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/bounding_box.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/bounding_box.py
@@ -318,10 +318,10 @@ class BoundingBox:
         rel_cx, rel_cy, rel_w, rel_h = ops.numpy.split(boxes, 4, axis=-1)
         half_rel_w = rel_w / 2.0
         half_rel_h = rel_h / 2.0
-        x1 = (rel_cx - half_rel_w) * height
-        y1 = (rel_cy - half_rel_h) * width
-        x2 = (rel_cx + half_rel_w) * height
-        y2 = (rel_cy + half_rel_h) * width
+        x1 = (rel_cx - half_rel_w) * width
+        y1 = (rel_cy - half_rel_h) * height
+        x2 = (rel_cx + half_rel_w) * width
+        y2 = (rel_cy + half_rel_h) * height
         return self.backend.numpy.concatenate([x1, y1, x2, y2], axis=-1)
 
     def _xyxy_to_yxyx(self, boxes, height=None, width=None):


### PR DESCRIPTION
The `_rel_center_xywh_to_xyxy` method in `BoundingBox` incorrectly multiplied x-coordinates by `height` and y-coordinates by `width`, producing wrong bounding box coordinates for non-square images.

This 4-line swap fixes the issue.

Fixes #22805

## Contributor Agreement
**Please check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.