### PR TITLE
[Fix] Dense layer GPU OOM with rank-3 input due to BatchMatMulV2 gradient materialization

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -622,6 +622,13 @@ def matmul(x1, x2):
             output = tf.tensordot(x1, x2, axes=1)
         elif x1_shape.rank == 1:
             output = tf.tensordot(x1, x2, axes=[[0], [-2]])
+        elif (
+            x2_shape.rank == 2
+            and x1_shape.rank is not None
+            and x1_shape.rank > 2
+            and output_type is None
+        ):
+            output = tf.tensordot(x1, x2, axes=[[-1], [0]])
         else:
             output = tf.matmul(x1, x2, output_type=output_type)
         return tf.cast(output, result_dtype)


### PR DESCRIPTION
## Description
Fixes: #22823 
The fix changes the TensorFlow backend matmul dense path so this case uses:

```tf.tensordot(x1, x2, axes=[[-1], [0]])```

instead of:

```tf.matmul(x1, x2)```

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
