### PR TITLE
MultiOptimizer support for model training #21741

### DIFF
--- a/keras/api/_tf_keras/keras/optimizers/__init__.py
+++ b/keras/api/_tf_keras/keras/optimizers/__init__.py
@@ -21,6 +21,10 @@ from keras.src.optimizers.lion import Lion as Lion
 from keras.src.optimizers.loss_scale_optimizer import (
     LossScaleOptimizer as LossScaleOptimizer,
 )
+from keras.src.optimizers.multi_optimizer import (
+    MultiOptimizer as MultiOptimizer,
+)
+from keras.src.optimizers.multi_optimizer import OptimizerMap as OptimizerMap
 from keras.src.optimizers.muon import Muon as Muon
 from keras.src.optimizers.nadam import Nadam as Nadam
 from keras.src.optimizers.optimizer import Optimizer as Optimizer

--- a/keras/api/optimizers/__init__.py
+++ b/keras/api/optimizers/__init__.py
@@ -21,6 +21,10 @@ from keras.src.optimizers.lion import Lion as Lion
 from keras.src.optimizers.loss_scale_optimizer import (
     LossScaleOptimizer as LossScaleOptimizer,
 )
+from keras.src.optimizers.multi_optimizer import (
+    MultiOptimizer as MultiOptimizer,
+)
+from keras.src.optimizers.multi_optimizer import OptimizerMap as OptimizerMap
 from keras.src.optimizers.muon import Muon as Muon
 from keras.src.optimizers.nadam import Nadam as Nadam
 from keras.src.optimizers.optimizer import Optimizer as Optimizer

--- a/keras/src/optimizers/__init__.py
+++ b/keras/src/optimizers/__init__.py
@@ -8,6 +8,7 @@ from keras.src.optimizers.adamw import AdamW
 from keras.src.optimizers.ftrl import Ftrl
 from keras.src.optimizers.lion import Lion
 from keras.src.optimizers.loss_scale_optimizer import LossScaleOptimizer
+from keras.src.optimizers.multi_optimizer import MultiOptimizer, OptimizerMap
 from keras.src.optimizers.muon import Muon
 from keras.src.optimizers.nadam import Nadam
 from keras.src.optimizers.optimizer import Optimizer
