### PR TITLE
Fix: KerasFileEditor eject HDF5 ExternalLink/SoftLink groups

### DIFF
--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -473,6 +473,19 @@ class KerasFileEditor:
             # IMPORTANT:
             # Never mutate inner_path; use local variable.
             current_inner_path = f"{inner_path}/{key}"
+
+            # Reject HDF5 `ExternalLink`/`SoftLink` children before any
+            # subscript. Without this guard a `data[key]` subscript would
+            # transparently follow the link into another HDF5 file on
+            # the host, completing CVE-2026-1669 for the editor path.
+            child_class = data.get(
+                key, default=None, getclass=True, getlink=True
+            )
+            if child_class in (h5py.ExternalLink, h5py.SoftLink):
+                raise ValueError(
+                    f"Not allowed: H5 file with {child_class.__name__}"
+                )
+
             value = data[key]
 
             # ------------------------------------------------------
@@ -483,14 +496,17 @@ class KerasFileEditor:
                 if len(value) == 0:
                     continue
 
-                # Skip empty "vars" groups
-                if "vars" in value.keys() and len(value["vars"]) == 0:
-                    continue
-
-                # Recurse into "vars" subgroup when present
+                # Recurse into "vars" subgroup when present. Resolve it
+                # through `safe_get_h5_group` so an attacker cannot use a
+                # nested `ExternalLink` named `vars` to redirect the
+                # editor into another HDF5 file.
                 if "vars" in value.keys():
+                    vars_group = saving_lib.safe_get_h5_group(value, "vars")
+                    # Skip empty "vars" groups
+                    if len(vars_group) == 0:
+                        continue
                     result[key], metadata = self._extract_weights_from_store(
-                        value["vars"],
+                        vars_group,
                         metadata=metadata,
                         inner_path=current_inner_path,
                     )

--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -474,10 +474,7 @@ class KerasFileEditor:
             # Never mutate inner_path; use local variable.
             current_inner_path = f"{inner_path}/{key}"
 
-            # Reject HDF5 `ExternalLink`/`SoftLink` children before any
-            # subscript. Without this guard a `data[key]` subscript would
-            # transparently follow the link into another HDF5 file on
-            # the host, completing CVE-2026-1669 for the editor path.
+            # Reject HDF5 `ExternalLink`/`SoftLink`.
             child_class = data.get(
                 key, default=None, getclass=True, getlink=True
             )
@@ -496,10 +493,7 @@ class KerasFileEditor:
                 if len(value) == 0:
                     continue
 
-                # Recurse into "vars" subgroup when present. Resolve it
-                # through `safe_get_h5_group` so an attacker cannot use a
-                # nested `ExternalLink` named `vars` to redirect the
-                # editor into another HDF5 file.
+                # Recurse into "vars" subgroup when present
                 if "vars" in value.keys():
                     vars_group = saving_lib.safe_get_h5_group(value, "vars")
                     # Skip empty "vars" groups

--- a/keras/src/saving/file_editor_test.py
+++ b/keras/src/saving/file_editor_test.py
@@ -113,16 +113,6 @@ class SavingTest(testing.TestCase):
         )
 
     def test_rejects_external_link_at_group_level(self):
-        """KerasFileEditor must not follow `h5py.ExternalLink` groups.
-
-        The dataset-level external-storage check added in PR #22057 (the
-        original CVE-2026-1669 fix) did not cover group-level
-        ``h5py.ExternalLink`` / ``h5py.SoftLink`` children, leaving the
-        editor's HDF5 traversal able to follow a 944-byte payload into
-        any HDF5 file the victim process can read. Loading such a file
-        must raise.
-        """
-        # Build a legitimate target file the attacker would like to read.
         target_fpath = os.path.join(
             self.get_temp_dir(), "victim_private.weights.h5"
         )
@@ -131,8 +121,6 @@ class SavingTest(testing.TestCase):
         )
         model.save_weights(target_fpath)
 
-        # Build the attacker payload: a `.weights.h5` whose only content
-        # is an `h5py.ExternalLink` pointing at the target file.
         attacker_fpath = os.path.join(
             self.get_temp_dir(), "attacker_payload.weights.h5"
         )
@@ -143,7 +131,6 @@ class SavingTest(testing.TestCase):
             KerasFileEditor(attacker_fpath)
 
     def test_rejects_soft_link_at_group_level(self):
-        """Same guard for `h5py.SoftLink` children inside the editor."""
         attacker_fpath = os.path.join(
             self.get_temp_dir(), "softlink_payload.weights.h5"
         )

--- a/keras/src/saving/file_editor_test.py
+++ b/keras/src/saving/file_editor_test.py
@@ -1,5 +1,6 @@
 import os
 
+import h5py
 import numpy as np
 import pytest
 
