### PR TITLE
Raise on zero-size pooling outputs when pool_size > input spatial dim

### DIFF
--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -134,10 +134,12 @@ def compute_pooling_output_shape(
             np.floor((spatial_shape - pool_size) / strides) + 1
         )
         for i in range(len(output_spatial_shape)):
-            if i not in none_dims and output_spatial_shape[i] < 0:
+            if i not in none_dims and output_spatial_shape[i] <= 0:
                 raise ValueError(
-                    "Computed output size would be negative. Received: "
-                    f"`inputs.shape={input_shape}` and `pool_size={pool_size}`."
+                    "Computed output size would be zero or negative. "
+                    f"Received: `inputs.shape={input_shape}`, "
+                    f"`pool_size={pool_size}`, `strides={strides}`, "
+                    f"`padding={padding}`."
                 )
     elif padding == "same":
         output_spatial_shape = np.floor((spatial_shape - 1) / strides) + 1

--- a/keras/src/ops/operation_utils_test.py
+++ b/keras/src/ops/operation_utils_test.py
@@ -90,6 +90,17 @@ class OperationUtilsTest(testing.TestCase):
         )
         self.assertEqual(output_shape, (1, 4, 4, 3))
 
+    def test_compute_pooling_output_shape_rejects_zero_output(self):
+        # pool_size > input spatial dim produces a zero-size output that the
+        # downstream model cannot use. The Conv equivalent was fixed in #22418;
+        # the pooling case should behave the same way.
+        with self.assertRaisesRegex(
+            ValueError, "Computed output size would be zero or negative"
+        ):
+            operation_utils.compute_pooling_output_shape(
+                (1, 5, 5, 3), pool_size=(20, 20), strides=(20, 20)
+            )
+
     def test_compute_conv_output_shape(self):
         input_shape = (1, 4, 4, 1)
         filters = 1


### PR DESCRIPTION
## Description

Fixes #22916.

`keras.layers.MaxPooling*` and `keras.layers.AveragePooling*` silently produce an output with a `0`-sized spatial dimension when `pool_size` exceeds the input spatial size — both in the symbolic and the eager paths. Downstream layers either crash with a confusing error or operate on an empty tensor.

This is the same family of bug as #22414 / #22416 for Conv, fixed in #22418 by changing the guard in `compute_conv_output_shape` from `< 0` to `<= 0`. The matching pooling case was missed at the time.

### Before

```python
import keras

keras.layers.MaxPooling2D(pool_size=(20, 20))(keras.Input(shape=(5, 5, 3))).shape
# -> (None, 0, 0, 3)  — silent
```

### After

```
ValueError: Computed output size would be zero or negative. Received:
`inputs.shape=[None 5 5 3]`, `pool_size=[20 20]`, `strides=(20, 20)`,
`padding=valid`.
```

Same fix applies to `MaxPooling1D`, `MaxPooling3D`, `AveragePooling1D`, `AveragePooling3D`. Dynamic spatial dimensions (`None`) still pass through unvalidated, matching the existing Conv behavior.

### Implementation

- `keras/src/ops/operation_utils.compute_pooling_output_shape`: change `output_spatial_shape[i] < 0` → `<= 0`, and update the error message to match the wording introduced for `compute_conv_output_shape` in #22418 (\"zero or negative\", with `strides` and `padding` included for context).
- `keras/src/ops/operation_utils_test.py`: add `test_compute_pooling_output_shape_rejects_zero_output` covering the new guard.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.