### PR TITLE
Implement erfc function in keras.ops

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -49,6 +49,7 @@ from keras.src.ops.linalg import solve_triangular as solve_triangular
 from keras.src.ops.linalg import svd as svd
 from keras.src.ops.math import cdist as cdist
 from keras.src.ops.math import erf as erf
+from keras.src.ops.math import erfc as erfc
 from keras.src.ops.math import erfinv as erfinv
 from keras.src.ops.math import extract_sequences as extract_sequences
 from keras.src.ops.math import fft as fft

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -49,6 +49,7 @@ from keras.src.ops.linalg import solve_triangular as solve_triangular
 from keras.src.ops.linalg import svd as svd
 from keras.src.ops.math import cdist as cdist
 from keras.src.ops.math import erf as erf
+from keras.src.ops.math import erfc as erfc
 from keras.src.ops.math import erfinv as erfinv
 from keras.src.ops.math import extract_sequences as extract_sequences
 from keras.src.ops.math import fft as fft

--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -289,6 +289,10 @@ def erf(x):
     return jax.lax.erf(x)
 
 
+def erfc(x):
+    return jax.scipy.special.erfc(x)
+
+
 def erfinv(x):
     return jax.lax.erf_inv(x)
 

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -310,6 +310,10 @@ def erf(x):
     return np.array(scipy.special.erf(x))
 
 
+def erfc(x):
+    return np.array(scipy.special.erfc(x))
+
+
 def erfinv(x):
     return np.array(scipy.special.erfinv(x))
 

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -23,3 +23,6 @@ NNOpsDtypeTest::test_ctc_decode
 RandAugmentTest::test_random_augment_randomness
 SegmentMinTest::test_segment_min_call
 SegmentProdTest::test_segment_prod_call
+MathOpsCorrectnessTest::test_erfc_operation_basic
+MathOpsCorrectnessTest::test_erfc_operation_dtype
+MathOpsCorrectnessTest::test_erfc_operation_edge_cases

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -904,6 +904,10 @@ def erf(x):
     return OpenVINOKerasTensor(erf)
 
 
+def erfc(x):
+    raise NotImplementedError("`erfc` is not supported with openvino backend")
+
+
 def erfinv(x):
     # TODO: Float64 infinity values are clamped on CPU backend,
     # breaking erfinv(±1) = ±inf

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -295,6 +295,10 @@ def erf(x):
     return tf.math.erf(x)
 
 
+def erfc(x):
+    return tf.math.erfc(x)
+
+
 def erfinv(x):
     return tf.math.erfinv(x)
 

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -406,6 +406,11 @@ def erf(x):
     return torch.erf(x)
 
 
+def erfc(x):
+    x = convert_to_tensor(x)
+    return torch.erfc(x)
+
+
 def erfinv(x):
     x = convert_to_tensor(x)
     return torch.erfinv(x)

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -1158,6 +1158,36 @@ def erf(x):
     return backend.math.erf(x)
 
 
+class Erfc(Operation):
+    def compute_output_spec(self, x):
+        return KerasTensor(shape=x.shape, dtype=x.dtype)
+
+    def call(self, x):
+        return backend.math.erfc(x)
+
+
+@keras_export("keras.ops.erfc")
+def erfc(x):
+    """Computes the complementary error function of `x`, element-wise.
+
+    Args:
+        x: Input tensor.
+
+    Returns:
+        A tensor with the same dtype as `x`.
+
+    Example:
+    >>> x = np.array([-3.0, -2.0, -1.0, 0.0, 1.0])
+    >>> keras.ops.erfc(x)
+    array([1.999978 , 1.9953222, 1.8427008, 1. , 0.1572992],
+      dtype=float32)
+    """
+    if any_symbolic_tensors((x,)):
+        return Erfc().symbolic_call(x)
+    x = backend.convert_to_tensor(x)
+    return backend.math.erfc(x)
+
+
 class Erfinv(Operation):
     def compute_output_spec(self, x):
         return KerasTensor(shape=x.shape, dtype=x.dtype)

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -979,6 +979,31 @@ class MathOpsCorrectnessTest(testing.TestCase):
         output_from_edge_erf_op = kmath.erf(edge_values)
         self.assertAllClose(output_from_edge_erf_op, expected_output, atol=1e-4)
 
+    def test_erfc_operation_basic(self):
+        sample_values = np.array([-3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0])
+
+        expected_output = scipy.special.erfc(sample_values)
+        output_from_erfc_op = kmath.erfc(sample_values)
+
+        self.assertAllClose(output_from_erfc_op, expected_output, atol=1e-4)
+
+    def test_erfc_operation_dtype(self):
+        for dtype in ("float32", "float64"):
+            sample_values = np.array(
+                [-3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0], dtype=dtype
+            )
+            expected_output = scipy.special.erfc(sample_values)
+            output_from_erfc_op = kmath.erfc(sample_values)
+            self.assertAllClose(output_from_erfc_op, expected_output, atol=1e-4)
+
+    def test_erfc_operation_edge_cases(self):
+        edge_values = np.array([1e5, -1e5, 1e-5, -1e-5], dtype=np.float64)
+        expected_output = scipy.special.erfc(edge_values)
+        output_from_edge_erfc_op = kmath.erfc(edge_values)
+        self.assertAllClose(
+            output_from_edge_erfc_op, expected_output, atol=1e-4
+        )
+
     def test_erfinv_operation_basic(self):
         # Sample values for testing
         sample_values = np.array([-3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0])


### PR DESCRIPTION
## Description
Adds keras.ops.erfc, which computes the complementary error function of each element in the input tensor.
Supported across NumPy, TensorFlow, PyTorch, and JAX backends. Not supported on OpenVINO.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
