### PR TITLE
Fix torch convert_to_tensor: honor explicit dtype for Python scalars

### DIFF
--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -207,19 +207,18 @@ def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
         if dtype is not None:
             x = x.to(to_torch_dtype(dtype))
         return x
-    if dtype is None:
-        if isinstance(x, bool):
-            return torch.as_tensor(x, dtype=torch.bool, device=get_device())
+    if isinstance(x, (bool, int, float, complex)):
+        if dtype is not None:
+            dt = to_torch_dtype(dtype)
+        elif isinstance(x, bool):
+            dt = torch.bool
         elif isinstance(x, int):
-            if x < -(2**31) or x >= 2**31:
-                return torch.as_tensor(
-                    x, dtype=torch.int64, device=get_device()
-                )
-            return torch.as_tensor(x, dtype=torch.int32, device=get_device())
+            dt = torch.int64 if x < -(2**31) or x >= 2**31 else torch.int32
         elif isinstance(x, float):
-            return torch.as_tensor(
-                x, dtype=to_torch_dtype(floatx()), device=get_device()
-            )
+            dt = to_torch_dtype(floatx())
+        else:
+            dt = torch.complex64
+        return torch.as_tensor(x, dtype=dt, device=get_device())
 
     # Convert to np in case of any array-like that is not list or tuple.
     if not isinstance(x, (list, tuple)):

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -1805,6 +1805,50 @@ class CoreOpsBehaviorTests(testing.TestCase):
         with self.assertRaises(ValueError):
             ops.convert_to_numpy(KerasTensor((2,)))
 
+    def test_convert_to_tensor_python_float_with_dtype(self):
+        # Regression: a Python float passed with an explicit dtype must
+        # not go through a float64 numpy intermediate. On the torch
+        # backend, torch.export would otherwise lift the float64
+        # constant into the graph before the cast runs.
+        t = ops.convert_to_tensor(1.5, dtype="float32")
+        self.assertEqual(backend.standardize_dtype(t.dtype), "float32")
+        t = ops.convert_to_tensor(1.5, dtype="float16")
+        self.assertEqual(backend.standardize_dtype(t.dtype), "float16")
+
+    def test_convert_to_tensor_python_int_with_dtype(self):
+        t = ops.convert_to_tensor(7, dtype="int16")
+        self.assertEqual(backend.standardize_dtype(t.dtype), "int16")
+        t = ops.convert_to_tensor(7, dtype="float32")
+        self.assertEqual(backend.standardize_dtype(t.dtype), "float32")
+
+    def test_convert_to_tensor_python_bool_with_dtype(self):
+        t = ops.convert_to_tensor(True, dtype="float32")
+        self.assertEqual(backend.standardize_dtype(t.dtype), "float32")
+        t = ops.convert_to_tensor(True)
+        self.assertEqual(backend.standardize_dtype(t.dtype), "bool")
+
+    @pytest.mark.skipif(
+        backend.backend() != "torch",
+        reason="torch.export graph inspection is torch-only.",
+    )
+    def test_convert_to_tensor_python_scalar_no_float64_in_export(self):
+        import torch
+
+        class M(torch.nn.Module):
+            def forward(self, x):
+                scalar = ops.convert_to_tensor(1e-7, dtype="float32")
+                return torch.maximum(x, scalar)
+
+        # torch.export requires all tensors on the same device. Force CPU
+        # so the test is independent of the runner's default device.
+        with backend.device("cpu"):
+            exported = torch.export.export(
+                M(), (torch.ones(5, dtype=torch.float32),)
+            )
+        for val in exported.constants.values():
+            if isinstance(val, torch.Tensor):
+                self.assertNotEqual(val.dtype, torch.float64)
+
     def test_scan_invalid_arguments(self):
         def cumsum(carry, xs):
             carry = carry + xs


### PR DESCRIPTION
Fixes #22815.

## Summary

On the torch backend, `convert_to_tensor(scalar, dtype=...)` for a Python `bool`/`int`/`float` was routed through `np.array(x)` before the cast. `np.array(1.5)` is `float64`, so under `torch.export` the float64 constant gets lifted into the traced graph *before* the `torch.as_tensor(..., dtype=float32)` cast runs. Strict downstream pipelines (e.g. `litert_torch.convert`) then reject the dtype mismatch.  The scalar fast paths in `convert_to_tensor` were gated on `dtype is None`, so when an explicit dtype was passed they were skipped and the value fell through to `np.array(x)`. Lift that gate: handle Python scalars in both cases by passing the requested dtype straight to `torch.as_tensor`. No numpy round-trip, no float64 intermediate. I also added the necessary tests. 

Repro from the issue:

```python
import os
os.environ["KERAS_BACKEND"] = "torch"
import torch, keras

class M(torch.nn.Module):
    def forward(self, x):
        return torch.maximum(x, keras.ops.convert_to_tensor(1e-7, dtype="float32"))

exported = torch.export.export(M(), (torch.ones(5, dtype=torch.float32),))
for name, val in exported.constants.items():
    print(name, val.dtype)
```

Before: `lifted_tensor_0 torch.float64`
After:  `lifted_tensor_0 torch.float32`

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.