@@ -27,6 +28,8 @@ ALL_OBJECTS = {
     Adamax,
     Adafactor,
     Muon,
+    MultiOptimizer,
+    OptimizerMap,
     Nadam,
     Ftrl,
     Lion,

--- a/keras/src/optimizers/__init__.py
+++ b/keras/src/optimizers/__init__.py
@@ -8,7 +8,8 @@ from keras.src.optimizers.adamw import AdamW
 from keras.src.optimizers.ftrl import Ftrl
 from keras.src.optimizers.lion import Lion
 from keras.src.optimizers.loss_scale_optimizer import LossScaleOptimizer
-from keras.src.optimizers.multi_optimizer import MultiOptimizer, OptimizerMap
+from keras.src.optimizers.multi_optimizer import MultiOptimizer
+from keras.src.optimizers.multi_optimizer import OptimizerMap
 from keras.src.optimizers.muon import Muon
 from keras.src.optimizers.nadam import Nadam
 from keras.src.optimizers.optimizer import Optimizer

--- a/keras/src/optimizers/multi_optimizer.py
+++ b/keras/src/optimizers/multi_optimizer.py
@@ -16,8 +16,7 @@ class OptimizerMap:
         optimizer: A list of optimizer instances.
         variable_identifier: A list of variable identifiers matching the
             optimizer list. Identifiers can be string regex patterns, Keras
-            Variables, list/tuple of Keras Variables, or callables returning a
-            boolean.
+            Variables, or list/tuple of Keras Variables.
     """
 
     def __init__(self, optimizer, variable_identifier):
@@ -53,9 +52,6 @@ class OptimizerMap:
         return None
 
     def _match(self, variable, identifier):
-        # If callable, evaluate it
-        if callable(identifier) and not isinstance(identifier, str):
-            return bool(identifier(variable))
         # If string, treat it as a regex pattern
         if isinstance(identifier, str):
             path = getattr(variable, "path", "") or ""
@@ -84,12 +80,11 @@ class MultiOptimizer(optimizer.Optimizer):
 
     # 2. Create mapping using different identifier types
     opt_map = keras.optimizers.OptimizerMap(
-        optimizer=[opt_adam, opt_sgd, opt_adam, opt_sgd, opt_adam],
+        optimizer=[opt_adam, opt_sgd, opt_adam, opt_sgd],
         variable_identifier=[
             "kernel",                            # variable name or path
             "^dense_1/.*",                       # regex pattern
             keras_var,                           # Keras Variable instance
-            lambda var: "bias" in var.name,      # custom callable function
             [var1, var2]                         # list/tuple
         ]
     )
@@ -130,7 +125,6 @@ class MultiOptimizer(optimizer.Optimizer):
         self.obj_map = obj_map
         self.default_optimizer = default_optimizer
 
-        # Disable loss scaling for all inner optimizers to avoid double scaling
         self.default_optimizer.loss_scale_factor = None
         for opt in self.obj_map.optimizer:
             opt.loss_scale_factor = None
@@ -225,6 +219,11 @@ class MultiOptimizer(optimizer.Optimizer):
             self.build(trainable_variables)
             self.built = True
 
+        # Statefully unscale gradients if loss_scale_factor is set
+        if self.loss_scale_factor is not None:
+            scale = self.loss_scale_factor
+            grads = [g if g is None else g / scale for g in grads]
+
         # Group gradients and variables by sub-optimizer
         optimizer_to_grads_and_vars = {
             opt: [] for opt in self._inner_optimizers
@@ -248,6 +247,11 @@ class MultiOptimizer(optimizer.Optimizer):
 
         if trainable_variables is None:
             trainable_variables = self._trainable_variables
+
+        # Statelessly unscale gradients if loss_scale_factor is set
+        if self.loss_scale_factor is not None:
+            scale = self.loss_scale_factor
+            grads = [g if g is None else g / scale for g in grads]
 
         own_var_count = len(self._variables)
         own_variables = optimizer_variables[:own_var_count]
@@ -366,10 +370,6 @@ class MultiOptimizer(optimizer.Optimizer):
                     serialized_identifiers.append(f"^({or_pattern})$")
                 else:
                     serialized_identifiers.append(identifier)
-            elif callable(identifier):
-                serialized_identifiers.append(
-                    serialization_lib.serialize_keras_object(identifier)
-                )
             else:
                 serialized_identifiers.append(identifier)
 
@@ -410,12 +410,7 @@ class MultiOptimizer(optimizer.Optimizer):
             for opt_config in serialized_opts
         ]
 
-        variable_identifiers = [
-            serialization_lib.deserialize_keras_object(
-                ident, custom_objects=custom_objects
-            )
-            for ident in obj_map_config["config"]["variable_identifier"]
-        ]
+        variable_identifiers = obj_map_config["config"]["variable_identifier"]
 
         map_cls = cls._get_map_class(
             obj_map_config["class_name"], custom_objects

--- a/keras/src/optimizers/multi_optimizer.py
+++ b/keras/src/optimizers/multi_optimizer.py
@@ -76,8 +76,7 @@ class MultiOptimizer(optimizer.Optimizer):
         default_optimizer: Default Keras Optimizer for any unmapped variables.
         name: String. The name of this optimizer.
     """
-
-    @tracking.no_automatic_dependency_tracking
+    
     def __init__(self, obj_map, default_optimizer, name=None, **kwargs):
         if not isinstance(obj_map, OptimizerMap):
             raise ValueError(
@@ -352,8 +351,6 @@ class MultiOptimizer(optimizer.Optimizer):
     def _get_map_class(cls, class_name, custom_objects=None):
         if custom_objects and class_name in custom_objects:
             return custom_objects[class_name]
-        if class_name == "OptimizerMap":
-            return OptimizerMap
         globals_dict = globals()
         if class_name in globals_dict:
             return globals_dict[class_name]

--- a/keras/src/optimizers/multi_optimizer.py
+++ b/keras/src/optimizers/multi_optimizer.py
@@ -2,6 +2,7 @@ import re
 
 from keras.src import ops
 from keras.src.api_export import keras_export
+from keras.src.backend.common.variables import Variable
 from keras.src.optimizers import optimizer
 from keras.src.saving import serialization_lib
 from keras.src.utils import tracking
@@ -85,7 +86,7 @@ class MultiOptimizer(optimizer.Optimizer):
     opt_map = keras.optimizers.OptimizerMap(
         optimizer=[opt_adam, opt_sgd, opt_adam, opt_sgd, opt_adam],
         variable_identifier=[
-            "kernel",                            # name substring
+            "kernel",                            # variable name or path
             "^dense_1/.*",                       # regex pattern
             keras_var,                           # Keras Variable instance
             lambda var: "bias" in var.name,      # custom callable function
@@ -210,9 +211,8 @@ class MultiOptimizer(optimizer.Optimizer):
 
     @property
     def iterations(self):
-        if self._inner_optimizers:
-            return self._inner_optimizers[0].iterations
-        return super().iterations
+        # master and inner optimizer iterations will be in sync.
+        return self._iterations
 
     def apply(self, grads, trainable_variables=None):
         if len(grads) == 0:
@@ -330,10 +330,12 @@ class MultiOptimizer(optimizer.Optimizer):
                 "optimizer weights before calling `set_weights()`."
             )
 
-        # Distribute weights back to wrapper and sub-optimizers
-        self._iterations.assign(weights[0])
+        # Distribute own variables dynamically (iterations, learning_rate, etc.)
+        own_var_count = len(self._variables)
+        for i in range(own_var_count):
+            self._variables[i].assign(weights[i])
 
-        idx = 1
+        idx = own_var_count
         for opt in self._inner_optimizers:
             num_opt_vars = len(opt.variables)
             if num_opt_vars > 0:
@@ -343,6 +345,34 @@ class MultiOptimizer(optimizer.Optimizer):
 
     def get_config(self):
         config = super().get_config()
+
+        serialized_identifiers = []
+        for identifier in self.obj_map.variable_identifier:
+            if isinstance(identifier, Variable):
+                serialized_identifiers.append(
+                    f"^{re.escape(identifier.path or identifier.name)}$"
+                )
+            elif isinstance(identifier, (list, tuple, set)):
+                if any(isinstance(item, Variable) for item in identifier):
+                    escaped_paths = []
+                    for item in identifier:
+                        if isinstance(item, Variable):
+                            escaped_paths.append(
+                                re.escape(item.path or item.name)
+                            )
+                        else:
+                            escaped_paths.append(re.escape(str(item)))
+                    or_pattern = "|".join(escaped_paths)
+                    serialized_identifiers.append(f"^({or_pattern})$")
+                else:
+                    serialized_identifiers.append(identifier)
+            elif callable(identifier):
+                serialized_identifiers.append(
+                    serialization_lib.serialize_keras_object(identifier)
+                )
+            else:
+                serialized_identifiers.append(identifier)
+
         serialized_map = {
             "class_name": self.obj_map.__class__.__name__,
             "config": {
@@ -350,7 +380,7 @@ class MultiOptimizer(optimizer.Optimizer):
                     serialization_lib.serialize_keras_object(opt)
                     for opt in self.obj_map.optimizer
                 ],
-                "variable_identifier": self.obj_map.variable_identifier,
+                "variable_identifier": serialized_identifiers,
             },
         }
         config.update(
@@ -379,7 +409,13 @@ class MultiOptimizer(optimizer.Optimizer):
             )
             for opt_config in serialized_opts
         ]
-        variable_identifiers = obj_map_config["config"]["variable_identifier"]
+
+        variable_identifiers = [
+            serialization_lib.deserialize_keras_object(
+                ident, custom_objects=custom_objects
+            )
+            for ident in obj_map_config["config"]["variable_identifier"]
+        ]
 
         map_cls = cls._get_map_class(
             obj_map_config["class_name"], custom_objects

--- a/keras/src/optimizers/multi_optimizer.py
+++ b/keras/src/optimizers/multi_optimizer.py
@@ -71,10 +71,41 @@ class OptimizerMap:
 class MultiOptimizer(optimizer.Optimizer):
     """An optimizer wrapper that delegates variables to different optimizers.
 
+    Example:
+
+    ```python
+    # 1. Define your sub-optimizers
+    opt_adam = keras.optimizers.Adam(learning_rate=1e-3)
+    opt_sgd = keras.optimizers.SGD(learning_rate=1e-2)
+    default_opt = keras.optimizers.RMSprop(learning_rate=1e-4)
+
+    # 2. Create mapping using different identifier types
+    opt_map = keras.optimizers.OptimizerMap(
+        optimizer=[opt_adam, opt_sgd, opt_adam, opt_sgd, opt_adam],
+        variable_identifier=[
+            "kernel",                            # 1. Match variable name substring
+            "^dense_1/.*",                       # 2. Match variable path regex pattern
+            keras_var,                           # 3. Match exact Keras Variable instance
+            lambda var: "bias" in var.name,      # 4. Match via custom callable function
+            [var1, var2]                         # 5. Match if variable is in list/tuple
+        ]
+    )
+
+    # 3. Wrap and compile
+    multi_opt = keras.optimizers.MultiOptimizer(
+        obj_map=opt_map,
+        default_optimizer=default_opt
+    )
+    model.compile(optimizer=multi_opt, loss="mse")
+    ```
+
+    Note: You can subclass `OptimizerMap` to define custom routing logic by
+    overriding its `__call__(self, variable)` method.
+
     Args:
-        obj_map: An OptimizerMap instance.
-        default_optimizer: Default Keras Optimizer for any unmapped variables.
-        name: String. The name of this optimizer.
+        obj_map: An `OptimizerMap` instance containing variable-to-optimizer rules.
+        default_optimizer: Default Keras `Optimizer` for any unmapped variables.
+        name: String. The name of this optimizer. Defaults to `"multi_optimizer"`.
     """
     
     def __init__(self, obj_map, default_optimizer, name=None, **kwargs):

--- a/keras/src/optimizers/multi_optimizer.py
+++ b/keras/src/optimizers/multi_optimizer.py
@@ -15,8 +15,8 @@ class OptimizerMap:
     Args:
         optimizer: A list of optimizer instances.
         variable_identifier: A list of variable identifiers matching the
-            optimizer list. Identifiers can be string regex patterns, Keras
-            Variables, or list/tuple of Keras Variables.
+            length of the optimizer list. Identifiers can be string regex
+            patterns, Keras Variables, or list/tuple of Keras Variables.
     """
 
     def __init__(self, optimizer, variable_identifier):
@@ -73,6 +73,7 @@ class MultiOptimizer(optimizer.Optimizer):
     Example:
 
     ```python
+
     # 1. Define your sub-optimizers
     opt_adam = keras.optimizers.Adam(learning_rate=1e-3)
     opt_sgd = keras.optimizers.SGD(learning_rate=1e-2)

--- a/keras/src/optimizers/multi_optimizer.py
+++ b/keras/src/optimizers/multi_optimizer.py
@@ -1,0 +1,362 @@
+import re
+from keras.src import backend
+from keras.src.api_export import keras_export
+from keras.src.optimizers import optimizer
+from keras.src.saving import serialization_lib
+from keras.src.utils import tracking
+from keras.src import ops
+
+
+@keras_export("keras.optimizers.OptimizerMap")
+class OptimizerMap:
+    """A class mapping variables to optimizers.
+
+    Args:
+        optimizer: A list of optimizer instances.
+        variable_identifier: A list of variable identifiers matching the
+            optimizer list. Identifiers can be string regex patterns, Keras
+            Variables, list/tuple of Keras Variables, or callables returning a
+            boolean.
+    """
+
+    def __init__(self, optimizer, variable_identifier):
+        self.optimizer = optimizer
+        self.variable_identifier = variable_identifier
+
+    def __call__(self, variable):
+        """Evaluates a single variable and returns its assigned optimizer.
+
+        Args:
+            variable: A single Keras Variable.
+
+        Returns:
+            An Optimizer instance if matched, or None.
+
+        Raises:
+            ValueError: If multiple different optimizers are mapped to the same
+                variable.
+        """
+        matched_optimizers = []
+        for opt, identifier in zip(self.optimizer, self.variable_identifier):
+            if self._match(variable, identifier):
+                if opt not in matched_optimizers:
+                    matched_optimizers.append(opt)
+
+        if len(matched_optimizers) > 1:
+            raise ValueError(
+                f"Multiple optimizers assigned to variable {variable.path or variable.name}: "
+                f"{matched_optimizers}"
+            )
+        elif len(matched_optimizers) == 1:
+            return matched_optimizers[0]
+        return None
+
+    def _match(self, variable, identifier):
+        # If identifier is a callable, evaluate it
+        if callable(identifier) and not isinstance(identifier, str):
+            return bool(identifier(variable))
+        # If identifier is a string, treat it as a regex pattern
+        if isinstance(identifier, str):
+            path = getattr(variable, "path", "") or ""
+            name = getattr(variable, "name", "") or ""
+            return bool(re.match(identifier, path) or re.match(identifier, name))
+        # If identifier is a list/tuple/set, check identity containment to avoid value-based comparison
+        if isinstance(identifier, (list, tuple, set)):
+            return any(variable is item for item in identifier)
+        # Direct identity comparison
+        return variable is identifier
+
+
+@keras_export("keras.optimizers.MultiOptimizer")
+class MultiOptimizer(optimizer.Optimizer):
+    """An optimizer wrapper that delegates variables to different optimizers.
+
+    Args:
+        obj_map: An OptimizerMap instance.
+        default_optimizer: Default Keras Optimizer for any unmapped variables.
+        name: String. The name of this optimizer.
+    """
+
+    @tracking.no_automatic_dependency_tracking
+    def __init__(self, obj_map, default_optimizer, name=None, **kwargs):
+        if not isinstance(obj_map, OptimizerMap):
+            raise ValueError(
+                f"obj_map must be an instance of OptimizerMap. Received: {obj_map}"
+            )
+        if not isinstance(default_optimizer, optimizer.Optimizer):
+            raise ValueError(
+                f"default_optimizer must be a Keras Optimizer instance. "
+                f"Received: {default_optimizer}"
+            )
+
+        # Always set learning_rate to 0.0 as it's not supported for MultiOptimizer
+        learning_rate = 0.0
+        super().__init__(learning_rate=learning_rate, name=name)
+
+        self.obj_map = obj_map
+        self.default_optimizer = default_optimizer
+
+        # Disable loss scaling for all inner optimizers to avoid double scaling
+        self.default_optimizer.loss_scale_factor = None
+        for opt in self.obj_map.optimizer:
+            opt.loss_scale_factor = None
+
+        # Unique inner optimizers list, keeping default optimizer at the end
+        unique_opts = []
+        for opt in self.obj_map.optimizer:
+            if opt not in unique_opts:
+                unique_opts.append(opt)
+        if self.default_optimizer not in unique_opts:
+            unique_opts.append(self.default_optimizer)
+        else:
+            unique_opts.remove(self.default_optimizer)
+            unique_opts.append(self.default_optimizer)
+
+        self._inner_optimizers = unique_opts
+
+    def _var_key(self, variable):
+        return id(variable)
+
+    @tracking.no_automatic_dependency_tracking
+    def build(self, var_list):
+        if self.built:
+            return
+
+        self._var_to_optimizer_idx = {}
+        self._optimizer_to_vars = {opt: [] for opt in self._inner_optimizers}
+
+        for var in var_list:
+            opt = self.obj_map(var)
+            if opt is None:
+                opt = self.default_optimizer
+
+            idx = self._inner_optimizers.index(opt)
+            self._var_to_optimizer_idx[self._var_key(var)] = idx
+            self._optimizer_to_vars[opt].append(var)
+
+        # Build all sub-optimizers
+        for opt, variables in self._optimizer_to_vars.items():
+            if variables:
+                opt.build(variables)
+
+        super().build(var_list)
+
+    def _get_optimizer_for_variable(self, variable):
+        idx = self._var_to_optimizer_idx.get(self._var_key(variable), None)
+        if idx is None:
+            raise ValueError(f"Variable {variable} not found in any optimizer.")
+        return self._inner_optimizers[idx]
+
+    def get_optimizer(self, index):
+        return self._inner_optimizers[index]
+
+    @property
+    def num_optimizers(self):
+        return len(self._inner_optimizers)
+
+    @property
+    def variables(self):
+        # MultiOptimizer iterations + all sub-optimizer variables
+        vars = self._variables[:]
+        for opt in self._inner_optimizers:
+            vars.extend(opt.variables)
+        return vars
+
+    @property
+    def learning_rate(self):
+        if self._inner_optimizers:
+            return self._inner_optimizers[0].learning_rate
+        return super().learning_rate
+
+    @learning_rate.setter
+    def learning_rate(self, value):
+        if self._inner_optimizers:
+            self._inner_optimizers[0].learning_rate = value
+        else:
+            super().learning_rate = value
+
+    @property
+    def iterations(self):
+        if self._inner_optimizers:
+            return self._inner_optimizers[0].iterations
+        return super().iterations
+
+    def apply(self, grads, trainable_variables=None):
+        if len(grads) == 0:
+            return
+
+        if trainable_variables is None:
+            trainable_variables = self._trainable_variables
+
+        if not self.built:
+            self.build(trainable_variables)
+            self.built = True
+
+        # Group gradients and variables by sub-optimizer
+        optimizer_to_grads_and_vars = {opt: [] for opt in self._inner_optimizers}
+        for grad, var in zip(grads, trainable_variables):
+            opt = self._get_optimizer_for_variable(var)
+            optimizer_to_grads_and_vars[opt].append((grad, var))
+
+        # Dispatch apply calls
+        for opt, grads_and_vars in optimizer_to_grads_and_vars.items():
+            if grads_and_vars:
+                sub_grads, sub_vars = zip(*grads_and_vars)
+                opt.apply(list(sub_grads), list(sub_vars))
+
+        # Keep master iterations in sync
+        self._iterations.assign_add(1)
+
+    def stateless_apply(self, optimizer_variables, grads, trainable_variables):
+        if len(grads) == 0:
+            return trainable_variables, optimizer_variables
+        
+        if trainable_variables is None:
+            trainable_variables = self._trainable_variables
+
+        own_var_count = len(self._variables)
+        own_variables = optimizer_variables[:own_var_count]
+        remaining_opt_vars = optimizer_variables[own_var_count:]
+        
+        inner_opt_variables = []
+        offset = 0
+        for opt in self._inner_optimizers:
+            opt_var_count = len(opt.variables)
+            opt_vars = remaining_opt_vars[offset:offset + opt_var_count]
+            inner_opt_variables.append(opt_vars)
+            offset += opt_var_count
+
+        optimizer_grads = [[] for _ in self._inner_optimizers]
+        optimizer_train_vars = [[] for _ in self._inner_optimizers]
+        optimizer_train_var_indices = [[] for _ in self._inner_optimizers]
+
+        for i, (grad, var) in enumerate(zip(grads, trainable_variables)):
+            # Map the incoming stateless tracer array to the static Keras Variable via index alignment
+            keras_var = self._trainable_variables[i]
+            opt = self._get_optimizer_for_variable(keras_var)
+            opt_idx = self._inner_optimizers.index(opt)
+            
+            optimizer_grads[opt_idx].append(grad)
+            optimizer_train_vars[opt_idx].append(var)
+            optimizer_train_var_indices[opt_idx].append(i)
+        
+        new_trainable_variables = list(trainable_variables)
+        new_inner_opt_variables = []
+
+        for opt_idx, opt in enumerate(self._inner_optimizers):
+            grads_group = optimizer_grads[opt_idx]
+            vars_group = optimizer_train_vars[opt_idx]
+            indices = optimizer_train_var_indices[opt_idx]
+            opt_vars = inner_opt_variables[opt_idx]
+
+            if grads_group:
+                updated_vars, updated_opt_vars = opt.stateless_apply(
+                    opt_vars, grads_group, vars_group
+                )
+                # Update the trainable variables at the correct indices
+                for j, idx in enumerate(indices):
+                    new_trainable_variables[idx] = updated_vars[j]
+                new_inner_opt_variables.extend(updated_opt_vars)
+            else:
+                new_inner_opt_variables.extend(opt_vars)
+
+        # Statelessly increment the master iterations counter
+        new_own_variables = list(own_variables)
+        if new_own_variables:
+            new_own_variables[0] = ops.cast(
+                new_own_variables[0] + 1, new_own_variables[0].dtype
+            )
+
+        new_optimizer_variables = new_own_variables + new_inner_opt_variables
+        return new_trainable_variables, new_optimizer_variables
+        
+    def scale_loss(self, loss):
+        if self.loss_scale_factor is not None:
+            return loss * self.loss_scale_factor
+        return loss
+
+    def finalize_variable_values(self, var_list):
+        optimizer_to_vars = {opt: [] for opt in self._inner_optimizers}
+        for var in var_list:
+            opt = self._get_optimizer_for_variable(var)
+            optimizer_to_vars[opt].append(var)
+
+        for opt, variables in optimizer_to_vars.items():
+            if variables:
+                opt.finalize_variable_values(variables)
+
+    def set_weights(self, weights):
+        if not self.built:
+            raise ValueError(
+                "You are calling `set_weights()` on an optimizer that has not "
+                "yet been built. Please call "
+                "`optimizer.build(trainable_variables)` to create the "
+                "optimizer weights before calling `set_weights()`."
+            )
+
+        # Distribute weights back to wrapper and sub-optimizers
+        self._iterations.assign(weights[0])
+
+        idx = 1
+        for opt in self._inner_optimizers:
+            num_opt_vars = len(opt.variables)
+            if num_opt_vars > 0:
+                opt_weights = weights[idx:idx + num_opt_vars]
+                opt.set_weights(opt_weights)
+                idx += num_opt_vars
+
+    def get_config(self):
+        config = super().get_config()
+        serialized_map = {
+            "class_name": self.obj_map.__class__.__name__,
+            "config": {
+                "optimizer": [
+                    serialization_lib.serialize_keras_object(opt)
+                    for opt in self.obj_map.optimizer
+                ],
+                "variable_identifier": self.obj_map.variable_identifier,
+            },
+        }
+        config.update({
+            "obj_map": serialized_map,
+            "default_optimizer": serialization_lib.serialize_keras_object(
+                self.default_optimizer
+            ),
+        })
+        return config
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        obj_map_config = config.pop("obj_map")
+        default_opt_config = config.pop("default_optimizer")
+
+        default_optimizer = serialization_lib.deserialize_keras_object(
+            default_opt_config, custom_objects=custom_objects
+        )
+
+        serialized_opts = obj_map_config["config"]["optimizer"]
+        optimizers_list = [
+            serialization_lib.deserialize_keras_object(
+                opt_config, custom_objects=custom_objects
+            )
+            for opt_config in serialized_opts
+        ]
+        variable_identifiers = obj_map_config["config"]["variable_identifier"]
+
+        map_cls = cls._get_map_class(obj_map_config["class_name"], custom_objects)
+        obj_map = map_cls(optimizers_list, variable_identifiers)
+
+        return cls(obj_map=obj_map, default_optimizer=default_optimizer, **config)
+
+    @classmethod
+    def _get_map_class(cls, class_name, custom_objects=None):
+        if custom_objects and class_name in custom_objects:
+            return custom_objects[class_name]
+        if class_name == "OptimizerMap":
+            return OptimizerMap
+        globals_dict = globals()
+        if class_name in globals_dict:
+            return globals_dict[class_name]
+        raise ValueError(
+            f"Could not find class {class_name} for OptimizerMap deserialization."
+        )

--- a/keras/src/optimizers/multi_optimizer.py
+++ b/keras/src/optimizers/multi_optimizer.py
@@ -1,10 +1,10 @@
 import re
-from keras.src import backend
+
+from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.optimizers import optimizer
 from keras.src.saving import serialization_lib
 from keras.src.utils import tracking
-from keras.src import ops
 
 
 @keras_export("keras.optimizers.OptimizerMap")
@@ -44,23 +44,25 @@ class OptimizerMap:
 
         if len(matched_optimizers) > 1:
             raise ValueError(
-                f"Multiple optimizers assigned to variable {variable.path or variable.name}: "
-                f"{matched_optimizers}"
+                f"Multiple optimizers assigned to variable "
+                f"{variable.path or variable.name}: {matched_optimizers}"
             )
         elif len(matched_optimizers) == 1:
             return matched_optimizers[0]
         return None
 
     def _match(self, variable, identifier):
-        # If identifier is a callable, evaluate it
+        # If callable, evaluate it
         if callable(identifier) and not isinstance(identifier, str):
             return bool(identifier(variable))
-        # If identifier is a string, treat it as a regex pattern
+        # If string, treat it as a regex pattern
         if isinstance(identifier, str):
             path = getattr(variable, "path", "") or ""
             name = getattr(variable, "name", "") or ""
-            return bool(re.match(identifier, path) or re.match(identifier, name))
-        # If identifier is a list/tuple/set, check identity containment to avoid value-based comparison
+            return bool(
+                re.match(identifier, path) or re.match(identifier, name)
+            )
+        # list/tuple/set
         if isinstance(identifier, (list, tuple, set)):
             return any(variable is item for item in identifier)
         # Direct identity comparison
@@ -83,11 +85,11 @@ class MultiOptimizer(optimizer.Optimizer):
     opt_map = keras.optimizers.OptimizerMap(
         optimizer=[opt_adam, opt_sgd, opt_adam, opt_sgd, opt_adam],
         variable_identifier=[
-            "kernel",                            # 1. Match variable name substring
-            "^dense_1/.*",                       # 2. Match variable path regex pattern
-            keras_var,                           # 3. Match exact Keras Variable instance
-            lambda var: "bias" in var.name,      # 4. Match via custom callable function
-            [var1, var2]                         # 5. Match if variable is in list/tuple
+            "kernel",                            # name substring
+            "^dense_1/.*",                       # regex pattern
+            keras_var,                           # Keras Variable instance
+            lambda var: "bias" in var.name,      # custom callable function
+            [var1, var2]                         # list/tuple
         ]
     )
 
@@ -103,15 +105,18 @@ class MultiOptimizer(optimizer.Optimizer):
     overriding its `__call__(self, variable)` method.
 
     Args:
-        obj_map: An `OptimizerMap` instance containing variable-to-optimizer rules.
+        obj_map: An `OptimizerMap` instance containing
+               variable-to-optimizer rules.
         default_optimizer: Default Keras `Optimizer` for any unmapped variables.
-        name: String. The name of this optimizer. Defaults to `"multi_optimizer"`.
+        name: String. The name of this optimizer. Defaults to
+              "multi_optimizer".
     """
-    
+
     def __init__(self, obj_map, default_optimizer, name=None, **kwargs):
         if not isinstance(obj_map, OptimizerMap):
             raise ValueError(
-                f"obj_map must be an instance of OptimizerMap. Received: {obj_map}"
+                f"obj_map must be an instance "
+                f"of OptimizerMap. Received: {obj_map}"
             )
         if not isinstance(default_optimizer, optimizer.Optimizer):
             raise ValueError(
@@ -119,9 +124,7 @@ class MultiOptimizer(optimizer.Optimizer):
                 f"Received: {default_optimizer}"
             )
 
-        # Always set learning_rate to 0.0 as it's not supported for MultiOptimizer
-        learning_rate = 0.0
-        super().__init__(learning_rate=learning_rate, name=name)
+        super().__init__(learning_rate=0.0, name=name)
 
         self.obj_map = obj_map
         self.default_optimizer = default_optimizer
@@ -223,7 +226,9 @@ class MultiOptimizer(optimizer.Optimizer):
             self.built = True
 
         # Group gradients and variables by sub-optimizer
-        optimizer_to_grads_and_vars = {opt: [] for opt in self._inner_optimizers}
+        optimizer_to_grads_and_vars = {
+            opt: [] for opt in self._inner_optimizers
+        }
         for grad, var in zip(grads, trainable_variables):
             opt = self._get_optimizer_for_variable(var)
             optimizer_to_grads_and_vars[opt].append((grad, var))
@@ -240,19 +245,19 @@ class MultiOptimizer(optimizer.Optimizer):
     def stateless_apply(self, optimizer_variables, grads, trainable_variables):
         if len(grads) == 0:
             return trainable_variables, optimizer_variables
-        
+
         if trainable_variables is None:
             trainable_variables = self._trainable_variables
 
         own_var_count = len(self._variables)
         own_variables = optimizer_variables[:own_var_count]
         remaining_opt_vars = optimizer_variables[own_var_count:]
-        
+
         inner_opt_variables = []
         offset = 0
         for opt in self._inner_optimizers:
             opt_var_count = len(opt.variables)
-            opt_vars = remaining_opt_vars[offset:offset + opt_var_count]
+            opt_vars = remaining_opt_vars[offset : offset + opt_var_count]
             inner_opt_variables.append(opt_vars)
             offset += opt_var_count
 
@@ -261,15 +266,16 @@ class MultiOptimizer(optimizer.Optimizer):
         optimizer_train_var_indices = [[] for _ in self._inner_optimizers]
 
         for i, (grad, var) in enumerate(zip(grads, trainable_variables)):
-            # Map the incoming stateless tracer array to the static Keras Variable via index alignment
+            # Map the incoming stateless tracer array
+            # to the static Keras Variable via index alignment
             keras_var = self._trainable_variables[i]
             opt = self._get_optimizer_for_variable(keras_var)
             opt_idx = self._inner_optimizers.index(opt)
-            
+
             optimizer_grads[opt_idx].append(grad)
             optimizer_train_vars[opt_idx].append(var)
             optimizer_train_var_indices[opt_idx].append(i)
-        
+
         new_trainable_variables = list(trainable_variables)
         new_inner_opt_variables = []
 
@@ -299,7 +305,7 @@ class MultiOptimizer(optimizer.Optimizer):
 
         new_optimizer_variables = new_own_variables + new_inner_opt_variables
         return new_trainable_variables, new_optimizer_variables
-        
+
     def scale_loss(self, loss):
         if self.loss_scale_factor is not None:
             return loss * self.loss_scale_factor
@@ -331,7 +337,7 @@ class MultiOptimizer(optimizer.Optimizer):
         for opt in self._inner_optimizers:
             num_opt_vars = len(opt.variables)
             if num_opt_vars > 0:
-                opt_weights = weights[idx:idx + num_opt_vars]
+                opt_weights = weights[idx : idx + num_opt_vars]
                 opt.set_weights(opt_weights)
                 idx += num_opt_vars
 
@@ -347,12 +353,14 @@ class MultiOptimizer(optimizer.Optimizer):
                 "variable_identifier": self.obj_map.variable_identifier,
             },
         }
