### PR TITLE
Replace cast+multiply masking with where in forward-pass layers

### DIFF
--- a/keras/src/activations/activations.py
+++ b/keras/src/activations/activations.py
@@ -90,9 +90,7 @@ class ReLU(ops.Operation):
         if threshold != 0:
             # computes x for x > threshold else 0
             threshold = ops.cast(threshold, dtype=x.dtype)
-            x = x * backend.cast(
-                backend.numpy.greater(x, threshold), dtype=x.dtype
-            )
+            x = backend.numpy.where(backend.numpy.greater(x, threshold), x, 0)
         elif max_value == 6:
             # if no threshold, then can use nn.relu6 native op for performance
             x = backend.nn.relu6(x)

--- a/keras/src/constraints/constraints.py
+++ b/keras/src/constraints/constraints.py
@@ -124,7 +124,7 @@ class NonNeg(Constraint):
 
     def __call__(self, w):
         w = backend.convert_to_tensor(w)
-        return ops.multiply(w, ops.greater_equal(w, 0.0))
+        return ops.where(ops.greater_equal(w, 0.0), w, 0)
 
 
 @keras_export(["keras.constraints.UnitNorm", "keras.constraints.unit_norm"])

--- a/keras/src/layers/attention/attention.py
+++ b/keras/src/layers/attention/attention.py
@@ -176,7 +176,7 @@ class Attention(Layer):
             max_value = 65504.0 if scores.dtype == "float16" else 1.0e9
             if len(padding_mask.shape) == 2:
                 padding_mask = ops.expand_dims(padding_mask, axis=-2)
-            scores -= max_value * ops.cast(padding_mask, dtype=scores.dtype)
+            scores = ops.where(padding_mask, scores - max_value, scores)
 
         weights = ops.softmax(scores, axis=-1)
         if training and self.dropout > 0:
@@ -232,9 +232,10 @@ class Attention(Layer):
             scores=scores, value=v, scores_mask=scores_mask, training=training
         )
         if q_mask is not None:
+            q_mask = ops.cast(q_mask, "bool")  # defensive casting
             # Mask of shape [batch_size, Tq, 1].
             q_mask = ops.expand_dims(q_mask, axis=-1)
-            attention_output *= ops.cast(q_mask, dtype=attention_output.dtype)
+            attention_output = ops.where(q_mask, attention_output, 0)
         if return_attention_scores:
             return (attention_output, attention_scores)
         else:

--- a/keras/src/layers/core/masking.py
+++ b/keras/src/layers/core/masking.py
@@ -61,8 +61,8 @@ class Masking(Layer):
         boolean_mask = ops.any(
             ops.not_equal(inputs, self.mask_value), axis=-1, keepdims=True
         )
-        # Set masked outputs to 0
-        outputs = inputs * backend.cast(boolean_mask, dtype=inputs.dtype)
+        # Set masked outputs to 0.
+        outputs = ops.where(boolean_mask, inputs, 0)
         # Compute the mask and outputs simultaneously.
         backend.set_keras_mask(outputs, mask=ops.squeeze(boolean_mask, axis=-1))
         return outputs

--- a/keras/src/layers/normalization/batch_normalization.py
+++ b/keras/src/layers/normalization/batch_normalization.py
@@ -439,29 +439,24 @@ class BatchNormalization(Layer):
                 synchronized=self.synchronized,
             )
 
