### PR TITLE
Supports symbolic and dynamic tensor shapes in `reshape`

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -7188,10 +7188,10 @@ def reshape(x, newshape):
     if not backend.is_tensor(newshape) and not isinstance(
         newshape, KerasTensor
     ):
-        if isinstance(newshape, int):
-            newshape = (newshape,)
-        else:
+        try:
             newshape = tuple(newshape)
+        except TypeError:
+            newshape = (newshape,)
         operation_utils.validate_reshape_shape(newshape)
     if any_symbolic_tensors((x, newshape)):
         return Reshape(newshape).symbolic_call(x)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -7193,7 +7193,7 @@ def reshape(x, newshape):
         else:
             newshape = tuple(newshape)
         operation_utils.validate_reshape_shape(newshape)
-    if any_symbolic_tensors((x,)):
+    if any_symbolic_tensors((x, newshape)):
         return Reshape(newshape).symbolic_call(x)
     return backend.numpy.reshape(x, newshape)
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -7185,8 +7185,12 @@ def reshape(x, newshape):
     Returns:
         The reshaped tensor.
     """
-    newshape = tuple(newshape)
-    operation_utils.validate_reshape_shape(newshape)
+    if not backend.is_tensor(newshape):
+        if isinstance(newshape, int):
+            newshape = (newshape,)
+        else:
+            newshape = tuple(newshape)
+        operation_utils.validate_reshape_shape(newshape)
     if any_symbolic_tensors((x,)):
         return Reshape(newshape).symbolic_call(x)
     return backend.numpy.reshape(x, newshape)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -7185,7 +7185,9 @@ def reshape(x, newshape):
     Returns:
         The reshaped tensor.
     """
-    if not backend.is_tensor(newshape) and not isinstance(newshape, KerasTensor):
+    if not backend.is_tensor(newshape) and not isinstance(
+        newshape, KerasTensor
+    ):
         if isinstance(newshape, int):
             newshape = (newshape,)
         else:

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -7185,7 +7185,7 @@ def reshape(x, newshape):
     Returns:
         The reshaped tensor.
     """
-    if not backend.is_tensor(newshape):
+    if not backend.is_tensor(newshape) and not isinstance(newshape, KerasTensor):
         if isinstance(newshape, int):
             newshape = (newshape,)
         else:

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6191,6 +6191,20 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         ):
             knp.reshape(x, (-1, -1, 5))
 
+    def test_reshape_symbolic_tensor_shape(self):
+        input_tensor = KerasTensor((None, 20))
+        shape_tensor = KerasTensor((2,), dtype="int32")
+        out = knp.reshape(input_tensor, shape_tensor)
+        self.assertEqual(out.shape, (None, None))
+
+        out2 = knp.reshape(input_tensor, (None, KerasTensor((), dtype="int32")))
+        self.assertEqual(out2.shape, (None, None))
+
+        # Only newshape is symbolic, x is a concrete array
+        out3 = knp.reshape(np.zeros((20,)), shape_tensor)
+        self.assertIsInstance(out3, KerasTensor)
+        self.assertEqual(out3.shape, (None, None))
+
     def test_roll(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertAllClose(knp.roll(x, 1), np.roll(x, 1))

--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -330,7 +330,8 @@ def compute_reshape_output_shape(input_shape, newshape, newshape_arg_name):
             return (None,) * shape[0]
         return (None,)
 
-    # Normalize dimensions by replacing symbolic tensors or dynamic values with `None`.
+    # Normalize dimensions by replacing symbolic tensors or
+    # dynamic values with `None`.
     newshape = tuple(
         dim if isinstance(dim, (int, np.integer)) else None for dim in newshape
     )

--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -2,8 +2,10 @@ import math
 
 import numpy as np
 
+from keras.src import backend
 from keras.src import tree
 from keras.src.api_export import keras_export
+from keras.src.backend import KerasTensor
 from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.backend_utils import to_tuple_or_list
 
@@ -290,6 +292,10 @@ def validate_reshape_shape(newshape, newshape_arg_name="newshape"):
     scalars resolved at runtime, such as `torch.SymInt` under `torch.compile`)
     are not validated here.
     """
