### PR TITLE
Implement fabs function across multiple backends and add tests

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -198,6 +198,7 @@ from keras.src.ops.numpy import exp2 as exp2
 from keras.src.ops.numpy import expand_dims as expand_dims
 from keras.src.ops.numpy import expm1 as expm1
 from keras.src.ops.numpy import eye as eye
+from keras.src.ops.numpy import fabs as fabs
 from keras.src.ops.numpy import flip as flip
 from keras.src.ops.numpy import fliplr as fliplr
 from keras.src.ops.numpy import flipud as flipud

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -74,6 +74,7 @@ from keras.src.ops.numpy import exp2 as exp2
 from keras.src.ops.numpy import expand_dims as expand_dims
 from keras.src.ops.numpy import expm1 as expm1
 from keras.src.ops.numpy import eye as eye
+from keras.src.ops.numpy import fabs as fabs
 from keras.src.ops.numpy import flip as flip
 from keras.src.ops.numpy import fliplr as fliplr
 from keras.src.ops.numpy import flipud as flipud

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -198,6 +198,7 @@ from keras.src.ops.numpy import exp2 as exp2
 from keras.src.ops.numpy import expand_dims as expand_dims
 from keras.src.ops.numpy import expm1 as expm1
 from keras.src.ops.numpy import eye as eye
+from keras.src.ops.numpy import fabs as fabs
 from keras.src.ops.numpy import flip as flip
 from keras.src.ops.numpy import fliplr as fliplr
 from keras.src.ops.numpy import flipud as flipud

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -74,6 +74,7 @@ from keras.src.ops.numpy import exp2 as exp2
 from keras.src.ops.numpy import expand_dims as expand_dims
 from keras.src.ops.numpy import expm1 as expm1
 from keras.src.ops.numpy import eye as eye
+from keras.src.ops.numpy import fabs as fabs
 from keras.src.ops.numpy import flip as flip
 from keras.src.ops.numpy import fliplr as fliplr
 from keras.src.ops.numpy import flipud as flipud

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -290,6 +290,9 @@ def abs(x):
 
 def fabs(x):
     x = convert_to_tensor(x)
+    dtype = standardize_dtype(x.dtype)
+    if "int" in dtype or dtype == "bool":
+        x = x.astype(config.floatx())
     return jnp.fabs(x)
 
 

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -288,6 +288,11 @@ def abs(x):
     return absolute(x)
 
 
+def fabs(x):
+    x = convert_to_tensor(x)
+    return jnp.fabs(x)
+
+
 def all(x, axis=None, keepdims=False):
     return jnp.all(x, axis=axis, keepdims=keepdims)
 

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -290,9 +290,6 @@ def abs(x):
 
 def fabs(x):
     x = convert_to_tensor(x)
-    dtype = standardize_dtype(x.dtype)
-    if "int" in dtype or dtype == "bool":
-        x = x.astype(config.floatx())
     return jnp.fabs(x)
 
 

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -135,6 +135,14 @@ def abs(x):
     return absolute(x)
 
 
+def fabs(x):
+    x = convert_to_tensor(x)
+    dtype = standardize_dtype(x.dtype)
+    if "int" in dtype or dtype == "bool":
+        x = x.astype(config.floatx())
+    return np.fabs(x)
+
+
 def all(x, axis=None, keepdims=False):
     axis = standardize_axis_for_numpy(axis)
     return np.all(x, axis=axis, keepdims=keepdims)

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -230,6 +230,17 @@ def abs(x):
     return OpenVINOKerasTensor(ov_opset.absolute(x).output(0))
 
 
+def fabs(x):
+    x = get_ov_output(x)
+    x_type = x.get_element_type()
+
+    if x_type.is_integral() or x_type == Type.boolean:
+        ov_type = OPENVINO_DTYPES[config.floatx()]
+        x = ov_opset.convert(x, ov_type).output(0)
+
+    return OpenVINOKerasTensor(ov_opset.absolute(x).output(0))
+
+
 def all(x, axis=None, keepdims=False):
     x = get_ov_output(x)
     x, axis = _resolve_axis(x, axis)

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -780,6 +780,15 @@ def abs(x):
     return absolute(x)
 
 
+@sparse.elementwise_unary
+def fabs(x):
+    x = convert_to_tensor(x)
+    dtype = standardize_dtype(x.dtype)
+    if "int" in dtype or dtype == "bool":
+        x = tf.cast(x, config.floatx())
+    return tf.abs(x)
+
+
 def all(x, axis=None, keepdims=False):
     x = tf.cast(x, "bool")
     return tf.reduce_all(x, axis=axis, keepdims=keepdims)

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -255,6 +255,14 @@ def abs(x):
     return absolute(x)
 
 
