### PR TITLE
Add keras.config.enable_tf32 toggle for cross-backend matmul precision

### DIFF
--- a/keras/api/_tf_keras/keras/config/__init__.py
+++ b/keras/api/_tf_keras/keras/config/__init__.py
@@ -8,9 +8,11 @@ from keras.src.backend.config import backend as backend
 from keras.src.backend.config import (
     disable_flash_attention as disable_flash_attention,
 )
+from keras.src.backend.config import disable_tf32 as disable_tf32
 from keras.src.backend.config import (
     enable_flash_attention as enable_flash_attention,
 )
+from keras.src.backend.config import enable_tf32 as enable_tf32
 from keras.src.backend.config import epsilon as epsilon
 from keras.src.backend.config import floatx as floatx
 from keras.src.backend.config import image_data_format as image_data_format
@@ -18,6 +20,7 @@ from keras.src.backend.config import (
     is_flash_attention_enabled as is_flash_attention_enabled,
 )
 from keras.src.backend.config import is_nnx_enabled as is_nnx_enabled
+from keras.src.backend.config import is_tf32_enabled as is_tf32_enabled
 from keras.src.backend.config import max_epochs as max_epochs
 from keras.src.backend.config import max_steps_per_epoch as max_steps_per_epoch
 from keras.src.backend.config import set_epsilon as set_epsilon

--- a/keras/api/config/__init__.py
+++ b/keras/api/config/__init__.py
@@ -8,9 +8,11 @@ from keras.src.backend.config import backend as backend
 from keras.src.backend.config import (
     disable_flash_attention as disable_flash_attention,
 )
+from keras.src.backend.config import disable_tf32 as disable_tf32
 from keras.src.backend.config import (
     enable_flash_attention as enable_flash_attention,
 )
+from keras.src.backend.config import enable_tf32 as enable_tf32
 from keras.src.backend.config import epsilon as epsilon
 from keras.src.backend.config import floatx as floatx
 from keras.src.backend.config import image_data_format as image_data_format
@@ -18,6 +20,7 @@ from keras.src.backend.config import (
     is_flash_attention_enabled as is_flash_attention_enabled,
 )
 from keras.src.backend.config import is_nnx_enabled as is_nnx_enabled
+from keras.src.backend.config import is_tf32_enabled as is_tf32_enabled
 from keras.src.backend.config import max_epochs as max_epochs
 from keras.src.backend.config import max_steps_per_epoch as max_steps_per_epoch
 from keras.src.backend.config import set_epsilon as set_epsilon

--- a/keras/src/backend/config.py
+++ b/keras/src/backend/config.py
@@ -288,6 +288,11 @@ def is_tf32_enabled():
 
     Returns:
         `False` if disabled. Otherwise, it indicates that it is enabled.
+
+    Example:
+
+    >>> keras.config.is_tf32_enabled()
+    True
     """
     from keras.src.backend.common import global_state
 

--- a/keras/src/backend/config.py
+++ b/keras/src/backend/config.py
@@ -248,6 +248,10 @@ def enable_tf32():
 
     Note that this only affects `float32` compute on supported GPUs. It has
     no effect on CPU, on TPU, or for other dtypes.
+
+    Example:
+
+    >>> keras.config.enable_tf32()
     """
     from keras.src.backend.common import global_state
 

--- a/keras/src/backend/config.py
+++ b/keras/src/backend/config.py
@@ -233,6 +233,80 @@ def is_flash_attention_enabled():
     return global_state.get_global_attribute("flash_attention", default=None)
 
 
