### PR TITLE
Reject symlinks in assets/ when loading directory-form models

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -387,9 +387,9 @@ def _load_model_from_dir(dirpath, custom_objects, compile, safe_mode):
                 f"Expected a {_VARS_FNAME_H5} or {_VARS_FNAME_NPZ} file."
             )
         if len(all_filenames) > 3:
-            asset_store = DiskIOStore(
-                file_utils.join(dirpath, _ASSETS_DIRNAME), mode="r"
-            )
+            assets_dirpath = file_utils.join(dirpath, _ASSETS_DIRNAME)
+            _validate_asset_dir_no_symlink_escape(assets_dirpath)
+            asset_store = DiskIOStore(assets_dirpath, mode="r")
 
         else:
             asset_store = None
@@ -973,6 +973,117 @@ def _load_container_state(
             )
 
 
+def _is_local_path(path):
+    """Return True if `path` looks like a local filesystem path.
+
+    Remote URIs (e.g. ``gs://`` or ``hdfs://``) have no concept of symbolic
+    links, so the symlink-escape check is a no-op for them. We only enforce
+    it on local paths to avoid false positives against non-POSIX backends.
+    """
+    if not isinstance(path, str):
+        path = str(path)
+    return "://" not in path
+
+
+def _reject_symlink_escape(path, root):
+    """Reject an asset path whose canonical target is outside ``root``.
+
+    A malicious model directory can ship an ``assets/.../<file>`` entry that
+    is a symlink to an arbitrary file on the victim machine (for instance
+    ``/etc/passwd``). When Keras layer code later opens the asset with
+    ``open(...)``, the symlink is followed and the target file's contents
+    are loaded into the model — a local-file disclosure vector.
+
+    Reject any path whose realpath escapes ``root``, and also reject any
+    intermediate component that is itself a symlink to keep behavior
+    predictable on case-insensitive filesystems.
+    """
+    if not _is_local_path(path) or not _is_local_path(root):
+        return
+
+    real_root = os.path.realpath(root)
+    real_path = os.path.realpath(path)
+    try:
+        common = os.path.commonpath([real_root, real_path])
+    except ValueError:
+        # Paths on different drives on Windows.
+        common = ""
+    if common != real_root:
+        raise ValueError(
+            f"Asset path {path!r} resolves to {real_path!r}, which is "
+            f"outside of the model asset root {real_root!r}. Refusing to "
+            "load to prevent symlink-based local file disclosure. If you "
+            "trust this directory, remove the offending symlink before "
+            "retrying."
+        )
+
+    # Walk every component between `root` and `path` and reject any symlink,
+    # even if it would resolve to a location inside `root`. Keras itself
+    # never writes symlinks into the asset tree, so the presence of one is
+    # a strong signal of tampering.
+    try:
+        rel = os.path.relpath(path, root)
+    except ValueError:
+        return
+    if rel in ("", "."):
+        return
+    cur = root
+    for part in rel.split(os.sep):
+        if not part or part == ".":
+            continue
+        cur = os.path.join(cur, part)
+        if os.path.islink(cur):
+            raise ValueError(
+                f"Asset path component {cur!r} is a symbolic link. "
+                "Symbolic links are not permitted inside a Keras model "
+                "asset directory."
+            )
+
+
+def _validate_asset_dir_no_symlink_escape(assets_dirpath):
+    """Scan an asset directory once and reject any unsafe symlink.
+
+    This is the single-pass equivalent of `_reject_symlink_escape` applied
+    to every entry under ``assets_dirpath``. It runs at load time before
+    any layer-side ``open(...)`` so a malicious directory is rejected up
+    front rather than partway through state restoration.
+    """
+    if not _is_local_path(assets_dirpath):
+        return
+    if not file_utils.exists(assets_dirpath):
+        return
+    if not file_utils.isdir(assets_dirpath):
+        return
+
+    real_root = os.path.realpath(assets_dirpath)
+    # `followlinks=False` keeps `os.walk` from descending into symlinked
+    # directories that point outside the asset tree.
+    for current_dir, dirnames, filenames in os.walk(
+        assets_dirpath, followlinks=False
+    ):
+        for name in list(dirnames) + filenames:
+            entry = os.path.join(current_dir, name)
+            if os.path.islink(entry):
+                raise ValueError(
+                    f"Found symbolic link inside model asset directory: "
+                    f"{entry!r}. Symbolic links are not permitted inside "
+                    "a Keras model asset directory; this may indicate a "
+                    "malicious model attempting to disclose local files "
+                    "via `keras.saving.load_model`."
+                )
+            real_entry = os.path.realpath(entry)
+            try:
+                common = os.path.commonpath([real_root, real_entry])
+            except ValueError:
+                common = ""
+            if common != real_root:
+                raise ValueError(
+                    f"Asset entry {entry!r} resolves to {real_entry!r}, "
+                    f"which is outside of the model asset root "
+                    f"{real_root!r}. Refusing to load."
+                )
+
+
 class DiskIOStore:
     """Asset store backed by disk storage.
 
@@ -1020,6 +1131,13 @@ class DiskIOStore:
             return self.working_dir
         path = file_utils.join(self.working_dir, path).replace("\\", "/")
         if file_utils.exists(path):
+            if self.mode == "r" and not self.archive:
+                # Defense in depth: in read-from-dir mode the working_dir
+                # is attacker-controlled. Reject any path that resolves
+                # outside the asset root via a symbolic link, otherwise
+                # layer-side `open(...)` calls would silently follow the
+                # link and disclose arbitrary local files.
+                _reject_symlink_escape(path, self.working_dir)
             return path
         return None
 

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -375,6 +375,15 @@ def _load_model_from_dir(dirpath, custom_objects, compile, safe_mode):
     model = _model_from_config(config_json, custom_objects, compile, safe_mode)
 
     all_filenames = file_utils.listdir(dirpath)
+    # Up-front validation: refuse to honor a symlinked asset tree before
+    # opening any store. Done outside the try/finally so failure here does
+    # not need to clean up half-initialized stores.
+    if len(all_filenames) > 3:
+        _validate_asset_dir_no_symlink_escape(
+            file_utils.join(dirpath, _ASSETS_DIRNAME)
+        )
+    weights_store = None
+    asset_store = None
     try:
         if _VARS_FNAME_H5 in all_filenames:
             weights_file_path = file_utils.join(dirpath, _VARS_FNAME_H5)
@@ -387,12 +396,9 @@ def _load_model_from_dir(dirpath, custom_objects, compile, safe_mode):
                 f"Expected a {_VARS_FNAME_H5} or {_VARS_FNAME_NPZ} file."
             )
         if len(all_filenames) > 3:
-            assets_dirpath = file_utils.join(dirpath, _ASSETS_DIRNAME)
-            _validate_asset_dir_no_symlink_escape(assets_dirpath)
-            asset_store = DiskIOStore(assets_dirpath, mode="r")
-
-        else:
-            asset_store = None
+            asset_store = DiskIOStore(
+                file_utils.join(dirpath, _ASSETS_DIRNAME), mode="r"
+            )
 
         failed_saveables = set()
         error_msgs = {}
@@ -407,8 +413,9 @@ def _load_model_from_dir(dirpath, custom_objects, compile, safe_mode):
         )
 
     finally:
-        weights_store.close()
-        if asset_store:
+        if weights_store is not None:
+            weights_store.close()
+        if asset_store is not None:
             asset_store.close()
 
     if failed_saveables:

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -812,12 +812,14 @@ class SavingTest(testing.TestCase):
         reason="POSIX symlink semantics required for this test.",
     )
     def test_load_model_from_dir_rejects_symlinked_asset(self):
-        """Regression test for huntr report 0090e3ec-d53e-4595-860c-b22bc990b905.
+        """Regression test for the huntr symlink disclosure report.
 
         A directory-form Keras model whose asset file is a symlink pointing
         outside of the asset tree must be rejected. Otherwise layer-side
         `open(...)` calls would follow the link and load arbitrary local
         file content into the model.
+
+        See: huntr report 0090e3ec-d53e-4595-860c-b22bc990b905.
         """
         # Save a TextVectorization model whose vocabulary is persisted as
         # an asset file (`adapt()` ensures `input_vocabulary is None`, which

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -806,7 +806,6 @@ class SavingTest(testing.TestCase):
         saving_lib.load_weights_only(model, temp_filepath)
         self.assertAllClose(model.predict(ref_input), ref_output, atol=1e-6)
 
