### PR TITLE
Fix: Mask out-of-bounds class IDs (#22835)

### DIFF
--- a/keras/src/metrics/iou_metrics.py
+++ b/keras/src/metrics/iou_metrics.py
@@ -123,19 +123,40 @@ class _IoUBase(Metric):
 
         sample_weight = ops.broadcast_to(sample_weight, ops.shape(y_true))
 
+        # Build a bounds mask to filter out-of-range class IDs
+        # (>= num_classes or < 0) so they never reach the
+        # confusion matrix. This is graph-safe (no Python ifs
+        # on tensor values).
+        num_cls = ops.convert_to_tensor(self.num_classes, dtype=y_true.dtype)
+        bounds_mask = ops.logical_and(
+            ops.logical_and(
+                ops.greater_equal(y_true, 0),
+                ops.less(y_true, num_cls),
+            ),
+            ops.logical_and(
+                ops.greater_equal(y_pred, 0),
+                ops.less(y_pred, num_cls),
+            ),
+        )
+
         if self.ignore_class is not None:
             ignore_class = ops.convert_to_tensor(
                 self.ignore_class, y_true.dtype
             )
-            valid_mask = ops.not_equal(y_true, ignore_class)
-            y_true = ops.where(valid_mask, y_true, 0)
-            y_pred = ops.where(valid_mask, y_pred, 0)
-            if sample_weight is not None:
-                sample_weight = ops.where(valid_mask, sample_weight, 0)
+            bounds_mask = ops.logical_and(
+                bounds_mask,
+                ops.not_equal(y_true, ignore_class),
+            )
+
+        y_true = ops.where(bounds_mask, y_true, 0)
+        y_pred = ops.where(bounds_mask, y_pred, 0)
+
+        if sample_weight is not None:
+            sample_weight = ops.where(bounds_mask, sample_weight, 0)
+            sample_weight = ops.cast(sample_weight, dtype=self.dtype)
 
         y_pred = ops.cast(y_pred, dtype=self.dtype)
         y_true = ops.cast(y_true, dtype=self.dtype)
-        sample_weight = ops.cast(sample_weight, dtype=self.dtype)
 
         current_cm = confusion_matrix(
             y_true,
@@ -284,16 +305,25 @@ class IoU(_IoUBase):
             denominator, target_class_ids, axis=-1
         )
         denominator = ops.cast(denominator, dtype="float32")
+        true_positives = ops.cast(true_positives, dtype="float32")
 
         # If the denominator is 0, we need to ignore the class.
-        num_valid_entries = ops.sum(
-            ops.cast(ops.greater(denominator, 1e-9), dtype="float32")
+        valid_entries = ops.cast(
+            ops.greater(denominator, 1e-9), dtype="float32"
         )
+        num_valid_entries = ops.sum(valid_entries)
 
-        iou = ops.divide(true_positives, denominator + backend.epsilon())
+        iou = ops.divide(
+            true_positives,
+            denominator + backend.epsilon(),
+        )
+        # Zero out IoU for absent classes so they
+        # contribute 0.0, not ~1.0.
+        iou = ops.where(valid_entries, iou, 0.0)
 
         return ops.divide(
-            ops.sum(iou, axis=self.axis), num_valid_entries + backend.epsilon()
+            ops.sum(iou, axis=self.axis),
+            num_valid_entries + backend.epsilon(),
         )
 
     def get_config(self):

--- a/keras/src/metrics/iou_metrics_test.py
+++ b/keras/src/metrics/iou_metrics_test.py
@@ -131,9 +131,7 @@ class IoUTest(testing.TestCase):
         y_true = [0, 0, 1, 1]
         y_pred = [0, 1, 0, 1]
 
-        obj = metrics.IoU(
-            num_classes=4, target_class_ids=[0, 1, 2, 3]
-        )
+        obj = metrics.IoU(num_classes=4, target_class_ids=[0, 1, 2, 3])
         result = obj(y_true, y_pred)
 
         # cm = [[1, 1, 0, 0],
@@ -145,9 +143,7 @@ class IoUTest(testing.TestCase):
         # iou_0 = 1 / (2+2-1) = 1/3
         # iou_1 = 1 / (2+2-1) = 1/3
         # mean = (1/3 + 1/3) / 2 = 1/3
-        expected_result = (
-            1 / (2 + 2 - 1) + 1 / (2 + 2 - 1)
-        ) / 2
+        expected_result = (1 / (2 + 2 - 1) + 1 / (2 + 2 - 1)) / 2
         self.assertAllClose(result, expected_result, atol=1e-3)
 
     @pytest.mark.requires_trainable_backend

--- a/keras/src/metrics/iou_metrics_test.py
+++ b/keras/src/metrics/iou_metrics_test.py
@@ -97,6 +97,59 @@ class IoUTest(testing.TestCase):
         expected_result = (1 / (1 + 1 - 1)) / 1
         self.assertAllClose(result, expected_result, atol=1e-3)
 
+    def test_out_of_range_y_true_ignored(self):
+        # Class 2 is out of range for num_classes=2 and should
+        # be silently filtered out, leaving only (0,0).
+        obj = metrics.IoU(num_classes=2, target_class_ids=[0, 1])
+        obj.update_state([0, 2], [0, 1])
+        # cm = [[1, 0],
+        #       [0, 0]]
+        # Only class 0 valid: iou_0 = 1/(1+1-1) = 1.0
+        self.assertAllClose(obj.result(), 1.0, atol=1e-3)
+
+    def test_out_of_range_y_pred_ignored(self):
+        obj = metrics.IoU(num_classes=2, target_class_ids=[0, 1])
+        obj.update_state([0, 1], [0, 2])
+        # Only first pair (0,0) counts.
+        self.assertAllClose(obj.result(), 1.0, atol=1e-3)
+
+    def test_negative_y_true_ignored(self):
+        obj = metrics.IoU(num_classes=2, target_class_ids=[0, 1])
+        obj.update_state([-1, 0], [0, 0])
+        # Only second pair (0,0) counts.
+        self.assertAllClose(obj.result(), 1.0, atol=1e-3)
+
+    def test_negative_y_pred_ignored(self):
+        obj = metrics.IoU(num_classes=2, target_class_ids=[0, 1])
+        obj.update_state([0, 1], [-1, 1])
+        # Only second pair (1,1) counts.
+        self.assertAllClose(obj.result(), 1.0, atol=1e-3)
+
+    def test_absent_class_contributes_zero(self):
+        # With num_classes=4 but only classes 0 and 1 present,
+        # classes 2 and 3 must contribute 0.0 to the mean.
+        y_true = [0, 0, 1, 1]
+        y_pred = [0, 1, 0, 1]
+
+        obj = metrics.IoU(
+            num_classes=4, target_class_ids=[0, 1, 2, 3]
+        )
+        result = obj(y_true, y_pred)
+
+        # cm = [[1, 1, 0, 0],
+        #       [1, 1, 0, 0],
+        #       [0, 0, 0, 0],
+        #       [0, 0, 0, 0]]
+        # Classes 2 and 3 are absent: denom=0, iou=0.
+        # Only classes 0 and 1 are valid.
+        # iou_0 = 1 / (2+2-1) = 1/3
+        # iou_1 = 1 / (2+2-1) = 1/3
+        # mean = (1/3 + 1/3) / 2 = 1/3
+        expected_result = (
+            1 / (2 + 2 - 1) + 1 / (2 + 2 - 1)
+        ) / 2
+        self.assertAllClose(result, expected_result, atol=1e-3)
+
     @pytest.mark.requires_trainable_backend
     def test_compilation(self):
         m_obj = metrics.MeanIoU(num_classes=2, ignore_class=0)
@@ -356,6 +409,38 @@ class MeanIoUTest(testing.TestCase):
         # sum_row = [0, 1], sum_col = [0, 1], true_positives = [0, 1]
         # iou = true_positives / (sum_row + sum_col - true_positives))
         expected_result = (0 + 1 / (1 + 1 - 1)) / 1
+        self.assertAllClose(result, expected_result, atol=1e-3)
+
+    def test_out_of_range_ignored(self):
+        # Class 3 is out of range for num_classes=2 and should
+        # be silently filtered out.
+        m_obj = metrics.MeanIoU(num_classes=2)
+        m_obj.update_state([0, 3], [0, 1])
+        # Only first pair (0,0) counts.
+        self.assertAllClose(m_obj.result(), 1.0, atol=1e-3)
+
+    def test_negative_ignored(self):
+        m_obj = metrics.MeanIoU(num_classes=2)
+        m_obj.update_state([0, -1], [0, 1])
+        # Only first pair (0,0) counts.
+        self.assertAllClose(m_obj.result(), 1.0, atol=1e-3)
+
+    def test_absent_class_contributes_zero(self):
+        # num_classes=3 but only class 0 is present.
+        # Classes 1 and 2 must contribute 0 to the mean.
+        y_true = [0, 0, 0, 0]
+        y_pred = [0, 0, 0, 0]
+
+        m_obj = metrics.MeanIoU(num_classes=3)
+        result = m_obj(y_true, y_pred)
+
+        # cm = [[4, 0, 0],
+        #       [0, 0, 0],
+        #       [0, 0, 0]]
+        # Only class 0 is valid: iou_0 = 4/(4+4-4) = 1.0
+        # Classes 1, 2 contribute 0.0.
+        # mean = 1.0 / 1 = 1.0
+        expected_result = 1.0
         self.assertAllClose(result, expected_result, atol=1e-3)
 
     @staticmethod


### PR DESCRIPTION
## Description

Fix: Mask out-of-bounds class IDs and fix absent-class logic to stay within range in IoU metrics (#22835)

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.