### PR TITLE
fix: setting a fix seed in update kernel initializer

### DIFF
--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -167,6 +167,12 @@ class EinsumDense(Layer):
         Updates the kernel initializer with the correct input and output axes.
         """
         config = self.kernel_initializer.get_config()
+        # RandomInitializer.get_config() returns the seed passed to the
+        # constructor, which is often None. However, to maintain backwards
+        # compatibility with the old behavior of having one initializer called
+        # multiple times, we pass the concrete seed when cloning the
+        # initializer.
+        config["seed"] = self.kernel_initializer.seed
         config["input_axes"] = input_axes
         config["output_axes"] = output_axes
         return self.kernel_initializer.__class__.from_config(config)


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
The changes avoid setting random seed on each update_kernel_initializer call. This change is done to ensure same weight initialization on multiple build calls created using same object.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