-        config.update({
-            "obj_map": serialized_map,
-            "default_optimizer": serialization_lib.serialize_keras_object(
-                self.default_optimizer
-            ),
-        })
+        config.update(
+            {
+                "obj_map": serialized_map,
+                "default_optimizer": serialization_lib.serialize_keras_object(
+                    self.default_optimizer
+                ),
+            }
+        )
         return config
 
     @classmethod
@@ -373,10 +381,14 @@ class MultiOptimizer(optimizer.Optimizer):
         ]
         variable_identifiers = obj_map_config["config"]["variable_identifier"]
 
-        map_cls = cls._get_map_class(obj_map_config["class_name"], custom_objects)
+        map_cls = cls._get_map_class(
+            obj_map_config["class_name"], custom_objects
+        )
         obj_map = map_cls(optimizers_list, variable_identifiers)
 
-        return cls(obj_map=obj_map, default_optimizer=default_optimizer, **config)
+        return cls(
+            obj_map=obj_map, default_optimizer=default_optimizer, **config
+        )
 
     @classmethod
     def _get_map_class(cls, class_name, custom_objects=None):
@@ -386,5 +398,6 @@ class MultiOptimizer(optimizer.Optimizer):
         if class_name in globals_dict:
             return globals_dict[class_name]
         raise ValueError(
-            f"Could not find class {class_name} for OptimizerMap deserialization."
+            f"Could not find class {class_name} for "
+            "OptimizerMap deserialization."
         )

