### PR TITLE
Engage flash SDPA in MHA/GQA causal-only path

### DIFF
--- a/keras/src/layers/attention/grouped_query_attention.py
+++ b/keras/src/layers/attention/grouped_query_attention.py
@@ -271,15 +271,29 @@ class GroupedQueryAttention(Layer):
         if key is None:
             key = value
 
-        attention_mask = self._compute_attention_mask(
-            query,
-            value,
-            query_mask=query_mask,
-            value_mask=value_mask,
-            key_mask=key_mask,
-            attention_mask=attention_mask,
-            use_causal_mask=use_causal_mask,
+        # When causal masking is the only mask source, route through the
+        # backend's native causal kernel by passing `is_causal=True` rather
+        # than materializing a [T, S] mask tensor.
+        causal_only = (
+            use_causal_mask
+            and query_mask is None
+            and value_mask is None
+            and key_mask is None
+            and attention_mask is None
+            and self.sliding_window is None
         )
+        if causal_only:
+            attention_mask = None
+        else:
+            attention_mask = self._compute_attention_mask(
+                query,
+                value,
+                query_mask=query_mask,
+                value_mask=value_mask,
+                key_mask=key_mask,
+                attention_mask=attention_mask,
+                use_causal_mask=use_causal_mask,
+            )
         if self.use_gate:
             gate = self._gate_dense(query)
         query = self._query_dense(query)
@@ -293,12 +307,16 @@ class GroupedQueryAttention(Layer):
             value, self.num_repeats, axis=2
         )  # (batch_dim, source_seq_len, query_heads, head_dim)
 
+        extra_attention_kwargs = (
+            {"use_causal_mask": True} if causal_only else {}
+        )
         output, scores = self._compute_attention(
             query,
             key,
             value,
             attention_mask=attention_mask,
             training=training,
+            **extra_attention_kwargs,
         )
         # (batch_dim, target_seq_len, feature_dim)
         if self.use_gate:
@@ -431,7 +449,13 @@ class GroupedQueryAttention(Layer):
         return ops.less(ops.abs(row_index - col_index), self.sliding_window)
 
     def _compute_attention(
-        self, query, key, value, attention_mask=None, training=None
+        self,
+        query,
+        key,
+        value,
+        attention_mask=None,
+        training=None,
+        use_causal_mask=False,
     ):
         # Check for flash attention constraints
         if self._flash_attention and self._return_attention_scores:
@@ -449,6 +473,20 @@ class GroupedQueryAttention(Layer):
         )
 
         if use_dot_product_attention:
+            if use_causal_mask and attention_mask is None:
+                # Skip materializing the [T, S] mask and let the backend
+                # use its native causal kernel.
+                attention_output = ops.dot_product_attention(
+                    query=query,
+                    key=key,
+                    value=value,
+                    bias=None,
+                    mask=None,
+                    scale=self._inverse_sqrt_head_dim,
+                    is_causal=True,
+                    flash_attention=self._flash_attention,
+                )
+                return attention_output, None
             if attention_mask is not None:
                 # Ensure attention_mask has the correct shape for broadcasting
                 # Expected shape: [batch_size, num_heads, query_seq_len,

--- a/keras/src/layers/attention/grouped_query_attention.py
+++ b/keras/src/layers/attention/grouped_query_attention.py
@@ -273,7 +273,9 @@ class GroupedQueryAttention(Layer):
 
         # When causal masking is the only mask source, route through the
         # backend's native causal kernel by passing `is_causal=True` rather
-        # than materializing a [T, S] mask tensor.
+        # than materializing a [T, S] mask tensor. Skipped when a subclass
+        # overrides `_compute_attention`, since such a subclass would
+        # receive `attention_mask=None` and silently do unmasked attention.
         causal_only = (
             use_causal_mask
             and query_mask is None
@@ -281,6 +283,8 @@ class GroupedQueryAttention(Layer):
             and key_mask is None
             and attention_mask is None
             and self.sliding_window is None
+            and type(self)._compute_attention
+            is GroupedQueryAttention._compute_attention
         )
         if causal_only:
             attention_mask = None

