### PR TITLE
Fix TPU test workflow job name rendering raw template expression

### DIFF
--- a/.github/workflows/tpu_tests.yml
+++ b/.github/workflows/tpu_tests.yml
@@ -27,15 +27,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        multi_device: [false, true]
-        backend: [jax]
+        include:
+          - backend: jax
+            multi_device: false
+            runner: linux-x86-ct6e-44-1tpu
+            name: Run tests on TPU
+          - backend: jax
+            multi_device: true
+            runner: linux-x86-ct5lp-112-4tpu
+            name: Run tests on multi-TPU
 
     container:
       image: python:3.11-slim
       options: --privileged --network host
 
-    name: ${{ format('Run tests on {0}TPU', matrix.multi_device && 'multi-' || '') }}
-    runs-on: ${{ matrix.multi_device && 'linux-x86-ct5lp-112-4tpu' || 'linux-x86-ct6e-44-1tpu' }}
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
 
     env:


### PR DESCRIPTION
Fixes #22776

The job name used `format()` with a boolean expression inside, which caused GitHub Actions to render the raw template in the checks UI.

Replace the dynamic expression with explicit `matrix.include` fields (`name_suffix`, `runner`) so the job name evaluates reliably to:
- `Run tests on TPU` for single-device
- `Run tests on multi-TPU` for multi-device

**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.