--- a/keras/src/optimizers/multi_optimizer_test.py
+++ b/keras/src/optimizers/multi_optimizer_test.py
@@ -210,6 +210,48 @@ class MultiOptimizerTest(testing.TestCase):
         # Verify callback correctly modified ONLY the first optimizer (opt_adam)
         self.assertAllClose(opt_adam.learning_rate, 5e-2)
         self.assertAllClose(opt_sgd.learning_rate, 1e-2)
+    
+    def test_optimizer_map_comprehensive(self):
+        with backend.name_scope("dense_1"):
+            w_dense1_kernel = backend.Variable([[1.0]], name="kernel")
+            w_dense1_bias = backend.Variable([[1.0]], name="bias")
+        with backend.name_scope("dense_2"):
+            w_dense2_kernel = backend.Variable([[1.0]], name="kernel")
+        w_exact = backend.Variable([[1.0]], name="exact_var")
+        w_other1 = backend.Variable([[1.0]], name="other1")
+        w_other2 = backend.Variable([[1.0]], name="other2")
+
+        opt_adam = optimizers.Adam(learning_rate=1e-3)
+        opt_sgd = optimizers.SGD(learning_rate=1e-2)
+
+        # Comprehensive mapping covering all 5 types of identifiers:
+        # 1. String substring matching
+        # 2. Regex matching
+        # 3. Keras Variable instance direct match
+        # 4. Callable match
+        # 5. List/Tuple of Keras variables
+        opt_map = optimizers.OptimizerMap(
+            optimizer=[opt_adam, opt_sgd, opt_adam, opt_sgd, opt_adam],
+            variable_identifier=[
+                "exact_var",
+                "^dense_1/.*",
+                w_dense2_kernel,
+                lambda var: "bias" in (var.path or var.name),
+                [w_other1, w_other2]
+            ]
+        )
+
+        # 1. Substring match -> opt_adam
+        self.assertEqual(opt_map(w_exact), opt_adam)
+        # 2. Regex match -> opt_sgd
+        self.assertEqual(opt_map(w_dense1_kernel), opt_sgd)
+        # 3. Keras Variable direct match -> opt_adam
+        self.assertEqual(opt_map(w_dense2_kernel), opt_adam)
+        # 4. Callable match -> opt_sgd (and matches dense_1/.* also mapping to opt_sgd)
+        self.assertEqual(opt_map(w_dense1_bias), opt_sgd)
+        # 5. List/Tuple match -> opt_adam
+        self.assertEqual(opt_map(w_other1), opt_adam)
+        self.assertEqual(opt_map(w_other2), opt_adam)
 
     def test_serialization(self):
         opt_adam = optimizers.Adam(learning_rate=1e-3)