+@keras_export("keras.config.enable_tf32")
+def enable_tf32():
+    """Enable TensorFloat-32 (TF32) for float32 matrix multiplications.
+
+    TF32 is a reduced-precision mode available on NVIDIA Ampere and later
+    GPUs that runs `float32` matmuls and convolutions on the tensor cores,
+    typically several times faster with a small loss of mantissa precision.
+
+    This is enabled by default. The JAX and TensorFlow backends already use
+    TF32 by default. The Torch backend does not, so without this Keras would
+    silently run `float32` matmuls slower on Torch than on the other
+    backends for the same model code.
+
+    Note that this only affects `float32` compute on supported GPUs. It has
+    no effect on CPU, on TPU, or for other dtypes.
+    """
+    from keras.src.backend.common import global_state
+
+    global_state.set_global_attribute("tf32", None)
+    _refresh_backend_tf32()
+
+
+@keras_export("keras.config.disable_tf32")
+def disable_tf32():
+    """Disable TensorFloat-32 (TF32) for float32 matrix multiplications.
+
+    Once disabled, `float32` matmuls run at full `float32` precision on all
+    backends. Use this when you need bit-for-bit `float32` accuracy and are
+    willing to give up the tensor-core speedup.
+    """
+    from keras.src.backend.common import global_state
+
+    global_state.set_global_attribute("tf32", False)
+    _refresh_backend_tf32()
+
+
+@keras_export("keras.config.is_tf32_enabled")
+def is_tf32_enabled():
+    """Checks whether TF32 is globally enabled in Keras.
+
+    TF32 lets `float32` matrix multiplications run on GPU tensor cores at
+    reduced mantissa precision for a large speedup. This function checks the
+    global Keras configuration. See `keras.config.enable_tf32` and
+    `keras.config.disable_tf32`.
+
+    Returns:
+        `False` if disabled. Otherwise, it indicates that it is enabled.
+    """
+    from keras.src.backend.common import global_state
+
+    return global_state.get_global_attribute("tf32", default=None)
+
+
+def _refresh_backend_tf32():
+    """Re-apply the current TF32 setting to the active backend.
+
+    The backend applies TF32 once at import time; this lets a later
+    `enable_tf32()` / `disable_tf32()` call take effect immediately.
+    """
+    name = backend()
+    try:
+        if name == "torch":
+            from keras.src.backend.torch.core import _apply_tf32
+        elif name == "jax":
+            from keras.src.backend.jax.core import _apply_tf32
+        elif name == "tensorflow":
+            from keras.src.backend.tensorflow.core import _apply_tf32
+        else:
+            return
+    except ImportError:
+        return
+    _apply_tf32()
+
+
 @keras_export("keras.config.is_nnx_enabled")
 def is_nnx_enabled():
     """Checks whether NNX specific features are enabled for the JAX backend.

--- a/keras/src/backend/config.py
+++ b/keras/src/backend/config.py
@@ -262,6 +262,10 @@ def disable_tf32():
     Once disabled, `float32` matmuls run at full `float32` precision on all
     backends. Use this when you need bit-for-bit `float32` accuracy and are
     willing to give up the tensor-core speedup.
+
+    Example:
+
+    >>> keras.config.disable_tf32()
     """
     from keras.src.backend.common import global_state
 

--- a/keras/src/backend/config.py
+++ b/keras/src/backend/config.py
@@ -241,13 +241,14 @@ def enable_tf32():
     GPUs that runs `float32` matmuls and convolutions on the tensor cores,
     typically several times faster with a small loss of mantissa precision.
 
-    This is enabled by default. The JAX and TensorFlow backends already use
-    TF32 by default. The Torch backend does not, so without this Keras would
-    silently run `float32` matmuls slower on Torch than on the other
-    backends for the same model code.
+    Off by default. Calling this opts the active backend into TF32 (Torch:
+    `set_float32_matmul_precision("high")` and `cudnn.allow_tf32 = True`;
+    JAX: `jax_default_matmul_precision = "default"`; TensorFlow:
+    `enable_tensor_float_32_execution(True)`). Doing nothing leaves each
+    backend at its own native default.
 
-    Note that this only affects `float32` compute on supported GPUs. It has
-    no effect on CPU, on TPU, or for other dtypes.
+    Only affects `float32` compute on supported GPUs. It has no effect on
+    CPU, on TPU, or for other dtypes.
 
     Example:
 
