### PR TITLE
Fix Keras LiteRT export for Keras 3 + TF 2.20 + Python 3.13

### DIFF
--- a/keras/src/export/litert.py
+++ b/keras/src/export/litert.py
@@ -1,6 +1,6 @@
-from keras.src import layers
-from keras.src import models
-from keras.src import tree
+import functools
+import tempfile
+
 from keras.src.export.export_utils import get_input_signature
 from keras.src.utils import io_utils
 from keras.src.utils.module_utils import tensorflow as tf
@@ -67,161 +67,63 @@ class LiteRTExporter:
         Returns:
             Path to exported model
         """
-        # 1. Resolve / infer input signature
         if self.input_signature is None:
-            # Use the standard get_input_signature which handles all model types
-            # and preserves nested structures (dicts, lists, etc.)
             self.input_signature = get_input_signature(self.model)
 
-        # 2. Determine input structure and create adapter if needed
-        # There are 3 cases:
-        # Case 1: Single input (not nested)
-        # Case 2: Flat list of inputs (list where flattened == original)
-        # Case 3: Nested structure (dicts, nested lists, etc.)
+        # Normalize input_signature for tf.function: must be a list/tuple
+        # of specs, one per positional argument. Wrap bare structures as
+        # a single argument.
+        if not isinstance(self.input_signature, (list, tuple)):
+            self.input_signature = [self.input_signature]
 
-        # Special handling for Functional models: get_input_signature wraps
-        # the structure in a list, so unwrap it for analysis
-        input_struct = self.input_signature
-        if (
-            isinstance(self.input_signature, list)
-            and len(self.input_signature) == 1
-        ):
-            input_struct = self.input_signature[0]
-
-        if not tree.is_nested(input_struct):
-            # Case 1: Single input - use as-is
-            model_to_convert = self.model
-            signature_for_conversion = self.input_signature
-        elif isinstance(input_struct, list) and len(input_struct) == len(
-            tree.flatten(input_struct)
-        ):
-            # Case 2: Flat list of inputs - use as-is
-            model_to_convert = self.model
-            signature_for_conversion = self.input_signature
-        else:
-            # Case 3: Nested structure (dict, nested lists, etc.)
-            # Create adapter model that converts flat list to nested structure
-            adapted_model = self._create_nested_inputs_adapter(input_struct)
-
-            # Flatten signature for TFLite conversion
-            signature_for_conversion = tree.flatten(input_struct)
-
-            # Use adapted model and flat list signature for conversion
-            model_to_convert = adapted_model
-
-        # Store original model reference for later use
-        original_model = self.model
-
-        # Temporarily replace self.model with the model to convert
-        self.model = model_to_convert
-
-        try:
-            # Convert the model to TFLite.
-            tflite_model = self._convert_to_tflite(signature_for_conversion)
-        finally:
-            # Restore original model
-            self.model = original_model
-
-        # Save the TFLite model to the specified file path.
         if not filepath.endswith(".tflite"):
             raise ValueError(
                 f"The LiteRT export requires the filepath to end with "
                 f"'.tflite'. Got: {filepath}"
             )
 
+        tflite_model = self._convert_to_tflite(self.input_signature)
+
         with open(filepath, "wb") as f:
             f.write(tflite_model)
 
         return filepath
 
-    def _create_nested_inputs_adapter(self, input_signature_struct):
-        """Create an adapter model that converts flat list inputs to nested
-        structure.
-
-        This adapter allows models expecting nested inputs (dicts, lists, etc.)
-        to be exported to TFLite format (which only supports positional/list
-        inputs).
-
-        Args:
-            input_signature_struct: Nested structure of InputSpecs (dict, list,
-                etc.)
-
-        Returns:
-            A Functional model that accepts flat list inputs and converts to
-            nested
-        """
-        # Get flat paths to preserve names and print input mapping
-        paths_and_specs = tree.flatten_with_path(input_signature_struct)
-        paths = [".".join(str(e) for e in p) for p, v in paths_and_specs]
-        io_utils.print_msg(f"Creating adapter for inputs: {paths}")
-
-        # Create Input layers for TFLite (flat list-based)
-        input_layers = []
-        for path, spec in paths_and_specs:
-            # Extract the input name from spec or path
-            name = (
-                spec.name
-                if hasattr(spec, "name") and spec.name
-                else (str(path[-1]) if path else "input")
-            )
-
-            input_layer = layers.Input(
-                shape=spec.shape[1:],  # Remove batch dimension
-                dtype=spec.dtype,
-                name=name,
-            )
-            input_layers.append(input_layer)
-
-        # Reconstruct the nested structure from flat list
-        inputs_structure = tree.pack_sequence_as(
-            input_signature_struct, input_layers
-        )
-
-        # Call the original model with nested inputs
-        outputs = self.model(inputs_structure)
-
-        # Build as Functional model (flat list inputs -> nested -> model ->
-        # output)
-        adapted_model = models.Model(inputs=input_layers, outputs=outputs)
-
-        # Preserve the original model's variables
-        adapted_model._variables = self.model.variables
-        adapted_model._trainable_variables = self.model.trainable_variables
-        adapted_model._non_trainable_variables = (
-            self.model.non_trainable_variables
-        )
-
-        return adapted_model
-
     def _convert_to_tflite(self, input_signature):
         """Converts the Keras model to TFLite format.
