### PR TITLE
Validate axis in symbolic sort/argsort/cumsum/cumprod/take

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1094,6 +1094,7 @@ class Argsort(Operation):
     def compute_output_spec(self, x):
         if self.axis is None:
             return KerasTensor([int(np.prod(x.shape))], dtype="int32")
+        canonicalize_axis(self.axis, len(x.shape))
         return KerasTensor(x.shape, dtype="int32")
 
 
@@ -2353,6 +2354,7 @@ class Cumprod(Operation):
             else:
                 output_shape = (int(np.prod(x.shape)),)
         else:
+            canonicalize_axis(self.axis, len(x.shape))
             output_shape = x.shape
         output_dtype = (
             backend.standardize_dtype(x.dtype)
@@ -2399,6 +2401,7 @@ class Cumsum(Operation):
             else:
                 output_shape = (int(np.prod(x.shape)),)
         else:
+            canonicalize_axis(self.axis, len(x.shape))
             output_shape = x.shape
         output_dtype = (
             backend.standardize_dtype(x.dtype)
@@ -7492,6 +7495,7 @@ class Sort(Operation):
             else:
                 output_shape = (int(np.prod(x.shape)),)
             return KerasTensor(output_shape, x.dtype)
+        canonicalize_axis(self.axis, len(x.shape))
         return KerasTensor(x.shape, x.dtype)
 
 
@@ -7743,8 +7747,7 @@ class Take(Operation):
         if self.axis is None:
             return KerasTensor(indices_shape, dtype=x.dtype)
 
-        # make sure axis is non-negative
-        axis = len(x_shape) + self.axis if self.axis < 0 else self.axis
+        axis = canonicalize_axis(self.axis, len(x_shape))
         output_shape = x_shape[:axis] + indices_shape + x_shape[axis + 1 :]
         return KerasTensor(output_shape, dtype=x.dtype, ragged=ragged)
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6265,6 +6265,24 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.sort(x, axis=None), np.sort(x, axis=None))
         self.assertAllClose(knp.Sort(axis=None)(x), np.sort(x, axis=None))
 
+    def test_symbolic_axis_out_of_range_raises(self):
+        # All five ops should reject out-of-range axis cleanly in the symbolic
+        # path, instead of either silently returning a wrong shape or failing
+        # with a backend-specific error at eager execution time.
+        a = backend.KerasTensor((3, 4))
+        idx = backend.KerasTensor((2,), dtype="int32")
+        msg = "axis 10 is out of bounds"
+        for fn in (
+            lambda: knp.sort(a, axis=10),
+            lambda: knp.argsort(a, axis=10),
+            lambda: knp.cumsum(a, axis=10),
+            lambda: knp.cumprod(a, axis=10),
+        ):
+            with self.assertRaisesRegex(ValueError, msg):
+                fn()
+        with self.assertRaisesRegex(ValueError, "axis 5 is out of bounds"):
+            knp.take(a, idx, axis=5)
+
     def test_split(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertIsInstance(knp.split(x, 2), list)


### PR DESCRIPTION
## Description

Fixes #22923.

Five `keras.ops` accept an out-of-range `axis` in their symbolic path without raising, while the eager path fails with a cryptic backend-specific error (e.g. TF `StridedSlice ... slice index 10 of dimension 0 out of bounds`). Other reduction ops (`argmax`, `argmin`, `sum`, `mean`, `max`, `min`, `std`, `var`) already validate cleanly via the shared `canonicalize_axis` helper.

### Before

```python
import keras, keras.ops as ops

a = keras.KerasTensor((3, 4))
print(ops.sort(a, axis=10).shape)      # (3, 4) — silent
print(ops.argsort(a, axis=10).shape)   # (3, 4) — silent
print(ops.cumsum(a, axis=10).shape)    # (3, 4) — silent
print(ops.cumprod(a, axis=10).shape)   # (3, 4) — silent
ops.take(a, keras.KerasTensor((2,), dtype="int32"), axis=5).shape
# (3, 4, 2) — silently composes shape from out-of-range axis
```

### After

All five now raise the same `ValueError` already used by sibling ops:

```
ValueError: axis 10 is out of bounds for an array with dimension 2.
```

### Implementation

Reuse the existing `canonicalize_axis` helper from `keras.src.backend.common.backend_utils`:

- `Sort.compute_output_spec`: validate when `self.axis is not None`.
- `Argsort.compute_output_spec`: same.
- `Cumsum.compute_output_spec` and `Cumprod.compute_output_spec`: validate when `self.axis is not None` (the flatten branch already special-cases `axis=None`).
- `Take.compute_output_spec`: replace the inline `axis = len(x_shape) + self.axis if self.axis < 0 else self.axis` (which silently composes wrong shapes for out-of-range axes) with `canonicalize_axis(self.axis, len(x_shape))`.

Added `test_symbolic_axis_out_of_range_raises` covering all five.

Continues the validation-consistency family: #22853 (conv), #22861 (conv_transpose), #22868 (reshape), #22919 (pooling, pending), #22922 (transpose, pending).

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.