+def fabs(x):
+    x = convert_to_tensor(x)
+    dtype = standardize_dtype(x.dtype)
+    if "int" in dtype or dtype == "bool":
+        x = cast(x, config.floatx())
+    return torch.abs(x)
+
+
 def all(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
     if axis is None:

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -186,6 +186,43 @@ def abs(x):
     return absolute(x)
 
 
+class Fabs(Operation):
+    def call(self, x):
+        return backend.numpy.fabs(x)
+
+    def compute_output_spec(self, x):
+        sparse = getattr(x, "sparse", False)
+        dtype = backend.standardize_dtype(getattr(x, "dtype", type(x)))
+        if "int" in dtype or dtype == "bool":
+            dtype = backend.floatx()
+        return KerasTensor(x.shape, dtype=dtype, sparse=sparse)
+
+
+@keras_export(["keras.ops.fabs", "keras.ops.numpy.fabs"])
+def fabs(x):
+    """Compute the absolute values element-wise.
+
+    Computes the absolute values elements wise. Integer or boolean inputs are
+    automatically promoted to the default floating-point type.
+    Complex values are not handled.
+
+    Args:
+        x: Input tensor.
+
+    Returns:
+        An array containing the absolute value of each element in `x`.
+
+    Example:
+
+    >>> x = keras.ops.convert_to_tensor([-1.2, 1.2])
+    >>> keras.ops.fabs(x)
+    array([1.2, 1.2], dtype=float32)
+    """
+    if any_symbolic_tensors((x,)):
+        return Fabs().symbolic_call(x)
+    return backend.numpy.fabs(x)
+
+
 class Add(Operation):
     def call(self, x1, x2):
         return backend.numpy.add(x1, x2)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -193,6 +193,10 @@ class Fabs(Operation):
     def compute_output_spec(self, x):
         sparse = getattr(x, "sparse", False)
         dtype = backend.standardize_dtype(getattr(x, "dtype", type(x)))
+        if "complex" in dtype:
+            raise TypeError(
+                f"fabs does not support complex inputs. Received: dtype={dtype}"
+            )
         if "int" in dtype or dtype == "bool":
             dtype = backend.floatx()
         return KerasTensor(x.shape, dtype=dtype, sparse=sparse)
@@ -202,9 +206,9 @@ class Fabs(Operation):
 def fabs(x):
     """Compute the absolute values element-wise.
 
-    Computes the absolute values elements wise. Integer or boolean inputs are
-    automatically promoted to the default floating-point type.
-    Complex values are not handled.
+    Integer or boolean inputs are automatically promoted to the
+    default floating-point type.
+    Complex values are not supported.
 
     Args:
         x: Input tensor.
@@ -214,12 +218,19 @@ def fabs(x):
 
     Example:
 
-    >>> x = keras.ops.convert_to_tensor([-1.2, 1.2])
+     >>> x = keras.ops.convert_to_tensor([-1, 2], dtype="int32")
     >>> keras.ops.fabs(x)
-    array([1.2, 1.2], dtype=float32)
+    array([1., 2.], dtype=float32)
     """
     if any_symbolic_tensors((x,)):
         return Fabs().symbolic_call(x)
+
+    x = backend.convert_to_tensor(x)
+    if "complex" in backend.standardize_dtype(x.dtype):
+        raise TypeError(
+            f"fabs does not support complex inputs. Received: x.dtype={x.dtype}"
+        )
+
     return backend.numpy.fabs(x)
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -8466,6 +8466,9 @@ class NumpyDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_fabs(self, dtype):
+        if "complex" in standardize_dtype(dtype):
+            self.skipTest("fabs does not support complex types")
+
         import jax.numpy as jnp
 
         x = knp.ones((1,), dtype=dtype)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1354,6 +1354,10 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.abs(x).shape, (None, 3))
 
+    def test_fabs(self):
+        x = KerasTensor((None, 3))
+        self.assertEqual(knp.fabs(x).shape, (None, 3))
+
     def test_absolute(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.absolute(x).shape, (None, 3))
@@ -2430,6 +2434,10 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
     def test_abs(self):
         x = KerasTensor((2, 3))
         self.assertEqual(knp.abs(x).shape, (2, 3))
+
+    def test_fabs(self):
+        x = KerasTensor((2, 3))
+        self.assertEqual(knp.fabs(x).shape, (2, 3))
 
     def test_absolute(self):
         x = KerasTensor((2, 3))
@@ -4954,6 +4962,12 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.abs(x), np.abs(x))
 
         self.assertAllClose(knp.Abs()(x), np.abs(x))
+
+    def test_fabs(self):
+        x = np.array([[-1, 2, -3], [3, -2, 1]])
+        self.assertAllClose(knp.fabs(x), np.fabs(x))
+
+        self.assertAllClose(knp.Fabs()(x), np.fabs(x))
 
     def test_absolute(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
@@ -8447,6 +8461,20 @@ class NumpyDtypeTest(testing.TestCase):
 
         self.assertEqual(
             standardize_dtype(knp.zeros([2, 3], dtype=dtype).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_fabs(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.fabs(x_jax).dtype)
+
+        self.assertEqual(standardize_dtype(knp.fabs(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Fabs().symbolic_call(x).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
Implements a new `fabs` operation to the Keras ops API, providing element-wise computation of the absolute value with automatic type promotion for integer and boolean inputs. The implementation covers all supported backends (TensorFlow, JAX, NumPy, OpenVINO, Torch)

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