@@ -263,9 +264,9 @@ def enable_tf32():
 def disable_tf32():
     """Disable TensorFloat-32 (TF32) for float32 matrix multiplications.
 
-    Once disabled, `float32` matmuls run at full `float32` precision on all
-    backends. Use this when you need bit-for-bit `float32` accuracy and are
-    willing to give up the tensor-core speedup.
+    Forces full `float32` precision on the active backend regardless of
+    its native default. Use this when you need bit-for-bit `float32`
+    accuracy and are willing to give up the tensor-core speedup.
 
     Example:
 
@@ -279,28 +280,25 @@ def disable_tf32():
 
 @keras_export("keras.config.is_tf32_enabled")
 def is_tf32_enabled():
-    """Checks whether TF32 is globally enabled in Keras.
+    """Checks whether TF32 has been explicitly enabled in Keras.
 
-    TF32 lets `float32` matrix multiplications run on GPU tensor cores at
-    reduced mantissa precision for a large speedup. This function checks the
-    global Keras configuration. See `keras.config.enable_tf32` and
-    `keras.config.disable_tf32`.
+    This reflects the Keras opt-in switch, not the active backend's native
+    precision setting. By default Keras leaves each backend at its own
+    default, in which case this returns `False` even if the backend (e.g.
+    JAX or TensorFlow) is running matmuls in TF32 internally.
 
     Returns:
-        `True` if TF32 is enabled (the default), `False` if it has been
-        explicitly disabled.
+        `True` if `keras.config.enable_tf32` has been called, `False`
+        otherwise.
 
     Example:
 
     >>> keras.config.is_tf32_enabled()
-    True
+    False
     """
     from keras.src.backend.common import global_state
 
-    # Stored as a strict bool by enable_tf32/disable_tf32. When neither has
-    # been called, the attribute is absent and we fall back to the Keras
-    # default (True).
-    return global_state.get_global_attribute("tf32", default=True) is True
+    return global_state.get_global_attribute("tf32", default=False) is True
 
 
 def _refresh_backend_tf32():

--- a/keras/src/backend/config.py
+++ b/keras/src/backend/config.py
@@ -255,7 +255,7 @@ def enable_tf32():
     """
     from keras.src.backend.common import global_state
 
-    global_state.set_global_attribute("tf32", None)
+    global_state.set_global_attribute("tf32", True)
     _refresh_backend_tf32()
 
 
@@ -287,7 +287,8 @@ def is_tf32_enabled():
     `keras.config.disable_tf32`.
 
     Returns:
-        `False` if disabled. Otherwise, it indicates that it is enabled.
+        `True` if TF32 is enabled (the default), `False` if it has been
+        explicitly disabled.
 
     Example:
 
@@ -296,7 +297,10 @@ def is_tf32_enabled():
     """
     from keras.src.backend.common import global_state
 
-    return global_state.get_global_attribute("tf32", default=None)
+    # Stored as a strict bool by enable_tf32/disable_tf32. When neither has
+    # been called, the attribute is absent and we fall back to the Keras
+    # default (True).
+    return global_state.get_global_attribute("tf32", default=True) is True
 
 
 def _refresh_backend_tf32():

--- a/keras/src/backend/config_test.py
+++ b/keras/src/backend/config_test.py
@@ -1,0 +1,60 @@
+from keras.src import backend
+from keras.src import testing
+from keras.src.backend import config
+
+
+class TF32ConfigTest(testing.TestCase):
+    def setUp(self):
+        super().setUp()
+        # Remember the starting state so each test restores it.
+        self._tf32_was_enabled = config.is_tf32_enabled()
+
+    def tearDown(self):
+        if self._tf32_was_enabled is False:
+            config.disable_tf32()
+        else:
+            config.enable_tf32()
+        super().tearDown()
+
+    def test_enabled_by_default(self):
+        # `is_tf32_enabled()` returns `False` only when explicitly disabled.
+        self.assertNotEqual(config.is_tf32_enabled(), False)
+
+    def test_disable_then_enable(self):
+        config.disable_tf32()
+        self.assertEqual(config.is_tf32_enabled(), False)
+        config.enable_tf32()
+        self.assertNotEqual(config.is_tf32_enabled(), False)
+
+    def test_toggle_applies_to_active_backend(self):
+        """Toggling the Keras flag re-applies to the active backend."""
+        if backend.backend() == "torch":
+            import torch
+
+            config.disable_tf32()
+            self.assertEqual(torch.get_float32_matmul_precision(), "highest")
+            config.enable_tf32()
+            self.assertEqual(torch.get_float32_matmul_precision(), "high")
+        elif backend.backend() == "tensorflow":
+            import tensorflow as tf
+
+            config.disable_tf32()
+            self.assertFalse(
+                tf.config.experimental.tensor_float_32_execution_enabled()
+            )
+            config.enable_tf32()
+            self.assertTrue(
+                tf.config.experimental.tensor_float_32_execution_enabled()
+            )
+        elif backend.backend() == "jax":
+            import jax
+
+            config.disable_tf32()
+            self.assertEqual(jax.config.jax_default_matmul_precision, "highest")
+            config.enable_tf32()
+            self.assertEqual(jax.config.jax_default_matmul_precision, "default")
+        else:
+            # Other backends (e.g. numpy/openvino) have no TF32 knob. The
+            # flag should still toggle without raising.
+            config.disable_tf32()
+            config.enable_tf32()