-        mask_weights = ops.cast(mask, inputs.dtype)
-        mask_weights_broadcasted = ops.expand_dims(mask_weights, axis=-1)
-        broadcasted_mask = ops.broadcast_to(
-            mask_weights_broadcasted, ops.shape(inputs)
-        )
-        weighted_inputs = broadcasted_mask * inputs
-
-        weighted_input_sum = ops.sum(
-            weighted_inputs,
+        mask_b = ops.cast(
+            ops.expand_dims(mask, axis=-1), "bool"
+        )  # defensive casting
+        mask_float = ops.cast(mask_b, inputs.dtype)
+        sum_of_weights = ops.sum(
+            ops.broadcast_to(mask_float, ops.shape(inputs)),
             self._reduction_axes,
             keepdims=True,
         )
-        sum_of_weights = ops.sum(
-            broadcasted_mask,
+        weighted_input_sum = ops.sum(
+            ops.where(mask_b, inputs, 0),
             self._reduction_axes,
             keepdims=True,
         )
         mean = weighted_input_sum / (sum_of_weights + backend.epsilon())
 
-        difference = weighted_inputs - mean
-        squared_difference = ops.square(difference)
         weighted_distsq = ops.sum(
-            broadcasted_mask * squared_difference,
+            ops.where(mask_b, ops.square(inputs - mean), 0),
             self._reduction_axes,
             keepdims=True,
         )

--- a/keras/src/layers/pooling/global_average_pooling1d.py
+++ b/keras/src/layers/pooling/global_average_pooling1d.py
@@ -1,4 +1,3 @@
-from keras.src import backend
 from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.layers.pooling.base_global_pooling import BaseGlobalPooling
@@ -71,14 +70,17 @@ class GlobalAveragePooling1D(BaseGlobalPooling):
     def call(self, inputs, mask=None):
         steps_axis = 1 if self.data_format == "channels_last" else 2
         if mask is not None:
-            mask = backend.cast(mask, inputs[0].dtype)
-            mask = ops.expand_dims(
-                mask, 2 if self.data_format == "channels_last" else 1
-            )
-            inputs *= mask
+            mask_b = ops.cast(
+                ops.expand_dims(
+                    mask, 2 if self.data_format == "channels_last" else 1
+                ),
+                "bool",
+            )  # defensive casting
+            masked_inputs = ops.where(mask_b, inputs, 0)
+            mask_float = ops.cast(mask_b, inputs.dtype)
             return ops.sum(
-                inputs, axis=steps_axis, keepdims=self.keepdims
-            ) / ops.sum(mask, axis=steps_axis, keepdims=self.keepdims)
+                masked_inputs, axis=steps_axis, keepdims=self.keepdims
+            ) / ops.sum(mask_float, axis=steps_axis, keepdims=self.keepdims)
         else:
             return ops.mean(inputs, axis=steps_axis, keepdims=self.keepdims)
 


### PR DESCRIPTION
## Description

Fixes part of #22386.

`tensor * ops.cast(bool_mask, tensor.dtype)` materializes a full float copy of the mask just to multiply by it. JAX and TF fuse this away during compilation, but torch runs it eagerly, so the intermediate sticks around and can push big layers into OOM.

I switched the forward-pass sites listed in the issue to use `where(mask, tensor, 0)` instead, which keeps the mask as a bool:

- `layers/attention/attention.py`: padding-mask bias and the q_mask zero-out after attention.
- `layers/normalization/batch_normalization.py`: reworked masked `_moments` so the weighted sums consume short-lived `where` results instead of holding a broadcasted mask, weighted inputs, difference, and squared difference all at once.
- `layers/core/masking.py`: post-mask zero step.
- `layers/pooling/global_average_pooling1d.py`: masked numerator. While I was there, this also stops `inputs *= mask` from mutating the caller's input tensor under the torch backend.
- `activations/activations.py`: ReLU with a custom threshold.
- `constraints/constraints.py`: `NonNeg`.

In the BN, GAP1D, and attention-q_mask sites I also added a defensive `ops.cast(mask, "bool")` on the user-supplied mask before it reaches `where`, matching the pattern already used in `MultiHeadAttention` and `GroupedQueryAttention`. Without it the bool `where` and the float `sum_of_weights` cast would disagree on non-binary masks.

Losses/metrics sites in #22386 are smaller. I'll send a follow-up for those.

### Tests

pytest passes on tensorflow, jax and torch (CPU) for each touched module:

- `keras/src/layers/attention/attention_test.py`
- `keras/src/layers/normalization/batch_normalization_test.py`
- `keras/src/layers/core/masking_test.py`
- `keras/src/layers/pooling/global_average_pooling_test.py`
- `keras/src/activations/activations_test.py`
- `keras/src/constraints/constraints_test.py`

### AI-assisted disclosure

Per the AI-Assisted Contribution Policy, disclosing that I used Claude Code to help draft the rewrites and tests. I reviewed every change, ran the full test suite per backend locally, and take responsibility for the code.

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.