+
+        Uses Keras ExportArchive as an intermediate SavedModel step.
+        This aligns with TensorFlow's official Keras 3 TFLite conversion path:
+        ExportArchive -> SavedModel -> from_saved_model.
+
+        Args:
+            input_signature: Input signature for the model to convert.
 
         Returns:
             A bytes object containing the serialized TFLite model.
         """
-        # Try direct conversion first for all models
-        try:
-            converter = tf.lite.TFLiteConverter.from_keras_model(self.model)
+        from keras.src import export as keras_export
+
+        with tempfile.TemporaryDirectory() as saved_model_dir:
+            archive = keras_export.ExportArchive()
+            archive.track(self.model)
+            archive.add_endpoint(
+                "serve",
+                functools.partial(self.model.__call__, training=False),
+                input_signature=input_signature,
+            )
+            archive.write_out(saved_model_dir, verbose=False)
+
+            converter = tf.lite.TFLiteConverter.from_saved_model(
+                saved_model_dir
+            )
             converter.target_spec.supported_ops = [
                 tf.lite.OpsSet.TFLITE_BUILTINS,
                 tf.lite.OpsSet.SELECT_TF_OPS,
             ]
-            # Keras 3 only supports resource variables
             converter.experimental_enable_resource_variables = True
-
-            # Apply any additional converter settings from kwargs
             self._apply_converter_kwargs(converter)
-
-            tflite_model = converter.convert()
-
-            return tflite_model
-
-        except Exception as e:
-            # If direct conversion fails, raise the error with helpful message
-            raise RuntimeError(
-                f"Direct TFLite conversion failed. This may be due to model "
-                f"complexity or unsupported operations. Error: {e}"
-            ) from e
+            return converter.convert()
 
     def _apply_converter_kwargs(self, converter):
         """Apply additional converter settings from kwargs.

--- a/keras/src/export/litert_test.py
+++ b/keras/src/export/litert_test.py
@@ -12,35 +12,18 @@ from keras.src import testing
 from keras.src import tree
 from keras.src.saving import saving_lib
 from keras.src.testing.test_utils import named_product
-from keras.src.utils.module_utils import litert
 from keras.src.utils.module_utils import tensorflow
 
-# Set up LiteRT interpreter with fallback logic:
-# 1. Try AI Edge LiteRT interpreter (preferred)
-# 2. Fall back to TensorFlow Lite interpreter if AI Edge LiteRT unavailable
-AI_EDGE_LITERT_AVAILABLE = False
-LiteRTInterpreter = None
+# LiteRT tests require the AI Edge LiteRT interpreter.
+if backend.backend() != "tensorflow":
+    LiteRTInterpreter = None
+else:
+    try:
+        from ai_edge_litert.interpreter import Interpreter as LiteRTInterpreter
+    except (ImportError, OSError):
+        LiteRTInterpreter = None
 
