### PR TITLE
Validate newshape in reshape for consistent backend behavior

### DIFF
--- a/keras/src/layers/reshaping/reshape.py
+++ b/keras/src/layers/reshaping/reshape.py
@@ -3,6 +3,7 @@ from keras.src.api_export import keras_export
 from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.layers.layer import Layer
 from keras.src.ops import operation_utils
+from keras.src.ops.operation_utils import validate_reshape_shape
 
 
 @keras_export("keras.layers.Reshape")
@@ -37,12 +38,7 @@ class Reshape(Layer):
     def __init__(self, target_shape, **kwargs):
         super().__init__(**kwargs)
         target_shape = tuple(target_shape)
-        # test validity of target_shape
-        if target_shape.count(-1) > 1:
-            raise ValueError(
-                "The `target_shape` argument must not contain more than one "
-                f"`-1` value. Received: target_shape={target_shape}"
-            )
+        validate_reshape_shape(target_shape, newshape_arg_name="target_shape")
         self.target_shape = target_shape
         self.built = True
 

--- a/keras/src/layers/reshaping/reshape_test.py
+++ b/keras/src/layers/reshaping/reshape_test.py
@@ -95,6 +95,20 @@ class ReshapeTest(testing.TestCase):
         reshaped = layers.Reshape((8,))(input_layer)
         self.assertEqual(reshaped.shape, (None, 8))
 
+    def test_reshape_rejects_invalid_target_shape(self):
+        # Negative values other than -1 are invalid.
+        with self.assertRaisesRegex(
+            ValueError, "non-negative integer.*-1.*target_shape=\\(-2, 5\\)"
+        ):
+            layers.Reshape(target_shape=(-2, 5))
+
+        # Existing constraint: at most one -1.
+        with self.assertRaisesRegex(
+            ValueError,
+            "at most one unknown dimension.*target_shape=\\(-1, -1, 5\\)",
+        ):
+            layers.Reshape(target_shape=(-1, -1, 5))
+
     def test_reshape_with_dynamic_batch_size_and_minus_one(self):
         input = KerasTensor((None, 6, 4))
         layer = layers.Reshape((-1, 8))

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -7185,6 +7185,8 @@ def reshape(x, newshape):
     Returns:
         The reshaped tensor.
     """
+    newshape = tuple(newshape)
+    operation_utils.validate_reshape_shape(newshape)
     if any_symbolic_tensors((x,)):
         return Reshape(newshape).symbolic_call(x)
     return backend.numpy.reshape(x, newshape)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6174,6 +6174,23 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.Reshape([3, 2])(x), np.reshape(x, [3, 2]))
         self.assertAllClose(knp.Reshape(-1)(x), np.reshape(x, -1))
 
+    def test_reshape_rejects_invalid_newshape(self):
+        x = np.zeros(20, dtype="float32")
+        # Negative values other than -1 should be rejected on every backend
+        # (NumPy alone accepted them silently, the other backends raised
+        # unrelated low-level errors).
+        with self.assertRaisesRegex(
+            ValueError, "non-negative integer.*-1.*newshape=\\(-2, 5\\)"
+        ):
+            knp.reshape(x, (-2, 5))
+
+        # More than one -1 is still rejected.
+        with self.assertRaisesRegex(
+            ValueError,
+            "at most one unknown dimension.*newshape=\\(-1, -1, 5\\)",
+        ):
+            knp.reshape(x, (-1, -1, 5))
+
     def test_roll(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertAllClose(knp.roll(x, 1), np.roll(x, 1))

--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -282,17 +282,35 @@ def compute_matmul_output_shape(shape1, shape2):
     return tuple(output_shape)
 
 
+def validate_reshape_shape(newshape, newshape_arg_name="newshape"):
+    """Validate the `newshape` argument of `reshape`.
+
+    Each dimension that is a concrete Python int must be either non-negative
+    or `-1` (with at most one `-1`). Dynamic dimensions (e.g. backend tensor
+    scalars resolved at runtime) are not validated here.
+    """
+    for dim in newshape:
+        if isinstance(dim, int) and dim < -1:
+            raise ValueError(
+                f"Each dimension in `{newshape_arg_name}` must be a "
+                "non-negative integer, or `-1` for a single unknown "
+                f"dimension. Received: {newshape_arg_name}={newshape}."
+            )
+    if [d for d in newshape if isinstance(d, int)].count(-1) > 1:
+        raise ValueError(
+            "There must be at most one unknown dimension (-1) in "
+            f"`{newshape_arg_name}`. Received: "
+            f"{newshape_arg_name}={newshape}."
+        )
+
+
 def compute_reshape_output_shape(input_shape, newshape, newshape_arg_name):
     """Converts `-1` in `newshape` to either an actual dimension or `None`.
 
     This utility does not special case the 0th dimension (batch size).
     """
+    validate_reshape_shape(newshape, newshape_arg_name)
     unknown_dim_count = newshape.count(-1)
-    if unknown_dim_count > 1:
-        raise ValueError(
-            "There must be at most one unknown dimension (-1) in "
-            f"{newshape_arg_name}. Received: {newshape_arg_name}={newshape}."
-        )
 
     # If there is a None in input_shape, we can't infer what the -1 is
     if None in input_shape:


### PR DESCRIPTION
## Description

Fixes #22867.

`keras.ops.reshape` and `keras.layers.Reshape` document that only `-1` may be used as a wildcard dimension in the target shape, but neither validates this. The result depends on the backend:

| Backend | `ops.reshape(np.zeros(20), (-2, 5))` |
|---------|---------------------------------------|
| NumPy | silently returns shape `(4, 5)` |
| TensorFlow | `InvalidArgumentError: Size 0 must be non-negative, not -2` |
| JAX | `TypeError: cannot reshape array ... (size -10)` |
| Torch | `RuntimeError: invalid shape dimension -2` |

Keras 3 promises a consistent API across backends; three backends reject with three different error types while NumPy silently produces a different result than the documented contract.

### After this PR

All four backends raise the same clear `ValueError` at the Keras level:

```
ValueError: Each dimension in `newshape` must be a non-negative integer,
or `-1` for a single unknown dimension. Received: newshape=(-2, 5).
```

The same validation runs at `keras.layers.Reshape.__init__` so invalid `target_shape` is caught at construction time rather than at call time with a confusing \"total size of the tensor must be unchanged\" message.

### Implementation

- Extracted a new `validate_reshape_shape` helper in `keras/src/ops/operation_utils.py`. It rejects any concrete-int dimension `< -1` and requires at most one `-1`. Dynamic dimensions (backend tensor scalars resolved at runtime, used by `Reshape.call`) pass through unchecked.
- `compute_reshape_output_shape` now delegates its existing `-1`-count check to the helper, so the same rule is applied everywhere.
- `keras.ops.reshape` calls the helper before dispatching, so the eager path gets the same validation as the symbolic path.
- `keras.layers.Reshape.__init__` calls the helper, surfacing invalid `target_shape` at construction time instead of at call time.
- Added regression tests in `keras/src/ops/numpy_test.py` and `keras/src/layers/reshaping/reshape_test.py`.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.