--- a/keras/src/backend/config_test.py
+++ b/keras/src/backend/config_test.py
@@ -10,21 +10,22 @@ class TF32ConfigTest(testing.TestCase):
         self._tf32_was_enabled = config.is_tf32_enabled()
 
     def tearDown(self):
-        if self._tf32_was_enabled is False:
-            config.disable_tf32()
-        else:
+        if self._tf32_was_enabled:
             config.enable_tf32()
+        else:
+            config.disable_tf32()
         super().tearDown()
 
     def test_enabled_by_default(self):
-        # `is_tf32_enabled()` returns `False` only when explicitly disabled.
-        self.assertNotEqual(config.is_tf32_enabled(), False)
+        self.assertIsInstance(config.is_tf32_enabled(), bool)
+        self.assertTrue(config.is_tf32_enabled())
 
     def test_disable_then_enable(self):
         config.disable_tf32()
-        self.assertEqual(config.is_tf32_enabled(), False)
+        self.assertIsInstance(config.is_tf32_enabled(), bool)
+        self.assertFalse(config.is_tf32_enabled())
         config.enable_tf32()
-        self.assertNotEqual(config.is_tf32_enabled(), False)
+        self.assertTrue(config.is_tf32_enabled())
 
     def test_toggle_applies_to_active_backend(self):
         """Toggling the Keras flag re-applies to the active backend."""
@@ -33,8 +34,10 @@ class TF32ConfigTest(testing.TestCase):
 
             config.disable_tf32()
             self.assertEqual(torch.get_float32_matmul_precision(), "highest")
+            self.assertFalse(torch.backends.cudnn.allow_tf32)
             config.enable_tf32()
             self.assertEqual(torch.get_float32_matmul_precision(), "high")
+            self.assertTrue(torch.backends.cudnn.allow_tf32)
         elif backend.backend() == "tensorflow":
             import tensorflow as tf
 

--- a/keras/src/backend/config_test.py
+++ b/keras/src/backend/config_test.py
@@ -1,63 +1,63 @@
 from keras.src import backend
 from keras.src import testing
 from keras.src.backend import config
+from keras.src.backend.common import global_state
 
 
 class TF32ConfigTest(testing.TestCase):
     def setUp(self):
         super().setUp()
-        # Remember the starting state so each test restores it.
-        self._tf32_was_enabled = config.is_tf32_enabled()
+        # Remember the starting state so each test restores it on teardown.
+        self._saved = global_state.get_global_attribute("tf32")
 
     def tearDown(self):
-        if self._tf32_was_enabled:
-            config.enable_tf32()
-        else:
-            config.disable_tf32()
+        global_state.set_global_attribute("tf32", self._saved)
         super().tearDown()
 
-    def test_enabled_by_default(self):
-        self.assertIsInstance(config.is_tf32_enabled(), bool)
-        self.assertTrue(config.is_tf32_enabled())
-
-    def test_disable_then_enable(self):
-        config.disable_tf32()
+    def test_default_is_disabled(self):
+        # Keras does not opt the active backend into TF32 unless asked.
+        global_state.set_global_attribute("tf32", None)
         self.assertIsInstance(config.is_tf32_enabled(), bool)
         self.assertFalse(config.is_tf32_enabled())
+
+    def test_enable_then_disable(self):
         config.enable_tf32()
+        self.assertIsInstance(config.is_tf32_enabled(), bool)
         self.assertTrue(config.is_tf32_enabled())
+        config.disable_tf32()
+        self.assertFalse(config.is_tf32_enabled())
 
     def test_toggle_applies_to_active_backend(self):
         """Toggling the Keras flag re-applies to the active backend."""
         if backend.backend() == "torch":
             import torch
 
-            config.disable_tf32()
-            self.assertEqual(torch.get_float32_matmul_precision(), "highest")
-            self.assertFalse(torch.backends.cudnn.allow_tf32)
             config.enable_tf32()
             self.assertEqual(torch.get_float32_matmul_precision(), "high")
             self.assertTrue(torch.backends.cudnn.allow_tf32)
