### PR TITLE
Fix validate_reshape_shape crash under torch.compile with dynamic shapes

### DIFF
--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -287,16 +287,22 @@ def validate_reshape_shape(newshape, newshape_arg_name="newshape"):
 
     Each dimension that is a concrete Python int must be either non-negative
     or `-1` (with at most one `-1`). Dynamic dimensions (e.g. backend tensor
-    scalars resolved at runtime) are not validated here.
+    scalars resolved at runtime, such as `torch.SymInt` under `torch.compile`)
+    are not validated here.
     """
+    neg_one_count = 0
     for dim in newshape:
-        if isinstance(dim, int) and dim < -1:
+        if not isinstance(dim, int):
+            continue
+        if dim < -1:
             raise ValueError(
                 f"Each dimension in `{newshape_arg_name}` must be a "
                 "non-negative integer, or `-1` for a single unknown "
                 f"dimension. Received: {newshape_arg_name}={newshape}."
             )
-    if [d for d in newshape if isinstance(d, int)].count(-1) > 1:
+        if dim == -1:
+            neg_one_count += 1
+    if neg_one_count > 1:
         raise ValueError(
             "There must be at most one unknown dimension (-1) in "
             f"`{newshape_arg_name}`. Received: "

--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -292,7 +292,7 @@ def validate_reshape_shape(newshape, newshape_arg_name="newshape"):
     """
     neg_one_count = 0
     for dim in newshape:
-        if not isinstance(dim, int):
+        if not isinstance(dim, (int, np.integer)):
             continue
         if dim < -1:
             raise ValueError(
@@ -300,7 +300,7 @@ def validate_reshape_shape(newshape, newshape_arg_name="newshape"):
                 "non-negative integer, or `-1` for a single unknown "
                 f"dimension. Received: {newshape_arg_name}={newshape}."
             )
-        if dim == -1:
+        elif dim == -1:
             neg_one_count += 1
     if neg_one_count > 1:
         raise ValueError(

--- a/keras/src/ops/operation_utils_test.py
+++ b/keras/src/ops/operation_utils_test.py
@@ -152,6 +152,36 @@ class OperationUtilsTest(testing.TestCase):
         )
         self.assertEqual(output_shape, (1, 4, 4, 3))
 
+    def test_validate_reshape_shape_rejects_invalid(self):
+        with self.assertRaisesRegex(ValueError, "non-negative integer"):
+            operation_utils.validate_reshape_shape((-2, 5))
+        with self.assertRaisesRegex(
+            ValueError, "at most one unknown dimension"
+        ):
+            operation_utils.validate_reshape_shape((-1, -1, 5))
+
+    def test_validate_reshape_shape_accepts_dynamic_dims(self):
+        # Non-int dimensions (e.g. backend tensor scalars such as
+        # ``torch.SymInt`` produced by ``ops.shape(x)`` under
+        # ``torch.compile``) must pass through without raising, even when
+        # mixed with a single ``-1`` sentinel. This is the path
+        # ``GroupNormalization._reshape_into_groups`` exercises and that
+        # previously crashed dynamo tracing (see fix for #22868).
+        class DynamicDim:
+            """Stand-in for a non-int dynamic shape value."""
+
+        d = DynamicDim()
+        # Mixed int / -1 / dynamic — must not raise.
+        operation_utils.validate_reshape_shape((-1, 32, d, d))
+        operation_utils.validate_reshape_shape((d, d, d))
+        operation_utils.validate_reshape_shape((d, -1, d, 8))
+        # A second ``-1`` sentinel mixed with dynamic dims is still
+        # rejected — dynamic dims do not absorb the ``-1`` count.
+        with self.assertRaisesRegex(
+            ValueError, "at most one unknown dimension"
+        ):
+            operation_utils.validate_reshape_shape((d, -1, d, -1, 4))
+
     def test_compute_reshape_output_shape(self):
         input_shape = (1, 4, 4, 1)
         target_shape = (16, 1)


### PR DESCRIPTION
## Description
 `validate_reshape_shape` (added in #22868) uses a list comprehension + `.count()` pattern:
  
  ```python
  if [d for d in newshape if isinstance(d, int)].count(-1) > 1:
  ```
 Under torch.compile, dynamo traces this through sympy. When newshape contains torch.SymInt values mixed with a Python -1 (which happens any time ops.shape(x) flows into a downstream ops.reshape), the comparison fails with:

 InternalTorchDynamoError: TypeError: Can only compare inequalities with Expr
  
GroupNormalization._reshape_into_groups hits this on every train step on torch + jit_compile=True. Affects diffusion-style models that pair GroupNormalization with attention blocks using ops.shape.

### Fix

Replace the list-comp + .count() with a single counter loop. Semantically identical for static shapes. Dynamic dims now pass through cleanly under dynamo. I also added a regression test in operation_utils_test.py for the mixed dynamic + -1 path. Existing #22868 tests still pass.

Made a Colab notebook to reproduce the error.

[Colab notebook](https://colab.research.google.com/drive/1LP4xZO1YgarcdhYOCMOpDb4DTZnfwHJD?usp=sharing)

Verified on A100 and H100, torch  2.10.0+cu128.
## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

