### PR TITLE
Unique ops

### DIFF
--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -1654,6 +1654,7 @@ def histogram(x, bins=10, range=None):
 def unique(
     x,
     sorted=True,
+    return_index=False,
     return_inverse=False,
     return_counts=False,
     axis=None,
@@ -1662,6 +1663,7 @@ def unique(
 ):
     return jnp.unique(
         x,
+        return_index=return_index,
         return_inverse=return_inverse,
         return_counts=return_counts,
         axis=axis,

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -1742,7 +1742,10 @@ def unique(
     values = output[0]
 
     if size is not None:
-        dim = axis if axis is not None else 0
+        if axis is None:
+            dim = 0
+        else:
+            dim = axis + x.ndim if axis < 0 else axis
         values_count = values.shape[dim]
 
         if values_count > size:

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -1715,6 +1715,7 @@ def histogram(x, bins=10, range=None):
 def unique(
     x,
     sorted=True,
+    return_index=False,
     return_inverse=False,
     return_counts=False,
     axis=None,
@@ -1726,13 +1727,14 @@ def unique(
     # but do not pass it to np.unique to avoid TypeError in older versions.
     output = np.unique(
         x,
+        return_index=return_index,
         return_inverse=return_inverse,
         return_counts=return_counts,
         axis=axis,
         equal_nan=False,
     )
 
-    if not (return_inverse or return_counts):
+    if not (return_index or return_inverse or return_counts):
         output = [output]
     else:
         output = list(output)
@@ -1749,7 +1751,9 @@ def unique(
             indices[dim] = slice(0, size)
             values = values[tuple(indices)]
             if return_counts:
-                output[-1] = output[-1][tuple(indices)]
+                output[-1] = output[-1][indices[dim]]
+            if return_index:
+                output[1] = output[1][indices[dim]]
 
         elif values_count < size:
             # Pad
@@ -1758,7 +1762,11 @@ def unique(
             fill = 0 if fill_value is None else fill_value
             values = np.pad(values, pad_width, constant_values=fill)
             if return_counts:
-                output[-1] = np.pad(output[-1], pad_width, constant_values=0)
+                output[-1] = np.pad(
+                    output[-1], pad_width[dim], constant_values=0
+                )
+            if return_index:
+                output[1] = np.pad(output[1], pad_width[dim], constant_values=1)
 
     output[0] = values
     return output[0] if len(output) == 1 else tuple(output)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -5,6 +5,7 @@ from keras.src import tree
 from keras.src.backend import config
 from keras.src.backend import standardize_dtype
 from keras.src.backend.common import dtypes
+from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.backend_utils import standardize_axis_for_numpy
 from keras.src.backend.numpy.core import convert_to_tensor
 
@@ -1745,7 +1746,7 @@ def unique(
         if axis is None:
             dim = 0
         else:
-            dim = axis + x.ndim if axis < 0 else axis
+            dim = canonicalize_axis(axis, x.ndim)
         values_count = values.shape[dim]
 
         if values_count > size:

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -5621,6 +5621,7 @@ def histogram(x, bins=10, range=None):
 def unique(
     x,
     sorted=True,
+    return_index=False,
     return_inverse=False,
     return_counts=False,
     axis=None,
@@ -5645,6 +5646,7 @@ def unique(
             and x_flat_pshape[0].get_length() == 0
         ):
             values = x_flat
+            indices = ov_opset.constant(np.array([], dtype=np.int32)).output(0)
             inverse = ov_opset.constant(np.array([], dtype=np.int32)).output(0)
             counts = ov_opset.constant(np.array([], dtype=np.int32)).output(0)
             dim = 0
@@ -5689,6 +5691,7 @@ def unique(
                     count_element_type="i32",
                 )
                 uniq_rows = uniq.output(0)
+                indices = uniq.output(1)
                 inverse = uniq.output(2)
                 counts = uniq.output(3)
 
@@ -5724,6 +5727,7 @@ def unique(
                     count_element_type="i32",
                 )
                 values = uniq.output(0)
+                indices = uniq.output(1)
                 inverse = uniq.output(2)
                 counts = uniq.output(3)
             dim = 0
@@ -5740,6 +5744,7 @@ def unique(
             dim_len_is_zero = True
         if dim_len_is_zero:
             values = x
+            indices = ov_opset.constant(np.array([], dtype=np.int32)).output(0)
             inverse = ov_opset.constant(np.array([], dtype=np.int32)).output(0)
             counts = ov_opset.constant(np.array([], dtype=np.int32)).output(0)
         else:
@@ -5751,6 +5756,7 @@ def unique(
                 count_element_type="i32",
             )
             values = uniq.output(0)
+            indices = uniq.output(1)
             inverse = uniq.output(2)
             counts = uniq.output(3)
 
@@ -5845,6 +5851,24 @@ def unique(
                 ov_opset.constant(inv_perm, Type.i32).output(0),
             ).output(0)
 
+        if return_index:
+            indices = ov_opset.gather(
+                indices,
+                trunc_idx,
+                ov_opset.constant(0, Type.i32).output(0),
+            ).output(0)
+            one_indices = ov_opset.constant(
+                1, indices.get_element_type()
+            ).output(0)
+            indices_pad = ov_opset.broadcast(
+                one_indices,
+                ov_opset.unsqueeze(
+                    pad_amount,
+                    ov_opset.constant([0], Type.i32).output(0),
+                ).output(0),
+            ).output(0)
+            indices = ov_opset.concat([indices, indices_pad], axis=0).output(0)
+
         if return_counts:
             counts = ov_opset.gather(
                 counts,
@@ -5867,6 +5891,8 @@ def unique(
         inverse = ov_opset.reshape(inverse, x_shape, False).output(0)
 
     outputs = [OpenVINOKerasTensor(values)]
+    if return_index:
+        outputs.append(OpenVINOKerasTensor(indices))
     if return_inverse:
         outputs.append(OpenVINOKerasTensor(inverse))
     if return_counts:

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -5732,7 +5732,7 @@ def unique(
                 counts = uniq.output(3)
             dim = 0
     else:
-        dim = axis + x_rank if axis < 0 else axis
+        dim = canonicalize_axis(axis, x_rank)
         axis_node = ov_opset.constant(dim, Type.i32).output(0)
         dim_len_is_zero = False
         x_pshape = x.get_partial_shape()

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -3780,6 +3780,7 @@ def histogram(x, bins=10, range=None):
 def unique(
     x,
     sorted=True,
+    return_index=False,
     return_inverse=False,
     return_counts=False,
     axis=None,
@@ -3801,6 +3802,13 @@ def unique(
         axis_to_use = tf.constant([dim], dtype=tf.int32)
         y, inverse, counts = tf.raw_ops.UniqueWithCountsV2(
             x=x, axis=axis_to_use, out_idx=tf.int32
+        )
+
+    if return_index:
+        num_unique = tf.shape(y)[dim]
+        dim_size = tf.shape(x)[0] if is_flatten else original_shape[dim]
+        unique_indices = tf.math.unsorted_segment_min(
+            tf.range(dim_size, dtype=tf.int32), inverse, num_unique
         )
 
     if sorted:
@@ -3830,6 +3838,8 @@ def unique(
             )
 
         y = tf.gather(y, sort_order, axis=dim)
+        if return_index:
+            unique_indices = tf.gather(unique_indices, sort_order)
         if return_counts:
             counts = tf.gather(counts, sort_order)
         if return_inverse:
@@ -3844,6 +3854,8 @@ def unique(
         # 1. Truncate using gather
         truncate_size = tf.minimum(values_count, size)
         y = tf.gather(y, tf.range(truncate_size), axis=dim)
+        if return_index:
+            unique_indices = tf.gather(unique_indices, tf.range(truncate_size))
         if return_counts:
             counts = tf.gather(counts, tf.range(truncate_size))
 
@@ -3857,6 +3869,11 @@ def unique(
         fill = tf.cast(0 if fill_value is None else fill_value, y.dtype)
         y = tf.pad(y, paddings, constant_values=fill)
 
+        if return_index:
+            unique_indices = tf.pad(
+                unique_indices, [[0, pad_amount]], constant_values=1
+            )
+
         if return_counts:
             counts = tf.pad(counts, [[0, pad_amount]], constant_values=0)
 
@@ -3864,6 +3881,8 @@ def unique(
         static_shape = y.shape.as_list()
         static_shape[dim] = size
         y.set_shape(static_shape)
+        if return_index:
+            unique_indices.set_shape([size])
         if return_counts:
             counts.set_shape([size])
 
@@ -3871,6 +3890,8 @@ def unique(
         inverse = tf.reshape(inverse, original_shape)
 
     results = [y]
+    if return_index:
+        results.append(unique_indices)
     if return_inverse:
         results.append(inverse)
     if return_counts:

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -2398,18 +2398,22 @@ def unique(
 
     values = output[0]
 
+    if axis is None:
+        dim = 0
+    else:
+        dim = axis + x.ndim if axis < 0 else axis
+
     if return_index:
         inverse = output[1]
         perm = torch.arange(
             inverse.size(0), dtype=inverse.dtype, device=inverse.device
         )
         inverse, perm = inverse.flip([0]), perm.flip([0])
-        unique_indices = inverse.new_empty(values.size(0)).scatter_(
+        unique_indices = inverse.new_empty(values.size(dim)).scatter_(
             0, inverse, perm
         )
 
     if size is not None:
-        dim = axis if axis is not None else 0
         values_count = values.shape[dim]
 
         if values_count > size:

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -2401,7 +2401,7 @@ def unique(
     if axis is None:
         dim = 0
     else:
-        dim = axis + x.ndim if axis < 0 else axis
+        dim = canonicalize_axis(axis, x.ndim)
 
     if return_index:
         inverse = output[1]

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -2404,9 +2404,8 @@ def unique(
             inverse.size(0), dtype=inverse.dtype, device=inverse.device
         )
         inverse, perm = inverse.flip([0]), perm.flip([0])
-        dim = 0 if axis is None else axis
-        unique_indices = inverse.new_empty(values.size(dim)).scatter_(
-            dim, inverse, perm
+        unique_indices = inverse.new_empty(values.size(0)).scatter_(
+            0, inverse, perm
         )
 
     if size is not None:

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -2408,9 +2408,8 @@ def unique(
         perm = torch.arange(
             inverse.size(0), dtype=inverse.dtype, device=inverse.device
         )
-        inverse, perm = inverse.flip([0]), perm.flip([0])
-        unique_indices = inverse.new_empty(values.size(dim)).scatter_(
-            0, inverse, perm
+        unique_indices = inverse.new_empty(values.size(dim)).scatter_reduce_(
+            0, inverse, perm, reduce="min", include_self=False
         )
 
     if size is not None:

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -2373,6 +2373,7 @@ def histogram(x, bins=10, range=None):
 def unique(
     x,
     sorted=True,
+    return_index=False,
     return_inverse=False,
     return_counts=False,
     axis=None,
@@ -2385,17 +2386,28 @@ def unique(
     output = torch.unique(
         x,
         sorted=sorted,  # Added sorted parameter here
-        return_inverse=return_inverse,
+        return_inverse=(return_inverse or return_index),
         return_counts=return_counts,
         dim=axis,
     )
 
-    if not (return_inverse or return_counts):
+    if not (return_inverse or return_counts or return_index):
         output = [output]
     else:
         output = list(output)
 
     values = output[0]
+
+    if return_index:
+        inverse = output[1]
+        perm = torch.arange(
+            inverse.size(0), dtype=inverse.dtype, device=inverse.device
+        )
+        inverse, perm = inverse.flip([0]), perm.flip([0])
+        dim = 0 if axis is None else axis
+        unique_indices = inverse.new_empty(values.size(dim)).scatter_(
+            dim, inverse, perm
+        )
 
     if size is not None:
         dim = axis if axis is not None else 0
@@ -2407,7 +2419,9 @@ def unique(
             indices[dim] = slice(0, size)
             values = values[tuple(indices)]
             if return_counts:
-                output[-1] = output[-1][tuple(indices)]
+                output[-1] = output[-1][indices[dim]]
+            if return_index:
+                unique_indices = unique_indices[indices[dim]]
 
         elif values_count < size:
             # Pad
@@ -2420,8 +2434,16 @@ def unique(
             values = torch.nn.functional.pad(values, pad_width, value=fill)
             if return_counts:
                 output[-1] = torch.nn.functional.pad(
-                    output[-1], pad_width, value=0
+                    output[-1], pad_width[idx : idx + 2], value=0
+                )
+            if return_index:
+                unique_indices = torch.nn.functional.pad(
+                    unique_indices, pad_width[idx : idx + 2], value=1
                 )
 
     output[0] = values
+    if return_index and return_inverse:
+        output.insert(1, unique_indices)
+    elif return_index:
+        output[1] = unique_indices
     return output[0] if len(output) == 1 else tuple(output)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -9626,6 +9626,7 @@ class Unique(Operation):
     def __init__(
         self,
         sorted=True,
+        return_index=False,
         return_inverse=False,
         return_counts=False,
         axis=None,
@@ -9636,6 +9637,7 @@ class Unique(Operation):
     ):
         super().__init__(name=name)
         self.sorted = sorted
+        self.return_index = return_index
         self.return_inverse = return_inverse
         self.return_counts = return_counts
         self.axis = axis
@@ -9646,6 +9648,7 @@ class Unique(Operation):
         return backend.numpy.unique(
             x,
             sorted=self.sorted,
+            return_index=self.return_index,
             return_inverse=self.return_inverse,
             return_counts=self.return_counts,
             axis=self.axis,
@@ -9667,6 +9670,11 @@ class Unique(Operation):
             values_shape[axis] = u_dim
 
         outputs = [KerasTensor(tuple(values_shape), dtype=x.dtype)]
+
+        # Indices of first occurrences shape is 1D
+        # with length matching the unique values
+        if self.return_index:
+            outputs.append(KerasTensor((u_dim,), dtype="int32"))
 
         # Inverse indices shape matches the original input size along axis
         if self.return_inverse:
@@ -9690,6 +9698,7 @@ class Unique(Operation):
 def unique(
     x,
     sorted=True,
+    return_index=False,
     return_inverse=False,
     return_counts=False,
     axis=None,
@@ -9706,6 +9715,8 @@ def unique(
         x: Input tensor.
         sorted: Whether to sort the unique elements in ascending order.
             Defaults to `True`.
+        return_index: If `True`, also return the indices of the first
+            occurrence of each unique element in `x`. Defaults to `False`.
         return_inverse: If `True`, also return the indices of the unique tensor
             (for the specified axis, if provided) that can be used to
             reconstruct `x`. Defaults to `False`.
@@ -9725,6 +9736,8 @@ def unique(
         A tensor or a tuple of tensors.
         - `unique_values`: The unique values. Shape is `(size,)` if `size` is
           provided and `axis=None`.
+        - `unique_index` (optional): The indices of the first occurrence of each
+          unique element in `x`. Only provided if `return_index` is `True`.
         - `unique_inverse` (optional): The indices to reconstruct the original
           array. Only provided if `return_inverse` is `True`.
         - `unique_counts` (optional): The number of occurrences of each unique
@@ -9762,6 +9775,7 @@ def unique(
     if any_symbolic_tensors((x,)):
         return Unique(
             sorted=sorted,
+            return_index=return_index,
             return_inverse=return_inverse,
             return_counts=return_counts,
             axis=axis,
@@ -9771,6 +9785,7 @@ def unique(
     return backend.numpy.unique(
         backend.convert_to_tensor(x),
         sorted=sorted,
+        return_index=return_index,
         return_inverse=return_inverse,
         return_counts=return_counts,
         axis=axis,

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -2373,8 +2373,11 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         out = knp.unique(x)
         self.assertEqual(out.shape, (None,))
 
-        v, inv, c = knp.unique(x, return_inverse=True, return_counts=True)
+        v, idx, inv, c = knp.unique(
+            x, return_index=True, return_inverse=True, return_counts=True
+        )
         self.assertEqual(v.shape, (None,))
+        self.assertEqual(idx.shape, (None,))
         self.assertEqual(inv.shape, (None, 3))  # Matches input shape
         self.assertEqual(c.shape, (None,))
 
@@ -3183,23 +3186,29 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor((2, 4))
 
         # Test with axis=0
-        v, inv = knp.unique(x, axis=0, return_inverse=True)
+        v, idx, inv = knp.unique(
+            x, axis=0, return_index=True, return_inverse=True
+        )
         # The size of the unique axis is unknown at compile time
         self.assertEqual(v.shape, (None, 4))
         # Inverse indices for axis is always 1D with length of that axis
         self.assertEqual(inv.shape, (2,))
+        self.assertEqual(idx.shape, (None,))
 
     def test_unique_symbolic_with_size(self):
         x = KerasTensor((2, 4))
 
-        v_flat = knp.unique(x, size=5)
+        v_flat, idx = knp.unique(x, return_index=True, size=5)
         self.assertEqual(v_flat.shape, (5,))
+        self.assertEqual(idx.shape, (5,))
 
-        v_axis0 = knp.unique(x, axis=0, size=3)
+        v_axis0, idx0 = knp.unique(x, return_index=True, axis=0, size=3)
         self.assertEqual(v_axis0.shape, (3, 4))
+        self.assertEqual(idx0.shape, (3,))
 
-        v_axis1 = knp.unique(x, axis=1, size=6)
+        v_axis1, idx1 = knp.unique(x, return_index=True, axis=1, size=6)
         self.assertEqual(v_axis1.shape, (2, 6))
+        self.assertEqual(idx1.shape, (6,))
 
 
 class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
@@ -7349,6 +7358,46 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         v, inv = op.call(x)
         self.assertAllClose(v, [[1, 2], [3, 4]])
         self.assertAllClose(inv, [0, 0, 1])
+
+        # test_unique_return_index_1d
+        x = np.array([3, 1, 2, 1])
+        expected_v = np.array([1, 2, 3])
+        # First occurrences of [1, 2, 3] are at source indices [1, 2, 0]
+        expected_idx = np.array([1, 2, 0])
+        v, idx = knp.unique(x, return_index=True)
+        self.assertAllClose(v, expected_v)
+        self.assertAllClose(idx, expected_idx)
+
+        # test_unique_return_index_axis_0
+        x = np.array([[1, 0], [0, 1], [1, 0]])
+        expected_v = np.array([[0, 1], [1, 0]])
+        # [0, 1] first occurs at row 1, [1, 0] first occurs at row 0
+        expected_idx = np.array([1, 0])
+        v, idx = knp.unique(x, axis=0, return_index=True)
+        self.assertAllClose(v, expected_v)
+        self.assertAllClose(idx, expected_idx)
+
+        # test_unique_return_index_combinations
+        x = np.array([3, 1, 2, 1])
+        v, idx, inv, counts = knp.unique(
+            x, return_index=True, return_inverse=True, return_counts=True
+        )
+        self.assertAllClose(v, [1, 2, 3])
+        self.assertAllClose(idx, [1, 2, 0])
+        self.assertAllClose(inv, [2, 0, 1, 0])
+        self.assertAllClose(counts, [2, 1, 1])
+
+        # test_unique_return_index_with_size
+        x = np.array([3, 1, 2, 1])
+        # Padding case
+        v, idx = knp.unique(x, return_index=True, size=5, fill_value=-1)
+        self.assertAllClose(v, [1, 2, 3, -1, -1])
+        self.assertAllClose(idx, [1, 2, 0, 1, 1])
+
+        # Truncation case
+        v, idx = knp.unique(x, return_index=True, size=2)
+        self.assertAllClose(v, [1, 2])
+        self.assertAllClose(idx, [1, 2])
 
 
 class NumpyArrayCreateOpsCorrectnessTest(testing.TestCase):

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -3210,6 +3210,12 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
         self.assertEqual(v_axis1.shape, (2, 6))
         self.assertEqual(idx1.shape, (6,))
 
+        v_axis_neg1, idx_neg1 = knp.unique(
+            x, return_index=True, axis=-1, size=6
+        )
+        self.assertEqual(v_axis1.shape, (2, 6))
+        self.assertEqual(idx1.shape, (6,))
+
 
 class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
     def test_add(self):
@@ -7406,6 +7412,37 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         # Source row map: row0->1, row1->0, row2->1, row3->2, row4->0
         self.assertAllClose(inv, [1, 0, 1, 2, 0])
         self.assertAllClose(counts, [2, 2, 1, 0, 0])
+
+        # test_unique_return_index_combinations_2d with negative axis
+        x = np.array([[1, 0], [0, 1], [1, 0], [2, 2], [0, 1]])
+        v, idx, inv, counts = knp.unique(
+            x,
+            axis=-1,
+            return_index=True,
+            return_inverse=True,
+            return_counts=True,
+            size=5,
+            fill_value=-1,
+        )
+        # Unique columns (sorted lexicographically): Col 1 before Col 0
+        # Resized to size=5 along last dimension (columns) via padding with -1
+        self.assertAllClose(
+            v,
+            [
+                [0, 1, -1, -1, -1],
+                [1, 0, -1, -1, -1],
+                [0, 1, -1, -1, -1],
+                [2, 2, -1, -1, -1],
+                [1, 0, -1, -1, -1],
+            ],
+        )
+        # Indices of first occurrences: [Col 1, Col 0]. Padded with 1.
+        self.assertAllClose(idx, [1, 0, 1, 1, 1])
+        # Mapping source columns to unique indexes:
+        # col 0 -> position 1, col 1 -> position 0
+        self.assertAllClose(inv, [1, 0])
+        # Both occur once. Padded with 0.
+        self.assertAllClose(counts, [1, 1, 0, 0, 0])
 
         # test_unique_return_index_with_size
         x = np.array([3, 1, 2, 1])

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -7387,6 +7387,26 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(inv, [2, 0, 1, 0])
         self.assertAllClose(counts, [2, 1, 1])
 
+        # test_unique_return_index_combinations_2d
+        x = np.array([[1, 0], [0, 1], [1, 0], [2, 2], [0, 1]])
+        v, idx, inv, counts = knp.unique(
+            x,
+            axis=0,
+            return_index=True,
+            return_inverse=True,
+            return_counts=True,
+            size=5,
+            fill_value=-1,
+        )
+        # Unique rows (sorted lexicographically): [0, 1], [1, 0], [2, 2]
+        self.assertAllClose(v, [[0, 1], [1, 0], [2, 2], [-1, -1], [-1, -1]])
+        # First occurrences of each row: [0, 1] at row 1,
+        # [1, 0] at row 0, [2, 2] at row 3
+        self.assertAllClose(idx, [1, 0, 3, 1, 1])
+        # Source row map: row0->1, row1->0, row2->1, row3->2, row4->0
+        self.assertAllClose(inv, [1, 0, 1, 2, 0])
+        self.assertAllClose(counts, [2, 2, 1, 0, 0])
+
         # test_unique_return_index_with_size
         x = np.array([3, 1, 2, 1])
         # Padding case


### PR DESCRIPTION
## Description
feat: Add `return_index` support to the `unique` operation

This PR introduces support for the `return_index` parameter within the `unique` operation across all supported backends.

Key Changes:
*   **`return_index` Functionality:**
    *   Implemented support for `return_index` in the following backends: `numpy`, `jax`, `torch`, `tensorflow`, and `openvino`.
    *   Indices returned by `return_index` are now padded with a value of `1` when the number of unique elements is less than the pre-defined size parameter.
    *   Added comprehensive test cases to validate the new `return_index` feature.

*   **Numpy Backend Bug Fix:**
    *   Fixed a bug in the `numpy` backend's `return_counts` index logic. The existing code incorrectly assumed `return_counts` would have the same shape as the input tensor, whereas it is always a 1-D array. This has been corrected.

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