-if backend.backend() == "tensorflow":
-    if litert.available:
-        try:
-            from ai_edge_litert.interpreter import (
-                Interpreter as LiteRTInterpreter,
-            )
-
-            AI_EDGE_LITERT_AVAILABLE = True
-        except (ImportError, OSError):
-            LiteRTInterpreter = tensorflow.lite.Interpreter
-    else:
-        LiteRTInterpreter = tensorflow.lite.Interpreter
-
-# Model types to test (LSTM only if AI Edge LiteRT is available)
 model_types = ["sequential", "functional"]
-# TODO(#21914): `"lstm"` does not work with ai-edge-litert==1.3.0.
-# Unfortunately, for TF 2.20.0, this is the only version which works. Uncomment
-# this part when we upgrade TF and ai-edge-litert.
-# if AI_EDGE_LITERT_AVAILABLE:
-#     model_types.append("lstm")
 
 
 class CustomModel(models.Model):
@@ -176,15 +159,12 @@ def _get_interpreter_outputs(interpreter):
 class ExportLitertTest(testing.TestCase):
     """Test suite for LiteRT (TFLite) model export functionality.
 
-    Tests use AI Edge LiteRT interpreter when available, otherwise fall back
-    to TensorFlow Lite interpreter for validation.
+    Tests use AI Edge LiteRT interpreter for validation.
     """
 
     @parameterized.named_parameters(named_product(model_type=model_types))
     def test_standard_model_export(self, model_type):
         """Test exporting standard model types to LiteRT format."""
-        if model_type == "lstm" and not AI_EDGE_LITERT_AVAILABLE:
-            self.skipTest("LSTM models require AI Edge LiteRT interpreter.")
 
         temp_filepath = os.path.join(
             self.get_temp_dir(), "exported_model.tflite"
@@ -1039,8 +1019,8 @@ class ExportLitertTest(testing.TestCase):
                 sig_output_values[i], ref_out, atol=1e-4, rtol=1e-4
             )
 
-    def test_dict_input_adapter_creation(self):
-        """Test that dict input adapter is created and works correctly."""
+    def test_dict_input_native(self):
+        """Test that dict inputs are handled natively without adapter."""
 
         # Create a model with dictionary inputs
         input1 = layers.Input(shape=(10,), name="x")
@@ -1049,11 +1029,11 @@ class ExportLitertTest(testing.TestCase):
         model = models.Model(inputs={"x": input1, "y": input2}, outputs=output)
 
         temp_filepath = os.path.join(
-            self.get_temp_dir(), "dict_adapter_model.tflite"
+            self.get_temp_dir(), "dict_native_model.tflite"
         )
 
-        # Export with verbose to verify adapter creation messages
-        model.export(temp_filepath, format="litert", verbose=True)
+        # Export the model
+        model.export(temp_filepath, format="litert")
 
         # Verify the file was created
         self.assertTrue(os.path.exists(temp_filepath))
@@ -1062,7 +1042,7 @@ class ExportLitertTest(testing.TestCase):
         interpreter = LiteRTInterpreter(model_path=temp_filepath)
         interpreter.allocate_tensors()
 
-        # Check input details - should have 2 inputs in list form
+        # Check input details - should have 2 inputs
         input_details = interpreter.get_input_details()
         self.assertEqual(len(input_details), 2)
 
@@ -1080,8 +1060,8 @@ class ExportLitertTest(testing.TestCase):
             )
         )
 
-        # Set inputs as list (adapter converts list to dict internally)
-        _set_interpreter_inputs(interpreter, [x_val, y_val])
+        # Set inputs as dict (native dict support)
+        _set_interpreter_inputs(interpreter, {"x": x_val, "y": y_val})
         interpreter.invoke()
         litert_output = _get_interpreter_outputs(interpreter)
 
@@ -1136,10 +1116,14 @@ class ExportLitertTest(testing.TestCase):
             self.get_temp_dir(), "dict_custom_sig_model.tflite"
         )
 
-        # Provide custom dict input signature
+        # Provide custom dict input signature with names
         input_signature = {
-            "input_x": layers.InputSpec(shape=(None, 10), dtype="float32"),
-            "input_y": layers.InputSpec(shape=(None, 10), dtype="float32"),
+            "input_x": layers.InputSpec(
+                shape=(None, 10), dtype="float32", name="input_x"
+            ),
+            "input_y": layers.InputSpec(
+                shape=(None, 10), dtype="float32", name="input_y"
+            ),
         }
 
         model.export(
@@ -1166,7 +1150,9 @@ class ExportLitertTest(testing.TestCase):
             )
         )
 