--- a/keras/src/optimizers/multi_optimizer_test.py
+++ b/keras/src/optimizers/multi_optimizer_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from keras.src import backend
 from keras.src import callbacks
 from keras.src import layers
@@ -20,18 +21,14 @@ class MultiOptimizerTest(testing.TestCase):
 
         # Test regex matching
         var_identifier = ["^dense/.*", "^conv/.*"]
-        opt_map = optimizers.OptimizerMap(
-            [opt_adam, opt_sgd], var_identifier
-        )
+        opt_map = optimizers.OptimizerMap([opt_adam, opt_sgd], var_identifier)
 
         self.assertEqual(opt_map(w_dense), opt_adam)
         self.assertEqual(opt_map(w_conv), opt_sgd)
         self.assertIsNone(opt_map(w_other))
 
         # Test direct variable reference matching
-        opt_map_direct = optimizers.OptimizerMap(
-            [opt_adam], [[w_dense]]
-        )
+        opt_map_direct = optimizers.OptimizerMap([opt_adam], [[w_dense]])
         self.assertEqual(opt_map_direct(w_dense), opt_adam)
         self.assertIsNone(opt_map_direct(w_conv))
 
@@ -99,8 +96,12 @@ class MultiOptimizerTest(testing.TestCase):
 
         multi_opt.build([w_mapped, w_unmapped])
 
-        self.assertEqual(multi_opt._get_optimizer_for_variable(w_mapped), opt_adam)
-        self.assertEqual(multi_opt._get_optimizer_for_variable(w_unmapped), default_opt)
+        self.assertEqual(
+            multi_opt._get_optimizer_for_variable(w_mapped), opt_adam
+        )
+        self.assertEqual(
+            multi_opt._get_optimizer_for_variable(w_unmapped), default_opt
+        )
 
     def test_stateful_apply(self):
         if backend.backend() == "jax":
@@ -116,7 +117,7 @@ class MultiOptimizerTest(testing.TestCase):
 
         opt_sgd_1 = optimizers.SGD(learning_rate=0.1)
         opt_sgd_2 = optimizers.SGD(learning_rate=1.0)
