### PR TITLE
Implement segment_prod function in keras.ops

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -63,6 +63,7 @@ from keras.src.ops.math import rfft as rfft
 from keras.src.ops.math import rsqrt as rsqrt
 from keras.src.ops.math import segment_max as segment_max
 from keras.src.ops.math import segment_min as segment_min
+from keras.src.ops.math import segment_prod as segment_prod
 from keras.src.ops.math import segment_sum as segment_sum
 from keras.src.ops.math import stft as stft
 from keras.src.ops.math import top_k as top_k

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -63,6 +63,7 @@ from keras.src.ops.math import rfft as rfft
 from keras.src.ops.math import rsqrt as rsqrt
 from keras.src.ops.math import segment_max as segment_max
 from keras.src.ops.math import segment_min as segment_min
+from keras.src.ops.math import segment_prod as segment_prod
 from keras.src.ops.math import segment_sum as segment_sum
 from keras.src.ops.math import stft as stft
 from keras.src.ops.math import top_k as top_k

--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -41,6 +41,17 @@ def segment_min(data, segment_ids, num_segments=None, sorted=False):
     )
 
 
+def segment_prod(data, segment_ids, num_segments=None, sorted=False):
+    if num_segments is None:
+        raise ValueError(
+            "Argument `num_segments` must be set when using the JAX backend. "
+            "Received: num_segments=None"
+        )
+    return jax.ops.segment_prod(
+        data, segment_ids, num_segments, indices_are_sorted=sorted
+    )
+
+
 def top_k(x, k, sorted=True):
     # Jax does not supported `sorted`, but in the case where `sorted=False`,
     # order is not guaranteed, so OK to return sorted output.

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -26,6 +26,8 @@ def _segment_reduction_fn(
         result = np.ones(data_shape, dtype=valid_data.dtype) * -np.inf
     elif reduction_method == np.minimum:
         result = np.ones(data_shape, dtype=valid_data.dtype) * np.inf
+    elif reduction_method == np.multiply:
+        result = np.ones(data_shape, dtype=valid_data.dtype)
     else:
         result = np.zeros(data_shape, dtype=valid_data.dtype)
 
@@ -56,6 +58,12 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
 def segment_min(data, segment_ids, num_segments=None, sorted=False):
     return _segment_reduction_fn(
         data, segment_ids, np.minimum, num_segments, sorted
+    )
+
+
+def segment_prod(data, segment_ids, num_segments=None, sorted=False):
+    return _segment_reduction_fn(
+        data, segment_ids, np.multiply, num_segments, sorted
     )
 
 

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -24,3 +24,4 @@ NNOpsCorrectnessTest::test_ctc_decode
 NNOpsDtypeTest::test_ctc_decode
 RandAugmentTest::test_random_augment_randomness
 SegmentMinTest::test_segment_min_call
+SegmentProdTest::test_segment_prod_call

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -141,6 +141,12 @@ def segment_min(data, segment_ids, num_segments=None, sorted=False):
     )
 
 
+def segment_prod(data, segment_ids, num_segments=None, sorted=False):
+    raise NotImplementedError(
+        "`segment_prod` is not supported with openvino backend"
+    )
+
+
 def top_k(x, k, sorted=True):
     x = get_ov_output(x)
     k_tensor = ov_opset.constant(k, dtype=Type.i32)

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -59,11 +59,11 @@ def segment_prod(data, segment_ids, num_segments=None, sorted=False):
                 "when using the tensorflow backend."
                 f"Received: num_segments={num_segments}, sorted={sorted}."
             )
-        return tf.math.segment_min(data, segment_ids)
+        return tf.math.segment_prod(data, segment_ids)
     else:
         if num_segments is None:
             num_segments = tf.cast(tf.reduce_max(segment_ids) + 1, tf.int32)
-        return tf.math.segment_prod(data, segment_ids, num_segments)
+        return tf.math.unsorted_segment_prod(data, segment_ids, num_segments)
 
 
 def top_k(x, k, sorted=True):

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -51,6 +51,21 @@ def segment_min(data, segment_ids, num_segments=None, sorted=False):
         return tf.math.unsorted_segment_min(data, segment_ids, num_segments)
 
 