-        _set_interpreter_inputs(interpreter, [x_val, y_val])
+        _set_interpreter_inputs(
+            interpreter, {"input_x": x_val, "input_y": y_val}
+        )
         interpreter.invoke()
         litert_output = _get_interpreter_outputs(interpreter)
 
@@ -1213,7 +1199,9 @@ class ExportLitertTest(testing.TestCase):
 
         interpreter = LiteRTInterpreter(model_path=temp_filepath)
         interpreter.allocate_tensors()
-        _set_interpreter_inputs(interpreter, [tokens_val, mask_val])
+        _set_interpreter_inputs(
+            interpreter, {"tokens": tokens_val, "mask": mask_val}
+        )
         interpreter.invoke()
         litert_output = _get_interpreter_outputs(interpreter)
 
@@ -1270,7 +1258,9 @@ class ExportLitertTest(testing.TestCase):
             )
         )
 
-        _set_interpreter_inputs(interpreter, [a_val, b_val])
+        _set_interpreter_inputs(
+            interpreter, {"branch_a": a_val, "branch_b": b_val}
+        )
         interpreter.invoke()
         litert_output = _get_interpreter_outputs(interpreter)
 

--- a/keras/src/export/saved_model_export_archive.py
+++ b/keras/src/export/saved_model_export_archive.py
@@ -373,7 +373,16 @@ class SavedModelExportArchive:
 
             if hasattr(self, "_tracked"):
                 for root in self._tracked:
-                    descendants = SavedModelTrackableView(root).descendants()
+                    try:
+                        descendants = SavedModelTrackableView(
+                            root
+                        ).descendants()
+                    except TypeError:
+                        # Python 3.13 + wrapt.ObjectProxy incompatibility:
+                        # inspect.getattr_static calls object.__getattribute__
+                        # on _DictWrapper objects, which raises TypeError.
+                        # Skip lookup-table tracking for this root.
+                        continue
                     for trackable in descendants:
                         if isinstance(trackable, TrackableResource):
                             self._tf_trackable._misc_assets.append(trackable)


### PR DESCRIPTION
## Fix Keras LiteRT Export for Keras 3 + TF 2.20 + Python 3.13

**Upstream bug:** https://github.com/tensorflow/tensorflow/issues/117453

### The Problem: Circular Dependency + Python 3.13 Incompatibility

The old `litert.py` called `tf.lite.TFLiteConverter.from_keras_model(model)`. This created a **circular dependency** that crashed on Keras 3 + TF 2.20 + Python 3.13:

```
Keras litert.py
    ↓ calls TF
TensorFlow TFLiteConverter.from_keras_model()
    ↓ sees Keras 3 model, imports
Keras ExportArchive(model)
    ↓ calls TF
TensorFlow saved_model.save(_tf_trackable)
    ↓ walks trackables with
TF SavedModelTrackableView.descendants()
    ↓ calls children() → is_tf_type() on
Keras _DictWrapper (wrapt.ObjectProxy)
    ↓ Python 3.13 inspect.getattr_static crashes on
ObjectProxy.__dict__ descriptor
    ↓
💥 TypeError: 'NoneType' object is not callable
```

There are **two independent crash points** in this loop:

1. **`_DictWrapper` + `wrapt.ObjectProxy` + Python 3.13**: TF 2.20's `tensor_util.is_tf_type()` calls `typing.Protocol.__instancecheck__()`, which uses `inspect.getattr_static()` to access `__dict__`. On Python 3.13, `wrapt.ObjectProxy`'s `__dict__` descriptor is incompatible with `getattr_static`, producing `TypeError`. This was fixed in TF main (commits `e1fab9f0bba`, `80c1d06aa8f`) but not backported to 2.20.

2. **`keras_deps` bridge unregistered**: If the SavedModel path fails, TF's converter falls back to `_freeze_keras_model()` → `_trace_model_call()` → `keras_deps.get_call_context_function()()`. Keras 3 never registered this function, so it returns `None` → `TypeError: 'NoneType' object is not callable`.