-        default_opt = optimizers.SGD(learning_rate=0.0)  # Should leave it unchanged
+        default_opt = optimizers.SGD(learning_rate=0.0)
 
         opt_map = optimizers.OptimizerMap(
             [opt_sgd_1, opt_sgd_2], ["^dense_1/.*", "^dense_2/.*"]
@@ -158,9 +159,7 @@ class MultiOptimizerTest(testing.TestCase):
         opt_sgd_1 = optimizers.SGD(learning_rate=0.1)
         opt_sgd_2 = optimizers.SGD(learning_rate=1.0)
 
-        opt_map = optimizers.OptimizerMap(
-            [opt_sgd_1], ["^dense_1/.*"]
-        )
+        opt_map = optimizers.OptimizerMap([opt_sgd_1], ["^dense_1/.*"])
         multi_opt = optimizers.MultiOptimizer(opt_map, opt_sgd_2)
 
         multi_opt.build([w1, w2])
@@ -184,11 +183,13 @@ class MultiOptimizerTest(testing.TestCase):
 
     def test_callback_integration(self):
         # Simple linear model
-        model = models.Sequential([
-            layers.Input(shape=(2,)),
-            layers.Dense(4, name="dense_1"),
-            layers.Dense(1, name="dense_2"),
-        ])
+        model = models.Sequential(
+            [
+                layers.Input(shape=(2,)),
+                layers.Dense(4, name="dense_1"),
+                layers.Dense(1, name="dense_2"),
+            ]
+        )
 
         opt_adam = optimizers.Adam(learning_rate=1e-1)
         opt_sgd = optimizers.SGD(learning_rate=1e-2)
@@ -205,12 +206,15 @@ class MultiOptimizerTest(testing.TestCase):
         lr_scheduler = callbacks.LearningRateScheduler(lambda epoch: 5e-2)
 
         # Getter/setter tests inside fit
-        model.fit(x, y, epochs=1, batch_size=8, callbacks=[lr_scheduler], verbose=0)
+        model.fit(
+            x, y, epochs=1, batch_size=8, callbacks=[lr_scheduler], verbose=0
+        )
 
-        # Verify callback correctly modified ONLY the first optimizer (opt_adam)
+        # Verify callback correctly modified ONLY the
+        # first optimizer (opt_adam)
         self.assertAllClose(opt_adam.learning_rate, 5e-2)
         self.assertAllClose(opt_sgd.learning_rate, 1e-2)
-    
+
     def test_optimizer_map_comprehensive(self):
         with backend.name_scope("dense_1"):
             w_dense1_kernel = backend.Variable([[1.0]], name="kernel")
@@ -237,8 +241,8 @@ class MultiOptimizerTest(testing.TestCase):
                 "^dense_1/.*",
                 w_dense2_kernel,
                 lambda var: "bias" in (var.path or var.name),
-                [w_other1, w_other2]
-            ]
+                [w_other1, w_other2],
+            ],
         )
 
         # 1. Substring match -> opt_adam
@@ -247,7 +251,8 @@ class MultiOptimizerTest(testing.TestCase):
         self.assertEqual(opt_map(w_dense1_kernel), opt_sgd)
         # 3. Keras Variable direct match -> opt_adam
         self.assertEqual(opt_map(w_dense2_kernel), opt_adam)
-        # 4. Callable match -> opt_sgd (and matches dense_1/.* also mapping to opt_sgd)
+        # 4. Callable match -> opt_sgd
+        # (and matches dense_1/.* also mapping to opt_sgd)
         self.assertEqual(opt_map(w_dense1_bias), opt_sgd)
         # 5. List/Tuple match -> opt_adam
         self.assertEqual(opt_map(w_other1), opt_adam)
@@ -267,12 +272,44 @@ class MultiOptimizerTest(testing.TestCase):
         reconstructed = optimizers.deserialize(config)
 
         self.assertEqual(reconstructed.num_optimizers, 3)
-        self.assertEqual(reconstructed.get_optimizer(0).__class__.__name__, "Adam")
-        self.assertEqual(reconstructed.get_optimizer(1).__class__.__name__, "SGD")
-        self.assertEqual(reconstructed.get_optimizer(2).__class__.__name__, "RMSprop")
+        self.assertEqual(
+            reconstructed.get_optimizer(0).__class__.__name__, "Adam"
+        )
+        self.assertEqual(
+            reconstructed.get_optimizer(1).__class__.__name__, "SGD"
+        )
+        self.assertEqual(
+            reconstructed.get_optimizer(2).__class__.__name__, "RMSprop"
+        )
 
         # Test with default mapping behavior after reconstruct
         with backend.name_scope("dense_1"):
             w = backend.Variable([[1.0]], name="kernel")
         reconstructed.build([w])
-        self.assertEqual(reconstructed._get_optimizer_for_variable(w).__class__.__name__, "Adam")
+        self.assertEqual(
+            reconstructed._get_optimizer_for_variable(w).__class__.__name__,
+            "Adam",
+        )
+
+    def test_loss_scaling(self):
+        opt_adam = optimizers.Adam(learning_rate=1e-3)
+        opt_sgd = optimizers.SGD(learning_rate=1e-2)
+        default_opt = optimizers.RMSprop(learning_rate=1e-4)
+
+        opt_map = optimizers.OptimizerMap(
+            [opt_adam, opt_sgd], ["^dense_1/.*", "^dense_2/.*"]
+        )
+        multi_opt = optimizers.MultiOptimizer(opt_map, default_opt)
+
+        # Assert that inner optimizers have their loss
+        # scaling disabled to prevent double scaling
+        self.assertIsNone(opt_adam.loss_scale_factor)
+        self.assertIsNone(opt_sgd.loss_scale_factor)
+        self.assertIsNone(default_opt.loss_scale_factor)
+
+        # Assert that wrapper scales loss
+        # correctly when loss_scale_factor is set
+        multi_opt.loss_scale_factor = 100.0
+        loss = backend.convert_to_tensor(2.0)
+        scaled_loss = multi_opt.scale_loss(loss)
+        self.assertAllClose(scaled_loss, 200.0)

--- a/keras/src/optimizers/multi_optimizer_test.py
+++ b/keras/src/optimizers/multi_optimizer_test.py
@@ -6,7 +6,6 @@ from keras.src import layers
 from keras.src import models
 from keras.src import optimizers
 from keras.src import testing
-from keras.src.saving.serialization_lib import enable_unsafe_deserialization
 
 
 class MultiOptimizerTest(testing.TestCase):
@@ -32,13 +31,6 @@ class MultiOptimizerTest(testing.TestCase):
         opt_map_direct = optimizers.OptimizerMap([opt_adam], [[w_dense]])
         self.assertEqual(opt_map_direct(w_dense), opt_adam)
         self.assertIsNone(opt_map_direct(w_conv))
-
-        # Test callable matching
-        opt_map_callable = optimizers.OptimizerMap(
-            [opt_adam], [lambda x: "dense" in (x.path or x.name)]
-        )
-        self.assertEqual(opt_map_callable(w_dense), opt_adam)
-        self.assertIsNone(opt_map_callable(w_conv))
 
         # Test conflict detection
         opt_map_conflict = optimizers.OptimizerMap(
@@ -223,7 +215,6 @@ class MultiOptimizerTest(testing.TestCase):
     def test_optimizer_map_comprehensive(self):
         with backend.name_scope("dense_1"):
             w_dense1_kernel = backend.Variable([[1.0]], name="kernel")
-            w_dense1_bias = backend.Variable([[1.0]], name="bias")
         with backend.name_scope("dense_2"):
             w_dense2_kernel = backend.Variable([[1.0]], name="kernel")
         w_exact = backend.Variable([[1.0]], name="exact_var")
@@ -233,19 +224,17 @@ class MultiOptimizerTest(testing.TestCase):
         opt_adam = optimizers.Adam(learning_rate=1e-3)
         opt_sgd = optimizers.SGD(learning_rate=1e-2)
 
-        # Comprehensive mapping covering all 5 types of identifiers:
+        # Comprehensive mapping covering 4 types of identifiers:
         # 1. String substring matching
         # 2. Regex matching
         # 3. Keras Variable instance direct match
-        # 4. Callable match
-        # 5. List/Tuple of Keras variables
+        # 4. List/Tuple of Keras variables
         opt_map = optimizers.OptimizerMap(
-            optimizer=[opt_adam, opt_sgd, opt_adam, opt_sgd, opt_adam],
+            optimizer=[opt_adam, opt_sgd, opt_adam, opt_adam],
             variable_identifier=[
                 "exact_var",
                 "^dense_1/.*",
                 w_dense2_kernel,
-                lambda var: "bias" in (var.path or var.name),
                 [w_other1, w_other2],
             ],
         )
@@ -256,10 +245,7 @@ class MultiOptimizerTest(testing.TestCase):
         self.assertEqual(opt_map(w_dense1_kernel), opt_sgd)
         # 3. Keras Variable direct match -> opt_adam
         self.assertEqual(opt_map(w_dense2_kernel), opt_adam)
-        # 4. Callable match -> opt_sgd
-        # (and matches dense_1/.* also mapping to opt_sgd)
-        self.assertEqual(opt_map(w_dense1_bias), opt_sgd)
-        # 5. List/Tuple match -> opt_adam
+        # 4. List/Tuple match -> opt_adam
         self.assertEqual(opt_map(w_other1), opt_adam)
         self.assertEqual(opt_map(w_other2), opt_adam)
 
@@ -341,29 +327,26 @@ class MultiOptimizerTest(testing.TestCase):
             "Adam",
         )
 