@@ -110,3 +111,46 @@ class SavingTest(testing.TestCase):
         self.assertEqual(
             len(keras.src.tree.flatten(model_weights_editor.weights_dict)), 8
         )
+
+    def test_rejects_external_link_at_group_level(self):
+        """KerasFileEditor must not follow `h5py.ExternalLink` groups.
+
+        The dataset-level external-storage check added in PR #22057 (the
+        original CVE-2026-1669 fix) did not cover group-level
+        ``h5py.ExternalLink`` / ``h5py.SoftLink`` children, leaving the
+        editor's HDF5 traversal able to follow a 944-byte payload into
+        any HDF5 file the victim process can read. Loading such a file
+        must raise.
+        """
+        # Build a legitimate target file the attacker would like to read.
+        target_fpath = os.path.join(
+            self.get_temp_dir(), "victim_private.weights.h5"
+        )
+        model = keras.Sequential(
+            [keras.Input(shape=(3,)), keras.layers.Dense(5)]
+        )
+        model.save_weights(target_fpath)
+
+        # Build the attacker payload: a `.weights.h5` whose only content
+        # is an `h5py.ExternalLink` pointing at the target file.
+        attacker_fpath = os.path.join(
+            self.get_temp_dir(), "attacker_payload.weights.h5"
+        )
+        with h5py.File(attacker_fpath, "w") as f:
+            f["layers"] = h5py.ExternalLink(target_fpath, "/layers")
+
+        with self.assertRaisesRegex(ValueError, "ExternalLink"):
+            KerasFileEditor(attacker_fpath)
+
+    def test_rejects_soft_link_at_group_level(self):
+        """Same guard for `h5py.SoftLink` children inside the editor."""
+        attacker_fpath = os.path.join(
+            self.get_temp_dir(), "softlink_payload.weights.h5"
+        )
+        with h5py.File(attacker_fpath, "w") as f:
+            real = f.create_group("real_layers")
+            real.create_dataset("inner", data=np.zeros((1,)))
+            f["layers"] = h5py.SoftLink("/real_layers")
+
+        with self.assertRaisesRegex(ValueError, "SoftLink"):
+            KerasFileEditor(attacker_fpath)


### PR DESCRIPTION
## Summary

`KerasFileEditor._extract_weights_from_store` walks the HDF5 tree with raw subscripts (`data[key]`, `value["vars"]`). When the input file is attacker-supplied — which is precisely the use case `KerasFileEditor` exists for (inspecting / editing weight files produced elsewhere) — either of those subscripts transparently follows an `h5py.ExternalLink` or `h5py.SoftLink` group into another HDF5 file on the host. The attacker-controlled payload can be as small as ~944 bytes and contains no Python code, so it bypasses any static-analysis-based defense and `safe_mode` is not consulted.

After the link is followed, `editor.weights_dict` is populated from the linked file. A subsequent `editor.save(...)` — part of the documented edit workflow — writes those tensors back out as regular datasets, turning the editor into a full cross-file disclosure / exfiltration channel for any HDF5 file (another user's weights checkpoint on a shared training cluster, an `~/.cache/huggingface/...` cached model, etc.) that the victim process can read.

## Relationship to CVE-2026-1669

PR #22057 (the original CVE-2026-1669 fix) already added a dataset-level `value.external` check to this exact method, but only covered `Dataset` external storage. The matching `ExternalLink` / `SoftLink` guard on `Group` children — which is what `saving_lib.safe_get_h5_group` was written to provide — was not applied here. This PR completes the fix.

## Fix

- Before subscripting `data[key]`, fetch the link class via `data.get(..., getclass=True, getlink=True)` and raise `ValueError` on `ExternalLink` / `SoftLink`. This mirrors `safe_get_h5_group` but handles the case where the child can be a `Dataset` rather than a `Group`.
- Resolve `value["vars"]` through `saving_lib.safe_get_h5_group` so a nested link named `vars` cannot be used to redirect the editor (the existing `len(value["vars"]) == 0` empty-skip is also routed through the same safe accessor).

Keras's own `save_model` / `save_weights` never emits `ExternalLink` or `SoftLink`, so legitimate weight files are unaffected — only attacker-crafted payloads are rejected.

## Test plan

- [x] `test_rejects_external_link_at_group_level` — constructs a ~944-byte `.weights.h5` whose `layers` group is an `h5py.ExternalLink` pointing at a legitimate weight file, then asserts `KerasFileEditor(...)` raises `ValueError`.
- [x] `test_rejects_soft_link_at_group_level` — same scenario with `h5py.SoftLink` to an in-file group, also rejected.
- [x] Existing `test_basics` and `test_scalar_weight` still pass — legitimate `.keras` / `.weights.h5` files are unaffected.

## Disclosure

Reported via huntr: https://huntr.com/bounties/d5688f27-73af-4853-8855-0c3a45c0f290

## Contributor agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.