--- a/keras/src/layers/attention/grouped_query_attention_test.py
+++ b/keras/src/layers/attention/grouped_query_attention_test.py
@@ -400,6 +400,35 @@ class GroupedQueryAttentionTest(testing.TestCase):
                 else:
                     self.assertEqual(scores[i, j], 0.0)
 
+    def test_causal_only_fast_path(self):
+        # When `use_causal_mask=True` is the only mask source, the layer
+        # should route through `dot_product_attention(is_causal=True)` and
+        # not materialize a [T, S] mask. The output must match the explicit
+        # mask path.
+        layer = layers.GroupedQueryAttention(
+            head_dim=4, num_query_heads=4, num_key_value_heads=2
+        )
+        x = np.random.RandomState(0).randn(2, 5, 16).astype("float32")
+        _ = layer(x, x, use_causal_mask=True)
+        fast = layer(x, x, use_causal_mask=True)
+
+        t = x.shape[1]
+        causal = np.tril(np.ones((1, t, t), dtype="bool"))
+        slow = layer(x, x, attention_mask=causal)
+
+        self.assertAllClose(fast, slow, atol=1e-5)
+
+    def test_causal_only_with_other_mask_falls_back(self):
+        # If any other mask is also present, the is_causal=True shortcut
+        # must not be taken since SDPA rejects mask + is_causal together.
+        layer = layers.GroupedQueryAttention(
+            head_dim=4, num_query_heads=4, num_key_value_heads=2
+        )
+        x = np.random.RandomState(0).randn(2, 5, 16).astype("float32")
+        extra_mask = np.ones((2, 5, 5), dtype="bool")
+        out = layer(x, x, attention_mask=extra_mask, use_causal_mask=True)
+        self.assertEqual(tuple(out.shape), (2, 5, 16))
+
     def test_sliding_window_validation(self):
         with self.assertRaisesRegex(ValueError, "sliding_window"):
             layers.GroupedQueryAttention(

--- a/keras/src/layers/attention/grouped_query_attention_test.py
+++ b/keras/src/layers/attention/grouped_query_attention_test.py
@@ -418,6 +418,25 @@ class GroupedQueryAttentionTest(testing.TestCase):
 
         self.assertAllClose(fast, slow, atol=1e-5)
 
+    def test_causal_only_skipped_for_subclass(self):
+        # A subclass with the previous _compute_attention signature must
+        # still receive the explicit causal mask, not None.
+        seen = {}
+
+        class Sub(layers.GroupedQueryAttention):
+            def _compute_attention(
+                self, query, key, value, attention_mask=None, training=None
+            ):
+                seen["mask_is_none"] = attention_mask is None
+                return super()._compute_attention(
+                    query, key, value, attention_mask, training
+                )
+
+        layer = Sub(head_dim=4, num_query_heads=4, num_key_value_heads=2)
+        x = np.random.RandomState(0).randn(2, 5, 16).astype("float32")
+        _ = layer(x, x, use_causal_mask=True)
+        self.assertFalse(seen["mask_is_none"])
+
     def test_causal_only_with_other_mask_falls_back(self):
         # If any other mask is also present, the is_causal=True shortcut
         # must not be taken since SDPA rejects mask + is_causal together.

--- a/keras/src/layers/attention/grouped_query_attention_test.py
+++ b/keras/src/layers/attention/grouped_query_attention_test.py
@@ -440,13 +440,26 @@ class GroupedQueryAttentionTest(testing.TestCase):
     def test_causal_only_with_other_mask_falls_back(self):
         # If any other mask is also present, the is_causal=True shortcut
         # must not be taken since SDPA rejects mask + is_causal together.
+        # A regression that silently kept the shortcut would also drop the
+        # extra mask entirely, so compare against the explicit merged-mask
+        # path to prove `extra_mask` is honored.
         layer = layers.GroupedQueryAttention(
             head_dim=4, num_query_heads=4, num_key_value_heads=2
         )
         x = np.random.RandomState(0).randn(2, 5, 16).astype("float32")
+        # Build once so both calls share weights.
+        layer.build(query_shape=x.shape, value_shape=x.shape)
+
+        # Non-trivial extra mask: query position 2 must not attend to key 3.
         extra_mask = np.ones((2, 5, 5), dtype="bool")
-        out = layer(x, x, attention_mask=extra_mask, use_causal_mask=True)
-        self.assertEqual(tuple(out.shape), (2, 5, 16))
+        extra_mask[:, 2, 3] = False
+        causal = np.tril(np.ones((5, 5), dtype="bool"))
+        merged = extra_mask & causal
+
+        out1 = layer(x, x, attention_mask=extra_mask, use_causal_mask=True)
+        out2 = layer(x, x, attention_mask=merged, use_causal_mask=False)
+        self.assertEqual(tuple(out1.shape), (2, 5, 16))
+        self.assertAllClose(out1, out2, atol=1e-5)
 
     def test_sliding_window_validation(self):
         with self.assertRaisesRegex(ValueError, "sliding_window"):

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -463,6 +463,7 @@ class MultiHeadAttention(Layer):
         attention_mask=None,
         training=None,
         return_attention_scores=False,
+        use_causal_mask=False,
     ):
         """Applies Dot-product attention with query, key, value tensors.
 
@@ -480,6 +481,11 @@ class MultiHeadAttention(Layer):
             training: Python boolean indicating whether the layer should behave
                 in training mode (adding dropout) or in inference mode (doing
                 nothing).
+            use_causal_mask: Boolean. When True and `attention_mask` is None,
+                routes through the backend's native causal kernel via
+                `dot_product_attention(is_causal=True)`. This skips
+                materializing an explicit [T, S] mask tensor and enables
+                torch's causal-only flash kernel.
 
         Returns:
           attention_output: Multi-headed outputs of attention computation.
@@ -501,6 +507,20 @@ class MultiHeadAttention(Layer):
         )
 
         if use_dot_product_attention:
+            if use_causal_mask and attention_mask is None:
+                # Skip materializing the [T, S] mask and let the backend
+                # use its native causal kernel.
+                attention_output = ops.dot_product_attention(
+                    query=query,
+                    key=key,
+                    value=value,
+                    bias=None,
+                    mask=None,
+                    scale=self._inverse_sqrt_key_dim,
+                    is_causal=True,
+                    flash_attention=self._flash_attention,
+                )
+                return attention_output, None
             if attention_mask is not None:
                 # Ensure attention_mask has the correct shape for broadcasting
                 # Expected shape: [batch_size, num_heads, query_seq_len,
@@ -579,15 +599,29 @@ class MultiHeadAttention(Layer):
         backend.set_keras_mask(value, None)
         backend.set_keras_mask(key, None)
 
-        attention_mask = self._compute_attention_mask(
-            query,
-            value,
-            query_mask=query_mask,
-            value_mask=value_mask,
-            key_mask=key_mask,
-            attention_mask=attention_mask,
-            use_causal_mask=use_causal_mask,
+        # When causal masking is the only mask source, route through the
+        # backend's native causal kernel by passing `is_causal=True` rather
+        # than materializing a [T, S] mask tensor.
+        causal_only = (
+            use_causal_mask
+            and query_mask is None
+            and value_mask is None
+            and key_mask is None
+            and attention_mask is None
+            and self._sliding_window is None
         )
+        if causal_only:
+            attention_mask = None
+        else:
+            attention_mask = self._compute_attention_mask(
+                query,
+                value,
+                query_mask=query_mask,
+                value_mask=value_mask,
+                key_mask=key_mask,
+                attention_mask=attention_mask,
+                use_causal_mask=use_causal_mask,
+            )
         #   N = `num_attention_heads`
         #   H = `size_per_head`
 
@@ -603,6 +637,11 @@ class MultiHeadAttention(Layer):
 
         # `value` = [B, S, N, H]
         value = self._value_dense(value)
+        # Only pass `use_causal_mask` when active so subclasses that override
+        # `_compute_attention` with the previous signature still work.
+        extra_attention_kwargs = (
+            {"use_causal_mask": True} if causal_only else {}
+        )
         attention_output, attention_scores = self._compute_attention(
             query,
             key,
@@ -610,6 +649,7 @@ class MultiHeadAttention(Layer):
             attention_mask,
             training,
             return_attention_scores,
+            **extra_attention_kwargs,
         )
         if self._use_gate:
             attention_output = self._output_dense(

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -601,7 +601,9 @@ class MultiHeadAttention(Layer):
 
         # When causal masking is the only mask source, route through the
         # backend's native causal kernel by passing `is_causal=True` rather
-        # than materializing a [T, S] mask tensor.
+        # than materializing a [T, S] mask tensor. Skipped when a subclass
+        # overrides `_compute_attention`, since such a subclass would
+        # receive `attention_mask=None` and silently do unmasked attention.
         causal_only = (
             use_causal_mask
             and query_mask is None
@@ -609,6 +611,8 @@ class MultiHeadAttention(Layer):
             and key_mask is None
             and attention_mask is None
             and self._sliding_window is None
+            and type(self)._compute_attention
+            is MultiHeadAttention._compute_attention
         )
         if causal_only:
             attention_mask = None

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -523,6 +523,36 @@ class MultiHeadAttentionTest(testing.TestCase):
                 else:
                     self.assertEqual(scores[i, j], 0.0)
 
+    def test_causal_only_fast_path(self):
+        # When `use_causal_mask=True` is the only mask source, the layer
+        # should route through `dot_product_attention(is_causal=True)` and
+        # not materialize a [T, S] mask. The output must match the explicit
+        # mask path bit-for-bit (or near it).
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        x = np.random.RandomState(0).randn(2, 5, 8).astype("float32")
+        # Force build so weights are shared between both calls.
+        _ = layer(x, x, use_causal_mask=True)
+        fast = layer(x, x, use_causal_mask=True)
+
+        # Reference: build the explicit causal mask and feed it as
+        # attention_mask, which bypasses the causal_only branch.
+        t = x.shape[1]
+        causal = np.tril(np.ones((1, t, t), dtype="bool"))
+        slow = layer(x, x, attention_mask=causal)
+
+        self.assertAllClose(fast, slow, atol=1e-5)
+
+    def test_causal_only_with_other_mask_falls_back(self):
+        # If any other mask source is present, the layer must NOT take the
+        # is_causal=True shortcut, because torch's SDPA rejects passing both
+        # an attn_mask and is_causal=True.
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        x = np.random.RandomState(0).randn(2, 5, 8).astype("float32")
+        # Build with the slow path so the test exercises the merged path.
+        extra_mask = np.ones((2, 5, 5), dtype="bool")
+        out = layer(x, x, attention_mask=extra_mask, use_causal_mask=True)
+        self.assertEqual(tuple(out.shape), (2, 5, 8))
+
     def test_sliding_window_validation(self):
         with self.assertRaisesRegex(ValueError, "sliding_window"):
             layers.MultiHeadAttention(num_heads=2, key_dim=4, sliding_window=0)

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -542,6 +542,38 @@ class MultiHeadAttentionTest(testing.TestCase):
 
         self.assertAllClose(fast, slow, atol=1e-5)
 
+    def test_causal_only_skipped_for_subclass(self):
+        # A subclass with the previous _compute_attention signature must not
+        # see the use_causal_mask kwarg, and must not receive attention_mask
+        # = None when use_causal_mask=True. Otherwise it would silently do
+        # unmasked attention.
+        seen = {}
+
+        class Sub(layers.MultiHeadAttention):
+            def _compute_attention(
+                self,
+                query,
+                key,
+                value,
+                attention_mask=None,
+                training=None,
+                return_attention_scores=False,
+            ):
+                seen["mask_is_none"] = attention_mask is None
+                return super()._compute_attention(
+                    query,
+                    key,
+                    value,
+                    attention_mask,
+                    training,
+                    return_attention_scores,
+                )
+
+        layer = Sub(num_heads=2, key_dim=4)
+        x = np.random.RandomState(0).randn(2, 5, 8).astype("float32")
+        _ = layer(x, x, use_causal_mask=True)
+        self.assertFalse(seen["mask_is_none"])
+
     def test_causal_only_with_other_mask_falls_back(self):
         # If any other mask source is present, the layer must NOT take the
         # is_causal=True shortcut, because torch's SDPA rejects passing both

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -577,13 +577,25 @@ class MultiHeadAttentionTest(testing.TestCase):
     def test_causal_only_with_other_mask_falls_back(self):
         # If any other mask source is present, the layer must NOT take the
         # is_causal=True shortcut, because torch's SDPA rejects passing both
-        # an attn_mask and is_causal=True.
+        # an attn_mask and is_causal=True. A regression that silently kept
+        # the shortcut would also drop the extra mask entirely, so compare
+        # against the explicit merged-mask path to prove `extra_mask` is
+        # honored.
         layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
         x = np.random.RandomState(0).randn(2, 5, 8).astype("float32")
-        # Build with the slow path so the test exercises the merged path.
+        # Build once so both calls share weights.
+        layer.build(query_shape=x.shape, value_shape=x.shape)
+
+        # Non-trivial extra mask: query position 2 must not attend to key 3.
         extra_mask = np.ones((2, 5, 5), dtype="bool")
-        out = layer(x, x, attention_mask=extra_mask, use_causal_mask=True)
-        self.assertEqual(tuple(out.shape), (2, 5, 8))
+        extra_mask[:, 2, 3] = False
+        causal = np.tril(np.ones((5, 5), dtype="bool"))
+        merged = extra_mask & causal
+
+        out1 = layer(x, x, attention_mask=extra_mask, use_causal_mask=True)
+        out2 = layer(x, x, attention_mask=merged, use_causal_mask=False)
+        self.assertEqual(tuple(out1.shape), (2, 5, 8))
+        self.assertAllClose(out1, out2, atol=1e-5)
 
     def test_sliding_window_validation(self):
         with self.assertRaisesRegex(ValueError, "sliding_window"):


### PR DESCRIPTION
## Description

`MultiHeadAttention(use_causal_mask=True)` today builds an explicit `[1, T, S]` causal mask and passes it to `dot_product_attention(..., mask=mask, is_causal=False)`. On torch this disqualifies the SDPA flash kernel (flash does not accept arbitrary masks) and dispatch falls to mem-efficient cutlass. Passing `is_causal=True` with no mask engages flash directly.

This PR routes through the `is_causal=True` path when causal masking is the only mask source. Anything with extra masks (key/query/value/attention mask, sliding window) keeps the existing path. Same change applied to `GroupedQueryAttention`.

### Benchmark (A100, torch 2.10.0+cu128, B=4, H=12, D=64, fp16, MHA forward)

| T | master | this PR | speedup |
|---:|---:|---:|---:|
| 1024 | 1.92 ms | 1.75 ms | 1.10x |
| 2048 | 1.92 ms | 1.74 ms | 1.11x |
| 4096 | 4.62 ms | **1.76 ms** | **2.62x** |

Profiler: master runs `fmha_cutlassF_f16_aligned_64x64_rf_sm80`, this PR runs `pytorch_flash::flash_fwd_kernel`. Outputs match to fp16 noise (max |d| ≤ 1e-3). Reproduction: [Colab](https://colab.research.google.com/drive/1nUJpesIOfPBXi1kDTOq9II8BFklCO9HS?usp=sharing).

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.