### PR TITLE
Remove duplication of qr in linalg and math modules for all backends

### DIFF
--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -63,16 +63,6 @@ def logsumexp(x, axis=None, keepdims=False):
     return jax.scipy.special.logsumexp(x, axis=axis, keepdims=keepdims)
 
 
-def qr(x, mode="reduced"):
-    if mode not in {"reduced", "complete"}:
-        raise ValueError(
-            "`mode` argument value not supported. "
-            "Expected one of {'reduced', 'complete'}. "
-            f"Received: mode={mode}"
-        )
-    return jnp.linalg.qr(x, mode=mode)
-
-
 def cdist(x, y):
     x = jnp.asarray(x)
     y = jnp.asarray(y)

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -86,16 +86,6 @@ def logsumexp(x, axis=None, keepdims=False):
     return scipy.special.logsumexp(x, axis=axis, keepdims=keepdims)
 
 
-def qr(x, mode="reduced"):
-    if mode not in {"reduced", "complete"}:
-        raise ValueError(
-            "`mode` argument value not supported. "
-            "Expected one of {'reduced', 'complete'}. "
-            f"Received: mode={mode}"
-        )
-    return np.linalg.qr(x, mode=mode)
-
-
 def cdist(x, y):
     x = np.asarray(x)
     y = np.asarray(y)

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -205,10 +205,6 @@ def logsumexp(x, axis=None, keepdims=False):
     return OpenVINOKerasTensor(log_sum_exp)
 
 
-def qr(x, mode="reduced"):
-    raise NotImplementedError("`qr` is not supported with openvino backend")
-
-
 def cdist(x, y):
     raise NotImplementedError(
         "`cdist` is not supported with the OpenVINO backend"

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -63,18 +63,6 @@ def logsumexp(x, axis=None, keepdims=False):
     return tf.math.reduce_logsumexp(x, axis=axis, keepdims=keepdims)
 
 
-def qr(x, mode="reduced"):
-    if mode not in {"reduced", "complete"}:
-        raise ValueError(
-            "`mode` argument value not supported. "
-            "Expected one of {'reduced', 'complete'}. "
-            f"Received: mode={mode}"
-        )
-    if mode == "reduced":
-        return tf.linalg.qr(x)
-    return tf.linalg.qr(x, full_matrices=True)
-
-
 def cdist(x, y):
     x = convert_to_tensor(x)
     y = convert_to_tensor(y)

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -90,18 +90,6 @@ def logsumexp(x, axis=None, keepdims=False):
     return torch.logsumexp(x, dim=axis, keepdim=keepdims)
 
 
-def qr(x, mode="reduced"):
-    x = convert_to_tensor(x)
-    if mode not in {"reduced", "complete"}:
-        raise ValueError(
-            "`mode` argument value not supported. "
-            "Expected one of {'reduced', 'complete'}. "
-            f"Received: mode={mode}"
-        )
-    x = convert_to_tensor(x)
-    return torch.linalg.qr(x, mode=mode)
-
-
 def cdist(x, y):
     x = convert_to_tensor(x)
     y = convert_to_tensor(y)


### PR DESCRIPTION
## Description
keras.ops.qr is defined in linalg.py, and always delegates to linalg.py implementation of qr for all backends.
This PR removes the duplication of qr in math.py, since there is no path that calls these implementations.

This same thing was previously done in #22691, but got accidently reverted in #22095. 

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