+def segment_prod(data, segment_ids, num_segments=None, sorted=False):
+    if sorted:
+        if num_segments is not None:
+            raise ValueError(
+                "Argument `num_segments` cannot be set when sorted is True "
+                "when using the tensorflow backend."
+                f"Received: num_segments={num_segments}, sorted={sorted}."
+            )
+        return tf.math.segment_min(data, segment_ids)
+    else:
+        if num_segments is None:
+            num_segments = tf.cast(tf.reduce_max(segment_ids) + 1, tf.int32)
+        return tf.math.segment_prod(data, segment_ids, num_segments)
+
+
 def top_k(x, k, sorted=True):
     return tf.math.top_k(x, k, sorted=sorted)
 

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -38,6 +38,8 @@ def _segment_reduction_fn(data, segment_ids, reduction_method, num_segments):
         result = torch.ones(*shape, device=get_device()) * -float("Inf")
     elif reduction_method == "amin":
         result = torch.ones(*shape, device=get_device()) * float("Inf")
+    elif reduction_method == "prod":
+        result = torch.ones(shape, device=get_device(), dtype=torch.float32)
     else:
         result = torch.zeros(*shape, device=get_device())
 
@@ -67,6 +69,12 @@ def segment_min(data, segment_ids, num_segments=None, sorted=False):
     data = convert_to_tensor(data)
     segment_ids = convert_to_tensor(segment_ids)
     return _segment_reduction_fn(data, segment_ids, "amin", num_segments)
+
+
+def segment_prod(data, segment_ids, num_segments=None, sorted=False):
+    data = convert_to_tensor(data)
+    segment_ids = convert_to_tensor(segment_ids)
+    return _segment_reduction_fn(data, segment_ids, "prod", num_segments)
 
 
 def top_k(x, k, sorted=True):

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -39,7 +39,7 @@ def _segment_reduction_fn(data, segment_ids, reduction_method, num_segments):
     elif reduction_method == "amin":
         result = torch.ones(*shape, device=get_device()) * float("Inf")
     elif reduction_method == "prod":
-        result = torch.ones(shape, device=get_device(), dtype=torch.float32)
+        result = torch.ones(*shape, device=get_device())
     else:
         result = torch.zeros(*shape, device=get_device())
 

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -197,8 +197,9 @@ def segment_prod(data, segment_ids, num_segments=None, sorted=False):
 
     Args:
         data: Input tensor.
-        segment_ids: A N-D tensor containing segment indices for each
-            element in `data`. data.shape[:len(segment_ids.shape)] should match.
+        segment_ids: A 1-D tensor containing segment indices for each
+            element in `data`. `data.shape[0]` should match
+            `segment_ids.shape[0]`.
         num_segments: An integer representing the total number of
             segments. If not specified, it is inferred from the maximum
             value in `segment_ids`.

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -180,6 +180,55 @@ def segment_min(data, segment_ids, num_segments=None, sorted=False):
     )
 
 
+class SegmentProd(SegmentReduction):
+    def call(self, data, segment_ids):
+        _segment_reduce_validation(data, segment_ids)
+        return backend.math.segment_prod(
+            data,
+            segment_ids,
+            num_segments=self.num_segments,
+            sorted=self.sorted,
+        )
+
+
+@keras_export("keras.ops.segment_prod")
+def segment_prod(data, segment_ids, num_segments=None, sorted=False):
+    """Computes the product of segments in a tensor.
+
+    Args:
+        data: Input tensor.
+        segment_ids: A N-D tensor containing segment indices for each
+            element in `data`. data.shape[:len(segment_ids.shape)] should match.
+        num_segments: An integer representing the total number of
+            segments. If not specified, it is inferred from the maximum
+            value in `segment_ids`.
+        sorted: A boolean indicating whether `segment_ids` is sorted.
+            Defaults to `False`.
+
+    Returns:
+        A tensor containing the product of segments, where each element
+        represents the product of the corresponding segment in `data`.
+
+    Example:
+
+    >>> data = keras.ops.convert_to_tensor([1, 2, 10, 20, 100, 200])
+    >>> segment_ids = keras.ops.convert_to_tensor([0, 0, 1, 1, 2, 2])
+    >>> num_segments = 3
+    >>> keras.ops.segment_prod(data, segment_ids, num_segments)
+    array([2, 200, 20000], dtype=int32)
+    """
+    _segment_reduce_validation(data, segment_ids)
+
+    if any_symbolic_tensors((data,)):
+        return SegmentProd(
+            num_segments,
+            sorted,
+        ).symbolic_call(data, segment_ids)
+    return backend.math.segment_prod(
+        data, segment_ids, num_segments=num_segments, sorted=sorted
+    )
+
+
 class TopK(Operation):
     def __init__(self, k, sorted=True, *, name=None):
         super().__init__(name=name)

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -210,7 +210,6 @@ def segment_prod(data, segment_ids, num_segments=None, sorted=False):
         represents the product of the corresponding segment in `data`.
 
     Example:
