### PR TITLE
Add fused bidirectional GRU for torch and harden gru() dispatch

### DIFF
--- a/keras/src/backend/jax/__init__.py
+++ b/keras/src/backend/jax/__init__.py
@@ -26,6 +26,7 @@ from keras.src.backend.jax.core import scatter
 from keras.src.backend.jax.core import shape
 from keras.src.backend.jax.core import stop_gradient
 from keras.src.backend.jax.core import vectorized_map
+from keras.src.backend.jax.rnn import bidirectional_gru
 from keras.src.backend.jax.rnn import bidirectional_lstm
 from keras.src.backend.jax.rnn import cudnn_ok
 from keras.src.backend.jax.rnn import gru

--- a/keras/src/backend/jax/rnn.py
+++ b/keras/src/backend/jax/rnn.py
@@ -533,6 +533,14 @@ def gru(
     return last_output, outputs, [h_last]
 
 
+def bidirectional_gru(*args, **kwargs):
+    # `jax.experimental.rnn` exposes a cuDNN `lstm` but no `gru`. There is
+    # no fused bidirectional GRU primitive on JAX, so we fall through to
+    # the layer-level two-pass path. That path is already JIT compiled and
+    # is the best we can do here.
+    raise NotImplementedError
+
+
 def unstack(x, axis=0):
     return [
         lax.index_in_dim(x, i, axis, keepdims=False)

--- a/keras/src/backend/numpy/__init__.py
+++ b/keras/src/backend/numpy/__init__.py
@@ -21,6 +21,7 @@ from keras.src.backend.numpy.core import is_tensor
 from keras.src.backend.numpy.core import random_seed_dtype
 from keras.src.backend.numpy.core import shape
 from keras.src.backend.numpy.core import vectorized_map
+from keras.src.backend.numpy.rnn import bidirectional_gru
 from keras.src.backend.numpy.rnn import bidirectional_lstm
 from keras.src.backend.numpy.rnn import cudnn_ok
 from keras.src.backend.numpy.rnn import gru

--- a/keras/src/backend/numpy/rnn.py
+++ b/keras/src/backend/numpy/rnn.py
@@ -212,6 +212,10 @@ def bidirectional_lstm(*args, **kwargs):
     raise NotImplementedError
 
 
+def bidirectional_gru(*args, **kwargs):
+    raise NotImplementedError
+
+
 def unstack(x, axis=0):
     return [x.take(i, axis) for i in range(x.shape[axis])]
 

--- a/keras/src/backend/openvino/__init__.py
+++ b/keras/src/backend/openvino/__init__.py
@@ -21,6 +21,7 @@ from keras.src.backend.openvino.core import is_tensor
 from keras.src.backend.openvino.core import random_seed_dtype
 from keras.src.backend.openvino.core import shape
 from keras.src.backend.openvino.core import vectorized_map
+from keras.src.backend.openvino.rnn import bidirectional_gru
 from keras.src.backend.openvino.rnn import bidirectional_lstm
 from keras.src.backend.openvino.rnn import cudnn_ok
 from keras.src.backend.openvino.rnn import gru

--- a/keras/src/backend/openvino/rnn.py
+++ b/keras/src/backend/openvino/rnn.py
@@ -830,3 +830,7 @@ def cudnn_ok(*args, **kwargs):
 
 def bidirectional_lstm(*args, **kwargs):
     raise NotImplementedError
+
+
+def bidirectional_gru(*args, **kwargs):
+    raise NotImplementedError

--- a/keras/src/backend/tensorflow/__init__.py
+++ b/keras/src/backend/tensorflow/__init__.py
@@ -25,6 +25,7 @@ from keras.src.backend.tensorflow.core import scatter
 from keras.src.backend.tensorflow.core import shape
 from keras.src.backend.tensorflow.core import stop_gradient
 from keras.src.backend.tensorflow.core import vectorized_map
+from keras.src.backend.tensorflow.rnn import bidirectional_gru
 from keras.src.backend.tensorflow.rnn import bidirectional_lstm
 from keras.src.backend.tensorflow.rnn import cudnn_ok
 from keras.src.backend.tensorflow.rnn import gru

--- a/keras/src/backend/tensorflow/rnn.py
+++ b/keras/src/backend/tensorflow/rnn.py
@@ -983,3 +983,7 @@ def _cudnn_lstm(
 
 def bidirectional_lstm(*args, **kwargs):
     raise NotImplementedError
+
+
+def bidirectional_gru(*args, **kwargs):
+    raise NotImplementedError

--- a/keras/src/backend/torch/__init__.py
+++ b/keras/src/backend/torch/__init__.py
@@ -40,6 +40,7 @@ from keras.src.backend.torch.core import shape
 from keras.src.backend.torch.core import stop_gradient
 from keras.src.backend.torch.core import to_torch_dtype
 from keras.src.backend.torch.core import vectorized_map
+from keras.src.backend.torch.rnn import bidirectional_gru
 from keras.src.backend.torch.rnn import bidirectional_lstm
 from keras.src.backend.torch.rnn import cudnn_ok
 from keras.src.backend.torch.rnn import gru

--- a/keras/src/backend/torch/rnn.py
+++ b/keras/src/backend/torch/rnn.py
@@ -2,7 +2,6 @@ import torch
 
 from keras.src import tree
 from keras.src.backend.torch.core import convert_to_tensor
-from keras.src.backend.torch.core import get_device
 
 
 def rnn(
@@ -747,18 +746,11 @@ def gru(
     unroll=False,
     reset_after=True,
 ):
-    cudnn_supported = cudnn_ok(
-        activation,
-        recurrent_activation,
-        unroll,
-        use_bias=bias is not None,
-    )
-
-    if not cudnn_supported or not reset_after or mask is not None:
+    # Neither path below supports masking. The fallback also only knows the
+    # `reset_after=True` formulation. For anything else, bounce back to the
+    # generic RNN loop.
+    if not reset_after or mask is not None:
         raise NotImplementedError
-
-    # Get device from inputs
-    device = get_device()
 
     # Convert to torch tensors (convert_to_tensor unwraps Variables)
     kernel = convert_to_tensor(kernel)
@@ -766,29 +758,59 @@ def gru(
     if bias is not None:
         bias = convert_to_tensor(bias)
 
-    inputs = convert_to_tensor(inputs, dtype="float32")
-    initial_state = convert_to_tensor(initial_state, dtype="float32")
+    # Cast inputs/state to the kernel's dtype so integer inputs are promoted
+    # to float and mixed-precision dtypes (e.g. float16) are respected.
+    compute_dtype = kernel.dtype
+    inputs = convert_to_tensor(inputs).to(compute_dtype)
+    initial_state = convert_to_tensor(initial_state).to(compute_dtype)
 
     # Preprocess for go_backwards by flipping the sequence
     if go_backwards:
         inputs = torch.flip(inputs, dims=[1])
 
-    # Move all tensors to the same device
-    inputs = inputs.to(device)
-    initial_state = initial_state.to(device)
-
-    try:
-        return _cudnn_gru(
-            inputs,
-            initial_state,
-            kernel,
-            recurrent_kernel,
-            bias,
-            return_sequences=return_sequences,
-            device=device,
+    # cuDNN only runs on CUDA. Skip it when inputs are on CPU, or when we
+    # are inside a TorchScript or Dynamo trace. The trace records device
+    # transfers that then fail device-consistency validation downstream.
+    device = inputs.device
+    cudnn_supported = (
+        device.type == "cuda"
+        and not torch.jit.is_tracing()
+        and not (
+            hasattr(torch.compiler, "is_compiling")
+            and torch.compiler.is_compiling()
         )
-    except Exception:
-        raise NotImplementedError
+        and cudnn_ok(
+            activation,
+            recurrent_activation,
+            unroll,
+            use_bias=bias is not None,
+        )
+    )
+
+    if cudnn_supported:
+        try:
+            return _cudnn_gru(
+                inputs,
+                initial_state,
+                kernel,
+                recurrent_kernel,
+                bias,
+                return_sequences=return_sequences,
+                device=device,
+            )
+        except Exception:
+            pass
+
+    return _fallback_gru(
+        inputs,
+        initial_state,
+        kernel,
+        recurrent_kernel,
+        bias,
+        activation,
+        recurrent_activation,
+        return_sequences,
+    )
 
 
 def prepare_gru_params(kernel, recurrent_kernel, bias, device):
@@ -876,6 +898,61 @@ def _cudnn_gru(
         outputs = last_output.unsqueeze(1)
 
     return last_output, outputs, [h_n]
+
+
+def _fallback_gru(
+    inputs,
+    initial_state,
+    kernel,
+    recurrent_kernel,
+    bias,
+    activation,
+    recurrent_activation,
+    return_sequences,
+):
+    """Pure-torch GRU (reset_after=True) with pre-computed input projections.
+
+    Used when cuDNN is not available (CPU, non-standard activations, etc.).
+    Pre-computes all input projections in a single matmul across timesteps,
+    then only computes the recurrent projection per step.
+    """
+    # (batch, time, features) -> (time, batch, features)
+    inputs = inputs.permute(1, 0, 2)
+
+    # bias for reset_after=True has shape (2, 3*units): row 0 is input bias,
+    # row 1 is recurrent bias. Apply each on its own projection side so the
+    # gating math matches the unbiased case bit-for-bit.
+    x_proj = torch.matmul(inputs, kernel)
+    if bias is not None:
+        x_proj = x_proj + bias[0]
+
+    time_steps = inputs.shape[0]
+    h = initial_state
+    outputs = []
+
+    for t in range(time_steps):
+        h_proj = torch.matmul(h, recurrent_kernel)
+        if bias is not None:
+            h_proj = h_proj + bias[1]
+
+        x_z, x_r, x_h = torch.chunk(x_proj[t], 3, dim=1)
+        h_z, h_r, h_h = torch.chunk(h_proj, 3, dim=1)
+
+        z = recurrent_activation(x_z + h_z)
+        r = recurrent_activation(x_r + h_r)
+        hh = activation(x_h + r * h_h)
+        h = z * h + (1.0 - z) * hh
+
+        outputs.append(h)
+
+    outputs = torch.stack(outputs, dim=0)  # (time, batch, units)
+    outputs = outputs.permute(1, 0, 2)  # (batch, time, units)
+
+    last_output = h
+    if not return_sequences:
+        outputs = last_output.unsqueeze(1)
+
+    return last_output, outputs, [h]
 
 
 def bidirectional_lstm(
@@ -1032,4 +1109,122 @@ def bidirectional_lstm(
     return (
         (fwd_last, fwd_outputs, [fwd_h_n, fwd_c_n]),
         (bwd_last, bwd_outputs, [bwd_h_n, bwd_c_n]),
+    )
+
+
+def bidirectional_gru(
+    inputs,
+    fwd_initial_state,
+    bwd_initial_state,
+    mask,
+    fwd_kernel,
+    fwd_recurrent_kernel,
+    fwd_bias,
+    bwd_kernel,
+    bwd_recurrent_kernel,
+    bwd_bias,
+    activation,
+    recurrent_activation,
+    return_sequences=False,
+    unroll=False,
+    reset_after=True,
+):
+    """Fused bidirectional cuDNN GRU for the torch backend.
+
+    Runs both directions in a single ``torch._VF.gru(bidirectional=True)``
+    call. Mirrors ``bidirectional_lstm`` above. Raises ``NotImplementedError``
+    on CPU, under tracing, with a mask, or with ``reset_after=False`` so the
+    caller falls back to the two-pass path. Returns
+    ``((fwd_last, fwd_outputs, [fwd_h_n]), (bwd_last, bwd_outputs, [bwd_h_n]))``
+    with backward outputs already in original time order.
+    """
+    if mask is not None or not reset_after:
+        raise NotImplementedError
+    if not cudnn_ok(
+        activation,
+        recurrent_activation,
+        unroll,
+        use_bias=fwd_bias is not None and bwd_bias is not None,
+    ):
+        raise NotImplementedError
+
+    fwd_kernel = convert_to_tensor(fwd_kernel)
+    fwd_recurrent_kernel = convert_to_tensor(fwd_recurrent_kernel)
+    bwd_kernel = convert_to_tensor(bwd_kernel)
+    bwd_recurrent_kernel = convert_to_tensor(bwd_recurrent_kernel)
+
+    compute_dtype = fwd_kernel.dtype
+    inputs = convert_to_tensor(inputs, dtype=compute_dtype)
+    fwd_h0 = convert_to_tensor(fwd_initial_state, dtype=compute_dtype)
+    bwd_h0 = convert_to_tensor(bwd_initial_state, dtype=compute_dtype)
+
+    # cuDNN only runs on CUDA. Fall back to the two-pass path when inputs
+    # are on CPU, or when we are inside a TorchScript or Dynamo trace. The
+    # trace records device transfers that then fail device-consistency
+    # validation downstream.
+    device = inputs.device
+    if (
+        device.type != "cuda"
+        or torch.jit.is_tracing()
+        or (
+            hasattr(torch.compiler, "is_compiling")
+            and torch.compiler.is_compiling()
+        )
+    ):
+        raise NotImplementedError
+
+    fwd_params = prepare_gru_params(
+        fwd_kernel, fwd_recurrent_kernel, fwd_bias, device
+    )
+    bwd_params = prepare_gru_params(
+        bwd_kernel, bwd_recurrent_kernel, bwd_bias, device
+    )
+
+    # torch._VF.gru with bidirectional=True expects 4 params per direction,
+    # forward direction first, then backward.
+    params = fwd_params + bwd_params
+
+    # cuDNN expects (num_layers * num_directions, batch, hidden) for h0.
+    h_0 = torch.stack([fwd_h0, bwd_h0], dim=0)
+
+    try:
+        outputs, h_n = torch._VF.gru(
+            inputs,
+            h_0,
+            params,
+            True,  # has_biases
+            1,  # num_layers
+            0.0,  # dropout
+            torch.is_grad_enabled(),  # training
+            True,  # bidirectional
+            True,  # batch_first
+        )
+    except (RuntimeError, TypeError, ValueError) as e:
+        raise NotImplementedError(f"cuDNN bidirectional GRU failed: {e}") from e
+
+    # outputs: (batch, seq_len, 2 * hidden_size). First half is the forward
+    # direction, second half is the backward direction (in original time
+    # order, courtesy of cuDNN).
+    hidden_size = fwd_recurrent_kernel.shape[0]
+    y_fwd = outputs[..., :hidden_size]
+    y_bwd = outputs[..., hidden_size:]
+
+    fwd_h_n, bwd_h_n = h_n[0], h_n[1]
+
+    # Forward "last" is the last timestep of the forward sweep. Backward
+    # "last" is the first timestep in original time order, which is the
+    # result after the full reverse sweep.
+    fwd_last = y_fwd[:, -1]
+    bwd_last = y_bwd[:, 0]
+
+    if return_sequences:
+        fwd_outputs = y_fwd
+        bwd_outputs = y_bwd
+    else:
+        fwd_outputs = fwd_last.unsqueeze(1)
+        bwd_outputs = bwd_last.unsqueeze(1)
+
+    return (
+        (fwd_last, fwd_outputs, [fwd_h_n]),
+        (bwd_last, bwd_outputs, [bwd_h_n]),
     )

--- a/keras/src/backend/torch/rnn.py
+++ b/keras/src/backend/torch/rnn.py
@@ -752,6 +752,31 @@ def gru(
     if not reset_after or mask is not None:
         raise NotImplementedError
 
+    # Activation/bias eligibility for cuDNN doesn't depend on tensor state, so
+    # check it before paying for conversions we might discard.
+    cudnn_activation_ok = cudnn_ok(
+        activation,
+        recurrent_activation,
+        unroll,
+        use_bias=bias is not None,
+    )
+
+    # Peek at the input device without materializing a full tensor: cuDNN
+    # only runs on CUDA, and we want to skip the rest of the conversion
+    # cost when we already know we'll fall back.
+    inputs_device_type = (
+        inputs.device.type if isinstance(inputs, torch.Tensor) else "cpu"
+    )
+    cudnn_runtime_ok = (
+        inputs_device_type == "cuda"
+        and not torch.jit.is_tracing()
+        and not (
+            hasattr(torch.compiler, "is_compiling")
+            and torch.compiler.is_compiling()
+        )
+    )
+    cudnn_supported = cudnn_activation_ok and cudnn_runtime_ok
+
     # Convert to torch tensors (convert_to_tensor unwraps Variables)
     kernel = convert_to_tensor(kernel)
     recurrent_kernel = convert_to_tensor(recurrent_kernel)
@@ -768,25 +793,6 @@ def gru(
     if go_backwards:
         inputs = torch.flip(inputs, dims=[1])
 
-    # cuDNN only runs on CUDA. Skip it when inputs are on CPU, or when we
-    # are inside a TorchScript or Dynamo trace. The trace records device
-    # transfers that then fail device-consistency validation downstream.
-    device = inputs.device
-    cudnn_supported = (
-        device.type == "cuda"
-        and not torch.jit.is_tracing()
-        and not (
-            hasattr(torch.compiler, "is_compiling")
-            and torch.compiler.is_compiling()
-        )
-        and cudnn_ok(
-            activation,
-            recurrent_activation,
-            unroll,
-            use_bias=bias is not None,
-        )
-    )
-
     if cudnn_supported:
         try:
             return _cudnn_gru(
@@ -796,7 +802,7 @@ def gru(
                 recurrent_kernel,
                 bias,
                 return_sequences=return_sequences,
-                device=device,
+                device=inputs.device,
             )
         except Exception:
             pass
@@ -1148,6 +1154,23 @@ def bidirectional_gru(
     ):
         raise NotImplementedError
 
+    # cuDNN only runs on CUDA. Bail out before paying for any
+    # convert_to_tensor work when inputs are on CPU, or when we are inside
+    # a TorchScript / Dynamo trace (the trace records device transfers
+    # that then fail device-consistency validation downstream).
+    inputs_device_type = (
+        inputs.device.type if isinstance(inputs, torch.Tensor) else "cpu"
+    )
+    if (
+        inputs_device_type != "cuda"
+        or torch.jit.is_tracing()
+        or (
+            hasattr(torch.compiler, "is_compiling")
+            and torch.compiler.is_compiling()
+        )
+    ):
+        raise NotImplementedError
+
     fwd_kernel = convert_to_tensor(fwd_kernel)
     fwd_recurrent_kernel = convert_to_tensor(fwd_recurrent_kernel)
     bwd_kernel = convert_to_tensor(bwd_kernel)
@@ -1157,21 +1180,7 @@ def bidirectional_gru(
     inputs = convert_to_tensor(inputs, dtype=compute_dtype)
     fwd_h0 = convert_to_tensor(fwd_initial_state, dtype=compute_dtype)
     bwd_h0 = convert_to_tensor(bwd_initial_state, dtype=compute_dtype)
-
-    # cuDNN only runs on CUDA. Fall back to the two-pass path when inputs
-    # are on CPU, or when we are inside a TorchScript or Dynamo trace. The
-    # trace records device transfers that then fail device-consistency
-    # validation downstream.
     device = inputs.device
-    if (
-        device.type != "cuda"
-        or torch.jit.is_tracing()
-        or (
-            hasattr(torch.compiler, "is_compiling")
-            and torch.compiler.is_compiling()
-        )
-    ):
-        raise NotImplementedError
 
     fwd_params = prepare_gru_params(
         fwd_kernel, fwd_recurrent_kernel, fwd_bias, device

--- a/keras/src/layers/rnn/bidirectional.py
+++ b/keras/src/layers/rnn/bidirectional.py
@@ -5,6 +5,7 @@ from keras.src import ops
 from keras.src import utils
 from keras.src.api_export import keras_export
 from keras.src.layers.layer import Layer
+from keras.src.layers.rnn.gru import GRU
 from keras.src.layers.rnn.lstm import LSTM
 from keras.src.saving import serialization_lib
 
@@ -207,6 +208,11 @@ class Bidirectional(Layer):
                 return self._call_fused_lstm(sequences, initial_state)
             except NotImplementedError:
                 pass
+        if self._can_attempt_fused_gru(mask, initial_state):
+            try:
+                return self._call_fused_gru(sequences, initial_state)
+            except NotImplementedError:
+                pass
 
         kwargs = {}
         if self.forward_layer._call_has_training_arg:
@@ -346,6 +352,108 @@ class Bidirectional(Layer):
         # The fused backend helper already returns backward outputs in
         # original time order, so the per-layer `ops.flip(y_rev)` that the
         # non-fused path applies is unnecessary here.
+        if self.merge_mode == "concat":
+            output = ops.concatenate([y, y_rev], axis=-1)
+        elif self.merge_mode == "sum":
+            output = y + y_rev
+        elif self.merge_mode == "ave":
+            output = (y + y_rev) / 2
+        elif self.merge_mode == "mul":
+            output = y * y_rev
+        elif self.merge_mode is None:
+            output = (y, y_rev)
+        else:
+            raise ValueError(
+                "Unrecognized value for `merge_mode`. "
+                f"Received: {self.merge_mode}. "
+                'Expected one of {"concat", "sum", "ave", "mul"}.'
+            )
+
+        if self.return_state:
+            states = tuple(fwd_states + bwd_states)
+            if self.merge_mode is None:
+                return output + states
+            return (output,) + states
+        return output
+
+    def _can_attempt_fused_gru(self, mask, initial_state=None):
+        # Layer-level preconditions for dispatching to
+        # `backend.bidirectional_gru`. The structure matches the LSTM gate
+        # above. The only differences are the layer type, the
+        # `reset_after=True` requirement (the cuDNN GRU formulation), and
+        # the state count (one h per direction, so length 2).
+        if mask is not None or self.stateful:
+            return False
+        if initial_state is not None and len(initial_state) != 2:
+            return False
+
+        fwd, bwd = self.forward_layer, self.backward_layer
+        if not isinstance(fwd, GRU) or not isinstance(bwd, GRU):
+            return False
+        if fwd.use_cudnn not in (True, "auto"):
+            return False
+        if bwd.use_cudnn not in (True, "auto"):
+            return False
+        if fwd.cell.dropout or fwd.cell.recurrent_dropout:
+            return False
+        if bwd.cell.dropout or bwd.cell.recurrent_dropout:
+            return False
+        if fwd.cell.units != bwd.cell.units:
+            return False
+        if fwd.cell.activation is not bwd.cell.activation:
+            return False
+        if fwd.cell.recurrent_activation is not bwd.cell.recurrent_activation:
+            return False
+        if not fwd.cell.use_bias or not bwd.cell.use_bias:
+            return False
+        if not fwd.cell.reset_after or not bwd.cell.reset_after:
+            return False
+        if not fwd.built or not bwd.built:
+            return False
+        return True
+
+    def _call_fused_gru(self, sequences, initial_state):
+        fwd_cell = self.forward_layer.cell
+        bwd_cell = self.backward_layer.cell
+        units = fwd_cell.units
+
+        sequences = ops.convert_to_tensor(sequences)
+        batch_size = ops.shape(sequences)[0]
+
+        if initial_state is None:
+            zeros = ops.zeros((batch_size, units), dtype=sequences.dtype)
+            fwd_h0, bwd_h0 = zeros, zeros
+        else:
+            fwd_h0, bwd_h0 = initial_state
+
+        fwd_out, bwd_out = backend.bidirectional_gru(
+            sequences,
+            fwd_h0,
+            bwd_h0,
+            mask=None,
+            fwd_kernel=fwd_cell.kernel,
+            fwd_recurrent_kernel=fwd_cell.recurrent_kernel,
+            fwd_bias=fwd_cell.bias,
+            bwd_kernel=bwd_cell.kernel,
+            bwd_recurrent_kernel=bwd_cell.recurrent_kernel,
+            bwd_bias=bwd_cell.bias,
+            activation=fwd_cell.activation,
+            recurrent_activation=fwd_cell.recurrent_activation,
+            return_sequences=self.return_sequences,
+            unroll=self.forward_layer.unroll,
+            reset_after=fwd_cell.reset_after,
+        )
+        fwd_last, fwd_seq, fwd_states = fwd_out
+        bwd_last, bwd_seq, bwd_states = bwd_out
+
+        if self.return_sequences:
+            y, y_rev = fwd_seq, bwd_seq
+        else:
+            y, y_rev = fwd_last, bwd_last
+
+        y = ops.cast(y, self.compute_dtype)
+        y_rev = ops.cast(y_rev, self.compute_dtype)
+
         if self.merge_mode == "concat":
             output = ops.concatenate([y, y_rev], axis=-1)
         elif self.merge_mode == "sum":

--- a/keras/src/layers/rnn/bidirectional_test.py
+++ b/keras/src/layers/rnn/bidirectional_test.py
@@ -401,3 +401,61 @@ class SimpleRNNTest(testing.TestCase):
             fv.assign(rv.value)
 
         self.assertAllClose(ref(x), fused(x), atol=1e-5)
+
+    def test_fused_gru_eligibility(self):
+        # Shared gating (use_cudnn, dropout, mask, initial_state arity)
+        # is already exercised by test_fused_lstm_eligibility. Cover only
+        # the GRU-specific gates here.
+
+        # GRU with use_cudnn != False passes.
+        bidi = layers.Bidirectional(layers.GRU(4, use_cudnn="auto"))
+        bidi.build((None, 5, 3))
+        self.assertTrue(bidi._can_attempt_fused_gru(mask=None))
+
+        # LSTM is not eligible.
+        lstm = layers.Bidirectional(layers.LSTM(4, use_cudnn="auto"))
+        lstm.build((None, 5, 3))
+        self.assertFalse(lstm._can_attempt_fused_gru(mask=None))
+
+        # reset_after=False is incompatible with the cuDNN GRU formulation.
+        legacy = layers.Bidirectional(
+            layers.GRU(4, use_cudnn="auto", reset_after=False)
+        )
+        legacy.build((None, 5, 3))
+        self.assertFalse(legacy._can_attempt_fused_gru(mask=None))
+
+        # GRU has one state per direction (length 2), not LSTM's four.
+        wrong_state = [np.zeros((2, 4), dtype="float32")] * 4
+        self.assertFalse(
+            bidi._can_attempt_fused_gru(mask=None, initial_state=wrong_state)
+        )
+
+    def test_fused_gru_matches_unfused(self):
+        # The fused path requires backend support (torch with cuDNN today).
+        # On other backends and on CPU runners, `backend.bidirectional_gru`
+        # raises `NotImplementedError` and the layer falls back to the
+        # two-call path, so this test trivially passes. On GPU it exercises
+        # the fused dispatch and asserts numerical equivalence with the
+        # two-call reference.
+        rng = np.random.default_rng(0)
+        x = rng.standard_normal((3, 6, 4)).astype("float32")
+
+        def _build(use_cudnn):
+            layer = layers.Bidirectional(
+                layers.GRU(
+                    5,
+                    use_cudnn=use_cudnn,
+                    return_sequences=True,
+                    kernel_initializer=initializers.GlorotUniform(seed=1),
+                    recurrent_initializer=initializers.Orthogonal(seed=2),
+                )
+            )
+            layer.build(x.shape)
+            return layer
+
+        ref = _build(use_cudnn=False)
+        fused = _build(use_cudnn="auto")
+        for rv, fv in zip(ref.weights, fused.weights):
+            fv.assign(rv.value)
+
+        self.assertAllClose(ref(x), fused(x), atol=1e-5)

--- a/keras/src/layers/rnn/bidirectional_test.py
+++ b/keras/src/layers/rnn/bidirectional_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from keras.src import backend
 from keras.src import initializers
 from keras.src import layers
 from keras.src import testing
@@ -459,3 +460,46 @@ class SimpleRNNTest(testing.TestCase):
             fv.assign(rv.value)
 
         self.assertAllClose(ref(x), fused(x), atol=1e-5)
+
+    def test_torch_cudnn_bidirectional_gru_dispatch_fires(self):
+        # `backend.bidirectional_gru` is wrapped by a try/except in the
+        # Bidirectional layer, so a regression in the fused cuDNN call
+        # silently routes every Bidirectional(GRU) call through the
+        # two-pass fallback while every existing test still passes.
+        # Assert that `torch._VF.gru` actually fires when the layer runs
+        # against cuDNN-eligible inputs on CUDA.
+        if backend.backend() != "torch":
+            self.skipTest("Guards the torch-backend cuDNN dispatch path.")
+
+        import torch
+
+        if not torch.cuda.is_available():
+            self.skipTest("Requires a CUDA device.")
+
+        from unittest import mock
+
+        x = torch.randn(4, 6, 5, device="cuda")
+        layer = layers.Bidirectional(
+            layers.GRU(8, use_cudnn="auto", return_sequences=True)
+        )
+        layer(x)  # build on cuda
+
+        real_vf_gru = torch._VF.gru
+        calls = []
+
+        def spy(*args, **kwargs):
+            calls.append(True)
+            return real_vf_gru(*args, **kwargs)
+
+        with mock.patch.object(torch._VF, "gru", side_effect=spy):
+            _ = layer(x)
+
+        self.assertGreaterEqual(
+            len(calls),
+            1,
+            msg=(
+                "torch._VF.gru was never invoked from Bidirectional(GRU); "
+                "the fused cuDNN dispatch is silently inactive and every "
+                "call is routing through the two-pass fallback."
+            ),
+        )

--- a/keras/src/layers/rnn/gru_test.py
+++ b/keras/src/layers/rnn/gru_test.py
@@ -433,3 +433,46 @@ class GRUTest(testing.TestCase):
 
         y = f(x_concrete)
         self.assertEqual(y.shape, (2, 5))
+
+    @pytest.mark.skipif(
+        backend.backend() != "torch",
+        reason="Guards the torch-backend cuDNN dispatch path.",
+    )
+    def test_torch_cudnn_dispatch_fires(self):
+        # The cuDNN path in `keras.src.backend.torch.rnn.gru` is wrapped in
+        # a `try/except` and falls back to `_fallback_gru` on failure. If a
+        # future change quietly breaks `_cudnn_gru` (as happened with the
+        # LSTM dispatch before #22874), every existing test would still pass
+        # against the slow fallback. This test asserts that `torch._VF.gru`
+        # is actually invoked when the layer is called with cuDNN-eligible
+        # inputs on CUDA, so the failure mode becomes loud.
+        import torch
+
+        if not torch.cuda.is_available():
+            self.skipTest("Requires a CUDA device.")
+
+        from unittest import mock
+
+        x = torch.randn(4, 6, 5, device="cuda")
+        layer = layers.GRU(8, return_sequences=True)
+        layer(x)  # build on cuda
+
+        real_vf_gru = torch._VF.gru
+        calls = []
+
+        def spy(*args, **kwargs):
+            calls.append(True)
+            return real_vf_gru(*args, **kwargs)
+
+        with mock.patch.object(torch._VF, "gru", side_effect=spy):
+            _ = layer(x)
+
+        self.assertGreaterEqual(
+            len(calls),
+            1,
+            msg=(
+                "torch._VF.gru was never invoked; cuDNN dispatch is silently "
+                "inactive and every call is routing through the pure-torch "
+                "fallback."
+            ),
+        )


### PR DESCRIPTION
## Description

Adds a fused `bidirectional_gru` to the torch backend so `Bidirectional(GRU)` runs a single `torch._VF.gru(bidirectional=True)` call instead of two unidirectional cuDNN dispatches. Closes the asymmetry with BiLSTM, which has had a fused path since #22791 / #22874. Other backends raise `NotImplementedError` (matches `bidirectional_lstm`).

Also hardens the unidirectional `gru()` dispatch with the same fixes #22874 applied to `lstm()`: it now keys off `inputs.device` instead of the global default, skips cuDNN under TorchScript / Dynamo trace, and falls through to a new `_fallback_gru` rather than raising `NotImplementedError`. Unlike the LSTM case, the cuDNN path for unidirectional GRU was already engaged on master, so this is hardening rather than a regression fix.

### Benchmark (Colab A100, torch 2.10.0+cu128)

Two-layer `Bidirectional(GRU(256))`, batch 64, seq 256, features 128, steady-state `model.fit` epoch.

|        | master  | this PR | speedup |
|--------|---------|---------|---------|
| epoch  | 1.591 s | 1.478 s | 1.08x   |

Dispatch trace confirms `Bidirectional(GRU)` makes one fused `_VF.gru` call on the branch vs two on master.

### Tests

`bidirectional_test.py` gains `test_fused_gru_eligibility` and `test_fused_gru_matches_unfused` mirroring the BiLSTM coverage. Existing rnn tests still pass on torch, jax, tf, numpy.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.