+            config.disable_tf32()
+            self.assertEqual(torch.get_float32_matmul_precision(), "highest")
+            self.assertFalse(torch.backends.cudnn.allow_tf32)
         elif backend.backend() == "tensorflow":
             import tensorflow as tf
 
-            config.disable_tf32()
-            self.assertFalse(
-                tf.config.experimental.tensor_float_32_execution_enabled()
-            )
             config.enable_tf32()
             self.assertTrue(
+                tf.config.experimental.tensor_float_32_execution_enabled()
+            )
+            config.disable_tf32()
+            self.assertFalse(
                 tf.config.experimental.tensor_float_32_execution_enabled()
             )
         elif backend.backend() == "jax":
             import jax
 
-            config.disable_tf32()
-            self.assertEqual(jax.config.jax_default_matmul_precision, "highest")
             config.enable_tf32()
             self.assertEqual(jax.config.jax_default_matmul_precision, "default")
+            config.disable_tf32()
+            self.assertEqual(jax.config.jax_default_matmul_precision, "highest")
         else:
             # Other backends (e.g. numpy/openvino) have no TF32 knob. The
             # flag should still toggle without raising.
-            config.disable_tf32()
             config.enable_tf32()
+            config.disable_tf32()

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -690,3 +690,20 @@ def device_scope(device_name):
     else:
         jax_device = device_name
     return jax.default_device(jax_device)
+
+
+def _apply_tf32():
+    """Honor `keras.config.is_tf32_enabled()` for float32 matmul precision.
+
+    JAX already uses TF32 for `float32` matmuls by default on supported
+    GPUs. This only forces full precision when TF32 is disabled in Keras.
+    Applied once at import and re-applied by `keras.config.enable_tf32` /
+    `disable_tf32`.
+    """
+    if config.is_tf32_enabled() is False:
+        jax.config.update("jax_default_matmul_precision", "highest")
+    else:
+        jax.config.update("jax_default_matmul_precision", "default")
+
+
+_apply_tf32()

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -693,17 +693,22 @@ def device_scope(device_name):
 
 
 def _apply_tf32():
-    """Honor `keras.config.is_tf32_enabled()` for float32 matmul precision.
+    """Push the Keras TF32 opt-in onto the JAX backend.
 
-    JAX already uses TF32 for `float32` matmuls by default on supported
-    GPUs. This only forces full precision when TF32 is disabled in Keras.
-    Applied once at import and re-applied by `keras.config.enable_tf32` /
-    `disable_tf32`.
+    No-op when the user has not called `keras.config.enable_tf32` or
+    `keras.config.disable_tf32`; in that case JAX keeps its native default
+    (TF32 on for `float32` matmuls). Otherwise we map the Keras setting
+    onto `jax_default_matmul_precision`.
     """
-    if config.is_tf32_enabled() is False:
-        jax.config.update("jax_default_matmul_precision", "highest")
-    else:
+    from keras.src.backend.common import global_state
+
+    val = global_state.get_global_attribute("tf32")
+    if val is None:
+        return
+    if val:
         jax.config.update("jax_default_matmul_precision", "default")
+    else:
+        jax.config.update("jax_default_matmul_precision", "highest")
 
 
 _apply_tf32()

--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -887,3 +887,21 @@ class name_scope(base_name_scope):
 
 def device_scope(device_name):
     return tf.device(device_name)
+
+
+def _apply_tf32():
+    """Honor `keras.config.is_tf32_enabled()` for float32 matmul precision.
+
+    TensorFlow already enables TF32 for `float32` matmuls by default on
+    supported GPUs. This only forces full precision when TF32 is disabled
+    in Keras. Applied once at import and re-applied by
+    `keras.config.enable_tf32` / `disable_tf32`.
+    """
+    from keras.src.backend.config import is_tf32_enabled
+
+    tf.config.experimental.enable_tensor_float_32_execution(
+        is_tf32_enabled() is not False
+    )
+
+
+_apply_tf32()

--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -890,18 +890,19 @@ def device_scope(device_name):
 
 
 def _apply_tf32():
-    """Honor `keras.config.is_tf32_enabled()` for float32 matmul precision.
+    """Push the Keras TF32 opt-in onto the TensorFlow backend.
 
-    TensorFlow already enables TF32 for `float32` matmuls by default on
-    supported GPUs. This only forces full precision when TF32 is disabled
-    in Keras. Applied once at import and re-applied by
-    `keras.config.enable_tf32` / `disable_tf32`.
+    No-op when the user has not called `keras.config.enable_tf32` or
+    `keras.config.disable_tf32`; in that case TF keeps its native default
+    (TF32 on for `float32` matmuls on supported GPUs). Otherwise we map
+    the Keras setting onto `enable_tensor_float_32_execution`.
     """