-
     >>> data = keras.ops.convert_to_tensor([1, 2, 10, 20, 100, 200])
     >>> segment_ids = keras.ops.convert_to_tensor([0, 0, 1, 1, 2, 2])
     >>> num_segments = 3

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1165,15 +1165,23 @@ class SegmentMinTest(testing.TestCase):
 
 class SegmentProdTest(testing.TestCase):
     def test_segment_prod_call(self):
+        data = np.array([[1, 4, 7], [3, 6, 9], [2, 5, 8]], dtype=np.float32)
+        segment_ids = np.array([0, 1, 0], dtype=np.int32)
+
+        segment_prod_op = kmath.SegmentProd(num_segments=2, sorted=False)
+
+        output = segment_prod_op.call(data, segment_ids)
+        expected_output = np.array(
+            [[2, 20, 56], [3, 6, 9]],
+            dtype=np.float32,
+        )
+        self.assertAllClose(output, expected_output)
+
+    def test_segment_prod_call_sorted(self):
         data = np.array([[1, 4, 7], [2, 5, 8], [3, 6, 9]], dtype=np.float32)
         segment_ids = np.array([0, 0, 1], dtype=np.int32)
 
-        num_segments = 2
-        sorted_segments = False
-
-        segment_prod_op = kmath.SegmentProd(
-            num_segments=num_segments, sorted=sorted_segments
-        )
+        segment_prod_op = kmath.SegmentProd(num_segments=2, sorted=True)
 
         output = segment_prod_op.call(data, segment_ids)
         expected_output = np.array(

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1177,7 +1177,30 @@ class SegmentProdTest(testing.TestCase):
         )
         self.assertAllClose(output, expected_output)
 
+    @pytest.mark.skipif(
+        backend.backend() == "tensorflow",
+        reason="Argument `num_segments` cannot be set when sorted is True "
+        f"when using the {backend.backend()}",
+    )
     def test_segment_prod_call_sorted(self):
+        data = np.array([[1, 4, 7], [2, 5, 8], [3, 6, 9]], dtype=np.float32)
+        segment_ids = np.array([0, 0, 1], dtype=np.int32)
+
+        segment_prod_op = kmath.SegmentProd(num_segments=2, sorted=True)
+
+        output = segment_prod_op.call(data, segment_ids)
+        expected_output = np.array(
+            [[2, 20, 56], [3, 6, 9]],
+            dtype=np.float32,
+        )
+        self.assertAllClose(output, expected_output)
+
+    @pytest.mark.skipif(
+        backend.backend() == "jax",
+        reason="Argument `num_segments` must be set "
+        f"when using the {backend.backend()}",
+    )
+    def test_segment_prod_call_sorted_without_num_segments(self):
         data = np.array([[1, 4, 7], [2, 5, 8], [3, 6, 9]], dtype=np.float32)
         segment_ids = np.array([0, 0, 1], dtype=np.int32)
 

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1181,7 +1181,7 @@ class SegmentProdTest(testing.TestCase):
         data = np.array([[1, 4, 7], [2, 5, 8], [3, 6, 9]], dtype=np.float32)
         segment_ids = np.array([0, 0, 1], dtype=np.int32)
 
-        segment_prod_op = kmath.SegmentProd(num_segments=2, sorted=True)
+        segment_prod_op = kmath.SegmentProd(sorted=True)
 
         output = segment_prod_op.call(data, segment_ids)
         expected_output = np.array(

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1163,6 +1163,26 @@ class SegmentMinTest(testing.TestCase):
         self.assertAllClose(output, expected_output)
 
 
+class SegmentProdTest(testing.TestCase):
+    def test_segment_prod_call(self):
+        data = np.array([[1, 4, 7], [2, 5, 8], [3, 6, 9]], dtype=np.float32)
+        segment_ids = np.array([0, 0, 1], dtype=np.int32)
+
+        num_segments = 2
+        sorted_segments = False
+
+        segment_prod_op = kmath.SegmentProd(
+            num_segments=num_segments, sorted=sorted_segments
+        )
+
+        output = segment_prod_op.call(data, segment_ids)
+        expected_output = np.array(
+            [[2, 20, 56], [3, 6, 9]],
+            dtype=np.float32,
+        )
+        self.assertAllClose(output, expected_output)
+
+
 class TopKTest(testing.TestCase):
     def test_top_k_call_values(self):
         data = np.array([[1, 3, 2], [4, 6, 5]], dtype=np.float32)


### PR DESCRIPTION
## Description
Adds keras.ops.segment_prod, which computes the product of values within each segment of a tensor, based on provided segment IDs.
Supported across NumPy, TensorFlow, PyTorch, and JAX backends. Not supported on OpenVINO.


## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