-    def test_serialization_with_callable(self):
-        opt_adam = optimizers.Adam(learning_rate=1e-3)
-        default_opt = optimizers.SGD(learning_rate=1e-2)
-
+    def test_gradient_unscaling(self):
         with backend.name_scope("dense_1"):
-            w = backend.Variable([[1.0]], name="kernel")
+            w = backend.Variable([[2.0, 2.0]], name="kernel")
 
-        # Mapping uses a callable function (serializable lambda)
-        opt_map = optimizers.OptimizerMap(
-            [opt_adam], [lambda var: "kernel" in (var.path or var.name)]
-        )
-        multi_opt = optimizers.MultiOptimizer(opt_map, default_opt)
+        # SGD with learning rate 0.1
+        opt_sgd = optimizers.SGD(learning_rate=0.1)
+        opt_map = optimizers.OptimizerMap([opt_sgd], ["^dense_1/.*"])
+        multi_opt = optimizers.MultiOptimizer(opt_map, opt_sgd)
 
-        # Enable unsafe deserialization for lambda loading in test
-        enable_unsafe_deserialization()
+        # Set loss scale factor
+        multi_opt.loss_scale_factor = 10.0
 
-        config = optimizers.serialize(multi_opt)
-        reconstructed = optimizers.deserialize(config)
+        multi_opt.build([w])
 
-        # Reconstructed optimizer should build and match
-        #  correctly via the deserialized lambda
-        reconstructed.build([w])
-        self.assertEqual(
-            reconstructed._get_optimizer_for_variable(w).__class__.__name__,
-            "Adam",
-        )
+        # Gradient is 10.0 (which is scaled by loss_scale_factor=10.0)
+        # Expected unscaled gradient is 10.0 / 10.0 = 1.0
+        # Expected weight update is:
+        # 2.0 - lr * unscaled_grad = 2.0 - 0.1 * 1.0 = 1.9
+        grads = [backend.convert_to_tensor([[10.0, 10.0]])]
+
+        multi_opt.apply(grads, [w])
+
+        self.assertAllClose(w.numpy(), [[1.9, 1.9]])

--- a/keras/src/optimizers/multi_optimizer_test.py
+++ b/keras/src/optimizers/multi_optimizer_test.py
@@ -1,0 +1,236 @@
+import numpy as np
+from keras.src import backend
+from keras.src import callbacks
+from keras.src import layers
+from keras.src import models
+from keras.src import optimizers
+from keras.src import testing
+
+
+class MultiOptimizerTest(testing.TestCase):
+    def test_optimizer_map_matching(self):
+        with backend.name_scope("dense"):
+            w_dense = backend.Variable([[1.0]], name="kernel")
+        with backend.name_scope("conv"):
+            w_conv = backend.Variable([[1.0]], name="kernel")
+        w_other = backend.Variable([[1.0]], name="bias")
+
+        opt_adam = optimizers.Adam(learning_rate=1e-3)
+        opt_sgd = optimizers.SGD(learning_rate=1e-2)
+
+        # Test regex matching
+        var_identifier = ["^dense/.*", "^conv/.*"]
+        opt_map = optimizers.OptimizerMap(
+            [opt_adam, opt_sgd], var_identifier
+        )
+
+        self.assertEqual(opt_map(w_dense), opt_adam)
+        self.assertEqual(opt_map(w_conv), opt_sgd)
+        self.assertIsNone(opt_map(w_other))
+
+        # Test direct variable reference matching
+        opt_map_direct = optimizers.OptimizerMap(
+            [opt_adam], [[w_dense]]
+        )
+        self.assertEqual(opt_map_direct(w_dense), opt_adam)
+        self.assertIsNone(opt_map_direct(w_conv))
+
+        # Test callable matching
+        opt_map_callable = optimizers.OptimizerMap(
+            [opt_adam], [lambda x: "dense" in (x.path or x.name)]
+        )
+        self.assertEqual(opt_map_callable(w_dense), opt_adam)
+        self.assertIsNone(opt_map_callable(w_conv))
+
+        # Test conflict detection
+        opt_map_conflict = optimizers.OptimizerMap(
+            [opt_adam, opt_sgd], [".*kernel.*", ".*dense.*"]
+        )
+        with self.assertRaises(ValueError):
+            opt_map_conflict(w_dense)
+
+    def test_multi_optimizer_initialization(self):
+        opt_adam = optimizers.Adam(learning_rate=1e-3)
+        opt_sgd = optimizers.SGD(learning_rate=1e-2)
+        default_opt = optimizers.RMSprop(learning_rate=1e-4)
+
+        opt_map = optimizers.OptimizerMap(
+            [opt_adam, opt_sgd], ["^dense_1/.*", "^dense_2/.*"]
+        )
+
+        multi_opt = optimizers.MultiOptimizer(opt_map, default_opt)
+
+        # Verify unique optimizers list, with default_optimizer at the end
+        self.assertEqual(multi_opt.num_optimizers, 3)
+        self.assertEqual(multi_opt.get_optimizer(0), opt_adam)
+        self.assertEqual(multi_opt.get_optimizer(1), opt_sgd)
+        self.assertEqual(multi_opt.get_optimizer(2), default_opt)
+
+    def test_learning_rate_get_set(self):
+        opt_adam = optimizers.Adam(learning_rate=1e-3)
+        opt_sgd = optimizers.SGD(learning_rate=1e-2)
+        default_opt = optimizers.RMSprop(learning_rate=1e-4)
+
+        opt_map = optimizers.OptimizerMap(
+            [opt_adam, opt_sgd], ["^dense_1/.*", "^dense_2/.*"]
+        )
+        multi_opt = optimizers.MultiOptimizer(opt_map, default_opt)
+
+        # Getter should return the first optimizer's learning rate
+        self.assertAllClose(multi_opt.learning_rate, 1e-3)
+
+        # Setter should only update the first optimizer's learning rate
+        multi_opt.learning_rate = 5e-3
+        self.assertAllClose(opt_adam.learning_rate, 5e-3)
+        self.assertAllClose(opt_sgd.learning_rate, 1e-2)
+        self.assertAllClose(default_opt.learning_rate, 1e-4)
+
+    def test_default_fallback(self):
+        with backend.name_scope("dense_1"):
+            w_mapped = backend.Variable([[1.0]], name="kernel")
+        with backend.name_scope("other"):
+            w_unmapped = backend.Variable([[1.0]], name="kernel")
+
+        opt_adam = optimizers.Adam(learning_rate=1e-3)
+        default_opt = optimizers.SGD(learning_rate=1e-2)
+
+        opt_map = optimizers.OptimizerMap([opt_adam], ["^dense_1/.*"])
+        multi_opt = optimizers.MultiOptimizer(opt_map, default_opt)
+
+        multi_opt.build([w_mapped, w_unmapped])
+
+        self.assertEqual(multi_opt._get_optimizer_for_variable(w_mapped), opt_adam)
+        self.assertEqual(multi_opt._get_optimizer_for_variable(w_unmapped), default_opt)
+
+    def test_stateful_apply(self):
+        if backend.backend() == "jax":
+            self.skipTest(
+                "stateful_apply is not supported with the JAX backend"
+            )
+        with backend.name_scope("dense_1"):
+            w1 = backend.Variable([[2.0, 2.0]], name="kernel")
+        with backend.name_scope("dense_2"):
+            w2 = backend.Variable([[3.0, 3.0]], name="kernel")
+        with backend.name_scope("other"):
+            w_fallback = backend.Variable([[4.0, 4.0]], name="kernel")
+
+        opt_sgd_1 = optimizers.SGD(learning_rate=0.1)
+        opt_sgd_2 = optimizers.SGD(learning_rate=1.0)
+        default_opt = optimizers.SGD(learning_rate=0.0)  # Should leave it unchanged
+
+        opt_map = optimizers.OptimizerMap(
+            [opt_sgd_1, opt_sgd_2], ["^dense_1/.*", "^dense_2/.*"]
+        )
+        multi_opt = optimizers.MultiOptimizer(opt_map, default_opt)
+
+        multi_opt.build([w1, w2, w_fallback])
+
+        grads = [
+            backend.convert_to_tensor([[1.0, 1.0]]),
+            backend.convert_to_tensor([[1.0, 1.0]]),
+            backend.convert_to_tensor([[1.0, 1.0]]),
+        ]
+
+        multi_opt.apply(grads, [w1, w2, w_fallback])
+
+        # w1: updated by opt_sgd_1 (lr=0.1) -> 2.0 - 0.1 * 1.0 = 1.9
+        self.assertAllClose(w1.numpy(), [[1.9, 1.9]])
+        # w2: updated by opt_sgd_2 (lr=1.0) -> 3.0 - 1.0 * 1.0 = 2.0
+        self.assertAllClose(w2.numpy(), [[2.0, 2.0]])
+        # w_fallback: updated by default_opt (lr=0.0) -> Remains 4.0
+        self.assertAllClose(w_fallback.numpy(), [[4.0, 4.0]])
+
+        # Verify iteration increment
+        self.assertEqual(int(multi_opt.iterations), 1)
+
+    def test_stateless_apply(self):
+        if backend.backend() == "tensorflow":
+            self.skipTest(
+                "stateless_apply is not supported with the TensorFlow backend "
+                "(as it is incompatible with tf.distribute)."
+            )
+
+        with backend.name_scope("dense_1"):
+            w1 = backend.Variable([[2.0, 2.0]], name="kernel")
+        with backend.name_scope("dense_2"):
+            w2 = backend.Variable([[3.0, 3.0]], name="kernel")
+
+        opt_sgd_1 = optimizers.SGD(learning_rate=0.1)
+        opt_sgd_2 = optimizers.SGD(learning_rate=1.0)
+
+        opt_map = optimizers.OptimizerMap(
+            [opt_sgd_1], ["^dense_1/.*"]
+        )
+        multi_opt = optimizers.MultiOptimizer(opt_map, opt_sgd_2)
+
+        multi_opt.build([w1, w2])
+
+        grads = [
+            backend.convert_to_tensor([[1.0, 1.0]]),
+            backend.convert_to_tensor([[1.0, 1.0]]),
+        ]
+
+        trainable_variables = [w1.numpy(), w2.numpy()]
+        optimizer_variables = [v.numpy() for v in multi_opt.variables]
+
+        new_trainable_vars, new_opt_vars = multi_opt.stateless_apply(
+            optimizer_variables, grads, trainable_variables
+        )
+
+        # w1 updated by SGD(0.1): 2.0 - 0.1 = 1.9
+        self.assertAllClose(new_trainable_vars[0], [[1.9, 1.9]])
+        # w2 updated by fallback SGD(1.0): 3.0 - 1.0 = 2.0
+        self.assertAllClose(new_trainable_vars[1], [[2.0, 2.0]])
+
+    def test_callback_integration(self):
+        # Simple linear model
+        model = models.Sequential([
+            layers.Input(shape=(2,)),
+            layers.Dense(4, name="dense_1"),
+            layers.Dense(1, name="dense_2"),
+        ])
+
+        opt_adam = optimizers.Adam(learning_rate=1e-1)
+        opt_sgd = optimizers.SGD(learning_rate=1e-2)
+
+        opt_map = optimizers.OptimizerMap([opt_adam], ["^dense_1/.*"])
+        multi_opt = optimizers.MultiOptimizer(opt_map, opt_sgd)
+
+        model.compile(optimizer=multi_opt, loss="mse")
+
+        x = np.random.uniform(size=(16, 2))
+        y = np.random.uniform(size=(16, 1))
+
+        # Custom schedule that forces an LR adjustment
+        lr_scheduler = callbacks.LearningRateScheduler(lambda epoch: 5e-2)
+
+        # Getter/setter tests inside fit
+        model.fit(x, y, epochs=1, batch_size=8, callbacks=[lr_scheduler], verbose=0)
+
+        # Verify callback correctly modified ONLY the first optimizer (opt_adam)
+        self.assertAllClose(opt_adam.learning_rate, 5e-2)
+        self.assertAllClose(opt_sgd.learning_rate, 1e-2)
+
+    def test_serialization(self):
+        opt_adam = optimizers.Adam(learning_rate=1e-3)
+        opt_sgd = optimizers.SGD(learning_rate=1e-2)
+        default_opt = optimizers.RMSprop(learning_rate=1e-4)
+
+        opt_map = optimizers.OptimizerMap(
+            [opt_adam, opt_sgd], ["^dense_1/.*", "^dense_2/.*"]
+        )
+        multi_opt = optimizers.MultiOptimizer(opt_map, default_opt)
+
+        config = optimizers.serialize(multi_opt)
+        reconstructed = optimizers.deserialize(config)
+
+        self.assertEqual(reconstructed.num_optimizers, 3)
+        self.assertEqual(reconstructed.get_optimizer(0).__class__.__name__, "Adam")
+        self.assertEqual(reconstructed.get_optimizer(1).__class__.__name__, "SGD")
+        self.assertEqual(reconstructed.get_optimizer(2).__class__.__name__, "RMSprop")
+
+        # Test with default mapping behavior after reconstruct
+        with backend.name_scope("dense_1"):
+            w = backend.Variable([[1.0]], name="kernel")
+        reconstructed.build([w])
+        self.assertEqual(reconstructed._get_optimizer_for_variable(w).__class__.__name__, "Adam")

