### PR TITLE
Fix: load_weights reject HDF5 ExternalLink/SoftLink on legacy .h5 dispatcher

### DIFF
--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -310,7 +310,14 @@ def load_weights(model, filepath, skip_mismatch=False, **kwargs):
             )
         with h5py.File(filepath, "r") as f:
             if "layer_names" not in f.attrs and "model_weights" in f:
-                f = f["model_weights"]
+                # Route this access through `safe_get_h5_group` so an
+                # attacker-supplied `.h5` cannot use an `h5py.ExternalLink`
+                # / `h5py.SoftLink` at the `model_weights` group to
+                # redirect the weight load into any other HDF5 file the
+                # process can read. `legacy_h5_format` already does the
+                # same on its own `f["model_weights"]` access; this
+                # dispatcher was the last raw subscript on the path.
+                f = saving_lib.safe_get_h5_group(f, "model_weights")
             if by_name:
                 legacy_h5_format.load_weights_from_hdf5_group_by_name(
                     f, model, skip_mismatch

--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -310,13 +310,6 @@ def load_weights(model, filepath, skip_mismatch=False, **kwargs):
             )
         with h5py.File(filepath, "r") as f:
             if "layer_names" not in f.attrs and "model_weights" in f:
-                # Route this access through `safe_get_h5_group` so an
-                # attacker-supplied `.h5` cannot use an `h5py.ExternalLink`
-                # / `h5py.SoftLink` at the `model_weights` group to
-                # redirect the weight load into any other HDF5 file the
-                # process can read. `legacy_h5_format` already does the
-                # same on its own `f["model_weights"]` access; this
-                # dispatcher was the last raw subscript on the path.
                 f = saving_lib.safe_get_h5_group(f, "model_weights")
             if by_name:
                 legacy_h5_format.load_weights_from_hdf5_group_by_name(

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import unittest.mock as mock
 
+import h5py
 import numpy as np
 from absl import logging
 from absl.testing import parameterized
@@ -295,6 +296,46 @@ class LoadWeightsTests(test_case.TestCase):
         model = self.get_model()
         with self.assertRaisesRegex(ValueError, "File format not supported"):
             model.load_weights("invalid_extension.pkl")
+
+    def test_load_weights_rejects_h5_external_link(self):
+        """Regression test for the legacy `.h5` dispatcher in `load_weights`.
+
+        A ~1 KB attacker payload whose `/model_weights` group is an
+        `h5py.ExternalLink` to another HDF5 file used to be followed by
+        the raw `f["model_weights"]` subscript in `saving_api.py`,
+        completing CVE-2026-1669 for the public `load_weights` API.
+        The dispatcher must reject the link rather than silently loading
+        the target file's weights into the victim model.
+        """
+        # Build a legitimate target file the attacker would want to read.
+        target_fpath = os.path.join(self.get_temp_dir(), "target.h5")
+        src_model = self.get_model()
+        save_model_to_hdf5(src_model, target_fpath)
+
+        # Build the attacker payload: only contains an `ExternalLink`.
+        attacker_fpath = os.path.join(self.get_temp_dir(), "attacker.h5")
+        with h5py.File(attacker_fpath, "w") as f:
+            f["model_weights"] = h5py.ExternalLink(
+                target_fpath, "/model_weights"
+            )
+
+        dest_model = self.get_model()
+        with self.assertRaisesRegex(ValueError, "ExternalLink"):
+            dest_model.load_weights(attacker_fpath)
+
+    def test_load_weights_rejects_h5_soft_link(self):
+        """Same guard for `h5py.SoftLink` at the `model_weights` group."""
+        attacker_fpath = os.path.join(
+            self.get_temp_dir(), "softlink_attacker.h5"
+        )
+        with h5py.File(attacker_fpath, "w") as f:
+            real = f.create_group("real_weights")
+            real.create_dataset("inner", data=np.zeros((1,)))
+            f["model_weights"] = h5py.SoftLink("/real_weights")
+
+        dest_model = self.get_model()
+        with self.assertRaisesRegex(ValueError, "SoftLink"):
+            dest_model.load_weights(attacker_fpath)
 
     def test_load_sharded_weights(self):
         src_model = self.get_model()

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -298,21 +298,10 @@ class LoadWeightsTests(test_case.TestCase):
             model.load_weights("invalid_extension.pkl")
 
     def test_load_weights_rejects_h5_external_link(self):
-        """Regression test for the legacy `.h5` dispatcher in `load_weights`.
-
-        A ~1 KB attacker payload whose `/model_weights` group is an
-        `h5py.ExternalLink` to another HDF5 file used to be followed by
-        the raw `f["model_weights"]` subscript in `saving_api.py`,
-        completing CVE-2026-1669 for the public `load_weights` API.
-        The dispatcher must reject the link rather than silently loading
-        the target file's weights into the victim model.
-        """
-        # Build a legitimate target file the attacker would want to read.
         target_fpath = os.path.join(self.get_temp_dir(), "target.h5")
         src_model = self.get_model()
         save_model_to_hdf5(src_model, target_fpath)
 
-        # Build the attacker payload: only contains an `ExternalLink`.
         attacker_fpath = os.path.join(self.get_temp_dir(), "attacker.h5")
         with h5py.File(attacker_fpath, "w") as f:
             f["model_weights"] = h5py.ExternalLink(
@@ -324,7 +313,6 @@ class LoadWeightsTests(test_case.TestCase):
             dest_model.load_weights(attacker_fpath)
 
     def test_load_weights_rejects_h5_soft_link(self):
-        """Same guard for `h5py.SoftLink` at the `model_weights` group."""
         attacker_fpath = os.path.join(
             self.get_temp_dir(), "softlink_attacker.h5"
         )


### PR DESCRIPTION
## Summary

`keras.saving.load_weights(model, "x.h5")` (and the equivalent `model.load_weights("x.h5")`) dispatches to `saving_api.py`, which opens the file and does

```python
with h5py.File(filepath, "r") as f:
    if "layer_names" not in f.attrs and "model_weights" in f:
        f = f["model_weights"]
```

as a **raw** `h5py` subscript. `h5py` transparently follows `h5py.ExternalLink` / `h5py.SoftLink` on plain subscripts, so a ~1 KB attacker-supplied `.h5` whose `model_weights` group is an `ExternalLink` redirects the entire weight load into any other HDF5 file the victim process can read. The target file's `/model_weights` subtree is written into the victim's in-process model, then exfiltrable via `model.get_weights()`, `model.save(...)`, or inference. `safe_mode` does not gate this code path.

## Relationship to CVE-2026-1669

This is the same vulnerability class as CVE-2026-1669. PR #22057 patched the equivalent accesses in `saving_lib.py` (new `.keras` format) and `file_editor.py`. PR #22801 then wrapped every `f[name]` access in `legacy/saving/legacy_h5_format.py` with `safe_get_h5_group`, including its own `f["model_weights"]` read at `legacy_h5_format.py:145`. Neither PR touched `saving/saving_api.py`, which is the dispatcher for the public `load_weights` API on legacy `.h5` files. This was the last raw subscript on the path; this PR closes it with the same one-line treatment.

## Fix

```diff
-        f = f["model_weights"]
+        f = saving_lib.safe_get_h5_group(f, "model_weights")
```

`saving_lib.safe_get_h5_group` already exists in the codebase and is the helper that the rest of the HDF5-loading code uses for exactly this purpose — it rejects `h5py.ExternalLink` / `h5py.SoftLink` and validates the child is a `Group`. `saving_api.py` already imports `saving_lib`, so the change is a single line plus an explanatory comment.

Keras's own `save_model` / `save_weights` never emits `ExternalLink` or `SoftLink`, so legitimate `.h5` weight files are unaffected — only attacker-crafted payloads are rejected.

## Test plan

- [x] `test_load_weights_rejects_h5_external_link` — builds a ~1 KB `.h5` whose `model_weights` is an `h5py.ExternalLink` pointing at a legitimate weight file, then asserts `model.load_weights(...)` raises `ValueError`.
- [x] `test_load_weights_rejects_h5_soft_link` — same scenario with `h5py.SoftLink` to an in-file group, also rejected.
- [x] Existing `test_load_weights[*_h5_*]` parameterized cases still pass — legitimate `.h5` / `.weights.h5` files load unchanged (verified locally: 45 passed, 7 pre-existing skips for bfloat16+h5).

## Disclosure

Reported via huntr: https://huntr.com/bounties/d5688f27-73af-4853-8855-0c3a45c0f290

## Contributor agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.