### PR TITLE
Fix torch Conv2DTranspose with padding='same' and stride > 1

### DIFF
--- a/keras/src/backend/common/backend_utils.py
+++ b/keras/src/backend/common/backend_utils.py
@@ -212,6 +212,62 @@ def compute_conv_transpose_padding_args_for_torch(
     return torch_paddings, torch_output_paddings
 
 
+def compute_conv_transpose_output_crops_for_torch(
+    input_shape,
+    kernel_shape,
+    strides,
+    padding,
+    output_padding,
+    dilation_rate,
+):
+    """Per-spatial-dim asymmetric (left, right) crop amounts for torch.
+
+    Torch's `conv_transpose*d` only supports symmetric `padding` plus a
+    right-side `output_padding`, which cannot express the asymmetric crops
+    that Keras "same" semantics requires when stride > 1 with an odd kernel.
+    We work around this by calling torch with `padding=0, output_padding=0`
+    (which produces the largest "natural" output of size
+    `(input - 1) * stride + effective_kernel`), then asymmetrically slicing
+    the spatial dims to the same window JAX would compute.
+
+    The slice on each side is `(effective_kernel - 1) - left_pad` from the
+    left and `(effective_kernel - 1) - right_pad` from the right, where
+    `left_pad` / `right_pad` come from the existing JAX helper. A negative
+    value means we need to extend with zero-padding instead of cropping.
+    """
+    num_spatial_dims = len(input_shape) - 2
+    kernel_spatial_shape = kernel_shape[:-2]
+
+    crops = []
+    for i in range(num_spatial_dims):
+        output_padding_i = (
+            output_padding
+            if output_padding is None or isinstance(output_padding, int)
+            else output_padding[i]
+        )
+        strides_i = strides if isinstance(strides, int) else strides[i]
+        dilation_rate_i = (
+            dilation_rate
+            if isinstance(dilation_rate, int)
+            else dilation_rate[i]
+        )
+        (
+            left_pad,
+            right_pad,
+        ) = _convert_conv_transpose_padding_args_from_keras_to_jax(
+            kernel_size=kernel_spatial_shape[i],
+            stride=strides_i,
+            dilation_rate=dilation_rate_i,
+            padding=padding,
+            output_padding=output_padding_i,
+        )
+        effective_kernel = (kernel_spatial_shape[i] - 1) * dilation_rate_i + 1
+        crop_left = (effective_kernel - 1) - left_pad
+        crop_right = (effective_kernel - 1) - right_pad
+        crops.append((crop_left, crop_right))
+    return crops
+
+
 def _get_output_shape_given_tf_padding(
     input_size, kernel_size, strides, padding, output_padding, dilation_rate
 ):

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -7,7 +7,7 @@ from keras.src.backend.common.backend_utils import (
     check_conv_transpose_input_channels,
 )
 from keras.src.backend.common.backend_utils import (
-    compute_conv_transpose_padding_args_for_torch,
+    compute_conv_transpose_output_crops_for_torch,
 )
 from keras.src.backend.torch.core import cast
 from keras.src.backend.torch.core import convert_to_tensor
@@ -722,10 +722,15 @@ def conv_transpose(
 
     data_format = backend.standardize_data_format(data_format)
     check_conv_transpose_input_channels(inputs, kernel, data_format)
-    (
-        torch_padding,
-        torch_output_padding,
-    ) = compute_conv_transpose_padding_args_for_torch(
+
+    # Torch's `conv_transpose*d` only takes a symmetric `padding` plus a
+    # right-side `output_padding`, which cannot reproduce the asymmetric
+    # padding Keras's "same" mode requires when stride > 1 with an odd
+    # kernel. We call torch with `padding=0, output_padding=0` (giving the
+    # largest "natural" output) and asymmetrically slice the spatial dims to
+    # the same window JAX would compute. Negative crops mean we extend with
+    # zero-padding to match JAX's left/right pad semantics.
+    crops = compute_conv_transpose_output_crops_for_torch(
         input_shape=inputs.shape,
         kernel_shape=kernel.shape,
         strides=strides,
@@ -733,26 +738,22 @@ def conv_transpose(
         output_padding=output_padding,
         dilation_rate=dilation_rate,
     )
+
     if data_format == "channels_last":
         inputs = _transpose_spatial_inputs(inputs)
     # Transpose kernel from keras format to torch format.
     kernel = _transpose_conv_kernel(kernel)
 
-    if data_format == "channels_last":
-        inputs = _maybe_convert_to_channels_last(inputs)
-        kernel = _maybe_convert_to_channels_last(kernel)
-
-    kernel_spatial_shape = kernel.shape[2:]
     if isinstance(dilation_rate, int):
-        dilation_rate = [dilation_rate] * len(kernel_spatial_shape)
+        dilation_rate = [dilation_rate] * num_spatial_dims
 
     if num_spatial_dims == 1:
         outputs = tnn.conv_transpose1d(
             inputs,
             kernel,
             stride=strides,
-            padding=torch_padding,
-            output_padding=torch_output_padding,
+            padding=0,
+            output_padding=0,
             dilation=dilation_rate,
         )
     elif num_spatial_dims == 2:
@@ -760,8 +761,8 @@ def conv_transpose(
             inputs,
             kernel,
             stride=strides,
-            padding=torch_padding,
-            output_padding=torch_output_padding,
+            padding=0,
+            output_padding=0,
             dilation=dilation_rate,
         )
     elif num_spatial_dims == 3:
@@ -769,8 +770,8 @@ def conv_transpose(
             inputs,
             kernel,
             stride=strides,
-            padding=torch_padding,
-            output_padding=torch_output_padding,
+            padding=0,
+            output_padding=0,
             dilation=dilation_rate,
         )
     else:
@@ -779,6 +780,29 @@ def conv_transpose(
             "corresponding to 1D, 2D and 3D inputs. Received input "
             f"shape: {inputs.shape}."
         )
+
+    # Apply asymmetric crop (or zero-pad if a crop amount is negative) to
+    # each spatial dim. `outputs` is NCHW-style here; spatial dims start at
+    # axis 2.
+    slices = [slice(None), slice(None)]
+    needs_zero_pad = any(cl < 0 or cr < 0 for cl, cr in crops)
+    for crop_left, crop_right in crops:
+        start = max(0, crop_left)
+        end = -crop_right if crop_right > 0 else None
+        slices.append(slice(start, end))
+    outputs = outputs[tuple(slices)]
+    if needs_zero_pad:
+        # torch's F.pad takes pads in REVERSE spatial order: last dim first.
+        pads = []
+        for crop_left, crop_right in reversed(crops):
+            pads.extend(
+                [
+                    -crop_left if crop_left < 0 else 0,
+                    -crop_right if crop_right < 0 else 0,
+                ]
+            )
+        outputs = tnn.pad(outputs, pads)
+
     if data_format == "channels_last":
         outputs = _transpose_spatial_outputs(outputs)
     return outputs

--- a/keras/src/layers/convolutional/conv_transpose_test.py
+++ b/keras/src/layers/convolutional/conv_transpose_test.py
@@ -6,9 +6,6 @@ from keras.src import backend
 from keras.src import layers
 from keras.src import testing
 from keras.src.backend.common.backend_utils import (
-    _convert_conv_transpose_padding_args_from_keras_to_torch,
-)
-from keras.src.backend.common.backend_utils import (
     compute_conv_transpose_output_shape,
 )
 from keras.src.backend.common.backend_utils import (
@@ -881,48 +878,6 @@ class ConvTransposeCorrectnessTest(testing.TestCase):
         )
         kc_layer.build(input_shape=input_shape)
         kc_layer.kernel.assign(kernel_weights)
-
-        # Special cases for Torch
-        if backend.backend() == "torch":
-            # Args that cause output_padding >= strides
-            # are clamped with a warning.
-            if (kernel_size, strides, padding, output_padding) in [
-                (2, 1, "same", None),
-                (4, 1, "same", None),
-            ]:
-                clamped_output_padding = strides - 1  # usually 0 when stride=1
-                expected_res = np_conv1d_transpose(
-                    x=input,
-                    kernel_weights=kernel_weights,
-                    bias_weights=np.zeros(shape=(1,)),
-                    strides=strides,
-                    padding=padding,
-                    output_padding=clamped_output_padding,
-                    data_format=backend.config.image_data_format(),
-                    dilation_rate=1,
-                )
-                with pytest.warns(UserWarning):
-                    kc_res = kc_layer(input)
-                self.assertAllClose(kc_res, expected_res, atol=1e-5)
-                return
-
-            # torch_padding > 0 and torch_output_padding > 0 case
-            # Torch output differs from TF.
-            (
-                torch_padding,
-                torch_output_padding,
-            ) = _convert_conv_transpose_padding_args_from_keras_to_torch(
-                kernel_size=kernel_size,
-                stride=strides,
-                dilation_rate=1,
-                padding=padding,
-                output_padding=output_padding,
-            )
-            if torch_padding > 0 and torch_output_padding > 0:
-                with pytest.raises(AssertionError):
-                    kc_res = kc_layer(input)
-                    self.assertAllClose(kc_res, expected_res, atol=1e-5)
-                return
 
         # Compare results
         kc_res = kc_layer(input)


### PR DESCRIPTION
## Description

The torch backend's `conv_transpose` produced values shifted by one pixel for `padding='same'` with `strides > 1` on odd kernels. Output shapes were correct so this slipped past CI, but the actual values diverged from JAX/TensorFlow by O(magnitude of input) for any real workload.

**Repro on master:**

```python
import os, numpy as np
os.environ["KERAS_BACKEND"] = "torch"  # try also "jax", "tensorflow"
import keras

rng = np.random.default_rng(42)
x = rng.standard_normal((4, 16, 16, 16)).astype("float32")
kernel = (rng.standard_normal((3, 3, 32, 16)) * 0.05).astype("float32")

layer = keras.layers.Conv2DTranspose(
    filters=32, kernel_size=3, strides=2, padding="same", use_bias=False
)
layer.build(x.shape)
layer.set_weights([kernel])
out = np.asarray(keras.ops.convert_to_numpy(layer(x)))
print(out.sum())
# torch  : 16.10
# jax    : 44.60
# tf     : 44.60
```

Sweep across all four `(padding, stride)` combinations:

| padding | stride | jax ↔ torch max\|Δ\| before | after |
|---|---|---|---|
| valid | 1 | 1.2e-6 | 1.2e-6 |
| valid | 2 | 5e-7 | 5e-7 |
| same | 1 | 1.2e-6 | 1.2e-6 |
| **same** | **2** | **2.23** | **5e-7** |

**Root cause:** `torch.nn.functional.conv_transpose*d` takes a symmetric `padding` plus right-only `output_padding`. Keras "same" with `stride > 1` and odd kernel requires asymmetric padding: for `stride=2, kernel=3`, JAX computes `(left_pad=2, right_pad=1)`, which the existing torch mapping at `_convert_conv_transpose_padding_args_from_keras_to_torch` replaced with `(padding=1, output_padding=1)` — same output shape, wrong spatial alignment. The helper acknowledged this with `warnings.warn(...)` when both values are positive, and the test suite documented it with `with pytest.raises(AssertionError): ...`, but neither prevented users from getting silently wrong outputs.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.