+
+    if backend.is_tensor(newshape) or isinstance(newshape, KerasTensor):
+        return
+
     neg_one_count = 0
     for dim in newshape:
         if not isinstance(dim, (int, np.integer)):
@@ -316,10 +322,23 @@ def compute_reshape_output_shape(input_shape, newshape, newshape_arg_name):
     This utility does not special case the 0th dimension (batch size).
     """
     validate_reshape_shape(newshape, newshape_arg_name)
+    # If `newshape` is a tensor, we infer the output rank based on its shape.
+    # For example, a 1D tensor of shape (4,) indicates a 4D output shape.
+    if backend.is_tensor(newshape) or isinstance(newshape, KerasTensor):
+        shape = getattr(newshape, "shape", None)
+        if shape and len(shape) == 1 and shape[0] is not None:
+            return (None,) * shape[0]
+        return (None,)
+
+    # Normalize dimensions by replacing symbolic tensors or dynamic values with `None`.
+    newshape = tuple(
+        dim if isinstance(dim, (int, np.integer)) else None for dim in newshape
+    )
     unknown_dim_count = newshape.count(-1)
 
-    # If there is a None in input_shape, we can't infer what the -1 is
-    if None in input_shape:
+    # If there is a None in input_shape or dynamic dimensions,
+    # we can't infer what the -1 is
+    if None in input_shape or None in newshape:
         return tuple(dim if dim != -1 else None for dim in newshape)
 
     input_size = math.prod(input_shape)

--- a/keras/src/ops/operation_utils_test.py
+++ b/keras/src/ops/operation_utils_test.py
@@ -190,6 +190,22 @@ class OperationUtilsTest(testing.TestCase):
         )
         self.assertEqual(output_shape, target_shape)
 
+    def test_compute_reshape_output_shape_symbolic_tensors(self):
+        # Entire newshape is a KerasTensor
+        input_shape = (2, 10)
+        shape_tensor = backend.KerasTensor((2,), dtype="int32")
+        output_shape = operation_utils.compute_reshape_output_shape(
+            input_shape, newshape=shape_tensor, newshape_arg_name="newshape"
+        )
+        self.assertEqual(output_shape, (None, None))
+
+        # Tuple containing a KerasTensor and -1
+        dim_tensor = backend.KerasTensor((), dtype="int32")
+        output_shape2 = operation_utils.compute_reshape_output_shape(
+            input_shape, newshape=(-1, dim_tensor), newshape_arg_name="newshape"
+        )
+        self.assertEqual(output_shape2, (None, None))
+
     def test_reduce_shape_no_axes_no_keepdims(self):
         input_shape = (1, 4, 4, 1)
         output_shape = operation_utils.reduce_shape(input_shape)


### PR DESCRIPTION
## Description

This PR fixes regressions introduced in commit #22868 when dynamically reshaping tensors using symbolic tensor dimensions (e.g. `ops.reshape(x, ops.shape(y))`).

### RCA
1. `reshape()` unconditionally cast `newshape` to a `tuple` and ran validation over its elements. When `newshape` was a symbolic tensor (e.g., in a `tf.function`), attempting to iterate over it caused an `OperatorNotAllowedInGraphError` / `NotImplementedError`.
2. Even when routing to the symbolic `Reshape` op, static shape inference (`compute_reshape_output_shape`) crashed when attempting `newshape.count(-1)` or `math.prod(newshape)` on tensor objects.

### Fix
- Updated `reshape()` and `validate_reshape_shape()` to skip explicit tuple iteration if `newshape` is a tensor.
- Updated symbolic execution routing to `if any_symbolic_tensors((x, newshape)):` to correctly route to `Reshape` when only the shape parameter is symbolic.
- In static shape inference, we normalize any non-integer dimensions (tensors, dynamic variables) to `None`. This ensures `KerasTensor.shape` tuples strictly contain concrete integers or `None` (for dynamic runtime dimensions). Runtime graph execution remains completely unaffected and receives the original tensor shapes.

### Fixes
- Fixes `keras-hub` model crashes during dynamic spatial formatting (e.g., `MoonshineBackbone`).

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
