### PR TITLE
Add sliding_window to MultiHeadAttention and GroupedQueryAttention

### DIFF
--- a/keras/src/layers/attention/grouped_query_attention.py
+++ b/keras/src/layers/attention/grouped_query_attention.py
@@ -39,11 +39,11 @@ class GroupedQueryAttention(Layer):
         dropout: Dropout probability.
         use_bias: Boolean, whether the dense layers use bias vectors/matrices.
         sliding_window: Optional positive integer. If set, restricts each
-            query position to attend only to the previous
-            `sliding_window - 1` key positions plus itself, producing the
-            local-window pattern used by Mistral, Llama-3 long-context, and
-            Phi-3. Composes naturally with `use_causal_mask=True` to give a
-            causal sliding window. Defaults to `None` (full attention).
+            query position to attend only to key positions within
+            `sliding_window - 1` of itself (a symmetric band). Composes
+            naturally with `use_causal_mask=True` to give the causal
+            sliding window used by Mistral, Llama-3 long-context, and
+            Phi-3. Defaults to `None` (full attention).
         flash_attention: If `None`, the layer attempts to use flash
             attention for faster and more memory-efficient attention
             computations when possible. This behavior can be configured using
@@ -422,9 +422,12 @@ class GroupedQueryAttention(Layer):
         """
         q_seq_length = ops.shape(query)[1]
         v_seq_length = q_seq_length if value is None else ops.shape(value)[1]
-        ones_mask = ops.ones((1, q_seq_length, v_seq_length), dtype="int32")
-        row_index = ops.cumsum(ones_mask, axis=-2)
-        col_index = ops.cumsum(ones_mask, axis=-1)
+        row_index = ops.reshape(
+            ops.arange(q_seq_length, dtype="int32"), (1, q_seq_length, 1)
+        )
+        col_index = ops.reshape(
+            ops.arange(v_seq_length, dtype="int32"), (1, 1, v_seq_length)
+        )
         return ops.less(ops.abs(row_index - col_index), self.sliding_window)
 
     def _compute_attention(

--- a/keras/src/layers/attention/grouped_query_attention.py
+++ b/keras/src/layers/attention/grouped_query_attention.py
@@ -38,6 +38,12 @@ class GroupedQueryAttention(Layer):
         num_key_value_heads: Number of key and value attention heads.
         dropout: Dropout probability.
         use_bias: Boolean, whether the dense layers use bias vectors/matrices.
+        sliding_window: Optional positive integer. If set, restricts each
+            query position to attend only to the previous
+            `sliding_window - 1` key positions plus itself, producing the
+            local-window pattern used by Mistral, Llama-3 long-context, and
+            Phi-3. Composes naturally with `use_causal_mask=True` to give a
+            causal sliding window. Defaults to `None` (full attention).
         flash_attention: If `None`, the layer attempts to use flash
             attention for faster and more memory-efficient attention
             computations when possible. This behavior can be configured using
@@ -101,6 +107,7 @@ class GroupedQueryAttention(Layer):
         num_key_value_heads,
         dropout=0.0,
         use_bias=True,
+        sliding_window=None,
         flash_attention=None,
         kernel_initializer="glorot_uniform",
         bias_initializer="zeros",
@@ -126,6 +133,14 @@ class GroupedQueryAttention(Layer):
         self.dropout = dropout
         self.use_bias = use_bias
         self.use_gate = use_gate
+        if sliding_window is not None and (
+            not isinstance(sliding_window, int) or sliding_window <= 0
+        ):
+            raise ValueError(
+                "`sliding_window` must be `None` or a positive integer. "
+                f"Received: sliding_window={sliding_window}"
+            )
+        self.sliding_window = sliding_window
         self._flash_attention = flash_attention or is_flash_attention_enabled()
         self.kernel_initializer = initializers.get(kernel_initializer)
         self.bias_initializer = initializers.get(bias_initializer)
@@ -354,6 +369,10 @@ class GroupedQueryAttention(Layer):
             # the shape of the causal mask is [1, T, S]
             mask = self._compute_causal_mask(query, value)
             auto_mask = mask if auto_mask is None else auto_mask & mask
+        if self.sliding_window is not None:
+            # the shape of the sliding window mask is [1, T, S]
+            mask = self._compute_sliding_window_mask(query, value)
+            auto_mask = mask if auto_mask is None else auto_mask & mask
         if auto_mask is not None:
             # merge attention_mask & automatic mask, to shape [B, T, S]
             attention_mask = (
@@ -391,6 +410,22 @@ class GroupedQueryAttention(Layer):
         row_index = ops.cumsum(ones_mask, axis=-2)
         col_index = ops.cumsum(ones_mask, axis=-1)
         return ops.greater_equal(row_index, col_index)
+
+    def _compute_sliding_window_mask(self, query, value=None):
+        """Computes a banded sliding-window mask of shape `(1, T, S)`.
+
+        Returns a symmetric band where each query position attends to keys
+        within `self.sliding_window - 1` positions on either side. When
+        ANDed with a causal mask, this yields the canonical causal
+        sliding-window pattern used by Mistral, Llama-3 long-context, and
+        Phi-3.
+        """
+        q_seq_length = ops.shape(query)[1]
+        v_seq_length = q_seq_length if value is None else ops.shape(value)[1]
+        ones_mask = ops.ones((1, q_seq_length, v_seq_length), dtype="int32")
+        row_index = ops.cumsum(ones_mask, axis=-2)
+        col_index = ops.cumsum(ones_mask, axis=-1)
+        return ops.less(ops.abs(row_index - col_index), self.sliding_window)
 
     def _compute_attention(
         self, query, key, value, attention_mask=None, training=None
@@ -539,6 +574,7 @@ class GroupedQueryAttention(Layer):
             "num_key_value_heads": self.num_key_value_heads,
             "use_bias": self.use_bias,
             "use_gate": self.use_gate,
+            "sliding_window": self.sliding_window,
             "dropout": self.dropout,
             "kernel_initializer": initializers.serialize(
                 self.kernel_initializer

--- a/keras/src/layers/attention/grouped_query_attention_test.py
+++ b/keras/src/layers/attention/grouped_query_attention_test.py
@@ -5,6 +5,7 @@ from absl.testing import parameterized
 from keras.src import backend
 from keras.src import initializers
 from keras.src import layers
+from keras.src import ops
 from keras.src import testing
 from keras.src.backend.config import disable_flash_attention
 from keras.src.backend.config import enable_flash_attention
@@ -378,6 +379,47 @@ class GroupedQueryAttentionTest(testing.TestCase):
             query=masked_query, value=masked_value, attention_mask=mask
         )
         self.assertAllClose(output, output_with_manual_mask)
+
+    def test_sliding_window(self):
+        layer = layers.GroupedQueryAttention(
+            head_dim=4,
+            num_query_heads=4,
+            num_key_value_heads=2,
+            sliding_window=3,
+        )
+        x = np.random.RandomState(0).randn(1, 6, 8).astype("float32")
+        _, scores = layer(
+            x, x, use_causal_mask=True, return_attention_scores=True
+        )
+        scores = ops.convert_to_numpy(scores)[0, 0]
+        for i in range(scores.shape[0]):
+            for j in range(scores.shape[1]):
+                in_window = (j <= i) and (i - j < 3)
+                if in_window:
+                    self.assertGreater(scores[i, j], 0.0)
+                else:
+                    self.assertEqual(scores[i, j], 0.0)
+
+    def test_sliding_window_validation(self):
+        with self.assertRaisesRegex(ValueError, "sliding_window"):
+            layers.GroupedQueryAttention(
+                head_dim=2,
+                num_query_heads=2,
+                num_key_value_heads=2,
+                sliding_window=0,
+            )
+
+    def test_sliding_window_serialization(self):
+        layer = layers.GroupedQueryAttention(
+            head_dim=4,
+            num_query_heads=2,
+            num_key_value_heads=2,
+            sliding_window=5,
+        )
+        config = layer.get_config()
+        self.assertEqual(config["sliding_window"], 5)
+        restored = layers.GroupedQueryAttention.from_config(config)
+        self.assertEqual(restored.sliding_window, 5)
 
     @parameterized.named_parameters(
         ("disable_flash_attention", False), ("enable_flash_attention", True)

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -52,6 +52,12 @@ class MultiHeadAttention(Layer):
             feature dim (the query input's last dimension).
         attention_axes: axes over which the attention is applied. `None` means
             attention over all axes, but batch, heads, and features.
+        sliding_window: Optional positive integer. If set, restricts each
+            query position to attend only to the previous
+            `sliding_window - 1` key positions plus itself, producing the
+            local-window pattern used by Mistral, Llama-3 long-context, and
+            Phi-3. Composes naturally with `use_causal_mask=True` to give a
+            causal sliding window. Defaults to `None` (full attention).
         flash_attention: If `None`, the layer attempts to use flash
             attention for faster and more memory-efficient attention
             computations when possible. This behavior can be configured using
@@ -115,6 +121,7 @@ class MultiHeadAttention(Layer):
         use_bias=True,
         output_shape=None,
         attention_axes=None,
+        sliding_window=None,
         flash_attention=None,
         kernel_initializer="glorot_uniform",
         bias_initializer="zeros",
@@ -163,6 +170,14 @@ class MultiHeadAttention(Layer):
                 f"Received: attention_axes={attention_axes}"
             )
         self._attention_axes = attention_axes
+        if sliding_window is not None and (
+            not isinstance(sliding_window, int) or sliding_window <= 0
+        ):
+            raise ValueError(
+                "`sliding_window` must be `None` or a positive integer. "
+                f"Received: sliding_window={sliding_window}"
+            )
+        self._sliding_window = sliding_window
         self.seed = seed
 
         self._inverse_sqrt_key_dim = 1.0 / math.sqrt(float(self._key_dim))
@@ -212,6 +227,7 @@ class MultiHeadAttention(Layer):
             "use_gate": self._use_gate,
             "output_shape": self._output_shape,
             "attention_axes": self._attention_axes,
+            "sliding_window": self._sliding_window,
             "kernel_initializer": initializers.serialize(
                 self._kernel_initializer
             ),
@@ -669,6 +685,10 @@ class MultiHeadAttention(Layer):
             # the shape of the causal mask is [1, T, S]
             mask = self._compute_causal_mask(query, value)
             auto_mask = mask if auto_mask is None else auto_mask & mask
+        if self._sliding_window is not None:
+            # the shape of the sliding window mask is [1, T, S]
+            mask = self._compute_sliding_window_mask(query, value)
+            auto_mask = mask if auto_mask is None else auto_mask & mask
 
         if attention_mask is not None:
             attention_mask = ops.cast(attention_mask, "bool")
@@ -709,6 +729,22 @@ class MultiHeadAttention(Layer):
         row_index = ops.cumsum(ones_mask, axis=-2)
         col_index = ops.cumsum(ones_mask, axis=-1)
         return ops.greater_equal(row_index, col_index)
+
+    def _compute_sliding_window_mask(self, query, value=None):
+        """Computes a banded sliding-window mask of shape `(1, T, S)`.
+
+        Returns a symmetric band where each query position attends to keys
+        within `self._sliding_window - 1` positions on either side. When
+        ANDed with a causal mask, this yields the canonical causal
+        sliding-window pattern used by Mistral, Llama-3 long-context, and
+        Phi-3.
+        """
+        q_seq_length = ops.shape(query)[1]
+        v_seq_length = q_seq_length if value is None else ops.shape(value)[1]
+        ones_mask = ops.ones((1, q_seq_length, v_seq_length), dtype="int32")
+        row_index = ops.cumsum(ones_mask, axis=-2)
+        col_index = ops.cumsum(ones_mask, axis=-1)
+        return ops.less(ops.abs(row_index - col_index), self._sliding_window)
 
     def compute_output_shape(
         self,

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -53,11 +53,11 @@ class MultiHeadAttention(Layer):
         attention_axes: axes over which the attention is applied. `None` means
             attention over all axes, but batch, heads, and features.
         sliding_window: Optional positive integer. If set, restricts each
-            query position to attend only to the previous
-            `sliding_window - 1` key positions plus itself, producing the
-            local-window pattern used by Mistral, Llama-3 long-context, and
-            Phi-3. Composes naturally with `use_causal_mask=True` to give a
-            causal sliding window. Defaults to `None` (full attention).
+            query position to attend only to key positions within
+            `sliding_window - 1` of itself (a symmetric band). Composes
+            naturally with `use_causal_mask=True` to give the causal
+            sliding window used by Mistral, Llama-3 long-context, and
+            Phi-3. Defaults to `None` (full attention).
         flash_attention: If `None`, the layer attempts to use flash
             attention for faster and more memory-efficient attention
             computations when possible. This behavior can be configured using
@@ -741,9 +741,12 @@ class MultiHeadAttention(Layer):
         """
         q_seq_length = ops.shape(query)[1]
         v_seq_length = q_seq_length if value is None else ops.shape(value)[1]
