### PR TITLE
[OpenVINO]  Fix dynamic batch shape propagation through ops.slice

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -1390,7 +1390,9 @@ def slice(inputs, start_indices, shape):
         return val
 
     for idx, length in enumerate(shape):
-        if length is not None and length >= 0:
+        if length is not None and (
+            isinstance(length, OpenVINOKerasTensor) or length >= 0
+        ):
             axes.append(idx)
             start_val = prepare_slice_index(get_ov_output(start_indices[idx]))
             stop_val = prepare_slice_index(

--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -99,23 +99,23 @@ class OpenVINOTrainer(base_trainer.Trainer):
 
         self.test_function = test_step
 
-    def _parameterize_data(self, data, dynamic_batch_size=False):
+    def _parameterize_data(self, data):
         if isinstance(data, (list, tuple)):
             parametrize_data = []
             for elem in data:
-                param_elem = self._parameterize_data(elem, dynamic_batch_size)
+                param_elem = self._parameterize_data(elem)
                 parametrize_data.append(param_elem)
         elif isinstance(data, dict):
             parametrize_data = dict()
             for elem_name, elem in data.items():
-                param_elem = self._parameterize_data(elem, dynamic_batch_size)
+                param_elem = self._parameterize_data(elem)
                 parametrize_data[elem_name] = param_elem
         elif isinstance(data, OpenVINOKerasTensor):
             parametrize_data = data
         elif isinstance(data, np.ndarray) or np.isscalar(data):
             ov_type = OPENVINO_DTYPES[str(data.dtype)]
             ov_shape = list(data.shape)
-            if dynamic_batch_size and len(ov_shape) > 0:
+            if len(ov_shape) > 0:
                 ov_shape[0] = -1
             param = ov_opset.parameter(shape=ov_shape, dtype=ov_type)
             parametrize_data = OpenVINOKerasTensor(param.output(0))
@@ -152,9 +152,7 @@ class OpenVINOTrainer(base_trainer.Trainer):
         del self.ov_compiled_model
 
         # prepare parameterized input
-        self.struct_params = self._parameterize_data(
-            data, dynamic_batch_size=True
-        )
+        self.struct_params = self._parameterize_data(data)
         # construct OpenVINO graph during calling Keras Model
         if self._call_has_training_arg:
             self.struct_outputs = self(self.struct_params, training=False)


### PR DESCRIPTION
## Description
`ops.slice` did `if length is not None and length >= 0`. On a OpenVINOKerasTensor, length >= 0 produces a boolean OpenVINOKerasTensor, and __bool__ attempts numerical evaluation at graph-build time, crashing because the tensor has no concrete value.

This PR skips the static >= 0 check for symbolic lengths and let OV resolve them at runtime. This PR also reverts #22681, since that workaround is no longer needed.
Part of the fix for dynamic batch shape propagation, alongside #22747.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
