### PR TITLE
Add keras.ops.erf test coverage and update NumPy backend dtype logic

### DIFF
--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from keras.src.backend import standardize_dtype
+from keras.src.backend.common import dtypes
 from keras.src.backend.jax.math import fft as jax_fft
 from keras.src.backend.jax.math import fft2 as jax_fft2
 from keras.src.backend.numpy.core import convert_to_tensor
@@ -307,7 +308,8 @@ def rsqrt(x):
 
 
 def erf(x):
-    return np.array(scipy.special.erf(x))
+    dtype = dtypes.result_type(x.dtype)
+    return scipy.special.erf(x).astype(dtype)
 
 
 def erfinv(x):

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -12,6 +12,8 @@ from keras.src.backend.common import dtypes
 from keras.src.backend.common import standardize_dtype
 from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.ops import math as kmath
+from keras.src.ops import numpy as knp
+from keras.src.testing.test_utils import named_product
 
 
 def _stft(
@@ -143,6 +145,11 @@ def _max_reduce(left, right):
 
 
 class MathOpsDynamicShapeTest(testing.TestCase):
+    def test_erf(self):
+        x = KerasTensor((None, 2, 3))
+        y = kmath.erf(x)
+        self.assertEqual(y.shape, (None, 2, 3))
+
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     def test_segment_reduce(self, segment_reduce_op):
         # 1D case
@@ -336,6 +343,11 @@ class MathOpsDynamicShapeTest(testing.TestCase):
 
 
 class MathOpsStaticShapeTest(testing.TestCase):
+    def test_erf(self):
+        x = KerasTensor((1, 2, 3))
+        y = kmath.erf(x)
+        self.assertEqual(y.shape, (1, 2, 3))
+
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     @pytest.mark.skipif(
         backend.backend() == "jax",
@@ -1071,6 +1083,22 @@ class MathDtypeTest(testing.TestCase):
     if backend.backend() == "torch":
         ALL_DTYPES = [x for x in ALL_DTYPES if x not in ("uint16", "uint32")]
         INT_DTYPES = [x for x in INT_DTYPES if x not in ("uint16", "uint32")]
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_erf(self, dtype):
+        import jax.lax as lax
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+
+        expected_dtype = standardize_dtype(lax.erf(x_jax).dtype)
+
+        self.assertEqual(standardize_dtype(kmath.erf(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(kmath.Erf().symbolic_call(x).dtype),
+            expected_dtype,
+        )
 
 
 class ExtractSequencesOpTest(testing.TestCase):


### PR DESCRIPTION
## Description
Added test coverage for erf in math_test, and updated the dtype test logic for the NumPy backend.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