### The Solution: Eliminate the Circular Dependency

Instead of handing the model to TF's `from_keras_model()` (which then re-imports Keras `ExportArchive`), we create `ExportArchive` **directly in Keras** and pass the resulting SavedModel to TF's `from_saved_model()`. This is TensorFlow's official Keras 3 conversion path.

```mermaid
flowchart TB
    subgraph OLD["❌ BROKEN: from_keras_model path"]
        K1["Keras litert.py"]
        T1["TF from_keras_model()"]
        K2["Keras ExportArchive"]
        T2["TF saved_model.save()"]
        T3["TrackableView.descendants()"]
        E1["💥 TypeError"]
        T4["_trace_model_call() fallback"]
        E2["💥 TypeError"]

        K1 --> T1
        T1 --> K2
        K2 --> T2
        T2 --> T3
        T3 --> E1
        T2 -.-> T4
        T4 --> E2
    end

    subgraph NEW["✅ FIXED: direct ExportArchive path"]
        K3["Keras litert.py"]
        K4["Keras ExportArchive"]
        T5["TF saved_model.save()"]
        T6["TF from_saved_model()"]
        E3["✅ .tflite"]

        K3 --> K4
        K4 --> T5
        T5 --> T6
        T6 --> E3
    end

    style E1 fill:#ffcdd2,stroke:#c62828
    style E2 fill:#ffcdd2,stroke:#c62828
    style E3 fill:#c8e6c9,stroke:#2e7d32
```

**Why this fixes both crashes:**
- **Crash 1 eliminated**: By controlling `ExportArchive` from Keras directly, we avoid TF's `from_keras_model()` code path entirely. The `_DictWrapper` issue in `SavedModelTrackableView` is also guarded with `try/except TypeError` (see change 2 below).
- **Crash 2 eliminated**: The `_freeze_keras_model()` fallback only exists in `from_keras_model()`. We never call it.

### Changes

#### 1. `keras/src/export/litert.py` — Complete rewrite of conversion path

| Before | After |
|--------|-------|
| `tf.lite.TFLiteConverter.from_keras_model(self.model)` | `ExportArchive` → `write_out()` → `tf.lite.TFLiteConverter.from_saved_model(saved_model_dir)` |
| 3-case adapter branching (single / flat list / nested) | Single path for all model types |
| `_create_nested_inputs_adapter()` wrapper model | Removed — dict inputs handled natively by SavedModel signatures |
| `try/except` around conversion with vague error message | Direct conversion, clear error propagation |

**Key code:**
```python
with tempfile.TemporaryDirectory() as saved_model_dir:
    archive = keras_export.ExportArchive()
    archive.track(self.model)
    archive.add_endpoint(
        "serve",
        functools.partial(self.model.__call__, training=False),
        input_signature=input_signature,
    )
    archive.write_out(saved_model_dir, verbose=False)

    converter = tf.lite.TFLiteConverter.from_saved_model(saved_model_dir)
    converter.target_spec.supported_ops = [
        tf.lite.OpsSet.TFLITE_BUILTINS,
        tf.lite.OpsSet.SELECT_TF_OPS,
    ]
    converter.experimental_enable_resource_variables = True
    return converter.convert()
```

#### 2. `keras/src/export/saved_model_export_archive.py` — Guard + context manager

Master already has `_patch_tf_is_tf_type_for_object_proxy()` (a context-manager backport of TF main's fix). This PR adds a defensive `try/except TypeError` around `SavedModelTrackableView(root).descendants()` so that even if the `is_tf_type` patch misses a case, the export continues (skipping lookup-table tracking for that root instead of crashing).

```python
if hasattr(self, "_tracked"):
    for root in self._tracked:
        try:
            descendants = SavedModelTrackableView(root).descendants()
        except TypeError:
            # Python 3.13 + wrapt.ObjectProxy incompatibility
            continue
        for trackable in descendants:
            ...
```

#### 3. `keras/src/export/litert_test.py` — Test updates

- **Removed `tf.lite.Interpreter` fallback** — tests now require `ai_edge_litert` interpreter exclusively
- Dict-input tests feed dicts natively to interpreter (no adapter flattening)
- Custom signature tests include `name=` in `InputSpec` to preserve TFLite input names


## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