-
     @pytest.mark.skipif(
         os.name == "nt",
         reason="POSIX symlink semantics required for this test.",
@@ -824,9 +823,7 @@ class SavingTest(testing.TestCase):
         # Save a TextVectorization model whose vocabulary is persisted as
         # an asset file (`adapt()` ensures `input_vocabulary is None`, which
         # causes the vocabulary table to be written to assets/...).
-        model = keras.Sequential(
-            [keras.layers.TextVectorization(name="vec")]
-        )
+        model = keras.Sequential([keras.layers.TextVectorization(name="vec")])
         model.layers[0].adapt(np.array(["a", "b", "c"]))
         zipped_path = os.path.join(self.get_temp_dir(), "real.keras")
         model.save(zipped_path)
@@ -868,9 +865,7 @@ class SavingTest(testing.TestCase):
     )
     def test_load_model_from_dir_rejects_symlink_to_inside_asset_root(self):
         """In-tree symlinks are also rejected as tamper indicators."""
-        model = keras.Sequential(
-            [keras.layers.TextVectorization(name="vec")]
-        )
+        model = keras.Sequential([keras.layers.TextVectorization(name="vec")])
         model.layers[0].adapt(np.array(["a", "b", "c"]))
         zipped_path = os.path.join(self.get_temp_dir(), "real.keras")
         model.save(zipped_path)

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -807,6 +807,100 @@ class SavingTest(testing.TestCase):
         self.assertAllClose(model.predict(ref_input), ref_output, atol=1e-6)
 
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="POSIX symlink semantics required for this test.",
+    )
+    def test_load_model_from_dir_rejects_symlinked_asset(self):
+        """Regression test for huntr report 0090e3ec-d53e-4595-860c-b22bc990b905.
+
+        A directory-form Keras model whose asset file is a symlink pointing
+        outside of the asset tree must be rejected. Otherwise layer-side
+        `open(...)` calls would follow the link and load arbitrary local
+        file content into the model.
+        """
+        # Save a TextVectorization model whose vocabulary is persisted as
+        # an asset file (`adapt()` ensures `input_vocabulary is None`, which
+        # causes the vocabulary table to be written to assets/...).
+        model = keras.Sequential(
+            [keras.layers.TextVectorization(name="vec")]
+        )
+        model.layers[0].adapt(np.array(["a", "b", "c"]))
+        zipped_path = os.path.join(self.get_temp_dir(), "real.keras")
+        model.save(zipped_path)
+
+        # Unpack the .keras zip into a plain directory — this is the
+        # directory form `_load_model_from_dir` consumes.
+        model_dir = os.path.join(self.get_temp_dir(), "model_dir")
+        os.makedirs(model_dir)
+        with zipfile.ZipFile(zipped_path) as zf:
+            zf.extractall(model_dir)
+
+        # Locate the asset file and swap it for a symlink that escapes the
+        # asset tree.
+        asset_path = None
+        for root, _, files in os.walk(model_dir):
+            for f in files:
+                if f == "vocabulary.txt":
+                    asset_path = os.path.join(root, f)
+                    break
+            if asset_path:
+                break
+        self.assertIsNotNone(
+            asset_path, "Expected to find a vocabulary.txt asset."
+        )
+
+        secret_path = os.path.join(self.get_temp_dir(), "secret.txt")
+        with open(secret_path, "w") as f:
+            f.write("super-secret-content")
+        os.unlink(asset_path)
+        os.symlink(secret_path, asset_path)
+
+        # The directory load must refuse to process the symlinked asset.
+        with self.assertRaisesRegex(ValueError, "symbolic link|symlink"):
+            saving_lib.load_model(model_dir)
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="POSIX symlink semantics required for this test.",
+    )
+    def test_load_model_from_dir_rejects_symlink_to_inside_asset_root(self):
+        """In-tree symlinks are also rejected as tamper indicators."""
+        model = keras.Sequential(
+            [keras.layers.TextVectorization(name="vec")]
+        )
+        model.layers[0].adapt(np.array(["a", "b", "c"]))
+        zipped_path = os.path.join(self.get_temp_dir(), "real.keras")
+        model.save(zipped_path)
+
+        model_dir = os.path.join(self.get_temp_dir(), "model_dir")
+        os.makedirs(model_dir)
+        with zipfile.ZipFile(zipped_path) as zf:
+            zf.extractall(model_dir)
+
+        asset_path = None
+        for root, _, files in os.walk(model_dir):
+            for f in files:
+                if f == "vocabulary.txt":
+                    asset_path = os.path.join(root, f)
+                    break
+            if asset_path:
+                break
+        self.assertIsNotNone(asset_path)
+
+        # Point the asset at a sibling file that lives inside the asset
+        # root. Keras itself never writes symlinks into the asset tree, so
+        # even an "inside" symlink is unsafe to honor.
+        sibling_path = os.path.join(os.path.dirname(asset_path), "alt.txt")
+        with open(sibling_path, "w") as f:
+            f.write("a\nb\nc\n")
+        os.unlink(asset_path)
+        os.symlink(sibling_path, asset_path)
+
+        with self.assertRaisesRegex(ValueError, "symbolic link|symlink"):
+            saving_lib.load_model(model_dir)
+
+
 class SavingAPITest(testing.TestCase):
     def test_saving_api_errors(self):
         from keras.src.saving import saving_api


