### PR TITLE
Fix: Validate large units in Dense.from_config to prevent OOM (#22819)

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -391,12 +391,15 @@ class Dense(Layer):
 
     @classmethod
     def from_config(cls, config):
-        MAX_UNITS = 1_000_000
+        MAX_UNITS = 100_000_000
         units = config.get("units")
-        if units is not None and units > MAX_UNITS:
+        if isinstance(units, (int, float)) and units > MAX_UNITS:
             raise ValueError(
-                f"units={units} exceeds maximum "
-                f"allowed value of {MAX_UNITS}."
+                f"The `units` argument in the config ({units}) "
+                f"exceeds the safety limit of {MAX_UNITS}. This check "
+                "is intended to prevent OOM errors during deserialization. "
+                "If this value is intentional, please verify your model "
+                "configuration."
             )
         config = config.copy()
         config["quantization_config"] = (

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -391,6 +391,13 @@ class Dense(Layer):
 
     @classmethod
     def from_config(cls, config):
+        MAX_UNITS = 1_000_000
+        units = config.get("units")
+        if units is not None and units > MAX_UNITS:
+            raise ValueError(
+                f"units={units} exceeds maximum "
+                f"allowed value of {MAX_UNITS}."
+            )
         config = config.copy()
         config["quantization_config"] = (
             serialization_lib.deserialize_keras_object(

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -129,6 +129,11 @@ class DenseTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "positive integer"):
             layers.Dense(units)
 
+    def test_dense_from_config_exceeds_max_units(self):
+        config = {"units": 100_000_001, "name": "dense"}
+        with self.assertRaisesRegex(ValueError, "exceeds the safety limit"):
+            layers.Dense.from_config(config)
+
     def test_dense_correctness(self):
         # With bias and activation.
         layer = layers.Dense(units=2, activation="relu")


### PR DESCRIPTION
## Description
This PR adds a boundary check in `Dense.from_config` to prevent unreasonably large `units` values from being passed to the backend during deserialization, which previously caused unhandled GPU OOM errors.


**Fixes #22819**

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.