### PR TITLE
Skip one-batch-ahead prefetch iterator on CPU

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -1090,9 +1090,11 @@ class JAXEpochIterator(EpochIterator):
         if distribution is not None:
             return self._get_distributed_iterator(distribution)
         else:
-            return self._one_batch_ahead_iterator(
-                self.data_adapter.get_jax_iterator()
-            )
+            iterator = self.data_adapter.get_jax_iterator()
+            # No benefit from look-ahead on CPU — avoid the overhead
+            if jax.default_backend() == "cpu":
+                return iterator
+            return self._one_batch_ahead_iterator(iterator)
 
     def _get_distributed_iterator(self, distribution):
         """Lazily compute layouts to reduce host to device transfer latency."""


### PR DESCRIPTION
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

[3c4f2cc6c788](https://github.com/keras-team/keras/commit/3c4f2cc6c788da9d26b40d11882e36cf87e79734) re-enabled the `_one_batch_ahead_iterator` for all JAX training/inference paths, which initiates `jax.device_put` one step ahead to overlap CPU to accelerator data transfer with compute. While this is beneficial for GPU/TPU workloads, it introduces pure CPU overhead since there is no asynchronous device transfer to overlap.

This PR skips `_one_batch_ahead_iterator` when the JAX default backend is "cpu", returning the raw iterator directly. This restores the previous CPU behavior while preserving the transfer-overlap optimization for GPU/TPU.