-        ones_mask = ops.ones((1, q_seq_length, v_seq_length), dtype="int32")
-        row_index = ops.cumsum(ones_mask, axis=-2)
-        col_index = ops.cumsum(ones_mask, axis=-1)
+        row_index = ops.reshape(
+            ops.arange(q_seq_length, dtype="int32"), (1, q_seq_length, 1)
+        )
+        col_index = ops.reshape(
+            ops.arange(v_seq_length, dtype="int32"), (1, 1, v_seq_length)
+        )
         return ops.less(ops.abs(row_index - col_index), self._sliding_window)
 
     def compute_output_shape(

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -490,6 +490,54 @@ class MultiHeadAttentionTest(testing.TestCase):
             _ = layer(query=masked_query, value=masked_value)
             self.assertLen(warning_logs, 0)
 
+    def test_sliding_window(self):
+        # Causal sliding window of size 3: each query should only attend to
+        # itself and the previous 2 keys. Verified via attention scores.
+        layer = layers.MultiHeadAttention(
+            num_heads=2, key_dim=4, sliding_window=3
+        )
+        x = np.random.RandomState(0).randn(1, 6, 8).astype("float32")
+        _, scores = layer(
+            x, x, use_causal_mask=True, return_attention_scores=True
+        )
+        scores = ops.convert_to_numpy(scores)[0, 0]  # (T, T) for first head
+        for i in range(scores.shape[0]):
+            for j in range(scores.shape[1]):
+                in_window = (j <= i) and (i - j < 3)
+                if in_window:
+                    self.assertGreater(scores[i, j], 0.0)
+                else:
+                    self.assertEqual(scores[i, j], 0.0)
+
+        # Bidirectional sliding window of size 3 (no causal mask): each
+        # query should attend to keys within `|i - j| < 3`.
+        layer = layers.MultiHeadAttention(
+            num_heads=2, key_dim=4, sliding_window=3
+        )
+        _, scores = layer(x, x, return_attention_scores=True)
+        scores = ops.convert_to_numpy(scores)[0, 0]
+        for i in range(scores.shape[0]):
+            for j in range(scores.shape[1]):
+                if abs(i - j) < 3:
+                    self.assertGreater(scores[i, j], 0.0)
+                else:
+                    self.assertEqual(scores[i, j], 0.0)
+
+    def test_sliding_window_validation(self):
+        with self.assertRaisesRegex(ValueError, "sliding_window"):
+            layers.MultiHeadAttention(num_heads=2, key_dim=4, sliding_window=0)
+        with self.assertRaisesRegex(ValueError, "sliding_window"):
+            layers.MultiHeadAttention(num_heads=2, key_dim=4, sliding_window=-3)
+
+    def test_sliding_window_serialization(self):
+        layer = layers.MultiHeadAttention(
+            num_heads=2, key_dim=4, sliding_window=5
+        )
+        config = layer.get_config()
+        self.assertEqual(config["sliding_window"], 5)
+        restored = layers.MultiHeadAttention.from_config(config)
+        self.assertEqual(restored._sliding_window, 5)
+
     @parameterized.named_parameters(
         ("disable_flash_attention", False), ("enable_flash_attention", True)
     )


### PR DESCRIPTION
## Description

Adds a `sliding_window` parameter to `MultiHeadAttention` and `GroupedQueryAttention`. When set to a positive integer, each query position attends to keys within `sliding_window - 1` positions on either side, producing the local-window pattern used by Mistral, Llama-3 long-context, and Phi-3. When combined with `use_causal_mask=True`, it yields the canonical causal sliding-window attention.

```python
mha = layers.MultiHeadAttention(num_heads=8, key_dim=64, sliding_window=128)
out = mha(query, value, use_causal_mask=True)  # causal sliding window
```

The mask is a symmetric band of width `2 * sliding_window - 1`, ANDed into the existing attention mask alongside the causal mask. This composes naturally with `attention_mask`, key/value masks, and causal masks.

The default `sliding_window=None` preserves existing behavior (full attention).

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.