### PR TITLE
Fix: Added validation for large units in Dense.from_config (#22819)

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -394,7 +394,8 @@ class Dense(Layer):
         MAX_UNITS = 1_000_000
         if config.get("units", 0) > MAX_UNITS:
             raise ValueError(
-                f"units={config.get('units')} exceeds maximum allowed value of {MAX_UNITS}."
+              f"units={config.get('units')} exceeds maximum "
+              f"allowed value of {MAX_UNITS}."
             )
         config = config.copy()
         config["quantization_config"] = (

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -394,8 +394,8 @@ class Dense(Layer):
         MAX_UNITS = 1_000_000
         if config.get("units", 0) > MAX_UNITS:
             raise ValueError(
-              f"units={config.get('units')} exceeds maximum "
-              f"allowed value of {MAX_UNITS}."
+                f"units={config.get('units')} exceeds maximum "
+                f"allowed value of {MAX_UNITS}."
             )
         config = config.copy()
         config["quantization_config"] = (

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -391,6 +391,11 @@ class Dense(Layer):
 
     @classmethod
     def from_config(cls, config):
+        MAX_UNITS = 1_000_000
+        if config.get("units", 0) > MAX_UNITS:
+            raise ValueError(
+                f"units={config.get('units')} exceeds maximum allowed value of {MAX_UNITS}."
+            )
         config = config.copy()
         config["quantization_config"] = (
             serialization_lib.deserialize_keras_object(


### PR DESCRIPTION
## Description
This PR adds a boundary check in `Dense.from_config` to prevent unreasonably large `units` values from being passed to the backend during deserialization, which previously caused unhandled GPU OOM errors.

**Fixes #22819**

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.