### PR TITLE
Fix dimension-shifting in ops.any, ops.all, and ops.prod for Torch backend

### DIFF
--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -257,13 +257,12 @@ def abs(x):
 
 def all(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
-    if axis is None:
-        return cast(torch.all(x), "bool")
     axis = to_tuple_or_list(axis)
-    for a in axis:
-        # `torch.all` does not handle multiple axes.
-        x = torch.all(x, dim=a, keepdim=keepdims)
-    return cast(x, "bool")
+    if axis == () or axis == []:
+        return cast(x, "bool")
+    if isinstance(axis, list):
+        axis = tuple(axis)
+    return cast(torch.all(x, dim=axis, keepdim=keepdims), "bool")
 
 
 def angle(x):
@@ -279,13 +278,12 @@ def angle(x):
 
 def any(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
-    if axis is None:
-        return cast(torch.any(x), "bool")
     axis = to_tuple_or_list(axis)
-    for a in axis:
-        # `torch.any` does not handle multiple axes.
-        x = torch.any(x, dim=a, keepdim=keepdims)
-    return cast(x, "bool")
+    if axis == () or axis == []:
+        return cast(x, "bool")
+    if isinstance(axis, list):
+        axis = tuple(axis)
+    return cast(torch.any(x, dim=axis, keepdim=keepdims), "bool")
 
 
 def amax(x, axis=None, keepdims=False):
@@ -1675,7 +1673,8 @@ def prod(x, axis=None, keepdims=False, dtype=None):
     if axis is None:
         return cast(torch.prod(x, dtype=to_torch_dtype(compute_dtype)), dtype)
     axis = to_tuple_or_list(axis)
-    for a in axis:
+    axis = [canonicalize_axis(a, x.ndim) for a in axis]
+    for a in sorted(axis, reverse=True):
         # `torch.prod` does not handle multiple axes.
         x = cast(
             torch.prod(

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -4805,6 +4805,14 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             np.all(x, axis=1, keepdims=True),
         )
 
+        # Multi-axis test
+        x = np.array(
+            [[[True, True], [True, False]], [[True, True], [True, True]]]
+        )
+        self.assertAllClose(knp.all(x, axis=(0, 1)), np.all(x, axis=(0, 1)))
+        self.assertAllClose(knp.all(x, axis=(0, 2)), np.all(x, axis=(0, 2)))
+        self.assertAllClose(knp.all(x, axis=(1, 2)), np.all(x, axis=(1, 2)))
+
         self.assertAllClose(knp.All()(x), np.all(x))
         self.assertAllClose(knp.All(axis=1)(x), np.all(x, axis=1))
         self.assertAllClose(
@@ -4822,6 +4830,14 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             knp.any(x, axis=1, keepdims=True),
             np.any(x, axis=1, keepdims=True),
         )
+
+        # Multi-axis test
+        x = np.array(
+            [[[True, False], [False, False]], [[False, False], [False, False]]]
+        )
+        self.assertAllClose(knp.any(x, axis=(0, 1)), np.any(x, axis=(0, 1)))
+        self.assertAllClose(knp.any(x, axis=(0, 2)), np.any(x, axis=(0, 2)))
+        self.assertAllClose(knp.any(x, axis=(1, 2)), np.any(x, axis=(1, 2)))
 
         self.assertAllClose(knp.Any()(x), np.any(x))
         self.assertAllClose(knp.Any(axis=1)(x), np.any(x, axis=1))
@@ -6082,6 +6098,12 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             knp.prod(x, axis=1, keepdims=True),
             np.prod(x, axis=1, keepdims=True),
         )
+
+        # Multi-axis test
+        x = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+        self.assertAllClose(knp.prod(x, axis=(0, 1)), np.prod(x, axis=(0, 1)))
+        self.assertAllClose(knp.prod(x, axis=(0, 2)), np.prod(x, axis=(0, 2)))
+        self.assertAllClose(knp.prod(x, axis=(1, 2)), np.prod(x, axis=(1, 2)))
 
         self.assertAllClose(knp.Prod()(x), np.prod(x))
         self.assertAllClose(knp.Prod(axis=1)(x), np.prod(x, axis=1))


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras/issues/22906

This PR fixes a dimension-shifting issue in the Keras Torch backend for multi-axis reduction operations: ops.any, ops.all, and ops.prod. The fix ensures that these operations correctly handle multiple axes when keepdims=False.

The Problem
In the Torch backend, multi-axis reductions were being processed sequentially in forward axis order. When keepdims=False, each reduction step collapses the tensor's rank, causing the indices of the remaining axes to shift. This leads to RuntimeError: Dimension out of range because the subsequent axis indices in the queue no longer exist in the collapsed intermediate tensor.

Example (Failure Case):
Reducing a 3D tensor of shape (2, 3, 4) on axis=(1, 2) with keepdims=False:
1. First reduction (Axis 1): The tensor is reduced along axis 1. The resulting shape is (2, 4).
2. Second reduction (Axis 2): The logic attempts to reduce the intermediate tensor along the original axis index 2.
3. Failure: Since the tensor is now 2D (indices 0 and 1), axis 2 is out of range, triggering a RuntimeError.

The Solution
   1. `ops.any` & `ops.all`: Refactored to utilize PyTorch's native support for tuple-based dim arguments. This allows the backend to handle multi-axis reduction in a single pass, avoiding sequential index-shifting entirely.
   2. `ops.prod`: Since torch.prod does not natively support multiple axes, the implementation was updated to perform sequential reduction in reverse axis order (highest index first). By collapsing the highest dimensions first, the indices of the lower-order axes remain stable and valid throughout the process.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
