### PR TITLE
Improve sub path resolution in `file_utils`.

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1778,14 +1778,23 @@ def _write_nested_dict_to_dir(tree, base_dir):
 
     Each dict key becomes a directory or filename. Leaf values (numpy
     arrays) are written as binary files.
+
+    Args:
+        tree: A nested dictionary of numpy arrays.
+        base_dir: The base directory to write the assets to. Must be resolved
+            via `file_utils.resolve_path` first.
     """
     for key, value in tree.items():
-        child_path = os.path.join(base_dir, key)
+        if os.path.sep in key or (os.path.altsep and os.path.altsep in key):
+            raise ValueError(f"Invalid asset path: {key}")
+        child_path = file_utils.resolve_sub_path(base_dir, key)
+        if child_path is None:
+            raise ValueError(f"Invalid asset path: {key}")
+
         if isinstance(value, dict):
             os.makedirs(child_path, exist_ok=True)
             _write_nested_dict_to_dir(value, child_path)
         elif isinstance(value, np.ndarray):
-            os.makedirs(os.path.dirname(child_path), exist_ok=True)
             with open(child_path, "wb") as f:
                 f.write(value.tobytes())
 
@@ -1857,6 +1866,7 @@ def _load_assets_from_dict(model, assets_dict):
         return
 
     with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_dir = file_utils.resolve_path(tmp_dir)
         _write_nested_dict_to_dir(assets_dict, tmp_dir)
 
         assets_store = DiskIOStore(tmp_dir, mode="r")

--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -44,20 +44,51 @@ def resolve_path(path):
     return os.path.realpath(os.path.abspath(path))
 
 
-def is_path_in_dir(path, base_dir):
-    return resolve_path(os.path.join(base_dir, path)).startswith(base_dir)
+def resolve_sub_path(base_dir, relative_path):
+    """Verify that a relative path stays within the base directory.
+
+    Args:
+        base_dir: The base directory to check against, must be resolved via
+            `resolve_path`.
+        relative_path: The relative path to check.
+
+    Returns:
+        The resolved path if it is within the base directory, None otherwise.
+    """
+    path = resolve_path(os.path.join(base_dir, relative_path))
+    try:
+        if os.path.commonpath([path, base_dir]) == base_dir:
+            return path
+        return None
+    except ValueError:
+        return None
 
 
-def is_link_in_dir(info, base):
-    tip = resolve_path(os.path.join(base, os.path.dirname(info.name)))
-    return is_path_in_dir(info.linkname, base_dir=tip)
+def is_link_in_dir(info, base_dir):
+    if info.islnk():
+        # Hard links resolve relative to the root.
+        return resolve_sub_path(base_dir, info.linkname) is not None
+
+    # Symlinks resolve relative to the directory of their destination.
+    destination = resolve_sub_path(base_dir, info.name)
+    if destination is None:
+        return False
+    link = resolve_path(
+        os.path.join(os.path.dirname(destination), info.linkname)
+    )
+    try:
+        if os.path.commonpath([link, base_dir]) == base_dir:
+            return True
+        return False
+    except ValueError:
+        return False
 
 
 def filter_safe_zipinfos(members, base_dir):
     base_dir = resolve_path(base_dir)
     for finfo in members:
         valid_path = False
-        if is_path_in_dir(finfo.filename, base_dir):
+        if resolve_sub_path(base_dir, finfo.filename) is not None:
             valid_path = True
             yield finfo
         if not valid_path:
@@ -76,7 +107,7 @@ def filter_safe_tarinfos(members, base_dir):
             if is_link_in_dir(finfo, base_dir):
                 valid_path = True
                 yield finfo
-        elif is_path_in_dir(finfo.name, base_dir):
+        elif resolve_sub_path(base_dir, finfo.name) is not None:
             valid_path = True
             yield finfo
         if not valid_path:

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -7,6 +7,8 @@ import urllib.request
 import zipfile
 from unittest.mock import patch
 
+from absl.testing import parameterized
+
 from keras.src.testing import test_case
 from keras.src.utils import file_utils
 
@@ -50,61 +52,93 @@ class ResolvePathTest(test_case.TestCase):
         self.assertEqual(resolved_path, os.path.realpath(os.path.abspath(path)))
 
 
-class IsPathInDirTest(test_case.TestCase):
-    def test_is_path_in_dir_with_absolute_paths(self):
+class ResolveSubPathTest(test_case.TestCase):
+    def test_resolve_sub_path_with_absolute_paths(self):
         base_dir = os.path.join(os.path.sep, "path", "to", "base_dir")
         path = os.path.join(base_dir, "file.txt")
-        self.assertTrue(file_utils.is_path_in_dir(path, base_dir))
+        resolved_path = file_utils.resolve_sub_path(base_dir, path)
+        self.assertEqual(resolved_path, path)
+
+    def test_resolve_sub_path_with_subdir(self):
+        base_dir = os.path.join(os.path.sep, "path", "to", "base_dir")
+        path = os.path.join("subdir", "file.txt")
+        resolved_path = file_utils.resolve_sub_path(base_dir, path)
+        self.assertEqual(
+            resolved_path, os.path.realpath(os.path.join(base_dir, path))
+        )
+
+    def test_resolve_sub_path_with_same_dir(self):
+        base_dir = os.path.join(os.path.sep, "path", "to", "base_dir")
+        resolved_path = file_utils.resolve_sub_path(base_dir, ".")
+        self.assertEqual(resolved_path, os.path.realpath(base_dir))
+
+    def test_resolve_sub_path_with_path_traversal(self):
+        base_dir = os.path.join(os.path.sep, "path", "to", "base_dir")
+        path = os.path.join("..", "other_dir", "file.txt")
+        self.assertIsNone(file_utils.resolve_sub_path(base_dir, path))
+
+    def test_resolve_sub_path_with_prefix_confusion(self):
+        base_dir = os.path.join(os.path.sep, "path", "to", "base_dir")
+        path = os.path.join("..", "base_dir_other", "file.txt")
+        self.assertIsNone(file_utils.resolve_sub_path(base_dir, path))
 
 
 class IsLinkInDirTest(test_case.TestCase):
-    def test_is_link_in_dir_with_absolute_paths(self):
-        base_dir = self.get_temp_dir()
-        link_path = os.path.join(base_dir, "symlink")
-        target_path = os.path.join(base_dir, "file.txt")
+    @parameterized.named_parameters(
+        [
+            {
+                "testcase_name": "hardlink_in",
+                "is_symlink": False,
+                "name": None,
+                "linkname": "file.txt",
+                "expected": True,
+            },
+            {
+                "testcase_name": "hardlink_out",
+                "is_symlink": False,
+                "name": None,
+                "linkname": "../file.txt",
+                "expected": False,
+            },
+            {
+                "testcase_name": "symlink_in",
+                "is_symlink": True,
+                "name": "folder/foo.txt",
+                "linkname": "../file.txt",
+                "expected": True,
+            },
+            {
+                "testcase_name": "symlink_dest_out",
+                "is_symlink": True,
+                "name": "../foo.txt",
+                "linkname": "file.txt",
+                "expected": False,
+            },
+            {
+                "testcase_name": "symlink_link_out",
+                "is_symlink": True,
+                "name": "folder/foo.txt",
+                "linkname": "../../file.txt",
+                "expected": False,
+            },
+        ]
+    )
+    def test_is_link_in_dir(self, is_symlink, name, linkname, expected):
+        base_dir = file_utils.resolve_path(self.get_temp_dir())
 
-        # Create the file.txt file.
-        with open(target_path, "w") as f:
-            f.write("Hello, world!")
-
-        os.symlink(target_path, link_path)
-
-        # Creating a stat_result-like object with a name attribute
-        info = os.lstat(link_path)
+        # Creating a TarInfo-like object with a name attribute
         info = type(
-            "stat_with_name",
+            "TarInfo",
             (object,),
             {
-                "name": os.path.basename(link_path),
-                "linkname": os.readlink(link_path),
+                "name": name,
+                "linkname": linkname,
+                "issym": lambda: is_symlink,
+                "islnk": lambda: not is_symlink,
             },
         )
 
-        self.assertTrue(file_utils.is_link_in_dir(info, base_dir))
-
-    def test_is_link_in_dir_with_relative_paths(self):
-        base_dir = self.get_temp_dir()
-        link_path = os.path.join(base_dir, "symlink")
-        target_path = os.path.join(base_dir, "file.txt")
-
-        # Create the file.txt file.
-        with open(target_path, "w") as f:
-            f.write("Hello, world!")
-
-        os.symlink(target_path, link_path)
-
-        # Creating a stat_result-like object with a name attribute
-        info = os.lstat(link_path)
-        info = type(
-            "stat_with_name",
-            (object,),
-            {
-                "name": os.path.basename(link_path),
-                "linkname": os.readlink(link_path),
-            },
-        )
-
-        self.assertTrue(file_utils.is_link_in_dir(info, base_dir))
+        self.assertEqual(file_utils.is_link_in_dir(info, base_dir), expected)
 
 
 class FilterSafePathsTest(test_case.TestCase):


### PR DESCRIPTION
- Replaced `is_path_in_dir` with `resolve_sub_path` which resolves a relative path and makes sure it stays within the `base_dir`.
- Fixed `is_link_in_dir` to correctly resolve the paths depending on whether it is a hard link or a symlink.
- Use `resolve_sub_path` in `saving_lib._write_nested_dict_to_dir` which is used by the Orbax reloading.

## Contributor Agreement
**Please review our
[AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy)
and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
