### PR TITLE
Validate input channels in conv/depthwise_conv/separable_conv symbolic path

### DIFF
--- a/keras/src/backend/common/backend_utils.py
+++ b/keras/src/backend/common/backend_utils.py
@@ -307,12 +307,13 @@ def standardize_axis_for_numpy(axis):
     return tuple(axis) if isinstance(axis, list) else axis
 
 
-def check_depthwise_conv_input_channels(inputs, kernel, data_format):
-    """Validate a depthwise/separable conv input against its kernel shape.
+def check_conv_input_channels(inputs, kernel, data_format):
+    """Validate a conv input against its kernel shape.
 
-    Called from backend `depthwise_conv` / `separable_conv` after `inputs` has
-    been converted to a concrete tensor. Produces a clear error message before
-    the backend op raises its own implementation-specific one.
+    Used by `conv`, `depthwise_conv`, and `separable_conv` — all share the
+    convention that the kernel's input-channel dimension is `kernel.shape[-2]`.
+    Produces a clear error message before the backend op raises its own
+    implementation-specific one.
     """
     input_channels = (
         inputs.shape[-1] if data_format == "channels_last" else inputs.shape[1]

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -16,9 +16,7 @@ from jax.experimental.pallas.ops.tpu.splash_attention import (
 )
 
 from keras.src import backend
-from keras.src.backend.common.backend_utils import (
-    check_depthwise_conv_input_channels,
-)
+from keras.src.backend.common.backend_utils import check_conv_input_channels
 from keras.src.backend.common.backend_utils import (
     compute_adaptive_pooling_window_sizes,
 )
@@ -788,7 +786,7 @@ def depthwise_conv(
     data_format = backend.standardize_data_format(data_format)
     inputs = convert_to_tensor(inputs)
     kernel = convert_to_tensor(kernel)
-    check_depthwise_conv_input_channels(inputs, kernel, data_format)
+    check_conv_input_channels(inputs, kernel, data_format)
     num_spatial_dims = inputs.ndim - 2
     dimension_numbers = _convert_to_lax_conv_dimension_numbers(
         num_spatial_dims,
@@ -838,7 +836,7 @@ def separable_conv(
     inputs = convert_to_tensor(inputs)
     depthwise_kernel = convert_to_tensor(depthwise_kernel)
     pointwise_kernel = convert_to_tensor(pointwise_kernel)
-    check_depthwise_conv_input_channels(inputs, depthwise_kernel, data_format)
+    check_conv_input_channels(inputs, depthwise_kernel, data_format)
     depthwise_conv_output = depthwise_conv(
         inputs,
         depthwise_kernel,

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -3,9 +3,7 @@ import numpy as np
 from jax import lax
 
 from keras.src import backend
-from keras.src.backend.common.backend_utils import (
-    check_depthwise_conv_input_channels,
-)
+from keras.src.backend.common.backend_utils import check_conv_input_channels
 from keras.src.backend.common.backend_utils import (
     compute_adaptive_pooling_window_sizes,
 )
@@ -688,7 +686,7 @@ def depthwise_conv(
     data_format = backend.standardize_data_format(data_format)
     inputs = convert_to_tensor(inputs)
     kernel = convert_to_tensor(kernel)
-    check_depthwise_conv_input_channels(inputs, kernel, data_format)
+    check_conv_input_channels(inputs, kernel, data_format)
     num_spatial_dims = inputs.ndim - 2
     dimension_numbers = _convert_to_lax_conv_dimension_numbers(
         num_spatial_dims,
@@ -740,7 +738,7 @@ def separable_conv(
     inputs = convert_to_tensor(inputs)
     depthwise_kernel = convert_to_tensor(depthwise_kernel)
     pointwise_kernel = convert_to_tensor(pointwise_kernel)
-    check_depthwise_conv_input_channels(inputs, depthwise_kernel, data_format)
+    check_conv_input_channels(inputs, depthwise_kernel, data_format)
     depthwise_conv_output = depthwise_conv(
         inputs,
         depthwise_kernel,

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -4,9 +4,7 @@ import warnings
 import tensorflow as tf
 
 from keras.src import backend
-from keras.src.backend.common.backend_utils import (
-    check_depthwise_conv_input_channels,
-)
+from keras.src.backend.common.backend_utils import check_conv_input_channels
 from keras.src.backend.common.backend_utils import (
     compute_adaptive_pooling_window_sizes,
 )
@@ -858,7 +856,7 @@ def depthwise_conv(
             "`inputs` rank must be 3 (1D conv) or 4 (2D conv). Received: "
             f"{inputs.ndim}."
         )
-    check_depthwise_conv_input_channels(inputs, kernel, data_format)
+    check_conv_input_channels(inputs, kernel, data_format)
     # Because we use `tf.nn.depthwise_conv2d` for both 1D and 2D convs, we set
     # `tf_data_format` using 2D conv format.
     tf_data_format = _convert_data_format(data_format, 4)
@@ -940,7 +938,7 @@ def separable_conv(
             "`num_spatial_dims` must be 1 or 2. Received: "
             f"num_spatial_dims={num_spatial_dims}."
         )
-    check_depthwise_conv_input_channels(inputs, depthwise_kernel, data_format)
+    check_conv_input_channels(inputs, depthwise_kernel, data_format)
     # Because we use `tf.nn.separable_conv2d` for both 1D and 2D convs, we set
     # `tf_data_format` using 2D conv format.
     tf_data_format = _convert_data_format(data_format, 4)

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -2,9 +2,7 @@ import torch
 import torch.nn.functional as tnn
 
 from keras.src import backend
-from keras.src.backend.common.backend_utils import (
-    check_depthwise_conv_input_channels,
-)
+from keras.src.backend.common.backend_utils import check_conv_input_channels
 from keras.src.backend.common.backend_utils import (
     compute_conv_transpose_padding_args_for_torch,
 )
@@ -666,7 +664,7 @@ def depthwise_conv(
     data_format = backend.standardize_data_format(data_format)
     inputs = convert_to_tensor(inputs)
     kernel = convert_to_tensor(kernel)
-    check_depthwise_conv_input_channels(inputs, kernel, data_format)
+    check_conv_input_channels(inputs, kernel, data_format)
     kernel = torch.reshape(
         kernel, kernel.shape[:-2] + (1, kernel.shape[-2] * kernel.shape[-1])
     )
@@ -686,7 +684,7 @@ def separable_conv(
     inputs = convert_to_tensor(inputs)
     depthwise_kernel = convert_to_tensor(depthwise_kernel)
     pointwise_kernel = convert_to_tensor(pointwise_kernel)
-    check_depthwise_conv_input_channels(inputs, depthwise_kernel, data_format)
+    check_conv_input_channels(inputs, depthwise_kernel, data_format)
     depthwise_conv_output = depthwise_conv(
         inputs,
         depthwise_kernel,

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -8,6 +8,7 @@ from keras.src.backend import KerasTensor
 from keras.src.backend import any_symbolic_tensors
 from keras.src.backend import config
 from keras.src.backend import standardize_data_format
+from keras.src.backend.common.backend_utils import check_conv_input_channels
 from keras.src.backend.common.backend_utils import (
     compute_conv_transpose_output_shape,
 )
@@ -1456,13 +1457,15 @@ class Conv(Operation):
         )
 
     def compute_output_spec(self, inputs, kernel):
+        data_format = standardize_data_format(self.data_format)
+        check_conv_input_channels(inputs, kernel, data_format)
         output_shape = operation_utils.compute_conv_output_shape(
             inputs.shape,
             kernel.shape[-1],
             kernel.shape[:-2],
             self.strides,
             self.padding,
-            self.data_format,
+            data_format,
             self.dilation_rate,
         )
         return KerasTensor(output_shape, dtype=inputs.dtype)
@@ -1551,13 +1554,15 @@ class DepthwiseConv(Operation):
         )
 
     def compute_output_spec(self, inputs, kernel):
+        data_format = standardize_data_format(self.data_format)
+        check_conv_input_channels(inputs, kernel, data_format)
         output_shape = operation_utils.compute_conv_output_shape(
             inputs.shape,
             kernel.shape[-1] * kernel.shape[-2],
             kernel.shape[:-2],
             self.strides,
             self.padding,
-            self.data_format,
+            data_format,
             self.dilation_rate,
         )
         return KerasTensor(output_shape, dtype=inputs.dtype)
@@ -1657,17 +1662,19 @@ class SeparableConv(Operation):
         )
 
     def compute_output_spec(self, inputs, depthwise_kernel, pointwise_kernel):
+        data_format = standardize_data_format(self.data_format)
+        check_conv_input_channels(inputs, depthwise_kernel, data_format)
         output_shape = list(
             depthwise_conv(
                 inputs,
                 depthwise_kernel,
                 self.strides,
                 self.padding,
-                self.data_format,
+                data_format,
                 self.dilation_rate,
             ).shape
         )
-        if self.data_format == "channels_last":
+        if data_format == "channels_last":
             output_shape[-1] = pointwise_kernel.shape[-1]
         else:
             output_shape[1] = pointwise_kernel.shape[-1]

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1150,6 +1150,52 @@ class NNOpsStaticShapeTest(testing.TestCase):
             (2, 4, 5, 5) if data_format == "channels_last" else (2, 5, 4, 5),
         )
 
+    def test_conv_input_channel_validation(self):
+        data_format = backend.config.image_data_format()
+        if data_format == "channels_last":
+            input_shape = (2, 10, 3)
+        else:
+            input_shape = (2, 3, 10)
+        inputs = KerasTensor(input_shape)
+        # kernel input channels (5) do not match the input's channels (3)
+        bad_kernel = KerasTensor([3, 5, 4])
+        bad_depthwise_kernel = KerasTensor([3, 5, 1])
+        pointwise_kernel = KerasTensor([1, 5, 4])
+
+        with self.assertRaisesRegex(
+            ValueError, "input channels must match the kernel"
+        ):
+            knn.conv(inputs, bad_kernel, padding="valid")
+
+        with self.assertRaisesRegex(
+            ValueError, "input channels must match the kernel"
+        ):
+            knn.depthwise_conv(inputs, bad_depthwise_kernel, padding="valid")
+
+        with self.assertRaisesRegex(
+            ValueError, "input channels must match the kernel"
+        ):
+            knn.separable_conv(
+                inputs,
+                bad_depthwise_kernel,
+                pointwise_kernel,
+                padding="valid",
+            )
+
+        # Dynamic channel dimension should NOT raise.
+        if data_format == "channels_last":
+            dyn_inputs = KerasTensor((2, 10, None))
+        else:
+            dyn_inputs = KerasTensor((2, None, 10))
+        knn.conv(dyn_inputs, bad_kernel, padding="valid")
+        knn.depthwise_conv(dyn_inputs, bad_depthwise_kernel, padding="valid")
+        knn.separable_conv(
+            dyn_inputs,
+            bad_depthwise_kernel,
+            pointwise_kernel,
+            padding="valid",
+        )
+
     def test_conv_transpose(self):
         data_format = backend.config.image_data_format()
         if data_format == "channels_last":


### PR DESCRIPTION
## Description

Fixes #22852.

`keras.ops.conv`, `keras.ops.depthwise_conv`, and `keras.ops.separable_conv` validate that the input tensor's channel dimension matches the kernel's input channels in their **eager** path, but the **symbolic** path (`compute_output_spec`) silently fabricates an output shape from the mismatched kernel. The mismatch only surfaces at eager execution time, after the model has already been wired up.

This change reuses the existing channel-validation helper (added in #22687 for the eager path) and calls it from the symbolic path for all three ops.

### Before

```python
import keras, keras.ops as ops, numpy as np

x_sym = keras.Input(shape=(10, 3))                              # 3 channels
kernel = np.random.normal(size=(3, 5, 4)).astype("float32")      # in_channels=5

ops.conv(x_sym, kernel, padding="valid").shape  # (None, 8, 4)  silent
```

### After

```
ValueError: The number of input channels must match the kernel's input
channels. Received: input channels=3, kernel input channels=5,
data_format='channels_last'.
```

Same fix applied to `depthwise_conv` and `separable_conv`. Dynamic channel dimensions (`None`) still pass through, matching the eager path's behavior.

### Implementation

- Renamed `check_depthwise_conv_input_channels` → `check_conv_input_channels` since the helper is identical for all three convs (they share the `kernel.shape[-2]` input-channel convention). Updated the four backend call sites accordingly.
- Added the call in `Conv.compute_output_spec`, `DepthwiseConv.compute_output_spec`, and `SeparableConv.compute_output_spec` in `keras/src/ops/nn.py`.
- Added `test_conv_input_channel_validation` in `NNOpsStaticShapeTest` covering all three ops, plus a dynamic-channel negative case.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.