### PR TITLE
Add masking test for RNN layer

### DIFF
--- a/keras/src/layers/rnn/rnn_test.py
+++ b/keras/src/layers/rnn/rnn_test.py
@@ -414,4 +414,78 @@ class RNNTest(testing.TestCase):
             x_bad = ops.random.uniform(shape=(1, timesteps, features))
             model(x_bad)
 
-    # TODO: test masking
+    def test_masking(self):
+        sequence = np.arange(24).reshape((2, 4, 3)).astype("float32")
+        mask = np.array([[True, True, True, False], [True, True, False, False]])
+
+        # Test unroll=False, return_sequences=False
+        layer = layers.RNN(OneStateRNNCell(2), unroll=False)
+        output = layer(sequence, mask=mask)
+        self.assertAllClose(
+            output,
+            np.array([[57.0, 57.0], [126.0, 126.0]]),
+            atol=1e-5,
+            rtol=1e-5,
+            tpu_atol=1e-3,
+            tpu_rtol=1e-3,
+        )
+
+        # Test unroll=True, return_sequences=False
+        layer = layers.RNN(OneStateRNNCell(2), unroll=True)
+        output = layer(sequence, mask=mask)
+        self.assertAllClose(
+            output,
+            np.array([[57.0, 57.0], [126.0, 126.0]]),
+            atol=1e-5,
+            rtol=1e-5,
+            tpu_atol=1e-3,
+            tpu_rtol=1e-3,
+        )
+
+        # Test unroll=False, return_sequences=True
+        layer = layers.RNN(
+            OneStateRNNCell(2), return_sequences=True, unroll=False
+        )
+        output = layer(sequence, mask=mask)
+        self.assertAllClose(
+            output,
+            np.array(
+                [
+                    [[3.0, 3.0], [18.0, 18.0], [57.0, 57.0], [57.0, 57.0]],
+                    [
+                        [39.0, 39.0],
+                        [126.0, 126.0],
+                        [126.0, 126.0],
+                        [126.0, 126.0],
+                    ],
+                ]
+            ),
+            atol=1e-5,
+            rtol=1e-5,
+            tpu_atol=1e-3,
+            tpu_rtol=1e-3,
+        )
+
+        # Test unroll=True, return_sequences=True
+        layer = layers.RNN(
+            OneStateRNNCell(2), return_sequences=True, unroll=True
+        )
+        output = layer(sequence, mask=mask)
+        self.assertAllClose(
+            output,
+            np.array(
+                [
+                    [[3.0, 3.0], [18.0, 18.0], [57.0, 57.0], [57.0, 57.0]],
+                    [
+                        [39.0, 39.0],
+                        [126.0, 126.0],
+                        [126.0, 126.0],
+                        [126.0, 126.0],
+                    ],
+                ]
+            ),
+            atol=1e-5,
+            rtol=1e-5,
+            tpu_atol=1e-3,
+            tpu_rtol=1e-3,
+        )


### PR DESCRIPTION
## Description
This PR implements the missing test case for masking in the base `RNN` layer (`# TODO: test masking` in `keras/src/layers/rnn/rnn_test.py`).

**Changes:**
- Added a `test_masking` method inside `RNNTest`.
- Uses `OneStateRNNCell` with dummy input sequences and boolean masks.
- Explicitly tests the combinations of `unroll=True/False` and `return_sequences=True/False` to verify that masked timesteps correctly propagate states and handle sequence outputs.
- Ensures numerical alignment with expected masking behavior in the test assertions.

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