-    from keras.src.backend.config import is_tf32_enabled
+    from keras.src.backend.common import global_state
 
-    tf.config.experimental.enable_tensor_float_32_execution(
-        is_tf32_enabled() is not False
-    )
+    val = global_state.get_global_attribute("tf32")
+    if val is None:
+        return
+    tf.config.experimental.enable_tensor_float_32_execution(bool(val))
 
 
 _apply_tf32()

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -834,21 +834,54 @@ class CustomGradientFunction(torch.autograd.Function):
         return (None,) + grads
 
 
-def _apply_tf32():
-    """Honor `keras.config.is_tf32_enabled()` for float32 matmul precision.
+_TF32_DEFAULT_WARNED = False
 
-    Torch defaults to full `float32` matmuls (`"highest"`), while JAX and
-    TF use TF32 by default. Mapping the Keras setting onto
-    `torch.set_float32_matmul_precision` keeps the Torch backend consistent
-    with the others. Applied once at import and re-applied by
-    `keras.config.enable_tf32` / `disable_tf32`.
+
+def _apply_tf32():
+    """Honor `keras.config.is_tf32_enabled()` on the Torch backend.
+
+    Torch defaults to full `float32` matmuls (`"highest"`) and to
+    `cudnn.allow_tf32 = False` for convolutions, while JAX and TF use TF32
+    by default for both. Mapping the Keras setting onto both knobs keeps
+    the Torch backend consistent with the others. Applied once at import
+    and re-applied by `keras.config.enable_tf32` / `disable_tf32`.
+
+    Emits a one-time `RuntimeWarning` when the Keras default is in effect
+    on a CUDA host, since that flips Torch's native precision behavior
+    relative to a vanilla Torch program.
     """
+    global _TF32_DEFAULT_WARNED
+    from keras.src.backend.common import global_state
     from keras.src.backend.config import is_tf32_enabled
 
-    if is_tf32_enabled() is False:
-        torch.set_float32_matmul_precision("highest")
-    else:
+    enabled = is_tf32_enabled()
+    if enabled:
         torch.set_float32_matmul_precision("high")
+        torch.backends.cudnn.allow_tf32 = True
+    else:
+        torch.set_float32_matmul_precision("highest")
+        torch.backends.cudnn.allow_tf32 = False
+
+    explicit = global_state.get_global_attribute("tf32") is not None
+    if (
+        not _TF32_DEFAULT_WARNED
+        and enabled
+        and not explicit
+        and torch.cuda.is_available()
+    ):
+        _TF32_DEFAULT_WARNED = True
+        import warnings
+
+        warnings.warn(
+            "Keras enables TensorFloat-32 (TF32) by default on the Torch "
+            "backend to match the JAX and TensorFlow defaults. float32 "
+            "matmuls and convolutions on Ampere+ GPUs now run at "
+            "tensor-core precision, which can produce small numerical "
+            "drift versus full float32. Call keras.config.disable_tf32() "
+            "to revert.",
+            category=RuntimeWarning,
+            stacklevel=2,
+        )
 
 
 _apply_tf32()

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -832,3 +832,23 @@ class CustomGradientFunction(torch.autograd.Function):
         if not isinstance(grads, tuple):
             grads = (grads,)
         return (None,) + grads
+
+
+def _apply_tf32():
+    """Honor `keras.config.is_tf32_enabled()` for float32 matmul precision.
+
+    Torch defaults to full `float32` matmuls (`"highest"`), while JAX and
+    TF use TF32 by default. Mapping the Keras setting onto
+    `torch.set_float32_matmul_precision` keeps the Torch backend consistent
+    with the others. Applied once at import and re-applied by
+    `keras.config.enable_tf32` / `disable_tf32`.
+    """
+    from keras.src.backend.config import is_tf32_enabled
+
+    if is_tf32_enabled() is False:
+        torch.set_float32_matmul_precision("highest")
+    else:
+        torch.set_float32_matmul_precision("high")
+
+
+_apply_tf32()

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -834,54 +834,26 @@ class CustomGradientFunction(torch.autograd.Function):
         return (None,) + grads
 
 
-_TF32_DEFAULT_WARNED = False
-
-
 def _apply_tf32():
-    """Honor `keras.config.is_tf32_enabled()` on the Torch backend.
+    """Push the Keras TF32 opt-in onto the Torch backend.
 
-    Torch defaults to full `float32` matmuls (`"highest"`) and to
-    `cudnn.allow_tf32 = False` for convolutions, while JAX and TF use TF32
-    by default for both. Mapping the Keras setting onto both knobs keeps
-    the Torch backend consistent with the others. Applied once at import
-    and re-applied by `keras.config.enable_tf32` / `disable_tf32`.
-
-    Emits a one-time `RuntimeWarning` when the Keras default is in effect
-    on a CUDA host, since that flips Torch's native precision behavior
-    relative to a vanilla Torch program.
+    No-op when the user has not called `keras.config.enable_tf32` or
+    `keras.config.disable_tf32`; in that case Torch keeps its native
+    defaults (`set_float32_matmul_precision("highest")` and
+    `cudnn.allow_tf32 = False`). Otherwise we toggle both the matmul
+    precision and the cuDNN conv flag together.
     """
