### PR TITLE
Fix fill_value handling bug in horizontal padding in torch backend's image.resize op

### DIFF
--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -306,7 +306,8 @@ def resize(
                         (batch_size, channels, height, img_box_wstart),
                         dtype=images.dtype,
                         device=images.device,
-                    ),
+                    )
+                    * fill_value,
                     padded_img,
                     torch.ones(
                         (batch_size, channels, height, img_box_wstart),

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -1482,6 +1482,38 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             atol=1.0,
         )
 
+    def test_resize_pad_to_aspect_ratio_fill_value_correctness(self):
+        fill_value = 0.5
+        x = np.zeros((1, 10, 10, 3), dtype="float32")
+        out = kimage.resize(
+            x,
+            size=(10, 20),
+            pad_to_aspect_ratio=True,
+            fill_value=fill_value,
+        )
+        out_np = backend.convert_to_numpy(out)
+        self.assertAllClose(
+            out_np[0, :, :5, :], np.ones((10, 5, 3)) * fill_value
+        )
+        self.assertAllClose(
+            out_np[0, :, 15:, :], np.ones((10, 5, 3)) * fill_value
+        )
+
+        x = np.zeros((1, 10, 10, 3), dtype="float32")
+        out = kimage.resize(
+            x,
+            size=(20, 10),
+            pad_to_aspect_ratio=True,
+            fill_value=fill_value,
+        )
+        out_np = backend.convert_to_numpy(out)
+        self.assertAllClose(
+            out_np[0, :5, :, :], np.ones((5, 10, 3)) * fill_value
+        )
+        self.assertAllClose(
+            out_np[0, 15:, :, :], np.ones((5, 10, 3)) * fill_value
+        )
+
     @parameterized.named_parameters(
         ("zero_height", (0, 10)),
         ("zero_width", (10, 0)),


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras/issues/22902

This PR fixes a numerical bug in the PyTorch backend where keras.ops.image.resize ignored the user-specified fill_value for horizontal left-side padding when pad_to_aspect_ratio=True. In the PyTorch backend's image.resize implementation, the left-side horizontal padding was hardcoded to 1.0 (white) because the fill_value multiplier was missing from the tensor operation. This resulted in incorrect padding colors whenever horizontal padding was required.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
