### PR TITLE
 Fix bin boundaries calculation in Discretization layer

### DIFF
--- a/keras/src/layers/preprocessing/discretization.py
+++ b/keras/src/layers/preprocessing/discretization.py
@@ -388,7 +388,7 @@ def compress_summary(summary, epsilon):
 
     percents = epsilon + np.arange(0.0, 1.0, epsilon)
     cum_weights = summary[1].cumsum()
-    cum_weight_percents = cum_weights / cum_weights[-1]
+    cum_weight_percents = cum_weights / (cum_weights[-1] + cum_weights[0])
     new_bins = np.interp(percents, cum_weight_percents, summary[0])
     cum_weights = np.interp(percents, cum_weight_percents, cum_weights)
     new_weights = cum_weights - np.concatenate(

--- a/keras/src/layers/preprocessing/discretization.py
+++ b/keras/src/layers/preprocessing/discretization.py
@@ -333,9 +333,9 @@ def summarize(values, epsilon):
     elements = np.size(values)
     num_buckets = 1.0 / epsilon
     increment = elements / num_buckets
-    start = max(increment, 1)
-    step = start
-    boundaries = values[int(start) - 1 :: int(step)]
+    step = max(increment, 1)
+    start = step - 1
+    boundaries = values[int(start) :: int(step)]
     weights = np.ones_like(boundaries)
     weights = weights * step
     return np.stack([boundaries, weights])

--- a/keras/src/layers/preprocessing/discretization.py
+++ b/keras/src/layers/preprocessing/discretization.py
@@ -333,9 +333,9 @@ def summarize(values, epsilon):
     elements = np.size(values)
     num_buckets = 1.0 / epsilon
     increment = elements / num_buckets
-    start = increment
+    start = max(increment, 1)
     step = max(increment, 1)
-    boundaries = values[int(start) :: int(step)]
+    boundaries = values[int(start) - 1 :: int(step)]
     weights = np.ones_like(boundaries)
     weights = weights * step
     return np.stack([boundaries, weights])
@@ -388,7 +388,7 @@ def compress_summary(summary, epsilon):
 
     percents = epsilon + np.arange(0.0, 1.0, epsilon)
     cum_weights = summary[1].cumsum()
-    cum_weight_percents = cum_weights / (cum_weights[-1] + cum_weights[0])
+    cum_weight_percents = cum_weights / cum_weights[-1]
     new_bins = np.interp(percents, cum_weight_percents, summary[0])
     cum_weights = np.interp(percents, cum_weight_percents, cum_weights)
     new_weights = cum_weights - np.concatenate(

--- a/keras/src/layers/preprocessing/discretization.py
+++ b/keras/src/layers/preprocessing/discretization.py
@@ -334,7 +334,7 @@ def summarize(values, epsilon):
     num_buckets = 1.0 / epsilon
     increment = elements / num_buckets
     start = max(increment, 1)
-    step = max(increment, 1)
+    step = start
     boundaries = values[int(start) - 1 :: int(step)]
     weights = np.ones_like(boundaries)
     weights = weights * step


### PR DESCRIPTION
## Description

### Problem
This PR fixes an issue where `Discretization` layer produced uneven bin boundaries, resulting in the last bin containing significantly more elements than others. After investigation, the root cause was found in `compress_summary` function: `cum_weight_percents` was normalized by the second-to-last value (`cum_weights[-1]`), not the last, as the last value is excluded in `summarize` function (variable `boundaries`). 

### Solution
The issue is fixed by including the last value in the `summarize` function. This is achieved by shifting the boundaries one position to the left: `boundaries = values[int(start) - 1 :: int(step)]`. To ensure that `int(start) - 1` is never negative, start is set to `start = max(increment, 1)`.

### Visualization

```Python
import tensorflow  as tf
import matplotlib.pyplot as plt

n = 10000
viz_step = 1  # increase to speed up

# array
x = tf.random.uniform((n,))

for num_bins in range(1, 101, viz_step):

    discretization = tf.keras.layers.Discretization(num_bins=num_bins)
    discretization.adapt(x)
    y = discretization(x)

    fig, axis = plt.subplots(1, 1, figsize=(4, 4))
    counts,bins, _ = axis.hist(y, bins=num_bins, rwidth=0.5)
    plt.title(num_bins)
    plt.show()

# batched dataset
batch1 = np.random.uniform(0, 10, n).astype(np.float32)
batch2 = np.random.uniform(5, 15, n).astype(np.float32)
batch3 = np.random.uniform(150, 250, n).astype(np.float32)

x = tf.data.Dataset.from_tensor_slices([batch1, batch2, batch3])
all_data = np.concatenate([batch1, batch2, batch3])

for num_bins in range(1, 101, viz_step):
    discretization = tf.keras.layers.Discretization(num_bins=num_bins)
    discretization.adapt(x)
    y = discretization(all_data).numpy()

    fig, axis = plt.subplots(1, 1, figsize=(4, 4))
    counts,bins, _ = axis.hist(y, bins=num_bins, rwidth=0.5)
    plt.title(num_bins)
    plt.show()
```

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