### PR DESCRIPTION
## Summary

`keras.saving.load_model(filepath)` accepts a directory as well as a `.keras` zip. When the path is a directory, `_load_model_from_dir` hands the model's `assets/` subtree to `DiskIOStore` in read-from-dir mode, which performs no extraction, no zipinfo / tarinfo filter, and no symlink check. Layer-side `load_assets(dir_path)` implementations then `open(...)` per-layer asset files (e.g. `assets/layers/<name>/_lookup_layer/vocabulary.txt`) and Python's `open` follows filesystem symlinks like any other file open.

A malicious model directory whose `vocabulary.txt` is a symlink to any file the victim process can read therefore causes Keras to load the target file's bytes into the model's vocabulary table. From there the attacker recovers them via `model.layers[i].get_vocabulary()`, by calling `model.save("exfil.keras")` and downloading the exported file, or by probing the model and reading back the integer token IDs that map to the leaked string.

This is **distinct** from CVE-2026-1669 (the HDF5 `h5py.ExternalLink` / `h5py.SoftLink` bug):

- CVE-2026-1669 lives in the HDF5 link layer; `safe_get_h5_group` / `safe_get_h5_dataset` are the defenses there.
- This bug lives at the POSIX filesystem layer — the assets are loose files, not HDF5 datasets — so the HDF5 link checks do not apply. The archive-extraction symlink filters (`filter_safe_zipinfos` / `filter_safe_tarinfos`) are also bypassed because the directory load path never extracts anything.