--- a/keras/src/optimizers/multi_optimizer_test.py
+++ b/keras/src/optimizers/multi_optimizer_test.py
@@ -6,6 +6,7 @@ from keras.src import layers
 from keras.src import models
 from keras.src import optimizers
 from keras.src import testing
+from keras.src.saving.serialization_lib import enable_unsafe_deserialization
 
 
 class MultiOptimizerTest(testing.TestCase):
@@ -182,6 +183,10 @@ class MultiOptimizerTest(testing.TestCase):
         self.assertAllClose(new_trainable_vars[1], [[2.0, 2.0]])
 
     def test_callback_integration(self):
+        if backend.backend() in ["numpy", "openvino"]:
+            self.skipTest(
+                "skipped test due to backend does not support fit function"
+            )
         # Simple linear model
         model = models.Sequential(
             [
@@ -313,3 +318,52 @@ class MultiOptimizerTest(testing.TestCase):
         loss = backend.convert_to_tensor(2.0)
         scaled_loss = multi_opt.scale_loss(loss)
         self.assertAllClose(scaled_loss, 200.0)
+
+    def test_serialization_with_variables(self):
+        opt_adam = optimizers.Adam(learning_rate=1e-3)
+        default_opt = optimizers.SGD(learning_rate=1e-2)
+
+        with backend.name_scope("dense_1"):
+            w = backend.Variable([[1.0]], name="kernel")
+
+        # Mapping uses direct Keras Variable instance in a list
+        opt_map = optimizers.OptimizerMap([opt_adam], [[w]])
+        multi_opt = optimizers.MultiOptimizer(opt_map, default_opt)
+
+        # Serializing should succeed without TypeError
+        config = optimizers.serialize(multi_opt)
+        reconstructed = optimizers.deserialize(config)
+
+        # Reconstructed optimizer should build and match variables correctly
+        reconstructed.build([w])
+        self.assertEqual(
+            reconstructed._get_optimizer_for_variable(w).__class__.__name__,
+            "Adam",
+        )
+
+    def test_serialization_with_callable(self):
+        opt_adam = optimizers.Adam(learning_rate=1e-3)
+        default_opt = optimizers.SGD(learning_rate=1e-2)
+
+        with backend.name_scope("dense_1"):
+            w = backend.Variable([[1.0]], name="kernel")
+
+        # Mapping uses a callable function (serializable lambda)
+        opt_map = optimizers.OptimizerMap(
+            [opt_adam], [lambda var: "kernel" in (var.path or var.name)]
+        )
+        multi_opt = optimizers.MultiOptimizer(opt_map, default_opt)
+
+        # Enable unsafe deserialization for lambda loading in test
+        enable_unsafe_deserialization()
+
+        config = optimizers.serialize(multi_opt)
+        reconstructed = optimizers.deserialize(config)
+
+        # Reconstructed optimizer should build and match
+        #  correctly via the deserialized lambda
+        reconstructed.build([w])
+        self.assertEqual(
+            reconstructed._get_optimizer_for_variable(w).__class__.__name__,
+            "Adam",
+        )


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
Added multi-optimizer support for training subnetworks with different optimizers.

Key Changes:

Implemented MultiOptimizer and OptimizerMap classes:
- OptimizerMap independently handles mapping between a variable identifier and an optimizer.
- MultiOptimizer distributes trainable and optimizer variables to their respective optimizers and performs build, apply, and stateless_apply operations.

Added unit tests for each component within MultiOptimizer:
- Rigorously tested variable mapping in OptimizerMap.
- Tested callback updates on learning rate and gradient updates performed via apply and stateless_apply.


## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