-    global _TF32_DEFAULT_WARNED
     from keras.src.backend.common import global_state
-    from keras.src.backend.config import is_tf32_enabled
 
-    enabled = is_tf32_enabled()
-    if enabled:
+    val = global_state.get_global_attribute("tf32")
+    if val is None:
+        return
+    if val:
         torch.set_float32_matmul_precision("high")
         torch.backends.cudnn.allow_tf32 = True
     else:
         torch.set_float32_matmul_precision("highest")
         torch.backends.cudnn.allow_tf32 = False
-
-    explicit = global_state.get_global_attribute("tf32") is not None
-    if (
-        not _TF32_DEFAULT_WARNED
-        and enabled
-        and not explicit
-        and torch.cuda.is_available()
-    ):
-        _TF32_DEFAULT_WARNED = True
-        import warnings
-
-        warnings.warn(
-            "Keras enables TensorFloat-32 (TF32) by default on the Torch "
-            "backend to match the JAX and TensorFlow defaults. float32 "
-            "matmuls and convolutions on Ampere+ GPUs now run at "
-            "tensor-core precision, which can produce small numerical "
-            "drift versus full float32. Call keras.config.disable_tf32() "
-            "to revert.",
-            category=RuntimeWarning,
-            stacklevel=2,
-        )
 
 
 _apply_tf32()


### PR DESCRIPTION
## Description

Keras has no portable knob for matmul precision. Today, controlling TF32 requires reaching into each backend's API: `torch.set_float32_matmul_precision` + `torch.backends.cudnn.allow_tf32`, `jax.config.update("jax_default_matmul_precision", ...)`, or `tf.config.experimental.enable_tensor_float_32_execution(...)`. A multi-backend Keras program needs three different calls to get consistent behavior.

This PR adds `keras.config.enable_tf32` / `disable_tf32` / `is_tf32_enabled`, mirroring the `flash_attention` helper trio. It's opt-in: Keras does not touch any backend's default unless the user explicitly calls one of these. Calling `enable_tf32()` once opts the active backend into TF32 (Torch: `"high"` + `cudnn.allow_tf32 = True`; JAX: `"default"` matmul precision; TensorFlow: `enable_tensor_float_32_execution(True)`).

### Why this matters

On a small MoE training step on NVIDIA A100-SXM4-40GB (torch 2.10.0+cu128, 8 experts top-2, B=16, L=512, D=512, `train_on_batch`):

| | TF32 off | TF32 on | speedup |
|---|---|---|---|
| MoE warm step | 99.9 ms | 24.9 ms | **4.01x** |
| Self CUDA total / 10 steps | 1.003 s | 248 ms | 4.04x |

TF32-on lands at parity with the JAX backend (~24.1 ms) and the TensorFlow backend (~25.0 ms) on the same model. Profiler evidence is unambiguous: with TF32 off the top GEMM kernels are `ampere_sgemm_*` / `cutlass_80_simt_sgemm_*` (CUDA cores, fp32); with TF32 on they become `cutlass_80_tensorop_s1688gemm_*` (tensor cores, TF32). Reproduction: [Colab](https://colab.research.google.com/drive/15nUbtaEicw9SoLQ-n-07lKGZ7448O8MM?usp=sharing).

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.