`safe_mode` does **not** gate this code path. Asset loading runs even when `safe_mode=True` (the default), so trusted-by-default users are still exposed.

## Fix

Reject symlinks under the asset directory at load time, and any path whose canonical target escapes the asset root, in two places:

- `_load_model_from_dir` performs a one-shot scan via `_validate_asset_dir_no_symlink_escape` **before** any layer-side `open(...)` so a malicious directory is refused up front rather than partway through state restoration.
- `DiskIOStore.get` adds defense-in-depth via `_reject_symlink_escape` for any other caller of the read-from-dir store.

Both helpers skip the check on remote URIs (e.g. `gs://`, `hdfs://`) since those backends have no concept of symbolic links.

Keras itself never writes symlinks into the asset tree, so any symlink found inside `assets/` — even one pointing to a sibling file inside the same tree — is treated as tamper evidence and rejected.

## Test plan

- [x] New `test_load_model_from_dir_rejects_symlinked_asset` — saves a `TextVectorization` model, unpacks it to a directory, swaps `vocabulary.txt` for a symlink to an out-of-tree file, and asserts `saving_lib.load_model(<dir>)` raises `ValueError`.
- [x] New `test_load_model_from_dir_rejects_symlink_to_inside_asset_root` — the same scenario but with the symlink target inside the asset directory; still rejected.
- [x] Existing directory-load tests (e.g. `test_save_unzipped`) still pass — non-symlink assets are unaffected.

## Disclosure

Reported by Ziyu Lin via huntr: https://huntr.com/bounties/0090e3ec-d53e-4595-860c-b22bc990b905

## Contributor agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.