### PR TITLE
Fix namespace hijacking and callable injection in deserialize_keras_object

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -732,6 +732,7 @@ def deserialize_keras_object(
     # so that we can catch any custom objects that the config refers to.
     custom_obj_scope = object_registration.CustomObjectScope(custom_objects)
     safe_mode_scope = SafeModeScope(safe_mode)
+    _validate_config(inner_config)
     with custom_obj_scope, safe_mode_scope:
         try:
             instance = cls.from_config(inner_config)
@@ -774,6 +775,29 @@ def _assert_no_registered_name_for_builtin(full_config, name, resolved_name):
     )
 
 
+def _validate_config(config, path="config", seen=None):
+    """Recursively validate that config contains no raw callable objects."""
+    if seen is None:
+        seen = set()
+    obj_id = id(config)
+    if obj_id in seen:
+        return
+    if isinstance(config, (dict, list, tuple)):
+        seen.add(obj_id)
+    if isinstance(config, dict):
+        for key, value in config.items():
+            _validate_config(value, path=f"{path}[{key!r}]", seen=seen)
+    elif isinstance(config, (list, tuple)):
+        for i, value in enumerate(config):
+            _validate_config(value, path=f"{path}[{i}]", seen=seen)
+    elif callable(config) and not isinstance(config, type):
+        raise TypeError(
+            f"Received a callable object in configuration at {path}. "
+            f"Callable objects are not safe to deserialize. "
+            f"Received: {config}"
+        )
+
+
 def _retrieve_class_or_fn(
     name, registered_name, module, obj_type, full_config, custom_objects=None
 ):
@@ -788,6 +812,30 @@ def _retrieve_class_or_fn(
             registered_name, custom_objects=custom_objects
         )
     if custom_obj is not None:
+        # Prevent namespace hijacking: if the config claims to be a Keras
+        # built-in class, do not allow a globally registered custom object
+        # to shadow it.
+        if obj_type == "class" and module:
+            package = module.split(".", maxsplit=1)[0]
+            if package in {"keras", "keras_hub", "keras_cv", "keras_nlp"}:
+                api_name = f"{module}.{name}"
+                builtin_obj = None
+                if api_name not in LOADING_APIS:
+                    builtin_obj = api_export.get_symbol_from_name(api_name)
+                if builtin_obj is None:
+                    try:
+                        mod = importlib.import_module(module)
+                        candidate = vars(mod).get(name, None)
+                        if isinstance(candidate, type) and issubclass(
+                            candidate, KerasSaveable
+                        ):
+                            builtin_obj = candidate
+                    except ModuleNotFoundError:
+                        pass
+                if builtin_obj is not None and builtin_obj is not custom_obj:
+                    _assert_no_registered_name_for_builtin(
+                        full_config, name, f"{module}.{name}"
+                    )
         return custom_obj
 
     if module:

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -733,6 +733,13 @@ def deserialize_keras_object(
     custom_obj_scope = object_registration.CustomObjectScope(custom_objects)
     safe_mode_scope = SafeModeScope(safe_mode)
     _validate_config(inner_config)
+    build_config = config.get("build_config", None)
+    if build_config:
+        _validate_config(build_config, path="build_config")
+    compile_config = config.get("compile_config", None)
+    if compile_config:
+        _validate_config(compile_config, path="compile_config")
+
     with custom_obj_scope, safe_mode_scope:
         try:
             instance = cls.from_config(inner_config)
@@ -745,11 +752,9 @@ def deserialize_keras_object(
                 " model's `from_config()` method."
                 f"\n\nconfig={config}.\n\nException encountered: {e}"
             )
-        build_config = config.get("build_config", None)
         if build_config and not instance.built:
             instance.build_from_config(build_config)
             instance.built = True
-        compile_config = config.get("compile_config", None)
         if compile_config:
             instance.compile_from_config(compile_config)
             instance.compiled = True

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -577,6 +577,88 @@ class SerializationLibTest(testing.TestCase):
         restored = serialization_lib.deserialize_keras_object(config)
         self.assertIsInstance(restored, MyDense)
 
+    def test_namespace_hijacking_blocked(self):
+        """Tests that registered_name cannot hijack built-in Keras classes."""
+
+        @keras.saving.register_keras_serializable(
+            package="MaliciousPackage", name="Dense"
+        )
+        class HiddenLogicDense(keras.layers.Dense):
+            pass
+
+        try:
+            hijacked_config = {
+                "module": "keras.layers",
+                "class_name": "Dense",
+                "config": {"units": 5, "activation": "relu"},
+                "registered_name": "MaliciousPackage>Dense",
+            }
+            with self.assertRaisesRegex(
+                ValueError, "resolved to a Keras built-in"
+            ):
+                serialization_lib.deserialize_keras_object(hijacked_config)
+        finally:
+            # Clean up global registration so other tests are not affected.
+            object_registration.GLOBAL_CUSTOM_OBJECTS.pop(
+                "MaliciousPackage>Dense", None
+            )
+            object_registration.GLOBAL_CUSTOM_NAMES.pop(HiddenLogicDense, None)
+
+    def test_callable_in_config_blocked(self):
+        """Tests that raw callable objects in config are rejected."""
+
+        def malicious_fn(*args, **kwargs):
+            return 1.0
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {
+                "units": 4,
+                "kernel_initializer": malicious_fn,
+            },
+        }
+        with self.assertRaisesRegex(TypeError, "Callable objects are not safe"):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_nested_callable_in_config_blocked(self):
+        """Tests that nested raw callable objects in config are rejected."""
+
+        def malicious_fn(*args, **kwargs):
+            return 1.0
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {
+                "units": 4,
+                "bias_initializer": {
+                    "class_name": "Ones",
+                    "module": "keras.initializers",
+                    "config": {"seed": malicious_fn},
+                },
+            },
+        }
+        with self.assertRaisesRegex(TypeError, "Callable objects are not safe"):
+            serialization_lib.deserialize_keras_object(config)
+
+    def test_list_callable_in_config_blocked(self):
+        """Tests that callables inside lists in config are rejected."""
+
+        def malicious_fn(*args, **kwargs):
+            return 1.0
+
+        config = {
+            "class_name": "Dense",
+            "module": "keras.layers",
+            "config": {
+                "units": 4,
+                "kernel_initializer": [malicious_fn],
+            },
+        }
+        with self.assertRaisesRegex(TypeError, "Callable objects are not safe"):
+            serialization_lib.deserialize_keras_object(config)
+
 
 @keras.saving.register_keras_serializable()
 class MyDense(keras.layers.Layer):


### PR DESCRIPTION
Fixes #22779 and #22705.

**Issue #22779 — Namespace Hijacking via Priority Inversion**
- Prevents globally registered custom objects from shadowing built-in Keras classes when the config claims a keras.* module.
- Resolves the built-in class first and rejects mismatched registered_name via _assert_no_registered_name_for_builtin.

**Issue #22705 — Callable Objects in Config**
- Adds _validate_config helper that recursively rejects raw callable objects in inner_config before passing to cls.from_config().
- Handles circular references to avoid RecursionError on malicious input.


- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
